### PR TITLE
fix(graph): expand entity aliases on creation; backfill existing entities (closes #7)

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -21,6 +21,33 @@ _SAFE_ENTITY_NAME_RE = re.compile(r'^[A-Za-z0-9가-힣\s\-_,()&·\.]{2,80}$')
 _ALLOWED_EXTRACT_TYPES = frozenset(("person", "org", "concept"))
 _ONTOLOGY_LABELS_KO = "공부, 연구, 가르침, 소속, 근무, 분류, 구성, 관련, 생산, 산업, 분야, 설립됨"
 
+# 괄호 패턴 — 반각/전각 모두 처리. e.g. "RAG (검색 증강 생성)" / "RAG（검색 증강 생성）"
+_PAREN_ALIAS_RE = re.compile(r'^(.+?)\s*[\(（](.+?)[\)）]\s*$')
+
+
+def _expand_alias_candidates(name: str) -> List[str]:
+    """이름에서 alias 후보를 자동 추출.
+
+    - 괄호 패턴 ``"X (Y)"`` → ``["X (Y)", "X", "Y"]``
+    - 그 외에는 ``[name]`` 만 반환
+
+    LLM이 풍부한 이름(`"RAG (검색 증강 생성)"`)으로 entity를 만들고,
+    질의 시점엔 짧은 형태(`"RAG"`)로 entity를 추출하기 때문에
+    매칭 갭을 메우려면 양쪽 형태를 모두 alias로 등록해야 한다.
+    """
+    if not isinstance(name, str):
+        return []
+    name = name.strip()
+    if not name:
+        return []
+    out: List[str] = [name]
+    m = _PAREN_ALIAS_RE.match(name)
+    if m:
+        for part in (m.group(1).strip(), m.group(2).strip()):
+            if part and part not in out and len(part) >= 2:
+                out.append(part)
+    return out
+
 
 class WikiGenerator:
 
@@ -205,10 +232,11 @@ class WikiGenerator:
 
         path = self.entity_path / entity_type / f"{normalized}.md"
 
-        # aliases
-        aliases = list({name})
-        if entity.get("attributes", {}).get("약자"):
-            aliases.append(entity["attributes"]["약자"])
+        # aliases — `"X (Y)"` 패턴은 outer/inner도 자동 등록 (Issue #7)
+        aliases = _expand_alias_candidates(name)
+        short = entity.get("attributes", {}).get("약자")
+        if short and short not in aliases:
+            aliases.append(short)
 
         # =========================
         # RELATIONS + Ontology 정규화

--- a/scripts/migrate_aliases.py
+++ b/scripts/migrate_aliases.py
@@ -1,0 +1,112 @@
+"""Backfill `aliases` for existing wiki entities (Issue #7 fix).
+
+For each entity .md under wiki/entity/{prod,test}, regenerate `aliases`
+from `name` via wiki_generator._expand_alias_candidates and merge with
+the existing list (dedup, preserve original order).
+
+Why: STEP 7 found that LLM-extracted entity names ("RAG") miss matching
+when the wiki entity is stored with a verbose name ("RAG (검색 증강
+생성)") because aliases only contained the full form. The fix adds
+short forms automatically — but pre-existing entities still need to
+be backfilled.
+
+Usage:
+    python scripts/migrate_aliases.py              # dry run, prints diff
+    python scripts/migrate_aliases.py --apply      # rewrite files
+
+The script preserves the body (everything after the closing `---`).
+Frontmatter is parsed with PyYAML and re-dumped with allow_unicode=True
+and sort_keys=False so existing key order survives the round-trip.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.wiki_generator import _expand_alias_candidates  # noqa: E402
+
+WIKI_BASE = ROOT / "wiki" / "entity"
+FM_RE     = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+def normalize_aliases(name: str, existing: object) -> list[str]:
+    """Merge expanded alias candidates with existing list (dedup, ordered)."""
+    if not isinstance(existing, list):
+        existing = [str(existing)] if existing else []
+    existing_str = [str(a).strip() for a in existing if a]
+    expanded     = _expand_alias_candidates(name)
+    seen: set[str] = set()
+    merged: list[str] = []
+    for a in [*existing_str, *expanded]:
+        if a and a not in seen:
+            seen.add(a)
+            merged.append(a)
+    return merged
+
+
+def process_file(path: Path, apply: bool) -> tuple[bool, list[str]]:
+    """Return (changed, added_aliases). Rewrites file if apply=True."""
+    text = path.read_text(encoding="utf-8")
+    m = FM_RE.match(text)
+    if not m:
+        return False, []
+    fm_text = m.group(1)
+    body    = m.group(2)
+    try:
+        fm = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        return False, []
+    name = fm.get("name", "")
+    if not name:
+        return False, []
+    existing = fm.get("aliases") or []
+    new_list = normalize_aliases(name, existing)
+    if new_list == ([str(a) for a in (existing or [])] if isinstance(existing, list) else [str(existing)]):
+        return False, []
+    added = [a for a in new_list if a not in (existing if isinstance(existing, list) else [])]
+    fm["aliases"] = new_list
+    if apply:
+        new_fm = yaml.safe_dump(
+            fm, allow_unicode=True, sort_keys=False, default_flow_style=False,
+        ).rstrip()
+        path.write_text(f"---\n{new_fm}\n---\n{body}", encoding="utf-8")
+    return True, added
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true",
+                    help="actually rewrite files (default: dry run)")
+    args = ap.parse_args()
+
+    files = sorted(WIKI_BASE.rglob("*.md"))
+    print(f"Scanning {len(files)} entity files under {WIKI_BASE.relative_to(ROOT)}/")
+    print(f"Mode: {'APPLY' if args.apply else 'DRY RUN'}\n")
+
+    changed = 0
+    total_added = 0
+    for f in files:
+        ok, added = process_file(f, apply=args.apply)
+        if ok:
+            changed += 1
+            total_added += len(added)
+            rel = f.relative_to(ROOT)
+            label = ", ".join(repr(a) for a in added) if added else "(re-ordered)"
+            print(f"  + {rel} -> {label}")
+
+    print(f"\nresult: {changed}/{len(files)} files would be updated, "
+          f"{total_added} aliases added")
+    if not args.apply and changed > 0:
+        print("Re-run with --apply to write changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #7 — STEP 7 root-cause: Graph utilization stuck at 33% because
`create_entity_file` only stored the entity's full name as its sole
alias. `build_entity_map_snapshot` already indexed every alias, but
the LLM extracts short forms ("RAG") while the wiki stored only the
verbose form ("RAG (검색 증강 생성)"). Normalized names diverged and
the lookup missed.

## Changes

- `core/wiki_generator.py`
  - Add `_expand_alias_candidates(name)` — for `"X (Y)"` patterns
    (full-width or half-width parens), return `["X (Y)", "X", "Y"]`
    so both the LLM's likely short form AND the verbose form become
    alias keys.
  - `create_entity_file` seeds aliases from this helper, then appends
    `attributes['약자']` if distinct.

- `scripts/migrate_aliases.py` (new)
  - One-shot backfill for entities created before this PR.
    Re-derives aliases from `name`, merges (dedup, ordered), rewrites
    frontmatter with `allow_unicode=True` and `sort_keys=False` so key
    order survives. Dry-run by default; `--apply` to write.

## Verification

| step | result |
| --- | --- |
| `_expand_alias_candidates` unit cases | covered (paren, full-width, len<2 filtered) |
| Local backfill on 161 entities | 8 files updated, 16 aliases added |
| `match_entities("RAG")` before | 0 hits |
| `match_entities("RAG")` after | `e_concept_f05f74ef` ✅ |
| Bidirectional (`검색 증강 생성`) | same entity_id ✅ |
| `Retrieval-Augmented Code Generation` | matches `RACG` ✅ |
| `TSLA` | matches `Tesla, Inc. (TSLA)` ✅ |

## Pending verification

- [ ] Reviewer manual: server restart + re-run `scripts/step7_query_test.py`
  to measure Graph utilization. Baseline was 4/12 = 33%; expected
  improvement based on the trace fix is significant on `retrieve` /
  `relation` / `compare` categories.

## Notes for reviewers

- This PR does not touch the (already correct) `build_entity_map_snapshot`
  — that side has been indexing aliases all along. The bug was purely
  on the producer side (`create_entity_file`).
- The migration script is idempotent and order-preserving; running it
  twice is a no-op.
- User-PDF entity files are gitignored, so the actual `.md` files
  modified by the migration do not appear in this diff. The migration
  script is the artifact; running it locally is the operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)