### PR TITLE
fix(graph): wiki/synonyms.yaml synonym table → bidirectional alias (#3 phase 1)

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -25,16 +25,65 @@ _ONTOLOGY_LABELS_KO = "공부, 연구, 가르침, 소속, 근무, 분류, 구성
 # 괄호 패턴 — 반각/전각 모두 처리. e.g. "RAG (검색 증강 생성)" / "RAG（검색 증강 생성）"
 _PAREN_ALIAS_RE = re.compile(r'^(.+?)\s*[\(（](.+?)[\)）]\s*$')
 
+# wiki/synonyms.yaml 한 번 로드해서 캐시. (Issue #3)
+# {surface_form_lower: [other_form1, other_form2, ...]} 양방향.
+_SYNONYM_INDEX: Dict[str, List[str]] | None = None
+
+
+def _load_synonyms() -> Dict[str, List[str]]:
+    """wiki/synonyms.yaml에서 synonym 그룹 로드 → 양방향 lookup index 빌드.
+
+    yaml 형식:
+      - canonical: 비트코인
+        aliases: [BTC, Bitcoin]
+
+    반환: ``{lowercase_form → [같은 그룹의 다른 form들]}``
+    """
+    global _SYNONYM_INDEX
+    if _SYNONYM_INDEX is not None:
+        return _SYNONYM_INDEX
+
+    index: Dict[str, List[str]] = {}
+    syn_path = Path(WIKI_DIR) / "synonyms.yaml"
+    if not syn_path.exists():
+        _SYNONYM_INDEX = index
+        return index
+
+    try:
+        groups = yaml.safe_load(syn_path.read_text(encoding="utf-8")) or []
+        if not isinstance(groups, list):
+            _SYNONYM_INDEX = index
+            return index
+        for g in groups:
+            if not isinstance(g, dict):
+                continue
+            canonical = (g.get("canonical") or "").strip()
+            aliases   = g.get("aliases") or []
+            if not canonical or not isinstance(aliases, list):
+                continue
+            forms = [canonical] + [str(a).strip() for a in aliases if a]
+            forms = [f for f in forms if f]
+            for f in forms:
+                others = [x for x in forms if x != f]
+                if others:
+                    index.setdefault(f.lower(), []).extend(others)
+    except Exception as e:
+        print(f"[SYNONYMS] load failed: {e}")
+
+    _SYNONYM_INDEX = index
+    return index
+
 
 def _expand_alias_candidates(name: str) -> List[str]:
     """이름에서 alias 후보를 자동 추출.
 
     - 괄호 패턴 ``"X (Y)"`` → ``["X (Y)", "X", "Y"]``
+    - synonym 매핑 (wiki/synonyms.yaml) → 같은 그룹의 다른 form 모두 추가
     - 그 외에는 ``[name]`` 만 반환
 
     LLM이 풍부한 이름(`"RAG (검색 증강 생성)"`)으로 entity를 만들고,
-    질의 시점엔 짧은 형태(`"RAG"`)로 entity를 추출하기 때문에
-    매칭 갭을 메우려면 양쪽 형태를 모두 alias로 등록해야 한다.
+    질의 시점엔 짧은 형태(`"RAG"`)로 entity를 추출하기 때문에 매칭 갭을
+    메우려면 양쪽 형태를 모두 alias로 등록해야 한다.
     """
     if not isinstance(name, str):
         return []
@@ -47,6 +96,15 @@ def _expand_alias_candidates(name: str) -> List[str]:
         for part in (m.group(1).strip(), m.group(2).strip()):
             if part and part not in out and len(part) >= 2:
                 out.append(part)
+
+    # synonym 매핑 (Issue #3)
+    syn_index = _load_synonyms()
+    # name 본체와 (괄호 분리된) 짧은 form 모두 lookup
+    for candidate in list(out):
+        for other in syn_index.get(candidate.lower(), []):
+            if other not in out:
+                out.append(other)
+
     return out
 
 

--- a/wiki/synonyms.yaml
+++ b/wiki/synonyms.yaml
@@ -1,0 +1,35 @@
+# PROJECT JAMES — Entity Synonym Map (Issue #3)
+#
+# Each entry is a synonym group: one canonical name plus a list of
+# surface forms that should resolve to the same entity. Loaded by
+# core/wiki_generator.py at module import time. Used to expand the
+# `aliases` field both at entity-creation time (new entities pick up
+# the canonical+all forms automatically) and via
+# scripts/migrate_aliases.py (one-shot backfill for existing entities).
+#
+# Why soft (alias) instead of hard merge:
+#   - Multiple .md files for the same concept stay separate; we just
+#     ensure each one's `aliases` includes every surface form.
+#   - graph_engine.build_entity_map_snapshot already indexes every
+#     alias, so lookups by any surface form land on the right entity.
+#   - No risk of breaking entity_id references in other files.
+#
+# Hard merge (collapse two entity files into one canonical, rewrite
+# all incoming target_ids) is a separate, riskier follow-up — out of
+# scope here.
+#
+# Add your own domain mappings below. Format:
+#
+#   - canonical: <preferred display name>
+#     aliases: [<form1>, <form2>, ...]
+
+# ── Crypto (sample) ───────────────────────────────────────────
+- canonical: 비트코인
+  aliases: [BTC, Bitcoin]
+
+- canonical: 이더리움
+  aliases: [ETH, Ethereum]
+
+# ── Add your own below ────────────────────────────────────────
+# - canonical: <name>
+#   aliases: [<form1>, <form2>]


### PR DESCRIPTION
## Summary

Phase 1 of #3 — adds the synonym table prerequisite from the issue's
proposed solution. Operators declare same-meaning surface forms in a
YAML file; they flow into every entity's `aliases` field automatically
(both at creation time and via the existing migration script).

## Why soft alias (this PR) instead of hard merge (follow-up)

Two entities with the same meaning (BTC.md + 비트코인.md) keep their
own .md files. They pick up each other's surface forms in `aliases`,
so `graph_engine.build_entity_map_snapshot` indexes "BTC", "Bitcoin",
"비트코인" as keys for either entity, and queries hit something
either way.

Hard merge — collapse both files into one canonical entity, rewrite
all incoming `target_id` references, consolidate relations — is a
riskier follow-up. It needs to scan every other entity for stale
target_ids and pick a winner per `(name, label)` collision. Tracked
separately as a new issue.

## Changes

- `wiki/synonyms.yaml` (new) — operator-editable synonym groups.
  Sample entries for BTC/Bitcoin and ETH/Ethereum; comments explain
  the format. Plain YAML so users with different domains can edit
  without touching code.
- `core/wiki_generator.py`
  - `_load_synonyms()` reads `wiki/synonyms.yaml` once, caches,
    builds a bidirectional `{form_lower → [other_forms]}` index.
    No-op when the file is absent or malformed.
  - `_expand_alias_candidates(name)` now appends every other surface
    form in the synonym group after the existing paren-pattern
    expansion. Existing call sites (`create_entity_file` +
    `scripts/migrate_aliases.py`) pick this up automatically.

## Verification on local 161-entity dataset

- `_load_synonyms`: 6 keys (3 forms × 2 groups, bidirectional).
- `_expand_alias_candidates("BTC")` → `['BTC', '비트코인', 'Bitcoin']`.
- `_expand_alias_candidates("비트코인")` → `['비트코인', 'BTC', 'Bitcoin']`.
- Migration dry-run: 3 files updated, 6 aliases added.

| File | Aliases added |
|---|---|
| `btc.md` | `비트코인`, `Bitcoin` |
| `비트코인.md` | `BTC`, `Bitcoin` |
| `이더리움.md` | `ETH`, `Ethereum` |

- After `--apply`: `match_entities("Bitcoin")` and
  `match_entities("ETH")` both resolve to the corresponding
  canonical entity_ids.

## Out of scope

- Hard merge of duplicate entities — separate, higher-risk follow-up.
  Will be tracked in a new issue right after this PR lands.
- Auto-discovery of dedup candidates (LLM-based clustering). Operator
  drives the YAML for now.

#3 stays **open** for the hard-merge follow-up. This PR closes only
the synonym-table prerequisite from #3's proposed solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)