### PR TITLE
security(v0.2): P0 fail-fast + remove plaintext default credentials

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,7 @@ JAMES implements defense-in-depth across the RAG pipeline.
 ### Authentication
 
 - JWT tokens with HS256 signing
-- 24-hour expiration (configurable)
+- 8-hour expiration (configurable via `JWT_EXPIRE` in `core/auth.py`)
 - Rate limiting: 30 requests / 60 seconds per user
 - Full audit log in SQLite (every request, decision, denial)
 

--- a/config.py
+++ b/config.py
@@ -139,9 +139,15 @@ CHROMA_COLLECTION = "james_prototype"
 #   Bash/Zsh:     export JAMES_API_KEY=your_key
 API_KEY = os.environ.get("JAMES_API_KEY", "")
 if not API_KEY:
-    print("[CONFIG] WARNING: JAMES_API_KEY not set — using dev fallback")
-    print("[CONFIG]          For production: set JAMES_API_KEY in .env or environment")
-    API_KEY = "dev_only_change_me"
+    # P0 보안 (v0.1.3.1 handover Item C) — fail-fast.
+    # 이전엔 "dev_only_change_me" hardcode fallback. WARNING 한 줄만 출력하고
+    # 그대로 운영 진입 가능했고, 그 secret으로 인증 통과한 client는 admin
+    # 권한까지 받음. 더이상 silent.
+    raise RuntimeError(
+        "JAMES_API_KEY must be set in .env or environment before starting "
+        "the server. Generate one with:\n"
+        "    python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+    )
 
 # ────────────────────────────────────────────────────────────────
 #  Upload limits
@@ -161,7 +167,7 @@ TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")
 # ────────────────────────────────────────────────────────────────
 print(f"[CONFIG] PROJECT JAMES ready")
 print(f"[CONFIG] BASE_DIR: {BASE_DIR}")
-print(f"[CONFIG] API_KEY source: {'env:JAMES_API_KEY' if os.environ.get('JAMES_API_KEY') else 'dev fallback'}")
+print("[CONFIG] API_KEY source: env:JAMES_API_KEY")
 
 if TESSERACT_PATH:
     print(f"[CONFIG] Tesseract: {TESSERACT_PATH}")

--- a/core/auth.py
+++ b/core/auth.py
@@ -21,17 +21,30 @@ import base64
 from typing import Optional, Dict
 from pathlib import Path
 
+# .env 자동 로드 보장 (config 모듈이 import 시점에 .env 파싱하여
+# os.environ에 주입). server_llmwiki는 config을 명시 import하지만,
+# core.auth만 단독 import되는 경로(테스트, 마이그레이션 스크립트 등)
+# 에서도 환경변수가 살아있도록 side-effect import.
+try:
+    import config  # noqa: F401
+except Exception:
+    pass
+
 # ─── 설정 ────────────────────────────────────────────────────
 
-JWT_SECRET = os.environ.get(
-    "JAMES_JWT_SECRET",
-    "james_dev_secret_change_in_prod_2026"   # 환경변수 없으면 경고
-)
+JWT_SECRET = os.environ.get("JAMES_JWT_SECRET")
+if not JWT_SECRET or len(JWT_SECRET) < 32:
+    # P0 보안 (v0.1.3.1 handover Item A) — fail-fast.
+    # 이전엔 하드코드 fallback이라 secret 미설정 환경에서 모든 JWT 서명이
+    # 동일 시크릿으로 이뤄져 위조 공격에 무방비였음. 더이상 silent.
+    raise RuntimeError(
+        "JAMES_JWT_SECRET must be set to a string of 32+ characters "
+        "before importing core.auth. Generate one with:\n"
+        "    python -c \"import secrets; print(secrets.token_urlsafe(32))\"\n"
+        "Then set it in .env or as an environment variable."
+    )
 JWT_ALGO   = "HS256"
-JWT_EXPIRE = 3600 * 8   # 8시간 (개발/운영 모두 적합)
-
-if JWT_SECRET == "james_dev_secret_change_in_prod_2026":
-    print("[AUTH] ⚠️  JAMES_JWT_SECRET 환경변수 미설정 — 개발 시크릿 사용 중 (운영 금지)")
+JWT_EXPIRE = 3600 * 8   # 8h. SECURITY.md와 일치.
 
 # 운영 모드 플래그 (환경변수로 제어)
 # JAMES_DEV_MODE=0 이면 X-Role 헤더 비활성화
@@ -56,7 +69,9 @@ def _get_conn() -> sqlite3.Connection:
     return conn
 
 def _init_db():
-    """DB 초기화 + 기본 계정 생성 (없을 때만)"""
+    """DB 초기화 + admin 계정 1개 (랜덤 또는 환경변수, 첫 부팅 한 번만)."""
+    import secrets as _secrets
+
     conn = _get_conn()
     try:
         conn.execute("""
@@ -70,19 +85,28 @@ def _init_db():
         """)
         conn.commit()
 
-        # 기본 계정 삽입 (이미 존재하면 무시)
-        defaults = [
-            ("admin",     _hash_password("admin_pw_change_me"), "admin"),
-            ("manager1",  _hash_password("manager_pw"),         "manager"),
-            ("employee1", _hash_password("employee_pw"),         "employee"),
-            ("guest",     _hash_password("guest_pw"),            "external"),
-        ]
-        conn.executemany(
-            "INSERT OR IGNORE INTO users (username, password_hash, role) VALUES (?, ?, ?)",
-            defaults,
+        # P0 보안 (v0.1.3.1 handover Item B) — admin 1개만, 랜덤 또는 환경변수.
+        # 이전엔 admin/manager1/employee1/guest 4계정 평문 비번이 소스에 박혀
+        # git log에서 누구나 볼 수 있었음. 이제:
+        #   1) 첫 부팅 시 admin 1개만 생성. manager/employee/external은 admin이
+        #      가입 endpoint로 직접 만들도록.
+        #   2) JAMES_INIT_ADMIN_PW 환경변수 우선. 없으면 16-byte URL-safe 랜덤.
+        #   3) 새로 생성된 경우에만 콘솔에 비번 출력 (기존 admin 있으면 무동작).
+        env_pw   = os.environ.get("JAMES_INIT_ADMIN_PW")
+        admin_pw = env_pw or _secrets.token_urlsafe(16)
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO users (username, password_hash, role) "
+            "VALUES (?, ?, ?)",
+            ("admin", _hash_password(admin_pw), "admin"),
         )
+        admin_created = cur.rowcount > 0
         conn.commit()
+
         print(f"[AUTH] SQLite USER_DB 초기화: {_DB_PATH}")
+        if admin_created and not env_pw:
+            print(f"[AUTH] Initial admin password (CHANGE IMMEDIATELY): {admin_pw}")
+        elif admin_created and env_pw:
+            print("[AUTH] admin created from JAMES_INIT_ADMIN_PW")
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

P0 security items A-D from `docs/handovers/v0.1.3.1-hotfix.md` (the
audit handover from a separate cloud Claude session). All four are
environment-independent (code-level facts) and land here as the first
v0.2.0 commit, separate from the v0.1.3.1 hotfix to keep
compat-breaking changes isolated.

## Changes

| Item | Severity | Change |
|---|---|---|
| **A** JWT_SECRET fail-fast | HIGH | `core/auth.py` raises `RuntimeError` if `JAMES_JWT_SECRET` is missing or under 32 chars (previously fell back to hardcoded dev string with a warning) |
| **B** Plaintext default creds | **CRITICAL** | `core/auth.py::_init_db` now seeds only `admin` with a 16-byte URL-safe random password (or `JAMES_INIT_ADMIN_PW` if set). manager / employee / external are no longer auto-created (admin creates them via the existing user mgmt). Generated password printed exactly once on first-boot insert |
| **C** API_KEY fail-fast | MEDIUM | `config.py` raises `RuntimeError` if `JAMES_API_KEY` is missing (previously fell back to `"dev_only_change_me"` with a warning) |
| **D** JWT expiration doc alignment | LOW | `SECURITY.md` now says "8-hour expiration" matching the actual code (`JWT_EXPIRE = 3600 * 8`) instead of the stale "24-hour" claim |

## Side-effect import in core/auth.py

`core/auth.py` now `import config` at the top (side-effect only) so
`.env` values land in `os.environ` before the `JWT_SECRET` length
check runs. Without this, importing `core.auth` from a context that
hadn't already imported `config` (test scripts, migrations) would
fail-fast even when `.env` had a valid value.

## Migration note for existing deployments

Existing local databases still contain the old `manager1` / `employee1`
/ `guest` rows from before this change, with the old plaintext-derived
hashes. Operators should:

```bash
sqlite3 james_users.db "DELETE FROM users WHERE username IN \
    ('manager1','employee1','guest')"
```

then re-create those accounts via the admin signup flow with fresh
passwords. The `admin` row itself is preserved (the new code doesn't
touch existing rows — `INSERT OR IGNORE`), and its password should be
rotated through the normal flow. The next fresh-DB deployment will
print a random admin password to the console exactly once on first
boot.

## Verification

- `import core.auth` on this PC: succeeds. JWT_SECRET length 43 (from
  `.env`), satisfies the 32+ requirement.
- `import config`: succeeds. API_KEY non-empty.
- `_init_db` no-ops on the existing `admin` row (`INSERT OR IGNORE`
  rowcount 0 → password print suppressed). Next fresh-DB boot will
  print the generated password once.
- Reviewer manual: in a fresh shell with `JAMES_JWT_SECRET` unset,
  `python -c "import core.auth"` should raise RuntimeError with the
  generation hint, not silently use a hardcoded value.

## Reference

`docs/handovers/v0.1.3.1-hotfix.md` PART "🔒 Security Audit", items
A / B / C / D and their P0 patch code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)