### PR TITLE
docs(consistency): align hybrid weights, rename JEPA to query_expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Open `http://localhost:8000`
      ↓
 [Query Router]         ← chat / coding / retrieval / web_search
      ↓
-[Hybrid Search]        ← Vector(60%) + BM25(20%) + keyword(20%)
+[Hybrid Search]        ← Vector(60%) + BM25(20%) + keyword(10%) + name(10%)
      ↓
 [Graph Engine]         ← DFS + confidence + sensitivity gating
      ↓

--- a/core/jepa_adapter.py
+++ b/core/jepa_adapter.py
@@ -1,188 +1,46 @@
 """
-PROJECT JAMES - JEPA Lite Adapter (Phase 5)
+PROJECT JAMES — Deprecation shim for the JEPA-named query expander.
 
-역할: query expansion only. 그 이상 없음.
+The module was renamed to ``core.query_expander`` in v0.2 (B3,
+docs/handovers/v0.1.3.1-hotfix.md) because it never implemented JEPA
+(Joint-Embedding Predictive Architecture). It is a keyword synonym
+dictionary plus a Korean stopword filter — no embedding, no
+predictor, no joint architecture.
 
-절대 제약:
-  ❌ reasoning 금지
-  ❌ LLM 호출 금지
-  ❌ Graph 접근 금지
-  ✅ token hard limit 필수 (JEPA_TOKEN_HARD_LIMIT=50)
-  ✅ timeout 필수 (JEPA_TIMEOUT_SEC=3.0)
-  ✅ 실패 시 original query 그대로 반환
+This shim re-exports the new module so existing imports (`from
+core.jepa_adapter import expand`) keep working through one minor.
+Plan: remove in v0.3.
+
+Update your imports:
+
+    # before
+    from core.jepa_adapter import expand, JEPA_TOKEN_HARD_LIMIT
+
+    # after
+    from core.query_expander import expand, TOKEN_HARD_LIMIT
 """
 
-import re
-import time
-import json
-import signal
-from datetime import datetime
-from typing import Optional
+import warnings as _warnings
 
-JEPA_TOKEN_HARD_LIMIT = 50     # expanded token 최대
-JEPA_TIMEOUT_SEC      = 3.0    # 이 안에 못 끝내면 bypass
-SYSTEM_LOG_PATH       = "james_system_log.jsonl"
+_warnings.warn(
+    "core.jepa_adapter is deprecated and will be removed in v0.3. "
+    "Use core.query_expander instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-# ─── 동의어 / 확장 사전 (keyword 기반, LLM 없음) ──────────
-
-_SYNONYM_MAP = {
-    # 학문
-    "경제":    ["경제학", "경제 이론", "경제 분야"],
-    "법":      ["법학", "법률", "법 이론"],
-    "심리":    ["심리학", "심리 이론"],
-    "물리":    ["물리학", "물리 이론"],
-    "AI":      ["인공지능", "머신러닝", "딥러닝"],
-    "인공지능": ["AI", "머신러닝", "딥러닝"],
-    # 조직
-    "회사":    ["기업", "조직", "법인"],
-    "대학":    ["대학교", "학교", "교육기관"],
-    # 관계
-    "소속":    ["근무", "재직", "속한"],
-    "공부":    ["학습", "연구", "전공"],
-    "연구":    ["공부", "탐구", "분석"],
-    # 일반
-    "누구":    ["어떤 사람", "인물"],
-    "무엇":    ["어떤 것", "어떤 분야"],
-    "어디":    ["어느 곳", "어느 기관"],
-}
-
-_STOPWORDS = {
-    "은", "는", "이", "가", "을", "를", "의", "에", "와", "과",
-    "도", "만", "에서", "로", "으로", "이란", "란", "인가",
-    "무엇", "어떤", "하는", "한다", "합니다", "했다", "인지",
-}
-
-
-def _log(step: str, detail: str, level: str = "INFO"):
-    try:
-        entry = {"time": datetime.now().isoformat(), "level": level,
-                 "step": f"jepa.{step}", "detail": detail[:200]}
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-
-
-def _tokenize_simple(text: str) -> list:
-    """공백 + 한글 단어 분리 (LLM 없이)"""
-    tokens = re.findall(r"[가-힣A-Za-z0-9]+", text)
-    return [t for t in tokens if t not in _STOPWORDS and len(t) >= 2]
-
-
-def _expand_keywords(tokens: list) -> list:
-    """동의어 사전 기반 확장 (LLM 없음)"""
-    expanded = list(tokens)
-    for token in tokens:
-        synonyms = _SYNONYM_MAP.get(token, [])
-        for syn in synonyms:
-            if syn not in expanded:
-                expanded.append(syn)
-    return expanded
-
-
-def _hard_truncate(tokens: list, limit: int = JEPA_TOKEN_HARD_LIMIT) -> list:
-    """token hard limit 강제 적용"""
-    return tokens[:limit]
-
-
-def expand(query: str) -> str:
-    """
-    query expansion only.
-
-    성공: expanded_query 반환
-    실패 / timeout / token 초과: original_query 반환
-
-    절대 LLM 호출 없음. keyword 기반 확장만.
-    """
-    if not query or not query.strip():
-        return query
-
-    t_start = time.time()
-
-    try:
-        # 1단계: 토크나이징
-        tokens = _tokenize_simple(query)
-        if not tokens:
-            return query
-
-        # timeout 체크
-        if time.time() - t_start > JEPA_TIMEOUT_SEC:
-            _log("timeout", f"tokenize 후 timeout | query={query[:50]}", "WARN")
-            return query
-
-        # 2단계: 확장
-        expanded_tokens = _expand_keywords(tokens)
-
-        # timeout 체크
-        if time.time() - t_start > JEPA_TIMEOUT_SEC:
-            _log("timeout", f"expand 후 timeout | query={query[:50]}", "WARN")
-            return query
-
-        # 3단계: token hard limit 적용
-        truncated = _hard_truncate(expanded_tokens, JEPA_TOKEN_HARD_LIMIT)
-        if len(truncated) < len(expanded_tokens):
-            _log("truncated",
-                 f"token 초과 {len(expanded_tokens)} → {len(truncated)}", "WARN")
-
-        # 4단계: 원본 query + 확장 키워드 결합
-        extra_terms = [t for t in truncated if t not in _tokenize_simple(query)]
-        if not extra_terms:
-            # 확장 없음 — 그러나 원본 자체가 token limit 초과 시 truncate
-            orig_tokens = _tokenize_simple(query)
-            if len(orig_tokens) > JEPA_TOKEN_HARD_LIMIT:
-                truncated_orig = orig_tokens[:JEPA_TOKEN_HARD_LIMIT]
-                print(f"[JEPA] 원본 hard truncate: {len(orig_tokens)} → {JEPA_TOKEN_HARD_LIMIT} tokens")
-                return " ".join(truncated_orig)
-            return query   # 원본이 limit 이하면 그대로
-
-        expanded_query = query + " " + " ".join(extra_terms[:10])
-
-        # [TOKEN-HARD-LIMIT] 최종 출력 전체 token 수 강제 제한
-        final_tokens   = _tokenize_simple(expanded_query)
-        if len(final_tokens) > JEPA_TOKEN_HARD_LIMIT:
-            truncated_final = final_tokens[:JEPA_TOKEN_HARD_LIMIT]
-            expanded_query  = " ".join(truncated_final)
-            print(f"[JEPA] hard truncate 적용: {len(final_tokens)} → {JEPA_TOKEN_HARD_LIMIT} tokens")
-
-        elapsed = time.time() - t_start
-        _log("expand_ok",
-             f"elapsed={elapsed:.3f}s tokens={len(truncated)} extra={len(extra_terms)}")
-
-        print(f"[JEPA] expand: '{query[:40]}' → +{extra_terms[:5]}")
-        return expanded_query
-
-    except Exception as e:
-        _log("expand_error", str(e), "WARN")
-        print(f"[JEPA] ⚠️ 확장 실패 → 원본 사용: {e}")
-        return query   # 실패 시 원본 반환
-
-
-# ─── 자가 테스트 ─────────────────────────────────────────────
-
-if __name__ == "__main__":
-    print("=== JEPA Adapter 자가 테스트 ===\n")
-
-    cases = [
-        ("김철수는 경제학을 공부하는가?",    True),
-        ("xkzq존재하지않는abc",              False),  # 확장 없음 → 원본
-        ("",                                  False),
-        ("AI 연구 기관은?",                   True),
-    ]
-
-    for query, expect_expanded in cases:
-        result = expand(query)
-        actually_expanded = result != query and bool(result)
-        ok = actually_expanded == expect_expanded or not query
-        icon = "✅" if ok else "❌"
-        print(f"  {icon} '{query[:30]}' → '{result[:50]}'")
-        if actually_expanded:
-            extra = result.replace(query, "").strip()
-            print(f"       확장어: {extra[:60]}")
-
-    # timeout 테스트 (간접)
-    import time as _t
-    t = _t.time()
-    r = expand("매우 긴 쿼리 " * 100)
-    elapsed = _t.time() - t
-    print(f"\n  timeout 테스트: elapsed={elapsed:.3f}s (< {JEPA_TIMEOUT_SEC}s 기대)")
-    print(f"  결과: {'✅ bypass 정상' if elapsed < 5 else '❌ 너무 느림'}")
+# Re-export everything from the new module so legacy imports keep working.
+from core.query_expander import (   # noqa: F401, E402
+    expand,
+    TOKEN_HARD_LIMIT,
+    TIMEOUT_SEC,
+    JEPA_TOKEN_HARD_LIMIT,
+    JEPA_TIMEOUT_SEC,
+    SYSTEM_LOG_PATH,
+    _SYNONYM_MAP,
+    _STOPWORDS,
+    _log,
+    _tokenize_simple,
+    _expand_keywords,
+    _hard_truncate,
+)

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -82,7 +82,7 @@ def retrieve(
 
     Path:
       1. original_query  → hybrid_search
-      2. expanded_query  → hybrid_search (JEPA 성공 시 다름, 실패 시 동일)
+      2. expanded_query  → hybrid_search (query_expander 성공 시 다름, 실패 시 동일)
       3. keyword_query   → hybrid_search
 
     결과 merge: 단순 concat → deduplicate
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     call_count[0] = 0
     retrieve(
         original_query="경제학",
-        expanded_query="경제학",   # JEPA 실패 시 동일
+        expanded_query="경제학",   # query_expander 실패 시 동일
         hybrid_search_fn=mock_search,
     )
     # original + keyword만 = 2회 (expanded 중복 제거)

--- a/core/query_expander.py
+++ b/core/query_expander.py
@@ -1,0 +1,198 @@
+"""
+PROJECT JAMES — Query Expander (was: core/jepa_adapter.py)
+
+역할: keyword 동의어 사전 기반 query 확장. **JEPA(Joint-Embedding
+Predictive Architecture, LeCun)와 무관** — 모듈 이름이 학술 용어와
+같았지만 실제 구현은 ``_SYNONYM_MAP`` 사전 lookup + 한국어 stopword
+필터의 단순 keyword expansion이다. v0.2 정합성 정정에서 리네임
+(`core.jepa_adapter` 는 deprecation shim).
+
+절대 제약:
+  ❌ reasoning 금지
+  ❌ LLM 호출 금지
+  ❌ Graph 접근 금지
+  ❌ embedding 사용 금지 (이 모듈은 embedding을 만들지도 사용하지도 않는다)
+  ✅ token hard limit 필수 (TOKEN_HARD_LIMIT=50)
+  ✅ timeout 필수 (TIMEOUT_SEC=3.0)
+  ✅ 실패 시 original query 그대로 반환
+"""
+
+import re
+import time
+import json
+from datetime import datetime
+from typing import Optional   # noqa: F401 — kept for downstream type hints
+
+TOKEN_HARD_LIMIT = 50     # expanded token 최대
+TIMEOUT_SEC      = 3.0    # 이 안에 못 끝내면 bypass
+
+# Backward-compatibility aliases (v0.1.x downstream + tests still import these).
+# 다음 마이너에서 제거 후보. 신규 코드는 위의 약식 이름 사용.
+JEPA_TOKEN_HARD_LIMIT = TOKEN_HARD_LIMIT
+JEPA_TIMEOUT_SEC      = TIMEOUT_SEC
+
+SYSTEM_LOG_PATH = "james_system_log.jsonl"
+
+# ─── 동의어 / 확장 사전 (keyword 기반, LLM 없음) ──────────
+
+_SYNONYM_MAP = {
+    # 학문
+    "경제":    ["경제학", "경제 이론", "경제 분야"],
+    "법":      ["법학", "법률", "법 이론"],
+    "심리":    ["심리학", "심리 이론"],
+    "물리":    ["물리학", "물리 이론"],
+    "AI":      ["인공지능", "머신러닝", "딥러닝"],
+    "인공지능": ["AI", "머신러닝", "딥러닝"],
+    # 조직
+    "회사":    ["기업", "조직", "법인"],
+    "대학":    ["대학교", "학교", "교육기관"],
+    # 관계
+    "소속":    ["근무", "재직", "속한"],
+    "공부":    ["학습", "연구", "전공"],
+    "연구":    ["공부", "탐구", "분석"],
+    # 일반
+    "누구":    ["어떤 사람", "인물"],
+    "무엇":    ["어떤 것", "어떤 분야"],
+    "어디":    ["어느 곳", "어느 기관"],
+}
+
+_STOPWORDS = {
+    "은", "는", "이", "가", "을", "를", "의", "에", "와", "과",
+    "도", "만", "에서", "로", "으로", "이란", "란", "인가",
+    "무엇", "어떤", "하는", "한다", "합니다", "했다", "인지",
+}
+
+
+def _log(step: str, detail: str, level: str = "INFO"):
+    try:
+        entry = {"time": datetime.now().isoformat(), "level": level,
+                 "step": f"query_expand.{step}", "detail": detail[:200]}
+        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+def _tokenize_simple(text: str) -> list:
+    """공백 + 한글 단어 분리 (LLM 없이)"""
+    tokens = re.findall(r"[가-힣A-Za-z0-9]+", text)
+    return [t for t in tokens if t not in _STOPWORDS and len(t) >= 2]
+
+
+def _expand_keywords(tokens: list) -> list:
+    """동의어 사전 기반 확장 (LLM 없음)"""
+    expanded = list(tokens)
+    for token in tokens:
+        synonyms = _SYNONYM_MAP.get(token, [])
+        for syn in synonyms:
+            if syn not in expanded:
+                expanded.append(syn)
+    return expanded
+
+
+def _hard_truncate(tokens: list, limit: int = TOKEN_HARD_LIMIT) -> list:
+    """token hard limit 강제 적용"""
+    return tokens[:limit]
+
+
+def expand(query: str) -> str:
+    """
+    query expansion only.
+
+    성공: expanded_query 반환
+    실패 / timeout / token 초과: original_query 반환
+
+    절대 LLM 호출 없음. keyword 기반 확장만.
+    """
+    if not query or not query.strip():
+        return query
+
+    t_start = time.time()
+
+    try:
+        # 1단계: 토크나이징
+        tokens = _tokenize_simple(query)
+        if not tokens:
+            return query
+
+        # timeout 체크
+        if time.time() - t_start > TIMEOUT_SEC:
+            _log("timeout", f"tokenize 후 timeout | query={query[:50]}", "WARN")
+            return query
+
+        # 2단계: 확장
+        expanded_tokens = _expand_keywords(tokens)
+
+        # timeout 체크
+        if time.time() - t_start > TIMEOUT_SEC:
+            _log("timeout", f"expand 후 timeout | query={query[:50]}", "WARN")
+            return query
+
+        # 3단계: token hard limit 적용
+        truncated = _hard_truncate(expanded_tokens, TOKEN_HARD_LIMIT)
+        if len(truncated) < len(expanded_tokens):
+            _log("truncated",
+                 f"token 초과 {len(expanded_tokens)} → {len(truncated)}", "WARN")
+
+        # 4단계: 원본 query + 확장 키워드 결합
+        extra_terms = [t for t in truncated if t not in _tokenize_simple(query)]
+        if not extra_terms:
+            # 확장 없음 — 그러나 원본 자체가 token limit 초과 시 truncate
+            orig_tokens = _tokenize_simple(query)
+            if len(orig_tokens) > TOKEN_HARD_LIMIT:
+                truncated_orig = orig_tokens[:TOKEN_HARD_LIMIT]
+                print(f"[QUERY-EXPAND] 원본 hard truncate: {len(orig_tokens)} → {TOKEN_HARD_LIMIT} tokens")
+                return " ".join(truncated_orig)
+            return query   # 원본이 limit 이하면 그대로
+
+        expanded_query = query + " " + " ".join(extra_terms[:10])
+
+        # [TOKEN-HARD-LIMIT] 최종 출력 전체 token 수 강제 제한
+        final_tokens   = _tokenize_simple(expanded_query)
+        if len(final_tokens) > TOKEN_HARD_LIMIT:
+            truncated_final = final_tokens[:TOKEN_HARD_LIMIT]
+            expanded_query  = " ".join(truncated_final)
+            print(f"[QUERY-EXPAND] hard truncate 적용: {len(final_tokens)} → {TOKEN_HARD_LIMIT} tokens")
+
+        elapsed = time.time() - t_start
+        _log("expand_ok",
+             f"elapsed={elapsed:.3f}s tokens={len(truncated)} extra={len(extra_terms)}")
+
+        print(f"[QUERY-EXPAND] expand: '{query[:40]}' → +{extra_terms[:5]}")
+        return expanded_query
+
+    except Exception as e:
+        _log("expand_error", str(e), "WARN")
+        print(f"[QUERY-EXPAND] ⚠️ 확장 실패 → 원본 사용: {e}")
+        return query   # 실패 시 원본 반환
+
+
+# ─── 자가 테스트 ─────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("=== Query Expander 자가 테스트 ===\n")
+
+    cases = [
+        ("김철수는 경제학을 공부하는가?",    True),
+        ("xkzq존재하지않는abc",              False),  # 확장 없음 → 원본
+        ("",                                  False),
+        ("AI 연구 기관은?",                   True),
+    ]
+
+    for query, expect_expanded in cases:
+        result = expand(query)
+        actually_expanded = result != query and bool(result)
+        ok = actually_expanded == expect_expanded or not query
+        icon = "✅" if ok else "❌"
+        print(f"  {icon} '{query[:30]}' → '{result[:50]}'")
+        if actually_expanded:
+            extra = result.replace(query, "").strip()
+            print(f"       확장어: {extra[:60]}")
+
+    # timeout 테스트 (간접)
+    import time as _t
+    t = _t.time()
+    r = expand("매우 긴 쿼리 " * 100)
+    elapsed = _t.time() - t
+    print(f"\n  timeout 테스트: elapsed={elapsed:.3f}s (< {TIMEOUT_SEC}s 기대)")
+    print(f"  결과: {'✅ bypass 정상' if elapsed < 5 else '❌ 너무 느림'}")

--- a/core/reasoning_engine.py
+++ b/core/reasoning_engine.py
@@ -591,13 +591,14 @@ class ReasoningEngine:
 
         # ── Retrieval → 기존 Loop 그대로 진행 ────────────────
 
-        # ── STEP 0.5b: JEPA query expansion [P5] ─────────────
-        # [STEP2-C] jepa_adapter.py 현재 비활성화 상태
+        # ── STEP 0.5b: query expansion [P5] ──────────────────
+        # core/query_expander.py (was core/jepa_adapter.py — 단순 동의어
+        # 사전, JEPA 메커니즘과 무관) 현재 비활성화 상태.
         # → Phase 9에서 멀티모달 임베딩 확장 시 재활성화 예정
         # → 현재는 원본 쿼리 그대로 사용 (0ms 오버헤드)
-        t_jepa = time.time()
-        expanded_query = safe_query   # JEPA 없이 원본 사용
-        self._elapsed(t_jepa, "STEP0.5 JEPA_expand")
+        t_qexp = time.time()
+        expanded_query = safe_query   # 확장 없이 원본 사용
+        self._elapsed(t_qexp, "STEP0.5 query_expand")
 
         # ── Loop 상태 초기화 ─────────────────────────────────
         loop_state = {

--- a/core/retrieval_engine.py
+++ b/core/retrieval_engine.py
@@ -263,6 +263,17 @@ class RetrievalEngine:
 
     @staticmethod
     def calculate_confidence(r: Dict) -> float:
+        """답변 신뢰도 점수 (0~1).
+
+        ``hybrid_search`` ranking 가중치(``0.6/0.2/0.1/0.1``)와는 별도
+        분포(``0.5/0.2/0.2/0.1``). vector 영향력을 약간 낮추고
+        keyword/name (표면 형태가 정확히 일치하는 신호)에 더 높은
+        confidence를 부여한다 — 검색 ranking은 의미 거리가 핵심이지만,
+        답변 confidence는 사용자 질의에 명시된 단어가 실제로 문서에
+        있다는 사실에 더 의존하는 게 자연스럽다는 판단.
+
+        합 = 1.0. ``round(..., 3)`` 후 ``[0, 1]`` 범위 강제.
+        """
         return max(0.0, min(1.0, round(
             r.get("vector_score", 0) * 0.5 +
             r.get("bm25_score", 0) * 0.2 +

--- a/tools/code/code_editor.py
+++ b/tools/code/code_editor.py
@@ -32,7 +32,7 @@ PROTECTED_FILES = {
     "graph_rag_engine.py", "graph_engine.py", "reasoning_engine.py",
     "retrieval_engine.py", "security_layer.py", "memory_loom.py",
     "memory_trust.py", "gemma_client.py", "auth.py", "config.py",
-    "jepa_adapter.py", "orchestrator.py",
+    "jepa_adapter.py", "query_expander.py", "orchestrator.py",
 }
 
 


### PR DESCRIPTION
## Summary

Two consistency cleanups from `docs/handovers/v0.1.3.1-hotfix.md` —
both factual fixes that align documentation with code.

### B2 — README hybrid search weights

README's architecture diagram said
`Vector(60%) + BM25(20%) + keyword(20%)`. The actual code at
`core/retrieval_engine.py::hybrid_search` uses **four signals**:
`0.6 * v + 0.2 * b + 0.1 * k + 0.1 * n` (vector / BM25 / keyword /
name). README now matches.

`calculate_confidence` further down in the same file uses a
different distribution (`0.5 / 0.2 / 0.2 / 0.1`). Both sum to 1.0
but the splits diverge intentionally — one is a search-ranking
weight, the other an answer-confidence weight. A new docstring on
`calculate_confidence` spells that out so future readers don't
assume it's a copy-paste mistake.

### B3 — `core/jepa_adapter.py` → `core/query_expander.py`

The module's own docstring already said it
`❌ LLM 호출 금지 / ❌ Graph 접근 금지`. It is a Korean keyword
synonym dictionary plus a stopword filter — no JEPA mechanism in
sight. Naming it "JEPA" (Joint-Embedding Predictive Architecture,
LeCun) misled readers from the ML side.

Changes:

- **`core/query_expander.py` (new)** — copy of the old module with:
  - docstring rewritten to state plainly what it is/isn't
  - constants renamed: `JEPA_TOKEN_HARD_LIMIT → TOKEN_HARD_LIMIT`,
    `JEPA_TIMEOUT_SEC → TIMEOUT_SEC` (legacy aliases kept on the
    new module for backward compat through this minor)
  - print prefix `[JEPA] → [QUERY-EXPAND]`
  - log step prefix `jepa.* → query_expand.*`
- **`core/jepa_adapter.py`** — deprecation shim. Re-exports
  everything from `core.query_expander` and emits a
  `DeprecationWarning` on import. Plan: remove in v0.3.
- `core/reasoning_engine.py` L594-600 comment updated.
- `core/orchestrator.py` L85, L169 comments updated.
- `tools/code/code_editor.py` `PROTECTED_FILES` gains
  `query_expander.py` while keeping `jepa_adapter.py` (the shim)
  protected.

## Verification

- `import core.query_expander` → `expand("AI 연구 기관은?")` returns
  expanded query and logs `[QUERY-EXPAND] expand: ...`.
- `import core.jepa_adapter` → succeeds, emits `DeprecationWarning`,
  re-exported `expand` is the same function object.
- `import core.reasoning_engine`, `core.orchestrator`,
  `tools.code.code_editor` — all succeed.
- `TOKEN_HARD_LIMIT == JEPA_TOKEN_HARD_LIMIT == 50`.

## Reference

- `docs/handovers/v0.1.3.1-hotfix.md` items **B2** and **B3**

🤖 Generated with [Claude Code](https://claude.com/claude-code)