### PR TITLE
fix(v0.2): wiki_reset CP949 + metadata LLM-error sentinel (closes #2, #4)

### DIFF
--- a/scripts/reset_for_production.py
+++ b/scripts/reset_for_production.py
@@ -27,6 +27,14 @@ import sqlite3
 from pathlib import Path
 from datetime import datetime
 
+# Issue #2: cp949 콘솔에서 box-drawing 문자 크래시 방지.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+try:
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except ImportError:
+    pass
+
 # ── 경로 설정 ──────────────────────────────────────────────────
 try:
     from config import BASE_DIR, WIKI_DIR, CHROMA_DIR, UPLOAD_DIR

--- a/tools/admin/seed_data.py
+++ b/tools/admin/seed_data.py
@@ -13,6 +13,16 @@ PROJECT JAMES — 시드 데이터 (테스트/검증용 기본 entity 8개)
   - frontmatter 표준 준수
 """
 
+# Issue #2: cp949 콘솔에서 box-drawing 문자 크래시 방지.
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.dirname(
+    _os.path.abspath(__file__)))))
+try:
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except ImportError:
+    pass
+
 from pathlib import Path
 from datetime import datetime
 

--- a/tools/admin/upload_simulator.py
+++ b/tools/admin/upload_simulator.py
@@ -23,6 +23,10 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__)))))
 
+# Issue #2: cp949 콘솔에서 box-drawing 문자 크래시 방지.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
 G = "\033[92m"; R = "\033[91m"; Y = "\033[93m"; C = "\033[96m"
 B = "\033[1m";  E = "\033[0m"
 

--- a/tools/admin/wiki_reset.py
+++ b/tools/admin/wiki_reset.py
@@ -28,6 +28,11 @@ from datetime import datetime
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__)))))
 
+# Issue #2: cp949 콘솔에서 box-drawing 문자(`═`, `─` …) 출력 시
+# UnicodeEncodeError 크래시 방지. 모든 print 전에 stdout 인코딩 강제.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
 try:
     from config import BASE_DIR, WIKI_DIR, CHROMA_DIR
 except ImportError:

--- a/utils/console.py
+++ b/utils/console.py
@@ -1,0 +1,41 @@
+"""Console encoding hardening for Windows scripts (Issue #2).
+
+Several admin scripts (`tools/admin/wiki_reset.py`,
+`tools/admin/seed_data.py`, `tools/admin/upload_simulator.py`,
+`scripts/reset_for_production.py`) print Unicode box-drawing
+characters (``═``, ``─``, ``│`` …) for visual section dividers. On a
+default Windows console (cp949 in Korean Windows), these chars raise
+
+    UnicodeEncodeError: 'cp949' codec can't encode character '═' …
+
+before the script can do anything useful. The workaround used so far
+has been to wrap each invocation in `PYTHONIOENCODING=utf-8`, which
+forces operators to remember it every time.
+
+This helper makes the encoding switch script-internal: each affected
+script calls `ensure_utf8_console()` at the top, so a plain
+`python tools/admin/wiki_reset.py --dry-run` works regardless of the
+host shell's default encoding.
+
+The reconfigure path (Python 3.7+) is preferred. If `reconfigure`
+isn't available or the streams aren't TextIOWrappers (rare; some
+embedded environments), it silently falls through — never raises.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def ensure_utf8_console() -> None:
+    """Reconfigure stdout/stderr to UTF-8 on Windows. No-op elsewhere
+    or when reconfiguration isn't supported."""
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            # Some test runners replace stdout with a non-TextIOWrapper.
+            # Box-drawing prints will still raise there, but we don't want
+            # to make matters worse — leave whatever the runner installed.
+            continue

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -7,6 +7,31 @@ import json
 from core.gemma_client import GemmaClient   # type/fallback retained
 from llm.router import RouterWrapper
 
+# Issue #4: LLM 호출이 실패하면 GemmaClient는 "[Gemma 오류] 404 …",
+# "[Gemma 응답 없음]" 같은 sentinel 문자열을 응답 자리에 그대로 반환한다.
+# 그게 safe_parse_json까지 살아남으면 비-JSON 텍스트 fallback에서
+# `summary = text[:100]`으로 entity의 user-visible 필드에 저장돼 wiki를
+# 오염시켰다 (실데이터 검증 중 발견 — STEP 7 발견 #2). 이 패턴을 만나면
+# summary를 비워서 wiki에 진단 텍스트가 새는 걸 막는다.
+_LLM_ERROR_SENTINELS = (
+    "[gemma 오류]",
+    "[gemma 응답 없음]",
+    "응답 없음",
+    "client error: not found",
+    "internal server error",
+    "timeouterror",
+    "connectionerror",
+    "[llm 분석 실패",
+)
+
+
+def _is_llm_error_sentinel(text: str) -> bool:
+    if not isinstance(text, str) or not text:
+        return False
+    low = text.lower()
+    return any(p in low for p in _LLM_ERROR_SENTINELS)
+
+
 class MetadataGenerator:
     def __init__(self):
         self.gemma_client = RouterWrapper("extract")
@@ -79,10 +104,18 @@ class MetadataGenerator:
             except Exception:
                 pass
 
+        # Issue #4: LLM 에러 sentinel을 사용자 visible summary로 저장하지 않는다.
+        # 일반 비-JSON 텍스트는 첫 100자로 fallback (LLM이 자유 형식 답변한 경우 등).
+        if _is_llm_error_sentinel(text):
+            return {
+                "keywords": [],
+                "summary":  "",
+                "category": "기타",
+            }
         return {
             "keywords": [],
-            "summary": text[:100] if text else "분석 실패",
-            "category": "기타"
+            "summary":  text[:100] if text else "",
+            "category": "기타",
         }
     
     def generate_metadata(self, text: str) -> dict:


### PR DESCRIPTION
## Summary

Two small Tier 3 fixes from STEP 7 findings, bundled in one PR.

### Issue #2 — Windows cp949 console crash on box-drawing chars

Several admin scripts print Unicode section dividers (`═`, `─`, `│`).
Default Windows console codepage is cp949 in Korean Windows, so the
first divider raises:

```
UnicodeEncodeError: 'cp949' codec can't encode character '═' …
```

Until now operators had to prepend `PYTHONIOENCODING=utf-8` to every
invocation. Fix: `utils/console.py::ensure_utf8_console()`
reconfigures stdout/stderr to UTF-8 on Windows; no-op elsewhere.
Each affected script calls it right after sys.path setup.

Affected scripts:

- `tools/admin/wiki_reset.py`
- `tools/admin/upload_simulator.py`
- `tools/admin/seed_data.py`
- `scripts/reset_for_production.py`

### Issue #4 — metadata fallback writes LLM error string to summary

When `core.gemma_client` / `RouterWrapper` fail, they return sentinel
strings instead of raising: `[Gemma 오류] 404 Client Error: ...`,
`[Gemma 응답 없음]`, etc. `utils.metadata.MetadataGenerator.safe_parse_json`
then fell through every JSON-extraction path and stuffed the diagnostic
text into the entity's `summary` field. Real example seen during STEP 7:

```yaml
summary: '[Gemma 오류] 404 Client Error: Not Found for url:
          http://127.0.0.1:11434/api/generate'
```

Fix: module-level `_is_llm_error_sentinel(text)` checks for known
error patterns (case-insensitive). When the final non-JSON fallback is
reached and the text looks like an LLM error sentinel, return empty
summary. Free-form non-error text still falls back to `text[:100]`
(an LLM that answered in prose is salvageable; an error message isn't).

## Verification

```
sentinel detection:
  [Gemma 오류] 404 ...  → detected, summary=""
  [Gemma 응답 없음]    → detected, summary=""
  TimeoutError: 90s    → detected, summary=""
  응답 없음            → detected, summary=""

non-sentinel:
  {"keywords":["AI"],"summary":"테스트 요약",...}
                       → parsed normally, summary="테스트 요약"
  이것은 일반 텍스트… → text[:100] preserved (not an error)
```

Reviewer manual on a fresh cp949 shell:
`python tools/admin/wiki_reset.py --dry-run` should print the section
banner cleanly without `UnicodeEncodeError`.

## References

- STEP 7 findings catalog #2 + #4
- `docs/handovers/v0.1.3.1-hotfix.md` (also flagged #2/#4 contextually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)