### PR TITLE
docs(handover): v0.1.4 SSH-from-tablet onboarding for PC Claude Code

### DIFF
--- a/docs/handovers/v0.1.4-ssh-onboarding.md
+++ b/docs/handovers/v0.1.4-ssh-onboarding.md
@@ -1,0 +1,389 @@
+# SSH-from-Tablet → PC Claude Code Handover (v0.1.4)
+
+> 작성: PC Claude Code 세션 (Opus 4.7) at v0.1.4 시점
+> 대상: 태블릿(갤럭시 탭) Termux + Tailscale → PC sshd → PC `claude` CLI
+> 상태: PC 셋업 미시작 (Phase 1.1~1.6 가이드만 있음). 코드는 깔끔, main `1d663c0`.
+
+이 문서는 두 가지를 같이 담는다.
+
+1. **SSH 셋업 절차** — PC 측 sshd + Tailscale, 태블릿 측 Termux + Tailscale.
+   이전 PC 세션에서 가이드까지만 만들고 실행은 안 했음. 처음부터 따라가면 됨.
+2. **Claude Code 세션 인계** — 새 PC SSH 세션에서 `claude`를 띄웠을 때
+   곧바로 v0.2 다음 작업으로 들어갈 수 있게 현재 상태와 우선순위 박제.
+
+장기적으로는 Anthropic이 Claude Code에 cloud sync를 추가하면 이 핸드오버
+경로 자체가 단순해질 것. 그때까지는 GitHub 브랜치 + 메모리 + 이 문서가
+device 간 sync의 실제 구현체.
+
+---
+
+## ⚠️ 보안 체크리스트 (셋업 시작 전 한 번, 사용 중 매번)
+
+PROJECT JAMES "보안 우선" 가치관 — SSH는 좋은 도구지만 잘못 쓰면 위험.
+이전 세션의 위험 분석을 그대로 옮긴다.
+
+### 셋업 시 반드시 (1회)
+
+| # | 항목 | 이유 |
+|---|---|---|
+| 1 | **Tailscale 사용** (포트 22 인터넷 노출 X) | 봇 brute-force 24h 노출 차단 |
+| 2 | Tailscale 계정 **2FA 활성화** | 계정 탈취 → mesh 모든 device 접근 |
+| 3 | sshd_config: `PasswordAuthentication no`, `PermitRootLogin no` | 비번 brute-force 차단 |
+| 4 | SSH key 생성 시 **passphrase 설정** (8자+) | 태블릿 도난 시 마지막 방어선 |
+| 5 | 태블릿 **지문 + PIN/패턴 강력 잠금** | 물리 침해 방지 |
+| 6 | Termux 키 권한 `chmod 600` | 다른 앱 read 차단 |
+| 7 | PC 사용자 권한 **표준 사용자** (admin 분리, UAC 활성) | 침해 시 피해 축소 |
+| 8 | sshd_config: `AllowUsers karu-` | 다른 사용자 차단 |
+
+### 사용 중 매번
+
+- ☐ destructive 명령 (`rm -rf`, force push, `DROP`, drop, format) — 태블릿 작은 화면에서 실수 위험. 신중. 의심되면 Claude에게 dry-run 먼저
+- ☐ 사용 후 SSH 세션 정상 종료 + 태블릿 lock
+- ☐ Tailscale ACL — 태블릿에서 PC만 접근 (다른 device 차단), 정기적 점검
+
+### 가장 큰 실재 위험
+
+**사용자 실수**. 어떤 셋업도 막지 못하는 카테고리. 답은 신중함 + git 백업 + Claude에게 destructive 작업 전 확인 받기.
+
+---
+
+## Phase 1 — PC 셋업 (Windows 11)
+
+PC 측에서 한 번만 하면 끝나는 작업. 관리자 PowerShell 필요.
+
+### 1.1 OpenSSH Server 설치 + 시작
+
+```powershell
+# 관리자 PowerShell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+Get-Service sshd | Format-List Name, Status, StartType
+```
+
+기대: `Status: Running`, `StartType: Automatic`.
+
+### 1.2 Windows 방화벽 — Public profile 22 차단
+
+```powershell
+# 관리자
+Get-NetFirewallRule -Name *OpenSSH* | Format-Table Name, DisplayName, Profile, Enabled, Action
+
+# 룰 없으면 Private만 허용:
+New-NetFirewallRule -Name 'OpenSSH-Server-Private' `
+    -DisplayName 'OpenSSH Server (Private)' `
+    -Enabled True -Direction Inbound -Protocol TCP -Action Allow `
+    -LocalPort 22 -Profile Private
+
+# Public profile 룰이 있으면 비활성:
+Get-NetFirewallRule -Name *OpenSSH* | `
+    Where-Object {$_.Profile -match 'Public'} | `
+    Disable-NetFirewallRule
+```
+
+이 단계가 핵심 보안 — 외부 인터넷에서 22번 직접 접근 차단. 태블릿은 Tailscale을 통해 Private interface로 접근.
+
+### 1.3 sshd_config 보안 강화
+
+`C:\ProgramData\ssh\sshd_config`을 **관리자 메모장**으로 열어 다음 줄 찾아 수정 (없으면 추가):
+
+```
+PasswordAuthentication no
+PermitRootLogin no
+PubkeyAuthentication yes
+AllowUsers karu-
+```
+
+저장 후:
+
+```powershell
+Restart-Service sshd
+```
+
+### 1.4 SSH key 생성 (태블릿 전용)
+
+**일반 사용자 PowerShell**:
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.ssh" | Out-Null
+ssh-keygen -t ed25519 -f "$env:USERPROFILE\.ssh\tablet_id" -C "galaxy-tab"
+```
+
+passphrase 입력 프롬프트에서 **8자+ 강력하게**. 빈 칸 두지 말 것.
+
+### 1.5 authorized_keys 등록 + 권한
+
+```powershell
+$pub = Get-Content "$env:USERPROFILE\.ssh\tablet_id.pub" -Raw
+Add-Content -Path "$env:USERPROFILE\.ssh\authorized_keys" -Value $pub.TrimEnd()
+
+# Windows OpenSSH는 권한 매우 까다로움
+icacls "$env:USERPROFILE\.ssh" `
+    /inheritance:r `
+    /grant "${env:USERNAME}:(OI)(CI)F" `
+    /grant "SYSTEM:(OI)(CI)F"
+icacls "$env:USERPROFILE\.ssh\authorized_keys" `
+    /inheritance:r `
+    /grant "${env:USERNAME}:F" `
+    /grant "SYSTEM:F"
+```
+
+확인: `icacls` 결과에 `BUILTIN\Administrators`나 다른 사용자 안 보여야. 있으면 OpenSSH가 키 무시.
+
+> **사용자 계정이 administrators 그룹이면** `~/.ssh/authorized_keys` 대신
+> `C:\ProgramData\ssh\administrators_authorized_keys`에 등록해야 함. 확인:
+> ```powershell
+> ([Security.Principal.WindowsIdentity]::GetCurrent().Groups | `
+>     ForEach-Object { $_.Translate([Security.Principal.NTAccount]) }) `
+>     -match "Administrators"
+> ```
+
+### 1.6 Tailscale 설치 + 2FA
+
+1. https://tailscale.com/download/windows → MSI 설치
+2. 작업표시줄 아이콘 우클릭 → Log in
+3. Google/Microsoft/이메일 로그인
+4. **즉시 https://login.tailscale.com/admin/settings/general → 2FA 활성화**
+
+```powershell
+tailscale status
+tailscale ip -4
+```
+
+PC의 Tailscale IP (보통 `100.x.x.x`)를 메모. 태블릿에서 이 IP로 접속.
+
+---
+
+## Phase 2 — 태블릿 (Galaxy Tab + 키보드)
+
+### 2.1 Termux 설치 — F-Droid 권장
+
+Play Store의 Termux는 오래되어 권장 X.
+
+1. https://f-droid.org/F-Droid.apk 다운로드 → 설치
+2. F-Droid에서 `Termux` 검색 → 설치
+
+### 2.2 Termux 첫 셋업
+
+```bash
+# Termux 안에서
+pkg update && pkg upgrade -y
+pkg install openssh nano -y
+```
+
+### 2.3 SSH key 옮기기 (PC → 태블릿)
+
+가장 안전: USB 케이블 + Internal Storage.
+
+1. PC: USB 연결
+2. PC: `tablet_id` 파일을 태블릿 `Download/` 폴더로 복사 (Windows 탐색기)
+3. 태블릿 Termux:
+
+```bash
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+cp /sdcard/Download/tablet_id ~/.ssh/
+chmod 600 ~/.ssh/tablet_id
+
+# 옮긴 후 Download 폴더에서 즉시 삭제 (USB 노출 방지)
+rm /sdcard/Download/tablet_id
+```
+
+PC의 `tablet_id.pub`도 옮길 필요 없음 (PC `authorized_keys`에 이미 등록).
+
+### 2.4 Tailscale Android 앱
+
+Play Store에서 `Tailscale` → 설치 → PC와 **같은 계정** 로그인. 연결되면 태블릿도 mesh의 `100.x.x.x` IP를 받음.
+
+### 2.5 SSH config (alias 편의)
+
+```bash
+# Termux
+nano ~/.ssh/config
+```
+
+내용:
+
+```
+Host james-pc
+    HostName 100.x.x.x         # ← Phase 1.6에서 적은 PC Tailscale IP
+    User karu-
+    IdentityFile ~/.ssh/tablet_id
+    IdentitiesOnly yes
+    ServerAliveInterval 60     # 키보드 안 만지면 자동 끊김 방지
+    ServerAliveCountMax 3
+```
+
+저장.
+
+### 2.6 첫 접속 + 검증
+
+```bash
+ssh james-pc
+```
+
+passphrase 입력 → PC 셸 진입. 첫 접속 시 host key 확인 yes.
+
+---
+
+## Phase 3 — Claude Code 실행
+
+### 3.1 PowerShell shell로 변경 (선택, 권장)
+
+Windows OpenSSH의 default shell은 `cmd.exe`. PowerShell이 PROJECT JAMES의 다른 명령들과 일관:
+
+PC 관리자 PowerShell:
+
+```powershell
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" `
+    -Name DefaultShell `
+    -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" `
+    -PropertyType String -Force
+```
+
+다음 SSH 접속부터 PowerShell.
+
+### 3.2 매번 세션 시작 흐름
+
+태블릿에서:
+
+```bash
+# 1. SSH 접속
+ssh james-pc
+
+# 2. 프로젝트로 이동 (cmd 또는 PowerShell)
+cd C:\Project\James-RAG-Evol-v010    # PowerShell
+# 또는
+cd /c/Project/James-RAG-Evol-v010    # bash
+
+# 3. 다른 device에서 작업한 게 있으면 sync
+git pull
+git status
+
+# 4. Claude Code 시작
+claude       # 또는 PC에 설치된 정확한 명령
+```
+
+### 3.3 Claude 세션 첫 메시지
+
+PC 메모리 (`~/.claude/projects/<this>/MEMORY.md`)가 자동 로드되니 짧은 프롬프트로 충분:
+
+```
+v0.2 다음 우선순위 #20 entity hard merge부터 시작
+```
+
+또는 명시적으로:
+
+```
+docs/handovers/v0.1.4-ssh-onboarding.md 읽고 컨텍스트 복원
+```
+
+---
+
+## 작업 컨텍스트 — v0.1.4 시점 (이 문서 작성 시점)
+
+### 코드 상태
+
+- main: `1d663c0` (PR #25 — feat(admin): per-task LLM model selection)
+- working tree: `wiki/prod/` 빈 폴더 1개 (자기진화 추정 잔재 — `推후 문제 발생 시 재논의`로 미룸)
+- 6 releases 발행: v0.1.0-alpha → v0.1.1 → v0.1.2 → v0.1.3 → v0.1.3.1 → v0.1.4
+
+### 환경 (PC)
+
+| 항목 | 값 |
+|---|---|
+| OS | Windows 11 |
+| Python | 3.14.4 |
+| `JAMES_API_KEY` | 4자 (짧음, 운영 시 32자 권장) |
+| `JAMES_JWT_SECRET` | 43자 ✅ |
+| `JAMES_LLM_MODEL` | `gemma4:e4b` |
+| Ollama 설치된 모델 | `gemma4:e4b` (8B), `qwen2.5-coder:32b`, `llava:13b` |
+| `gh` CLI | 2.92.0, Hashevolution 인증됨 |
+| Tailscale | (Phase 1.6 진행 시 추가) |
+
+### 5개 open issue (다음 작업 후보, priority:medium)
+
+| # | 제목 | 추천 작업 |
+|---|---|---|
+| **#20** | Entity hard merge — collapse synonym groups into canonical .md | 다음 1순위. BTC.md + 비트코인.md → 1 canonical, target_id 재매핑. `tools/admin/entity_hard_dedup.py` 신규 도구 |
+| **#5** | Entity type 정확도 (product → org) | LLM extraction 프롬프트 강화 |
+| **#6** | Relation 라벨 다양화 (RELATED_TO 91%) | LLM 프롬프트 + 후처리 — #5와 묶어서 |
+| **#14** | Upload progress UI (XHR migration) | frontend/HANDOVER_WEB_UI.md 5단계와 합본 가능 |
+| **#8** | 위험 코딩 정책 결정 | SECURITY.md 정책 + `core/security_layer.py` 키워드 분류기 |
+
+### 운영 트랙 (별도 epic, `docs/handovers/v0.1.3.1-hotfix.md` 참고)
+
+| 항목 | 가치 |
+|---|---|
+| **B1 RAGAS** 벤치마크 통합 | 영업 자료 1순위 |
+| **B4 컨트리뷰터** 1명 확보 | bus factor 1 → 2 (사업화 전제) |
+| **B5 외부 red-team** | 보안 마케팅 (P0 보안 ✅ 완료, 진행 가능) |
+
+### 이번 사이클의 운영 패턴 (지키면 빠름)
+
+1. **Branch 명명**: `chore/v0.2-…`, `fix/v0.2-…`, `feat/v0.2-…`, `docs/v0.2-…`, `security/v0.2-…`
+2. **PR body 작성**: PowerShell 5.1의 `gh pr create --body "…"` 인자 escape 문제 → 임시 BOM-없는 UTF-8 파일 + `--body-file` 사용 (한글/특수문자 안전)
+3. **Self-merge**: `gh pr merge $num --squash --delete-branch` 후 `git checkout main && git pull --rebase`
+4. **Release 발행**: 의미있는 단위마다 (v0.1.x). 핵심 변화는 release notes에 박힘
+5. **Issue close**: PR title에 `closes #N` 또는 `closes #N, closes #M` (콤마만 쓰면 첫번째만 close됨 — `closes #N, closes #M` 형식)
+
+### 메모리 (`~/.claude/projects/<this>/`)
+
+- `MEMORY.md` 인덱스
+- `user_profile.md` — Hashevolution, 보안 + Graph-RAG, 한국어/Windows
+- `feedback_workflow.md` — 단계별 + 보안/fallback/이식성 우선
+- `project_state.md` — v0.1.4 + 5 open issues + 우선순위 박힘
+- `step7_findings_pointer.md` — `reports/step7_findings.md` 가리킴
+
+태블릿 SSH 세션은 PC 메모리 그대로 사용 (디스크 공유). Claude는 자동으로 로드.
+
+### 워크플로우 도구
+
+- `scripts/step7_query_test.py` — 12 쿼리 회귀 테스트 (서버 떠있을 때 실행)
+- `scripts/migrate_aliases.py`, `scripts/migrate_inverse_relations.py` — wiki entity backfill (멱등)
+- `scripts/post_step7_remaining.py` + `scripts/post_step7_issues.ps1` — GitHub issue 일괄 등록
+- `tools/admin/wiki_reset.py` — 사용자 데이터 리셋 (이젠 cp949 안 깨짐, #2 fixed)
+- 새 endpoint: `POST /admin/llm/select?task_type=X&model=Y`, `GET /admin/llm/selections` (#15)
+
+---
+
+## 알려진 한계 + 사용 팁 (태블릿 + SSH)
+
+### 화면 크기
+
+태블릿 + 키보드라도 PC 모니터보다 좁음. Bash 출력이 길면 가독성 ↓.
+
+```bash
+git log --oneline -10            # 짧게
+gh issue list --limit 5
+... | head -20                   # 잘라보기
+... | less                       # 페이지 단위
+```
+
+### 인터넷 의존
+
+PC가 켜진 상태 + 태블릿 인터넷 + Tailscale mesh 셋이 다 살아야 동작. 카페·이동 중 Wi-Fi 불안정 시 SSH 끊김 → `ServerAliveInterval`로 일부 완화.
+
+### Claude Code의 도구 풀 권한
+
+태블릿에서 `claude` 띄우면 PC 사용자 (karu-) 권한 그대로. `Edit`, `Bash`, `git`, `gh` 모두 동작 — **destructive 명령도 동작**. 작은 화면에서 실수 위험 ↑. 의심되면 Claude에게:
+
+```
+이 작업 dry-run으로 먼저 보여줘
+```
+
+### Anthropic 차세대
+
+Claude Code의 cloud sync 기능이 추가되면 이 SSH 경로 자체가 단순해질 가능성. 그때까지는 GitHub 브랜치 + 메모리 + 이 핸드오버가 device 간 sync의 실제 구현체.
+
+---
+
+## 인계 정보
+
+- 작성: PC Claude Code 세션 (Opus 4.7), v0.1.4 시점
+- 위치: `docs/handovers/v0.1.4-ssh-onboarding.md` (main에 push)
+- 동반 핸드오버:
+  - `docs/handovers/v0.1.3.1-hotfix.md` — 보안/비즈니스/엔지니어링 종합 (별도 노트북 클라우드 세션이 작성)
+  - `frontend/HANDOVER_WEB_UI.md` — Web UI 5단계 평가 (웹 클라우드 세션이 작성)
+
+이 세 문서가 device-sync 워크플로우의 누적 산출물.


### PR DESCRIPTION
## Summary

Adds `docs/handovers/v0.1.4-ssh-onboarding.md` so an incoming Galaxy
Tab → Termux + Tailscale → PC sshd → PC `claude` CLI session can
pick the project up at v0.1.4 without a separate context dump.

## Combined into one file (intentional)

The document interleaves two threads the prior PC session left open:

1. **SSH setup walkthrough** — Phase 1 (PC: OpenSSH Server, firewall,
   `sshd_config`, ed25519 key, `authorized_keys` ACL, Tailscale, 2FA).
   Phase 2 (Tablet: Termux from F-Droid, openssh, key transfer over
   USB, Tailscale Android, `~/.ssh/config`). Phase 3 (default shell
   to PowerShell, per-session start flow).
2. **Claude Code session handover** — current main commit, env state
   (which var is short and needs hardening), 5 open issues in
   priority order with one-line implementation hints, the
   business-track epic (B1 RAGAS / B4 contributor / B5 red-team)
   from `v0.1.3.1-hotfix.md`, and the operational patterns this
   cycle converged on (branch naming, BOM-less UTF-8 PR bodies for
   PS5.1, `closes #N, closes #M` issue-close gotcha).

The reader is the same person — operator coming back from a tablet
— and they need both layers in the same scroll. Splitting would
mean cross-referencing across files inside an unfamiliar shell.

## Existing handovers untouched

- `docs/handovers/v0.1.3.1-hotfix.md` — engineering + P0 security +
  business audit from the off-PC cloud session
- `frontend/HANDOVER_WEB_UI.md` — UI evaluation from the web cloud
  session

The three documents together are this project's device-sync workflow
output until Anthropic ships proper Claude Code cloud sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)