### PR TITLE
docs(v0.2): add ARCHITECTURE.md + 6-axis ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,37 +29,101 @@
 
 ---
 
-## v0.2.0 — Real-Data Validation (next, ~2-3 months)
+## v0.2.0 — Foundation Hardening (next, ~3-4 months)
 
-**Theme**: Replace synthetic data with real data; harden weak points.
+**Theme**: Make the v0.1 capabilities trustworthy enough to recommend
+to a second user. Six axes, all of them P0/P1.
 
-### Priorities
+### Axis 1 — Architecture Separation (P0)
 
-- **Real-data testing**
-  - 30+ real entities across diverse domains
-  - User-tested query patterns
-  - Edge case discovery and fixing
+Goal: no single file owns more than one responsibility.
 
-- **Multimodal completion**
-  - Full LLaVA integration for image understanding
-  - Whisper integration for audio transcription
-  - PDF table extraction improvements
+- [ ] Split `core/reasoning_engine.py` (50 KB) into:
+      `pipeline.py` (loop), `answer.py` (generation),
+      `parsing.py` (JSON/citation extraction)
+- [ ] Consolidate `memory_*` (5 files, ~70 KB) into
+      `core/memory/` package with documented public API
+- [ ] Move `tools/self/` behind a sub-process boundary
+      (no in-proc access to core modules)
+- [ ] Public typed interfaces for: `Retriever`, `GraphEngine`,
+      `PolicyEngine`, `Reasoner`, `OutputFilter`
 
-- **Self-evolution proof**
-  - Demonstrate end-to-end: feedback → proposal → patch → deploy
-  - Quality metrics for evolved patches
-  - Rollback mechanism testing
+**Done when**: `import` graph is acyclic and each module has < 20 KB.
 
-- **Performance**
-  - Profile and optimize hot paths
-  - Reduce p50/p99 response time
-  - Embedding cache improvements
+### Axis 2 — Evaluation Harness (P0)
 
-- **Documentation**
-  - Tutorial: building a custom domain
-  - Tutorial: extending the ontology
-  - Architecture deep-dive
-  - Video walkthrough
+Goal: every change is measured against the same yardsticks.
+
+- [ ] Lock STEP 7 12-query suite as committed regression baseline
+      (currently runs locally only)
+- [ ] Integrate **RAGAS** for retrieval / faithfulness / answer relevance
+- [ ] Adopt a **LegalBench** subset for domain stress test
+      (replaces vague "legal-style" prompts)
+- [ ] Add `scripts/bench.py` that runs all three on every PR locally
+- [ ] Publish numbers in PR descriptions for any change touching
+      `core/retrieval_engine.py`, `core/graph_engine.py`,
+      `core/reasoning_engine.py`
+
+**Done when**: a PR cannot land without bench numbers attached.
+
+### Axis 3 — Observability / Tracing (P1)
+
+Goal: any answer can be debugged without re-running it.
+
+- [ ] OpenTelemetry-style `trace_id` end-to-end
+- [ ] Structured stage logs:
+      `query → retrieve → rerank → graph → tool → answer`
+- [ ] `GET /admin/trace/{id}` returns full pipeline replay
+- [ ] Per-stage latency histograms in `/admin/metrics`
+
+**Done when**: a hallucination report can be diagnosed by trace_id alone.
+
+### Axis 4 — Security Boundary (P1)
+
+Goal: policy is a layer, not a sprinkle.
+
+- [ ] Extract `core/policy_engine.py` — single point of role/sensitivity
+      decisions, called by retrieval / graph / output / tools
+- [ ] Capability tokens for tool access (no direct fs path strings)
+- [ ] Multimodal inputs (image/audio/web) flagged and quarantined
+      before joining the LLM context
+- [ ] External red-team pass on prompt injection (replace pattern-only
+      defense with ML guard + patterns)
+
+**Done when**: removing the policy engine breaks at least 4 modules
+(meaning every consumer is wired through it).
+
+### Axis 5 — Controlled Evolution (P1)
+
+Goal: self-evolution cannot deploy without a human.
+
+- [ ] Wire opt-in env flag `JAMES_ENABLE_EVOLUTION=0` (default off)
+- [ ] feedback → candidate → eval → **approval (human)** → deploy → rollback
+- [ ] Eval gate uses the Axis 2 harness — no bypass
+- [ ] Audit log records approver, timestamp, before/after metrics
+
+**Done when**: any patch deployed has an `approved_by` field in the
+audit DB, and deploy without it is rejected.
+
+### Axis 6 — Real-Data Validation (carries forward from v0.1)
+
+Goal: numbers from real data, not just synthetic.
+
+- [ ] 30+ real entities across diverse domains (carries from v0.1)
+- [ ] User-tested query patterns (carries from v0.1)
+- [ ] Multimodal pipeline integration completion
+- [ ] Edge case discovery and fixing
+
+**Done when**: a second user (not the maintainer) can run the bench
+suite on their own corpus end-to-end without intervention.
+
+### Known cuts from earlier v0.2 plan
+
+The following moved to v0.3 to keep v0.2 focused:
+
+- Self-evolution end-to-end demonstration → folded into Axis 5
+- Performance profiling → after Axis 1 (premature otherwise)
+- Tutorial documentation → after Axis 1 stabilizes
 
 ---
 
@@ -162,4 +226,4 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ---
 
-**Last updated**: v0.1.0 release
+**Last updated**: v0.2.0-dev (foundation hardening plan)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# JAMES — Architecture & Design Principles
+
+> Engineering reference for contributors. Describes what JAMES is,
+> what it deliberately is not, and the trust boundaries that govern
+> all design decisions.
+>
+> Status: living document. Last updated: v0.2.0-dev.
+
+---
+
+## 1. Mission
+
+A **local-first, auditable knowledge reasoning system** that answers
+questions over a private knowledge base with:
+
+- explicit reasoning paths (sources + graph trace)
+- role-based access at every stage
+- human-supervised improvement loop
+
+JAMES sits **alongside** systems of record (ERP, DMS, CMS) — never
+replaces them.
+
+---
+
+## 2. Non-goals
+
+JAMES is deliberately **not**:
+
+- a general-purpose AGI or fully autonomous agent
+- a replacement for ERP, accounting, inventory, or booking systems
+- a cloud-only SaaS (cloud is opt-in, not default)
+- a self-modifying system without human approval
+- a real-time transactional database
+- a legal advisor (analytical assistance only; final review by qualified professionals)
+
+If a feature request implies any of the above, it belongs in a
+**downstream product** built on top of JAMES, not in JAMES itself.
+
+---
+
+## 3. Design Principles
+
+| # | Principle | Operational meaning |
+|---|---|---|
+| 1 | **Local-first** | Default deployment is single-machine, no external network calls required for core path. |
+| 2 | **Evidence-based reasoning** | Every answer must cite source documents and graph paths; ungrounded answers are flagged. |
+| 3 | **Policy-aware retrieval** | RBAC + ABAC checks fire at retrieval, graph, and output stages — not just at the API edge. |
+| 4 | **Auditability over performance** | When in doubt, log more. Audit log is append-only and never silently dropped. |
+| 5 | **Human-supervised evolution** | Self-evolution **proposes**; humans **approve**. Deploy without approval is a bug. |
+| 6 | **Sandboxed multimodality** | Image, audio, web content are untrusted inputs by default; extraction does not bypass policy. |
+| 7 | **Composable boundaries** | Components communicate over typed interfaces, not shared globals. |
+
+---
+
+## 4. Component Layers
+
+```
+                ┌──────────────────────────────────────────┐
+                │              Frontend / API              │
+                └────────────────────┬─────────────────────┘
+                                     │
+                ┌────────────────────▼─────────────────────┐
+                │         Auth + Policy Engine             │  ← RBAC/ABAC
+                └────────────────────┬─────────────────────┘
+                                     │
+        ┌────────────────────────────┼────────────────────────────┐
+        │                            │                            │
+   ┌────▼─────┐               ┌──────▼────┐              ┌────────▼─────┐
+   │  Query   │               │ Retrieval │              │     Tool     │
+   │  Router  │               │ (Hybrid)  │              │    Router    │
+   └────┬─────┘               └──────┬────┘              └────────┬─────┘
+        │                            │                            │
+        │                      ┌─────▼─────┐               ┌──────▼─────┐
+        │                      │   Graph   │               │  Sandbox   │
+        │                      │   Engine  │               │  (FS/Web)  │
+        │                      └─────┬─────┘               └──────┬─────┘
+        │                            │                            │
+        └────────────┬───────────────┴────────────────────────────┘
+                     │
+              ┌──────▼──────┐                  ┌──────────────┐
+              │  Reasoning  │                  │    Memory    │
+              │    Loop     │ ◀──────────────▶ │ (Trust-gated)│
+              └──────┬──────┘                  └──────────────┘
+                     │
+              ┌──────▼──────┐
+              │   Output    │  ← PII + role mask
+              │   Filter    │
+              └──────┬──────┘
+                     │
+              ┌──────▼──────┐
+              │  Audit Log  │  (append-only, every decision)
+              └─────────────┘
+```
+
+Each box is a **module with a typed interface**. No box reaches into
+another's internals.
+
+---
+
+## 5. Trust Zones
+
+| Zone | Source | Default trust | Hardening |
+|---|---|---|---|
+| User input (authenticated) | UI / API | **low** | sanitize, instruction-isolate |
+| Internal documents | uploaded files, wiki | medium | content scan on ingest |
+| Memory (system-tagged) | reasoning loop, system events | medium | role-locked writes |
+| Memory (user-tagged) | feedback, comments | **low** until validated | trust score gate |
+| Multimodal extraction | OCR, ASR, vision | **low** | content scan + isolate |
+| Web search results | Tavily, DDG | **low** | content scan + isolate |
+| Tool output | sandbox | medium | path/command allowlist |
+
+Anything labeled **low** must pass `extract_data_only()` before
+joining the LLM context.
+
+---
+
+## 6. Evolution Boundaries
+
+Self-evolution is **disabled by default**. To enable:
+
+1. Set `JAMES_ENABLE_EVOLUTION=1` (explicit opt-in)
+2. Configure `JAMES_EVOLUTION_APPROVER_ROLE` (default: `admin`)
+3. Patches flow: `feedback → candidate → 4-gate eval → approval → deploy → rollback-ready`
+
+A patch reaches `deploy` only after a human with the approver role
+explicitly approves it. Auto-approval is a bug, not a feature.
+
+---
+
+## 7. What JAMES is good at (and what it's not)
+
+### Strong fits
+
+- Q&A over private document corpora with role-restricted access
+- Auditable reasoning over ontology-rich domains (legal, compliance, internal knowledge)
+- Local-only environments with no acceptable cloud egress
+- Domains where "why this answer?" matters as much as the answer
+
+### Poor fits
+
+- Real-time transactional systems (booking, POS, ledger)
+- Workflow / approval engines (use a BPM; JAMES can be a node inside one)
+- Pure summarization at scale (a smaller specialized pipeline is cheaper)
+- General-purpose chat (the policy + audit overhead is wasted)
+
+---
+
+## 8. Versioning of this document
+
+Architectural changes (new layer, trust-zone change, removal of
+non-goal) require a PR to this file with an `architecture` label.
+Module-internal changes do not.
+
+---
+
+## 9. 한국어 요약 (간단)
+
+JAMES는 **로컬에서 실행되며, 추론 근거를 추적하고, 정책에 따라
+권한을 검사하며, 사람이 승인한 변경만 적용되는** 지식 추론
+시스템입니다. ERP·회계·예약 같은 **시스템 오브 레코드를 대체하지
+않으며**, 그 위에 얹는 분석·검색·정책 레이어로 동작합니다.
+자세한 영문 본문 참조.


### PR DESCRIPTION
## Summary

Establishes the design foundation for v0.2.0 work in two engineering documents:

- **`docs/ARCHITECTURE.md`** (new) — design principles, non-goals, component layers, trust zones, evolution boundaries. The reference contributors check before proposing structural changes.
- **`ROADMAP.md`** (rewrite of v0.2 section) — re-frames v0.2.0 as a six-axis "Foundation Hardening" plan that maps directly to issues #29-#33. Real-Data Validation (carry-forward from v0.1) preserved as Axis 6. Multi-agent / Neo4j moved to v0.3 to keep v0.2 scope crisp.

This PR is documentation-only (no code, no behavioral change). It prepares the ground for issue work to land on a shared baseline.

## Origin

Two commits cherry-picked from `claude/sync-sessions-across-devices-XO5In`. The other commits on that branch were either:

- already imported to main via PR #21 (the 4 handover doc commits — confirmed byte-identical on both sides), or
- behind several merged PRs (\#22-\#28) and would have removed recent work if merged directly.

Cherry-pick onto a fresh branch from main keeps history clean and avoids touching anything outside docs.

## Axis ↔ issue mapping

| Axis | Priority | Issue |
|---|---|---|
| 1 — Architecture Separation | P0 | #29 |
| 2 — Evaluation Harness | P0 | #30 |
| 3 — Observability | P1 | #31 |
| 4 — Security Boundary | P1 | #32 |
| 5 — Controlled Evolution | P1 | #33 |
| 6 — Real-Data Validation | carry-forward | (#5, #6, #14, #8 absorbed) |

Each axis has explicit "Done when" criteria in ROADMAP.md. PRs against \#29-\#33 should reference the corresponding axis.

## Test plan

- [x] `docs/ARCHITECTURE.md` renders cleanly on GitHub (single fenced code block for the layer diagram, no nested-fence breakage)
- [x] `ROADMAP.md` keeps "Real-Data Validation" content (Axis 6) — nothing dropped from prior plan
- [x] No code/config files modified — diff is `docs/ARCHITECTURE.md` (new) + `ROADMAP.md` (~89/-25)
- [ ] Reviewer skim of both docs for any direction conflicts with current main behavior

## Out of scope

- Creating new GitHub labels (`refactor`, `architecture`, `observability`, `infra`, `testing`, `evaluation`, `self-evolution`) — must be added in repo Settings before \#29-\#33 can be retagged. Tracked separately.
- Any code change toward the six axes — each axis lands as its own PR per Test plan in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)