### PR TITLE
fix(server): UTF-8 console at server entry to prevent cp949 print crashes

### DIFF
--- a/james_e2e_test.py
+++ b/james_e2e_test.py
@@ -29,6 +29,10 @@ PROJECT JAMES — E2E 통합 테스트 (Phase 1~7 유기적 연결 검증)
   james_phase7_test.py    ← 유지 (파일 구조 확인)
   이 파일                 ← 신규 (전체 유기적 E2E)
 """
+# Reconfigure stdout to UTF-8 before any top-level prints (this script emits
+# Korean banners + emoji on import). See utils/console.py for rationale.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
 
 import sys, os, json, re, time, traceback
 from pathlib import Path

--- a/james_phase55_test.py
+++ b/james_phase55_test.py
@@ -13,6 +13,10 @@ Phase 5.5 통과 기준:
   [P55-6] 감사 로그   — tool_used + protected_block + admin_override 기록
   [P55-7] 보안 유지   — Core Engine 무수정 + 기존 보안 100% 유지
 """
+# Reconfigure stdout to UTF-8 before any top-level prints (this script emits
+# Korean banners + emoji on import). See utils/console.py for rationale.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
 
 import sys
 import os

--- a/james_phase5_test.py
+++ b/james_phase5_test.py
@@ -15,6 +15,10 @@ Phase 5 통과 기준:
   [P5-7] 기존 DFS node 3~5 유지
   [P5-8] 기존 GraphRAG 응답 품질 저하 없음
 """
+# Reconfigure stdout to UTF-8 before any top-level prints (this script emits
+# Korean banners + emoji on import). See utils/console.py for rationale.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
 
 import sys
 import time

--- a/james_phase6_gate.py
+++ b/james_phase6_gate.py
@@ -18,6 +18,10 @@ Phase 6 진입 체크리스트:
   A등급 (≥90%) → 실패 항목 수정 후 재검증
   B등급 이하   → Phase 6 진입 금지
 """
+# Reconfigure stdout to UTF-8 before any top-level prints (this script emits
+# Korean banners + emoji on import). See utils/console.py for rationale.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
 
 import sys
 import time

--- a/james_phase6_test.py
+++ b/james_phase6_test.py
@@ -17,6 +17,10 @@ Phase 6 통과 기준:
   [P6-8] Query Router 분기 동작    ← 신규
   [P6-9] Memory Step 1 동작        ← 신규
 """
+# Reconfigure stdout to UTF-8 before any top-level prints (this script emits
+# Korean banners + emoji on import). See utils/console.py for rationale.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
 
 import sys
 import os

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -9,6 +9,13 @@ Phase 4 변경:
   [P4-SRV-5] Instruction Isolation 문서 업로드 시 적용
 """
 
+# Reconfigure stdout/stderr to UTF-8 BEFORE any imports that print (config.py
+# emits banner lines on import). Otherwise non-ASCII chars in any TIMING /
+# diagnostic print path crash with UnicodeEncodeError on Windows cp949 console
+# and propagate up to FastAPI as HTTP 400. Same helper used by admin scripts (#2/#24).
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
 import os
 import sqlite3
 import uuid


### PR DESCRIPTION
## Summary

- `server_llmwiki.py` and 5 test scripts crash on a default Windows console (cp949) when any production-path `print()` includes non-ASCII (Korean text, emoji ⚠️ ✅ ❌, em-dash —). Root cause: console codec, not the prints.
- Fix: call `utils.console.ensure_utf8_console()` at each entry point before the first print. Same helper already used by 4 admin scripts in PR #24 (Issue #2).
- 6 files, +27 lines, no behavior change beyond stdout encoding.

## The bug

Discovered while running STEP 7 verification for PR #35:

```
File "C:\Project\James-RAG-Evol-v010\core\reasoning_engine.py", line 81, in _elapsed
    print(f"[TIMING] {label}: {e:.2f}s{flag}")
UnicodeEncodeError: 'cp949' codec can't encode character '⚠' in position 30
INFO:     127.0.0.1:57278 - "POST /query/ HTTP/1.1" 400 Bad Request
```

`_elapsed` appends `flag = " ⚠️" if e > 10 else ""` — the warning emoji is a deliberate visual signal for slow stages. On Windows the print crashes, and because the crash happens inside the FastAPI request handler, the exception turns into HTTP 400 to the client. The bug is silent on POSIX (UTF-8 by default) and silent on Windows when operators remember `PYTHONIOENCODING=utf-8` — making it intermittent and easy to miss in dev.

Same class of bug exists in 5 test entry points (`james_e2e_test.py:51` em-dash —, `james_phase{5,55,6}_test.py` ✅/❌/💥 emoji, `james_phase6_gate.py` Korean banners). They crash at module-import time, so even `python -c "import james_e2e_test"` failed.

## Why entry-point fix, not per-print fix

The codebase has dozens of production prints with non-ASCII (Korean diagnostic messages throughout `core/*`, `processors/*`, `tools/*`). Patching each one is whack-a-mole and would miss future additions. Entry-point reconfiguration covers the entire class once and stays correct as new prints are added.

`utils.console.ensure_utf8_console()` was added in PR #24 (Issue #2) for exactly this purpose. It uses `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` on Windows and is a no-op on Linux/macOS. Already proven on 4 admin scripts (`tools/admin/{wiki_reset,seed_data,upload_simulator}.py`, `scripts/reset_for_production.py`).

## Files changed

| File | Lines added | Why |
|---|---|---|
| `server_llmwiki.py` | +7 | Production server (the original 400 source) |
| `james_e2e_test.py` | +4 | Korean banner + em-dash at top-level print |
| `james_phase5_test.py` | +4 | ✅/❌/💥 emoji in `test()` helper |
| `james_phase55_test.py` | +4 | Same |
| `james_phase6_test.py` | +4 | Same |
| `james_phase6_gate.py` | +4 | Same |

The call must happen **before** `import config` (config emits banner lines on import). Insertion point in `server_llmwiki.py` is right after the module docstring, before the first stdlib import.

## Verification

### Server (the original repro)
- Stopped the existing server, restarted **without** `PYTHONIOENCODING=utf-8` (default cp949 console).
- Sent 2 queries via `/query/`:
  - "RAG가 무엇인가?" → HTTP 200, answer_len 1769, graph_paths 15
  - "BlackRock과 비트코인 ETF는 무슨 연관이 있어?" → HTTP 200, answer_len 1944, graph_paths 46

Both queries triggered the >10s `_elapsed` ⚠️ branch (visible in server log). Before this PR: both would return HTTP 400.

### Test scripts
```
$ unset PYTHONIOENCODING PYTHONUTF8
$ for f in james_{e2e,phase5,phase55,phase6}_test james_phase6_gate; do python -c "import $f"; done
# all clean (previously: UnicodeEncodeError on em-dash / emoji)
```

## Out of scope

- Not modifying individual `print()` calls anywhere. The fix is structural.
- Not adding `ensure_utf8_console()` to non-print entry points (e.g., short utility scripts, library modules) — only the 6 here have observed top-level / runtime print crashes.
- Not changing the helper itself — already correct from PR #24.

## Test plan

- [x] Server starts on default cp949 console without crash
- [x] `/query/` returns 200 (not 400) for queries that trigger the ⚠️ slow flag
- [x] `python -c "import james_X"` clean for all 5 test scripts
- [x] No behavior change beyond stdout encoding (Linux/macOS unaffected — `ensure_utf8_console` is no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
