### PR TITLE
fix(extract): tighten entity-extraction prompt for type accuracy + label diversity (#5, #6)

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -668,22 +668,49 @@ class WikiGenerator:
         # generate_metadata 와 같은 형식으로 통일 (그쪽이 안정적으로 동작 검증됨)
         text = (content or "")[:2000]
 
+        # Issue #5: products/tools (Claude Code, Aider, GPT-4) were misclassified
+        # as `org`. Issue #6: 91% of relations defaulted to 관련 (RELATED_TO),
+        # leaving the 11 ontology-specific labels under-used. Both addressed by
+        # tightening this single prompt with explicit type rules + label hints
+        # by entity-type pair + "use 관련 only when nothing else fits".
         prompt = (
-            "You must output ONLY a JSON object. "
-            "No explanation, no thinking, no markdown. Just raw JSON.\n\n"
-            "Output format:\n"
-            '{"entities": [{"name": "X", "type": "person|org|concept", "description": "한줄설명"}], '
-            '"relations": [{"source": "X", "target": "Y", "label": "관련", "confidence": 0.7}]}\n\n'
-            f"Allowed relation labels (Korean only): {_ONTOLOGY_LABELS_KO}\n"
-            "Max 6 entities and 6 relations. "
-            "Extract only entities EXPLICITLY named in the document below. No inference.\n\n"
+            "Output ONLY raw JSON. No explanation, no markdown.\n"
+            "Format: {\"entities\": [{\"name\":\"X\",\"type\":\"person|org|concept\","
+            "\"description\":\"한줄\"}], \"relations\": [{\"source\":\"X\","
+            "\"target\":\"Y\",\"label\":\"관련\",\"confidence\":0.7}]}\n\n"
+
+            "TYPES (3 only):\n"
+            "  person  = individual (Sam Altman, 이재명)\n"
+            "  org     = company/institution (Anthropic, 삼성전자, 한국은행)\n"
+            "  concept = idea, method, tech, AND products/tools/services\n"
+            "            (RAG, GPT-4, Claude Code, Aider, 비트코인, 갤럭시)\n"
+            "RULE: a product/tool is CONCEPT, the maker is ORG.\n"
+            "  e.g. Anthropic=org, Claude Code=concept (Anthropic 'produces' Claude Code).\n"
+            "  Same name must NEVER appear as both org and concept.\n\n"
+
+            f"RELATION LABELS (Korean, pick from): {_ONTOLOGY_LABELS_KO}\n"
+            "Prefer specific label by type pair, NOT 관련:\n"
+            "  person→org     => 근무 / 소속\n"
+            "  person→concept => 연구 / 공부\n"
+            "  org→person     => 설립됨\n"
+            "  org→concept    => 생산 / 분야\n"
+            "  concept→concept=> 분류 / 구성\n"
+            "Use 관련 ONLY when none of the above fits.\n\n"
+
+            "Max 6 entities, 6 relations. Extract only entities EXPLICITLY named below.\n\n"
             "Document:\n"
             + text
             + "\n\nJSON:"
         )
         try:
             from llm.router import call_router
-            response = call_router(prompt, task_type="extract", use_cache=False)
+            # max_tokens=1500: original prompt was short and default 0 (unlimited)
+            # was fine; the longer enriched prompt above pushed total context high
+            # enough that the model began truncating its JSON response (~700 chars
+            # in). Explicit budget keeps a complete 6-entity / 6-relation JSON in.
+            response = call_router(
+                prompt, task_type="extract", use_cache=False, max_tokens=1500,
+            )
         except Exception as e:
             print(f"[ENTITY-EXTRACT] LLM call FAIL: {e}")
             return {"entities": [], "relations": []}


### PR DESCRIPTION
## Summary

Single prompt change in `wiki_generator._llm_extract_document_entities()` that addresses both:
- **#5** — entity type misclassification (`Claude Code` → `org` instead of `concept`)
- **#6** — relation label skew (91% of relations defaulting to `관련` / RELATED_TO)

Plus a small Ollama-side fix (`max_tokens=1500`) needed because the enriched prompt was hitting truncation under the previous unlimited-default budget.

## What changed

### Entity types — explicit product/tool guidance

The prompt now spells out that the 3 allowed types include products/tools/services under `concept`, with worked examples and a contrastive rule:

> RULE: a product/tool is CONCEPT, the maker is ORG.
>   e.g. Anthropic=org, Claude Code=concept (Anthropic 'produces' Claude Code).
>   Same name must NEVER appear as both org and concept.

### Relation labels — type-pair → label cheat sheet

Replaces a flat comma-separated list with concrete pairings:

> Prefer specific label by type pair, NOT 관련:
> ```
> person→org     => 근무 / 소속
> person→concept => 연구 / 공부
> org→person     => 설립됨
> org→concept    => 생산 / 분야
> concept→concept=> 분류 / 구성
> ```
> Use 관련 ONLY when none of the above fits.

### `max_tokens=1500`

The enriched prompt added ~500 chars. First test run with default `max_tokens=0` (Ollama's "use model default") truncated the JSON response at ~700 chars mid-object, causing extraction to return empty `{entities:[], relations:[]}`. Explicit budget keeps a complete 6-entity / 6-relation JSON in.

## Verification

Diagnostic script invoked `_llm_extract_document_entities()` directly on two fixed test texts. Compared BEFORE vs AFTER:

### Test 1 — `ai_products` (focused on #5)

| | BEFORE | AFTER |
|---|---|---|
| entities | Anthropic=org, Dario=person, Claude=concept, OpenAI=org, Microsoft=org, RAG=concept | Anthropic=org, Dario=person, Claude=concept, OpenAI=org, **Sam Altman=person**, **GPT-4=concept** |
| relations | 5 (설립됨, 생산, **관련**, 분류×2) | 4 (설립됨, 생산×2, 소속) — **0 관련** |
| #5 product test | (Claude Code/GPT-4/Aider not extracted) | **GPT-4 correctly classified as concept** ✅ |

### Test 2 — `kr_finance` (focused on #6)

| | BEFORE | AFTER |
|---|---|---|
| entities | 이재용=person, 삼성전자=org, 한국은행=org, 갤럭시=concept, BTC ETF=concept, 비트코인=concept | 이재용=person, 삼성전자=org, 한국은행=org, 갤럭시=concept, BTC ETF=concept, **BlackRock=org**, **Fidelity=org** |
| relations | 6 (소속, 생산×3, 분야, 분류) — 0 관련 | 6 (소속, 생산×3, 결정¹, 분류) — 0 관련|

¹ "결정" is off-spec; downstream `normalize_relation()` maps unknown labels to RELATED_TO with a `[ONTOLOGY] 미등록 relation` warning. Soft fallback, no crash.

### Honest limit

These short curated test texts already showed reasonable label distribution under the **old** prompt (1/11 = 9% 관련 across the two test runs). The 91% 관련 skew measured in STEP 7 came from longer, messier PDF chunks. The prompt enhancements should carry over to those — verifiable on the next round of real PDF uploads but not directly demonstrable in this PR.

The strongest concrete signal in the test set is the **GPT-4 type classification** (correctly `concept` post-fix, not extracted at all in baseline).

## Out of scope

- Adding a 4th `product` entity type (option A in #5). Would cascade into `core/ontology.py::ALLOWED_RELATIONS`, downstream graph code, and require migrating existing 161 entities. The simpler prompt fix (option B) handles the reported failure modes.
- Post-process fallback that rewrites `관련` → stronger label by type pair (option 2 in #6). Defer until we have data on whether the prompt-only fix is sufficient.

## Test plan

- [x] Diagnostic script before/after on 2 fixed test texts (results above)
- [x] Type accuracy: GPT-4 → concept ✅ (was missing entirely BEFORE)
- [x] Label diversity preserved (still 0 관련 across both AFTER tests)
- [x] No code-path crash; existing `_is_safe_extracted_entity` validation still gates output
- [ ] Reviewer optional: upload a real PDF and inspect newly-created `wiki/entity/prod/*.md` for type+label distribution improvement at scale

Closes #5, closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
