### PR TITLE
feat(upload): per-file progress bar + queue indicator + cancel via XHR (#14)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -365,6 +365,42 @@
   }
   .folder-input::placeholder { color: var(--muted); opacity: .6; }
 
+  /* ── 진행 표시 (Issue #14) ── */
+  .file-progress-row {
+    display: flex; align-items: center; gap: 6px;
+    margin-top: 4px;
+  }
+  .file-progress-bar {
+    flex: 1; height: 3px;
+    background: rgba(255,255,255,.06);
+    border-radius: 2px; overflow: hidden;
+  }
+  .file-progress-fill {
+    height: 100%; width: 0;
+    background: linear-gradient(90deg, var(--accent2), var(--accent));
+    transition: width .15s ease;
+  }
+  .file-progress-pct {
+    font-size: 9px; font-family: var(--font-mono);
+    color: var(--muted); min-width: 32px; text-align: right;
+  }
+  .queue-progress {
+    margin: 0 16px 8px; padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 11px; font-family: var(--font-mono);
+  }
+  .queue-progress-text { color: var(--accent2); margin-bottom: 4px; word-break: break-all; }
+  .queue-progress-bar  {
+    height: 2px; background: rgba(255,255,255,.06);
+    border-radius: 1px; overflow: hidden;
+  }
+  .queue-progress-fill {
+    height: 100%; width: 0; background: var(--accent);
+    transition: width .2s ease;
+  }
+
   .upload-btn {
     margin: 0 16px 16px;
     width: calc(100% - 32px);
@@ -702,6 +738,12 @@
     </div>
 
     <div class="file-list" id="file-list"></div>
+
+    <!-- 큐 진행 표시 (Issue #14) — 다중 파일 업로드 동안 표시 -->
+    <div class="queue-progress" id="queue-progress" style="display:none;">
+      <div class="queue-progress-text" id="queue-progress-text"></div>
+      <div class="queue-progress-bar"><div class="queue-progress-fill" id="queue-progress-fill"></div></div>
+    </div>
 
     <button class="upload-btn" id="upload-btn" onclick="uploadFiles()" disabled>
       <span data-i18n="upload.btn_default">업로드 및 분석</span>

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -107,6 +107,10 @@ const TRANSLATIONS = {
     'upload.category':       'Category: {cat}',
     'upload.sensitivity':    'Security: {level}',
     'upload.complete_msg':   'Upload complete:\n\n{summary}',
+    'upload.cancel':         'Cancel',
+    'upload.aborted':        'Cancelled',
+    'upload.queue_progress': 'Uploading {current}/{total} — {filename}',
+    'upload.percent':        '{pct}%',
 
     'admin.dashboard':       'Dashboard',
     'admin.users':           'Users',
@@ -415,6 +419,10 @@ const TRANSLATIONS = {
     'upload.category':       '분류: {cat}',
     'upload.sensitivity':    '보안: {level}',
     'upload.complete_msg':   '파일 업로드 완료:\n\n{summary}',
+    'upload.cancel':         '취소',
+    'upload.aborted':        '취소됨',
+    'upload.queue_progress': '업로드 중 {current}/{total} — {filename}',
+    'upload.percent':        '{pct}%',
 
     'admin.dashboard':       '대시보드',
     'admin.users':           '사용자',

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -36,6 +36,7 @@ function addFiles(files) {
       id:          Date.now() + '_' + Math.random().toString(36).slice(2,6),
       status:      'ready',
       instruction: '',   // 파일별 저장 지시
+      xhr:         null, // in-flight XMLHttpRequest (set during upload, cleared after)
     };
     uploadQueue.push(item);
     renderFileItem(item);
@@ -43,13 +44,25 @@ function addFiles(files) {
   updateUploadBtn();
 }
 
-/* ── 파일 제거 ── */
-function removeFile(id) {
+/* ── 파일 제거 또는 진행 중 취소 ──
+ *  Issue #14: when upload is in flight (item.status === 'upload' and xhr
+ *  exists), the same per-file button now aborts the XMLHttpRequest instead
+ *  of removing from the queue. The 'abort' handler in uploadOne() then
+ *  surfaces it as `error` with label '취소됨'.
+ */
+function removeOrCancel(id) {
+  const item = uploadQueue.find(i => String(i.id) === String(id));
+  if (item && item.status === 'upload' && item.xhr) {
+    try { item.xhr.abort(); } catch (_) {}
+    return;   // do not remove DOM yet — uploadFiles loop will reach the catch and re-render
+  }
   uploadQueue = uploadQueue.filter(i => String(i.id) !== String(id));
   const el = document.getElementById(`file-${id}`);
   if (el) el.remove();
   updateUploadBtn();
 }
+// Backwards-compat alias for any inline onclick that still calls removeFile
+function removeFile(id) { removeOrCancel(id); }
 
 /* ── 업로드 버튼 상태 ── */
 function updateUploadBtn() {
@@ -91,7 +104,11 @@ function renderFileItem(item) {
         <div class="file-size">${formatSize(item.file.size)}</div>
       </div>
       <span class="file-status status-ready" id="status-${item.id}">대기</span>
-      <button class="remove-btn" onclick="removeFile('${item.id}')" title="제거">✕</button>
+      <button class="remove-btn" id="action-${item.id}" onclick="removeOrCancel('${item.id}')" title="제거">✕</button>
+    </div>
+    <div class="file-progress-row" id="progress-${item.id}" style="display:none;">
+      <div class="file-progress-bar"><div class="file-progress-fill" id="progress-fill-${item.id}"></div></div>
+      <span class="file-progress-pct" id="progress-pct-${item.id}">0%</span>
     </div>
     <div class="file-folder-row">
       <span class="folder-icon">📂</span>
@@ -118,8 +135,37 @@ function setStatus(id, status, label) {
   if (!el) return;
   el.className = `file-status status-${status}`;
   el.textContent = label;
-  const btn = el.parentElement?.querySelector('.remove-btn');
-  if (btn) btn.style.display = (status === 'ready' || status === 'error') ? '' : 'none';
+  // Action button: stays visible across all states; title swaps to '취소' during upload.
+  const btn = document.getElementById(`action-${id}`);
+  if (btn) {
+    if (status === 'upload')      { btn.style.display = ''; btn.title = '취소'; }
+    else if (status === 'done')   { btn.style.display = 'none'; }
+    else                           { btn.style.display = ''; btn.title = '제거'; }
+  }
+  // Per-file progress bar visible only during upload.
+  const prog = document.getElementById(`progress-${id}`);
+  if (prog) prog.style.display = (status === 'upload') ? '' : 'none';
+}
+
+function setProgress(id, pct) {
+  const fill = document.getElementById(`progress-fill-${id}`);
+  if (fill) fill.style.width = pct + '%';
+  const lbl  = document.getElementById(`progress-pct-${id}`);
+  if (lbl)  lbl.textContent = pct + '%';
+}
+
+/* ── 큐 진행 표시 (Issue #14) ──
+ *  pass `total + 1` for current to hide the queue indicator after the run.
+ */
+function setQueueProgress(current, total, filename) {
+  const box = document.getElementById('queue-progress');
+  if (!box) return;
+  if (current > total || total <= 0) { box.style.display = 'none'; return; }
+  box.style.display = '';
+  const txt = document.getElementById('queue-progress-text');
+  if (txt) txt.textContent = `업로드 중 ${current}/${total} — ${filename}`;
+  const fill = document.getElementById('queue-progress-fill');
+  if (fill) fill.style.width = Math.round(((current - 1) / total) * 100) + '%';
 }
 
 /* ── 전체 공통 지시 → 빈 파일에 적용 ── */
@@ -135,6 +181,53 @@ function applyGlobalInstruction() {
   });
 }
 
+/* ── 단일 파일 업로드 (XHR + progress) — Issue #14 ──
+ *  fetch()로는 upload progress 이벤트를 받을 수 없어 XMLHttpRequest로
+ *  바꿨다. xhr.upload.onprogress가 e.loaded/e.total을 주므로 파일별
+ *  진행률을 실시간 표시한다. xhr.abort()로 in-flight 취소 가능.
+ *
+ *  반환: 성공 시 server JSON, 실패/취소 시 throw (메시지 'aborted'/네트워크 등).
+ */
+function uploadOne(item) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    item.xhr = xhr;
+
+    xhr.upload.addEventListener('progress', (e) => {
+      if (e.lengthComputable) {
+        setProgress(item.id, Math.round((e.loaded / e.total) * 100));
+      }
+    });
+    xhr.addEventListener('load', () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try { resolve(JSON.parse(xhr.responseText || '{}')); }
+        catch (_) { reject(new Error('invalid JSON response')); }
+      } else {
+        let detail = `${xhr.status} ${xhr.statusText}`;
+        try {
+          const body = JSON.parse(xhr.responseText || '{}');
+          if (body && body.detail) detail = body.detail;
+        } catch (_) {}
+        reject(new Error(detail));
+      }
+    });
+    xhr.addEventListener('error', () => reject(new Error('network error')));
+    xhr.addEventListener('abort', () => reject(new Error('aborted')));
+
+    const form = new FormData();
+    form.append('file',        item.file);
+    form.append('api_key',     getApiKey());
+    form.append('source_type', SOURCE_TYPE);
+    if (item.instruction.trim())
+      form.append('instruction', item.instruction.trim());
+
+    xhr.open('POST', `${API}/upload/`);
+    const tok = localStorage.getItem('james_token') || '';
+    if (tok) xhr.setRequestHeader('Authorization', `Bearer ${tok}`);
+    xhr.send(form);
+  });
+}
+
 /* ── 업로드 실행 ── */
 async function uploadFiles() {
   const pending = uploadQueue.filter(i => i.status === 'ready');
@@ -147,33 +240,19 @@ async function uploadFiles() {
   btn.disabled = true;
   btn.textContent = '업로드 중...';
 
-  const tok = localStorage.getItem('james_token') || '';
   let successCount = 0;
   const results = [];
+  const total   = pending.length;
 
-  for (const item of pending) {
+  for (let idx = 0; idx < pending.length; idx++) {
+    const item = pending[idx];
+    item.status = 'upload';
     setStatus(item.id, 'upload', '전송 중');
+    setProgress(item.id, 0);
+    setQueueProgress(idx + 1, total, item.file.name);
     try {
-      const form = new FormData();
-      form.append('file',        item.file);
-      form.append('api_key',     getApiKey());
-      form.append('source_type', SOURCE_TYPE);
-      if (item.instruction.trim())
-        form.append('instruction', item.instruction.trim());
-
-      const headers = {};
-      if (tok) headers['Authorization'] = `Bearer ${tok}`;
-
-      const r = await fetch(`${API}/upload/`, {
-        method: 'POST', headers, body: form,
-      });
-
-      if (!r.ok) {
-        const err = await r.json().catch(() => ({}));
-        throw new Error(err.detail || `${r.status} ${r.statusText}`);
-      }
-
-      const data = await r.json();
+      const data = await uploadOne(item);
+      setProgress(item.id, 100);
       setStatus(item.id, 'done', '완료');
       item.status = 'done';
       successCount++;
@@ -182,14 +261,18 @@ async function uploadFiles() {
         instruction: item.instruction,
         ...data,
       });
-
     } catch (err) {
-      setStatus(item.id, 'error', `실패: ${err.message.slice(0,20)}`);
+      const aborted = err && err.message === 'aborted';
+      const label   = aborted ? '취소됨' : `실패: ${(err.message || '').slice(0,20)}`;
+      setStatus(item.id, 'error', label);
       item.status = 'error';
-      console.error(`업로드 실패: ${item.file.name}`, err);
+      if (!aborted) console.error(`업로드 실패: ${item.file.name}`, err);
+    } finally {
+      item.xhr = null;
     }
   }
 
+  setQueueProgress(total + 1, total, '');   // hide
   btn.textContent = '업로드 및 분석';
   updateUploadBtn();
 


### PR DESCRIPTION
## Summary

Migrate `frontend/static/upload.js` from `fetch()` to `XMLHttpRequest` so the upload pipeline can show progress. Adds:
- per-file progress bar (loaded/total bytes from `xhr.upload.progress`)
- queue indicator above the upload button: "업로드 중 3/30 — file.pdf" + aggregate bar
- per-file cancel via the existing remove button (overloaded: pre-upload removes from queue, mid-upload calls `xhr.abort()`)
- 4 new i18n keys (en + ko) pre-positioned for the next migration cycle

Server-side **NOT** changed — `/upload/` already accepts streamed multipart bodies. `fetch()` with `ReadableStream` doesn't help on the upload side; XHR is the simpler and only meaningful path here.

## Why XHR, not fetch+stream

`fetch()` does not surface upload progress events. The browser buffers the entire request body and you only see "request finished" once the server responds. `ReadableStream` is a download-side primitive; it doesn't help when YOU are sending bytes.

`XMLHttpRequest.upload.addEventListener("progress", ...)` is the only standard browser API that emits per-chunk upload progress. Issue #14 itself documented this — confirmed.

## What changed

### `frontend/static/upload.js` (+143 / -30)

| Section | Change |
|---|---|
| `addFiles()` | New `xhr` field on each item (set during upload, cleared after) |
| `removeFile()` | Replaced by `removeOrCancel()`. If `status === 'upload'` and `xhr` exists, calls `xhr.abort()` (which the abort handler turns into status='error' label='취소됨'). Otherwise removes from queue. `removeFile` kept as a 1-line alias for backwards-compat. |
| `renderFileItem()` | Action button id now `action-{id}` for direct lookup. Adds `<div class="file-progress-row" id="progress-{id}">` between top row and folder row, hidden until upload starts. |
| `setStatus()` | Uses the new direct id; toggles action button title between '제거' and '취소' based on status; hides progress row when not uploading. |
| `setProgress(id, pct)` | New helper. Sets `.file-progress-fill` width and `.file-progress-pct` text. |
| `setQueueProgress(current, total, filename)` | New helper for the queue indicator. Pass `total + 1` for current to hide. |
| `uploadOne(item)` | New Promise wrapper around XMLHttpRequest. Handles `progress`/`load`/`error`/`abort` events; resolves with parsed JSON on 2xx, rejects with `Error('aborted'\|'network error'\|server detail)` otherwise. |
| `uploadFiles()` | Loop now indexed (for queue counter), calls `uploadOne()`, sets per-file 0% then 100%, calls `setQueueProgress(total + 1, total, '')` at the end to hide the indicator. Aborted error gets a friendlier label and is not logged to console. |

### `frontend/index.html` (+42)

CSS for the new elements (gradient progress fill, mono-font percentage, thin queue bar). New DOM block placed between `.file-list` and the upload button:

```html
<div class="queue-progress" id="queue-progress" style="display:none;">
  <div class="queue-progress-text" id="queue-progress-text"></div>
  <div class="queue-progress-bar"><div class="queue-progress-fill" id="queue-progress-fill"></div></div>
</div>
```

### `frontend/static/i18n.js` (+8)

4 new keys in each of `en` and `ko`:

| Key | en | ko |
|---|---|---|
| `upload.cancel` | Cancel | 취소 |
| `upload.aborted` | Cancelled | 취소됨 |
| `upload.queue_progress` | Uploading {current}/{total} — {filename} | 업로드 중 {current}/{total} — {filename} |
| `upload.percent` | {pct}% | {pct}% |

`upload.js` does not yet call `t()` (legacy file-wide hardcoded Korean strings). The keys are pre-positioned for the next i18n migration cycle, matching the existing pattern of unused-but-prepared `upload.*` keys in i18n.js.

## Verification

### Static
- ✅ `node --check frontend/static/upload.js` clean
- ✅ `node --check frontend/static/i18n.js` clean
- ✅ Server start; `GET /`, `GET /static/upload.js`, `GET /static/i18n.js` → 200
- ✅ DOM check: `<div id="queue-progress">`, `<div id="queue-progress-fill">` present in served HTML
- ✅ JS symbol check: `uploadOne`, `removeOrCancel`, `setProgress`, `setQueueProgress` present in served upload.js

### NOT verified (cannot browser-test from CLI)
- 🔲 Visual progress bar fill animation during a real upload
- 🔲 Cancel mid-upload UX (XHR abort → status flip to '취소됨')
- 🔲 Queue indicator updating across multiple files
- 🔲 Drag/drop unchanged behavior

These require a human at a browser. Per CLAUDE.md guidance ("if you can't test the UI, say so explicitly rather than claiming success"). Static wiring (DOM, CSS, JS parse) is correct; runtime UX is the reviewer's confirmation.

## Out of scope

- Migrating the rest of `upload.js` to `t()` calls (the file is mostly hardcoded Korean — broader i18n migration is a separate cleanup).
- Server-side upload streaming changes — already supported.
- Multi-file parallelism (still serial for predictable per-file feedback).

## Test plan (for reviewer browser test)

- [ ] Drag/drop one PDF — progress bar appears under file name, fills 0→100%, then status turns '완료'.
- [ ] Drag/drop 5+ files — queue indicator above upload button shows "업로드 중 N/total — current.pdf"; aggregate bar fills smoothly.
- [ ] Click ✕ on a file currently uploading — XHR aborts, status flips to '취소됨' (red), next file in queue continues.
- [ ] Click ✕ on a file in 'ready' state — removed from queue (existing behavior).
- [ ] Network failure mid-upload — status shows '실패: …'.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
