### PR TITLE
docs(v0.2): add CLAUDE.md session primer + platform readiness framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# JAMES — Session Briefing for Claude Code
+
+> Read this first. This file orients any new Claude Code session to
+> the project's current direction in under 60 seconds.
+
+## What JAMES is
+
+A local-first, auditable knowledge reasoning system.
+See `docs/ARCHITECTURE.md` for full design principles and non-goals.
+
+## Where we are right now
+
+- **Current version**: v0.1.4 → moving to v0.2.0
+- **Active theme**: Foundation Hardening (6 axes — see `ROADMAP.md`)
+- **Strategic frame**: We are not building a single product.
+  We are building a **mother platform** from which domain packs
+  (legal, food, retail, travel, etc.) will branch off **only at v1.0**.
+  See `docs/PLATFORM_READINESS.md` for the 6-dimension readiness
+  framework and the v0.2 → v0.3 → v0.4 → v1.0 gate definitions.
+
+## Critical rules for this session
+
+1. **Do not add new domain features** (legal-specific, food-specific,
+   retail-specific, etc.) until v1.0. Mother-hardening mode. Any
+   domain-coupled work pollutes the platform contract and will be
+   reverted in review.
+   See `docs/handovers/v0.2.1-business-track.md` §3 for the explicit
+   "no parallel domains" rule and what it forbids.
+
+2. **Every PR touching `core/retrieval`, `core/graph`, or
+   `core/reasoning` must paste bench numbers** in the description
+   (Axis 2 of v0.2 ROADMAP). PRs without numbers will not land.
+
+3. **Self-evolution is opt-in only**. Any change that allows
+   auto-deploy without an `approver_username` in the audit log
+   is a bug, not a feature.
+
+4. **Architecture changes** (new module, new trust zone, removal
+   of a non-goal) require a PR to `docs/ARCHITECTURE.md` with the
+   `architecture` label.
+
+5. **Module size gate**: no file in `core/` exceeds 20 KB. If your
+   change pushes a file over, split first.
+
+## Where to look next
+
+| Purpose | File |
+|---|---|
+| Strategic vision + 6-dimension readiness | `docs/PLATFORM_READINESS.md` |
+| Architecture & non-goals | `docs/ARCHITECTURE.md` |
+| 6-axis v0.2 plan + future v0.3/v0.4/v1.0 | `ROADMAP.md` |
+| Active session brief (start here for tasks) | `docs/handovers/v0.2.0-platform-track.md` |
+| Business track (current cycle) | `docs/handovers/v0.2.1-business-track.md` |
+| Open issues by priority | `gh issue list --label priority:high` |
+| STEP 7 regression baseline | `eval/regression/step7_queries.json` (or `scripts/step7_query_test.py`) |
+
+## What this session should NOT do
+
+- Fork or specialize the project for a vertical (legal, food, retail, travel, finance)
+- Add a feature without a corresponding regression test in the eval harness
+- Bypass `PolicyEngine` for a "quick fix"
+- Disable the human approval gate on self-evolution
+- Enable auto-merge on PRs touching trust boundaries (auth, policy, sandbox)
+- Promise plugin API stability before v0.3 lands
+
+## Operational conventions (PR / commit / branch)
+
+- Branch naming: `fix/v0.2-<topic>`, `chore/v0.2-<topic>`, `docs/v0.2-<topic>`,
+  `feat/v0.3-<topic>` (only after v0.2 closes)
+- Commit messages: conventional commits (`fix:`, `feat:`, `refactor:`,
+  `chore:`, `docs:`, `test:`)
+- PR body: include `## Summary`, `## Verification`, `## Out of scope`
+  sections; bench numbers if applicable
+- Issue closing: use `Closes #N` in the PR body, **not** in the commit
+  message (GitHub gotcha — commit-message close from squash-merge can
+  miss multi-issue cases)
+- Always work on a non-main branch; PR into main; self-merge after
+  bench verification
+
+## 한국어 요약
+
+자메스는 **v1.0까지 "범용 모체"로만** 강화합니다. 도메인 분화(법률·식품·유통·여행 등)는 v1.0 이후에만 시작합니다. 이 세션에서 도메인 코드를 추가하지 마세요. v0.2의 6축 Foundation Hardening이 현재 우선순위입니다. 자세한 내용은 `docs/PLATFORM_READINESS.md` 참조.

--- a/docs/PLATFORM_READINESS.md
+++ b/docs/PLATFORM_READINESS.md
@@ -1,0 +1,255 @@
+# JAMES — Platform Readiness Framework
+
+> How we measure when JAMES is ready to be a "mother platform" from
+> which domain packs (legal, food, retail, etc.) can branch off
+> safely without breaking the core.
+
+Status: living document. Last updated: v0.1.4 (planning v0.2 entry).
+
+---
+
+## 1. Why this document exists
+
+JAMES is technically capable of solving multiple verticals
+(legal contract analysis, food/beverage retail, travel ticketing,
+franchise compliance, etc.). The temptation to "ship a vertical"
+is constant.
+
+**That temptation is the single biggest risk to the project.**
+
+A platform that ships verticals before its extension contract is
+stable becomes a per-vertical fork tree. Every later vertical pays
+the cost of every earlier vertical's shortcuts. Most "platforms"
+that fail, fail this way.
+
+This document defines:
+
+- the **6 dimensions** that determine mother-platform readiness
+- the **gates at v0.2 / v0.3 / v0.4 / v1.0** that must be passed
+  before each level of domain branching is allowed
+- the **3 forms of branching** (Pack / Distribution / Vertical
+  Product) and when each is appropriate
+
+If a contributor proposes work that conflicts with this framework,
+the burden of proof is on them to update this document first.
+
+---
+
+## 2. The 6 readiness dimensions
+
+| # | Dimension | What it measures | How we test it |
+|---|---|---|---|
+| A | **Architecture stability** | module boundaries, file size, no circular imports | `pydeps core/` acyclic, all `core/` files < 20 KB |
+| B | **Extension API stability** | plugin interface, version policy, backward compatibility commitment | Plugin loader exists; SemVer; deprecation policy documented |
+| C | **Evaluation contract** | every change measured against a fixed yardstick; domain packs inherit it | RAGAS + STEP-N suite locked; PR contract enforces bench numbers |
+| D | **Operational maturity** | HTTPS, SSO, backup, observability, audit | Multi-tenancy isolation; OpenTelemetry exporter; backup/restore CLI |
+| E | **Security boundary** | PolicyEngine extracted; external red-team passed | All policy decisions go through one module; red-team report public |
+| F | **Production proof** | at least one external user runs production for ≥ 6 months without core regression | Customer attestation; uptime metrics published |
+
+A dimension is **passed** only when the test is automated and
+re-runnable. Manual confirmations do not count.
+
+---
+
+## 3. Gates by milestone
+
+### Gate v0.2 — Foundation (currently in progress)
+
+**Theme**: make the v0.1 capabilities trustworthy enough to recommend
+to a second user.
+
+**Pass criteria** (all 6 dimensions partially satisfied):
+
+- A: Architecture — `core/` modules ≤ 20 KB; `pydeps` acyclic
+- B: Extension API — *not yet*; this gate does not require it
+- C: Eval — STEP 7 locked as committed regression; RAGAS integrated
+- D: Ops — structured logs with `trace_id` end-to-end; `/admin/trace/{id}`
+- E: Security — `PolicyEngine` extracted; capability tokens for tools
+- F: Production — single-user reproducible deployment validated
+
+**Allowed at this gate**: bug fixes, refactors, eval harness work.
+
+**Forbidden at this gate**: domain packs, vertical UIs, marketing
+domain claims in README/ROADMAP.
+
+### Gate v0.3 — Platform Skeleton
+
+**Theme**: define and freeze the extension contract.
+
+**Pass criteria**:
+
+- B: Extension API — `core/plugins/base.py` defines 4 plugin types
+  (Ontology / Prompt / UI panel / Scorer); plugin loader respects
+  `JAMES_PLUGINS=` env var
+- B: Reference Pack — JAMES's own default behavior runs as
+  `packs/general/` (dogfood: removing the pack disables JAMES;
+  swapping it changes domain)
+- C: Eval contract — every pack must pass RAGAS + STEP-N; merge
+  blocked otherwise
+- D: Ops — multi-instance hosting (same code, different workspace)
+  via `JAMES_WORKSPACE=` env var
+- A versioning policy committed to repo: SemVer; deprecation
+  guaranteed for 12 months
+
+**Allowed at this gate**: building one Reference Pack inside the repo.
+
+**Forbidden at this gate**: external/customer domain packs (the API
+is not yet proven through real third-party use).
+
+### Gate v0.4 — First Domain Pilot
+
+**Theme**: prove the platform contract by running ONE real domain
+in production for 6 months.
+
+**Pass criteria**:
+
+- B: One non-general domain pack (`packs/legal/` or `packs/food/`)
+  exists and is loaded as a plugin without core code changes
+- F: One external customer runs the pilot for ≥ 6 months
+- F: Zero core regressions caused by the pack during the pilot
+- C: Pack passes both general and domain-specific eval suites
+- E: External red-team pass on prompt injection (replace pattern-only
+  defense with ML guard + patterns)
+
+**Allowed at this gate**: building exactly one domain pack with
+a paying or signed-PoC customer.
+
+**Forbidden at this gate**: a second domain pack (we don't yet know
+if the contract works for non-trivial diversity — wait for v1.0).
+
+### Gate v1.0 — Production-Grade Mother
+
+**Theme**: make domain branching safe for outsiders.
+
+**Pass criteria**:
+
+- D: HTTPS / SSO / SAML / LDAP / multi-tenancy production-ready
+- D: SOC2 or ISO27001 readiness assessment (not full cert; readiness)
+- D: Backup / restore / rollback CLI tested under simulated failure
+- D: Prometheus + OpenTelemetry exporter
+- B: Public SDK + plugin author guide (`docs/PLUGIN_AUTHORING.md`)
+- F: Bus factor ≥ 2 (at least one non-maintainer with full commit history
+  and PR review responsibility)
+- E: Annual external red-team scheduled
+
+**Allowed at this gate**: external developers can publish their own
+domain packs. Marketplace conversation begins.
+
+**Forbidden**: nothing related to platform stability — but please
+keep building Domain Packs first (Distribution / Vertical Product
+require sustained customer demand, not aspiration).
+
+---
+
+## 4. Branching forms (when v1.0 is passed)
+
+A domain can branch from JAMES in one of three forms. The right
+choice depends on the domain's traction.
+
+### 4.1 Domain Pack (lightweight)
+
+- **Contains**: ontology + prompts + UI templates + rule book
+- **Touches core**: zero lines
+- **Build cost**: 2~4 months per domain
+- **Analogy**: VS Code extension
+- **Examples**: `packs/cafe/`, `packs/franchise/`, `packs/clinic/`,
+  `packs/legal/`
+- **When to use**: first 1~3 deployments in a domain. Validates fit.
+
+### 4.2 Domain Distribution (medium)
+
+- **Contains**: Pack + custom integrations (POS, EHR, GDS, ERP, e-결재)
+- **Touches core**: zero lines (integrations are sub-modules)
+- **Build cost**: 4~8 months per domain
+- **Analogy**: Linux distribution (Ubuntu vs CentOS)
+- **Examples**: "JAMES-Cafe with Cafe24 connector", "JAMES-Pharmacy
+  with claim-system connector"
+- **When to use**: domain has signed > 3 customers and needs
+  industry-standard integrations.
+
+### 4.3 Vertical Product (heavy)
+
+- **Contains**: Distribution + own brand + own UI + own billing + own sales
+- **Touches core**: zero lines (still uses mother as engine)
+- **Build cost**: 12+ months per vertical
+- **Analogy**: WordPress.com vs WordPress.org; Salesforce Industry Clouds
+- **Examples**: "JAMES Legal" SaaS product, "JAMES Cafe" point-of-sale companion
+- **When to use**: domain has predictable revenue ≥ ARR 5억 and demands
+  isolated brand / SLA / billing.
+
+**Typical evolution**: Pack → market validation → Distribution →
+revenue validation → Vertical Product. Skipping a step is the most
+common failure mode.
+
+---
+
+## 5. The "do not branch yet" trap
+
+The most common project-killing pattern:
+
+| Wrong pattern | Consequence |
+|---|---|
+| Build a domain pack while v0.2 architecture is still moving | Pack pressure freezes the wrong abstractions; refactor cost balloons |
+| Promise a domain customer "we'll add X" before v0.3 plugin API exists | Forces core fork; later domains pay the cost forever |
+| Try two domains at once before the first is stable in production | Neither generalizes; both diverge from the platform contract |
+| Market the platform's domain coverage before v0.4 pilot completes | Sales-marketing-eng feedback loop forces unsupported promises into the codebase |
+
+Discipline: **before each gate is passed, the next form of branching
+is forbidden** (see Gate sections above).
+
+---
+
+## 6. Strategic timeline (calendar estimate)
+
+Assumes current solo-maintainer + AI-pair pace; team scaling can
+compress this.
+
+| Milestone | Cumulative time | Cumulative team | Cumulative cost (KRW) |
+|---|---|---|---|
+| v0.2 (Foundation) | 4 months | 1 + Claude | 0 ~ 0.5억 |
+| v0.3 (Platform Skeleton) | 10 months | 2~3 | 2~3억 |
+| v0.4 (First Pilot) | 16 months | 4~5 | 5~7억 |
+| v1.0 (Mother-ready) | 22 months | 6~8 | 10~15억 |
+
+Beyond v1.0, the platform compounds: each new Domain Pack reuses
+mother-level investments (security, observability, eval, policy)
+that would otherwise have to be rebuilt per vertical.
+
+---
+
+## 7. Domain candidates currently being evaluated (for reference only)
+
+These are domains that have been informally evaluated against JAMES's
+current capabilities. **Inclusion here is not a roadmap promise** —
+none will be built before v0.3 at the earliest.
+
+| Domain | Match strength | Earliest entry gate |
+|---|---|---|
+| Legal contract analysis (B2B 법무팀) | high | v0.4 (first pilot candidate) |
+| Food / beverage retail (franchise HQ) | high | v0.4 (alternative pilot) |
+| Travel ticketing (OTA, refund disputes) | medium-high | v1.0+ |
+| Franchise compliance (가맹사업법) | medium-high | v1.0+ (extends legal pack) |
+| Retail / distribution (supplier 360°) | medium | v1.0+ |
+| Personal knowledge / second brain | medium | v1.0+ Domain Pack |
+
+The decision of which domain becomes the v0.4 First Pilot will be
+made in the v0.3 cycle, based on (a) which has signed PoC interest,
+(b) which has clearer regulatory / legal liability boundaries.
+
+---
+
+## 8. How to update this document
+
+- Adding a dimension or changing a gate criterion: PR with
+  `architecture` label and rationale; require maintainer approval.
+- Updating the timeline: PR with current-cycle metrics that justify
+  the change.
+- Adding a domain candidate: PR with informal fit-check; no roadmap
+  commitment.
+- Removing the "no branching before v1.0" discipline: do not.
+
+---
+
+## 9. 한국어 요약
+
+자메스는 **v1.0(약 22개월 후)까지** 도메인 분화 없이 "모체 플랫폼"으로만 강화합니다. 6가지 측정 차원(아키텍처/확장 API/평가/운영/보안/프로덕션 검증)이 모두 임계치를 넘어야 도메인 분화가 안전합니다. 그 전까지는 도메인 작업이 모체를 깨뜨리는 가장 큰 위험이며, **각 게이트 통과 전에는 다음 단계의 분화가 금지**됩니다. 도메인 후보(법률·식품·유통·여행 등)는 informally 평가만 진행하고, 실제 코드 작업은 v0.3 이후에 결정합니다.


### PR DESCRIPTION
## Summary

Adds two foundational documents that frame all future work in the v0.2+ cycle.

- `CLAUDE.md` (new, repo root) — auto-loaded by Claude Code at session start. Orients any new session to the project's current direction in under 60 seconds: what JAMES is, current version, strategic frame, 5 critical session rules, where to look next, what NOT to do, and operational PR/commit/branch conventions.
- `docs/PLATFORM_READINESS.md` (new) — formalizes the "mother platform, not a single product" frame. Defines:
  - 6 readiness dimensions (architecture, extension API, eval, ops, security, production proof)
  - Gate criteria at v0.2 / v0.3 / v0.4 / v1.0
  - 3 branching forms (Pack / Distribution / Vertical Product) and when each is appropriate
  - The "do not branch yet" anti-pattern catalog
  - Domain candidates evaluated informally (legal, food, travel, government) — explicitly NOT roadmap commitments

## Why this PR exists

JAMES is technically capable of solving multiple verticals. The temptation to "ship a vertical" before the extension contract is stable is the single biggest project risk. This PR records the contract that prevents that mistake.

The 6-dimension framework gives engineering and contributor sessions an objective measurement of "are we ready to branch yet?" rather than relying on subjective judgment.

## Verification

- Both files render correctly on GitHub markdown
- All cross-references between the two files resolve
- `CLAUDE.md` references to `docs/PLATFORM_READINESS.md`, `docs/ARCHITECTURE.md`, `ROADMAP.md`, `docs/handovers/v0.2.0-platform-track.md`, `docs/handovers/v0.2.1-business-track.md` are valid (the two handover files arrive in the follow-up PR)
- No domain-specific or customer-specific content (sanitized for public repo)
- Korean summary section present at end of each file

## Out of scope

- Handover docs (`v0.2.0-platform-track.md`, `v0.2.1-business-track.md`) — follow-up PR
- `ROADMAP.md` updates aligning v0.3 / v0.4 / v1.0 sections with these gates — follow-up PR
- `CONTRIBUTING.md` cycle-constraint section — follow-up PR
- Plugin API design (`core/plugins/base.py`) — v0.3 work, not v0.2

## Suggested merge order

This PR first, then the follow-up PR (`docs/v0.2-handovers-and-constraints`). The follow-up handover files reference `CLAUDE.md` and `docs/PLATFORM_READINESS.md` from this PR.

Co-authored-by: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHTqkBLcngShLtrN3PCaRv)_