### PR TITLE
docs(v0.2): add v0.2.0/v0.2.1 handovers + align ROADMAP v0.3-v1.0 + cycle constraints in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,33 @@ python <relevant_test>.py
 
 ---
 
+## Before Picking a Task — Current Cycle Constraints
+
+JAMES is in a deliberate **mother-hardening cycle** (v0.2 → v0.4).
+Some otherwise-attractive contributions are out of scope **until v1.0**:
+
+- ❌ **Domain-specific features** (legal-only, food-only, retail-only,
+  travel-only, government-only, etc.) — these belong in domain packs,
+  and the plugin API is not yet frozen. See
+  `docs/PLATFORM_READINESS.md` §3 for gate definitions.
+- ❌ **Customer-specific features** added to mother (`core/`) — must
+  live in a pack, never in mother.
+- ❌ **Marketing claims** about specific verticals beyond the
+  "domain candidates" table.
+
+Read these two documents before opening a domain-flavored PR:
+
+- `docs/handovers/v0.2.0-platform-track.md` — engineering priorities
+  for the current cycle (PolicyEngine, RAGAS, trace_id, STEP 7 lock)
+- `docs/handovers/v0.2.1-business-track.md` §3 — the
+  "no parallel domains" rule and what it forbids
+
+If your contribution feels domain-shaped but you believe it's
+genuinely mother-level, open a Discussion **before** the PR —
+it saves both sides a round of review.
+
+---
+
 ## Where to Start
 
 ### Easy First Contributions
@@ -83,8 +110,8 @@ python <relevant_test>.py
 
 - **Ontology extensions** — new relation types
 - **Self-evolution improvements** — Patch Pipeline robustness
-- **Graph DB backend** — Neo4j integration (v0.3 priority)
-- **Multi-agent system** — agent orchestration (v0.3 priority)
+- **Graph DB backend** — Neo4j integration (post-v1.0; was tentatively v0.3)
+- **Multi-agent system** — agent orchestration (post-v1.0; was tentatively v0.3)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 > **Note**: This roadmap describes intended directions, not commitments.
 > Priorities will shift based on user feedback and real-world testing.
 
+For the underlying readiness framework (6 dimensions, gate criteria,
+branching forms), see [`docs/PLATFORM_READINESS.md`](docs/PLATFORM_READINESS.md).
+
 ---
 
 ## v0.1.0 — Foundation (current, alpha)
@@ -127,76 +130,132 @@ The following moved to v0.3 to keep v0.2 focused:
 
 ---
 
-## v0.3.0 — Multi-Agent + Graph DB (~6 months)
+## v0.3.0 — Platform Skeleton (~6 months after v0.2)
 
-**Theme**: Scale beyond single-user, optional graph DB backend.
+**Theme**: define and freeze the extension contract that all future
+domain packs will be built against.
 
-### Priorities
+**Required for**: any domain pack work (forbidden until this gate passes).
 
-- **Optional Neo4j backend**
-  - Migrate from markdown wiki to graph DB
-  - Cypher query support
-  - Backward compatibility with markdown
+### Deliverables
 
-- **Multi-agent system**
-  - Specialist agents (researcher, coder, security)
-  - Agent-to-agent communication
-  - Task decomposition + delegation
+- [ ] `core/plugins/base.py` — typed interfaces for 4 plugin types:
+  - `OntologyPack` (entity types, relations, hierarchies)
+  - `PromptPack` (system prompts, few-shot examples per task)
+  - `UIPanel` (server-rendered admin/user widgets)
+  - `Scorer` (custom retrieval/answer scoring overrides)
+- [ ] `core/plugins/loader.py` — `JAMES_PLUGINS=general,reference`
+      env-driven dynamic loader; signed manifest; SemVer enforcement
+- [ ] `packs/general/` — JAMES's default behavior extracted as a
+      pack (dogfood gate: removing it disables JAMES; swapping changes
+      domain)
+- [ ] `docs/PLUGIN_AUTHORING.md` — author guide
+- [ ] `JAMES_WORKSPACE=` env var for multi-instance hosting (same
+      code, different data root)
+- [ ] SemVer + 12-month deprecation policy committed to
+      `docs/VERSIONING.md`
+- [ ] Eval contract: every pack passes RAGAS + STEP-N before merge
 
-- **Better evaluation**
-  - Automated benchmarking
-  - Comparison with other RAG systems
-  - Domain-specific accuracy tests
+### Done when
 
-- **API improvements**
-  - OpenAI-compatible API for drop-in replacement
-  - Streaming responses
-  - Webhook support
+- A new contributor can build a no-op pack from `docs/PLUGIN_AUTHORING.md`
+  alone in < 1 day, load it, and observe its effect.
+- The dogfood test passes: `packs/general/` produces byte-identical
+  STEP 7 results to v0.2 main; deleting the pack breaks the server
+  cleanly with a clear "no pack loaded" error.
+
+### Out of scope (deferred to v0.4)
+
+- Any domain-specific pack (legal, food, retail)
+- External plugin marketplace
+- Plugin signing infrastructure beyond manifest hash
 
 ---
 
-## v1.0.0 — Production Hardening (~12 months)
+## v0.4.0 — First Domain Pilot (~6 months after v0.3)
 
-**Theme**: Enterprise-ready features.
+**Theme**: prove the platform contract by running ONE real domain
+in production for 6 months with one external customer.
 
-### Priorities
+**Required for**: a second domain pack (forbidden until this gate passes).
 
-- **Multi-tenancy**
-  - Per-tenant data isolation
-  - Per-tenant model selection
-  - Quota management
+### Deliverables
 
-- **HTTPS + Production deployment**
-  - Default TLS configuration
-  - Docker deployment guide
-  - Kubernetes Helm charts
+- [ ] **One** domain pack chosen from informal candidates
+      (likely `packs/legal/` or `packs/food/`)
+      — selection criteria: signed PoC interest + clear legal
+      liability boundary
+- [ ] Customer onboarding playbook (`docs/CUSTOMER_ONBOARDING.md`)
+- [ ] External red-team pass on prompt injection
+      (replaces pattern-only defense with ML guard + patterns)
+- [ ] Public eval results in `eval/RESULTS.md` (mother + first pack)
+- [ ] 6-month no-core-regression production track record
 
-- **Compliance preparation**
-  - GDPR data deletion support
-  - SOC 2 audit log requirements
-  - Data residency options
+### Done when
 
-- **Advanced security**
-  - Rate limit per role / per endpoint
-  - Anomaly detection on audit log
-  - Optional 2FA
+- One paying or formal-PoC customer has run the deployment for
+  6 months with no core code change attributable to their domain
+  needs (only pack-level changes).
 
-- **Operational tooling**
-  - Backup / restore CLI
-  - Migration scripts
-  - Health check endpoint
-  - Prometheus metrics
+### Out of scope
+
+- A second domain pack
+- Vertical Product packaging
+- Public marketplace
+
+---
+
+## v1.0.0 — Production-Grade Mother (~6 months after v0.4)
+
+**Theme**: make domain branching safe for outsiders. After this gate,
+external developers can publish their own packs.
+
+### Deliverables
+
+- [ ] HTTPS / SSO / SAML / LDAP — production defaults
+- [ ] Multi-tenancy (per-tenant data isolation, per-tenant pack
+      selection, quota management)
+- [ ] SOC 2 or ISO 27001 readiness assessment
+- [ ] Backup / restore / rollback CLI tested under simulated failure
+- [ ] Prometheus + OpenTelemetry exporters
+- [ ] Public SDK and plugin author guide finalized
+- [ ] Bus factor ≥ 2 (one non-maintainer with full commit/review history)
+- [ ] Annual external red-team schedule established
+
+### Done when
+
+- A third party (not a customer) builds and publishes a pack against
+  the v1.0 SDK without contacting maintainers.
+- The platform survives a single-maintainer 30-day absence with no
+  customer-visible regressions.
+
+### Out of scope
+
+- Vertical Products (separate business decision per domain after v1.0)
+- Federation across multiple JAMES instances (Beyond v1.0 section)
 
 ---
 
 ## Beyond v1.0 — Speculative
 
-Things being considered, no commitment:
+After v1.0, growth is by domain accumulation, not core feature
+addition. See `docs/PLATFORM_READINESS.md` §4 for the three branching
+forms (Pack / Distribution / Vertical Product) and selection criteria.
 
+Long-considered, no commitment:
+
+- **Optional Neo4j backend** — migrate from markdown wiki to graph DB,
+  Cypher query support, backward compatibility with markdown
+  (was tentatively v0.3; reframed as post-v1.0 optimization)
+- **Multi-agent system** — specialist agents (researcher, coder,
+  security), agent-to-agent communication, task decomposition
+  (was tentatively v0.3; reframed as post-v1.0 capability)
+- **OpenAI-compatible API** for drop-in replacement
+- **Streaming responses + Webhook support**
 - **Federation**: connect multiple JAMES instances
 - **On-device fine-tuning**: LoRA adapters per user
 - **Edge deployment**: smaller models for embedded use
-- **Plugin marketplace**: community-contributed tools
+- **Plugin marketplace**: community-contributed packs
 - **Visual graph editor**: web UI for ontology editing
 - **Voice interface**: ASR + TTS pipeline
 
@@ -214,6 +273,10 @@ We prioritize based on:
 3. Strategic alignment with the project's direction
 4. Community contribution (volunteer-friendly tasks first)
 
+Domain-specific feature requests during v0.2 — v0.4 are out of scope.
+See `docs/handovers/v0.2.1-business-track.md` §3 for the rationale
+and the "no parallel domains" rule.
+
 ---
 
 ## Versioning
@@ -223,7 +286,10 @@ We follow [Semantic Versioning](https://semver.org/):
 - `MAJOR.MINOR.PATCH-PRERELEASE`
 - `0.x.y` versions may contain breaking changes
 - `1.0.0` and beyond will follow strict semver
+- After v1.0 ships, plugin API gets its own SemVer track with a
+  12-month deprecation guarantee (see `docs/PLATFORM_READINESS.md`
+  Gate v0.3 criteria)
 
 ---
 
-**Last updated**: v0.2.0-dev (foundation hardening plan)
+**Last updated**: v0.2.1 (platform readiness gates added)

--- a/docs/handovers/v0.2.0-platform-track.md
+++ b/docs/handovers/v0.2.0-platform-track.md
@@ -1,0 +1,121 @@
+# v0.2.0 — Platform Track Handover
+
+> Active handover. If you are a Claude Code session opening this
+> repo, after reading `CLAUDE.md` at the root, read this next.
+>
+> Supersedes: `docs/handovers/v0.1.4-next-session.md` (engineering
+> task list still valid; this doc adds the strategic frame above it).
+
+---
+
+## 1. The strategic shift
+
+As of v0.1.4 (commit `bd12eb7`), the project's strategic frame is
+formalized:
+
+> **JAMES is a mother platform, not a product.**
+>
+> Domain packs (legal, food, retail, travel, finance, etc.) will
+> branch from it **only at v1.0**, approximately 22 months from now.
+> Until then, all work hardens the mother. Domain-specific code
+> introduced before v1.0 will be reverted in review.
+
+This frame is documented in `docs/PLATFORM_READINESS.md`. Read that
+file before proposing any work that touches a domain (legal clauses,
+food labels, POS connectors, etc.).
+
+## 2. Where v0.2 stands today
+
+- **Axis 1 (Architecture Separation)** — substantially done:
+  - `core/memory_*` consolidated into `core/memory/` package (PR #35)
+  - `core/reasoning_engine.py` split into `engine.py` (16 KB),
+    `modes.py`, `pipeline.py` (PRs #37, #38, #39)
+  - All `core/` files now < 20 KB except `memory/store.py` (21 KB,
+    follow-up issue exists)
+- **Axis 2 (Eval Harness)** — not started
+- **Axis 3 (Observability)** — not started
+- **Axis 4 (Security Boundary)** — not started; `PolicyEngine`
+  extraction is next
+- **Axis 5 (Controlled Evolution)** — not started; opt-in flag
+  + approval gate
+- **Axis 6 (Real-Data Validation)** — partially done via STEP 7
+
+## 3. Next session's recommended priorities
+
+In order. Do not jump ahead unless an issue is blocked.
+
+### P0 — Axis 4 PolicyEngine extraction
+- Create `core/policy_engine.py` as the single source of policy
+  decisions
+- Replace direct `check_access` imports across retrieval / graph /
+  output / tools with `PolicyEngine` calls
+- Verification: removing the engine breaks ≥ 4 modules
+
+### P0 — Axis 2 RAGAS integration
+- Add `ragas>=0.2.0` to `requirements.txt`
+- New harness `eval/ragas/run_ragas.py`
+- PR contract: any change to `core/retrieval/` or `core/reasoning/`
+  must paste bench summary
+
+### P1 — Axis 3 trace_id propagation
+- `trace_id = uuid7()` at API edge, propagated via contextvar
+- Structured stage logs: `query → retrieve → rerank → graph → tool → answer`
+- `GET /admin/trace/{id}` returns full pipeline replay
+
+### P1 — Lock STEP 7 as committed regression
+- Move `scripts/step7_query_test.py` queries into
+  `eval/regression/step7_queries.json`
+- Add `scripts/bench.py --suite=step7`
+
+### P2 — Module size cleanup (#29 follow-up)
+- Split `core/memory/store.py` (21 KB) along algorithm boundaries
+
+## 4. Open issues snapshot
+
+Run `gh issue list` for the live list. Highlights as of last update:
+
+- Issue #5 — Entity type classification: products mislabeled as org
+- Issue #6 — Relation label distribution skewed (RELATED_TO = 91%)
+- Issue #8 — Define policy for risky coding requests
+- Issue #14 — Upload progress UI (frontend)
+- Issue #29 — Architecture split (mostly resolved by PRs #35-#39;
+  store.py size remains)
+
+## 5. Things to deliberately NOT do this cycle
+
+- Do not propose a domain pack (legal, food, retail). v0.3 is the
+  earliest reasonable point and we are not there.
+- Do not modify `docs/PLATFORM_READINESS.md` to allow earlier
+  branching. The discipline is the asset.
+- Do not enable self-evolution by default. Even after Axis 5
+  lands, the default is OFF.
+- Do not couple `PolicyEngine` to a specific domain's role taxonomy
+  (it must accept a pluggable role schema).
+
+## 6. Branch / PR / commit conventions
+
+(Same as `CLAUDE.md` — repeated here for handover self-containment.)
+
+- Branches: `fix/v0.2-<topic>`, `chore/v0.2-<topic>`,
+  `docs/v0.2-<topic>`
+- PR body sections: `## Summary`, `## Verification`,
+  `## Out of scope`; bench numbers if applicable
+- Issue closing: `Closes #N` in PR body, not commit message
+- Always non-main branch → PR → self-merge after bench check
+
+## 7. Companion documents
+
+| Document | Purpose |
+|---|---|
+| `CLAUDE.md` | Session-start primer (read first) |
+| `docs/PLATFORM_READINESS.md` | Strategic frame + 6-dimension gates |
+| `docs/ARCHITECTURE.md` | Design principles + non-goals |
+| `ROADMAP.md` | v0.2 → v0.3 → v0.4 → v1.0 plan |
+| `docs/handovers/v0.2.1-business-track.md` | Business-frame companion to this doc |
+| `docs/handovers/v0.1.4-next-session.md` | Previous engineering task list (still valid for tasks; this doc adds frame) |
+| `docs/handovers/v0.1.3.1-hotfix.md` | Historical: P0 security fixes + business audit |
+| `frontend/HANDOVER_WEB_UI.md` | UI redesign track (separate branch) |
+
+## 8. 한국어 요약
+
+이 사이클(v0.2)부터 자메스는 **모체 플랫폼**으로만 강화합니다. 도메인 작업은 v1.0 이후. 다음 세션은 Axis 4 (PolicyEngine 분리) → Axis 2 (RAGAS) → Axis 3 (trace_id) → Axis 2 (STEP 7 lock) 순서로 진행하세요. 자세한 전략 컨텍스트는 `docs/PLATFORM_READINESS.md`, 세션 진입 규칙은 루트의 `CLAUDE.md` 참조.

--- a/docs/handovers/v0.2.1-business-track.md
+++ b/docs/handovers/v0.2.1-business-track.md
@@ -1,0 +1,226 @@
+# v0.2.1 — Business Track Handover
+
+> Companion to `v0.2.0-platform-track.md`.
+> v0.2.0 covers ENGINEERING. This file covers the BUSINESS frame
+> that engineering must NOT couple to, but should be aware of.
+>
+> Status: living document. Last updated: v0.2.1 entry.
+
+---
+
+## 0. Why this file exists separately
+
+If a Claude Code session conflates engineering decisions with
+business hypotheses, the platform fails:
+
+- A code change is made to "make customer X happy" → mother hardens
+  around one domain's assumptions → other domains can no longer fit
+  cleanly.
+- A roadmap milestone is renamed to match a sales pitch → technical
+  priorities follow sales rather than platform health.
+
+This document records the business hypothesis so it is **legible to
+engineering sessions but not mixed into engineering decisions**.
+Code sessions read it for context, not for instructions.
+
+---
+
+## 1. Strategic frame (one paragraph)
+
+JAMES is a mother platform. We will build the mother + ONE reference
+domain pack (cafe / 음료 매장) with zero starting capital over
+18–24 months. After the first reference pack runs in production with
+one customer for 6+ months, we will pursue capital and add the
+remaining domains (travel, then government) sequentially. We will
+NOT pursue any of the three domains in parallel before the first one
+is operationally proven.
+
+---
+
+## 2. Target market (long horizon)
+
+JAMES targets the intersection of three constraints:
+
+- **Local / on-prem only** (cloud-rejecting customers)
+- **Multi-domain accumulation potential** (not single-domain SaaS)
+- **Korean-language-first**, English second
+
+This intersection is small but real. Three domains are on the long
+horizon, ranked by capital-zero entry feasibility:
+
+| Domain | Barrier | Zero-capital entry | Earliest realistic gate |
+|---|---|---|---|
+| Cafe / franchise HQ (음료) | low | ~10% | v0.4 First Pilot (free PoC) |
+| Travel / OTA (여행) | medium | ~3% | After seed funding, post-v0.4 |
+| Government (정부) | high | ~1% | After Series A + GS/CC certs (~3 yrs) |
+
+The operator's earlier sketch of "자메스0 / 자메스00 / 자메스000"
+domain forks is recorded here as a long-horizon option. It does
+NOT happen before mother v1.0.
+
+---
+
+## 3. The "no parallel domains" rule
+
+This rule overrides any feature request, customer ask, or roadmap
+PR during v0.2 ~ v0.4.
+
+> Until the first domain pack (cafe) has run in production for
+> 6 months without a mother-level regression, no second domain is
+> introduced — in code, marketing, or roadmap text.
+
+Concrete prohibitions during v0.2 ~ v0.4:
+
+- No `packs/travel/`, `packs/government/`, or related stub directories
+- No README mention of travel or government use cases beyond the
+  "domain candidates" table in `docs/PLATFORM_READINESS.md`
+- No grant application that promises three-vertical delivery in the
+  v1.0 timeline
+- No capital pitch that names all three domains as near-term revenue
+- No customer-specific feature added to mother during this window
+
+This rule is recorded because the operator has already correctly
+identified the temptation as the project's biggest risk.
+
+---
+
+## 4. Capital path (high level only)
+
+Specific tactical details — target company lists, financial
+projections, contact strategies, cold-email templates — live in
+**private operator notes outside this repository**.
+
+Public summary only:
+
+| Phase | Source | Indicative size | Indicative timing |
+|---|---|---|---|
+| Non-dilutive seed | Korean government programs (창진원 예비창업패키지, NIPA, K-Global) | 1~3억 | months 6~12 |
+| Bootstrap revenue (optional) | Custom RAG / GraphRAG consulting (1~2 customers) | 1~3억/year | months 6~24 |
+| Dilutive seed | Korean VC seed round | 3~10억 | months 16~22, after first PoC reference |
+| Series A | follow-on after first pilot success | 30억+ | months 30+ |
+
+The first grant application target is **예비창업패키지 (창업진흥원)**,
+opening Feb–Mar each year. The actual application draft lives as a
+separate artifact (private notes), not in this handover.
+
+---
+
+## 5. Engineering ↔ business interaction rules
+
+| Decision type | Where it is made |
+|---|---|
+| Module split, refactor, eval threshold | **Engineering** (code session) |
+| Roadmap calendar slip | Engineering, with rationale in PR body |
+| Domain pack to build first | **Business** (this doc); engineering executes |
+| Roadmap milestone rename | Engineering only — never to match a sales pitch |
+| Customer-specific feature | **Forbidden during v0.2 ~ v0.4** |
+| Marketing claim added to README | Business, but requires concrete evidence in code |
+
+If a code session encounters an ambiguous request that smells like
+"add this for customer X" — pause and confirm with the operator
+before shipping.
+
+---
+
+## 6. The 18–24 month skeleton (calendar)
+
+```
+M  0–4    v0.2 Foundation Hardening (engineering only)
+M  1      ★ Submit 예비창업패키지 application (annual cycle)
+M  4–10   v0.3 Platform Skeleton + general reference pack
+M  6–9    ★ Government grant decision (if approved: ~1억 non-dilutive)
+M 10–16   packs/cafe/ — first non-general reference pack
+M 14–18   Free PoC with one cafe franchise HQ
+M 16–22   ★ Seed fundraising (dilutive) — using cafe PoC as evidence
+M 22+     Travel domain begins (only after seed closes)
+M 36+     Government domain begins (only after Series A or equivalent)
+```
+
+This calendar is aspirational. Slips of 30–50% are normal for solo
++ AI-paired open-source projects. **The discipline above survives
+the slip; the calendar does not.**
+
+---
+
+## 7. What stays in this repo vs what stays private
+
+**Public (this repo, OK to commit)**:
+- Strategic frame (one paragraph)
+- Domain horizon table (no specific company names)
+- Discipline rules
+- High-level capital path (order-of-magnitude figures only)
+- Calendar skeleton
+
+**Private (operator's local notes, NEVER committed)**:
+- Specific franchise / OTA / agency target lists
+- Cold-email templates and individual contact information
+- Detailed financial projections
+- Investor target lists
+- Personal runway, salary, equity intentions
+- Co-founder candidate names and conversations
+
+If a code session sees information that looks private leaking into
+a PR or commit, flag it before merge.
+
+---
+
+## 8. Decision log (append-only)
+
+| Date | Decision | Rationale |
+|---|---|---|
+| v0.2.1 entry | Cafe selected as first domain | Lowest legal liability + accessible PoC partner space + modest hardware/infra demand |
+| v0.2.1 entry | Government deferred to ~3 years | CC/GS certification cost (~5억+) and procurement registration require corporate maturity that solo OSS does not have |
+| v0.2.1 entry | Travel deferred to post-seed | GDS/CRS integration complexity + competitive density (large OTAs run in-house AI teams) |
+| v0.2.1 entry | "No parallel domains" rule adopted | Operator-confirmed risk that simultaneous pursuit destroys mother contract |
+| v0.2.1 entry | Long-horizon naming "자메스0/00/000" recorded but not adopted | Marketing-friendly named packs (e.g. JAMES Brew / Compass / Atlas) preferred; final naming deferred until pre-seed |
+
+Future decisions append below. Do not delete history.
+
+---
+
+## 9. Companion documents
+
+| Document | Purpose |
+|---|---|
+| `CLAUDE.md` | Session-start primer (read first) |
+| `docs/PLATFORM_READINESS.md` | 6-dimension readiness + v0.3/v0.4/v1.0 gates |
+| `docs/ARCHITECTURE.md` | Design principles + non-goals |
+| `ROADMAP.md` | Engineering milestones |
+| `docs/handovers/v0.2.0-platform-track.md` | Engineering track handover |
+| **`docs/handovers/v0.2.1-business-track.md`** | **This file — business track** |
+| (private) operator notes | Tactical details outside repo |
+
+The two v0.2 handovers (.0 engineering + .1 business) together
+define the v0.2 cycle's full context. Subsequent cycles add a
+new matched pair (e.g. v0.3.0-platform-track + v0.3.1-business-track).
+
+---
+
+## 10. How to update this document
+
+- **Strategic frame change** (e.g. add a fourth domain horizon):
+  PR with the `business-track` label and rationale; require operator
+  approval. Engineering does not approve business frame changes.
+- **Decision log append**: any operator-level decision that changes
+  the calendar, capital path, or domain order. Append-only.
+- **Tactical detail leak**: if a contributor adds private-flavor
+  content (specific names, real financial figures), revert the PR
+  and move the content to private notes.
+
+---
+
+## 11. 한국어 요약
+
+이 문서는 **사업 가설을 기록**하되 **엔지니어링 결정에 직접 영향을 주지 않도록 분리**합니다. 핵심 규칙 5가지:
+
+1. **음료(cafe) 1개 도메인 우선**, 여행·정부는 음료 PoC 6개월 운영 후에만 진입
+2. v0.2 ~ v0.4 동안 **3개 도메인 병행 금지** (마케팅·코드·로드맵 모두)
+3. 자본 경로: 예비창업패키지 → 음료 PoC → 시드. 정부 시장은 약 3년 후
+4. 구체적 영업 대상·재무 수치·투자자 명단은 **이 저장소가 아닌 비공개 노트**에 보관
+5. "고객 X를 위한 기능 추가" 류 요청은 v0.2 ~ v0.4 동안 **금지**
+
+엔지니어링 세션은 이 문서를 컨텍스트로 읽되, 코드 결정 자체는
+`ROADMAP.md`와 `docs/PLATFORM_READINESS.md`를 따릅니다.
+
+장기 horizon으로 메모된 "자메스0 / 자메스00 / 자메스000" 분화 구상은
+v1.0 이후의 옵션이며 그 전엔 어떠한 형태로도 코드·마케팅에 반영하지 않습니다.


### PR DESCRIPTION
## Summary

Completes the v0.2 cycle's strategic documentation. Companion to PR #42 (CLAUDE.md + PLATFORM_READINESS.md).

Four artifacts:

1. **`docs/handovers/v0.2.0-platform-track.md`** (new) — engineering track handover. P0/P1 priorities for the next session: Axis 4 PolicyEngine, Axis 2 RAGAS, Axis 3 trace_id, Axis 2 STEP 7 lock. Supersedes `v0.1.4-next-session.md` as the active session brief.

2. **`docs/handovers/v0.2.1-business-track.md`** (new) — business track companion. Records the "mother + cafe domain only, others later" discipline, the "no parallel domains" rule, the 18–24 month capital path skeleton, the engineering ↔ business interaction boundaries, and the append-only decision log. Public-safe content only; tactical details (target lists, financials, contacts) explicitly designated to live in private operator notes outside the repo.

3. **`ROADMAP.md`** (modified) — replaces the previous v0.3 (Multi-Agent + Graph DB) and v1.0 (Production Hardening) sections with three new sections aligned with the readiness gates from `docs/PLATFORM_READINESS.md`:
   - v0.3 — Platform Skeleton (plugin API, reference pack dogfood, multi-instance hosting)
   - v0.4 — First Domain Pilot (one domain pack, one external customer, 6-month no-regression track record)
   - v1.0 — Production-Grade Mother (multi-tenancy, SSO, certifications, bus factor ≥ 2, public SDK)
   
   The previous v0.3 items (Neo4j, multi-agent) move to "Beyond v1.0" speculative with a note that they were tentatively v0.3 and have been reframed as post-v1.0 optimization/capability.

4. **`CONTRIBUTING.md`** (modified) — adds "Before Picking a Task — Current Cycle Constraints" section between Quick Start and Where to Start, listing forbidden contribution categories (domain-specific, customer-specific, vertical marketing claims) with pointers to the readiness framework and handovers. Also corrects the "(v0.3 priority)" labels on Neo4j and multi-agent in the Advanced subsection to "post-v1.0; was tentatively v0.3".

## Why this PR exists

PR #42 records the strategic frame. This PR records the operational consequences: how engineering sessions know what to do next (handover), how the roadmap reflects the gates (ROADMAP.md), and how external contributors learn the cycle constraints before they open a domain-shaped PR (CONTRIBUTING.md).

## Verification

- All four files render correctly on GitHub markdown
- All cross-references resolve (ARCHITECTURE.md, PLATFORM_READINESS.md, CLAUDE.md from PR #42, ROADMAP.md, the two handovers)
- ROADMAP.md preserves the v0.1 and v0.2 6-axis sections from PR #34 unchanged; only v0.3/v1.0 sections replaced and Beyond-v1.0 section augmented
- CONTRIBUTING.md preserves all existing content; one section inserted, two labels corrected
- No domain-specific or customer-specific commitment language present (sanitized for public repo)
- Korean summary section present in both handover files

## Out of scope

- Plugin API design (`core/plugins/base.py`) — v0.3 work
- Axis 4 PolicyEngine extraction — separate issue, separate PR
- RAGAS integration — separate issue, separate PR
- Specific company / investor / contact lists — by explicit design, those live in private operator notes outside the repo

## Suggested merge order

PR #42 first (this PR's handovers reference `CLAUDE.md` and `docs/PLATFORM_READINESS.md` from #42), then this one. After both land, any new Claude Code session opening the repo picks up the full mother-platform context in under 60 seconds.

Co-authored-by: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHTqkBLcngShLtrN3PCaRv)_