### PR TITLE
feat(policy): introduce PolicyEngine skeleton (#44 phase 1/4)

### DIFF
--- a/core/policy_engine.py
+++ b/core/policy_engine.py
@@ -1,0 +1,150 @@
+"""PolicyEngine — single source of role/sensitivity decisions (#44, Axis 4 phase 1).
+
+Phase 1 scope: skeleton only. Every decision method delegates to the
+existing `core/security_layer.py` primitives, preserving behavior bit for
+bit. Subsequent migration PRs will:
+
+  Phase 2 — move call sites off direct `check_access` imports onto
+            `PolicyEngine.can_retrieve / can_walk / can_emit` (one PR per
+            consumer: retrieval, graph, output).
+  Phase 3 — sandbox migration to capability tokens (`can_call_tool`).
+  Phase 4 — multimodal extractor outputs wrapped in `TrustedContent`.
+
+After all four phases, direct `check_access` imports outside of
+`security_layer.py` (the implementation backend) and `policy_engine.py`
+(this file) become a regression — the v0.2 ROADMAP Axis 4 "done when"
+criterion in the issue says removing this file should break ≥ 4 modules
+on import.
+
+Design notes:
+  - `Decision` is frozen + carries `applied_rule` for audit-log correlation.
+  - Methods take primitives (role + dict), no engine state. Trivially
+    mockable in tests, stateless in production.
+  - `can_call_tool` is intentionally restrictive in phase 1 (admin-only)
+    until the capability-token model lands. Existing `tools/router.py`
+    admin gates remain authoritative — call sites MAY bypass this method
+    during phases 1-2.
+  - `TrustedContent` is defined now so its identity stays stable across
+    the migration PRs that will start returning it from extractors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Result of a policy check.
+
+    Attributes:
+      allowed: binary verdict.
+      reason: short human-readable string for logs / operator UI.
+      applied_rule: canonical rule id for audit-log correlation,
+                    e.g. "policy.retrieve.abac" or "policy.tool.admin_only".
+    """
+    allowed: bool
+    reason: str
+    applied_rule: str
+
+
+@dataclass(frozen=True)
+class TrustedContent:
+    """Wrapper for content with a known provenance + trust level.
+
+    Phase 4 of #44: every multimodal extractor returns one of these
+    instead of a raw string. The reasoning pipeline then runs
+    `extract_data_only()` against `low`-trust content before joining it
+    into the LLM context.
+    """
+    text:   str
+    source: str    # "user" | "doc" | "ocr" | "asr" | "vision" | "web"
+    trust:  str    # "high" | "medium" | "low"
+
+
+class PolicyEngine:
+    """Single point of role/sensitivity policy decisions.
+
+    Phase 1: every method delegates to `core.security_layer` functions,
+    preserving exact existing behavior. The intent of this PR is the
+    *call-site contract* — future policy changes should touch one file
+    instead of the whole codebase.
+    """
+
+    def can_retrieve(self, role: str, doc_meta: Dict[str, Any]) -> Decision:
+        """Vector retrieval: may this role see this document?
+
+        Delegates to `security_layer.check_access(role, meta)`. The
+        sensitivity field is read from `doc_meta.sensitivity` (default
+        "public") and compared against `ROLE_LEVEL[role]`.
+        """
+        from core.security_layer import check_access
+        ok = bool(check_access(role, doc_meta or {}))
+        return Decision(
+            allowed=ok,
+            reason="abac.role_ge_sensitivity" if ok else "abac.role_lt_sensitivity",
+            applied_rule="policy.retrieve.abac",
+        )
+
+    def can_walk(self, role: str, entity: Dict[str, Any]) -> Decision:
+        """Graph DFS: may this role traverse to this entity?
+
+        Same ABAC primitive as `can_retrieve`. Kept as a separate method
+        because phase-2 graph migration will likely add traversal-depth
+        and relation-type guards distinct from retrieval policy.
+        """
+        from core.security_layer import check_access
+        ok = bool(check_access(role, entity or {}))
+        return Decision(
+            allowed=ok,
+            reason="abac.role_ge_sensitivity" if ok else "abac.role_lt_sensitivity",
+            applied_rule="policy.walk.abac",
+        )
+
+    def can_call_tool(
+        self,
+        role:  str,
+        tool:  str,
+        args:  Optional[Dict[str, Any]] = None,
+    ) -> Decision:
+        """Tool execution: may this role invoke this tool with these args?
+
+        Phase 1: admin-only. The capability-token model arrives in the
+        sandbox migration PR (#44 phase 3). Until then, callers may
+        bypass this method; the existing admin checks in
+        `tools/router.py::execute_tool` and `tools/code/sandbox.py`
+        remain authoritative.
+
+        Args:
+          role:  caller role.
+          tool:  tool name (e.g. "read_file", "execute_command").
+          args:  reserved for capability-token scope match in phase 3
+                 (currently ignored).
+        """
+        ok = (role == "admin")
+        return Decision(
+            allowed=ok,
+            reason="role.is_admin" if ok else "role.not_admin",
+            applied_rule="policy.tool.admin_only",
+        )
+
+    def can_emit(self, role: str, content: str) -> Decision:
+        """Output gate: may this role receive this content?
+
+        Phase 1: always allow. `security_layer.filter_answer_by_role()`
+        already mutates content per role (PII masking, person-name
+        redaction); the binary emit/no-emit decision is therefore a
+        no-op today. Phase 2+ may promote real secret/keyword leak
+        post-checks into this method.
+        """
+        return Decision(
+            allowed=True,
+            reason="policy.emit.always_allow_v1",
+            applied_rule="policy.emit.passthrough",
+        )
+
+
+# Module-level convenience singleton.
+# Phase-2 migration: call sites prefer `from core.policy_engine import default_engine`
+# over instantiating their own. The engine is stateless, so a singleton is fine.
+default_engine = PolicyEngine()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,6 +114,50 @@ joining the LLM context.
 
 ---
 
+## 5.5 PolicyEngine (single source of policy decisions)
+
+`core/policy_engine.py` is the only module that may decide whether a
+role is allowed to perform an action. Every consumer (retrieval, graph
+walk, tool invocation, output emission) takes a `PolicyEngine` instance
+and asks one of four typed methods:
+
+| Method | Question answered |
+|---|---|
+| `can_retrieve(role, doc_meta) -> Decision` | Vector retrieval: may this role see this document? |
+| `can_walk(role, entity) -> Decision`        | Graph DFS: may this role traverse to this entity? |
+| `can_call_tool(role, tool, args) -> Decision` | Tool execution: may this role invoke this tool? |
+| `can_emit(role, content) -> Decision`       | Output gate: may this role receive this content? |
+
+`Decision` is `(allowed: bool, reason: str, applied_rule: str)` —
+frozen dataclass; `applied_rule` is the canonical id used in audit-log
+correlation, e.g. `policy.retrieve.abac` or `policy.tool.admin_only`.
+
+**TrustedContent** is the wrapper every multimodal extractor (OCR,
+ASR, vision, web) returns instead of a raw string. Carries
+`(text, source, trust)` so the reasoning pipeline knows whether to run
+`extract_data_only()` before joining content into the LLM context.
+
+**Done-when criterion**: removing `core/policy_engine.py` causes ≥ 4
+modules to fail import. That is the proof that every policy decision
+runs through one chokepoint — the goal of v0.2 ROADMAP Axis 4.
+
+**Migration phases** (#44):
+
+1. Skeleton (this section, lands in v0.2): every method delegates to
+   `core/security_layer.py` primitives. No behavior change.
+2. Move retrieval / graph / output call sites onto the engine
+   (one PR each, with bench numbers per CLAUDE.md rule 2).
+3. Sandbox migration to capability tokens (`can_call_tool`).
+4. Multimodal extractors return `TrustedContent`; reasoning pipeline
+   gates `low`-trust content through `extract_data_only()` at one
+   chokepoint.
+
+After all four phases, direct `check_access` imports outside of
+`security_layer.py` (the implementation backend) and `policy_engine.py`
+become a regression.
+
+---
+
 ## 6. Evolution Boundaries
 
 Self-evolution is **disabled by default**. To enable:


### PR DESCRIPTION
## Summary

First PR for issue #44 (v0.2 ROADMAP **Axis 4 — Security Boundary**). Creates `core/policy_engine.py` as the single source of policy decisions. **No behavior change** — every method delegates to existing `core/security_layer.py` primitives. Subsequent PRs migrate consumers off direct `check_access()` imports onto the typed methods.

The "done when" criterion from #44 ("removing `core/policy_engine.py` should break ≥ 4 modules on import") is the goal of phases 2-4 — this PR sets the foundation.

## What lands

### `core/policy_engine.py` (new, 150 LOC, ~6 KB)

| Symbol | Purpose |
|---|---|
| `Decision` | Frozen dataclass: `(allowed: bool, reason: str, applied_rule: str)`. `applied_rule` is the canonical id used in audit-log correlation, e.g. `policy.retrieve.abac` or `policy.tool.admin_only`. |
| `TrustedContent` | Frozen dataclass stub for phase 4: `(text, source, trust)`. Defined now so its identity stays stable across migration PRs that will return it from extractors. |
| `PolicyEngine` | 4 typed decision methods (see below) |
| `default_engine` | Module-level singleton (the engine is stateless, so a singleton is fine) |

The four decision methods:

| Method | Phase-1 implementation |
|---|---|
| `can_retrieve(role, doc_meta) -> Decision` | Delegates to `security_layer.check_access(role, meta)`. Bit-for-bit equivalent. |
| `can_walk(role, entity) -> Decision` | Same primitive as `can_retrieve`. Kept as a separate method because phase 2 graph migration may add traversal-depth and relation-type guards distinct from retrieval policy. |
| `can_call_tool(role, tool, args) -> Decision` | Phase 1: admin-only. Capability-token model arrives in phase 3 (sandbox migration). Existing `tools/router.py::execute_tool` admin gates remain authoritative; callers MAY bypass this method during phases 1-2. |
| `can_emit(role, content) -> Decision` | Phase 1: always allow. `filter_answer_by_role()` in `security_layer` already mutates content per role (PII / person redaction). Phase 2+ may promote real keyword/secret-leak post-checks. |

### `docs/ARCHITECTURE.md` §5.5 (new section)

Documents the 4-method interface, `Decision` shape, `TrustedContent` purpose, and the 4-phase migration order matching #44. Slots between §5 (Trust Zones) and §6 (Evolution Boundaries).

## Verification (equivalence harness)

```
OK: import + instantiation
OK: 6/6 ABAC equivalence cases pass
  admin    + confidential = allowed
  external + confidential = denied
  manager  + internal     = allowed
  employee + public       = allowed
  external + public       = allowed
  external + secret       = denied
OK: can_call_tool admin=True external=False
OK: can_emit phase-1 = True
OK: Decision shape - allowed=True rule='policy.retrieve.abac' reason='abac.role_ge_sensitivity'
OK: default_engine is PolicyEngine? True
OK: TrustedContent TrustedContent(text='hello', source='ocr', trust='low')
OK: compileall core/ = True
```

Each `can_retrieve(role, meta).allowed` matches `check_access(role, meta)` for the role/sensitivity pairs above. No silent behavior drift.

## CLAUDE.md compliance

- **Rule 2** (bench numbers for `core/{retrieval,graph,reasoning}` PRs): **N/A** — this PR creates a new file in `core/` but does not touch any of those three subtrees. The retrieval / graph migration PRs (#44 phase 2) will include STEP 7 + RAGAS numbers.
- **Rule 4** (architecture changes need `docs/ARCHITECTURE.md` PR + label): ARCHITECTURE.md §5.5 added; PR labeled `architecture`.
- **Rule 5** (no `core/` file > 20 KB): `policy_engine.py` = 5.9 KB.

## Out of scope (later phases of #44)

| Phase | Scope | Rough PR count |
|---|---|---|
| **Phase 2** | Migrate `core/retrieval_engine.py`, `core/graph_engine.py`, `core/security_layer.py::filter_answer_by_role` call sites onto the engine. STEP 7 + RAGAS numbers in PR description per CLAUDE.md rule 2. | 1 per consumer (~3 PRs) |
| **Phase 3** | Sandbox capability tokens. Real `can_call_tool` impl. `tools/code/sandbox.py` migration. New `tests/test_capability_tokens.py`. | 1 PR |
| **Phase 4** | Multimodal extractors return `TrustedContent`. Reasoning pipeline gates `low`-trust content through `extract_data_only()` at one chokepoint. Regression test on poisoned-PNG fixture. | 1 PR |

After all 4 phases land, removing `core/policy_engine.py` should fail import in ≥ 4 modules — the "done when" criterion from #44.

## Test plan

- [x] `from core.policy_engine import PolicyEngine, Decision, TrustedContent, default_engine` clean
- [x] 6/6 ABAC equivalence cases match `check_access`
- [x] `can_call_tool` admin-only verdict
- [x] `Decision` shape (frozen dataclass with `applied_rule`)
- [x] `TrustedContent` constructible
- [x] `python -m compileall -q core/` clean
- [ ] Reviewer optional: `python -c "import core.policy_engine"` from a fresh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)
