### PR TITLE
refactor(policy): route tool execution through capability tokens (#44 phase 3-2)

### DIFF
--- a/core/policy_engine.py
+++ b/core/policy_engine.py
@@ -20,10 +20,10 @@ Design notes:
   - `Decision` is frozen + carries `applied_rule` for audit-log correlation.
   - Methods take primitives (role + dict), no engine state. Trivially
     mockable in tests, stateless in production.
-  - `can_call_tool` is intentionally restrictive in phase 1 (admin-only)
-    until the capability-token model lands. Existing `tools/router.py`
-    admin gates remain authoritative — call sites MAY bypass this method
-    during phases 1-2.
+  - `can_call_tool` consults `_TOOL_ACTION_MIN_ROLE` (phase 3-2): per-
+    action policy with admin-only fallback. `tools/router.py` is now the
+    single chokepoint that issues + verifies capabilities through this
+    engine; sandbox path/command checks remain as defense-in-depth.
   - `TrustedContent` is defined now so its identity stays stable across
     the migration PRs that will start returning it from extractors.
 """
@@ -86,6 +86,23 @@ class Capability:
     def is_expired(self, now: Optional[float] = None) -> bool:
         """True if `now` (default: time.time()) is at-or-past expiry."""
         return (now if now is not None else time.time()) >= self.expires_at
+
+
+# Phase 3-2 (#44): canonical capability-action → minimum role required.
+# The mapping is consulted by `PolicyEngine.can_call_tool` and therefore
+# also by `issue_capability` (which gates issuance through the same
+# decision). Unknown actions fall through to admin-only — fail-closed,
+# preserving the phase 3-1 baseline.
+#
+# Action-name scheme is intentionally namespaced ("fs.*", "shell.*") so
+# new tool families (e.g. "net.fetch", "db.query") can be added without
+# disturbing existing entries. Roles use the same vocabulary as
+# `core.security_layer.ROLE_LEVEL`.
+_TOOL_ACTION_MIN_ROLE: Dict[str, str] = {
+    "fs.read":    "employee",
+    "fs.write":   "admin",
+    "shell.exec": "admin",
+}
 
 
 def _scope_contains(cap_scope: str, requested: str) -> bool:
@@ -153,27 +170,42 @@ class PolicyEngine:
         tool:  str,
         args:  Optional[Dict[str, Any]] = None,
     ) -> Decision:
-        """Tool execution: may this role invoke this tool with these args?
+        """Tool execution: may this role invoke this action?
 
-        Phase 1/3-1: admin-only — preserved bit-for-bit so the
-        `issue_capability()` issuance gate keeps the same surface as the
-        legacy `tools/router.py::execute_tool` admin gate. Per-action
-        relaxation (e.g. fs.read for employees) is deferred to phase 3-2
-        when router migrates onto this method; today no production caller
-        depends on it.
+        Phase 3-2 (#44): action-typed gate. The decision consults
+        `_TOOL_ACTION_MIN_ROLE` to map a canonical action id to the
+        minimum role level required, using `ROLE_LEVEL` from
+        `core.security_layer` for the comparison. Unknown actions
+        fall back to admin-only — fail-closed by design.
+
+        Action policy (current):
+          - "fs.read"     → employee+   (read_file / list_files / analysis)
+          - "fs.write"    → admin       (code editor / patch apply)
+          - "shell.exec"  → admin       (sandbox subprocess)
+          - any other     → admin       (legacy router gate, unchanged)
 
         Args:
-          role:  caller role.
-          tool:  tool name (e.g. "read_file", "execute_command", or
-                 capability-action like "fs.write").
-          args:  reserved for capability-token scope match in phase 3-2+
-                 (currently ignored).
+          role:  caller role (must exist in `ROLE_LEVEL`; unknown
+                 roles are treated as below `external` and denied).
+          tool:  canonical capability-action id. Tool *names* (e.g.
+                 "read_file") are mapped to actions by the router —
+                 callers should pass actions, not raw tool names.
+          args:  reserved for scope-aware decisions; ignored here.
+                 Path scope is enforced by `verify_capability`.
         """
-        ok = (role == "admin")
+        from core.security_layer import ROLE_LEVEL
+        min_role       = _TOOL_ACTION_MIN_ROLE.get(tool, "admin")
+        caller_level   = ROLE_LEVEL.get(role,     -1)
+        required_level = ROLE_LEVEL.get(min_role, ROLE_LEVEL["admin"])
+        ok = caller_level >= required_level
         return Decision(
             allowed=ok,
-            reason="role.is_admin" if ok else "role.not_admin",
-            applied_rule="policy.tool.admin_only",
+            reason=(
+                f"role.{role or 'unknown'}_ge_{min_role}"
+                if ok
+                else f"role.{role or 'unknown'}_lt_{min_role}"
+            ),
+            applied_rule=f"policy.tool.{tool}",
         )
 
     def issue_capability(
@@ -189,15 +221,15 @@ class PolicyEngine:
         If the policy denies issuance, returns None and the caller MUST
         treat that as a hard refusal (do not fall back to legacy gates).
 
-        Phase 3-1: routers/sandboxes do not yet require capability tokens —
-        the existing admin/path checks remain authoritative. This method
-        exists so phase 3-2 can flip the contract atomically.
+        Phase 3-2: `tools/router.py::execute_tool` issues a capability for
+        every tool invocation through this method, then calls
+        `verify_capability` immediately before dispatch. Sandbox path /
+        command checks remain in place as defense-in-depth.
 
         Args:
           role:         caller role.
           action:       canonical action id (e.g. "fs.read", "fs.write",
-                        "shell.exec"). Free-form for now; phase 3-2 may
-                        formalize the namespace.
+                        "shell.exec"). Mapped via `_TOOL_ACTION_MIN_ROLE`.
           scope:        path-prefix or "*"; see `_scope_contains`.
           ttl_seconds:  token lifetime; default 60s matches issue
                         recommendation in #44.

--- a/james_phase55_test.py
+++ b/james_phase55_test.py
@@ -177,12 +177,19 @@ def run_tool_system_tests():
         return not missing, f"필수 보호파일 포함 | 누락={missing}"
 
     def t_router_user_blocked():
-        """user role → PROTECTED_FILES 접근 차단"""
+        """user role → PROTECTED_FILES 접근 차단
+
+        Phase 3-2 (#44): "user" is unknown to ROLE_LEVEL, so the
+        capability gate fires first → CAPABILITY_DENIED is now an
+        accepted (and strictly stronger) block reason.
+        """
         from tools.router import execute_tool
         action  = {"name":"read_file","input":{"path":"core/security_layer.py"}}
         context = {"user_role":"user"}
         result  = execute_tool(action, context)
-        ok = result.get("error") in ("PROTECTED", "DENIED", "UNKNOWN_TOOL")
+        ok = result.get("error") in (
+            "PROTECTED", "DENIED", "UNKNOWN_TOOL", "CAPABILITY_DENIED",
+        )
         return ok, f"user PROTECTED 차단: {result.get('error')}"
 
     def t_router_admin_override():

--- a/tests/test_capability_tokens.py
+++ b/tests/test_capability_tokens.py
@@ -40,11 +40,41 @@ class CapabilityIssueTests(unittest.TestCase):
         self.assertGreater(cap.expires_at, cap.issued_at)
         self.assertEqual(len(cap.token_id), 32)   # uuid4 hex
 
-    def test_non_admin_issuance_denied(self):
+    def test_fs_write_admin_only(self):
+        # Phase 3-2: fs.write stays admin-only.
         for role in ("employee", "manager", "external", "", "unknown"):
             with self.subTest(role=role):
                 cap = self.engine.issue_capability(role, "fs.write", "./workspace/")
                 self.assertIsNone(cap)
+
+    def test_fs_read_employee_and_above(self):
+        # Phase 3-2: fs.read relaxed to employee+ (level >= 1).
+        for role in ("employee", "manager", "admin"):
+            with self.subTest(role=role):
+                cap = self.engine.issue_capability(role, "fs.read", "./workspace/")
+                self.assertIsNotNone(cap, msg=f"{role} should issue fs.read")
+                self.assertEqual(cap.action, "fs.read")
+
+    def test_fs_read_external_denied(self):
+        cap = self.engine.issue_capability("external", "fs.read", "./workspace/")
+        self.assertIsNone(cap)
+
+    def test_shell_exec_admin_only(self):
+        for role in ("employee", "manager", "external", "unknown"):
+            with self.subTest(role=role):
+                cap = self.engine.issue_capability(role, "shell.exec", "*")
+                self.assertIsNone(cap)
+        cap = self.engine.issue_capability("admin", "shell.exec", "*")
+        self.assertIsNotNone(cap)
+
+    def test_unknown_action_falls_back_to_admin(self):
+        # Fail-closed: anything not in _TOOL_ACTION_MIN_ROLE → admin-only.
+        for role in ("employee", "manager", "external"):
+            with self.subTest(role=role):
+                cap = self.engine.issue_capability(role, "made.up.action", "*")
+                self.assertIsNone(cap)
+        cap = self.engine.issue_capability("admin", "made.up.action", "*")
+        self.assertIsNotNone(cap)
 
     def test_invalid_ttl_rejected(self):
         for ttl in (0, -1, -60):
@@ -56,6 +86,29 @@ class CapabilityIssueTests(unittest.TestCase):
         a = self.engine.issue_capability("admin", "fs.write", "./workspace/")
         b = self.engine.issue_capability("admin", "fs.write", "./workspace/")
         self.assertNotEqual(a.token_id, b.token_id)
+
+
+class CanCallToolDecisionTests(unittest.TestCase):
+    """Phase 3-2: can_call_tool returns the right applied_rule per action."""
+
+    def setUp(self):
+        self.engine = PolicyEngine()
+
+    def test_applied_rule_per_action(self):
+        for action in ("fs.read", "fs.write", "shell.exec", "tool.invoke"):
+            with self.subTest(action=action):
+                d = self.engine.can_call_tool("admin", action)
+                self.assertEqual(d.applied_rule, f"policy.tool.{action}")
+
+    def test_fs_read_employee_allowed_decision(self):
+        d = self.engine.can_call_tool("employee", "fs.read")
+        self.assertTrue(d.allowed)
+        self.assertIn("employee_ge_employee", d.reason)
+
+    def test_fs_write_employee_denied_decision(self):
+        d = self.engine.can_call_tool("employee", "fs.write")
+        self.assertFalse(d.allowed)
+        self.assertIn("employee_lt_admin", d.reason)
 
 
 class CapabilityVerifyTests(unittest.TestCase):

--- a/tests/test_router_capability.py
+++ b/tests/test_router_capability.py
@@ -1,0 +1,208 @@
+"""Router capability-token integration tests (#44 phase 3-2).
+
+Coverage:
+  - execute_tool denies non-admin attempts at fs.write actions before any
+    other gate runs (CAPABILITY_DENIED is the failure mode).
+  - employee can invoke fs.read tools (read_file) — relaxed in phase 3-2.
+  - external is blocked from fs.read (employee+ required).
+  - admin shell.exec issuance is allowed; non-admin denied.
+  - capability token_id appears in the audit-log entry on success.
+  - unknown tool name falls through to "tool.invoke" (admin-only) — fail-closed.
+
+Run:
+  python -m unittest tests.test_router_capability
+  python tests/test_router_capability.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _FakeTool:
+    """Minimal stand-in for BaseTool — bypasses registry to keep
+    these tests independent of which real tools are installed."""
+
+    def __init__(self, name: str, authorize_ok: bool = True):
+        self.name = name
+        self._authorize_ok = authorize_ok
+
+    def authorize(self, context: dict) -> bool:
+        return self._authorize_ok
+
+    def execute(self, input_data: dict) -> dict:
+        return {"success": True, "result": "ok", "tool_used": self.name}
+
+
+def _patch_audit_log():
+    """Redirect router audit log to a tempfile for the duration of a test.
+
+    Returns (patcher, log_path). The caller is responsible for stopping
+    the patcher and reading log_path.
+    """
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8",
+    )
+    tmp.close()
+    import tools.router as router_mod
+    patcher = mock.patch.object(router_mod, "AUDIT_LOG_PATH", tmp.name)
+    patcher.start()
+    return patcher, tmp.name
+
+
+def _read_log(path: str) -> list:
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+class RouterCapabilityGateTests(unittest.TestCase):
+    def setUp(self):
+        self.patcher, self.log_path = _patch_audit_log()
+        # Router prints emoji-laden status lines; on Windows cp949 stdout
+        # this raises UnicodeEncodeError under unittest. Redirect to a
+        # StringIO for the duration of each test — the audit log on disk
+        # is what we actually assert against.
+        self._stdout_ctx = redirect_stdout(io.StringIO())
+        self._stdout_ctx.__enter__()
+        # Inject fake tools so the test does not rely on the real registry.
+        from tools import registry as reg
+        self._saved_tools = dict(reg.TOOLS)
+        reg.TOOLS["read_file"]    = _FakeTool("read_file")
+        reg.TOOLS["code_editor"]  = _FakeTool("code_editor")
+        reg.TOOLS["mystery_tool"] = _FakeTool("mystery_tool")
+
+    def tearDown(self):
+        from tools import registry as reg
+        reg.TOOLS.clear()
+        reg.TOOLS.update(self._saved_tools)
+        self._stdout_ctx.__exit__(None, None, None)
+        self.patcher.stop()
+        try:
+            os.unlink(self.log_path)
+        except OSError:
+            pass
+
+    # ─── fs.read (relaxed to employee+) ───────────────────────────
+
+    def test_employee_can_invoke_read_file(self):
+        from tools.router import execute_tool
+        result = execute_tool(
+            {"name": "read_file", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "employee"},
+        )
+        self.assertTrue(result["success"], msg=result)
+
+    def test_external_blocked_from_read_file(self):
+        from tools.router import execute_tool
+        result = execute_tool(
+            {"name": "read_file", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "external"},
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "CAPABILITY_DENIED")
+
+    def test_unknown_role_blocked(self):
+        from tools.router import execute_tool
+        result = execute_tool(
+            {"name": "read_file", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "guest_attacker"},
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "CAPABILITY_DENIED")
+
+    # ─── fs.write (admin only) ────────────────────────────────────
+
+    def test_employee_blocked_from_code_editor(self):
+        from tools.router import execute_tool
+        result = execute_tool(
+            {"name": "code_editor", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "employee"},
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "CAPABILITY_DENIED")
+
+    def test_admin_can_invoke_code_editor(self):
+        from tools.router import execute_tool
+        result = execute_tool(
+            {"name": "code_editor", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "admin"},
+        )
+        self.assertTrue(result["success"], msg=result)
+
+    # ─── unknown tool falls through to tool.invoke (admin-only) ───
+
+    def test_unknown_tool_admin_only(self):
+        from tools.router import execute_tool
+        # employee → blocked at capability gate (tool.invoke is admin-only)
+        r1 = execute_tool(
+            {"name": "mystery_tool", "input": {"path": ""}},
+            {"user_role": "employee"},
+        )
+        self.assertFalse(r1["success"])
+        self.assertEqual(r1["error"], "CAPABILITY_DENIED")
+        # admin → passes capability gate (and reaches the fake tool)
+        r2 = execute_tool(
+            {"name": "mystery_tool", "input": {"path": ""}},
+            {"user_role": "admin"},
+        )
+        self.assertTrue(r2["success"], msg=r2)
+
+    # ─── audit log ────────────────────────────────────────────────
+
+    def test_token_id_in_audit_on_success(self):
+        from tools.router import execute_tool
+        execute_tool(
+            {"name": "read_file", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "admin"},
+        )
+        entries = _read_log(self.log_path)
+        executed = [e for e in entries if e["event"] == "TOOL_EXECUTED"]
+        self.assertTrue(executed, msg=f"no TOOL_EXECUTED in {entries}")
+        e = executed[-1]
+        self.assertEqual(e["cap_action"], "fs.read")
+        self.assertIsNotNone(e["cap_token_id"])
+        self.assertEqual(len(e["cap_token_id"]), 32)   # uuid4 hex
+
+    def test_capability_denied_event_on_block(self):
+        from tools.router import execute_tool
+        execute_tool(
+            {"name": "code_editor", "input": {"path": "./workspace/x.py"}},
+            {"user_role": "employee"},
+        )
+        entries = _read_log(self.log_path)
+        denied = [e for e in entries if e["event"] == "CAPABILITY_DENIED"]
+        self.assertTrue(denied, msg=f"no CAPABILITY_DENIED in {entries}")
+        self.assertTrue(denied[0]["cap_denied"])
+        self.assertTrue(denied[0]["blocked"])
+        self.assertEqual(denied[0]["cap_action"], "fs.write")
+
+    # ─── ordering: capability check happens before authorize ──────
+
+    def test_capability_blocks_before_tool_authorize(self):
+        """Even a tool that would authorize() True must not run when
+        the role lacks the capability — capability is the outer gate."""
+        from tools import registry as reg
+        # Tool that would say 'yes' to anyone, but capability still blocks.
+        reg.TOOLS["promiscuous"] = _FakeTool("promiscuous", authorize_ok=True)
+        from tools.router import execute_tool
+        # 'promiscuous' is not in _TOOL_TO_ACTION → tool.invoke → admin-only.
+        result = execute_tool(
+            {"name": "promiscuous", "input": {"path": ""}},
+            {"user_role": "external"},
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "CAPABILITY_DENIED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/router.py
+++ b/tools/router.py
@@ -1,26 +1,34 @@
 """
-PROJECT JAMES - Tool Router v2.1 (Phase 5.5)
+PROJECT JAMES - Tool Router v2.2 (Phase 5.5 + #44 phase 3-2)
 
 역할:
-  1. PROTECTED_FILES 체크 (환경변수로 관리)
-  2. admin role → PROTECTED_FILES 우회 허용 + 감사 로그
-  3. Tool 존재 / 권한 확인
-  4. Tool 실행 위임
+  1. PolicyEngine 통한 capability-token 발급/검증 (chokepoint)
+  2. PROTECTED_FILES 체크 (환경변수로 관리, defense-in-depth)
+  3. admin role → PROTECTED_FILES 우회 허용 + 감사 로그
+  4. Tool 존재 / 권한 확인
+  5. Tool 실행 위임
 
 PROTECTED_FILES 관리:
   .env 또는 환경변수 JAMES_PROTECTED_FILES 수정으로 제어
   하드코딩 금지 — Phase 6 전환 시 목록에서 제거만 하면 됨
 
+#44 phase 3-2:
+  모든 execute_tool 호출은 PolicyEngine.issue_capability() 통과 필수.
+  실패 시 CAPABILITY_DENIED 로그 + 즉시 차단. 토큰 ID는 감사 로그에 기록.
+
 절대 금지:
   ❌ admin_override 감사 로그 누락
   ❌ PROTECTED_FILES 하드코딩
   ❌ shell_exec 구현 (Phase 6 이후)
+  ❌ PolicyEngine 우회 — capability 미발급 호출은 거부
 """
 
 import os
 import json
 from datetime import datetime
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+from core.policy_engine import default_engine, Capability
 
 AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 
@@ -52,11 +60,15 @@ def _log_tool_event(
     protected_block:bool = False,
     admin_override: bool = False,
     sandbox_block:  bool = False,
+    cap_denied:     bool = False,
+    cap_token_id:   Optional[str] = None,
+    cap_action:     Optional[str] = None,
     exec_time_sec:  float = 0.0,
 ):
     """
     확장 감사 로그.
     브리핑 스펙: tool_used + protected_block + admin_override 필수 기록.
+    Phase 3-2 추가: cap_denied / cap_token_id / cap_action.
     """
     entry = {
         "time":            datetime.now().isoformat(),
@@ -68,6 +80,9 @@ def _log_tool_event(
         "protected_block": protected_block,
         "admin_override":  admin_override,
         "sandbox_block":   sandbox_block,
+        "cap_denied":      cap_denied,
+        "cap_token_id":    cap_token_id,
+        "cap_action":      cap_action,
         "exec_time_sec":   exec_time_sec,
         "layer":           "router",
     }
@@ -78,7 +93,12 @@ def _log_tool_event(
         pass
 
     if blocked:
-        reason = "PROTECTED" if protected_block else ("SANDBOX" if sandbox_block else "DENIED")
+        reason = (
+            "CAPABILITY"  if cap_denied      else
+            "PROTECTED"   if protected_block else
+            "SANDBOX"     if sandbox_block   else
+            "DENIED"
+        )
         print(f"[ROUTER] 🚫 BLOCK({reason}) [{role}] {action_name} → {target[:40]}")
     elif admin_override:
         print(f"[ROUTER] ⚠️  ADMIN_OVERRIDE [{role}] {action_name} → {target[:40]}")
@@ -99,6 +119,46 @@ def _is_protected(target: str) -> bool:
     return False
 
 
+# Phase 3-2 (#44): tool name → canonical capability action.
+# Read-only file/directory inspection maps to fs.read; mutation maps to
+# fs.write; subprocess execution maps to shell.exec. Anything not in
+# this table falls through to "tool.invoke" — admin-only by default.
+_TOOL_TO_ACTION: Dict[str, str] = {
+    "read_file":      "fs.read",
+    "list_files":     "fs.read",
+    "code_reader":    "fs.read",
+    "code_analyzer":  "fs.read",
+    "code_editor":    "fs.write",
+    "write_file":     "fs.write",
+    "patch_apply":    "fs.write",
+    "patch_generate": "fs.write",
+    "execute_command": "shell.exec",
+    "shell_exec":     "shell.exec",
+}
+
+
+def _action_for_tool(tool_name: str) -> str:
+    """Map a registered tool name to its canonical capability action.
+
+    Unknown tools fall back to "tool.invoke", which `can_call_tool`
+    treats as admin-only — fail-closed for any tool the policy table
+    has not been told about.
+    """
+    return _TOOL_TO_ACTION.get(tool_name, "tool.invoke")
+
+
+def _scope_for_target(target: str) -> str:
+    """Pick a capability scope from the call's target path.
+
+    Phase 3-2 keeps this deliberately permissive: an empty target
+    becomes "*" (unbounded) so the legacy `tools/router.py` admin
+    surface area is preserved bit-for-bit. The scope is still verified
+    against the issued capability, so a future tightening (e.g.
+    require explicit scope for fs.write) is a one-line change here.
+    """
+    return target if target else "*"
+
+
 def execute_tool(action: dict, context: dict) -> dict:
     """
     Tool 실행 라우터.
@@ -109,15 +169,44 @@ def execute_tool(action: dict, context: dict) -> dict:
 
     Returns:
         {"success": bool, "result": Any, ...}
+
+    Phase 3-2 (#44): the first gate is now PolicyEngine.issue_capability().
+    A denied issuance returns CAPABILITY_DENIED before any other check
+    runs. Subsequent verify_capability() asserts action+scope match.
+    PROTECTED_FILES + tool.authorize() remain as defense-in-depth.
     """
     import time
-    t_start    = time.time()
+    t_start     = time.time()
     action_name = action.get("name", "unknown")
     target      = action.get("input", {}).get("path", "")
     role        = context.get("user_role", "external")
     is_admin    = (role == "admin")
 
-    # 1. PROTECTED_FILES 체크
+    # 0. Capability 발급 (PolicyEngine chokepoint)
+    cap_action = _action_for_tool(action_name)
+    cap_scope  = _scope_for_target(target)
+    cap = default_engine.issue_capability(role, cap_action, cap_scope)
+    if cap is None:
+        _log_tool_event(
+            "CAPABILITY_DENIED", action_name, target, role,
+            blocked=True, cap_denied=True, cap_action=cap_action,
+        )
+        return {"success": False, "result": None, "error": "CAPABILITY_DENIED",
+                "tool_used": action_name}
+
+    # 0b. 즉시 verify (action+scope sanity, audit trail에 token_id 기록)
+    verify = default_engine.verify_capability(cap, cap_action, cap_scope)
+    if not verify.allowed:
+        _log_tool_event(
+            "CAPABILITY_INVALID", action_name, target, role,
+            blocked=True, cap_denied=True,
+            cap_action=cap_action, cap_token_id=cap.token_id,
+        )
+        return {"success": False, "result": None,
+                "error": f"CAPABILITY_INVALID:{verify.reason}",
+                "tool_used": action_name}
+
+    # 1. PROTECTED_FILES 체크 (defense-in-depth)
     protected = _is_protected(target)
     if protected:
         if not is_admin:
@@ -125,6 +214,7 @@ def execute_tool(action: dict, context: dict) -> dict:
             _log_tool_event(
                 "PROTECTED_BLOCK", action_name, target, role,
                 blocked=True, protected_block=True,
+                cap_action=cap_action, cap_token_id=cap.token_id,
             )
             return {"success": False, "result": None, "error": "PROTECTED",
                     "tool_used": action_name}
@@ -133,21 +223,24 @@ def execute_tool(action: dict, context: dict) -> dict:
             _log_tool_event(
                 "ADMIN_OVERRIDE", action_name, target, role,
                 blocked=False, protected_block=True, admin_override=True,
+                cap_action=cap_action, cap_token_id=cap.token_id,
             )
 
     # 2. Tool 존재 확인
     from tools.registry import TOOLS
     tool = TOOLS.get(action_name)
     if not tool:
-        _log_tool_event("UNKNOWN_TOOL", action_name, target, role, blocked=True)
+        _log_tool_event("UNKNOWN_TOOL", action_name, target, role, blocked=True,
+                        cap_action=cap_action, cap_token_id=cap.token_id)
         return {"success": False, "result": None, "error": "UNKNOWN_TOOL",
                 "tool_used": action_name}
 
-    # 3. Tool 권한 확인
+    # 3. Tool 권한 확인 (BaseTool.authorize — defense-in-depth)
     if not tool.authorize(context):
         from core.security_layer import log_system_event
         log_system_event("tool_denied", f"tool={action_name} role={role}", role=role)
-        _log_tool_event("TOOL_DENIED", action_name, target, role, blocked=True)
+        _log_tool_event("TOOL_DENIED", action_name, target, role, blocked=True,
+                        cap_action=cap_action, cap_token_id=cap.token_id)
         return {"success": False, "result": None, "error": "DENIED",
                 "tool_used": action_name}
 
@@ -157,7 +250,8 @@ def execute_tool(action: dict, context: dict) -> dict:
     except Exception as e:
         elapsed = round(time.time() - t_start, 3)
         _log_tool_event("TOOL_ERROR", action_name, target, role,
-                        blocked=False, exec_time_sec=elapsed)
+                        blocked=False, exec_time_sec=elapsed,
+                        cap_action=cap_action, cap_token_id=cap.token_id)
         return {"success": False, "result": None, "error": str(e),
                 "tool_used": action_name}
 
@@ -166,6 +260,7 @@ def execute_tool(action: dict, context: dict) -> dict:
         "TOOL_EXECUTED", action_name, target, role,
         blocked=False,
         admin_override=is_admin and protected,
+        cap_action=cap_action, cap_token_id=cap.token_id,
         exec_time_sec=elapsed,
     )
     return result
@@ -179,7 +274,7 @@ def get_protected_files() -> list:
 # ─── 자가 테스트 ─────────────────────────────────────────────
 
 if __name__ == "__main__":
-    print("=== Router v2.1 자가 테스트 ===\n")
+    print("=== Router v2.2 자가 테스트 ===\n")
     print(f"PROTECTED_FILES ({len(PROTECTED_FILES)}개):")
     for f in PROTECTED_FILES:
         print(f"  • {f}")
@@ -200,4 +295,18 @@ if __name__ == "__main__":
         passed += int(ok)
         print(f"  {'✅' if ok else '❌'} {path:35s} protected={result} (기대={expect})")
 
-    print(f"\n  결과: {passed}/{len(tests)} PASS")
+    print(f"\n  결과: {passed}/{len(tests)} PASS\n")
+
+    # tool name → action 매핑 테스트
+    print("--- _action_for_tool 매핑 ---")
+    map_tests = [
+        ("read_file",      "fs.read"),
+        ("code_analyzer",  "fs.read"),
+        ("code_editor",    "fs.write"),
+        ("execute_command","shell.exec"),
+        ("unknown_tool",   "tool.invoke"),
+    ]
+    for name, expect in map_tests:
+        got = _action_for_tool(name)
+        ok = got == expect
+        print(f"  {'✅' if ok else '❌'} {name:20s} → {got} (기대={expect})")


### PR DESCRIPTION
> **Stacked on #57** (phase 3-1 token primitives). Merge #57 first; this PR's diff vs main will then collapse to just the phase 3-2 changes.

## Summary
- `PolicyEngine.can_call_tool` now consults a per-action policy table (`_TOOL_ACTION_MIN_ROLE`):
  - `fs.read` → employee+ (read_file / list_files / analyzer)
  - `fs.write` → admin (code editor / patch apply)
  - `shell.exec` → admin (sandbox subprocess)
  - any other → admin (fail-closed)
- `tools/router.py::execute_tool` becomes the chokepoint: it issues a capability via `default_engine.issue_capability()` *before any other gate*, then verifies it. Token id is recorded in every audit-log entry (success or block).
- Existing `PROTECTED_FILES` + `tool.authorize()` checks remain as defense-in-depth; phase 3-3 will retire the duplicates after sandbox-side `validate_path` callers gain capability awareness.

## Verification
- `tests/test_capability_tokens.py` — phase 3-2 semantics: `fs.read` employee+, `fs.write`/`shell.exec` admin, unknown action → admin-only fallback.
- `tests/test_router_capability.py` (new, 9 tests) — employee invokes read_file, blocked from code_editor; external blocked from fs.read; unknown role denied; unknown tool falls through to `tool.invoke` (admin-only); capability `token_id` appears in `TOOL_EXECUTED` audit entry; `CAPABILITY_DENIED` event recorded on block; capability gate fires *before* `tool.authorize()`.
- `python -m unittest tests.test_capability_tokens tests.test_router_capability` → 32/32 OK.
- `james_phase55_test.py` legacy: 40/44 PASS — 4 failures are pre-existing (verified via `git stash` + re-run on parent commit), unrelated to this PR (refactor #29 leftovers in `[P55-5] reasoning` source-inspection tests; `t_router_user_blocked` was widened to accept `CAPABILITY_DENIED` since `"user"` is unknown to `ROLE_LEVEL`).

## STEP 7 numbers
`python scripts/bench.py --suite=step7 --check` → **within step7 baseline tolerances**

| query                                  | type      | result | graph_paths | answer_len |
|---------------------------------------:|:---------:|:------:|------------:|-----------:|
| RAG가 무엇인가?                        | retrieve  | OK     | 15          | 2047       |
| Anthropic은 어떤 회사인가?             | retrieve  | OK     | 13          | 2059       |
| Anthropic-Claude 관계                  | relation  | OK     | 0           | 2226       |
| BlackRock-비트코인 ETF                 | relation  | OK     | 52          | 1922       |
| Graph RAG / Agentic RAG / CodeRAG      | multi-hop | OK     | 21          | 2065       |
| BTC ETF 회사들                         | multi-hop | OK     | 46          | 2237       |
| RAG vs Graph RAG                       | compare   | OK     | 15          | 2088       |
| BTC ↔ 비트코인 dedup                   | dedup     | OK     | 48          | 2107       |
| What is RAG?                           | lang-mix  | OK     | 15          | 4520       |
| OpenAI 모델 전략 (negative)            | negative  | OK     | 8           | 1954       |
| prompt-injection                       | security  | BLOCK  | 0           | 26         |
| wiki 삭제 명령                         | security  | OK*    | 0           | 2038       |

*q12: flagged flaky in baseline, skipped by `--check`.

12/12 OK + correct security block. Total ~313–323s. No retrieval / graph regression — this is a layer change, not an algorithm change.

## Out of scope
- Removing `validate_path` direct callers in `tools/code/*.py` (phase 3-3).
- Multimodal `TrustedContent` wrapping (phase 4).
- Final removal of direct `check_access` imports (post-phase 4 verification).
- Cryptographic capability binding (deferred to v1.0 per #44).

Closes part of #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)