### PR TITLE
refactor(policy): enforce capability gate at tool sites (#44 phase 3-3)

### DIFF
--- a/james_phase55_test.py
+++ b/james_phase55_test.py
@@ -249,16 +249,18 @@ def run_read_file_tests():
                f"name={tool.name} sandbox={tool.requires_sandbox}"
 
     def t_read_normal():
+        # Phase 3-3 (#44): "user" is not in ROLE_LEVEL — use "employee"
+        # (the canonical non-admin internal role) to test the success path.
         from tools.code.read_file import ReadFileTool
         tool   = ReadFileTool()
-        result = tool.execute({"path":"./workspace/_diag_test.py","role":"user"})
+        result = tool.execute({"path":"./workspace/_diag_test.py","role":"employee"})
         ok = result.get("success") and "hello" in str(result.get("result",""))
         return ok, f"정상 읽기={ok} | {str(result.get('result',''))[:40]}"
 
     def t_read_path_escape():
         from tools.code.read_file import ReadFileTool
         tool   = ReadFileTool()
-        result = tool.execute({"path":"../secret.py","role":"user"})
+        result = tool.execute({"path":"../secret.py","role":"employee"})
         return not result.get("success"), f"경로 탈출 차단={not result.get('success')}"
 
     def t_read_authorize_employee():
@@ -277,7 +279,7 @@ def run_read_file_tests():
         from tools.code.read_file import ReadFileTool
         tool   = ReadFileTool()
         result = tool.execute({"path":"./workspace/_diag_test.py",
-                                "start_line":2,"end_line":2,"role":"user"})
+                                "start_line":2,"end_line":2,"role":"employee"})
         ok = result.get("success") and "hello" in str(result.get("result",""))
         return ok, f"라인 범위 읽기={ok}"
 

--- a/tests/test_sandbox_capability.py
+++ b/tests/test_sandbox_capability.py
@@ -1,0 +1,169 @@
+"""Sandbox-side capability gate tests (#44 phase 3-3).
+
+Coverage:
+  - policy_validate_path enforces PolicyEngine action policy
+    (fs.read employee+, fs.write admin) before sandbox validate_path.
+  - tools/code/* and tools/patch/patch_generator route through
+    policy_validate_path even when called directly (not via router).
+  - Legacy validate_path primitive still exists for sandbox internal use.
+
+Run:
+  python -m unittest tests.test_sandbox_capability
+  python tests/test_sandbox_capability.py
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class PolicyValidatePathTests(unittest.TestCase):
+    """policy_validate_path: fail-closed gate before legacy validate_path."""
+
+    def setUp(self):
+        # Suppress emoji-laden stdout (Windows cp949 unittest hostility).
+        self._stdout_ctx = redirect_stdout(io.StringIO())
+        self._stdout_ctx.__enter__()
+
+    def tearDown(self):
+        self._stdout_ctx.__exit__(None, None, None)
+
+    # ─── fs.read (employee+) ─────────────────────────────────────
+
+    def test_employee_fs_read_workspace_allowed(self):
+        from tools.code.sandbox import policy_validate_path
+        ok, _ = policy_validate_path("./workspace/a.py", "employee", "fs.read")
+        self.assertTrue(ok)
+
+    def test_external_fs_read_denied_at_policy(self):
+        from tools.code.sandbox import policy_validate_path
+        ok, reason = policy_validate_path("./workspace/a.py", "external", "fs.read")
+        self.assertFalse(ok)
+        self.assertIn("policy.denied", reason)
+
+    def test_unknown_role_fs_read_denied(self):
+        from tools.code.sandbox import policy_validate_path
+        ok, reason = policy_validate_path("./workspace/a.py", "user", "fs.read")
+        self.assertFalse(ok)
+        self.assertIn("policy.denied", reason)
+
+    # ─── fs.write (admin only) ───────────────────────────────────
+
+    def test_employee_fs_write_denied_at_policy(self):
+        from tools.code.sandbox import policy_validate_path
+        ok, reason = policy_validate_path("./workspace/a.py", "employee", "fs.write")
+        self.assertFalse(ok)
+        self.assertIn("policy.denied", reason)
+
+    def test_admin_fs_write_workspace_allowed(self):
+        from tools.code.sandbox import policy_validate_path
+        ok, _ = policy_validate_path("./workspace/a.py", "admin", "fs.write")
+        self.assertTrue(ok)
+
+    # ─── defense-in-depth: legacy sandbox patterns still apply ──
+
+    def test_admin_blocked_at_legacy_pattern(self):
+        # PolicyEngine grants fs.write for admin, but sandbox's
+        # BLOCKED_PATH_PATTERNS still bars core/ — defense-in-depth.
+        from tools.code.sandbox import policy_validate_path
+        ok, reason = policy_validate_path(
+            "./core/security_layer.py", "admin", "fs.write",
+        )
+        self.assertFalse(ok)
+
+    def test_employee_outside_allowed_paths_blocked(self):
+        # Even with fs.read policy passing, legacy sandbox blocks
+        # employee from paths outside ALLOWED_PATHS.
+        from tools.code.sandbox import policy_validate_path
+        ok, _ = policy_validate_path("./other_dir/a.py", "employee", "fs.read")
+        self.assertFalse(ok)
+
+
+class ToolMigrationTests(unittest.TestCase):
+    """Direct tool calls (bypassing router) still hit PolicyEngine."""
+
+    def setUp(self):
+        self._stdout_ctx = redirect_stdout(io.StringIO())
+        self._stdout_ctx.__enter__()
+        # Workspace fixture for tool reads.
+        self._tmpdir = tempfile.mkdtemp(prefix="james_phase33_")
+        # tools depend on the literal "./workspace" prefix being in
+        # ALLOWED_PATHS — easier to use that prefix directly.
+        os.makedirs("./workspace", exist_ok=True)
+        self._fixture = "./workspace/_phase33_fixture.py"
+        with open(self._fixture, "w", encoding="utf-8") as f:
+            f.write("# fixture\nprint('hi')\n")
+
+    def tearDown(self):
+        self._stdout_ctx.__exit__(None, None, None)
+        try:
+            os.unlink(self._fixture)
+        except OSError:
+            pass
+
+    # ─── CodeReader ──────────────────────────────────────────────
+
+    def test_code_reader_external_blocked(self):
+        from tools.code.code_reader import CodeReader
+        reader = CodeReader(user_role="external")
+        ok, msg, _ = reader.read_file(self._fixture)
+        self.assertFalse(ok)
+        self.assertIn("경로 차단", msg)
+
+    def test_code_reader_employee_allowed(self):
+        from tools.code.code_reader import CodeReader
+        reader = CodeReader(user_role="employee")
+        ok, _, meta = reader.read_file(self._fixture)
+        self.assertTrue(ok, msg=meta)
+
+    # ─── CodeEditor ──────────────────────────────────────────────
+
+    def test_code_editor_employee_blocked(self):
+        from tools.code.code_editor import CodeEditor
+        editor = CodeEditor(user_role="employee")
+        ok, msg = editor.write_file(
+            "./workspace/_phase33_employee.py", "# nope\n",
+        )
+        self.assertFalse(ok)
+        self.assertIn("경로 차단", msg)
+        # Make sure the file was NOT written despite legacy validate_path
+        # would have allowed it (this is the whole point of phase 3-3).
+        self.assertFalse(os.path.exists("./workspace/_phase33_employee.py"))
+
+    def test_code_editor_admin_allowed(self):
+        from tools.code.code_editor import CodeEditor
+        editor = CodeEditor(user_role="admin")
+        target = "./workspace/_phase33_admin.py"
+        try:
+            ok, _ = editor.write_file(target, "# ok\n")
+            self.assertTrue(ok)
+            self.assertTrue(os.path.exists(target))
+        finally:
+            try:
+                os.unlink(target)
+            except OSError:
+                pass
+
+    # ─── ReadFileTool (BaseTool) — role from input_data ──────────
+
+    def test_read_file_tool_external_blocked(self):
+        from tools.code.read_file import ReadFileTool
+        tool = ReadFileTool()
+        result = tool.execute({"path": self._fixture, "role": "external"})
+        self.assertFalse(result["success"])
+
+    def test_read_file_tool_employee_allowed(self):
+        from tools.code.read_file import ReadFileTool
+        tool = ReadFileTool()
+        result = tool.execute({"path": self._fixture, "role": "employee"})
+        self.assertTrue(result["success"], msg=result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/code/code_analyzer.py
+++ b/tools/code/code_analyzer.py
@@ -17,7 +17,7 @@ import time
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
-from tools.code.sandbox import validate_path, log_security_event
+from tools.code.sandbox import policy_validate_path, log_security_event
 from tools.code.code_reader import CodeReader
 
 AUDIT_LOG_PATH = "james_audit_tool.jsonl"
@@ -57,8 +57,8 @@ class CodeAnalyzer:
     """
 
     def __init__(self, user_role: str = "admin"):
-        self.reader    = CodeReader()
         self.user_role = user_role
+        self.reader    = CodeReader(user_role=user_role)
         self._engine   = None   # lazy init
 
     def _get_engine(self):
@@ -92,8 +92,8 @@ class CodeAnalyzer:
         """
         t_start = time.time()
 
-        # 1. Sandbox 경로 검증
-        path_ok, reason = validate_path(path)
+        # 1. PolicyEngine + sandbox 경로 검증 (#44 phase 3-3)
+        path_ok, reason = policy_validate_path(path, self.user_role, "fs.read")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"analyze:{path}")
             return False, f"경로 차단: {reason}", {}

--- a/tools/code/code_editor.py
+++ b/tools/code/code_editor.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-from tools.code.sandbox import validate_path, validate_command, log_security_event
+from tools.code.sandbox import policy_validate_path, validate_command, log_security_event
 
 AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 BACKUP_DIR     = "./workspace/.backups"
@@ -56,11 +56,16 @@ def _log_edit(path: str, operation: str, success: bool, detail: str = ""):
 
 class CodeEditor:
     """
-    Sandbox 통과 후 안전한 파일 수정 도구.
+    PolicyEngine + Sandbox 통과 후 안전한 파일 수정 도구.
     수정 전 자동 백업, 모든 변경 diff 기록.
+
+    Phase 3-3 (#44): 모든 경로 검증이 PolicyEngine.issue_capability(
+    "fs.write")를 거친다. fs.write는 admin-only이므로 비-admin role로
+    이 클래스를 instantiate해 호출해도 차단된다 (자가 테스트는 admin).
     """
 
-    def __init__(self):
+    def __init__(self, user_role: str = "admin"):
+        self.user_role = user_role
         os.makedirs(BACKUP_DIR, exist_ok=True)
 
     # ─── 보호 파일 확인 ──────────────────────────────────────
@@ -102,7 +107,7 @@ class CodeEditor:
         Sandbox 검증 → 보호 파일 확인 → 백업 → 쓰기 → 로그.
         """
         # 1. Sandbox 경로 검증
-        path_ok, reason = validate_path(path)
+        path_ok, reason = policy_validate_path(path, self.user_role, "fs.write")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"write:{path}")
             _log_edit(path, "write", False, reason)
@@ -152,7 +157,7 @@ class CodeEditor:
         Returns:
             (success, message, diff)
         """
-        path_ok, reason = validate_path(path)
+        path_ok, reason = policy_validate_path(path, self.user_role, "fs.write")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"replace:{path}")
             return False, f"경로 차단: {reason}", ""
@@ -204,7 +209,7 @@ class CodeEditor:
         content:   str,
     ) -> Tuple[bool, str]:
         """특정 라인 이후 내용 삽입."""
-        path_ok, reason = validate_path(path)
+        path_ok, reason = policy_validate_path(path, self.user_role, "fs.write")
         if not path_ok:
             return False, f"경로 차단: {reason}"
 
@@ -232,7 +237,7 @@ class CodeEditor:
 
     def restore_backup(self, path: str) -> Tuple[bool, str]:
         """가장 최근 백업으로 복원."""
-        path_ok, _ = validate_path(path)
+        path_ok, _ = policy_validate_path(path, self.user_role, "fs.write")
         if not path_ok:
             return False, "경로 차단"
 

--- a/tools/code/code_reader.py
+++ b/tools/code/code_reader.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from tools.code.sandbox import validate_path, log_security_event, ALLOWED_PATHS
+from tools.code.sandbox import policy_validate_path, log_security_event, ALLOWED_PATHS
 
 AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 
@@ -51,8 +51,15 @@ def _log_read(path: str, lines: int, success: bool):
 class CodeReader:
     """
     workspace 내 파일 읽기 전용 도구.
-    모든 접근은 Sandbox 검증 후 허용.
+    모든 접근은 PolicyEngine + Sandbox 검증 후 허용.
+
+    Phase 3-3 (#44): 인스턴스 단위 user_role을 보관해 모든 경로 검증이
+    PolicyEngine.issue_capability("fs.read")를 거치도록 한다. 외부에서
+    role을 지정하지 않으면 admin (호환성 — 자가 테스트 / 직접 호출).
     """
+
+    def __init__(self, user_role: str = "admin"):
+        self.user_role = user_role
 
     def read_file(
         self,
@@ -71,8 +78,8 @@ class CodeReader:
         Returns:
             (success, content, metadata)
         """
-        # Sandbox 경로 검증
-        path_ok, reason = validate_path(path)
+        # PolicyEngine + sandbox 경로 검증 (#44 phase 3-3)
+        path_ok, reason = policy_validate_path(path, self.user_role, "fs.read")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"read:{path} → {reason}")
             _log_read(path, 0, False)
@@ -140,7 +147,7 @@ class CodeReader:
         """
         workspace 내 파일 목록 조회.
         """
-        path_ok, reason = validate_path(directory)
+        path_ok, reason = policy_validate_path(directory, self.user_role, "fs.read")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"list:{directory}")
             return False, []
@@ -171,7 +178,7 @@ class CodeReader:
         """
         디렉토리 구조 트리 형태 반환.
         """
-        path_ok, reason = validate_path(directory)
+        path_ok, reason = policy_validate_path(directory, self.user_role, "fs.read")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"structure:{directory}")
             return False, f"차단: {reason}"

--- a/tools/code/read_file.py
+++ b/tools/code/read_file.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from tools.base_tool import BaseTool
-from tools.code.sandbox import validate_path, log_security_event
+from tools.code.sandbox import policy_validate_path, log_security_event
 
 SUPPORTED_EXT = {
     ".py",".js",".ts",".java",".cpp",".c",".h",".go",".rs",
@@ -46,8 +46,8 @@ class ReadFileTool(BaseTool):
         end_line   = input_data.get("end_line")
         role       = input_data.get("role", "user")
 
-        # Sandbox 경로 검증
-        path_ok, reason = validate_path(path, role)
+        # PolicyEngine + sandbox 경로 검증 (#44 phase 3-3)
+        path_ok, reason = policy_validate_path(path, role, "fs.read")
         if not path_ok:
             log_security_event("PATH_VIOLATION", f"read:{path}", role=role)
             return self._error(f"경로 차단: {reason}")
@@ -84,7 +84,7 @@ class ReadFileTool(BaseTool):
 
     def list_files(self, directory: str = "./workspace", role: str = "user") -> dict:
         """디렉토리 내 파일 목록."""
-        path_ok, reason = validate_path(directory, role)
+        path_ok, reason = policy_validate_path(directory, role, "fs.read")
         if not path_ok:
             return self._error(f"경로 차단: {reason}")
         p = Path(directory)

--- a/tools/code/sandbox.py
+++ b/tools/code/sandbox.py
@@ -1,7 +1,14 @@
 """
-PROJECT JAMES - Mini Sandbox v2.1 (Phase 5.5)
+PROJECT JAMES - Mini Sandbox v2.2 (Phase 5.5 + #44 phase 3-3)
 
-v2.1 변경:
+v2.2 변경:
+  - policy_validate_path() 신규 — PolicyEngine.issue_capability /
+    verify_capability를 거친 후 기존 validate_path를 호출
+    (defense-in-depth)
+  - tools/code/* 및 tools/patch/* 의 validate_path 직접 호출자가
+    policy_validate_path로 마이그레이션
+
+v2.1 (유지):
   - admin role → ALLOWED_PATHS 우회 가능 (경로 제한 해제)
   - BLOCKED_COMMANDS → admin도 차단 (명령어는 예외 없음)
   - admin_override → 감사 로그 반드시 기록
@@ -17,6 +24,7 @@ v2.1 변경:
   user/employee/manager role:
     ❌ ALLOWED_PATHS 외 접근 차단
     ❌ BLOCKED_COMMANDS 차단
+    ❌ PolicyEngine action 자격 (fs.read employee+, fs.write admin) 미충족 시 차단
 """
 
 import os
@@ -144,6 +152,64 @@ def validate_command(command: str) -> Tuple[bool, str]:
             return False, f"위험 패턴: '{pattern}'"
 
     return True, ""
+
+
+# ─── PolicyEngine 통합 검증 (#44 phase 3-3) ──────────────────
+
+def policy_validate_path(
+    path:   str,
+    role:   str,
+    action: str = "fs.read",
+) -> Tuple[bool, str]:
+    """경로 접근을 PolicyEngine + sandbox validate_path 둘 다 통과해야 허용.
+
+    Phase 3-3 (#44): tool-side 호출자(read_file, code_reader,
+    code_editor, code_analyzer, patch_generator)가 PolicyEngine을
+    bypass 하지 못하도록 강제. router를 거치지 않은 직접 호출
+    경로(자가 테스트, CLI, 다른 tool 간 호출)에서도 정책이 적용됨.
+
+    검증 순서:
+      1. PolicyEngine.issue_capability(role, action, path)
+         - role이 action에 대해 자격 미달 → (False, "policy.denied(...)")
+         - 자격 통과 → 짧은 capability 토큰 발급
+      2. PolicyEngine.verify_capability(cap, action, path)
+         - scope/action 미스매치 → (False, "policy.invalid(...)")
+      3. 기존 sandbox validate_path(path, role)
+         - BLOCKED_PATH_PATTERNS / ALLOWED_PATHS 검사 (defense-in-depth)
+
+    Args:
+      path:    경로 (sandbox validate_path와 동일 의미).
+      role:    호출자 role (admin/manager/employee/external).
+      action:  policy action id.
+               - "fs.read"  : 파일/디렉토리 읽기 (employee+ 허용)
+               - "fs.write" : 파일 수정/패치 (admin only)
+
+    Returns:
+      (True, "") on success, otherwise (False, reason).
+    """
+    from core.policy_engine import default_engine
+
+    cap = default_engine.issue_capability(role, action, path or "*")
+    if cap is None:
+        reason = f"policy.denied(role={role!r}, action={action!r})"
+        log_security_event(
+            "POLICY_DENIED",
+            f"path={path[:60] if path else ''} action={action}",
+            blocked=True, role=role,
+        )
+        return False, reason
+
+    verify = default_engine.verify_capability(cap, action, path or "*")
+    if not verify.allowed:
+        log_security_event(
+            "POLICY_INVALID",
+            f"path={path[:60] if path else ''} action={action} reason={verify.reason}",
+            blocked=True, role=role,
+        )
+        return False, f"policy.invalid({verify.reason})"
+
+    # PolicyEngine 통과 후에도 기존 sandbox 경로 정책은 적용 — defense-in-depth.
+    return validate_path(path, role)
 
 
 # ─── 통합 검증 ───────────────────────────────────────────────

--- a/tools/patch/patch_generator.py
+++ b/tools/patch/patch_generator.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from tools.code.sandbox import validate_path
+from tools.code.sandbox import policy_validate_path
 from tools.router import _is_protected
 
 PATCH_LOG_PATH = "james_patch_log.jsonl"
@@ -95,8 +95,8 @@ def generate_patch(
                 "error": f"FORBIDDEN: {target} (보안/핵심 파일)",
             }
 
-    # 3. 경로 검증 (workspace 내 또는 admin 우회)
-    path_ok, reason = validate_path(target, user_role)
+    # 3. PolicyEngine + 경로 검증 (#44 phase 3-3) — fs.write (admin only)
+    path_ok, reason = policy_validate_path(target, user_role, "fs.write")
     if not path_ok:
         _log_patch("BLOCKED_PATH", patch_id, reason)
         return {"patch_id": patch_id, "status": "BLOCKED", "error": reason}


### PR DESCRIPTION
## Summary
- `tools/code/sandbox.py` 에 `policy_validate_path()` 추가. PolicyEngine `issue_capability` → `verify_capability` → 기존 `validate_path` (defense-in-depth) 순서로 검증.
- `tools/code/{code_reader,code_editor,code_analyzer,read_file}.py` 와 `tools/patch/patch_generator.py` — 5개 직접 호출자가 모두 `policy_validate_path` 를 통과하도록 마이그레이션. router 우회 호출도 정책이 적용됨.
- `CodeReader` / `CodeEditor` 에 `user_role` 인스턴스 필드 추가 (default `"admin"` — 기존 자가 테스트 / 직접 호출 호환).
- `james_phase55_test.py` — `ROLE_LEVEL` 미등록 role `\"user\"` → `\"employee\"` 보정.

## Verification
- `tests/test_sandbox_capability.py` 신규 — **13/13 PASS** (PolicyEngine gate, defense-in-depth 잔존 검사, 도구 마이그레이션).
- `python -m unittest discover -s tests` — **45/45 PASS**.
- `python james_phase55_test.py` — **40/44 (A등급, 90.9%)**. 4개 실패는 모두 본 변경 이전부터 존재하던 Phase 6 / Multi-LLM router / reasoning execute_tool 결선 항목으로 본 PR 범위 밖.

## Out of scope
- Phase 6 reasoning loop의 `execute_tool` 결선 (Phase 5.5 P55-5 실패 항목) — 별도 사이클.
- Multi-LLM router 부재 (P55-4) — Phase 6 이후.
- 도메인별 capability 확장 (legal/food/retail) — v1.0 이후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)