### PR TITLE
feat(eval): RAGAS baseline + drift check + RESULTS.md numbers (#46 phase 2)

### DIFF
--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -2,48 +2,59 @@
 
 This page tracks regression metrics across the v0.2 → v1.0 hardening cycle. Numbers are committed only when they reflect a representative-hardware run on a tagged release branch — drift between commits is expected (LLM nondeterminism); committing every nightly run would bury signal under noise.
 
+Both suites are gated by `--check` mode of their runner. PRs touching `core/retrieval`, `core/graph`, or `core/reasoning` paste the relevant suite numbers in the description (CLAUDE.md rule 2).
+
 ## Hardware fingerprint (committed alongside numbers)
 
 | Field | Value |
 |---|---|
-| OS | tbd |
-| RAM | tbd |
-| GPU | tbd |
-| Ollama LLM model | tbd (`config.GEMMA_MODEL`, default `gemma4:e4b`) |
+| OS | Windows 11 Home 10.0.26200 |
+| CPU | AMD Ryzen 7 7700 8-Core |
+| RAM | 32 GB |
+| GPU | NVIDIA GeForce RTX 4070 SUPER (12 GB VRAM) |
+| Ollama LLM model | `gemma4:e4b` (`config.GEMMA_MODEL` default) |
 | Embedding model | `models/miniLM` (paraphrase-multilingual-MiniLM-L12-v2) |
 
 ## STEP 7 — internal regression baseline
 
-12 hand-crafted queries on the project's own wiki entities. Locked in PR #TBD (Issue #45).
+12 hand-crafted queries on the project's own wiki entities. Locked by `scripts/bench.py --suite=step7 --check` against `eval/regression/step7_baseline.json` (PR #52 / Issue #45). Baseline derived from 5 runs spanning the v0.2 reasoning split (PRs #35 / #37 / #38 / #39).
 
-| Metric | v0.2 baseline | Current | Δ |
+| Metric | v0.2 baseline | Tolerance | Source |
 |---|---|---|---|
-| Total elapsed (12 queries) | tbd | — | — |
-| q11 security block bytes | tbd | — | — |
-| Median graph_paths | tbd | — | — |
+| Total elapsed (12 queries) | 298.9 s — 413.7 s (mean 377.7 s) | ± 30 % | `step7_baseline.json::totals` |
+| q11 security block answer bytes | 26 (byte-identical) | exact | `step7_baseline.json::q11.answer_len_exact` |
+| q3 graph_paths | 0 (no Anthropic↔Claude edge yet) | ± 2 | `step7_baseline.json::q3` |
+| q11 graph_paths | 0 (security block before graph) | exact | `step7_baseline.json::q11` |
+| q1 / q4 / q6 / q8 / q10 graph_paths bands | 8 — 52 (per-query), see baseline | ± 2 | `step7_baseline.json::queries` |
 
-Re-run: `python scripts/step7_query_test.py` (after `python server_llmwiki.py`).
+Re-run: `python scripts/bench.py --suite=step7` (live JAMES server at `127.0.0.1:8000`, then `--check` to gate against baseline).
+
+q12 is marked `flaky` in the baseline (5-run history: 1 OK / 4 timeout) and excluded from `--check`. Investigation tracked outside this page.
 
 ## RAGAS — third-party retrieval / generation metrics
 
-Public-knowledge fixture (`eval/ragas/fixture_v0.2.json`, 3 rows). Harness landed in PR #TBD (Issue #46). The first run on representative hardware after merge becomes the v0.2 baseline.
+Public-knowledge fixture (`eval/ragas/fixture_v0.2.json`, 3 rows). Harness landed in PR #51 (Issue #46 phase 1); baseline + `--check` drift detection in PR #64 (Issue #46 phase 2). Baseline derived from 2 representative-hardware runs on the fingerprint above.
 
-| Metric | v0.2 baseline | Description |
-|---|---|---|
-| `context_precision` | tbd | Of the retrieved contexts, what fraction are relevant to the question? |
-| `context_recall` | tbd | Of the information needed to answer, what fraction is present in retrieved contexts? |
-| `faithfulness` | tbd | Of the claims in the response, what fraction are grounded in retrieved contexts? |
-| `answer_relevancy` | tbd | How directly does the response address the user's question? |
+| Metric | v0.2 baseline | Tolerance | Description |
+|---|---|---|---|
+| `context_precision` | 1.000 (min) — 1.000 (max) | ± 0.10 | Of the retrieved contexts, what fraction are relevant to the question? (embedding-based) |
+| `context_recall` | 1.000 — 1.000 | ± 0.10 | Of the information needed to answer, what fraction is present in retrieved contexts? (embedding-based) |
+| `faithfulness` | 1.000 — 1.000 | ± 0.15 | Of the claims in the response, what fraction are grounded in retrieved contexts? (LLM-judge) |
+| `answer_relevancy` | 0.649 — 0.757 | ± 0.15 | How directly does the response address the user's question? (LLM-judge) |
 
-Re-run: `python eval/ragas/run_ragas.py` (Ollama must be running at `127.0.0.1:11434`).
+Total run elapsed: 93.5 s — 95.5 s (mean 94.5 s).
+
+Re-run: `python eval/ragas/run_ragas.py` (Ollama must be running at `127.0.0.1:11434`); `--check` to gate, `--update-baseline` to widen the band on intentional scope changes.
 
 ## Reproducibility note
 
-RAGAS uses an LLM as judge (faithfulness, answer_relevancy especially) and embeddings (context_precision, context_recall). Both are nondeterministic — expect ±10% drift across machines and runs. The baseline is a band, not a point. PRs that drift > 15% on any metric should investigate.
+RAGAS uses an LLM as judge (faithfulness, answer_relevancy especially) and embeddings (context_precision, context_recall). Judge metrics are nondeterministic — the `answer_relevancy` band already spans 0.649 → 0.757 across 2 same-machine runs, and the dev-machine reference number from PR #51 (0.678) sits inside that band. The baseline is therefore a band, not a point. Embedding metrics tighten quickly: both `context_*` are 1.000 across all runs because the fixture is small and unambiguous. PRs that drift `answer_relevancy` past `[0.649, 0.757] ± 0.15` (i.e. outside [0.499, 0.907]) should investigate before merging.
 
 ## Out of scope (deferred)
 
-- LegalBench subset — separate issue, after #46
-- BEIR / MS MARCO — too large for laptop, defer to v0.3
-- KLUE-RC (Korean public benchmark) — no clean public option yet, watch for v0.4
-- Domain-specific eval suites (legal, food, etc.) — those arrive with their respective domain packs in v0.3+
+- Live `/query/` integration for the RAGAS harness — Issue #46 phase 3, depends on a runner reusing the `bench.py` shape.
+- LegalBench subset — separate issue, after phase 3.
+- BEIR / MS MARCO — too large for laptop, defer to v0.3.
+- KLUE-RC (Korean public benchmark) — no clean public option yet, watch for v0.4.
+- Domain-specific eval suites (legal, food, etc.) — those arrive with their respective domain packs in v0.3+.
+- CI enforcement of the PR-contract rule — separate Axis 2-C issue (CLAUDE.md rule 2 is human-enforced today).

--- a/eval/ragas/baseline.json
+++ b/eval/ragas/baseline.json
@@ -1,0 +1,50 @@
+{
+  "version": "ragas-v1",
+  "description": "Initial v0.2 RAGAS baseline from representative-hardware runs on 2026-05-07 (samples=2, 1× plain run + 1× --update-baseline run, ~3.5min total). Band endpoints will widen as additional runs accumulate via `python eval/ragas/run_ragas.py --update-baseline`. Tolerance bands compensate for LLM-judge nondeterminism (answer_relevancy / faithfulness) — see `--check` semantics in run_ragas.py.",
+  "fixture": "fixture_v0.2.json",
+  "samples": 2,
+  "tolerance": {
+    "embedding_metric_abs": 0.1,
+    "judge_metric_abs": 0.15
+  },
+  "metrics": {
+    "context_precision": {
+      "min": 1.0,
+      "max": 1.0,
+      "judge_based": false
+    },
+    "context_recall": {
+      "min": 1.0,
+      "max": 1.0,
+      "judge_based": false
+    },
+    "faithfulness": {
+      "min": 1.0,
+      "max": 1.0,
+      "judge_based": true
+    },
+    "answer_relevancy": {
+      "min": 0.649,
+      "max": 0.7572,
+      "judge_based": true
+    }
+  },
+  "totals": {
+    "elapsed_min": 93.5,
+    "elapsed_max": 95.5,
+    "elapsed_mean": 94.5
+  },
+  "fingerprint": {
+    "os": "Windows 11 Home 10.0.26200",
+    "cpu": "AMD Ryzen 7 7700 8-Core",
+    "ram_gb": 32,
+    "gpu": "NVIDIA GeForce RTX 4070 SUPER (12 GB VRAM)",
+    "ollama_model": "gemma4:e4b",
+    "embedding_model": "paraphrase-multilingual-MiniLM-L12-v2"
+  },
+  "invariants": [
+    "Embedding-based metrics (context_precision, context_recall) tighten over runs — tolerance 0.10 is the upper bound for noise.",
+    "Judge-based metrics (faithfulness, answer_relevancy) drift more — tolerance 0.15 covers Ollama gemma4:e4b judge variance observed across PR #51 (0.678) and PR #64 (0.649).",
+    "elapsed_seconds is informational only — not gated by --check (depends on machine + concurrent ollama load)."
+  ]
+}

--- a/eval/ragas/run_ragas.py
+++ b/eval/ragas/run_ragas.py
@@ -1,16 +1,8 @@
 """RAGAS evaluation harness for JAMES (Issue #46, Axis 2-B).
 
-Phase-1 scope: ship a working harness shell, NOT a baseline. The harness
-is wired to local infra (Ollama as judge LLM, sentence-transformers for
-embeddings) so the first run on a clean laptop produces real numbers
-without OpenAI/HF/Cohere tokens. The first committed baseline lands in
-a follow-up PR after a representative-hardware run.
-
-Why this PR doesn't commit baseline numbers:
-  - The "first run after merge becomes the v0.2 baseline" line in #46
-    is intentional: the baseline must be reproducible on the user's
-    Windows + Ollama + 16 GB box. Pre-committing a number from this
-    development machine would lie about reproducibility.
+Phase-2 (#46): committed baseline + drift detection. `--check` compares
+the current run against `eval/ragas/baseline.json` and exits 1 on hard
+drift (mirroring `scripts/bench.py` shape).
 
 Components (all local, no third-party API tokens required):
   - Judge LLM: Ollama via its OpenAI-compatible endpoint
@@ -21,14 +13,27 @@ Components (all local, no third-party API tokens required):
     so retrieval-side and eval-side share semantic space.
   - Fixture: eval/ragas/fixture_v0.2.json — 3 hand-crafted public-
     knowledge rows. Pre-baked retrieved_contexts so we don't need a
-    live JAMES /query/ to exercise the harness. Phase 2 swaps this
-    for live retrieval once #45 lands a bench.py runner.
+    live JAMES /query/ to exercise the harness. Phase 3 swaps this
+    for live retrieval once a runner reuses the bench.py shape.
 
 Output: reports/ragas_<timestamp>.json (gitignored). Summary table
         printed to stdout.
 
 Usage:
     python eval/ragas/run_ragas.py
+        Run the fixture, save report, print summary.
+
+    python eval/ragas/run_ragas.py --check
+        Same run, then compare against committed baseline. Exit 1 on
+        any hard-locked drift (per-metric absolute drift > tolerance).
+        LLM-judge metrics (faithfulness, answer_relevancy) get a wider
+        tolerance than embedding-based metrics (context_*).
+
+    python eval/ragas/run_ragas.py --update-baseline
+        DESTRUCTIVE: rewrite the committed baseline from this run's
+        numbers. Use only for an intentional scope change (model swap,
+        fixture refresh) with diff visible in PR review.
+
     python eval/ragas/run_ragas.py --fixture eval/ragas/fixture_v0.2.json
 """
 from __future__ import annotations
@@ -38,7 +43,7 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
@@ -116,9 +121,110 @@ def _load_fixture(path: Path) -> List[dict]:
     return rows
 
 
+# RAGAS metrics fall into two families with different reproducibility
+# characteristics:
+#   - embedding-based (context_precision, context_recall): cosine
+#     similarity over deterministic miniLM embeddings → tight band
+#   - judge-based (faithfulness, answer_relevancy): rely on the Ollama
+#     LLM as a judge → wider band (LLM nondeterminism, parser flakiness)
+# Tolerance values are absolute drift in the [0, 1] metric space.
+_JUDGE_METRICS    = {"faithfulness", "answer_relevancy"}
+_EMBEDDING_METRICS = {"context_precision", "context_recall"}
+
+
+def _load_baseline() -> Optional[dict]:
+    path = ROOT / "eval" / "ragas" / "baseline.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _check_baseline(summary: dict, baseline: dict) -> Tuple[bool, List[str]]:
+    """Compare run against committed baseline.
+
+    Hard fails (return False):
+      - any metric drifts beyond its per-family tolerance band.
+      - any metric absent in current run that baseline expects.
+
+    Soft messages: per-metric drift line for the operator log.
+    """
+    tol_judge     = baseline.get("tolerance", {}).get("judge_metric_abs",     0.15)
+    tol_embedding = baseline.get("tolerance", {}).get("embedding_metric_abs", 0.10)
+    bm = baseline.get("metrics", {}) or {}
+
+    msgs:  List[str] = []
+    fails: List[str] = []
+    for metric_name, band in bm.items():
+        cur = summary.get(metric_name)
+        if cur is None:
+            fails.append(
+                f"{metric_name}: missing in current run (baseline expected "
+                f"[{band.get('min', '?')}, {band.get('max', '?')}])"
+            )
+            continue
+        tol = tol_judge if metric_name in _JUDGE_METRICS else tol_embedding
+        lo = band.get("min", 0.0) - tol
+        hi = band.get("max", 1.0) + tol
+        if not (lo <= cur <= hi):
+            fails.append(
+                f"{metric_name}: {cur:.3f} outside band "
+                f"[{band.get('min'):.3f}, {band.get('max'):.3f}] ± {tol}"
+            )
+        else:
+            msgs.append(
+                f"{metric_name}: {cur:.3f} ∈ "
+                f"[{band.get('min'):.3f}, {band.get('max'):.3f}] ± {tol}"
+            )
+
+    return (len(fails) == 0), msgs + fails
+
+
+def _update_baseline(summary: dict, elapsed: float) -> None:
+    """Replace baseline metric bands with the current run's values.
+
+    Conservative shift: existing tolerance / fingerprint / description
+    fields stay as-is; only the per-metric band endpoints + samples
+    counter + elapsed_seconds move. To re-fingerprint on a hardware
+    change, edit the file directly in the same PR.
+    """
+    path = ROOT / "eval" / "ragas" / "baseline.json"
+    if not path.exists():
+        raise RuntimeError(
+            f"no existing baseline at {path} — bootstrap by running once "
+            "without --update-baseline, then write the file by hand for "
+            "the first commit."
+        )
+    bl = json.loads(path.read_text(encoding="utf-8"))
+    bm = bl.setdefault("metrics", {})
+    for metric_name, value in summary.items():
+        if value is None:
+            continue
+        band = bm.setdefault(metric_name, {"min": value, "max": value})
+        band["min"] = round(min(band.get("min", value), value), 4)
+        band["max"] = round(max(band.get("max", value), value), 4)
+    bl["samples"] = bl.get("samples", 0) + 1
+    totals = bl.setdefault("totals", {})
+    if elapsed:
+        totals["elapsed_min"]  = round(min(totals.get("elapsed_min",  elapsed), elapsed), 1)
+        totals["elapsed_max"]  = round(max(totals.get("elapsed_max",  elapsed), elapsed), 1)
+        totals["elapsed_mean"] = round(
+            (totals["elapsed_min"] + totals["elapsed_max"]) / 2, 1
+        )
+    path.write_text(json.dumps(bl, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--fixture", default=str(ROOT / "eval" / "ragas" / "fixture_v0.2.json"))
+    ap.add_argument(
+        "--check", action="store_true",
+        help="compare against committed eval/ragas/baseline.json; exit 1 on regression",
+    )
+    ap.add_argument(
+        "--update-baseline", action="store_true",
+        help="DESTRUCTIVE: extend baseline bands from this run "
+             "(use only on intentional scope-change PRs)",
+    )
     args = ap.parse_args()
 
     fixture_path = Path(args.fixture)
@@ -187,6 +293,29 @@ def main() -> int:
         else:
             print(f"  {k:<22s} {v:.3f}")
     print(f"\nsaved: {out_path.relative_to(ROOT)}")
+
+    # --update-baseline: rewrite committed baseline before any check.
+    if args.update_baseline:
+        _update_baseline(summary, elapsed)
+        print("[RAGAS] baseline file updated from this run")
+        return 0
+
+    # --check: compare against committed baseline
+    if args.check:
+        baseline = _load_baseline()
+        if baseline is None:
+            print("[RAGAS] no baseline at eval/ragas/baseline.json — cannot check")
+            return 1
+        ok, msgs = _check_baseline(summary, baseline)
+        print()
+        for m in msgs:
+            print(f"  {m}")
+        if ok:
+            print("\n[RAGAS] OK — within baseline tolerances")
+            return 0
+        print(f"\n[RAGAS] FAIL — {sum(1 for m in msgs if 'outside band' in m or 'missing' in m)} regression(s)")
+        return 1
+
     return 0
 
 


### PR DESCRIPTION
## Summary

- **#46 phase 2** — lands the deferred verification items from the RAGAS harness PR (#51): a representative-hardware baseline, a `--check` drift gate mirroring `scripts/bench.py`, and concrete numbers in `eval/RESULTS.md` replacing the v0.2 "tbd" placeholders. Closes #46.

## Changes

### `eval/ragas/run_ragas.py`
- `--check`: compares the run's per-metric mean against `eval/ragas/baseline.json`. Hard-fail on absolute drift outside the per-family tolerance (0.10 for embedding metrics, 0.15 for LLM-judge metrics). Exit 0 on OK, 1 on regression — same shape as `bench.py`.
- `--update-baseline`: shifts band endpoints from the current run; conservative — preserves tolerance / fingerprint / description.
- LLM-judge metrics get the wider band because Ollama `gemma4:e4b` judge variance for `answer_relevancy` was observed to span 0.649 → 0.757 across same-machine runs (and 0.678 on the dev machine in PR #51), all of which sit inside the committed `[0.649, 0.757] ± 0.15` band.

### `eval/ragas/baseline.json` (new)
Initial v0.2 baseline from 2 representative-hardware runs on this fingerprint:

| Metric | min | max | tolerance |
|---|---|---|---|
| `context_precision` | 1.000 | 1.000 | ± 0.10 |
| `context_recall` | 1.000 | 1.000 | ± 0.10 |
| `faithfulness` | 1.000 | 1.000 | ± 0.15 |
| `answer_relevancy` | 0.649 | 0.757 | ± 0.15 |
| elapsed (s, informational) | 93.5 | 95.5 | — |

### `eval/RESULTS.md`
- Replaces the "tbd" cells with concrete numbers for **both** suites (STEP 7 + RAGAS). Hardware fingerprint table populated. Tightened reproducibility note (the warning band for `answer_relevancy` is `[0.499, 0.907]`).

## Verification

- `python eval/ragas/run_ragas.py` — initial run, 93.5 s, summary `1.000 / 1.000 / 1.000 / 0.649`.
- `python eval/ragas/run_ragas.py --check` — 90.9 s, summary `1.000 / 1.000 / 1.000 / 0.661`, exit 0:
  ```
  context_precision: 1.000 ∈ [1.000, 1.000] ± 0.1
  context_recall:    1.000 ∈ [1.000, 1.000] ± 0.1
  faithfulness:      1.000 ∈ [1.000, 1.000] ± 0.15
  answer_relevancy:  0.661 ∈ [0.649, 0.649] ± 0.15
  [RAGAS] OK — within baseline tolerances
  ```
- `python eval/ragas/run_ragas.py --update-baseline` — 95.5 s, summary `1.000 / 1.000 / 1.000 / 0.757`, baseline widened to `answer_relevancy [0.649, 0.757]`.
- `python -m unittest discover -s tests` — **80/80 PASS** (no test files modified).

## Bench

This PR does not touch `core/retrieval`, `core/graph`, or `core/reasoning`. The `step7_baseline.json` bands are read-only here. STEP 7 12-query trace is unaffected.

## #46 verification checklist

- [x] `python eval/ragas/run_ragas.py` completes on the local box without OOM.
- [x] Baseline committed; `eval/ragas/baseline.json` is the v0.2 baseline.
- [x] `eval/RESULTS.md` shows numbers for STEP 7 (Axis 2-A) + RAGAS (this PR).
- [x] Numbers reproducible within ±10–15% on the same machine across same-day runs (3-sample observed spread on `answer_relevancy`: 0.108).

## Out of scope

- Live `/query/` integration for the RAGAS harness — Issue #46 phase 3, will reuse the `bench.py` runner shape to drive STEP 7 queries through the live server.
- LegalBench / BEIR / MS MARCO subsets — out of laptop budget; deferred.
- CI enforcement of the bench/RAGAS gates — separate Axis 2-C issue (CLAUDE.md rule 2 is human-enforced today).
