### PR TITLE
feat(eval): live /query/ integration for RAGAS (#65 phase 3)

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -386,6 +386,12 @@ def run_retrieval_pipeline(
         "graph_paths":   loop_state["graph_paths"],
         "graph_used":    len(loop_state["graph_context"]),
         "sources":       [d.get("source", "unknown") for d in loop_state["docs"][:3]],
+        # [#65 phase 3] full chunk texts that fed the LLM, surfaced for
+        # RAGAS `context_precision` / `context_recall` evaluation against
+        # the live retrieval path. The /query/ endpoint admin-gates the
+        # exposure; consumers outside the endpoint already see the same
+        # data via `loop_state["docs"]` if they hold the engine.
+        "retrieved_contexts": [d.get("text", "") for d in loop_state["docs"]],
         "blocked":       False,
         "timing_sec":    round(total, 2),
         "unified_score": round(unified_score if "unified_score" in dir() else 0.0, 3),

--- a/eval/ragas/run_ragas.py
+++ b/eval/ragas/run_ragas.py
@@ -107,18 +107,100 @@ def _build_embeddings():
     return LangchainEmbeddingsWrapper(_LocalSentenceTransformerEmbeddings(model_path))
 
 
-def _load_fixture(path: Path) -> List[dict]:
+def _load_fixture(path: Path, live: bool = False) -> List[dict]:
+    """Load and validate a fixture file.
+
+    In offline mode (default) every row must already carry RAGAS's full
+    required set (`user_input`, `retrieved_contexts`, `response`,
+    `reference`). In `--live` mode the fixture only needs `user_input`
+    and `reference`; the runner will fill `retrieved_contexts` and
+    `response` from the live `/query/` endpoint.
+    """
     raw = json.loads(path.read_text(encoding="utf-8"))
     rows = raw.get("rows") or []
     if not rows:
         raise RuntimeError(f"fixture {path} has no rows")
-    # Validate every required field exists (RAGAS will fail cryptically otherwise)
-    required = ("user_input", "retrieved_contexts", "response", "reference")
+    required = ("user_input", "reference") if live else (
+        "user_input", "retrieved_contexts", "response", "reference",
+    )
     for i, r in enumerate(rows):
         missing = [k for k in required if k not in r]
         if missing:
             raise RuntimeError(f"fixture row {i}: missing fields {missing}")
     return rows
+
+
+# ─── #65 phase 3: live /query/ driver ────────────────────────
+
+def _load_api_key() -> str:
+    """Mirror `scripts/bench.py::_load_api_key`. Read from JAMES_API_KEY env
+    var, falling back to the project's `.env` file (utf-8-sig-tolerant)."""
+    import os
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = ROOT / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    raise RuntimeError(
+        "JAMES_API_KEY not found in .env or environment. "
+        "Set it before running with --live."
+    )
+
+
+def _drive_live(rows: List[dict], base_url: str, timeout: int) -> List[dict]:
+    """For each fixture row, POST `user_input` to `/query/` and replace
+    `retrieved_contexts` + `response` with the live server's answer.
+
+    The endpoint requires admin role (for `include_contexts=true`); the
+    runner uses `JAMES_API_KEY` for auth. `session_id` is unique per row
+    so the conversation memory does not bleed between rows.
+
+    Rows the server returns blocked / errored are kept with empty
+    contexts and a placeholder response — RAGAS will mark them NaN and
+    drop them from the metric mean (same handling the offline path
+    already gets).
+    """
+    import requests
+    api_key = _load_api_key()
+    print(f"[RAGAS] live driver → {base_url}/query/ ({len(rows)} rows)")
+
+    out: List[dict] = []
+    for i, r in enumerate(rows, start=1):
+        payload = {
+            "api_key":          api_key,
+            "question":         r["user_input"],
+            "session_id":       f"ragas_live_{i}",
+            "include_contexts": True,
+        }
+        try:
+            t0 = time.time()
+            resp = requests.post(
+                f"{base_url}/query/", json=payload, timeout=timeout,
+            )
+            elapsed = round(time.time() - t0, 1)
+            data = resp.json() if resp.status_code == 200 else {}
+        except Exception as e:
+            print(f"[RAGAS]   row {i}: live query failed — {e}")
+            data, elapsed = {}, 0.0
+
+        contexts = data.get("retrieved_contexts") or []
+        response = data.get("answer") or ""
+        if data.get("blocked"):
+            print(f"[RAGAS]   row {i}: BLOCKED in {elapsed}s")
+        else:
+            print(f"[RAGAS]   row {i}: {len(contexts)} ctx, "
+                  f"{len(response)} chars, {elapsed}s")
+
+        out.append({
+            "user_input":         r["user_input"],
+            "retrieved_contexts": contexts,
+            "response":           response,
+            "reference":          r["reference"],
+        })
+    return out
 
 
 # RAGAS metrics fall into two families with different reproducibility
@@ -225,11 +307,28 @@ def main() -> int:
         help="DESTRUCTIVE: extend baseline bands from this run "
              "(use only on intentional scope-change PRs)",
     )
+    ap.add_argument(
+        "--live", action="store_true",
+        help="drive each fixture row through /query/ on a running JAMES server "
+             "(replaces pre-baked retrieved_contexts/response with live data)",
+    )
+    ap.add_argument(
+        "--base-url", default="http://127.0.0.1:8000",
+        help="JAMES server base URL for --live (default: http://127.0.0.1:8000)",
+    )
+    ap.add_argument(
+        "--live-timeout", type=int, default=120,
+        help="per-query timeout in seconds for --live (default: 120)",
+    )
     args = ap.parse_args()
 
     fixture_path = Path(args.fixture)
-    rows = _load_fixture(fixture_path)
-    print(f"[RAGAS] loaded {len(rows)} rows from {fixture_path.name}")
+    rows = _load_fixture(fixture_path, live=args.live)
+    print(f"[RAGAS] loaded {len(rows)} rows from {fixture_path.name}"
+          + (" (live mode)" if args.live else ""))
+
+    if args.live:
+        rows = _drive_live(rows, args.base_url, args.live_timeout)
 
     # Build engines lazily so an import error in optional deps is reported
     # with context rather than a cryptic top-level traceback.

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -284,6 +284,13 @@ class QueryRequest(BaseModel):
     source_type:      str = "prod"
     session_id:       str = "default"   # 대화 세션 구분
     session_language: str = ""          # [STEP2-A] 세션 언어 (빈 문자열=기본)
+    # [#65 phase 3] admin-only debug field. When True AND the resolved
+    # role is "admin", the response carries `retrieved_contexts` (the
+    # actual chunk texts that fed the LLM). Used by `eval/ragas/run_ragas.py
+    # --live` to drive RAGAS evaluation against the live retrieval path.
+    # Non-admin callers see no behavior change — the field is silently
+    # dropped from the response shape.
+    include_contexts: bool = False
 
 class QueryResponse(BaseModel):
     question:       str
@@ -297,6 +304,8 @@ class QueryResponse(BaseModel):
     mode:           str   = ""
     session_id:     str   = ""
     direction_id:   str   = ""
+    # [#65 phase 3] populated only when request.include_contexts AND role==admin.
+    retrieved_contexts: Optional[list] = None
 
 class UploadResponse(BaseModel):
     status:      str
@@ -641,7 +650,7 @@ async def query(
     except Exception:
         pass
 
-    return {
+    response = {
         "question":      question,
         "answer":        answer,
         "sources":       result.get("sources", []),
@@ -656,6 +665,13 @@ async def query(
             result.get("mode",""), question
         ) if not result.get("blocked") else "",
     }
+    # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
+    # fed the LLM are surfaced only when (a) caller opted in via
+    # `include_contexts=true` AND (b) resolved role is "admin". Other
+    # roles see the same response shape as before.
+    if data.include_contexts and role == "admin":
+        response["retrieved_contexts"] = result.get("retrieved_contexts", [])
+    return response
 
 
 @app.get("/status/", response_model=StatusResponse, summary="서버 상태")

--- a/tests/test_query_include_contexts.py
+++ b/tests/test_query_include_contexts.py
@@ -1,0 +1,180 @@
+"""`/query/` admin-only `include_contexts` field — #65 phase 3.
+
+The endpoint admin-gates exposure of `retrieved_contexts` so the chunk
+texts that fed the LLM never leak to non-admin callers. RAGAS `--live`
+mode is the intended consumer.
+
+These tests are source-level + Pydantic-level — they don't spin up a
+server. Live integration is verified by the operator running
+`python eval/ragas/run_ragas.py --live --check` against the JAMES
+server (see PR #66 verification list); the contract tests here ensure a
+future refactor cannot silently break the admin gate.
+
+Run:
+  python -m unittest tests.test_query_include_contexts
+  python tests/test_query_include_contexts.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class QueryRequestSchemaTests(unittest.TestCase):
+    """Pydantic model accepts the new field with the documented default."""
+
+    def test_default_include_contexts_is_false(self):
+        from server_llmwiki import QueryRequest
+        m = QueryRequest(api_key="x", question="hello")
+        self.assertEqual(m.include_contexts, False)
+
+    def test_explicit_include_contexts_true(self):
+        from server_llmwiki import QueryRequest
+        m = QueryRequest(api_key="x", question="hello", include_contexts=True)
+        self.assertEqual(m.include_contexts, True)
+
+    def test_response_schema_carries_optional_retrieved_contexts(self):
+        from server_llmwiki import QueryResponse
+        # Default omits the field (None); explicit list passes through.
+        m1 = QueryResponse(question="q", answer="a", sources=[])
+        self.assertIsNone(m1.retrieved_contexts)
+        m2 = QueryResponse(question="q", answer="a", sources=[],
+                           retrieved_contexts=["chunk1", "chunk2"])
+        self.assertEqual(m2.retrieved_contexts, ["chunk1", "chunk2"])
+
+
+class AdminGateContractTests(unittest.TestCase):
+    """Source-level contract: the admin gate must remain in place.
+
+    A future refactor could plausibly move the gate into a helper or
+    drop the role check entirely. These checks force a reviewer to
+    consciously decide before that happens — same pattern as
+    `tests/test_policy_quarantine.py::PipelineIntegrationTests`.
+    """
+
+    def test_endpoint_admin_gates_retrieved_contexts(self):
+        import server_llmwiki as srv
+        import inspect
+        src = inspect.getsource(srv)
+        # The exposure must be gated on BOTH the request flag AND the role.
+        self.assertIn(
+            'data.include_contexts and role == "admin"',
+            src,
+            "/query/ must gate retrieved_contexts on (include_contexts=True "
+            "AND role==admin) — see #65 phase 3 admin-gate contract.",
+        )
+        # And the field name must match what RAGAS --live reads.
+        self.assertIn(
+            'response["retrieved_contexts"]',
+            src,
+            "endpoint response key must be `retrieved_contexts` — RAGAS "
+            "--live looks for this exact key.",
+        )
+
+    def test_pipeline_result_carries_retrieved_contexts(self):
+        # The pipeline result is the source of truth — even if the endpoint
+        # is bypassed (e.g. import-level callers), the chunk texts must be
+        # available for downstream consumers.
+        import core.reasoning.pipeline as pipeline_mod
+        import inspect
+        src = inspect.getsource(pipeline_mod)
+        self.assertIn(
+            '"retrieved_contexts":',
+            src,
+            "pipeline.py result dict must include `retrieved_contexts` — "
+            "see #65 phase 3 RAGAS hook.",
+        )
+
+
+class RunRagasLiveModeTests(unittest.TestCase):
+    """Smoke-level: --live flag is wired and the loader accepts a sparse
+    fixture (only `user_input` + `reference`).
+
+    Doesn't actually drive a live server (the verification step does that).
+    """
+
+    def test_loader_accepts_sparse_fixture_in_live_mode(self):
+        import json, tempfile
+        from pathlib import Path
+        from eval.ragas.run_ragas import _load_fixture
+
+        sparse = {
+            "version": "test",
+            "rows": [
+                {"user_input": "Q1?", "reference": "A1."},
+                {"user_input": "Q2?", "reference": "A2."},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8",
+        ) as f:
+            json.dump(sparse, f)
+            path = Path(f.name)
+        try:
+            rows_offline_should_fail = None
+            try:
+                _load_fixture(path, live=False)
+            except RuntimeError as e:
+                rows_offline_should_fail = str(e)
+            self.assertIsNotNone(
+                rows_offline_should_fail,
+                "offline mode must reject a sparse fixture (no retrieved_contexts)",
+            )
+
+            rows = _load_fixture(path, live=True)
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["user_input"], "Q1?")
+            self.assertEqual(rows[1]["reference"],  "A2.")
+        finally:
+            path.unlink()
+
+    def test_drive_live_dispatches_post_with_admin_payload(self):
+        # Stub `requests.post` to capture the payload the runner sends to
+        # /query/. Asserts include_contexts=True and api_key threaded.
+        from eval.ragas import run_ragas
+        from unittest.mock import patch, MagicMock
+
+        captured = {}
+
+        class _StubResp:
+            status_code = 200
+            def json(self_inner):
+                return {
+                    "answer":              "live answer",
+                    "retrieved_contexts": ["chunk1", "chunk2"],
+                    "blocked":             False,
+                }
+
+        def _stub_post(url, json=None, timeout=None):
+            captured["url"]     = url
+            captured["payload"] = json
+            captured["timeout"] = timeout
+            return _StubResp()
+
+        with patch.object(run_ragas, "_load_api_key", return_value="dummy-key"), \
+             patch("requests.post", side_effect=_stub_post):
+            out = run_ragas._drive_live(
+                rows=[{"user_input": "Q?", "reference": "A."}],
+                base_url="http://127.0.0.1:8000",
+                timeout=120,
+            )
+
+        self.assertEqual(captured["url"], "http://127.0.0.1:8000/query/")
+        self.assertEqual(captured["payload"]["question"], "Q?")
+        self.assertEqual(captured["payload"]["api_key"], "dummy-key")
+        self.assertTrue(captured["payload"]["include_contexts"],
+                        "live driver must send include_contexts=True")
+        self.assertTrue(captured["payload"]["session_id"].startswith("ragas_live_"),
+                        "session_id must be unique per row to isolate memory")
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["response"], "live answer")
+        self.assertEqual(out[0]["retrieved_contexts"], ["chunk1", "chunk2"])
+        self.assertEqual(out[0]["reference"], "A.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **#65 phase 3** — RAGAS now drives the live `/query/` endpoint instead of using a pre-baked fixture. Closes the "we are evaluating the fixture, not JAMES" gap from PRs #51/#64. Closes #65.
- New admin-only `include_contexts` request flag exposes `retrieved_contexts` (the actual chunks fed to the LLM) on the response. Non-admin callers see no shape change.
- `run_ragas.py --live` posts each fixture row's question to `/query/`, replaces the pre-baked `retrieved_contexts` + `response` with live data, keeps `user_input` + `reference`.

## Changes

### `server_llmwiki.py`
- `QueryRequest.include_contexts: bool = False`.
- `/query/` returns `retrieved_contexts: list[str]` **only** when `data.include_contexts and role == "admin"`. The dual gate (request flag + role) keeps chunk text out of non-admin responses even if a future caller flips the flag.
- `QueryResponse.retrieved_contexts: Optional[list] = None`.

### `core/reasoning/pipeline.py`
- Result dict adds `"retrieved_contexts": [d.get("text", "") for d in loop_state["docs"]]` — purely additive (one new key). The endpoint owns exposure.

### `eval/ragas/run_ragas.py`
- `--live`, `--base-url` (default `http://127.0.0.1:8000`), `--live-timeout` (default 120s) flags.
- `_drive_live(rows, base_url, timeout)` — POSTs each row with `include_contexts=true`, threads `JAMES_API_KEY` (same loader as `scripts/bench.py`), uses unique `session_id="ragas_live_<n>"` so memory doesn't bleed between rows.
- `_load_fixture(path, live=True)` accepts sparse fixtures that only carry `user_input` + `reference` — future live-only fixtures don't have to carry placeholder context lists.

### `tests/test_query_include_contexts.py` (new)
7 tests covering:
- Pydantic schema (default false, explicit True/False, optional response field).
- Source-level admin-gate contract — guards against a future refactor silently dropping the gate.
- Pipeline result dict carries `retrieved_contexts`.
- `_load_fixture` sparse-mode contract.
- `_drive_live` dispatches POST with the documented payload shape (api_key, question, `ragas_live_*` session_id, include_contexts=true).

## Verification

- `python -m unittest discover -s tests` — **87/87 PASS** (80 prior + 7 new).
- `python scripts/bench.py --suite=step7 --check` — **exit 0**.
  | q | graph_paths (band) | answer |
  |---|---|---|
  | 1 | 15 ([15, 15]) | 1998 chars |
  | 2 | 18 ([13, 23]) | 2344 |
  | 3 | 0 ([0, 0]) | 1947 |
  | 4 | 46 ([46, 52]) | 1998 |
  | 5 | 21 ([15, 21]) | 2280 |
  | 6 | 46 ([46, 46]) | 2000 |
  | 7 | 15 ([10, 15]) | 2364 |
  | 8 | 48 ([48, 48]) | 2152 |
  | 9 | 15 ([10, 15]) | 4015 |
  | 10 | 8 ([8, 8]) | 2244 |
  | 11 | 0 (BLOCK, **26 bytes byte-identical**) | — |
  | 12 | flaky — skipped | — |

  Total elapsed 321.6 s ∈ [298.9, 413.7] ± 30 %. Pipeline change is one new dict key — algorithmic surface untouched.
- Live RAGAS verification (`python eval/ragas/run_ragas.py --live`) is the operator's post-merge step — see "Out of scope" below.

## Bench

This PR touches `core/reasoning/pipeline.py` (purely additive: one new key in the result dict). STEP 7 numbers above satisfy the CLAUDE.md rule 2 PR contract.

## #65 verification checklist

- [x] Endpoint admin-gate contract test passes (source-level — guards a future refactor).
- [x] Pipeline result carries `retrieved_contexts` for downstream consumers.
- [x] `--live` driver dispatches the documented payload (unit-tested with a stubbed `requests.post`).
- [x] `unittest discover` exits 0.
- [x] `bench.py --check` exits 0.
- [ ] Live `--live --check` against a running JAMES server — **operator follow-up** (the live numbers will differ from the baseline-on-fixture; expected to widen `eval/ragas/baseline.json` via `--update-baseline` once the live distribution is observed).

## Out of scope

- Live `--update-baseline` run on representative content — operator step. The existing baseline was set on fixture data; live numbers from the same machine on this same fixture will likely shift `answer_relevancy` (the LLM judge sees a real RAG answer instead of the hand-authored fixture response).
- A dedicated live-only fixture for project-content questions — the existing `fixture_v0.2.json` (RAG / Anthropic / BlackRock) overlaps with the live wiki's coverage, so it works for the first integration round.
- Public corpus ingestion (SQuAD / scidocs subset), LegalBench / BEIR / MS MARCO subsets — laptop budget, deferred.
- CI enforcement of the bench/RAGAS gates — separate Axis 2-C issue.
