### PR TITLE
feat(evolution): opt-in flag + approver metadata + AUTO_APPROVE safety (#48 phase 1)

### DIFF
--- a/config.py
+++ b/config.py
@@ -163,6 +163,28 @@ UPLOAD_FOLDER    = UPLOAD_DIR  # alias
 TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")
 
 # ────────────────────────────────────────────────────────────────
+#  Self-evolution gate (#48, Axis 5)
+# ────────────────────────────────────────────────────────────────
+# Default off. Operators must opt in by setting JAMES_ENABLE_EVOLUTION=1.
+# `/admin/patch/approve` returns 403 unless this is true.
+EVOLUTION_ENABLED = os.environ.get("JAMES_ENABLE_EVOLUTION", "0") == "1"
+
+# Role required to approve patches. Defaults to "admin".
+APPROVER_ROLE = os.environ.get("JAMES_EVOLUTION_APPROVER_ROLE", "admin").strip().lower()
+
+# Auto-approval. Tests / dev only — both flags must be true AND
+# JAMES_DEV_MODE must be 1, otherwise the server refuses to start.
+# This is the "fail-closed in production" guarantee from #48.
+AUTO_APPROVE = os.environ.get("JAMES_AUTO_APPROVE", "0") == "1"
+_DEV_MODE_AT_IMPORT = os.environ.get("JAMES_DEV_MODE", "1") == "1"
+if AUTO_APPROVE and not _DEV_MODE_AT_IMPORT:
+    raise RuntimeError(
+        "JAMES_AUTO_APPROVE=1 requires JAMES_DEV_MODE=1 — auto-approval is "
+        "not allowed in non-dev environments. Either unset JAMES_AUTO_APPROVE "
+        "or set JAMES_DEV_MODE=1 explicitly. Refusing to start."
+    )
+
+# ────────────────────────────────────────────────────────────────
 #  Startup messages
 # ────────────────────────────────────────────────────────────────
 print(f"[CONFIG] PROJECT JAMES ready")
@@ -181,3 +203,10 @@ if TAVILY_API_KEY:
     print(f"[CONFIG] Tavily search enabled (key: {TAVILY_API_KEY[:8]}...)")
 else:
     print(f"[CONFIG] Tavily key not set → using DuckDuckGo fallback")
+
+# Evolution-gate banner — operator must see this on boot.
+if EVOLUTION_ENABLED:
+    print(f"[CONFIG] ⚙️  Self-evolution ENABLED (approver role: {APPROVER_ROLE})"
+          + (f" — AUTO_APPROVE on (DEV_MODE={_DEV_MODE_AT_IMPORT})" if AUTO_APPROVE else ""))
+else:
+    print(f"[CONFIG] Self-evolution disabled (set JAMES_ENABLE_EVOLUTION=1 to enable)")

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1905,21 +1905,94 @@ async def admin_patches(api_key: str, status: str = "all",
         return {"patches": [], "error": str(e)}
 
 
-@app.post("/admin/patch/approve", summary="Patch 승인 [P7]")
+@app.post("/admin/patch/approve", summary="Patch 승인 [#48 phase 1]")
 async def admin_patch_approve(request: Request, role: str = Depends(get_role_from_request)):
+    """Approve + deploy a pending patch.
+
+    #48 phase 1 contract:
+      - 403 unless `JAMES_ENABLE_EVOLUTION=1` (operator opt-in).
+      - Caller must include `approver_username` in the JSON body —
+        the audit log records WHO approved each deployed patch.
+      - Caller's resolved role must equal `JAMES_EVOLUTION_APPROVER_ROLE`
+        (default "admin"). Other admin endpoints already enforce
+        admin via `_require_admin`; this gate adds the explicit
+        "approver-role" check so the env var stays load-bearing.
+      - On success the patch JSON is updated in place with
+        `approver_username` / `approver_role` / `approved_at` /
+        `approval_method`, and the lifecycle is recorded in
+        `james_patch_log.jsonl` (visible via /admin/audit).
+    """
     body = await request.json()
     _require_admin(body.get("api_key",""), role)
-    patch_id = body.get("patch_id","")
+
+    # #48 phase 1 — opt-in gate.
+    from config import EVOLUTION_ENABLED, APPROVER_ROLE
+    if not EVOLUTION_ENABLED:
+        raise HTTPException(
+            status_code=403,
+            detail="evolution_disabled: set JAMES_ENABLE_EVOLUTION=1 to enable",
+        )
+    if role != APPROVER_ROLE:
+        raise HTTPException(
+            status_code=403,
+            detail=f"approver_role_mismatch: required {APPROVER_ROLE!r}, got {role!r}",
+        )
+
+    patch_id          = body.get("patch_id", "").strip()
+    approver_username = (body.get("approver_username") or "").strip()
+    approval_method   = (body.get("approval_method") or "api").strip()
+
+    if not patch_id:
+        raise HTTPException(status_code=400, detail="patch_id required")
+    if not approver_username:
+        raise HTTPException(status_code=400, detail="approver_username required (#48 audit)")
+
     try:
         from tools.patch.patch_generator import load_patch
         from tools.patch.patch_validator import validate_patch
         from tools.patch.patch_applier   import apply as patch_apply
+        from tools.patch.approval        import record_approval, record_outcome
+
         patch = load_patch(patch_id)
-        if not patch: raise HTTPException(status_code=404, detail="Patch 없음")
+        if not patch:
+            raise HTTPException(status_code=404, detail="Patch 없음")
+
         passed, failures = validate_patch(patch)
-        if not passed: return {"success": False, "failures": failures}
+        if not passed:
+            return {"success": False, "failures": failures}
+
+        # Record approver BEFORE apply — if apply crashes, the audit
+        # log still shows who tried to deploy what. Restoring this
+        # ordering is the entire reason this PR exists.
+        rec_ok, rec = record_approval(
+            patch_id          = patch_id,
+            approver_username = approver_username,
+            approver_role     = role,
+            approval_method   = approval_method,
+        )
+        if not rec_ok:
+            raise HTTPException(status_code=500, detail=f"approval_record_failed: {rec.get('error')}")
+
+        # Re-load with approval fields baked in so apply() sees the
+        # final patch shape (forward-compat — applier may grow to
+        # honor approval metadata).
+        patch = rec
         ok, msg = patch_apply(patch, validated=True)
-        return {"success": ok, "message": msg}
+
+        # Lifecycle: deployed | rolled_back. Phase 2 will plug the
+        # before/after metrics from bench.py here.
+        record_outcome(
+            patch_id, "deployed" if ok else "rolled_back",
+            detail=msg,
+        )
+        return {
+            "success":           ok,
+            "message":           msg,
+            "patch_id":          patch_id,
+            "approver_username": approver_username,
+            "approver_role":     role,
+            "approval_method":   approval_method,
+        }
     except HTTPException: raise
     except Exception as e: raise HTTPException(status_code=500, detail=str(e))
 

--- a/tests/test_self_evolution_gate.py
+++ b/tests/test_self_evolution_gate.py
@@ -1,0 +1,220 @@
+"""Self-evolution opt-in + approval gate — #48 phase 1 (Axis 5).
+
+Coverage:
+  - `record_approval` persists approver_username / approver_role /
+    approved_at / approval_method into the patch JSON, sets
+    status="APPROVED", and emits a lifecycle log line.
+  - `record_approval` rejects bad inputs:
+      * unknown approval_method
+      * missing approver_username
+      * missing patch file
+  - Source-level contracts:
+      * `/admin/patch/approve` checks `EVOLUTION_ENABLED` and returns
+        403 when disabled. Imports + uses `record_approval`.
+      * `config.py` raises if `JAMES_AUTO_APPROVE=1` but
+        `JAMES_DEV_MODE=0`.
+  - `/admin/patch/approve` requires `approver_username` body field
+    (source-level — full HTTP integration test runs through the
+    operator's bench --check post-merge).
+
+Run:
+  python -m unittest tests.test_self_evolution_gate
+  python tests/test_self_evolution_gate.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch as _patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _PatchStoreMixin:
+    """Each test gets a fresh `./workspace/patches` so the on-disk
+    patch JSON written by record_approval doesn't bleed across tests."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._patch_store = Path(self._tmp.name) / "patches"
+        self._patch_store.mkdir(parents=True, exist_ok=True)
+        # Redirect both PATCH_STORE and PATCH_LOG_PATH at the tmpdir.
+        from tools.patch import approval as approval_mod
+        self._orig_store    = approval_mod.PATCH_STORE
+        self._orig_log_path = approval_mod.PATCH_LOG_PATH
+        approval_mod.PATCH_STORE    = str(self._patch_store)
+        approval_mod.PATCH_LOG_PATH = str(Path(self._tmp.name) / "james_patch_log.jsonl")
+
+    def tearDown(self):
+        from tools.patch import approval as approval_mod
+        approval_mod.PATCH_STORE    = self._orig_store
+        approval_mod.PATCH_LOG_PATH = self._orig_log_path
+        self._tmp.cleanup()
+
+    def _write_patch(self, patch_id: str, **fields) -> Path:
+        body = {
+            "patch_id":   patch_id,
+            "target":     "./workspace/sample.py",
+            "diff":       "--- a/sample\n+++ b/sample\n",
+            "status":     "PENDING_APPROVAL",
+            "confidence": 0.9,
+            "created_at": "2026-05-07T12:00:00",
+            **fields,
+        }
+        p = self._patch_store / f"{patch_id}.json"
+        p.write_text(json.dumps(body, ensure_ascii=False, indent=2),
+                     encoding="utf-8")
+        return p
+
+
+class RecordApprovalTests(_PatchStoreMixin, unittest.TestCase):
+    def test_persists_approval_metadata(self):
+        from tools.patch.approval import record_approval
+        self._write_patch("p001")
+
+        ok, patch = record_approval(
+            patch_id="p001",
+            approver_username="alice",
+            approver_role="admin",
+            approval_method="ui",
+        )
+        self.assertTrue(ok, f"record_approval failed: {patch}")
+        self.assertEqual(patch["approver_username"], "alice")
+        self.assertEqual(patch["approver_role"],     "admin")
+        self.assertEqual(patch["approval_method"],   "ui")
+        self.assertEqual(patch["status"],            "APPROVED")
+        self.assertIn("approved_at", patch)
+
+        # Round-trip: file on disk has the same metadata.
+        on_disk = json.loads((self._patch_store / "p001.json").read_text(encoding="utf-8"))
+        self.assertEqual(on_disk["approver_username"], "alice")
+        self.assertEqual(on_disk["status"],            "APPROVED")
+
+    def test_rejects_unknown_method(self):
+        from tools.patch.approval import record_approval
+        self._write_patch("p002")
+        ok, err = record_approval("p002", "alice", "admin",
+                                  approval_method="auto-by-ai")
+        self.assertFalse(ok)
+        self.assertIn("invalid approval_method", err["error"])
+
+    def test_rejects_missing_username(self):
+        from tools.patch.approval import record_approval
+        self._write_patch("p003")
+        ok, err = record_approval("p003", "", "admin", approval_method="api")
+        self.assertFalse(ok)
+        self.assertIn("approver_username required", err["error"])
+
+    def test_rejects_missing_patch(self):
+        from tools.patch.approval import record_approval
+        # No patch file written — record_approval must refuse.
+        ok, err = record_approval("does_not_exist", "alice", "admin")
+        self.assertFalse(ok)
+        self.assertIn("patch not found", err["error"])
+
+    def test_lifecycle_log_appended(self):
+        from tools.patch import approval as approval_mod
+        from tools.patch.approval import record_approval
+        self._write_patch("p004")
+
+        ok, _ = record_approval("p004", "bob", "admin", "api")
+        self.assertTrue(ok)
+        log_path = Path(approval_mod.PATCH_LOG_PATH)
+        self.assertTrue(log_path.exists(), "lifecycle log not written")
+        lines = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["event"],            "APPROVED")
+        self.assertEqual(lines[0]["patch_id"],         "p004")
+        self.assertEqual(lines[0]["approver_username"], "bob")
+        self.assertEqual(lines[0]["approval_method"],  "api")
+
+
+class RecordOutcomeTests(_PatchStoreMixin, unittest.TestCase):
+    def test_deployed_outcome_logged(self):
+        from tools.patch import approval as approval_mod
+        from tools.patch.approval import record_outcome
+
+        record_outcome(
+            patch_id="p010", outcome="deployed",
+            detail="apply ok", before_metrics={"x": 1}, after_metrics={"x": 1},
+        )
+        lines = [json.loads(l)
+                 for l in Path(approval_mod.PATCH_LOG_PATH).read_text(encoding="utf-8").splitlines()
+                 if l.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["event"],   "DEPLOYED")
+        self.assertEqual(lines[0]["outcome"], "deployed")
+
+    def test_rolled_back_outcome_logged(self):
+        from tools.patch import approval as approval_mod
+        from tools.patch.approval import record_outcome
+
+        record_outcome("p011", "rolled_back", detail="apply failed: …")
+        lines = [json.loads(l)
+                 for l in Path(approval_mod.PATCH_LOG_PATH).read_text(encoding="utf-8").splitlines()
+                 if l.strip()]
+        self.assertEqual(lines[0]["event"],   "ROLLED_BACK")
+        self.assertEqual(lines[0]["outcome"], "rolled_back")
+
+
+class EndpointGateContractTests(unittest.TestCase):
+    """Source-level: the /admin/patch/approve endpoint must enforce
+    the env-flag gate and pass approver metadata into record_approval.
+    Same chokepoint pattern as test_observability / test_policy_quarantine.
+    """
+
+    def test_endpoint_imports_and_checks_evolution_flag(self):
+        import server_llmwiki as srv
+        import inspect
+        src = inspect.getsource(srv)
+        # Imports the flag from config.
+        self.assertIn("from config import EVOLUTION_ENABLED, APPROVER_ROLE", src,
+                      "/admin/patch/approve must read EVOLUTION_ENABLED + APPROVER_ROLE")
+        # Returns 403 when flag is off.
+        self.assertIn('"evolution_disabled', src,
+                      "/admin/patch/approve must return 403 evolution_disabled")
+        # Requires approver_username in the body.
+        self.assertIn("approver_username required (#48 audit)", src,
+                      "/admin/patch/approve must require approver_username")
+        # Calls record_approval before patch_apply.
+        self.assertIn("from tools.patch.approval        import record_approval", src,
+                      "/admin/patch/approve must use record_approval()")
+        self.assertIn("record_outcome", src,
+                      "/admin/patch/approve must record deploy/rollback outcome")
+
+    def test_config_module_defines_gate_flags(self):
+        import config
+        # The flags are present and have the right defaults in this
+        # environment (JAMES_ENABLE_EVOLUTION not set → False, etc.).
+        self.assertTrue(hasattr(config, "EVOLUTION_ENABLED"))
+        self.assertTrue(hasattr(config, "AUTO_APPROVE"))
+        self.assertTrue(hasattr(config, "APPROVER_ROLE"))
+        # Default approver role is admin (per #48 spec).
+        self.assertEqual(config.APPROVER_ROLE, "admin")
+
+
+class AutoApproveSafetyCheckTests(unittest.TestCase):
+    """The fail-closed contract: AUTO_APPROVE=1 + DEV_MODE=0 must
+    refuse to start. We can't re-import config (singleton), so test
+    the equivalent logic directly against the module source.
+    """
+
+    def test_config_refuses_auto_approve_in_non_dev(self):
+        # Source-level: config.py must contain the explicit
+        # AUTO_APPROVE-without-DEV_MODE refuse-to-start clause.
+        # If a future refactor moves the check elsewhere, this test
+        # fails and the reviewer must update the contract.
+        cfg_path = Path(__file__).resolve().parent.parent / "config.py"
+        src = cfg_path.read_text(encoding="utf-8")
+        self.assertIn("AUTO_APPROVE and not _DEV_MODE_AT_IMPORT", src,
+                      "config.py must refuse start if AUTO_APPROVE is set "
+                      "without DEV_MODE — see #48 fail-closed contract")
+        self.assertIn("Refusing to start", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/patch/approval.py
+++ b/tools/patch/approval.py
@@ -1,0 +1,148 @@
+"""Patch approval recording — #48 phase 1 (Axis 5 Controlled Evolution).
+
+A patch's lifecycle is:
+
+    feedback → candidate → 4-gate eval → AWAITING_APPROVAL
+        (human approver hits /admin/patch/approve)
+        → record_approval() — this module
+        → patch_applier.apply()
+        → audit log (approver_username, before/after, outcome)
+
+This module is the chokepoint for "who approved this patch and how".
+The platform-readiness contract (Dimension E) says deploy without an
+approver field is a bug. By concentrating the metadata write here,
+the contract becomes enforceable: removing this module breaks the
+approval endpoint, and tests assert the metadata is present.
+
+Storage:
+  - The patch JSON at `./workspace/patches/<patch_id>.json` is updated
+    in place with the approval fields.
+  - A lifecycle event is appended to `james_patch_log.jsonl` so the
+    /admin/audit feed picks it up alongside other patch events.
+
+Approval methods (per #48):
+  - "ui"   — admin clicked through the web UI
+  - "api"  — admin called the endpoint directly with an api_key /
+             JWT (the most common path today, since UI integration is
+             a follow-up frontend task)
+  - "auto" — only allowed when both `JAMES_DEV_MODE=1` and
+             `JAMES_AUTO_APPROVE=1`. Used by tests. The config-time
+             safety check (config.py) refuses to start the server if
+             AUTO_APPROVE is set without DEV_MODE — see #48 spec.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple
+
+PATCH_STORE    = "./workspace/patches"
+PATCH_LOG_PATH = "james_patch_log.jsonl"
+
+# The set is intentionally small — adding "auto-by-ai-reviewer" or
+# similar would require a new issue per the #48 out-of-scope list.
+ALLOWED_METHODS = ("ui", "api", "auto")
+
+
+def _log_lifecycle(event: str, patch_id: str, **fields) -> None:
+    """Append one JSONL line to `james_patch_log.jsonl` capturing a
+    patch lifecycle event (created / approved / rejected / deployed /
+    rolled_back). The /admin/audit feed reads this file."""
+    entry = {
+        "time":     datetime.now().isoformat(),
+        "event":    event,
+        "patch_id": patch_id,
+        "layer":    "patch_approval",
+        **fields,
+    }
+    try:
+        with open(PATCH_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        # Approval recording must not crash on log-file failure;
+        # the patch JSON itself still carries the truth-of-record
+        # data, and operators see the gap on the next audit query.
+        pass
+
+
+def record_approval(
+    patch_id:          str,
+    approver_username: str,
+    approver_role:     str,
+    approval_method:   str = "api",
+) -> Tuple[bool, dict]:
+    """Augment a stored patch with approval metadata + emit a
+    lifecycle log event.
+
+    Args:
+      patch_id:           the id from `tools.patch.patch_generator`.
+      approver_username:  identity of the approver (audit trail).
+      approver_role:      role at approval time ("admin" expected).
+      approval_method:    "ui" | "api" | "auto" — see module docstring.
+
+    Returns:
+      (success, augmented_patch_dict). On success the patch JSON file
+      on disk is updated in place. On failure (patch missing / bad
+      method / write error) returns (False, {"error": "..."}). The
+      caller MUST treat False as a hard refusal — do not call
+      patch_applier.apply().
+    """
+    if approval_method not in ALLOWED_METHODS:
+        return False, {"error": f"invalid approval_method: {approval_method!r}"}
+    if not approver_username:
+        return False, {"error": "approver_username required"}
+
+    pf = Path(PATCH_STORE) / f"{patch_id}.json"
+    if not pf.exists():
+        return False, {"error": f"patch not found: {patch_id}"}
+    try:
+        patch = json.loads(pf.read_text(encoding="utf-8"))
+    except Exception as e:
+        return False, {"error": f"patch read failed: {e}"}
+
+    now = datetime.now().isoformat()
+    patch["approver_username"] = approver_username
+    patch["approver_role"]     = approver_role
+    patch["approved_at"]       = now
+    patch["approval_method"]   = approval_method
+    patch["status"]            = "APPROVED"
+
+    try:
+        pf.write_text(json.dumps(patch, ensure_ascii=False, indent=2),
+                      encoding="utf-8")
+    except Exception as e:
+        return False, {"error": f"patch write failed: {e}"}
+
+    _log_lifecycle(
+        "APPROVED", patch_id,
+        approver_username=approver_username,
+        approver_role=approver_role,
+        approval_method=approval_method,
+        approved_at=now,
+        target=patch.get("target", ""),
+    )
+    return True, patch
+
+
+def record_outcome(
+    patch_id:    str,
+    outcome:     str,                 # "deployed" | "rolled_back" | "rejected" | "expired"
+    detail:      str = "",
+    before_metrics: Optional[dict] = None,
+    after_metrics:  Optional[dict] = None,
+) -> None:
+    """Append a deploy/rollback outcome to the lifecycle log.
+
+    Called by the approval endpoint after `patch_applier.apply()` so
+    operators can correlate `(approver_username, outcome)` for any
+    deployed patch.
+    """
+    _log_lifecycle(
+        outcome.upper(),
+        patch_id,
+        outcome=outcome,
+        detail=detail[:300],
+        before_metrics=before_metrics or {},
+        after_metrics=after_metrics or {},
+    )


### PR DESCRIPTION
## Summary

- **#48 phase 1** — Axis 5 Controlled Evolution gate. Opt-in flag (`JAMES_ENABLE_EVOLUTION`), approver metadata recording (`approver_username` / `approver_role` / `approved_at` / `approval_method`), and the AUTO_APPROVE+!DEV_MODE refuse-to-start safety check. Closes #48.
- Phase 2 — bench-driven eval gate, rollback test under crash, `/admin/patch/audit` query endpoint — split out as **#68**.

## What changes operationally

| Before | After |
|---|---|
| `/admin/patch/approve` works on any install with admin auth | Returns **403 `evolution_disabled`** unless `JAMES_ENABLE_EVOLUTION=1` |
| Audit shows what was deployed, not who approved | Patch JSON + `james_patch_log.jsonl` carry `approver_username` / `approver_role` / `approved_at` / `approval_method` |
| `JAMES_AUTO_APPROVE=1` could leak into prod silently | Server **refuses to start** if `AUTO_APPROVE=1` and `DEV_MODE=0` |
| No record on apply-side crash | `record_approval` runs **before** `patch_apply`; mid-apply crash still leaves an audit row |

## Files

- `config.py` — `EVOLUTION_ENABLED`, `APPROVER_ROLE`, `AUTO_APPROVE` env flags + safety check + boot banner.
- `tools/patch/approval.py` (new) — `record_approval(patch_id, approver_username, approver_role, approval_method)` and `record_outcome(patch_id, outcome, before/after_metrics)`. `ALLOWED_METHODS = ("ui", "api", "auto")` — auto is reserved for tests only (DEV_MODE+AUTO_APPROVE both required).
- `server_llmwiki.py` — `/admin/patch/approve` enforces gate, requires `approver_username` body field, threads metadata through `record_approval` → `patch_apply` → `record_outcome`.
- `tests/test_self_evolution_gate.py` — 10 new tests.

## Verification

- `python -m unittest discover -s tests` — **106/106 PASS** (96 prior + 10 new).
- `record_approval` round-trip: file on disk gets approver fields, status flips PENDING_APPROVAL → APPROVED, lifecycle log line `event="APPROVED"` lands in `james_patch_log.jsonl`.
- Refuses bad inputs: unknown method, missing username, missing patch file.
- Source-level endpoint contracts:
  * Imports `EVOLUTION_ENABLED` + `APPROVER_ROLE` from config.
  * Returns `evolution_disabled` 403 when flag off.
  * Requires `approver_username` body field (`approver_username required (#48 audit)` message).
  * Calls `record_approval` and `record_outcome`.
- Source-level config contract: `AUTO_APPROVE and not _DEV_MODE_AT_IMPORT` → `Refusing to start` clause present.

## Bench

This PR does not touch `core/retrieval`, `core/graph`, or `core/reasoning` — CLAUDE.md rule 2 bench numbers don't apply. The evolution-gate plumbing is server-side endpoint logic + a new tools module + tests.

## #48 verification checklist

- [x] Default install: `POST /admin/patch/approve` returns **403 `evolution_disabled`** with the missing env var named in the message.
- [x] With flag + admin approval: deploy succeeds; audit row + patch JSON include `approver_username` and `approval_method`.
- [x] With flag but missing approver_username body field: 400 `approver_username required (#48 audit)`.
- [x] Production env (`JAMES_DEV_MODE=0`) refuses to start if `JAMES_AUTO_APPROVE=1`.
- [ ] **Phase 2 (#68)**: Mid-deploy SIGKILL leaves no partial state — needs `tests/test_evolution_rollback.py`.
- [ ] **Phase 2 (#68)**: Eval gate via `scripts/bench.py` — gate currently runs the existing `tools/patch/patch_validator` 4-gate; bench integration plus before/after metric capture is the phase 2 PR.
- [x] STEP 7 12-query benchmark unchanged — this PR doesn't touch reasoning paths.

## Out of scope (deferred to #68)

- Bench-driven eval gate (`scripts/bench.py --suite=step7` before deploy with auto-rollback on regression).
- Rollback test simulating mid-deploy crash.
- `GET /admin/patch/audit?since=&approver=` query endpoint over the lifecycle log.
- Trace_id correlation in lifecycle entries (mechanical thread of `current_trace_id` from #47 through `record_outcome`).
