### PR TITLE
feat(observability): JAMES_TRACE_STDOUT toggle restores console mirror

### DIFF
--- a/core/observability.py
+++ b/core/observability.py
@@ -41,6 +41,13 @@ Usage from a request handler:
 Fire-and-forget: `log_stage` swallows IO errors so a disk-full event
 never crashes a live query. Failures are silent — the request still
 succeeds and the operator notices via missing traces.
+
+Console mirror (operator workflow):
+  Set `JAMES_TRACE_STDOUT=1` before launching the server to mirror
+  every `log_stage` line to stdout in addition to the JSONL file. This
+  restores the pre-#67 PowerShell debug-watcher workflow without
+  rolling back the per-trace file design. Default off — production
+  consoles stay clean, the JSONL files remain authoritative.
 """
 from __future__ import annotations
 
@@ -140,15 +147,25 @@ def log_stage(stage: str, **fields) -> None:
         "ts_ns":    time.time_ns(),
         **fields,
     }
+    line = json.dumps(entry, ensure_ascii=False, default=str)
     try:
         path = _trace_file_for(tid)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+            f.write(line + "\n")
     except Exception:
         # Silent — observability must never wedge a request on disk
         # failure. Operators see the gap (missing trace) and act.
         pass
+    # Optional stdout mirror — restores the pre-#67 PowerShell
+    # debug-watcher workflow. Toggled per-process via env var so a
+    # production deploy stays quiet by default. Wrapped in try so a
+    # cp949 console encoding crash can never wedge a live request.
+    if os.getenv("JAMES_TRACE_STDOUT", "").strip() in ("1", "true", "TRUE", "yes"):
+        try:
+            print(f"[trace {tid[:8]}] {line}", flush=True)
+        except Exception:
+            pass
 
 
 def read_trace(trace_id: str, day: Optional[str] = None) -> list:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -189,5 +189,101 @@ class TraceFileLayoutTests(unittest.TestCase):
             self.assertEqual(obj["trace_id"], tid)
 
 
+class StdoutMirrorTests(unittest.TestCase):
+    """JAMES_TRACE_STDOUT toggle — restores the pre-#67 PowerShell
+    debug-watcher workflow without rolling back per-trace JSONL files.
+    Default off (production stays quiet); env=1 mirrors every line to
+    stdout. The mirror must never break the JSONL write contract."""
+
+    def setUp(self):
+        from core.observability import set_trace_root, current_trace_id
+        self._tmp = tempfile.TemporaryDirectory()
+        set_trace_root(Path(self._tmp.name))
+        current_trace_id.set("")
+        self._orig_env = os.environ.get("JAMES_TRACE_STDOUT")
+
+    def tearDown(self):
+        from core.observability import set_trace_root
+        set_trace_root(None)
+        self._tmp.cleanup()
+        if self._orig_env is None:
+            os.environ.pop("JAMES_TRACE_STDOUT", None)
+        else:
+            os.environ["JAMES_TRACE_STDOUT"] = self._orig_env
+
+    def _capture_stdout(self, fn):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fn()
+        return buf.getvalue()
+
+    def test_stdout_silent_by_default(self):
+        from core.observability import start_trace, log_stage
+        os.environ.pop("JAMES_TRACE_STDOUT", None)
+        def run():
+            start_trace()
+            log_stage("retrieve", top_k=8)
+        out = self._capture_stdout(run)
+        self.assertEqual(out, "",
+                         "log_stage must NOT print when JAMES_TRACE_STDOUT unset")
+
+    def test_stdout_mirrors_when_enabled(self):
+        from core.observability import start_trace, log_stage
+        os.environ["JAMES_TRACE_STDOUT"] = "1"
+        captured = {}
+        def run():
+            captured["tid"] = start_trace()
+            log_stage("retrieve", top_k=8, top_vector_score=0.82)
+        out = self._capture_stdout(run)
+        self.assertIn("[trace ", out, "stdout mirror missing trace prefix")
+        self.assertIn(captured["tid"][:8], out,
+                      "stdout mirror must include trace_id short form")
+        self.assertIn('"stage": "retrieve"', out,
+                      "stdout mirror must contain the JSONL line")
+        self.assertIn('"top_k": 8', out)
+
+    def test_stdout_truthy_variants(self):
+        from core.observability import start_trace, log_stage
+        for val in ("1", "true", "TRUE", "yes"):
+            os.environ["JAMES_TRACE_STDOUT"] = val
+            def run():
+                start_trace()
+                log_stage("smoke")
+            out = self._capture_stdout(run)
+            self.assertIn("[trace ", out, f"value {val!r} should enable mirror")
+
+    def test_stdout_falsy_variants_stay_silent(self):
+        from core.observability import start_trace, log_stage
+        for val in ("0", "false", "no", ""):
+            os.environ["JAMES_TRACE_STDOUT"] = val
+            def run():
+                start_trace()
+                log_stage("smoke")
+            out = self._capture_stdout(run)
+            self.assertEqual(out, "", f"value {val!r} must not enable mirror")
+
+    def test_jsonl_still_written_when_mirror_enabled(self):
+        # The mirror is additive — JSONL file write must still succeed.
+        from core.observability import start_trace, log_stage, read_trace
+        os.environ["JAMES_TRACE_STDOUT"] = "1"
+        def run():
+            tid = start_trace()
+            log_stage("retrieve", top_k=8)
+            return tid
+        tid = None
+        # Use the capture helper just to keep the test stdout clean
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            tid = run()
+        rows = read_trace(tid)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["stage"], "retrieve")
+        self.assertEqual(rows[0]["top_k"], 8)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `JAMES_TRACE_STDOUT=1` env toggle to `core/observability.log_stage()` — mirrors each JSONL line to stdout in addition to the per-trace file.
- Restores the pre-#67 PowerShell debug-watcher workflow without rolling back the per-trace file design (JSONL files remain authoritative).
- Default off — production consoles stay quiet. Mirror is additive and wrapped in try so a cp949 console encoding crash cannot wedge a live request.

## Verification

- 5 new tests in `tests/test_observability.py::StdoutMirrorTests` (14/14 pass total in test_observability):
  - `test_stdout_silent_by_default` — env unset, no stdout emission
  - `test_stdout_mirrors_when_enabled` — env=1 emits `[trace <8-char>] <jsonl>` line
  - `test_stdout_truthy_variants` — `1`/`true`/`TRUE`/`yes` all enable
  - `test_stdout_falsy_variants_stay_silent` — `0`/`false`/`no`/`""` stay quiet
  - `test_jsonl_still_written_when_mirror_enabled` — file write contract preserved when mirror on
- Bench numbers: not applicable — change is in observability emit path, not retrieval/graph/reasoning.

## Operator usage

```powershell
# PowerShell
$env:JAMES_TRACE_STDOUT = "1"; python server_llmwiki.py
```

```bash
# Bash
JAMES_TRACE_STDOUT=1 python server_llmwiki.py
```

## Out of scope

- `GET /admin/trace/{trace_id}` endpoint and `/admin/metrics` per-stage latency histograms — remain as the rest of #47 phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)