### PR TITLE
feat(reasoning): response_style presets (brief/standard/detailed) cap answer length

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -95,6 +95,7 @@ class ReasoningEngine:
         user_role:   str        = None,
         source_type: Optional[str] = "prod",   # [P4.5-2] 기본 prod
         session_id:  str        = "default",   # [P7-FIX] 메모리 시스템 연동
+        response_style: str     = "",          # brief / standard / detailed — see core/response_style.py
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -232,7 +233,7 @@ class ReasoningEngine:
 
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":
-            return handle_chat(self, safe_query, system_prompt, memory_context, user_role, t_start)
+            return handle_chat(self, safe_query, system_prompt, memory_context, user_role, t_start, response_style=response_style)
         if mode == "wiki_edit":
             return handle_wiki_edit(self, safe_query, system_prompt, user_role, t_start)
         if mode == "self_evolve":
@@ -246,6 +247,7 @@ class ReasoningEngine:
         from core.reasoning.pipeline import run_retrieval_pipeline
         return run_retrieval_pipeline(
             self, safe_query, system_prompt, user_role, source_type, t_start,
+            response_style=response_style,
         )
 
 
@@ -283,8 +285,19 @@ class ReasoningEngine:
         return "general"
 
     def _generate_answer(self, question: str, context: str,
-                          system_prompt: str = "") -> str:
-        """RAG context + LLM 자유 추론. 한/영 자동 감지."""
+                          system_prompt: str = "",
+                          response_style: str = "") -> str:
+        """RAG context + LLM 자유 추론. 한/영 자동 감지.
+
+        `response_style`: brief / standard / detailed — see
+        `core/response_style.py`. Empty string falls through to env
+        var then `standard` default. Brief drops the 📚/💡 structural
+        rule entirely; standard/detailed keep it but with different
+        token caps.
+        """
+        from core.response_style import resolve_style
+        style = resolve_style(response_style)
+
         safe_q    = RetrievalEngine._sanitize(question, 300)
         sys_block = f"{system_prompt}\n\n" if system_prompt else ""
 
@@ -297,42 +310,50 @@ class ReasoningEngine:
             lbl_data = "📚 Data-based"
             lbl_inf  = "💡 Reasoning"
             no_data  = "No relevant internal data"
-            rule_txt = (
-                "Answer structure:\n"
-                "📚 Data-based: (facts from internal data only, or 'No relevant data')\n"
-                "💡 Reasoning: (free analysis using data + knowledge)\n"
-                "Rules: Both sections required. Data-based = confirmed facts only.\n"
-            )
+            rule_txt = style.rule_text_en
         else:
             lbl_data = "📚 자료 기반"
             lbl_inf  = "💡 추론"
             no_data  = "관련 내부 자료 없음"
-            rule_txt = (
-                "답변 구조:\n"
-                "📚 자료 기반: (내부 자료 사실만. 없으면 '관련 자료 없음')\n"
-                "💡 추론: (자료와 지식을 연결한 자유 분석)\n"
-                "규칙: 두 섹션 모두 작성. 자료 기반은 확인된 사실만.\n"
-            )
+            rule_txt = style.rule_text_ko
 
         if context and len(context.strip()) >= 50:
-            prompt = (
-                f"{sys_block}"
-                f"[{'Internal Data' if is_en else '내부 자료'}]\n{context[:1000]}\n\n"
-                f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
-                f"{rule_txt}\n"
-                f"{'Answer' if is_en else '답변'}:\n"
-            )
+            if style.force_two_sections:
+                prompt = (
+                    f"{sys_block}"
+                    f"[{'Internal Data' if is_en else '내부 자료'}]\n{context[:1000]}\n\n"
+                    f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
+                    f"{rule_txt}\n"
+                    f"{'Answer' if is_en else '답변'}:\n"
+                )
+            else:
+                # brief: no 📚/💡 split — single concise paragraph.
+                prompt = (
+                    f"{sys_block}"
+                    f"[{'Internal Data' if is_en else '내부 자료'}]\n{context[:1000]}\n\n"
+                    f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
+                    f"{rule_txt}"
+                    f"{'Answer' if is_en else '답변'}:\n"
+                )
         else:
-            prompt = (
-                f"{sys_block}"
-                f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
-                f"{lbl_data}: {no_data}\n{lbl_inf}:\n"
-            )
+            if style.force_two_sections:
+                prompt = (
+                    f"{sys_block}"
+                    f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
+                    f"{lbl_data}: {no_data}\n{lbl_inf}:\n"
+                )
+            else:
+                prompt = (
+                    f"{sys_block}"
+                    f"[{'Question' if is_en else '질문'}]\n{safe_q}\n\n"
+                    f"{rule_txt}"
+                    f"{'Answer' if is_en else '답변'}:\n"
+                )
 
         try:
             answer = self.llm.call_gemma(
                 prompt, timeout=120, use_cache=True,
-                max_tokens=2000,   # 긴 답변 허용 (기존 700 → 2000)
+                max_tokens=style.max_tokens,
             )
             if not answer or any(answer.startswith(p) for p in self._LLM_ERROR_PREFIXES):
                 return "답변 생성에 실패했습니다."

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -32,7 +32,11 @@ def handle_chat(
     memory_context: str,
     user_role: str,
     t_start: float,
+    response_style: str = "",
 ) -> Dict[str, Any]:
+    from core.response_style import resolve_style
+    style = resolve_style(response_style)
+
     t_direct = time.time()
     try:
         # system_prompt + memory_context 주입
@@ -40,7 +44,7 @@ def handle_chat(
         mem_prefix = f"{memory_context}\n\n" if memory_context else ""
         raw_answer = engine.llm.call_gemma(
             f"{sys_prefix}{mem_prefix}질문: {safe_query}\n\n답변:",
-            use_cache=True, timeout=60, max_tokens=2000,
+            use_cache=True, timeout=60, max_tokens=style.max_tokens,
         )
         # [P7-FIX] 글자 사이 \n 제거 → 세로줄 방지
         if raw_answer:

--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -34,6 +34,7 @@ def run_retrieval_pipeline(
     user_role: str,
     source_type: str,
     t_start: float,
+    response_style: str = "",
 ) -> Dict[str, Any]:
     # ── STEP 0.5b: query expansion [P5] ──────────────────
     # core/query_expander.py (was core/jepa_adapter.py — 단순 동의어
@@ -307,15 +308,19 @@ def run_retrieval_pipeline(
                 combined_context = web_clean + "\n\n" + safe_context
             else:
                 combined_context = safe_context
+            from core.response_style import resolve_style as _resolve_style
+            _style = _resolve_style(response_style)
             answer_raw = engine.llm.call_gemma(
                 f"{sys_prefix}"
                 f"{'[웹 검색 결과 포함]' if web_context else ''}"
                 f"\n질문: {safe_query}\n\n답변:",
-                use_cache=(not web_context), timeout=90, max_tokens=2000,
+                use_cache=(not web_context), timeout=90,
+                max_tokens=_style.max_tokens,
             ) if not combined_context.strip() else engine._generate_answer(
                 safe_query,
                 combined_context,
-                system_prompt
+                system_prompt,
+                response_style=response_style,
             )
             answer_raw = answer_raw if answer_raw else ""
 
@@ -325,19 +330,21 @@ def run_retrieval_pipeline(
                 print(f"[ROUTER] retrieval_fallback (score={unified_score:.3f}) → LLM 직접")
                 answer = answer_raw
             else:
-                answer = engine._generate_answer(safe_query, safe_context, system_prompt)
+                answer = engine._generate_answer(safe_query, safe_context, system_prompt, response_style=response_style)
         else:
             # 관련 자료 있음 → System Prompt + RAG 컨텍스트 + LLM 답변
-            answer = engine._generate_answer(safe_query, safe_context, system_prompt)
+            answer = engine._generate_answer(safe_query, safe_context, system_prompt, response_style=response_style)
 
         # [P7] "자료 없음" 단독 응답(추론 없음)이면 system_prompt 포함 재시도
         _no_data = ("자료에 없음. 관련된", "답변 생성에 실패", "LLM 응답 생성 중 오류")
         if answer and any(answer.startswith(p) for p in _no_data):
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
+            from core.response_style import resolve_style as _resolve_style
+            _style_retry = _resolve_style(response_style)
             retry = engine.llm.call_gemma(
                 f"{sys_prefix}질문: {safe_query}\n\n"
                 "📚 자료 기반: 관련 내부 자료 없음\n💡 추론:",
-                use_cache=False, timeout=60, max_tokens=2000,
+                use_cache=False, timeout=60, max_tokens=_style_retry.max_tokens,
             )
             if retry and not any(retry.startswith(p) for p in engine._LLM_ERROR_PREFIXES):
                 print(f"[ROUTER] post_check → 재시도 (persona 포함)")

--- a/core/response_style.py
+++ b/core/response_style.py
@@ -1,0 +1,136 @@
+"""Response-style presets — controls answer length, structure, and tone
+across all LLM call sites in the reasoning pipeline.
+
+Why this module exists
+----------------------
+Pre-this-PR every LLM call hard-coded `max_tokens=2000` and the
+`_generate_answer` system prompt forced a two-section structure
+(📚 자료 기반 + 💡 추론). End-result: every answer was long and
+verbose, even for trivial chat. Operators reported "답변이 너무 길고
+복잡" (issue raised in 2026-05-08 user-feedback session).
+
+Three presets, one resolver
+---------------------------
+
+`brief`     max_tokens=600,  no forced section split — direct answer.
+`standard`  max_tokens=1200, two sections but compact (DEFAULT).
+`detailed`  max_tokens=2000, full two-section with extensive reasoning
+            (preserves pre-this-PR behavior as opt-in).
+
+Resolution order (highest precedence first):
+  1. explicit `style=` kwarg from caller
+  2. `JAMES_RESPONSE_STYLE` env var
+  3. fallback to `standard`
+
+Why a separate module rather than inlining
+- Three call sites need it: `engine._generate_answer`, `modes.handle_chat`,
+  `pipeline.run_retrieval_pipeline` web fallback. A shared resolver keeps
+  the precedence rule in one place — adding a fourth call site doesn't
+  duplicate the env-var read.
+- The structural rule (📚/💡 prompt block) lives next to the token cap
+  it's paired with, so changing one without the other isn't possible.
+
+This is mother-platform behavior. No domain-specific style logic lives
+here — domain packs may eventually override via Axis 3 / v0.3 plugin
+contract, but that's out of scope for v0.2.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+# Public preset names — use these strings everywhere, not literals.
+BRIEF = "brief"
+STANDARD = "standard"
+DETAILED = "detailed"
+
+VALID_STYLES = (BRIEF, STANDARD, DETAILED)
+
+
+@dataclass(frozen=True)
+class StylePreset:
+    """Resolved style — what each call site needs to issue an LLM call.
+
+    `name`: preset id for logging / response echo.
+    `max_tokens`: hard cap passed to call_gemma.
+    `force_two_sections`: when True, the 📚/💡 structural rule is
+        added to the prompt; when False, the model gets a single-shot
+        prompt with no structural template.
+    `rule_text_ko` / `rule_text_en`: the literal rule block injected
+        into the prompt when `force_two_sections=True`.
+    """
+    name:               str
+    max_tokens:         int
+    force_two_sections: bool
+    rule_text_ko:       str
+    rule_text_en:       str
+
+
+# Concrete presets — keep them grouped here so a reviewer changing one
+# notices the others. The two-section rules differ by language; the
+# brief rule is intentionally empty (no template at all).
+_PRESETS: dict[str, StylePreset] = {
+    BRIEF: StylePreset(
+        name=BRIEF,
+        max_tokens=600,
+        force_two_sections=False,
+        rule_text_ko="간결하게 핵심만 한 문단으로 답변하세요.\n",
+        rule_text_en="Answer concisely in one short paragraph.\n",
+    ),
+    STANDARD: StylePreset(
+        name=STANDARD,
+        max_tokens=1200,
+        force_two_sections=True,
+        rule_text_ko=(
+            "답변 구조 (간결하게):\n"
+            "📚 자료 기반: 내부 자료 사실만. 없으면 '관련 자료 없음'\n"
+            "💡 추론: 자료를 연결한 짧은 분석 (3-4문장)\n"
+        ),
+        rule_text_en=(
+            "Answer structure (concise):\n"
+            "📚 Data-based: facts from internal data only, or 'No relevant data'\n"
+            "💡 Reasoning: short analysis tying data together (3-4 sentences)\n"
+        ),
+    ),
+    DETAILED: StylePreset(
+        name=DETAILED,
+        max_tokens=2000,
+        force_two_sections=True,
+        rule_text_ko=(
+            "답변 구조:\n"
+            "📚 자료 기반: (내부 자료 사실만. 없으면 '관련 자료 없음')\n"
+            "💡 추론: (자료와 지식을 연결한 자유 분석)\n"
+            "규칙: 두 섹션 모두 작성. 자료 기반은 확인된 사실만.\n"
+        ),
+        rule_text_en=(
+            "Answer structure:\n"
+            "📚 Data-based: (facts from internal data only, or 'No relevant data')\n"
+            "💡 Reasoning: (free analysis using data + knowledge)\n"
+            "Rules: Both sections required. Data-based = confirmed facts only.\n"
+        ),
+    ),
+}
+
+
+def resolve_style(explicit: str = "") -> StylePreset:
+    """Resolve the active style preset for an LLM call.
+
+    Args:
+      explicit: caller-provided style id (from API request kwarg).
+                Empty string / None / unknown values fall through to
+                the env var, then the default.
+
+    Resolution order: explicit kwarg → JAMES_RESPONSE_STYLE env →
+    `standard` default. Unknown values at any layer fall through to
+    the next layer rather than raising — this matches the rest of the
+    reasoning pipeline's defensive defaults (a typo in a config never
+    crashes a live request).
+    """
+    candidate = (explicit or "").strip().lower()
+    if candidate in _PRESETS:
+        return _PRESETS[candidate]
+    env = (os.getenv("JAMES_RESPONSE_STYLE", "") or "").strip().lower()
+    if env in _PRESETS:
+        return _PRESETS[env]
+    return _PRESETS[STANDARD]

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -291,6 +291,10 @@ class QueryRequest(BaseModel):
     # Non-admin callers see no behavior change — the field is silently
     # dropped from the response shape.
     include_contexts: bool = False
+    # Response shape control — brief / standard / detailed. Empty
+    # string falls through to JAMES_RESPONSE_STYLE env then `standard`.
+    # See core/response_style.py for the resolver and preset defs.
+    response_style:   str  = ""
 
 class QueryResponse(BaseModel):
     question:       str
@@ -596,6 +600,7 @@ async def query(
         user_role        = role,
         session_id       = session_id,
         session_language = data.session_language,  # [STEP2-A] 세션 언어
+        response_style   = data.response_style,    # brief/standard/detailed
     )
     elapsed = time.time() - t_start
 

--- a/tests/test_response_style.py
+++ b/tests/test_response_style.py
@@ -1,0 +1,175 @@
+"""Response-style preset resolver and call-site contracts.
+
+Coverage:
+  - `resolve_style()`: explicit kwarg → env var → `standard` default
+    precedence. Unknown values fall through rather than raising.
+  - Each preset's max_tokens + force_two_sections fields match the
+    documented contract (brief=600/no-split, standard=1200/two-section,
+    detailed=2000/two-section).
+  - Source-level contract: every LLM call site in core/reasoning/
+    derives max_tokens from `resolve_style(...)` rather than hard-
+    coding 2000 — a future refactor that re-introduces the literal
+    fails the contract test and a reviewer makes a conscious choice.
+
+Run:
+  python -m unittest tests.test_response_style
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class ResolveStyleTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_env = os.environ.get("JAMES_RESPONSE_STYLE")
+
+    def tearDown(self):
+        if self._orig_env is None:
+            os.environ.pop("JAMES_RESPONSE_STYLE", None)
+        else:
+            os.environ["JAMES_RESPONSE_STYLE"] = self._orig_env
+
+    def test_default_is_standard(self):
+        from core.response_style import resolve_style, STANDARD
+        os.environ.pop("JAMES_RESPONSE_STYLE", None)
+        s = resolve_style()
+        self.assertEqual(s.name, STANDARD)
+        self.assertEqual(s.max_tokens, 1200)
+        self.assertTrue(s.force_two_sections)
+
+    def test_explicit_brief(self):
+        from core.response_style import resolve_style, BRIEF
+        s = resolve_style("brief")
+        self.assertEqual(s.name, BRIEF)
+        self.assertEqual(s.max_tokens, 600)
+        self.assertFalse(s.force_two_sections,
+                         "brief must NOT force the 📚/💡 two-section split")
+
+    def test_explicit_detailed(self):
+        from core.response_style import resolve_style, DETAILED
+        s = resolve_style("detailed")
+        self.assertEqual(s.name, DETAILED)
+        self.assertEqual(s.max_tokens, 2000,
+                         "detailed preserves the pre-this-PR 2000-token cap")
+        self.assertTrue(s.force_two_sections)
+
+    def test_explicit_kwarg_beats_env(self):
+        from core.response_style import resolve_style, BRIEF
+        os.environ["JAMES_RESPONSE_STYLE"] = "detailed"
+        s = resolve_style("brief")
+        self.assertEqual(s.name, BRIEF,
+                         "explicit kwarg must override env var")
+
+    def test_env_var_used_when_no_explicit(self):
+        from core.response_style import resolve_style, BRIEF
+        os.environ["JAMES_RESPONSE_STYLE"] = "brief"
+        s = resolve_style()
+        self.assertEqual(s.name, BRIEF)
+        s = resolve_style("")
+        self.assertEqual(s.name, BRIEF, "empty string treated as no explicit")
+
+    def test_env_var_case_insensitive(self):
+        from core.response_style import resolve_style, BRIEF
+        for val in ("BRIEF", "Brief", "  brief  "):
+            os.environ["JAMES_RESPONSE_STYLE"] = val
+            s = resolve_style()
+            self.assertEqual(s.name, BRIEF, f"env value {val!r} should resolve")
+
+    def test_unknown_falls_through_to_default(self):
+        from core.response_style import resolve_style, STANDARD
+        os.environ.pop("JAMES_RESPONSE_STYLE", None)
+        # Unknown explicit AND no env → standard. Defensive: a typo in
+        # API call must not raise — this matches the rest of the
+        # reasoning pipeline's behavior.
+        s = resolve_style("verbose")
+        self.assertEqual(s.name, STANDARD)
+        s = resolve_style("nonsense-value")
+        self.assertEqual(s.name, STANDARD)
+
+    def test_unknown_explicit_falls_to_env_not_default(self):
+        from core.response_style import resolve_style, BRIEF
+        os.environ["JAMES_RESPONSE_STYLE"] = "brief"
+        # Unknown explicit but valid env → env wins (not default).
+        s = resolve_style("nonsense")
+        self.assertEqual(s.name, BRIEF,
+                         "unknown explicit must fall through to env, not skip it")
+
+    def test_rule_text_brief_has_no_emoji_split(self):
+        from core.response_style import resolve_style
+        s = resolve_style("brief")
+        self.assertNotIn("📚", s.rule_text_ko)
+        self.assertNotIn("💡", s.rule_text_ko)
+        self.assertNotIn("📚", s.rule_text_en)
+        self.assertNotIn("💡", s.rule_text_en)
+
+    def test_rule_text_standard_keeps_split_but_compact(self):
+        from core.response_style import resolve_style
+        s = resolve_style("standard")
+        self.assertIn("📚", s.rule_text_ko)
+        self.assertIn("💡", s.rule_text_ko)
+        # Standard rule text is shorter than detailed — the user-visible
+        # difference between them is conciseness.
+        s_detailed = resolve_style("detailed")
+        self.assertLess(len(s.rule_text_ko), len(s_detailed.rule_text_ko),
+                        "standard rule text must be shorter than detailed")
+
+
+class CallSiteContractTests(unittest.TestCase):
+    """Source-level: every LLM call site in core/reasoning/ must derive
+    max_tokens from resolve_style — no hard-coded 2000 literal allowed.
+    A future refactor that re-introduces 2000 will fail here and a
+    reviewer will make a conscious choice."""
+
+    def test_engine_generate_answer_uses_style(self):
+        import core.reasoning.engine as eng
+        import inspect
+        src = inspect.getsource(eng._generate_answer if hasattr(eng, "_generate_answer")
+                                else eng.ReasoningEngine._generate_answer)
+        self.assertIn("resolve_style", src,
+                      "_generate_answer must call resolve_style")
+        self.assertIn("style.max_tokens", src,
+                      "_generate_answer must use style.max_tokens, not literal")
+        self.assertNotIn("max_tokens=2000", src,
+                         "literal max_tokens=2000 must be removed from _generate_answer")
+
+    def test_modes_handle_chat_uses_style(self):
+        import core.reasoning.modes as modes_mod
+        import inspect
+        src = inspect.getsource(modes_mod.handle_chat)
+        self.assertIn("resolve_style", src,
+                      "handle_chat must call resolve_style")
+        self.assertIn("style.max_tokens", src,
+                      "handle_chat must use style.max_tokens, not literal")
+        self.assertNotIn("max_tokens=2000", src,
+                         "literal max_tokens=2000 must be removed from handle_chat")
+
+    def test_pipeline_uses_style_for_web_fallback(self):
+        import core.reasoning.pipeline as pipeline_mod
+        import inspect
+        src = inspect.getsource(pipeline_mod.run_retrieval_pipeline)
+        self.assertIn("resolve_style", src,
+                      "pipeline must call resolve_style for web fallback")
+        # Both call_gemma sites in pipeline (web fallback + retry) must
+        # use style.max_tokens, not 2000. We accept any style variable
+        # name (`_style.max_tokens` / `_style_retry.max_tokens` etc).
+        self.assertNotIn("max_tokens=2000", src,
+                         "literal max_tokens=2000 must be removed from pipeline")
+
+    def test_query_endpoint_passes_response_style(self):
+        import server_llmwiki as srv
+        import inspect
+        src = inspect.getsource(srv)
+        self.assertIn("response_style", src,
+                      "/query/ must accept and forward response_style")
+        self.assertIn("response_style:   str", src,
+                      "QueryRequest must declare response_style field")
+        self.assertIn("response_style   = data.response_style", src,
+                      "/query/ must forward data.response_style to rag_engine.query")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduces `core/response_style.py` with three presets — `brief` (600 tok, no 📚/💡 split), `standard` (1200 tok, two-section compact, **new default**), `detailed` (2000 tok, two-section full — preserves prior behavior as opt-in).
- Three reasoning-pipeline LLM call sites (`engine._generate_answer`, `modes.handle_chat`, `pipeline.run_retrieval_pipeline` web fallback + retry) now derive `max_tokens` and the structural rule from the preset instead of hard-coded `max_tokens=2000`.
- Resolution order: explicit kwarg → `JAMES_RESPONSE_STYLE` env → `standard` default. Unknown values fall through rather than raise.
- API surface: `QueryRequest` gains a `response_style: str = ""` field; `/query/` forwards it to `rag_engine.query`.

## Why

User feedback (2026-05-08 session): "답변이 너무 길고 복잡" — every answer was verbose multi-paragraph output regardless of question complexity. Root cause was three combined factors: `max_tokens=2000` everywhere + forced two-section prompt + no user toggle.

## Verification

- 14/14 unit tests pass in `tests/test_response_style.py`
  - Resolver precedence (explicit > env > default), case-insensitive env, unknown value fall-through
  - Preset invariants (brief=600/no-split, standard=1200/two-section, detailed=2000/two-section)
  - Source-level contracts: every LLM call site in `core/reasoning/` derives `max_tokens` from `resolve_style` (no literal `max_tokens=2000` allowed). A future refactor that re-introduces the literal will fail the contract test and a reviewer makes a conscious choice.
- 42/42 regression suite pass (`test_risky_coding_policy` + `test_observability` + `test_response_style`).

## Bench numbers

- STEP 7 baseline impact: q1–q10 are gated on `graph_paths_min/max` (retrieval/graph counts), not on `answer_len`. Lowering `max_tokens` to 1200 affects only the truncation cap of the LLM response — retrieval/graph stages are untouched. q11 / q12 block invariants (`answer_len_exact=26`, `blocked=true`) are unaffected (block path runs in `pre_check` before any `max_tokens` decision).
- Will run STEP 7 bench post-merge as a sanity check; expected outcome is same `graph_paths` distribution with shorter `answer_len` for non-blocked queries.

## Out of scope

- Frontend UI toggle for `response_style` (radio buttons / dropdown) — backend API + env var work first; UI in a follow-up.
- Per-mode preset overrides (e.g. `wiki_edit` always brief, `self_evolve` always detailed) — future enhancement once we see real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)