### PR TITLE
feat(reasoning): natural-flow answer prompt — 핵심→근거→대안 (PR #72 follow-up)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -292,11 +292,10 @@ class ReasoningEngine:
                           response_style: str = "") -> str:
         """RAG context + LLM 자유 추론. 한/영 자동 감지.
 
-        `response_style`: brief / standard / detailed — see
-        `core/response_style.py`. Empty string falls through to env
-        var then `standard` default. Brief drops the 📚/💡 structural
-        rule entirely; standard/detailed keep it but with different
-        token caps.
+        `response_style`: kept for API back-compat — v2 always returns
+        the NATURAL_PRESET (single natural-flow guide, no rigid
+        emoji-section template). See core/response_style.py for the
+        v1→v2 redesign rationale.
         """
         from core.response_style import resolve_style
         style = resolve_style(response_style)
@@ -330,7 +329,10 @@ class ReasoningEngine:
                     f"{'Answer' if is_en else '답변'}:\n"
                 )
             else:
-                # brief: no 📚/💡 split — single concise paragraph.
+                # Natural-flow path (v2 default): rule_txt teaches
+                # 핵심→근거→대안 prose composition without the rigid
+                # 📚/💡 labels. The model picks length from the prompt,
+                # not from a token budget.
                 prompt = (
                     f"{sys_block}"
                     f"[{'Internal Data' if is_en else '내부 자료'}]\n{context[:1000]}\n\n"

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -37,21 +37,26 @@ def handle_chat(
     from core.response_style import resolve_style
     style = resolve_style(response_style)
 
+    # Detect language by Korean character ratio to pick the
+    # right-language flow guide. Same heuristic as engine._generate_answer.
+    korean_chars = sum(1 for c in safe_query if "가" <= c <= "힣")
+    is_ko = korean_chars >= max(1, len(safe_query) * 0.2)
+    rule_txt = style.rule_text_ko if is_ko else style.rule_text_en
+
     t_direct = time.time()
     try:
-        # system_prompt + memory_context 주입
+        # system_prompt + memory_context + flow guide 주입
         sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
         mem_prefix = f"{memory_context}\n\n" if memory_context else ""
         raw_answer = engine.llm.call_gemma(
-            f"{sys_prefix}{mem_prefix}질문: {safe_query}\n\n답변:",
+            f"{sys_prefix}{mem_prefix}{rule_txt}\n질문: {safe_query}\n\n답변:",
             use_cache=True, timeout=60, max_tokens=style.max_tokens,
         )
-        # [P7-FIX] 글자 사이 \n 제거 → 세로줄 방지
+        # Preserve paragraph breaks (\n\n) — user feedback wants
+        # natural 문단 separation, not a single block of text.
+        # Collapse 3+ newlines to exactly 2 to keep things tidy.
         if raw_answer:
-            # \n\n 이상 → 단락 구분 (공백)
-            answer = re.sub(r'\n{2,}', ' ', raw_answer)
-            # 단일 \n → 완전 제거 (한국어 글자 사이 세로줄 방지)
-            answer = re.sub(r'\n', '', answer).strip()
+            answer = re.sub(r"\n{3,}", "\n\n", raw_answer).strip()
         else:
             answer = ""
         if not answer or any(answer.startswith(p) for p in engine._LLM_ERROR_PREFIXES):

--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -310,10 +310,15 @@ def run_retrieval_pipeline(
                 combined_context = safe_context
             from core.response_style import resolve_style as _resolve_style
             _style = _resolve_style(response_style)
+            # Pick the right-language flow guide for the no-context
+            # web-fallback prompt below. Same heuristic as engine + chat.
+            _korean = sum(1 for c in safe_query if "가" <= c <= "힣")
+            _is_ko = _korean >= max(1, len(safe_query) * 0.2)
+            _rule = _style.rule_text_ko if _is_ko else _style.rule_text_en
             answer_raw = engine.llm.call_gemma(
                 f"{sys_prefix}"
                 f"{'[웹 검색 결과 포함]' if web_context else ''}"
-                f"\n질문: {safe_query}\n\n답변:",
+                f"\n{_rule}\n질문: {safe_query}\n\n답변:",
                 use_cache=(not web_context), timeout=90,
                 max_tokens=_style.max_tokens,
             ) if not combined_context.strip() else engine._generate_answer(
@@ -341,14 +346,19 @@ def run_retrieval_pipeline(
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
             from core.response_style import resolve_style as _resolve_style
             _style_retry = _resolve_style(response_style)
+            _korean_r = sum(1 for c in safe_query if "가" <= c <= "힣")
+            _is_ko_r = _korean_r >= max(1, len(safe_query) * 0.2)
+            _rule_r = _style_retry.rule_text_ko if _is_ko_r else _style_retry.rule_text_en
             retry = engine.llm.call_gemma(
-                f"{sys_prefix}질문: {safe_query}\n\n"
-                "📚 자료 기반: 관련 내부 자료 없음\n💡 추론:",
+                f"{sys_prefix}{_rule_r}\n"
+                f"질문: {safe_query}\n\n"
+                "(내부 자료에는 직접 언급이 없습니다. "
+                "위 가이드를 따라 자연스럽게 답하세요.)\n답변:",
                 use_cache=False, timeout=60, max_tokens=_style_retry.max_tokens,
             )
             if retry and not any(retry.startswith(p) for p in engine._LLM_ERROR_PREFIXES):
                 print(f"[ROUTER] post_check → 재시도 (persona 포함)")
-                answer = "📚 자료 기반: 관련 내부 자료 없음\n💡 추론: " + retry
+                answer = retry
 
     except Exception as e:
         engine._log("generate_answer", e, user_role)

--- a/core/response_style.py
+++ b/core/response_style.py
@@ -1,38 +1,34 @@
-"""Response-style presets — controls answer length, structure, and tone
-across all LLM call sites in the reasoning pipeline.
+"""Response-style — natural-flow answer prompt.
 
-Why this module exists
-----------------------
-Pre-this-PR every LLM call hard-coded `max_tokens=2000` and the
-`_generate_answer` system prompt forced a two-section structure
-(📚 자료 기반 + 💡 추론). End-result: every answer was long and
-verbose, even for trivial chat. Operators reported "답변이 너무 길고
-복잡" (issue raised in 2026-05-08 user-feedback session).
+Why this module exists (v2 — 2026-05-08 redesign)
+--------------------------------------------------
+v1 (PR #72) tried to control answer length via three max_token presets
+(brief=600, standard=1200, detailed=2000) plus a rigid 📚/💡 two-section
+template. User feedback rejected the approach: cutting tokens makes
+answers feel truncated, and the emoji-labelled sections feel mechanical.
 
-Three presets, one resolver
----------------------------
+What the user wants instead: a Claude-style natural answer flow —
+**core answer → supporting evidence → alternative perspective / follow-up
+suggestion** — composed as connected prose, with the model picking
+the right length for the question.
 
-`brief`     max_tokens=600,  no forced section split — direct answer.
-`standard`  max_tokens=1200, two sections but compact (DEFAULT).
-`detailed`  max_tokens=2000, full two-section with extensive reasoning
-            (preserves pre-this-PR behavior as opt-in).
+v2 design
+---------
+- Single preset (`NATURAL`). The `brief` / `standard` / `detailed` ids
+  still resolve to it for backward compat (so existing API consumers
+  keep working) but they all behave identically.
+- `max_tokens=2000` everywhere — generous, the model picks the actual
+  length based on question complexity.
+- `force_two_sections=False` — no rigid template. The `rule_text_*`
+  block teaches the flow as guidance, not a formatting requirement.
+- Rule text instructs prose composition, explicit "do NOT use 📚/💡
+  labels", and "short questions get short answers, complex questions
+  get the full flow".
 
-Resolution order (highest precedence first):
-  1. explicit `style=` kwarg from caller
-  2. `JAMES_RESPONSE_STYLE` env var
-  3. fallback to `standard`
-
-Why a separate module rather than inlining
-- Three call sites need it: `engine._generate_answer`, `modes.handle_chat`,
-  `pipeline.run_retrieval_pipeline` web fallback. A shared resolver keeps
-  the precedence rule in one place — adding a fourth call site doesn't
-  duplicate the env-var read.
-- The structural rule (📚/💡 prompt block) lives next to the token cap
-  it's paired with, so changing one without the other isn't possible.
-
-This is mother-platform behavior. No domain-specific style logic lives
-here — domain packs may eventually override via Axis 3 / v0.3 plugin
-contract, but that's out of scope for v0.2.
+The module-level constants (BRIEF / STANDARD / DETAILED / VALID_STYLES)
+and `resolve_style()` API are preserved so the call sites in
+core/reasoning/engine.py / modes.py / pipeline.py and the
+QueryRequest.response_style field continue to work without churn.
 """
 from __future__ import annotations
 
@@ -40,7 +36,10 @@ import os
 from dataclasses import dataclass
 
 
-# Public preset names — use these strings everywhere, not literals.
+# Public preset names — kept for backward compat with existing call
+# sites and the QueryRequest.response_style API field. All three now
+# resolve to the same NATURAL preset (length is picked by the model,
+# not by the caller).
 BRIEF = "brief"
 STANDARD = "standard"
 DETAILED = "detailed"
@@ -53,12 +52,15 @@ class StylePreset:
     """Resolved style — what each call site needs to issue an LLM call.
 
     `name`: preset id for logging / response echo.
-    `max_tokens`: hard cap passed to call_gemma.
-    `force_two_sections`: when True, the 📚/💡 structural rule is
-        added to the prompt; when False, the model gets a single-shot
-        prompt with no structural template.
-    `rule_text_ko` / `rule_text_en`: the literal rule block injected
-        into the prompt when `force_two_sections=True`.
+    `max_tokens`: hard cap passed to call_gemma. 2000 is generous; the
+        model picks actual length from the prompt's flow guidance, not
+        from a token budget.
+    `force_two_sections`: legacy field — always False in v2. Kept on
+        the dataclass so any caller still reading it gets a sane value.
+    `rule_text_ko` / `rule_text_en`: the natural-flow guidance block
+        injected into the answer prompt. Teaches the 핵심→근거→대안
+        flow as guidance (not a rigid template) and explicitly forbids
+        the old 📚/💡 emoji labels.
     """
     name:               str
     max_tokens:         int
@@ -67,70 +69,56 @@ class StylePreset:
     rule_text_en:       str
 
 
-# Concrete presets — keep them grouped here so a reviewer changing one
-# notices the others. The two-section rules differ by language; the
-# brief rule is intentionally empty (no template at all).
-_PRESETS: dict[str, StylePreset] = {
-    BRIEF: StylePreset(
-        name=BRIEF,
-        max_tokens=600,
-        force_two_sections=False,
-        rule_text_ko="간결하게 핵심만 한 문단으로 답변하세요.\n",
-        rule_text_en="Answer concisely in one short paragraph.\n",
+# The one natural-flow preset. All public ids resolve to this.
+NATURAL_PRESET = StylePreset(
+    name="natural",
+    max_tokens=2000,
+    force_two_sections=False,
+    rule_text_ko=(
+        "답변 작성 가이드:\n"
+        "- 자연스러운 한국어 문단으로 답하세요. 번호 매기기, 'STEP 1', "
+        "'📚 자료 기반', '💡 추론' 같은 라벨은 사용하지 마세요.\n"
+        "- 흐름은 다음을 따르되 강제는 아닙니다:\n"
+        "  (1) 질문에 대한 핵심 답을 먼저 한 두 문장으로 직접 제시.\n"
+        "  (2) 내부 자료에서 근거가 되는 부분을 자연스럽게 이어서 설명. "
+        "근거가 없으면 '제공된 자료에는 직접 언급이 없습니다'라고 명시.\n"
+        "  (3) 관련 시각, 한계, 또는 후속으로 물어볼 만한 내용을 짧게 덧붙이세요.\n"
+        "- 짧은 질문엔 핵심 답만으로 충분합니다. 복잡한 질문일수록 (2)(3)을 채우세요.\n"
+        "- 글자수 제약 없음. 내용에 맞는 자연스러운 길이로.\n"
     ),
-    STANDARD: StylePreset(
-        name=STANDARD,
-        max_tokens=1200,
-        force_two_sections=True,
-        rule_text_ko=(
-            "답변 구조 (간결하게):\n"
-            "📚 자료 기반: 내부 자료 사실만. 없으면 '관련 자료 없음'\n"
-            "💡 추론: 자료를 연결한 짧은 분석 (3-4문장)\n"
-        ),
-        rule_text_en=(
-            "Answer structure (concise):\n"
-            "📚 Data-based: facts from internal data only, or 'No relevant data'\n"
-            "💡 Reasoning: short analysis tying data together (3-4 sentences)\n"
-        ),
+    rule_text_en=(
+        "Answer composition guide:\n"
+        "- Write in natural English prose. Do NOT use numbered lists, "
+        "'STEP 1' headers, or '📚 Data-based' / '💡 Reasoning' labels.\n"
+        "- Follow this flow as guidance (not a rigid template):\n"
+        "  (1) Direct answer to the question in one or two sentences first.\n"
+        "  (2) Supporting evidence from the internal data, woven into "
+        "the prose. If the data does not directly cover the question, "
+        "say so explicitly.\n"
+        "  (3) Briefly add a related angle, limitation, or a useful "
+        "follow-up question.\n"
+        "- Short questions deserve short answers. Fill in (2) and (3) "
+        "only when the question warrants it.\n"
+        "- No character-count limit. Pick a length that fits the content.\n"
     ),
-    DETAILED: StylePreset(
-        name=DETAILED,
-        max_tokens=2000,
-        force_two_sections=True,
-        rule_text_ko=(
-            "답변 구조:\n"
-            "📚 자료 기반: (내부 자료 사실만. 없으면 '관련 자료 없음')\n"
-            "💡 추론: (자료와 지식을 연결한 자유 분석)\n"
-            "규칙: 두 섹션 모두 작성. 자료 기반은 확인된 사실만.\n"
-        ),
-        rule_text_en=(
-            "Answer structure:\n"
-            "📚 Data-based: (facts from internal data only, or 'No relevant data')\n"
-            "💡 Reasoning: (free analysis using data + knowledge)\n"
-            "Rules: Both sections required. Data-based = confirmed facts only.\n"
-        ),
-    ),
-}
+)
 
 
 def resolve_style(explicit: str = "") -> StylePreset:
-    """Resolve the active style preset for an LLM call.
+    """Resolve the active style preset.
 
-    Args:
-      explicit: caller-provided style id (from API request kwarg).
-                Empty string / None / unknown values fall through to
-                the env var, then the default.
+    v2: ignores `explicit` (and the `JAMES_RESPONSE_STYLE` env) — all
+    inputs resolve to NATURAL_PRESET. Kept as a function so the call
+    sites don't need to change. The signature also documents that
+    explicit style ids are accepted (for forward compat if a future
+    pack-level override resurrects the preset distinction).
 
-    Resolution order: explicit kwarg → JAMES_RESPONSE_STYLE env →
-    `standard` default. Unknown values at any layer fall through to
-    the next layer rather than raising — this matches the rest of the
-    reasoning pipeline's defensive defaults (a typo in a config never
-    crashes a live request).
+    The env var is still read so an unrecognised value here doesn't
+    silently differ from the v1 behavior — but since all values now
+    map to NATURAL, the read is informational only.
     """
-    candidate = (explicit or "").strip().lower()
-    if candidate in _PRESETS:
-        return _PRESETS[candidate]
-    env = (os.getenv("JAMES_RESPONSE_STYLE", "") or "").strip().lower()
-    if env in _PRESETS:
-        return _PRESETS[env]
-    return _PRESETS[STANDARD]
+    # Read but ignore — preserves the v1 API surface for any caller
+    # that introspects this function's behavior.
+    _ = (explicit or "").strip().lower()
+    _ = (os.getenv("JAMES_RESPONSE_STYLE", "") or "").strip().lower()
+    return NATURAL_PRESET

--- a/tests/test_response_style.py
+++ b/tests/test_response_style.py
@@ -1,15 +1,23 @@
-"""Response-style preset resolver and call-site contracts.
+"""Response-style — natural-flow answer prompt.
+
+v2 redesign (2026-05-08): the v1 brief/standard/detailed presets
+were rejected by user feedback ("글자수를 짧게 하기 위해 자르는게
+아니고 문단을 나눠서 핵심 답변, 근거, 대안제시"). v2 collapses to
+one NATURAL_PRESET that teaches a Claude-style flow without rigid
+emoji-section template; max_tokens stays generous and the model
+picks length from the prompt.
 
 Coverage:
-  - `resolve_style()`: explicit kwarg → env var → `standard` default
-    precedence. Unknown values fall through rather than raising.
-  - Each preset's max_tokens + force_two_sections fields match the
-    documented contract (brief=600/no-split, standard=1200/two-section,
-    detailed=2000/two-section).
-  - Source-level contract: every LLM call site in core/reasoning/
-    derives max_tokens from `resolve_style(...)` rather than hard-
-    coding 2000 — a future refactor that re-introduces the literal
-    fails the contract test and a reviewer makes a conscious choice.
+  - All public ids (brief / standard / detailed) and explicit "" /
+    None / unknown values resolve to NATURAL_PRESET (one preset only).
+  - NATURAL preset properties: max_tokens=2000, force_two_sections
+    is False (legacy field — kept for API compat), rule_text mentions
+    the 핵심/근거/대안 flow and explicitly forbids 📚/💡 labels.
+  - Source-level contracts:
+      * engine._generate_answer / modes.handle_chat / pipeline web
+        fallback all derive max_tokens from resolve_style (no literal).
+      * No call site retains the literal "📚 자료 기반" or "💡 추론"
+        as a forced template (v1 had these baked in; v2 must not).
 
 Run:
   python -m unittest tests.test_response_style
@@ -23,7 +31,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-class ResolveStyleTests(unittest.TestCase):
+class NaturalFlowResolverTests(unittest.TestCase):
     def setUp(self):
         self._orig_env = os.environ.get("JAMES_RESPONSE_STYLE")
 
@@ -33,142 +41,115 @@ class ResolveStyleTests(unittest.TestCase):
         else:
             os.environ["JAMES_RESPONSE_STYLE"] = self._orig_env
 
-    def test_default_is_standard(self):
-        from core.response_style import resolve_style, STANDARD
+    def test_default_resolves_to_natural(self):
+        from core.response_style import resolve_style, NATURAL_PRESET
         os.environ.pop("JAMES_RESPONSE_STYLE", None)
-        s = resolve_style()
-        self.assertEqual(s.name, STANDARD)
-        self.assertEqual(s.max_tokens, 1200)
-        self.assertTrue(s.force_two_sections)
+        self.assertIs(resolve_style(), NATURAL_PRESET)
 
-    def test_explicit_brief(self):
-        from core.response_style import resolve_style, BRIEF
-        s = resolve_style("brief")
-        self.assertEqual(s.name, BRIEF)
-        self.assertEqual(s.max_tokens, 600)
-        self.assertFalse(s.force_two_sections,
-                         "brief must NOT force the 📚/💡 two-section split")
+    def test_all_legacy_ids_resolve_to_natural(self):
+        from core.response_style import resolve_style, NATURAL_PRESET
+        for legacy in ("brief", "standard", "detailed",
+                       "BRIEF", "Standard", "  detailed  "):
+            self.assertIs(resolve_style(legacy), NATURAL_PRESET,
+                          f"legacy id {legacy!r} must resolve to NATURAL")
 
-    def test_explicit_detailed(self):
-        from core.response_style import resolve_style, DETAILED
-        s = resolve_style("detailed")
-        self.assertEqual(s.name, DETAILED)
-        self.assertEqual(s.max_tokens, 2000,
-                         "detailed preserves the pre-this-PR 2000-token cap")
-        self.assertTrue(s.force_two_sections)
+    def test_unknown_values_resolve_to_natural(self):
+        from core.response_style import resolve_style, NATURAL_PRESET
+        for val in ("verbose", "nonsense", "", "  "):
+            self.assertIs(resolve_style(val), NATURAL_PRESET)
 
-    def test_explicit_kwarg_beats_env(self):
-        from core.response_style import resolve_style, BRIEF
-        os.environ["JAMES_RESPONSE_STYLE"] = "detailed"
-        s = resolve_style("brief")
-        self.assertEqual(s.name, BRIEF,
-                         "explicit kwarg must override env var")
-
-    def test_env_var_used_when_no_explicit(self):
-        from core.response_style import resolve_style, BRIEF
-        os.environ["JAMES_RESPONSE_STYLE"] = "brief"
-        s = resolve_style()
-        self.assertEqual(s.name, BRIEF)
-        s = resolve_style("")
-        self.assertEqual(s.name, BRIEF, "empty string treated as no explicit")
-
-    def test_env_var_case_insensitive(self):
-        from core.response_style import resolve_style, BRIEF
-        for val in ("BRIEF", "Brief", "  brief  "):
+    def test_env_var_does_not_change_outcome_in_v2(self):
+        from core.response_style import resolve_style, NATURAL_PRESET
+        for val in ("brief", "detailed", "anything"):
             os.environ["JAMES_RESPONSE_STYLE"] = val
-            s = resolve_style()
-            self.assertEqual(s.name, BRIEF, f"env value {val!r} should resolve")
+            self.assertIs(resolve_style(), NATURAL_PRESET,
+                          f"env={val!r} must still return NATURAL in v2")
 
-    def test_unknown_falls_through_to_default(self):
-        from core.response_style import resolve_style, STANDARD
-        os.environ.pop("JAMES_RESPONSE_STYLE", None)
-        # Unknown explicit AND no env → standard. Defensive: a typo in
-        # API call must not raise — this matches the rest of the
-        # reasoning pipeline's behavior.
-        s = resolve_style("verbose")
-        self.assertEqual(s.name, STANDARD)
-        s = resolve_style("nonsense-value")
-        self.assertEqual(s.name, STANDARD)
+    def test_natural_preset_properties(self):
+        from core.response_style import NATURAL_PRESET
+        self.assertEqual(NATURAL_PRESET.name, "natural")
+        self.assertEqual(NATURAL_PRESET.max_tokens, 2000,
+                         "v2 keeps generous max_tokens — length is "
+                         "picked by the model from the prompt, not by a cap")
+        self.assertFalse(NATURAL_PRESET.force_two_sections,
+                         "v2 must NOT force the rigid 📚/💡 template")
 
-    def test_unknown_explicit_falls_to_env_not_default(self):
-        from core.response_style import resolve_style, BRIEF
-        os.environ["JAMES_RESPONSE_STYLE"] = "brief"
-        # Unknown explicit but valid env → env wins (not default).
-        s = resolve_style("nonsense")
-        self.assertEqual(s.name, BRIEF,
-                         "unknown explicit must fall through to env, not skip it")
-
-    def test_rule_text_brief_has_no_emoji_split(self):
-        from core.response_style import resolve_style
-        s = resolve_style("brief")
-        self.assertNotIn("📚", s.rule_text_ko)
-        self.assertNotIn("💡", s.rule_text_ko)
-        self.assertNotIn("📚", s.rule_text_en)
-        self.assertNotIn("💡", s.rule_text_en)
-
-    def test_rule_text_standard_keeps_split_but_compact(self):
-        from core.response_style import resolve_style
-        s = resolve_style("standard")
-        self.assertIn("📚", s.rule_text_ko)
-        self.assertIn("💡", s.rule_text_ko)
-        # Standard rule text is shorter than detailed — the user-visible
-        # difference between them is conciseness.
-        s_detailed = resolve_style("detailed")
-        self.assertLess(len(s.rule_text_ko), len(s_detailed.rule_text_ko),
-                        "standard rule text must be shorter than detailed")
+    def test_rule_text_teaches_flow_not_rigid_template(self):
+        from core.response_style import NATURAL_PRESET
+        ko = NATURAL_PRESET.rule_text_ko
+        en = NATURAL_PRESET.rule_text_en
+        # Flow elements present in Korean rule
+        self.assertIn("핵심 답", ko)
+        self.assertIn("근거", ko)
+        # Flow elements present in English rule
+        self.assertIn("Direct answer", en)
+        self.assertIn("evidence", en.lower())
+        # Explicit ban on the v1 emoji template
+        self.assertIn("📚", ko, "rule must mention the forbidden label so it's clear what NOT to use")
+        self.assertIn("📚", en)
+        # Explicit "no character-count limit" — user said 글자수 상관없다
+        self.assertIn("글자수 제약 없음", ko)
+        self.assertIn("character-count limit", en)
 
 
 class CallSiteContractTests(unittest.TestCase):
-    """Source-level: every LLM call site in core/reasoning/ must derive
-    max_tokens from resolve_style — no hard-coded 2000 literal allowed.
-    A future refactor that re-introduces 2000 will fail here and a
-    reviewer will make a conscious choice."""
+    """Source-level: every LLM call site in core/reasoning/ derives
+    max_tokens from resolve_style. No literal `max_tokens=2000` and
+    no literal forced "📚 자료 기반" / "💡 추론" label injection
+    survives in v2."""
 
-    def test_engine_generate_answer_uses_style(self):
+    def test_engine_uses_resolve_style(self):
         import core.reasoning.engine as eng
         import inspect
-        src = inspect.getsource(eng._generate_answer if hasattr(eng, "_generate_answer")
-                                else eng.ReasoningEngine._generate_answer)
-        self.assertIn("resolve_style", src,
-                      "_generate_answer must call resolve_style")
-        self.assertIn("style.max_tokens", src,
-                      "_generate_answer must use style.max_tokens, not literal")
-        self.assertNotIn("max_tokens=2000", src,
-                         "literal max_tokens=2000 must be removed from _generate_answer")
+        src = inspect.getsource(eng.ReasoningEngine._generate_answer)
+        self.assertIn("resolve_style", src)
+        self.assertIn("style.max_tokens", src)
+        self.assertNotIn("max_tokens=2000", src)
 
-    def test_modes_handle_chat_uses_style(self):
+    def test_modes_handle_chat_uses_style_and_flow(self):
         import core.reasoning.modes as modes_mod
         import inspect
         src = inspect.getsource(modes_mod.handle_chat)
-        self.assertIn("resolve_style", src,
-                      "handle_chat must call resolve_style")
-        self.assertIn("style.max_tokens", src,
-                      "handle_chat must use style.max_tokens, not literal")
-        self.assertNotIn("max_tokens=2000", src,
-                         "literal max_tokens=2000 must be removed from handle_chat")
+        self.assertIn("resolve_style", src)
+        self.assertIn("style.max_tokens", src)
+        self.assertNotIn("max_tokens=2000", src)
+        # Flow guide injected into the chat prompt — pre-v2 chat had no rule.
+        self.assertIn("rule_txt", src,
+                      "handle_chat must inject the natural-flow rule_text "
+                      "into the prompt (pre-v2 it didn't)")
 
-    def test_pipeline_uses_style_for_web_fallback(self):
+    def test_pipeline_uses_style(self):
         import core.reasoning.pipeline as pipeline_mod
         import inspect
         src = inspect.getsource(pipeline_mod.run_retrieval_pipeline)
-        self.assertIn("resolve_style", src,
-                      "pipeline must call resolve_style for web fallback")
-        # Both call_gemma sites in pipeline (web fallback + retry) must
-        # use style.max_tokens, not 2000. We accept any style variable
-        # name (`_style.max_tokens` / `_style_retry.max_tokens` etc).
-        self.assertNotIn("max_tokens=2000", src,
-                         "literal max_tokens=2000 must be removed from pipeline")
+        self.assertIn("resolve_style", src)
+        self.assertNotIn("max_tokens=2000", src)
+        # No retry-path forced "📚 자료 기반: 관련 내부 자료 없음" prefix.
+        # The v1 retry concatenated this string verbatim into the answer
+        # — v2 lets the model phrase it naturally.
+        self.assertNotIn(
+            '"📚 자료 기반: 관련 내부 자료 없음\\n💡 추론: " + retry',
+            src,
+            "v2 must not force the 📚/💡 template into the retry path",
+        )
 
-    def test_query_endpoint_passes_response_style(self):
-        import server_llmwiki as srv
+
+class ChatParagraphPreservationTests(unittest.TestCase):
+    """User feedback explicitly said 문단을 나눠서. The pre-v2
+    handle_chat post-processed `\\n\\n` → space, killing paragraph
+    breaks. v2 must preserve them."""
+
+    def test_handle_chat_preserves_paragraph_breaks(self):
+        import core.reasoning.modes as modes_mod
         import inspect
-        src = inspect.getsource(srv)
-        self.assertIn("response_style", src,
-                      "/query/ must accept and forward response_style")
-        self.assertIn("response_style:   str", src,
-                      "QueryRequest must declare response_style field")
-        self.assertIn("response_style   = data.response_style", src,
-                      "/query/ must forward data.response_style to rag_engine.query")
+        src = inspect.getsource(modes_mod.handle_chat)
+        # The v1 regex `r'\n{2,}'` → ' ' must be gone.
+        self.assertNotIn(r"r'\n{2,}'", src,
+                         "v1 paragraph-collapse regex must be removed")
+        self.assertNotIn(r'r"\n{2,}"', src)
+        # v2 collapses 3+ newlines to exactly 2 — preserves \n\n.
+        self.assertIn(r'r"\n{3,}"', src,
+                      "v2 must collapse 3+ newlines to 2, preserving paragraphs")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replaces PR #72's three-preset max-token-capping approach with a single **NATURAL_PRESET** that teaches a Claude-style answer flow via prompt guidance. `max_tokens=2000` across the board — the model picks length from the prompt, not from a budget.

- Single `NATURAL_PRESET`. Legacy ids (`brief` / `standard` / `detailed`) and `JAMES_RESPONSE_STYLE` env all resolve to it for API back-compat.
- Flow guide injected into chat / RAG / web-fallback / no-data-retry prompts: **direct answer → supporting evidence (woven into prose) → brief follow-up angle**. Rule explicitly forbids `📚 / 💡` labels and "STEP 1" headers; says "short questions deserve short answers".
- Fixes pre-existing paragraph-killing post-process in `handle_chat` (`\n{2,}` → ' ' was collapsing paragraphs into a single block). v2 preserves `\n\n` and only collapses 3+ newlines to 2.

## Why

User feedback rejected PR #72: "글자수를 짧게 하기 위해 자르는게 아니고, 문단을 나눠서 핵심 답변, 근거, 대안제시로 자연스럽게 이어질수 있도록 형식을 개선. 글자수는 상관없다. 클로드 너의 추론과 대화 방식을 적용". Two specific issues:
- Token caps make answers feel truncated mid-thought.
- The 📚/💡 emoji-section template feels mechanical and breaks the natural prose flow.

## Verification

- 10/10 unit tests pass in `tests/test_response_style.py`
  - Resolver convergence: all legacy ids + unknowns + env-var → `NATURAL_PRESET`
  - Preset invariants: `max_tokens=2000`, `force_two_sections=False`
  - Rule-text content: mentions 핵심답/근거/Direct answer/evidence + explicit "no character-count limit" waiver
  - Source contracts: no `max_tokens=2000` literal in any reasoning call site, no forced `📚 자료 기반: 관련 내부 자료 없음 + 💡 추론` retry-path concatenation
  - Paragraph preservation: `handle_chat` no longer collapses `\n\n` to space
- 46/46 regression suite pass (risky-coding + observability + response_style + meta).

## Bench numbers

Not applicable. Change is in answer-composition prompt and post-process only — retrieval / graph / scoring stages untouched. STEP 7 q1–q12 timing/graph_paths invariants unaffected; q13 (meta-mode) bypasses this code entirely.

## Out of scope

- Per-mode flow override (e.g. wiki_edit always brief, self_evolve always detailed) — still possible via the `StylePreset` dataclass surface; can land later if usage signals it.
- Streaming responses — unrelated; would require a separate refactor of the LLM call path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)