### PR TITLE
fix(reasoning): expand meta-mode fast patterns for casual chat phrasings (PR #73 follow-up)

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -103,15 +103,28 @@ class IntentClassifier:
         # `retrieval` and produced hallucinated answers because the wiki
         # file *list* is not in any vector chunk. Now routed to handle_meta
         # which calls tools/wiki/wiki_editor.py::list_entities() directly.
-        # Keep narrow — must combine an "inventory verb" with a wiki/data
-        # noun, or be one of the canonical phrasings, so we don't hijack
-        # legitimate retrieval like "BlackRock 목록 알려줘".
+        #
+        # Patterns must combine an inventory verb (목록 / 보여 / 알려 / 뭐
+        # / 있는지 / list / show / what ... do you have) with a wiki/data
+        # noun (wiki / 자료 / 문서 / 데이터 / entity / knowledge). This
+        # keeps "BlackRock 목록 알려줘" (specific topic) out of meta.
         "meta": [
+            # 캐논 형식: "wiki 목록", "내부 자료 보여줘"
             r"(wiki|위키|내부\s*자료|보유\s*자료|가지고\s*있는)\s*(목록|리스트|보여)",
             r"(어떤|무슨)\s*(자료|문서|wiki|위키|entity|엔티티).{0,15}(있|가지)",
             r"^(자료|문서|entity|엔티티)\s*(목록|리스트)\s*[?\.!]?$",
-            r"(list|show)\s+(all\s+)?(entities|wiki|documents|files)",
-            r"^what\s+do\s+you\s+(have|know\s+about)",
+            # 캐주얼 한국어: "데이터 뭐 있는지", "문서 뭐가 있어"
+            r"(데이터|자료|문서|wiki|위키|entity|엔티티|knowledge)\s*(뭐|무슨|어떤)",
+            r"(뭐|무슨|어떤)\s*(자료|문서|데이터|wiki|entity)\s*(있|가지|보유)",
+            # 캐주얼 한국어: "저장된 데이터", "갖고 있는 자료", "보유 자료"
+            r"(저장된|보유|갖고\s*있는|가지고\s*있는|아는)\s*\S{0,5}\s*(데이터|자료|문서|정보|내용|것|거)",
+            # 캐주얼 한국어: "아는거 뭐 있어", "알고 있는 거 뭐"
+            r"(아는|알고\s*있는)\s*(거|것).{0,8}(뭐|무슨|어떤)",
+            r"내부\s*에?\s*(무슨|뭐|어떤)\s*(자료|문서|데이터|것|거)",
+            # 영어 — 더 유연하게 (PR #73 패턴은 'what do you' 만 잡음)
+            r"(list|show)\s+(all\s+|me\s+)?(your\s+)?(entities|wiki|documents|files|data|knowledge)",
+            r"^what\s+(\S+\s+){0,3}do\s+you\s+(have|know)",
+            r"(your|the)\s+(knowledge\s*base|data\s*set|wiki|files|documents)\b",
         ],
     }
 

--- a/tests/test_meta_mode.py
+++ b/tests/test_meta_mode.py
@@ -30,22 +30,48 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 class FastPatternRoutingTests(unittest.TestCase):
     """The fast-path classifier must catch inventory queries before
-    they fall through to retrieval. These five forms are the canonical
-    user-feedback signature ('어떤 자료가 있어?' from 2026-05-08)."""
+    they fall through to retrieval. v2 (2026-05-08 follow-up): user
+    reported the chat page didn't trigger meta mode — root cause was
+    the v1 patterns covered only formal phrasings ('wiki 목록 보여줘')
+    and missed the casual ones a real user actually types
+    ('데이터 뭐 있는지 보여줘', 'what data do you have'). v2 adds 7
+    more patterns covering casual KO + flexible EN forms."""
 
-    def test_korean_inventory_phrasings_route_to_meta(self):
+    def test_korean_formal_inventory_phrasings_route_to_meta(self):
         from core.intent_classifier import IntentClassifier
         cls = IntentClassifier()
         for q in (
             "wiki 목록 보여줘",
+            "wiki 목록",
             "내부 자료 목록 보여줘",
+            "내부 자료 목록",
             "어떤 자료가 있어?",
             "무슨 문서가 있는지 알려줘",
             "보유 자료 리스트 보여줘",
         ):
             mode = cls.classify_fast(q)
             self.assertEqual(mode, "meta",
-                             f"inventory phrasing should route to meta: {q!r}, got {mode!r}")
+                             f"formal inventory should route to meta: {q!r}, got {mode!r}")
+
+    def test_korean_casual_inventory_phrasings_route_to_meta(self):
+        # v2 — these are the phrasings the user actually typed in
+        # chat that fell through to retrieval and produced hallucinated
+        # answers. Must now route to meta via fast pattern (no LLM
+        # latency, no misclassification risk).
+        from core.intent_classifier import IntentClassifier
+        cls = IntentClassifier()
+        for q in (
+            "내부에 무슨 자료 있는지 알려줘",
+            "데이터 뭐 있는지 보여줘",
+            "문서 뭐가 있어?",
+            "저장된 데이터 보여줘",
+            "갖고 있는 자료 알려줘",
+            "아는거 뭐 있어?",
+            "내부에 어떤 데이터 있어",
+        ):
+            mode = cls.classify_fast(q)
+            self.assertEqual(mode, "meta",
+                             f"casual inventory should route to meta: {q!r}, got {mode!r}")
 
     def test_english_inventory_phrasings_route_to_meta(self):
         from core.intent_classifier import IntentClassifier
@@ -53,8 +79,11 @@ class FastPatternRoutingTests(unittest.TestCase):
         for q in (
             "list all entities",
             "show all wiki",
+            "show me your knowledge base",
             "what do you have?",
             "what do you know about",
+            "what data do you have",          # v2 — earlier missed this
+            "your knowledge base",            # v2 — noun-phrase pattern
         ):
             mode = cls.classify_fast(q)
             self.assertEqual(mode, "meta",
@@ -63,7 +92,8 @@ class FastPatternRoutingTests(unittest.TestCase):
     def test_specific_topic_does_NOT_route_to_meta(self):
         # "BlackRock 정보 알려줘" — specific topic retrieval. Must NOT
         # be hijacked by the meta pattern (the user wants content, not
-        # an inventory).
+        # an inventory). The v2 broader patterns increase the risk of
+        # hijacking — this test guards that risk.
         from core.intent_classifier import IntentClassifier
         cls = IntentClassifier()
         for q in (
@@ -71,10 +101,24 @@ class FastPatternRoutingTests(unittest.TestCase):
             "비트코인에 대해 설명해줘",
             "RAG가 무엇인가?",
             "Anthropic은 어떤 회사인가?",
+            "BTC ETF 출시한 회사 목록",   # specific-topic + 목록
+            "OpenAI의 최신 모델 전략",
         ):
             mode = cls.classify_fast(q)
             self.assertNotEqual(mode, "meta",
                                 f"specific-topic query must NOT route to meta: {q!r}")
+
+    def test_too_short_or_ambiguous_falls_through_to_llm(self):
+        # "뭐 있어?" alone is ambiguous (could be office / dinner /
+        # anything). It should NOT be hijacked into meta — let the LLM
+        # classifier decide based on full context. "안녕" is a clear chat.
+        from core.intent_classifier import IntentClassifier
+        cls = IntentClassifier()
+        # "안녕" has its own chat fast-pattern (not meta).
+        self.assertEqual(cls.classify_fast("안녕"), "chat")
+        # "뭐 있어?" too vague — must NOT match meta. (May or may not
+        # match other patterns; we only assert it's not meta.)
+        self.assertNotEqual(cls.classify_fast("뭐 있어?"), "meta")
 
 
 class RoleAllowedTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds 7 more fast patterns to `IntentClassifier.FAST_PATTERNS['meta']` so casual user phrasings route to meta mode without falling through to the LLM classifier (which often misroutes them back to retrieval).

## Why

User reported that PR #73's meta mode didn't trigger on the chat page. Root cause: v1 patterns covered only formal phrasings ('wiki 목록 보여줘', 'list all entities'); real users type casual forms like '데이터 뭐 있는지 보여줘' / '아는거 뭐 있어?' / 'what data do you have'. These fell through to LLM classification which (small model + long prompt) often misrouted to retrieval — exactly the original bug.

The chat page (`/query/` endpoint) already routes through `IntentClassifier.classify` — no plumbing change needed. The fix is purely in the pattern set.

## Verification

Live coverage check:
- **Positive: 15/15** — all formal + casual KO + EN forms route to meta via fast pattern (no LLM latency).
- **Negative: 8/8** — specific-topic queries (`BlackRock 정보`, `BTC ETF 출시한 회사 목록`) still fall through. `'뭐 있어?'` alone (too ambiguous) is not hijacked.

Unit tests:
- `tests/test_meta_mode.py::FastPatternRoutingTests` gains `test_korean_casual_inventory_phrasings_route_to_meta` (7 new phrasings) and `test_too_short_or_ambiguous_falls_through_to_llm` (over-broad matching guard).
- 10/10 tests in `test_meta_mode.py` pass.
- 48/48 regression suite pass.

## Bench numbers

Not applicable. Pattern-set change in `intent_classifier.py` only — no retrieval/graph/reasoning surface touched. STEP 7 q1–q12 unchanged; q13 (meta-mode) still routes via the canonical `wiki 목록 보여줘` baseline phrasing.

## Out of scope

- LLM `CLASSIFY_PROMPT` re-tuning — would help LLM-fallback accuracy but the fast patterns already cover the realistic cases.
- Pagination of `list_entities()` — for a 200-entity wiki the bucket summary handler already produces compact output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)