### PR TITLE
feat(evolution): bench eval gate + auto-rollback (#68 phase 2-A)

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1984,15 +1984,39 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
         patch = rec
         ok, msg = patch_apply(patch, validated=True)
 
-        # Lifecycle: deployed | rolled_back. Phase 2 will plug the
-        # before/after metrics from bench.py here.
+        # If apply() itself failed, no bench gate to run — record and exit.
+        if not ok:
+            record_outcome(patch_id, "rolled_back", detail=f"apply failed: {msg}")
+            return {
+                "success":           False,
+                "message":           msg,
+                "outcome":           "rolled_back",
+                "patch_id":          patch_id,
+                "approver_username": approver_username,
+                "approver_role":     role,
+                "approval_method":   approval_method,
+            }
+
+        # #68 phase 2-A: bench eval gate. Re-runs STEP 7 against the
+        # live server in a subprocess (asyncio.to_thread so the event
+        # loop can serve the bench's incoming /query/ requests). On
+        # regression, the gate auto-rolls-back inside run_bench_gate
+        # and returns outcome_label='rolled_back'.
+        from tools.patch.bench_gate import run_bench_gate
+        gate = await run_bench_gate(patch_id, patch.get("target", ""))
+
         record_outcome(
-            patch_id, "deployed" if ok else "rolled_back",
-            detail=msg,
+            patch_id, gate.outcome_label,
+            detail=gate.detail,
+            before_metrics=gate.before_metrics,
+            after_metrics=gate.after_metrics,
         )
         return {
-            "success":           ok,
+            "success":           gate.passed,
             "message":           msg,
+            "outcome":           gate.outcome_label,
+            "before_metrics":    gate.before_metrics,
+            "after_metrics":     gate.after_metrics,
             "patch_id":          patch_id,
             "approver_username": approver_username,
             "approver_role":     role,

--- a/tests/test_evolution_bench_gate.py
+++ b/tests/test_evolution_bench_gate.py
@@ -1,0 +1,273 @@
+"""Bench eval gate for self-evolution patches — #68 phase 2-A.
+
+Coverage:
+  - `run_bench_gate` returns `outcome_label='deployed'` on bench pass,
+    `outcome_label='rolled_back'` on bench fail (with rollback fired).
+  - `JAMES_EVOLUTION_GATE=0` skips the bench check; outcome_label is
+    `deployed_gate_skipped` and `after_metrics={"gate":"skipped"}`.
+  - `_summarize_report` produces the compact dict shape we ship to
+    the audit log (small enough to keep `james_patch_log.jsonl`
+    human-scannable).
+  - `_latest_bench_report` picks the most-recent bench file by mtime
+    and returns None when the reports/ dir is empty.
+  - Source-level: `/admin/patch/approve` calls `run_bench_gate` and
+    forwards `before_metrics`/`after_metrics`/`outcome` to
+    `record_outcome`. A future refactor that drops the gate must
+    consciously break this contract test.
+  - Subprocess timeout / launch-failure paths fail-closed (gate
+    treats them as regressions and rolls back).
+
+Run:
+  python -m unittest tests.test_evolution_bench_gate
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch as mock_patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class GateEnabledEnvTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_EVOLUTION_GATE")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_EVOLUTION_GATE", None)
+        else:
+            os.environ["JAMES_EVOLUTION_GATE"] = self._orig
+
+    def test_default_enabled(self):
+        from tools.patch.bench_gate import _gate_enabled
+        os.environ.pop("JAMES_EVOLUTION_GATE", None)
+        self.assertTrue(_gate_enabled())
+
+    def test_explicit_off_variants(self):
+        from tools.patch.bench_gate import _gate_enabled
+        for v in ("0", "false", "FALSE", "no", ""):
+            os.environ["JAMES_EVOLUTION_GATE"] = v
+            self.assertFalse(_gate_enabled(),
+                             f"value {v!r} must disable the gate")
+
+    def test_explicit_on_variants(self):
+        from tools.patch.bench_gate import _gate_enabled
+        for v in ("1", "true", "yes", "anything"):
+            os.environ["JAMES_EVOLUTION_GATE"] = v
+            self.assertTrue(_gate_enabled())
+
+
+class TimeoutClampTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_EVOLUTION_GATE_TIMEOUT_S")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_EVOLUTION_GATE_TIMEOUT_S", None)
+        else:
+            os.environ["JAMES_EVOLUTION_GATE_TIMEOUT_S"] = self._orig
+
+    def test_default_600(self):
+        from tools.patch.bench_gate import _gate_timeout_s
+        os.environ.pop("JAMES_EVOLUTION_GATE_TIMEOUT_S", None)
+        self.assertEqual(_gate_timeout_s(), 600)
+
+    def test_clamp_low(self):
+        from tools.patch.bench_gate import _gate_timeout_s
+        os.environ["JAMES_EVOLUTION_GATE_TIMEOUT_S"] = "5"
+        self.assertEqual(_gate_timeout_s(), 30, "must clamp >= 30")
+
+    def test_clamp_high(self):
+        from tools.patch.bench_gate import _gate_timeout_s
+        os.environ["JAMES_EVOLUTION_GATE_TIMEOUT_S"] = "99999"
+        self.assertEqual(_gate_timeout_s(), 3600, "must clamp <= 3600")
+
+    def test_garbage_falls_back_to_600(self):
+        from tools.patch.bench_gate import _gate_timeout_s
+        os.environ["JAMES_EVOLUTION_GATE_TIMEOUT_S"] = "not-a-number"
+        self.assertEqual(_gate_timeout_s(), 600)
+
+
+class ReportPickerTests(unittest.TestCase):
+    """_latest_bench_report + _summarize_report shape contracts."""
+
+    def test_latest_picks_most_recent(self):
+        from tools.patch import bench_gate as bg
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            old = tdp / "bench_aaa_step7_20260101_000000.json"
+            new = tdp / "bench_bbb_step7_20260507_120000.json"
+            old.write_text("{}", encoding="utf-8")
+            time.sleep(0.05)  # ensure mtime ordering
+            new.write_text("{}", encoding="utf-8")
+            with mock_patch.object(bg, "REPORTS_DIR", tdp):
+                got = bg._latest_bench_report("step7")
+                self.assertEqual(got, new)
+
+    def test_latest_returns_none_when_empty(self):
+        from tools.patch import bench_gate as bg
+        with tempfile.TemporaryDirectory() as td:
+            with mock_patch.object(bg, "REPORTS_DIR", Path(td)):
+                self.assertIsNone(bg._latest_bench_report("step7"))
+
+    def test_summarize_compact_shape(self):
+        from tools.patch.bench_gate import _summarize_report
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump({
+                "git_sha": "abc1234",
+                "total_seconds": 321.6,
+                "queries": 3,
+                "results": [
+                    {"id": 1, "status": "ok", "blocked": False},
+                    {"id": 2, "status": "ok", "blocked": True},
+                    {"id": 3, "status": "error"},
+                ],
+            }, f)
+            path = Path(f.name)
+        try:
+            s = _summarize_report(path)
+            self.assertEqual(s["git_sha"], "abc1234")
+            self.assertEqual(s["total_seconds"], 321.6)
+            self.assertEqual(s["queries"], 3)
+            self.assertEqual(s["ok"], 1)
+            self.assertEqual(s["blocked"], 1)
+            self.assertEqual(s["errors"], 1)
+            self.assertIn(s["report_file"], path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_summarize_handles_missing(self):
+        from tools.patch.bench_gate import _summarize_report
+        self.assertEqual(_summarize_report(None), {})
+        self.assertEqual(_summarize_report(Path("/nonexistent/foo.json")), {})
+
+
+class GateOutcomeTests(unittest.TestCase):
+    """End-to-end on the gate orchestration. Mocks the subprocess
+    runner so we don't actually need a live server."""
+
+    def setUp(self):
+        self._orig_gate = os.environ.get("JAMES_EVOLUTION_GATE")
+        os.environ["JAMES_EVOLUTION_GATE"] = "1"
+
+    def tearDown(self):
+        if self._orig_gate is None:
+            os.environ.pop("JAMES_EVOLUTION_GATE", None)
+        else:
+            os.environ["JAMES_EVOLUTION_GATE"] = self._orig_gate
+
+    def _run(self, patch_id, target, suite="step7"):
+        from tools.patch.bench_gate import run_bench_gate
+        return asyncio.run(run_bench_gate(patch_id, target, suite=suite))
+
+    def test_skipped_when_env_off(self):
+        from tools.patch.bench_gate import run_bench_gate
+        os.environ["JAMES_EVOLUTION_GATE"] = "0"
+        result = self._run("p1", "./workspace/dummy.py")
+        self.assertTrue(result.passed)
+        self.assertEqual(result.outcome_label, "deployed_gate_skipped")
+        self.assertEqual(result.after_metrics, {"gate": "skipped"})
+
+    def test_passed_when_subprocess_returncode_0(self):
+        from tools.patch import bench_gate as bg
+        with mock_patch.object(
+            bg, "_run_bench_check_blocking",
+            return_value=(True, "ok"),
+        ), mock_patch.object(
+            bg, "_summarize_report",
+            side_effect=[{"queries": 13, "ok": 11}, {"queries": 13, "ok": 11}],
+        ):
+            result = self._run("p1", "./workspace/dummy.py")
+        self.assertTrue(result.passed)
+        self.assertEqual(result.outcome_label, "deployed")
+        self.assertEqual(result.after_metrics["queries"], 13)
+        self.assertIn("bench gate passed", result.detail)
+
+    def test_rollback_fired_on_subprocess_returncode_1(self):
+        from tools.patch import bench_gate as bg
+        # Stub restore_latest so we can assert it was called.
+        called = {}
+        def _fake_restore(target):
+            called["target"] = target
+            return True, "rollback ok"
+        # Patch the lazy import target: tools.patch.patch_applier.restore_latest
+        with mock_patch.object(
+            bg, "_run_bench_check_blocking",
+            return_value=(False, "q1: graph_paths=2 outside band"),
+        ), mock_patch.object(
+            bg, "_summarize_report",
+            side_effect=[{"queries": 13}, {"queries": 13, "errors": 1}],
+        ), mock_patch(
+            "tools.patch.patch_applier.restore_latest", _fake_restore
+        ):
+            result = self._run("p1", "./workspace/dummy.py")
+        self.assertFalse(result.passed)
+        self.assertEqual(result.outcome_label, "rolled_back")
+        self.assertEqual(called["target"], "./workspace/dummy.py")
+        self.assertIn("rollback=ok", result.detail)
+        self.assertIn("bench regression", result.detail)
+
+    def test_rollback_failure_recorded_in_detail(self):
+        from tools.patch import bench_gate as bg
+        def _broken_restore(target):
+            return False, "no backup found"
+        with mock_patch.object(
+            bg, "_run_bench_check_blocking",
+            return_value=(False, "regression"),
+        ), mock_patch.object(
+            bg, "_summarize_report",
+            return_value={},
+        ), mock_patch(
+            "tools.patch.patch_applier.restore_latest", _broken_restore
+        ):
+            result = self._run("p1", "./workspace/dummy.py")
+        self.assertFalse(result.passed)
+        self.assertEqual(result.outcome_label, "rolled_back")
+        self.assertIn("rollback=FAIL", result.detail)
+        self.assertIn("no backup found", result.detail)
+
+    def test_subprocess_launch_failure_treated_as_regression(self):
+        from tools.patch import bench_gate as bg
+        # Real _run_bench_check_blocking with a bogus python path that
+        # doesn't exist — subprocess.run raises FileNotFoundError.
+        with mock_patch.object(bg, "sys") as mock_sys:
+            mock_sys.executable = "/totally/not/a/real/python/binary"
+            with mock_patch.object(bg, "_summarize_report", return_value={}), \
+                 mock_patch("tools.patch.patch_applier.restore_latest",
+                            return_value=(True, "ok")):
+                result = self._run("p1", "./workspace/dummy.py")
+            self.assertFalse(result.passed)
+            self.assertEqual(result.outcome_label, "rolled_back")
+
+
+class ApproveEndpointContractTests(unittest.TestCase):
+    """Source-level: /admin/patch/approve must call run_bench_gate
+    and pass before/after metrics into record_outcome."""
+
+    def test_approve_endpoint_invokes_gate(self):
+        import server_llmwiki as srv
+        import inspect
+        src = inspect.getsource(srv)
+        self.assertIn("from tools.patch.bench_gate import run_bench_gate", src,
+                      "/admin/patch/approve must import run_bench_gate")
+        self.assertIn("await run_bench_gate(", src,
+                      "approve handler must await run_bench_gate")
+        self.assertIn("before_metrics=gate.before_metrics", src,
+                      "approve handler must forward before_metrics")
+        self.assertIn("after_metrics=gate.after_metrics", src,
+                      "approve handler must forward after_metrics")
+        self.assertIn("gate.outcome_label", src,
+                      "approve handler must use gate.outcome_label, not its own ok/fail string")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/patch/bench_gate.py
+++ b/tools/patch/bench_gate.py
@@ -1,0 +1,215 @@
+"""Bench eval gate for self-evolution patch deploys (#68 phase 2-A).
+
+After `patch_apply()` succeeds inside `/admin/patch/approve`, this
+module re-runs the STEP 7 regression suite against the live server
+via `scripts/bench.py --check`. On any regression beyond the
+configured tolerance, the gate triggers an auto-rollback via
+`patch_applier.restore_latest()` and records the outcome in the
+patch lifecycle log.
+
+Why a subprocess rather than calling the runner in-process
+- bench.py imports `requests` and POSTs against the live server
+  (the same uvicorn process that's handling the approve request).
+  Doing this in-process would require an HTTP-self-call from inside
+  an async handler — fragile and easy to deadlock. A subprocess is
+  simpler and matches the operator-CLI invocation pattern.
+- Running the subprocess in `asyncio.to_thread` lets the event loop
+  keep serving the bench's incoming /query/ requests while the
+  approve handler is blocked waiting for the gate result.
+
+What goes in the audit log
+- `before_metrics`: latest pre-deploy bench report (most recent
+  reports/bench_*_step7_*.json that existed before this approve).
+- `after_metrics`: bench report produced by THIS gate run.
+- `outcome`: "deployed" if gate passes, "rolled_back" otherwise.
+  `record_outcome.detail` carries the bench failure summary.
+
+Operator overrides
+- `JAMES_EVOLUTION_GATE=0` skips the bench check entirely. The
+  approve still records before_metrics if available; after_metrics
+  becomes `{"gate": "skipped"}`. Audit-trail intact, gate disabled.
+  Default ON.
+- `JAMES_EVOLUTION_GATE_TIMEOUT_S` (default 600) — bench subprocess
+  wall-clock cap. Beyond this the gate fails (treated as regression)
+  and rollback fires.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+REPORTS_DIR = ROOT / "reports"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of one bench-gate run.
+
+    `passed`: True if bench --check exited 0 OR the gate was skipped.
+    `outcome_label`: feeds `record_outcome(outcome=...)` directly —
+        "deployed" / "rolled_back" / "deployed_gate_skipped".
+    `detail`: short human-readable summary for the audit log.
+    `before_metrics` / `after_metrics`: pre-deploy and post-deploy
+        bench summaries (the dicts stored on the lifecycle entry).
+    """
+    passed:         bool
+    outcome_label:  str
+    detail:         str
+    before_metrics: dict
+    after_metrics:  dict
+
+
+def _gate_enabled() -> bool:
+    """Default ON. Set JAMES_EVOLUTION_GATE=0 (or false / no) to skip."""
+    val = os.getenv("JAMES_EVOLUTION_GATE", "1").strip().lower()
+    return val not in ("0", "false", "no", "")
+
+
+def _gate_timeout_s() -> int:
+    raw = os.getenv("JAMES_EVOLUTION_GATE_TIMEOUT_S", "600").strip()
+    try:
+        n = int(raw)
+        return max(30, min(n, 3600))
+    except Exception:
+        return 600
+
+
+def _latest_bench_report(suite: str = "step7") -> Optional[Path]:
+    """Most recent reports/bench_*_<suite>_*.json (mtime sort).
+
+    Used as `before_metrics` source — the snapshot of system state
+    at the time of the approve request, before this patch is applied.
+    None if no prior bench has been run. The audit entry then carries
+    `before_metrics={}` — still useful, just no comparison baseline.
+    """
+    if not REPORTS_DIR.exists():
+        return None
+    candidates = sorted(
+        REPORTS_DIR.glob(f"bench_*_{suite}_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _summarize_report(path: Optional[Path]) -> dict:
+    """Compact a bench JSON report into the small dict that goes into
+    the audit log. Keep it tight — the lifecycle JSONL must remain
+    human-scannable; full bench reports stay on disk under reports/.
+
+    Shape:
+      {"git_sha": ..., "total_seconds": ..., "queries": N,
+       "ok": M, "blocked": K, "report_file": "bench_<sha>_<...>.json"}
+    """
+    if path is None or not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"report_file": path.name, "parse_error": True}
+    results = data.get("results") or []
+    return {
+        "report_file":   path.name,
+        "git_sha":       data.get("git_sha", ""),
+        "total_seconds": data.get("total_seconds", 0),
+        "queries":       data.get("queries", len(results)),
+        "ok":            sum(1 for r in results if r.get("status") == "ok" and not r.get("blocked")),
+        "blocked":       sum(1 for r in results if r.get("blocked")),
+        "errors":        sum(1 for r in results if r.get("status") not in ("ok",)),
+    }
+
+
+def _run_bench_check_blocking(suite: str, timeout_s: int) -> tuple[bool, str]:
+    """Synchronous bench subprocess. Returns (passed, stderr_tail).
+
+    Caller wraps in `asyncio.to_thread` so the event loop can serve
+    the bench's incoming /query/ requests while we wait.
+    """
+    cmd = [sys.executable, "scripts/bench.py", f"--suite={suite}", "--check"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"bench timeout after {timeout_s}s"
+    except FileNotFoundError as e:
+        return False, f"bench launch failed: {e}"
+    passed = (proc.returncode == 0)
+    tail = (proc.stdout or "")[-400:] + (proc.stderr or "")[-400:]
+    return passed, tail.strip()
+
+
+async def run_bench_gate(
+    patch_id: str,
+    target:   str,
+    suite:    str = "step7",
+) -> GateResult:
+    """Run the eval gate after a successful patch_apply().
+
+    Caller responsibility:
+      - Call AFTER `patch_apply` succeeded (not before).
+      - On `result.passed=False`, the patch file is already rolled
+        back via `restore_latest(target)` inside this function.
+      - Pass the returned `before_metrics` / `after_metrics` to
+        `record_outcome()`.
+    """
+    before = _summarize_report(_latest_bench_report(suite))
+
+    if not _gate_enabled():
+        return GateResult(
+            passed=True,
+            outcome_label="deployed_gate_skipped",
+            detail="JAMES_EVOLUTION_GATE=0 — eval gate skipped",
+            before_metrics=before,
+            after_metrics={"gate": "skipped"},
+        )
+
+    passed, tail = await asyncio.to_thread(
+        _run_bench_check_blocking, suite, _gate_timeout_s()
+    )
+
+    # The bench run produces a NEW report file regardless of pass/fail.
+    # Pick that up as after_metrics.
+    after = _summarize_report(_latest_bench_report(suite))
+
+    if passed:
+        return GateResult(
+            passed=True,
+            outcome_label="deployed",
+            detail=f"bench gate passed; {after.get('queries', '?')} queries",
+            before_metrics=before,
+            after_metrics=after,
+        )
+
+    # Regression — auto-rollback. Lazy import to avoid pulling
+    # patch_applier into smoke-test paths that don't need it.
+    rb_msg = ""
+    try:
+        from tools.patch.patch_applier import restore_latest
+        rb_ok, rb_msg = restore_latest(target)
+    except Exception as e:
+        rb_ok = False
+        rb_msg = f"rollback raised: {e}"
+
+    detail = (
+        f"bench regression — rollback={'ok' if rb_ok else 'FAIL'}; "
+        f"{rb_msg}; bench tail: {tail[-200:]}"
+    )
+    return GateResult(
+        passed=False,
+        outcome_label="rolled_back",
+        detail=detail[:300],
+        before_metrics=before,
+        after_metrics=after,
+    )


### PR DESCRIPTION
## Summary

After `/admin/patch/approve` calls `patch_apply()` successfully, the new `tools/patch/bench_gate.py` re-runs `scripts/bench.py --suite=step7 --check` in a subprocess and:
- **bench pass** → `record_outcome("deployed", before/after_metrics)`
- **bench fail** → `restore_latest(target)` + `record_outcome("rolled_back", before/after_metrics, detail=bench failure tail)`

Subprocess wrapped in `asyncio.to_thread` so the FastAPI event loop can serve the bench's incoming `/query/` requests while the approve handler is blocked waiting for the gate result. (Self-call deadlock would otherwise be possible.)

## Audit log shape (per #68 verification §A)

```jsonc
{"event": "DEPLOYED", "patch_id": "...",
 "outcome": "deployed",
 "before_metrics": {"git_sha": "...", "queries": 13, "ok": 11, ...},
 "after_metrics":  {"git_sha": "...", "queries": 13, "ok": 11, ...},
 "detail": "bench gate passed; 13 queries"}
```

## Operator overrides

| env var | default | effect |
|---|---|---|
| `JAMES_EVOLUTION_GATE` | `1` | `0`/`false`/`no` skips the bench check (audit still records deploy with `after_metrics={"gate":"skipped"}`) |
| `JAMES_EVOLUTION_GATE_TIMEOUT_S` | `600` | Bench wall-clock cap, clamped to `[30, 3600]` |

## Verification

- 17/17 unit tests in `tests/test_evolution_bench_gate.py` covering:
  - Env truthy/falsy + timeout clamp + parse-fail fallback
  - `_latest_bench_report` mtime ordering + None on empty dir
  - `_summarize_report` compact-shape contract + missing-file safety
  - `run_bench_gate` orchestration: skipped / passed / rolled_back / rollback-failure-recorded / subprocess-launch-failure-fail-closed
  - Source contract: `/admin/patch/approve` calls `run_bench_gate` and forwards `before_metrics` / `after_metrics` / `outcome_label` into `record_outcome`
- 65/65 regression suite pass.

## Bench numbers

Not applicable — change adds an outer gate that USES bench. No inner change to retrieval/graph/reasoning. STEP 7 q1–q13 invariants unaffected.

## Out of scope (separate phase 2 PRs to follow)

- **2-B**: `tests/test_evolution_rollback.py` simulating mid-deploy crash with byte-identical recovery assertion.
- **2-C**: `GET /admin/patch/audit?since=&approver=&outcome=&limit=` query endpoint over `james_patch_log.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)