### PR TITLE
fix(encoding): explicit utf-8 on Windows-fragile open/subprocess sites

### DIFF
--- a/james_phase55_test.py
+++ b/james_phase55_test.py
@@ -238,7 +238,11 @@ def run_read_file_tests():
     print("="*55)
 
     os.makedirs("./workspace", exist_ok=True)
-    with open("./workspace/_diag_test.py", "w") as f:
+    # encoding="utf-8" required: on Windows the default is cp949, which
+    # would silently corrupt the Korean comment. ReadFileTool then reads
+    # with utf-8 + errors="replace" and emits � replacement chars in
+    # the test report (visible in older james_phase55_report.json runs).
+    with open("./workspace/_diag_test.py", "w", encoding="utf-8") as f:
         f.write("# 진단 테스트 파일\nprint('hello')\nx = 1 + 2\n")
 
     def t_read_tool_exists():

--- a/james_phase6_test.py
+++ b/james_phase6_test.py
@@ -296,7 +296,9 @@ def run_patch_flow_checks():
 
     os.makedirs("./workspace/patches", exist_ok=True)
     os.makedirs("./workspace", exist_ok=True)
-    with open("./workspace/_patch_test.py", "w") as f:
+    # encoding="utf-8" required: Windows default is cp949 → Korean
+    # comment would be saved in cp949 and corrupt downstream utf-8 reads.
+    with open("./workspace/_patch_test.py", "w", encoding="utf-8") as f:
         f.write("# 테스트 파일\nx = 1\n")
 
     def t_generator_exists():

--- a/tests/test_korean_encoding.py
+++ b/tests/test_korean_encoding.py
@@ -1,0 +1,155 @@
+"""Korean encoding regression guard.
+
+Background: Windows default `open()` encoding is cp949. Korean text
+written without an explicit `encoding="utf-8"` lands as cp949 bytes,
+which downstream utf-8 readers (ReadFileTool, CodeReader, server
+parsers) then mojibake. The visible artifact is `���` replacement
+chars in tool output / lifecycle logs / phase reports.
+
+This file exists so a future contributor reintroducing the bug fails
+the test rather than discovering it months later in a stray report
+file.
+
+Coverage:
+  - Source-level: scan the three known-fragile self-test sites and
+    `tools/patch/bench_gate.py` subprocess call to assert they keep
+    the explicit `encoding="utf-8"` after edits.
+  - Behavioral: round-trip a Korean string through write+read using
+    the patterns the production code uses, asserting no replacement
+    chars survive.
+
+Run:
+  python -m unittest tests.test_korean_encoding
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class WriteEncodingExplicitTests(unittest.TestCase):
+    """The three self-test files that previously corrupted Korean
+    comments must keep `encoding="utf-8"` on their workspace open()
+    calls. A regression here means a future edit dropped the kwarg
+    and the bug is back."""
+
+    def _assert_open_w_has_utf8(self, source: str, target_substr: str) -> None:
+        """Assert that the source contains an `open(..., "w", encoding="utf-8")`
+        call whose path argument contains `target_substr`. The path may
+        be a longer relative form (e.g. "./workspace/_diag_test.py") —
+        the substring just has to appear before `, "w", encoding=`."""
+        normalized = " ".join(source.split())
+        # The path string ends with target_substr; what follows is
+        # `, "w", encoding="utf-8"`. Either quote style is accepted.
+        needle_a = f'{target_substr}", "w", encoding="utf-8"'
+        needle_b = f"{target_substr}', 'w', encoding=\"utf-8\""
+        needle_c = f"{target_substr}\", 'w', encoding=\"utf-8\""  # mixed quotes
+        self.assertTrue(
+            any(n in normalized for n in (needle_a, needle_b, needle_c)),
+            f"open(..., 'w', encoding='utf-8') missing for path containing "
+            f"{target_substr!r}; this re-introduces the cp949 corruption bug.",
+        )
+
+    def test_phase55_diag_test_uses_utf8(self):
+        path = Path(__file__).resolve().parent.parent / "james_phase55_test.py"
+        src = path.read_text(encoding="utf-8")
+        self._assert_open_w_has_utf8(src, "_diag_test.py")
+
+    def test_phase6_patch_test_uses_utf8(self):
+        path = Path(__file__).resolve().parent.parent / "james_phase6_test.py"
+        src = path.read_text(encoding="utf-8")
+        self._assert_open_w_has_utf8(src, "_patch_test.py")
+
+    def test_code_reader_self_test_uses_utf8(self):
+        path = Path(__file__).resolve().parent.parent / "tools" / "code" / "code_reader.py"
+        src = path.read_text(encoding="utf-8")
+        # code_reader.py self-test path is "./workspace/test.py"
+        self._assert_open_w_has_utf8(src, "test.py")
+
+
+class SubprocessEncodingTests(unittest.TestCase):
+    """bench_gate.py runs scripts/bench.py as a subprocess and captures
+    stdout/stderr to record_outcome.detail. Without encoding="utf-8"
+    on subprocess.run, Korean query strings printed by bench.py decode
+    via locale.getpreferredencoding() (cp949 on Korean Windows),
+    landing mojibake into the audit log."""
+
+    def test_bench_gate_subprocess_uses_utf8_explicitly(self):
+        from tools.patch import bench_gate as bg
+        src = inspect.getsource(bg._run_bench_check_blocking)
+        self.assertIn('encoding="utf-8"', src,
+                      "bench_gate subprocess.run must declare encoding='utf-8' "
+                      "to avoid cp949 mojibake on the captured tail")
+        self.assertIn('errors="replace"', src,
+                      "bench_gate subprocess.run should set errors='replace' "
+                      "so an unexpected non-utf-8 byte sequence does not crash")
+
+
+class WriteRoundtripTests(unittest.TestCase):
+    """Behavioral guard: writing Korean with the standard utf-8 pattern
+    and reading it back must NOT produce replacement characters.
+
+    The point isn't to test Python's stdlib — it's to demonstrate the
+    expected pattern so a contributor copying from this test gets it
+    right by default."""
+
+    def test_korean_roundtrip_utf8_no_mojibake(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", suffix=".py", delete=False
+        ) as f:
+            payload = "# 진단 테스트 파일\nprint('hello')\n"
+            f.write(payload)
+            path = Path(f.name)
+        try:
+            # Read back via the same pattern ReadFileTool / CodeReader use:
+            # explicit utf-8 + errors='replace'.
+            content = path.read_text(encoding="utf-8", errors="replace")
+            self.assertEqual(content, payload,
+                             "roundtrip must preserve Korean exactly")
+            self.assertNotIn("�", content,
+                             "no Unicode replacement char allowed")
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_korean_corruption_demo_when_encoding_omitted(self):
+        # Demonstrates the bug we're guarding against: writing without
+        # encoding on Windows = cp949, reading with utf-8 = replacement
+        # chars. On non-Windows this test is a no-op (locale defaults
+        # are usually utf-8). The assertion is conditional.
+        if sys.platform != "win32":
+            self.skipTest("cp949 corruption only manifests on Windows defaults")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False  # NO encoding kwarg
+        ) as f:
+            payload = "# 진단 테스트 파일\n"
+            try:
+                f.write(payload)
+                wrote_ok = True
+            except UnicodeEncodeError:
+                # Some Windows configs reject Korean → cp949 outright.
+                # That's a different failure mode but same root cause.
+                wrote_ok = False
+            path = Path(f.name)
+
+        try:
+            if not wrote_ok:
+                # Skip the read assertion — Python refused to write.
+                # The point (open() without encoding is unsafe) is made.
+                return
+            corrupted = path.read_text(encoding="utf-8", errors="replace")
+            # On cp949 Windows the read produces replacement chars.
+            self.assertIn("�", corrupted,
+                          "expected replacement chars from cp949→utf-8 misdecode")
+        finally:
+            path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/code/code_reader.py
+++ b/tools/code/code_reader.py
@@ -217,7 +217,10 @@ if __name__ == "__main__":
 
     import os
     os.makedirs("./workspace", exist_ok=True)
-    with open("./workspace/test.py", "w") as f:
+    # encoding="utf-8" required: Windows default is cp949 → Korean
+    # comment would be saved in cp949 and CodeReader's utf-8 read
+    # would emit replacement chars.
+    with open("./workspace/test.py", "w", encoding="utf-8") as f:
         f.write("# 테스트 파일\nprint('hello')\n")
 
     reader = CodeReader()

--- a/tools/patch/bench_gate.py
+++ b/tools/patch/bench_gate.py
@@ -139,6 +139,13 @@ def _run_bench_check_blocking(suite: str, timeout_s: int) -> tuple[bool, str]:
             cwd=str(ROOT),
             capture_output=True,
             text=True,
+            # encoding/errors required on Windows: bench.py prints
+            # Korean query strings; without explicit utf-8 the parent
+            # decodes via locale.getpreferredencoding() which is cp949
+            # on Korean Windows installs, mojibaking the captured tail
+            # that lands in record_outcome.detail.
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_s,
         )
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary

Found during a session-end Korean-encoding audit. Three self-test files write Korean comments via `open(..., "w")` without an explicit encoding kwarg. On Windows the default is **cp949**, so the bytes land as cp949 — and downstream utf-8 readers (ReadFileTool / CodeReader / file processors) emit replacement chars (`���`) on read.

**Direct evidence**: `james_phase55_report.json:138` has `# ���� �׽�Ʈ ����` visible on disk from a prior phase55 run (original source: `# 진단 테스트 파일`).

## Sites fixed

| # | File | Issue |
|---|---|---|
| 1 | `james_phase55_test.py:241` | `open("./workspace/_diag_test.py", "w")` — no encoding |
| 2 | `james_phase6_test.py:299` | `open("./workspace/_patch_test.py", "w")` — no encoding |
| 3 | `tools/code/code_reader.py:220` | self-test `open("./workspace/test.py", "w")` — no encoding |
| 4 | `tools/patch/bench_gate.py` | `subprocess.run(..., text=True)` decoded bench stdout via `locale.getpreferredencoding()` (cp949 on Korean Windows) — Korean query strings landed mojibake into `record_outcome.detail` |

## Production impact

- Sites 1–3 only ran in self-tests — no production code path affected (but `james_phase55_report.json` had visible mojibake in test detail strings).
- Site 4 affected the audit log `detail` field on every patch deploy when the bench printed Korean query strings — silently mojibaked but didn't crash.
- GitHub PR / commit / issue text was unaffected (all written via HEREDOC + git which is utf-8 throughout).

## Verification

- `tests/test_korean_encoding.py` — 6 tests:
  - Source-level guards (3): each fixed `open(...,"w",...)` keeps `encoding="utf-8"` after future edits — re-introduction breaks the test
  - Source-level (1): `bench_gate._run_bench_check_blocking` keeps `encoding="utf-8"` + `errors="replace"` on the subprocess call
  - Behavioral (1): Korean roundtrip via the canonical pattern preserves bytes exactly (no `�`)
  - Behavioral demo (1, Windows-only): writing without encoding then reading with utf-8 produces the documented replacement chars — proves the bug is real
- 94/94 regression suite pass.

## Bench numbers

Not applicable. Change is in self-test setup + subprocess output decoding. No retrieval/graph/reasoning surface touched.

## Out of scope

- Migrating remaining `open()` calls in scripts under `scripts/legacy/` — those are deprecated paths (gitignored helper output already).
- Adding a project-wide pre-commit lint that flags `open(..., 'w'` without `encoding=`. Useful but bigger scope; can be a follow-up if a third sister-bug appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)