### PR TITLE
fix(frontend): same-origin API URL — fixes mixed-content block on phone

### DIFF
--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -1,6 +1,10 @@
 /* PROJECT JAMES — Admin JS */
 
-const API  = 'http://127.0.0.1:8000';
+// Same-origin: works on PC (http://127.0.0.1:8000), phone via
+// Tailscale Serve (https://james.xxx.ts.net), or any future reverse
+// proxy. Avoids the mixed-content block when the page is loaded
+// over https but the API was hardcoded to http.
+const API  = window.location.origin;
 let token  = sessionStorage.getItem('james_token') || '';
 let apiKey = localStorage.getItem('james_api_key') || '';
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1,6 +1,10 @@
 /* PROJECT JAMES — Chat JS */
 
-const API = 'http://127.0.0.1:8000';
+// Same-origin: works on PC (http://127.0.0.1:8000), phone via
+// Tailscale Serve (https://james.xxx.ts.net), or any future reverse
+// proxy. Avoids the mixed-content block when the page is loaded
+// over https but the API was hardcoded to http.
+const API = window.location.origin;
 let SOURCE_TYPE = 'prod';
 let token    = sessionStorage.getItem('james_token') || '';
 let userRole = sessionStorage.getItem('james_role')  || '';


### PR DESCRIPTION
## Summary

`frontend/static/chat.js:3` and `frontend/static/admin.js:3` hardcoded `const API = 'http://127.0.0.1:8000'`. Three problems on a phone accessing JAMES via Tailscale Serve (`https://james.xxx.ts.net`):

1. The phone's `127.0.0.1` is the phone itself, not the host.
2. HTTPS pages cannot fetch HTTP URLs (browsers block as mixed content).
3. Even on PC the absolute URL needlessly bypasses any reverse-proxy setup the operator might add later.

Replace both with `window.location.origin`. Behavior:

| Access from | Origin | Now resolves to |
|---|---|---|
| PC localhost | `http://127.0.0.1:8000` | same-origin to itself |
| Phone via Tailscale | `https://james.xxx.ts.net` | same-origin |
| Future reverse proxy | whatever it serves | same-origin |

## Verification

- Tested manually on PC (localhost) — backwards compatible.
- Tested on phone — confirms the mixed-content block was the cause of `Failed to fetch`.
- No core / retrieval / graph / reasoning surface touched.

## Bench numbers

Not applicable — frontend-only one-line change per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)