### PR TITLE
fix(hardware): debug trail in _get_gpu — diagnose silent 'GPU Unknown' (item #5)

### DIFF
--- a/tests/test_hardware_inspector.py
+++ b/tests/test_hardware_inspector.py
@@ -1,0 +1,86 @@
+"""hardware_inspector._get_gpu — debug-trail + fallback ordering.
+
+Coverage:
+  - On a real machine the call returns either {found: True} via
+    one of the three fallbacks, or {found: False} with a non-empty
+    `debug` trail. Either way it MUST NOT raise.
+  - The `debug` field is always a list (added in this PR — replaces
+    silent `except: pass`).
+  - JAMES_HW_DEBUG=1 mirrors trace lines to stdout (operator workflow).
+
+Run:
+  python -m unittest tests.test_hardware_inspector
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+class GpuDebugTrailTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_HW_DEBUG")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_HW_DEBUG", None)
+        else:
+            os.environ["JAMES_HW_DEBUG"] = self._orig
+
+    def test_returns_dict_with_required_keys(self):
+        from tools.system.hardware_inspector import _get_gpu
+        r = _get_gpu()
+        for k in ("name", "vram_gb", "found", "debug"):
+            self.assertIn(k, r, f"missing key: {k}")
+        self.assertIsInstance(r["debug"], list,
+                              "debug field must be a list (was added "
+                              "in this PR — silent except replacement)")
+
+    def test_debug_trail_non_empty_on_any_outcome(self):
+        # Either at least one fallback wrote a trace line, or all
+        # three exhausted (still a non-empty trail). The bug we're
+        # guarding against is silent-everything → impossible to diagnose.
+        from tools.system.hardware_inspector import _get_gpu
+        r = _get_gpu()
+        self.assertGreater(len(r["debug"]), 0,
+                           "debug trail must record at least one trace "
+                           "line; silent fallback was the v0.2.0 bug")
+
+    def test_stdout_silent_when_env_off(self):
+        from tools.system.hardware_inspector import _get_gpu
+        os.environ.pop("JAMES_HW_DEBUG", None)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _get_gpu()
+        self.assertNotIn("[HW_GPU]", buf.getvalue(),
+                         "trace must not leak to stdout when env unset")
+
+    def test_stdout_mirrors_when_env_on(self):
+        from tools.system.hardware_inspector import _get_gpu
+        os.environ["JAMES_HW_DEBUG"] = "1"
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _get_gpu()
+        self.assertIn("[HW_GPU]", buf.getvalue(),
+                      "JAMES_HW_DEBUG=1 must mirror trace to stdout")
+
+    def test_does_not_raise(self):
+        # Hard contract: regardless of platform / driver state,
+        # _get_gpu never raises. /hardware/ endpoint depends on this.
+        from tools.system.hardware_inspector import _get_gpu
+        try:
+            _get_gpu()
+        except Exception as e:
+            self.fail(f"_get_gpu raised: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/system/hardware_inspector.py
+++ b/tools/system/hardware_inspector.py
@@ -56,8 +56,20 @@ def _get_ram() -> Dict:
 
 
 def _get_gpu() -> Dict:
-    """GPU 정보 측정 (nvidia-smi 또는 다른 방법)."""
-    info = {"name": "Unknown", "vram_gb": 0, "found": False}
+    """GPU 정보 측정 (pynvml → nvidia-smi → wmic 3-단계 fallback).
+
+    Each fallback's failure reason is recorded in `info["debug"]` so a
+    "GPU Unknown 0GB" outcome can be diagnosed without re-running the
+    whole stack. The user-facing fields (`name` / `vram_gb` / `found`)
+    are unchanged. Set `JAMES_HW_DEBUG=1` to also print to stdout.
+    """
+    info = {"name": "Unknown", "vram_gb": 0, "found": False, "debug": []}
+
+    def _trace(msg: str) -> None:
+        info["debug"].append(msg)
+        if os.environ.get("JAMES_HW_DEBUG", "").strip() in ("1", "true", "yes"):
+            print(f"[HW_GPU] {msg}", flush=True)
+
     # 방법 1: pynvml
     try:
         import pynvml
@@ -69,52 +81,80 @@ def _get_gpu() -> Dict:
         info["vram_gb"] = round(mem.total / 1024**3, 1)
         info["used_gb"] = round(mem.used  / 1024**3, 1)
         info["found"]   = True
+        _trace(f"pynvml OK: {info['name']} {info['vram_gb']}GB")
         return info
-    except Exception:
-        pass
+    except ImportError as e:
+        _trace(f"pynvml not installed ({e}); falling back to nvidia-smi")
+    except Exception as e:
+        _trace(f"pynvml failed ({type(e).__name__}: {e}); falling back to nvidia-smi")
+
     # 방법 2: nvidia-smi subprocess
     try:
         import subprocess
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=name,memory.total",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=5
+            capture_output=True, text=True, timeout=5,
+            encoding="utf-8", errors="replace",
         )
         if result.returncode == 0:
             lines = result.stdout.strip().split('\n')
-            if lines:
+            if lines and lines[0]:
                 parts = lines[0].split(',')
                 if len(parts) >= 2:
                     info["name"]    = parts[0].strip()
                     info["vram_gb"] = round(int(parts[1].strip()) / 1024, 1)
                     info["found"]   = True
-    except Exception:
-        pass
-    # 방법 3: Windows WMI (GPU 이름만)
-    if not info["found"]:
-        try:
-            import subprocess
-            result = subprocess.run(
-                ["wmic", "path", "win32_VideoController",
-                 "get", "name,AdapterRAM", "/format:csv"],
-                capture_output=True, text=True, timeout=5
-            )
-            if result.returncode == 0:
-                for line in result.stdout.splitlines():
-                    parts = line.strip().split(',')
-                    if len(parts) >= 3 and parts[2].strip():
-                        name = parts[2].strip()
-                        if name and name != "Name":
-                            info["name"]  = name
-                            info["found"] = True
-                            try:
-                                vram = int(parts[1].strip())
-                                info["vram_gb"] = round(vram / 1024**3, 1)
-                            except Exception:
-                                pass
-                            break
-        except Exception:
-            pass
+                    _trace(f"nvidia-smi OK: {info['name']} {info['vram_gb']}GB")
+                    return info
+                _trace(f"nvidia-smi parse failed: parts={parts!r}")
+            else:
+                _trace(f"nvidia-smi returned empty stdout")
+        else:
+            _trace(f"nvidia-smi exit={result.returncode} "
+                   f"stderr={(result.stderr or '')[:120]!r}")
+    except FileNotFoundError:
+        _trace("nvidia-smi not found in PATH; falling back to wmic")
+    except subprocess.TimeoutExpired:
+        _trace("nvidia-smi timeout (>5s); falling back to wmic")
+    except Exception as e:
+        _trace(f"nvidia-smi failed ({type(e).__name__}: {e}); falling back to wmic")
+
+    # 방법 3: Windows WMI (GPU 이름만 — VRAM은 4GB 이상에서 부정확)
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["wmic", "path", "win32_VideoController",
+             "get", "name,AdapterRAM", "/format:csv"],
+            capture_output=True, text=True, timeout=5,
+            encoding="utf-8", errors="replace",
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                parts = line.strip().split(',')
+                if len(parts) >= 3 and parts[2].strip():
+                    name = parts[2].strip()
+                    if name and name != "Name":
+                        info["name"]  = name
+                        info["found"] = True
+                        try:
+                            vram = int(parts[1].strip())
+                            info["vram_gb"] = round(vram / 1024**3, 1)
+                        except Exception:
+                            pass
+                        _trace(f"wmic OK: {info['name']} {info['vram_gb']}GB")
+                        return info
+            _trace(f"wmic returned no usable rows: stdout={result.stdout[:200]!r}")
+        else:
+            _trace(f"wmic exit={result.returncode}")
+    except FileNotFoundError:
+        _trace("wmic not found in PATH (Windows 11 24H2+ removed it)")
+    except subprocess.TimeoutExpired:
+        _trace("wmic timeout (>5s)")
+    except Exception as e:
+        _trace(f"wmic failed ({type(e).__name__}: {e})")
+
+    _trace("ALL fallbacks exhausted; GPU info unavailable")
     return info
 
 


### PR DESCRIPTION
## Summary

Phone screenshot from a live server showed **'GPU Unknown 0GB VRAM'** on the admin hardware page, despite the host having an RTX 4070 SUPER that `nvidia-smi` detects fine when called directly. Root cause was unobservable because `_get_gpu`'s three fallbacks (pynvml → nvidia-smi → wmic) were all wrapped in `except Exception: pass` — silent failure.

This PR adds a `debug: list[str]` field to the return dict. Every fallback path writes a trace line (success or specific failure reason: `ImportError` / `FileNotFoundError` / `TimeoutExpired` / parse error / non-zero exit). On full exhaustion the trail records "ALL fallbacks exhausted" so the absence of a working path is itself visible.

Console mirror via `JAMES_HW_DEBUG=1` (default off — operators set it during a one-shot diagnose, no production noise).

## Direct verification

Run on maintainer's machine (RTX 4070 SUPER, pynvml not installed in the active venv):

```
[HW_GPU] pynvml not installed (No module named 'pynvml'); falling back to nvidia-smi
[HW_GPU] nvidia-smi OK: NVIDIA GeForce RTX 4070 SUPER 12.0GB
```

So the code itself returns the right values. The running server that produced the phone screenshot was using stale module state. **After restart with this PR**, operators see the trail and can diagnose future "Unknown" reports without re-running diagnostics.

## Bonus

- subprocess calls now declare `encoding="utf-8"` + `errors="replace"` (consistent with PR #80's cp949 fix).

## Verification

- 5/5 new tests in `tests/test_hardware_inspector.py`:
  - return shape contract (4 required keys + `debug` as list)
  - debug trail non-empty on any outcome (the silent-everything bug)
  - `JAMES_HW_DEBUG` truthy/falsy mirror behavior
  - hard contract: never raises (server endpoint depends on this)
- **141/141 regression suite pass** (5 new + 136 prior).

## Bench numbers

Not applicable — diagnostic field added; user-facing `name` / `vram_gb` / `found` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)