### PR TITLE
feat(reasoning): answer flow v3 — intent verification + next-action suggestions (item #2)

### DIFF
--- a/core/response_style.py
+++ b/core/response_style.py
@@ -70,36 +70,59 @@ class StylePreset:
 
 
 # The one natural-flow preset. All public ids resolve to this.
+#
+# v3 (2026-05-08, item #2 user feedback):
+#   - Add an upfront "intent verification" step. The purpose is
+#     ACCURACY — when the question is ambiguous, the model briefly
+#     restates what it understood before answering. When the question
+#     is unambiguous, it skips the restate and answers directly.
+#   - Add a closing "next actions" block (2-3 numbered options the
+#     user can pick). Lets the user steer the next turn without
+#     re-typing context.
+#
+# These two additions move the answer toward Claude's conversational
+# style: confirm-then-answer-then-suggest. Avoid heavy templating
+# (rigid 1./2./3. headers, emoji labels) — the rule says "guidance,
+# not template" so short questions still get short prose answers.
 NATURAL_PRESET = StylePreset(
     name="natural",
     max_tokens=2000,
     force_two_sections=False,
     rule_text_ko=(
         "답변 작성 가이드:\n"
-        "- 자연스러운 한국어 문단으로 답하세요. 번호 매기기, 'STEP 1', "
-        "'📚 자료 기반', '💡 추론' 같은 라벨은 사용하지 마세요.\n"
-        "- 흐름은 다음을 따르되 강제는 아닙니다:\n"
-        "  (1) 질문에 대한 핵심 답을 먼저 한 두 문장으로 직접 제시.\n"
-        "  (2) 내부 자료에서 근거가 되는 부분을 자연스럽게 이어서 설명. "
-        "근거가 없으면 '제공된 자료에는 직접 언급이 없습니다'라고 명시.\n"
-        "  (3) 관련 시각, 한계, 또는 후속으로 물어볼 만한 내용을 짧게 덧붙이세요.\n"
-        "- 짧은 질문엔 핵심 답만으로 충분합니다. 복잡한 질문일수록 (2)(3)을 채우세요.\n"
+        "- 자연스러운 한국어 문단으로 답하세요. 'STEP 1', '📚 자료 기반', "
+        "'💡 추론' 같은 라벨은 사용하지 마세요.\n"
+        "- 다음 흐름을 따르되 강제는 아닙니다 (짧은 질문엔 짧게):\n"
+        "  • 의도 확인 (정확성 검증 목적): 질문이 애매하면 한 줄로 "
+        "    \"X를 묻는 거 맞나요?\" 라고 짧게 재확인. 명확하면 생략.\n"
+        "  • 핵심 답: 한두 문장으로 직접 답.\n"
+        "  • 근거: 내부 자료의 어느 부분에서 나온 답인지 자연스럽게 인용. "
+        "    근거가 없으면 \"제공된 자료에는 직접 언급이 없습니다\"라고 명시.\n"
+        "  • 다음 작업 제안: 관련해서 물어볼 만한 내용 또는 후속 행동 "
+        "    2-3개를 짧게 제시. 사용자가 번호로 답할 수 있게 \"다음 중 어떤 "
+        "    걸 원하시나요? (1) ... (2) ... (3) ...\" 형식 권장.\n"
+        "- 단순 사실 확인 (예: \"X가 뭐야?\")엔 의도 확인과 다음 작업 제안 "
+        "  생략 가능. 복잡한 질문일수록 모든 단계 채우세요.\n"
         "- 글자수 제약 없음. 내용에 맞는 자연스러운 길이로.\n"
     ),
     rule_text_en=(
         "Answer composition guide:\n"
-        "- Write in natural English prose. Do NOT use numbered lists, "
-        "'STEP 1' headers, or '📚 Data-based' / '💡 Reasoning' labels.\n"
-        "- Follow this flow as guidance (not a rigid template):\n"
-        "  (1) Direct answer to the question in one or two sentences first.\n"
-        "  (2) Supporting evidence from the internal data, woven into "
-        "the prose. If the data does not directly cover the question, "
-        "say so explicitly.\n"
-        "  (3) Briefly add a related angle, limitation, or a useful "
-        "follow-up question.\n"
-        "- Short questions deserve short answers. Fill in (2) and (3) "
-        "only when the question warrants it.\n"
-        "- No character-count limit. Pick a length that fits the content.\n"
+        "- Natural English prose. No 'STEP 1' headers or "
+        "'📚 Data-based' / '💡 Reasoning' labels.\n"
+        "- Follow this flow as guidance (short questions get short answers):\n"
+        "  • Intent check (accuracy purpose): if the question is "
+        "    ambiguous, briefly restate as \"You're asking about X, right?\". "
+        "    Skip when unambiguous.\n"
+        "  • Direct answer: one or two sentences.\n"
+        "  • Evidence: weave in which part of the internal data the "
+        "    answer comes from. If the data doesn't cover it, say so.\n"
+        "  • Next actions: 2-3 short options the user could pick from "
+        "    next, formatted so they can reply with a number: "
+        "    \"What would you like next? (1) ... (2) ... (3) ...\"\n"
+        "- For simple fact-checks (\"What is X?\"), intent check and "
+        "  next-actions are optional. Fill them in when the question "
+        "  warrants it.\n"
+        "- No character-count limit. Pick a length that fits.\n"
     ),
 )
 

--- a/tests/test_response_style.py
+++ b/tests/test_response_style.py
@@ -78,10 +78,9 @@ class NaturalFlowResolverTests(unittest.TestCase):
         from core.response_style import NATURAL_PRESET
         ko = NATURAL_PRESET.rule_text_ko
         en = NATURAL_PRESET.rule_text_en
-        # Flow elements present in Korean rule
+        # Core flow elements (v2 baseline)
         self.assertIn("핵심 답", ko)
         self.assertIn("근거", ko)
-        # Flow elements present in English rule
         self.assertIn("Direct answer", en)
         self.assertIn("evidence", en.lower())
         # Explicit ban on the v1 emoji template
@@ -90,6 +89,30 @@ class NaturalFlowResolverTests(unittest.TestCase):
         # Explicit "no character-count limit" — user said 글자수 상관없다
         self.assertIn("글자수 제약 없음", ko)
         self.assertIn("character-count limit", en)
+
+    def test_rule_text_v3_intent_verify_and_next_actions(self):
+        # v3 (item #2 user feedback): intent verification step (for
+        # accuracy) + next-actions block (numbered options the user
+        # can pick) must be present in the prose guide.
+        from core.response_style import NATURAL_PRESET
+        ko = NATURAL_PRESET.rule_text_ko
+        en = NATURAL_PRESET.rule_text_en
+        # KO — intent check phrase
+        self.assertIn("의도 확인", ko,
+                      "v3: intent verification must be in the rule")
+        self.assertIn("정확성", ko,
+                      "v3: intent check rationale must mention 정확성 — "
+                      "user said the purpose is accuracy, not tone")
+        # KO — next-actions block
+        self.assertIn("다음 작업", ko,
+                      "v3: closing 'next actions' block must be in the rule")
+        self.assertIn("(1)", ko,
+                      "v3: numbered options example must show (1)..(2)..(3) form")
+        # EN — same elements
+        self.assertIn("Intent check", en)
+        self.assertIn("accuracy", en.lower())
+        self.assertIn("Next actions", en)
+        self.assertIn("(1)", en)
 
 
 class CallSiteContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

User feedback (2026-05-08, item #2):
> 대화 끝 부분은 자메스가 다음 할일을 스스로 판단해서 제안하고 사용자에게 선택권을 주는 방식으로 개선. 답변에 사용자의 질문의 의도를 파악하는 것은 좋으나, 질문의 의도가 정확성을 파악하기 위한 것이 주요 목적이되게 해라.

Two additions to `core/response_style.NATURAL_PRESET`:

### 1. Intent verification (front of answer)
- Brief restate when the question is **ambiguous**: `"X를 묻는 거 맞나요?"`
- Purpose explicitly framed as **ACCURACY** (per user note), not tone or rapport.
- Skipped on unambiguous questions to preserve the short-question-short-answer contract.

### 2. Next-action suggestions (end of answer)
- 2-3 numbered options the user can reply to with a number: `"(1) ... (2) ... (3) ..."`
- Lets the user steer the next turn without re-typing context.
- Skipped on simple fact-checks; mandatory on complex / open questions.

Both are **guidance, not strict template** — the rule literally says *"단순 사실 확인엔 의도 확인과 다음 작업 제안 생략 가능"* so a short fact question like *"X가 뭐야?"* still gets a short prose answer.

## Verification

- 11/11 tests in `tests/test_response_style.py`:
  - Existing v2 baseline test preserved (`test_rule_text_teaches_flow_not_rigid_template`)
  - New `test_rule_text_v3_intent_verify_and_next_actions` guards: KO `의도 확인` / `정확성` / `다음 작업` / `(1)` numbered form; EN `Intent check` / `accuracy` / `Next actions` / `(1)`
- **239/239 regression suite pass** (full discover-run).

## Bench numbers

Not applicable — answer-composition prompt change only. No retrieval / graph / scoring surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)