### PR TITLE
fix(frontend): chat history restore + session persistence (item #3-a)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -85,6 +85,10 @@ window.addEventListener('DOMContentLoaded', () => {
     if (key) localStorage.setItem('james_api_key', key);
   }
   updateRoleBadge();
+  // item #3-a: 이전 대화 복원 (자가 호출 누락 버그 fix).
+  // restoreHistory는 정의만 되어 있고 호출되지 않아 매번 빈 화면이었음.
+  // localStorage에 저장된 HISTORY_KEY 데이터 그대로 화면에 재구성한다.
+  try { restoreHistory(); } catch (e) { console.warn('[JAMES] restoreHistory 실패:', e); }
 });
 
 
@@ -92,19 +96,26 @@ window.addEventListener('DOMContentLoaded', () => {
    대화 세션 관리
 ════════════════════════════════ */
 
-// 세션 ID — 탭 단위 유지 (새 탭은 새 세션)
+// 세션 ID — localStorage 영속화 (item #3-a, 2026-05-08).
+// 이전: sessionStorage → 폰 브라우저 닫으면 소실 → HISTORY_KEY 변경 →
+// 옛 history는 localStorage에 남았지만 표시 안 됨 (orphan).
+// 지금: localStorage라 같은 사용자가 다시 들어와도 같은 세션 ID 유지,
+// "새 대화 시작" 버튼(clearHistory)으로 명시적 종료 시에만 새 세션.
 function getSessionId() {
-  let sid = sessionStorage.getItem('james_session');
+  let sid = localStorage.getItem('james_session');
   if (!sid) {
     sid = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2,8);
-    sessionStorage.setItem('james_session', sid);
+    localStorage.setItem('james_session', sid);
   }
   return sid;
 }
 
 const SESSION_ID = getSessionId();
 const HISTORY_KEY = `james_history_${SESSION_ID}`;
-const MAX_STORED  = 50;  // localStorage 최대 저장 턴 수
+// item #3-a: 50 → 200. 50턴은 ~25 사용자-자메스 페어로 모바일 사용 한 번이면
+// 금방 cap. 200이면 ~100 페어, 며칠치 대화 보존 가능. localStorage 5MB 한도
+// 안에 안전 (200턴 × 평균 1KB ≈ 200KB).
+const MAX_STORED  = 200;
 
 /* ── 대화 localStorage 저장 ── */
 function saveToLocal(role, text, meta = {}) {
@@ -152,6 +163,9 @@ async function clearHistory() {
     method:  'DELETE',
     headers: getAuthHeaders(),
   }).catch(() => {});
+  // item #3-a: session_id가 localStorage에 영속이라, 초기화하면 신규 세션
+  // ID 발급해야 다음 reload 시 옛 SID가 다시 살아나지 않음.
+  localStorage.removeItem('james_session');
   location.reload();
 }
 
@@ -798,7 +812,7 @@ async function switchSession(sessionId) {
     return;
   }
   // 세션 전환: sessionStorage 업데이트 + 히스토리 로드
-  sessionStorage.setItem('james_session', sessionId);
+  localStorage.setItem('james_session', sessionId);
   toggleSessionPanel();
 
   // 현재 메시지 초기화 후 해당 세션 히스토리 표시
@@ -844,7 +858,7 @@ async function switchSession(sessionId) {
 function newSession() {
   // 새 세션 ID 생성
   const newSid = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2,8);
-  sessionStorage.setItem('james_session', newSid);
+  localStorage.setItem('james_session', newSid);
   toggleSessionPanel();
 
   // 화면 초기화

--- a/tests/test_chat_history_persistence.py
+++ b/tests/test_chat_history_persistence.py
@@ -1,0 +1,116 @@
+"""Chat history persistence — item #3-a (2026-05-08 user feedback).
+
+Source-level contracts on frontend/static/chat.js. We don't have a JS
+test runner; this Python test scans the JS source to assert the
+three contracts the v3-a fix promises:
+
+  (1) `MAX_STORED` is at least 200 (was 50; user reported the cap
+      was hit too quickly when returning to the chat).
+  (2) `getSessionId()` reads/writes `localStorage` (not sessionStorage)
+      so the session ID survives browser close / phone re-open.
+  (3) `restoreHistory()` is actually CALLED on DOMContentLoaded — the
+      v0.2.0 bug was that it was defined but never invoked, so the
+      restore path was dead.
+  (4) `clearHistory()` removes the session id key so a fresh session
+      is minted on the next page load.
+
+Run:
+  python -m unittest tests.test_chat_history_persistence
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class ChatHistoryContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = Path(__file__).resolve().parent.parent / "frontend" / "static" / "chat.js"
+        cls.src = path.read_text(encoding="utf-8")
+        cls.normalized = " ".join(cls.src.split())
+
+    def test_max_stored_at_least_200(self):
+        # Match `const MAX_STORED  =  200;` allowing whitespace variance.
+        # Look for a numeric assignment to MAX_STORED.
+        import re
+        m = re.search(r"const\s+MAX_STORED\s*=\s*(\d+)", self.src)
+        self.assertIsNotNone(m, "MAX_STORED const not found")
+        n = int(m.group(1))
+        self.assertGreaterEqual(n, 200,
+                                f"MAX_STORED={n} too low; user reported "
+                                f"50 was hit quickly. v3-a bumped to 200.")
+
+    def test_session_id_persists_in_local_storage(self):
+        # The bug we fixed: session_id was in sessionStorage, lost on
+        # browser close. v3-a moves it to localStorage.
+        # Match 'james_session' as a complete key — sibling keys like
+        # 'james_session_lang' (language) must NOT trigger.
+        import re
+        # Key followed by closing quote + ) or , (read or write usage).
+        self.assertTrue(
+            re.search(
+                r"localStorage\.getItem\(\s*['\"]james_session['\"]\s*\)",
+                self.src,
+            ),
+            "getSessionId must read 'james_session' from localStorage "
+            "(was sessionStorage in v0.2.0 — caused orphaned history)",
+        )
+        self.assertTrue(
+            re.search(
+                r"localStorage\.setItem\(\s*['\"]james_session['\"]\s*,",
+                self.src,
+            ),
+            "getSessionId must persist 'james_session' to localStorage",
+        )
+        # And the OLD sessionStorage path for james_session must be gone.
+        # Match exact key — 'james_session_lang' (sibling) is fine.
+        self.assertFalse(
+            re.search(
+                r"sessionStorage\.(get|set)Item\(\s*['\"]james_session['\"]",
+                self.src,
+            ),
+            "sessionStorage read/write of 'james_session' must be removed",
+        )
+
+    def test_restore_history_is_called_on_dom_content_loaded(self):
+        # The v0.2.0 bug was that restoreHistory() was defined but
+        # never invoked. The DOMContentLoaded init handler now calls it.
+        self.assertIn(
+            "restoreHistory()",
+            self.src,
+            "restoreHistory must be CALLED on DOMContentLoaded — "
+            "defining it without invoking it was the v0.2.0 bug",
+        )
+        # The call must be inside a DOMContentLoaded handler. Look for
+        # a window.addEventListener('DOMContentLoaded' window that
+        # contains the call.
+        idx = self.src.index("restoreHistory()")
+        # Find the nearest preceding "DOMContentLoaded" within 800 chars.
+        prelude = self.src[max(0, idx - 800):idx]
+        self.assertIn("DOMContentLoaded", prelude,
+                      "restoreHistory() must be invoked inside a "
+                      "DOMContentLoaded handler so existing history "
+                      "is shown on page load")
+
+    def test_clear_history_resets_session_id(self):
+        # If session_id stays in localStorage even after clearHistory,
+        # the user can't actually "start fresh" without manually
+        # clearing storage. v3-a removes the session key on clear.
+        idx = self.src.index("async function clearHistory")
+        # Look at the 800 chars after the function signature.
+        body = self.src[idx:idx + 800]
+        self.assertIn(
+            "localStorage.removeItem('james_session')",
+            body,
+            "clearHistory must clear james_session from localStorage "
+            "so the next reload mints a fresh session",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback (2026-05-08): *"외부에서 다시 대화 돌아왔을때 이전 대화를 모두 볼수 있도록 조치 검토"*.

Three v0.2.0 bugs combined to make returning users see a blank chat:

### Bug 1: session id in sessionStorage (per-tab, lost on browser close)
SESSION_ID was in `sessionStorage` — when the phone browser closed and re-opened, a NEW session id was minted and `HISTORY_KEY` pointed at a fresh empty slot. The old conversation was still in `localStorage` under the old key, just unreferenced.

### Bug 2: MAX_STORED = 50
About 25 user/james pairs. A single focused mobile session hit the cap and started rolling off the front. Bumped to 200 (~100 pairs, days of conversation), still safely under the 5MB localStorage budget (200 × 1KB ≈ 200KB).

### Bug 3: `restoreHistory()` defined but never CALLED
The function could correctly rebuild messages from stored turns, but nothing on `DOMContentLoaded` ever invoked it — every page load showed a blank chat regardless of stored history.

## Changes

- All `james_session` reads/writes moved to `localStorage` (3 sites: `getSessionId`, `switchSession`, `newSession`). `sessionStorage` still holds ephemeral state (tokens, language hint).
- `MAX_STORED` 50 → 200.
- `restoreHistory()` now invoked inside the existing `DOMContentLoaded` init handler.
- `clearHistory()` also removes `james_session` so a deliberate 초기화 mints a fresh session on next reload.

## Verification

- 4 source-level contracts in `tests/test_chat_history_persistence.py` (we don't have a JS test runner — assertions scan chat.js):
  - `MAX_STORED >= 200`
  - localStorage round-trip on `'james_session'` key (exact match — sibling `'james_session_lang'` must NOT trigger)
  - `restoreHistory()` invoked inside a `DOMContentLoaded` handler
  - `clearHistory` removes `'james_session'` from localStorage
- **243/243 regression suite pass.**

## Out of scope

- Item #3-b (요약 클릭 → 원본 펼침): clickable summary expand UI for older sessions. Separate PR — requires a `/admin/history/sessions/<sid>` endpoint to be useful.

## Bench numbers

Not applicable — frontend behavior change only. No retrieval / graph / scoring surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)