### PR TITLE
feat(admin): session-summary click → original turns expand modal (item #3-b)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -410,7 +410,7 @@
       <div class="page-title"><span data-i18n="memory.page_title">🧠 Memory 현황</span></div>
       <div class="cards" id="memory-cards"></div>
 
-      <div class="section-title">▸ <span data-i18n="memory.longterm_title">장기 기억 (세션 요약)</span></div>
+      <div class="section-title">▸ <span data-i18n="memory.longterm_title">장기 기억 (세션 요약)</span> <span style="font-size:11px;color:var(--muted);margin-left:8px">(행 클릭 → 원본 대화 펼침)</span></div>
       <div class="table-wrap">
         <table>
           <thead><tr><th data-i18n="common.date">날짜</th><th data-i18n="common.topic">주제</th><th data-i18n="common.summary">요약</th><th data-i18n="common.actions">액션</th></tr></thead>
@@ -418,12 +418,36 @@
         </table>
       </div>
 
-      <div class="section-title">▸ <span data-i18n="memory.session_list">세션 목록</span></div>
+      <div class="section-title">▸ <span data-i18n="memory.session_list">세션 목록</span> <span style="font-size:11px;color:var(--muted);margin-left:8px">(행 클릭 → 원본 대화 펼침)</span></div>
       <div class="table-wrap">
         <table>
           <thead><tr><th data-i18n="session.id">세션 ID</th><th data-i18n="session.turns">대화 수</th><th data-i18n="common.start">시작</th><th data-i18n="common.last">마지막</th><th data-i18n="common.actions">액션</th></tr></thead>
           <tbody id="sessions-body"><tr><td colspan="5" class="loading" data-i18n="common.loading">로딩 중...</td></tr></tbody>
         </table>
+      </div>
+
+      <!-- item #3-b: session original-turns expand modal -->
+      <div id="session-turns-modal"
+           style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);
+                  z-index:9999;align-items:flex-start;justify-content:center;
+                  overflow-y:auto;padding:40px 16px"
+           onclick="closeSessionTurns(event)">
+        <div style="background:var(--card,#1e1e2e);border:1px solid var(--border);
+                    border-radius:8px;padding:20px;max-width:820px;width:100%;
+                    max-height:85vh;overflow-y:auto" onclick="event.stopPropagation()">
+          <div style="display:flex;justify-content:space-between;align-items:center;
+                      margin-bottom:12px;border-bottom:1px solid var(--border);
+                      padding-bottom:8px">
+            <div id="session-turns-title"
+                 style="font-size:16px;font-weight:600">세션 원본 대화</div>
+            <button onclick="closeSessionTurns()"
+                    style="background:transparent;border:0;color:var(--muted);
+                           cursor:pointer;font-size:20px">×</button>
+          </div>
+          <div id="session-turns-meta"
+               style="font-size:11px;color:var(--muted);font-family:var(--font-mono);margin-bottom:12px"></div>
+          <div id="session-turns-body" style="display:flex;flex-direction:column;gap:8px"></div>
+        </div>
       </div>
 
       <div class="section-title">▸ Preferences</div>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -437,14 +437,24 @@ async function loadLongTerm() {
   try {
     const data = await api('/history/long-term/?limit=10');
     const tbody = document.getElementById('long-term-body');
-    tbody.innerHTML = (data.summaries || []).map(s => `
-      <tr>
-        <td class="mono">${s.saved_at?.slice(0,10) || '-'}</td>
-        <td>${s.topic || '-'}</td>
-        <td style="max-width:400px;font-size:12px">${s.summary?.slice(0,120) || '-'}</td>
-        <td>-</td>
-      </tr>
-    `).join('') || `<tr><td colspan='4' class='empty'>${t('mem.no_longterm')}</td></tr>`;
+    tbody.innerHTML = (data.summaries || []).map(s => {
+      // item #3-b: row click → original turns modal. session_id is
+      // present in the API response (memory/store.py:492).
+      const sid = s.session_id || '';
+      const onclick = sid
+        ? `onclick="openSessionTurns('${escapeHtml(sid)}', '${escapeHtml((s.topic || '').slice(0, 40))}')"`
+        : '';
+      const cursor = sid ? 'cursor:pointer' : '';
+      const hint   = sid ? '' : ' <em style="color:var(--muted);font-size:10px">(no session_id)</em>';
+      return `
+        <tr style="${cursor}" ${onclick}>
+          <td class="mono">${s.saved_at?.slice(0,10) || '-'}</td>
+          <td>${escapeHtml(s.topic || '-')}${hint}</td>
+          <td style="max-width:400px;font-size:12px">${escapeHtml((s.summary || '').slice(0,120) || '-')}</td>
+          <td>${sid ? '🔍 펼침' : '-'}</td>
+        </tr>
+      `;
+    }).join('') || `<tr><td colspan='4' class='empty'>${t('mem.no_longterm')}</td></tr>`;
   } catch (e) {
     document.getElementById('long-term-body').innerHTML =
       `<tr><td colspan="4" class="empty">${e.message}</td></tr>`;
@@ -455,22 +465,81 @@ async function loadSessions() {
   try {
     const data = await api('/history/sessions/');
     const tbody = document.getElementById('sessions-body');
-    tbody.innerHTML = (data.sessions || []).map(s => `
-      <tr>
-        <td class="mono" style="font-size:10px">${s.session_id?.slice(0,20) || '-'}</td>
-        <td class="mono">${s.turn_count ?? 0} turns</td>
-        <td class="mono">${s.started?.slice(0,16) || '-'}</td>
-        <td class="mono">${s.last?.slice(0,16) || '-'}</td>
-        <td>
-          <button class="btn btn-approve" style="font-size:10px"
-            onclick="summarizeAndDelete('${s.session_id}')" data-i18n='mem.summarize_delete'>Summarize & Delete</button>
-        </td>
-      </tr>
-    `).join('') || `<tr><td colspan='5' class='empty'>${t('mem.no_sessions')}</td></tr>`;
+    tbody.innerHTML = (data.sessions || []).map(s => {
+      const sid = s.session_id || '';
+      // item #3-b: session_id 셀 + turn_count 셀 클릭 → 원본 펼침
+      // (액션 버튼은 그대로 두고 행 일부만 클릭 가능하게 — 실수로
+      // summarize&delete 버튼 누르는 사고 방지)
+      const expandable = sid
+        ? `onclick="openSessionTurns('${escapeHtml(sid)}', '${escapeHtml(sid.slice(0,20))}')" style="cursor:pointer"`
+        : '';
+      return `
+        <tr>
+          <td class="mono" style="font-size:10px" ${expandable}>${escapeHtml(sid.slice(0,20)) || '-'}</td>
+          <td class="mono" ${expandable}>${s.turn_count ?? 0} turns</td>
+          <td class="mono">${s.started?.slice(0,16) || '-'}</td>
+          <td class="mono">${s.last?.slice(0,16) || '-'}</td>
+          <td>
+            <button class="btn btn-approve" style="font-size:10px"
+              onclick="summarizeAndDelete('${escapeHtml(sid)}')" data-i18n='mem.summarize_delete'>Summarize & Delete</button>
+          </td>
+        </tr>
+      `;
+    }).join('') || `<tr><td colspan='5' class='empty'>${t('mem.no_sessions')}</td></tr>`;
   } catch (e) {
     document.getElementById('sessions-body').innerHTML =
       `<tr><td colspan="5" class="empty">${e.message}</td></tr>`;
   }
+}
+
+/* ── item #3-b: 세션 원본 대화 펼침 modal ── */
+async function openSessionTurns(sessionId, label) {
+  const modal = document.getElementById('session-turns-modal');
+  const titleEl = document.getElementById('session-turns-title');
+  const metaEl  = document.getElementById('session-turns-meta');
+  const bodyEl  = document.getElementById('session-turns-body');
+
+  if (titleEl) titleEl.textContent = `세션 원본 대화 — ${label || sessionId}`;
+  if (metaEl)  metaEl.textContent  = `로딩 중... (session_id=${sessionId})`;
+  if (bodyEl)  bodyEl.innerHTML    = '';
+  modal.style.display = 'flex';
+
+  try {
+    const data = await api(`/history/?session_id=${encodeURIComponent(sessionId)}&limit=200`);
+    const turns = data.turns || [];
+    if (metaEl) metaEl.textContent = `session_id=${sessionId} · ${turns.length} 턴`;
+    if (turns.length === 0) {
+      bodyEl.innerHTML = `<div style="color:var(--muted);text-align:center;padding:20px">이 세션에 저장된 턴이 없습니다.</div>`;
+      return;
+    }
+    bodyEl.innerHTML = turns.map(turn => {
+      const isUser = (turn.role || turn.speaker || '').toLowerCase().includes('user');
+      const text   = turn.content || turn.text || turn.answer || '';
+      const ts     = turn.created_at || turn.time || turn.timestamp || '';
+      const tsShort = (ts || '').slice(0, 19).replace('T', ' ');
+      return `
+        <div style="display:flex;flex-direction:column;gap:4px;
+                    background:${isUser ? 'rgba(124,106,247,.10)' : 'var(--bg)'};
+                    border-left:3px solid ${isUser ? '#7c6af7' : '#3da78a'};
+                    padding:10px 12px;border-radius:4px">
+          <div style="font-size:10px;color:var(--muted);font-family:var(--font-mono);
+                      display:flex;justify-content:space-between">
+            <span>${isUser ? '🗨️ user' : '🤖 james'}${turn.mode ? ' · mode=' + escapeHtml(turn.mode) : ''}</span>
+            <span>${escapeHtml(tsShort)}</span>
+          </div>
+          <div style="white-space:pre-wrap;font-size:13px">${escapeHtml(text)}</div>
+        </div>
+      `;
+    }).join('');
+  } catch (e) {
+    if (metaEl) metaEl.textContent = '';
+    bodyEl.innerHTML = `<div style="color:var(--red,#f06292);text-align:center;padding:20px">로드 실패: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function closeSessionTurns(e) {
+  if (e && e.target.id !== 'session-turns-modal') return;
+  document.getElementById('session-turns-modal').style.display = 'none';
 }
 
 async function summarizeAndDelete(sessionId) {

--- a/tests/test_admin_history_expand.py
+++ b/tests/test_admin_history_expand.py
@@ -1,0 +1,128 @@
+"""Admin Memory page — session click-to-expand modal (item #3-b).
+
+Source-level contracts:
+  - admin.html has the session-turns modal (title / meta / body
+    placeholders) and the (.json) close handler.
+  - admin.js loadLongTerm passes session_id into openSessionTurns
+    when present, marks rows as cursor:pointer only when a session_id
+    is available.
+  - admin.js loadSessions makes the session_id and turn_count cells
+    clickable but leaves the action button alone (no accidental
+    summarize&delete on click).
+  - admin.js openSessionTurns calls /history/?session_id=&limit=
+    and renders turns; XSS-safe via escapeHtml on every operator-
+    controlled text field.
+
+Run:
+  python -m unittest tests.test_admin_history_expand
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class HtmlContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (Path(__file__).resolve().parent.parent
+                    / "frontend" / "admin.html").read_text(encoding="utf-8")
+
+    def test_modal_present(self):
+        self.assertIn('id="session-turns-modal"', self.html,
+                      "session-turns modal container missing from admin.html")
+
+    def test_modal_has_title_meta_body_placeholders(self):
+        for el in ('id="session-turns-title"',
+                   'id="session-turns-meta"',
+                   'id="session-turns-body"'):
+            self.assertIn(el, self.html,
+                          f"modal placeholder {el} missing")
+
+    def test_close_handler_present(self):
+        # Backdrop click handler + explicit X button handler both wire
+        # to closeSessionTurns.
+        self.assertIn('onclick="closeSessionTurns(event)"', self.html,
+                      "backdrop click handler missing")
+        self.assertIn('onclick="closeSessionTurns()"', self.html,
+                      "X button handler missing")
+
+    def test_long_term_table_advertises_clickable_rows(self):
+        # The user-visible hint (행 클릭 → 원본 대화 펼침) is what
+        # tells operators why rows are clickable. Drift is a UX bug.
+        self.assertIn("행 클릭", self.html,
+                      "the section title hint must inform operators "
+                      "that rows are clickable for expand")
+
+
+class JsContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (Path(__file__).resolve().parent.parent
+                  / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+
+    def test_open_session_turns_function_exists(self):
+        self.assertIn("async function openSessionTurns", self.js,
+                      "openSessionTurns function missing")
+        # Hits the /history/ endpoint with session_id + limit.
+        idx = self.js.index("async function openSessionTurns")
+        body = self.js[idx:idx + 2200]
+        self.assertIn("/history/?session_id=", body,
+                      "must fetch /history/ for the session")
+        self.assertIn("limit=", body,
+                      "must request a generous limit (200) for full expansion")
+
+    def test_close_session_turns_function_exists(self):
+        self.assertIn("function closeSessionTurns", self.js,
+                      "closeSessionTurns missing")
+
+    def test_long_term_row_uses_session_id_when_available(self):
+        idx = self.js.index("async function loadLongTerm")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("openSessionTurns(", body,
+                      "loadLongTerm rows must wire to openSessionTurns")
+        # Conditional: only attach onclick when session_id present.
+        self.assertIn("s.session_id", body,
+                      "loadLongTerm must read session_id from each summary")
+
+    def test_sessions_action_button_not_overridden(self):
+        # Sanity: the summarize&delete button must NOT call
+        # openSessionTurns by accident — operators expect distinct
+        # behaviors for "expand" vs "delete".
+        idx = self.js.index("async function loadSessions")
+        body = self.js[idx:idx + 1800]
+        self.assertIn("summarizeAndDelete(", body,
+                      "summarize&delete button must remain functional")
+        # The button itself must not also be wired to expand.
+        # Look for the <button ... onclick="summarizeAndDelete..."> region
+        # and assert it doesn't contain openSessionTurns inside the button tag.
+        m = re.search(
+            r'<button[^>]*summarizeAndDelete[^>]*>',
+            body,
+        )
+        self.assertIsNotNone(m, "summarize button regex missing")
+        self.assertNotIn("openSessionTurns", m.group(),
+                         "the summarize button must not also be wired "
+                         "to expand — operators get confused if a single "
+                         "click does two things")
+
+    def test_xss_escaping_in_modal_render(self):
+        # Operator-controlled text (turn.content, mode) must be
+        # escapeHtml'd before being injected into innerHTML.
+        idx = self.js.index("async function openSessionTurns")
+        body = self.js[idx:idx + 2200]
+        # We expect at least 4 escapeHtml() calls in the render block.
+        count = body.count("escapeHtml(")
+        self.assertGreaterEqual(count, 4,
+                                f"openSessionTurns has only {count} escapeHtml "
+                                f"calls; operator-controlled text must be "
+                                f"escaped to prevent XSS in the admin UI")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"요약 정리된 창을 클릭시 다시 답변 원본 표시"*.

Item #3-a (PR #90) restored the **current** session's history on chat reload. This PR adds the second half: **previous** sessions are now expandable from the admin Memory page. Click any `장기 기억 (세션 요약)` row or any `세션 목록` row → modal pops up with the full turn-by-turn conversation, color-coded (🟣 user / 🟢 james), with timestamps and mode tags.

## Architecture

No new backend endpoint — reuses `/history/?session_id=&limit=200` which already existed. The missing piece was the frontend wiring.

| Surface | Change |
|---|---|
| `admin.html` | New `#session-turns-modal` with title / meta / body slots; backdrop click + X button both close. Section titles get a "(행 클릭 → 원본 대화 펼침)" hint. |
| `admin.js::loadLongTerm` | Each row gets `onclick="openSessionTurns(...)"` when the summary carries a `session_id`. Rows without it fall back gracefully ("no session_id" label, no cursor pointer). |
| `admin.js::loadSessions` | session_id + turn_count cells made clickable. **The existing summarize&delete action button is intentionally NOT also wired** — single-click confusion would lose data. Regex-checked in tests. |
| `admin.js::openSessionTurns` | Fetches `/history/`, renders turns as styled cards. `escapeHtml` on every operator-controlled field (XSS guard for admin UI consuming wiki/user content). |

## Verification

- 9 unit tests in `tests/test_admin_history_expand.py`:
  - HTML: modal + 3 placeholders + close handlers + section hint
  - JS: `openSessionTurns` / `closeSessionTurns` exist, hit `/history/` with limit, `loadLongTerm` reads `s.session_id`, summarize&delete button NOT also wired to `openSessionTurns` (explicit regex guard), >= 4 `escapeHtml` calls in modal render
- **263/263 regression suite pass** (9 new + 254 prior).

## Bench numbers

Not applicable — admin UX surface, no retrieval / graph / scoring touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)