### PR TITLE
feat(export): document export — md/txt/docx download per answer (item #4)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -511,7 +511,11 @@ function appendJamesMsg(data) {
     metaHtml += `</div>`;
   }
 
-  // 👍👎 피드백 버튼
+  // 👍👎 피드백 버튼 + 📥 export 드롭다운 (item #4)
+  // export 트리거는 메시지 단위로 — 사용자가 마음에 드는 답변만 저장 가능.
+  // 답변 텍스트는 data attr에 그대로 보관 (formatAnswer는 HTML 변환이라
+  // 다운로드용 원본을 별도 보관해야 함).
+  const answerEscapedAttr = encodeURIComponent(answer);
   const fbHtml = dirId ? `
     <div class="feedback-btns" style="display:flex;gap:6px;margin-top:6px">
       <button class="fb-btn" onclick="sendFeedback('${dirId}', 'explicit_positive', this)"
@@ -522,6 +526,18 @@ function appendJamesMsg(data) {
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
                transition:all .15s" title="별로예요">👎</button>
+      <button class="fb-btn" onclick="exportAnswer(this, 'md')" data-content="${answerEscapedAttr}"
+        style="background:none;border:1px solid var(--border);border-radius:6px;
+               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
+               transition:all .15s" title=".md 다운로드">📥 .md</button>
+      <button class="fb-btn" onclick="exportAnswer(this, 'docx')" data-content="${answerEscapedAttr}"
+        style="background:none;border:1px solid var(--border);border-radius:6px;
+               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
+               transition:all .15s" title=".docx 다운로드 (Word)">📥 .docx</button>
+      <button class="fb-btn" onclick="exportAnswer(this, 'txt')" data-content="${answerEscapedAttr}"
+        style="background:none;border:1px solid var(--border);border-radius:6px;
+               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
+               transition:all .15s" title=".txt 다운로드 (Notepad)">📥 .txt</button>
     </div>` : '';
 
   div.innerHTML = `
@@ -535,6 +551,62 @@ function appendJamesMsg(data) {
   `;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
+}
+
+/* ── item #4: 답변 export 다운로드 ──
+   서버 /export/에 POST → blob 받아 a[download] 트릭으로 다운로드.
+   docx fallback (python-docx 미설치 시 .md로 저장)이 발생하면 X-James-
+   Export-Fallback 헤더가 와서 사용자에게 toast로 알림. */
+async function exportAnswer(btn, fmt) {
+  const content = decodeURIComponent(btn.dataset.content || '');
+  if (!content.trim()) {
+    alert('답변 내용이 비어 있어 저장할 수 없습니다.');
+    return;
+  }
+  const orig = btn.textContent;
+  btn.textContent = '⏳ 저장 중...';
+  btn.disabled = true;
+  try {
+    const r = await fetch(`${API}/export/`, {
+      method:  'POST',
+      headers: {'Content-Type': 'application/json', ...getAuthHeaders()},
+      body: JSON.stringify({
+        api_key: getApiKey(),
+        content: content,
+        format:  fmt,
+      }),
+    });
+    if (!r.ok) {
+      const err = await r.text();
+      throw new Error(`export ${r.status}: ${err.slice(0, 120)}`);
+    }
+    const blob   = await r.blob();
+    const actual = r.headers.get('X-James-Export-Format') || fmt;
+    const fallbk = r.headers.get('X-James-Export-Fallback') || '';
+    // Content-Disposition에서 filename 추출
+    const cd = r.headers.get('Content-Disposition') || '';
+    const m  = cd.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/);
+    const name = m ? decodeURIComponent(m[1] || m[2]) : `james_answer.${actual}`;
+
+    const url = URL.createObjectURL(blob);
+    const a   = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 500);
+
+    if (fallbk) {
+      // 다운로드는 됐지만 요청 포맷이 fallback으로 내려간 경우 알림
+      alert(`다운로드 완료 (${actual}). 참고: ${fallbk}`);
+    }
+  } catch (e) {
+    alert(`저장 실패: ${e.message}`);
+  } finally {
+    btn.textContent = orig;
+    btn.disabled = false;
+  }
 }
 
 /* ── 피드백 전송 ── */

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -17,12 +17,14 @@ from utils.console import ensure_utf8_console
 ensure_utf8_console()
 
 import os
+import re
 import sqlite3
 import uuid
 import time
 import json
 from datetime import datetime
 from collections import defaultdict
+from urllib.parse import quote
 from fastapi import FastAPI, UploadFile, File, HTTPException, Form, Header, Depends, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import JSONResponse, HTMLResponse, FileResponse
@@ -2274,6 +2276,69 @@ async def admin_metrics_get(
         "stage_filter": stage_filter or "",
         "stages":       stats,
     }
+
+
+@app.post("/export/", summary="답변 문서 export [item #4]")
+async def export_answer(request: Request, role: str = Depends(get_role_from_request)):
+    """Export an answer (or arbitrary content) to .md / .txt / .docx.
+
+    Body:
+      content:   text to export (typically a JAMES answer the user
+                 wants to save).
+      format:    "md" / "txt" / "docx" (default "md"). "pdf" is
+                 documented as v0.3+ and silently downgrades to "md"
+                 with `fallback_reason` set in the response headers.
+      filename:  optional stem (no extension). Sanitized server-side.
+      api_key:   required (matches the rest of the API contract).
+
+    Returns: file bytes with proper MIME + Content-Disposition.
+
+    Why a POST instead of GET: the answer content may be hundreds of
+    KB. URL length limits would bite a GET. Also keeps the answer
+    text out of access logs.
+
+    Auth: api_key check only (no admin requirement). Any logged-in
+    user may export their own answers — same trust model as the
+    chat /query/ endpoint.
+    """
+    from fastapi.responses import Response
+    body = await request.json()
+    api_key  = body.get("api_key", "")
+    content  = body.get("content", "") or ""
+    fmt      = body.get("format", "md")
+    filename = body.get("filename", "")
+
+    verify_api_key(api_key)
+    if not isinstance(content, str):
+        raise HTTPException(status_code=400, detail="content must be a string")
+    # Sanity cap — 1MB of text is more than enough for an answer.
+    if len(content.encode("utf-8")) > 1_000_000:
+        raise HTTPException(
+            status_code=413,
+            detail="content too large (>1MB); split into multiple exports",
+        )
+
+    from tools.export.document_exporter import export_document
+    result = export_document(content, format=fmt, filename=filename)
+
+    # ASCII-encode the filename for the header. Browsers handle utf-8
+    # via the filename* RFC 5987 form when present, but the plain
+    # `filename=` must stay ASCII-safe.
+    ascii_name = re.sub(r"[^\w.\-]+", "_", result.filename)
+    headers = {
+        "Content-Disposition":
+            f'attachment; filename="{ascii_name}"; '
+            f"filename*=UTF-8''{quote(result.filename)}",
+        "X-James-Export-Format": result.actual_format,
+    }
+    if result.fallback_reason:
+        headers["X-James-Export-Fallback"] = result.fallback_reason[:256]
+
+    return Response(
+        content=result.data,
+        media_type=result.mime,
+        headers=headers,
+    )
 
 
 @app.get("/admin/audit", summary="감사 로그 [P7]")

--- a/tests/test_document_export.py
+++ b/tests/test_document_export.py
@@ -1,0 +1,201 @@
+"""Document export — tools/export/document_exporter + /export/ endpoint
+(item #4, 2026-05-08 user feedback).
+
+Coverage:
+  - export_document for md / txt / docx (success + python-docx
+    fallback to md when the dep is missing).
+  - export_document for unknown / pdf format (graceful md fallback
+    with documented `fallback_reason`).
+  - _safe_filename strips path traversal, control chars, caller-
+    supplied extension; clamps length; gives a default for empty.
+  - Round-trip: md/txt bytes are valid utf-8 and round-trip equal
+    to the input (md is passthrough; txt is sanitized but never
+    raises on Korean / emoji / long content).
+  - Source-level: /export/ endpoint POST exists, accepts the
+    documented body fields, sends Content-Disposition.
+
+Run:
+  python -m unittest tests.test_document_export
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class SafeFilenameTests(unittest.TestCase):
+    def test_strips_path_traversal(self):
+        from tools.export.document_exporter import _safe_filename
+        for raw, expected_substring_check in [
+            ("../../etc/passwd",        "passwd"),
+            ("..\\..\\system32\\evil",  "evil"),
+            ("/absolute/path/file",     "file"),
+        ]:
+            got = _safe_filename(raw)
+            self.assertNotIn("/", got)
+            self.assertNotIn("\\", got)
+            self.assertNotIn("..", got)
+
+    def test_strips_user_extension(self):
+        from tools.export.document_exporter import _safe_filename
+        # We own format → caller's `.exe` / `.docx` etc must be removed.
+        self.assertNotIn(".exe", _safe_filename("malicious.exe"))
+        self.assertNotIn(".docx", _safe_filename("foo.docx"))
+        # But internal dots elsewhere are fine.
+        self.assertIn("v1", _safe_filename("notes.v1.draft"))
+
+    def test_strips_control_chars(self):
+        from tools.export.document_exporter import _safe_filename
+        got = _safe_filename("name\x00with\x01nulls\x1f")
+        self.assertNotIn("\x00", got)
+        self.assertNotIn("\x01", got)
+        self.assertNotIn("\x1f", got)
+
+    def test_clamp_length(self):
+        from tools.export.document_exporter import _safe_filename
+        long_in = "a" * 500
+        got = _safe_filename(long_in)
+        self.assertLessEqual(len(got), 80)
+
+    def test_default_when_all_bad(self):
+        from tools.export.document_exporter import _safe_filename
+        got = _safe_filename("///\\\\<<>>")
+        self.assertNotEqual(got, "")
+        self.assertEqual(got, "james_answer")
+
+
+class ExportDocumentTests(unittest.TestCase):
+    def test_md_passthrough(self):
+        from tools.export.document_exporter import export_document
+        content = "# Title\n\n- bullet 한글\n\nparagraph 1234"
+        r = export_document(content, format="md")
+        self.assertEqual(r.actual_format, "md")
+        self.assertEqual(r.fallback_reason, "")
+        self.assertTrue(r.filename.endswith(".md"))
+        self.assertEqual(r.data.decode("utf-8"), content)
+        self.assertIn("text/markdown", r.mime)
+
+    def test_txt_strips_markdown_markers(self):
+        from tools.export.document_exporter import export_document
+        content = "# Header\n\n**bold** and _italic_\n\n- bullet"
+        r = export_document(content, format="txt")
+        self.assertEqual(r.actual_format, "txt")
+        text = r.data.decode("utf-8")
+        # Header marker stripped.
+        self.assertNotIn("# Header", text)
+        self.assertIn("Header", text)
+        # **bold** → bold (no asterisks on a sole-bold line).
+        # The regex preserves the inner word.
+        self.assertIn("bold", text)
+        # Bullet "- " → "• "
+        self.assertIn("• bullet", text)
+
+    def test_docx_falls_back_to_md_when_unavailable(self):
+        # python-docx is NOT in this venv (verified by docstring run
+        # earlier). Confirm fallback behavior is documented + clean.
+        from tools.export.document_exporter import export_document
+        content = "# Title\n\nbody"
+        r = export_document(content, format="docx")
+        try:
+            import docx  # noqa: F401
+            python_docx_available = True
+        except ImportError:
+            python_docx_available = False
+        if python_docx_available:
+            self.assertEqual(r.actual_format, "docx")
+            self.assertGreater(len(r.data), 100,
+                               "docx blob must be non-trivial")
+        else:
+            self.assertEqual(r.actual_format, "md",
+                             "docx requested but python-docx missing → md")
+            self.assertIn("python-docx", r.fallback_reason)
+            self.assertIn("pip install", r.fallback_reason)
+
+    def test_pdf_documented_as_deferred(self):
+        from tools.export.document_exporter import export_document, PDF_DEFERRED_NOTE
+        r = export_document("anything", format="pdf")
+        self.assertEqual(r.actual_format, "md")
+        self.assertEqual(r.fallback_reason, PDF_DEFERRED_NOTE)
+        self.assertIn("v0.3", r.fallback_reason,
+                      "fallback reason must point to the deferral version")
+
+    def test_unknown_format_falls_back_to_md(self):
+        from tools.export.document_exporter import export_document
+        r = export_document("x", format="xlsx-totally-invalid")
+        self.assertEqual(r.actual_format, "md")
+        self.assertIn("unsupported format", r.fallback_reason)
+
+    def test_korean_content_roundtrips(self):
+        from tools.export.document_exporter import export_document
+        content = "# 한글 제목\n\n안녕 자메스. **굵게** _기울임_ `code`"
+        for fmt in ("md", "txt"):
+            r = export_document(content, format=fmt)
+            # Bytes decode as utf-8 — never errors. The exact post-
+            # transform text differs per format but must always be
+            # well-formed.
+            r.data.decode("utf-8")  # raises UnicodeDecodeError on bad output
+
+    def test_default_filename_is_timestamped(self):
+        from tools.export.document_exporter import export_document
+        r = export_document("x", format="md")
+        self.assertTrue(r.filename.startswith("james_answer_"))
+        self.assertTrue(r.filename.endswith(".md"))
+
+    def test_caller_filename_sanitized(self):
+        from tools.export.document_exporter import export_document
+        r = export_document("x", format="md", filename="../../evil.exe")
+        self.assertTrue(r.filename.endswith(".md"))
+        self.assertNotIn("..", r.filename)
+        self.assertNotIn(".exe", r.filename)
+
+
+class ExportEndpointSourceContractTests(unittest.TestCase):
+    """Source-level: /export/ endpoint exists, accepts api_key /
+    content / format / filename, sets Content-Disposition with a
+    sanitized ASCII fallback + utf-8 RFC 5987 filename* form."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_endpoint_registered(self):
+        self.assertIn('@app.post("/export/"', self.src,
+                      "/export/ POST endpoint missing")
+
+    def test_endpoint_validates_api_key(self):
+        idx = self.src.index('@app.post("/export/"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn("verify_api_key(api_key)", body,
+                      "/export/ must validate api_key")
+
+    def test_endpoint_calls_export_document(self):
+        idx = self.src.index('@app.post("/export/"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn("from tools.export.document_exporter import export_document", body)
+        self.assertIn("export_document(content, format=fmt", body)
+
+    def test_content_disposition_has_utf8_form(self):
+        idx = self.src.index('@app.post("/export/"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn('Content-Disposition', body)
+        self.assertIn("filename*=UTF-8''", body,
+                      "RFC 5987 utf-8 filename form must be present "
+                      "so Korean filenames survive the download header")
+
+    def test_size_cap_enforced(self):
+        idx = self.src.index('@app.post("/export/"')
+        body = self.src[idx:idx + 2500]
+        # 1MB cap is a small DoS guard.
+        self.assertIn("1_000_000", body,
+                      "/export/ must cap content size to avoid memory DoS")
+        self.assertIn("status_code=413", body,
+                      "oversize content must return HTTP 413")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/export/document_exporter.py
+++ b/tools/export/document_exporter.py
@@ -1,0 +1,229 @@
+"""Document export — render a JAMES answer to .md / .docx / .txt.
+
+Item #4 (2026-05-08 user feedback):
+  "문서 등 양식에 맞는 파일로 제시하라는 명령어가 작동 가능?"
+
+Scope at v0.2:
+  - .md   — always works (text passthrough; native JAMES output is
+            already mostly markdown so no transformation needed)
+  - .txt  — always works (strips markdown markers for plain prose)
+  - .docx — works when python-docx is importable; otherwise falls
+            back to .md output and the response_dict carries a
+            `fallback_reason` so the UI can show why
+  - .pdf  — NOT supported in v0.2 (would need reportlab/weasyprint
+            which has heavy native deps); falls back to .md
+
+Why bytes-in-memory rather than a temp file
+  The export endpoint sends FileResponse with the bytes directly.
+  No temp file = no leak surface, no /tmp filling up under load,
+  no race between caller download + cleanup.
+
+Why not import python-docx at module load
+  Lazy import inside `_export_docx`. Cold-start performance for the
+  normal `.md` / `.txt` path stays free. ImportError handled
+  explicitly (falls back to md, not crash).
+
+Filename safety
+  `_safe_filename` strips path traversal characters + clamps length.
+  Caller-supplied filename is treated as untrusted (operator could
+  pass anything via the API).
+"""
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Tuple
+
+
+SUPPORTED_FORMATS = ("md", "txt", "docx")
+PDF_DEFERRED_NOTE = (
+    "PDF export is deferred to v0.3 — heavy native deps. "
+    "Returning markdown instead."
+)
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """Returned by `export_document`. Caller wires `data` into the
+    HTTP response, `mime` into Content-Type, `filename` into the
+    Content-Disposition attachment hint.
+
+    `actual_format` may differ from the requested format when a
+    fallback fired (e.g. requested docx, python-docx unavailable,
+    fell back to md). `fallback_reason` is a human-readable note
+    the UI can surface so the operator knows WHY.
+    """
+    data:            bytes
+    mime:            str
+    filename:        str
+    actual_format:   str
+    fallback_reason: str = ""
+
+
+# ─── Filename hygiene ────────────────────────────────────────────
+
+_FILENAME_BAD_CHARS = re.compile(r"[\x00-\x1f<>:\"/\\|?*]+")
+
+
+def _safe_filename(raw: str, default_stem: str = "james_answer") -> str:
+    """Strip path traversal + control chars; clamp to 80 chars.
+
+    Returns just the stem (caller appends the extension based on
+    actual_format). An all-bad-character input produces the default.
+    """
+    stem = (raw or "").strip()
+    # Drop any path component the caller might have included.
+    stem = stem.replace("\\", "/").rsplit("/", 1)[-1]
+    # Drop a user-supplied extension — we own the format mapping.
+    stem = re.sub(r"\.[A-Za-z0-9]{1,5}$", "", stem)
+    stem = _FILENAME_BAD_CHARS.sub("_", stem)
+    stem = stem.strip("._ ")
+    if not stem:
+        stem = default_stem
+    return stem[:80]
+
+
+# ─── Format-specific renderers ───────────────────────────────────
+
+def _export_md(content: str) -> bytes:
+    """Pass-through. JAMES native output is already markdown-flavored
+    (the natural-flow prompt produces prose, not raw HTML)."""
+    return content.encode("utf-8")
+
+
+def _export_txt(content: str) -> bytes:
+    """Strip the most common markdown markers so .txt is clean prose.
+
+    Conservative — leaves URLs, parentheses, etc untouched. The goal
+    is "looks reasonable in Notepad", not full markdown→plaintext."""
+    text = content
+    # Headers: "# Title" / "## Sub" → "Title" / "Sub"
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    # Bold/italic markers around words: **x** / *x* / __x__ / _x_
+    text = re.sub(r"(\*\*|__)(.+?)\1", r"\2", text)
+    text = re.sub(r"(\*|_)(.+?)\1", r"\2", text)
+    # Inline code: `x` → x
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    # Bullets: "- " / "* " → "• "
+    text = re.sub(r"^\s*[-*]\s+", "• ", text, flags=re.MULTILINE)
+    return text.encode("utf-8")
+
+
+def _export_docx(content: str) -> Tuple[bytes, str]:
+    """Render content to a .docx via python-docx. On ImportError
+    return (md_bytes, fallback_reason) instead of raising — keeps
+    the export path resilient to missing optional deps."""
+    try:
+        from docx import Document  # type: ignore
+    except ImportError as e:
+        return (
+            _export_md(content),
+            f"python-docx not installed ({e}); returning markdown instead. "
+            f"Install with: pip install python-docx"
+        )
+
+    doc = Document()
+    # Render line-by-line. Each line that begins with `# ... ` gets
+    # mapped to a Word heading; bullets and quoted lines get their
+    # own styles. Plain lines are paragraphs. Conservative — this
+    # is a v0.2 first cut, not a full markdown engine.
+    for raw_line in content.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            doc.add_paragraph("")
+            continue
+        h = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if h:
+            level = min(len(h.group(1)), 4)
+            doc.add_heading(h.group(2), level=level)
+            continue
+        bul = re.match(r"^\s*[-*•]\s+(.+)$", line)
+        if bul:
+            doc.add_paragraph(bul.group(1), style="List Bullet")
+            continue
+        if line.startswith(">"):
+            doc.add_paragraph(line.lstrip("> ").strip(), style="Intense Quote")
+            continue
+        doc.add_paragraph(line)
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue(), ""
+
+
+# ─── Public entry point ──────────────────────────────────────────
+
+_MIME_BY_FORMAT = {
+    "md":   "text/markdown; charset=utf-8",
+    "txt":  "text/plain; charset=utf-8",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+_EXT_BY_FORMAT = {"md": ".md", "txt": ".txt", "docx": ".docx"}
+
+
+def export_document(
+    content:  str,
+    format:   str = "md",
+    filename: str = "",
+) -> ExportResult:
+    """Render `content` as the requested format.
+
+    Args:
+      content:  the answer text to export. Pass empty string and
+                you get an empty file (no error — caller's choice).
+      format:   one of `md` / `txt` / `docx`. Unknown values fall
+                back to `md` with a fallback_reason. `pdf` is
+                explicitly noted as v0.3+ work.
+      filename: optional stem. Sanitized; default is
+                `james_answer_<UTC-stamp>` if empty/invalid.
+
+    Returns:
+      ExportResult with bytes, MIME, sanitized filename (with the
+      correct extension applied based on `actual_format`), and a
+      `fallback_reason` when the format was downgraded.
+    """
+    requested = (format or "md").strip().lower()
+    actual = requested
+    fallback_reason = ""
+
+    if requested == "pdf":
+        actual = "md"
+        fallback_reason = PDF_DEFERRED_NOTE
+    elif requested not in SUPPORTED_FORMATS:
+        actual = "md"
+        fallback_reason = (
+            f"unsupported format {requested!r}; supported: "
+            f"{', '.join(SUPPORTED_FORMATS)}. Returning markdown."
+        )
+
+    # Resolve stem.
+    if not filename:
+        stem = f"james_answer_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}"
+    else:
+        stem = _safe_filename(filename)
+
+    if actual == "md":
+        data = _export_md(content)
+    elif actual == "txt":
+        data = _export_txt(content)
+    elif actual == "docx":
+        data, docx_fallback = _export_docx(content)
+        if docx_fallback:
+            # python-docx missing → degrade to md, keep both reasons.
+            actual = "md"
+            fallback_reason = docx_fallback
+    else:
+        # Defensive — should never reach here given the prelude.
+        data = _export_md(content)
+        actual = "md"
+
+    return ExportResult(
+        data=data,
+        mime=_MIME_BY_FORMAT[actual],
+        filename=stem + _EXT_BY_FORMAT[actual],
+        actual_format=actual,
+        fallback_reason=fallback_reason,
+    )


### PR DESCRIPTION
## Summary

User feedback: *"문서 등 양식에 맞는 파일로 제시하라는 명령어가 작동 가능?"*.

Each james message bubble in chat now has three small download buttons next to 👍/👎: **📥 .md / 📥 .docx / 📥 .txt**. Click → server renders the answer into the requested format → browser triggers download.

## Backend

| Component | Behavior |
|---|---|
| `tools/export/document_exporter.py` | `export_document(content, format, filename)` → `ExportResult` (data, mime, filename, actual_format, fallback_reason) |
| `.md` | Passthrough — JAMES output is already markdown-flavored |
| `.txt` | Strips headers / bold / italic / inline code / bullets for clean Notepad output |
| `.docx` | Uses `python-docx` if importable; gracefully falls back to `.md` with documented `fallback_reason` when the optional dep is missing |
| `.pdf` | Silently downgrades to `.md` with v0.3-deferred note (heavy native deps) |
| Unknown | Graceful md fallback (operator typos don't 500) |
| `_safe_filename` | Strips path traversal, control chars, user extensions; clamps to 80 chars; defaults to UTC-timestamped stem |
| `POST /export/` | api_key required (no admin gate — same trust model as `/query/`); 1MB cap (HTTP 413); Content-Disposition has both ASCII fallback **and** RFC 5987 utf-8 form (`filename*=UTF-8''...`) so Korean filenames survive |

## Frontend

`exportAnswer(btn, fmt)` POSTs the original answer text (from `data-content` attribute, `encodeURIComponent`-wrapped so embedded HTML doesn't break parsing), decodes the blob, parses filename from `Content-Disposition`, triggers `a[download]`, and shows an alert if the server downgraded format.

## Verification

18 unit tests in `tests/test_document_export.py`:
- **SafeFilenameTests** (5): path traversal, user extension, control chars, length clamp, all-bad → default
- **ExportDocumentTests** (8): md passthrough, txt marker stripping, docx with/without python-docx, pdf deferred fallback, unknown format graceful fallback, Korean roundtrip, default timestamp filename, caller filename sanitization
- **ExportEndpointSourceContractTests** (5): route registered, api_key validated, calls `export_document`, Content-Disposition has utf-8 RFC 5987 form, 1MB cap → HTTP 413

**281/281 regression suite pass** (18 new + 263 prior).

## Out of scope

- PDF export → v0.3 (needs reportlab/weasyprint or browser print-to-PDF)
- Natural-language routing (`"이 답변 docx로 줘"` → `mode=document_export`) — buttons cover the primary UX; chat-level routing can come later if usage warrants
- Bulk export of multiple answers — single-message is enough for v0.2.1

## Bench numbers

Not applicable — new endpoint, no retrieval / graph / scoring surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)