### PR TITLE
fix(config): default LLM model gemma2:2b → gemma4:e4b (matches RESULTS.md)

### DIFF
--- a/config.py
+++ b/config.py
@@ -137,7 +137,7 @@ POPPLER_PATH = _detect_poppler()
 # Ollama runs as a service — usually no need to specify binary path.
 # If you need to start it from JAMES, set OLLAMA_PATH env var.
 OLLAMA_PATH    = os.environ.get("OLLAMA_PATH", "")  # blank = use system 'ollama' on PATH
-GEMMA_MODEL    = os.environ.get("JAMES_LLM_MODEL", "gemma2:2b")
+GEMMA_MODEL    = os.environ.get("JAMES_LLM_MODEL", "gemma4:e4b")
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
 # ────────────────────────────────────────────────────────────────

--- a/tests/test_default_llm_model.py
+++ b/tests/test_default_llm_model.py
@@ -1,0 +1,63 @@
+"""Default LLM model name guard.
+
+Real user 2026-05-08 hit a "0.03s 답변 생성 실패" bug because
+config.GEMMA_MODEL defaulted to `gemma2:2b` while the project's
+documented + actually-installed model is `gemma4:e4b`. Ollama
+rejected the unknown model name immediately, the chat handler saw
+an LLM error, and returned the fallback "죄송합니다".
+
+eval/RESULTS.md documents `gemma4:e4b` as the bench fingerprint
+model. The default in config.py must match that documented value
+so a fresh clone + ollama-pull-as-documented works out of the box.
+
+This file pins the default. JAMES_LLM_MODEL env var still overrides
+freely (operators on different hardware can use a smaller model).
+
+Run:
+  python -m unittest tests.test_default_llm_model
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class DefaultModelNameTests(unittest.TestCase):
+    def test_config_default_matches_documented_results_md(self):
+        # Config source-level: the literal default must match the
+        # value documented in eval/RESULTS.md "Hardware fingerprint".
+        config_path = Path(__file__).resolve().parent.parent / "config.py"
+        config_src = config_path.read_text(encoding="utf-8")
+        results_md = (Path(__file__).resolve().parent.parent
+                      / "eval" / "RESULTS.md").read_text(encoding="utf-8")
+
+        # Config side — extract the default fallback inside the env getter.
+        import re
+        m = re.search(
+            r'GEMMA_MODEL\s*=\s*os\.environ\.get\(\s*["\']JAMES_LLM_MODEL["\']\s*,\s*["\']([^"\']+)["\']',
+            config_src,
+        )
+        self.assertIsNotNone(m, "GEMMA_MODEL fallback default not found "
+                             "in config.py — pattern broken or refactored")
+        config_default = m.group(1)
+
+        # RESULTS.md side — the model name must appear in the
+        # Hardware fingerprint table line.
+        self.assertIn(
+            f"`{config_default}`",
+            results_md,
+            f"config default {config_default!r} not mentioned in "
+            f"eval/RESULTS.md. The user's environment is calibrated "
+            f"on the RESULTS.md value; drift between the two causes "
+            f"a fresh setup to fail with 'gemma2:2b: model not found' "
+            f"or similar Ollama errors."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Real user 2026-05-08: fresh server, all setup correct, login OK, admin role OK — but every chat query failed in 0.03s with `"죄송합니다. 답변을 생성하지 못했습니다."`.

Diagnosis showed Ollama running with three models installed (`gemma4:e4b`, `llava:13b`, `qwen2.5-coder:32b`) but `config.GEMMA_MODEL` defaulted to `gemma2:2b` — **NOT** in Ollama's installed list. Ollama rejected the unknown model name immediately → chat handler saw an error sentinel and returned the fallback message.

## Root cause

Drift between config.py default and `eval/RESULTS.md`:
- `config.py:140` defaulted to `"gemma2:2b"` (v0.1 leftover)
- `eval/RESULTS.md` Hardware Fingerprint documents `gemma4:e4b` as the LLM model

Fresh clones following the docs pull `gemma4:e4b`, but the code asks for `gemma2:2b` → silent mismatch → every chat fails until the operator adds `JAMES_LLM_MODEL=gemma4:e4b` to `.env`.

## Fix

Align `config.py`'s default with the documented `RESULTS.md` value. Operators on smaller hardware can still set `JAMES_LLM_MODEL` to a lighter model (`gemma2:2b` stays a valid choice if explicitly pulled).

## Verification

`tests/test_default_llm_model.py` — 1 source-level guard:
- `config.GEMMA_MODEL` fallback default appears as a backtick-fenced reference in `eval/RESULTS.md`
- Drift between the two causes the bug we're fixing; the test makes future drift impossible without a deliberate breaking-test change

**286/286 regression suite pass.**

## Bench numbers

Not applicable — config default change. The actual model used at bench time is whatever `JAMES_LLM_MODEL` env says, so RESULTS.md numbers stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)