### PR TITLE
feat(reasoning): real reasoning stream — replaces fake 2.5s timer

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -375,7 +375,14 @@ async function sendMessage() {
     }
   }
 
-  const typing = appendTyping();
+  // Real reasoning stream: client-generated trace_id is sent to the
+  // server, which uses it as the trace key. Frontend immediately
+  // starts polling /trace/poll/{trace_id} so we can display each
+  // reasoning stage as it actually happens (vs. the v0.2.0 fake
+  // 2.5s timer placeholder).
+  const traceId = (crypto.randomUUID ? crypto.randomUUID() : 't_' + Date.now() + '_' + Math.random().toString(36).slice(2,8))
+                  .replace(/-/g, '').slice(0, 32);
+  const typing = appendTyping(traceId);
   document.getElementById('send-btn').disabled = true;
 
   try {
@@ -388,6 +395,7 @@ async function sendMessage() {
         source_type:      SOURCE_TYPE,
         session_id:       SESSION_ID,
         session_language: sessionStorage.getItem('james_session_lang') || '',
+        trace_id:         traceId,
       }),
     });
 
@@ -635,39 +643,109 @@ async function sendFeedback(directionId, signal, btn) {
   }
 }
 
-function appendTyping() {
+/* ── Real reasoning stream — polls /trace/poll/{trace_id} ──
+   v0.2.0의 fake 2.5초 타이머를 진짜 stage event 폴링으로 교체.
+   각 stage(auth → retrieve → graph → answer → complete)가 실제로
+   서버에서 발생할 때마다 클라이언트가 잡아서 라인을 추가한다.
+
+   Stage별 메타데이터를 함께 표시:
+     retrieve · top_k=8 · top_vec=0.82 (250ms 누적)
+     graph    · entities=3 · paths=15 (+180ms)
+     answer   · 1820ms · 412 chars
+*/
+function appendTyping(traceId) {
   const messages = document.getElementById('messages');
   const div = document.createElement('div');
   div.className = 'msg james';
   div.innerHTML = `
     <div class="avatar james">🧠</div>
-    <div class="bubble" style="min-width:180px">
-      <div id="thinking-steps" style="display:flex;flex-direction:column;gap:4px;font-size:12px">
-        <div id="tstep-1" style="color:var(--accent);font-weight:600">${t('chat.thinking_search')}</div>
-        <div id="tstep-2" style="color:var(--muted)">${t('chat.thinking_graph')}</div>
-        <div id="tstep-3" style="color:var(--muted)">${t('chat.thinking_answer')}</div>
+    <div class="bubble" style="min-width:200px">
+      <div id="thinking-${traceId}" style="display:flex;flex-direction:column;gap:4px;
+                  font-size:11px;font-family:var(--font-mono);color:var(--muted)">
+        <div style="font-style:italic">⏳ 추론 중...</div>
       </div>
     </div>
   `;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
 
-  // 단계별 순차 활성화 (2.5초 간격)
-  const steps = ['tstep-1','tstep-2','tstep-3'];
-  let cur = 0;
-  const timer = setInterval(() => {
-    const prev = document.getElementById(steps[cur]);
-    if (prev) { prev.style.color='var(--muted)'; prev.style.fontWeight='400'; }
-    if (cur < steps.length - 1) {
-      cur++;
-      const next = document.getElementById(steps[cur]);
-      if (next) { next.style.color='var(--accent)'; next.style.fontWeight='600'; }
+  // 폴링 상태
+  const seenStages = new Set();   // stage 종류별 1회만 표시 (반복 retrieve 등은 합산)
+  let lastNs   = 0;
+  let stopped  = false;
+  const t0     = Date.now();
+
+  const STAGE_META = {
+    auth:     { icon: '🔐', label: '권한 확인', color: '#999' },
+    retrieve: { icon: '🔍', label: '내부 자료 검색', color: '#7c6af7' },
+    rerank:   { icon: '🎯', label: '재정렬',          color: '#7c6af7' },
+    graph:    { icon: '🕸️', label: '관계 그래프 탐색', color: '#3da78a' },
+    tool:     { icon: '🔧', label: '도구 호출',       color: '#ffb74d' },
+    answer:   { icon: '🤖', label: 'LLM 답변 생성',   color: '#f06292' },
+    complete: { icon: '✅', label: '완료',            color: '#4caf7d' },
+  };
+
+  const apply = (events) => {
+    const container = document.getElementById(`thinking-${traceId}`);
+    if (!container) return;
+    // 첫 진짜 이벤트 도착 시 placeholder 제거
+    if (events.length > 0 && container.querySelector('div[style*="italic"]')) {
+      container.innerHTML = '';
     }
-  }, 2500);
+    events.forEach(ev => {
+      const stage = ev.stage;
+      if (!stage || seenStages.has(stage)) return;   // 1회 표시
+      seenStages.add(stage);
+      const m = STAGE_META[stage] || { icon: '·', label: stage, color: '#999' };
+      const ms = Date.now() - t0;
+      // stage별 의미있는 필드 일부만 추출 (시각적 잡음 줄임)
+      const detail = [];
+      if (ev.top_k != null)           detail.push(`top_k=${ev.top_k}`);
+      if (ev.top_vector_score != null) detail.push(`vec=${ev.top_vector_score.toFixed(2)}`);
+      if (ev.entities_extracted != null) detail.push(`ent=${ev.entities_extracted}`);
+      if (ev.paths_walked != null)    detail.push(`paths=${ev.paths_walked}`);
+      if (ev.latency_ms != null)      detail.push(`${ev.latency_ms}ms`);
+      if (ev.answer_len != null)      detail.push(`${ev.answer_len}자`);
+      if (ev.elapsed_ms != null)      detail.push(`총 ${ev.elapsed_ms}ms`);
+      const detailStr = detail.length ? ` · ${detail.join(' · ')}` : '';
+      const line = document.createElement('div');
+      line.style.cssText = `display:flex;align-items:center;gap:6px;color:${m.color}`;
+      line.innerHTML = `<span>${m.icon}</span><span style="font-weight:600">${m.label}</span><span style="color:var(--muted);font-size:10px">${detailStr} · @${ms}ms</span>`;
+      container.appendChild(line);
+    });
+    messages.scrollTop = messages.scrollHeight;
+  };
+
+  // 200ms 폴링 (auth → retrieve → graph → answer 보통 1-3초 안에 도착)
+  const poll = async () => {
+    if (stopped) return;
+    try {
+      const r = await fetch(`${API}/trace/poll/${traceId}?api_key=${encodeURIComponent(getApiKey())}&after_ns=${lastNs}`, {
+        headers: getAuthHeaders(),
+      });
+      if (r.ok) {
+        const data = await r.json();
+        const evs = data.events || [];
+        if (evs.length > 0) {
+          lastNs = evs[evs.length - 1].ts_ns || lastNs;
+          apply(evs);
+        }
+        if (data.complete) {
+          stopped = true;
+          return;
+        }
+      }
+    } catch (_) {
+      // 네트워크 일시 오류는 무시 — 다음 tick에 재시도
+    }
+    if (!stopped) setTimeout(poll, 200);
+  };
+  // 첫 호출 약간 지연 (서버에 첫 stage 도달 시간 확보)
+  setTimeout(poll, 100);
 
   return {
     remove() {
-      clearInterval(timer);
+      stopped = true;
       div.remove();
     }
   };

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -315,6 +315,12 @@ class QueryRequest(BaseModel):
     # string falls through to JAMES_RESPONSE_STYLE env then `standard`.
     # See core/response_style.py for the resolver and preset defs.
     response_style:   str  = ""
+    # Client-supplied trace_id (item: real reasoning stream). When set,
+    # the server uses this id instead of generating a new one — letting
+    # the client poll /trace/poll/{trace_id} for stage events as they
+    # arrive (real reasoning stream, replacing the fake 2.5s timer
+    # placeholder). Empty → server generates uuid7 as before.
+    trace_id:         str  = ""
 
 class QueryResponse(BaseModel):
     question:       str
@@ -602,8 +608,19 @@ async def query(
 
     # [#47 phase 1] start a trace at the API edge. Stage logs from any
     # downstream module reading `current_trace_id` correlate to this id.
+    # Client-supplied trace_id takes precedence (real-reasoning-stream
+    # feature) — lets the client poll /trace/poll/{trace_id} the moment
+    # it sends the request, before /query/ has returned a response.
+    # Sanity-check the supplied id (alphanumeric + hyphens only, 8-64
+    # chars) to keep filesystem path-safety guarantees from
+    # observability._trace_file_for.
     from core.observability import start_trace, log_stage
-    trace_id = start_trace()
+    import re as _re
+    client_tid = (data.trace_id or "").strip()
+    if client_tid and _re.fullmatch(r"[A-Za-z0-9_\-]{8,64}", client_tid):
+        trace_id = start_trace(client_tid)
+    else:
+        trace_id = start_trace()
 
     question   = data.question.strip()
     session_id = data.session_id or "default"
@@ -2197,6 +2214,57 @@ async def admin_patch_reject(request: Request, role: str = Depends(get_role_from
         d["status"] = "REJECTED"
         pf.write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
     return {"success": True, "patch_id": patch_id, "status": "REJECTED"}
+
+
+@app.get("/trace/poll/{trace_id}", summary="실시간 추론 단계 polling [real-reasoning-stream]")
+async def trace_poll(
+    trace_id: str,
+    api_key:  str,
+    after_ns: int = 0,
+    role:     str = Depends(get_role_from_request),
+):
+    """Stream real reasoning stages as they arrive in the JSONL file.
+
+    Client flow:
+      1. Generate a uuid hex on the client (e.g. crypto.randomUUID).
+      2. Submit POST /query/ with the trace_id field in the body.
+      3. Immediately start polling this endpoint every ~200ms with
+         after_ns increasing each call (last seen ts_ns) — minimises
+         duplicate transfer.
+      4. Render each new event in the chat bubble (retrieve / graph /
+         answer / complete with their actual fields).
+      5. Stop polling when the response arrives OR an event with
+         stage='complete' is in the returned list.
+
+    Auth: api_key only (no admin requirement). The trace_id itself
+    acts as a capability — uuid hex is unguessable, so a different
+    user cannot poll someone else's trace. Same trust model as
+    /query/.
+
+    Path arg sanitization: only alphanumerics + hyphen + underscore
+    (8-64 chars). Keeps `core.observability._trace_file_for` from
+    looking outside `reports/trace/<day>/`.
+    """
+    verify_api_key(api_key)
+
+    # Path traversal guard — same regex as /query/'s client_tid check.
+    import re as _re
+    if not _re.fullmatch(r"[A-Za-z0-9_\-]{8,64}", trace_id):
+        raise HTTPException(status_code=400,
+                            detail="invalid trace_id format")
+
+    from core.observability import read_trace
+    rows = read_trace(trace_id)
+    # Only return events newer than the last seen timestamp.
+    new_rows = [r for r in rows if int(r.get("ts_ns") or 0) > int(after_ns or 0)]
+    is_complete = any(r.get("stage") == "complete" for r in rows)
+
+    return {
+        "trace_id":  trace_id,
+        "events":    new_rows,
+        "complete":  is_complete,
+        "total":     len(rows),
+    }
 
 
 @app.get("/admin/trace/{trace_id}", summary="단일 trace 재생 [#81 phase 3-A]")

--- a/tests/test_real_reasoning_stream.py
+++ b/tests/test_real_reasoning_stream.py
@@ -1,0 +1,277 @@
+"""Real reasoning stream — client-supplied trace_id + /trace/poll/.
+
+Replaces the v0.2.0 fake 2.5s timer placeholder with actual per-stage
+events streamed from the trace JSONL file. User feedback 2026-05-08:
+"형식적으로 만들어놓은 거 말고 클로드 방식을 따라 실제 추론과정을
+표시될 수 있도록 개선".
+
+Coverage:
+  - QueryRequest accepts trace_id field; default empty.
+  - /query/ uses client-supplied trace_id when valid; falls back to
+    server-generated when empty / invalid.
+  - Path-traversal guard rejects malformed trace_ids both at /query/
+    and /trace/poll/.
+  - /trace/poll/{trace_id} requires api_key but NOT admin role
+    (capability-token model: trace_id itself is the secret).
+  - /trace/poll/ filters events by `after_ns` (incremental polling
+    avoids redundant transfer).
+  - /trace/poll/ flags `complete` when a 'complete' stage exists.
+  - Behavioral: write a few stages via log_stage, then verify the
+    polling endpoint returns them in order with correct fields.
+  - Frontend contract: appendTyping accepts a traceId arg and polls
+    /trace/poll/.
+
+Run:
+  python -m unittest tests.test_real_reasoning_stream
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _admin_headers():
+    from core.auth import create_token
+    return {"Authorization": f"Bearer {create_token('test-admin', 'admin')}"}
+
+
+def _api_key():
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+class QueryRequestTraceIdTests(unittest.TestCase):
+    """Source-level: QueryRequest must accept trace_id; /query/
+    uses client-supplied id when valid, generates own when empty."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_querryrequest_has_trace_id_field(self):
+        # Locate QueryRequest body — bounded by next class or function def.
+        import re
+        m = re.search(
+            r"class QueryRequest\(BaseModel\):(.+?)(?=\nclass |\n@app\.|\nasync def )",
+            self.src, re.DOTALL,
+        )
+        self.assertIsNotNone(m, "QueryRequest class block not found")
+        body = m.group(1)
+        self.assertIn("trace_id", body,
+                      "QueryRequest must declare trace_id field")
+        # Default must be empty string (back-compat).
+        self.assertTrue(re.search(r'trace_id\s*:\s*str\s*=\s*""', body),
+                        "trace_id must default to empty string for back-compat")
+
+    def test_query_endpoint_validates_and_uses_client_trace_id(self):
+        idx = self.src.index('@app.post("/query/"')
+        body = self.src[idx:idx + 2500]
+        # Sanity-check format must be enforced (path traversal guard).
+        self.assertIn(r'fullmatch(r"[A-Za-z0-9_\-]{8,64}"', body,
+                      "/query/ must regex-validate client_tid format "
+                      "before passing to start_trace()")
+        # Both branches present: with valid id, fallback when not.
+        self.assertIn("start_trace(client_tid)", body)
+        self.assertIn("start_trace()", body,
+                      "fallback to server-generated id on empty/invalid")
+
+
+class TracePollEndpointSourceTests(unittest.TestCase):
+    """The new GET /trace/poll/{trace_id} endpoint must require
+    api_key (NOT admin), validate trace_id format, return events
+    newer than after_ns, and flag completion."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_poll_endpoint_registered(self):
+        self.assertIn('@app.get("/trace/poll/{trace_id}"', self.src,
+                      "polling endpoint must be GET /trace/poll/{trace_id}")
+
+    def test_poll_endpoint_uses_api_key_not_admin(self):
+        idx = self.src.index('@app.get("/trace/poll/{trace_id}"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn("verify_api_key(api_key)", body,
+                      "must validate api_key")
+        # Must NOT be admin-gated — the user wouldn't be able to see
+        # their own reasoning stream otherwise.
+        self.assertNotIn("_require_admin(", body,
+                         "polling endpoint must NOT be admin-gated; "
+                         "trace_id capability-token model is sufficient")
+
+    def test_poll_endpoint_validates_trace_id_format(self):
+        idx = self.src.index('@app.get("/trace/poll/{trace_id}"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn(r'fullmatch(r"[A-Za-z0-9_\-]{8,64}"', body,
+                      "trace_id path arg must be regex-validated to "
+                      "prevent traversal into reports/trace/")
+        self.assertIn("status_code=400", body,
+                      "invalid trace_id must return 400")
+
+    def test_poll_endpoint_filters_by_after_ns(self):
+        idx = self.src.index('@app.get("/trace/poll/{trace_id}"')
+        body = self.src[idx:idx + 2500]
+        self.assertIn("after_ns", body,
+                      "polling endpoint must accept after_ns param "
+                      "for incremental fetching")
+        self.assertIn('"complete"', body,
+                      "response must flag complete=true when 'complete' "
+                      "stage is present, so the client can stop polling")
+
+
+class TracePollBehavioralTests(unittest.TestCase):
+    """End-to-end via TestClient: write events via log_stage, poll
+    them back. Uses a tmpdir trace root so we don't disturb
+    reports/trace/."""
+
+    def setUp(self):
+        from core.observability import set_trace_root, current_trace_id
+        self._tmp = tempfile.TemporaryDirectory()
+        set_trace_root(Path(self._tmp.name))
+        current_trace_id.set("")
+        self._api_key = _api_key()
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing; cannot exercise endpoint")
+
+    def tearDown(self):
+        from core.observability import set_trace_root
+        set_trace_root(None)
+        self._tmp.cleanup()
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def test_invalid_trace_id_format_400(self):
+        client = self._client()
+        for bad in ("short", "..", "../etc/passwd", "a" * 100, ""):
+            r = client.get(
+                f"/trace/poll/{bad}",
+                params={"api_key": self._api_key},
+            )
+            self.assertNotEqual(r.status_code, 200,
+                                f"bad trace_id {bad!r} must not return 200")
+
+    def test_polling_returns_events_in_order(self):
+        from core.observability import start_trace, log_stage
+        # Use a CLIENT-style trace_id so we mirror real usage.
+        client_tid = "abcd1234efgh5678ijkl9012mnop3456"
+        tid = start_trace(client_tid)
+        log_stage("auth", role="admin", allowed=True)
+        log_stage("retrieve", top_k=8, top_vector_score=0.82)
+        log_stage("graph", entities_extracted=3, paths_walked=15)
+        log_stage("answer", latency_ms=1820, answer_len=412)
+        log_stage("complete", elapsed_ms=2200)
+
+        client = self._client()
+        r = client.get(
+            f"/trace/poll/{tid}",
+            params={"api_key": self._api_key},
+        )
+        self.assertEqual(r.status_code, 200, f"poll failed: {r.text}")
+        data = r.json()
+        self.assertEqual(data["trace_id"], tid)
+        self.assertTrue(data["complete"], "complete must be True after 'complete' stage")
+        self.assertEqual(data["total"], 5)
+        stages = [e["stage"] for e in data["events"]]
+        self.assertEqual(stages, ["auth", "retrieve", "graph", "answer", "complete"])
+
+    def test_after_ns_filters_already_seen(self):
+        from core.observability import start_trace, log_stage
+        client_tid = "ffff1111eeee2222dddd3333cccc4444"
+        start_trace(client_tid)
+        log_stage("auth")
+        log_stage("retrieve", top_k=8)
+        client = self._client()
+
+        # First poll: no after_ns → both events.
+        r = client.get(
+            f"/trace/poll/{client_tid}",
+            params={"api_key": self._api_key},
+        )
+        self.assertEqual(len(r.json()["events"]), 2)
+        last_ts = r.json()["events"][-1]["ts_ns"]
+
+        # Add a third event.
+        log_stage("graph", paths_walked=10)
+
+        # Poll with after_ns = previous last → only the new one.
+        r2 = client.get(
+            f"/trace/poll/{client_tid}",
+            params={"api_key": self._api_key, "after_ns": last_ts},
+        )
+        evs = r2.json()["events"]
+        self.assertEqual(len(evs), 1, f"after_ns filter failed: {evs}")
+        self.assertEqual(evs[0]["stage"], "graph")
+
+
+class FrontendChatJsContractTests(unittest.TestCase):
+    """chat.js must:
+      - Generate a client-side trace_id and send it in the /query/ body
+      - Pass that trace_id to appendTyping()
+      - appendTyping calls /trace/poll/{trace_id} on a recurring poll
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (Path(__file__).resolve().parent.parent
+                  / "frontend" / "static" / "chat.js"
+                  ).read_text(encoding="utf-8")
+
+    def test_send_message_generates_trace_id(self):
+        idx = self.js.index("async function sendMessage")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("crypto.randomUUID", body,
+                      "sendMessage should use crypto.randomUUID() for trace_id "
+                      "(falls back to manual id when missing)")
+        self.assertIn("trace_id:", body,
+                      "/query/ body must include trace_id field")
+        self.assertIn("appendTyping(traceId)", body,
+                      "appendTyping must receive the trace_id so it knows "
+                      "which trace to poll")
+
+    def test_append_typing_polls_real_trace(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("/trace/poll/", body,
+                      "appendTyping must poll /trace/poll/{traceId}")
+        self.assertIn("after_ns=", body,
+                      "polling must use after_ns for incremental fetching")
+        # The fake 2.5s setInterval timer must be GONE.
+        self.assertNotIn("2500", body,
+                         "fake 2.5s placeholder timer must be removed")
+        # A complete-flag check must stop the polling loop.
+        self.assertIn("complete", body,
+                      "polling loop must stop on data.complete = true")
+
+    def test_stage_metadata_displayed(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4000]
+        # Real per-stage labels must replace the static three-step UI.
+        for stage_token in ("retrieve", "graph", "answer", "complete"):
+            self.assertIn(f'{stage_token}:', body,
+                          f"stage {stage_token!r} must have its own metadata mapping")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"형식적으로 만들어놓은 거 말고 클로드 방식을 따라 실제 추론과정을 표시될 수 있도록 개선"*.

The v0.2.0 chat UI showed three static labels with a 2.5s setInterval timer — completely decoupled from server reality. Slow queries showed "Generating answer" before retrieval finished; fast queries flashed all three before there was anything to display.

This PR wires the chat bubble to the **real per-stage trace stream** that `core/observability::log_stage` already emits.

## Architecture

```
Client                        Server
──────                        ──────
generate uuid32 → trace_id
                              
POST /query/ {... trace_id} → use trace_id (or generate if empty)
                              start log_stage("auth", ...)
[start polling] →             continue log_stage("retrieve", ...)
GET /trace/poll/{tid}         continue log_stage("graph", ...)
   ?after_ns=N
←  events: [...]              continue log_stage("answer", ...)
[render lines] →              log_stage("complete", ...)
                              
←  /query/ response           [done]
[stop polling]
```

## Real per-stage display (replaces 3 static labels)

```
🔐 권한 확인 · @8ms
🔍 내부 자료 검색 · top_k=8 · vec=0.82 · @42ms
🕸️ 관계 그래프 탐색 · ent=3 · paths=15 · @380ms
🤖 LLM 답변 생성 · 1820ms · 412자 · @2200ms
✅ 완료 · 총 2240ms
```

Each line is keyed off the actual `log_stage` event with its actual fields. No more flashing through stages on a fixed timer.

## Verification

12 unit tests in `tests/test_real_reasoning_stream.py`:

**Source-level**:
- `QueryRequest` has `trace_id: str = ""` (back-compat default)
- `/query/` regex-validates client_tid + has both branches
- `/trace/poll/{trace_id}` registered, api_key (not admin), regex-validated, after_ns filter, complete flag

**Behavioral via TestClient**:
- Invalid trace_id formats (`short`, `..`, `../etc/passwd`, 100-char) all rejected
- Valid trace returns events in chronological order with complete=true
- `after_ns` filters already-seen events

**Frontend contract**:
- `sendMessage` uses `crypto.randomUUID`, sends `trace_id` in body, passes `traceId` to `appendTyping`
- `appendTyping` polls `/trace/poll/`, uses `after_ns`, **no 2500 timer literal** survives, stops on `complete`
- Per-stage metadata mapping covers retrieve/graph/answer/complete

**298/298 regression suite pass.**

## Bench numbers

Not applicable — UI/observability glue, no retrieval/graph/scoring change. STEP 7 invariants unaffected.

## Out of scope

- Server-Sent Events (SSE) — polling at 200ms is fine at v0.2 scale; SSE may come later if multi-user load matters.
- Streaming answer text (token-by-token) — currently the answer arrives whole. Token streaming is a bigger refactor of the LLM call path; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)