### PR TITLE
feat(frontend): mobile-responsive UI — phone + tablet sizing (≤768/480px)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -2,7 +2,8 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="theme-color" content="#0c0d10">
 <title>JAMES Admin</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
@@ -239,6 +240,9 @@
   .loading { color: var(--muted); font-size: 13px; padding: 20px; }
   .empty   { color: var(--muted); font-size: 13px; padding: 32px; text-align: center; }
 </style>
+<!-- mobile-responsive overrides — kept after inline styles so @media
+     rules win at narrow viewports without !important on every line -->
+<link rel="stylesheet" href="/static/mobile.css">
 </head>
 <body>
 <header>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,8 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="theme-color" content="#0c0d10">
 <title>PROJECT JAMES</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
@@ -712,6 +713,9 @@
   @keyframes slideUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
   @keyframes bounce  { 0%,60%,100% { transform: translateY(0); } 30% { transform: translateY(-5px); } }
 </style>
+<!-- mobile-responsive overrides — kept after inline styles so @media
+     rules win at narrow viewports without !important on every line -->
+<link rel="stylesheet" href="/static/mobile.css">
 </head>
 <body>
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -1,0 +1,298 @@
+/* PROJECT JAMES — mobile responsive overrides
+ *
+ * Strategy: desktop-first inline styles in index.html / admin.html
+ * stay untouched; this stylesheet adds @media-gated overrides for
+ * narrow viewports (≤ 768px tablet, ≤ 480px phone).
+ *
+ * Loaded as the LAST stylesheet via <link> at the bottom of <head>
+ * so its rules win over the inline base styles. No !important
+ * needed — same specificity, later position.
+ *
+ * Three principles:
+ *   1) Touch targets ≥ 44×44px (Apple HIG / Material guidelines).
+ *   2) No fixed widths < 100vw — anything horizontal must reflow
+ *      or scroll, never clip.
+ *   3) Bottom-anchored input area + safe-area-inset-bottom for
+ *      iOS notch / home-bar.
+ */
+
+/* ─────────────────────────────────────────────────────────
+ * Tablet + phone (≤ 768px)
+ * ────────────────────────────────────────────────────────*/
+@media (max-width: 768px) {
+  body { font-size: 15px; }
+
+  /* ── 헤더 — 모바일은 여러 요소가 한 줄에 못 들어감 ── */
+  header {
+    padding: 8px 12px;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .header-right {
+    gap: 4px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .logo { font-size: 13px; }
+  .logo::before { width: 18px; height: 18px; }
+
+  /* PROD/TEST 토글 — 작게 */
+  .source-toggle { font-size: 10px; }
+  .source-toggle button { padding: 5px 8px; min-height: 30px; }
+
+  /* KO|EN, ADMIN, 로그인, etc. */
+  .nav-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+    min-height: 36px;          /* touch target */
+  }
+
+  .role-badge {
+    padding: 4px 10px;
+    font-size: 11px;
+  }
+
+  /* ─────────────── chat 페이지 ─────────────── */
+
+  /* 사이드바 — 모바일에선 화면 가득, 닫혔을 때 0 */
+  .sidebar {
+    position: fixed;
+    z-index: 50;
+    inset: 0 auto 0 0;          /* top:0 right:auto bottom:0 left:0 */
+    width: 88vw;
+    max-width: 360px;
+    box-shadow: 4px 0 16px rgba(0, 0, 0, 0.4);
+  }
+  .sidebar.collapsed { width: 0; box-shadow: none; }
+  .sidebar-open-btn {
+    width: 44px;
+    height: 44px;
+    font-size: 18px;
+  }
+
+  /* 메시지 영역 — 패딩 줄이고 chat 가장자리까지 사용 */
+  .messages {
+    padding: 16px 12px 12px;
+    gap: 14px;
+  }
+  .msg { max-width: 100%; }
+  .bubble {
+    padding: 10px 14px;
+    font-size: 14.5px;
+    border-radius: 12px;
+    line-height: 1.55;
+  }
+  .avatar { width: 28px; height: 28px; font-size: 12px; }
+
+  /* 웰컴 — 좁은 화면에 맞게 */
+  .welcome { padding: 24px 16px; }
+  .welcome-title { font-size: 22px; }
+  .welcome-sub { font-size: 13px; }
+  .welcome-chips { gap: 6px; margin-top: 20px; }
+  .chip { padding: 8px 12px; font-size: 12px; }
+
+  /* 입력 영역 — 모바일은 항상 바닥 + iOS safe-area */
+  .input-area, #input-area, footer.input-area {
+    padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0));
+    gap: 6px;
+  }
+  textarea, input[type="text"], #chat-input {
+    font-size: 16px;             /* iOS 자동 줌 방지 (≥ 16px) */
+    padding: 10px 12px;
+    min-height: 44px;
+    border-radius: 10px;
+  }
+  button, .btn {
+    min-height: 36px;
+    min-width: 36px;
+  }
+
+  /* 답변 옆 buttons (👍 👎 📥) — 가로 스크롤 가능하게 */
+  .feedback-btns {
+    flex-wrap: wrap;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .fb-btn {
+    flex-shrink: 0;
+    padding: 6px 12px !important;
+    min-height: 32px;
+    font-size: 13px !important;
+  }
+
+  /* 그래프 패스 / 메타 정보 — 폰트 살짝 작게 */
+  .graph-paths { font-size: 11px; padding: 8px 10px; }
+  .meta { font-size: 11px; gap: 6px; }
+
+  /* ─────────────── admin 페이지 ─────────────── */
+
+  /* admin layout — 사이드 nav가 가로로 좁아질 수 있도록 */
+  .admin-layout, .admin-sidebar, .admin-nav {
+    width: 100%;
+  }
+  /* 어드민 nav를 상단 드로워 형태로 (모바일) */
+  .admin-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 8px 0;
+  }
+  .admin-nav, .nav-list, ul.nav {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 4px;
+    padding: 4px 8px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .nav-item {
+    flex-shrink: 0;
+    padding: 8px 14px;
+    min-height: 40px;
+    font-size: 13px;
+    border-radius: 8px;
+    white-space: nowrap;
+  }
+
+  /* 페이지 본문 — 패딩 줄이고 카드들 세로 stack */
+  .page, .admin-page, main.admin-content {
+    padding: 12px;
+  }
+  .page-title { font-size: 16px; margin-bottom: 12px; }
+  .section-title { font-size: 13px; margin: 12px 0 8px; }
+
+  /* 카드 그리드 → 단일 컬럼 */
+  .cards {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 8px !important;
+  }
+  .card { padding: 10px !important; }
+  .card-label { font-size: 10px; }
+  .card-value { font-size: 18px !important; }
+  .card-sub { font-size: 10px; }
+
+  /* 테이블 — 가로 스크롤 가능하게 */
+  .table-wrap, .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    border-radius: 8px;
+  }
+  .table-wrap table, .admin-page table {
+    min-width: 480px;            /* 너무 좁으면 스크롤 트리거 */
+    font-size: 12px;
+  }
+  .table-wrap th, .table-wrap td,
+  .admin-page th, .admin-page td {
+    padding: 8px 6px;
+  }
+
+  /* hardware 카드, 설정 카드 등 min-width 280/260/220px → 100% */
+  [style*="min-width:280px"],
+  [style*="min-width:260px"],
+  [style*="min-width:220px"],
+  [style*="min-width:200px"] {
+    min-width: 0 !important;
+    width: 100%;
+  }
+
+  /* entities/sessions 검색 입력 + 필터 — 한 줄 → 두 줄 */
+  #entities-search, #entities-etype-filter {
+    width: 100%;
+    min-width: 0 !important;
+  }
+  #entities-counter { width: 100%; text-align: right; }
+
+  /* 페이징 버튼 — 터치 타겟 키움 */
+  #entities-prev, #entities-next {
+    min-height: 40px;
+    padding: 8px 16px !important;
+  }
+
+  /* 상세 modal / 세션 turns modal — 풀화면 */
+  #entity-detail-modal, #session-turns-modal,
+  #login-modal, #admin-login-modal {
+    padding: 12px !important;
+  }
+  #entity-detail-modal > div, #session-turns-modal > div,
+  #login-modal > div, #admin-login-modal > div {
+    max-width: 100% !important;
+    max-height: 92vh !important;
+    padding: 14px !important;
+    border-radius: 10px;
+  }
+  #entity-detail-body, #session-turns-body {
+    font-size: 12px;
+    max-height: 65vh !important;
+  }
+
+  /* dashboard 차트 — 너비 100% */
+  #dash-chart > div[style*="display:flex"],
+  #dash-chart > div[style*="display: flex"] {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────
+ * Phone (≤ 480px) — 더 좁은 폰
+ * ────────────────────────────────────────────────────────*/
+@media (max-width: 480px) {
+  /* 헤더 한 줄에 다 못 넣으면 숨김 우선순위:
+   * 우선 PROD/TEST 토글은 ⋮ 메뉴로 보내야 깔끔하지만 v0.2 범위 외 — 일단 작게만. */
+  .source-toggle button { padding: 4px 6px; font-size: 9px; }
+
+  /* 카드 단일 컬럼 */
+  .cards { grid-template-columns: 1fr !important; }
+
+  /* 웰컴 — 폰 화면 작아서 아주 컴팩트하게 */
+  .welcome-title { font-size: 18px; }
+  .welcome-sub { font-size: 12px; }
+
+  .bubble { font-size: 14px; padding: 9px 12px; }
+
+  /* 어드민 nav-item 더 작게 */
+  .nav-item { padding: 6px 10px; font-size: 12px; min-height: 36px; }
+
+  /* 어드민 페이지 본문 */
+  .page-title { font-size: 15px; }
+  .section-title { font-size: 12px; }
+}
+
+/* ─────────────────────────────────────────────────────────
+ * 가로 모드 (landscape) 폰 — 헤더가 너무 두꺼워지면 안됨
+ * ────────────────────────────────────────────────────────*/
+@media (max-width: 920px) and (max-height: 480px) {
+  header { padding: 4px 10px; }
+  .messages { padding: 8px 12px; }
+  .welcome { padding: 12px; }
+  .welcome-title { font-size: 18px; margin-bottom: 4px; }
+}
+
+/* ─────────────────────────────────────────────────────────
+ * 다크 모드 명시 + 시스템 모드 존중
+ * (자메스 기본은 dark — 여기선 모바일 전용 미세 조정만)
+ * ────────────────────────────────────────────────────────*/
+@media (max-width: 768px) and (prefers-color-scheme: dark) {
+  /* 폰 OLED 화면에서 가독성 */
+  .bubble { line-height: 1.6; }
+}
+
+/* ─────────────────────────────────────────────────────────
+ * 접근성 — 모바일 사용자 다수가 큰 글자 선호
+ * 시스템 폰트 크기 설정 존중 (rem이 아닌 곳도 대응)
+ * ────────────────────────────────────────────────────────*/
+@media (max-width: 768px) {
+  /* 줄바꿈 안 되어 잘리는 텍스트 방지 */
+  td, th, .card-value, .badge-status {
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+  /* 코드 블록 — 가로 스크롤 */
+  pre, code {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+  }
+}

--- a/tests/test_mobile_responsive.py
+++ b/tests/test_mobile_responsive.py
@@ -1,0 +1,190 @@
+"""Mobile responsive UI — frontend/static/mobile.css contract tests.
+
+User feedback (2026-05-08): "웹 뿐만 아니라 폰 사이즈에서도 보기에
+적합한 ui로 개선 가능?".
+
+Strategy: a separate `mobile.css` adds @media-gated overrides for
+≤768px (tablet), ≤480px (phone), and short-landscape phones. Loaded
+LAST in <head> so its rules win over inline base styles by source
+order alone (no !important spam needed).
+
+Coverage:
+  - mobile.css exists with the expected breakpoints.
+  - Both index.html and admin.html link mobile.css AFTER inline
+    <style>, so the cascade wins for narrow viewports.
+  - Both HTMLs have viewport meta with viewport-fit=cover (iOS
+    notch / safe-area), and a theme-color matching --bg.
+  - Touch-target rules: buttons / nav-items / textareas have
+    min-height ≥ 36px (Apple HIG / Material standard 44 minimum,
+    36 acceptable for inline / secondary controls).
+  - iOS-zoom-on-focus guard: input/textarea font-size ≥ 16px in
+    the mobile rule block.
+  - Safe-area-inset-bottom honored in input area padding.
+
+Run:
+  python -m unittest tests.test_mobile_responsive
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+CSS_PATH = ROOT / "frontend" / "static" / "mobile.css"
+INDEX_HTML = ROOT / "frontend" / "index.html"
+ADMIN_HTML = ROOT / "frontend" / "admin.html"
+
+
+class CssExistsAndCoversBreakpointsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.css = CSS_PATH.read_text(encoding="utf-8")
+
+    def test_css_file_exists(self):
+        self.assertTrue(CSS_PATH.exists(),
+                        "frontend/static/mobile.css must exist")
+
+    def test_breakpoint_768px_present(self):
+        # Tablet + phone primary breakpoint.
+        self.assertRegex(
+            self.css,
+            r"@media\s*\(\s*max-width\s*:\s*768px\s*\)",
+            "768px breakpoint missing",
+        )
+
+    def test_breakpoint_480px_present(self):
+        # Tighter phone breakpoint.
+        self.assertRegex(
+            self.css,
+            r"@media\s*\(\s*max-width\s*:\s*480px\s*\)",
+            "480px breakpoint missing",
+        )
+
+    def test_landscape_short_breakpoint_present(self):
+        # Phone landscape — header must stay tight.
+        self.assertRegex(
+            self.css,
+            r"@media\s*\(\s*max-width\s*:\s*920px\s*\)\s*and\s*\(\s*max-height\s*:\s*480px\s*\)",
+            "landscape phone breakpoint missing",
+        )
+
+
+class TouchTargetAndIosGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.css = CSS_PATH.read_text(encoding="utf-8")
+
+    def test_input_font_size_at_least_16px(self):
+        # iOS zooms in on focus when input font-size < 16px. The
+        # mobile.css rule for textarea/input must declare ≥16px.
+        # We look inside the 768px block.
+        block_match = re.search(
+            r"@media\s*\(\s*max-width\s*:\s*768px\s*\)\s*\{(.+?)\n\}\s*\n\s*/\*",
+            self.css, re.DOTALL,
+        )
+        # The block end matching is fragile; just search globally for
+        # the relevant rule.
+        self.assertRegex(
+            self.css,
+            r"textarea[^{]*\{[^}]*font-size\s*:\s*16px",
+            "textarea must have font-size: 16px in mobile.css "
+            "(iOS zoom-on-focus guard)",
+        )
+
+    def test_buttons_have_touch_target_min_height(self):
+        # Some button class must declare min-height >= 36px in the
+        # mobile breakpoint. We accept the rule "button, .btn"
+        # OR per-component min-heights elsewhere.
+        self.assertRegex(
+            self.css,
+            r"min-height\s*:\s*(36|40|44|48)px",
+            "no touch-target min-height rule found in mobile.css",
+        )
+
+    def test_safe_area_inset_bottom_honored(self):
+        self.assertIn(
+            "env(safe-area-inset-bottom",
+            self.css,
+            "input area padding must use env(safe-area-inset-bottom) "
+            "for iOS home-bar / notch devices",
+        )
+
+
+class HtmlLinksMobileCssTests(unittest.TestCase):
+    """Both index.html and admin.html must link mobile.css AFTER
+    their inline <style> block — source order = cascade order, so
+    later rules win without !important spam."""
+
+    def _read(self, path: Path) -> str:
+        return path.read_text(encoding="utf-8")
+
+    def test_index_html_links_mobile_css_after_style(self):
+        html = self._read(INDEX_HTML)
+        link_pos = html.find('href="/static/mobile.css"')
+        style_close_pos = html.find("</style>")
+        self.assertGreater(link_pos, 0,
+                           "index.html does not <link> mobile.css")
+        self.assertGreater(link_pos, style_close_pos,
+                           "mobile.css link must come AFTER </style> "
+                           "so cascade source-order wins")
+
+    def test_admin_html_links_mobile_css_after_style(self):
+        html = self._read(ADMIN_HTML)
+        link_pos = html.find('href="/static/mobile.css"')
+        style_close_pos = html.find("</style>")
+        self.assertGreater(link_pos, 0,
+                           "admin.html does not <link> mobile.css")
+        self.assertGreater(link_pos, style_close_pos,
+                           "mobile.css link must come AFTER </style>")
+
+    def test_viewport_fit_cover_for_safe_area(self):
+        # Both HTMLs need viewport-fit=cover for env(safe-area-*) to
+        # actually do anything on iOS.
+        for path in (INDEX_HTML, ADMIN_HTML):
+            html = self._read(path)
+            self.assertIn(
+                "viewport-fit=cover",
+                html,
+                f"{path.name} viewport meta missing viewport-fit=cover; "
+                f"env(safe-area-inset-*) is a no-op without it",
+            )
+
+    def test_theme_color_meta_present(self):
+        # Mobile browsers tint the address bar to theme-color.
+        # Without it, the system white address bar clashes with
+        # JAMES's dark theme on Android Chrome.
+        for path in (INDEX_HTML, ADMIN_HTML):
+            html = self._read(path)
+            self.assertRegex(
+                html,
+                r'<meta\s+name="theme-color"',
+                f"{path.name} missing theme-color meta — Android "
+                f"address bar will not match the dark theme",
+            )
+
+
+class AvoidsUnreachableCssTests(unittest.TestCase):
+    """Sanity: rules using !important should be limited to cases
+    where overriding inline-style is actually necessary."""
+
+    def test_no_excessive_important(self):
+        css = CSS_PATH.read_text(encoding="utf-8")
+        # Count !important occurrences. Inline-style overrides need
+        # this; a small number is fine. Excessive use indicates the
+        # cascade strategy is broken.
+        count = css.count("!important")
+        self.assertLessEqual(
+            count, 25,
+            f"!important used {count} times in mobile.css; aim for "
+            f"≤ 25 (inline-style overrides only). Restructure rules "
+            f"or rely on source-order cascade if higher."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"웹 뿐만 아니라 폰 사이즈에서도 보기에 적합한 ui로 개선 가능?"*.

The v0.2.0 frontend had a `viewport` meta tag but **zero `@media` rules**. Layouts depended on flex with hard `min-width: 220-280px` that prevented reflow on phones — long horizontal rows clipped, sidebars ate the screen, tables overflowed without scroll, the 14px input font triggered iOS focus-zoom.

## What changes

New file `frontend/static/mobile.css` with three breakpoints, loaded LAST in `<head>` so source-order cascade beats inline styles without `!important` spam:

| Breakpoint | Target |
|---|---|
| ≤ 768px | Tablet + phone primary mobile layout |
| ≤ 480px | Tighter spacing, single-column cards |
| ≤ 920px AND ≤ 480px height | Landscape phone — compact header |

**Key rules**:
- Header wraps; controls get ≥36px touch targets
- Sidebar → overlay drawer (88vw, max 360px) on mobile
- Messages padding 28px → 16/12px; bubble max-width 820px → 100%
- Welcome title 28px → 22 → 18px
- Chat input pinned bottom + `env(safe-area-inset-bottom)` (iOS home-bar/notch)
- Input font-size = 16px (iOS focus-zoom guard)
- Admin nav becomes horizontal scroll bar
- Cards grid 4-col → 2-col → 1-col
- Tables wrapped with horizontal scroll
- Hard `min-width: 280/260/220/200px` → `0` + `width: 100%`
- Modals (entity/session/login) full-width with safe inset

**Both HTMLs gain**:
- `viewport-fit=cover` (required for `env(safe-area-*)` to apply)
- `<meta name="theme-color" content="#0c0d10">` (Android dark address-bar tint)

## Verification

12 unit tests in `tests/test_mobile_responsive.py`:
- `mobile.css` exists with 768/480/landscape breakpoints
- Both HTMLs link `mobile.css` AFTER inline `</style>` (cascade order)
- Both HTMLs have `viewport-fit=cover` + `theme-color` meta
- Input `font-size: 16px` in mobile rule (iOS zoom guard)
- Touch-target `min-height: 36-48px` rule present
- `env(safe-area-inset-bottom)` in input area
- `!important` usage bounded (≤25, inline-style overrides only)

**310/310 regression suite pass** (12 new + 298 prior).

## Bench numbers

Not applicable — pure CSS + meta-tag change. No retrieval / graph / scoring touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)