### PR TITLE
fix(reasoning): specific-topic queries no longer routed to meta (item #5)

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -177,14 +177,67 @@ chat / retrieval / meta / coding / wiki_edit / self_evolve / agent / app_dev"""
                 pass
         return self._llm
 
+    # ─── Specific-topic guard (item #5, 2026-05-08) ───────────────
+    # User reported "팔란티어에 대해 어떤 자료가 있지?" routes to
+    # meta (full wiki list) when they actually wanted retrieval
+    # (Palantir-specific content). The meta patterns catch any
+    # query with "어떤 자료" / "어떤 정보" / "내부 자료" type phrasings.
+    # When a specific topic prefix is present (X에 대해 / X 관련 /
+    # X의 자료), meta routing is wrong — fall through to retrieval.
+    #
+    # Generic data nouns (wiki / 자료 / 데이터 / 내부 / entity / etc.)
+    # don't count as specific topics — those still route to meta.
+    _GENERIC_DATA_NOUNS = {
+        "wiki", "위키", "자료", "문서", "데이터", "내부",
+        "entity", "엔티티", "knowledge", "정보", "것", "거",
+        "내용", "기록", "보유", "저장된", "전체", "모든",
+        "data", "info", "files", "documents",
+    }
+
+    def _has_specific_topic_prefix(self, q: str) -> bool:
+        """True if the query has a specific-topic prefix that should
+        override meta routing.
+
+        Patterns recognised:
+          - "X에 대해" / "X에 관해" / "X에 관한" / "X에서"
+          - "X 관련" / "X관련"
+          - "X의 (자료|문서|데이터|정보|내용)" — genitive + data noun
+          - Topic noun X must NOT be in _GENERIC_DATA_NOUNS — a
+            "wiki에 대해 어떤 자료" still routes to meta.
+        """
+        m = re.search(
+            r"(\S+?)\s*("
+            r"에\s*(대해|관해|관한|에서)"           # X에 대해/관해/...
+            r"|관련(된)?"                            # X 관련(된)
+            r"|의\s+(자료|문서|데이터|정보|내용|기록)"  # X의 자료/정보/...
+            r")",
+            q,
+        )
+        if not m:
+            return False
+        topic = m.group(1).strip().lower()
+        # Strip Korean particles attached to the noun.
+        topic = re.sub(r"(은|는|이|가|을|를|의|와|과)$", "", topic)
+        if not topic:
+            return False
+        # Generic-data nouns don't count — those queries are still meta.
+        return topic not in self._GENERIC_DATA_NOUNS
+
     def classify_fast(self, query: str) -> Optional[str]:
         """
         명확한 패턴은 LLM 없이 즉시 분류.
         불명확하면 None 반환 → classify_llm으로 위임.
+
+        item #5: meta 패턴은 specific-topic 사전 검사 통과시에만
+        매칭. "팔란티어에 대해 어떤 자료" 같은 specific-topic 질의는
+        meta가 아닌 retrieval로 보내야 함.
         """
         q = query.lower().strip()
+        skip_meta = self._has_specific_topic_prefix(q)
 
         for mode, patterns in self.FAST_PATTERNS.items():
+            if skip_meta and mode == "meta":
+                continue   # specific-topic 질의는 meta 우회
             for pat in patterns:
                 if re.search(pat, q, re.IGNORECASE):
                     return mode

--- a/tests/test_meta_mode.py
+++ b/tests/test_meta_mode.py
@@ -108,6 +108,56 @@ class FastPatternRoutingTests(unittest.TestCase):
             self.assertNotEqual(mode, "meta",
                                 f"specific-topic query must NOT route to meta: {q!r}")
 
+    def test_specific_topic_with_inventory_verb_NOT_meta(self):
+        # Item #5 (2026-05-08 user feedback): "팔란티어에 대해 어떤
+        # 자료가 있지?" was routing to meta (returning the full wiki
+        # list) when the user actually wanted Palantir-specific
+        # retrieval. Specific-topic prefix overrides meta even when
+        # an inventory verb is present.
+        from core.intent_classifier import IntentClassifier
+        cls = IntentClassifier()
+        for q in (
+            "팔란티어에 대해 어떤 자료가 있지?",
+            "비트코인에 관해 어떤 자료가 있어?",
+            "BlackRock 관련 자료 있나?",
+            "Anthropic에 대해 무슨 정보 있어?",
+            "RAG에 대해 어떤 자료",
+        ):
+            mode = cls.classify_fast(q)
+            self.assertNotEqual(mode, "meta",
+                                f"specific-topic + inventory verb must NOT route "
+                                f"to meta: {q!r} (got {mode!r})")
+
+    def test_generic_data_noun_in_topic_position_still_meta(self):
+        # Sanity: when the "topic" is itself a generic data noun
+        # (wiki, 자료, 내부 etc), meta is still correct because
+        # _has_specific_topic_prefix returns False for these.
+        from core.intent_classifier import IntentClassifier
+        cls = IntentClassifier()
+        for q in (
+            "wiki에 대해 어떤 자료가 있어?",
+            "내부에 어떤 자료 있는지",
+        ):
+            mode = cls.classify_fast(q)
+            self.assertEqual(mode, "meta",
+                             f"generic-data-noun topic should still route "
+                             f"to meta: {q!r}")
+
+    def test_has_specific_topic_prefix_logic(self):
+        # Direct unit-test of the helper so the rules are explicit.
+        from core.intent_classifier import IntentClassifier
+        cls = IntentClassifier()
+        # Specific-topic prefixes — return True
+        for q in ("팔란티어에 대해 어떤", "비트코인 관련 자료",
+                  "blackrock에 관해", "anthropic의 정보"):
+            self.assertTrue(cls._has_specific_topic_prefix(q.lower()),
+                            f"expected specific-topic prefix in {q!r}")
+        # No specific-topic prefix — return False
+        for q in ("어떤 자료가 있어", "wiki 목록 보여줘",
+                  "내부에 어떤 데이터", "wiki에 대해 어떤"):
+            self.assertFalse(cls._has_specific_topic_prefix(q.lower()),
+                             f"expected NO specific-topic prefix in {q!r}")
+
     def test_too_short_or_ambiguous_falls_through_to_llm(self):
         # "뭐 있어?" alone is ambiguous (could be office / dinner /
         # anything). It should NOT be hijacked into meta — let the LLM


### PR DESCRIPTION
## Summary

User screenshot 2026-05-08: *"팔란티어에 대해 어떤 자료가 있지?"* returned the **full wiki listing** (162 entities) — meta-mode inventory — when the user wanted Palantir-specific retrieval.

## Root cause

PR #76 broadened meta fast-patterns to catch casual phrasings. The regex `(어떤|무슨)\s*(자료|...)\s*.{0,15}(있|가지)` correctly catches *"어떤 자료가 있어?"* but ALSO matches *"팔란티어에 대해 어떤 자료가 있지?"* — same regex, completely different intent.

## Fix

Pre-gate before meta matching. `classify_fast` now calls `_has_specific_topic_prefix(q)` and skips meta when True. The helper recognises three Korean prefix forms:
- `"X에 대해/관해/관한/에서"`
- `"X 관련(된)"`
- `"X의 (자료|문서|데이터|정보|내용|기록)"`

**Critical**: the topic noun X is checked against `_GENERIC_DATA_NOUNS` (wiki/자료/문서/데이터/내부/entity/...). Only NON-generic topics flip the gate. This preserves meta routing for *"wiki에 대해 어떤 자료가 있어?"* (topic=wiki, generic).

Korean particle stripping (은/는/이/가/을/를/의/와/과) on the matched topic so *"blackrock과"* / *"anthropic의"* resolve cleanly.

## Verification

3 new tests in `tests/test_meta_mode.py`:
- `test_specific_topic_with_inventory_verb_NOT_meta` — 5 specific topics with inventory verbs all skip meta
- `test_generic_data_noun_in_topic_position_still_meta` — 2 generic "topics" preserve meta
- `test_has_specific_topic_prefix_logic` — direct unit test of the helper across 4 specific + 4 non-specific phrasings

**313/313 regression suite pass** (3 new + 310 prior).

## Bench numbers

Not applicable — intent classifier change only. STEP 7 q1-q12 routing unchanged (none have specific-topic prefix + inventory verb pattern); q13 (canonical inventory) still meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)