### PR TITLE
fix(coding): config.CODING_MODEL + diagnostic log_stage in handle_coding (item #3)

### DIFF
--- a/config.py
+++ b/config.py
@@ -138,6 +138,11 @@ POPPLER_PATH = _detect_poppler()
 # If you need to start it from JAMES, set OLLAMA_PATH env var.
 OLLAMA_PATH    = os.environ.get("OLLAMA_PATH", "")  # blank = use system 'ollama' on PATH
 GEMMA_MODEL    = os.environ.get("JAMES_LLM_MODEL", "gemma4:e4b")
+# Coding-specialised model. Used by handle_coding via llm.router →
+# QwenCoderClient. Operators can swap to a smaller/faster model
+# (e.g. gemma4:e4b) if the 32B coder is too heavy for their tunnel
+# / reverse proxy timeout.
+CODING_MODEL   = os.environ.get("JAMES_CODING_MODEL", "qwen2.5-coder:32b")
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
 # ────────────────────────────────────────────────────────────────

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -456,27 +456,62 @@ def handle_coding(
     user_role: str,
     t_start: float,
 ) -> Dict[str, Any]:
+    """Coding mode handler.
+
+    Routes to qwen2.5-coder via `llm.router.route(task_type="coding")`.
+    On any failure (model not installed / Ollama not responding /
+    timeout), falls back to the default GEMMA_MODEL via call_gemma so
+    the user still gets an answer. All errors are logged via
+    log_stage so the operator can see what happened in /trace/poll/.
+
+    Operator override: set JAMES_CODING_MODEL env to a lighter model
+    (e.g. gemma4:e4b) if the 32B qwen-coder cold-start is hitting
+    your tunnel / proxy timeout.
+    """
+    from core.observability import log_stage
     t_code = time.time()
     answer = ""
+
+    # Stage logged so /trace/poll/ shows what's happening in real time.
+    log_stage("coding_route", model="qwen-coder", query_len=len(safe_query))
+
     try:
         from llm.router import route as llm_route
         llm = llm_route(safe_query, task_type="coding")
-        # [P7] System Prompt를 coding 지시에도 포함
-        coding_prompt = (
-            f"{system_prompt}\n\n" if system_prompt else ""
-        ) + safe_query
+        log_stage("coding_llm_pick", llm_name=getattr(llm, "name", "?"),
+                  available=getattr(llm, "is_available", lambda: True)())
+
+        sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
+        coding_prompt = sys_prefix + safe_query
         messages = [{"role": "user", "content": coding_prompt}]
-        answer   = llm.generate(messages, timeout=120)
+        answer = llm.generate(messages, timeout=120)
+        log_stage("coding_done",
+                  latency_ms=int((time.time() - t_code) * 1000),
+                  answer_len=len(answer or ""))
     except Exception as e:
         engine._log("coding_llm", e, user_role)
+        log_stage("coding_llm_error", error=f"{type(e).__name__}: {e}")
+        # Fallback: default GEMMA_MODEL via the engine's RouterWrapper
         try:
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
             answer = engine.llm.call_gemma(
                 f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:",
                 use_cache=True, timeout=90,
             )
-        except Exception:
-            answer = "코딩 답변 생성 중 오류가 발생했습니다."
+            log_stage("coding_fallback_done",
+                      latency_ms=int((time.time() - t_code) * 1000),
+                      answer_len=len(answer or ""))
+        except Exception as e2:
+            log_stage("coding_fallback_error",
+                      error=f"{type(e2).__name__}: {e2}")
+            # Surface the actual error class to the user — silent generic
+            # message hides the diagnostic. Real cause is now visible
+            # both in the answer and the trace.
+            answer = (
+                f"코딩 답변 생성 실패. 원인: {type(e).__name__} "
+                f"(LLM router → coder), 그 후 fallback도 실패: "
+                f"{type(e2).__name__}. 서버 콘솔에서 자세한 trace 확인."
+            )
 
     # [P7] Patch Pipeline 자동 실행
     try:

--- a/tests/test_coding_mode.py
+++ b/tests/test_coding_mode.py
@@ -1,0 +1,128 @@
+"""Coding mode handler — config + diagnostic guards (item #3).
+
+User report 2026-05-08: "코딩 작업하고싶다 하면, 연결오류:
+failed to fetch". The 'Failed to fetch' is browser-side — server
+likely hung on the 32B qwen-coder cold-start, exceeding tunnel
+timeout. v0.2.0 handle_coding caught the exception generically and
+returned "코딩 답변 생성 중 오류가 발생했습니다." with no detail —
+operator had no way to tell whether it was the LLM, the network,
+or somewhere downstream.
+
+This PR adds:
+
+  (A) config.CODING_MODEL — `os.environ.get("JAMES_CODING_MODEL",
+      "qwen2.5-coder:32b")`. Fixes a silent ImportError fallback in
+      QwenCoderClient.__init__. Operators can swap to a lighter
+      coder model via env.
+  (B) log_stage events at each step (route / pick / done / error /
+      fallback) so /trace/poll/ surfaces exactly where the call
+      stopped. Operator-visible diagnostic.
+  (C) Fallback message that names the actual exception classes
+      instead of the generic "오류가 발생했습니다".
+
+Coverage:
+  - config.CODING_MODEL is defined and reads from env.
+  - handle_coding emits log_stage at all four points: route /
+    llm_pick / done / error.
+  - Source-level: QwenCoderClient still tries `from config import
+    CODING_MODEL` (back-compat with PR #18 import).
+
+Run:
+  python -m unittest tests.test_coding_mode
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class ConfigCodingModelTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_CODING_MODEL")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_CODING_MODEL", None)
+        else:
+            os.environ["JAMES_CODING_MODEL"] = self._orig
+
+    def test_config_exposes_coding_model(self):
+        # config.CODING_MODEL must be importable.
+        import config
+        # Re-read the source to catch the hard-coded default literal.
+        src = (Path(__file__).resolve().parent.parent / "config.py").read_text(encoding="utf-8")
+        self.assertRegex(
+            src,
+            r'CODING_MODEL\s*=\s*os\.environ\.get\(\s*["\']JAMES_CODING_MODEL["\']\s*,\s*["\']qwen2\.5-coder:32b["\']',
+            "config.CODING_MODEL must read JAMES_CODING_MODEL env with "
+            "qwen2.5-coder:32b as the documented fallback default",
+        )
+        self.assertTrue(hasattr(config, "CODING_MODEL"),
+                        "config module must export CODING_MODEL attribute")
+        # Should be a non-empty string.
+        self.assertIsInstance(config.CODING_MODEL, str)
+        self.assertTrue(config.CODING_MODEL)
+
+
+class HandleCodingDiagnosticTests(unittest.TestCase):
+    """The handler must emit log_stage events that surface in
+    /trace/poll/, so an operator hitting 'Failed to fetch' can see
+    what actually happened (route attempt / model pick / generate
+    error / fallback success-or-fail)."""
+
+    @classmethod
+    def setUpClass(cls):
+        import core.reasoning.modes as modes_mod
+        cls.src = inspect.getsource(modes_mod.handle_coding)
+
+    def test_imports_log_stage(self):
+        self.assertIn("from core.observability import log_stage", self.src,
+                      "handle_coding must import log_stage for diagnostics")
+
+    def test_logs_route_pick_done_phases(self):
+        # Each of the four diagnostic events must appear.
+        for stage_name in ("coding_route", "coding_llm_pick",
+                           "coding_done", "coding_llm_error"):
+            self.assertIn(f'log_stage("{stage_name}"', self.src,
+                          f"missing log_stage('{stage_name}'...) — operator "
+                          f"will not see this phase in /trace/poll/")
+
+    def test_logs_fallback_success_and_error(self):
+        # The fallback path must also be observable.
+        for stage_name in ("coding_fallback_done", "coding_fallback_error"):
+            self.assertIn(f'log_stage("{stage_name}"', self.src,
+                          f"fallback path missing log_stage('{stage_name}')")
+
+    def test_failure_message_names_exception_classes(self):
+        # The catch-all answer must include the actual exception class
+        # name so the user can tell qwen-cold-start vs Ollama-down vs
+        # timeout etc. apart.
+        self.assertIn("type(e).__name__", self.src,
+                      "fallback failure message must include type(e).__name__ "
+                      "(silent generic 오류 message hides the diagnostic)")
+        self.assertIn("type(e2).__name__", self.src,
+                      "double-failure path must also surface e2 class name")
+
+
+class QwenCoderClientImportPathTests(unittest.TestCase):
+    """QwenCoderClient still imports CODING_MODEL via try/except —
+    after this PR the import succeeds and uses config's value
+    instead of the hard-coded fallback."""
+
+    def test_qwen_coder_imports_coding_model_from_config(self):
+        src = (Path(__file__).resolve().parent.parent
+               / "llm" / "providers" / "deepseek_client.py"
+               ).read_text(encoding="utf-8")
+        self.assertIn("from config import CODING_MODEL", src,
+                      "QwenCoderClient must continue to import CODING_MODEL "
+                      "from config (the import fallback in __init__ is "
+                      "back-compat — should normally succeed now)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User report 2026-05-08: *"코딩 작업하고싶다 하면, 연결오류: failed to fetch"*. The "Failed to fetch" is browser-side — likely the server hung on the qwen2.5-coder:32b cold-start (32B model, several-hundred-MB VRAM load), exceeding Tailscale Serve / reverse-proxy timeout. v0.2.0 handle_coding caught the exception generically and returned `"코딩 답변 생성 중 오류가 발생했습니다."` with no detail — no way to tell LLM hang from network failure from coder-not-installed.

## Three changes

### 1. `config.CODING_MODEL` added
`os.environ.get("JAMES_CODING_MODEL", "qwen2.5-coder:32b")`. Fixes a silent ImportError fallback in `QwenCoderClient.__init__` (the import always failed and the hard-coded literal was used). Operators can now swap to a lighter coder model via env:
```
JAMES_CODING_MODEL=gemma4:e4b
```

### 2. `handle_coding` emits log_stage at 5 points
| stage | when |
|---|---|
| `coding_route` | entry |
| `coding_llm_pick` | model picked + `is_available()` result |
| `coding_done` | success — latency + answer_len |
| `coding_llm_error` | primary path exception |
| `coding_fallback_done` / `coding_fallback_error` | fallback observability |

`/trace/poll/{trace_id}` (PR #97) surfaces these live in the chat bubble. No more opaque "Failed to fetch" — operator sees exactly where the call stopped.

### 3. Catch-all error names actual exception class
`type(e).__name__` + `type(e2).__name__` instead of generic message. Operator can distinguish qwen-cold-start vs Ollama-down vs timeout etc.

## Verification

6 tests in `tests/test_coding_mode.py`:
- `config.CODING_MODEL` defined with documented default literal + importable as str attribute
- `handle_coding` imports `log_stage`
- 5 documented log_stage events all present
- Failure message includes `type(e).__name__` + `type(e2).__name__`
- `QwenCoderClient` still imports CODING_MODEL from config (back-compat)

**319/319 regression suite pass.**

## Bench numbers

Not applicable — coding mode handler + config default change. STEP 7 q1-q12 unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)