### PR TITLE
feat(frontend): reasoning stream — spinner + shimmer animations (item #1)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -659,10 +659,12 @@ function appendTyping(traceId) {
   div.className = 'msg james';
   div.innerHTML = `
     <div class="avatar james">🧠</div>
-    <div class="bubble" style="min-width:200px">
-      <div id="thinking-${traceId}" style="display:flex;flex-direction:column;gap:4px;
-                  font-size:11px;font-family:var(--font-mono);color:var(--muted)">
-        <div style="font-style:italic">⏳ 추론 중...</div>
+    <div class="bubble" style="min-width:220px">
+      <div id="thinking-${traceId}" class="thinking-stream">
+        <div class="thinking-placeholder">
+          <span class="thinking-spinner-dot"></span>
+          <span class="thinking-shimmer-text">추론 시작 중</span>
+        </div>
       </div>
     </div>
   `;
@@ -670,49 +672,90 @@ function appendTyping(traceId) {
   messages.scrollTop = messages.scrollHeight;
 
   // 폴링 상태
-  const seenStages = new Set();   // stage 종류별 1회만 표시 (반복 retrieve 등은 합산)
+  const seenStages = new Set();   // stage 종류별 1회만 표시
   let lastNs   = 0;
   let stopped  = false;
+  let activeLine = null;          // 현재 spinner 돌고 있는 line (item #1)
   const t0     = Date.now();
 
+  // Stage별 메타 — 아이콘은 이모지 + spinner 클래스 분리,
+  // 색상은 CSS 변수로 라인에 inject (shimmer + spinner border 색)
   const STAGE_META = {
-    auth:     { icon: '🔐', label: '권한 확인', color: '#999' },
-    retrieve: { icon: '🔍', label: '내부 자료 검색', color: '#7c6af7' },
-    rerank:   { icon: '🎯', label: '재정렬',          color: '#7c6af7' },
-    graph:    { icon: '🕸️', label: '관계 그래프 탐색', color: '#3da78a' },
-    tool:     { icon: '🔧', label: '도구 호출',       color: '#ffb74d' },
-    answer:   { icon: '🤖', label: 'LLM 답변 생성',   color: '#f06292' },
-    complete: { icon: '✅', label: '완료',            color: '#4caf7d' },
+    auth:        { icon: '🔐', label: '권한 확인',          color: '#999'    },
+    risky_coding_blocked: { icon: '🛑', label: '위험 명령 차단', color: '#f06292' },
+    retrieve:    { icon: '🔍', label: '내부 자료 검색',     color: '#7c6af7' },
+    rerank:      { icon: '🎯', label: '재정렬',              color: '#7c6af7' },
+    graph:       { icon: '🕸️', label: '관계 그래프 탐색',   color: '#3da78a' },
+    tool:        { icon: '🔧', label: '도구 호출',           color: '#ffb74d' },
+    coding_route: { icon: '⌨️', label: '코딩 LLM 라우팅',    color: '#ffb74d' },
+    coding_llm_pick: { icon: '⚙️', label: '모델 선택',       color: '#ffb74d' },
+    coding_done: { icon: '✓',  label: '코딩 완료',           color: '#4caf7d' },
+    coding_llm_error: { icon: '⚠️', label: '코더 LLM 오류',  color: '#f06292' },
+    coding_fallback_done: { icon: '↻', label: 'Fallback 완료', color: '#ffb74d' },
+    answer:      { icon: '🤖', label: 'LLM 답변 생성',       color: '#f06292' },
+    complete:    { icon: '✅', label: '완료',                color: '#4caf7d' },
+  };
+
+  // 현재 active line을 done으로 마감 (다음 stage 시작 시 호출)
+  const markActiveAsDone = () => {
+    if (activeLine) {
+      activeLine.classList.remove('thinking-active');
+      activeLine.classList.add('thinking-done');
+      activeLine = null;
+    }
   };
 
   const apply = (events) => {
     const container = document.getElementById(`thinking-${traceId}`);
     if (!container) return;
     // 첫 진짜 이벤트 도착 시 placeholder 제거
-    if (events.length > 0 && container.querySelector('div[style*="italic"]')) {
-      container.innerHTML = '';
+    if (events.length > 0) {
+      const ph = container.querySelector('.thinking-placeholder');
+      if (ph) ph.remove();
     }
     events.forEach(ev => {
       const stage = ev.stage;
-      if (!stage || seenStages.has(stage)) return;   // 1회 표시
+      if (!stage || seenStages.has(stage)) return;
       seenStages.add(stage);
-      const m = STAGE_META[stage] || { icon: '·', label: stage, color: '#999' };
+
+      // 새 stage 도착 → 이전 active를 done으로
+      markActiveAsDone();
+
+      const m = STAGE_META[stage] || { icon: '·', label: stage, color: '#888' };
       const ms = Date.now() - t0;
-      // stage별 의미있는 필드 일부만 추출 (시각적 잡음 줄임)
+
+      // 의미있는 detail 필드 일부만
       const detail = [];
-      if (ev.top_k != null)           detail.push(`top_k=${ev.top_k}`);
-      if (ev.top_vector_score != null) detail.push(`vec=${ev.top_vector_score.toFixed(2)}`);
+      if (ev.top_k != null)              detail.push(`top_k=${ev.top_k}`);
+      if (ev.top_vector_score != null)   detail.push(`vec=${ev.top_vector_score.toFixed(2)}`);
       if (ev.entities_extracted != null) detail.push(`ent=${ev.entities_extracted}`);
-      if (ev.paths_walked != null)    detail.push(`paths=${ev.paths_walked}`);
-      if (ev.latency_ms != null)      detail.push(`${ev.latency_ms}ms`);
-      if (ev.answer_len != null)      detail.push(`${ev.answer_len}자`);
-      if (ev.elapsed_ms != null)      detail.push(`총 ${ev.elapsed_ms}ms`);
+      if (ev.paths_walked != null)       detail.push(`paths=${ev.paths_walked}`);
+      if (ev.latency_ms != null)         detail.push(`${ev.latency_ms}ms`);
+      if (ev.answer_len != null)         detail.push(`${ev.answer_len}자`);
+      if (ev.elapsed_ms != null)         detail.push(`총 ${ev.elapsed_ms}ms`);
       const detailStr = detail.length ? ` · ${detail.join(' · ')}` : '';
+
       const line = document.createElement('div');
-      line.style.cssText = `display:flex;align-items:center;gap:6px;color:${m.color}`;
-      line.innerHTML = `<span>${m.icon}</span><span style="font-weight:600">${m.label}</span><span style="color:var(--muted);font-size:10px">${detailStr} · @${ms}ms</span>`;
+      // complete stage는 즉시 done 표시 (spinner 없음)
+      const isFinal = (stage === 'complete' || stage.endsWith('_done')
+                       || stage === 'coding_llm_error');
+      line.className = 'thinking-line ' + (isFinal ? 'thinking-done' : 'thinking-active');
+      line.style.setProperty('--stage-color', m.color);
+
+      line.innerHTML = `
+        <span class="thinking-icon">${m.icon}</span>
+        <span class="thinking-label thinking-shimmer-text">${escHtml(m.label)}</span>
+        <span class="thinking-detail">${escHtml(detailStr)} <span class="thinking-elapsed">@${ms}ms</span></span>
+      `;
       container.appendChild(line);
+
+      if (!isFinal) {
+        activeLine = line;
+      } else {
+        activeLine = null;
+      }
     });
+    // 폴링이 complete 받으면 모든 라인 done으로
     messages.scrollTop = messages.scrollHeight;
   };
 
@@ -732,6 +775,7 @@ function appendTyping(traceId) {
         }
         if (data.complete) {
           stopped = true;
+          markActiveAsDone();   // 마지막 active line 마감 (item #1)
           return;
         }
       }

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -17,6 +17,118 @@
  */
 
 /* ─────────────────────────────────────────────────────────
+ * Reasoning stream animations (item #1, 2026-05-08)
+ * 응답 추론 과정 — 활성 stage는 spinner 회전 + 텍스트 shimmer,
+ * 완료된 stage는 정적/회색. 진짜 진행 중인 단계가 시각적으로
+ * 명확하게 살아있어 보이게.
+ *
+ * 구조: each `.thinking-line` toggles between:
+ *   .thinking-active  — 현재 진행 중 (spinner + shimmer)
+ *   .thinking-done    — 완료 (정적, 살짝 흐림)
+ * --stage-color CSS 변수에 stage별 색상이 inject됨 (chat.js).
+ * ────────────────────────────────────────────────────────*/
+@keyframes james-spin {
+  to { transform: rotate(360deg); }
+}
+@keyframes james-pulse-dot {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50%      { opacity: 1.0; transform: scale(1.05); }
+}
+@keyframes james-shimmer {
+  0%   { background-position: -180% 0; }
+  100% { background-position:  180% 0; }
+}
+
+.thinking-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--muted, #888);
+  min-height: 24px;
+}
+.thinking-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-style: italic;
+  opacity: 0.85;
+}
+.thinking-spinner-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--accent, #7c6af7);
+  animation: james-pulse-dot 1.0s ease-in-out infinite;
+  flex-shrink: 0;
+}
+.thinking-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: opacity .35s ease, color .35s ease;
+  color: var(--stage-color, currentColor);
+  --stage-color: currentColor;
+}
+.thinking-icon {
+  flex-shrink: 0;
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+  width: 18px; text-align: center;
+  transform-origin: 50% 50%;
+}
+.thinking-label {
+  font-weight: 600;
+  font-family: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--stage-color, #7c6af7) 0%,
+    rgba(255, 255, 255, 0.92) 45%,
+    var(--stage-color, #7c6af7) 90%
+  );
+  background-size: 200% 100%;
+  background-position: 0 0;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+.thinking-detail {
+  color: var(--muted, #888);
+  font-size: 11px;
+  margin-left: 2px;
+}
+.thinking-elapsed {
+  color: var(--muted, #888);
+  opacity: 0.7;
+}
+
+/* Active state: spinner 회전 + label shimmer */
+.thinking-line.thinking-active .thinking-icon {
+  animation: james-spin 1.4s linear infinite;
+  filter: drop-shadow(0 0 4px var(--stage-color, #7c6af7));
+}
+.thinking-line.thinking-active .thinking-label {
+  animation: james-shimmer 2.4s linear infinite;
+}
+
+/* Done state: spinner 정지, 색상 흐림 */
+.thinking-line.thinking-done {
+  opacity: 0.55;
+}
+.thinking-line.thinking-done .thinking-icon {
+  animation: none;
+  filter: none;
+}
+.thinking-line.thinking-done .thinking-label {
+  animation: none;
+  background: none;
+  -webkit-text-fill-color: var(--stage-color, var(--muted, #888));
+  color: var(--stage-color, var(--muted, #888));
+}
+
+/* ─────────────────────────────────────────────────────────
  * Tablet + phone (≤ 768px)
  * ────────────────────────────────────────────────────────*/
 @media (max-width: 768px) {

--- a/tests/test_real_reasoning_stream.py
+++ b/tests/test_real_reasoning_stream.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -251,8 +252,14 @@ class FrontendChatJsContractTests(unittest.TestCase):
                       "which trace to poll")
 
     def test_append_typing_polls_real_trace(self):
+        # Bound the window to the appendTyping function only — find
+        # the next top-level `function ` declaration.
         idx = self.js.index("function appendTyping(traceId)")
-        body = self.js[idx:idx + 4000]
+        # Look for next standalone `function NAME(` after our function
+        # to bound the search.
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 8000
+        body = self.js[idx:end]
         self.assertIn("/trace/poll/", body,
                       "appendTyping must poll /trace/poll/{traceId}")
         self.assertIn("after_ns=", body,
@@ -266,7 +273,9 @@ class FrontendChatJsContractTests(unittest.TestCase):
 
     def test_stage_metadata_displayed(self):
         idx = self.js.index("function appendTyping(traceId)")
-        body = self.js[idx:idx + 4000]
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 8000
+        body = self.js[idx:end]
         # Real per-stage labels must replace the static three-step UI.
         for stage_token in ("retrieve", "graph", "answer", "complete"):
             self.assertIn(f'{stage_token}:', body,

--- a/tests/test_reasoning_ui_animation.py
+++ b/tests/test_reasoning_ui_animation.py
@@ -1,0 +1,146 @@
+"""Reasoning stream UI animations — item #1 (2026-05-08).
+
+User wanted "움직이는 아이콘" + "자연스럽게 반짝이는 글자" instead
+of static text. PR #97 wired real per-stage events; this PR adds the
+visual polish — spinner on the icon for active stages, shimmer on
+the label, fade for done stages.
+
+Source-level contracts only (CSS animation behavior can't be
+unit-tested cheaply without a headless browser):
+
+  - mobile.css defines @keyframes james-spin / james-pulse-dot /
+    james-shimmer.
+  - mobile.css has .thinking-line.thinking-active / .thinking-done
+    selectors with the documented CSS variable hook (--stage-color).
+  - chat.js appendTyping creates lines with the right class names
+    and toggles active → done correctly.
+
+Run:
+  python -m unittest tests.test_reasoning_ui_animation
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+CSS  = ROOT / "frontend" / "static" / "mobile.css"
+JS   = ROOT / "frontend" / "static" / "chat.js"
+
+
+class CssAnimationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.css = CSS.read_text(encoding="utf-8")
+
+    def test_three_keyframes_defined(self):
+        for name in ("james-spin", "james-pulse-dot", "james-shimmer"):
+            self.assertRegex(
+                self.css,
+                rf"@keyframes\s+{re.escape(name)}\s*\{{",
+                f"@keyframes {name} missing",
+            )
+
+    def test_active_class_animates_spinner_and_shimmer(self):
+        # Active stage: icon spinning + label shimmering.
+        self.assertRegex(
+            self.css,
+            r"\.thinking-line\.thinking-active\s+\.thinking-icon[^{]*\{[^}]*animation\s*:\s*james-spin",
+            "active stage icon must run james-spin animation",
+        )
+        self.assertRegex(
+            self.css,
+            r"\.thinking-line\.thinking-active\s+\.thinking-label[^{]*\{[^}]*animation\s*:\s*james-shimmer",
+            "active stage label must run james-shimmer animation",
+        )
+
+    def test_done_class_stops_animations(self):
+        # Done stage: animations explicitly disabled.
+        m = re.search(
+            r"\.thinking-line\.thinking-done\s+\.thinking-icon[^{]*\{([^}]*)\}",
+            self.css,
+        )
+        self.assertIsNotNone(m, "done-state icon rule missing")
+        self.assertIn("animation: none", m.group(1),
+                      "done-state must explicitly disable icon animation")
+
+        # Label too — done state should stop shimmer.
+        m2 = re.search(
+            r"\.thinking-line\.thinking-done\s+\.thinking-label[^{]*\{([^}]*)\}",
+            self.css,
+        )
+        self.assertIsNotNone(m2, "done-state label rule missing")
+        self.assertIn("animation: none", m2.group(1))
+
+    def test_stage_color_css_variable(self):
+        # Each stage's color is injected via --stage-color so chat.js
+        # can write the per-stage tint without inline styles.
+        self.assertIn("--stage-color", self.css,
+                      "CSS must use a --stage-color variable for "
+                      "per-stage tinting")
+        # Used in label gradient + drop-shadow.
+        self.assertIn("var(--stage-color", self.css)
+
+
+class ChatJsContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_appendtyping_uses_thinking_line_classes(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4500]
+        # Must add `thinking-active` for in-progress stages and
+        # `thinking-done` for the final-state ones.
+        self.assertIn("thinking-active", body,
+                      "appendTyping must apply thinking-active class "
+                      "to in-progress stages")
+        self.assertIn("thinking-done", body,
+                      "appendTyping must apply thinking-done class "
+                      "to completed stages")
+
+    def test_active_to_done_transition_present(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4500]
+        # markActiveAsDone should remove the active class and add
+        # the done class — that's how each new stage's arrival
+        # closes out the previous stage.
+        self.assertIn("classList.remove('thinking-active')", body,
+                      "markActiveAsDone must remove the active class")
+        self.assertIn("classList.add('thinking-done')", body,
+                      "markActiveAsDone must add the done class")
+
+    def test_stage_color_set_via_css_variable(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4500]
+        self.assertIn("setProperty('--stage-color'", body,
+                      "appendTyping must set --stage-color CSS variable "
+                      "on each line so the CSS shimmer/spinner picks "
+                      "up the per-stage tint")
+
+    def test_complete_stage_marks_active_as_done(self):
+        idx = self.js.index("function appendTyping(traceId)")
+        body = self.js[idx:idx + 4500]
+        # When data.complete arrives, the current active line must
+        # be closed out — otherwise it keeps spinning forever.
+        self.assertIn("markActiveAsDone()", body,
+                      "complete-handler must call markActiveAsDone()")
+
+    def test_no_static_old_thinking_search_label(self):
+        # The v0.2.0 fake "Searching internal documents..." labels
+        # were replaced by the polling stream in PR #97. They must
+        # not have come back.
+        body = self.js
+        self.assertNotIn("chat.thinking_search", body,
+                         "old i18n key chat.thinking_search must not be "
+                         "referenced from chat.js — it was the fake "
+                         "static label that PR #97 removed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"움직이는 아이콘을 써서 글자도 자연스럽게 반짝이게 개선"*. PR #97 wired the real per-stage event stream but rendering was static — no indication of which stage was IN PROGRESS vs DONE.

## What changes

### CSS (`mobile.css`, top-level — applies desktop + mobile)
| Keyframe | Effect |
|---|---|
| `james-spin` | 1.4s linear infinite rotation |
| `james-pulse-dot` | Placeholder dot pulse (0.85→1.05) |
| `james-shimmer` | Gradient sweep across label text |

| Class | Behavior |
|---|---|
| `.thinking-line.thinking-active` | Icon rotates + drop-shadow tinted by `--stage-color`; label runs gradient shimmer (`--stage-color → white → --stage-color`) |
| `.thinking-line.thinking-done` | `opacity: 0.55`, animations disabled, label solid color |

`--stage-color` CSS variable injected per-line by `chat.js` so each stage's tint propagates to spinner glow / shimmer gradient without inline-style spam.

### JS (`chat.js::appendTyping`)
- Each event creates a `.thinking-active` line with `style.setProperty('--stage-color', ...)`
- `markActiveAsDone()` flips active → done before adding the next stage, so only the LATEST stage spins
- `data.complete` arrival also calls `markActiveAsDone()` (final stage doesn't spin forever)
- Added stage metadata for: `coding_route` / `coding_llm_pick` / `coding_done` / `coding_llm_error` / `coding_fallback_done` (PR #100) + `risky_coding_blocked` (PR #70)

## Verification

9 tests in `tests/test_reasoning_ui_animation.py`:
- **CSS**: 3 keyframes defined, active runs spinner+shimmer, done disables both, `--stage-color` variable used in gradient+shadow
- **JS**: appendTyping uses both classes, markActiveAsDone removes/adds right classes, `--stage-color` set via setProperty, complete handler calls markActiveAsDone, old fake i18n key NOT referenced

Plus a small fix to `tests/test_real_reasoning_stream.py` — its window-bounding logic now finds the next `function NAME(` declaration instead of using arbitrary char limits, so the polling-code search doesn't miss when the function grows.

**328/328 regression suite pass.**

## Bench numbers

Not applicable — pure CSS + JS render polish. No retrieval/graph/scoring touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)