### PR TITLE
feat(frontend): chat page drag-drop file upload (item #7)

### DIFF
--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -8,7 +8,7 @@ document.getElementById('file-input').addEventListener('change', e => {
   e.target.value = '';
 });
 
-/* ── 드래그 앤 드롭 ── */
+/* ── 드래그 앤 드롭 (사이드바 dropzone) ── */
 const dropZone = document.getElementById('drop-zone');
 ['dragenter','dragover'].forEach(ev =>
   dropZone.addEventListener(ev, e => {
@@ -25,6 +25,110 @@ const dropZone = document.getElementById('drop-zone');
 dropZone.addEventListener('drop', e => {
   addFiles(Array.from(e.dataTransfer.files));
 });
+
+/* ── item #7: 챗 페이지 전체에 드래그 앤 드롭 ──
+   메시지 입력하기 전에 파일을 어디든 떨어뜨리면 자동으로 큐에 추가.
+   드래그 진입 시 풀스크린 오버레이로 "여기에 놓아주세요" 시각 신호.
+
+   주의: drop 이벤트는 일반 윈도우에선 default가 "브라우저가 파일 열기"
+   라서 드래그가 페이지 밖으로 나가도 preventDefault 안 하면 새 탭에서
+   파일이 열림. 따라서 window 단위로 dragover/drop 모두 preventDefault.
+*/
+(function setupChatDropzone() {
+  // chat 페이지에서만 활성. admin.html에는 messages 컨테이너 없음.
+  if (!document.getElementById('messages')) return;
+
+  // 드래그 카운터 — dragenter/leave가 자식 요소에서도 발생해서
+  // 단순 boolean으론 깜빡임. counter로 진짜 leave 추적.
+  let dragDepth = 0;
+  let overlay = null;
+
+  function ensureOverlay() {
+    if (overlay) return overlay;
+    overlay = document.createElement('div');
+    overlay.id = 'chat-drop-overlay';
+    overlay.style.cssText = `
+      position:fixed; inset:0;
+      background:rgba(99,102,241,0.18);
+      backdrop-filter: blur(2px);
+      border:3px dashed var(--accent, #6366f1);
+      border-radius:12px;
+      z-index:10000;
+      display:none;
+      align-items:center; justify-content:center;
+      pointer-events:none;
+      transition:opacity .15s ease;
+    `;
+    overlay.innerHTML = `
+      <div style="background:var(--surface,#14161a); padding:24px 32px;
+                  border-radius:16px; border:1px solid var(--border,#25282f);
+                  box-shadow:0 12px 40px rgba(0,0,0,.5); text-align:center;
+                  pointer-events:none">
+        <div style="font-size:48px; margin-bottom:8px">📥</div>
+        <div style="font-size:16px; font-weight:600; color:var(--text,#fff)">
+          여기에 놓으면 업로드 큐에 추가됩니다
+        </div>
+        <div style="font-size:12px; color:var(--muted,#888); margin-top:6px">
+          이미지 / PDF / Word / 텍스트 파일 지원
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function showOverlay() {
+    ensureOverlay().style.display = 'flex';
+  }
+  function hideOverlay() {
+    if (overlay) overlay.style.display = 'none';
+  }
+
+  // window 전체에 등록 — 페이지 안 어느 곳이든 드롭 가능
+  window.addEventListener('dragenter', e => {
+    // 파일 드래그만 처리 (텍스트 드래그/링크는 무시)
+    if (!e.dataTransfer || !e.dataTransfer.types) return;
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    dragDepth++;
+    if (dragDepth === 1) showOverlay();
+  });
+
+  window.addEventListener('dragover', e => {
+    if (!e.dataTransfer || !e.dataTransfer.types) return;
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();   // 새 탭에서 파일 열리는 default 차단
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  window.addEventListener('dragleave', e => {
+    if (!e.dataTransfer || !e.dataTransfer.types) return;
+    if (!e.dataTransfer.types.includes('Files')) return;
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) hideOverlay();
+  });
+
+  window.addEventListener('drop', e => {
+    if (!e.dataTransfer || !e.dataTransfer.files) return;
+    e.preventDefault();
+    dragDepth = 0;
+    hideOverlay();
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+
+    addFiles(files);
+    // 사이드바 자동 열기 — 큐 / 진행률 보이도록
+    if (typeof toggleSidebar === 'function') {
+      const sb = document.getElementById('sidebar');
+      if (sb && sb.classList.contains('collapsed')) {
+        toggleSidebar();
+      }
+    }
+    if (typeof toast === 'function') {
+      toast(`파일 ${files.length}개 추가됨`, 'success');
+    }
+  });
+})();
 
 /* ── 파일 추가 ── */
 function addFiles(files) {

--- a/tests/test_chat_drag_drop.py
+++ b/tests/test_chat_drag_drop.py
@@ -1,0 +1,98 @@
+"""Chat-page drag-drop file upload (item #7, 2026-05-08).
+
+User feedback: "이미지나 문서 파일을 대화창에도 업로드 드롭 가능하게".
+
+Source-level contracts on frontend/static/upload.js:
+
+  - The chat page (detected via #messages presence) registers
+    window-level dragenter/dragover/dragleave/drop handlers.
+  - drop calls addFiles(...) so the file enters the same upload
+    queue as the sidebar dropzone.
+  - dragover preventDefault is present (else browser opens the
+    file in a new tab when the user misses the dropzone).
+  - Files-only filter — dragenter ignores text/link drags so a
+    word-drag-select doesn't show the overlay.
+  - Visual overlay (#chat-drop-overlay) created once and toggled.
+  - Drop-counter pattern (dragDepth) so child-element dragenter
+    doesn't cause overlay flicker.
+  - Sidebar auto-opens on drop so the user sees the upload queue.
+
+Run:
+  python -m unittest tests.test_chat_drag_drop
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+JS = Path(__file__).resolve().parent.parent / "frontend" / "static" / "upload.js"
+
+
+class ChatDropzoneContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_setup_function_exists(self):
+        self.assertIn("setupChatDropzone", self.js,
+                      "setupChatDropzone IIFE missing")
+
+    def test_chat_page_detection(self):
+        # Should bail out if #messages doesn't exist (not chat page).
+        self.assertIn("getElementById('messages')", self.js)
+
+    def test_window_listeners_registered(self):
+        # All four drag events on window scope.
+        for ev in ("dragenter", "dragover", "dragleave", "drop"):
+            self.assertIn(f"window.addEventListener('{ev}'", self.js,
+                          f"window.addEventListener('{ev}') missing")
+
+    def test_dragover_prevent_default(self):
+        # Critical: without preventDefault on dragover, drop never fires
+        # AND missed-target drops open the file in a new tab.
+        idx = self.js.index("window.addEventListener('dragover'")
+        body = self.js[idx:idx + 600]
+        self.assertIn("e.preventDefault()", body,
+                      "dragover handler must call e.preventDefault()")
+
+    def test_files_only_filter(self):
+        # Should ignore text drags / link drags via dataTransfer.types check.
+        self.assertIn("includes('Files')", self.js,
+                      "must filter to file drags only — text drags should "
+                      "not trigger the overlay")
+
+    def test_drop_calls_add_files(self):
+        idx = self.js.index("window.addEventListener('drop'")
+        body = self.js[idx:idx + 800]
+        self.assertIn("addFiles(files)", body,
+                      "drop handler must call addFiles(files) to enter "
+                      "the same queue as the sidebar dropzone")
+
+    def test_drop_counter_pattern(self):
+        # Without a counter, child-element dragenter causes overlay flicker.
+        self.assertIn("dragDepth", self.js,
+                      "drop-counter pattern (dragDepth) missing — overlay "
+                      "will flicker when dragging across child elements")
+
+    def test_visual_overlay_created(self):
+        self.assertIn("chat-drop-overlay", self.js,
+                      "visual overlay element missing")
+        # Overlay should have user-visible affordance text.
+        self.assertIn("여기에 놓으면", self.js,
+                      "overlay must show user-visible drop hint")
+
+    def test_sidebar_auto_open_on_drop(self):
+        # User wants to see queue progress after dropping.
+        idx = self.js.index("window.addEventListener('drop'")
+        body = self.js[idx:idx + 1200]
+        self.assertIn("toggleSidebar", body,
+                      "drop handler should auto-open sidebar so user sees "
+                      "the upload queue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"이미지나 문서 파일을 대화창에도 업로드 드롭 가능하게"*. Pre-PR drops only worked inside the sidebar `#drop-zone` — easy to miss + sidebar collapsed by default on mobile.

This adds a window-level drag-drop handler in `upload.js`, **chat page only** (detected via `#messages` presence — admin.html has no messages container, so no overlay clutter there).

## Behavior

| Event | Action |
|---|---|
| `dragenter` (Files) | Full-screen overlay: `📥 여기에 놓으면 업로드 큐에 추가됩니다` |
| `dragover` | `preventDefault()` + `dropEffect = "copy"` — without this, missed drops open file in new tab |
| `dragleave` | Counter-based exit (`dragDepth--`) — no flicker on child-element transitions |
| `drop` | `addFiles(files)` (same queue as sidebar) → auto-open sidebar → toast |

**Files-only filter**: `dataTransfer.types.includes('Files')` on every handler — text drags / URL drags don't trigger the overlay.

## Verification

9 source-level contracts in `tests/test_chat_drag_drop.py`:
- `setupChatDropzone` IIFE + `#messages` detection guard
- All 4 window listeners registered
- `dragover` preventDefault (new-tab-open guard)
- `Files`-only filter (text-drag flicker guard)
- `drop` calls `addFiles`
- `dragDepth` counter pattern (flicker guard)
- `#chat-drop-overlay` element + Korean affordance text
- Sidebar auto-open on drop

**360/360 regression suite pass.**

## Bench numbers

Not applicable — frontend UX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)