### PR TITLE
feat(frontend): folder drag-drop + folder picker upload (item #8)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -790,12 +790,28 @@
 
     <div class="drop-zone" id="drop-zone" onclick="document.getElementById('file-input').click()">
       <input type="file" id="file-input" multiple accept="image/*,video/*,audio/*,.pdf,.txt,.md,.json">
+      <!-- item #8: 폴더 통째 선택용 hidden input. webkitdirectory 사용 시
+           accept 무시되고 디렉토리 picker가 뜸. -->
+      <input type="file" id="folder-input" multiple webkitdirectory directory
+             style="display:none">
       <div class="drop-icon">📂</div>
       <div class="drop-label">
         <span data-i18n="upload.drag_label">클릭하거나 드래그하여 파일 추가</span><br>
-        <span class="drop-types"><span data-i18n="upload.types">이미지 · 영상 · 오디오 · PDF · 문서</span></span>
+        <span class="drop-types"><span data-i18n="upload.types">이미지 · 영상 · 오디오 · PDF · 문서</span></span><br>
+        <span class="drop-types" style="margin-top:4px;display:inline-block">
+          폴더 통째로 드래그도 가능
+        </span>
       </div>
     </div>
+    <!-- item #8: 폴더 선택 버튼 (드래그 외 클릭 경로) -->
+    <button type="button"
+            onclick="event.stopPropagation(); document.getElementById('folder-input').click()"
+            style="margin-top:6px;width:100%;padding:8px;
+                   background:var(--surface-2);border:1px solid var(--border);
+                   border-radius:6px;color:var(--text-soft);font-size:12px;
+                   cursor:pointer;font-family:var(--font-ui)">
+      📁 폴더 선택
+    </button>
 
     <div class="instruction-box">
       <label><span data-i18n="upload.common_label">💬 공통 저장 지시 (폴더 미지정 파일에 적용)</span></label>

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -2,11 +2,100 @@
 
 let uploadQueue = [];
 
-/* ── 파일 입력 처리 ── */
+/* ── 파일 입력 처리 (file + webkitdirectory 둘 다 지원) ── */
+function _captureRelPath(f) {
+  // <input type="file" webkitdirectory>로 폴더를 선택한 경우
+  // file.webkitRelativePath에 "folder/sub/file.ext" 형태. 큐 표시 +
+  // 서버 전송 시 활용을 위해 file.relPath로 보존.
+  if (f.webkitRelativePath) {
+    try { f.relPath = f.webkitRelativePath; } catch (_) {}
+  }
+  return f;
+}
 document.getElementById('file-input').addEventListener('change', e => {
-  addFiles(Array.from(e.target.files));
+  addFiles(Array.from(e.target.files).map(_captureRelPath));
   e.target.value = '';
 });
+// item #8: 폴더 선택 input (별도 hidden input, webkitdirectory)
+const _folderInput = document.getElementById('folder-input');
+if (_folderInput) {
+  _folderInput.addEventListener('change', e => {
+    const files = Array.from(e.target.files).map(_captureRelPath);
+    addFiles(files);
+    if (typeof toast === 'function' && files.length > 0) {
+      toast(`폴더에서 파일 ${files.length}개 추가됨`, 'success');
+    }
+    e.target.value = '';
+  });
+}
+
+/* ── item #8: DataTransfer에서 파일 추출 (폴더 재귀 지원) ──
+   dataTransfer.files는 폴더 안의 파일을 안 펼침. webkitGetAsEntry()로
+   FileSystemEntry를 받아 디렉토리 traversal. 미지원 환경은 dataTransfer.
+   files로 fallback (top-level 파일만).
+
+   재귀 readEntries는 한 번에 최대 100개까지 반환 — empty 받을 때까지
+   loop. createReader 인스턴스 재사용해야 다음 batch가 옴 (중요).
+*/
+async function _filesFromEntry(entry, pathPrefix = '') {
+  if (!entry) return [];
+  if (entry.isFile) {
+    return new Promise((resolve) => {
+      entry.file(file => {
+        try { file.relPath = pathPrefix + file.name; } catch (_) {}
+        resolve([file]);
+      }, () => resolve([]));   // 권한 거부 등 — 빈 배열로 무시
+    });
+  }
+  if (entry.isDirectory) {
+    const reader = entry.createReader();
+    let all = [];
+    // readEntries는 batch별로 최대 ~100. 빈 배열 올 때까지 반복.
+    while (true) {
+      const batch = await new Promise((resolve) => {
+        reader.readEntries(resolve, () => resolve([]));
+      });
+      if (!batch || batch.length === 0) break;
+      for (const child of batch) {
+        const childPath = pathPrefix + entry.name + '/';
+        const subFiles = await _filesFromEntry(child, childPath);
+        all = all.concat(subFiles);
+      }
+    }
+    return all;
+  }
+  return [];
+}
+
+async function _filesFromDataTransfer(dataTransfer) {
+  // 1. items API (폴더 traversal 가능)
+  if (dataTransfer.items && dataTransfer.items.length > 0) {
+    const entries = [];
+    for (const item of dataTransfer.items) {
+      if (item.kind !== 'file') continue;
+      const getEntry = item.webkitGetAsEntry || item.getAsEntry;
+      if (typeof getEntry === 'function') {
+        const entry = getEntry.call(item);
+        if (entry) {
+          entries.push(entry);
+          continue;
+        }
+      }
+      // entry API 없는 경우 직접 file만
+      const f = item.getAsFile?.();
+      if (f) entries.push({ isFile: true, isDirectory: false,
+                             file: cb => cb(f), name: f.name });
+    }
+    let all = [];
+    for (const entry of entries) {
+      const files = await _filesFromEntry(entry, '');
+      all = all.concat(files);
+    }
+    if (all.length > 0) return all;
+  }
+  // 2. fallback: 평탄한 dataTransfer.files (폴더 traversal 불가)
+  return Array.from(dataTransfer.files || []);
+}
 
 /* ── 드래그 앤 드롭 (사이드바 dropzone) ── */
 const dropZone = document.getElementById('drop-zone');
@@ -22,8 +111,10 @@ const dropZone = document.getElementById('drop-zone');
     dropZone.classList.remove('drag-over');
   })
 );
-dropZone.addEventListener('drop', e => {
-  addFiles(Array.from(e.dataTransfer.files));
+dropZone.addEventListener('drop', async e => {
+  // item #8: 폴더 통째 드롭 시 webkitGetAsEntry로 재귀 traverse.
+  const files = await _filesFromDataTransfer(e.dataTransfer);
+  if (files.length > 0) addFiles(files);
 });
 
 /* ── item #7: 챗 페이지 전체에 드래그 앤 드롭 ──
@@ -108,12 +199,13 @@ dropZone.addEventListener('drop', e => {
     if (dragDepth === 0) hideOverlay();
   });
 
-  window.addEventListener('drop', e => {
-    if (!e.dataTransfer || !e.dataTransfer.files) return;
+  window.addEventListener('drop', async e => {
+    if (!e.dataTransfer) return;
     e.preventDefault();
     dragDepth = 0;
     hideOverlay();
-    const files = Array.from(e.dataTransfer.files);
+    // item #8: 폴더 드롭 시 재귀 traverse — sidebar drop과 동일 함수 사용
+    const files = await _filesFromDataTransfer(e.dataTransfer);
     if (files.length === 0) return;
 
     addFiles(files);
@@ -125,7 +217,10 @@ dropZone.addEventListener('drop', e => {
       }
     }
     if (typeof toast === 'function') {
-      toast(`파일 ${files.length}개 추가됨`, 'success');
+      // 폴더 드롭이면 내부 파일 다 펼쳐진 합계가 보임
+      const folderHint = files.some(f => f.relPath && f.relPath.includes('/'))
+                        ? ' (폴더 포함)' : '';
+      toast(`파일 ${files.length}개 추가됨${folderHint}`, 'success');
     }
   });
 })();

--- a/tests/test_folder_upload.py
+++ b/tests/test_folder_upload.py
@@ -1,0 +1,153 @@
+"""Folder drop + folder-picker upload (item #8, 2026-05-08).
+
+User feedback: "파일 업로드 창에도 폴더 전체도 드롭 하고 업로드
+가능하게 개선 검토".
+
+Two ways to upload a folder:
+  (A) Drag a folder onto the dropzone — webkitGetAsEntry traversal
+      recursively walks the directory tree.
+  (B) Click "📁 폴더 선택" button — <input type="file" webkitdirectory>
+      opens the OS folder picker.
+
+In both cases each File gets a `relPath` attribute reflecting the
+folder structure ("folder/sub/file.ext"). Existing addFiles() queue
+treats these as ordinary files; relPath is opt-in metadata for
+future per-folder routing.
+
+Source-level contracts:
+  - upload.js exports _filesFromEntry / _filesFromDataTransfer
+    helpers for tests.
+  - Both drop sites (sidebar #drop-zone + window-level chat overlay)
+    use _filesFromDataTransfer instead of dataTransfer.files
+    directly.
+  - readEntries loop until empty (handles batch limit).
+  - <input id="folder-input" webkitdirectory> exists in chat HTML.
+  - "📁 폴더 선택" button onclick → folder-input.click().
+  - file-input change handler captures webkitRelativePath into
+    f.relPath via _captureRelPath helper.
+
+Run:
+  python -m unittest tests.test_folder_upload
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS   = ROOT / "frontend" / "static" / "upload.js"
+HTML = ROOT / "frontend" / "index.html"
+
+
+class JsHelpersTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_filesfromentry_function_exists(self):
+        self.assertIn("async function _filesFromEntry", self.js,
+                      "_filesFromEntry helper missing")
+
+    def test_filesfromdatatransfer_function_exists(self):
+        self.assertIn("async function _filesFromDataTransfer", self.js,
+                      "_filesFromDataTransfer helper missing")
+
+    def test_uses_webkit_get_as_entry(self):
+        self.assertIn("webkitGetAsEntry", self.js,
+                      "must use webkitGetAsEntry for folder traversal")
+
+    def test_recursive_directory_handling(self):
+        idx = self.js.index("async function _filesFromEntry")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("entry.isDirectory", body)
+        self.assertIn("entry.createReader", body)
+        # readEntries returns batches — must loop until empty.
+        self.assertIn("readEntries", body)
+        self.assertIn("while (true)", body,
+                      "readEntries batch loop must continue until empty")
+
+    def test_falls_back_to_dataTransfer_files(self):
+        # When items / entries API unavailable, fall back to
+        # dataTransfer.files (top-level only — best we can do).
+        self.assertIn("dataTransfer.files", self.js,
+                      "fallback to dataTransfer.files when entries API is unavailable")
+
+    def test_capture_rel_path_helper(self):
+        self.assertIn("function _captureRelPath", self.js,
+                      "_captureRelPath helper missing — needed to copy "
+                      "webkitRelativePath into f.relPath")
+        self.assertIn("webkitRelativePath", self.js,
+                      "webkitRelativePath must be read by file picker handler")
+
+
+class DropHandlersUseHelperTests(unittest.TestCase):
+    """Both drop handlers (sidebar + chat-page) must use the new
+    _filesFromDataTransfer helper, NOT raw dataTransfer.files."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_sidebar_drop_uses_helper(self):
+        # Sidebar dropZone.addEventListener('drop', ...) handler.
+        idx = self.js.index("dropZone.addEventListener('drop'")
+        body = self.js[idx:idx + 500]
+        self.assertIn("_filesFromDataTransfer", body,
+                      "sidebar drop handler must use _filesFromDataTransfer "
+                      "(not raw dataTransfer.files) so folders are walked")
+
+    def test_chat_window_drop_uses_helper(self):
+        # window-level drop handler (item #7).
+        idx = self.js.index("window.addEventListener('drop'")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("_filesFromDataTransfer", body,
+                      "chat window drop handler must use _filesFromDataTransfer")
+
+
+class HtmlFolderInputTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_folder_input_present(self):
+        self.assertIn('id="folder-input"', self.html,
+                      "folder-input <input> missing")
+        self.assertIn("webkitdirectory", self.html,
+                      "folder-input must have webkitdirectory attribute")
+
+    def test_folder_select_button_present(self):
+        # Visible "폴더 선택" button.
+        self.assertIn("폴더 선택", self.html)
+        # Triggering folder-input click via JS onclick.
+        self.assertIn("folder-input').click()", self.html,
+                      "polder button must trigger folder-input.click()")
+
+    def test_dropzone_label_mentions_folder_support(self):
+        # Affordance text — user should know folder-drop works too.
+        self.assertIn("폴더 통째로 드래그", self.html,
+                      "dropzone label should mention folder drag support")
+
+
+class FolderInputJsHandlerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_folder_input_change_handler(self):
+        # The folder-input listener must exist and call addFiles.
+        self.assertIn("getElementById('folder-input')", self.js,
+                      "folder-input handler missing")
+        idx = self.js.index("getElementById('folder-input')")
+        body = self.js[idx:idx + 800]
+        self.assertIn("addFiles(", body,
+                      "folder-input change must call addFiles")
+        self.assertIn("_captureRelPath", body,
+                      "folder-input handler must capture relPath via helper")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"파일 업로드 창에도 폴더 전체도 드롭 하고 업로드 가능하게 개선 검토"*. Pre-PR drops only saw top-level files in `dataTransfer.files` — folder structure was invisible.

## Two paths now work

### A. Drag a folder onto either dropzone
`_filesFromDataTransfer` uses `webkitGetAsEntry` to walk the tree. `_filesFromEntry` is async-recursive on `.isDirectory`, with a `while(true)` loop on `readEntries` (batch limit ~100/call — critical to keep calling until empty).

Each File gets a `.relPath` attribute reflecting its path within the folder ("subdir/file.ext").

### B. Click "📁 폴더 선택" button
Hidden `<input id="folder-input" webkitdirectory>` opens the OS folder picker. Same flow afterwards.

## Implementation

| File | Change |
|---|---|
| `upload.js` | New `_filesFromEntry` / `_filesFromDataTransfer` helpers + `_captureRelPath`. Both drop handlers (sidebar + chat-overlay) updated to use the helper. file-input + folder-input change listeners share `_captureRelPath` for `webkitRelativePath` capture. |
| `index.html` | Hidden folder-input + visible "📁 폴더 선택" button + dropzone label mentions folder drag. |

Toast adds "(폴더 포함)" suffix when relPath has "/" — clear UI signal that folder structure was preserved.

## Verification

12 source-level contracts in `tests/test_folder_upload.py`:
- **JsHelpers** (6): both helper functions exist, webkitGetAsEntry usage, recursive directory handling with while-loop on readEntries, fallback to dataTransfer.files, _captureRelPath + webkitRelativePath
- **DropHandlersUseHelper** (2): sidebar + chat-window handlers both use _filesFromDataTransfer
- **HtmlFolderInput** (3): folder-input element + button + affordance label
- **FolderInputJsHandler** (1): folder-input change listener calls addFiles + _captureRelPath

**372/372 regression suite pass.**

## Bench numbers

Not applicable — frontend upload UX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)