### PR TITLE
feat(chat): mode picker + auto-recommendation in chat page (item #6)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -97,6 +97,7 @@ class ReasoningEngine:
         source_type: Optional[str] = "prod",   # [P4.5-2] 기본 prod
         session_id:  str        = "default",   # [P7-FIX] 메모리 시스템 연동
         response_style: str     = "",          # brief / standard / detailed — see core/response_style.py
+        mode_override:  str     = "",          # item #6: 클라이언트가 chat/coding/retrieval 등 명시 → router 우회
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -224,13 +225,31 @@ class ReasoningEngine:
 
         # ── Query Router (STEP 0.5a) ─────────────────────────
         # pre_check 통과 후에만 진입. 보안 순서 유지.
-        try:
-            from core.query_router import QueryRouter
-            mode = QueryRouter().route(safe_query, user_role=user_role)
-            print(f"[ROUTER] mode={mode} | query='{safe_query[:40]}'")
-        except Exception as e:
-            self._log("query_router", e, user_role)
-            mode = "retrieval"   # fallback → 기존 Loop
+        # item #6: mode_override가 있으면 router 건너뛰고 그 모드 사용
+        # (클라이언트가 챗 페이지 dropdown으로 명시한 경우). 단,
+        # role-allowed 체크는 그대로 적용해서 권한 우회 방지.
+        from core.intent_classifier import ROLE_ALLOWED
+        VALID_OVERRIDES = {"chat", "retrieval", "meta", "coding",
+                           "wiki_edit", "self_evolve"}
+        override = (mode_override or "").strip().lower()
+        if override and override in VALID_OVERRIDES:
+            allowed = ROLE_ALLOWED.get(user_role, {"chat", "retrieval"})
+            if override in allowed:
+                mode = override
+                print(f"[ROUTER] mode={mode} (client override) | query='{safe_query[:40]}'")
+            else:
+                # 권한 없는 모드 override → router 정상 사용
+                print(f"[ROUTER] override {override!r} 권한 없음 (role={user_role}) → 자동 라우팅")
+                override = ""
+
+        if not override or override not in VALID_OVERRIDES:
+            try:
+                from core.query_router import QueryRouter
+                mode = QueryRouter().route(safe_query, user_role=user_role)
+                print(f"[ROUTER] mode={mode} | query='{safe_query[:40]}'")
+            except Exception as e:
+                self._log("query_router", e, user_role)
+                mode = "retrieval"   # fallback → 기존 Loop
 
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -851,9 +851,25 @@
       </div>
     </div>
 
-    <!-- item #4: 대화 전체 복사 버튼 (input area 위) -->
-    <div class="conv-actions" style="display:flex;justify-content:flex-end;
-                                      gap:6px;padding:0 16px 4px;font-size:11px">
+    <!-- item #6: 모드 picker + 자동 추천 배지 (input area 위) -->
+    <div class="conv-actions" style="display:flex;justify-content:space-between;
+                                      align-items:center;gap:6px;
+                                      padding:4px 16px;font-size:11px;flex-wrap:wrap">
+      <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
+        <select id="mode-picker"
+                onchange="onModePickerChange()"
+                style="background:var(--surface);border:1px solid var(--border);
+                       color:var(--text);padding:4px 10px;border-radius:6px;
+                       font-size:11px;cursor:pointer">
+          <option value="auto">🤖 자동</option>
+        </select>
+        <span id="mode-recommend"
+              style="display:none;font-size:11px;color:var(--accent-fg);
+                     padding:2px 8px;border:1px solid var(--accent-fg);
+                     border-radius:6px;cursor:pointer"
+              onclick="acceptModeRecommend()"
+              title="권장 모드로 전환"></span>
+      </div>
       <button onclick="copyConversation()"
               style="background:none;border:1px solid var(--border);
                      border-radius:6px;padding:4px 10px;cursor:pointer;

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -89,7 +89,90 @@ window.addEventListener('DOMContentLoaded', () => {
   // restoreHistory는 정의만 되어 있고 호출되지 않아 매번 빈 화면이었음.
   // localStorage에 저장된 HISTORY_KEY 데이터 그대로 화면에 재구성한다.
   try { restoreHistory(); } catch (e) { console.warn('[JAMES] restoreHistory 실패:', e); }
+
+  // item #6: 모드 picker 옵션 로드 + 자동 추천 등록
+  try { loadModePickerOptions(); } catch (e) { console.warn('[JAMES] mode picker 로드 실패:', e); }
 });
+
+/* ── item #6: 모드 picker + 자동 추천 ──
+   서버에서 role-allowed 모드 옵션을 받아 dropdown 채움. 사용자 입력에
+   따라 키워드 매치로 자동 추천 배지 표시 (현재 선택과 다를 때만).
+   사용자가 명시적으로 모드를 고르면 selectedMode = 그 값, /query/에
+   mode_override로 전달. "auto"면 mode_override 빈 문자열 → 서버는
+   intent_classifier로 자동 분류. */
+let MODE_OPTIONS = [];          // [{key, label, desc, keywords}]
+let selectedMode = 'auto';      // current dropdown value
+let recommendedMode = '';       // last-recommended (auto-suggest)
+
+async function loadModePickerOptions() {
+  try {
+    const r = await fetch(`${API}/llm/modes/?api_key=${encodeURIComponent(getApiKey())}`, {
+      headers: getAuthHeaders(),
+    });
+    if (!r.ok) return;
+    const data = await r.json();
+    MODE_OPTIONS = data.modes || [];
+    const sel = document.getElementById('mode-picker');
+    if (!sel) return;
+    sel.innerHTML = MODE_OPTIONS.map(m =>
+      `<option value="${escHtml(m.key)}" title="${escHtml(m.desc || '')}">${escHtml(m.label)}</option>`
+    ).join('');
+    sel.value = selectedMode;
+  } catch (e) {
+    console.warn('[JAMES] /llm/modes/ fetch 실패:', e);
+  }
+}
+
+function onModePickerChange() {
+  const sel = document.getElementById('mode-picker');
+  selectedMode = sel ? sel.value : 'auto';
+  hideModeRecommend();
+}
+
+function acceptModeRecommend() {
+  if (!recommendedMode) return;
+  const sel = document.getElementById('mode-picker');
+  if (sel) {
+    sel.value = recommendedMode;
+    selectedMode = recommendedMode;
+  }
+  hideModeRecommend();
+}
+
+function hideModeRecommend() {
+  const banner = document.getElementById('mode-recommend');
+  if (banner) banner.style.display = 'none';
+  recommendedMode = '';
+}
+
+// 입력 시 keyword 매치 → 다른 모드 추천
+let _recTimer = null;
+function checkModeRecommendation(text) {
+  if (!text || text.length < 4) { hideModeRecommend(); return; }
+  if (_recTimer) clearTimeout(_recTimer);
+  _recTimer = setTimeout(() => {
+    if (selectedMode !== 'auto') return;   // 명시적으로 골랐으면 간섭 X
+    if (!MODE_OPTIONS.length) return;
+    const lower = text.toLowerCase();
+    let best = null;
+    for (const m of MODE_OPTIONS) {
+      if (m.key === 'auto') continue;
+      const kws = m.keywords || [];
+      const hit = kws.some(k => lower.includes(k.toLowerCase()));
+      if (hit) { best = m; break; }
+    }
+    if (best && best.key !== selectedMode) {
+      recommendedMode = best.key;
+      const banner = document.getElementById('mode-recommend');
+      if (banner) {
+        banner.textContent = `💡 ${best.label} 권장 — 클릭하여 전환`;
+        banner.style.display = 'inline-block';
+      }
+    } else {
+      hideModeRecommend();
+    }
+  }, 350);
+}
 
 
 /* ════════════════════════════════
@@ -323,6 +406,8 @@ function getAuthHeaders() {
 function autoResize(el) {
   el.style.height = 'auto';
   el.style.height = Math.min(el.scrollHeight, 160) + 'px';
+  // item #6: 입력 시 모드 추천 키워드 매치 (debounced)
+  try { checkModeRecommendation(el.value || ''); } catch (_) {}
 }
 
 /* ── 키 핸들러 ── */
@@ -406,6 +491,8 @@ async function sendMessage() {
         session_id:       SESSION_ID,
         session_language: sessionStorage.getItem('james_session_lang') || '',
         trace_id:         traceId,
+        // item #6: mode_override (auto면 빈 문자열 → 서버 자동 분류)
+        mode_override:    (selectedMode && selectedMode !== 'auto') ? selectedMode : '',
       }),
     });
 

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -321,6 +321,11 @@ class QueryRequest(BaseModel):
     # arrive (real reasoning stream, replacing the fake 2.5s timer
     # placeholder). Empty → server generates uuid7 as before.
     trace_id:         str  = ""
+    # item #6: client-side mode picker. When non-empty + recognised +
+    # role-allowed, bypasses the QueryRouter intent classifier and
+    # routes straight to that mode handler. Permitted values:
+    # chat / retrieval / meta / coding / wiki_edit / self_evolve.
+    mode_override:    str  = ""
 
 class QueryResponse(BaseModel):
     question:       str
@@ -638,6 +643,7 @@ async def query(
         session_id       = session_id,
         session_language = data.session_language,  # [STEP2-A] 세션 언어
         response_style   = data.response_style,    # brief/standard/detailed
+        mode_override    = data.mode_override,     # item #6: chat 페이지 모드 picker
     )
     elapsed = time.time() - t_start
 
@@ -752,6 +758,52 @@ async def status(api_key: str):
 @app.get("/admin/web-search-status", summary="웹 검색 엔진 상태 [3-E]")
 
 # ── [4-B] Ollama + LLM 추천 API ──────────────────────────────────
+
+@app.get("/llm/modes/", summary="챗 페이지 모드 picker 옵션 [item #6]")
+async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
+    """Mode picker가 채울 옵션 목록.
+
+    api_key만 검증 (admin 아님). role-allowed 모드만 반환해서 클라이언트
+    가 권한 없는 모드를 보지 않도록 한다.
+
+    각 옵션:
+      key:         서버에 보낼 mode_override 값
+      label:       사용자 노출 라벨
+      desc:        한 줄 설명
+      keywords:    자동 추천에 사용 (클라이언트 측 keyword match)
+    """
+    verify_api_key(api_key)
+    from core.intent_classifier import ROLE_ALLOWED
+    allowed = ROLE_ALLOWED.get(role, {"chat", "retrieval"})
+
+    options = [
+        {"key": "auto",     "label": "🤖 자동",
+         "desc": "질문 의도를 자동 분류 (기본)",
+         "keywords": []},
+        {"key": "chat",     "label": "💬 일상 대화",
+         "desc": "검색 없이 LLM 직답",
+         "keywords": ["안녕", "고마워", "hi", "hello"]},
+        {"key": "retrieval","label": "🔍 자료 검색",
+         "desc": "내부 wiki + 그래프 추론",
+         "keywords": ["뭐야", "무엇", "설명", "알려줘", "what is"]},
+        {"key": "meta",     "label": "📚 자료 목록",
+         "desc": "보유 wiki 인벤토리",
+         "keywords": ["목록", "리스트", "어떤 자료", "list"]},
+        {"key": "coding",   "label": "💻 코딩",
+         "desc": "qwen2.5-coder 모델 사용",
+         "keywords": ["코드", "함수", "버그", "python", "def ",
+                      "javascript", "code", "function"]},
+        {"key": "wiki_edit","label": "✏️ Wiki 편집 (admin)",
+         "desc": "지식 추가/수정/삭제",
+         "keywords": ["수정해", "추가해", "삭제해"]},
+        {"key": "self_evolve","label": "🧬 자기진화 (admin)",
+         "desc": "코드 분석 / 자기 개선",
+         "keywords": ["네 코드", "구조 분석", "스스로"]},
+    ]
+    # auto는 항상 허용. 나머지는 role 권한 확인.
+    filtered = [o for o in options if o["key"] == "auto" or o["key"] in allowed]
+    return {"modes": filtered, "role": role}
+
 
 @app.get("/admin/llm/installed", summary="설치된 Ollama 모델 목록 [4-B]")
 async def llm_installed(api_key: str, role: str = Depends(get_role_from_request)):

--- a/tests/test_chat_mode_picker.py
+++ b/tests/test_chat_mode_picker.py
@@ -1,0 +1,182 @@
+"""Chat-page model/mode picker + auto-recommendation (item #6).
+
+User feedback (2026-05-08): "모델변경 및 설치를 챗 웹페이지의 대화창에
+붙여주고, 어떤 질문에 어떤 모델이 적용하는것이 좋은지 추천".
+
+Architecture:
+  Backend
+    - QueryRequest gains `mode_override: str = ""`.
+    - /query/ forwards it to rag_engine.query as mode_override.
+    - engine.query: when override is non-empty + valid +
+      role-allowed, bypasses QueryRouter and dispatches directly.
+      Otherwise (empty or unauthorised), falls back to the normal
+      intent_classifier path.
+    - New non-admin endpoint GET /llm/modes/?api_key=... returns
+      role-filtered options for the picker dropdown.
+
+  Frontend
+    - Dropdown (#mode-picker) above the input area, populated
+      from /llm/modes/ on page load.
+    - Recommendation badge (#mode-recommend) shown when:
+        selectedMode === 'auto'
+        AND user input matches another mode's keywords
+      Click → selectedMode flips to the recommended one.
+    - sendMessage sends `mode_override` field to /query/.
+
+Run:
+  python -m unittest tests.test_chat_mode_picker
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class BackendModeOverrideTests(unittest.TestCase):
+    """QueryRequest accepts mode_override; /query/ forwards it;
+    engine.query bypasses router when override is valid + allowed."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.srv_src = inspect.getsource(srv)
+        import core.reasoning.engine as eng
+        cls.eng_src = inspect.getsource(eng)
+
+    def test_query_request_field(self):
+        m = re.search(
+            r"class QueryRequest\(BaseModel\):(.+?)(?=\nclass |\n@app\.|\nasync def )",
+            self.srv_src, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        body = m.group(1)
+        self.assertIn("mode_override", body)
+        self.assertTrue(re.search(r'mode_override\s*:\s*str\s*=\s*""', body),
+                        "mode_override default must be empty string for back-compat")
+
+    def test_query_endpoint_forwards_field(self):
+        idx = self.srv_src.index('@app.post("/query/"')
+        body = self.srv_src[idx:idx + 2500]
+        self.assertIn("mode_override", body,
+                      "/query/ must forward data.mode_override into rag_engine.query")
+        self.assertIn("data.mode_override", body)
+
+    def test_engine_query_signature_has_param(self):
+        self.assertRegex(
+            self.eng_src,
+            r"mode_override\s*:\s*str\s*=\s*[\"']{2}",
+            "engine.query must declare mode_override: str = '' kwarg",
+        )
+
+    def test_engine_query_validates_override(self):
+        # Engine must check the override is a known mode AND role-allowed.
+        # Bound to query() function — find next `def ` after.
+        idx = self.eng_src.index("def query(")
+        m = re.search(r"\n    def\s+\w+\(", self.eng_src[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 12000
+        body = self.eng_src[idx:end]
+        self.assertIn("VALID_OVERRIDES", body,
+                      "engine must whitelist valid override modes")
+        self.assertIn("ROLE_ALLOWED", body,
+                      "engine must enforce role gate on the override "
+                      "(client cannot escalate via mode picker)")
+        # Fallback to router when override is empty / invalid.
+        self.assertIn("QueryRouter", body)
+
+
+class LlmModesEndpointTests(unittest.TestCase):
+    """Non-admin GET /llm/modes/ returns role-filtered picker options."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _endpoint_body(self) -> str:
+        # Bound to ONLY this endpoint's body — next @app. is end.
+        idx = self.src.index('@app.get("/llm/modes/"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 4000
+        return self.src[idx:end]
+
+    def test_endpoint_registered(self):
+        self.assertIn('@app.get("/llm/modes/"', self.src,
+                      "/llm/modes/ endpoint missing")
+
+    def test_endpoint_uses_api_key_not_admin(self):
+        body = self._endpoint_body()
+        self.assertIn("verify_api_key(api_key)", body,
+                      "/llm/modes/ must validate api_key")
+        self.assertNotIn("_require_admin(", body,
+                         "/llm/modes/ must NOT require admin — chat users need it")
+
+    def test_endpoint_returns_role_filtered_options(self):
+        body = self._endpoint_body()
+        self.assertIn("ROLE_ALLOWED", body,
+                      "endpoint must filter options by role")
+        self.assertIn('"auto"', body,
+                      "auto option must always be present")
+        self.assertIn("keywords", body,
+                      "each option must include keywords for client-side recommendation")
+
+
+class FrontendChatJsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+
+    def test_load_mode_picker_options_function(self):
+        self.assertIn("async function loadModePickerOptions", self.js)
+        self.assertIn("/llm/modes/", self.js,
+                      "loadModePickerOptions must fetch /llm/modes/")
+
+    def test_send_message_includes_mode_override(self):
+        idx = self.js.index("async function sendMessage()")
+        body = self.js[idx:idx + 3000]
+        self.assertIn("mode_override:", body,
+                      "sendMessage body must include mode_override field")
+
+    def test_check_recommendation_function(self):
+        self.assertIn("function checkModeRecommendation", self.js)
+        self.assertIn("recommendedMode", self.js,
+                      "module-scope recommendedMode variable missing")
+
+    def test_recommendation_only_when_auto_selected(self):
+        # Spec: don't pop recommendation if user explicitly picked a mode.
+        idx = self.js.index("function checkModeRecommendation")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("selectedMode !== 'auto'", body,
+                      "recommendation should be suppressed when user has "
+                      "explicitly picked a non-auto mode")
+
+    def test_accept_recommend_function(self):
+        self.assertIn("function acceptModeRecommend", self.js)
+
+
+class FrontendChatHtmlTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_mode_picker_select_present(self):
+        self.assertIn('id="mode-picker"', self.html,
+                      "<select id='mode-picker'> missing in chat HTML")
+        self.assertIn('onchange="onModePickerChange()"', self.html)
+
+    def test_recommend_badge_present(self):
+        self.assertIn('id="mode-recommend"', self.html,
+                      "recommendation badge element missing")
+        self.assertIn('onclick="acceptModeRecommend()"', self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"모델변경 및 설치를 챗 웹페이지의 대화창에 붙여주고, 어떤 질문에 어떤 모델이 적용하는것이 좋은지 추천"*. Pre-PR mode picking was admin-only — chat users had no control or visibility.

## Architecture

### Backend
- `QueryRequest.mode_override: str = ""` — `/query/` forwards to `rag_engine.query`.
- `engine.query`: when override is non-empty, recognised (`VALID_OVERRIDES` whitelist) AND **role-allowed** (`ROLE_ALLOWED` table — client cannot escalate via picker), bypasses `QueryRouter`. Otherwise falls through to normal intent classification.
- **New `GET /llm/modes/`** — non-admin (api_key only). Returns role-filtered picker options:
  ```json
  [{"key": "...", "label": "...", "desc": "...", "keywords": [...]}, ...]
  ```
  External sees 4 modes (auto/chat/retrieval/meta); admin sees all 7.

### Frontend
- `<select id="mode-picker">` above input area, populated on load
- Recommendation badge pops when user input matches another mode's keywords **AND** `selectedMode === 'auto'`. Click → flip. Suppressed when user explicitly picked non-auto.
- `autoResize` calls `checkModeRecommendation(text)` on every keystroke (debounced 350ms)
- `sendMessage` body includes `mode_override` (empty for auto)

| Input | Recommendation |
|---|---|
| "파이썬 함수 작성해줘" | 💻 코딩 권장 |
| "wiki 목록 보여줘" | 📚 자료 목록 권장 |
| "안녕" | (no banner) |

## Verification

14 tests in `tests/test_chat_mode_picker.py`:
- **Backend**: `mode_override` field, `/query/` forwards, engine signature + `VALID_OVERRIDES` + `ROLE_ALLOWED` + fallback
- **Endpoint**: `/llm/modes/` registered, api_key not admin, role-filtered with `keywords`
- **JS**: `loadModePickerOptions` fetches endpoint, sendMessage includes field, recommendation has `selectedMode !== 'auto'` suppression
- **HTML**: `#mode-picker` with `onModePickerChange`, `#mode-recommend` badge

**386/386 regression suite pass.**

## Bench numbers

Not applicable — UX additions; existing routing path unchanged when `mode_override` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)