### PR TITLE
feat(frontend): graph paths hidden by default + toggle (item #5-B)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -601,10 +601,25 @@ function appendJamesMsg(data) {
   const div = document.createElement('div');
   div.className = 'msg james';
 
+  // item #5-B: graph paths는 기본 hidden — 사용자가 "그래프 보기"
+  // 토글 클릭 시 펼침. 답변 가시성을 해치는 큰 paths 리스트 (최대
+  // 50개)가 매번 깔리던 문제 해결.
   let pathsHtml = '';
   if (paths.length > 0) {
+    const pathsId = 'gp_' + Math.random().toString(36).slice(2, 9);
     const list = paths.map(p => `<div>→ ${escHtml(p)}</div>`).join('');
-    pathsHtml = `<div class="graph-paths"><div class="path-title">GRAPH PATHS</div>${list}</div>`;
+    pathsHtml = `
+      <details class="graph-paths-details" style="margin-top:6px">
+        <summary class="graph-paths-toggle"
+                 style="cursor:pointer;font-size:11px;color:var(--muted);
+                        font-family:var(--font-mono);user-select:none;
+                        padding:2px 0">
+          🕸️ 그래프 경로 ${paths.length}개 보기
+        </summary>
+        <div id="${pathsId}" class="graph-paths" style="margin-top:6px">
+          <div class="path-title">GRAPH PATHS</div>${list}
+        </div>
+      </details>`;
   }
 
   let metaHtml = '';

--- a/tests/test_graph_path_toggle.py
+++ b/tests/test_graph_path_toggle.py
@@ -1,0 +1,86 @@
+"""Graph path toggle (item #5-B, 2026-05-08).
+
+User feedback: "그래프 path는 기본적으로 표시 안되나, 사용자가
+원할경우 보이는 방식".
+
+Pre-PR every james message rendered all `graph_paths` (often 10-50
+entries) as static text under the answer. This created visual noise
+on every retrieval answer and pushed feedback buttons + next-action
+suggestions out of view on mobile.
+
+Now wrapped in <details> with summary "🕸️ 그래프 경로 N개 보기".
+Native HTML element — keyboard / screen-reader accessible, no JS
+state to manage. Default closed; click to expand.
+
+Source-level contracts (no JS test runner — assertions scan chat.js):
+  - <details> element used (not raw div)
+  - <summary> with toggle text including "그래프 경로" and the count
+  - Default closed (no `open` attribute on details)
+  - graph-paths div still rendered inside the details (so existing
+    .graph-paths CSS still styles it)
+
+Run:
+  python -m unittest tests.test_graph_path_toggle
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+JS = Path(__file__).resolve().parent.parent / "frontend" / "static" / "chat.js"
+
+
+class GraphPathToggleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_details_element_used(self):
+        # Must be <details> — native disclosure widget. No raw <div>
+        # with manual show/hide (more fragile, less accessible).
+        self.assertIn("<details", self.js,
+                      "graph paths must be wrapped in <details>")
+        self.assertIn("<summary", self.js,
+                      "<summary> child required for the toggle label")
+
+    def test_summary_label_includes_count_and_emoji(self):
+        # User-visible affordance: the toggle should clearly say what
+        # it reveals + how many paths there are.
+        # Look for the literal Korean label.
+        self.assertIn("그래프 경로", self.js,
+                      "summary label must include '그래프 경로'")
+        # Count interpolation present.
+        self.assertIn("${paths.length}", self.js,
+                      "summary must show paths.length so user knows the size "
+                      "before deciding to expand")
+
+    def test_default_closed_no_open_attr(self):
+        # `<details open>` would defeat the purpose — default must
+        # be closed. Find the opening details tag.
+        m = re.search(r"<details[^>]*?>", self.js)
+        self.assertIsNotNone(m, "details tag missing")
+        self.assertNotIn(" open", m.group(),
+                         "details must NOT have `open` attr — default closed")
+
+    def test_existing_graph_paths_class_preserved(self):
+        # Existing CSS .graph-paths styles continue to apply once
+        # expanded — must keep the same classname inside <details>.
+        self.assertIn('class="graph-paths"', self.js)
+
+    def test_pathsHtml_uses_paths_length_branch(self):
+        # The rendering is gated on paths.length > 0 — empty paths
+        # arrays should not render the toggle either.
+        # Find the paths render block.
+        idx = self.js.index("let pathsHtml")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("paths.length > 0", body,
+                      "must guard rendering on non-empty paths array")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"그래프 path는 기본적으로 표시 안되나, 사용자가 원할경우 보이는 방식"*. Pre-PR every retrieval answer rendered all graph_paths (10-50 entries) inline — pushed feedback buttons / next-action suggestions out of view on mobile.

## Change

Wrapped in native `<details>` element:
```html
<details>
  <summary>🕸️ 그래프 경로 ${paths.length}개 보기</summary>
  <div class="graph-paths">...</div>
</details>
```

Native disclosure widget — keyboard + screen-reader accessible, no JS state. Default closed, click to expand. Existing `.graph-paths` CSS class preserved inside.

## Verification

5 source-level contracts in `tests/test_graph_path_toggle.py`:
- `<details>` + `<summary>` used (not raw div + manual JS)
- Summary label includes `그래프 경로` + `${paths.length}` count
- No `open` attr → default closed
- `.graph-paths` class preserved for existing CSS
- Render gated on `paths.length > 0`

**410/410 regression suite pass.**

## Bench numbers

Not applicable — frontend display only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)