### PR TITLE
feat(chat): mode picker shows real model names + install button (item #6)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -863,6 +863,13 @@
                        font-size:11px;cursor:pointer">
           <option value="auto">🤖 자동</option>
         </select>
+        <button id="mode-install-btn"
+                onclick="triggerModelInstall()"
+                style="display:none;background:var(--accent-soft);
+                       border:1px solid var(--accent);color:var(--accent-fg);
+                       padding:4px 10px;border-radius:6px;font-size:11px;
+                       cursor:pointer;font-family:var(--font-ui)"
+                title="선택한 모드의 모델이 미설치 — 클릭하여 ollama pull"></button>
         <span id="mode-recommend"
               style="display:none;font-size:11px;color:var(--accent-fg);
                      padding:2px 8px;border:1px solid var(--accent-fg);

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -114,10 +114,17 @@ async function loadModePickerOptions() {
     MODE_OPTIONS = data.modes || [];
     const sel = document.getElementById('mode-picker');
     if (!sel) return;
-    sel.innerHTML = MODE_OPTIONS.map(m =>
-      `<option value="${escHtml(m.key)}" title="${escHtml(m.desc || '')}">${escHtml(m.label)}</option>`
-    ).join('');
+    // item #6: 옵션 라벨에 실제 모델명 + 설치 상태 표시
+    sel.innerHTML = MODE_OPTIONS.map(m => {
+      const modelTag = m.model ? ` (${m.model})` : '';
+      const status = m.installed ? '' : ' ⚠️ 미설치';
+      return `<option value="${escHtml(m.key)}"
+                      title="${escHtml(m.desc || '')}${modelTag}"
+                      data-model="${escHtml(m.model || '')}"
+                      data-installed="${m.installed ? '1' : '0'}">${escHtml(m.label)}${escHtml(modelTag)}${status}</option>`;
+    }).join('');
     sel.value = selectedMode;
+    updateInstallButton();
   } catch (e) {
     console.warn('[JAMES] /llm/modes/ fetch 실패:', e);
   }
@@ -127,6 +134,57 @@ function onModePickerChange() {
   const sel = document.getElementById('mode-picker');
   selectedMode = sel ? sel.value : 'auto';
   hideModeRecommend();
+  updateInstallButton();
+}
+
+/* ── item #6: 선택된 모드의 모델이 미설치면 "설치" 버튼 노출 ──
+   admin role만 실제 install 트리거 가능 (서버에서도 가드). 비-admin
+   에겐 "관리자에게 설치 요청" 안내. */
+function updateInstallButton() {
+  const btn = document.getElementById('mode-install-btn');
+  if (!btn) return;
+  const opt = MODE_OPTIONS.find(m => m.key === selectedMode);
+  if (!opt || opt.installed || !opt.model) {
+    btn.style.display = 'none';
+    return;
+  }
+  btn.style.display = 'inline-block';
+  btn.dataset.model = opt.model;
+  btn.textContent = `📦 ${opt.model} 설치`;
+  btn.title = `${opt.model} 모델이 Ollama에 없습니다. 클릭하여 설치 시작 (admin 전용).`;
+}
+
+async function triggerModelInstall() {
+  const btn = document.getElementById('mode-install-btn');
+  const model = btn?.dataset?.model;
+  if (!model) return;
+  if (userRole !== 'admin') {
+    toast(`설치는 admin 권한 필요. 관리자에게 \`ollama pull ${model}\` 요청.`, 'error');
+    return;
+  }
+  if (!confirm(`Ollama에 ${model} 모델을 설치합니다.\n수 GB 다운로드 — 백그라운드로 진행됩니다.\n계속할까요?`)) return;
+  const orig = btn.textContent;
+  btn.textContent = '⏳ 설치 시작...';
+  btn.disabled = true;
+  try {
+    const r = await fetch(`${API}/llm/install/?api_key=${encodeURIComponent(getApiKey())}&model=${encodeURIComponent(model)}`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+    });
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      throw new Error(err.detail || `HTTP ${r.status}`);
+    }
+    const data = await r.json();
+    toast(data.message || '설치 시작됨', 'success');
+    // 30초 후 모드 picker 갱신 (다운로드 진행 중일 가능성 높음)
+    setTimeout(loadModePickerOptions, 30000);
+  } catch (e) {
+    toast(`설치 실패: ${e.message}`, 'error');
+  } finally {
+    btn.textContent = orig;
+    btn.disabled = false;
+  }
 }
 
 function acceptModeRecommend() {

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -761,7 +761,7 @@ async def status(api_key: str):
 
 @app.get("/llm/modes/", summary="챗 페이지 모드 picker 옵션 [item #6]")
 async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
-    """Mode picker가 채울 옵션 목록.
+    """Mode picker가 채울 옵션 목록 + 실제 모델명 + 설치 상태.
 
     api_key만 검증 (admin 아님). role-allowed 모드만 반환해서 클라이언트
     가 권한 없는 모드를 보지 않도록 한다.
@@ -771,38 +771,122 @@ async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
       label:       사용자 노출 라벨
       desc:        한 줄 설명
       keywords:    자동 추천에 사용 (클라이언트 측 keyword match)
+      model:       실제 Ollama 모델 태그 (없으면 빈 문자열 — meta 등)
+      installed:   Ollama에 설치되어 있는지 (false면 client에서 "Install" 버튼)
     """
     verify_api_key(api_key)
     from core.intent_classifier import ROLE_ALLOWED
+    from config import GEMMA_MODEL, CODING_MODEL
     allowed = ROLE_ALLOWED.get(role, {"chat", "retrieval"})
+
+    # 설치된 모델 set 한 번에 조회 (Ollama API).
+    installed_set = set()
+    try:
+        import urllib.request
+        with urllib.request.urlopen(
+            "http://localhost:11434/api/tags", timeout=2,
+        ) as r:
+            data = json.loads(r.read())
+        for m in data.get("models", []):
+            installed_set.add(m.get("name", ""))
+    except Exception:
+        pass   # Ollama 미실행 — installed=False로 모두 표시됨
+
+    def _mark(model: str) -> bool:
+        """Ollama list와 매칭. 정확 일치 OR 태그 prefix (e.g.
+        gemma4:e4b ≈ gemma4)."""
+        if not model:
+            return True   # meta 같이 LLM 안 쓰는 모드는 항상 'installed'
+        if model in installed_set:
+            return True
+        prefix = model.split(":", 1)[0]
+        return any(name.startswith(prefix + ":") or name == prefix
+                   for name in installed_set)
 
     options = [
         {"key": "auto",     "label": "🤖 자동",
          "desc": "질문 의도를 자동 분류 (기본)",
-         "keywords": []},
+         "keywords": [],
+         "model": "", "installed": True},
         {"key": "chat",     "label": "💬 일상 대화",
          "desc": "검색 없이 LLM 직답",
-         "keywords": ["안녕", "고마워", "hi", "hello"]},
+         "keywords": ["안녕", "고마워", "hi", "hello"],
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
         {"key": "retrieval","label": "🔍 자료 검색",
          "desc": "내부 wiki + 그래프 추론",
-         "keywords": ["뭐야", "무엇", "설명", "알려줘", "what is"]},
+         "keywords": ["뭐야", "무엇", "설명", "알려줘", "what is"],
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
         {"key": "meta",     "label": "📚 자료 목록",
-         "desc": "보유 wiki 인벤토리",
-         "keywords": ["목록", "리스트", "어떤 자료", "list"]},
+         "desc": "보유 wiki 인벤토리 (LLM 미사용)",
+         "keywords": ["목록", "리스트", "어떤 자료", "list"],
+         "model": "", "installed": True},
         {"key": "coding",   "label": "💻 코딩",
-         "desc": "qwen2.5-coder 모델 사용",
+         "desc": f"코딩 특화 모델",
          "keywords": ["코드", "함수", "버그", "python", "def ",
-                      "javascript", "code", "function"]},
+                      "javascript", "code", "function"],
+         "model": CODING_MODEL, "installed": _mark(CODING_MODEL)},
         {"key": "wiki_edit","label": "✏️ Wiki 편집 (admin)",
          "desc": "지식 추가/수정/삭제",
-         "keywords": ["수정해", "추가해", "삭제해"]},
+         "keywords": ["수정해", "추가해", "삭제해"],
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
         {"key": "self_evolve","label": "🧬 자기진화 (admin)",
          "desc": "코드 분석 / 자기 개선",
-         "keywords": ["네 코드", "구조 분석", "스스로"]},
+         "keywords": ["네 코드", "구조 분석", "스스로"],
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
     ]
     # auto는 항상 허용. 나머지는 role 권한 확인.
     filtered = [o for o in options if o["key"] == "auto" or o["key"] in allowed]
     return {"modes": filtered, "role": role}
+
+
+@app.post("/llm/install/", summary="Ollama 모델 설치 (admin) [item #6]")
+async def llm_install(api_key: str, model: str,
+                      role: str = Depends(get_role_from_request)):
+    """Trigger `ollama pull <model>` in a subprocess.
+
+    Admin-gated — model installation is heavy (multi-GB download)
+    and exposing it to non-admin would let any chat user fill the
+    operator's disk.
+
+    Validates model name against an allowlist (config defaults +
+    a few well-known alternatives). Arbitrary input rejected with
+    400 — operator must use the admin LLM page for non-listed models.
+    """
+    _require_admin(api_key, role)
+    from config import GEMMA_MODEL, CODING_MODEL
+    # Allowlist — only models we explicitly support in mode router.
+    # Operators wanting to install something else use /admin/llm/...
+    ALLOWED_MODELS = {
+        GEMMA_MODEL, CODING_MODEL,
+        "gemma4:e4b", "gemma3:12b", "gemma3:27b",
+        "qwen2.5-coder:32b", "qwen2.5-coder:7b",
+        "llava:13b",
+    }
+    if model not in ALLOWED_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"model not in allowlist. Use admin /admin/llm/install for arbitrary models.",
+        )
+
+    import subprocess
+    try:
+        # Don't block — fire-and-forget. Operator polls /llm/modes/
+        # afterwards to see installed flip to True.
+        subprocess.Popen(
+            ["ollama", "pull", model],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return {"ok": True, "model": model,
+                "message": f"`ollama pull {model}` 시작됨 (백그라운드 진행). 잠시 후 모드 picker가 자동 갱신됩니다."}
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=503,
+            detail="ollama CLI가 PATH에 없습니다. 시스템에 ollama 설치 후 재시도.",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500,
+                            detail=f"install 시작 실패: {type(e).__name__}: {e}")
 
 
 @app.get("/admin/llm/installed", summary="설치된 Ollama 모델 목록 [4-B]")

--- a/tests/test_model_names_install.py
+++ b/tests/test_model_names_install.py
@@ -1,0 +1,187 @@
+"""Mode picker shows real model names + install button (item #6).
+
+User feedback (2026-05-08): "챗 llm 모델변경 기능에 실제 모델명도
+기입 / 모델이 없으면 설치 가능한 버튼도 추가".
+
+Backend changes:
+  - GET /llm/modes/ response now includes per-mode `model` (the
+    actual Ollama tag from config — e.g. gemma4:e4b) and
+    `installed` boolean (queried from Ollama API at request time,
+    matched by exact tag OR family prefix).
+  - POST /llm/install/?model= triggers `ollama pull <model>` in
+    a fire-and-forget subprocess. Admin-gated. Allowlist check on
+    `model` param so a chat user can't fill the operator's disk
+    by spamming arbitrary model names.
+
+Frontend changes:
+  - Mode picker option labels now show "(model_tag)" + "⚠️ 미설치"
+    suffix when not installed.
+  - "📦 model 설치" button appears when selected mode's model is
+    not installed. admin-only — non-admin sees a toast explaining.
+
+Run:
+  python -m unittest tests.test_model_names_install
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class LlmModesEndpointTests(unittest.TestCase):
+    """The /llm/modes/ response shape gains model + installed fields,
+    queries Ollama for installed list."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _endpoint_body(self) -> str:
+        idx = self.src.index('@app.get("/llm/modes/"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 6000
+        return self.src[idx:end]
+
+    def test_response_includes_model_field(self):
+        body = self._endpoint_body()
+        # Each option dict now has `model` and `installed` keys.
+        self.assertIn('"model":', body,
+                      "options must include `model` field")
+        self.assertIn('"installed":', body,
+                      "options must include `installed` boolean")
+
+    def test_uses_config_models_not_hardcoded(self):
+        body = self._endpoint_body()
+        # Don't hardcode "gemma4:e4b" / "qwen2.5-coder:32b" — read from config.
+        # If user changes JAMES_LLM_MODEL via env, picker must reflect it.
+        self.assertIn("from config import GEMMA_MODEL, CODING_MODEL", body,
+                      "must import config models so .env override propagates")
+        self.assertIn("GEMMA_MODEL", body)
+        self.assertIn("CODING_MODEL", body)
+
+    def test_queries_ollama_for_installed_list(self):
+        body = self._endpoint_body()
+        # Ollama tags API (port 11434) → set of installed model names.
+        self.assertIn("api/tags", body,
+                      "must hit Ollama /api/tags to determine installed status")
+
+    def test_installed_match_handles_family_prefix(self):
+        body = self._endpoint_body()
+        # gemma4:e4b should match if "gemma4" base is installed even
+        # under a different tag. Look for the prefix logic.
+        self.assertIn('split(":", 1)[0]', body,
+                      "installed-match must handle family prefix "
+                      "(gemma4:e4b ≈ gemma4)")
+
+
+class LlmInstallEndpointTests(unittest.TestCase):
+    """POST /llm/install/ triggers ollama pull, admin-only,
+    allowlist-validated."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _endpoint_body(self) -> str:
+        idx = self.src.index('@app.post("/llm/install/"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 6000
+        return self.src[idx:end]
+
+    def test_endpoint_registered(self):
+        self.assertIn('@app.post("/llm/install/"', self.src,
+                      "/llm/install/ POST endpoint missing")
+
+    def test_admin_only(self):
+        body = self._endpoint_body()
+        self.assertIn("_require_admin(api_key, role)", body,
+                      "install must be admin-gated — multi-GB downloads "
+                      "shouldn't be exposed to chat users")
+
+    def test_model_allowlist(self):
+        body = self._endpoint_body()
+        self.assertIn("ALLOWED_MODELS", body,
+                      "install must validate model name against allowlist — "
+                      "arbitrary input could fill the operator's disk")
+        self.assertIn("status_code=400", body,
+                      "non-allowlisted model must return 400")
+
+    def test_uses_subprocess_popen_fire_and_forget(self):
+        body = self._endpoint_body()
+        # Don't BLOCK the request thread — `ollama pull` can take
+        # several minutes. Subprocess.Popen lets it run in background.
+        self.assertIn("subprocess.Popen", body,
+                      "must use Popen (not run/check_output) so request "
+                      "doesn't block on multi-minute downloads")
+
+    def test_handles_missing_ollama_cli(self):
+        body = self._endpoint_body()
+        # If ollama isn't in PATH, return 503 with a clear message
+        # rather than 500 with stack trace.
+        self.assertIn("FileNotFoundError", body)
+        self.assertIn("status_code=503", body,
+                      "missing ollama CLI must produce a clear 503")
+
+
+class FrontendInstallButtonTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+        cls.html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_install_button_in_html(self):
+        self.assertIn('id="mode-install-btn"', self.html,
+                      "install button missing from index.html")
+        self.assertIn('onclick="triggerModelInstall()"', self.html)
+
+    def test_picker_options_show_model_tag_and_status(self):
+        # loadModePickerOptions builds option labels with model tag +
+        # "⚠️ 미설치" suffix on uninstalled models.
+        idx = self.js.index("async function loadModePickerOptions")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("m.model", body,
+                      "option label must include the actual model tag")
+        self.assertIn("미설치", body,
+                      "uninstalled options must show 미설치 marker")
+        self.assertIn("data-installed", body,
+                      "option should carry data-installed for client-side check")
+
+    def test_update_install_button_function(self):
+        self.assertIn("function updateInstallButton", self.js)
+        idx = self.js.index("function updateInstallButton")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("style.display = 'none'", body,
+                      "button hidden when selected mode is installed")
+        self.assertIn("style.display = 'inline-block'", body,
+                      "button shown when not installed")
+        self.assertIn("opt.installed", body,
+                      "must check the installed flag")
+
+    def test_trigger_model_install_admin_check(self):
+        idx = self.js.index("async function triggerModelInstall")
+        body = self.js[idx:idx + 2500]
+        # Client-side guard — show message before hitting server. Server
+        # also enforces but the toast is faster feedback.
+        self.assertIn("userRole !== 'admin'", body,
+                      "client must show admin-required message before request")
+        # Confirm prompt — multi-GB download is destructive.
+        self.assertIn("confirm(", body,
+                      "must confirm before triggering — large download")
+        # Hits the install endpoint.
+        self.assertIn("/llm/install/", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"챗 llm 모델변경 기능에 실제 모델명도 기입 / 모델이 없으면 설치 가능한 버튼도 추가"*.

## Backend

### `/llm/modes/` enhanced
Each option now carries:
```json
{"key": "coding", "label": "💻 코딩",
 "model": "qwen2.5-coder:32b",
 "installed": false, ...}
```
- `model`: read from `config.GEMMA_MODEL` / `config.CODING_MODEL` (`.env` override propagates)
- `installed`: queried at request time via Ollama `/api/tags`, matches by exact tag OR family prefix (`gemma4:e4b ≈ any gemma4:*`)

### New `POST /llm/install/?model=`
- Fires `ollama pull <model>` via `subprocess.Popen` (non-blocking — multi-GB download)
- **Admin-gated**: non-admin can't fill operator's disk
- **Allowlist** on `model` param: rejected names → 400
- Missing `ollama` CLI → 503 with clear message

## Frontend

- Picker option labels: `"💻 코딩 (qwen2.5-coder:32b) ⚠️ 미설치"`
- `📦 model 설치` button next to picker, shown when selected mode's model is uninstalled
- Non-admin click → toast `"관리자에게 ollama pull X 요청"`
- Admin click → confirm prompt → POST `/llm/install/`
- 30s after install trigger, picker auto-refreshes to flip `installed: true`

## Verification

13 tests in `tests/test_model_names_install.py`:
- **LlmModes** (4): `model`+`installed` shape, config-driven (not hardcoded), Ollama /api/tags query, family-prefix match
- **LlmInstall** (5): admin-gated, allowlist+400, subprocess.Popen (fire-and-forget), FileNotFoundError→503
- **Frontend** (4): install button HTML, picker label format, updateInstallButton toggling, triggerModelInstall admin-check + confirm + endpoint

**432/432 regression suite pass.**

## Bench numbers

Not applicable — UX additions on top of existing routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)