### PR TITLE
fix(frontend): suggestion chips support 4 numbered formats (item #A1)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -765,34 +765,50 @@ function appendJamesMsg(data) {
   messages.scrollTop = messages.scrollHeight;
 }
 
-/* ── item #1-B: "(1) ... (2) ... (3) ..." 제안 추출 ──
-   답변 텍스트에서 다음 행동 제안 chip을 만들어낸다. 두 가지 일반적
-   포맷을 인식:
-     "(1) X (2) Y (3) Z"          — 한 줄 인라인
-     "(1) X\n(2) Y\n(3) Z"        — 줄바꿈 분리
-   숫자 1-9까지. 각 제안은 다음 마커 직전까지로 잘림.
+/* ── item #1-B + #A1: 다음-행동 제안 추출 (다중 포맷 지원) ──
+   v1은 "(1) X (2) Y (3) Z" 한 형식만 매칭 → LLM이 "1) X" "1. X"
+   "① X" 같은 변형으로 답하면 chip이 안 나오는 간헐 누락 발생
+   (사용자 보고 2026-05-08).
 
-   답변 끝 부분(마지막 250자) 안에서만 매칭 — 본문 중간에 우연히
-   "(1) 첫째" 같은 패턴이 들어가도 제안으로 오해 안 함. */
+   v2는 SUGGESTION_PATTERNS 배열을 순서대로 시도. 첫 번째로 ≥2개를
+   찾는 패턴의 결과를 채택. 패턴 우선순위:
+     ① "(1) X (2) Y (3) Z"   — strict, 우리가 권장하는 포맷
+     ② "1) X 2) Y 3) Z"      — 우괄호만
+     ③ "1. X\n2. Y\n3. Z"    — 다행 번호 목록
+     ④ "① X ② Y ③ Z"          — 원문자
+
+   답변 끝 600자만 검사 — 본문 중간 "(1) 첫째" 등을 제안으로
+   오해하지 않도록 tail 제한. */
+const SUGGESTION_PATTERNS = [
+  /\((\d)\)\s*([^\n()][^\n(]*?)(?=\s*\(\d\)|\s*$)/g,
+  /(?:^|[\s\n])(\d)\)\s+([^\n)]+?)(?=\s+\d\)|\n|$)/g,
+  /(?:^|\n)\s*(\d)\.\s+([^\n]+)/g,
+  /([①②③④⑤⑥⑦⑧⑨])\s+([^\n①-⑨]+?)(?=\s*[①-⑨]|$)/g,
+];
+
 function extractNextActionSuggestions(answerText) {
   if (!answerText) return [];
   const tail = answerText.length > 600
              ? answerText.slice(-600)
              : answerText;
-  // 숫자 인덱스 + 텍스트. (1) X 다음에 (2)/(3)/.../EOF.
-  const re = /\((\d)\)\s*([^\n()][^\n(]*?)(?=\s*\(\d\)|\s*$)/g;
-  const out = [];
-  let m;
-  while ((m = re.exec(tail)) !== null) {
-    const text = m[2].trim().replace(/[\.。]+$/, '');
-    if (text.length >= 4 && text.length <= 200) {
-      out.push({ n: parseInt(m[1], 10), text });
+  for (const re of SUGGESTION_PATTERNS) {
+    re.lastIndex = 0;
+    const out = [];
+    let m;
+    while ((m = re.exec(tail)) !== null) {
+      const text = m[2].trim().replace(/[\.。]+$/, '');
+      if (text.length >= 4 && text.length <= 200) {
+        // 동일 텍스트 중복 제거 (예: "1. X" 다음 "1) X" 둘 다 매칭 방지)
+        if (!out.some(o => o.text === text)) {
+          out.push({ n: out.length + 1, text });
+        }
+      }
+      if (out.length >= 5) break;
     }
-    if (out.length >= 5) break;
+    // 최소 2개 — 단일 매칭은 본문 잔재(예: "1단계: ...")일 가능성.
+    if (out.length >= 2) return out;
   }
-  // 최소 2개일 때만 제안 chip으로 인정 — 단일 "(1)" 같은 가짜
-  // 패턴 (예: "1단계: ...")은 무시.
-  return out.length >= 2 ? out : [];
+  return [];
 }
 
 /* 제안 chip 클릭 → 입력창에 채우고 즉시 전송 */

--- a/tests/test_suggestion_click.py
+++ b/tests/test_suggestion_click.py
@@ -1,24 +1,26 @@
-"""Next-action suggestion chips (item #1-B, 2026-05-08).
+"""Next-action suggestion chips (item #1-B / #A1, 2026-05-08).
 
-User feedback: "답변 대화창에 자메스가 다음 제안하는 방식은 사용자가
+User feedback round 1: "답변 대화창에 자메스가 다음 제안하는 방식은 사용자가
 클릭 선택하면 자동으로 질문될수 있도록 설정".
+User feedback round 2: "선택지가 일단 제시되면 클릭 가능하도록 개선" —
+LLM이 (1)/1)/1./① 등 다양한 포맷으로 답해서 chip이 간헐적으로 안 나옴.
 
-PR #89's natural-flow rule already produces "다음 중 어떤 걸
-원하시나요? (1) ... (2) ... (3) ..." at the end of complex
-answers. This PR makes those numbered options interactive:
-parses them out of the answer text, renders as clickable chips,
-clicks fill the input and auto-send.
+PR #110 (round 1) extracted "(N) text" only. This file's tests cover
+the multi-format expansion (#A1): SUGGESTION_PATTERNS array tries
+strict → right-paren → period-numbered → circled-digit, takes the
+first format that yields ≥2 suggestions.
 
 Coverage:
-  - extractNextActionSuggestions(text) parses "(1) X (2) Y (3) Z"
-    inline and "(1) X\\n(2) Y\\n(3) Z" multi-line.
-  - Tail-only matching — body-middle "(1) 첫째" is not mistaken for
-    a suggestion.
-  - Min 2 suggestions required — single "(1)" rejected.
+  - SUGGESTION_PATTERNS array with 4 regex literals.
+  - "(1) X (2) Y (3) Z"   strict — original format
+  - "1) X 2) Y 3) Z"      right-paren only
+  - "1. X\\n2. Y\\n3. Z"  numbered-list format
+  - "① X ② Y ③ Z"          circled-digit format
+  - Min 2 suggestions per pattern; otherwise fall through to next.
   - Length bounds: each suggestion 4-200 chars.
+  - Tail-only matching — body-middle "(1) 첫째" not mistaken.
   - askSuggestion(idx, btn) reads data-suggestion (URI-decoded),
-    fills input, calls sendMessage with a small delay (UX —
-    user can intercept).
+    fills input, calls sendMessage with a small delay.
   - chip rendering inside appendJamesMsg with onclick wired.
 
 Run:
@@ -37,46 +39,102 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 JS = Path(__file__).resolve().parent.parent / "frontend" / "static" / "chat.js"
 
 
+def _extract_patterns(js_src: str):
+    """Pull each regex literal out of the SUGGESTION_PATTERNS array.
+
+    The JS source declares:
+        const SUGGESTION_PATTERNS = [
+          /pattern1/g,
+          /pattern2/g,
+          ...
+        ];
+
+    We grab the array body and re-extract each `/.../g` literal.
+    """
+    arr = re.search(
+        r"const\s+SUGGESTION_PATTERNS\s*=\s*\[(.+?)\];",
+        js_src,
+        re.DOTALL,
+    )
+    assert arr, "SUGGESTION_PATTERNS array literal not found"
+    body = arr.group(1)
+    pats = re.findall(r"/(.+?)/g", body)
+    return [re.compile(p) for p in pats]
+
+
 class SuggestionExtractionTests(unittest.TestCase):
-    """Behavioral parity: regex pattern in JS must match the
-    documented inputs/outputs. We mirror the JS regex in Python re."""
+    """Behavioral parity: each regex in SUGGESTION_PATTERNS must match
+    the documented inputs/outputs. We mirror the JS extraction in Python."""
 
     @classmethod
     def setUpClass(cls):
         cls.js = JS.read_text(encoding="utf-8")
-        # Extract the regex literal from JS source.
-        # Pattern: const re = /...../g;
-        m = re.search(r"const\s+re\s*=\s*/(.+?)/g\s*;", cls.js)
-        assert m, "could not locate suggestion regex literal"
-        cls.py_pat = re.compile(m.group(1))
+        cls.py_pats = _extract_patterns(cls.js)
+        # Sanity — we expect 4 patterns currently.
+        assert len(cls.py_pats) >= 4, \
+            f"expected ≥4 patterns in SUGGESTION_PATTERNS, got {len(cls.py_pats)}"
 
     def _extract(self, text):
-        # Simulate the JS function's tail-restriction (last 600 chars).
+        # Simulate the JS function's tail-restriction (last 600 chars)
+        # plus the multi-pattern fallback.
         tail = text[-600:] if len(text) > 600 else text
-        out = []
-        for m in self.py_pat.finditer(tail):
-            t = m.group(2).strip().rstrip(".。")
-            if 4 <= len(t) <= 200:
-                out.append({"n": int(m.group(1)), "text": t})
-            if len(out) >= 5:
-                break
-        return out if len(out) >= 2 else []
+        for py_pat in self.py_pats:
+            out = []
+            for m in py_pat.finditer(tail):
+                t = m.group(2).strip().rstrip(".。")
+                if 4 <= len(t) <= 200:
+                    if not any(o["text"] == t for o in out):
+                        out.append({"n": len(out) + 1, "text": t})
+                if len(out) >= 5:
+                    break
+            if len(out) >= 2:
+                return out
+        return []
 
-    def test_inline_three_options_parsed(self):
+    # ── pattern 1: "(1) X (2) Y (3) Z" ──
+    def test_inline_paren_three_options_parsed(self):
         text = "답변 본문... 다음 중 어떤 걸 원하시나요? (1) BlackRock 자세히 (2) 비트코인 ETF 출시 시점 (3) 다른 회사들"
         s = self._extract(text)
         self.assertEqual(len(s), 3)
         self.assertEqual(s[0]["text"], "BlackRock 자세히")
         self.assertIn("ETF", s[1]["text"])
 
-    def test_multiline_options_parsed(self):
+    def test_multiline_paren_options_parsed(self):
         text = "답변... (1) 첫번째 옵션\n(2) 두번째 옵션\n(3) 세번째 옵션"
         s = self._extract(text)
         self.assertEqual(len(s), 3)
 
+    # ── pattern 2: "1) X 2) Y 3) Z" right-paren only (LLM 자주 출력) ──
+    def test_right_paren_only_format(self):
+        text = "본문 답변. 더 알아볼 항목: 1) BlackRock 추가 분석 2) 비트코인 ETF 시기 3) 경쟁사 비교"
+        s = self._extract(text)
+        self.assertGreaterEqual(len(s), 2,
+            "1) X 2) Y format must yield ≥2 chips")
+        self.assertIn("BlackRock", s[0]["text"])
+
+    # ── pattern 3: "1. X\n2. Y\n3. Z" 다행 번호 목록 ──
+    def test_period_numbered_list_format(self):
+        text = (
+            "본문 답변.\n\n"
+            "다음 제안:\n"
+            "1. BlackRock 추가 정보 확인\n"
+            "2. 비트코인 ETF 출시 시기\n"
+            "3. 경쟁사 비교 분석\n"
+        )
+        s = self._extract(text)
+        self.assertGreaterEqual(len(s), 2,
+            "numbered-list format (1.\\n2.\\n3.) must yield chips")
+
+    # ── pattern 4: "① X ② Y ③ Z" 원문자 ──
+    def test_circled_digit_format(self):
+        text = "본문... 추가 질문: ① BlackRock 자세히 ② 비트코인 ETF 시점 ③ 경쟁사 비교"
+        s = self._extract(text)
+        self.assertGreaterEqual(len(s), 2,
+            "circled-digit format must yield chips")
+
+    # ── 거짓-매칭 방지 ──
     def test_min_two_suggestions(self):
-        # Single "(1) something" should NOT be rendered as a chip
-        # — could be body content, not a next-action list.
+        # Single "(1) something" should NOT be rendered as chip.
         text = "답변 본문 (1) 첫째로 X를 한다. 본문 계속..."
         s = self._extract(text)
         self.assertEqual(s, [],
@@ -90,12 +148,9 @@ class SuggestionExtractionTests(unittest.TestCase):
                          "very-short single-token suggestions rejected")
 
     def test_long_suggestion_truncated(self):
-        # 200-char max — anything past that is body text being misread.
         long_text = "(1) " + ("a" * 250) + " (2) bbbb (3) cccc"
         s = self._extract(long_text)
-        # The 250-char one rejected; (2)/(3) accepted but len < 2 filter
-        # keeps them paired. Behavior: at most we get 2 items if both
-        # pass — here (1) excluded, so we have (2) + (3).
+        # 250-char (1) rejected; (2) and (3) accepted.
         self.assertEqual(len(s), 2)
         for item in s:
             self.assertLessEqual(len(item["text"]), 200)
@@ -108,6 +163,31 @@ class JsContractTests(unittest.TestCase):
 
     def test_extract_function_exists(self):
         self.assertIn("function extractNextActionSuggestions", self.js)
+
+    def test_patterns_array_declared(self):
+        # The new structure — multi-pattern fallback.
+        self.assertIn("SUGGESTION_PATTERNS", self.js,
+            "must export SUGGESTION_PATTERNS array for multi-format fallback")
+        # ≥4 regex literals inside the array.
+        arr = re.search(
+            r"const\s+SUGGESTION_PATTERNS\s*=\s*\[(.+?)\];",
+            self.js, re.DOTALL,
+        )
+        self.assertIsNotNone(arr)
+        n_patterns = len(re.findall(r"/.+?/g", arr.group(1)))
+        self.assertGreaterEqual(n_patterns, 4,
+            f"expected ≥4 fallback patterns, got {n_patterns}")
+
+    def test_function_iterates_patterns(self):
+        idx = self.js.index("function extractNextActionSuggestions")
+        body = self.js[idx:idx + 1500]
+        # Must loop through patterns and return early on first ≥2 hit.
+        self.assertIn("for (const re of SUGGESTION_PATTERNS", body,
+            "must iterate patterns")
+        self.assertIn("re.lastIndex = 0", body,
+            "must reset lastIndex (regex with /g flag is stateful)")
+        self.assertIn(">= 2", body,
+            "must require ≥2 to accept a pattern's result")
 
     def test_ask_suggestion_function(self):
         self.assertIn("function askSuggestion", self.js)
@@ -123,7 +203,6 @@ class JsContractTests(unittest.TestCase):
                       "small delay before send so user can intercept")
 
     def test_chip_rendered_in_message(self):
-        # appendJamesMsg builds suggestionsHtml with chips.
         idx = self.js.index("function appendJamesMsg")
         m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
         end = idx + 1 + m.start() if m else idx + 8000
@@ -136,8 +215,6 @@ class JsContractTests(unittest.TestCase):
                       "chip must carry data-suggestion attribute")
 
     def test_tail_only_matching(self):
-        # Function should only look at the tail of the answer to
-        # avoid matching body-mid "(1) 첫째" content.
         self.assertIn("slice(-600)", self.js,
                       "extraction must restrict to answer tail (600 chars)")
 


### PR DESCRIPTION
## Summary

User feedback (2026-05-08): *"선택지가 일단 제시되면 클릭 가능하도록 개선"* — chips appear only sometimes.

## Root cause

PR #110's regex matched only `(1) X (2) Y (3) Z`. The LLM frequently produces other numbered formats depending on prompt phase / model variant — those got rendered as plain text, not chips.

## Fix

Replace single regex with `SUGGESTION_PATTERNS` array. Try patterns in order, first one that yields ≥2 matches wins. Min-2 rule kept (single match likely body-mid `1단계: ...`).

| Order | Pattern | Example |
|---|---|---|
| ① strict | `(N) X` | `(1) BlackRock 자세히` |
| ② right-paren | `N) X` | `1) BlackRock 자세히` |
| ③ period list | `N. X` (multi-line) | `1. BlackRock\n2. 비트코인` |
| ④ circled digit | `① X` | `① BlackRock` |

## Verification

`tests/test_suggestion_click.py` — 14 tests (was 9):
- **SuggestionExtractionTests** (8): one per pattern + 4 rejection tests (min-2, short, long, body-middle)
- **JsContractTests** (6): patterns array literal, multi-pattern loop with `lastIndex = 0` reset, ≥2 gate, chip render contract, tail-only matching

**437/437 regression suite pass.**

## Bench numbers

Not applicable — frontend extraction only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)