### PR TITLE
feat(chat): per-mode model catalog + secondary picker (item #A2)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -863,6 +863,15 @@
                        font-size:11px;cursor:pointer">
           <option value="auto">🤖 자동</option>
         </select>
+        <span id="model-picker-wrap"
+              style="display:none;align-items:center;gap:4px"
+              title="이 모드에서 사용할 모델 선택">
+          <select id="model-picker"
+                  onchange="onModelPickerChange()"
+                  style="background:var(--surface);border:1px solid var(--border);
+                         color:var(--text);padding:4px 10px;border-radius:6px;
+                         font-size:11px;cursor:pointer"></select>
+        </span>
         <button id="mode-install-btn"
                 onclick="triggerModelInstall()"
                 style="display:none;background:var(--accent-soft);

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -100,9 +100,14 @@ window.addEventListener('DOMContentLoaded', () => {
    사용자가 명시적으로 모드를 고르면 selectedMode = 그 값, /query/에
    mode_override로 전달. "auto"면 mode_override 빈 문자열 → 서버는
    intent_classifier로 자동 분류. */
-let MODE_OPTIONS = [];          // [{key, label, desc, keywords}]
-let selectedMode = 'auto';      // current dropdown value
+let MODE_OPTIONS = [];          // [{key, label, desc, keywords, models}]
+let selectedMode = 'auto';      // current mode-picker value
+let selectedModel = '';         // [#A2] current model-picker value (secondary dropdown)
 let recommendedMode = '';       // last-recommended (auto-suggest)
+
+/* [#A2] localStorage 키 — 모드별 선택한 모델 기억. 다른 세션/탭에서도
+   동일 선택을 유지. */
+function _modelKey(mode) { return `james_model_${mode}`; }
 
 async function loadModePickerOptions() {
   try {
@@ -124,34 +129,102 @@ async function loadModePickerOptions() {
                       data-installed="${m.installed ? '1' : '0'}">${escHtml(m.label)}${escHtml(modelTag)}${status}</option>`;
     }).join('');
     sel.value = selectedMode;
+    refreshModelPicker();
     updateInstallButton();
   } catch (e) {
     console.warn('[JAMES] /llm/modes/ fetch 실패:', e);
   }
 }
 
+/* ── [#A2] 두 번째 dropdown — 모드별 모델 후보 ──
+   모드가 바뀌면 그 모드의 models[] 후보로 다시 채운다. 후보가 0-1개
+   이거나 mode가 auto/meta면 picker 숨김.
+   weight 표기:
+     light  → 🪶 (가벼움 / 빠름)
+     medium → ⚖️
+     heavy  → 🐘 (무거움 / 정확)
+   미설치 모델은 ⚠️ 마커 + 설치 버튼이 그 모델 install 동작. */
+function refreshModelPicker() {
+  const wrap = document.getElementById('model-picker-wrap');
+  const sel  = document.getElementById('model-picker');
+  if (!wrap || !sel) return;
+  const opt = MODE_OPTIONS.find(m => m.key === selectedMode);
+  const models = opt && Array.isArray(opt.models) ? opt.models : [];
+  if (models.length < 2) {
+    // 후보 1개 이하 — 두 번째 dropdown은 가치 X. 숨김.
+    wrap.style.display = 'none';
+    selectedModel = (models[0] && models[0].tag) || (opt && opt.model) || '';
+    return;
+  }
+  wrap.style.display = 'inline-flex';
+  // localStorage에서 직전 선택 복구; 없으면 default 모델.
+  const saved = localStorage.getItem(_modelKey(selectedMode)) || '';
+  const savedValid = models.some(m => m.tag === saved);
+  selectedModel = savedValid
+                ? saved
+                : (models.find(m => m.default) || models[0]).tag;
+  const weightIcon = w => w === 'light' ? '🪶'
+                       : w === 'heavy' ? '🐘'
+                       : '⚖️';
+  sel.innerHTML = models.map(m => {
+    const status = m.installed ? '' : ' ⚠️';
+    return `<option value="${escHtml(m.tag)}"
+                    data-installed="${m.installed ? '1' : '0'}"
+                    data-weight="${escHtml(m.weight)}"
+                    title="${escHtml(m.weight)}${m.installed ? '' : ' (미설치)'}">${weightIcon(m.weight)} ${escHtml(m.tag)}${status}</option>`;
+  }).join('');
+  sel.value = selectedModel;
+}
+
+function onModelPickerChange() {
+  const sel = document.getElementById('model-picker');
+  if (!sel) return;
+  selectedModel = sel.value;
+  localStorage.setItem(_modelKey(selectedMode), selectedModel);
+  updateInstallButton();
+}
+
 function onModePickerChange() {
   const sel = document.getElementById('mode-picker');
   selectedMode = sel ? sel.value : 'auto';
   hideModeRecommend();
+  refreshModelPicker();
   updateInstallButton();
 }
 
-/* ── item #6: 선택된 모드의 모델이 미설치면 "설치" 버튼 노출 ──
+/* ── item #6 + #A2: 선택된 모드+모델이 미설치면 "설치" 버튼 노출 ──
    admin role만 실제 install 트리거 가능 (서버에서도 가드). 비-admin
-   에겐 "관리자에게 설치 요청" 안내. */
+   에겐 "관리자에게 설치 요청" 안내.
+
+   [#A2 변경] 후보 dropdown이 활성화된 모드는 *현재 선택한* 후보의
+   설치 상태를 보고 결정. dropdown 없는 모드는 기본 모델로 폴백. */
 function updateInstallButton() {
   const btn = document.getElementById('mode-install-btn');
   if (!btn) return;
   const opt = MODE_OPTIONS.find(m => m.key === selectedMode);
-  if (!opt || opt.installed || !opt.model) {
+  if (!opt) { btn.style.display = 'none'; return; }
+  // [#A2] 현재 선택한 모델로 install 결정
+  let target = '';
+  let installed = true;
+  const models = Array.isArray(opt.models) ? opt.models : [];
+  if (models.length >= 2) {
+    const cur = models.find(m => m.tag === selectedModel)
+              || models.find(m => m.default)
+              || models[0];
+    target    = cur.tag;
+    installed = !!cur.installed;
+  } else {
+    target    = opt.model || '';
+    installed = !!opt.installed;
+  }
+  if (!target || installed) {
     btn.style.display = 'none';
     return;
   }
   btn.style.display = 'inline-block';
-  btn.dataset.model = opt.model;
-  btn.textContent = `📦 ${opt.model} 설치`;
-  btn.title = `${opt.model} 모델이 Ollama에 없습니다. 클릭하여 설치 시작 (admin 전용).`;
+  btn.dataset.model = target;
+  btn.textContent = `📦 ${target} 설치`;
+  btn.title = `${target} 모델이 Ollama에 없습니다. 클릭하여 설치 시작 (admin 전용).`;
 }
 
 async function triggerModelInstall() {

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -759,9 +759,68 @@ async def status(api_key: str):
 
 # ── [4-B] Ollama + LLM 추천 API ──────────────────────────────────
 
-@app.get("/llm/modes/", summary="챗 페이지 모드 picker 옵션 [item #6]")
+# item #A2: 모드별 선택 가능한 모델 카탈로그.
+#   - chat/retrieval/wiki_edit/self_evolve: 일반 대화/추론 (gemma 계열)
+#     무게: light (e4b) → medium (12b) → heavy (27b)
+#   - coding: 코딩 특화 (qwen-coder 계열) + gemma fallback
+# 사용자가 mode 선택 시 두 번째 dropdown으로 후보 중 골라 사용.
+# 설치되지 않은 후보는 그대로 노출하되 [⚠️ 미설치] 마커 + 설치 버튼.
+# weight 분류는 어림짐작 (실제 파라미터 수가 아닌 *체감* 무게):
+#   light  ≤ 4B  — 빠른 일상 대화
+#   medium ≤ 13B — 균형, 분석 가능
+#   heavy  ≥ 20B — 상세 분석/추론, 응답 느림
+def _model_catalog():
+    """Mode → ordered list of (tag, weight) candidates.
+
+    Default-first ordering — picker selects index 0 unless localStorage
+    has a saved choice. Operator's `.env` (JAMES_LLM_MODEL,
+    JAMES_CODING_MODEL) is prepended if not already in the list, so a
+    custom config still appears as a candidate even if it isn't in the
+    canonical catalog.
+    """
+    from config import GEMMA_MODEL, CODING_MODEL
+    chat_default = GEMMA_MODEL
+    code_default = CODING_MODEL
+    chat_cands = [
+        (chat_default,    "light"),
+        ("gemma3:12b",    "medium"),
+        ("gemma3:27b",    "heavy"),
+    ]
+    # If operator has overridden GEMMA_MODEL to something not in our list,
+    # keep it as a candidate so the UI still shows their config.
+    if not any(c[0] == chat_default for c in chat_cands):
+        chat_cands.insert(0, (chat_default, "medium"))
+    code_cands = [
+        ("qwen2.5-coder:7b",  "light"),
+        (code_default,        "heavy"),
+        ("gemma4:e4b",        "light"),  # fallback for tiny boxes
+    ]
+    if not any(c[0] == code_default for c in code_cands):
+        code_cands.insert(0, (code_default, "heavy"))
+    return {
+        "chat":         chat_cands,
+        "retrieval":    chat_cands,
+        "wiki_edit":    chat_cands,
+        "self_evolve":  chat_cands,
+        "coding":       code_cands,
+        # auto/meta intentionally absent — auto inherits whatever the
+        # routed mode picks; meta does not call the LLM.
+    }
+
+# /llm/install/ allowlist auto-derived from catalog so adding a candidate
+# above does NOT also require remembering to update the install gate.
+def _allowed_install_models():
+    out = set()
+    for cands in _model_catalog().values():
+        for tag, _ in cands:
+            if tag:
+                out.add(tag)
+    return out
+
+
+@app.get("/llm/modes/", summary="챗 페이지 모드 picker 옵션 [item #6 + #A2]")
 async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
-    """Mode picker가 채울 옵션 목록 + 실제 모델명 + 설치 상태.
+    """Mode picker가 채울 옵션 목록 + 모델 후보 카탈로그.
 
     api_key만 검증 (admin 아님). role-allowed 모드만 반환해서 클라이언트
     가 권한 없는 모드를 보지 않도록 한다.
@@ -771,8 +830,11 @@ async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
       label:       사용자 노출 라벨
       desc:        한 줄 설명
       keywords:    자동 추천에 사용 (클라이언트 측 keyword match)
-      model:       실제 Ollama 모델 태그 (없으면 빈 문자열 — meta 등)
-      installed:   Ollama에 설치되어 있는지 (false면 client에서 "Install" 버튼)
+      model:       기본(default) 모델 태그 — backward compat
+      installed:   기본 모델 설치 상태 — backward compat
+      models:      [item #A2] 후보 리스트 — 두 번째 dropdown용
+                   각 원소: {"tag": str, "weight": "light|medium|heavy",
+                            "installed": bool, "default": bool}
     """
     verify_api_key(api_key)
     from core.intent_classifier import ROLE_ALLOWED
@@ -803,36 +865,56 @@ async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
         return any(name.startswith(prefix + ":") or name == prefix
                    for name in installed_set)
 
+    catalog = _model_catalog()
+
+    def _models_for(mode_key: str, default_tag: str) -> list:
+        """Build the candidate list dict for a mode."""
+        cands = catalog.get(mode_key, [])
+        out = []
+        for tag, weight in cands:
+            out.append({
+                "tag":       tag,
+                "weight":    weight,
+                "installed": _mark(tag),
+                "default":   tag == default_tag,
+            })
+        return out
+
     options = [
         {"key": "auto",     "label": "🤖 자동",
          "desc": "질문 의도를 자동 분류 (기본)",
          "keywords": [],
-         "model": "", "installed": True},
+         "model": "", "installed": True, "models": []},
         {"key": "chat",     "label": "💬 일상 대화",
          "desc": "검색 없이 LLM 직답",
          "keywords": ["안녕", "고마워", "hi", "hello"],
-         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL),
+         "models": _models_for("chat", GEMMA_MODEL)},
         {"key": "retrieval","label": "🔍 자료 검색",
          "desc": "내부 wiki + 그래프 추론",
          "keywords": ["뭐야", "무엇", "설명", "알려줘", "what is"],
-         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL),
+         "models": _models_for("retrieval", GEMMA_MODEL)},
         {"key": "meta",     "label": "📚 자료 목록",
          "desc": "보유 wiki 인벤토리 (LLM 미사용)",
          "keywords": ["목록", "리스트", "어떤 자료", "list"],
-         "model": "", "installed": True},
+         "model": "", "installed": True, "models": []},
         {"key": "coding",   "label": "💻 코딩",
          "desc": f"코딩 특화 모델",
          "keywords": ["코드", "함수", "버그", "python", "def ",
                       "javascript", "code", "function"],
-         "model": CODING_MODEL, "installed": _mark(CODING_MODEL)},
+         "model": CODING_MODEL, "installed": _mark(CODING_MODEL),
+         "models": _models_for("coding", CODING_MODEL)},
         {"key": "wiki_edit","label": "✏️ Wiki 편집 (admin)",
          "desc": "지식 추가/수정/삭제",
          "keywords": ["수정해", "추가해", "삭제해"],
-         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL),
+         "models": _models_for("wiki_edit", GEMMA_MODEL)},
         {"key": "self_evolve","label": "🧬 자기진화 (admin)",
          "desc": "코드 분석 / 자기 개선",
          "keywords": ["네 코드", "구조 분석", "스스로"],
-         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL)},
+         "model": GEMMA_MODEL, "installed": _mark(GEMMA_MODEL),
+         "models": _models_for("self_evolve", GEMMA_MODEL)},
     ]
     # auto는 항상 허용. 나머지는 role 권한 확인.
     filtered = [o for o in options if o["key"] == "auto" or o["key"] in allowed]
@@ -853,15 +935,11 @@ async def llm_install(api_key: str, model: str,
     400 — operator must use the admin LLM page for non-listed models.
     """
     _require_admin(api_key, role)
-    from config import GEMMA_MODEL, CODING_MODEL
-    # Allowlist — only models we explicitly support in mode router.
-    # Operators wanting to install something else use /admin/llm/...
-    ALLOWED_MODELS = {
-        GEMMA_MODEL, CODING_MODEL,
-        "gemma4:e4b", "gemma3:12b", "gemma3:27b",
-        "qwen2.5-coder:32b", "qwen2.5-coder:7b",
-        "llava:13b",
-    }
+    # [#A2] Allowlist auto-derived from MODEL_CATALOG so adding a
+    # candidate above does NOT require remembering to update this gate.
+    # llava is kept as a manual extra (vision support — not in catalog
+    # but operators sometimes pull it for multimodal experiments).
+    ALLOWED_MODELS = _allowed_install_models() | {"llava:13b"}
     if model not in ALLOWED_MODELS:
         raise HTTPException(
             status_code=400,

--- a/tests/test_model_catalog_per_mode.py
+++ b/tests/test_model_catalog_per_mode.py
@@ -1,0 +1,214 @@
+"""Per-mode model catalog + secondary picker (item #A2, 2026-05-08).
+
+User feedback: "llm 선택사항은 대부분의 경우 젬마 4로 설정되어 있는데,
+일상 대화 챗, 기본 상식은 좀더 가벼운 모델 중 선택 가능하도록하고,
+구체적인 자료 분석과 기능 활용은 무거운 모델중 선택 가능하게 개선.
+코딩도 딱 하나의 모델이 아니라 가능한 모델 다 표시, 설치 여부까지
+선택하도록 확장 개선".
+
+Backend:
+  - /llm/modes/ response gains a `models` array per option (besides
+    the existing `model` / `installed` fields kept for backward compat).
+    Each candidate: {"tag": str, "weight": "light|medium|heavy",
+                     "installed": bool, "default": bool}
+  - Mode → catalog mapping centralised in `_model_catalog()` so adding
+    a candidate doesn't require touching multiple places.
+  - /llm/install/?model= allowlist auto-derives from the catalog
+    (operators don't have to remember to update the install gate when
+    adding a candidate).
+
+Frontend:
+  - Secondary <select id="model-picker"> next to the mode dropdown.
+  - Hidden when mode has 0-1 candidates (auto / meta / configs with no
+    alternatives).
+  - Selection persists in localStorage key `james_model_<mode>`.
+  - Install button now follows the *currently selected* candidate, not
+    just the mode default.
+
+Run:
+  python -m unittest tests.test_model_catalog_per_mode
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class ModelCatalogTests(unittest.TestCase):
+    """The catalog dict shape + central listing."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.srv = srv
+        cls.src = inspect.getsource(srv)
+
+    def test_catalog_function_exists(self):
+        self.assertIn("def _model_catalog", self.src,
+                      "must centralise mode→model candidates in a function")
+        self.assertTrue(callable(getattr(self.srv, "_model_catalog", None)))
+
+    def test_catalog_covers_chat_retrieval_coding(self):
+        cat = self.srv._model_catalog()
+        for mode in ("chat", "retrieval", "coding", "wiki_edit", "self_evolve"):
+            self.assertIn(mode, cat,
+                          f"mode {mode} missing from catalog")
+            self.assertGreaterEqual(len(cat[mode]), 2,
+                f"mode {mode} should expose ≥2 candidates so secondary "
+                f"picker has something to select between")
+
+    def test_chat_has_lighter_default_than_coding(self):
+        # User wants 일상대화=light, coding=heavy. Verify the *first*
+        # entry (default) is light for chat, heavy for coding.
+        cat = self.srv._model_catalog()
+        chat0 = cat["chat"][0]   # (tag, weight)
+        code0 = cat["coding"][0]
+        # chat's default may be light or medium (env override possible)
+        self.assertIn(chat0[1], ("light", "medium"),
+            f"chat default should be light/medium, got {chat0[1]}")
+        # coding's default should be heavy (config.CODING_MODEL = qwen 32b)
+        # OR an explicit operator override — accept any but must include
+        # at least one heavy candidate.
+        weights = [w for _, w in cat["coding"]]
+        self.assertIn("heavy", weights,
+            "coding mode should offer at least one heavy candidate")
+
+    def test_weights_are_recognised(self):
+        cat = self.srv._model_catalog()
+        valid = {"light", "medium", "heavy"}
+        for mode, cands in cat.items():
+            for tag, weight in cands:
+                self.assertIn(weight, valid,
+                              f"unknown weight '{weight}' for {mode}/{tag}")
+
+    def test_install_allowlist_auto_derived(self):
+        self.assertIn("def _allowed_install_models", self.src,
+                      "install allowlist must auto-derive from catalog")
+        allowed = self.srv._allowed_install_models()
+        cat = self.srv._model_catalog()
+        for mode, cands in cat.items():
+            for tag, _ in cands:
+                self.assertIn(tag, allowed,
+                              f"catalog tag {tag} (in {mode}) not in install allowlist")
+
+    def test_install_endpoint_uses_derived_allowlist(self):
+        # The /llm/install/ handler should call _allowed_install_models()
+        # — not have a hardcoded set.
+        m = re.search(r'@app\.post\("/llm/install/"', self.src)
+        self.assertIsNotNone(m)
+        body = self.src[m.start():m.start() + 3000]
+        self.assertIn("_allowed_install_models", body,
+                      "install handler must derive ALLOWED_MODELS from catalog")
+
+
+class LlmModesResponseShapeTests(unittest.TestCase):
+    """The /llm/modes/ response now carries `models[]` per option."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _endpoint_body(self) -> str:
+        idx = self.src.index('@app.get("/llm/modes/"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 8000
+        return self.src[idx:end]
+
+    def test_models_array_field_in_options(self):
+        body = self._endpoint_body()
+        self.assertIn('"models":', body,
+                      "options must include `models` array (per-mode catalog)")
+
+    def test_models_for_helper_exists(self):
+        body = self._endpoint_body()
+        self.assertIn("_models_for", body,
+                      "needs helper to build per-mode candidate list")
+
+    def test_candidate_shape_has_tag_weight_installed_default(self):
+        body = self._endpoint_body()
+        for field in ('"tag":', '"weight":', '"installed":', '"default":'):
+            self.assertIn(field, body,
+                          f"candidate dict missing {field}")
+
+    def test_meta_and_auto_get_empty_models(self):
+        body = self._endpoint_body()
+        # auto and meta don't use the LLM (or use the routed mode's),
+        # so they should have models=[]. Verify the literal exists.
+        # (Two empty lists per the literal.)
+        self.assertGreaterEqual(body.count('"models": []'), 2,
+            "auto and meta should have models=[]")
+
+    def test_backward_compat_model_installed_kept(self):
+        body = self._endpoint_body()
+        # Existing fields must remain — old clients (<#A2) still work.
+        self.assertIn('"model":', body)
+        self.assertIn('"installed":', body)
+
+
+class FrontendSecondaryPickerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+        cls.html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_model_picker_in_html(self):
+        self.assertIn('id="model-picker"', self.html,
+                      "secondary <select id='model-picker'> missing")
+        self.assertIn('id="model-picker-wrap"', self.html,
+                      "wrapper for hide/show needed")
+        self.assertIn('onchange="onModelPickerChange()"', self.html)
+
+    def test_refresh_model_picker_function(self):
+        self.assertIn("function refreshModelPicker", self.js,
+                      "refreshModelPicker handles populating the dropdown")
+        idx = self.js.index("function refreshModelPicker")
+        body = self.js[idx:idx + 2500]
+        # Hide when 0-1 candidates (no point in a dropdown).
+        self.assertIn("models.length < 2", body,
+                      "must hide picker when fewer than 2 candidates")
+        # Per-mode localStorage key.
+        self.assertIn("_modelKey(", body,
+                      "must restore selection from localStorage")
+
+    def test_localstorage_key_per_mode(self):
+        self.assertIn("function _modelKey", self.js)
+        idx = self.js.index("function _modelKey")
+        body = self.js[idx:idx + 200]
+        self.assertIn("james_model_", body,
+                      "localStorage key must be per-mode (james_model_<mode>)")
+
+    def test_on_model_picker_change_persists(self):
+        self.assertIn("function onModelPickerChange", self.js)
+        idx = self.js.index("function onModelPickerChange")
+        body = self.js[idx:idx + 600]
+        self.assertIn("localStorage.setItem", body,
+                      "selection must persist to localStorage")
+
+    def test_mode_change_refreshes_model_picker(self):
+        idx = self.js.index("function onModePickerChange")
+        body = self.js[idx:idx + 500]
+        self.assertIn("refreshModelPicker", body,
+                      "changing mode must repopulate model dropdown")
+
+    def test_install_button_targets_selected_model(self):
+        idx = self.js.index("function updateInstallButton")
+        body = self.js[idx:idx + 1500]
+        # Now follows currently-selected candidate, not just the mode default.
+        self.assertIn("selectedModel", body,
+                      "install button must read selectedModel for accurate install target")
+        self.assertIn("models.length >= 2", body,
+                      "must branch on multi-candidate vs single-default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"일상 대화 챗 → 가벼운 모델, 자료 분석 → 무거운 모델, 코딩 → 가능한 모델 다 표시 + 설치 여부 선택"*.

Adds a **secondary dropdown** next to the existing mode picker that exposes a per-mode candidate catalog with installed status. User picks weight (🪶 / ⚖️ / 🐘) per task type.

## Backend

### `_model_catalog()` — centralised mode → candidate map
| Mode | Candidates (default first) |
|---|---|
| chat / retrieval / wiki_edit / self_evolve | `gemma4:e4b` 🪶 → `gemma3:12b` ⚖️ → `gemma3:27b` 🐘 |
| coding | `qwen2.5-coder:7b` 🪶 → `qwen2.5-coder:32b` 🐘 → `gemma4:e4b` 🪶 |

`.env` overrides (`JAMES_LLM_MODEL`, `JAMES_CODING_MODEL`) auto-prepend if not in canonical catalog.

### `/llm/modes/` response shape
```json
{
  "key": "coding",
  "model": "qwen2.5-coder:32b",
  "installed": true,
  "models": [
    {"tag": "qwen2.5-coder:7b",  "weight": "light", "installed": false, "default": false},
    {"tag": "qwen2.5-coder:32b", "weight": "heavy", "installed": true,  "default": true},
    {"tag": "gemma4:e4b",        "weight": "light", "installed": true,  "default": false}
  ]
}
```
Existing `model` / `installed` kept — backward compat.

### `_allowed_install_models()`
`/llm/install/` allowlist auto-derives from catalog. Adding a candidate no longer requires updating two places. `llava:13b` retained as manual extra (vision experiments).

## Frontend

- `<select id="model-picker">` wrapped in `#model-picker-wrap` (hidden when <2 candidates).
- `refreshModelPicker()` populates from `opt.models`. Weight icons: 🪶 / ⚖️ / 🐘. ⚠️ on uninstalled.
- localStorage key `james_model_<mode>` persists per-mode selection across sessions/tabs.
- Install button now follows the **currently selected** candidate, not just mode default.

## Verification

`tests/test_model_catalog_per_mode.py` — **17 tests**:
- **ModelCatalogTests** (6): catalog covers 5 modes / chat≤medium, coding has heavy / weights valid / install allowlist auto-derived
- **LlmModesResponseShapeTests** (5): `models[]` per option, candidate shape, auto+meta get `[]`, backward-compat fields kept
- **FrontendSecondaryPickerTests** (6): HTML elements present, hide-on-<2, localStorage persistence, install button reads `selectedModel`

**454/454 regression suite pass.**

## Out of scope (deferred to follow-up)

Server-side `selected_model` LLM override. Picker exposes the catalog and lets the user install missing models, but the active `/query/` call still uses the mode's default. Wiring the override through `engine.query → modes.py → call_gemma` is a separate PR (touches 6 mode handlers; safer with focused diff).

## Bench numbers

Not applicable — config + UX surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)