### PR TITLE
feat(export): .py file export from chat answers (item #A4-B)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -766,22 +766,24 @@ function appendJamesMsg(data) {
   // item #4: export 버튼은 사용자가 직전 질문에 "보고서로 / 파일로
   // 만들어줘" 같은 키워드를 넣었을 때만 표시. 평상시 chat 답변엔
   // 시각적 잡음 없음. 답변 단위로 결정 — 다음 답변엔 다시 hidden.
+  // [#A4-B] 답변에 ```code``` 블록이 있으면 .py 버튼도 추가 — 사용자가
+  // "파이썬 파일로" 명시 안 해도 코드 블록 답변엔 항상 .py export 가능.
   const showExportBtns = !!pendingReportRequest;
   pendingReportRequest = false;   // consume the flag
+  const hasCodeBlock = /```[\s\S]*?```/.test(answer);
   const answerEscapedAttr = encodeURIComponent(answer);
+  const _expBtnStyle = "background:none;border:1px solid var(--border);border-radius:6px;padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;transition:all .15s";
+  const pyExportBtn = hasCodeBlock ? `
+      <button class="fb-btn export-btn" onclick="exportAnswer(this, 'py')" data-content="${answerEscapedAttr}"
+        style="${_expBtnStyle}" title=".py 다운로드 (코드 블록만 추출)">📥 .py</button>` : '';
   const exportButtons = showExportBtns ? `
       <button class="fb-btn export-btn" onclick="exportAnswer(this, 'md')" data-content="${answerEscapedAttr}"
-        style="background:none;border:1px solid var(--border);border-radius:6px;
-               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title=".md 다운로드">📥 .md</button>
+        style="${_expBtnStyle}" title=".md 다운로드">📥 .md</button>
       <button class="fb-btn export-btn" onclick="exportAnswer(this, 'docx')" data-content="${answerEscapedAttr}"
-        style="background:none;border:1px solid var(--border);border-radius:6px;
-               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title=".docx 다운로드 (Word)">📥 .docx</button>
+        style="${_expBtnStyle}" title=".docx 다운로드 (Word)">📥 .docx</button>
       <button class="fb-btn export-btn" onclick="exportAnswer(this, 'txt')" data-content="${answerEscapedAttr}"
-        style="background:none;border:1px solid var(--border);border-radius:6px;
-               padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title=".txt 다운로드 (Notepad)">📥 .txt</button>` : '';
+        style="${_expBtnStyle}" title=".txt 다운로드 (Notepad)">📥 .txt</button>${pyExportBtn}`
+    : pyExportBtn;
   const fbHtml = dirId ? `
     <div class="feedback-btns" style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap">
       <button class="fb-btn" onclick="sendFeedback('${dirId}', 'explicit_positive', this)"

--- a/tests/test_py_export.py
+++ b/tests/test_py_export.py
@@ -1,0 +1,163 @@
+"""Python file (.py) export support (item #A4-B, 2026-05-08).
+
+User feedback: "대화에서 파일로 제시하라고 할때 워드 파일,
+파이썬 코딩 파일 등 제시할수 있는 성능이 되는지 확인".
+
+Existing /export/ supports md / txt / docx (PR #93). This adds .py
+so users can save coding-mode answers directly as runnable Python.
+
+Strategy:
+  - When the answer has fenced ```python``` (or ```py```/```) blocks,
+    the .py output is just the concatenated code. User gets clean
+    runnable Python without manually scraping the prose.
+  - When no fenced blocks exist, prose is escaped as `#`-prefixed
+    comments. The file imports cleanly (no syntax error) and acts
+    as a self-describing reference.
+  - Export header always includes the timestamp + source so the
+    file is self-describing.
+
+Frontend:
+  - .py button auto-appears when answer contains ```...``` regardless
+    of the report-request flag. Coding answers always offer it.
+  - When the user said "파일로/보고서로", the full set (.md/.docx/.txt)
+    plus .py shows up.
+
+Run:
+  python -m unittest tests.test_py_export
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class PyExporterTests(unittest.TestCase):
+    """tools/export/document_exporter.py — _export_py + integration."""
+
+    @classmethod
+    def setUpClass(cls):
+        from tools.export import document_exporter as dx
+        cls.dx = dx
+
+    def test_py_in_supported_formats(self):
+        self.assertIn("py", self.dx.SUPPORTED_FORMATS,
+                      "py must be a recognised export format")
+
+    def test_py_mime_and_extension(self):
+        self.assertEqual(self.dx._MIME_BY_FORMAT["py"],
+                         "text/x-python; charset=utf-8")
+        self.assertEqual(self.dx._EXT_BY_FORMAT["py"], ".py")
+
+    def test_export_py_extracts_python_blocks(self):
+        content = (
+            "여기 함수입니다.\n\n"
+            "```python\n"
+            "def add(a, b):\n"
+            "    return a + b\n"
+            "```\n\n"
+            "그리고 사용 예:\n"
+            "```py\n"
+            "print(add(1, 2))\n"
+            "```\n"
+        )
+        result = self.dx.export_document(content, format="py")
+        self.assertEqual(result.actual_format, "py")
+        self.assertEqual(result.fallback_reason, "")
+        self.assertTrue(result.filename.endswith(".py"))
+        body = result.data.decode("utf-8")
+        self.assertIn("def add(a, b):", body)
+        self.assertIn("print(add(1, 2))", body)
+        # The prose ("여기 함수입니다") should NOT leak into the .py body.
+        self.assertNotIn("여기 함수입니다", body,
+            "non-fenced prose should not appear when code blocks exist")
+
+    def test_export_py_unspecified_lang_block_treated_as_code(self):
+        # ``` ... ``` (no language) — operator-friendly: many LLMs omit
+        # the lang tag. We accept these blocks too.
+        content = (
+            "분석:\n\n"
+            "```\n"
+            "import sys\n"
+            "print(sys.version)\n"
+            "```\n"
+        )
+        result = self.dx.export_document(content, format="py")
+        body = result.data.decode("utf-8")
+        self.assertIn("import sys", body)
+        self.assertIn("print(sys.version)", body)
+
+    def test_export_py_no_code_falls_back_to_comments(self):
+        # Pure-prose answer → escape every line as `# comment` so the
+        # file imports cleanly and reads as documentation.
+        content = "이것은 코드가 없는 답변입니다.\n\n2번째 문단."
+        result = self.dx.export_document(content, format="py")
+        self.assertEqual(result.actual_format, "py",
+            "no fallback to md when prose-only — comments are valid Python")
+        body = result.data.decode("utf-8")
+        # Each non-empty line should start with '#'.
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            self.assertTrue(stripped.startswith("#"),
+                f"prose line not commented out: {line!r}")
+        # Content should still be preserved.
+        self.assertIn("코드가 없는 답변", body)
+
+    def test_export_py_header_has_timestamp(self):
+        result = self.dx.export_document("```py\nx=1\n```", format="py")
+        body = result.data.decode("utf-8")
+        # Header line should mention "Exported from JAMES" and have a date.
+        self.assertIn("Exported from JAMES", body)
+        self.assertRegex(body, r"\d{4}-\d{2}-\d{2}",
+            "timestamp must be ISO-style YYYY-MM-DD")
+
+    def test_export_py_long_prose_line_split(self):
+        # Lines >200 chars get split so flake8/pylint don't fire on
+        # every line of the resulting .py.
+        long_line = "긴 문장입니다. " * 30   # ~270+ chars
+        content = long_line
+        result = self.dx.export_document(content, format="py")
+        body = result.data.decode("utf-8")
+        for line in body.splitlines():
+            self.assertLess(len(line), 200,
+                f"line longer than 200 chars: len={len(line)}")
+
+
+class FrontendPyButtonTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+
+    def test_py_button_in_appendJamesMsg(self):
+        # The button literal must reference 'py' format with code-block
+        # detection.
+        idx = self.js.index("function appendJamesMsg")
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 8000
+        body = self.js[idx:end]
+        self.assertIn("exportAnswer(this, 'py')", body,
+                      ".py export button missing")
+        self.assertIn("hasCodeBlock", body,
+                      "must detect code blocks before showing .py button")
+        self.assertIn("```", body,
+                      "must check for fenced code blocks in answer")
+
+    def test_py_button_shown_independently_of_report_keyword(self):
+        # The user shouldn't have to type "파이썬 파일로" to get .py — if
+        # the answer has code blocks, we offer it.
+        idx = self.js.index("const pyExportBtn")
+        body = self.js[idx:idx + 600]
+        self.assertIn("hasCodeBlock", body,
+                      "py button gated on hasCodeBlock, not pendingReportRequest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/export/document_exporter.py
+++ b/tools/export/document_exporter.py
@@ -37,7 +37,7 @@ from datetime import datetime
 from typing import Tuple
 
 
-SUPPORTED_FORMATS = ("md", "txt", "docx")
+SUPPORTED_FORMATS = ("md", "txt", "docx", "py")
 PDF_DEFERRED_NOTE = (
     "PDF export is deferred to v0.3 — heavy native deps. "
     "Returning markdown instead."
@@ -111,6 +111,54 @@ def _export_txt(content: str) -> bytes:
     return text.encode("utf-8")
 
 
+def _export_py(content: str) -> bytes:
+    """Render a chat answer to a .py file.
+
+    User scenario: in coding mode the LLM produces an answer with one
+    or more ```python ... ``` fences. They want to save just the code
+    (not the prose around it) as runnable .py.
+
+    Strategy:
+      - Pull out ```python / ```py / unspecified-language fenced blocks.
+      - Concatenate in order, with a single blank line between blocks.
+      - Prepend a header comment recording the export timestamp +
+        the source so the file is self-describing.
+      - If the answer has no fenced blocks at all, write the entire
+        prose as `#`-prefixed comments — preserves the answer text
+        as a documentation-only `.py`. The file still imports cleanly
+        (just does nothing) so it's a safe fallback.
+
+    No syntax validation — running the code is the user's call. We
+    don't want to swallow code that contains pseudo-code or partial
+    snippets the user explicitly asked for.
+    """
+    code_re = re.compile(r"```(?:python|py)?\s*\n([\s\S]*?)```", re.IGNORECASE)
+    blocks = [m.group(1).strip() for m in code_re.finditer(content)]
+    blocks = [b for b in blocks if b]
+    header = (
+        f"# Exported from JAMES at {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+        f"# Source: chat answer\n\n"
+    )
+    if blocks:
+        body = "\n\n".join(blocks) + "\n"
+    else:
+        # No fenced code → escape prose as comments. Lines longer than
+        # 200 chars get split so flake8/pylint don't flag the resulting
+        # file with line-too-long on every line.
+        lines = []
+        for raw_line in content.splitlines():
+            line = raw_line.rstrip()
+            if not line:
+                lines.append("#")
+                continue
+            while len(line) > 197:
+                lines.append("# " + line[:197])
+                line = line[197:]
+            lines.append("# " + line)
+        body = "\n".join(lines) + "\n"
+    return (header + body).encode("utf-8")
+
+
 def _export_docx(content: str) -> Tuple[bytes, str]:
     """Render content to a .docx via python-docx. On ImportError
     return (md_bytes, fallback_reason) instead of raising — keeps
@@ -159,9 +207,10 @@ _MIME_BY_FORMAT = {
     "md":   "text/markdown; charset=utf-8",
     "txt":  "text/plain; charset=utf-8",
     "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "py":   "text/x-python; charset=utf-8",
 }
 
-_EXT_BY_FORMAT = {"md": ".md", "txt": ".txt", "docx": ".docx"}
+_EXT_BY_FORMAT = {"md": ".md", "txt": ".txt", "docx": ".docx", "py": ".py"}
 
 
 def export_document(
@@ -215,6 +264,8 @@ def export_document(
             # python-docx missing → degrade to md, keep both reasons.
             actual = "md"
             fallback_reason = docx_fallback
+    elif actual == "py":
+        data = _export_py(content)
     else:
         # Defensive — should never reach here given the prelude.
         data = _export_md(content)


### PR DESCRIPTION
## Summary

User feedback: *"대화에서 파일로 제시하라고 할때 워드 파일, 파이썬 코딩 파일 등 제시할수 있는 성능이 되는지 확인"*.

Live check confirmed:
- ✅ **.docx** works (python-docx already in requirements.txt — `from docx import Document` produces 35 KB file in test)
- ❌ **.py** missing — added here

## Backend (`tools/export/document_exporter.py`)

- `SUPPORTED_FORMATS` gains `"py"`
- MIME `text/x-python; charset=utf-8`, extension `.py`
- `_export_py(content)` extracts fenced code blocks:
  - ` ```python ` / ` ```py ` / ` ``` ` (no language) — operator-friendly, LLMs often omit lang
- Prose-only fallback: every line escaped as `#` comment so the file imports cleanly + reads as documentation
- Header: `# Exported from JAMES at YYYY-MM-DD HH:MM:SS UTC`
- Long prose lines split below 200 chars (flake8/pylint quiet on the comment fallback)

## Frontend (`chat.js`)

- `📥 .py` button auto-appears when `answer` contains ` ```...``` `, **independent** of the report-request flag — coding answers always offer it without forcing user to type "파이썬 파일로"
- When user requests report ("보고서로/파일로"), full `.md/.docx/.txt + .py` set shows up

## Verification

`tests/test_py_export.py` — **9 tests**:
- **PyExporterTests** (7): SUPPORTED_FORMATS, MIME+ext, fenced extraction (python/py/no-lang), prose-only comment fallback, timestamp header, 200-char line split
- **FrontendPyButtonTests** (2): button literal + `hasCodeBlock` gate

**476/476 regression suite pass.**

## Bench numbers

Not applicable — export rendering only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)