### PR TITLE
feat(frontend): brain-neural icon + multi-stop gradient shimmer (item #1-A)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1062,6 +1062,31 @@ async function sendFeedback(directionId, signal, btn) {
      graph    · entities=3 · paths=15 (+180ms)
      answer   · 1820ms · 412 chars
 */
+/* [#1-A] 추론 단계용 SVG 아이콘 — 로봇 헤드 윤곽 + 내부에 3개 뉴런
+   노드 + 노드 간 연결선. 활성 시 각 뉴런이 phase가 다른 깜빡임 +
+   pulse glow. CSS .brain-pulse-active에 의해 애니메이션 활성/정지.
+   stage-color CSS 변수로 색상 inject (chat.js의 stage 메타와 연동). */
+function brainPulseSvg(active = true) {
+  const cls = 'brain-pulse' + (active ? ' brain-pulse-active' : '');
+  return `<span class="${cls}" aria-hidden="true">
+    <svg viewBox="0 0 24 24">
+      <!-- 로봇 헤드 외곽 — 부드러운 둥근 사각형 + 안테나 -->
+      <path class="brain-outline"
+            d="M5 7 Q5 4 8 4 L16 4 Q19 4 19 7 L19 16 Q19 19 16 19 L8 19 Q5 19 5 16 Z" />
+      <line class="brain-outline" x1="12" y1="2" x2="12" y2="4" />
+      <circle class="brain-outline" cx="12" cy="2" r="1" />
+      <!-- 뉴런 연결선 (먼저 그려서 노드 아래) -->
+      <path class="neuron-link" d="M8.5 8 L12 12 L15.5 8" />
+      <path class="neuron-link" d="M12 12 L9 15" />
+      <path class="neuron-link" d="M12 12 L15 15" />
+      <!-- 뉴런 노드 3개, 각각 다른 phase로 깜빡 -->
+      <circle class="neuron neuron-1" cx="8.5" cy="8"  r="1.6" />
+      <circle class="neuron neuron-2" cx="15.5" cy="8" r="1.6" />
+      <circle class="neuron neuron-3" cx="12" cy="14"  r="1.6" />
+    </svg>
+  </span>`;
+}
+
 function appendTyping(traceId) {
   const messages = document.getElementById('messages');
   const div = document.createElement('div');
@@ -1071,8 +1096,8 @@ function appendTyping(traceId) {
     <div class="bubble" style="min-width:220px">
       <div id="thinking-${traceId}" class="thinking-stream">
         <div class="thinking-placeholder">
-          <span class="thinking-spinner-dot"></span>
-          <span class="thinking-shimmer-text">추론 시작 중</span>
+          ${brainPulseSvg(true)}
+          <span class="thinking-shimmer-text thinking-label">추론 시작 중</span>
         </div>
       </div>
     </div>

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -17,10 +17,15 @@
  */
 
 /* ─────────────────────────────────────────────────────────
- * Reasoning stream animations (item #1, 2026-05-08)
+ * Reasoning stream animations (item #1, 2026-05-08; #1-A 2차 개선)
  * 응답 추론 과정 — 활성 stage는 spinner 회전 + 텍스트 shimmer,
  * 완료된 stage는 정적/회색. 진짜 진행 중인 단계가 시각적으로
  * 명확하게 살아있어 보이게.
+ *
+ * #1-A 변경 (사용자 피드백 2026-05-08):
+ *   "뇌신경이 반짝이는 로봇 모양 아이콘 + 첨부된 글자도 그라데이션하게
+ *   반짝이게" — 단색 shimmer → 무지개 multi-stop. SVG 브레인-뉴런
+ *   아이콘 (.brain-pulse) 추가. 기존 .thinking-label은 그대로 활용.
  *
  * 구조: each `.thinking-line` toggles between:
  *   .thinking-active  — 현재 진행 중 (spinner + shimmer)
@@ -37,6 +42,61 @@
 @keyframes james-shimmer {
   0%   { background-position: -180% 0; }
   100% { background-position:  180% 0; }
+}
+
+/* [#1-A] 브레인-뉴런 아이콘 — 로봇 헤드 윤곽 + 내부 노드들이
+   서로 다른 phase로 깜빡. 각 뉴런이 ⌀5px, fill에 stage-color
+   inject되어 stage 별로 다르게 보임. */
+@keyframes james-neuron-blink-1 {
+  0%, 100% { opacity: 0.25; }
+  20%, 40% { opacity: 1; }
+}
+@keyframes james-neuron-blink-2 {
+  0%, 100% { opacity: 0.25; }
+  35%, 55% { opacity: 1; }
+}
+@keyframes james-neuron-blink-3 {
+  0%, 100% { opacity: 0.25; }
+  60%, 80% { opacity: 1; }
+}
+@keyframes james-neuron-pulse {
+  0%, 100% { transform: scale(1);    filter: drop-shadow(0 0 1px var(--stage-color, #7c6af7)); }
+  50%      { transform: scale(1.06); filter: drop-shadow(0 0 6px var(--stage-color, #7c6af7)); }
+}
+.brain-pulse {
+  width: 22px; height: 22px;
+  display: inline-block;
+  flex-shrink: 0;
+  vertical-align: middle;
+  --stage-color: #7c6af7;
+}
+.brain-pulse svg { width: 100%; height: 100%; overflow: visible; }
+.brain-pulse .brain-outline {
+  fill: none;
+  stroke: var(--stage-color, #7c6af7);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 2px var(--stage-color, #7c6af7));
+}
+.brain-pulse .neuron {
+  fill: var(--stage-color, #7c6af7);
+  transform-origin: center;
+  transform-box: fill-box;
+}
+.brain-pulse .neuron-link {
+  stroke: var(--stage-color, #7c6af7);
+  stroke-width: 0.6;
+  opacity: 0.45;
+  fill: none;
+}
+.brain-pulse.brain-pulse-active .neuron-1 { animation: james-neuron-blink-1 1.4s ease-in-out infinite,
+                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .neuron-2 { animation: james-neuron-blink-2 1.4s ease-in-out infinite,
+                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .neuron-3 { animation: james-neuron-blink-3 1.4s ease-in-out infinite,
+                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .brain-outline {
+  animation: james-shimmer 2.4s linear infinite;
 }
 
 .thinking-stream {
@@ -78,21 +138,27 @@
   width: 18px; text-align: center;
   transform-origin: 50% 50%;
 }
+/* [#1-A] thinking-label — 무지개 multi-stop gradient + glow.
+   기존 stage-color → white → stage-color 단순 패턴 대비, 보색 한
+   stop을 더해 "반짝거림"이 명확. text-shadow로 살짝 후광. */
 .thinking-label {
   font-weight: 600;
   font-family: inherit;
   background: linear-gradient(
     90deg,
     var(--stage-color, #7c6af7) 0%,
-    rgba(255, 255, 255, 0.92) 45%,
-    var(--stage-color, #7c6af7) 90%
+    rgba(255, 255, 255, 0.95) 30%,
+    var(--stage-accent, #f06292) 50%,
+    rgba(255, 255, 255, 0.95) 70%,
+    var(--stage-color, #7c6af7) 100%
   );
-  background-size: 200% 100%;
+  background-size: 220% 100%;
   background-position: 0 0;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
   color: transparent;
+  filter: drop-shadow(0 0 1px var(--stage-color, #7c6af7));
 }
 .thinking-detail {
   color: var(--muted, #888);

--- a/tests/test_brain_icon_shimmer.py
+++ b/tests/test_brain_icon_shimmer.py
@@ -1,0 +1,166 @@
+"""Brain-neural icon + improved gradient shimmer (item #1-A, 2026-05-08).
+
+User feedback: "챗의 답변 추론 과정 ui를 뇌신경이 반짝이는 로봇 모양
+아이콘을 쓰고, 첨부된 글자도 그라데이션하게 반짝이게 수정".
+
+Changes:
+  - SVG brain-pulse icon: rounded-square robot head + antenna + 3
+    neuron nodes that blink with different phases + pulse glow.
+    Replaces the static spinner-dot in the thinking placeholder.
+  - Multi-stop rainbow gradient on .thinking-label: stage-color →
+    white → accent → white → stage-color (was: stage-color → white →
+    stage-color, less eye-catching).
+  - drop-shadow glow on the label text for a "sparkling" feel.
+
+Run:
+  python -m unittest tests.test_brain_icon_shimmer
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS_PATH  = ROOT / "frontend" / "static" / "chat.js"
+CSS_PATH = ROOT / "frontend" / "static" / "mobile.css"
+
+
+class BrainPulseSvgTests(unittest.TestCase):
+    """The brainPulseSvg() helper renders an SVG with the expected
+    structural elements (outline, links, 3 neurons)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS_PATH.read_text(encoding="utf-8")
+
+    def test_helper_exists(self):
+        self.assertIn("function brainPulseSvg", self.js,
+                      "brainPulseSvg helper must exist")
+
+    def test_used_in_appendTyping(self):
+        idx = self.js.index("function appendTyping")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("brainPulseSvg(", body,
+                      "appendTyping must call brainPulseSvg for the placeholder icon")
+
+    def test_svg_contains_outline_and_neurons(self):
+        # The function returns a string with the SVG markup. Pull it
+        # out and check element counts.
+        idx = self.js.index("function brainPulseSvg")
+        end = self.js.index("function appendTyping", idx)
+        body = self.js[idx:end]
+        self.assertIn("<svg", body)
+        self.assertIn('class="brain-outline"', body,
+                      "must include the head/antenna outline")
+        # Three neuron nodes with distinct phase classes.
+        self.assertIn('class="neuron neuron-1"', body)
+        self.assertIn('class="neuron neuron-2"', body)
+        self.assertIn('class="neuron neuron-3"', body)
+        # Connecting lines between neurons.
+        self.assertIn('class="neuron-link"', body,
+                      "neuron-link path missing — visual cue connecting nodes")
+
+    def test_active_class_toggle(self):
+        idx = self.js.index("function brainPulseSvg")
+        end = self.js.index("function appendTyping", idx)
+        body = self.js[idx:end]
+        self.assertIn("brain-pulse-active", body,
+            "active flag must add brain-pulse-active class for animation")
+
+    def test_aria_hidden_for_screen_readers(self):
+        # Decorative — don't pollute screen reader output.
+        idx = self.js.index("function brainPulseSvg")
+        end = self.js.index("function appendTyping", idx)
+        body = self.js[idx:end]
+        self.assertIn('aria-hidden="true"', body,
+                      "decorative SVG should be aria-hidden")
+
+
+class ShimmerCssTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.css = CSS_PATH.read_text(encoding="utf-8")
+
+    def test_brain_pulse_class_present(self):
+        self.assertIn(".brain-pulse {", self.css,
+                      "missing .brain-pulse base class")
+        self.assertIn(".brain-pulse-active", self.css,
+                      "missing active-state CSS")
+
+    def test_three_neuron_blink_keyframes(self):
+        # Three different phase keyframes so neurons don't blink in
+        # lockstep — gives the "neural firing" feel.
+        for kf in ("james-neuron-blink-1",
+                   "james-neuron-blink-2",
+                   "james-neuron-blink-3"):
+            self.assertIn(f"@keyframes {kf}", self.css,
+                          f"missing keyframe {kf}")
+
+    def test_neuron_pulse_keyframe_uses_drop_shadow(self):
+        # The pulse should glow — look for drop-shadow inside the
+        # james-neuron-pulse keyframe block.
+        m = re.search(r"@keyframes\s+james-neuron-pulse\s*\{([^}]*\}[^@]*)\}",
+                      self.css, re.DOTALL)
+        self.assertIsNotNone(m,
+            "james-neuron-pulse keyframe missing")
+        self.assertIn("drop-shadow", m.group(0),
+            "neuron pulse must use drop-shadow for glow effect")
+
+    def test_thinking_label_uses_multistop_gradient(self):
+        # Locate .thinking-label rule. Must have ≥4 colour stops in the
+        # gradient (stage-color, white, accent, white, stage-color).
+        m = re.search(r"\.thinking-label\s*\{([^}]+)\}", self.css)
+        self.assertIsNotNone(m, ".thinking-label rule missing")
+        body = m.group(1)
+        # linear-gradient(...) — count comma-separated stops inside.
+        grad = re.search(r"linear-gradient\(([^;]+)\);", body, re.DOTALL)
+        self.assertIsNotNone(grad, "must use a linear-gradient")
+        stops = grad.group(1).split(",")
+        self.assertGreaterEqual(len(stops), 6,
+            f"shimmer gradient must have ≥6 segments incl direction "
+            f"and 5 colour stops (got {len(stops)})")
+
+    def test_thinking_label_has_glow(self):
+        m = re.search(r"\.thinking-label\s*\{([^}]+)\}", self.css)
+        self.assertIsNotNone(m)
+        self.assertIn("drop-shadow", m.group(1),
+            "label needs a glow filter for sparkling effect")
+
+
+class IntegrationTests(unittest.TestCase):
+    """The placeholder line composition uses the new helper + label
+    classes so styling cascades correctly."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS_PATH.read_text(encoding="utf-8")
+
+    def test_placeholder_uses_thinking_label_class(self):
+        # Without thinking-label class, the gradient CSS doesn't apply.
+        idx = self.js.index("function appendTyping")
+        body = self.js[idx:idx + 1500]
+        # Find the placeholder div.
+        m = re.search(r"thinking-placeholder.+?</div>", body, re.DOTALL)
+        self.assertIsNotNone(m)
+        ph_html = m.group(0)
+        self.assertIn("thinking-label", ph_html,
+            "placeholder text must carry .thinking-label so gradient applies")
+
+    def test_placeholder_no_longer_uses_static_dot(self):
+        # The old .thinking-spinner-dot was a CSS pulse on a single dot —
+        # replaced by brain-pulse. Verify it's gone from the placeholder.
+        idx = self.js.index("function appendTyping")
+        body = self.js[idx:idx + 1500]
+        m = re.search(r"thinking-placeholder.+?</div>", body, re.DOTALL)
+        ph_html = m.group(0)
+        self.assertNotIn("thinking-spinner-dot", ph_html,
+            "old static dot should be replaced by brainPulseSvg")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"챗의 답변 추론 과정 ui를 뇌신경이 반짝이는 로봇 모양 아이콘을 쓰고, 첨부된 글자도 그라데이션하게 반짝이게 수정"*.

## Changes

### Brain-pulse SVG (new)
- Rounded-square robot head silhouette + small antenna
- 3 neuron nodes connected by lines, each blinks with **different keyframe phase** (1/2/3) — async firing visual
- `drop-shadow` glow scales up at peak for sparkle effect
- `brainPulseSvg(active)` helper — `active=true` adds `.brain-pulse-active` class

### Reasoning UI integration
- `appendTyping()` placeholder now uses `brainPulseSvg(true)` instead of the static `.thinking-spinner-dot`
- Placeholder text picks up `.thinking-label` class so the new gradient applies (was a different class with no styling)

### Shimmer text upgrade (`.thinking-label`)
- **Before**: 3-stop gradient `stage-color → white → stage-color` (subtle, one-toned)
- **After**: 5-stop gradient `stage-color → white → accent → white → stage-color` with `--stage-accent` CSS var (default `#f06292`)
- `background-size: 220%` widens the sweep — two highlight peaks instead of one
- `drop-shadow` glow keeps stroke visible against bubble background

## Verification

`tests/test_brain_icon_shimmer.py` — **12 tests**:
- **BrainPulseSvgTests** (5): helper exists + used by `appendTyping`, SVG contains outline+3 neurons+links, active class toggle, `aria-hidden`
- **ShimmerCssTests** (5): `.brain-pulse` rules, 3 phase keyframes, `drop-shadow` in pulse, ≥5 gradient stops, label glow
- **IntegrationTests** (2): placeholder uses `thinking-label`, old static dot removed

**488/488 regression suite pass.**

## Bench numbers

Not applicable — frontend animation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)