### PR TITLE
feat(admin): web search config panel — role + threshold + status (item #A6-1)

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -268,10 +268,13 @@ def run_retrieval_pipeline(
         sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
 
         # [P7] retrieval 결과 품질에 따라 분기
+        # [#A6-1 2026-05-08] threshold 0.30 → core.web_search_config에서
+        # 동적 로드. operator가 /admin/web-search-config/ 로 조정 가능.
+        from core.web_search_config import get_threshold, is_role_allowed
         low_relevance = (
             not safe_context
             or len(safe_context.strip()) < 50
-            or unified_score < 0.30
+            or unified_score < get_threshold()
         )
 
         if low_relevance:
@@ -284,7 +287,10 @@ def run_retrieval_pipeline(
                     record_search, should_promote_to_longterm,
                     save_as_longterm, update_knowledge_level, is_save_command,
                 )
-                if user_role == "admin":  # 보안: admin만 웹 검색
+                # [#A6-1] admin-only hardcode → role allowlist (settings).
+                # 기본값은 ["admin"]이라 기존 동작과 동일. operator가
+                # admin 페이지에서 manager/employee 등을 추가 가능.
+                if is_role_allowed(user_role):
                     print(f"[WEB] 내부 자료 부족 → 웹 검색: {safe_query[:40]}")
                     web_results = search_web(safe_query, max_results=4)
                     if web_results:

--- a/core/web_search_config.py
+++ b/core/web_search_config.py
@@ -1,0 +1,132 @@
+"""Web search configuration — admin-tunable.
+
+[#A6-1, 2026-05-08] User asked for three knobs:
+  (a) per-role permission — currently hardcoded admin-only in
+      pipeline.py:287. Admins want to extend to manager/employee on
+      a case-by-case basis.
+  (b) admin warning when TAVILY_API_KEY is missing — toast at admin
+      load time, not silent log.
+  (d) low_relevance threshold (0.30 default) — admins want to tune
+      based on their corpus density. Sparse internal data → lower
+      threshold (more web fallback). Rich corpus → higher threshold
+      (avoid unnecessary web calls).
+
+Storage: JSON at <BASE_DIR>/web_search_config.json. Read on every
+query (file is < 1KB, cost is negligible). Defaults applied when
+file is missing or fields absent — first-run servers behave
+identically to the pre-#A6-1 hardcoded values.
+
+This module is the single source of truth — pipeline.py reads via
+is_role_allowed / get_threshold, and the /admin/web-search-config/
+endpoint reads/writes via load / save.
+
+Why a separate file (not core/memory): the latter is a SQLite layer
+designed for chat history and persona, not configuration. Keeping
+this as a JSON file makes operator inspection easy (just `cat the
+file`) and avoids a SQLite migration just to store two fields.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+try:
+    from config import BASE_DIR
+except ImportError:
+    BASE_DIR = "."
+
+_CONFIG_PATH = os.path.join(BASE_DIR, "web_search_config.json")
+
+_DEFAULTS: Dict = {
+    "allowed_roles": ["admin"],
+    "threshold":     0.30,
+}
+
+# Roles we recognise. Used to validate admin updates so a typo
+# doesn't quietly disable the gate. Keep in sync with the rest of
+# the auth surface (core.auth) — currently 4 distinct roles.
+VALID_ROLES = {"admin", "manager", "employee", "external"}
+
+
+def load() -> Dict:
+    """Read settings from disk, layered over defaults.
+
+    A missing or unreadable file returns the defaults — never raises,
+    so a corrupt config doesn't take down /query/. Operators see the
+    server fall back to admin-only + 0.30 threshold and can fix the
+    file when convenient.
+    """
+    if not os.path.exists(_CONFIG_PATH):
+        return dict(_DEFAULTS)
+    try:
+        with open(_CONFIG_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return dict(_DEFAULTS)
+    out = dict(_DEFAULTS)
+    if isinstance(data, dict):
+        if isinstance(data.get("allowed_roles"), list):
+            out["allowed_roles"] = [r for r in data["allowed_roles"] if r in VALID_ROLES]
+            if not out["allowed_roles"]:
+                # All roles got filtered out — defensive: don't leave
+                # the system with an empty allowlist (no one could
+                # use web search). Restore default.
+                out["allowed_roles"] = list(_DEFAULTS["allowed_roles"])
+        if isinstance(data.get("threshold"), (int, float)):
+            t = float(data["threshold"])
+            if 0.0 <= t <= 1.0:
+                out["threshold"] = t
+    return out
+
+
+def save(allowed_roles: List[str], threshold: float) -> Dict:
+    """Persist settings. Caller is responsible for input validation
+    (the /admin/ endpoint does it before calling here).
+
+    Returns the new config dict for the caller to echo back to the
+    UI without needing a follow-up GET.
+    """
+    cfg = {
+        "allowed_roles": list(allowed_roles),
+        "threshold":     float(threshold),
+    }
+    with open(_CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, ensure_ascii=False)
+    return cfg
+
+
+def is_role_allowed(role: str) -> bool:
+    """Used by pipeline.py — does this role get to trigger a web
+    search when retrieval is sparse?"""
+    return role in load().get("allowed_roles", [])
+
+
+def get_threshold() -> float:
+    """unified_score below which web search is considered."""
+    return float(load().get("threshold", _DEFAULTS["threshold"]))
+
+
+def validate_update(allowed_roles: List, threshold) -> Tuple[List[str], float, str]:
+    """Admin endpoint pre-flight. Returns (clean_roles, clean_threshold,
+    error). When error is non-empty, caller raises HTTPException(400).
+
+    Empty allowed_roles list is rejected — silently disabling web
+    search is rarely the operator's intent and is harder to debug
+    later. If they really want to disable it, they can clear
+    TAVILY_API_KEY and uninstall ddg packages instead.
+    """
+    if not isinstance(allowed_roles, list):
+        return [], 0.0, "allowed_roles must be a list"
+    bad = [r for r in allowed_roles if r not in VALID_ROLES]
+    if bad:
+        return [], 0.0, f"unknown role(s): {bad}; valid: {sorted(VALID_ROLES)}"
+    if not allowed_roles:
+        return [], 0.0, "allowed_roles cannot be empty (set TAVILY_API_KEY='' to disable)"
+    try:
+        t = float(threshold)
+    except (TypeError, ValueError):
+        return [], 0.0, "threshold must be a number"
+    if not (0.0 <= t <= 1.0):
+        return [], 0.0, f"threshold must be in [0.0, 1.0], got {t}"
+    return list(allowed_roles), t, ""

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -834,6 +834,75 @@
           <button class="btn btn-primary" onclick="saveSettings()" data-i18n="set.save_server">Save Server Settings</button>
         </div>
       </div>
+
+      <!-- [#A6-1] Web Search Settings — admin-tunable role permission +
+           threshold + live engine status. Loaded by loadWebSearchConfig()
+           on page mount. -->
+      <div class="section-title">▸ <span data-i18n="set.web_search_title">🌐 Web Search</span></div>
+      <div class="table-wrap" style="padding: 8px 20px;">
+        <div class="setting-row" style="align-items:flex-start">
+          <div>
+            <div class="setting-label">Engine Status</div>
+            <div class="setting-sub">현재 활성 검색 엔진 + 키 설정 상태 (실시간)</div>
+          </div>
+          <div id="web-search-status-display"
+               style="font-family:var(--font-mono);font-size:12px;
+                      min-width:260px;color:var(--muted)">
+            checking...
+          </div>
+        </div>
+        <div class="setting-row" style="align-items:flex-start">
+          <div>
+            <div class="setting-label">Allowed Roles</div>
+            <div class="setting-sub">웹 검색을 트리거할 수 있는 role.
+              비어있으면 안됨 (web search 비활성화는 .env에서 TAVILY_API_KEY 제거).
+            </div>
+          </div>
+          <div id="web-search-roles"
+               style="display:flex;flex-direction:column;gap:6px;min-width:260px">
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px">
+              <input type="checkbox" value="admin"    class="ws-role-cb" checked> admin
+            </label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px">
+              <input type="checkbox" value="manager"  class="ws-role-cb"> manager
+            </label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px">
+              <input type="checkbox" value="employee" class="ws-role-cb"> employee
+            </label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px">
+              <input type="checkbox" value="external" class="ws-role-cb"> external
+            </label>
+          </div>
+        </div>
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">Relevance Threshold
+              <span style="font-weight:600;color:var(--accent)">
+                (Current: <span id="ws-threshold-val">0.30</span>)
+              </span>
+            </div>
+            <div class="setting-sub">unified_score 가 이 값 미만이면 웹 검색 트리거.
+              낮추면 (0.20) 자료 풍부한 corpus에서도 자주 나가고,
+              높이면 (0.50) 자료 부족해도 내부만 사용.
+            </div>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;min-width:260px">
+            <input type="range" id="ws-threshold" min="0.05" max="0.80" step="0.05"
+                   value="0.30"
+                   style="flex:1;accent-color:var(--accent)"
+                   oninput="document.getElementById('ws-threshold-val').textContent=Number(this.value).toFixed(2)">
+            <div style="display:flex;gap:4px">
+              <span style="font-size:11px;padding:2px 7px;border-radius:4px;
+                           background:var(--bg2);color:var(--muted)">0.05</span>
+              <span style="font-size:11px;padding:2px 7px;border-radius:4px;
+                           background:var(--bg2);color:var(--muted)">0.80</span>
+            </div>
+          </div>
+        </div>
+        <div style="padding: 16px 0; display:flex; justify-content:flex-end;">
+          <button class="btn btn-primary" onclick="saveWebSearchConfig()">Save Web Search Settings</button>
+        </div>
+      </div>
     </div>
 
   </div>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -760,6 +760,8 @@ async function loadSettings() {
     // 체크박스는 기본값으로 초기화
     buildProtectedCheckboxes('');
   }
+  // [#A6-1] settings 진입 시 웹 검색 설정도 함께 로드
+  try { loadWebSearchConfig(); } catch (e) { console.warn(e); }
 }
 
 function updatePersonaPreview(p) {
@@ -825,6 +827,84 @@ async function saveSettings() {
     const badge = document.getElementById('model-current-badge');
     if (badge) badge.textContent = `${t('set.model_checking').replace('checking...','').trim()} ${body.model}`;
     alert(t('set.server_saved'));
+  } catch (e) {
+    alert(`Failed: ${e.message}`);
+  }
+}
+
+/* ── [#A6-1] Web Search 설정 — role 권한 + threshold 조정 + 엔진 상태 ──
+   admin 페이지 settings 섹션에서 사용. loadSettings에서 같이 호출되어
+   체크박스/슬라이더 채움. saveWebSearchConfig는 별도 버튼 (다른 설정과
+   충돌 없이 독립 저장 — TAVILY 키 변경/엔진 전환 시 별도 reload 가능). */
+async function loadWebSearchConfig() {
+  try {
+    const data = await api('/admin/web-search-config/');
+    // 엔진 상태 표시 (engine_status: tavily/duckduckgo/none)
+    const statusEl = document.getElementById('web-search-status-display');
+    if (statusEl) {
+      const s = data.engine_status || {};
+      const active = s.active_engine || 'none';
+      const lines = [];
+      if (active === 'tavily') {
+        lines.push(`✅ Tavily 활성화 (key set, advanced 모드)`);
+      } else if (active === 'duckduckgo') {
+        lines.push(`🦆 DuckDuckGo fallback`);
+        if (!s.tavily_key) lines.push(`⚠️ TAVILY_API_KEY 미설정`);
+        if (s.tavily_exhausted) lines.push(`⚠️ Tavily 할당량 소진`);
+      } else {
+        lines.push(`❌ 검색 엔진 없음`);
+        if (!s.tavily_installed) lines.push(`pip install tavily-python`);
+        if (!s.ddg_installed) lines.push(`pip install duckduckgo-search`);
+      }
+      statusEl.innerHTML = lines.map(l => `<div>${l}</div>`).join('');
+
+      // [#A6-1 (b)] TAVILY_API_KEY 미설정 + DDG가 active이면 토스트 경고.
+      // 운영자는 .env에 키 추가하면 advanced 검색 + raw_content 본문까지
+      // 무료 1000회/월 사용 가능. 어드민 페이지 진입 1회만 alert.
+      if (!s.tavily_key && active === 'duckduckgo' && !window._toastedTavily) {
+        window._toastedTavily = true;
+        if (typeof toast === 'function') {
+          toast('⚠️ TAVILY_API_KEY 미설정 — DDG fallback 동작 중. .env에 추가 추천 (free 1000/월).', 'warn');
+        }
+      }
+    }
+    // 체크박스 채움
+    const allowed = new Set(data.allowed_roles || ['admin']);
+    document.querySelectorAll('.ws-role-cb').forEach(cb => {
+      cb.checked = allowed.has(cb.value);
+    });
+    // threshold slider
+    const slider = document.getElementById('ws-threshold');
+    const val    = document.getElementById('ws-threshold-val');
+    if (slider && data.threshold != null) {
+      slider.value = data.threshold;
+      if (val) val.textContent = Number(data.threshold).toFixed(2);
+    }
+  } catch (e) {
+    console.warn('[admin] /admin/web-search-config/ load 실패:', e);
+  }
+}
+
+async function saveWebSearchConfig() {
+  const roles = Array.from(document.querySelectorAll('.ws-role-cb'))
+                     .filter(cb => cb.checked)
+                     .map(cb => cb.value);
+  if (roles.length === 0) {
+    alert('Allowed Roles는 최소 1개 필요. (전부 비활성화하려면 .env에서 TAVILY_API_KEY 제거)');
+    return;
+  }
+  const threshold = parseFloat(document.getElementById('ws-threshold').value);
+  try {
+    await api('/admin/web-search-config/', 'POST', {
+      api_key:       apiKey,
+      allowed_roles: roles,
+      threshold,
+    });
+    if (typeof toast === 'function') {
+      toast(`✅ 웹 검색 설정 저장됨 (roles=${roles.join(',')}, threshold=${threshold})`, 'success');
+    } else {
+      alert('Web search settings saved.');
+    }
   } catch (e) {
     alert(`Failed: ${e.message}`);
   }

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1066,6 +1066,56 @@ async def llm_delete(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# ─── [#A6-1] Web search admin config — role permission + threshold ───
+
+@app.get("/admin/web-search-config/", summary="웹 검색 설정 조회 [#A6-1]")
+async def get_web_search_config(api_key: str,
+                                 role: str = Depends(get_role_from_request)):
+    """[#A6-1] Admin reads:
+       - allowed_roles: which roles can trigger web search
+       - threshold: unified_score below which web fallback fires
+       - engine_status: live key/installed/exhausted state from
+                        get_search_engine_status() so the admin UI
+                        can render the right toast (TAVILY missing,
+                        DDG fallback active, both missing, etc.)
+    """
+    _require_admin(api_key, role)
+    from core.web_search_config import load
+    from tools.web.web_searcher import get_search_engine_status
+    cfg = load()
+    return {
+        **cfg,
+        "engine_status": get_search_engine_status(),
+    }
+
+
+class WebSearchConfigUpdate(BaseModel):
+    api_key:        str
+    allowed_roles:  list
+    threshold:      float
+
+
+@app.post("/admin/web-search-config/", summary="웹 검색 설정 갱신 [#A6-1]")
+async def set_web_search_config(data: WebSearchConfigUpdate,
+                                 role: str = Depends(get_role_from_request)):
+    """Persist web-search settings. Validates role names against
+    core.web_search_config.VALID_ROLES and threshold ∈ [0.0, 1.0].
+    Empty allowed_roles is rejected — silently disabling web search
+    is rarely the intent and harder to debug later (operator can
+    clear TAVILY_API_KEY instead if they really want it off)."""
+    _require_admin(data.api_key, role)
+    from core.web_search_config import save, validate_update
+    clean_roles, clean_threshold, err = validate_update(
+        data.allowed_roles, data.threshold,
+    )
+    if err:
+        raise HTTPException(status_code=400, detail=err)
+    cfg = save(clean_roles, clean_threshold)
+    _write_audit(role, "/admin/web-search-config/",
+                 query=f"roles={clean_roles} threshold={clean_threshold}")
+    return {"ok": True, **cfg}
+
+
 # ─── Issue #15: per-task model selection persistence ───────────
 
 def _list_installed_ollama_models() -> set:

--- a/tests/test_web_search_admin_panel.py
+++ b/tests/test_web_search_admin_panel.py
@@ -1,0 +1,265 @@
+"""Web search admin config — role permission + threshold (item #A6-1).
+
+User feedback (2026-05-08):
+  (a) admin 외 user role도 웹 검색 허용 가능 — 어드민 페이지에서 role별
+      설정 가능 여부 조정.
+  (b) TAVILY_API_KEY 미설정 시 어드민에 토스트 경고.
+  (d) low_relevance threshold 0.30 — 어떻게 조정하면 좋을지 admin 가능.
+
+Backend:
+  - core/web_search_config.py — JSON-backed config with VALID_ROLES,
+    load(), save(), is_role_allowed(), get_threshold(), validate_update().
+  - /admin/web-search-config/ GET + POST endpoints (admin-gated).
+  - core/reasoning/pipeline.py reads is_role_allowed + get_threshold
+    instead of hardcoded 'admin' + 0.30.
+
+Frontend:
+  - admin.html settings page — Web Search section with role
+    checkboxes + threshold slider + engine status display.
+  - admin.js loadWebSearchConfig + saveWebSearchConfig.
+  - When TAVILY_API_KEY missing + DDG active, toast warning fires
+    once on admin page settings load.
+
+Run:
+  python -m unittest tests.test_web_search_admin_panel
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class WebSearchConfigModuleTests(unittest.TestCase):
+    """core/web_search_config.py — JSON-backed settings."""
+
+    def setUp(self):
+        # Each test gets a temp config file so we don't touch the
+        # real one in the working dir.
+        self.tmpdir = tempfile.mkdtemp()
+        self.cfg_path = os.path.join(self.tmpdir, "web_search_config.json")
+        # Patch _CONFIG_PATH for the test.
+        from core import web_search_config as wsc
+        self.wsc = wsc
+        self._orig_path = wsc._CONFIG_PATH
+        wsc._CONFIG_PATH = self.cfg_path
+
+    def tearDown(self):
+        self.wsc._CONFIG_PATH = self._orig_path
+        if os.path.exists(self.cfg_path):
+            os.unlink(self.cfg_path)
+        os.rmdir(self.tmpdir)
+
+    def test_defaults_when_no_file(self):
+        cfg = self.wsc.load()
+        self.assertEqual(cfg["allowed_roles"], ["admin"])
+        self.assertEqual(cfg["threshold"], 0.30)
+
+    def test_save_then_load_roundtrip(self):
+        self.wsc.save(["admin", "manager"], 0.45)
+        cfg = self.wsc.load()
+        self.assertEqual(cfg["allowed_roles"], ["admin", "manager"])
+        self.assertAlmostEqual(cfg["threshold"], 0.45)
+
+    def test_corrupt_file_falls_back_to_defaults(self):
+        with open(self.cfg_path, "w", encoding="utf-8") as f:
+            f.write("not json {")
+        cfg = self.wsc.load()
+        self.assertEqual(cfg["allowed_roles"], ["admin"])
+        self.assertEqual(cfg["threshold"], 0.30)
+
+    def test_unknown_roles_filtered_out_on_load(self):
+        with open(self.cfg_path, "w", encoding="utf-8") as f:
+            json.dump({"allowed_roles": ["admin", "wizard"]}, f)
+        cfg = self.wsc.load()
+        self.assertEqual(cfg["allowed_roles"], ["admin"],
+            "unknown roles must be silently filtered, valid kept")
+
+    def test_empty_allowed_roles_after_filter_uses_default(self):
+        with open(self.cfg_path, "w", encoding="utf-8") as f:
+            json.dump({"allowed_roles": ["wizard"]}, f)
+        cfg = self.wsc.load()
+        # After filtering, list is empty → restore default.
+        self.assertEqual(cfg["allowed_roles"], ["admin"],
+            "empty list after filter must restore default (don't lock everyone out)")
+
+    def test_threshold_out_of_range_rejected_on_load(self):
+        with open(self.cfg_path, "w", encoding="utf-8") as f:
+            json.dump({"threshold": 5.0}, f)
+        cfg = self.wsc.load()
+        self.assertEqual(cfg["threshold"], 0.30,
+            "out-of-range threshold must fall back to default")
+
+    def test_is_role_allowed(self):
+        self.wsc.save(["admin", "manager"], 0.30)
+        self.assertTrue(self.wsc.is_role_allowed("admin"))
+        self.assertTrue(self.wsc.is_role_allowed("manager"))
+        self.assertFalse(self.wsc.is_role_allowed("employee"))
+        self.assertFalse(self.wsc.is_role_allowed(""))
+
+    def test_get_threshold(self):
+        self.wsc.save(["admin"], 0.42)
+        self.assertAlmostEqual(self.wsc.get_threshold(), 0.42)
+
+    def test_validate_update_rejects_unknown_role(self):
+        _, _, err = self.wsc.validate_update(["admin", "wizard"], 0.30)
+        self.assertIn("unknown role", err)
+
+    def test_validate_update_rejects_empty_list(self):
+        _, _, err = self.wsc.validate_update([], 0.30)
+        self.assertIn("cannot be empty", err)
+
+    def test_validate_update_rejects_out_of_range(self):
+        _, _, err = self.wsc.validate_update(["admin"], 1.5)
+        self.assertIn("[0.0, 1.0]", err)
+
+    def test_validate_update_accepts_valid(self):
+        roles, t, err = self.wsc.validate_update(
+            ["admin", "manager"], 0.4
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(roles, ["admin", "manager"])
+        self.assertAlmostEqual(t, 0.4)
+
+
+class PipelineUsesConfigTests(unittest.TestCase):
+    """pipeline.py must read from core.web_search_config, not hardcode."""
+
+    @classmethod
+    def setUpClass(cls):
+        from core.reasoning import pipeline
+        cls.src = inspect.getsource(pipeline)
+
+    def test_imports_config_helpers(self):
+        self.assertIn("from core.web_search_config import", self.src,
+            "pipeline.py must import is_role_allowed + get_threshold")
+        self.assertIn("get_threshold", self.src)
+        self.assertIn("is_role_allowed", self.src)
+
+    def test_threshold_constant_replaced(self):
+        # The hardcoded literal `unified_score < 0.30` should be gone
+        # — replaced by `unified_score < get_threshold()`.
+        self.assertNotIn("unified_score < 0.30", self.src,
+            "hardcoded 0.30 threshold must be replaced by get_threshold()")
+        self.assertIn("unified_score < get_threshold()", self.src,
+            "must call get_threshold() in low_relevance check")
+
+    def test_role_check_uses_helper(self):
+        # `if user_role == "admin"` → `if is_role_allowed(user_role)`.
+        self.assertIn("is_role_allowed(user_role)", self.src,
+            "role gate must call is_role_allowed, not hardcode admin")
+        # Make sure the previous hardcoded check is no longer in the
+        # web-search branch (it could still appear elsewhere).
+        # Locate the web search block and check inside.
+        m = re.search(
+            r"is_role_allowed\(user_role\).+?print\(f\"\[WEB\]",
+            self.src, re.DOTALL,
+        )
+        self.assertIsNotNone(m,
+            "is_role_allowed must gate the WEB log path")
+
+
+class AdminEndpointTests(unittest.TestCase):
+    """server_llmwiki.py — /admin/web-search-config/ GET + POST."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_get_endpoint_registered(self):
+        self.assertIn('@app.get("/admin/web-search-config/"', self.src,
+            "GET /admin/web-search-config/ must be registered")
+
+    def test_post_endpoint_registered(self):
+        self.assertIn('@app.post("/admin/web-search-config/"', self.src,
+            "POST /admin/web-search-config/ must be registered")
+
+    def test_post_admin_gated(self):
+        # Find POST handler body, must require admin.
+        m = re.search(
+            r'@app\.post\("/admin/web-search-config/".+?'
+            r'@app\.|\Z',
+            self.src, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        body = m.group(0)
+        self.assertIn("_require_admin", body,
+            "POST must call _require_admin")
+
+    def test_post_validates_via_helper(self):
+        m = re.search(
+            r'@app\.post\("/admin/web-search-config/".+?'
+            r'@app\.|\Z',
+            self.src, re.DOTALL,
+        )
+        body = m.group(0)
+        self.assertIn("validate_update", body,
+            "POST must call validate_update for input checks")
+        self.assertIn("status_code=400", body,
+            "validation error must produce 400")
+
+
+class FrontendAdminPanelTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "admin.html").read_text(encoding="utf-8")
+        cls.js   = (ROOT / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+
+    def test_html_section_present(self):
+        self.assertIn("Web Search", self.html,
+            "admin.html settings page must contain Web Search section")
+        self.assertIn('id="ws-threshold"', self.html,
+            "threshold slider missing")
+        self.assertIn('class="ws-role-cb"', self.html,
+            "role checkboxes missing")
+        self.assertIn('id="web-search-status-display"', self.html,
+            "engine status display target missing")
+
+    def test_load_function_exists(self):
+        self.assertIn("async function loadWebSearchConfig", self.js)
+        self.assertIn("'/admin/web-search-config/'", self.js,
+            "loadWebSearchConfig must hit /admin/web-search-config/")
+
+    def test_save_function_exists(self):
+        self.assertIn("async function saveWebSearchConfig", self.js)
+        idx = self.js.index("async function saveWebSearchConfig")
+        body = self.js[idx:idx + 1500]
+        self.assertIn(".ws-role-cb", body,
+            "save must read role checkbox state")
+        self.assertIn("threshold", body)
+
+    def test_loadSettings_chains_web_config(self):
+        # When admin enters settings page, both core settings + web
+        # search config should load.
+        idx = self.js.index("async function loadSettings")
+        body = self.js[idx:idx + 4500]
+        self.assertIn("loadWebSearchConfig", body,
+            "loadSettings must also trigger loadWebSearchConfig")
+
+    def test_tavily_missing_toast_warning(self):
+        # When tavily_key=false + active=duckduckgo, frontend shows
+        # a toast warning. We just check the conditional + toast
+        # call exist.
+        idx = self.js.index("async function loadWebSearchConfig")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("tavily_key", body,
+            "must inspect engine_status.tavily_key")
+        self.assertIn("TAVILY_API_KEY", body,
+            "warning copy must mention the env var name")
+        self.assertIn("toast", body,
+            "must call toast() helper for the warning")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback (2026-05-08):
- **(a)** admin 외 user role도 웹 검색 허용 — 어드민 페이지 role별 설정
- **(b)** TAVILY_API_KEY 미설정 시 어드민에 토스트 경고
- **(d)** low_relevance threshold 0.30 — admin 조정 가능

## Live verification (this server)

| 항목 | 상태 |
|---|---|
| TAVILY_API_KEY (.env) | ✅ `tvly-dev...` set |
| tavily-python | ✅ installed |
| duckduckgo-search | ✅ installed |
| active_engine | **tavily** |

## Backend

### `core/web_search_config.py` (new)
JSON-backed at `<BASE_DIR>/web_search_config.json`. Defaults applied when file missing/invalid (admin-only + 0.30 — identical to pre-#A6-1 behaviour).

| API | Purpose |
|---|---|
| `load()` | Read settings; defaults if missing/corrupt |
| `save(roles, threshold)` | Persist (caller validates) |
| `is_role_allowed(role)` | Used by pipeline.py |
| `get_threshold()` | Used by pipeline.py |
| `validate_update(...)` | Pre-flight for POST endpoint |

Empty `allowed_roles` rejected (don't silently lock everyone out — disable via clearing `TAVILY_API_KEY` instead).

### `core/reasoning/pipeline.py:271-289`
```diff
- or unified_score < 0.30
+ or unified_score < get_threshold()
- if user_role == "admin":
+ if is_role_allowed(user_role):
```

### `server_llmwiki.py`
- `GET /admin/web-search-config/` — config + live `get_search_engine_status()`
- `POST /admin/web-search-config/` — admin-gated, `validate_update()`, 400 on bad input, audit logged

## Frontend

### `admin.html` settings page — new "🌐 Web Search" section
- **Engine status** block (real-time)
- **Allowed Roles** — 4 checkboxes (admin/manager/employee/external)
- **Relevance Threshold** — slider 0.05-0.80, step 0.05
- Save button (independent of Server Settings)

### `admin.js`
- `loadWebSearchConfig()` — chained from `loadSettings`
- Renders engine status as readable lines
- Fires toast warning **once per session** when `tavily_key=false` + DDG active
- `saveWebSearchConfig()` — client-side ≥1 role validation + POST + toast

## Verification

`tests/test_web_search_admin_panel.py` — **24 tests**:
- **WebSearchConfigModuleTests** (12): defaults, roundtrip, corrupt-file fallback, unknown-role filter, empty-list-after-filter restore, out-of-range threshold fallback, `is_role_allowed`, `get_threshold`, `validate_update` reject unknown role / empty / OOR / accept valid
- **PipelineUsesConfigTests** (3): imports + `0.30` replaced + `'admin'` replaced
- **AdminEndpointTests** (4): GET/POST registered, POST admin-gated, POST validates with 400
- **FrontendAdminPanelTests** (5): HTML elements, load function + endpoint, save reads state, loadSettings chains, TAVILY warning wired

**552/552 regression suite pass.**

## Bench numbers

Not applicable — config + admin UI. `get_threshold` / `is_role_allowed` are file read + JSON parse (~0.1ms).

## Out of scope (next PRs)

- **#A6-2** 답변 bubble에 "🌐 웹 검색 사용됨" 배지 + URL 표시
- **#A6-3** 장기 저장 자동 promote → admin confirm 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)