### PR TITLE
feat(evo): web→wiki long-term save now requires admin confirm (item #A6-3)

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -302,7 +302,13 @@ def run_retrieval_pipeline(
 
                         # 장기 전환 조건 확인
                         if should_promote_to_longterm(safe_query) or is_save_command(safe_query):
-                            # 요약 생성 후 wiki entity 저장
+                            # [#A6-3 2026-05-08] 즉시 save_as_longterm → admin
+                            # confirm proposal로 전환. 이전엔 사용자 쿼리만으로
+                            # operator 모르는 사이 외부 출처가 wiki에 들어가
+                            # 이후 retrieval에서 회수됐다. 이제 admin이 명시적
+                            # 승인하기 전엔 wiki에 안 들어감 — pending proposal
+                            # 만 생성. 단기 저장 (record_search) + KnowledgeTracker
+                            # 단기 +2점은 그대로 (이미 위에서 적용).
                             try:
                                 summary_prompt = (
                                     f"아래 검색 결과를 한국어로 200자 이내 핵심 요약:\n"
@@ -312,11 +318,38 @@ def run_retrieval_pipeline(
                                     summary_prompt, timeout=30, use_cache=False, max_tokens=300
                                 )
                                 if summary:
-                                    save_as_longterm(safe_query, web_results, summary, user_role)
-                                    update_knowledge_level(safe_query, is_longterm=True)
-                                    print(f"[WEB→WIKI] 장기 지식 전환 (검색 {search_count}회)")
+                                    from tools.self.evo_analyzer import (
+                                        _make_proposal, save_proposal,
+                                    )
+                                    p = _make_proposal(
+                                        prop_type   = "web_longterm_save",
+                                        title       = f"[웹→Wiki] 장기 저장: {safe_query[:40]}",
+                                        description = (
+                                            f"웹 검색 누적 {search_count}회 (≥2 또는 명시 저장 요청). "
+                                            f"승인 시 검색 결과를 wiki entity로 영구 저장 + vector "
+                                            f"인덱싱. 거절하면 단기 저장만 유지."
+                                        ),
+                                        content     = (
+                                            f"[요약]\n{summary}\n\n"
+                                            f"[출처 ({len(web_results)}건)]\n"
+                                            + "\n".join(
+                                                f"- {r.get('title','')[:60]} ({r.get('url','')})"
+                                                for r in web_results[:5]
+                                            )
+                                        ),
+                                        metadata    = {
+                                            "auto_action":  "web_longterm_save",
+                                            "query":        safe_query,
+                                            "summary":      summary,
+                                            "web_results":  web_results,
+                                            "user_role":    user_role,
+                                            "search_count": search_count,
+                                        },
+                                    )
+                                    save_proposal(p)
+                                    print(f"[WEB→WIKI] admin confirm proposal 생성: {p['proposal_id']}")
                             except Exception as we:
-                                print(f"[WEB→WIKI] 요약/저장 실패: {we}")
+                                print(f"[WEB→WIKI] proposal 생성 실패: {we}")
                         else:
                             print(f"[WEB] 단기 저장 (누적 {search_count}회 / 2회 이상이면 장기 전환)")
             except Exception as we:

--- a/tests/test_longterm_save_admin_confirm.py
+++ b/tests/test_longterm_save_admin_confirm.py
@@ -1,0 +1,192 @@
+"""Web → wiki long-term save admin confirm flow (item #A6-3, 2026-05-08).
+
+User feedback (c part 2): "메모리 장기화하여 자료화로 만들 때에는
+어드민에게 선택 할 수 있도록 할 것".
+
+Before: pipeline.py auto-saved to wiki when search_count ≥ 2 OR user
+said "저장해줘" — operator had no idea external content was being
+indexed into their knowledge base.
+
+After: pipeline creates a proposal with type "web_longterm_save" via
+_make_proposal + save_proposal. Admin sees it in /admin/proposals/
+(existing UI handles it — buttons + executor dispatch). On approve
+EvoExecutor._execute_web_longterm_save calls the original
+save_as_longterm + KnowledgeTracker boost. On reject, only short-
+term knowledge boost stays (already applied above the gate).
+
+Run:
+  python -m unittest tests.test_longterm_save_admin_confirm
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class PipelineProposalCreationTests(unittest.TestCase):
+    """pipeline.py creates a proposal instead of auto-saving."""
+
+    @classmethod
+    def setUpClass(cls):
+        from core.reasoning import pipeline
+        cls.src = inspect.getsource(pipeline)
+
+    def test_no_direct_save_as_longterm_call(self):
+        # The auto-save path that fires on should_promote_to_longterm
+        # must no longer call save_as_longterm directly. The function
+        # is still imported (it's used by the executor on approve), but
+        # not invoked from the pipeline branch.
+        # Look for the should_promote_to_longterm gate; inside that
+        # branch, `save_as_longterm(` should NOT appear.
+        m = inspect.findsource
+        # Practical check: locate the if-block for should_promote_to_longterm
+        # and confirm the body uses _make_proposal instead of
+        # save_as_longterm.
+        idx = self.src.index("should_promote_to_longterm(safe_query)")
+        # The block ends at "else:" of the same indentation. Use a
+        # generous slice and check both presences.
+        block = self.src[idx:idx + 3000]
+        self.assertIn("_make_proposal", block,
+            "promotion branch must create a proposal (admin confirm)")
+        self.assertIn("save_proposal", block,
+            "must persist the proposal via save_proposal")
+        # Confirm the auto-save path was removed from this block.
+        self.assertNotIn("save_as_longterm(safe_query, web_results, summary",
+            block,
+            "promotion branch must not auto-save anymore — admin gate required")
+
+    def test_proposal_type_is_web_longterm_save(self):
+        idx = self.src.index("should_promote_to_longterm(safe_query)")
+        block = self.src[idx:idx + 3000]
+        self.assertIn('"web_longterm_save"', block,
+            'proposal type must be "web_longterm_save" (registered with executor)')
+
+    def test_proposal_metadata_carries_query_summary_results_role(self):
+        idx = self.src.index("should_promote_to_longterm(safe_query)")
+        block = self.src[idx:idx + 3000]
+        for field in ('"query"', '"summary"', '"web_results"', '"user_role"'):
+            self.assertIn(field, block,
+                f"proposal metadata must include {field} so executor can save")
+
+    def test_short_term_signals_unchanged(self):
+        # Short-term update_knowledge_level (single search) and
+        # record_search counter must still fire — they're applied above
+        # the promotion gate in the same try block.
+        # Just check those calls still exist in the file.
+        self.assertIn("update_knowledge_level(safe_query, is_longterm=False)",
+                      self.src,
+            "short-term knowledge level boost must remain (proposal flow only "
+            "gates the LONG-term promotion)")
+        self.assertIn("record_search(safe_query)", self.src)
+
+
+class ExecutorHandlesNewTypeTests(unittest.TestCase):
+    """EvoExecutor.execute dispatches web_longterm_save."""
+
+    @classmethod
+    def setUpClass(cls):
+        from tools.self import evo_analyzer
+        cls.evo = evo_analyzer
+        cls.src = inspect.getsource(evo_analyzer)
+
+    def test_risk_level_registered(self):
+        self.assertIn('"web_longterm_save":', self.src,
+            "RISK_LEVELS must register web_longterm_save")
+
+    def test_executor_dispatches_new_type(self):
+        # Look for the dispatch chain in EvoExecutor.execute().
+        idx = self.src.index("class EvoExecutor")
+        end = self.src.index("def _execute_wiki_add", idx)
+        body = self.src[idx:end]
+        self.assertIn('prop_type == "web_longterm_save"', body,
+            "execute() must dispatch web_longterm_save proposals")
+        self.assertIn("self._execute_web_longterm_save", body,
+            "must call the dedicated handler method")
+
+    def test_handler_method_present(self):
+        self.assertIn("def _execute_web_longterm_save", self.src,
+            "_execute_web_longterm_save method missing")
+
+    def test_handler_validates_metadata(self):
+        idx = self.src.index("def _execute_web_longterm_save")
+        end = self.src.index("def _execute_wiki_add", idx)
+        body = self.src[idx:end]
+        # Must check for required metadata fields and return failure
+        # gracefully if missing.
+        self.assertIn('"query"', body)
+        self.assertIn('"summary"', body)
+        self.assertIn('"web_results"', body)
+        self.assertIn("metadata 누락", body,
+            "must produce a clear error when metadata is incomplete")
+
+    def test_handler_calls_save_as_longterm(self):
+        idx = self.src.index("def _execute_web_longterm_save")
+        end = self.src.index("def _execute_wiki_add", idx)
+        body = self.src[idx:end]
+        self.assertIn("save_as_longterm(", body,
+            "approved proposal must call save_as_longterm to actually save")
+        self.assertIn("update_knowledge_level", body,
+            "approved save must trigger long-term knowledge boost (+5)")
+
+
+class ExecutorIntegrationTests(unittest.TestCase):
+    """End-to-end via EvoExecutor.execute with a fake proposal."""
+
+    @classmethod
+    def setUpClass(cls):
+        from tools.self.evo_analyzer import EvoExecutor
+        cls.executor = EvoExecutor()
+
+    def _fake_proposal(self, **meta):
+        return {
+            "proposal_id": "test_proposal_001",
+            "type":        "web_longterm_save",
+            "title":       "test",
+            "description": "test",
+            "content":     "test",
+            "metadata":    meta,
+            "status":      "pending",
+        }
+
+    def test_missing_metadata_returns_failure(self):
+        proposal = self._fake_proposal(query="", summary="", web_results=[])
+        result = self.executor.execute(proposal)
+        self.assertFalse(result["success"])
+        self.assertIn("metadata", result["message"])
+
+    def test_save_path_invoked_with_complete_metadata(self):
+        # Mock save_as_longterm to confirm the executor calls it with
+        # the right args.
+        proposal = self._fake_proposal(
+            query="블랙록 IBIT 운용 자산",
+            summary="블랙록 IBIT는 ...",
+            web_results=[{"url": "https://example.com", "title": "IBIT"}],
+            user_role="admin",
+        )
+        with patch("tools.web.web_searcher.save_as_longterm",
+                   return_value="/wiki/web_blackrock.md") as mock_save, \
+             patch("tools.web.web_searcher.update_knowledge_level"):
+            result = self.executor.execute(proposal)
+        self.assertTrue(result["success"],
+            f"approved save should succeed: {result.get('message')}")
+        self.assertTrue(mock_save.called,
+            "save_as_longterm must be invoked")
+        # Args verification — query, results, summary, role.
+        args, _ = mock_save.call_args
+        self.assertEqual(args[0], "블랙록 IBIT 운용 자산")
+        self.assertEqual(args[2], "블랙록 IBIT는 ...")
+        self.assertEqual(args[3], "admin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/self/evo_analyzer.py
+++ b/tools/self/evo_analyzer.py
@@ -36,10 +36,15 @@ REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
 # 위험도 정의
 RISK_LEVELS = {
-    "wiki_add":     "low",    # 새 지식 추가 — 낮음
-    "wiki_update":  "low",    # 지식 수정 — 낮음
-    "config_update":"medium", # 설정 변경 — 중간
-    "code_patch":   "high",   # 코드 변경 — 높음
+    "wiki_add":            "low",    # 새 지식 추가 — 낮음
+    "wiki_update":         "low",    # 지식 수정 — 낮음
+    "config_update":       "medium", # 설정 변경 — 중간
+    "code_patch":          "high",   # 코드 변경 — 높음
+    # [#A6-3] 웹 검색 결과 → wiki entity 장기 저장 admin confirm.
+    # 외부 출처(low-trust)가 wiki에 들어가 retrieval 결과로 회수되므로
+    # operator가 한 번 검토해야 한다. risk=medium으로 다른 자동 작업과
+    # 같은 우선순위로 표시.
+    "web_longterm_save":   "medium",
 }
 
 # 관찰 기준
@@ -282,6 +287,9 @@ class EvoExecutor:
                 result = self._execute_code_patch(proposal)
             elif prop_type == "config_update":
                 result = self._execute_config_update(proposal)
+            elif prop_type == "web_longterm_save":
+                # [#A6-3] admin이 confirm한 웹 검색 결과를 wiki entity로 저장.
+                result = self._execute_web_longterm_save(proposal)
             else:
                 result["message"] = f"알 수 없는 제안 유형: {prop_type}"
 
@@ -291,6 +299,53 @@ class EvoExecutor:
 
         result["elapsed_sec"] = round(time.time() - t_start, 2)
         return result
+
+    def _execute_web_longterm_save(self, proposal: Dict) -> Dict:
+        """[#A6-3] admin이 confirm한 웹 검색 결과를 wiki entity로 저장.
+
+        Pipeline은 이전엔 should_promote_to_longterm 조건 만족 시
+        save_as_longterm을 즉시 호출했다 — operator 모르는 사이 wiki에
+        외부 출처가 추가됨. 이제는 proposal로 큐잉, admin이 admin 페이지
+        Proposals에서 검토 후 Approve.
+
+        Metadata expected (pipeline.py가 채움):
+          query:        원본 사용자 쿼리
+          summary:      LLM 200자 요약 (이미 생성)
+          web_results:  search_web 결과 list (URL/title/snippet/body)
+          user_role:    원 호출자 role (audit용)
+        """
+        from tools.web.web_searcher import save_as_longterm, update_knowledge_level
+        meta = proposal.get("metadata", {}) or {}
+        query        = meta.get("query", "")
+        summary      = meta.get("summary", "")
+        web_results  = meta.get("web_results", [])
+        original_role = meta.get("user_role", "admin")
+        if not (query and summary and web_results):
+            return {
+                "success": False,
+                "message": "metadata 누락 (query/summary/web_results 필요)",
+                "details": {"missing": [
+                    k for k in ("query", "summary", "web_results")
+                    if not meta.get(k)
+                ]},
+            }
+        try:
+            path = save_as_longterm(query, web_results, summary, original_role)
+            if not path:
+                return {"success": False,
+                        "message": "save_as_longterm가 None 반환 (저장 실패)",
+                        "details": {}}
+            # admin 승인 후 저장 완료 → KnowledgeTracker 장기 +5점
+            update_knowledge_level(query, is_longterm=True)
+            return {
+                "success": True,
+                "message": f"wiki entity 저장 완료: {path}",
+                "details": {"path": str(path), "topic": query[:30]},
+            }
+        except Exception as e:
+            return {"success": False,
+                    "message": f"저장 실패: {type(e).__name__}: {e}",
+                    "details": {}}
 
     def _execute_wiki_add(self, proposal: Dict) -> Dict:
         """wiki 새 entity 추가."""


### PR DESCRIPTION
## Summary

User feedback (c part 2): *"메모리 장기화하여 자료화로 만들 때에는 어드민에게 선택 할 수 있도록 할 것"*.

**Before**: `pipeline.py` auto-saved web search results to wiki when `search_count ≥ 2` OR user said "저장해줘" — operator had no idea external (low-trust) content was being indexed into their knowledge base.

**After**: same gate now creates a `web_longterm_save` proposal. Admin reviews on `/admin/proposals/` page. On Approve, EvoExecutor dispatches a new handler that invokes the original save path.

## Backend

### `core/reasoning/pipeline.py`
- Inside the `if should_promote_to_longterm(...) or is_save_command(...):` branch:
- Replaced direct `save_as_longterm` call with `_make_proposal` + `save_proposal`
- Summary still LLM-generated synchronously (needed for proposal content)
- `metadata` stashes `{query, summary, web_results, user_role, search_count}`
- **Short-term signals unchanged** — `record_search` + `update_knowledge_level(is_longterm=False)` still fire on every web search

### `tools/self/evo_analyzer.py`
- `RISK_LEVELS["web_longterm_save"] = "medium"` (external content crosses trust boundary)
- `EvoExecutor.execute()` dispatches new type → `_execute_web_longterm_save`
- Handler validates metadata (returns clear failure on missing fields), calls `save_as_longterm` + `update_knowledge_level(is_longterm=True)`

## Frontend (no changes needed)

`admin.js loadProposals` already renders any pending proposal with Approve/Reject buttons. The new `web_longterm_save` type appears with risk=medium (yellow) and the pipeline-composed title `"[웹→Wiki] 장기 저장: <query>"`. Existing approve flow → `/admin/proposals/{id}/approve` → `approve_and_execute` → `EvoExecutor` → new handler.

## Verification

`tests/test_longterm_save_admin_confirm.py` — **11 tests**:
- **PipelineProposalCreationTests** (4): direct `save_as_longterm` removed, proposal type literal, metadata fields, short-term signals unchanged
- **ExecutorHandlesNewTypeTests** (5): RISK_LEVELS, dispatch, handler exists, validates metadata, calls save+boost
- **ExecutorIntegrationTests** (2): missing metadata → failure dict, complete metadata → save called with right args

**549/549 regression suite pass.**

## Bench numbers

Not applicable — workflow change. User-facing latency identical (summary LLM call already in old flow); only persistence is deferred to admin approval.

## #A6 batch complete

| | (a) per-role | (b) toast warn | (c) badge | (c) admin save | (d) threshold |
|---|---|---|---|---|---|
| | ✅ #122 | ✅ #122 | ✅ #123 | **✅ this PR** | ✅ #122 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)