### PR TITLE
feat(frontend): faster shimmer + rotating placeholder phrases (item #A8-1)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1154,6 +1154,20 @@ function brainPulseSvg(active = true) {
   </span>`;
 }
 
+/* [#A8-1] placeholder 멘트 rotation — 첫 stage 도착 전 사용자에게
+   "뭔가 진행 중" 신호 강화. 1.6초마다 다른 멘트로 회전. 고정된
+   "추론 시작 중" 한 줄보다 다이내믹하게 보임. */
+const THINKING_PLACEHOLDER_PHRASES = [
+  '추론 시작 중',
+  '질문 의도 분석 중',
+  '내부 자료 살펴보는 중',
+  '관련 지식 정리 중',
+  '관계 그래프 탐색 중',
+  '근거 검토 중',
+  '답변 정리 중',
+  '마무리하는 중',
+];
+
 function appendTyping(traceId) {
   const messages = document.getElementById('messages');
   const div = document.createElement('div');
@@ -1164,13 +1178,27 @@ function appendTyping(traceId) {
       <div id="thinking-${traceId}" class="thinking-stream">
         <div class="thinking-placeholder">
           ${brainPulseSvg(true)}
-          <span class="thinking-shimmer-text thinking-label">추론 시작 중</span>
+          <span class="thinking-shimmer-text thinking-label thinking-placeholder-text"
+                data-trace="${traceId}">추론 시작 중</span>
         </div>
       </div>
     </div>
   `;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
+
+  // [#A8-1] placeholder rotation — 첫 stage 이벤트 도착 시 stop.
+  // 토큰 1개 늘릴 때 마다 다음 멘트로 자연 전환되는 듯한 효과.
+  let phraseIdx = 0;
+  const placeholderEl = div.querySelector('.thinking-placeholder-text');
+  const rotateTimer = setInterval(() => {
+    if (!placeholderEl || !placeholderEl.isConnected) {
+      clearInterval(rotateTimer);
+      return;
+    }
+    phraseIdx = (phraseIdx + 1) % THINKING_PLACEHOLDER_PHRASES.length;
+    placeholderEl.textContent = THINKING_PLACEHOLDER_PHRASES[phraseIdx];
+  }, 1600);
 
   // 폴링 상태
   const seenStages = new Set();   // stage 종류별 1회만 표시
@@ -1210,9 +1238,11 @@ function appendTyping(traceId) {
     const container = document.getElementById(`thinking-${traceId}`);
     if (!container) return;
     // 첫 진짜 이벤트 도착 시 placeholder 제거
+    // [#A8-1] placeholder rotation timer도 함께 stop.
     if (events.length > 0) {
       const ph = container.querySelector('.thinking-placeholder');
       if (ph) ph.remove();
+      try { clearInterval(rotateTimer); } catch (_) {}
     }
     events.forEach(ev => {
       const stage = ev.stage;

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -89,14 +89,14 @@
   opacity: 0.45;
   fill: none;
 }
-.brain-pulse.brain-pulse-active .neuron-1 { animation: james-neuron-blink-1 1.4s ease-in-out infinite,
-                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
-.brain-pulse.brain-pulse-active .neuron-2 { animation: james-neuron-blink-2 1.4s ease-in-out infinite,
-                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
-.brain-pulse.brain-pulse-active .neuron-3 { animation: james-neuron-blink-3 1.4s ease-in-out infinite,
-                                                       james-neuron-pulse 1.4s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .neuron-1 { animation: james-neuron-blink-1 0.9s ease-in-out infinite,
+                                                       james-neuron-pulse 0.9s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .neuron-2 { animation: james-neuron-blink-2 0.9s ease-in-out infinite,
+                                                       james-neuron-pulse 0.9s ease-in-out infinite; }
+.brain-pulse.brain-pulse-active .neuron-3 { animation: james-neuron-blink-3 0.9s ease-in-out infinite,
+                                                       james-neuron-pulse 0.9s ease-in-out infinite; }
 .brain-pulse.brain-pulse-active .brain-outline {
-  animation: james-shimmer 2.4s linear infinite;
+  animation: james-shimmer 1.2s linear infinite;
 }
 
 .thinking-stream {
@@ -176,7 +176,7 @@
   filter: drop-shadow(0 0 4px var(--stage-color, #7c6af7));
 }
 .thinking-line.thinking-active .thinking-label {
-  animation: james-shimmer 2.4s linear infinite;
+  animation: james-shimmer 1.2s linear infinite;
 }
 
 /* Done state: spinner 정지, 색상 흐림 */

--- a/tests/test_reasoning_dynamic.py
+++ b/tests/test_reasoning_dynamic.py
@@ -1,0 +1,116 @@
+"""Reasoning UI dynamic improvements (item #A8-1, 2026-05-09).
+
+User feedback: "추론중 표시 글자 그라데이션 애니메이션을 조금도 빠르게
+움직이도록 설정하고 '추론 시작중' 외에 다른 멘트로 전환되는 등
+다이내믹하게 개선".
+
+CSS:
+  - james-shimmer animation 2.4s → 1.2s (gradient sweep speed)
+  - neuron-blink + neuron-pulse 1.4s → 0.9s (faster firing)
+
+JS:
+  - THINKING_PLACEHOLDER_PHRASES — 8 phrases that rotate every 1.6s
+    until the first real stage event arrives. Stops cleanly when
+    apply() removes the placeholder.
+
+Run:
+  python -m unittest tests.test_reasoning_dynamic
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS  = ROOT / "frontend" / "static" / "chat.js"
+CSS = ROOT / "frontend" / "static" / "mobile.css"
+
+
+class ShimmerSpeedTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.css = CSS.read_text(encoding="utf-8")
+
+    def test_shimmer_animation_faster(self):
+        # All james-shimmer animation declarations must be ≤ 1.5s.
+        for m in re.finditer(r"animation:\s*james-shimmer\s+([\d.]+)s", self.css):
+            duration = float(m.group(1))
+            self.assertLessEqual(duration, 1.5,
+                f"james-shimmer animation duration {duration}s — must be ≤1.5s "
+                f"for the 'dynamic' feel user requested")
+
+    def test_neuron_blink_faster(self):
+        # Each .brain-pulse-active .neuron-N rule must use ≤ 1.0s.
+        for m in re.finditer(
+            r"\.brain-pulse-active\s+\.neuron-\d.+?(\d+\.?\d*)s",
+            self.css, re.DOTALL,
+        ):
+            duration = float(m.group(1))
+            self.assertLessEqual(duration, 1.0,
+                f"neuron-N animation {duration}s — must be ≤1.0s")
+
+
+class PlaceholderRotationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_phrases_array_exists(self):
+        self.assertIn("THINKING_PLACEHOLDER_PHRASES", self.js,
+            "must declare a phrase rotation array")
+
+    def test_at_least_5_phrases(self):
+        m = re.search(
+            r"const\s+THINKING_PLACEHOLDER_PHRASES\s*=\s*\[(.+?)\];",
+            self.js, re.DOTALL,
+        )
+        self.assertIsNotNone(m, "couldn't locate phrases array literal")
+        # Count single-quoted strings inside.
+        phrases = re.findall(r"'([^']+)'", m.group(1))
+        self.assertGreaterEqual(len(phrases), 5,
+            f"expected ≥5 phrases, got {len(phrases)}")
+        # First phrase must still be the original "추론 시작 중" so
+        # there's no jarring change for users who saw the prior copy.
+        self.assertEqual(phrases[0], "추론 시작 중",
+            "first phrase should remain '추론 시작 중' for continuity")
+
+    def test_rotation_interval_set_in_appendTyping(self):
+        idx = self.js.index("function appendTyping")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("setInterval", body,
+            "appendTyping must use setInterval to rotate phrases")
+        # Interval should be 1-2s — fast enough to feel alive but not
+        # vertigo-inducing.
+        m = re.search(r"setInterval\(\(?\)\s*=>\s*\{[\s\S]+?\}\s*,\s*(\d+)\s*\)",
+                      body)
+        self.assertIsNotNone(m, "couldn't extract interval delay")
+        delay = int(m.group(1))
+        self.assertGreaterEqual(delay, 800)
+        self.assertLessEqual(delay, 2500)
+
+    def test_rotation_clears_when_placeholder_removed(self):
+        # When the first stage event arrives we remove the placeholder.
+        # The rotation timer must also clear or it'd leak intervals
+        # forever (and try to .textContent on a detached node).
+        idx = self.js.index("첫 진짜 이벤트 도착 시 placeholder 제거")
+        body = self.js[idx:idx + 800]
+        self.assertIn("clearInterval(rotateTimer)", body,
+            "must clearInterval when placeholder is removed")
+
+    def test_placeholder_text_class_present(self):
+        # The rotation logic targets .thinking-placeholder-text — ensure
+        # the placeholder span actually carries that class.
+        idx = self.js.index("function appendTyping")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("thinking-placeholder-text", body,
+            "placeholder span must have a stable selector class for the "
+            "rotation timer to find it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"추론중 표시 글자 그라데이션 애니메이션을 조금도 빠르게 + '추론 시작중' 외에 다른 멘트로 전환되는 등 다이내믹하게 개선"*.

## Changes

### CSS — speed up
| | Before | After |
|---|---|---|
| `james-shimmer` sweep | 2.4s | **1.2s** (2× faster) |
| neuron blink + pulse | 1.4s | **0.9s** |

Three neurons keep their distinct phase keyframes — still fire out of sync, just faster.

### JS — phrase rotation
`THINKING_PLACEHOLDER_PHRASES` (8-phrase array):
1. 추론 시작 중
2. 질문 의도 분석 중
3. 내부 자료 살펴보는 중
4. 관련 지식 정리 중
5. 관계 그래프 탐색 중
6. 근거 검토 중
7. 답변 정리 중
8. 마무리하는 중

`appendTyping` starts `setInterval(1600ms)` that rotates `placeholder.textContent`. Index 0 stays "추론 시작 중" for continuity. Stops cleanly when first real stage event arrives (`apply()` calls `clearInterval`).

## Verification

`tests/test_reasoning_dynamic.py` — **7 tests**:
- **ShimmerSpeedTests** (2): shimmer ≤ 1.5s, neuron ≤ 1.0s
- **PlaceholderRotationTests** (5): phrases array, ≥5 entries with first = 추론 시작 중, setInterval 800-2500ms, clearInterval cleanup, selector class present

**581/581 regression suite pass.**

## Bench numbers

Not applicable — frontend animation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)