### PR TITLE
feat(admin): password 👁️ toggle on admin login modal (item #A8-3)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -930,10 +930,22 @@
     </div>
     <div style="margin-bottom:14px;">
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">PASSWORD</div>
-      <input id="admin-login-pw" type="password" placeholder="••••••••"
-             autocomplete="new-password"
-             onkeydown="if(event.key==='Enter') doAdminLogin()"
-             style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:10px 14px;color:var(--text);font-size:14px;outline:none;">
+      <!-- [#A8-3] password 옆에 👁️ toggle — chat 페이지와 동일 패턴 -->
+      <div style="position:relative">
+        <input id="admin-login-pw" type="password" placeholder="••••••••"
+               autocomplete="new-password"
+               onkeydown="if(event.key==='Enter') doAdminLogin()"
+               style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:10px 40px 10px 14px;color:var(--text);font-size:14px;outline:none;">
+        <button type="button"
+                id="admin-login-pw-toggle"
+                onclick="toggleAdminPwVisibility()"
+                aria-label="show/hide password"
+                title="비밀번호 보기/숨기기"
+                style="position:absolute;right:8px;top:50%;
+                       transform:translateY(-50%);background:none;
+                       border:none;cursor:pointer;color:var(--muted);
+                       font-size:14px;padding:4px 6px">👁️</button>
+      </div>
     </div>
     <div id="admin-login-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:12px;font-family:var(--font-mono);"></div>
     <button onclick="doAdminLogin()"

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -48,6 +48,21 @@ function showAdminLoginModal() {
   }
 }
 
+/* [#A8-3] admin password 보기/숨기기 토글. chat 페이지와 동일 패턴 —
+   input.type 'password' ↔ 'text' swap + emoji 변경. */
+function toggleAdminPwVisibility() {
+  const input = document.getElementById('admin-login-pw');
+  const btn   = document.getElementById('admin-login-pw-toggle');
+  if (!input) return;
+  if (input.type === 'password') {
+    input.type = 'text';
+    if (btn) btn.textContent = '🙈';
+  } else {
+    input.type = 'password';
+    if (btn) btn.textContent = '👁️';
+  }
+}
+
 async function doAdminLogin() {
   const username = document.getElementById('admin-login-id')?.value.trim() || 'admin';
   const password = document.getElementById('admin-login-pw')?.value || '';

--- a/tests/test_admin_pw_eye.py
+++ b/tests/test_admin_pw_eye.py
@@ -1,0 +1,79 @@
+"""Admin login password 👁️ toggle (item #A8-3, 2026-05-09).
+
+User feedback: "패쓰워드 란에도 보이고 가리는 기능 눈 모양 토글 설치".
+PR #117 added it to the chat page login modal. This PR brings parity
+to the admin login modal.
+
+Run:
+  python -m unittest tests.test_admin_pw_eye
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+HTML = ROOT / "frontend" / "admin.html"
+JS   = ROOT / "frontend" / "static" / "admin.js"
+
+
+class HtmlTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_toggle_button_present(self):
+        self.assertIn('id="admin-login-pw-toggle"', self.html,
+            "admin login pw toggle button missing")
+        self.assertIn('toggleAdminPwVisibility()', self.html,
+            "toggle button must wire to toggleAdminPwVisibility()")
+
+    def test_default_emoji(self):
+        m = re.search(
+            r'id="admin-login-pw-toggle"[^>]*>(.*?)</button>',
+            self.html,
+        )
+        self.assertIsNotNone(m, "couldn't locate toggle button content")
+        self.assertIn("👁️", m.group(1),
+            "default emoji should be 👁️ (visible)")
+
+    def test_password_field_padding_for_button(self):
+        # Padding-right ≥ 32px so the eye button doesn't overlap text.
+        m = re.search(
+            r'id="admin-login-pw"[^>]*style="([^"]+)"',
+            self.html,
+        )
+        self.assertIsNotNone(m)
+        style = m.group(1)
+        # The padding shorthand is `10px 40px 10px 14px` — right side 40px.
+        self.assertIn("10px 40px 10px 14px", style,
+            "padding-right must accommodate the eye button (40px)")
+
+
+class JsHelperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_toggle_function_exists(self):
+        self.assertIn("function toggleAdminPwVisibility", self.js,
+            "missing toggleAdminPwVisibility helper")
+
+    def test_toggle_swaps_both_directions(self):
+        idx = self.js.index("function toggleAdminPwVisibility")
+        body = self.js[idx:idx + 600]
+        self.assertIn("input.type = 'text'", body,
+            "must reveal: type='password' → type='text'")
+        self.assertIn("input.type = 'password'", body,
+            "must hide: type='text' → type='password'")
+        self.assertIn("'🙈'", body,
+            "emoji must flip when revealed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"패쓰워드 란에도 보이고 가리는 기능 눈 모양 토글 설치"*. Chat login already had this (PR #117); admin login modal didn't — fixing parity.

## Changes

### `admin.html`
- Wrap `#admin-login-pw` in `position:relative` container
- Pad input 40px right for eye button
- `<button id="admin-login-pw-toggle">` with 👁️ emoji

### `admin.js`
- `toggleAdminPwVisibility()` — mirror of chat's `toggleApiKeyVisibility`. Swaps `input.type` `'password'` ↔ `'text'` + emoji `👁️` ↔ `🙈`.

## Verification

`tests/test_admin_pw_eye.py` — **5 tests**: toggle button + emoji + padding (HTML) / function + both swap directions (JS).

**597/597 regression suite pass.**

## Bench numbers

Not applicable — auth UX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)