### PR TITLE
feat(auth): chat ↔ admin SSO via shared localStorage (item #A8-4)

### DIFF
--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -5,7 +5,16 @@
 // proxy. Avoids the mixed-content block when the page is loaded
 // over https but the API was hardcoded to http.
 const API  = window.location.origin;
-let token  = sessionStorage.getItem('james_token') || '';
+// [#A8-4] SSO — token + role을 localStorage에서 읽어 챗 페이지와 공유.
+// 이전 sessionStorage 값이 있으면 1회 마이그레이션 (사용자가 새로 로그인
+// 하지 않아도 즉시 어드민 페이지 진입 가능).
+(function _migrateAdminSessionToLocal() {
+  for (const k of ['james_token', 'james_role']) {
+    const sess = sessionStorage.getItem(k);
+    if (sess && !localStorage.getItem(k)) localStorage.setItem(k, sess);
+  }
+})();
+let token  = localStorage.getItem('james_token') || '';
 let apiKey = localStorage.getItem('james_api_key') || '';
 
 /* ── [STEP 5-A] 언어 토글 ── */
@@ -31,11 +40,32 @@ window.addEventListener('DOMContentLoaded', async () => {
     apiKey = prompt('JAMES API Key:') || '';
     localStorage.setItem('james_api_key', apiKey);
   }
-  const storedRole = sessionStorage.getItem('james_role') || '';
+  // [#A8-4] localStorage에서 role 읽음 — chat에서 admin으로 로그인했다면
+  // 자동으로 dashboard 진입. 비-admin role이거나 token 없으면 modal.
+  const storedRole = localStorage.getItem('james_role') || '';
   if (!token || storedRole !== 'admin') {
     showAdminLoginModal();
   } else {
     loadDashboard();
+  }
+});
+
+/* [#A8-4] cross-tab sync — 다른 탭(chat 페이지)에서 로그인/로그아웃 →
+   이 어드민 탭의 token/role 즉시 동기화. admin role 잃으면 모달 자동
+   띄움. localStorage storage 이벤트는 *다른* 탭의 변경만 받으므로 본
+   탭이 자체 변경한 상태와 충돌 안 함. */
+window.addEventListener('storage', (e) => {
+  if (e.key !== 'james_token' && e.key !== 'james_role') return;
+  token = localStorage.getItem('james_token') || '';
+  const role = localStorage.getItem('james_role') || '';
+  if (!token || role !== 'admin') {
+    // admin 권한 잃음 → modal 띄워 재로그인 유도
+    showAdminLoginModal();
+  } else {
+    // admin 권한 회복 → modal 닫고 dashboard
+    const modal = document.getElementById('admin-login-modal');
+    if (modal) modal.style.display = 'none';
+    try { loadDashboard(); } catch (_) {}
   }
 });
 
@@ -92,8 +122,10 @@ async function doAdminLogin() {
     if (role !== 'admin'){ if(errEl) errEl.textContent = `Admin role required (role: ${role})`; return; }
 
     token = tok;
-    sessionStorage.setItem('james_token', token);
-    sessionStorage.setItem('james_role',  role);
+    // [#A8-4] localStorage — chat 페이지와 공유. 다른 탭의 storage 이벤트로
+    // chat 페이지 role-badge 자동 갱신.
+    localStorage.setItem('james_token', token);
+    localStorage.setItem('james_role',  role);
 
     const modal = document.getElementById('admin-login-modal');
     if (modal) modal.style.display = 'none';
@@ -181,7 +213,9 @@ async function api(path, method='GET', body=null) {
   const r   = await fetch(`${API}${path}${sep}api_key=${apiKey}`, opts);
   if (r.status === 401) {
     token = '';
-    sessionStorage.removeItem('james_token');
+    // [#A8-4] localStorage 전환 — 401 시 chat 페이지 role-badge도 자동 갱신.
+    localStorage.removeItem('james_token');
+    localStorage.removeItem('james_role');
     alert(t('auth.expired_refresh'));
     location.reload();
     return {};

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -6,8 +6,20 @@
 // over https but the API was hardcoded to http.
 const API = window.location.origin;
 let SOURCE_TYPE = 'prod';
-let token    = sessionStorage.getItem('james_token') || '';
-let userRole = sessionStorage.getItem('james_role')  || '';
+// [#A8-4] SSO — token + role을 localStorage에 저장. sessionStorage는
+// per-tab이라 챗 ↔ 어드민 새 탭에서 인식 안 됨. localStorage는 같은 origin
+// 내 모든 탭/창 공유. JWT 자체에 만료(exp) 박혀있어서 server-side 검증
+// 시점에 거절되므로 localStorage 잔존이 보안 위협 안 됨.
+// 이전 sessionStorage에 저장된 token이 있으면 마이그레이션해서 사용성
+// 깨지지 않도록 한 번 옮긴다.
+(function _migrateSessionToLocal() {
+  for (const k of ['james_token', 'james_role']) {
+    const sess = sessionStorage.getItem(k);
+    if (sess && !localStorage.getItem(k)) localStorage.setItem(k, sess);
+  }
+})();
+let token    = localStorage.getItem('james_token') || '';
+let userRole = localStorage.getItem('james_role')  || '';
 
 /* ── [STEP 5-A / 5-C] 언어 토글 ── */
 function toggleLang() {
@@ -33,12 +45,12 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 });
 
-/* ── 토큰 유틸 ── */
-function getToken()  { return sessionStorage.getItem('james_token') || token || ''; }
+/* ── 토큰 유틸 [#A8-4 SSO localStorage] ── */
+function getToken()  { return localStorage.getItem('james_token') || token || ''; }
 function saveToken(t, role) {
   token = t; userRole = role;
-  sessionStorage.setItem('james_token', t);
-  sessionStorage.setItem('james_role',  role);
+  localStorage.setItem('james_token', t);
+  localStorage.setItem('james_role',  role);
 }
 
 // JWT 만료까지 남은 초 (파싱 실패 시 0)
@@ -58,7 +70,7 @@ function checkTokenExpiry() {
   if (left === 0) {
     // 이미 만료 — 자동 재로그인 유도
     token = '';
-    sessionStorage.removeItem('james_token');
+    localStorage.removeItem('james_token');
     updateRoleBadge();
     const warn = document.createElement('div');
     warn.style.cssText = 'position:fixed;top:60px;left:50%;transform:translateX(-50%);' +
@@ -506,10 +518,10 @@ async function doLogin() {
       return;
     }
 
-    // 토큰 저장
+    // 토큰 저장 [#A8-4 SSO]
     token    = data.access_token;
     userRole = data.role || 'employee';
-    sessionStorage.setItem('james_token', token);
+    localStorage.setItem('james_token', token);
     localStorage.setItem('james_role',  userRole);
 
     closeLogin();
@@ -526,11 +538,24 @@ async function doLogin() {
 function logout() {
   token    = '';
   userRole = '';
-  sessionStorage.removeItem('james_token');
-  sessionStorage.removeItem('james_role');
+  localStorage.removeItem('james_token');
+  localStorage.removeItem('james_role');
   updateRoleBadge();
   toast('로그아웃 완료', 'success');
 }
+
+/* [#A8-4] cross-tab sync — 다른 탭(어드민 페이지 등)에서 로그인/로그아웃
+   하면 즉시 이 탭에도 반영. localStorage의 storage 이벤트는 *다른* 탭의
+   변경만 받음 (자기 자신 변경 제외) — chat에서 로그인하고 어드민 새 탭
+   열면 어드민이 즉시 로그인 상태로 보이고, 반대로 어드민에서 로그아웃
+   하면 chat 탭의 role-badge도 즉시 갱신된다. */
+window.addEventListener('storage', (e) => {
+  if (e.key === 'james_token' || e.key === 'james_role') {
+    token    = localStorage.getItem('james_token') || '';
+    userRole = localStorage.getItem('james_role')  || '';
+    try { updateRoleBadge(); } catch (_) {}
+  }
+});
 
 function updateRoleBadge() {
   const badge    = document.getElementById('role-badge');
@@ -668,7 +693,7 @@ async function sendMessage() {
 
     if (r.status === 401) {
       token = '';
-      sessionStorage.removeItem('james_token');
+      localStorage.removeItem('james_token');
       updateRoleBadge();
       appendMsg('james', '⚠️ 인증이 만료됐습니다. 다시 로그인해주세요.');
       showLogin();

--- a/tests/test_sso_localstorage.py
+++ b/tests/test_sso_localstorage.py
@@ -1,0 +1,205 @@
+"""Chat ↔ Admin SSO via shared localStorage (item #A8-4, 2026-05-09).
+
+User feedback: "챗 페이지 어드민 페이지 중 어느 하나에 로그인 하면
+둘다 자동 로그인 처리되도록 로그인 시스템 통합".
+
+Before:
+  - chat.js mixed sessionStorage (token) + localStorage (role)
+  - admin.js used sessionStorage for both token + role
+  → sessionStorage is per-tab so opening admin.html in a new tab
+    after chat login lost the session.
+
+After:
+  - Both pages use localStorage for james_token + james_role.
+  - Initial load migrates any leftover sessionStorage values.
+  - Both pages add a 'storage' event listener to react to cross-tab
+    auth changes (login in one tab → other tab updates badge or
+    closes modal).
+
+Run:
+  python -m unittest tests.test_sso_localstorage
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+CHAT_JS  = ROOT / "frontend" / "static" / "chat.js"
+ADMIN_JS = ROOT / "frontend" / "static" / "admin.js"
+
+
+class StorageBackendTests(unittest.TestCase):
+    """All james_token / james_role accesses must go through localStorage."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.chat = CHAT_JS.read_text(encoding="utf-8")
+        cls.admin = ADMIN_JS.read_text(encoding="utf-8")
+
+    def _count_session_token_role(self, src):
+        """Count remaining sessionStorage references to james_token /
+        james_role (both get/set/removeItem)."""
+        pattern = r"sessionStorage\.(get|set|remove)Item\(['\"]james_(token|role)"
+        return len(re.findall(pattern, src))
+
+    def test_chat_no_session_token_role(self):
+        # The migration block at the top is allowed to read sessionStorage
+        # ONCE — but only inside the migration IIFE. Outside the migration,
+        # all references must be localStorage.
+        # Count the total references and subtract the migration ones (2:
+        # one getItem for james_token, one for james_role).
+        total = self._count_session_token_role(self.chat)
+        # Migration block reads each key with getItem once.
+        migration_idx = self.chat.index("_migrateSessionToLocal")
+        migration_end = self.chat.index("})()", migration_idx)
+        migration_block = self.chat[migration_idx:migration_end]
+        migration_refs = self._count_session_token_role(migration_block)
+        non_migration = total - migration_refs
+        self.assertEqual(non_migration, 0,
+            f"chat.js still has {non_migration} non-migration sessionStorage "
+            f"references to james_token/role — should all be localStorage")
+
+    def test_admin_no_session_token_role(self):
+        total = self._count_session_token_role(self.admin)
+        migration_idx = self.admin.index("_migrateAdminSessionToLocal")
+        migration_end = self.admin.index("})()", migration_idx)
+        migration_block = self.admin[migration_idx:migration_end]
+        migration_refs = self._count_session_token_role(migration_block)
+        non_migration = total - migration_refs
+        self.assertEqual(non_migration, 0,
+            f"admin.js still has {non_migration} non-migration sessionStorage "
+            f"references to james_token/role — should all be localStorage")
+
+    def test_chat_initial_token_read_from_localstorage(self):
+        self.assertIn("localStorage.getItem('james_token')", self.chat,
+            "chat.js must read initial token from localStorage")
+        self.assertIn("localStorage.getItem('james_role')", self.chat,
+            "chat.js must read initial role from localStorage")
+
+    def test_admin_initial_token_read_from_localstorage(self):
+        self.assertIn("localStorage.getItem('james_token')", self.admin,
+            "admin.js must read initial token from localStorage")
+        self.assertIn("localStorage.getItem('james_role')", self.admin,
+            "admin.js must check role from localStorage on init")
+
+
+class MigrationTests(unittest.TestCase):
+    """One-shot migration from sessionStorage → localStorage on first load."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.chat = CHAT_JS.read_text(encoding="utf-8")
+        cls.admin = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_chat_has_migration_iife(self):
+        self.assertIn("_migrateSessionToLocal", self.chat,
+            "chat.js must have a migration IIFE at top")
+        idx = self.chat.index("_migrateSessionToLocal")
+        body = self.chat[idx:idx + 800]
+        self.assertIn("james_token", body)
+        self.assertIn("james_role", body)
+        self.assertIn("sessionStorage.getItem", body,
+            "migration must read from sessionStorage")
+        self.assertIn("localStorage.setItem", body,
+            "migration must write to localStorage")
+
+    def test_admin_has_migration_iife(self):
+        self.assertIn("_migrateAdminSessionToLocal", self.admin,
+            "admin.js must have a migration IIFE")
+
+
+class CrossTabSyncTests(unittest.TestCase):
+    """Both pages add a 'storage' event listener for cross-tab sync."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.chat = CHAT_JS.read_text(encoding="utf-8")
+        cls.admin = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_chat_listens_for_storage_event(self):
+        self.assertIn("addEventListener('storage'", self.chat,
+            "chat.js must add 'storage' event listener for cross-tab SSO")
+        idx = self.chat.index("addEventListener('storage'")
+        body = self.chat[idx:idx + 800]
+        self.assertIn("james_token", body,
+            "listener must filter on james_token / james_role")
+        self.assertIn("updateRoleBadge", body,
+            "listener must call updateRoleBadge to refresh UI")
+
+    def test_admin_listens_for_storage_event(self):
+        self.assertIn("addEventListener('storage'", self.admin,
+            "admin.js must add 'storage' event listener for cross-tab SSO")
+        idx = self.admin.index("addEventListener('storage'")
+        body = self.admin[idx:idx + 1200]
+        self.assertIn("james_token", body)
+        self.assertIn("showAdminLoginModal", body,
+            "listener must show login modal when admin role is lost")
+
+    def test_admin_listener_only_admin_role_keeps_dashboard(self):
+        # If a different (non-admin) role gets set in localStorage from
+        # the chat page, the admin tab should NOT silently auto-allow.
+        # Verify the role check is present.
+        idx = self.admin.index("addEventListener('storage'")
+        body = self.admin[idx:idx + 1200]
+        self.assertIn("'admin'", body,
+            "must specifically check role === 'admin' before re-entering dashboard")
+
+
+class LoginPersistenceTests(unittest.TestCase):
+    """doLogin / doAdminLogin write to localStorage so other tabs see it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.chat = CHAT_JS.read_text(encoding="utf-8")
+        cls.admin = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_chat_doLogin_writes_localstorage(self):
+        idx = self.chat.index("async function doLogin")
+        end = self.chat.index("function logout", idx)
+        body = self.chat[idx:end]
+        self.assertIn("localStorage.setItem('james_token'", body,
+            "doLogin must persist token to localStorage")
+        self.assertIn("localStorage.setItem('james_role'", body,
+            "doLogin must persist role to localStorage")
+
+    def test_admin_doAdminLogin_writes_localstorage(self):
+        idx = self.admin.index("async function doAdminLogin")
+        # Bound at next async function or function decl.
+        m = re.search(r"\n(async )?function\s+\w+\s*\(", self.admin[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 3000
+        body = self.admin[idx:end]
+        self.assertIn("localStorage.setItem('james_token'", body,
+            "doAdminLogin must persist token to localStorage for SSO")
+        self.assertIn("localStorage.setItem('james_role'", body,
+            "doAdminLogin must persist role to localStorage")
+
+
+class LogoutClearsBothTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chat = CHAT_JS.read_text(encoding="utf-8")
+        cls.admin = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_chat_logout_removes_localstorage(self):
+        idx = self.chat.index("function logout")
+        body = self.chat[idx:idx + 600]
+        self.assertIn("localStorage.removeItem('james_token')", body)
+        self.assertIn("localStorage.removeItem('james_role')", body)
+
+    def test_admin_401_removes_localstorage(self):
+        # Admin api() helper handles 401 — must clear localStorage so
+        # chat tab role-badge updates too.
+        idx = self.admin.index("if (r.status === 401)")
+        body = self.admin[idx:idx + 600]
+        self.assertIn("localStorage.removeItem('james_token')", body,
+            "admin 401 path must clear localStorage james_token")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"챗 페이지 어드민 페이지 중 어느 하나에 로그인 하면 둘다 자동 로그인 처리되도록 로그인 시스템 통합"*.

## Before

- `chat.js`: mixed sessionStorage (token) + localStorage (role)
- `admin.js`: sessionStorage for both
- → sessionStorage is **per-tab**, so opening admin.html in a new tab after chat login lost the session

## After

- Both pages use **localStorage** for `james_token` + `james_role`
- One-shot migration IIFE on each page picks up leftover sessionStorage values
- `storage` event listener on each page reacts to cross-tab auth changes:
  - **chat**: refreshes role-badge when admin tab logs out
  - **admin**: shows login modal if admin role lost; auto-enters dashboard if admin role granted elsewhere

## Security tradeoff

Tokens persist across browser restarts. Acceptable for single-user setup (Tailscale, personal device):
- JWT `exp` claim validated server-side
- 401 responses clear localStorage automatically
- Explicit logout clears immediately

For shared devices, shorten JWT expiry on the server.

## Verification

`tests/test_sso_localstorage.py` — **13 tests** across 5 classes:
- **StorageBackendTests** (4): zero non-migration sessionStorage refs in either file, both read from localStorage
- **MigrationTests** (2): IIFE in both files
- **CrossTabSyncTests** (3): listeners + role checks
- **LoginPersistenceTests** (2): doLogin / doAdminLogin write localStorage
- **LogoutClearsBothTests** (2): cleanup paths

**610/610 regression suite pass.**

## Bench numbers

Not applicable — auth state migration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)