### PR TITLE
feat(chat): "📥 위키 저장" chip on web-search answers (item #A8-7)

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -274,6 +274,9 @@ def run_retrieval_pipeline(
     # User-reported crash: pipeline.py:498 UnboundLocalError. 사용자 환경에서
     # 첫 query에 500 응답 → 이 줄을 try 밖으로 빼서 항상 binding 보장.
     web_results: list = []
+    # [#A8-7] 웹 검색 성공 시 함께 만든 web_longterm_save proposal id.
+    # chat 페이지의 "📥 위키 저장" chip이 이걸로 approve API 직접 호출.
+    pending_save_proposal_id: str = ""
 
     try:
         sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
@@ -311,15 +314,15 @@ def run_retrieval_pipeline(
                         # 단기 지식 레벨 +2
                         update_knowledge_level(safe_query, is_longterm=False)
 
-                        # 장기 전환 조건 확인
-                        if should_promote_to_longterm(safe_query) or is_save_command(safe_query):
-                            # [#A6-3 2026-05-08] 즉시 save_as_longterm → admin
-                            # confirm proposal로 전환. 이전엔 사용자 쿼리만으로
-                            # operator 모르는 사이 외부 출처가 wiki에 들어가
-                            # 이후 retrieval에서 회수됐다. 이제 admin이 명시적
-                            # 승인하기 전엔 wiki에 안 들어감 — pending proposal
-                            # 만 생성. 단기 저장 (record_search) + KnowledgeTracker
-                            # 단기 +2점은 그대로 (이미 위에서 적용).
+                        # [#A8-7 2026-05-09] 모든 웹 검색 결과에 대해 proposal
+                        # 생성 (이전에는 search_count ≥ 2 또는 명시 저장 명령
+                        # 시에만). chat 페이지의 "📥 위키 저장" chip이 첫 검색
+                        # 부터 즉시 사용 가능해야 하므로. should_promote /
+                        # is_save_command가 true면 자동 임포턴스 표시 정도로
+                        # 확장 가능하지만 현재 단순화 — admin이 chat 또는
+                        # admin 페이지에서 명시 승인.
+                        always_propose = True   # [#A8-7] 항상 만들기
+                        if always_propose:
                             try:
                                 summary_prompt = (
                                     f"아래 검색 결과를 한국어로 200자 이내 핵심 요약:\n"
@@ -358,11 +361,10 @@ def run_retrieval_pipeline(
                                         },
                                     )
                                     save_proposal(p)
+                                    pending_save_proposal_id = p['proposal_id']
                                     print(f"[WEB→WIKI] admin confirm proposal 생성: {p['proposal_id']}")
                             except Exception as we:
                                 print(f"[WEB→WIKI] proposal 생성 실패: {we}")
-                        else:
-                            print(f"[WEB] 단기 저장 (누적 {search_count}회 / 2회 이상이면 장기 전환)")
             except Exception as we:
                 print(f"[WEB] 검색 모듈 오류: {we}")
 
@@ -522,6 +524,8 @@ def run_retrieval_pipeline(
         # [#A6-2] web search 사용 여부 + 출처
         "web_used":      web_used,
         "web_sources":   web_sources,
+        # [#A8-7] chat-side "위키 저장" chip이 approve할 proposal id (있을 때만)
+        "pending_save_proposal_id": pending_save_proposal_id,
         # [#65 phase 3] full chunk texts that fed the LLM, surfaced for
         # RAGAS `context_precision` / `context_recall` evaluation against
         # the live retrieval path. The /query/ endpoint admin-gates the

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -789,6 +789,28 @@ function appendJamesMsg(data) {
       (data.mode||'') + ':' + (data.answer||'').slice(0,40)
     )).slice(0,12) : '');
 
+  // [#A8-7] 웹 검색 답변에 "📥 위키 저장" chip — 사용자 직접 승인 흐름.
+  // pending_save_proposal_id가 있고 admin role이면 chip 노출. click →
+  // /admin/proposals/{id}/approve로 직접 wiki entity 생성. 비-admin은
+  // chip 미표시 (서버에서 거절될 거라 무의미). data 객체에 chip 상태 보관.
+  let saveWikiChip = '';
+  if (data.web_used && data.pending_save_proposal_id && userRole === 'admin') {
+    saveWikiChip = `
+      <div style="margin-top:6px">
+        <button class="next-action-chip save-wiki-btn"
+                onclick="approveWikiSave(this)"
+                data-proposal-id="${escHtml(data.pending_save_proposal_id)}"
+                style="text-align:left;background:rgba(76,175,125,.10);
+                       border:1px solid rgba(76,175,125,.45);border-radius:8px;
+                       padding:8px 12px;cursor:pointer;color:var(--text);
+                       font-size:12px;width:100%;font-family:inherit;
+                       transition:all .15s">
+          <span style="color:#4caf7d;font-weight:600;margin-right:6px">📥</span>
+          <span>이 자료를 위키로 저장 (장기 기억화)</span>
+        </button>
+      </div>`;
+  }
+
   // [#A6-2] 웹 검색 사용됨 배지 + 출처 URL
   // 답변에 외부 데이터(low-trust web)가 섞였음을 사용자에게 명시.
   // 출처 URL 노출로 신뢰도 자가 판단 가능. internal-only 답변엔 미표시.
@@ -967,6 +989,7 @@ function appendJamesMsg(data) {
     <div>
       <div class="bubble">${formatAnswerWithParagraphs(answer)}${pathsHtml}</div>
       ${webBadge}
+      ${saveWikiChip}
       ${confidenceBadge}
       ${metaHtml}
       ${forceWebChip}
@@ -1022,6 +1045,47 @@ function extractNextActionSuggestions(answerText) {
     if (out.length >= 2) return out;
   }
   return [];
+}
+
+/* [#A8-7] "📥 위키 저장" chip 클릭 핸들러.
+   chat 답변에 노출된 pending_save_proposal_id로 /admin/proposals/{id}/approve
+   직접 호출. admin role 필요 (chip 자체가 admin에게만 보이지만 server-side
+   에서도 거절). 성공 시 toast + chip을 "✓ 저장됨" 으로 disable. */
+async function approveWikiSave(btn) {
+  if (!btn || btn.disabled) return;
+  const id = btn.dataset.proposalId || '';
+  if (!id) return;
+  if (!confirm('이 검색 결과를 wiki entity로 영구 저장합니다.\n저장 후 retrieval에 활용됩니다.\n계속하시겠습니까?')) return;
+  btn.disabled = true;
+  btn.style.opacity = '0.55';
+  const labelEl = btn.querySelector('span:last-child');
+  if (labelEl) labelEl.textContent = '저장 중...';
+  try {
+    const r = await fetch(
+      `${API}/admin/proposals/${encodeURIComponent(id)}/approve?api_key=${encodeURIComponent(getApiKey())}`,
+      {
+        method:  'POST',
+        headers: getAuthHeaders(),
+        body:    JSON.stringify({api_key: getApiKey()}),
+      },
+    );
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      throw new Error(err.detail || `HTTP ${r.status}`);
+    }
+    const data = await r.json();
+    if (data.success === false) {
+      throw new Error(data.message || '저장 실패');
+    }
+    if (labelEl) labelEl.textContent = '✓ 위키에 저장됨';
+    btn.style.background = 'rgba(76,175,125,.18)';
+    toast(`✅ 위키 저장 완료${data.details?.path ? ': ' + data.details.path : ''}`, 'success');
+  } catch (e) {
+    btn.disabled = false;
+    btn.style.opacity = '';
+    if (labelEl) labelEl.textContent = '이 자료를 위키로 저장 (장기 기억화)';
+    toast(`저장 실패: ${e.message}`, 'error');
+  }
 }
 
 /* [#A8-6] "🌐 웹 검색으로 더 조사" chip 클릭 핸들러.

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -355,6 +355,9 @@ class QueryResponse(BaseModel):
     # 사용됨" 배지 + 출처 리스트. internal-only 답변엔 둘 다 빈/false.
     web_used:       bool  = False
     web_sources:    list  = []
+    # [#A8-7] chat-side "📥 위키 저장" chip이 approve API에 보낼 proposal id.
+    # 빈 문자열이면 chip 숨김. web_used=true일 때만 채워진다.
+    pending_save_proposal_id: str = ""
 
 class UploadResponse(BaseModel):
     status:      str
@@ -747,6 +750,8 @@ async def query(
         # [#A6-2] 웹 검색 사용됨 배지 + 출처 URL (자료 부족 fallback 시).
         "web_used":      bool(result.get("web_used", False)),
         "web_sources":   result.get("web_sources", []),
+        # [#A8-7] chat-side 위키 저장 chip용 proposal id
+        "pending_save_proposal_id": result.get("pending_save_proposal_id", ""),
     }
     # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
     # fed the LLM are surfaced only when (a) caller opted in via

--- a/tests/test_chat_wiki_save.py
+++ b/tests/test_chat_wiki_save.py
@@ -1,0 +1,139 @@
+"""Chat-side wiki save chip (item #A8-7, 2026-05-09).
+
+User feedback: "웹 검색 자료 제시한 답변과 자료에 대해서는 해당
+대화창에서 장기 기억 자료화 위키 엔티티 추출 하여 데이터베이스화
+여부를 사용자에게 물어보고 수행할수 있도록 로직과 ui 만들기".
+
+Flow:
+  1. Pipeline always creates a web_longterm_save proposal when web
+     search succeeds (#A6-3 had a 2+ search gate; #A8-7 drops it).
+  2. Pipeline returns pending_save_proposal_id in result dict.
+  3. Server forwards to QueryResponse and /query/ response body.
+  4. Chat bubble renders "📥 위키 저장" chip when:
+       web_used == true  AND  pending_save_proposal_id  AND  role==admin
+  5. Click → confirm dialog → POST /admin/proposals/{id}/approve →
+     toast + chip flips to "✓ 저장됨".
+
+Run:
+  python -m unittest tests.test_chat_wiki_save
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class PipelineProposalAlwaysCreatedTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from core.reasoning import pipeline
+        cls.src = inspect.getsource(pipeline)
+
+    def test_pending_save_proposal_id_in_outer_scope(self):
+        # Like web_results, pending_save_proposal_id must be initialized
+        # before the try: block so it survives early-fail paths.
+        try_idx  = self.src.index("\n    try:\n        sys_prefix = ")
+        init_idx = self.src.index('pending_save_proposal_id: str = ""')
+        self.assertLess(init_idx, try_idx,
+            "pending_save_proposal_id must be initialised BEFORE try:")
+
+    def test_proposal_no_longer_gated_on_search_count(self):
+        # The old gate `should_promote_to_longterm(safe_query) or
+        # is_save_command(safe_query)` is replaced by always_propose=True.
+        # The marker variable + the `if always_propose:` branch must be
+        # present so chat-side chip can save even on first search.
+        self.assertIn("always_propose", self.src,
+            "must use always_propose marker to drop the search-count gate")
+        self.assertIn("if always_propose:", self.src,
+            "branch condition must be `if always_propose:`")
+
+    def test_proposal_id_captured_after_save(self):
+        idx = self.src.index("save_proposal(p)")
+        body = self.src[idx:idx + 400]
+        self.assertIn("pending_save_proposal_id = p['proposal_id']", body,
+            "must capture proposal id immediately after save_proposal")
+
+    def test_return_dict_includes_field(self):
+        return_idx = self.src.rindex("return {")
+        body = self.src[return_idx:return_idx + 1500]
+        self.assertIn('"pending_save_proposal_id"', body,
+            "return dict must include pending_save_proposal_id")
+
+
+class ResponseShapeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_response_model_has_field(self):
+        m = re.search(
+            r"class QueryResponse\(BaseModel\):(.+?)class\s+\w+\(",
+            self.src, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        body = m.group(1)
+        self.assertIn("pending_save_proposal_id", body,
+            "QueryResponse must declare pending_save_proposal_id")
+        self.assertIn('pending_save_proposal_id: str = ""', body,
+            "field default must be empty string")
+
+    def test_query_handler_propagates_field(self):
+        idx = self.src.index('@app.post("/query/"')
+        end = self.src.index('@app.', idx + 10)
+        body = self.src[idx:end]
+        self.assertIn('"pending_save_proposal_id"', body,
+            "/query/ handler must include the field in response")
+        self.assertIn('result.get("pending_save_proposal_id"', body,
+            "must read from pipeline result dict")
+
+
+class FrontendChipTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+
+    def test_chip_rendered_when_web_used_and_admin(self):
+        idx = self.js.index("function appendJamesMsg")
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 12000
+        body = self.js[idx:end]
+        self.assertIn("save-wiki-btn", body,
+            "chip class missing")
+        self.assertIn("data.web_used", body)
+        self.assertIn("pending_save_proposal_id", body,
+            "must inspect pending_save_proposal_id")
+        self.assertIn("userRole === 'admin'", body,
+            "chip must be admin-only (server also rejects non-admin)")
+        self.assertIn("approveWikiSave(this)", body,
+            "chip onclick must call approveWikiSave")
+        self.assertIn("data-proposal-id", body,
+            "chip must carry proposal id via data attr")
+        self.assertIn("${saveWikiChip}", body,
+            "saveWikiChip must be interpolated into bubble HTML")
+
+    def test_approve_helper_exists_and_calls_endpoint(self):
+        self.assertIn("async function approveWikiSave", self.js)
+        idx = self.js.index("async function approveWikiSave")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("dataset.proposalId", body,
+            "must read proposal id from data attr")
+        self.assertIn("/admin/proposals/", body,
+            "must POST to admin proposal approve endpoint")
+        self.assertIn("/approve", body)
+        self.assertIn("confirm(", body,
+            "must confirm before saving (destructive — adds to wiki)")
+        # Toast on success/failure
+        self.assertIn("toast(", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_longterm_save_admin_confirm.py
+++ b/tests/test_longterm_save_admin_confirm.py
@@ -41,39 +41,34 @@ class PipelineProposalCreationTests(unittest.TestCase):
         from core.reasoning import pipeline
         cls.src = inspect.getsource(pipeline)
 
+    def _proposal_block(self) -> str:
+        # [#A8-7 update 2026-05-09] Locator changed: gate moved from
+        # `should_promote_to_longterm(safe_query) or is_save_command(...)`
+        # to a simpler `if always_propose:` branch (always create the
+        # proposal so the chat-side save chip can offer it on first
+        # search too). Anchor on always_propose now.
+        idx = self.src.index("always_propose")
+        return self.src[idx:idx + 3000]
+
     def test_no_direct_save_as_longterm_call(self):
-        # The auto-save path that fires on should_promote_to_longterm
-        # must no longer call save_as_longterm directly. The function
-        # is still imported (it's used by the executor on approve), but
-        # not invoked from the pipeline branch.
-        # Look for the should_promote_to_longterm gate; inside that
-        # branch, `save_as_longterm(` should NOT appear.
-        m = inspect.findsource
-        # Practical check: locate the if-block for should_promote_to_longterm
-        # and confirm the body uses _make_proposal instead of
-        # save_as_longterm.
-        idx = self.src.index("should_promote_to_longterm(safe_query)")
-        # The block ends at "else:" of the same indentation. Use a
-        # generous slice and check both presences.
-        block = self.src[idx:idx + 3000]
+        # The promotion branch must not call save_as_longterm directly
+        # — it must persist a proposal for admin (or chat-side) confirm.
+        block = self._proposal_block()
         self.assertIn("_make_proposal", block,
             "promotion branch must create a proposal (admin confirm)")
         self.assertIn("save_proposal", block,
             "must persist the proposal via save_proposal")
-        # Confirm the auto-save path was removed from this block.
         self.assertNotIn("save_as_longterm(safe_query, web_results, summary",
             block,
             "promotion branch must not auto-save anymore — admin gate required")
 
     def test_proposal_type_is_web_longterm_save(self):
-        idx = self.src.index("should_promote_to_longterm(safe_query)")
-        block = self.src[idx:idx + 3000]
+        block = self._proposal_block()
         self.assertIn('"web_longterm_save"', block,
             'proposal type must be "web_longterm_save" (registered with executor)')
 
     def test_proposal_metadata_carries_query_summary_results_role(self):
-        idx = self.src.index("should_promote_to_longterm(safe_query)")
-        block = self.src[idx:idx + 3000]
+        block = self._proposal_block()
         for field in ('"query"', '"summary"', '"web_results"', '"user_role"'):
             self.assertIn(field, block,
                 f"proposal metadata must include {field} so executor can save")


### PR DESCRIPTION
## Summary

User feedback: *"웹 검색 자료 제시한 답변과 자료에 대해서는 해당 대화창에서 장기 기억 자료화 위키 엔티티 추출 하여 데이터베이스화 여부를 사용자에게 물어보고 수행할수 있도록 로직과 ui 만들기"*.

## Before vs After

| | Before (#A6-3) | After (this PR) |
|---|---|---|
| Save trigger | admin → /admin/proposals/ → Approve | chat bubble chip → confirm → done |
| First-search save | ❌ (gated on search_count ≥ 2) | ✅ always available |
| Context switch | Yes (chat → admin tab) | No (stays in chat) |

## Backend

### `pipeline.py`
- `pending_save_proposal_id` outer-scope (alongside `web_results`) — survives early-fail paths
- Old gate `should_promote_to_longterm OR is_save_command` → `if always_propose:` (search-count gate dropped)
- Capture `p['proposal_id']` into outer-scope after `save_proposal(p)`
- Return dict carries `pending_save_proposal_id`

### `server_llmwiki.py`
- `QueryResponse.pending_save_proposal_id: str = ""`
- `/query/` handler forwards from pipeline result

## Frontend (`chat.js`)

`appendJamesMsg` shows `📥 이 자료를 위키로 저장 (장기 기억화)` chip when:
- `data.web_used === true`
- `data.pending_save_proposal_id` non-empty
- `userRole === 'admin'`

Click → `confirm()` → POST `/admin/proposals/{id}/approve` → toast + chip flips to `✓ 위키에 저장됨`. On failure, restores chip + error toast.

## Test fix

Old `tests/test_longterm_save_admin_confirm.py` anchored on `"should_promote_to_longterm(safe_query)"` literal — gate removed. Switched to `always_propose` anchor via shared `_proposal_block()` helper. Same 3 assertions hold.

## Verification

`tests/test_chat_wiki_save.py` — **8 tests**:
- PipelineProposalAlwaysCreatedTests (4): outer-scope init, marker, capture, return field
- ResponseShapeTests (2): model + handler
- FrontendChipTests (2): conditional render + approve flow

**635/635 regression suite pass.**

## Bench numbers

`pipeline.py` touch — bench territory. Existing q1-q12 hit internal-only retrieval; `always_propose` branch only fires on web search. STEP 7 baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)