### PR TITLE
feat(install): live progress + non-blocking navigation (item #A8-8)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -242,6 +242,69 @@ function updateInstallButton() {
   btn.title = `${target} 모델이 Ollama에 없습니다. 클릭하여 설치 시작 (admin 전용).`;
 }
 
+/* [#A8-8 2026-05-09] 모델 설치 — 진행률 표시 + non-blocking 페이지 이동.
+   서버는 ollama HTTP /api/pull 스트림을 백그라운드 thread로 파싱해서
+   _install_progress 딕트에 percent/status를 기록.
+   클라는 2.5s 간격으로 GET /admin/llm/install-progress?model=... 폴링.
+   설치 버튼이 "📦 X 설치" → "⏳ 23.5% (X)" → "✅ 설치됨" 으로 라이브 갱신.
+   사용자가 다른 페이지로 이동해도 서버 백그라운드 thread는 계속 돌아감. */
+let _installPollTimer = null;
+
+function _stopInstallPoll() {
+  if (_installPollTimer) { clearInterval(_installPollTimer); _installPollTimer = null; }
+}
+
+async function _pollInstallProgress(model, btn) {
+  try {
+    const r = await fetch(
+      `${API}/admin/llm/install-progress?api_key=${encodeURIComponent(getApiKey())}&model=${encodeURIComponent(model)}`,
+      { headers: getAuthHeaders() },
+    );
+    if (!r.ok) {
+      // 401이면 admin 권한 잃음 — poll 중단.
+      if (r.status === 401) _stopInstallPoll();
+      return;
+    }
+    const p = await r.json();
+    if (!btn || !btn.isConnected) {
+      // 버튼이 사라졌으면 (모드 picker 재로드 등) — 최소 한 번 더 알림.
+      _stopInstallPoll();
+      return;
+    }
+    if (p.error) {
+      btn.textContent = `❌ ${model} 실패`;
+      btn.title = p.error;
+      _stopInstallPoll();
+      btn.disabled = false;
+      toast(`설치 실패: ${p.error}`, 'error');
+      return;
+    }
+    if (p.done) {
+      btn.textContent = `✅ ${model} 설치 완료`;
+      btn.style.background = 'rgba(76,175,125,.18)';
+      _stopInstallPoll();
+      btn.disabled = true;   // 완료된 모델은 다시 설치 불필요
+      toast(`✅ ${model} 설치 완료`, 'success');
+      // 모드 picker 갱신 → installed=true로 라벨 새로고침
+      setTimeout(loadModePickerOptions, 600);
+      return;
+    }
+    // 진행 중 — percent 또는 status 표시.
+    const pctStr = p.percent != null ? `${p.percent}%` : '';
+    const statusStr = p.status || '진행 중';
+    if (p.percent != null) {
+      btn.textContent = `⏳ ${pctStr} (${model})`;
+    } else {
+      btn.textContent = `⏳ ${statusStr}...`;
+    }
+    btn.title = `${model} 설치 — ${statusStr}${p.completed != null && p.total != null ?
+      ` (${(p.completed/1e9).toFixed(2)}/${(p.total/1e9).toFixed(2)} GB)` : ''}`;
+  } catch (e) {
+    // 네트워크 일시 단절 — 다음 tick에 다시 시도. 폴링 멈추진 않음.
+    console.warn('[install-poll]', e);
+  }
+}
+
 async function triggerModelInstall() {
   const btn = document.getElementById('mode-install-btn');
   const model = btn?.dataset?.model;
@@ -250,8 +313,7 @@ async function triggerModelInstall() {
     toast(`설치는 admin 권한 필요. 관리자에게 \`ollama pull ${model}\` 요청.`, 'error');
     return;
   }
-  if (!confirm(`Ollama에 ${model} 모델을 설치합니다.\n수 GB 다운로드 — 백그라운드로 진행됩니다.\n계속할까요?`)) return;
-  const orig = btn.textContent;
+  if (!confirm(`Ollama에 ${model} 모델을 설치합니다.\n수 GB 다운로드 — 백그라운드로 진행됩니다.\n진행 중에도 다른 페이지 이동 가능합니다.\n계속할까요?`)) return;
   btn.textContent = '⏳ 설치 시작...';
   btn.disabled = true;
   try {
@@ -263,15 +325,14 @@ async function triggerModelInstall() {
       const err = await r.json().catch(() => ({}));
       throw new Error(err.detail || `HTTP ${r.status}`);
     }
-    const data = await r.json();
-    toast(data.message || '설치 시작됨', 'success');
-    // 30초 후 모드 picker 갱신 (다운로드 진행 중일 가능성 높음)
-    setTimeout(loadModePickerOptions, 30000);
+    // 설치 시작 OK — 진행률 폴링 시작.
+    _stopInstallPoll();   // 이전 폴링 잔재 제거
+    _pollInstallProgress(model, btn);   // 즉시 1회
+    _installPollTimer = setInterval(() => _pollInstallProgress(model, btn), 2500);
   } catch (e) {
     toast(`설치 실패: ${e.message}`, 'error');
-  } finally {
-    btn.textContent = orig;
     btn.disabled = false;
+    btn.textContent = `📦 ${model} 설치`;
   }
 }
 

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -941,50 +941,142 @@ async def llm_modes(api_key: str, role: str = Depends(get_role_from_request)):
     return {"modes": filtered, "role": role}
 
 
-@app.post("/llm/install/", summary="Ollama 모델 설치 (admin) [item #6]")
+# [#A8-8] In-memory install progress tracker. Keyed by model tag.
+# Populated by the background thread that streams Ollama's pull API.
+# Frontend polls /admin/llm/install-progress?model=... every 2s.
+# Survives single server lifetime — restart wipes (operator can re-pull
+# if needed; partial Ollama downloads resume on retry).
+_install_progress: dict = {}   # model -> {status, percent, completed, total, error}
+_install_lock     = None       # set lazily — threading import deferred
+
+
+def _start_install_with_progress(model: str) -> None:
+    """Background thread: stream Ollama's POST /api/pull and write
+    progress to _install_progress[model]. Ollama returns NDJSON like:
+        {"status": "pulling manifest"}
+        {"status": "downloading", "digest": "...", "total": N, "completed": N}
+        {"status": "verifying sha256"}
+        {"status": "success"}
+    We compute percent = completed / total when both fields present.
+    """
+    import threading, urllib.request, json as _json
+    global _install_lock
+    if _install_lock is None:
+        _install_lock = threading.Lock()
+
+    def _runner():
+        try:
+            req = urllib.request.Request(
+                "http://localhost:11434/api/pull",
+                data=_json.dumps({"name": model, "stream": True}).encode(),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=3600) as r:
+                for raw in r:   # NDJSON line stream
+                    line = raw.decode("utf-8", errors="ignore").strip()
+                    if not line:
+                        continue
+                    try:
+                        evt = _json.loads(line)
+                    except Exception:
+                        continue
+                    status    = evt.get("status", "")
+                    completed = evt.get("completed")
+                    total     = evt.get("total")
+                    percent   = None
+                    if isinstance(completed, (int, float)) and isinstance(total, (int, float)) and total > 0:
+                        percent = round((completed / total) * 100, 1)
+                    with _install_lock:
+                        _install_progress[model] = {
+                            "status":    status,
+                            "completed": completed,
+                            "total":     total,
+                            "percent":   percent,
+                            "error":     "",
+                            "done":      status == "success",
+                        }
+                    if status == "success":
+                        break
+        except Exception as e:
+            with _install_lock:
+                _install_progress[model] = {
+                    "status":    "error",
+                    "completed": None,
+                    "total":     None,
+                    "percent":   None,
+                    "error":     f"{type(e).__name__}: {e}",
+                    "done":      True,
+                }
+
+    t = threading.Thread(target=_runner, daemon=True, name=f"ollama-pull-{model}")
+    t.start()
+
+
+@app.post("/llm/install/", summary="Ollama 모델 설치 (admin) [item #6 + #A8-8]")
 async def llm_install(api_key: str, model: str,
                       role: str = Depends(get_role_from_request)):
-    """Trigger `ollama pull <model>` in a subprocess.
+    """Trigger `ollama pull <model>` via Ollama's HTTP streaming API
+    in a background thread. Returns immediately so the admin page can
+    show a progress bar while the multi-GB download runs.
 
-    Admin-gated — model installation is heavy (multi-GB download)
-    and exposing it to non-admin would let any chat user fill the
-    operator's disk.
+    Admin-gated. Model name validated against catalog allowlist.
 
-    Validates model name against an allowlist (config defaults +
-    a few well-known alternatives). Arbitrary input rejected with
-    400 — operator must use the admin LLM page for non-listed models.
+    [#A8-8 2026-05-09] Replaced subprocess.Popen with HTTP streaming —
+    the CLI fire-and-forget had no progress visibility. Now the
+    background thread parses Ollama's NDJSON pull stream and writes
+    {percent, completed, total, status} to _install_progress[model],
+    which the admin UI polls.
     """
     _require_admin(api_key, role)
-    # [#A2] Allowlist auto-derived from MODEL_CATALOG so adding a
-    # candidate above does NOT require remembering to update this gate.
-    # llava is kept as a manual extra (vision support — not in catalog
-    # but operators sometimes pull it for multimodal experiments).
     ALLOWED_MODELS = _allowed_install_models() | {"llava:13b"}
     if model not in ALLOWED_MODELS:
         raise HTTPException(
             status_code=400,
-            detail=f"model not in allowlist. Use admin /admin/llm/install for arbitrary models.",
+            detail="model not in allowlist. Use admin /admin/llm/install for arbitrary models.",
         )
-
-    import subprocess
+    # Reset any prior progress entry so the polling client gets fresh state.
+    _install_progress[model] = {
+        "status":    "starting",
+        "completed": None,
+        "total":     None,
+        "percent":   0.0,
+        "error":     "",
+        "done":      False,
+    }
     try:
-        # Don't block — fire-and-forget. Operator polls /llm/modes/
-        # afterwards to see installed flip to True.
-        subprocess.Popen(
-            ["ollama", "pull", model],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        return {"ok": True, "model": model,
-                "message": f"`ollama pull {model}` 시작됨 (백그라운드 진행). 잠시 후 모드 picker가 자동 갱신됩니다."}
+        _start_install_with_progress(model)
     except FileNotFoundError:
         raise HTTPException(
             status_code=503,
-            detail="ollama CLI가 PATH에 없습니다. 시스템에 ollama 설치 후 재시도.",
+            detail="ollama API에 접근할 수 없습니다 (localhost:11434). ollama 서비스가 실행 중인지 확인.",
         )
     except Exception as e:
         raise HTTPException(status_code=500,
                             detail=f"install 시작 실패: {type(e).__name__}: {e}")
+    return {"ok": True, "model": model,
+            "message": f"{model} 설치 시작됨. 진행 상황은 admin 페이지 또는 "
+                       f"GET /admin/llm/install-progress?model={model} 로 확인."}
+
+
+@app.get("/admin/llm/install-progress", summary="모델 설치 진행률 [item #A8-8]")
+async def llm_install_progress(api_key: str, model: str,
+                                role: str = Depends(get_role_from_request)):
+    """Frontend polls this every 2-3s while the install button is in
+    progress mode. Returns the latest snapshot of the background
+    thread's progress dict, or {status: 'idle'} if no install is/was
+    running for this model.
+
+    Response shape:
+      {status, percent, completed, total, done, error, model}
+    """
+    _require_admin(api_key, role)
+    snap = _install_progress.get(model)
+    if not snap:
+        return {"model": model, "status": "idle",
+                "percent": None, "completed": None, "total": None,
+                "done": False, "error": ""}
+    return {"model": model, **snap}
 
 
 @app.get("/admin/llm/installed", summary="설치된 Ollama 모델 목록 [4-B]")

--- a/tests/test_install_progress.py
+++ b/tests/test_install_progress.py
@@ -1,0 +1,195 @@
+"""Model install progress tracker (item #A8-8, 2026-05-09).
+
+User feedback: "<이 pc에 맞는 llm 모델 설치> 할 때에는 설치 진행과정이
+표시 되어야하며, 설치시 챗 페이지 이동이 가능하도록 개선".
+
+Backend:
+  - _install_progress dict + _install_lock for thread-safe writes
+  - _start_install_with_progress(model) spawns a daemon thread that
+    streams Ollama's POST /api/pull NDJSON output and writes
+    {status, percent, completed, total, error, done} to the dict.
+  - POST /llm/install/ now resets dict + starts the thread (was
+    subprocess.Popen fire-and-forget).
+  - GET /admin/llm/install-progress?model=X returns the snapshot.
+
+Frontend:
+  - triggerModelInstall starts a 2.5s setInterval polling the new
+    endpoint. Button text updates live: "📦 X 설치" → "⏳ 23.5% (X)"
+    → "✅ X 설치 완료". Page navigation doesn't kill the server-side
+    thread (operator can move to chat while download runs).
+
+Run:
+  python -m unittest tests.test_install_progress
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class BackendTrackerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.srv = srv
+        cls.src = inspect.getsource(srv)
+
+    def test_progress_dict_exists(self):
+        self.assertTrue(hasattr(self.srv, "_install_progress"),
+            "_install_progress dict must be a module-level variable")
+        self.assertIsInstance(self.srv._install_progress, dict)
+
+    def test_start_install_helper_exists(self):
+        self.assertTrue(hasattr(self.srv, "_start_install_with_progress"),
+            "_start_install_with_progress helper must exist")
+
+    def test_helper_uses_threading(self):
+        h = inspect.getsource(self.srv._start_install_with_progress)
+        self.assertIn("threading", h,
+            "must use threading.Thread for non-blocking install")
+        self.assertIn("daemon=True", h,
+            "thread must be daemon so it doesn't block server shutdown")
+        self.assertIn("ollama", h.lower())
+
+    def test_helper_streams_ollama_pull(self):
+        h = inspect.getsource(self.srv._start_install_with_progress)
+        # Hits Ollama's /api/pull with stream:true.
+        self.assertIn("/api/pull", h,
+            "must POST to Ollama /api/pull endpoint")
+        self.assertIn('"stream": True', h,
+            "must request streaming NDJSON response")
+
+    def test_helper_computes_percent(self):
+        h = inspect.getsource(self.srv._start_install_with_progress)
+        # percent = completed / total when both numeric.
+        self.assertIn("completed", h)
+        self.assertIn("total", h)
+        self.assertIn("percent", h)
+
+    def test_helper_records_error_on_exception(self):
+        h = inspect.getsource(self.srv._start_install_with_progress)
+        self.assertIn("except Exception", h,
+            "must catch exception (network blip, bad model name)")
+        self.assertIn('"error"', h,
+            "error path must populate error field for client visibility")
+
+
+class InstallEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _endpoint_body(self) -> str:
+        idx = self.src.index('@app.post("/llm/install/"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 5000
+        return self.src[idx:end]
+
+    def test_endpoint_uses_thread_helper_not_subprocess(self):
+        body = self._endpoint_body()
+        self.assertIn("_start_install_with_progress", body,
+            "endpoint must call the threading helper")
+        # subprocess.Popen for ollama pull is gone.
+        self.assertNotIn('subprocess.Popen(\n            ["ollama", "pull"', body,
+            "old fire-and-forget Popen path must be replaced")
+
+    def test_endpoint_resets_progress_state(self):
+        body = self._endpoint_body()
+        self.assertIn("_install_progress[model] = {", body,
+            "must seed a fresh progress entry so polling returns "
+            "'starting' immediately, not 'idle'")
+        self.assertIn('"status":    "starting"', body,
+            "initial state should be 'starting'")
+
+
+class ProgressEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_get_endpoint_registered(self):
+        self.assertIn('@app.get("/admin/llm/install-progress"', self.src,
+            "GET /admin/llm/install-progress must be registered")
+
+    def test_endpoint_admin_gated(self):
+        idx = self.src.index('@app.get("/admin/llm/install-progress"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 3000
+        body = self.src[idx:end]
+        self.assertIn("_require_admin", body,
+            "progress endpoint must be admin-gated")
+
+    def test_endpoint_returns_idle_for_unknown_model(self):
+        idx = self.src.index('@app.get("/admin/llm/install-progress"')
+        rest = self.src[idx + 1:]
+        m = re.search(r"\n@app\.", rest)
+        end = idx + 1 + m.start() if m else idx + 3000
+        body = self.src[idx:end]
+        self.assertIn('"status": "idle"', body,
+            "unknown / never-installed model should return 'idle' status")
+
+
+class FrontendPollingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+
+    def test_poll_helper_present(self):
+        self.assertIn("function _pollInstallProgress", self.js,
+            "polling helper missing")
+        self.assertIn("/admin/llm/install-progress", self.js,
+            "must hit the progress endpoint")
+
+    def test_poll_uses_setInterval(self):
+        idx = self.js.index("async function triggerModelInstall")
+        m = re.search(r"\nasync function|\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 4500
+        body = self.js[idx:end]
+        self.assertIn("setInterval", body,
+            "must poll on an interval (every 2.5s)")
+        # Non-blocking — interval doesn't await per tick.
+        self.assertIn("_installPollTimer", body,
+            "must store the timer handle so it can be cleared on success/failure")
+
+    def test_poll_clears_on_done(self):
+        idx = self.js.index("function _pollInstallProgress")
+        m = re.search(r"\nasync function|\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 4500
+        body = self.js[idx:end]
+        self.assertIn("p.done", body,
+            "must check the done flag")
+        self.assertIn("_stopInstallPoll", body,
+            "must call _stopInstallPoll on success/failure")
+
+    def test_poll_updates_button_label(self):
+        idx = self.js.index("function _pollInstallProgress")
+        body = self.js[idx:idx + 3000]
+        # Live progress label.
+        self.assertIn("p.percent", body,
+            "must read percent from response")
+        self.assertIn("⏳", body)
+        self.assertIn("✅", body,
+            "must flip to ✅ when done")
+
+    def test_confirm_message_mentions_navigation(self):
+        # User wants explicit confirmation that navigation is OK during install.
+        idx = self.js.index("async function triggerModelInstall")
+        body = self.js[idx:idx + 3000]
+        self.assertIn("페이지 이동", body,
+            "confirm dialog should mention page navigation is OK during install")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"설치 진행과정이 표시 되어야하며, 설치시 챗 페이지 이동이 가능하도록 개선"*.

## Before vs After

| | Before | After |
|---|---|---|
| Backend trigger | `subprocess.Popen([ollama, pull, ...])` fire-and-forget | Daemon thread streams Ollama `/api/pull` NDJSON |
| Progress visibility | None — button hung at "⏳ 설치 시작..." | Live `⏳ 23.5% (model)` updating every 2.5s |
| Done signal | 30s timer, then re-fetch picker | `done:true` from server, immediate flip to `✅ 설치 완료` |
| Survives navigation | Yes (silent) | Yes (operator informed via confirm dialog) |

## Backend

### Module state
- `_install_progress: dict` — model → snapshot
- `_install_lock` — threading.Lock (lazy init)

### `_start_install_with_progress(model)`
Daemon thread that POSTs to `localhost:11434/api/pull` with `stream:true`, parses NDJSON line-by-line:
```
{"status": "downloading", "completed": 1234567, "total": 9876543}
{"status": "verifying sha256"}
{"status": "success"}
```
Writes `{status, percent, completed, total, error, done}` under lock. Exception → records error + done=true.

### `POST /llm/install/` (refactored)
1. Reset `_install_progress[model]` to `{status: 'starting', percent: 0}`
2. Spawn the thread
3. Return immediately

### `GET /admin/llm/install-progress?model=X` (new)
Returns live snapshot. `{status: 'idle'}` if never installed.

## Frontend

`_pollInstallProgress` runs on `setInterval(2500ms)`:
- `p.error` → `❌ X 실패` + toast + stop
- `p.done` → `✅ X 설치 완료` + green tint + reload picker
- otherwise → `⏳ NN.N% (model)` with byte sizes in title

`triggerModelInstall` confirm dialog now states **"진행 중에도 다른 페이지 이동 가능"**.

## Verification

`tests/test_install_progress.py` — **16 tests**:
- BackendTrackerTests (6): dict + helper exist, threading.Thread daemon=True, streams /api/pull, computes percent, error path
- InstallEndpointTests (2): uses thread helper, resets progress
- ProgressEndpointTests (3): registered, admin-gated, idle fallback
- FrontendPollingTests (5): helper + endpoint, setInterval + handle, clears on done, ⏳→✅ flip, confirm copy

**651/651 regression suite pass.**

## Bench numbers

Not applicable — admin install path; bench queries don't touch this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)