### PR TITLE
feat(ui): knowledge + security + report intelligence polish (item #A8-9)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,17 +8,25 @@
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
-  /* ── 리셋 & 변수 ── */
+  /* ── 리셋 & 변수 ──
+     [#A8-9 2026-05-09] palette polish — 보고서 관리 시스템 분위기.
+     surface tone slightly cooler (slate ↔ navy mix) for a more
+     enterprise/intelligence look. Accent stays indigo but a touch
+     deeper. New --report-bg for "report card" backgrounds. */
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
-    --bg:        #0c0d10;
-    --surface:   #14161a;
-    --surface-2: #1a1d22;
-    --border:    #25282f;
-    --border-2:  #1c1f25;
-    --accent:    #6366f1;
-    --accent-soft: rgba(99,102,241,.12);
-    --accent-fg: #a5b4fc;
+    --bg:        #0a0c11;       /* deeper navy-black */
+    --surface:   #131620;       /* slate-tinted surface */
+    --surface-2: #181c26;
+    --border:    #262a36;
+    --border-2:  #1d212c;
+    --accent:    #5258e6;       /* deeper indigo, less playful */
+    --accent-soft: rgba(82,88,230,.13);
+    --accent-fg: #a7afff;
+    /* [#A8-9] secondary brand mark — "intelligence cyan" — used for
+       status badges + section dividers to suggest a knowledge OS. */
+    --brand-2:   #4fc3f7;
+    --brand-2-soft: rgba(79,195,247,.10);
     --text:      #ececf1;
     --text-soft: #c4c6cf;
     --muted:     #8a8d99;
@@ -30,6 +38,23 @@
     --radius-lg: 10px;
     --font-mono: 'JetBrains Mono', ui-monospace, monospace;
     --font-ui:   'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
+    /* [#A8-9] subtle elevation for "report card" surfaces — answer
+       bubbles, settings rows, etc. Sits one notch above flat. */
+    --shadow-card: 0 1px 0 rgba(255,255,255,.02) inset,
+                   0 8px 24px rgba(0,0,0,.18);
+  }
+
+  /* [#A8-9] thin top accent rail — gives every page a subtle "system
+     header" stripe like enterprise dashboards. Doesn't move with
+     scroll, doesn't intrude on layout (1px high). */
+  body::before {
+    content: '';
+    position: fixed; top: 0; left: 0; right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent) 0%, var(--brand-2) 100%);
+    opacity: .9;
+    z-index: 999;
+    pointer-events: none;
   }
 
   body {
@@ -63,13 +88,33 @@
     font-family: var(--font-ui);
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
   }
+  /* [#A8-9] logo mark — gradient now blends accent (indigo) into
+     brand-2 (intelligence cyan) for a knowledge/security feel. Thin
+     inner shine via box-shadow inset adds depth without ostentation. */
   .logo::before {
     content: '';
     width: 22px; height: 22px;
     border-radius: 6px;
-    background: linear-gradient(135deg, var(--accent), #818cf8);
+    background: linear-gradient(135deg, var(--accent) 0%, var(--brand-2) 100%);
+    box-shadow: 0 0 0 1px rgba(255,255,255,.04) inset,
+                0 2px 6px rgba(82,88,230,.30);
+  }
+  /* [#A8-9] tagline shim — "지식·보안 인텔리전스" appears beside the
+     logo on wide screens, hides on phones. Tells visitors what JAMES
+     IS without forcing them to read welcome copy. */
+  .logo .tagline {
+    color: var(--muted-2);
+    font-weight: 400;
+    font-size: 11px;
+    letter-spacing: .4px;
+    border-left: 1px solid var(--border-2);
+    padding-left: 10px;
+    margin-left: 2px;
+  }
+  @media (max-width: 700px) {
+    .logo .tagline { display: none; }
   }
   .logo span { color: var(--muted); font-weight: 500; }
   .header-right { display: flex; gap: 8px; align-items: center; }
@@ -548,9 +593,13 @@
     word-break: break-word;
     overflow-wrap: break-word;
   }
+  /* [#A8-9] james bubble = "report card" — subtle elevation +
+     left-side accent rail to suggest a structured document. */
   .msg.james .bubble {
     background: var(--surface);
     border: 1px solid var(--border-2);
+    border-left: 2px solid var(--accent-fg);
+    box-shadow: var(--shadow-card);
     color: var(--text);
   }
   .msg.user .bubble {
@@ -759,7 +808,14 @@
 
 <!-- ── 헤더 ── -->
 <header>
-  <div class="logo">JAMES <span>· Knowledge AI</span></div>
+  <!-- [#A8-9] brand mark + tagline. JAMES is the product name;
+       the tagline frames it as a knowledge + security intelligence
+       suite, not a chat toy. -->
+  <div class="logo">
+    JAMES
+    <span>· Knowledge AI</span>
+    <span class="tagline">지식 · 보안 · 보고서 인텔리전스</span>
+  </div>
   <div class="header-right">
     <div class="source-toggle">
       <button class="active" onclick="setSource('prod', this)">PROD</button>
@@ -875,10 +931,19 @@
   <section class="chat-area">
     <div class="messages" id="messages">
       <div class="welcome" id="welcome">
+        <!-- [#A8-9] welcome reframed: knowledge + security + report
+             intelligence (was generic "Graph-RAG 지식 추론 엔진"). -->
         <div class="welcome-title">Welcome to <span>JAMES</span></div>
         <div class="welcome-sub">
-          <span data-i18n="app.subtitle">보안 중심 Graph-RAG 지식 추론 엔진</span><br>
-          <span data-i18n="app.welcome">무엇이든 물어보세요</span>
+          <span data-i18n="app.subtitle">지식·보안·보고서 인텔리전스 시스템</span><br>
+          <span style="font-size:12px;color:var(--muted-2);font-family:var(--font-mono);
+                       letter-spacing:.5px;display:inline-block;margin-top:6px;
+                       padding:2px 10px;border:1px solid var(--border-2);border-radius:4px">
+            Knowledge · Security · Reporting Intelligence
+          </span><br>
+          <span data-i18n="app.welcome" style="display:inline-block;margin-top:10px">
+            물어보거나, 자료를 업로드하거나, 보고서를 요청하세요.
+          </span>
         </div>
         <div class="welcome-chips">
           <span class="chip" onclick="useChip(this)" data-i18n="chat.example1">경제학이란 무엇인가?</span>

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -1,0 +1,191 @@
+"""UI polish — knowledge + security + report intelligence (item #A8-9).
+
+User feedback (2026-05-09): "웹페이지 전체 ui 분위기를 사무적으로
+지식과 보안을 갖춘 스마트한 보고서 관리 시스템이라는 점을 잘 나타날수
+있게하는 디자인으로 개선".
+
+Goals (subjective; tests assert presence not aesthetics):
+  - Slate-tinted palette (cooler greys/blues for enterprise feel)
+  - Logo gets a tagline that frames product as knowledge+security+report
+  - James answer bubble feels like a "report card" (left accent rail
+    + subtle box-shadow elevation)
+  - Welcome screen reframes from generic "지식 추론 엔진" to
+    "지식·보안·보고서 인텔리전스"
+  - Top accent rail (1-2px gradient stripe) for system-header look
+
+Run:
+  python -m unittest tests.test_ui_report_polish
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+HTML = ROOT / "frontend" / "index.html"
+
+
+class PaletteTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_brand_2_var_added(self):
+        # Secondary brand colour for "intelligence cyan" — used by
+        # status badges / dividers.
+        self.assertIn("--brand-2:", self.html,
+            "must declare --brand-2 secondary brand colour for the polish")
+        self.assertIn("--brand-2-soft:", self.html,
+            "soft variant for tinted backgrounds")
+
+    def test_shadow_card_var_added(self):
+        # Custom elevation token for "report card" surfaces.
+        self.assertIn("--shadow-card:", self.html,
+            "must declare --shadow-card token for elevation")
+        m = re.search(r"--shadow-card:\s*([^;]+);", self.html)
+        self.assertIsNotNone(m)
+        self.assertIn("rgba(0,0,0", m.group(1),
+            "shadow should include a dark rgba layer")
+
+    def test_palette_cooler_tones(self):
+        # The base bg should still be near-black but slightly tinted
+        # toward navy/slate. Specifically: NOT pure black (#000) and
+        # NOT the prior neutral #0c0d10 — should land on something
+        # cooler like #0a0c11.
+        m = re.search(r"--bg:\s*(#[0-9a-fA-F]{6})", self.html)
+        self.assertIsNotNone(m)
+        bg = m.group(1).lower()
+        self.assertNotEqual(bg, "#000000",
+            "pure black is too aggressive — keep slight tint")
+        # New value should be different from the prior #0c0d10 baseline.
+        self.assertNotEqual(bg, "#0c0d10",
+            "palette polish should refresh the bg tint")
+
+
+class TopAccentRailTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_body_before_pseudo_present(self):
+        # Subtle "system header" stripe at the top of every page.
+        self.assertIn("body::before", self.html,
+            "must add ::before stripe on body for system-header look")
+        m = re.search(r"body::before\s*\{([^}]+)\}", self.html)
+        self.assertIsNotNone(m)
+        block = m.group(1)
+        self.assertIn("position: fixed", block,
+            "stripe must be fixed-position so it stays during scroll")
+        self.assertIn("height", block)
+        # Gradient between accent + brand-2.
+        self.assertIn("linear-gradient", block,
+            "stripe should use a gradient (accent → brand-2)")
+        self.assertIn("var(--accent)", block)
+        self.assertIn("var(--brand-2)", block)
+
+    def test_stripe_is_thin(self):
+        # Should be visually subtle — 1-3px tall, not a thick band.
+        m = re.search(r"body::before\s*\{[^}]*height:\s*(\d+)px", self.html)
+        self.assertIsNotNone(m, "couldn't extract stripe height")
+        height = int(m.group(1))
+        self.assertLessEqual(height, 4,
+            f"stripe height {height}px too thick — must be ≤ 4px")
+
+
+class LogoTaglineTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_tagline_class_in_html(self):
+        self.assertIn('class="tagline"', self.html,
+            "must include a tagline span for the logo")
+
+    def test_tagline_copy_mentions_security_and_reporting(self):
+        # The tagline frames JAMES as more than chat — knowledge/
+        # security/reporting suite.
+        m = re.search(r'class="tagline"[^>]*>([^<]+)<', self.html)
+        self.assertIsNotNone(m)
+        copy = m.group(1)
+        # Must mention 보안 (security) and either 지식 (knowledge) or
+        # 보고서 (reporting).
+        self.assertIn("보안", copy,
+            "tagline must mention 보안 (security) for the brand framing")
+        self.assertTrue("지식" in copy or "보고서" in copy,
+            f"tagline must mention 지식 or 보고서; got {copy!r}")
+
+    def test_logo_mark_uses_brand_2(self):
+        # The square mark should blend accent → brand-2 for the
+        # "intelligence" feel.
+        m = re.search(r"\.logo::before\s*\{([^}]+)\}", self.html)
+        self.assertIsNotNone(m)
+        block = m.group(1)
+        self.assertIn("var(--brand-2)", block,
+            "logo mark gradient should include the new brand-2 stop")
+
+
+class ReportCardBubbleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_james_bubble_has_left_accent_rail(self):
+        # The .msg.james .bubble selector should pick up a left
+        # border accent — a thin colour stripe on the left edge that
+        # makes the answer feel like a structured report.
+        m = re.search(r"\.msg\.james\s+\.bubble\s*\{([^}]+)\}", self.html)
+        self.assertIsNotNone(m, "couldn't locate james bubble rule")
+        body = m.group(1)
+        self.assertIn("border-left", body,
+            "james bubble must have a left accent rail")
+
+    def test_james_bubble_has_elevation(self):
+        m = re.search(r"\.msg\.james\s+\.bubble\s*\{([^}]+)\}", self.html)
+        self.assertIsNotNone(m)
+        body = m.group(1)
+        self.assertIn("box-shadow", body,
+            "james bubble must use box-shadow for elevation")
+        self.assertIn("var(--shadow-card)", body,
+            "should reference the new --shadow-card token")
+
+
+class WelcomeReframeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_welcome_subtitle_mentions_security_and_reporting(self):
+        # Old copy: "보안 중심 Graph-RAG 지식 추론 엔진".
+        # New: 지식 + 보안 + 보고서 angle.
+        m = re.search(
+            r'<div class="welcome-sub">(.+?)</div>',
+            self.html, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        sub = m.group(1)
+        self.assertIn("보안", sub,
+            "welcome subtitle must mention 보안")
+        self.assertIn("보고서", sub,
+            "welcome subtitle must mention 보고서 — the new framing")
+
+    def test_welcome_has_english_descriptor(self):
+        # Subtle uppercase English descriptor in mono — feels like an
+        # enterprise product UI (e.g., "Knowledge · Security · Reporting").
+        m = re.search(
+            r'<div class="welcome-sub">(.+?)</div>',
+            self.html, re.DOTALL,
+        )
+        sub = m.group(1)
+        self.assertTrue(
+            "Knowledge" in sub and "Security" in sub,
+            "welcome should include an English descriptor mentioning "
+            "Knowledge + Security for enterprise framing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback: *"웹페이지 전체 ui 분위기를 사무적으로 지식과 보안을 갖춘 스마트한 보고서 관리 시스템"*.

Five small but coherent visual cues that reframe JAMES from "Graph-RAG chat toy" to "knowledge + security + report intelligence suite". No layout/component changes — palette + branding only.

## Five touches

### 1. Palette (cooler enterprise tones)
| Var | Before | After |
|---|---|---|
| `--bg` | `#0c0d10` | **`#0a0c11`** |
| `--surface` | `#14161a` | **`#131620`** (slate tint) |
| `--accent` | `#6366f1` | **`#5258e6`** (deeper indigo) |
| `--brand-2` | — | **`#4fc3f7`** (intelligence cyan) |
| `--shadow-card` | — | report-card elevation token |

### 2. Top accent rail (`body::before`)
2px fixed-position gradient stripe (accent → brand-2). Enterprise system-header vibe without consuming layout.

### 3. Logo mark + tagline
- Square mark gradient blends accent → brand-2
- New `<span class="tagline">지식 · 보안 · 보고서 인텔리전스</span>` (hides on phones)

### 4. James bubble = "report card"
- 2px left accent rail (`--accent-fg`)
- `box-shadow: var(--shadow-card)` for lifted-document feel

### 5. Welcome reframe
- Subtitle: `보안 중심 Graph-RAG 지식 추론 엔진` → `지식·보안·보고서 인텔리전스 시스템`
- English descriptor banner: `Knowledge · Security · Reporting Intelligence`
- CTA copy: 물어보기 / 업로드 / 보고서 요청

## What this is NOT

- A redesign — layouts unchanged
- A theme switcher — single dark theme polished
- A logo replacement

## Verification

`tests/test_ui_report_polish.py` — **12 tests** across 5 classes (PaletteTests, TopAccentRailTests, LogoTaglineTests, ReportCardBubbleTests, WelcomeReframeTests).

**663/663 regression suite pass.**

## Bench numbers

Not applicable — visual styling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)