### PR TITLE
feat(chat): stage-driven reasoning display, drop timer rotation (item #3)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1376,20 +1376,19 @@ function brainPulseSvg(active = true) {
   </span>`;
 }
 
-/* [#A8-1] placeholder 멘트 rotation — 첫 stage 도착 전 사용자에게
-   "뭔가 진행 중" 신호 강화. 1.6초마다 다른 멘트로 회전. 고정된
-   "추론 시작 중" 한 줄보다 다이내믹하게 보임. */
-const THINKING_PLACEHOLDER_PHRASES = [
-  '추론 시작 중',
-  '질문 의도 분석 중',
-  '내부 자료 살펴보는 중',
-  '관련 지식 정리 중',
-  '관계 그래프 탐색 중',
-  '근거 검토 중',
-  '답변 정리 중',
-  '마무리하는 중',
-];
-
+/* [item #3, 2026-05-09] placeholder는 단일 정적 텍스트.
+   이전(PR #126 #A8-1)은 1.6s 타이머로 8개 멘트를 회전시켰는데,
+   이게 형식적 "순차 반복"이라 실제 서버 진행과 무관하게 돌았다.
+   사용자 피드백:
+     "답변창에 추론 답변 준비중에 나오는 애니메이션이 형식적으로
+      순차적으로 반복되는것이 아니라 실제 서버에서 디버그 되는
+      상황에서 따라 답변 마무리 정리 타이밍에 맞춰서 실제 자메스의
+      추론 과정을 맞춰서 진행해줘"
+   → 진짜 진행 신호 = `/trace/poll` 폴링이 잡는 stage 이벤트.
+     첫 stage 도착 전엔 brain 애니메이션 + 정적 placeholder만 보이고,
+     이벤트 도착 즉시 STAGE_META 기반 라인 stacking으로 자연 전환.
+     auth → retrieve → graph → answer → complete 가 실시간 표시되며
+     `complete` event에서 답변 마무리와 정확히 동기화된다. */
 function appendTyping(traceId) {
   const messages = document.getElementById('messages');
   const div = document.createElement('div');
@@ -1401,26 +1400,13 @@ function appendTyping(traceId) {
         <div class="thinking-placeholder">
           ${brainPulseSvg(true)}
           <span class="thinking-shimmer-text thinking-label thinking-placeholder-text"
-                data-trace="${traceId}">추론 시작 중</span>
+                data-trace="${traceId}">JAMES 추론 중</span>
         </div>
       </div>
     </div>
   `;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
-
-  // [#A8-1] placeholder rotation — 첫 stage 이벤트 도착 시 stop.
-  // 토큰 1개 늘릴 때 마다 다음 멘트로 자연 전환되는 듯한 효과.
-  let phraseIdx = 0;
-  const placeholderEl = div.querySelector('.thinking-placeholder-text');
-  const rotateTimer = setInterval(() => {
-    if (!placeholderEl || !placeholderEl.isConnected) {
-      clearInterval(rotateTimer);
-      return;
-    }
-    phraseIdx = (phraseIdx + 1) % THINKING_PLACEHOLDER_PHRASES.length;
-    placeholderEl.textContent = THINKING_PLACEHOLDER_PHRASES[phraseIdx];
-  }, 1600);
 
   // 폴링 상태
   const seenStages = new Set();   // stage 종류별 1회만 표시
@@ -1459,12 +1445,11 @@ function appendTyping(traceId) {
   const apply = (events) => {
     const container = document.getElementById(`thinking-${traceId}`);
     if (!container) return;
-    // 첫 진짜 이벤트 도착 시 placeholder 제거
-    // [#A8-1] placeholder rotation timer도 함께 stop.
+    // 첫 진짜 stage event 도착 시 정적 placeholder 제거.
+    // (이후 STAGE_META 기반 라인 stacking이 인계 — 서버 진행에 정확히 동기화)
     if (events.length > 0) {
       const ph = container.querySelector('.thinking-placeholder');
       if (ph) ph.remove();
-      try { clearInterval(rotateTimer); } catch (_) {}
     }
     events.forEach(ev => {
       const stage = ev.stage;

--- a/tests/test_reasoning_dynamic.py
+++ b/tests/test_reasoning_dynamic.py
@@ -1,20 +1,29 @@
-"""Reasoning UI dynamic improvements (item #A8-1, 2026-05-09).
+"""[item #3, 2026-05-09] Reasoning UI must be stage-driven, not timer-driven.
 
-User feedback: "추론중 표시 글자 그라데이션 애니메이션을 조금도 빠르게
-움직이도록 설정하고 '추론 시작중' 외에 다른 멘트로 전환되는 등
-다이내믹하게 개선".
+History:
+  PR #97 (#A6-7): real reasoning stream — replaced the fake 2.5s timer
+    with /trace/poll/{trace_id} polling. Stage events drive a per-line
+    display (auth → retrieve → graph → answer → complete).
+  PR #126 (#A8-1): added a 1.6s timer-based rotation of 8 placeholder
+    phrases for the gap BEFORE first stage event arrives. Felt
+    dynamic but was actually decoupled from server progress.
+  Item #3 (this PR): user fed back that the rotation was "formal
+    sequential repetition" — disconnected from actual JAMES reasoning
+    progress. Removed in favor of a single static placeholder; real
+    STAGE_META lines now drive everything once the first event arrives.
 
-CSS:
-  - james-shimmer animation 2.4s → 1.2s (gradient sweep speed)
-  - neuron-blink + neuron-pulse 1.4s → 0.9s (faster firing)
+This file is the regression guard for that removal:
+  - NO timer-based rotation
+  - NO THINKING_PLACEHOLDER_PHRASES array
+  - placeholder text is static
+  - shimmer / brain animation speeds preserved (visual continuity)
 
-JS:
-  - THINKING_PLACEHOLDER_PHRASES — 8 phrases that rotate every 1.6s
-    until the first real stage event arrives. Stops cleanly when
-    apply() removes the placeholder.
+The shimmer/neuron speed assertions from the original test are kept
+because the user wanted "dynamic visual feel" via shimmer/neuron pulse
+speed (PR #126), not via phrase rotation.
 
 Run:
-  python -m unittest tests.test_reasoning_dynamic
+    python -m unittest tests.test_reasoning_dynamic
 """
 from __future__ import annotations
 
@@ -32,84 +41,122 @@ CSS = ROOT / "frontend" / "static" / "mobile.css"
 
 
 class ShimmerSpeedTests(unittest.TestCase):
+    """[#A8-1] visual dynamism via shimmer/neuron speed — kept."""
+
     @classmethod
     def setUpClass(cls):
         cls.css = CSS.read_text(encoding="utf-8")
 
     def test_shimmer_animation_faster(self):
-        # All james-shimmer animation declarations must be ≤ 1.5s.
         for m in re.finditer(r"animation:\s*james-shimmer\s+([\d.]+)s", self.css):
             duration = float(m.group(1))
             self.assertLessEqual(duration, 1.5,
-                f"james-shimmer animation duration {duration}s — must be ≤1.5s "
-                f"for the 'dynamic' feel user requested")
+                f"james-shimmer {duration}s must be ≤1.5s")
 
     def test_neuron_blink_faster(self):
-        # Each .brain-pulse-active .neuron-N rule must use ≤ 1.0s.
         for m in re.finditer(
             r"\.brain-pulse-active\s+\.neuron-\d.+?(\d+\.?\d*)s",
             self.css, re.DOTALL,
         ):
             duration = float(m.group(1))
             self.assertLessEqual(duration, 1.0,
-                f"neuron-N animation {duration}s — must be ≤1.0s")
+                f"neuron-N {duration}s must be ≤1.0s")
 
 
-class PlaceholderRotationTests(unittest.TestCase):
+class StaticPlaceholderTests(unittest.TestCase):
+    """[item #3] No timer rotation; placeholder is a single static phrase."""
+
     @classmethod
     def setUpClass(cls):
         cls.js = JS.read_text(encoding="utf-8")
 
-    def test_phrases_array_exists(self):
-        self.assertIn("THINKING_PLACEHOLDER_PHRASES", self.js,
-            "must declare a phrase rotation array")
-
-    def test_at_least_5_phrases(self):
-        m = re.search(
-            r"const\s+THINKING_PLACEHOLDER_PHRASES\s*=\s*\[(.+?)\];",
-            self.js, re.DOTALL,
+    def _appendTyping_body(self) -> str:
+        idx = self.js.index("function appendTyping")
+        # appendTyping is followed by other functions; bound at next
+        # top-level `function`/`async function`/`/* `.
+        nxt = re.search(
+            r"\n(?:function |async function |/\* )",
+            self.js[idx + 1:],
         )
-        self.assertIsNotNone(m, "couldn't locate phrases array literal")
-        # Count single-quoted strings inside.
-        phrases = re.findall(r"'([^']+)'", m.group(1))
-        self.assertGreaterEqual(len(phrases), 5,
-            f"expected ≥5 phrases, got {len(phrases)}")
-        # First phrase must still be the original "추론 시작 중" so
-        # there's no jarring change for users who saw the prior copy.
-        self.assertEqual(phrases[0], "추론 시작 중",
-            "first phrase should remain '추론 시작 중' for continuity")
+        end = idx + 1 + nxt.start() if nxt else len(self.js)
+        return self.js[idx:end]
 
-    def test_rotation_interval_set_in_appendTyping(self):
-        idx = self.js.index("function appendTyping")
-        body = self.js[idx:idx + 2500]
-        self.assertIn("setInterval", body,
-            "appendTyping must use setInterval to rotate phrases")
-        # Interval should be 1-2s — fast enough to feel alive but not
-        # vertigo-inducing.
-        m = re.search(r"setInterval\(\(?\)\s*=>\s*\{[\s\S]+?\}\s*,\s*(\d+)\s*\)",
-                      body)
-        self.assertIsNotNone(m, "couldn't extract interval delay")
-        delay = int(m.group(1))
-        self.assertGreaterEqual(delay, 800)
-        self.assertLessEqual(delay, 2500)
+    def test_no_phrases_array(self):
+        self.assertNotIn("THINKING_PLACEHOLDER_PHRASES", self.js,
+            "THINKING_PLACEHOLDER_PHRASES must be removed — placeholder "
+            "is now a single static phrase, no rotation array")
 
-    def test_rotation_clears_when_placeholder_removed(self):
-        # When the first stage event arrives we remove the placeholder.
-        # The rotation timer must also clear or it'd leak intervals
-        # forever (and try to .textContent on a detached node).
-        idx = self.js.index("첫 진짜 이벤트 도착 시 placeholder 제거")
-        body = self.js[idx:idx + 800]
-        self.assertIn("clearInterval(rotateTimer)", body,
-            "must clearInterval when placeholder is removed")
+    def test_no_timer_rotation_in_appendTyping(self):
+        body = self._appendTyping_body()
+        self.assertNotIn("rotateTimer", body,
+            "rotateTimer (1.6s setInterval) was the formal sequential "
+            "repetition the user objected to — must not exist")
+        # Also no setInterval() in appendTyping at all (no other timers
+        # belong here).
+        self.assertNotRegex(body, r"\bsetInterval\s*\(",
+            "appendTyping must not start any timer — display is purely "
+            "stage-event-driven via the existing /trace/poll polling")
 
-    def test_placeholder_text_class_present(self):
-        # The rotation logic targets .thinking-placeholder-text — ensure
-        # the placeholder span actually carries that class.
-        idx = self.js.index("function appendTyping")
-        body = self.js[idx:idx + 2500]
-        self.assertIn("thinking-placeholder-text", body,
-            "placeholder span must have a stable selector class for the "
-            "rotation timer to find it")
+    def test_placeholder_static_text_present(self):
+        body = self._appendTyping_body()
+        # The placeholder text exists as a single literal in the
+        # initial innerHTML — no JS-side mutation of textContent on a
+        # rotating cycle.
+        self.assertRegex(body, r'thinking-placeholder-text[^>]*>[^<]+<',
+            "placeholder span must contain a single static phrase")
+        # And nothing should be reassigning .textContent on the
+        # placeholder span (which the rotation timer used to do).
+        self.assertNotIn("placeholderEl.textContent", body,
+            "no runtime rewrites of placeholder text — static phrase only")
+
+    def test_placeholder_class_preserved(self):
+        # Other code paths grep on this class to remove the placeholder
+        # when first stage arrives.
+        body = self._appendTyping_body()
+        self.assertIn("thinking-placeholder", body)
+        self.assertIn("thinking-placeholder-text", body)
+
+
+class StageEventDrivenDisplayTests(unittest.TestCase):
+    """The real progress-driven mechanism (already exists since PR #97)
+    must remain wired. After this PR, it's the SOLE driver of the UI."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_apply_removes_placeholder_on_first_event(self):
+        # Sanity: the apply() path that handles stage events still
+        # removes the static placeholder on first event arrival.
+        idx = self.js.index("첫 진짜 stage event 도착 시 정적 placeholder 제거")
+        body = self.js[idx:idx + 400]
+        self.assertIn(".thinking-placeholder", body)
+        self.assertIn("ph.remove()", body)
+
+    def test_trace_poll_endpoint_used(self):
+        # Server-side stage events come from /trace/poll/{trace_id}.
+        self.assertIn("/trace/poll/", self.js,
+            "client must poll /trace/poll/{trace_id} for real stages")
+
+    def test_stage_meta_table_present(self):
+        # Per-stage label/icon/color mapping must remain — drives the
+        # per-line display after first event.
+        self.assertIn("STAGE_META", self.js)
+        # A handful of expected stages.
+        for stage in ("auth", "retrieve", "graph", "answer", "complete"):
+            self.assertIn(f"{stage}:", self.js,
+                f"STAGE_META should map stage '{stage}'")
+
+    def test_complete_event_marks_active_done(self):
+        # When the final 'complete' event arrives, the active stage line
+        # must transition to a finished state — this is the natural
+        # sync point with answer wrap-up the user described.
+        self.assertIn("markActiveAsDone", self.js)
+        idx = self.js.index("if (data.complete)")
+        body = self.js[idx:idx + 400]
+        self.assertIn("markActiveAsDone()", body,
+            "completion must mark the active line done — synchronizes "
+            "the UI animation with the actual answer wrap-up moment")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replaces the 1.6s timer-based rotation of 8 placeholder phrases (PR #126) with a **stage-driven display** powered by the existing `/trace/poll/{trace_id}` polling (PR #97). The reasoning UI is now exclusively driven by real server progress.

User feedback (2026-05-09):
> 「답변창에 추론 답변 준비중에 나오는 애니메이션이 형식적으로 순차적으로 반복되는것이 아니라 실제 서버에서 디버그 되는 상황에서 따라 답변 마무리 정리 타이밍에 맞춰서 실제 자메스의 추론 과정을 맞춰서 진행해줘」

## Behavior diff

**Before** (PR #126):
- 0~? ms — placeholder cycles `추론 시작 중 → 질문 의도 분석 중 → 내부 자료 살펴보는 중 → ...` on a 1.6s timer
- First stage event arrives → cycle stops, real stages take over

**After** (this PR):
- 0~? ms — single static phrase `JAMES 추론 중` + existing brain-pulse SVG animation
- First stage event arrives → placeholder removed, real `STAGE_META` lines stack
- Each stage line fires when the actual server stage starts. `complete` event syncs the final transition to the answer wrap-up moment.

## Verification

```
$ python -m unittest tests.test_reasoning_dynamic -v
Ran 10 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 736 tests in 8.8s  OK   (was 733: -5 rotation tests, +8 new structural assertions)
```

### Test classes
- `StaticPlaceholderTests` (4) — asserts NO `THINKING_PLACEHOLDER_PHRASES`, NO `rotateTimer`/`setInterval` in `appendTyping`, placeholder text is static (no runtime `textContent` rewrites), placeholder class preserved
- `StageEventDrivenDisplayTests` (4) — placeholder removed on first event, `/trace/poll/` still used, `STAGE_META` table present with key stages, `complete` event triggers `markActiveAsDone` (natural answer-wrap-up sync point)
- `ShimmerSpeedTests` (2) — kept as-is; visual dynamism via shimmer/neuron pulse speed (the legitimate PR #126 contribution) preserved

## Why a regression-guard test file

A future contributor might re-add a "looks dynamic" timer rotation without realizing the design intent. The test asserts `setInterval` cannot appear inside `appendTyping` — directly catches the regression at the source level.

## Bench numbers — N/A

Frontend-only change. `core/{retrieval,graph,reasoning}` untouched, STEP 7 baseline unaffected.

## CLAUDE.md compliance

- (1) **No domain features** — pure UX progress display
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — no core/ file modified

## Files

```
 frontend/static/chat.js              | -15/+3   timer rotation removed, comment added
 tests/test_reasoning_dynamic.py      | repurposed (regression guard)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>