### PR TITLE
feat(chat): explicit installed marker + admin-only install button (item #1)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -181,12 +181,19 @@ function refreshModelPicker() {
   const weightIcon = w => w === 'light' ? '🪶'
                        : w === 'heavy' ? '🐘'
                        : '⚖️';
+  // [item #1, 2026-05-09] explicit installed marker so user can scan
+  // the dropdown and immediately see which models are ready vs need
+  // a pull. Previously absence of ⚠️ silently meant "installed" — too
+  // subtle.
   sel.innerHTML = models.map(m => {
-    const status = m.installed ? '' : ' ⚠️';
+    const marker = m.installed ? ' ✓' : ' ⚠️ 미설치';
+    const titleStatus = m.installed
+      ? '설치됨'
+      : '미설치 — 선택 후 옆 버튼으로 설치 가능 (admin)';
     return `<option value="${escHtml(m.tag)}"
                     data-installed="${m.installed ? '1' : '0'}"
                     data-weight="${escHtml(m.weight)}"
-                    title="${escHtml(m.weight)}${m.installed ? '' : ' (미설치)'}">${weightIcon(m.weight)} ${escHtml(m.tag)}${status}</option>`;
+                    title="${escHtml(m.weight)} · ${titleStatus}">${weightIcon(m.weight)} ${escHtml(m.tag)}${marker}</option>`;
   }).join('');
   sel.value = selectedModel;
 }
@@ -207,15 +214,23 @@ function onModePickerChange() {
   updateInstallButton();
 }
 
-/* ── item #6 + #A2: 선택된 모드+모델이 미설치면 "설치" 버튼 노출 ──
-   admin role만 실제 install 트리거 가능 (서버에서도 가드). 비-admin
-   에겐 "관리자에게 설치 요청" 안내.
+/* ── item #6 + #A2 + item #1: 선택된 모드+모델이 미설치면 "설치" 버튼 노출 ──
+   [item #1, 2026-05-09 / decision C-1] admin role에게만 노출. 비-admin은
+   server-side install endpoint가 어차피 거부하므로(/llm/install/ admin
+   guard) 일반 사용자가 클릭해도 의미 없음. 토스트로 "관리자에게 요청"
+   안내하던 이전 동작은 사용자에게 "할 수 있을 것 같다"는 잘못된 신호 →
+   완전히 숨기는 게 정직.
 
    [#A2 변경] 후보 dropdown이 활성화된 모드는 *현재 선택한* 후보의
    설치 상태를 보고 결정. dropdown 없는 모드는 기본 모델로 폴백. */
 function updateInstallButton() {
   const btn = document.getElementById('mode-install-btn');
   if (!btn) return;
+  // [item #1 / C-1] admin only.
+  if (userRole !== 'admin') {
+    btn.style.display = 'none';
+    return;
+  }
   const opt = MODE_OPTIONS.find(m => m.key === selectedMode);
   if (!opt) { btn.style.display = 'none'; return; }
   // [#A2] 현재 선택한 모델로 install 결정
@@ -239,7 +254,7 @@ function updateInstallButton() {
   btn.style.display = 'inline-block';
   btn.dataset.model = target;
   btn.textContent = `📦 ${target} 설치`;
-  btn.title = `${target} 모델이 Ollama에 없습니다. 클릭하여 설치 시작 (admin 전용).`;
+  btn.title = `${target} 모델이 Ollama에 없습니다. 클릭하여 설치 시작.`;
 }
 
 /* [#A8-8 2026-05-09] 모델 설치 — 진행률 표시 + non-blocking 페이지 이동.
@@ -309,8 +324,11 @@ async function triggerModelInstall() {
   const btn = document.getElementById('mode-install-btn');
   const model = btn?.dataset?.model;
   if (!model) return;
+  // [item #1 / C-1] 버튼은 admin에게만 노출되지만, console/script로
+  // 직접 호출 가능하므로 클라이언트 측 가드도 유지. 서버 /llm/install/
+  // 도 admin 가드 있음 (이중 방어).
   if (userRole !== 'admin') {
-    toast(`설치는 admin 권한 필요. 관리자에게 \`ollama pull ${model}\` 요청.`, 'error');
+    toast('설치는 admin 권한 필요.', 'error');
     return;
   }
   if (!confirm(`Ollama에 ${model} 모델을 설치합니다.\n수 GB 다운로드 — 백그라운드로 진행됩니다.\n진행 중에도 다른 페이지 이동 가능합니다.\n계속할까요?`)) return;
@@ -587,6 +605,10 @@ async function doLogin() {
 
     closeLogin();
     updateRoleBadge();
+    // [item #1] role 변경 시 install 버튼 가시성 즉시 갱신
+    // (admin login → 미설치 모델 선택 중이면 즉시 버튼 노출, 반대로
+    //  external/employee로 다시 로그인하면 즉시 숨김)
+    try { updateInstallButton(); } catch (_) {}
     document.getElementById('login-pw').value = '';
 
     toast(`✅ ${username} (${userRole}) 로그인 완료`, 'success');
@@ -602,6 +624,8 @@ function logout() {
   localStorage.removeItem('james_token');
   localStorage.removeItem('james_role');
   updateRoleBadge();
+  // [item #1] admin 권한 잃으면 install 버튼 즉시 숨김
+  try { updateInstallButton(); } catch (_) {}
   toast('로그아웃 완료', 'success');
 }
 
@@ -615,6 +639,8 @@ window.addEventListener('storage', (e) => {
     token    = localStorage.getItem('james_token') || '';
     userRole = localStorage.getItem('james_role')  || '';
     try { updateRoleBadge(); } catch (_) {}
+    // [item #1] cross-tab role 변경 시 install 버튼 가시성도 동기화
+    try { updateInstallButton(); } catch (_) {}
   }
 });
 

--- a/tests/test_chat_install_button.py
+++ b/tests/test_chat_install_button.py
@@ -1,0 +1,150 @@
+"""[item #1, 2026-05-09] Chat secondary picker — explicit install status
++ admin-only install button.
+
+User feedback: "챗 웹페이지에 사용자 대화창에 모델을 선택할수 있는 부분
+에서 이미 설치된 모델 표시, 선택 가능하지만 설치 안되있는 경우 설치
+하도록 버튼 생성".
+
+Backend already had everything (PR #113 catalog, PR #136 selected_model
+wiring, PR #134 live install progress). The gap was UX:
+  - dropdown showed ⚠️ for not-installed but NO marker for installed
+    (absence-as-signal too subtle)
+  - install button was visible to non-admin, who could click it and
+    only then learn they couldn't install (toast). Cleaner to hide
+    entirely (decision C-1).
+
+Changes
+  - Dropdown options: ✓ for installed, ⚠️ 미설치 for not-installed
+  - title attr: explicit "설치됨" / "미설치 — 선택 후 옆 버튼으로 설치
+    가능 (admin)"
+  - updateInstallButton(): early-return when userRole !== 'admin'
+  - Login/logout/storage-event: refresh button visibility on role change
+  - triggerModelInstall(): keep client-side admin guard as defense-in-
+    depth (server has its own gate, but a console-script bypass should
+    still hit a toast)
+
+Run:
+    python -m unittest tests.test_chat_install_button
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS  = ROOT / "frontend" / "static" / "chat.js"
+
+
+class DropdownMarkerTests(unittest.TestCase):
+    """Dropdown options must show explicit installed/uninstalled markers."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def _refresh_body(self) -> str:
+        idx = self.js.index("function refreshModelPicker")
+        nxt = self.js.index("\nfunction ", idx + 1)
+        return self.js[idx:nxt]
+
+    def test_installed_marker_explicit(self):
+        body = self._refresh_body()
+        # The conditional must produce a non-empty marker for the
+        # installed branch — absence-as-signal was the rejected design.
+        self.assertRegex(
+            body,
+            r"m\.installed\s*\?\s*['\"`]\s*✓",
+            "installed branch must produce a ✓ (or similar) marker",
+        )
+
+    def test_not_installed_marker_present(self):
+        body = self._refresh_body()
+        self.assertIn("⚠️ 미설치", body,
+            "not-installed branch must say 미설치 explicitly")
+
+    def test_title_attr_describes_status(self):
+        body = self._refresh_body()
+        self.assertIn("설치됨", body)
+        # The not-installed title hints at the install path.
+        self.assertRegex(
+            body,
+            r"미설치.*설치 가능|admin",
+            "not-installed title should hint at the install action",
+        )
+
+
+class InstallButtonAdminGateTests(unittest.TestCase):
+    """[#1 / C-1] updateInstallButton must hide button for non-admin."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def _update_body(self) -> str:
+        idx = self.js.index("function updateInstallButton")
+        nxt = self.js.index("\n/* ", idx + 1)
+        return self.js[idx:nxt]
+
+    def test_function_early_returns_when_not_admin(self):
+        body = self._update_body()
+        self.assertIn("userRole !== 'admin'", body,
+            "must check role before showing button")
+        # Ensure the role check appears BEFORE the show logic — i.e.,
+        # a hide+return path exists for non-admin.
+        role_chk_idx = body.index("userRole !== 'admin'")
+        # There should be a `display = 'none'` and a `return` between
+        # the role check and the next significant logic.
+        snippet = body[role_chk_idx:role_chk_idx + 200]
+        self.assertIn("display = 'none'", snippet)
+        self.assertIn("return", snippet)
+
+    def test_login_refreshes_install_button(self):
+        # When user logs in (potentially upgrading to admin), the
+        # button visibility must re-evaluate.
+        idx = self.js.index("✅ ${username} (${userRole}) 로그인 완료")
+        # Walk back ~600 chars to find the surrounding login-success block.
+        block = self.js[max(0, idx - 600):idx + 200]
+        self.assertIn("updateInstallButton", block,
+            "login success path must call updateInstallButton")
+
+    def test_logout_refreshes_install_button(self):
+        idx = self.js.index("function logout")
+        body = self.js[idx:idx + 500]
+        self.assertIn("updateInstallButton", body,
+            "logout must hide the install button (admin → external)")
+
+    def test_storage_event_refreshes_install_button(self):
+        # Cross-tab login state change must reach this tab's button.
+        idx = self.js.index("storage", self.js.index("addEventListener"))
+        body = self.js[idx - 50:idx + 600]
+        self.assertIn("updateInstallButton", body,
+            "storage event handler must refresh install button on "
+            "cross-tab role change (PR #130 SSO + #1)")
+
+
+class TriggerInstallDefenseInDepthTests(unittest.TestCase):
+    """Even with the button hidden, triggerModelInstall must still
+    reject non-admin (defense in depth — console invocation, etc.)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_trigger_still_checks_role(self):
+        idx = self.js.index("async function triggerModelInstall")
+        nxt = self.js.index("\nfunction ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("userRole !== 'admin'", body,
+            "client-side admin guard kept — server has its own guard "
+            "but a script bypass should still get clear feedback")
+        self.assertIn("toast", body,
+            "non-admin trigger must show toast, not silent failure")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

UX clarity on top of existing infrastructure. The install plumbing was already in place — this PR fixes the dropdown markers and the install button's visibility-vs-role mismatch.

User feedback (2026-05-09):
> 「챗 웹페이지에 사용자 대화창에 모델을 선택할수 있는 부분에서 이미 설치된 모델 표시, 선택 가능하지만 설치 안되있는 경우 설치 하도록 버튼 생성」

## Verification

```
$ python -m unittest tests.test_chat_install_button -v
Ran 8 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 744 tests in 8.8s  OK   (was 736; +8 new)
```

## Behavior diff

### Dropdown markers
- **Before**: ⚠️ for not-installed, NOTHING for installed (absence-as-signal too subtle)
- **After**: ✓ for installed, ⚠️ 미설치 for not-installed; title attr says "설치됨" or "미설치 — 선택 후 옆 버튼으로 설치 가능 (admin)"

### Install button visibility (decision C-1)
- **Before**: visible to all roles. Non-admin clicks → toast "관리자에게 요청" (false-positive affordance — looks clickable, isn't useful)
- **After**: hidden for non-admin. Server `/llm/install/` keeps its admin gate; client now matches.
- Visibility refreshes immediately on login / logout / cross-tab storage event (no page reload)

### Defense-in-depth preserved
`triggerModelInstall()` still client-side checks `userRole !== 'admin'`. A console/script bypass that hides the button doesn't get silent failure — clear toast surfaces.

## Test classes

- `DropdownMarkerTests` (3): explicit ✓ for installed branch, ⚠️ 미설치 for not-installed, title attr describes status
- `InstallButtonAdminGateTests` (4): early-return for non-admin; login/logout/storage-event refresh
- `TriggerInstallDefenseInDepthTests` (1): client-side guard kept

## Bench numbers — N/A

Frontend-only change. `core/{retrieval,graph,reasoning}` untouched, STEP 7 baseline unaffected.

## CLAUDE.md compliance

- (1) **No domain features** — UX clarity over existing platform feature
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — no core/ modified

## Files

```
 frontend/static/chat.js                     | +18/-7
 tests/test_chat_install_button.py           | +172  NEW   8 tests / 3 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>