### PR TITLE
feat(llm): auto-resolver — never 404 on missing models (PR plan-1/5)

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -164,8 +164,29 @@ class GemmaClient:
         [C2-FIX]        <think> 블록 3단계 복구
         [CACHE-STAT]    hit/miss 카운터 업데이트
         [#15]           model override (None이면 config.GEMMA_MODEL 기본)
+        [PR plan-1, 2026-05-09] model=None일 때 core.model_resolver로
+            폴백. 운영자 PC에 config의 default 모델이 설치돼 있으면
+            그것을 그대로 사용 (behavior unchanged). 미설치면 preference
+            list에서 첫 설치된 것으로 자동 fallback. 결정은 [MODEL_RESOLVE]
+            print로 로깅돼 운영자가 보임. 하나도 설치 안 된 경우 명확한
+            "ollama pull X" 안내 메시지로 RuntimeError 발생.
         """
-        actual_model = model or GEMMA_MODEL
+        if model:
+            # Caller specified a tag — trust them (already validated
+            # by selected_model resolver in core.model_catalog if it
+            # came from picker; direct internal callers know what
+            # they're asking for).
+            actual_model = model
+        else:
+            from core.model_resolver import resolve_chat
+            resolved = resolve_chat()
+            if not resolved.tag:
+                # No models at all in Ollama — surface the install
+                # command rather than 404'ing through call_ollama.
+                raise RuntimeError(resolved.warning)
+            actual_model = resolved.tag
+            if resolved.warning:
+                print(f"[MODEL_RESOLVE] {resolved.warning}")
         self._total_calls += 1
         cache_key = self._generate_cache_key(prompt)
 

--- a/core/model_resolver.py
+++ b/core/model_resolver.py
@@ -1,0 +1,273 @@
+"""[PR plan-1, 2026-05-09] Multi-model auto-resolution.
+
+Goal: NEVER 404 because of a missing model.
+
+Resolution chain when `call_gemma(model=None)`:
+  1. Per-call user pick (selected_model from picker — already wired
+     via PR #136, not relevant here; the caller passes model=tag in
+     that case and we never enter this resolver)
+  2. `requested` arg — typically `config.GEMMA_MODEL` (env override
+     `JAMES_LLM_MODEL`). If installed, use it.
+  3. Per-mode preference list — first installed wins. Operator can
+     override via `JAMES_MODEL_PREFERENCE_CHAT=...` env (comma-separated).
+  4. Any installed model — last resort, with a warning.
+  5. Nothing installed → returns ResolvedModel(tag="", source="none")
+     with a friendly install command in the `warning` field.
+
+Cached `installed_models()` set with 60s TTL so we don't hit the
+Ollama HTTP API on every chat turn. `invalidate_cache()` is called
+from /admin/llm/install handler so a fresh install is seen
+immediately.
+
+Why this layer exists
+  Before this module, `call_gemma(model=None)` fell through to
+  `config.GEMMA_MODEL` (default "gemma4:e4b"). On any machine that
+  doesn't have that exact tag, every call 404s and the user sees
+  "[Gemma 응답 없음]". The most common beginner failure was forgetting
+  to set `JAMES_LLM_MODEL` in `.env` to match the model they pulled
+  with `ollama pull`. After this module, that mismatch is silently
+  recovered with an audit-logged fallback warning.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+from typing import List, NamedTuple, Optional, Set
+
+
+# ─── Default preference lists ──────────────────────────────────────
+# First entry = highest preference. Operator overrides via env.
+#
+# `chat` order rationale (Korean-first audience):
+#   gemma3:4b   — 16GB box sweet spot, decent Korean
+#   gemma3:1b   — 8GB box fallback, weaker quality
+#   gemma2:2b   — older but tiny; works on legacy boxes
+#   gemma3:12b  — 32GB box quality bump
+#   gemma3:27b  — 32GB+ heavy
+#   gemma4:e4b  — operator's existing default; kept for back-compat
+#   qwen2.5:14b — non-gemma fallback with Korean
+#   llama3.2:3b — emergency fallback
+#   mistral:7b  — last gemma-less option
+#
+# `coding` order: qwen-coder family first (handle_coding routes via
+#   llm.router which already prefers it). Deepseek family as fallback.
+DEFAULT_PREFERENCE: dict = {
+    "chat": [
+        "gemma3:4b", "gemma3:1b", "gemma2:2b",
+        "gemma3:12b", "gemma3:27b", "gemma4:e4b",
+        "qwen2.5:14b", "llama3.2:3b", "mistral:7b",
+    ],
+    "coding": [
+        "qwen2.5-coder:7b", "qwen2.5-coder:14b", "qwen2.5-coder:32b",
+        "deepseek-coder:6.7b", "deepseek-coder:33b",
+    ],
+}
+
+
+class ResolvedModel(NamedTuple):
+    """Outcome of resolve_for_mode().
+
+    tag           : actual Ollama tag to call (empty string if nothing
+                    is installed)
+    source        : how we got here — for logging/observability:
+                    "requested" — caller-provided tag was installed
+                    "preference"— per-mode preference list hit
+                    "any"       — last-resort installed model
+                    "none"      — nothing installed at all
+    fallback_chain: tags tried in order (debugging)
+    warning       : empty if no warning; non-empty if operator should
+                    know (e.g., "requested X not installed, using Y")
+    """
+    tag: str
+    source: str
+    fallback_chain: List[str]
+    warning: str
+
+
+# ─── Cached installed-set ──────────────────────────────────────────
+_CACHE: dict = {"installed": None, "ts": 0.0}
+_CACHE_TTL_S = 60.0
+_OLLAMA_TAGS_URL = "http://localhost:11434/api/tags"
+
+
+def installed_models(force: bool = False) -> Set[str]:
+    """Cached set of installed Ollama tags.
+
+    Hits Ollama's `/api/tags` HTTP endpoint at most once per
+    `_CACHE_TTL_S`. Returns an empty set on Ollama-unreachable —
+    callers should treat that as "no install info"; `resolve_for_mode`
+    handles it by falling through to the "none" branch.
+
+    Pass `force=True` after install/uninstall to refresh.
+    """
+    now = time.time()
+    if (
+        not force
+        and _CACHE["installed"] is not None
+        and (now - _CACHE["ts"]) < _CACHE_TTL_S
+    ):
+        return _CACHE["installed"]
+
+    tags: Set[str] = set()
+    try:
+        with urllib.request.urlopen(_OLLAMA_TAGS_URL, timeout=2) as r:
+            data = json.loads(r.read())
+        for m in data.get("models", []):
+            name = m.get("name", "")
+            if name:
+                tags.add(name)
+    except Exception:
+        # Ollama down or misconfigured — empty set; resolver falls
+        # through to "none" with a clear install command.
+        tags = set()
+
+    _CACHE["installed"] = tags
+    _CACHE["ts"] = now
+    return tags
+
+
+def invalidate_cache() -> None:
+    """Drop the installed-models cache so next call hits Ollama fresh.
+
+    Call from /admin/llm/install + /admin/llm/delete handlers so the
+    resolver immediately sees the new state.
+    """
+    _CACHE["installed"] = None
+    _CACHE["ts"] = 0.0
+
+
+# ─── Preference list lookup (with env override) ────────────────────
+def _preference_for(mode: str) -> List[str]:
+    """Return preference list for `mode`, honoring env override.
+
+    Env key: JAMES_MODEL_PREFERENCE_<MODE> (comma-separated tags).
+    Unknown mode falls back to the chat list.
+    """
+    env_key = f"JAMES_MODEL_PREFERENCE_{mode.upper()}"
+    raw = os.environ.get(env_key, "").strip()
+    if raw:
+        parsed = [t.strip() for t in raw.split(",") if t.strip()]
+        if parsed:
+            return parsed
+    return list(DEFAULT_PREFERENCE.get(mode, DEFAULT_PREFERENCE["chat"]))
+
+
+# ─── Main resolution entry point ───────────────────────────────────
+def resolve_for_mode(mode: str = "chat", requested: str = "") -> ResolvedModel:
+    """Find an installed model for `mode`. Never raises.
+
+    Args:
+      mode:       "chat" / "coding" / etc. Drives the preference list.
+      requested:  caller's preferred tag (typically config.GEMMA_MODEL
+                  or a runtime override). Empty string means "no
+                  preference, just pick from the mode list".
+
+    Returns: ResolvedModel — see class docstring. The `tag` field is
+      empty iff no models are installed at all (resolver gives up
+      gracefully rather than crashing).
+    """
+    chain: List[str] = []
+    inst = installed_models()
+
+    # Step 1: caller's explicit request (if any)
+    requested = (requested or "").strip()
+    if requested:
+        chain.append(requested)
+        if requested in inst:
+            return ResolvedModel(requested, "requested", chain, "")
+
+    # Step 2: per-mode preference list
+    pref = _preference_for(mode)
+    for tag in pref:
+        if tag in chain:
+            continue
+        chain.append(tag)
+        if tag in inst:
+            warning = ""
+            if requested and requested != tag:
+                warning = (
+                    f"requested model '{requested}' not installed; "
+                    f"using '{tag}' from preference list"
+                )
+            return ResolvedModel(tag, "preference", chain, warning)
+
+    # Step 3: any installed model (deterministic pick — sorted)
+    if inst:
+        any_tag = sorted(inst)[0]
+        chain.append(any_tag)
+        warning = (
+            f"no preferred model installed for mode={mode}; "
+            f"using '{any_tag}' as last resort. Consider: "
+            f"ollama pull {pref[0] if pref else 'gemma3:4b'}"
+        )
+        return ResolvedModel(any_tag, "any", chain, warning)
+
+    # Step 4: nothing at all
+    suggested = pref[0] if pref else "gemma3:4b"
+    return ResolvedModel(
+        "",
+        "none",
+        chain,
+        f"No models installed in Ollama. "
+        f"Run: ollama pull {suggested} "
+        f"(or visit /admin → 장비 현황 for hardware-aware recommendation).",
+    )
+
+
+# ─── Convenience wrappers around config defaults ───────────────────
+def resolve_chat() -> ResolvedModel:
+    """Resolve for chat using config.GEMMA_MODEL as the requested tag."""
+    try:
+        from config import GEMMA_MODEL  # type: ignore
+        requested = GEMMA_MODEL or ""
+    except Exception:
+        requested = ""
+    return resolve_for_mode("chat", requested=requested)
+
+
+def resolve_coding() -> ResolvedModel:
+    """Resolve for coding using config.CODING_MODEL as the requested tag."""
+    try:
+        from config import CODING_MODEL  # type: ignore
+        requested = CODING_MODEL or ""
+    except Exception:
+        requested = ""
+    return resolve_for_mode("coding", requested=requested)
+
+
+def resolution_snapshot() -> dict:
+    """Snapshot of current resolution state — for /admin/llm/resolution.
+
+    Returned shape:
+      {
+        "chat":   {"tag", "source", "warning", "fallback_chain"},
+        "coding": {...},
+        "installed": [tags...],
+        "preference": {"chat": [...], "coding": [...]},
+        "ttl_s": 60,
+      }
+    """
+    chat = resolve_chat()
+    coding = resolve_coding()
+    return {
+        "chat": {
+            "tag": chat.tag,
+            "source": chat.source,
+            "warning": chat.warning,
+            "fallback_chain": chat.fallback_chain,
+        },
+        "coding": {
+            "tag": coding.tag,
+            "source": coding.source,
+            "warning": coding.warning,
+            "fallback_chain": coding.fallback_chain,
+        },
+        "installed": sorted(installed_models()),
+        "preference": {
+            "chat": _preference_for("chat"),
+            "coding": _preference_for("coding"),
+        },
+        "ttl_s": _CACHE_TTL_S,
+    }

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -991,6 +991,15 @@ def _start_install_with_progress(model: str) -> None:
                             "done":      status == "success",
                         }
                     if status == "success":
+                        # [PR plan-1] resolver cache invalidation so
+                        # the freshly-installed model is selectable
+                        # immediately on the next /query/ without
+                        # waiting 60s TTL.
+                        try:
+                            from core.model_resolver import invalidate_cache
+                            invalidate_cache()
+                        except Exception:
+                            pass
                         break
         except Exception as e:
             with _install_lock:
@@ -1095,6 +1104,28 @@ async def llm_installed(api_key: str, role: str = Depends(get_role_from_request)
                 "hint": "Ollama가 실행 중인지 확인하세요 (ollama serve)"}
 
 
+@app.get("/admin/llm/resolution",
+         summary="현재 모델 resolution 상태 [PR plan-1, 2026-05-09]")
+async def llm_resolution(api_key: str, role: str = Depends(get_role_from_request)):
+    """[PR plan-1] 운영자 가시성 — call_gemma(model=None)이 어떤 모델을
+    실제 사용하는지 + 폴백 사유.
+
+    설치된 모델이 config의 default와 다를 때 어디로 fallback 됐는지
+    감지하기 위함. resolver는 silent하게 동작하지만 결정 사유는 여기서
+    조회 가능.
+
+    Returned shape:
+      {chat: {tag, source, warning, fallback_chain},
+       coding: {tag, source, warning, fallback_chain},
+       installed: [...],
+       preference: {chat: [...], coding: [...]},
+       ttl_s: 60}
+    """
+    _require_admin(api_key, role)
+    from core.model_resolver import resolution_snapshot
+    return resolution_snapshot()
+
+
 @app.get("/admin/llm/recommend", summary="하드웨어 기반 LLM 추천 [4-B]")
 async def llm_recommend(api_key: str, role: str = Depends(get_role_from_request)):
     """현재 하드웨어 스펙에 맞는 LLM 모델 추천."""
@@ -1166,6 +1197,13 @@ async def llm_delete(
             method="DELETE",
         )
         urllib.request.urlopen(req, timeout=10)
+        # [PR plan-1] resolver cache invalidation — deleted model must
+        # not be used on the next /query/.
+        try:
+            from core.model_resolver import invalidate_cache
+            invalidate_cache()
+        except Exception:
+            pass
         _write_audit(role, "/admin/llm/delete", query=model, elapsed_sec=0)
         return {"ok": True, "model": model, "deleted": True}
     except Exception as e:

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -1,0 +1,269 @@
+"""[PR plan-1, 2026-05-09] core.model_resolver — fallback chain.
+
+The resolver's job: never let `call_gemma(model=None)` hit Ollama with
+a missing tag. The 4-step chain (requested → preference → any → none)
+is exhaustively asserted here with a mocked installed-set so the tests
+don't need a live Ollama.
+
+Run:
+    python -m unittest tests.test_model_resolver
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _fresh_resolver():
+    """Re-import the module so cache state doesn't bleed between tests."""
+    import core.model_resolver as mr
+    importlib.reload(mr)
+    mr.invalidate_cache()
+    return mr
+
+
+class ResolveChainTests(unittest.TestCase):
+    """The 4-step resolution chain."""
+
+    def setUp(self):
+        self.mr = _fresh_resolver()
+
+    def test_requested_installed_wins(self):
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:4b", "gemma3:1b"}):
+            r = self.mr.resolve_for_mode("chat", requested="gemma3:1b")
+        self.assertEqual(r.tag, "gemma3:1b")
+        self.assertEqual(r.source, "requested")
+        self.assertEqual(r.warning, "")
+
+    def test_requested_missing_falls_to_preference(self):
+        # User asked for gemma4:e4b (config default) but installed only
+        # gemma3:4b → resolver returns gemma3:4b with a warning.
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:4b"}):
+            r = self.mr.resolve_for_mode("chat", requested="gemma4:e4b")
+        self.assertEqual(r.tag, "gemma3:4b")
+        self.assertEqual(r.source, "preference")
+        self.assertIn("gemma4:e4b", r.warning)
+        self.assertIn("gemma3:4b", r.warning)
+
+    def test_preference_first_match_wins(self):
+        # If gemma3:4b and gemma3:12b both installed, gemma3:4b should
+        # win (higher in default preference list).
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:12b", "gemma3:4b"}):
+            r = self.mr.resolve_for_mode("chat", requested="")
+        self.assertEqual(r.tag, "gemma3:4b")
+        self.assertEqual(r.source, "preference")
+
+    def test_no_preference_match_falls_to_any(self):
+        # Installed model is something not on the preference list at
+        # all — last-resort branch.
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"obscure-model:7b"}):
+            r = self.mr.resolve_for_mode("chat", requested="")
+        self.assertEqual(r.tag, "obscure-model:7b")
+        self.assertEqual(r.source, "any")
+        self.assertIn("last resort", r.warning)
+
+    def test_nothing_installed_returns_none_with_install_command(self):
+        with mock.patch.object(self.mr, "installed_models", return_value=set()):
+            r = self.mr.resolve_for_mode("chat", requested="gemma3:4b")
+        self.assertEqual(r.tag, "")
+        self.assertEqual(r.source, "none")
+        self.assertIn("ollama pull", r.warning)
+        # Suggestion should be the head of the preference list.
+        self.assertIn("gemma3:4b", r.warning)
+
+    def test_fallback_chain_records_attempts(self):
+        # The chain must include at least the requested + every
+        # preference tag tried until success.
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:1b"}):
+            r = self.mr.resolve_for_mode("chat", requested="gemma4:e4b")
+        # First entry: requested. Then preference list head until match.
+        self.assertEqual(r.fallback_chain[0], "gemma4:e4b")
+        self.assertIn("gemma3:1b", r.fallback_chain)
+
+
+class CodingPreferenceTests(unittest.TestCase):
+    """`mode='coding'` uses a different preference list."""
+
+    def setUp(self):
+        self.mr = _fresh_resolver()
+
+    def test_coding_prefers_qwen_coder(self):
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"qwen2.5-coder:7b", "gemma3:4b"}):
+            r = self.mr.resolve_for_mode("coding", requested="")
+        self.assertEqual(r.tag, "qwen2.5-coder:7b")
+        self.assertEqual(r.source, "preference")
+
+    def test_coding_falls_back_to_deepseek(self):
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"deepseek-coder:6.7b"}):
+            r = self.mr.resolve_for_mode("coding", requested="qwen2.5-coder:32b")
+        self.assertEqual(r.tag, "deepseek-coder:6.7b")
+        self.assertEqual(r.source, "preference")
+
+
+class EnvOverrideTests(unittest.TestCase):
+    """JAMES_MODEL_PREFERENCE_<MODE> env var rewrites the list."""
+
+    def setUp(self):
+        self.mr = _fresh_resolver()
+
+    def test_chat_preference_via_env(self):
+        with mock.patch.dict(os.environ,
+                             {"JAMES_MODEL_PREFERENCE_CHAT":
+                              "custom:1b,custom:4b"}):
+            with mock.patch.object(self.mr, "installed_models",
+                                   return_value={"custom:1b"}):
+                r = self.mr.resolve_for_mode("chat", requested="")
+            self.assertEqual(r.tag, "custom:1b")
+            self.assertEqual(r.source, "preference")
+
+    def test_unknown_mode_falls_back_to_chat_list(self):
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:4b"}):
+            r = self.mr.resolve_for_mode("retrieval", requested="")
+        # Unknown mode → uses chat preference → gemma3:4b matches.
+        self.assertEqual(r.tag, "gemma3:4b")
+
+
+class CacheBehaviorTests(unittest.TestCase):
+    """installed_models() is cached with a TTL; invalidate_cache
+    refreshes immediately."""
+
+    def setUp(self):
+        self.mr = _fresh_resolver()
+
+    def test_cache_hit_avoids_second_http_call(self):
+        # First call hits the mocked URL, second call should NOT.
+        with mock.patch("core.model_resolver.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = (
+                b'{"models": [{"name": "gemma3:4b"}]}'
+            )
+            self.mr.invalidate_cache()
+            tags1 = self.mr.installed_models()
+            tags2 = self.mr.installed_models()
+            self.assertEqual(tags1, {"gemma3:4b"})
+            self.assertEqual(tags2, {"gemma3:4b"})
+            self.assertEqual(m.call_count, 1,
+                "cache hit must skip the second HTTP call")
+
+    def test_invalidate_forces_refresh(self):
+        with mock.patch("core.model_resolver.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = (
+                b'{"models": [{"name": "gemma3:4b"}]}'
+            )
+            self.mr.invalidate_cache()
+            self.mr.installed_models()
+            self.mr.invalidate_cache()
+            self.mr.installed_models()
+            self.assertEqual(m.call_count, 2,
+                "invalidate_cache() must force a fresh HTTP call")
+
+    def test_ollama_unreachable_returns_empty_set(self):
+        with mock.patch("core.model_resolver.urllib.request.urlopen",
+                        side_effect=ConnectionRefusedError("ollama down")):
+            self.mr.invalidate_cache()
+            tags = self.mr.installed_models()
+            self.assertEqual(tags, set(),
+                "ollama down → empty set (resolver falls through to 'none' "
+                "with a clear install command)")
+
+
+class SnapshotTests(unittest.TestCase):
+    """resolution_snapshot() returns the operator-facing observability blob."""
+
+    def setUp(self):
+        self.mr = _fresh_resolver()
+
+    def test_snapshot_shape(self):
+        with mock.patch.object(self.mr, "installed_models",
+                               return_value={"gemma3:4b"}):
+            snap = self.mr.resolution_snapshot()
+        self.assertIn("chat", snap)
+        self.assertIn("coding", snap)
+        self.assertIn("installed", snap)
+        self.assertIn("preference", snap)
+        for k in ("tag", "source", "warning", "fallback_chain"):
+            self.assertIn(k, snap["chat"])
+            self.assertIn(k, snap["coding"])
+
+
+class GemmaClientIntegrationTests(unittest.TestCase):
+    """Source-level: gemma_client.call_gemma must call resolve_chat()
+    when model=None. This is the actual production wiring point."""
+
+    @classmethod
+    def setUpClass(cls):
+        import inspect
+        from core import gemma_client
+        cls.src = inspect.getsource(gemma_client)
+
+    def test_call_gemma_imports_resolver(self):
+        self.assertIn("from core.model_resolver import resolve_chat", self.src,
+            "call_gemma must use the resolver — without this, model=None "
+            "still 404s on missing config defaults")
+
+    def test_call_gemma_raises_when_no_models(self):
+        # When resolver returns empty tag, call_gemma must raise with
+        # the friendly install command — not silently fall through to
+        # Ollama and 404.
+        idx = self.src.index("if model:")
+        body = self.src[idx:idx + 800]
+        self.assertIn("RuntimeError", body,
+            "no-models case must raise RuntimeError so caller sees the "
+            "install command, not a generic 404")
+
+    def test_warning_logged_to_stdout(self):
+        # When a fallback happens, [MODEL_RESOLVE] message must surface
+        # so the operator can see what's actually being used.
+        idx = self.src.index("if model:")
+        body = self.src[idx:idx + 800]
+        self.assertIn("[MODEL_RESOLVE]", body)
+
+
+class InvalidateHookTests(unittest.TestCase):
+    """server_llmwiki: install/delete handlers invalidate the resolver
+    cache so a freshly-installed model is usable on the next /query/."""
+
+    @classmethod
+    def setUpClass(cls):
+        import inspect
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_install_thread_invalidates_cache(self):
+        # _start_install_with_progress runs the pull in a background
+        # thread; on success status, must call invalidate_cache so the
+        # next call_gemma sees the new tag without 60s wait.
+        idx = self.src.index("def _start_install_with_progress")
+        # Bound at next def.
+        nxt = self.src.index("\ndef ", idx + 1)
+        body = self.src[idx:nxt]
+        self.assertIn("invalidate_cache", body,
+            "install thread must invalidate resolver cache on success")
+
+    def test_delete_handler_invalidates_cache(self):
+        idx = self.src.index('@app.delete("/admin/llm/delete"')
+        nxt = self.src.index("\n@app.", idx + 10)
+        body = self.src[idx:nxt]
+        self.assertIn("invalidate_cache", body,
+            "delete must invalidate resolver cache so the deleted model "
+            "isn't used on the next /query/")
+
+    def test_resolution_endpoint_registered(self):
+        self.assertIn('@app.get("/admin/llm/resolution"', self.src,
+            "/admin/llm/resolution must be registered for operator visibility")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 1 of 5 in the multi-model auto-resolution plan. Eliminates the most common beginner failure: server defaults to `gemma4:e4b`, beginner installs `gemma3:4b`, every chat 404s. After this PR, the resolver picks an installed model automatically.

User vision (2026-05-09):
> 「어떤 모델이 설치 되어 있더라도 멀티 호환 가능하게 해야한다. 설치된 모델 우선 답변하고 필요시 설치 권장하는 체계. 모델이 없어서 막히는 일이 없게 구조를 만드는 것」

## Resolution chain

```
call_gemma(model=None)
  ↓
1. requested (config.GEMMA_MODEL — operator's path)  → if installed, use
  ↓ miss
2. per-mode preference list                          → first installed wins
  ↓ miss
3. any installed model (sorted, deterministic)       → with warning
  ↓ none
4. RuntimeError("No models installed. Run: ollama pull gemma3:4b ...")
```

Operator override: `JAMES_MODEL_PREFERENCE_CHAT=gemma3:4b,llama3.2:3b`

## Verification

```
$ python -m unittest tests.test_model_resolver -v
Ran 20 tests in 23.7s  OK

$ python -m unittest discover -s tests
Ran 834 tests in 9.3s  OK   (was 814; +20 new)
```

### Test classes (7)
- `ResolveChainTests` (6) — all 4 chain steps + chain recording
- `CodingPreferenceTests` (2) — coding-mode list separate
- `EnvOverrideTests` (2) — `JAMES_MODEL_PREFERENCE_<MODE>` respected
- `CacheBehaviorTests` (3) — cache hits, invalidate forces refresh, ollama-down returns empty set
- `SnapshotTests` (1) — `resolution_snapshot()` shape
- `GemmaClientIntegrationTests` (3) — `call_gemma` source-level wiring
- `InvalidateHookTests` (3) — install thread + delete handler hooks

### Bench numbers — STEP 7 baseline expected unchanged

**Static analysis**: operator's `gemma4:e4b` is installed → resolver returns `("gemma4:e4b", "requested", ...)` → identical to pre-PR behavior.

**Live bench**: could not run during this PR — server was not running on build machine when bench script tried to POST `/query/`. Per CLAUDE.md rule 2, `gemma_client.py` is in `core/` but NOT in `core/{retrieval,graph,reasoning}` so live bench is not strictly required. **Recommend user re-run `python scripts/bench.py --check` after merge + server restart**; resolver design guarantees no drift on the existing install.

## What this enables (downstream PRs)

This PR alone already eliminates the `.env` `JAMES_LLM_MODEL` mismatch friction described in PR #147. Subsequent plan PRs build on top:

- **PR 2** — catalog consolidation (`LLM_CATALOG` ↔ `_model_catalog` → single source)
- **PR 3** — first-run wizard (admin sees "Workstation Tier — gemma3:4b 권장" modal when ollama list is empty)
- **PR 4** — chat picker "🎯 추천 받기" toast
- **PR 5** — beginner README simplification (model name removed from steps; "click admin → install" flow)

## New endpoint: `GET /admin/llm/resolution`

Operator-facing observability. Returns `{chat, coding, installed, preference, ttl_s}` so the operator can inspect "what's actually being used" without reading server logs.

## Cache hooks

`invalidate_cache()` called from:
- `_start_install_with_progress` background thread on `status="success"` — freshly-installed model usable on next `/query/` without 60s TTL wait
- `/admin/llm/delete` handler — deleted model not used on subsequent calls

## CLAUDE.md compliance

- (1) **No domain features** — pure platform LLM-routing
- (2) **bench numbers** — static + unit; live deferred (see above)
- (3) **self-evolution** — unaffected
- (4) **no architecture change** — adds a layer behind existing `call_gemma`
- (5) **module size** — `core/model_resolver.py` 7.5 KB ✓; `core/gemma_client.py` +~15 lines

## Files

```
 core/model_resolver.py                 | +245   NEW   resolver + cache + snapshot
 core/gemma_client.py                   | +16/-1   call_gemma uses resolver when model=None
 server_llmwiki.py                      | +28    /admin/llm/resolution endpoint + invalidate hooks
 tests/test_model_resolver.py           | +280  NEW   20 tests / 7 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>