### PR TITLE
feat(admin): first-run wizard — auto-recommend + install on empty Ollama (PR plan-3/5)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1053,5 +1053,80 @@
     </button>
   </div>
 </div>
+
+<!-- ── First-run wizard 모달 [PR plan-3, 2026-05-09] ──────────────
+     트리거: admin 진입 시 /admin/llm/resolution.installed가 비었거나
+            chat resolver source=="none"이면 자동 표시.
+     역할:   하드웨어 측정 결과 + 추천 모델 + 원클릭 설치.
+     닫힘:   "나중에" 버튼으로 dismiss (sessionStorage에 기록 — 재진입
+            시 다시 안 띄움). 설치 완료 시 자동 닫힘. -->
+<div class="modal-overlay" id="firstrun-wizard-modal"
+     style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.88);
+            align-items:center;justify-content:center;z-index:400;">
+  <div style="background:var(--surface);border:1px solid var(--border);
+              border-radius:14px;padding:36px;width:560px;max-width:92vw;
+              box-shadow:0 24px 80px rgba(0,0,0,.8);max-height:88vh;overflow-y:auto;">
+    <div style="font-size:18px;font-weight:600;color:var(--accent-fg);
+                margin-bottom:8px;letter-spacing:.3px;">
+      🎯 처음 실행 — LLM 모델 설치 필요
+    </div>
+    <div style="font-size:13px;color:var(--muted);margin-bottom:20px;line-height:1.6;">
+      Ollama에 설치된 모델이 없어서 답변을 만들 수 없습니다.
+      이 PC의 사양에 맞는 모델을 자동 추천해드립니다.
+    </div>
+
+    <div id="firstrun-hw-summary"
+         style="background:var(--surface-2);border:1px solid var(--border);
+                border-radius:8px;padding:12px 14px;margin-bottom:16px;
+                font-size:12px;color:var(--text-soft);line-height:1.5;">
+      <div class="loading">하드웨어 측정 중...</div>
+    </div>
+
+    <div style="font-size:11px;color:var(--muted);text-transform:uppercase;
+                letter-spacing:.4px;margin-bottom:8px;">
+      🤖 권장 모델 (이 PC에서 작동 가능한 것 중 우선순위)
+    </div>
+    <div id="firstrun-recommendations"
+         style="background:var(--bg);border:1px solid var(--border);
+                border-radius:8px;padding:8px;margin-bottom:14px;
+                max-height:280px;overflow-y:auto;">
+      <div class="loading" style="padding:20px;text-align:center;color:var(--muted)">
+        추천 계산 중...
+      </div>
+    </div>
+
+    <!-- 진행률 표시 (설치 시작 후 활성화) -->
+    <div id="firstrun-progress" style="display:none;background:var(--surface-2);
+         border:1px solid var(--accent);border-radius:8px;padding:12px;
+         margin-bottom:14px;font-size:12px">
+      <div id="firstrun-progress-text"
+           style="color:var(--accent-fg);margin-bottom:6px">설치 시작 중...</div>
+      <div style="background:var(--bg);height:6px;border-radius:3px;overflow:hidden">
+        <div id="firstrun-progress-bar"
+             style="background:var(--accent);height:100%;width:0%;
+                    transition:width .3s"></div>
+      </div>
+    </div>
+
+    <div style="display:flex;gap:10px;margin-top:18px">
+      <button id="firstrun-later-btn"
+              onclick="firstRunDismiss()"
+              style="flex:1;padding:11px;background:var(--surface-2);
+                     border:1px solid var(--border);border-radius:8px;
+                     color:var(--muted);font-size:13px;cursor:pointer;">
+        나중에 (이 세션 동안 다시 안 띄움)
+      </button>
+      <button id="firstrun-refresh-btn"
+              onclick="firstRunCheck()"
+              style="padding:11px 16px;background:var(--surface-2);
+                     border:1px solid var(--border);border-radius:8px;
+                     color:var(--muted);font-size:13px;cursor:pointer;"
+              title="모델 설치 후 다시 확인">
+        ↻ 새로고침
+      </button>
+    </div>
+  </div>
+</div>
+
 </body>
 </html>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -66,6 +66,8 @@ window.addEventListener('storage', (e) => {
     const modal = document.getElementById('admin-login-modal');
     if (modal) modal.style.display = 'none';
     try { loadDashboard(); } catch (_) {}
+    // [PR plan-3] cross-tab login 후에도 first-run wizard 체크
+    setTimeout(() => { try { firstRunCheck(); } catch (_) {} }, 600);
   }
 });
 
@@ -130,10 +132,221 @@ async function doAdminLogin() {
     const modal = document.getElementById('admin-login-modal');
     if (modal) modal.style.display = 'none';
     loadDashboard();
+    // [PR plan-3] 로그인 후 LLM 모델 readiness 체크. 0개면 wizard 노출.
+    setTimeout(() => { try { firstRunCheck(); } catch (_) {} }, 600);
 
   } catch (e) {
     if(errEl) errEl.textContent = `Server error: ${e.message}`;
   }
+}
+
+/* ── [PR plan-3, 2026-05-09] First-run wizard ───────────────────
+   처음 admin 진입 시 (또는 ollama list가 비었을 때) 모달 띄움.
+   하드웨어 측정 → 추천 모델 → 원클릭 설치 흐름.
+   sessionStorage('james_firstrun_dismissed')에 dismiss 기록 — 재진입
+   시 안 띄움. 그러나 firstRunCheck()는 항상 호출되며 dismiss 됐어도
+   ↻ 새로고침 버튼이 강제 표시 가능. */
+
+let _firstRunInstallPoll = null;
+
+async function firstRunCheck() {
+  // 이번 세션에서 이미 dismiss됐고 모델이 ≥1개면 wizard 안 띄움.
+  // 강제 표시는 firstRunShow() 직접 호출.
+  try {
+    const data = await api('/admin/llm/resolution');
+    const installed = data.installed || [];
+    const dismissed = sessionStorage.getItem('james_firstrun_dismissed') === '1';
+    if (installed.length === 0) {
+      // 모델 0개면 dismiss 무시하고 강제 표시 (실제로 답변이 안 됨)
+      firstRunShow(data);
+    } else if (!dismissed) {
+      // 모델 ≥1개여도 chat resolver가 fallback 상태면 알림 (정보 차원)
+      const chatWarn = (data.chat || {}).warning || '';
+      if (chatWarn && chatWarn.includes('not installed')) {
+        // toast — modal까지는 띄우지 않음
+        if (typeof toast === 'function') {
+          toast(`ℹ️ ${chatWarn}`, 'info');
+        }
+      }
+    }
+    // hide wizard if it was shown but now we have models
+    if (installed.length > 0) {
+      const m = document.getElementById('firstrun-wizard-modal');
+      if (m) m.style.display = 'none';
+    }
+  } catch (e) {
+    console.warn('[firstrun] resolution check failed:', e.message);
+  }
+}
+
+async function firstRunShow(resolutionData) {
+  const modal = document.getElementById('firstrun-wizard-modal');
+  if (!modal) return;
+  modal.style.display = 'flex';
+
+  // 1) 하드웨어 측정 + 추천
+  const hwBox = document.getElementById('firstrun-hw-summary');
+  const recBox = document.getElementById('firstrun-recommendations');
+  if (hwBox) hwBox.innerHTML = '<div class="loading">측정 중...</div>';
+  if (recBox) recBox.innerHTML = '<div class="loading" style="padding:20px;text-align:center">로딩...</div>';
+
+  try {
+    const recData = await api('/admin/llm/recommend');
+    if (!recData.ok) throw new Error(recData.error || 'recommend failed');
+    const summary = recData.specs_summary || {};
+    if (hwBox) {
+      hwBox.innerHTML = `
+        <div><strong>🖥️ 이 PC 사양</strong></div>
+        <div>GPU: ${_escHtml(summary.gpu || '?')}</div>
+        <div>RAM: ${_escHtml(summary.ram || '?')}</div>
+        <div>전체 등급: <strong style="color:var(--accent-fg)">Level ${summary.level || '?'}</strong></div>
+      `;
+    }
+    // 우선 첫 번째 chat-feasible 모델을 강조, 나머지는 sub list.
+    const recs = recData.recommendations || [];
+    const chatFeasible = recs.filter(r => r.feasible &&
+                                          (r.purpose || []).includes('chat'));
+    const codingFeasible = recs.filter(r => r.feasible &&
+                                            (r.purpose || []).includes('coding'));
+    if (recBox) {
+      let html = '';
+      if (chatFeasible.length === 0) {
+        html += `<div style="padding:14px;color:var(--warn);font-size:12px">
+          ⚠️ 이 PC 사양에 적합한 chat 모델이 없습니다. 가장 가벼운 모델 (gemma3:1b)을 시도해보세요.
+        </div>`;
+        // Force-show gemma3:1b as fallback.
+        html += _firstRunRow({tag:'gemma3:1b', desc:'초경량 (CPU-only OK)',
+                              size_gb:1.0, purpose:['chat']}, true);
+      } else {
+        // Top chat candidate gets star + 강조
+        html += '<div style="font-size:11px;color:var(--muted);padding:6px 10px;text-transform:uppercase;letter-spacing:.3px">💬 일상 대화</div>';
+        chatFeasible.slice(0, 3).forEach((r, i) => {
+          html += _firstRunRow(r, i === 0);
+        });
+        if (codingFeasible.length > 0) {
+          html += '<div style="font-size:11px;color:var(--muted);padding:6px 10px;margin-top:8px;text-transform:uppercase;letter-spacing:.3px">💻 코딩</div>';
+          codingFeasible.slice(0, 2).forEach(r => {
+            html += _firstRunRow(r, false);
+          });
+        }
+      }
+      recBox.innerHTML = html;
+    }
+  } catch (e) {
+    if (hwBox) hwBox.innerHTML = `<div style="color:#c00">측정 실패: ${_escHtml(e.message)}</div>`;
+    if (recBox) recBox.innerHTML = `<div style="padding:20px;text-align:center;color:#c00">추천 로드 실패: ${_escHtml(e.message)}</div>`;
+  }
+}
+
+function _firstRunRow(r, primary) {
+  const sizeGB = (r.size_gb != null) ? `${r.size_gb}GB` : '';
+  const desc = _escHtml(r.desc || r.description || '');
+  const tag = _escHtml(r.tag || r.name || '');
+  const stars = primary ? '⭐ ' : '   ';
+  const bg = primary ? 'rgba(99,102,241,.10)' : 'transparent';
+  const border = primary ? 'border:1px solid var(--accent);' : 'border:1px solid var(--border);';
+  return `<div style="${border}background:${bg};border-radius:7px;padding:10px 12px;margin:4px 6px;
+                       display:flex;align-items:center;gap:10px;font-size:13px">
+    <div style="flex:1;min-width:0">
+      <div style="${primary?'color:var(--accent-fg);font-weight:600':''}">${stars}${tag}</div>
+      <div style="font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+        ${desc}${sizeGB ? ' · ' + sizeGB : ''}
+      </div>
+    </div>
+    <button onclick="firstRunInstall('${tag.replace(/'/g, "\\'")}')"
+            style="padding:7px 14px;background:var(--accent);color:#fff;
+                   border:0;border-radius:6px;cursor:pointer;font-size:12px;
+                   font-weight:600;flex-shrink:0">
+      📦 설치
+    </button>
+  </div>`;
+}
+
+async function firstRunInstall(model) {
+  if (!model) return;
+  const progressBox = document.getElementById('firstrun-progress');
+  const progressText = document.getElementById('firstrun-progress-text');
+  const progressBar = document.getElementById('firstrun-progress-bar');
+  if (progressBox) progressBox.style.display = 'block';
+  if (progressText) progressText.textContent = `${model} 설치 시작 중...`;
+
+  try {
+    const r = await fetch(
+      `${API}/llm/install/?api_key=${encodeURIComponent(apiKey)}&model=${encodeURIComponent(model)}`,
+      {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` },
+      },
+    );
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      throw new Error(err.detail || `HTTP ${r.status}`);
+    }
+    // 진행률 폴링
+    if (_firstRunInstallPoll) clearInterval(_firstRunInstallPoll);
+    _firstRunInstallPoll = setInterval(() => _firstRunPollProgress(model), 2500);
+    _firstRunPollProgress(model);   // 즉시 1회
+  } catch (e) {
+    if (progressText) progressText.textContent = `❌ 설치 실패: ${e.message}`;
+  }
+}
+
+async function _firstRunPollProgress(model) {
+  try {
+    const r = await fetch(
+      `${API}/admin/llm/install-progress?api_key=${encodeURIComponent(apiKey)}&model=${encodeURIComponent(model)}`,
+      { headers: { 'Authorization': `Bearer ${token}` } },
+    );
+    if (!r.ok) {
+      if (r.status === 401) {
+        // 세션 만료 — 폴링 중단 + localStorage 정리 (chat tab role
+        // badge도 같이 업데이트되도록 SSO 일관성 유지).
+        clearInterval(_firstRunInstallPoll);
+        _firstRunInstallPoll = null;
+        try {
+          localStorage.removeItem('james_token');
+          localStorage.removeItem('james_role');
+        } catch (_) {}
+      }
+      return;
+    }
+    const p = await r.json();
+    const progressText = document.getElementById('firstrun-progress-text');
+    const progressBar = document.getElementById('firstrun-progress-bar');
+    if (p.error) {
+      if (progressText) progressText.textContent = `❌ ${model} 실패: ${p.error}`;
+      clearInterval(_firstRunInstallPoll);
+      _firstRunInstallPoll = null;
+      return;
+    }
+    if (p.done) {
+      if (progressText) progressText.textContent = `✅ ${model} 설치 완료! 이제 답변할 수 있습니다.`;
+      if (progressBar) progressBar.style.width = '100%';
+      clearInterval(_firstRunInstallPoll);
+      _firstRunInstallPoll = null;
+      // 자동 닫기 (3초 후)
+      setTimeout(() => {
+        const modal = document.getElementById('firstrun-wizard-modal');
+        if (modal) modal.style.display = 'none';
+      }, 3000);
+      return;
+    }
+    if (progressText) {
+      const pctStr = (p.percent != null) ? `${p.percent}%` : (p.status || '진행 중');
+      progressText.textContent = `⏳ ${model}: ${pctStr}`;
+    }
+    if (progressBar && p.percent != null) {
+      progressBar.style.width = `${p.percent}%`;
+    }
+  } catch (e) {
+    console.warn('[firstrun-poll]', e);
+  }
+}
+
+function firstRunDismiss() {
+  sessionStorage.setItem('james_firstrun_dismissed', '1');
+  const modal = document.getElementById('firstrun-wizard-modal');
+  if (modal) modal.style.display = 'none';
 }
 
 

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -237,6 +237,35 @@ async def on_startup():
         # Housekeeping must never block server startup.
         print(f"[STARTUP] trace prune skipped: {e}")
 
+    # [PR plan-3, 2026-05-09] LLM readiness check + friendly install
+    # guidance. If Ollama has 0 models, every /query/ would fail. We
+    # emit a clear console banner pointing operators to the admin
+    # first-run wizard so they don't waste time debugging "[Gemma 응답
+    # 없음]" mysteries. Resolver gracefully degrades — no crash, just
+    # a clear next-step.
+    try:
+        from core.model_resolver import resolution_snapshot
+        snap = resolution_snapshot()
+        installed = snap.get("installed", [])
+        if not installed:
+            chat_warn = snap.get("chat", {}).get("warning", "")
+            print("=" * 60)
+            print("[STARTUP] ⚠️  Ollama에 설치된 모델이 0개입니다.")
+            print("[STARTUP]   → /query/ 호출 시 실패하거나 RuntimeError 발생.")
+            print("[STARTUP]   → 다음 중 하나로 모델을 설치하세요:")
+            print("[STARTUP]      a) admin 페이지(/admin) 접속 → 자동 추천 wizard")
+            print("[STARTUP]      b) 터미널에서: ollama pull gemma3:4b")
+            if chat_warn:
+                print(f"[STARTUP]   resolver 메시지: {chat_warn}")
+            print("=" * 60)
+        else:
+            chat_tag = snap.get("chat", {}).get("tag", "")
+            chat_src = snap.get("chat", {}).get("source", "")
+            print(f"[STARTUP] LLM 준비됨 — chat 모델: {chat_tag} (source: {chat_src}, "
+                  f"설치된 모델 {len(installed)}개)")
+    except Exception as e:
+        print(f"[STARTUP] LLM readiness check skipped: {e}")
+
     async def _index():
         await asyncio.sleep(3)
         try:

--- a/tests/test_first_run_wizard.py
+++ b/tests/test_first_run_wizard.py
@@ -1,0 +1,194 @@
+"""[PR plan-3, 2026-05-09] Admin first-run wizard.
+
+Goal: when an operator opens /admin and Ollama has 0 models installed,
+show a hardware-aware install wizard so the operator never has to
+guess which `ollama pull <X>` to run.
+
+Components covered:
+  Backend
+    - server startup banner: friendly console message when ollama is
+      empty, pointing to admin wizard
+  Frontend
+    - admin.html : firstrun-wizard-modal with placeholders for HW
+      summary + recommendations + progress
+    - admin.js   : firstRunCheck / firstRunShow / firstRunInstall /
+      _firstRunPollProgress / firstRunDismiss
+    - Trigger    : after admin login success (existing flow), call
+      firstRunCheck via setTimeout
+    - Dismiss    : sessionStorage so a re-login doesn't re-popup;
+      ↻ refresh button always re-checks
+
+Run:
+    python -m unittest tests.test_first_run_wizard
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class StartupBannerTests(unittest.TestCase):
+    """server_llmwiki on_startup must check resolver + emit a clear
+    banner pointing at the admin wizard when no models are installed."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def test_on_startup_calls_resolution_snapshot(self):
+        idx = self.src.index("async def on_startup")
+        nxt = self.src.index("\nasync def ", idx + 1)
+        body = self.src[idx:nxt]
+        self.assertIn("resolution_snapshot", body,
+            "on_startup must check Ollama state via resolution_snapshot")
+
+    def test_empty_models_emits_banner(self):
+        idx = self.src.index("async def on_startup")
+        nxt = self.src.index("\nasync def ", idx + 1)
+        body = self.src[idx:nxt]
+        # The banner must mention the admin wizard path so operator
+        # knows where to go.
+        self.assertIn("/admin", body)
+        self.assertRegex(body, r"ollama pull",
+            "banner must show the install command as a fallback")
+        # The 'no models installed' branch is conditional on the
+        # `installed` list being empty (Python `if not installed:`).
+        self.assertTrue(
+            "not installed" in body or "if not snap" in body or "0개" in body,
+            "must branch on empty installed list",
+        )
+
+    def test_startup_failure_does_not_crash_server(self):
+        # Resolver call must be wrapped in try/except so a bad Ollama
+        # state never blocks startup.
+        idx = self.src.index("resolution_snapshot")
+        # Look back ~400 chars for a try.
+        prelude = self.src[max(0, idx - 400):idx]
+        self.assertIn("try:", prelude)
+
+
+class FrontendModalTests(unittest.TestCase):
+    """admin.html must declare firstrun-wizard-modal + sub-elements."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "admin.html").read_text(encoding="utf-8")
+
+    def test_modal_present(self):
+        self.assertIn('id="firstrun-wizard-modal"', self.html)
+
+    def test_required_subelements(self):
+        for elem_id in ("firstrun-hw-summary",
+                         "firstrun-recommendations",
+                         "firstrun-progress",
+                         "firstrun-progress-text",
+                         "firstrun-progress-bar",
+                         "firstrun-later-btn"):
+            self.assertIn(f'id="{elem_id}"', self.html,
+                f"modal must contain element with id={elem_id}")
+
+    def test_dismiss_button_calls_firstRunDismiss(self):
+        self.assertIn("onclick=\"firstRunDismiss()\"", self.html)
+
+    def test_refresh_button_calls_firstRunCheck(self):
+        self.assertIn("onclick=\"firstRunCheck()\"", self.html)
+
+
+class FrontendJsTests(unittest.TestCase):
+    """admin.js must define the wizard functions + wire them to login flow."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+
+    def test_required_functions_defined(self):
+        for fn in ("firstRunCheck", "firstRunShow", "firstRunInstall",
+                   "_firstRunPollProgress", "firstRunDismiss",
+                   "_firstRunRow"):
+            self.assertIn(f"function {fn}", self.js,
+                f"function '{fn}' must be defined")
+
+    def test_check_uses_resolution_endpoint(self):
+        idx = self.js.index("async function firstRunCheck")
+        nxt = self.js.index("\n", self.js.index("}", idx + 200))
+        body = self.js[idx:idx + 1500]
+        self.assertIn("/admin/llm/resolution", body,
+            "firstRunCheck must call /admin/llm/resolution")
+
+    def test_show_uses_recommend_endpoint(self):
+        idx = self.js.index("async function firstRunShow")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("/admin/llm/recommend", body)
+
+    def test_install_uses_install_endpoint(self):
+        idx = self.js.index("async function firstRunInstall")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("/llm/install/", body)
+
+    def test_install_polls_progress(self):
+        idx = self.js.index("async function _firstRunPollProgress")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("/admin/llm/install-progress", body)
+        self.assertIn("p.done", body,
+            "must check 'done' flag from progress endpoint")
+
+    def test_dismiss_sets_session_flag(self):
+        idx = self.js.index("function firstRunDismiss")
+        body = self.js[idx:idx + 400]
+        self.assertIn("sessionStorage", body,
+            "dismiss must persist via sessionStorage so re-login "
+            "doesn't immediately re-popup the wizard")
+
+    def test_check_runs_after_login(self):
+        # The login success path (existing — modal hidden + loadDashboard)
+        # must trigger firstRunCheck via setTimeout (so dashboard
+        # loads first).
+        idx = self.js.index("if (modal) modal.style.display = 'none'")
+        body = self.js[idx:idx + 500]
+        self.assertIn("firstRunCheck", body,
+            "login success must trigger firstRunCheck")
+
+    def test_xss_guard_on_model_tag(self):
+        # The recommendation rendering must escape the model tag —
+        # tags come from server but are rendered into innerHTML.
+        idx = self.js.index("function _firstRunRow")
+        nxt = self.js.index("\nfunction ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("_escHtml", body,
+            "_firstRunRow must use _escHtml for tag/desc fields")
+
+
+class TriggerSemantics(unittest.TestCase):
+    """Wizard must NOT show when models are already installed."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+
+    def test_check_only_shows_when_empty(self):
+        # The function body must branch on installed.length === 0.
+        idx = self.js.index("async function firstRunCheck")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("installed.length === 0", body,
+            "wizard must only show when ollama list is empty")
+        # And must hide the modal when models exist (recovery case).
+        self.assertIn("display = 'none'", body)
+
+    def test_dismiss_respected_when_models_exist(self):
+        # If user dismissed AND models exist, no re-popup.
+        idx = self.js.index("async function firstRunCheck")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("james_firstrun_dismissed", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 3 of 5 in the multi-model auto-resolution plan. Wires together the hardware-aware install flow the user originally envisioned.

User vision (2026-05-09):
> 「처음 제일 가벼운 모델을 설치 권장하더라도 세팅 작업에서는 어드민 페이지에 하드웨어 성능을 따져보고 그것에 맞는 설치 권장을 해주는 것이 나의 원래 아이디어였다」

When admin opens `/admin` and Ollama has 0 models, a hardware-aware wizard appears: HW summary → top recommendations → ⭐ top chat pick → 📦 one-click install with live progress bar → auto-close on success.

## What changed

### Server startup banner (D-2)
`on_startup` checks `resolution_snapshot()`. Empty installed list → banner pointing at `/admin` wizard + `ollama pull gemma3:4b` fallback. Non-empty → one-line confirmation: `"[STARTUP] LLM 준비됨 — chat 모델: X (source: Y, 설치된 모델 N개)"`.

### Frontend modal (admin.html)
`firstrun-wizard-modal` with HW summary, recommendations list, progress bar, dismiss/refresh buttons. z-index 400 over background.

### Frontend logic (admin.js)
- `firstRunCheck()` → calls `/admin/llm/resolution`; empty → show; non-empty + fallback → toast
- `firstRunShow()` → populates HW + recs, stars top chat candidate
- `_firstRunRow(r, primary)` → row with `_escHtml` (XSS guard)
- `firstRunInstall(model)` → POST `/llm/install/` + polling
- `_firstRunPollProgress(model)` → 2.5s polling, auto-close on done, 401 clears localStorage (SSO consistency)
- `firstRunDismiss()` → sessionStorage flag

Trigger points:
- After admin login success → `setTimeout(firstRunCheck, 600)`
- After cross-tab login (storage event) → same

## Verification

```
$ python -m unittest tests.test_first_run_wizard
Ran 17 tests in 6.1s  OK

$ python -m unittest discover -s tests
Ran 874 tests in 9.0s  OK   (was 857; +17 new)
```

### Test classes
- `StartupBannerTests` (3) — resolution_snapshot called, banner points at admin + `ollama pull`, try/except guards startup
- `FrontendModalTests` (4) — modal + sub-elements, dismiss + refresh buttons wired
- `FrontendJsTests` (8) — 5 functions defined, correct endpoints, sessionStorage dismiss, post-login trigger, XSS guard
- `TriggerSemantics` (2) — only shows when installed empty, dismissed respected when models exist

## Bench numbers — STEP 7 baseline expected unchanged

Pure UX addition. No `call_gemma` path touched. Server startup banner is a `print()` — no impact on `/query/`. Operator's existing install does NOT trigger the wizard (installed ≥ 1 → wizard hidden).

## CLAUDE.md compliance

- (1) **No domain features**
- (2) **bench numbers** — N/A (no `core/{retrieval,graph,reasoning}` touched)
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — N/A (admin.html + admin.js + tests)

## Files

```
 server_llmwiki.py                | +28      on_startup banner
 frontend/admin.html              | +75   NEW modal HTML + CSS
 frontend/static/admin.js         | +220  wizard funcs + storage event hook
 tests/test_first_run_wizard.py   | +185  NEW   17 tests / 4 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>