### PR TITLE
feat(chat): defensive resolution + 🎯 추천 link to admin (PR plan-4/5)

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -172,11 +172,22 @@ class GemmaClient:
             "ollama pull X" 안내 메시지로 RuntimeError 발생.
         """
         if model:
-            # Caller specified a tag — trust them (already validated
-            # by selected_model resolver in core.model_catalog if it
-            # came from picker; direct internal callers know what
-            # they're asking for).
-            actual_model = model
+            # Caller specified a tag — verify it's installed before
+            # hitting Ollama. If not installed, the resolver falls
+            # through to the preference list (defense for picker
+            # selecting a not-yet-pulled model).
+            # [PR plan-4, 2026-05-09] gracefully handles "user picked
+            # gemma3:12b in dropdown but only gemma3:4b is installed".
+            from core.model_resolver import installed_models, resolve_for_mode
+            if model in installed_models():
+                actual_model = model
+            else:
+                resolved = resolve_for_mode("chat", requested=model)
+                if not resolved.tag:
+                    raise RuntimeError(resolved.warning)
+                actual_model = resolved.tag
+                if resolved.warning:
+                    print(f"[MODEL_RESOLVE] {resolved.warning}")
         else:
             from core.model_resolver import resolve_chat
             resolved = resolve_chat()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -982,6 +982,17 @@
                        padding:4px 10px;border-radius:6px;font-size:11px;
                        cursor:pointer;font-family:var(--font-ui)"
                 title="선택한 모드의 모델이 미설치 — 클릭하여 ollama pull"></button>
+        <!-- [PR plan-4] 추천 모델 가이드로 admin 페이지 이동 -->
+        <a id="mode-recommend-link"
+           href="/admin"
+           target="_blank"
+           rel="noopener"
+           style="font-size:11px;color:var(--muted);text-decoration:none;
+                  padding:4px 8px;border:1px dashed var(--border);
+                  border-radius:6px;cursor:pointer"
+           title="이 PC에 맞는 모델 자동 추천 (admin 페이지)">
+          🎯 추천
+        </a>
         <span id="mode-recommend"
               style="display:none;font-size:11px;color:var(--accent-fg);
                      padding:2px 8px;border:1px solid var(--accent-fg);

--- a/tests/test_chat_recommend_link.py
+++ b/tests/test_chat_recommend_link.py
@@ -1,0 +1,95 @@
+"""[PR plan-4, 2026-05-09] Chat picker recommend link + defensive resolution.
+
+Two contracts asserted here:
+
+1. **call_gemma defensive resolution**: when the caller passes a
+   specific tag (model=picked) but the tag isn't installed, the
+   resolver should still fall through to the preference list rather
+   than 404. This protects the picker selection path which had a
+   gap — `selected_model` was validated against the catalog
+   (PR #136) but the catalog only checks "is this tag listed", not
+   "is this tag actually installed in Ollama right now".
+
+2. **chat picker UI**: index.html surfaces a 🎯 추천 link next to
+   the install button so users can self-route to the admin first-run
+   wizard for hardware-aware recommendations.
+
+Run:
+    python -m unittest tests.test_chat_recommend_link
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class CallGemmaDefensiveResolutionTests(unittest.TestCase):
+    """call_gemma must fall through to resolver even when the caller
+    passes a specific tag — if that tag isn't installed."""
+
+    @classmethod
+    def setUpClass(cls):
+        from core import gemma_client
+        cls.src = inspect.getsource(gemma_client)
+
+    def test_truthy_model_path_checks_installed(self):
+        # The 'if model:' branch must consult installed_models() and
+        # only use the tag directly if it's actually present.
+        idx = self.src.index("if model:")
+        body = self.src[idx:idx + 1200]
+        self.assertIn("installed_models", body,
+            "call_gemma's truthy-model branch must verify the tag is "
+            "actually installed in Ollama before hitting it")
+
+    def test_truthy_model_falls_through_resolver(self):
+        idx = self.src.index("if model:")
+        body = self.src[idx:idx + 1200]
+        self.assertIn("resolve_for_mode", body,
+            "missing tag must trigger resolver fallback "
+            "(not just call ollama and 404)")
+
+
+class ChatRecommendLinkTests(unittest.TestCase):
+    """index.html must surface a 🎯 추천 link next to the install button."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_recommend_link_present(self):
+        self.assertIn('id="mode-recommend-link"', self.html,
+            "🎯 추천 link must exist next to install button")
+
+    def test_recommend_link_targets_admin(self):
+        idx = self.html.index('id="mode-recommend-link"')
+        body = self.html[idx:idx + 600]
+        self.assertIn('href="/admin"', body,
+            "recommend link should route to /admin (first-run wizard lives there)")
+        # New tab so user doesn't lose chat context.
+        self.assertIn('target="_blank"', body)
+
+    def test_recommend_link_visible_to_all_roles(self):
+        # Unlike the install button (admin-only), the recommend link
+        # is visible to all — non-admin can SEE recommendations even
+        # if they can't install. The link doesn't have role-based hide.
+        # Bound the body at the </a> tag so we don't pick up sibling
+        # elements that may have their own display:none.
+        idx = self.html.index('id="mode-recommend-link"')
+        end = self.html.index("</a>", idx)
+        body = self.html[idx:end]
+        self.assertNotIn("display:none", body,
+            "recommend link must be visible by default — non-admin "
+            "should at least see what models exist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -226,8 +226,10 @@ class GemmaClientIntegrationTests(unittest.TestCase):
     def test_warning_logged_to_stdout(self):
         # When a fallback happens, [MODEL_RESOLVE] message must surface
         # so the operator can see what's actually being used.
+        # Window enlarged to 1500 chars — PR plan-4 added defensive
+        # resolution comments, pushing the print() further down.
         idx = self.src.index("if model:")
-        body = self.src[idx:idx + 800]
+        body = self.src[idx:idx + 1500]
         self.assertIn("[MODEL_RESOLVE]", body)
 
 


### PR DESCRIPTION
## Summary

PR 4 of 5 in the multi-model auto-resolution plan. Closes the picker→404 gap and adds a 🎯 추천 link in chat for self-discovery.

### Two contracts

**1. Defensive resolution in call_gemma**

PR plan-1 only fell back when `model=None`. The picker passes `model=picked_tag` after catalog validation — but the catalog only checks "is this tag listed", not "is this tag actually installed in Ollama". So a user picking `gemma3:12b` (listed) when only `gemma3:4b` is installed would 404.

After this PR: `if model:` branch consults `installed_models()` first. Miss → `resolve_for_mode("chat", requested=model)` falls through to the preference list with a `[MODEL_RESOLVE]` log.

**2. 🎯 추천 link in chat**

Next to the existing install button. Opens `/admin` in a new tab → first-run wizard (PR plan-3). Visible to all roles — discovery is for everyone, privileged install stays admin-gated (decision C-1).

## Verification

```
$ python -m unittest tests.test_chat_recommend_link -v
Ran 5 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 879 tests in 8.9s  OK   (was 874; +5 new)
```

### Test classes
- `CallGemmaDefensiveResolutionTests` (2) — truthy-model path checks `installed_models()`, falls through to `resolve_for_mode` on miss
- `ChatRecommendLinkTests` (3) — link present, targets `/admin` in new tab, visible to all roles

### Existing test widened
`test_model_resolver.test_warning_logged_to_stdout` window 800 → 1500 chars (defensive comments push the `print()` further down).

## Bench numbers — STEP 7 baseline expected unchanged

Operator's PC has `gemma4:e4b` installed → `call_gemma`'s truthy-model branch finds it in `installed_models()` → uses it directly → identical pre-PR behavior. Defensive fallback only fires when picker selects a not-yet-pulled model.

## CLAUDE.md compliance

- (1) **No domain features** — defensive UX
- (2) **bench numbers** — `gemma_client.py` is in `core/` but not in `core/{retrieval,graph,reasoning}` per rule 2 strict reading
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — `core/gemma_client.py` +~10 lines

## Files

```
 core/gemma_client.py                | +13/-3   defensive resolution branch
 frontend/index.html                 | +13      🎯 추천 link
 tests/test_chat_recommend_link.py   | +95   NEW   5 tests / 2 classes
 tests/test_model_resolver.py        |  +1/-1   window 800→1500
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>