### PR TITLE
feat(graph): neighborhood explorer + query reasoning overlay

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -210,6 +210,102 @@
   .answer-card.ac-collapsed .ac-paths,
   .answer-card.ac-collapsed .ac-history { display: none; }
   .answer-card.ac-collapsed { padding: 8px 14px; }
+  /* [PR explorer, 2026-05-09] Neighborhood panel — slides from left
+     so it doesn't clash with the answer card on the right. */
+  .neighbor-panel {
+    position: absolute; left: 16px; top: 60px;
+    width: min(280px, calc(100% - 280px - 32px));
+    max-height: calc(100% - 100px);
+    background: rgba(20,22,26,.95);
+    border: 1px solid var(--border);
+    border-radius: 10px; padding: 14px;
+    font-size: 13px; color: var(--text);
+    overflow-y: auto;
+    display: none;
+    z-index: 25;
+  }
+  .neighbor-panel .np-close {
+    position: absolute; top: 8px; right: 10px;
+    background: transparent; border: none; color: var(--muted);
+    font-size: 18px; cursor: pointer; padding: 0; line-height: 1;
+  }
+  .neighbor-panel .np-title {
+    font-size: 14px; font-weight: 600; color: var(--accent-fg);
+    margin-bottom: 4px; padding-right: 24px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .neighbor-panel .np-meta {
+    font-size: 11px; color: var(--muted);
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-2);
+  }
+  .neighbor-panel .np-list { display: flex; flex-direction: column; gap: 1px; }
+  .neighbor-panel .np-item {
+    padding: 7px 8px; border-radius: 5px;
+    cursor: pointer; display: flex; align-items: center; gap: 8px;
+    transition: background .12s, color .12s;
+    font-size: 12px;
+  }
+  .neighbor-panel .np-item:hover {
+    background: rgba(99,102,241,.12);
+    color: var(--accent-fg);
+  }
+  .neighbor-panel .np-arrow {
+    color: var(--muted); font-family: var(--font-mono); flex-shrink: 0;
+  }
+  .neighbor-panel .np-name {
+    flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .neighbor-panel .np-rel {
+    font-size: 10px; color: var(--muted-2);
+    font-family: var(--font-mono); flex-shrink: 0;
+  }
+  .neighbor-panel .np-empty {
+    padding: 20px; text-align: center; color: var(--muted); font-size: 12px;
+  }
+
+  /* [PR explorer] Reasoning overlay during query — small inline
+     widget above the query bar. */
+  .query-reasoning-overlay {
+    position: absolute;
+    bottom: 64px; left: 50%; transform: translateX(-50%);
+    background: rgba(20,22,26,.95);
+    border: 1px solid var(--accent);
+    border-radius: 18px;
+    padding: 6px 14px;
+    font-size: 12px; color: var(--accent-fg);
+    display: none;             /* shown by JS */
+    align-items: center; gap: 8px;
+    z-index: 30;
+    box-shadow: 0 8px 32px rgba(99,102,241,.18);
+    animation: qr-fade-in .18s ease-out;
+  }
+  @keyframes qr-fade-in {
+    from { opacity: 0; transform: translate(-50%, 6px); }
+    to   { opacity: 1; transform: translate(-50%, 0); }
+  }
+  .qr-brain { display: inline-block; line-height: 0; }
+  .qr-neuron { animation: qr-blink 1.0s infinite; opacity: .9; }
+  .qr-neuron.qr-n2 { animation-delay: .3s; }
+  .qr-neuron.qr-n3 { animation-delay: .6s; }
+  @keyframes qr-blink {
+    0%, 100% { opacity: .35; }
+    50%      { opacity: 1; }
+  }
+  .qr-text {
+    font-weight: 500; letter-spacing: .2px;
+    background: linear-gradient(90deg, var(--accent-fg), #fff, var(--accent-fg));
+    background-size: 200% 100%;
+    -webkit-background-clip: text; background-clip: text;
+    color: transparent; -webkit-text-fill-color: transparent;
+    animation: qr-shimmer 1.2s linear infinite;
+  }
+  @keyframes qr-shimmer {
+    from { background-position: 0% 0; }
+    to   { background-position: -200% 0; }
+  }
+
   /* [#4-2 h/i] history list — clickable rows under the current answer. */
   .answer-card .ac-history {
     margin-top: 12px; padding-top: 10px;
@@ -326,6 +422,14 @@
     <div class="overlay tr" id="overlay-counts"></div>
     <div class="overlay bl" data-i18n="graph.hint">Ask a question below — the path the answer travels will pulse on the graph.</div>
     <div class="tooltip" id="hover-tip"></div>
+
+    <!-- [PR explorer] Neighborhood explorer panel — left side, slides
+         in on node click. -->
+    <div class="neighbor-panel" id="neighbor-panel"></div>
+
+    <!-- [PR explorer] Query reasoning overlay — inline widget above
+         the query bar during /query/ inflight wait. -->
+    <div class="query-reasoning-overlay" id="query-reasoning-overlay"></div>
 
     <div class="answer-card" id="answer-card">
       <button class="ac-close" onclick="closeAnswer()" title="닫기 + 그래프 기본 모드로 복귀">×</button>

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -404,6 +404,148 @@
       { x: (node.x || 0) * ratio, y: (node.y || 0) * ratio, z: (node.z || 0) * ratio },
       node, 700,
     );
+    // [PR explorer, 2026-05-09] click → neighborhood explorer.
+    // Lights up the clicked node, animates pulses to its direct
+    // neighbors, opens a side panel with their names. Clicking a name
+    // in the panel recurs the same animation from that neighbor.
+    exploreFromNode(node);
+  }
+
+  // ─── [PR explorer] Neighborhood explorer ────────────────────────
+  // 1) compute direct neighbors of the clicked node
+  // 2) activate edges + nodes for visual highlight (uses #4-2 path
+  //    persistence machinery — same Set semantics)
+  // 3) replay sprite pulses from center → each neighbor (staggered)
+  // 4) render a side panel with neighbor names; click → recurse
+  function getNeighbors(node) {
+    if (!node) return [];
+    var nodeId = node.id;
+    var out = [];
+    var seenIds = new Set();
+    data.links.forEach(function (l) {
+      var sId = linkSrc(l);
+      var tId = linkTgt(l);
+      if (sId === nodeId && !seenIds.has(tId)) {
+        var n = nodeIdx.get(tId);
+        if (n) { out.push({ neighbor: n, edge: l, direction: 'out' });
+                 seenIds.add(tId); }
+      } else if (tId === nodeId && !seenIds.has(sId)) {
+        var n2 = nodeIdx.get(sId);
+        if (n2) { out.push({ neighbor: n2, edge: l, direction: 'in' });
+                  seenIds.add(sId); }
+      }
+    });
+    return out;
+  }
+
+  function exploreFromNode(node) {
+    if (!node) return;
+    var neighbors = getNeighbors(node);
+
+    // Reset prior path lighting (neighborhood explorer takes over).
+    clearActivePath(/*skipRefresh*/true);
+    activePathNodes.add(node.id);
+    neighbors.forEach(function (item) {
+      activePathNodes.add(item.neighbor.id);
+      // Edge key direction-aware — we store edges as (src,tgt) per
+      // edgeIdx; pick the matching direction.
+      var k1 = edgeKey(node.id, item.neighbor.id);
+      var k2 = edgeKey(item.neighbor.id, node.id);
+      if (edgeIdx.has(k1)) activePathEdges.add(k1);
+      else if (edgeIdx.has(k2)) activePathEdges.add(k2);
+    });
+    refreshLabels();
+
+    // Sprite pulses outward — staggered so the eye can follow flow.
+    var stepMs = 0;
+    neighbors.forEach(function (item) {
+      setTimeout(function () { spawnPulse(node, item.neighbor); }, stepMs);
+      stepMs += STEP_GAP / 2;   // slightly faster than path replay
+    });
+
+    // Re-trigger force-graph render so links re-color.
+    if (graph) {
+      graph.linkColor(graph.linkColor());
+      graph.linkWidth(graph.linkWidth());
+    }
+
+    renderNeighborPanel(node, neighbors);
+  }
+
+  function renderNeighborPanel(centerNode, neighbors) {
+    var panel = document.getElementById('neighbor-panel');
+    if (!panel) return;
+    panel.style.display = 'block';
+    var rows = neighbors.slice(0, 50).map(function (item) {
+      var rel = (item.edge && item.edge.type) || 'RELATED_TO';
+      var arrow = item.direction === 'out' ? '→' : '←';
+      // Pre-compute the safe id for inline onclick (id is system-generated
+      // hex, but use JSON.stringify defense regardless).
+      var idJs = JSON.stringify(item.neighbor.id);
+      return '<div class="np-item" onclick="onNeighborClick(' + idJs + ')">' +
+             '<span class="np-arrow">' + arrow + '</span>' +
+             '<span class="np-name">' + escapeHtml(item.neighbor.name || '?') + '</span>' +
+             '<span class="np-rel">' + escapeHtml(rel) + '</span>' +
+             '</div>';
+    }).join('');
+    if (neighbors.length === 0) {
+      rows = '<div class="np-empty">연결된 이웃 없음</div>';
+    }
+    panel.innerHTML =
+      '<button class="np-close" onclick="closeNeighborPanel()" ' +
+      'title="닫기">×</button>' +
+      '<div class="np-title">🔗 ' + escapeHtml(centerNode.name || '?') + '</div>' +
+      '<div class="np-meta">' + neighbors.length + '개 직접 연결' +
+      (neighbors.length > 50 ? ' (50개까지 표시)' : '') + '</div>' +
+      '<div class="np-list">' + rows + '</div>';
+  }
+
+  window.onNeighborClick = function (neighborId) {
+    var n = nodeIdx.get(neighborId);
+    if (!n) return;
+    // Camera move + recursive explore.
+    onNodeClick(n);
+  };
+
+  window.closeNeighborPanel = function () {
+    var panel = document.getElementById('neighbor-panel');
+    if (panel) panel.style.display = 'none';
+    clearActivePath();
+  };
+
+  // ─── [PR explorer] Query reasoning overlay ──────────────────────
+  // Same vibe as the chat page brain animation, simplified — no
+  // /trace/poll polling, just a steady "추론 중" pulse during the
+  // /query/ inflight wait. Once paths arrive, activatePath takes
+  // over with sprite pulses on graph edges (already wired).
+  function showReasoningOverlay() {
+    var ov = document.getElementById('query-reasoning-overlay');
+    if (!ov) return;
+    ov.innerHTML =
+      '<span class="qr-brain" aria-hidden="true">' +
+      '<svg viewBox="0 0 24 24" width="22" height="22">' +
+      '<path d="M5 7 Q5 4 8 4 L16 4 Q19 4 19 7 L19 16 Q19 19 16 19 ' +
+      'L8 19 Q5 19 5 16 Z" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.4"/>' +
+      '<line x1="12" y1="2" x2="12" y2="4" stroke="currentColor" ' +
+      'stroke-width="1.4"/>' +
+      '<circle cx="12" cy="2" r="1" fill="currentColor"/>' +
+      '<circle class="qr-neuron qr-n1" cx="8.5"  cy="8"  r="1.6" ' +
+      'fill="currentColor"/>' +
+      '<circle class="qr-neuron qr-n2" cx="15.5" cy="8"  r="1.6" ' +
+      'fill="currentColor"/>' +
+      '<circle class="qr-neuron qr-n3" cx="12"   cy="14" r="1.6" ' +
+      'fill="currentColor"/>' +
+      '</svg></span>' +
+      '<span class="qr-text">JAMES 추론 중</span>';
+    ov.style.display = 'inline-flex';
+  }
+
+  function hideReasoningOverlay() {
+    var ov = document.getElementById('query-reasoning-overlay');
+    if (!ov) return;
+    ov.style.display = 'none';
+    ov.innerHTML = '';
   }
 
   // ─── Path-string parser ────────────────────────────────────
@@ -745,6 +887,10 @@
     clearActivePath();
     btn.disabled = true;
     btn.textContent = '...';
+    // [PR explorer] reasoning overlay during the inflight wait —
+    // mirrors the brain-pulse vibe of the chat page so the user knows
+    // JAMES is thinking, not stuck.
+    showReasoningOverlay();
     try {
       var r = await fetch(API + '/query/', {
         method:  'POST',
@@ -768,6 +914,7 @@
       var errEntry = recordAnswer(q, String(e), []);
       renderAnswerCard(errEntry);
     } finally {
+      hideReasoningOverlay();
       btn.disabled = false;
       btn.textContent = t('graph.ask') || 'Ask';
       box.value = '';                     // clear input for next question

--- a/tests/test_graph_explorer.py
+++ b/tests/test_graph_explorer.py
@@ -1,0 +1,273 @@
+"""[PR explorer, 2026-05-09] Graph node-click neighborhood explorer +
+query reasoning overlay.
+
+User feedback (2026-05-09):
+> "추론 그래프에서 한개의 엔티티를 클릭하면 이름이 뜨는 동시에 그 스팟이
+>  불이 들어오고, 직접 연결된 선과 연결된 엔티티 스팟들로 불빛이 이동하면서
+>  흐르는 애니메이션 구현. 그리고 그 스팟들의 이름이 옆에 자연스럽게 목록
+>  창으로 뜨고, 그 목록의 스팟 이름을 클릭하면 그 스팟으로 이동하며 다시
+>  같은 방식의 로직 구현"
+>
+> "질문시에 답변을 추론하는 동안 대화챗에서와 같이 추론 애니메이션이 뜨도록
+>  하고 엔티티 스팟과 graph path 경로 반짝이게"
+
+Two features in one PR (graph.js + graph.html):
+
+  Feature A — Neighborhood explorer
+    onNodeClick now triggers exploreFromNode which:
+      1. computes direct neighbors via getNeighbors(node)
+      2. lights up center + neighbors via activePathNodes/Edges
+         (uses #4-2 path persistence machinery — same Set semantics)
+      3. fires staggered sprite pulses outward
+      4. opens a side panel with neighbor names + relation labels;
+         clicking a name → recursive explore from that neighbor
+
+  Feature B — Query reasoning overlay
+    showReasoningOverlay/hideReasoningOverlay called from askQuestion's
+    try/finally. Renders an inline brain-pulse widget above the query
+    bar with a shimmer "JAMES 추론 중" text. Path sparkle on /query/
+    completion was already wired (PR #143 #4-2 activatePath).
+
+Run:
+    python -m unittest tests.test_graph_explorer
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS  = ROOT / "frontend" / "static" / "graph.js"
+HTML = ROOT / "frontend" / "graph.html"
+
+
+# ─── Feature A — neighborhood explorer ───────────────────────────
+class GetNeighborsTests(unittest.TestCase):
+    """getNeighbors must walk data.links and return both incoming +
+    outgoing edges' counterparts."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_function_defined(self):
+        self.assertIn("function getNeighbors", self.js)
+
+    def test_walks_both_directions(self):
+        idx = self.js.index("function getNeighbors")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # Outgoing edge: source==nodeId case
+        self.assertIn("sId === nodeId", body)
+        # Incoming edge: target==nodeId case
+        self.assertIn("tId === nodeId", body)
+
+    def test_dedupes_neighbors(self):
+        # An entity can be both source and target of separate edges to
+        # the same other entity; we want it listed once.
+        idx = self.js.index("function getNeighbors")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("seenIds", body,
+            "duplicates must be filtered via seenIds set")
+
+
+class ExploreFromNodeTests(unittest.TestCase):
+    """exploreFromNode wires up activation + pulse + panel."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_function_defined(self):
+        self.assertIn("function exploreFromNode", self.js)
+
+    def test_resets_prior_path(self):
+        idx = self.js.index("function exploreFromNode")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("clearActivePath", body,
+            "must clear prior path lighting when starting new exploration")
+
+    def test_activates_neighbor_set(self):
+        idx = self.js.index("function exploreFromNode")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("activePathNodes.add", body)
+        self.assertIn("activePathEdges.add", body)
+        self.assertIn("refreshLabels", body)
+
+    def test_spawns_pulses_staggered(self):
+        idx = self.js.index("function exploreFromNode")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("spawnPulse", body,
+            "must call spawnPulse for visual flow")
+        self.assertIn("setTimeout", body,
+            "pulses must be staggered (setTimeout) so the eye can follow")
+
+    def test_renders_panel(self):
+        idx = self.js.index("function exploreFromNode")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("renderNeighborPanel", body)
+
+
+class NeighborPanelTests(unittest.TestCase):
+    """renderNeighborPanel must produce safe HTML + clickable rows."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_panel_div_in_html(self):
+        self.assertIn('id="neighbor-panel"', self.html)
+        self.assertIn('class="neighbor-panel"', self.html)
+
+    def test_panel_styled(self):
+        # Sliding-from-left posture so it doesn't clash with answer-card.
+        self.assertIn(".neighbor-panel", self.html)
+        self.assertRegex(self.html, r"\.neighbor-panel[^{]*\{[^}]*left:", re.DOTALL)
+
+    def test_render_function_uses_escapehtml(self):
+        idx = self.js.index("function renderNeighborPanel")
+        nxt = self.js.index("\n  ", idx + 100)   # bound at next top-level
+        # Find a stable end: the closing of the function
+        end = self.js.index("\n  window.onNeighborClick", idx)
+        body = self.js[idx:end]
+        # Names + relation labels come from the snapshot — escape them.
+        self.assertGreaterEqual(body.count("escapeHtml"), 2,
+            "renderNeighborPanel must escape both name and relation")
+
+    def test_neighbor_click_handler_global(self):
+        # Inline onclick="onNeighborClick(...)" needs window-level export.
+        self.assertIn("window.onNeighborClick", self.js)
+
+    def test_close_panel_handler_global(self):
+        self.assertIn("window.closeNeighborPanel", self.js)
+
+    def test_neighbor_click_uses_json_stringify(self):
+        # The id is interpolated into an inline onclick string. Even if
+        # the system-generated id format is safe, defense-in-depth is
+        # JSON.stringify (quoting + escaping).
+        idx = self.js.index("function renderNeighborPanel")
+        nxt = self.js.index("\n  window.", idx + 100)
+        body = self.js[idx:nxt]
+        self.assertIn("JSON.stringify", body,
+            "id interpolation into inline onclick must use JSON.stringify "
+            "for defense-in-depth")
+
+
+class OnNodeClickIntegrationTests(unittest.TestCase):
+    """onNodeClick must call exploreFromNode after camera nudge."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_onNodeClick_calls_explore(self):
+        idx = self.js.index("function onNodeClick")
+        # Find the closing brace of onNodeClick
+        nxt = self.js.index("\n  //", idx + 100)   # next top-level comment
+        body = self.js[idx:nxt]
+        self.assertIn("exploreFromNode(node)", body,
+            "onNodeClick must trigger neighborhood exploration")
+
+
+# ─── Feature B — query reasoning overlay ─────────────────────────
+class ReasoningOverlayTests(unittest.TestCase):
+    """showReasoningOverlay/hideReasoningOverlay + askQuestion wiring."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_overlay_div_in_html(self):
+        self.assertIn('id="query-reasoning-overlay"', self.html)
+        self.assertIn('class="query-reasoning-overlay"', self.html)
+
+    def test_overlay_initially_hidden(self):
+        # CSS rule must default display:none — JS toggles it.
+        self.assertRegex(
+            self.html,
+            r"\.query-reasoning-overlay[^{]*\{[^}]*display:\s*none",
+            re.DOTALL,
+        )
+
+    def test_show_function_defined(self):
+        self.assertIn("function showReasoningOverlay", self.js)
+
+    def test_hide_function_defined(self):
+        self.assertIn("function hideReasoningOverlay", self.js)
+
+    def test_overlay_renders_brain_svg(self):
+        idx = self.js.index("function showReasoningOverlay")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # Brain SVG (path + neurons) — same vibe as chat page brainPulseSvg
+        self.assertIn("svg viewBox", body)
+        self.assertIn("qr-neuron", body,
+            "overlay must contain pulsing neuron circles for the 'thinking' vibe")
+
+    def test_overlay_renders_text_label(self):
+        idx = self.js.index("function showReasoningOverlay")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("JAMES 추론 중", body,
+            "overlay must show a 'thinking' text label so the user "
+            "knows the system is working, not stuck")
+
+    def test_askQuestion_calls_show(self):
+        idx = self.js.index("window.askQuestion")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("showReasoningOverlay()", body,
+            "askQuestion must show overlay before /query/ POST")
+
+    def test_askQuestion_hides_in_finally(self):
+        idx = self.js.index("window.askQuestion")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # finally block ensures hide even on error path
+        self.assertRegex(body, r"finally\s*\{[\s\S]+?hideReasoningOverlay",
+            "askQuestion's finally block must hide overlay so it never "
+            "stays stuck on error paths")
+
+
+class CssAnimationTests(unittest.TestCase):
+    """The neuron blink + shimmer animations should be defined in CSS."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_neuron_blink_keyframes(self):
+        self.assertIn("@keyframes qr-blink", self.html)
+
+    def test_shimmer_keyframes(self):
+        self.assertIn("@keyframes qr-shimmer", self.html)
+
+    def test_neurons_have_staggered_delay(self):
+        # n2 + n3 should have animation-delay so the three neurons don't
+        # blink in unison (matches chat page brain SVG behavior).
+        self.assertRegex(
+            self.html,
+            r"\.qr-neuron\.qr-n2[^{]*\{[^}]*animation-delay",
+            re.DOTALL,
+        )
+        self.assertRegex(
+            self.html,
+            r"\.qr-neuron\.qr-n3[^{]*\{[^}]*animation-delay",
+            re.DOTALL,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two interactive features added to `/admin/graph`:

User feedback (2026-05-09):
> 「추론 그래프에서 한개의 엔티티를 클릭하면 이름이 뜨는 동시에 그 스팟이 불이 들어오고, 직접 연결된 선과 연결된 엔티티 스팟들로 불빛이 이동하면서 흐르는 애니메이션 구현. 그리고 그 스팟들의 이름이 옆에 자연스럽게 목록 창으로 뜨고, 그 목록의 스팟 이름을 클릭하면 그 스팟으로 이동하며 다시 같은 방식의 로직 구현」
>
> 「질문시에 답변을 추론하는 동안 대화챗에서와 같이 추론 애니메이션이 뜨도록 하고 엔티티 스팟과 graph path 경로 반짝이게」

## Feature A — Neighborhood explorer

Click any node →
1. Center node + direct neighbors light up (via `activePathNodes` / `activePathEdges` — same machinery as #4-2 path persistence, so labels appear via `refreshLabels`)
2. Sprite pulses fire outward staggered (`STEP_GAP/2` — slightly faster than path replay)
3. Side panel slides in from the **left** (so it doesn't clash with the right-side answer card)
4. Panel lists neighbor names + relation labels; click a name → recursive explore from that neighbor

XSS hardening:
- Names + relation labels rendered via `escapeHtml`
- Neighbor id interpolated into inline `onclick` via `JSON.stringify` (defense-in-depth — ids are system-generated hex)

## Feature B — Query reasoning overlay

`showReasoningOverlay` / `hideReasoningOverlay` called from `askQuestion`'s try/finally. Renders an inline brain-pulse widget above the query bar during `/query/` inflight:
- 3 SVG neurons blinking with staggered delay (mirrors chat page #A8-1)
- Shimmer "JAMES 추론 중" text
- finally block guarantees hide even on error paths

Path sparkle on `/query/` completion was already wired (PR #143 #4-2 `activatePath`) — this PR adds the **during-wait** feedback so the user knows the system is thinking, not stuck.

## Verification

```
$ python -m unittest tests.test_graph_explorer -v
Ran 26 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 905 tests in 8.9s  OK   (was 879; +26 new)
```

### Test classes
- `GetNeighborsTests` (3) — function defined, walks both directions, dedupes via seenIds
- `ExploreFromNodeTests` (4) — clears prior path, activates sets, staggered pulses, renders panel
- `NeighborPanelTests` (6) — div + CSS, escapeHtml on name + relation, window-level handlers, JSON.stringify defense
- `OnNodeClickIntegrationTests` (1) — onNodeClick calls exploreFromNode
- `ReasoningOverlayTests` (7) — show/hide functions, askQuestion try/finally hooks, SVG + label present
- `CssAnimationTests` (3) — qr-blink + qr-shimmer keyframes, staggered neuron delays

## Bench numbers — N/A

Frontend-only change. No `core/{retrieval,graph,reasoning}` touched. STEP 7 baseline unaffected.

## CLAUDE.md compliance

- (1) **No domain features** — observability UX
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — frontend file, not under core/ gate

## Files

```
 frontend/static/graph.js                 | +160     explorer + overlay funcs
 frontend/graph.html                      | +110/-0  panel + overlay HTML/CSS
 tests/test_graph_explorer.py             | +260  NEW   26 tests / 7 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>