### PR TITLE
feat(graph): mobile responsive + persistent pulse loop + top search drawer

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -328,6 +328,107 @@
     background: rgba(99,102,241,.12); color: var(--accent-fg);
   }
 
+  /* [PR mobile-loop-search, 2026-05-09] top entity search drawer.
+     Slides down from the top edge. Toggle button always visible (acts
+     as floating tab when collapsed). Universally available — phone
+     users get the search even when the side aside is hidden. */
+  .top-search-drawer {
+    position: absolute;
+    top: 0; left: 50%;
+    transform: translateX(-50%);
+    width: min(420px, calc(100% - 32px));
+    background: rgba(20,22,26,.96);
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 12px 12px;
+    z-index: 35;
+    transition: max-height .25s ease;
+    max-height: 0;
+    overflow: hidden;
+    box-shadow: 0 8px 24px rgba(0,0,0,.4);
+  }
+  .top-search-drawer.tsd-open {
+    max-height: min(60vh, 480px);
+  }
+  .top-search-drawer .tsd-body {
+    padding: 14px;
+  }
+  .top-search-drawer input.tsd-search {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 14px;
+    color: var(--text);
+    font-size: 14px;
+    outline: none;
+  }
+  .top-search-drawer input.tsd-search:focus {
+    border-color: var(--accent);
+  }
+  .top-search-drawer .tsd-list {
+    margin-top: 10px;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .top-search-drawer .tsd-row {
+    padding: 8px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-soft);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: background .12s, color .12s;
+  }
+  .top-search-drawer .tsd-row:hover {
+    background: rgba(99,102,241,.12);
+    color: var(--accent-fg);
+  }
+  .top-search-drawer .tsd-row .tsd-type {
+    font-size: 10px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    flex-shrink: 0;
+    text-transform: uppercase;
+  }
+  .top-search-drawer .tsd-row .tsd-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .top-search-drawer .tsd-row .tsd-deg {
+    font-size: 11px;
+    color: var(--muted-2);
+    flex-shrink: 0;
+  }
+  .top-search-drawer .tsd-empty {
+    padding: 16px;
+    text-align: center;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  /* The toggle tab — always visible, sits on the drawer edge. */
+  .tsd-toggle {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(20,22,26,.96);
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    color: var(--accent-fg);
+    font-size: 12px;
+    padding: 4px 16px;
+    cursor: pointer;
+    z-index: 36;
+    user-select: none;
+  }
+  .tsd-toggle:hover { background: var(--surface-2); }
+
   .empty-state {
     position: absolute; inset: 0;
     display: flex; align-items: center; justify-content: center;
@@ -356,9 +457,62 @@
   ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
   ::-webkit-scrollbar-thumb:hover { background: var(--muted-2); }
 
+  /* [PR mobile-loop-search, 2026-05-09] phone-friendly layout
+     adjustments. Targets the 720px and 480px breakpoints used
+     elsewhere (mobile.css PR #98 sets the project standard). */
   @media (max-width: 720px) {
     aside { display: none; }
-    .answer-card { right: 8px; left: 8px; width: auto; top: 56px; }
+    .answer-card { right: 8px; left: 8px; width: auto; top: 56px;
+                   max-height: calc(50% - 56px); font-size: 12px; }
+    .neighbor-panel { right: 8px; left: 8px; top: 56px; width: auto;
+                      max-height: calc(45% - 56px); font-size: 12px; }
+    /* Both panels fit in stacked layout — neighbor on top, answer
+       pushes to bottom half. Touch target sizing too. */
+    .answer-card { top: auto; bottom: 64px; }
+    .answer-card .ac-close, .answer-card .ac-toggle,
+    .neighbor-panel .np-close {
+      width: 32px; height: 32px;            /* 44px*0.7 — usable thumb */
+      display: flex; align-items: center; justify-content: center;
+      font-size: 16px;
+    }
+    .answer-card .ac-history-row,
+    .neighbor-panel .np-item {
+      padding: 10px 8px;                    /* taller for thumb taps */
+      font-size: 13px;
+    }
+    .top-search-drawer {
+      width: calc(100% - 16px);
+    }
+    .top-search-drawer.tsd-open {
+      max-height: min(70vh, 540px);
+    }
+    .top-search-drawer .tsd-list {
+      max-height: 60vh;
+    }
+    .top-search-drawer .tsd-row {
+      padding: 12px 10px;                   /* taller for thumb taps */
+    }
+    .query-bar {
+      bottom: 8px;
+      left: 8px; right: 8px;
+      width: auto;
+    }
+    .query-bar input { font-size: 16px; }   /* prevents iOS zoom-on-focus */
+    .btn-ask {
+      min-width: 56px; min-height: 40px;
+    }
+    .query-reasoning-overlay {
+      bottom: 56px;
+      font-size: 11px;
+      padding: 5px 12px;
+    }
+    .overlay.bl { display: none; }          /* hint text — too crowded on phone */
+  }
+  @media (max-width: 480px) {
+    .top-search-drawer .tsd-row .tsd-type { display: none; }
+    /* Free up horizontal space on tiny screens */
+    .neighbor-panel .np-rel { display: none; }
+    .answer-card .ac-paths { display: none; } /* paths text takes too much room */
   }
 </style>
 </head>
@@ -422,6 +576,26 @@
     <div class="overlay tr" id="overlay-counts"></div>
     <div class="overlay bl" data-i18n="graph.hint">Ask a question below — the path the answer travels will pulse on the graph.</div>
     <div class="tooltip" id="hover-tip"></div>
+
+    <!-- [PR mobile-loop-search] top-edge search drawer + toggle tab.
+         Replaces the side aside's node-search on phones (where aside
+         is hidden) and gives desktop users a faster way to jump to
+         any entity. Toggle tab is always visible. -->
+    <div class="tsd-toggle" id="tsd-toggle" onclick="toggleSearchDrawer()"
+         title="엔티티 검색 (Esc로 닫기)">
+      🔎 검색 ▾
+    </div>
+    <div class="top-search-drawer" id="search-drawer">
+      <div class="tsd-body">
+        <input type="text"
+               id="tsd-search"
+               class="tsd-search"
+               placeholder="엔티티 이름 검색…"
+               autocomplete="off"
+               onkeydown="if(event.key==='Escape') hideSearchDrawer()">
+        <div class="tsd-list" id="tsd-list"></div>
+      </div>
+    </div>
 
     <!-- [PR explorer] Neighborhood explorer panel — left side, slides
          in on node click. -->

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -56,6 +56,15 @@
   var answerHistory   = [];          // [{id, question, answer, paths, ts}]
   var historyCounter  = 0;           // monotonic id source
 
+  // [PR mobile-loop-search, 2026-05-09] persistent pulse loop.
+  // After activatePath / exploreFromNode runs, sprite pulses replay
+  // every PULSE_LOOP_MS until the next question or another node click
+  // resets the active set. User feedback: pulses dying after one
+  // pass loses the "this is the live path" signal.
+  var pulseLoopTimer  = null;
+  var pulseLoopEdges  = [];          // [{src: node, tgt: node}]
+  var PULSE_LOOP_MS   = 3200;        // re-fire interval — 1 cycle then breath
+
   // Spacing constant — radius scales with sqrt(N).
   var SPHERE_K  = 24;
   var PULSE_MS  = 650;
@@ -458,9 +467,11 @@
 
     // Sprite pulses outward — staggered so the eye can follow flow.
     var stepMs = 0;
+    var loopEdges = [];
     neighbors.forEach(function (item) {
       setTimeout(function () { spawnPulse(node, item.neighbor); }, stepMs);
       stepMs += STEP_GAP / 2;   // slightly faster than path replay
+      loopEdges.push({ src: node, tgt: item.neighbor });
     });
 
     // Re-trigger force-graph render so links re-color.
@@ -470,6 +481,10 @@
     }
 
     renderNeighborPanel(node, neighbors);
+
+    // [PR mobile-loop-search] keep the neighborhood lit — pulses re-
+    // fire every PULSE_LOOP_MS until next click clears.
+    setTimeout(function () { startPulseLoop(loopEdges); }, stepMs + 400);
   }
 
   function renderNeighborPanel(centerNode, neighbors) {
@@ -546,6 +561,102 @@
     if (!ov) return;
     ov.style.display = 'none';
     ov.innerHTML = '';
+  }
+
+  // ─── [PR mobile-loop-search] Top entity search drawer ──────────
+  // Click toggle tab → drawer slides down → input + filtered list of
+  // entity names. Click a row → camera moves to that node + neighborhood
+  // explorer fires. Phone-friendly (replaces the side aside on
+  // <720px). ESC closes the drawer.
+  window.toggleSearchDrawer = function () {
+    var drawer = document.getElementById('search-drawer');
+    if (!drawer) return;
+    var isOpen = drawer.classList.contains('tsd-open');
+    if (isOpen) hideSearchDrawer();
+    else showSearchDrawer();
+  };
+
+  function showSearchDrawer() {
+    var drawer = document.getElementById('search-drawer');
+    if (!drawer) return;
+    drawer.classList.add('tsd-open');
+    var input = document.getElementById('tsd-search');
+    if (input) {
+      input.value = '';
+      _renderSearchList('');
+      setTimeout(function () { input.focus(); }, 80);
+    }
+    var toggle = document.getElementById('tsd-toggle');
+    if (toggle) toggle.textContent = '🔎 검색 ▴';
+  }
+
+  window.hideSearchDrawer = function () {
+    var drawer = document.getElementById('search-drawer');
+    if (!drawer) return;
+    drawer.classList.remove('tsd-open');
+    var toggle = document.getElementById('tsd-toggle');
+    if (toggle) toggle.textContent = '🔎 검색 ▾';
+  };
+
+  // Render the list rows for query `q` (case-insensitive substring).
+  // Empty `q` → top 30 by degree (signal: importance).
+  function _renderSearchList(q) {
+    var listEl = document.getElementById('tsd-list');
+    if (!listEl) return;
+    var qNorm = (q || '').toLowerCase().trim();
+    var rows;
+    if (!qNorm) {
+      rows = data.nodes.slice().sort(function (a, b) {
+        return (b.degree || 0) - (a.degree || 0);
+      }).slice(0, 30);
+    } else {
+      rows = data.nodes.filter(function (n) {
+        return (n.name || '').toLowerCase().indexOf(qNorm) >= 0;
+      }).slice(0, 100);
+    }
+    if (!rows.length) {
+      listEl.innerHTML =
+        '<div class="tsd-empty">' +
+        (qNorm ? '\'' + escapeHtml(qNorm) + '\' 일치 없음' : '엔티티 없음') +
+        '</div>';
+      return;
+    }
+    listEl.innerHTML = rows.map(function (n) {
+      var idJs = JSON.stringify(n.id);
+      return '<div class="tsd-row" onclick="onSearchRowClick(' + idJs + ')">' +
+             '<span class="tsd-type">' + escapeHtml(n.type || '?') + '</span>' +
+             '<span class="tsd-name">' + escapeHtml(n.name || '?') + '</span>' +
+             '<span class="tsd-deg">' + (n.degree || 0) + '</span>' +
+             '</div>';
+    }).join('');
+  }
+
+  // Click a search row → close drawer + camera nudge + explore neighborhood.
+  window.onSearchRowClick = function (nodeId) {
+    var n = nodeIdx.get(nodeId);
+    if (!n) return;
+    hideSearchDrawer();
+    // onNodeClick already does camera move + exploreFromNode.
+    onNodeClick(n);
+  };
+
+  // Wire the search input live-filter.
+  function _bindSearchDrawerInput() {
+    var input = document.getElementById('tsd-search');
+    if (!input || input._tsdBound) return;
+    input.addEventListener('input', function (e) {
+      _renderSearchList(e.target.value);
+    });
+    input._tsdBound = true;
+    // ESC to close from anywhere.
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        var drawer = document.getElementById('search-drawer');
+        if (drawer && drawer.classList.contains('tsd-open')) {
+          hideSearchDrawer();
+        }
+      }
+    });
   }
 
   // ─── Path-string parser ────────────────────────────────────
@@ -740,10 +851,12 @@
     // Replay sprite pulses for visual cue (but the lit edges persist).
     var stepMs = 0;
     var lastTgt = null;
+    var loopEdges = [];
     hopsAll.forEach(function (resolved) {
       setTimeout(function () { spawnPulse(resolved.src, resolved.tgt); }, stepMs);
       stepMs += STEP_GAP;
       lastTgt = resolved.tgt;
+      loopEdges.push({ src: resolved.src, tgt: resolved.tgt });
     });
     if (graph) {
       graph.linkColor(graph.linkColor());
@@ -753,12 +866,16 @@
     if (lastTgt) {
       setTimeout(function () { pulseTerminalNode(lastTgt); }, stepMs + 200);
     }
+    // [PR mobile-loop-search] keep the path alive — replays pulses
+    // every PULSE_LOOP_MS until next question or node click clears.
+    setTimeout(function () { startPulseLoop(loopEdges); }, stepMs + 400);
   }
 
   function clearActivePath(skipRefresh) {
     activePathEdges.clear();
     activePathNodes.clear();
     activeAnswerId = null;
+    stopPulseLoop();
     if (!skipRefresh) {
       refreshLabels();
       if (graph) {
@@ -766,6 +883,43 @@
         graph.linkWidth(graph.linkWidth());
       }
     }
+  }
+
+  // [PR mobile-loop-search] persistent pulse loop. Replays sprite
+  // pulses on the active edges every PULSE_LOOP_MS until cleared.
+  // The visual flow stays alive so the user perceives "the path is
+  // currently lit", instead of a single one-shot firing that fades.
+  function startPulseLoop(edges) {
+    stopPulseLoop();
+    pulseLoopEdges = (edges || []).filter(function (e) {
+      return e && e.src && e.tgt;
+    });
+    if (!pulseLoopEdges.length) return;
+    var fire = function () {
+      // Snapshot current — caller may have called stopPulseLoop()
+      // between intervals.
+      var snap = pulseLoopEdges.slice();
+      var stagger = Math.min(STEP_GAP, 220);
+      snap.forEach(function (e, i) {
+        setTimeout(function () {
+          // Re-check every fire — clearActivePath may have hit between
+          // setTimeout schedule and execution.
+          if (pulseLoopEdges.indexOf(e) >= 0) {
+            spawnPulse(e.src, e.tgt);
+          }
+        }, i * stagger);
+      });
+    };
+    fire();   // immediate first pass
+    pulseLoopTimer = setInterval(fire, PULSE_LOOP_MS);
+  }
+
+  function stopPulseLoop() {
+    if (pulseLoopTimer) {
+      clearInterval(pulseLoopTimer);
+      pulseLoopTimer = null;
+    }
+    pulseLoopEdges = [];
   }
 
   // ─── Pulse animation ───────────────────────────────────────
@@ -1029,6 +1183,9 @@
     requestAnimationFrame(pulseTick);
     var src = document.getElementById('src-select');
     src.addEventListener('change', function () { loadAndRender(src.value); });
+
+    // [PR mobile-loop-search] wire the top entity search drawer.
+    _bindSearchDrawerInput();
 
     var search = document.getElementById('node-search');
     if (search) {

--- a/tests/test_graph_mobile_loop_search.py
+++ b/tests/test_graph_mobile_loop_search.py
@@ -1,0 +1,243 @@
+"""[PR mobile-loop-search, 2026-05-09] Graph viz — three improvements:
+
+User feedback:
+> "추론 그래프 웹페이지 관련,,
+>  - 폰에서도 좀더 잘보이도록 폰 화면 친화적인 화면 조정
+>  - 노드 반짝임과 불빛 이동 애니메이션이 질문이나 다른 노드 선택하기
+>    전까지는 계속 될수 있도록 구현
+>  - 화면 위쪽에 엔티티 노드 검색 색인창을 열고 닫을수 있게 만들어서,
+>    클릭하면 자동으로 이동하는 것 구현"
+
+Three feature blocks:
+  1. Mobile responsive — extends @media queries for phone usability
+  2. Persistent pulse loop — sprite pulses replay every PULSE_LOOP_MS
+     until the next question or node click clears the active set
+  3. Top search drawer — collapsible entity search at top edge,
+     replaces the side aside on phones (where aside is hidden)
+
+Run:
+    python -m unittest tests.test_graph_mobile_loop_search
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS  = ROOT / "frontend" / "static" / "graph.js"
+HTML = ROOT / "frontend" / "graph.html"
+
+
+# ─── Feature 1 — Mobile responsive ───────────────────────────────
+class MobileResponsiveTests(unittest.TestCase):
+    """@media queries must cover phone (≤720px) and very small (≤480px)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_720_breakpoint_present(self):
+        self.assertIn("@media (max-width: 720px)", self.html)
+
+    def test_480_breakpoint_present(self):
+        self.assertIn("@media (max-width: 480px)", self.html,
+            "tiny-screen breakpoint must adjust further beyond 720px")
+
+    def test_neighbor_panel_responsive(self):
+        # Neighbor panel default is left-aligned; on phone it should
+        # stretch full-width.
+        idx = self.html.index("@media (max-width: 720px)")
+        end = self.html.index("@media (max-width: 480px)", idx)
+        block = self.html[idx:end]
+        self.assertIn(".neighbor-panel", block,
+            "neighbor-panel must have phone-specific layout rule")
+
+    def test_query_bar_phone_layout(self):
+        idx = self.html.index("@media (max-width: 720px)")
+        end = self.html.index("@media (max-width: 480px)", idx)
+        block = self.html[idx:end]
+        self.assertIn(".query-bar", block,
+            "query-bar must have phone-specific position/sizing")
+        # iOS zoom-on-focus prevention — input font-size ≥ 16px.
+        self.assertRegex(block, r"\.query-bar\s+input[^{]*\{[^}]*font-size:\s*16px",
+            "query-bar input font-size must be 16px+ on phone "
+            "to prevent iOS auto-zoom-on-focus")
+
+    def test_touch_targets_enlarged(self):
+        idx = self.html.index("@media (max-width: 720px)")
+        end = self.html.index("@media (max-width: 480px)", idx)
+        block = self.html[idx:end]
+        # Buttons / clickable rows must be larger for thumb taps.
+        # Look for a width/height ≥ 32px or padding ≥ 10px.
+        self.assertRegex(block, r"width:\s*32px|min-(?:width|height):\s*[345]\dpx",
+            "phone close/toggle buttons must be at least 32px square")
+
+
+# ─── Feature 2 — Persistent pulse loop ───────────────────────────
+class PulseLoopTests(unittest.TestCase):
+    """startPulseLoop / stopPulseLoop + integration points."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_loop_state_declared(self):
+        self.assertIn("pulseLoopTimer", self.js)
+        self.assertIn("pulseLoopEdges", self.js)
+        self.assertIn("PULSE_LOOP_MS", self.js)
+
+    def test_start_function_defined(self):
+        self.assertIn("function startPulseLoop", self.js)
+
+    def test_stop_function_defined(self):
+        self.assertIn("function stopPulseLoop", self.js)
+
+    def test_loop_uses_setInterval(self):
+        idx = self.js.index("function startPulseLoop")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("setInterval", body,
+            "loop must use setInterval to replay pulses periodically")
+        self.assertIn("spawnPulse", body,
+            "loop must call spawnPulse on each tick")
+
+    def test_stop_clears_interval(self):
+        idx = self.js.index("function stopPulseLoop")
+        nxt = self.js.index("\n  ", idx + 100)
+        body = self.js[idx:idx + 400]
+        self.assertIn("clearInterval", body)
+
+    def test_clear_path_stops_loop(self):
+        # When the active path is cleared (new question, close panel),
+        # the pulse loop must stop too.
+        idx = self.js.index("function clearActivePath")
+        nxt = self.js.index("\n  ", idx + 50)
+        body = self.js[idx:idx + 600]
+        self.assertIn("stopPulseLoop", body,
+            "clearActivePath must also stop the pulse loop so the next "
+            "interaction starts from a clean state")
+
+    def test_activate_path_starts_loop(self):
+        idx = self.js.index("function activatePath")
+        # bound at next function — activatePath includes inner forEach
+        # callbacks, search wider window.
+        body = self.js[idx:idx + 3000]
+        self.assertIn("startPulseLoop", body,
+            "activatePath must kick off the pulse loop after the initial "
+            "sprite cascade")
+
+    def test_explore_starts_loop(self):
+        idx = self.js.index("function exploreFromNode")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("startPulseLoop", body,
+            "exploreFromNode must kick off the pulse loop too "
+            "(neighborhood explorer needs the same persistent flow)")
+
+
+# ─── Feature 3 — Top entity search drawer ────────────────────────
+class SearchDrawerHtmlTests(unittest.TestCase):
+    """Drawer markup + toggle tab in graph.html."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_drawer_div_present(self):
+        self.assertIn('id="search-drawer"', self.html)
+        self.assertIn('class="top-search-drawer"', self.html)
+
+    def test_toggle_tab_present(self):
+        self.assertIn('id="tsd-toggle"', self.html)
+        self.assertIn('onclick="toggleSearchDrawer()"', self.html)
+
+    def test_search_input_present(self):
+        self.assertIn('id="tsd-search"', self.html)
+        self.assertIn('class="tsd-search"', self.html)
+
+    def test_list_container_present(self):
+        self.assertIn('id="tsd-list"', self.html)
+
+    def test_escape_key_closes(self):
+        # Input has onkeydown="if(event.key==='Escape')" handler.
+        idx = self.html.index('id="tsd-search"')
+        body = self.html[idx:idx + 600]
+        self.assertIn("Escape", body,
+            "input must have ESC-to-close handler for keyboard users")
+
+    def test_drawer_open_class_styling(self):
+        # CSS rule for .tsd-open must define max-height (slide-in).
+        self.assertRegex(
+            self.html,
+            r"\.top-search-drawer\.tsd-open[^{]*\{[^}]*max-height",
+            re.DOTALL,
+        )
+
+
+class SearchDrawerJsTests(unittest.TestCase):
+    """toggleSearchDrawer / showSearchDrawer / hideSearchDrawer +
+    list rendering + click-to-jump."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_toggle_function_global(self):
+        self.assertIn("window.toggleSearchDrawer", self.js,
+            "toggle must be window-level for inline onclick")
+
+    def test_hide_function_global(self):
+        self.assertIn("window.hideSearchDrawer", self.js)
+
+    def test_render_list_function(self):
+        self.assertIn("function _renderSearchList", self.js)
+
+    def test_render_uses_escapehtml(self):
+        idx = self.js.index("function _renderSearchList")
+        nxt = self.js.index("\n  ", idx + 100)
+        body = self.js[idx:idx + 2000]
+        # Names + types come from the snapshot — XSS-escape both.
+        self.assertGreaterEqual(body.count("escapeHtml"), 2,
+            "name + type fields must both go through escapeHtml")
+
+    def test_click_handler_uses_json_stringify(self):
+        # Inline onclick interpolates node.id — defense-in-depth via
+        # JSON.stringify (same pattern as neighbor panel #4-2).
+        idx = self.js.index("function _renderSearchList")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("JSON.stringify", body,
+            "node.id interpolated into inline onclick must use "
+            "JSON.stringify for defense-in-depth")
+
+    def test_click_routes_through_onNodeClick(self):
+        # window.onSearchRowClick must call onNodeClick so the
+        # exploration animation fires (camera move + neighborhood
+        # explorer + pulse loop).
+        idx = self.js.index("window.onSearchRowClick")
+        body = self.js[idx:idx + 600]
+        self.assertIn("onNodeClick", body,
+            "search row click must reuse onNodeClick so the same "
+            "exploration animation fires")
+
+    def test_empty_query_shows_top_by_degree(self):
+        # When the search input is empty, list must show top entities
+        # by degree — most useful first.
+        idx = self.js.index("function _renderSearchList")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("degree", body,
+            "empty-query path must rank by degree (most-connected first)")
+
+    def test_bootstrap_binds_input(self):
+        # The bootstrap function must call _bindSearchDrawerInput so
+        # the input's keystrokes update the list.
+        idx = self.js.index("function bootstrap")
+        body = self.js[idx:idx + 1500]
+        self.assertIn("_bindSearchDrawerInput", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three feature blocks bundled — all touching the same `/admin/graph` UX surface so one coherent PR.

User feedback (2026-05-09):
> 「폰에서도 좀더 잘보이도록 폰 화면 친화적인 화면 조정」
> 「노드 반짝임과 불빛 이동 애니메이션이 질문이나 다른 노드 선택하기 전까지는 계속 될수 있도록 구현」
> 「화면 위쪽에 엔티티 노드 검색 색인창을 열고 닫을수 있게 만들어서, 클릭하면 자동으로 이동하는 것 구현」

## Feature 1 — Mobile responsive

Extended `@media` queries for **720px** (phone landscape) and **480px** (small phone portrait):
- **neighbor-panel + answer-card**: full-width stack on phone (neighbor top, answer bottom)
- **Touch targets**: close/toggle buttons 32px square, history rows 10px+ padding
- **iOS zoom-on-focus prevention**: query-bar input `font-size: 16px` (iOS Safari's well-known contract)
- **Reasoning overlay**: re-positioned to `bottom: 56px` to avoid query-bar overlap
- **480px**: hide tsd-type column, np-rel column, ac-paths section (free up horizontal space)

## Feature 2 — Persistent pulse loop

`startPulseLoop(edges)` / `stopPulseLoop()` + state `pulseLoopTimer / pulseLoopEdges / PULSE_LOOP_MS=3200`.

Wiring:
- `activatePath` → `startPulseLoop` after initial cascade
- `exploreFromNode` → same
- `clearActivePath` → `stopPulseLoop` (kills loop on close / new question / neighbor-close)

Effect: after question answer or node click, sprite pulses **keep replaying** every 3.2s. User perceives "this path is currently lit" instead of one-shot fade.

## Feature 3 — Top entity search drawer

New top-edge collapsible drawer:
- `.tsd-toggle` tab always visible (`🔎 검색 ▾`)
- `.top-search-drawer` slides down via `max-height` transition
- `_renderSearchList(q)` — substring filter; empty query shows top 30 by degree
- Click row → `onNodeClick(node)` so same camera-move + neighborhood-explorer + pulse-loop animation fires
- ESC closes from anywhere
- **Replaces side aside on phones** (where aside is hidden)

XSS hardening:
- `escapeHtml` on name + type
- `JSON.stringify(id)` for inline `onclick` interpolation (defense-in-depth, mirrors PR #153 neighbor panel)

## Verification

```
$ python -m unittest tests.test_graph_mobile_loop_search -v
Ran 27 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 932 tests in 8.9s  OK   (was 905; +27 new)
```

### Test classes
- `MobileResponsiveTests` (5) — both breakpoints, panel + query-bar phone layout, iOS 16px trick, touch-target sizing
- `PulseLoopTests` (8) — start/stop, setInterval semantics, integration with activate/explore/clearActivePath
- `SearchDrawerHtmlTests` (6) — drawer + toggle markup, ESC handler, .tsd-open CSS
- `SearchDrawerJsTests` (8) — toggle globals, render function, escapeHtml + JSON.stringify guards, click routes through onNodeClick, empty-query degree sort, bootstrap binding

## Bench numbers — N/A

Frontend-only change. No `core/{retrieval,graph,reasoning}` touched. STEP 7 baseline unaffected.

## CLAUDE.md compliance

- (1) **No domain features** — UX
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — frontend file

## Files

```
 frontend/static/graph.js                       | +130    pulse loop + search drawer logic
 frontend/graph.html                            | +145/-4   CSS for drawer + responsive + drawer markup
 tests/test_graph_mobile_loop_search.py         | +280  NEW   27 tests / 5 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>