### PR TITLE
feat(graph): camera centering improvement + soft wrap-around glow

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -65,6 +65,12 @@
   var pulseLoopEdges  = [];          // [{src: node, tgt: node}]
   var PULSE_LOOP_MS   = 3200;        // re-fire interval — 1 cycle then breath
 
+  // [PR camera-glow, 2026-05-09] node halos — soft glowing sprite
+  // around each active path node, scale + opacity pulsing on a sine
+  // so the node "breathes". Replaces the static "active node" feel
+  // with the wrap-around glow the user described.
+  var nodeHalos       = new Map();   // nodeId → THREE.Sprite
+
   // Spacing constant — radius scales with sqrt(N).
   var SPHERE_K  = 24;
   var PULSE_MS  = 650;
@@ -404,14 +410,21 @@
 
   function onNodeClick(node) {
     if (!node || !graph) return;
-    // Aim camera at the node.
-    var distance = 240;
+    // [PR camera-glow, 2026-05-09] camera centering — move closer +
+    // longer animation so the user clearly sees the screen travel to
+    // the picked node. Previous setting felt subtle when the click
+    // came from the search drawer or neighbor panel rather than a
+    // direct 3D click.
+    var distance = 110;        // closer view of the node
     var ratio = 1;
     var d = Math.hypot(node.x || 1, node.y || 1, node.z || 1);
     if (d > 0) ratio = (d + distance) / d;
     graph.cameraPosition(
-      { x: (node.x || 0) * ratio, y: (node.y || 0) * ratio, z: (node.z || 0) * ratio },
-      node, 700,
+      { x: (node.x || 0) * ratio,
+        y: (node.y || 0) * ratio,
+        z: (node.z || 0) * ratio },
+      node,
+      1200,                    // slower, more visible move
     );
     // [PR explorer, 2026-05-09] click → neighborhood explorer.
     // Lights up the clicked node, animates pulses to its direct
@@ -464,6 +477,7 @@
       else if (edgeIdx.has(k2)) activePathEdges.add(k2);
     });
     refreshLabels();
+    refreshNodeHalos();   // [PR camera-glow] halo center + neighbors
 
     // Sprite pulses outward — staggered so the eye can follow flow.
     var stepMs = 0;
@@ -848,6 +862,7 @@
       });
     });
     refreshLabels();
+    refreshNodeHalos();   // [PR camera-glow] halos around path nodes
     // Replay sprite pulses for visual cue (but the lit edges persist).
     var stepMs = 0;
     var lastTgt = null;
@@ -876,6 +891,7 @@
     activePathNodes.clear();
     activeAnswerId = null;
     stopPulseLoop();
+    refreshNodeHalos();              // [PR camera-glow] kill halos
     if (!skipRefresh) {
       refreshLabels();
       if (graph) {
@@ -883,6 +899,65 @@
         graph.linkWidth(graph.linkWidth());
       }
     }
+  }
+
+  // [PR camera-glow] Sync nodeHalos with activePathNodes. Add halos
+  // for newly-active nodes, dispose for nodes that left the active set.
+  function refreshNodeHalos() {
+    if (!graph) return;
+    var scene = graph.scene && graph.scene();
+    if (!scene || typeof THREE === 'undefined') return;
+    var color = getCss('--brand-2', '#4fc3f7');
+    // Add halos for newly-active nodes.
+    activePathNodes.forEach(function (nodeId) {
+      if (nodeHalos.has(nodeId)) return;
+      var n = nodeIdx.get(nodeId);
+      if (!n) return;
+      var tex = getGlowTexture(color);
+      if (!tex) return;
+      var mat = new THREE.SpriteMaterial({
+        map:         tex,
+        color:       0xffffff,
+        transparent: true,
+        opacity:     0.55,
+        blending:    THREE.AdditiveBlending,
+        depthWrite:  false,
+      });
+      var sp = new THREE.Sprite(mat);
+      sp.scale.set(20, 20, 1);
+      sp.userData.isHalo = true;
+      sp.userData.nodeId = nodeId;
+      sp.userData.bornMs = performance.now();
+      scene.add(sp);
+      nodeHalos.set(nodeId, sp);
+    });
+    // Remove halos for nodes that left the active set.
+    nodeHalos.forEach(function (sp, nodeId) {
+      if (!activePathNodes.has(nodeId)) {
+        disposeSprite(sp);
+        nodeHalos.delete(nodeId);
+      }
+    });
+  }
+
+  // [PR camera-glow] Per-frame halo update — position-tracking + sine
+  // pulse. Called from pulseTick alongside tickLabelPositions.
+  function tickNodeHalos() {
+    if (!nodeHalos.size) return;
+    var now = performance.now();
+    nodeHalos.forEach(function (sp, nodeId) {
+      var n = nodeIdx.get(nodeId);
+      if (!n || !sp) return;
+      sp.position.set(n.x || 0, n.y || 0, n.z || 0);
+      // Per-halo phase offset (born time) so halos pulse out of sync —
+      // looks more organic than uniform breathing.
+      var t = ((now - (sp.userData.bornMs || 0)) / 1800) % 1;   // 1.8s period
+      var phase = Math.sin(t * Math.PI * 2);
+      // Scale 17..23, opacity 0.4..0.7 — gentle wrap-around feel.
+      var s = 20 + 3 * phase;
+      sp.scale.set(s, s, 1);
+      sp.material.opacity = 0.55 + 0.15 * phase;
+    });
   }
 
   // [PR mobile-loop-search] persistent pulse loop. Replays sprite
@@ -922,6 +997,40 @@
     pulseLoopEdges = [];
   }
 
+  // ─── [PR camera-glow, 2026-05-09] Soft radial-gradient texture ─
+  // Cached canvas-based gradient — used as the map for traveling
+  // pulse sprites AND for node halos. The "wraps around" feel the
+  // user requested comes from a soft falloff at the edge instead of
+  // the hard square sprite previously used.
+  var _glowTexCache = new Map();
+  function _hexToRgba(hex, a) {
+    var h = (hex || '').replace('#', '');
+    if (h.length === 3) h = h.split('').map(function(c){return c+c}).join('');
+    if (h.length !== 6) return 'rgba(79,195,247,' + a + ')';   // fallback
+    var r = parseInt(h.substr(0, 2), 16);
+    var g = parseInt(h.substr(2, 2), 16);
+    var b = parseInt(h.substr(4, 2), 16);
+    return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+  }
+  function getGlowTexture(hexColor) {
+    if (typeof THREE === 'undefined') return null;
+    if (_glowTexCache.has(hexColor)) return _glowTexCache.get(hexColor);
+    var canvas = document.createElement('canvas');
+    canvas.width = 128; canvas.height = 128;
+    var ctx = canvas.getContext('2d');
+    var grad = ctx.createRadialGradient(64, 64, 0, 64, 64, 64);
+    grad.addColorStop(0,   _hexToRgba(hexColor, 1.0));   // bright core
+    grad.addColorStop(0.3, _hexToRgba(hexColor, 0.7));
+    grad.addColorStop(0.6, _hexToRgba(hexColor, 0.25));
+    grad.addColorStop(1,   _hexToRgba(hexColor, 0));     // soft falloff
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, 128, 128);
+    var tex = new THREE.CanvasTexture(canvas);
+    tex.minFilter = THREE.LinearFilter;
+    _glowTexCache.set(hexColor, tex);
+    return tex;
+  }
+
   // ─── Pulse animation ───────────────────────────────────────
   function spawnPulse(srcNode, tgtNode) {
     if (!graph || !srcNode || !tgtNode) return;
@@ -929,15 +1038,20 @@
     var scene = graph.scene();
     if (!scene) return;
 
+    // [PR camera-glow] use the soft gradient texture for a comet-like
+    // wrap-around glow instead of the hard square sprite.
+    var color = getCss('--brand-2', '#4fc3f7');
+    var tex = getGlowTexture(color);
     var spriteMat = new THREE.SpriteMaterial({
-      color:       new THREE.Color(getCss('--brand-2', '#4fc3f7')),
+      map:         tex,
+      color:       0xffffff,        // texture carries the color
       transparent: true,
       opacity:     0.95,
       blending:    THREE.AdditiveBlending,
       depthWrite:  false,
     });
     var sprite = new THREE.Sprite(spriteMat);
-    sprite.scale.set(8, 8, 1);
+    sprite.scale.set(14, 14, 1);    // was 8 — softer, more "fluid light"
     sprite.position.set(srcNode.x || 0, srcNode.y || 0, srcNode.z || 0);
     scene.add(sprite);
 
@@ -986,6 +1100,8 @@
     }
     // [#4-2 c-label/f] keep labels glued to their nodes per frame.
     tickLabelPositions();
+    // [PR camera-glow] halo position-track + sine pulse per frame.
+    tickNodeHalos();
     requestAnimationFrame(pulseTick);
   }
 

--- a/tests/test_graph_camera_glow.py
+++ b/tests/test_graph_camera_glow.py
@@ -1,0 +1,222 @@
+"""[PR camera-glow, 2026-05-09] Graph camera centering + soft glow.
+
+User feedback:
+> "선택된 노드 연결된 노드 목록 창에서 특정 노드를 클릭하면 선택한
+>  노드로 화면이 이동해야한다. 검색창에서 선택한 노드로도 이동하도록
+>  개선."
+> "선택된 노드와 연결된 선을 따라 이동하는 불빛은 노드와 선 모양을
+>  감싸는 형식으로 자연스럽게 반짝이는 방식으로 구현"
+
+Two improvements:
+
+  1. Camera centering — onNodeClick already moved the camera but the
+     animation was subtle (distance=240, 700ms). Tightened to
+     distance=110 (closer view) + 1200ms (longer animation) so the
+     screen-travel-to-node is clearly visible when the click came
+     from the search drawer or neighbor panel.
+
+  2. Wrap-around glow — replaces the hard square sprite with a soft
+     radial-gradient texture for both:
+       (a) traveling pulse sprites (size 14 vs old 8 — softer/larger)
+       (b) NEW node halos for active path nodes — sine-pulsing
+           Sprite around each lit node, 1.8s breathing period
+
+  Together: the path doesn't just have a moving dot, the active nodes
+  themselves "wrap" with a soft glow that breathes.
+
+Run:
+    python -m unittest tests.test_graph_camera_glow
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS  = ROOT / "frontend" / "static" / "graph.js"
+
+
+# ─── Item 1 — Camera centering ──────────────────────────────────
+class CameraCenteringTests(unittest.TestCase):
+    """onNodeClick must move camera with closer + longer animation."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def _click_body(self) -> str:
+        idx = self.js.index("function onNodeClick")
+        # Bound at next comment-block divider
+        nxt = self.js.index("// ─", idx + 100)
+        return self.js[idx:nxt]
+
+    def test_distance_tightened(self):
+        body = self._click_body()
+        # Old code had `distance = 240`; new code should be closer
+        # (≤ 200) so the camera move is visible.
+        m = re.search(r"distance\s*=\s*(\d+)", body)
+        self.assertIsNotNone(m, "distance literal must be present")
+        d = int(m.group(1))
+        self.assertLessEqual(d, 200,
+            f"camera distance {d} too far — should be ≤200 so move "
+            "is visibly impactful when triggered from search/neighbor")
+        self.assertGreater(d, 50,
+            "but not too close — node should still be in viewable distance")
+
+    def test_animation_duration_longer(self):
+        body = self._click_body()
+        # cameraPosition(..., node, <duration>) — find the duration arg.
+        m = re.search(r"cameraPosition\([\s\S]+?node,\s*(\d+)", body)
+        self.assertIsNotNone(m, "cameraPosition with duration arg expected")
+        ms = int(m.group(1))
+        self.assertGreaterEqual(ms, 1000,
+            f"camera animation {ms}ms too short — should be ≥1000ms so "
+            "the screen-travel motion is clearly visible")
+
+    def test_explore_still_called_after_camera(self):
+        body = self._click_body()
+        # The order matters: camera move FIRST (so user sees screen
+        # travel), then exploreFromNode (which lights up neighbors).
+        cam_idx = body.index("cameraPosition")
+        explore_idx = body.index("exploreFromNode")
+        self.assertLess(cam_idx, explore_idx,
+            "cameraPosition must be called BEFORE exploreFromNode so "
+            "the visual order matches user mental model: travel → light up")
+
+
+# ─── Item 2 — Soft glow texture ─────────────────────────────────
+class GlowTextureTests(unittest.TestCase):
+    """Radial gradient texture helper."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_get_glow_texture_function(self):
+        self.assertIn("function getGlowTexture", self.js)
+
+    def test_hex_to_rgba_helper(self):
+        # We need to produce rgba colors with varying alpha for the
+        # gradient stops — supporting #abc + #aabbcc shorthand.
+        self.assertIn("function _hexToRgba", self.js)
+
+    def test_uses_radial_gradient(self):
+        idx = self.js.index("function getGlowTexture")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("createRadialGradient", body,
+            "must use createRadialGradient for the soft falloff")
+        # Multiple color stops (bright core → soft falloff)
+        self.assertGreaterEqual(body.count("addColorStop"), 3,
+            "gradient should have ≥3 stops for a smooth falloff curve")
+
+    def test_texture_cached(self):
+        # Cache map so we don't re-create the canvas on every spawnPulse.
+        self.assertIn("_glowTexCache", self.js)
+        idx = self.js.index("function getGlowTexture")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn(".has(", body)
+        self.assertIn(".set(", body)
+
+
+class SpawnPulseUsesGlowTests(unittest.TestCase):
+    """spawnPulse must use the glow texture for soft sprites."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_uses_glow_texture(self):
+        idx = self.js.index("function spawnPulse")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("getGlowTexture", body,
+            "spawnPulse must use the radial gradient texture for the "
+            "soft 'comet' look the user described")
+
+    def test_sprite_scale_increased(self):
+        # Was 8x8 — bumped to ≥12 for softer "fluid light" look.
+        idx = self.js.index("function spawnPulse")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        m = re.search(r"sprite\.scale\.set\((\d+)", body)
+        self.assertIsNotNone(m)
+        scale = int(m.group(1))
+        self.assertGreaterEqual(scale, 12,
+            f"sprite scale {scale} too small — should be ≥12 for the "
+            "softer/larger wrap-around look")
+
+
+# ─── Item 2 — Node halos ────────────────────────────────────────
+class NodeHaloTests(unittest.TestCase):
+    """nodeHalos Map + refresh + per-frame tick."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_node_halos_state(self):
+        self.assertRegex(self.js, r"nodeHalos\s*=\s*new Map\(\)",
+            "nodeHalos must be a Map (nodeId → Sprite)")
+
+    def test_refresh_function_defined(self):
+        self.assertIn("function refreshNodeHalos", self.js)
+
+    def test_tick_function_defined(self):
+        self.assertIn("function tickNodeHalos", self.js)
+
+    def test_tick_uses_sine_pulse(self):
+        idx = self.js.index("function tickNodeHalos")
+        nxt = self.js.index("\n  ", idx + 100)
+        body = self.js[idx:idx + 1500]
+        self.assertIn("Math.sin", body,
+            "halo must pulse via sine for organic breathing feel")
+        self.assertIn(".scale.set", body,
+            "halo must animate scale (size pulse)")
+        self.assertIn(".material.opacity", body,
+            "halo must animate opacity (brightness pulse)")
+
+    def test_tick_called_in_pulse_tick(self):
+        idx = self.js.index("function pulseTick")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("tickNodeHalos", body,
+            "tickNodeHalos must run every frame from pulseTick")
+
+    def test_refresh_called_from_activate_path(self):
+        # When a path activates, halos should appear on the path nodes.
+        idx = self.js.index("function activatePath")
+        body = self.js[idx:idx + 3500]
+        self.assertIn("refreshNodeHalos", body,
+            "activatePath must refresh halos to show on path nodes")
+
+    def test_refresh_called_from_explore(self):
+        idx = self.js.index("function exploreFromNode")
+        body = self.js[idx:idx + 2500]
+        self.assertIn("refreshNodeHalos", body,
+            "exploreFromNode must refresh halos for center + neighbors")
+
+    def test_refresh_called_from_clear(self):
+        # Closing the path must dispose halos so they don't linger.
+        idx = self.js.index("function clearActivePath")
+        body = self.js[idx:idx + 600]
+        self.assertIn("refreshNodeHalos", body,
+            "clearActivePath must trigger halo cleanup (dispose)")
+
+    def test_halo_disposed_on_inactive(self):
+        # refreshNodeHalos must dispose Sprite + texture on removal
+        # to avoid GPU memory leaks across many path switches.
+        idx = self.js.index("function refreshNodeHalos")
+        nxt = self.js.index("\n  // ", idx + 100)
+        body = self.js[idx:nxt]
+        self.assertIn("disposeSprite", body,
+            "halos for inactive nodes must be disposed (existing helper)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two improvements to `/admin/graph` per user feedback:

User feedback (2026-05-09):
> 「선택된 노드 연결된 노드 목록 창에서 특정 노드를 클릭하면 선택한 노드로 화면이 이동해야한다. 검색창에서 선택한 노드로도 이동하도록 개선.」
> 「선택된 노드와 연결된 선을 따라 이동하는 불빛은 노드와 선 모양을 감싸는 형식으로 자연스럽게 반짝이는 방식으로 구현」

## Item 1 — Camera centering

`onNodeClick` already moved the camera but felt subtle (distance=240, 700ms). Tightened:
- **distance**: 240 → 110 (closer view of the picked node)
- **animation duration**: 700ms → 1200ms (slower, more visible)
- **Order preserved**: camera move first → `exploreFromNode` second (visual sequence matches mental model: travel → light up)

Search drawer + neighbor panel already route through `onNodeClick` (PR #154 / #153) so they automatically inherit the smoother animation.

## Item 2 — Wrap-around glow

### (a) Soft radial-gradient texture
`getGlowTexture(hex)` renders a 128x128 canvas with `createRadialGradient` (4 stops: bright core → soft falloff → transparent edge). Cached per-color.

### (b) `spawnPulse` uses gradient sprite
- Was: hard square sprite, scale 8x8
- Now: gradient texture map, scale 14x14 — softer "fluid light" / comet feel

### (c) NEW node halos
`nodeHalos` Map (nodeId → Sprite). Each active path node gets a sine-pulsing halo on a 1.8s period. **Per-halo phase offset** (born time) so halos don't breathe in unison — looks organic.

Lifecycle:
- `activatePath` / `exploreFromNode` → `refreshNodeHalos` (add for new active nodes)
- `clearActivePath` → `refreshNodeHalos` (dispose Sprite + texture for removed nodes — GPU leak guard)
- `pulseTick` → `tickNodeHalos` (per-frame position-track + sine scale + opacity)

Together: the path doesn't just have a moving dot; the active nodes "wrap" with a soft glow that breathes.

## Verification

```
$ python -m unittest tests.test_graph_camera_glow -v
Ran 18 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 950 tests in 9.0s  OK   (was 932; +18 new)
```

### Test classes
- `CameraCenteringTests` (3) — distance ≤200, animation ≥1000ms, camera-before-explore order
- `GlowTextureTests` (4) — `getGlowTexture` + `_hexToRgba`, `createRadialGradient` with ≥3 stops, cache used
- `SpawnPulseUsesGlowTests` (2) — uses gradient, scale ≥12
- `NodeHaloTests` (9) — Map, refresh + tick functions, sine pulse, integration with activate/explore/clearActivePath, dispose on inactive

## Bench numbers — N/A

Frontend-only. No `core/{retrieval,graph,reasoning}` touched. STEP 7 baseline unaffected.

## CLAUDE.md compliance

- (1) **No domain features** — UX
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — frontend file

## Files

```
 frontend/static/graph.js                | +110/-6   camera tuning + glow texture + halo system
 tests/test_graph_camera_glow.py         | +234  NEW   18 tests / 4 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>