### PR TITLE
fix(graph): neighbor + search panels click handlers (HTML attr quoting bug)

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -505,28 +505,48 @@
     var panel = document.getElementById('neighbor-panel');
     if (!panel) return;
     panel.style.display = 'block';
-    var rows = neighbors.slice(0, 50).map(function (item) {
-      var rel = (item.edge && item.edge.type) || 'RELATED_TO';
-      var arrow = item.direction === 'out' ? '→' : '←';
-      // Pre-compute the safe id for inline onclick (id is system-generated
-      // hex, but use JSON.stringify defense regardless).
-      var idJs = JSON.stringify(item.neighbor.id);
-      return '<div class="np-item" onclick="onNeighborClick(' + idJs + ')">' +
-             '<span class="np-arrow">' + arrow + '</span>' +
-             '<span class="np-name">' + escapeHtml(item.neighbor.name || '?') + '</span>' +
-             '<span class="np-rel">' + escapeHtml(rel) + '</span>' +
-             '</div>';
-    }).join('');
+    // [PR click-fix, 2026-05-09] use data-id + addEventListener instead
+    // of inline onclick. The previous inline form interpolated
+    // JSON.stringify(id) (which produces "double-quoted" output) into
+    // a double-quoted HTML attribute → attribute parser broke at the
+    // first inner ", onclick handler never registered. Direct 3D
+    // node click worked because force-graph registers via callback,
+    // not HTML attribute. Bug surfaced as "panel click does nothing".
+    var rowsHtml;
     if (neighbors.length === 0) {
-      rows = '<div class="np-empty">연결된 이웃 없음</div>';
+      rowsHtml = '<div class="np-empty">연결된 이웃 없음</div>';
+    } else {
+      rowsHtml = neighbors.slice(0, 50).map(function (item) {
+        var rel = (item.edge && item.edge.type) || 'RELATED_TO';
+        var arrow = item.direction === 'out' ? '→' : '←';
+        return '<div class="np-item" data-neighbor-id="' +
+               escapeHtml(item.neighbor.id) + '">' +
+               '<span class="np-arrow">' + arrow + '</span>' +
+               '<span class="np-name">' + escapeHtml(item.neighbor.name || '?') + '</span>' +
+               '<span class="np-rel">' + escapeHtml(rel) + '</span>' +
+               '</div>';
+      }).join('');
     }
     panel.innerHTML =
-      '<button class="np-close" onclick="closeNeighborPanel()" ' +
+      '<button class="np-close" data-action="close-neighbor" ' +
       'title="닫기">×</button>' +
       '<div class="np-title">🔗 ' + escapeHtml(centerNode.name || '?') + '</div>' +
       '<div class="np-meta">' + neighbors.length + '개 직접 연결' +
       (neighbors.length > 50 ? ' (50개까지 표시)' : '') + '</div>' +
-      '<div class="np-list">' + rows + '</div>';
+      '<div class="np-list">' + rowsHtml + '</div>';
+
+    // Wire programmatic click handlers — bypass HTML-attribute
+    // quoting issues (and works identically across mouse/touch).
+    var closeBtn = panel.querySelector('[data-action="close-neighbor"]');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () { closeNeighborPanel(); });
+    }
+    panel.querySelectorAll('[data-neighbor-id]').forEach(function (row) {
+      row.addEventListener('click', function () {
+        var id = row.getAttribute('data-neighbor-id');
+        if (id) onNeighborClick(id);
+      });
+    });
   }
 
   window.onNeighborClick = function (neighborId) {
@@ -635,14 +655,24 @@
         '</div>';
       return;
     }
+    // [PR click-fix, 2026-05-09] data-id + addEventListener instead
+    // of inline onclick (same JSON.stringify-into-double-quoted-attr
+    // bug as renderNeighborPanel — see that fn's comment).
     listEl.innerHTML = rows.map(function (n) {
-      var idJs = JSON.stringify(n.id);
-      return '<div class="tsd-row" onclick="onSearchRowClick(' + idJs + ')">' +
+      return '<div class="tsd-row" data-search-id="' +
+             escapeHtml(n.id) + '">' +
              '<span class="tsd-type">' + escapeHtml(n.type || '?') + '</span>' +
              '<span class="tsd-name">' + escapeHtml(n.name || '?') + '</span>' +
              '<span class="tsd-deg">' + (n.degree || 0) + '</span>' +
              '</div>';
     }).join('');
+    // Wire click handlers programmatically.
+    listEl.querySelectorAll('[data-search-id]').forEach(function (row) {
+      row.addEventListener('click', function () {
+        var id = row.getAttribute('data-search-id');
+        if (id) onSearchRowClick(id);
+      });
+    });
   }
 
   // Click a search row → close drawer + camera nudge + explore neighborhood.

--- a/tests/test_graph_explorer.py
+++ b/tests/test_graph_explorer.py
@@ -152,16 +152,35 @@ class NeighborPanelTests(unittest.TestCase):
     def test_close_panel_handler_global(self):
         self.assertIn("window.closeNeighborPanel", self.js)
 
-    def test_neighbor_click_uses_json_stringify(self):
-        # The id is interpolated into an inline onclick string. Even if
-        # the system-generated id format is safe, defense-in-depth is
-        # JSON.stringify (quoting + escaping).
+    def test_neighbor_click_uses_data_attr_and_listener(self):
+        # [PR click-fix, 2026-05-09] earlier versions interpolated
+        # JSON.stringify(id) into an inline onclick attribute, but
+        # JSON's double quotes collided with the HTML attribute's
+        # double quotes → onclick was never registered → click did
+        # nothing. Now we use data-neighbor-id + addEventListener.
+        # Same pattern as direct 3D node click (force-graph callback).
         idx = self.js.index("function renderNeighborPanel")
-        nxt = self.js.index("\n  window.", idx + 100)
-        body = self.js[idx:nxt]
-        self.assertIn("JSON.stringify", body,
-            "id interpolation into inline onclick must use JSON.stringify "
-            "for defense-in-depth")
+        # Bound at first non-comment statement using either old or new
+        # pattern's exit point.
+        end = self.js.index("\n  window.onNeighborClick", idx + 100)
+        body = self.js[idx:end]
+        # Must use data-neighbor-id attribute (not inline onclick with
+        # interpolated id) — the active "click works" contract.
+        self.assertIn('data-neighbor-id', body,
+            "neighbor row must carry data-neighbor-id (not inline onclick "
+            "with interpolated id) to dodge HTML-attribute quoting bugs")
+        # And must wire addEventListener — that's how the click actually
+        # reaches the handler.
+        self.assertIn("addEventListener('click'", body,
+            "click handler must be programmatic (addEventListener), "
+            "matching the direct-3D-click code path that always worked")
+        # Negative regression guard: must NOT use the broken pattern.
+        self.assertNotRegex(
+            body,
+            r"onclick=\"onNeighborClick\(.*?\+\s*idJs",
+            "must not interpolate raw JSON-stringified id into inline "
+            "onclick — that's the bug we just fixed",
+        )
 
 
 class OnNodeClickIntegrationTests(unittest.TestCase):

--- a/tests/test_graph_mobile_loop_search.py
+++ b/tests/test_graph_mobile_loop_search.py
@@ -204,14 +204,29 @@ class SearchDrawerJsTests(unittest.TestCase):
         self.assertGreaterEqual(body.count("escapeHtml"), 2,
             "name + type fields must both go through escapeHtml")
 
-    def test_click_handler_uses_json_stringify(self):
-        # Inline onclick interpolates node.id — defense-in-depth via
-        # JSON.stringify (same pattern as neighbor panel #4-2).
+    def test_search_row_uses_data_attr_and_listener(self):
+        # [PR click-fix, 2026-05-09] earlier versions interpolated
+        # JSON.stringify(id) into an inline onclick attribute. JSON's
+        # double quotes collided with HTML attribute's double quotes →
+        # onclick syntax error → click did nothing. Now we use
+        # data-search-id + addEventListener (same pattern as the
+        # always-working direct 3D node click).
         idx = self.js.index("function _renderSearchList")
-        body = self.js[idx:idx + 2000]
-        self.assertIn("JSON.stringify", body,
-            "node.id interpolated into inline onclick must use "
-            "JSON.stringify for defense-in-depth")
+        body = self.js[idx:idx + 2500]
+        self.assertIn('data-search-id', body,
+            "search row must carry data-search-id, not inline onclick "
+            "with interpolated id (HTML-attr quoting bug)")
+        self.assertIn("addEventListener('click'", body,
+            "click handler must be programmatic — matches direct-3D "
+            "click which always worked")
+        # Negative regression guard — must not regress to the broken
+        # inline-onclick pattern.
+        self.assertNotRegex(
+            body,
+            r"onclick=\"onSearchRowClick\(.*?\+\s*idJs",
+            "must not interpolate raw JSON-stringified id into inline "
+            "onclick — that's the bug we just fixed",
+        )
 
     def test_click_routes_through_onNodeClick(self):
         # window.onSearchRowClick must call onNodeClick so the


### PR DESCRIPTION
## Summary

User caught two real bugs:
> 「검색 색인창을 통한 노드 선택이 작동 안하고
>  노드 선택시 뜨는 연결된 노드 창에서 노드 선택 작동 안하고 있다.」

User's diagnosis was exactly right — phone wasn't the issue. The fix is to apply the **same logic as direct 3D click** (force-graph callback). This PR does that.

## Bug

Both `renderNeighborPanel` (PR #153) and `_renderSearchList` (PR #154) interpolated `JSON.stringify(id)` into an inline `onclick` attribute:

```js
var idJs = JSON.stringify(item.neighbor.id);
// → '"e_org_98fe1967"'   (JSON wraps in double quotes)
'<div onclick="onNeighborClick(' + idJs + ')">'
// → '<div onclick="onNeighborClick("e_org_98fe1967")">'
//                                  ^ HTML attribute parser breaks here
```

HTML attribute uses double quotes; `JSON.stringify` produces double quotes. Inner `"` closed the attribute → parser broke → `onclick` handler **never registered** → click silently no-op'd.

**Direct 3D node click always worked** because force-graph registers via `graph.onNodeClick(fn)` JS callback, bypassing HTML attribute parsing entirely. That's the "same logic" the user pointed at.

## Fix

Switched both panels to `data-{kind}-id` attributes + programmatic `addEventListener`:

```js
'<div data-neighbor-id="' + escapeHtml(id) + '">'
...
panel.querySelectorAll('[data-neighbor-id]').forEach(function (row) {
  row.addEventListener('click', function () {
    onNeighborClick(row.getAttribute('data-neighbor-id'));
  });
});
```

Same pattern for search drawer rows + close buttons. Works identically across mouse/touch (and explains why phone behavior matched desktop — same broken parser, same silent no-op).

## Tests updated

The original tests were too weak — they only matched `"JSON.stringify"` anywhere in the function body, which the comment **about the bug** also satisfies. The new tests check the actual rendered pattern:

- `test_neighbor_click_uses_data_attr_and_listener` — asserts `data-neighbor-id` present, `addEventListener('click'` wired, negative regression guard against broken `onclick="...idJs..."` pattern
- `test_search_row_uses_data_attr_and_listener` — same for search drawer

```
$ python -m unittest tests.test_graph_explorer tests.test_graph_mobile_loop_search
Ran 53 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 950 tests in 8.9s  OK   (was 950; net 0 — 2 tests rewritten in place)
```

## Bench numbers — N/A

Frontend-only. No `core/{retrieval,graph,reasoning}` touched.

## CLAUDE.md compliance

- (1) **No domain features** — bug fix
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — frontend file

## Files

```
 frontend/static/graph.js                       | +35/-15   data-attr + addEventListener
 tests/test_graph_explorer.py                   | +25/-9    rewritten test, regression guard
 tests/test_graph_mobile_loop_search.py         | +21/-9    rewritten test, regression guard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>