### PR TITLE
feat(graph): auto-suggested questions on node click (3 chips above query bar)

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -328,6 +328,54 @@
     background: rgba(99,102,241,.12); color: var(--accent-fg);
   }
 
+  /* [PR suggested-q, 2026-05-09] auto-suggested questions strip
+     above the query bar. Shown after a node click; cleared on
+     submit / panel close. */
+  .suggested-questions {
+    position: absolute;
+    bottom: 64px;
+    left: 16px; right: 16px;
+    display: none;
+    flex-wrap: wrap;
+    gap: 6px;
+    z-index: 28;
+    pointer-events: auto;
+    justify-content: center;
+  }
+  .sq-chip {
+    background: rgba(20,22,26,.92);
+    border: 1px solid var(--accent);
+    border-radius: 16px;
+    padding: 6px 12px;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: min(360px, 100%);
+    overflow: hidden;
+    transition: background .15s, transform .1s;
+    font-family: var(--font-ui);
+    line-height: 1.3;
+  }
+  .sq-chip:hover {
+    background: rgba(99,102,241,.20);
+    transform: translateY(-1px);
+  }
+  .sq-chip:active {
+    transform: translateY(0);
+  }
+  .sq-chip .sq-icon {
+    flex-shrink: 0;
+    color: var(--accent-fg);
+  }
+  .sq-chip .sq-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   /* [PR mobile-loop-search, 2026-05-09] top entity search drawer.
      Slides down from the top edge. Toggle button always visible (acts
      as floating tab when collapsed). Universally available — phone
@@ -506,6 +554,17 @@
       font-size: 11px;
       padding: 5px 12px;
     }
+    /* [PR suggested-q] chips wrap on phone, slightly smaller. */
+    .suggested-questions {
+      bottom: 60px;
+      left: 8px; right: 8px;
+      gap: 4px;
+    }
+    .sq-chip {
+      font-size: 11px;
+      padding: 5px 10px;
+      max-width: 100%;
+    }
     .overlay.bl { display: none; }          /* hint text — too crowded on phone */
   }
   @media (max-width: 480px) {
@@ -604,6 +663,11 @@
     <!-- [PR explorer] Query reasoning overlay — inline widget above
          the query bar during /query/ inflight wait. -->
     <div class="query-reasoning-overlay" id="query-reasoning-overlay"></div>
+
+    <!-- [PR suggested-q, 2026-05-09] auto-suggested questions chips.
+         Populated by renderSuggestedQuestions after a node click;
+         cleared on submit / panel close. -->
+    <div class="suggested-questions" id="suggested-questions"></div>
 
     <div class="answer-card" id="answer-card">
       <button class="ac-close" onclick="closeAnswer()" title="닫기 + 그래프 기본 모드로 복귀">×</button>

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -496,6 +496,11 @@
 
     renderNeighborPanel(node, neighbors);
 
+    // [PR suggested-q, 2026-05-09] auto-suggest 3 questions related
+    // to the clicked node + its top neighbors. User can click one to
+    // fire the query immediately, or just type their own.
+    renderSuggestedQuestions(generateSuggestedQuestions(node, neighbors));
+
     // [PR mobile-loop-search] keep the neighborhood lit — pulses re-
     // fire every PULSE_LOOP_MS until next click clears.
     setTimeout(function () { startPulseLoop(loopEdges); }, stepMs + 400);
@@ -560,6 +565,8 @@
     var panel = document.getElementById('neighbor-panel');
     if (panel) panel.style.display = 'none';
     clearActivePath();
+    // [PR suggested-q] chips are tied to the active node — hide too.
+    clearSuggestedQuestions();
   };
 
   // ─── [PR explorer] Query reasoning overlay ──────────────────────
@@ -595,6 +602,122 @@
     if (!ov) return;
     ov.style.display = 'none';
     ov.innerHTML = '';
+  }
+
+  // ─── [PR suggested-q, 2026-05-09] Auto-suggested questions ─────
+  // After clicking a node, generate 3 questions from (node + top
+  // neighbors) and offer them above the query bar. Click a chip →
+  // fills query box + submits. Pure client-side templates so there's
+  // no server roundtrip; user can always type their own.
+  //
+  // Korean particle handling: helper picks the right form
+  // (은/는, 이/가, 과/와, 을/를) based on whether the entity name
+  // ends with a 받침 (jongseong). Falls back to consonant/vowel
+  // heuristic for English names.
+  function _hasJongseong(s) {
+    if (!s) return false;
+    var c = s.slice(-1);
+    var code = c.charCodeAt(0);
+    if (code >= 0xAC00 && code <= 0xD7A3) {
+      return ((code - 0xAC00) % 28) !== 0;
+    }
+    if (/[a-z]/i.test(c)) {
+      return !/[aeiou]/i.test(c);
+    }
+    return false;
+  }
+  function _ko_p(name, withJong, withoutJong) {
+    return _hasJongseong(name) ? withJong : withoutJong;
+  }
+
+  function generateSuggestedQuestions(node, neighbors) {
+    if (!node) return [];
+    var name = node.name || '?';
+    var type = (node.type || 'concept').toLowerCase();
+    var sortedNs = (neighbors || []).slice().sort(function (a, b) {
+      var bw = (b.edge && b.edge.weight) || 0;
+      var aw = (a.edge && a.edge.weight) || 0;
+      return bw - aw;
+    });
+    var top1 = sortedNs[0] && sortedNs[0].neighbor && sortedNs[0].neighbor.name;
+    var top2 = sortedNs[1] && sortedNs[1].neighbor && sortedNs[1].neighbor.name;
+
+    var questions = [];
+
+    // Q1 — about the node itself (entity-type aware)
+    var p_eun = _ko_p(name, '은', '는');
+    var p_i = _ko_p(name, '이', '가');
+    if (type === 'person') {
+      questions.push(name + p_eun + ' 누구이고, 어떤 활동을 했어?');
+    } else if (type === 'org') {
+      questions.push(name + p_eun + ' 어떤 조직이고 주요 활동은 뭐야?');
+    } else if (type === 'document') {
+      questions.push(name + ' 문서의 핵심 내용은?');
+    } else {
+      questions.push(name + p_i + ' 무엇인지 설명해줘');
+    }
+
+    // Q2 — relationship with the highest-weight neighbor
+    if (top1) {
+      var p_gwa = _ko_p(name, '과', '와');
+      questions.push(name + p_gwa + ' ' + top1 + '의 관계를 설명해줘');
+    }
+
+    // Q3 — comparison/summary across top 2 neighbors, or single
+    // summary fallback when there's only one neighbor.
+    if (top1 && top2) {
+      var p_eul = _ko_p(name, '을', '를');
+      questions.push(name + p_eul + ' 중심으로 ' + top1 +
+                     ', ' + top2 + '의 연결 흐름을 정리해줘');
+    } else if (top1) {
+      var p_e = _ko_p(name, '과', '와');
+      questions.push(name + p_e + ' 관련된 다른 엔티티들도 정리해줘');
+    } else {
+      questions.push(name + '의 주요 특징을 알려줘');
+    }
+
+    return questions.slice(0, 3);
+  }
+
+  function renderSuggestedQuestions(questions) {
+    var box = document.getElementById('suggested-questions');
+    if (!box) return;
+    if (!questions || !questions.length) {
+      box.style.display = 'none';
+      box.innerHTML = '';
+      return;
+    }
+    box.innerHTML = questions.map(function (q) {
+      return '<button class="sq-chip" data-sq-question="' +
+             escapeHtml(q) + '" title="' + escapeHtml(q) + '">' +
+             '<span class="sq-icon">💬</span>' +
+             '<span class="sq-text">' + escapeHtml(q) + '</span>' +
+             '</button>';
+    }).join('');
+    box.style.display = 'flex';
+    // Programmatic listeners (same data-attr + addEventListener pattern
+    // used elsewhere in this file — see PR #157 for the inline-onclick
+    // quoting bug we're avoiding).
+    box.querySelectorAll('[data-sq-question]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var q = btn.getAttribute('data-sq-question');
+        if (!q) return;
+        var input = document.getElementById('qbox');
+        if (input) {
+          input.value = q;
+          if (typeof window.askQuestion === 'function') {
+            window.askQuestion();
+          }
+        }
+      });
+    });
+  }
+
+  function clearSuggestedQuestions() {
+    var box = document.getElementById('suggested-questions');
+    if (!box) return;
+    box.style.display = 'none';
+    box.innerHTML = '';
   }
 
   // ─── [PR mobile-loop-search] Top entity search drawer ──────────
@@ -1185,6 +1308,9 @@
     if (!q) return;
     // [#4-2 j] new question → clear current path before new one fires.
     clearActivePath();
+    // [PR suggested-q] hide chips once the user committed to a query
+    // (clicking a chip OR typing their own — both submit through here).
+    clearSuggestedQuestions();
     btn.disabled = true;
     btn.textContent = '...';
     // [PR explorer] reasoning overlay during the inflight wait —

--- a/tests/test_graph_answer_lifecycle.py
+++ b/tests/test_graph_answer_lifecycle.py
@@ -99,7 +99,9 @@ class PathPersistenceTests(unittest.TestCase):
 
     def test_ask_question_clears_path_first(self):
         # [#4-2 j] new question must reset before firing.
-        idx = self.js.index("window.askQuestion")
+        # Anchor on the function definition (not just the symbol —
+        # other code calls window.askQuestion now too).
+        idx = self.js.index("window.askQuestion = async function")
         body = self.js[idx:idx + 1500]
         self.assertIn("clearActivePath()", body,
             "askQuestion must clearActivePath() before firing — old path "

--- a/tests/test_graph_explorer.py
+++ b/tests/test_graph_explorer.py
@@ -244,14 +244,20 @@ class ReasoningOverlayTests(unittest.TestCase):
             "knows the system is working, not stuck")
 
     def test_askQuestion_calls_show(self):
-        idx = self.js.index("window.askQuestion")
+        # Anchor on the function definition itself, not just the
+        # symbol — other code may now CALL window.askQuestion (e.g.,
+        # the suggested-questions chip click handler).
+        idx = self.js.index("window.askQuestion = async function")
         nxt = self.js.index("\n  function ", idx + 1)
         body = self.js[idx:nxt]
         self.assertIn("showReasoningOverlay()", body,
             "askQuestion must show overlay before /query/ POST")
 
     def test_askQuestion_hides_in_finally(self):
-        idx = self.js.index("window.askQuestion")
+        # Anchor on the function definition itself, not just the
+        # symbol — other code may now CALL window.askQuestion (e.g.,
+        # the suggested-questions chip click handler).
+        idx = self.js.index("window.askQuestion = async function")
         nxt = self.js.index("\n  function ", idx + 1)
         body = self.js[idx:nxt]
         # finally block ensures hide even on error path

--- a/tests/test_graph_suggested_questions.py
+++ b/tests/test_graph_suggested_questions.py
@@ -1,0 +1,233 @@
+"""[PR suggested-q, 2026-05-09] Auto-suggested questions on node click.
+
+User feedback:
+> "추론 그래프에서 노드 선택시 연결된 노드들과의 연관된 질문을 형성해서
+>  사용자에게 이 질문에 대한 분석이나 답변을 원하는지 3가지 정도 자동
+>  생성해서 질문란 쪽에 함께 제시하는 방식을 검토"
+
+Pure client-side template generation:
+  - generateSuggestedQuestions(node, neighbors) — 3 questions max
+    Q1: about the node itself (entity-type aware: person / org /
+        document / concept)
+    Q2: relationship with the highest-weight neighbor
+    Q3: comparison/summary across top 2 neighbors (or single-neighbor
+        fallback)
+  - Korean particle helpers (_hasJongseong, _ko_p) so 은/는, 이/가,
+    과/와, 을/를 are picked correctly per entity name.
+  - renderSuggestedQuestions(qs) → chip strip above query bar
+  - clearSuggestedQuestions() — on submit / panel close
+
+Run:
+    python -m unittest tests.test_graph_suggested_questions
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS = ROOT / "frontend" / "static" / "graph.js"
+HTML = ROOT / "frontend" / "graph.html"
+
+
+class GeneratorContractTests(unittest.TestCase):
+    """Source-level: generateSuggestedQuestions has the right shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_generator_function_defined(self):
+        self.assertIn("function generateSuggestedQuestions", self.js)
+
+    def test_returns_at_most_3_questions(self):
+        idx = self.js.index("function generateSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn(".slice(0, 3)", body,
+            "generator must cap output at 3 questions")
+
+    def test_handles_each_entity_type(self):
+        idx = self.js.index("function generateSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # Branches for person / org / document / fallback (concept etc.)
+        for type_kw in ("person", "org", "document"):
+            self.assertIn("'" + type_kw + "'", body,
+                f"generator must branch on entity type '{type_kw}' "
+                "for natural-sounding questions")
+
+    def test_uses_top_neighbor_by_weight(self):
+        idx = self.js.index("function generateSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # Top neighbor selected by edge weight, not array order.
+        self.assertIn("edge", body)
+        self.assertIn("weight", body)
+        self.assertIn(".sort", body,
+            "neighbors must be sorted by edge weight before picking the "
+            "top one for the relationship question")
+
+
+class KoreanParticleHelperTests(unittest.TestCase):
+    """_hasJongseong / _ko_p must handle Korean syllables + English fallback."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_has_jongseong_function(self):
+        self.assertIn("function _hasJongseong", self.js)
+
+    def test_ko_particle_function(self):
+        self.assertIn("function _ko_p", self.js)
+
+    def test_jongseong_uses_hangul_unicode_block(self):
+        idx = self.js.index("function _hasJongseong")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # The Korean precomposed-syllable Unicode block: U+AC00..U+D7A3.
+        # Modulo 28 gives the 종성(jongseong) index — 0 means no batchim.
+        self.assertIn("0xAC00", body)
+        self.assertIn("0xD7A3", body)
+        self.assertIn("28", body,
+            "must use the (code - 0xAC00) % 28 trick to detect 종성")
+
+    def test_english_fallback_present(self):
+        idx = self.js.index("function _hasJongseong")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # English consonant ending → treat as 받침; vowel ending → no.
+        self.assertIn("[a-z]", body,
+            "must have an English fallback heuristic for non-Korean names")
+
+    def test_generator_uses_particle_helper(self):
+        idx = self.js.index("function generateSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        # Must call _ko_p with Korean particle pairs.
+        self.assertIn("_ko_p(", body)
+        self.assertIn("'은'", body)
+        self.assertIn("'는'", body)
+        self.assertIn("'과'", body)
+        self.assertIn("'와'", body)
+
+
+class RendererTests(unittest.TestCase):
+    """renderSuggestedQuestions / clearSuggestedQuestions DOM contract."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_render_function_defined(self):
+        self.assertIn("function renderSuggestedQuestions", self.js)
+
+    def test_clear_function_defined(self):
+        self.assertIn("function clearSuggestedQuestions", self.js)
+
+    def test_renders_into_correct_container(self):
+        idx = self.js.index("function renderSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("'suggested-questions'", body,
+            "must target the #suggested-questions container")
+
+    def test_chips_use_data_attr_and_listener(self):
+        # Same pattern as PR #157's click-handler fix — never use
+        # inline onclick with raw-id interpolation.
+        idx = self.js.index("function renderSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("data-sq-question", body,
+            "chips must carry data-sq-question, not inline onclick")
+        self.assertIn("addEventListener('click'", body,
+            "click handler must be programmatic — matches PR #157 pattern")
+
+    def test_chip_click_triggers_askQuestion(self):
+        idx = self.js.index("function renderSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("window.askQuestion", body,
+            "chip click must populate qbox + invoke askQuestion to fire "
+            "the query immediately")
+
+    def test_chip_text_uses_escapeHtml(self):
+        # Question strings come from concatenated user-data-controlled
+        # entity names — escape on the way to innerHTML.
+        idx = self.js.index("function renderSuggestedQuestions")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("escapeHtml", body)
+
+    def test_html_container_present(self):
+        self.assertIn('id="suggested-questions"', self.html)
+
+    def test_initial_display_none(self):
+        # CSS rule must default to display:none — JS toggles to flex.
+        self.assertRegex(
+            self.html,
+            r"\.suggested-questions[^{]*\{[^}]*display:\s*none",
+            re.DOTALL,
+        )
+
+
+class IntegrationTests(unittest.TestCase):
+    """Integration with explore + askQuestion + close handlers."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+
+    def test_exploreFromNode_renders_suggestions(self):
+        idx = self.js.index("function exploreFromNode")
+        body = self.js[idx:idx + 3000]
+        self.assertIn("renderSuggestedQuestions", body,
+            "exploreFromNode must populate the chip strip alongside "
+            "the neighbor panel")
+
+    def test_askQuestion_clears_chips(self):
+        # Anchor on the actual function definition (other places call
+        # window.askQuestion now too).
+        idx = self.js.index("window.askQuestion = async function")
+        nxt = self.js.index("\n  function ", idx + 1)
+        body = self.js[idx:nxt]
+        self.assertIn("clearSuggestedQuestions()", body,
+            "submitting a question must hide the chips so they don't "
+            "linger past the query they relate to")
+
+    def test_closeNeighborPanel_clears_chips(self):
+        idx = self.js.index("window.closeNeighborPanel")
+        body = self.js[idx:idx + 600]
+        self.assertIn("clearSuggestedQuestions", body,
+            "closing the neighbor panel must also clear the chips — "
+            "they're tied to the active node")
+
+
+class MobileResponsiveTests(unittest.TestCase):
+    """Phone breakpoint tweaks the chip strip."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = HTML.read_text(encoding="utf-8")
+
+    def test_phone_breakpoint_adjusts_chips(self):
+        # 720px @media block must reference .suggested-questions or
+        # .sq-chip so the chips are sized for thumb taps.
+        idx = self.html.index("@media (max-width: 720px)")
+        end = self.html.index("@media (max-width: 480px)", idx)
+        block = self.html[idx:end]
+        self.assertTrue(
+            ".suggested-questions" in block or ".sq-chip" in block,
+            "phone media block must adjust chip strip sizing/positioning",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User feedback (2026-05-09):
> 「추론 그래프에서 노드 선택시 연결된 노드들과의 연관된 질문을 형성해서 사용자에게 이 질문에 대한 분석이나 답변을 원하는지 3가지 정도 자동 생성해서 질문란 쪽에 함께 제시하는 방식을 검토」

Implementation: pure client-side template generation, 3 chips floated above the query bar. Click → fills query box + submits. No server roundtrip, no LLM cost.

## Generator

`generateSuggestedQuestions(node, neighbors)` — 3 questions max:
- **Q1** about the node itself (entity-type aware)
  - person → "Alex Karp는 누구이고, 어떤 활동을 했어?"
  - org → "Anthropic은 어떤 조직이고 주요 활동은 뭐야?"
  - document → "PLTR_03_… 문서의 핵심 내용은?"
  - concept → "비트코인이 무엇인지 설명해줘"
- **Q2** relationship with the **highest-weight** neighbor (sorts by edge.weight first)
  - "비트코인과 IBIT의 관계를 설명해줘"
- **Q3** multi-neighbor summary, or single-neighbor fallback
  - "비트코인을 중심으로 IBIT, MSBT의 연결 흐름을 정리해줘"

## Korean particle handling

`_hasJongseong` / `_ko_p` — picks 은/는, 이/가, 과/와, 을/를 correctly:
- Korean syllable: `(code - 0xAC00) % 28 != 0` → 종성 있음 → 받침 form
- English consonant ending → treat as 받침
- English vowel ending / others → no 받침

Standard "받침 유무" trick from Korean i18n libraries.

## Renderer

`renderSuggestedQuestions(qs)` — chip strip into `#suggested-questions`. Each chip uses `data-sq-question` + `addEventListener` (same pattern as PR #157's click-handler fix; never inline onclick).

`clearSuggestedQuestions()` — hides + empties on submit / panel close so chips don't linger.

## Integration (3 hooks)

- `exploreFromNode` → render after neighbor panel
- `window.askQuestion` start → clear (user committed)
- `closeNeighborPanel` → clear (chips tied to active node)

## Other test fixes

`test_graph_explorer` / `test_graph_answer_lifecycle`: anchored on `window.askQuestion = async function` (not just the symbol — chip click handlers also call it now).

## Verification

```
$ python -m unittest tests.test_graph_suggested_questions -v
Ran 21 tests in 0.0s  OK

$ python -m unittest discover -s tests
Ran 976 tests in 9.0s  OK   (was 955; +21 new)
```

### Test classes
- `GeneratorContractTests` (4) — 3-cap, entity-type branches, sort-by-weight
- `KoreanParticleHelperTests` (5) — Hangul Unicode block math, English fallback, generator uses helper
- `RendererTests` (7) — defined, correct container, data-attr + addEventListener, escapeHtml, initial display:none
- `IntegrationTests` (3) — explore renders, askQuestion + closePanel clear
- `MobileResponsiveTests` (1) — phone breakpoint adjusts chips

## Bench numbers — N/A

Frontend-only. No `core/{retrieval,graph,reasoning}` touched.

## CLAUDE.md compliance

- (1) **No domain features** — UX
- (2) **bench numbers** — N/A
- (3) **self-evolution** — unaffected
- (4) **no architecture change**
- (5) **module size** — frontend file

## Files

```
 frontend/static/graph.js                    | +130     generator + renderer + helpers
 frontend/graph.html                         | +60/-0   chip CSS + mobile + container
 tests/test_graph_explorer.py                |  +5/-3   anchor on async function
 tests/test_graph_answer_lifecycle.py        |  +3/-1   anchor on async function
 tests/test_graph_suggested_questions.py     | +236  NEW   21 tests / 5 classes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>