### PR TITLE
chore(gitignore): wildcard wiki/entity/prod patterns (W7-hotfix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,12 +59,16 @@ reports/bench_*.json
 reports/trace/
 
 # 사용자 PDF에서 추출된 wiki entity (개인 데이터, repo에 푸시 X)
-# 폴더 구조는 유지 (wiki_generator/wiki_reset가 자동 재생성)
-wiki/entity/prod/concept/*.md
-wiki/entity/prod/org/*.md
-wiki/entity/prod/person/*.md
-wiki/entity/prod/document/*.md
-wiki/entity/prod/system_internal/*.md
+# [W7-hotfix 2026-05-10, W1 진단 §2-C] 이전엔 5 카테고리 한정 패턴이라
+# food/event/relation 등 신규 카테고리 추가 시 자동으로 ignored 되지 않아
+# 누수 위험. wildcard 로 모든 카테고리 커버 + 미래 카테고리도 자동 보호.
+wiki/entity/prod/**/*.md
+# defense — entity/ 없이 prod 직속에 데이터를 넣는 경로도 차단
+# (구조 의도와 별개로 누수 가능 경로 막음).
+wiki/prod/
+# 메타 파일은 명시적으로 추적 — 카테고리 인덱스 / 폴더 보존용 .gitkeep
+!wiki/entity/prod/**/index.md
+!wiki/entity/prod/**/.gitkeep
 
 # ── ML 모델 / 임베딩 캐시 ──────────────────────────────────────
 models/

--- a/tests/test_gitignore_wiki.py
+++ b/tests/test_gitignore_wiki.py
@@ -1,0 +1,131 @@
+"""[W7-hotfix 2026-05-10, W1 진단 §2-C] .gitignore wiki 패턴 회귀.
+
+W1 진단 결과: 기존 .gitignore 가 wiki/entity/prod/{concept,org,person,
+document,system_internal}/*.md 5 카테고리만 ignore 했다.
+
+문제:
+  • 새 카테고리 (food/, event/, relation/ 등) 추가 시 자동으로 ignored
+    안 됨 → 사용자 데이터 누수 가능.
+  • wiki/prod/ (entity/ 없이 prod 직속) 도 .gitignore 등재 X.
+
+W1 §2-C 권고:
+  → wildcard 패턴 (wiki/entity/prod/**/*.md) + 메타 파일 unignore +
+    wiki/prod/ defense.
+
+이 테스트는 git check-ignore CLI 로 실제 git matcher 의 동작을 검증한다 —
+정규식으로 .gitignore 텍스트를 파싱하지 않고 git 자신의 매칭 로직을
+사용하므로 syntax edge case 까지 신뢰 가능.
+
+Run:
+    python -m unittest tests.test_gitignore_wiki
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _is_ignored(rel_path: str) -> bool:
+    """git check-ignore 로 path 가 ignored 인지 확인.
+
+    git check-ignore exit code:
+      0 = ignored
+      1 = NOT ignored
+      128 = error (path 형식 오류 등)
+    """
+    # `--no-index` 없이 호출 — repo 의 실제 .gitignore 만 본다.
+    # `-q` 로 stdout 억제, 종료 코드만 사용.
+    proc = subprocess.run(
+        ["git", "check-ignore", "-q", rel_path],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 128:
+        raise RuntimeError(
+            f"git check-ignore error for {rel_path!r}: {proc.stderr}"
+        )
+    return proc.returncode == 0
+
+
+class ExistingCategoriesStillIgnoredTests(unittest.TestCase):
+    """기존 5 카테고리는 그대로 ignored — 회귀 가드."""
+
+    def test_concept_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/concept/foo.md"))
+
+    def test_org_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/org/foo.md"))
+
+    def test_person_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/person/foo.md"))
+
+    def test_document_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/document/foo.md"))
+
+    def test_system_internal_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/system_internal/foo.md"))
+
+
+class FutureCategoriesAlsoIgnoredTests(unittest.TestCase):
+    """W1 §2-C 핵심 — 신규 카테고리도 자동 ignored."""
+
+    def test_food_category_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/food/x.md"))
+
+    def test_event_category_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/event/x.md"))
+
+    def test_relation_category_ignored(self):
+        self.assertTrue(_is_ignored("wiki/entity/prod/relation/x.md"))
+
+    def test_deeply_nested_md_ignored(self):
+        # wildcard ** 가 깊은 경로도 커버.
+        self.assertTrue(
+            _is_ignored("wiki/entity/prod/concept/sub/deep/x.md")
+        )
+
+
+class MetaFilesPreservedTests(unittest.TestCase):
+    """index.md / .gitkeep 같은 메타 파일은 추적 대상."""
+
+    def test_category_index_md_not_ignored(self):
+        # 카테고리 인덱스 (예: 카테고리 요약 페이지) 는 추적되어야.
+        self.assertFalse(
+            _is_ignored("wiki/entity/prod/concept/index.md"),
+            "카테고리 index.md 가 ignored 됨 — 추적 의도와 충돌",
+        )
+
+    def test_gitkeep_not_ignored(self):
+        # 빈 카테고리 폴더를 git 에 보존하려면 .gitkeep 추적 필요.
+        self.assertFalse(
+            _is_ignored("wiki/entity/prod/person/.gitkeep"),
+        )
+
+    def test_top_level_wiki_index_not_ignored(self):
+        # wiki/index.md 는 시스템 메타 — 항상 tracked.
+        self.assertFalse(_is_ignored("wiki/index.md"))
+
+    def test_wiki_synonyms_not_ignored(self):
+        self.assertFalse(_is_ignored("wiki/synonyms.yaml"))
+
+
+class DefenseAgainstWrongPathTests(unittest.TestCase):
+    """wiki/prod/ (entity/ 없이) 도 누수 차단."""
+
+    def test_wiki_prod_direct_md_ignored(self):
+        self.assertTrue(_is_ignored("wiki/prod/foo.md"))
+
+    def test_wiki_prod_subdir_ignored(self):
+        self.assertTrue(_is_ignored("wiki/prod/concept/foo.md"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
W1 진단 §2-C 권고. 기존 .gitignore 가 5 카테고리 한정 패턴이라 신규
카테고리 (food/, event/, relation/) 추가 시 자동으로 ignored 안 되어
사용자 데이터 누수 위험. wildcard 로 모든 카테고리 + 미래 카테고리도
자동 보호.

## Changes
| 변경 | 효과 |
|---|---|
| 5 카테고리 한정 → `wiki/entity/prod/**/*.md` | 신규 카테고리 자동 차단 |
| `wiki/prod/` 추가 | entity/ 우회 경로 누수 차단 |
| `!wiki/entity/prod/**/index.md` | 카테고리 인덱스 추적 유지 |
| `!wiki/entity/prod/**/.gitkeep` | 빈 폴더 보존 가능 |

## Tests
\`tests/test_gitignore_wiki.py\` — 15 tests, \`git check-ignore\` CLI 로
실제 matcher 동작 검증 (정규식 파싱 X — git 자신의 매칭 로직 사용).

| Class | Coverage |
|---|---|
| ExistingCategoriesStillIgnored | 5 카테고리 회귀 (concept/org/person/document/system_internal) |
| FutureCategoriesAlsoIgnored | food/event/relation/deep-nested 자동 ignored |
| MetaFilesPreserved | index.md / .gitkeep / synonyms.yaml 추적 유지 |
| DefenseAgainstWrongPath | wiki/prod/ 도 누수 차단 |

전체 회귀: **991/991 OK**.

## Verification
\`\`\`bash
git check-ignore -v wiki/entity/prod/food/x.md   # → ignored ✓
git check-ignore -v wiki/entity/prod/concept/index.md  # → NOT ignored ✓
git check-ignore -v wiki/prod/x.md               # → ignored ✓
\`\`\`

## Out of scope
- \`scripts/verify_clean_install.py\` 자동 검증 스크립트 (W1 §2-C 옵션 권고)
  → 별도 PR 검토. 이 hotfix 는 .gitignore 만.

## CLAUDE.md 통과
- Rule #1 도메인 추가 X ✅
- Rule #2 core/retrieval/graph/reasoning 변경 X ✅
- Rule #5 config-only 변경 — 모듈 게이트 무관 ✅

Closes — W1 진단 §② (PR #165 보고서 후속).