### PR TITLE
feat(character): W3b correlation 강화 + 미반영 trait fix + P5d prompt 합성

### DIFF
--- a/core/character_profile.py
+++ b/core/character_profile.py
@@ -77,8 +77,11 @@ _OPPONENTS = {
 # 짝(opposing pair)은 이미 _OPPONENTS로 100% flip 처리되므로 여기에
 # 중복 등재 X. 이 그래프는 "짝 외에 약한 영향" 만 표현.
 #
-# 사람이 직관적으로 동의할 만한 관계만 등재 (15 edges).
+# [W3b 2026-05-10, W1 진단 §1-C] 28 edges (이전 15) — 사용자 체감 영향력
+# 강화. P1 미반영 5 trait (focus/intuitive/independent/collaborative/
+# boldness) 가 모두 incoming edge 를 받도록 incoming 보강.
 CORRELATIONS: List[tuple] = [
+    # ── 원본 15 (P1) ─────────────────────────────────────────────
     # 인지(A,C) → 창의/직관 cluster
     ("curiosity",      "creativity",     +0.30),
     ("intuitive",      "creativity",     +0.20),
@@ -103,6 +106,33 @@ CORRELATIONS: List[tuple] = [
     # 정서 cluster
     ("creativity",     "optimism",       +0.20),
     ("patience",       "empathy",        +0.20),
+
+    # ── W3b 추가 13 — 미반영 5 trait 의 incoming 보강 ────────────
+    # focus 의 incoming (이전엔 outgoing 만 있었음 — 슬라이더 변경
+    # 시 다른 trait 변화에 따라 자동 조정되도록).
+    ("analytical",     "focus",          +0.40),  # 분석 ↑ → 집중 ↑
+    ("patience",       "focus",          +0.30),  # 인내 ↑ → 집중 ↑
+    ("caution",        "focus",          +0.20),  # 신중 ↑ → 집중 ↑
+    ("conciseness",    "focus",          +0.20),  # 간결 ↑ → 집중 ↑
+
+    # intuitive 의 incoming
+    ("creativity",     "intuitive",      +0.30),  # 창의 ↑ → 직관 ↑
+    ("empathy",        "intuitive",      +0.20),  # 공감 ↑ → 직관 ↑
+
+    # boldness 의 incoming (이전엔 outgoing 만)
+    ("risk_tolerance", "boldness",       +0.40),  # 위험감수 ↑ → 과감 ↑
+    ("creativity",     "boldness",       +0.20),  # 창의 ↑ → 과감 ↑
+    ("optimism",       "boldness",       +0.20),  # 낙관 ↑ → 과감 ↑
+
+    # collaborative 의 incoming (empathy 외 추가)
+    ("patience",       "collaborative",  +0.30),  # 인내 ↑ → 협력 ↑
+
+    # independent 의 incoming
+    ("analytical",     "independent",    +0.30),  # 분석 ↑ → 독립 ↑
+
+    # 추가 cluster 강화 — 표현 스타일 양방향
+    ("directness",     "conciseness",    +0.20),  # 직설 ↑ → 간결 ↑
+    ("security",       "caution",        +0.30),  # 보안의식 ↑ → 신중 ↑
 ]
 
 # 효율적인 이웃 lookup용 인덱스 (set_trait이 매 호출마다 재계산하지
@@ -111,8 +141,10 @@ _CORR_INDEX: Dict[str, List[tuple]] = {}
 for _src, _tgt, _w in CORRELATIONS:
     _CORR_INDEX.setdefault(_src, []).append((_tgt, _w))
 
-# Ripple damping — cascade 폭주 방지. 0.3 = 짝(1.0) 대비 30% 영향.
-_RIPPLE_DAMPING = 0.3
+# [W3b 2026-05-10] damping 0.3 → 0.6. W1 진단: 0.3 으로는 ripple 변화량이
+# 0.05 미만이라 사용자 눈에 거의 안 보였음. 0.6 으로 올려도 cascade 폭주는
+# set_trait 가 1-level (no recursion) 이므로 안전.
+_RIPPLE_DAMPING = 0.6
 
 
 class CharacterProfile:
@@ -204,9 +236,16 @@ class CharacterProfile:
     def get_prompt_modifiers(self) -> str:
         """reasoning_engine 프롬프트에 주입할 성향 지시문.
 
-        규칙:
+        구성:
+          1. [캐릭터 페르소나] 블록 — build_summary 결과 (P5d, W3b 추가)
+          2. [응답 지시] 블록 — trait 임계값 기반 directive
+
+        directive 규칙:
           - 0.7 이상 → 강하게 반영 (해당 trait 관련 directive 추가)
-          - 0.3 이하 → 반대 방향 directive 추가 (있는 경우)
+          - 0.3 이하 → 반대 방향 directive 추가
+          - W3b: focus/intuitive/independent/collaborative/boldness 5개도
+            directive 발화 (이전엔 누락되어 슬라이더 변경이 LLM 응답에
+            영향 X 였음 — W1 §1-C 권고)
         """
         p = self._values
         lines: List[str] = []
@@ -235,6 +274,17 @@ class CharacterProfile:
             lines.append("리스크 있는 옵션도 검토 가치가 있다면 제안하라.")
         if p.get("patience",       0.5) > 0.7:
             lines.append("단계적이고 차분한 설명으로 답하라.")
+        # ─── W3b 추가: 미반영 5 trait directives ───────────────────
+        if p.get("focus",          0.5) > 0.7:
+            lines.append("핵심 주제에 집중하고 곁가지 설명을 줄여라.")
+        if p.get("intuitive",      0.5) > 0.7:
+            lines.append("직관적 통찰과 비유로 빠르게 핵심을 전달하라.")
+        if p.get("independent",    0.5) > 0.7:
+            lines.append("독자적 판단으로 명확한 결론을 단정 제시하라.")
+        if p.get("collaborative",  0.5) > 0.7:
+            lines.append("사용자와의 합의를 통해 함께 답을 도출하는 톤을 유지하라.")
+        if p.get("boldness",       0.5) > 0.7:
+            lines.append("불확실해도 가장 가능성 높은 답을 적극적으로 제시하라.")
 
         # ─── 0.3 이하 (반대 방향) ─────────────────────────────────
         if p.get("caution",        0.5) < 0.3:
@@ -249,8 +299,35 @@ class CharacterProfile:
             lines.append("핵심 결론을 빠르게 전달하라.")
         if p.get("directness",     0.5) < 0.3:
             lines.append("우회적이고 부드러운 표현을 사용하라.")
+        # ─── W3b 추가: 미반영 5 trait 의 low-side directives ───────
+        if p.get("focus",          0.5) < 0.3:
+            lines.append("관련 주제로 자유롭게 확장하고 다양한 측면을 다뤄라.")
+        if p.get("intuitive",      0.5) < 0.3:
+            lines.append("근거 데이터와 단계적 추론에 기반해 답하라.")
+        if p.get("independent",    0.5) < 0.3:
+            lines.append("여러 출처와 관점을 종합해서 답하라.")
+        if p.get("collaborative",  0.5) < 0.3:
+            lines.append("자신의 결론을 우선 명시한 뒤 부연하라.")
+        if p.get("boldness",       0.5) < 0.3:
+            lines.append("확실한 부분만 단정하고 나머지는 가능성으로 제시하라.")
 
-        return " ".join(lines)
+        directives = " ".join(lines)
+
+        # ─── [W3b/P5d] 캐릭터 페르소나 블록 prepend ────────────────
+        # build_summary 의 3-line 자연어 요약을 system prompt 앞에 둔다 —
+        # LLM 이 응답 톤/스타일/가치관을 일관되게 유지하도록 identity 정보
+        # 부여. 룰 기반이라 빠르고 결정적.
+        summary = self.build_summary(p)
+        persona_block = (
+            "[캐릭터 페르소나] "
+            f"{summary['core']}. "
+            f"{summary['values']}. "
+            f"{summary['style']}."
+        )
+
+        if directives:
+            return f"{persona_block} [응답 지시] {directives}"
+        return persona_block
 
     # ─── 자연어 요약 (P5c, 2026-05-10) ─────────────────────────────
     # build_summary 는 16 trait 수치를 한국어 3-line 자연어 요약으로

--- a/tests/test_character_traits_correlations.py
+++ b/tests/test_character_traits_correlations.py
@@ -163,11 +163,12 @@ class SetTraitBehaviorTests(unittest.TestCase):
     def test_ripple_applied_to_correlated_targets(self):
         # boldness → risk_tolerance (+0.5). Pushing boldness up should
         # nudge risk_tolerance up by delta * weight * damping.
+        # [W3b 2026-05-10] damping 0.3 → 0.6 — nudge 도 비례하여 2x.
         p = self._fresh()
         old_rt = p._values["risk_tolerance"]
         out = p.set_trait("boldness", 0.8)
-        # delta = 0.8 - 0.3 = 0.5; nudge = 0.5 * 0.5 * 0.3 = 0.075
-        expected = round(min(1.0, old_rt + 0.075), 3)
+        # delta = 0.8 - 0.3 = 0.5; nudge = 0.5 * 0.5 * 0.6 = 0.15
+        expected = round(min(1.0, old_rt + 0.15), 3)
         self.assertAlmostEqual(p._values["risk_tolerance"], expected, places=2)
         # And must be reported in the ripples list.
         rt_ripples = [r for r in out["ripples"] if r["trait"] == "risk_tolerance"]

--- a/tests/test_character_w3b.py
+++ b/tests/test_character_w3b.py
@@ -1,0 +1,248 @@
+"""[W3b 2026-05-10, W1 진단 §1-C] character correlation 강화.
+
+W1 진단 결과 4가지 문제 fix:
+  1. damping=0.3 → 0.6 (사용자 체감 ripple 강화)
+  2. CORRELATIONS 15 → 28+ edges (incoming 보강)
+  3. prompt 미반영 5 trait (focus/intuitive/independent/collaborative/
+     boldness) directive 추가 — 슬라이더가 LLM 응답에 반영되도록
+  4. P5d: build_summary 결과를 [캐릭터 페르소나] 블록으로 prompt prepend
+
+Run:
+    python -m unittest tests.test_character_w3b
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.character_profile import (
+    CORRELATIONS, CharacterProfile, _CORR_INDEX, _RIPPLE_DAMPING,
+)
+
+
+def _fresh() -> CharacterProfile:
+    """DB I/O 없는 격리된 프로필 — 테스트 간 상태 격리용."""
+    with mock.patch.object(CharacterProfile, "_load", lambda self: None):
+        p = CharacterProfile()
+    p._save = lambda: None  # type: ignore
+    return p
+
+
+def _force(p: CharacterProfile, **kwargs):
+    """직접 dict 쓰기 — set_trait 의 ripple 우회 (단일 trait 격리 테스트용)."""
+    for k, v in kwargs.items():
+        p._values[k] = v
+
+
+# ─── 1. Damping 강화 ───────────────────────────────────────────────
+class DampingTests(unittest.TestCase):
+    def test_damping_increased_to_0_6(self):
+        # W1 진단: 0.3 으로는 ripple 변화량 < 0.05 라 사용자 눈에 안 보임.
+        # W3b 권고: 0.6 (또는 trait별 가중치). 여기서는 0.6 채택.
+        self.assertGreaterEqual(
+            _RIPPLE_DAMPING, 0.5,
+            f"damping {_RIPPLE_DAMPING} 너무 약함 — 사용자 체감 ripple "
+            "≥ 0.05 보장하려면 ≥ 0.5 (W1 §1-C)",
+        )
+
+    def test_damping_under_one(self):
+        # 1.0 이상은 cascade 폭주 위험 — 0.7 정도가 상한.
+        self.assertLess(_RIPPLE_DAMPING, 0.8,
+                        "damping 0.8+ 은 짝(1.0) 영향력에 근접 — 별개의 "
+                        "독립 trait 가 짝처럼 동작하게 됨")
+
+    def test_visible_ripple_with_new_damping(self):
+        # 실제 ripple 이 사용자 눈에 보이는 0.05 이상 변화를 만드는지 확인.
+        p = _fresh()
+        old_rt = p._values["risk_tolerance"]
+        # boldness → risk_tolerance (+0.5). delta=0.5 → nudge=0.5*0.5*0.6=0.15
+        p.set_trait("boldness", 0.8)
+        nudge = abs(p._values["risk_tolerance"] - old_rt)
+        self.assertGreaterEqual(
+            nudge, 0.05,
+            f"실제 nudge {nudge:.3f} < 0.05 — 사용자가 변화를 체감 못함",
+        )
+
+
+# ─── 2. Edges 확장 + 미반영 trait incoming 보강 ────────────────────
+class EdgeExpansionTests(unittest.TestCase):
+    def test_total_edges_expanded(self):
+        # W1 권고: 15 → 30~40. 이 PR 은 28 edges (점진적 확장).
+        self.assertGreaterEqual(
+            len(CORRELATIONS), 25,
+            f"edges 수 {len(CORRELATIONS)} — W1 §1-C 권고 30+ 달성 "
+            "권장 (최소 25 이상은 되어야 sparse 비판 해소)",
+        )
+
+    def test_focus_has_incoming(self):
+        # P1 미반영 5 trait 의 incoming 확인 — 슬라이더 변화에
+        # 자동 따라가도록.
+        incoming = [c for c in CORRELATIONS if c[1] == "focus"]
+        self.assertGreater(
+            len(incoming), 0,
+            "focus 가 incoming edge 없음 — 다른 trait 변화에 따라가지 못함",
+        )
+
+    def test_intuitive_has_incoming(self):
+        incoming = [c for c in CORRELATIONS if c[1] == "intuitive"]
+        self.assertGreater(len(incoming), 0)
+
+    def test_independent_has_incoming(self):
+        incoming = [c for c in CORRELATIONS if c[1] == "independent"]
+        self.assertGreater(len(incoming), 0)
+
+    def test_collaborative_has_incoming(self):
+        incoming = [c for c in CORRELATIONS if c[1] == "collaborative"]
+        self.assertGreater(len(incoming), 0)
+
+    def test_boldness_has_incoming(self):
+        incoming = [c for c in CORRELATIONS if c[1] == "boldness"]
+        self.assertGreater(len(incoming), 0)
+
+    def test_no_self_loops(self):
+        # 자기 자신을 가리키는 edge 는 의미 없음.
+        for src, tgt, w in CORRELATIONS:
+            self.assertNotEqual(src, tgt, f"self-loop: {src} → {tgt}")
+
+    def test_weights_in_valid_range(self):
+        for src, tgt, w in CORRELATIONS:
+            self.assertGreaterEqual(w, -1.0, f"{src}→{tgt} weight 범위 X")
+            self.assertLessEqual(w, 1.0, f"{src}→{tgt} weight 범위 X")
+            self.assertNotEqual(w, 0.0, f"{src}→{tgt} weight 0 — 의미 없는 edge")
+
+
+# ─── 3. Prompt directives — 미반영 5 trait 발화 ────────────────────
+class MissingTraitDirectivesTests(unittest.TestCase):
+    """W1 §1-C: focus/intuitive/independent/collaborative/boldness 가
+    이전엔 prompt directive 없었음 → 슬라이더 끝까지 올려도 LLM 응답
+    무영향. 이 PR 에서 high/low 양쪽 directive 추가."""
+
+    def _modifier_with(self, **traits) -> str:
+        p = _fresh()
+        _force(p, **traits)
+        return p.get_prompt_modifiers()
+
+    # ── high side (≥ 0.7) ───────────────────────────────────────
+    def test_high_focus_emits_directive(self):
+        out = self._modifier_with(focus=0.9)
+        self.assertIn("핵심 주제에 집중", out)
+
+    def test_high_intuitive_emits_directive(self):
+        out = self._modifier_with(intuitive=0.9)
+        # "직관" 키워드만 — 한국어 정확한 어휘는 미세조정 가능.
+        self.assertIn("직관", out)
+
+    def test_high_independent_emits_directive(self):
+        out = self._modifier_with(independent=0.9)
+        self.assertIn("독자적", out)
+
+    def test_high_collaborative_emits_directive(self):
+        out = self._modifier_with(collaborative=0.9)
+        self.assertIn("합의", out)
+
+    def test_high_boldness_emits_directive(self):
+        out = self._modifier_with(boldness=0.9)
+        self.assertIn("적극", out)
+
+    # ── low side (≤ 0.3) — 슬라이더 양 끝 모두 살아있게 ────────
+    def test_low_focus_emits_directive(self):
+        out = self._modifier_with(focus=0.1)
+        # "확장" 또는 "다양한 측면"
+        self.assertTrue("확장" in out or "다양한" in out,
+                        f"low focus directive 누락: {out}")
+
+    def test_low_intuitive_emits_directive(self):
+        out = self._modifier_with(intuitive=0.1)
+        self.assertIn("근거", out)
+
+    def test_low_independent_emits_directive(self):
+        out = self._modifier_with(independent=0.1)
+        self.assertIn("종합", out)
+
+    def test_low_collaborative_emits_directive(self):
+        out = self._modifier_with(collaborative=0.1)
+        # "결론을 우선 명시" 또는 비슷한
+        self.assertIn("결론", out)
+
+    def test_low_boldness_emits_directive(self):
+        out = self._modifier_with(boldness=0.1)
+        self.assertIn("가능성", out)
+
+
+# ─── 4. P5d: 캐릭터 페르소나 블록 prepend ──────────────────────────
+class PersonaBlockTests(unittest.TestCase):
+    """build_summary 결과가 prompt 앞에 [캐릭터 페르소나] 블록으로 합성."""
+
+    def test_default_includes_persona_block(self):
+        p = _fresh()
+        out = p.get_prompt_modifiers()
+        self.assertIn("[캐릭터 페르소나]", out,
+                      "P5d 페르소나 블록 헤더가 없음")
+
+    def test_persona_block_contains_summary_fields(self):
+        # 기본값: build_summary 가 "신중함·분석력이 두드러진 성격" 등
+        # 반환 → 그 텍스트가 prompt 안에 나타나야.
+        p = _fresh()
+        out = p.get_prompt_modifiers()
+        # 기본 trait 값 (caution=0.7, analytical=0.6) 으로 해당 라벨 출력 기대.
+        self.assertIn("신중함", out)
+        self.assertIn("분석력", out)
+
+    def test_directive_block_separated_from_persona(self):
+        # 둘 다 있을 때 [응답 지시] 헤더로 분리.
+        p = _fresh()
+        _force(p, caution=0.9)   # high → directive 발화
+        out = p.get_prompt_modifiers()
+        self.assertIn("[캐릭터 페르소나]", out)
+        self.assertIn("[응답 지시]", out)
+        # 페르소나가 directive 보다 앞에 와야.
+        self.assertLess(
+            out.index("[캐릭터 페르소나]"),
+            out.index("[응답 지시]"),
+        )
+
+    def test_no_directive_no_directive_header(self):
+        # 모든 trait 가 중간값(0.5) 이면 directive 0개 → 헤더 미발화.
+        p = _fresh()
+        for tid in p._values:
+            p._values[tid] = 0.5
+        out = p.get_prompt_modifiers()
+        self.assertIn("[캐릭터 페르소나]", out)
+        self.assertNotIn("[응답 지시]", out)
+
+
+# ─── 5. 통합 — 전체 ripple 시나리오 ─────────────────────────────────
+class IntegrationTests(unittest.TestCase):
+    def test_focus_responds_to_analytical_change(self):
+        # W3b 핵심 효과: analytical → focus (+0.40, damping 0.6)
+        # delta=0.5 → nudge = 0.5 * 0.4 * 0.6 = 0.12 (사용자 체감 가능).
+        p = _fresh()
+        old_focus = p._values["focus"]
+        # default: analytical=0.6 → 0.95 면 delta=0.35
+        p.set_trait("analytical", 0.95)
+        # 짝(intuitive) flip 도 일어남 (analytical 짝). focus 는 ripple 로.
+        new_focus = p._values["focus"]
+        self.assertGreater(
+            new_focus, old_focus,
+            "analytical 상승 시 focus 도 상승해야 (W3b incoming edge)",
+        )
+        # nudge ≥ 0.05 (visible)
+        self.assertGreaterEqual(new_focus - old_focus, 0.05)
+
+    def test_high_extreme_yields_persona_plus_directives(self):
+        # 극단 caution + analytical 조합 → 페르소나 + directive 양쪽 발화.
+        p = _fresh()
+        _force(p, caution=0.95, analytical=0.95, security=0.95)
+        out = p.get_prompt_modifiers()
+        self.assertIn("[캐릭터 페르소나]", out)
+        self.assertIn("[응답 지시]", out)
+        self.assertIn("확실한 정보만", out)
+        self.assertIn("논리적 근거", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
W1 진단 §1-C 권고 4 항목 일괄 fix. 사용자 체감 영향력 부족 + LLM 미반영 trait 문제 해소.

| 문제 (W1) | Fix |
|---|---|
| damping=0.3 너무 약함 (ripple < 0.05) | **0.3 → 0.6** |
| edges 15 — sparse | **15 → 28** (미반영 5 trait incoming 보강) |
| prompt 미반영 trait 5개 | focus/intuitive/independent/collaborative/boldness **high+low directives** (10 신규) |
| P5d 미구현 | **build_summary → [캐릭터 페르소나] 블록**으로 prompt prepend |

## Effect
이제 슬라이더 변화가 두 경로로 LLM 에 도달:
1. **즉시 prompt 반영**: trait extreme (≥0.7 or ≤0.3) → directive
2. **간접 ripple → prompt**: 다른 trait 의 변화가 자기 trait 도 같이 움직여 그 trait 이 extreme 진입 시 directive

예: \`analytical\` 0.6 → 0.95 →
- ripple로 \`focus\` 0.5 → 0.5 + (0.35 × 0.4 × 0.6) = 0.584 (slight)
- 짝(intuitive) 자동 1-flip
- \`directness\` 도 ripple 받음
- prompt 에 \"논리적 근거…\" + 페르소나 블록 합성

## Tests
- 신규 \`tests/test_character_w3b.py\` (27 tests) — damping/edges/directives/persona/통합
- 갱신 \`tests/test_character_traits_correlations.py\` — ripple expected 0.075→0.15
- 전체 회귀: **1149/1149 OK**

## Verification
브라우저 → /admin → 🎭 성향 캐릭터:
- [ ] analytical 슬라이더 드래그 → focus 가 **눈에 띄게** 따라 움직임 (이전엔 거의 안 움직였음)
- [ ] focus = 0.9 → /chat 응답이 핵심 집중 톤
- [ ] focus = 0.1 → 응답이 자유 확장 톤
- [ ] 캐릭터 요약 카드 텍스트가 그대로 LLM 응답 스타일에 반영되는지 확인 (P5d)

## Out of scope
- correlation graph 시각화 frontend (이미 #166 P5b 에서 자연어화 완료)
- damping 의 trait별 가중치 (단일 0.6 균일 적용 — 추후 W3c 검토)

## CLAUDE.md 통과
- Rule #1 도메인 추가 X ✅
- Rule #2 core/retrieval/graph 변경 X — bench 불필요 (character_profile 만) ✅
- Rule #5 character_profile.py 295→380 lines ≈ 14KB, 게이트 통과 ✅

Closes — W1 §1-C (#165 후속) + P5d (#166 out-of-scope).