### PR TITLE
chore(gitignore): cover wiki/media/prod + web_search_config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,15 @@ wiki/entity/prod/**/*.md
 # defense — entity/ 없이 prod 직속에 데이터를 넣는 경로도 차단
 # (구조 의도와 별개로 누수 가능 경로 막음).
 wiki/prod/
+# media (audio/video) 추출 산출물 — entity 와 동일한 사용자 데이터
+wiki/media/prod/
 # 메타 파일은 명시적으로 추적 — 카테고리 인덱스 / 폴더 보존용 .gitkeep
 !wiki/entity/prod/**/index.md
 !wiki/entity/prod/**/.gitkeep
+
+# 운영자 튜닝 가능한 런타임 설정 (web search role/threshold 등).
+# 코드 안에 안전한 기본값 존재 — 운영자별 오버라이드는 로컬에만.
+web_search_config.json
 
 # ── ML 모델 / 임베딩 캐시 ──────────────────────────────────────
 models/


### PR DESCRIPTION
## Summary

W7-hotfix (#168) pattern continuation. Two new local-only paths were showing as untracked in working tree:

- `wiki/media/prod/` — audio/video extraction artifacts (same user-data category as `wiki/entity/prod/`, just a new media subtree introduced after the original W7 pattern was set)
- `web_search_config.json` — operator-tunable runtime overrides (admin role allowlist + similarity threshold). Module already has safe defaults in `core/web_search_config.py`, so per-operator tuning belongs locally, not in the repo.

Same intent as #168: keep new data/config paths out of the public repo without relying on operators remembering to add ignores manually.

## Verification

- [x] `git status` clean after applying ignore (verified locally — both untracked entries disappear)
- [x] No code change, no behavior change
- [x] Defaults in `core/web_search_config.py` cover the missing-file path (`_DEFAULTS` block); first-run servers behave identically

## Out of scope

- No changes to `core/retrieval`, `core/graph`, or `core/reasoning` → bench paste not required (CLAUDE.md rule 2)
- Not a domain feature (CLAUDE.md rule 1) ✅
- Not a self-evolution change (rule 3) ✅
- Not an architecture change (rule 4) ✅
- Module size N/A (rule 5) ✅