### PR TITLE
feat(auth): bcrypt password hashing + transparent legacy migration (W4 P1-A)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -1,5 +1,5 @@
 """
-PROJECT JAMES - JWT 인증 모듈 (Phase 4)
+PROJECT JAMES - JWT 인증 모듈 (Phase 4 + W4 P1-A)
 
 Phase 4 변경:
   [P4-AUTH-1] USER_DB → SQLite 영구화
@@ -9,6 +9,13 @@ Phase 4 변경:
   [P4-AUTH-2] X-Role 개발용 헤더 → 운영 모드에서 비활성화 설정 추가
 
 JWT_SECRET는 Phase 3.5에서 이미 환경변수화 완료 (os.environ.get)
+
+W4 P1-A 변경 (2026-05-11):
+  비밀번호 해시 SHA256(salt 없음, rainbow-table 취약) → bcrypt.
+  password_hash 컬럼에 알고리즘 prefix(`bcrypt$...`)를 두고, prefix 가
+  없는 64-char hex 는 legacy SHA256 으로 인식한다. 로그인 성공 시점에
+  legacy → bcrypt 로 transparent rehash 가 일어나므로 운영 중단 없이
+  점진 마이그레이션 된다. signup endpoint 와 비번 정책은 별도 PR(P1-B).
 """
 
 import os
@@ -18,6 +25,7 @@ import hmac
 import json
 import time
 import base64
+import bcrypt
 from typing import Optional, Dict
 from pathlib import Path
 
@@ -60,8 +68,54 @@ try:
 except ImportError:
     _DB_PATH = "james_users.db"
 
-def _hash_password(pw: str) -> str:
+def _hash_sha256_legacy(pw: str) -> str:
+    """[LEGACY, W4 P1-A] Pre-W4 unsalted SHA256 hex digest.
+
+    Kept only so verify_password() can authenticate accounts created
+    before bcrypt migration. New hashes always go through hash_password().
+    Do not call this from new code.
+    """
     return hashlib.sha256(pw.encode()).hexdigest()
+
+
+def hash_password(pw: str) -> str:
+    """bcrypt with algorithm prefix.
+
+    Format: ``bcrypt$<bcrypt-output>``. The prefix lets verify_password()
+    distinguish from pre-W4 SHA256 hex (no prefix, 64-char) and from any
+    future algorithm without ambiguity.
+    """
+    h = bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt())
+    return "bcrypt$" + h.decode("utf-8")
+
+
+def verify_password(pw: str, stored: str) -> bool:
+    """Verify a password against a stored hash.
+
+    Handles both the new ``bcrypt$...`` form and the legacy unsalted
+    SHA256 hex (exactly 64 hex chars, no prefix). Returns False on any
+    parse error rather than raising — callers treat that as
+    authentication failure.
+    """
+    if not stored:
+        return False
+    if stored.startswith("bcrypt$"):
+        try:
+            return bcrypt.checkpw(pw.encode("utf-8"), stored[7:].encode("utf-8"))
+        except Exception:
+            return False
+    if len(stored) == 64 and all(c in "0123456789abcdef" for c in stored):
+        return hmac.compare_digest(_hash_sha256_legacy(pw), stored)
+    return False
+
+
+# Backward-compat alias. External callers (and existing tests) imported
+# `_hash_password`; the name is preserved but now produces a bcrypt hash.
+# Anyone comparing the return value byte-for-byte against another call
+# will break (bcrypt salts every output); they should switch to
+# verify_password(). Tracked for cleanup once those callers migrate.
+_hash_password = hash_password
+
 
 def _get_conn() -> sqlite3.Connection:
     conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
@@ -206,6 +260,29 @@ def verify_token(token: str) -> Optional[Dict]:
 
 # ─── 인증 ────────────────────────────────────────────────────
 
+def _rehash_to_bcrypt(username: str, password: str) -> None:
+    """Replace a legacy SHA256 hash with bcrypt on a verified login.
+
+    Best-effort: any DB error is logged but does not block the login
+    (the user has already authenticated successfully). Re-running this
+    on subsequent logins is harmless — verify_password() will see the
+    bcrypt prefix and skip migration entirely.
+    """
+    new_hash = hash_password(password)
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?",
+            (new_hash, username),
+        )
+        conn.commit()
+        print(f"[AUTH] legacy SHA256 → bcrypt rehashed: {username}")
+    except Exception as e:
+        print(f"[AUTH] bcrypt 마이그레이션 실패 (로그인은 성공): {e}")
+    finally:
+        conn.close()
+
+
 def authenticate(username: str, password: str) -> Optional[Dict]:
     """로그인 → SQLite 조회 → token 반환"""
     user = _get_user(username)
@@ -216,10 +293,13 @@ def authenticate(username: str, password: str) -> Optional[Dict]:
         print(f"[AUTH] 비활성 계정: {username}")
         return None
 
-    pw_hash = _hash_password(password)
-    if not hmac.compare_digest(pw_hash, user["password_hash"]):
+    stored = user["password_hash"]
+    if not verify_password(password, stored):
         print(f"[AUTH] 비밀번호 불일치: {username}")
         return None
+
+    if not stored.startswith("bcrypt$"):
+        _rehash_to_bcrypt(username, password)
 
     role  = user["role"]
     token = create_token(username, role)

--- a/tests/test_password_bcrypt.py
+++ b/tests/test_password_bcrypt.py
@@ -1,0 +1,179 @@
+"""W4 P1-A — bcrypt password hashing + transparent legacy migration.
+
+Coverage:
+  - ``hash_password`` returns the ``bcrypt$...`` envelope and round-trips
+    through ``verify_password``.
+  - ``verify_password`` accepts a pre-W4 unsalted SHA256 hex digest (the
+    on-disk format every existing account uses).
+  - ``verify_password`` rejects malformed input rather than raising.
+  - ``authenticate()`` succeeds against a SHA256-seeded row and
+    transparently rewrites that row to bcrypt on the way out — so the
+    next login uses the strong hash without operator action.
+
+Run:
+  python -m unittest tests.test_password_bcrypt
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Set JWT secret BEFORE importing core.auth — the module's import-time
+# guard rejects a missing/short secret with RuntimeError.
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-bcrypt-suite-32chars-min",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core import auth as auth_mod  # noqa: E402
+
+
+def _seed_legacy_row(path: str, username: str, password: str, role: str = "admin") -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute(
+        "INSERT OR REPLACE INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        (username, hashlib.sha256(password.encode()).hexdigest(), role),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_hash(path: str, username: str) -> str:
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(
+            "SELECT password_hash FROM users WHERE username = ?", (username,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+class HashRoundTripTests(unittest.TestCase):
+    def test_bcrypt_envelope_and_verify(self):
+        h = auth_mod.hash_password("correct_password_42")
+        self.assertTrue(h.startswith("bcrypt$"),
+                        f"expected bcrypt$ envelope, got {h[:20]!r}")
+        self.assertTrue(auth_mod.verify_password("correct_password_42", h))
+
+    def test_bcrypt_rejects_wrong_password(self):
+        h = auth_mod.hash_password("right_one")
+        self.assertFalse(auth_mod.verify_password("wrong_one", h))
+
+    def test_bcrypt_unicode_password(self):
+        h = auth_mod.hash_password("한글_비밀번호_42")
+        self.assertTrue(auth_mod.verify_password("한글_비밀번호_42", h))
+        self.assertFalse(auth_mod.verify_password("한글_비밀번호_43", h))
+
+    def test_two_hashes_of_same_password_differ(self):
+        # bcrypt salts every call — same password must produce different
+        # hashes (otherwise the salt isn't doing its job).
+        a = auth_mod.hash_password("same_password")
+        b = auth_mod.hash_password("same_password")
+        self.assertNotEqual(a, b)
+        self.assertTrue(auth_mod.verify_password("same_password", a))
+        self.assertTrue(auth_mod.verify_password("same_password", b))
+
+
+class LegacySha256AcceptanceTests(unittest.TestCase):
+    """Existing accounts on disk were stored as raw SHA256 hex. The
+    verifier must accept that form so logins don't break the day this
+    PR ships — migration happens later, on successful login."""
+
+    def test_verify_accepts_legacy_sha256(self):
+        legacy = hashlib.sha256(b"oldpw").hexdigest()
+        self.assertTrue(auth_mod.verify_password("oldpw", legacy))
+
+    def test_verify_rejects_wrong_password_against_legacy(self):
+        legacy = hashlib.sha256(b"oldpw").hexdigest()
+        self.assertFalse(auth_mod.verify_password("not_oldpw", legacy))
+
+    def test_verify_handles_empty_or_garbage_stored(self):
+        # Defensive: bad rows must not raise. Authentication path
+        # treats this as "deny" — never crash the request.
+        self.assertFalse(auth_mod.verify_password("any", ""))
+        self.assertFalse(auth_mod.verify_password("any", "not-a-hash"))
+        self.assertFalse(auth_mod.verify_password("any", "bcrypt$garbage"))
+
+
+class TransparentMigrationTests(unittest.TestCase):
+    """authenticate() must rewrite legacy rows to bcrypt on first
+    successful login, with zero operator action and zero user-visible
+    disruption. This is the core W4 P1-A promise."""
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.path = self._tmp.name
+        _seed_legacy_row(self.path, "admin", "oldpw", "admin")
+        # Point the module at our temp DB. Restored in tearDown.
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.path
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.path).unlink(missing_ok=True)
+
+    def test_login_with_legacy_password_succeeds(self):
+        result = auth_mod.authenticate("admin", "oldpw")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["role"], "admin")
+        self.assertEqual(result["username"], "admin")
+        self.assertIn("token", result)
+
+    def test_legacy_row_rewritten_to_bcrypt_on_success(self):
+        before = _read_hash(self.path, "admin")
+        self.assertEqual(len(before), 64,
+                         "test setup must seed a 64-char SHA256 hex digest")
+
+        result = auth_mod.authenticate("admin", "oldpw")
+        self.assertIsNotNone(result)
+
+        after = _read_hash(self.path, "admin")
+        self.assertTrue(after.startswith("bcrypt$"),
+                        f"row should now be bcrypt, got {after[:20]!r}")
+        # New password still verifies (we did not change the password,
+        # only the stored representation).
+        self.assertTrue(auth_mod.verify_password("oldpw", after))
+
+    def test_second_login_does_not_re_rehash(self):
+        # First login migrates. Second login should see bcrypt$ and
+        # leave the row alone.
+        self.assertIsNotNone(auth_mod.authenticate("admin", "oldpw"))
+        first = _read_hash(self.path, "admin")
+        self.assertIsNotNone(auth_mod.authenticate("admin", "oldpw"))
+        second = _read_hash(self.path, "admin")
+        # Same bcrypt hash both times — no churn.
+        self.assertEqual(first, second,
+                         "post-migration logins must NOT re-hash; that "
+                         "would invalidate stable equality checks and "
+                         "increase needless write load")
+
+    def test_failed_login_does_not_migrate(self):
+        before = _read_hash(self.path, "admin")
+        self.assertIsNone(auth_mod.authenticate("admin", "wrong_password"))
+        after = _read_hash(self.path, "admin")
+        self.assertEqual(before, after,
+                         "rehash must only happen on a verified login")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reset_password.py
+++ b/tests/test_reset_password.py
@@ -1,16 +1,18 @@
 """tools/admin/reset_password.py — unit tests + auth.py compatibility.
 
 Coverage:
-  - `hash_password` produces byte-identical output to
-    `core.auth._hash_password` (so a reset row will authenticate
-    correctly via the existing `authenticate()` flow).
-  - `reset_password()` updates an existing row in a temp DB.
-  - `reset_password()` refuses to create a new user (the silent-mint
+  - The script's hash format is *verifier-compatible* with
+    ``core.auth.verify_password`` (W4 P1-A: bcrypt salts every output,
+    so byte equality is no longer meaningful — round-trip through the
+    verifier is).
+  - ``reset_password()`` updates an existing row in a temp DB and the
+    new password authenticates through ``core.auth.verify_password``.
+  - ``reset_password()`` refuses to create a new user (the silent-mint
     footgun the script's docstring promises to avoid).
-  - `main()` returns the documented exit codes:
+  - ``main()`` returns the documented exit codes:
       0 success / 1 generic / 2 no-such-user / 3 cancelled
   - End-to-end: reset password via main() then verify via the same
-    sha256 the auth path uses.
+    path the auth module uses.
 
 Run:
   python -m unittest tests.test_reset_password
@@ -70,19 +72,32 @@ def _row(path: str, username: str) -> dict | None:
 
 
 class HashCompatibilityTests(unittest.TestCase):
-    """The script-side hash MUST match what authenticate() expects.
-    A drift here would silently lock the user out — fail loudly."""
+    """The script's hash MUST authenticate through core.auth.verify_password.
+    bcrypt salts every output, so we round-trip rather than compare bytes —
+    a drift in *format* (prefix, encoding, algorithm) would silently lock
+    the user out. Fail loudly on that."""
 
-    def test_hash_byte_identical_to_auth_module(self):
+    def test_script_hash_verifies_via_auth_module(self):
         from tools.admin.reset_password import hash_password
-        from core.auth import _hash_password as auth_hash
-        for pw in ("simple", "한글비밀번호", "abc!@#$%^&*()_+",
-                   "long" * 200, ""):
-            self.assertEqual(
-                hash_password(pw), auth_hash(pw),
-                f"hash mismatch for password {pw[:20]!r}; resetting "
+        from core.auth import verify_password
+        # 한글 + emoji + symbols + boundary lengths. Empty string is
+        # excluded — the script's CLI rejects it (and bcrypt accepts it
+        # in principle, but the policy is "non-empty").
+        for pw in ("simple", "한글비밀번호", "abc!@#$%^&*()_+", "long" * 17):
+            h = hash_password(pw)
+            self.assertTrue(h.startswith("bcrypt$"),
+                            f"expected bcrypt$ prefix, got {h[:20]!r}")
+            self.assertTrue(
+                verify_password(pw, h),
+                f"reset hash for {pw[:20]!r} did not verify — resetting "
                 f"would lock the user out of the real authenticate() path",
             )
+
+    def test_script_hash_rejects_wrong_password(self):
+        from tools.admin.reset_password import hash_password
+        from core.auth import verify_password
+        h = hash_password("right_password_42")
+        self.assertFalse(verify_password("wrong_password_42", h))
 
 
 class ResetPasswordCoreTests(unittest.TestCase):
@@ -96,12 +111,17 @@ class ResetPasswordCoreTests(unittest.TestCase):
         Path(self.path).unlink(missing_ok=True)
 
     def test_existing_user_password_updated(self):
-        from tools.admin.reset_password import reset_password, hash_password
+        from tools.admin.reset_password import reset_password
+        from core.auth import verify_password
         ok = reset_password(self.path, "admin", "new_secret_pw_42")
         self.assertTrue(ok)
         row = _row(self.path, "admin")
-        self.assertEqual(row["password_hash"], hash_password("new_secret_pw_42"),
-                         "row hash must match the new password")
+        # bcrypt: salt-randomized → can't compare bytes. Verify instead.
+        self.assertTrue(row["password_hash"].startswith("bcrypt$"))
+        self.assertTrue(
+            verify_password("new_secret_pw_42", row["password_hash"]),
+            "post-reset hash must verify against the new password",
+        )
 
     def test_nonexistent_user_refused(self):
         from tools.admin.reset_password import reset_password
@@ -199,17 +219,23 @@ class EndToEndAuthCompatTests(unittest.TestCase):
 
     def test_reset_then_authenticate_with_new_pw_succeeds(self):
         from tools.admin.reset_password import reset_password
-        from core.auth import _hash_password as auth_hash
+        from core.auth import verify_password
 
         new_pw = "fresh_password_42"
         self.assertTrue(reset_password(self.path, "admin", new_pw))
 
-        # Simulate the comparison core.auth.authenticate makes:
-        #   hmac.compare_digest(_hash_password(input), row.password_hash)
+        # Mirror what core.auth.authenticate does internally:
+        #   verify_password(input, row.password_hash)
         row = _row(self.path, "admin")
-        self.assertEqual(auth_hash(new_pw), row["password_hash"],
-                         "post-reset hash must match auth.authenticate's "
-                         "comparison; otherwise the user is still locked out")
+        self.assertTrue(
+            verify_password(new_pw, row["password_hash"]),
+            "post-reset hash must verify against auth.authenticate's "
+            "comparison; otherwise the user is still locked out",
+        )
+        # And the previous (legacy SHA256 of "oldpw") seed no longer
+        # passes — proving the row was actually rewritten, not just
+        # double-written.
+        self.assertFalse(verify_password("oldpw", row["password_hash"]))
 
 
 if __name__ == "__main__":

--- a/tools/admin/reset_password.py
+++ b/tools/admin/reset_password.py
@@ -32,9 +32,11 @@ Usage
 
 Hash compatibility
 ------------------
-The hash is `sha256(pw.encode()).hexdigest()` — identical to
-`core.auth._hash_password`. A regression test asserts byte-for-byte
-parity (see `tests/test_reset_password.py::HashCompatibilityTests`).
+The hash format is ``bcrypt$<bcrypt-output>``, identical to
+``core.auth.hash_password`` (W4 P1-A, 2026-05-11). bcrypt salts every
+output, so the regression test asserts *verification* parity (a hash
+produced here authenticates through ``core.auth.verify_password``),
+not byte-for-byte equality.
 
 Exit codes:
   0  — password updated successfully
@@ -46,11 +48,12 @@ from __future__ import annotations
 
 import argparse
 import getpass
-import hashlib
 import os
 import sqlite3
 import sys
 from pathlib import Path
+
+import bcrypt
 
 # Korean prints below; cp949 default Windows consoles crash on emoji
 # without this. Same helper PR #36 wires into the server.
@@ -63,13 +66,14 @@ except Exception:
 
 
 def hash_password(pw: str) -> str:
-    """Identical algorithm to core.auth._hash_password.
+    """Identical format to core.auth.hash_password (W4 P1-A).
 
     Replicated here (not imported) so this script stays standalone —
-    importing core.auth triggers `_init_db()` as a side effect, which
+    importing core.auth triggers ``_init_db()`` as a side effect, which
     is undesirable for a one-shot maintenance tool.
     """
-    return hashlib.sha256(pw.encode()).hexdigest()
+    h = bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt())
+    return "bcrypt$" + h.decode("utf-8")
 
 
 def _default_db_path() -> str:


### PR DESCRIPTION
## Summary

Pre-W4 password storage was an unsalted SHA256 hex digest — vulnerable to rainbow-table lookup and modern GPU brute force. This PR introduces bcrypt as the new format and migrates existing rows transparently on next successful login. No operator action required, no user-visible step added.

### Format change

\`password_hash\` now carries an algorithm envelope:
- \`bcrypt\$<bcrypt-output>\` — new accounts + migrated accounts
- 64 hex chars, no prefix — pre-W4 legacy, accepted on input only and rewritten on first login

\`verify_password()\` handles both. \`authenticate()\` detects the legacy form and rewrites the row to bcrypt after the user's password is verified — exactly once per account.

### What it covers

**core/auth.py**
- \`hash_password\` / \`verify_password\` — new public API
- \`_hash_sha256_legacy\` — kept solely as the verifier path for old rows (not for new writes)
- \`_rehash_to_bcrypt\` — best-effort UPDATE on successful legacy login
- \`authenticate()\` — uses \`verify_password\` + triggers rehash on legacy hit
- \`_hash_password\` alias preserved (now produces bcrypt) so reset tools and existing tests keep working without import churn

**tools/admin/reset_password.py**
- Standalone (still does not import core.auth) but produces the bcrypt envelope
- Docstring updated; byte-equality claim replaced with verification parity

**tests/test_reset_password.py**
- Byte-equality assertions → \`verify_password\` round-trip
- Added: post-reset hash must verify; previous seed password must NOT

**tests/test_password_bcrypt.py (new)** — 11 tests
- bcrypt envelope + round-trip + unicode + salt-uniqueness
- Legacy SHA256 acceptance + garbage-row defense
- \`authenticate()\` success path against a legacy row
- Row is rewritten to \`bcrypt\$\` on success — and only on success
- Second login does not re-rehash (no write churn)

### Scope deliberately limited

This is **P1-A of W4 (Phase 1)**. It does NOT add signup, password policy validation, or the admin approval UI — those are P1-B. Splitting reduces blast radius on a security-critical change: the migration logic lands first, runs against existing accounts, and can be observed before any new entry point opens.

## Verification

\`\`\`
python -m unittest discover tests
Ran 1133 tests in 32.899s
OK
\`\`\`

21 of those are auth-related (\`test_password_bcrypt\` + \`test_reset_password\`); all previously-passing login + admin password-eye tests remain green.

## Out of scope

- POST /signup/ endpoint — P1-B (next PR)
- Password policy (length / complexity) — P1-B
- Admin pending-user approval UI — P2
- API key rotation — P3
- Removing the \`_hash_password\` alias — kept for backward compat this cycle; can drop in P2/P3 once all callers migrate

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — does not touch \`core/retrieval\`, \`core/graph\`, or \`core/reasoning\`. \`core/auth.py\` only.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) ✅ — no new module, no new trust zone; same Authentication boundary, stronger hash.
- Rule 5 (file size) ✅ — core/auth.py 239 → ~310 lines, well below 20 KB.