### PR TITLE
feat(auth): POST /signup/ + password/username policy (W4 P1-B)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,8 +50,30 @@ JAMES implements defense-in-depth across the RAG pipeline.
 
 - JWT tokens with HS256 signing
 - 8-hour expiration (configurable via `JWT_EXPIRE` in `core/auth.py`)
-- Rate limiting: 30 requests / 60 seconds per user
+- Passwords stored as **bcrypt** (W4 P1-A, 2026-05-11) with an
+  algorithm envelope (`bcrypt$...`). Pre-W4 unsalted SHA256 hex
+  digests are accepted on input only and rewritten to bcrypt on the
+  next successful login (transparent migration).
+- Rate limiting: 30 requests / 60 seconds per IP across
+  `/query/`, `/upload/`, `/login/`, `/signup/`
 - Full audit log in SQLite (every request, decision, denial)
+
+### Account creation (W4 P1-B)
+
+- `POST /signup/` is public and creates a row with `active=0`,
+  `role=external`. The account cannot log in until an admin approves
+  and assigns a role.
+- Success and duplicate produce the same 200 response body — an
+  anonymous caller cannot enumerate existing usernames through this
+  endpoint. The audit log distinguishes (`signup_pending` vs
+  `signup_rejected_duplicate`) for operator review.
+- Password policy: 8..72 characters (72 = bcrypt input window),
+  must contain at least one letter and one digit. Korean and other
+  unicode letters count. The 72-char ceiling is a hard reject rather
+  than silent truncation so two long passwords cannot ever collide.
+- Username policy: 3..32 characters, lowercase + digits + `_-` only.
+  Case-folding collisions (`Admin` vs `admin`) are blocked at signup,
+  not at login.
 
 ---
 

--- a/core/auth.py
+++ b/core/auth.py
@@ -19,6 +19,7 @@ W4 P1-A 변경 (2026-05-11):
 """
 
 import os
+import re
 import sqlite3
 import hashlib
 import hmac
@@ -26,7 +27,8 @@ import json
 import time
 import base64
 import bcrypt
-from typing import Optional, Dict
+from dataclasses import dataclass
+from typing import Optional, Dict, Tuple
 from pathlib import Path
 
 # .env 자동 로드 보장 (config 모듈이 import 시점에 .env 파싱하여
@@ -204,6 +206,116 @@ def deactivate_user(username: str) -> bool:
         conn.execute("UPDATE users SET active = 0 WHERE username = ?", (username,))
         conn.commit()
         return conn.total_changes > 0
+    finally:
+        conn.close()
+
+
+# ─── W4 P1-B: self-service signup + policy validation ─────────
+
+# Hard upper bound chosen to match bcrypt's native 72-byte input window.
+# Above that, bcrypt silently truncates — two distinct longer passwords
+# would hash to the same value. Rejecting >72 keeps the verifier
+# semantically honest. Lower bound 8 mirrors OWASP minimum and the
+# reset_password CLI's pre-existing policy.
+PASSWORD_MIN_LEN = 8
+PASSWORD_MAX_LEN = 72
+USERNAME_MIN_LEN = 3
+USERNAME_MAX_LEN = 32
+USERNAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+
+def validate_password_policy(pw: str) -> Optional[str]:
+    """Return None if the password is acceptable, else a user-visible
+    Korean error message. Policy is deliberately public — the error
+    text can be shown to anonymous callers without leaking anything.
+
+    Rules:
+      - 8..72 characters (72 = bcrypt input window, see constant above)
+      - must contain at least one letter and at least one digit
+        (case + symbols not required, sacrificing some entropy for
+        usability and Korean-keyboard reality)
+    """
+    if not isinstance(pw, str):
+        return "비밀번호는 문자열이어야 합니다."
+    if len(pw) < PASSWORD_MIN_LEN:
+        return f"비밀번호는 최소 {PASSWORD_MIN_LEN}자 이상이어야 합니다."
+    if len(pw) > PASSWORD_MAX_LEN:
+        return f"비밀번호는 최대 {PASSWORD_MAX_LEN}자까지 허용됩니다."
+    has_alpha = any(c.isalpha() for c in pw)
+    has_digit = any(c.isdigit() for c in pw)
+    if not (has_alpha and has_digit):
+        return "비밀번호는 영문과 숫자를 각각 한 글자 이상 포함해야 합니다."
+    return None
+
+
+def validate_username(name: str) -> Optional[str]:
+    """Return None if the username is acceptable, else a Korean message.
+
+    Lowercase is enforced (not just preferred) so ``Admin`` and ``admin``
+    can never coexist — the schema has no case-insensitive PK and we'd
+    rather fail at signup than discover the collision at login.
+    """
+    if not isinstance(name, str):
+        return "사용자명은 문자열이어야 합니다."
+    if len(name) < USERNAME_MIN_LEN or len(name) > USERNAME_MAX_LEN:
+        return f"사용자명은 {USERNAME_MIN_LEN}~{USERNAME_MAX_LEN}자여야 합니다."
+    if not USERNAME_PATTERN.match(name):
+        return ("사용자명은 영문 소문자·숫자·하이픈(-)·언더스코어(_) "
+                "만 사용할 수 있습니다.")
+    return None
+
+
+@dataclass(frozen=True)
+class SignupResult:
+    """Outcome of a signup attempt.
+
+    The server collapses ``ok`` and ``duplicate`` into the same response
+    body so an anonymous caller cannot probe which usernames exist.
+    The status field exists for audit logging, not for the response.
+    """
+    status: str                # "ok" | "duplicate" | "policy"
+    error:  Optional[str] = None   # populated only when status == "policy"
+
+
+def signup(username: str, password: str) -> SignupResult:
+    """Create a pending user row (active=0, role=external).
+
+    - Validates username + password against the public policy.
+    - Refuses duplicates by silently leaving the existing row alone
+      (the caller will report success either way — see SignupResult).
+    - Never raises; DB failures are logged and reported as policy errors
+      so the endpoint can return a 400, not a 500.
+    """
+    pw_err = validate_password_policy(password)
+    if pw_err is not None:
+        return SignupResult(status="policy", error=pw_err)
+    name_err = validate_username(username)
+    if name_err is not None:
+        return SignupResult(status="policy", error=name_err)
+
+    conn = _get_conn()
+    try:
+        existing = conn.execute(
+            "SELECT 1 FROM users WHERE username = ?", (username,)
+        ).fetchone()
+        if existing:
+            return SignupResult(status="duplicate")
+
+        conn.execute(
+            "INSERT INTO users (username, password_hash, role, active) "
+            "VALUES (?, ?, ?, 0)",
+            (username, hash_password(password), "external"),
+        )
+        conn.commit()
+        return SignupResult(status="ok")
+    except sqlite3.IntegrityError:
+        # Race: another request inserted the same username between the
+        # SELECT and the INSERT. Treat as duplicate (the safe answer).
+        return SignupResult(status="duplicate")
+    except Exception as e:
+        print(f"[AUTH] signup DB 오류: {e}")
+        return SignupResult(status="policy",
+                            error="가입 처리 중 오류가 발생했습니다.")
     finally:
         conn.close()
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,6 +112,37 @@ another's internals.
 Anything labeled **low** must pass `extract_data_only()` before
 joining the LLM context.
 
+### 5.1 Account states (W4 P1-B, 2026-05-11)
+
+Authentication has three identity states. A request's role only
+materializes once it reaches **authenticated**; the earlier states
+exist so that account creation and admin review have explicit,
+auditable transitions.
+
+```
+anonymous (no token)
+   │  POST /signup/ — public, rate-limited
+   ▼
+pending (DB row, active=0, role=external)
+   │  admin approval + role assignment (W4 P2, upcoming)
+   ▼
+authenticated (active=1, role ∈ {admin, manager, employee, external})
+```
+
+Invariants:
+
+- `authenticate()` returns `None` for any row with `active=0`. A
+  pending account cannot be probed by repeated login attempts to
+  learn whether the username exists — `/login/` returns 401 in either
+  case (no row vs. row-but-pending).
+- `/signup/` collapses success and duplicate into the same 200 body.
+  An anonymous caller cannot enumerate usernames through it.
+- Password policy violations bypass that collapse and return 400 —
+  the rule text itself is public and leaks nothing about accounts.
+- Pending rows always hold `role=external` regardless of what the
+  signer requested. Role assignment happens in the admin approval
+  flow, never at signup time.
+
 ---
 
 ## 5.5 PolicyEngine (single source of policy decisions)

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -35,7 +35,10 @@ from typing import Optional
 from config import UPLOAD_DIR, WIKI_DIR, CHROMA_DIR, API_KEY, MAX_UPLOAD_BYTES
 from core.graph_rag_engine import RAGEngine
 from core.feedback_engine import FeedbackEngine
-from core.auth import authenticate, get_role_from_token, add_user, ALLOWED_ROLES, DEV_MODE
+from core.auth import (
+    authenticate, get_role_from_token, add_user, ALLOWED_ROLES, DEV_MODE,
+    signup as _auth_signup, SignupResult,
+)
 from core.policy_engine import default_engine
 from processors.file_processor import FileProcessor
 
@@ -349,6 +352,18 @@ class LoginResponse(BaseModel):
     role:         str
     username:     str
 
+# W4 P1-B — self-service signup.
+class SignupRequest(BaseModel):
+    username: str
+    password: str
+
+class SignupResponse(BaseModel):
+    ok:      bool
+    # Identical message for success and duplicate (enumeration defense).
+    # Policy-violation responses populate this with the specific reason
+    # and return HTTP 400 instead of 200.
+    message: str
+
 class QueryRequest(BaseModel):
     api_key:          str
     question:         str
@@ -440,8 +455,9 @@ async def rate_limit_middleware(request: Request, call_next):
     ip = get_client_ip(request)
     endpoint = request.url.path
 
-    # 체크 필요한 엔드포인트만
-    if endpoint in ("/query/", "/upload/", "/login/"):
+    # 체크 필요한 엔드포인트만. /signup/ 도 unauthenticated 표적이라
+    # 같은 IP-window 로 brute-force 시도를 차단한다.
+    if endpoint in ("/query/", "/upload/", "/login/", "/signup/"):
         if not _rate_limiter.check(ip, endpoint):
             remaining = _rate_limiter.remaining(ip)
             _write_audit(
@@ -475,6 +491,44 @@ async def login(data: LoginRequest, request: Request):
     # access_token 필드 추가 (프론트엔드 호환)
     result["access_token"] = result.get("token", "")
     return result
+
+
+# W4 P1-B — self-service signup. Creates a pending (active=0,
+# role=external) row. An admin must approve and assign a role before
+# the account can log in. The endpoint never reveals whether a username
+# already exists: success and duplicate share one response body and
+# both return 200. Only policy violations get a distinct 400.
+_SIGNUP_ACCEPTED_MSG = "가입 요청이 접수되었습니다. 관리자 승인 후 사용 가능합니다."
+
+@app.post("/signup/", response_model=SignupResponse,
+          summary="회원가입 신청 (관리자 승인 후 활성화)")
+async def signup(data: SignupRequest, request: Request):
+    ip     = get_client_ip(request)
+    result = _auth_signup(data.username, data.password)
+
+    if result.status == "policy":
+        _write_audit(
+            "anonymous", "/signup/", query=data.username,
+            security_event=f"signup_rejected_policy: {result.error}",
+            ip_address=ip,
+        )
+        # Policy reasons are deliberately public — the rule itself does
+        # not leak account existence, only the rule.
+        raise HTTPException(status_code=400, detail=result.error)
+
+    if result.status == "duplicate":
+        # Audit log distinguishes; the response intentionally does not.
+        _write_audit(
+            "anonymous", "/signup/", query=data.username,
+            security_event="signup_rejected_duplicate", ip_address=ip,
+        )
+    else:  # "ok"
+        _write_audit(
+            "anonymous", "/signup/", query=data.username,
+            security_event="signup_pending", ip_address=ip,
+        )
+
+    return SignupResponse(ok=True, message=_SIGNUP_ACCEPTED_MSG)
 
 
 @app.post("/upload/", response_model=UploadResponse, summary="파일 업로드 (admin 전용)")

--- a/tests/test_password_policy.py
+++ b/tests/test_password_policy.py
@@ -1,0 +1,112 @@
+"""W4 P1-B — password + username policy validation.
+
+Covers the pure-function policy validators in ``core.auth`` so the
+signup endpoint test can focus on the HTTP shape and not re-verify
+every policy edge case.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-policy-suite-32chars-min",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.auth import (  # noqa: E402
+    validate_password_policy,
+    validate_username,
+    PASSWORD_MIN_LEN,
+    PASSWORD_MAX_LEN,
+    USERNAME_MIN_LEN,
+    USERNAME_MAX_LEN,
+)
+
+
+class PasswordPolicyTests(unittest.TestCase):
+    def test_accepts_minimum_acceptable(self):
+        # 8 chars, letter + digit
+        self.assertIsNone(validate_password_policy("abcd1234"))
+
+    def test_accepts_long_within_bcrypt_window(self):
+        pw = "a" * 70 + "12"
+        self.assertEqual(len(pw), 72)
+        self.assertIsNone(validate_password_policy(pw))
+
+    def test_rejects_too_short(self):
+        msg = validate_password_policy("abc12")
+        self.assertIsNotNone(msg)
+        self.assertIn(str(PASSWORD_MIN_LEN), msg)
+
+    def test_rejects_too_long_to_avoid_bcrypt_truncation(self):
+        # 73 chars — bcrypt would silently drop the last byte. Reject.
+        msg = validate_password_policy("a" * 71 + "12")
+        self.assertIsNotNone(msg)
+        self.assertIn(str(PASSWORD_MAX_LEN), msg)
+
+    def test_rejects_letters_only(self):
+        msg = validate_password_policy("abcdefghij")
+        self.assertIsNotNone(msg)
+        self.assertIn("숫자", msg)
+
+    def test_rejects_digits_only(self):
+        msg = validate_password_policy("12345678")
+        self.assertIsNotNone(msg)
+        self.assertIn("영문", msg)
+
+    def test_accepts_unicode_letters_with_digit(self):
+        # 한글 letters count as alpha via str.isalpha — intentional.
+        # The policy is "letter + digit", not "ASCII letter + digit".
+        # 6 char Korean + 2 digit = 8, exactly at PASSWORD_MIN_LEN.
+        self.assertIsNone(validate_password_policy("한글비밀번호12"))
+
+    def test_rejects_non_string(self):
+        self.assertIsNotNone(validate_password_policy(None))         # type: ignore[arg-type]
+        self.assertIsNotNone(validate_password_policy(12345678))     # type: ignore[arg-type]
+
+
+class UsernamePolicyTests(unittest.TestCase):
+    def test_accepts_lowercase_alphanumeric(self):
+        self.assertIsNone(validate_username("alice"))
+        self.assertIsNone(validate_username("user_01"))
+        self.assertIsNone(validate_username("a-b-c"))
+
+    def test_rejects_uppercase(self):
+        # Case-folding collision with admin is the reason. Reject loudly.
+        msg = validate_username("Alice")
+        self.assertIsNotNone(msg)
+
+    def test_rejects_korean(self):
+        msg = validate_username("앨리스")
+        self.assertIsNotNone(msg)
+
+    def test_rejects_space(self):
+        msg = validate_username("alice bob")
+        self.assertIsNotNone(msg)
+
+    def test_rejects_special_chars(self):
+        for bad in ("alice!", "alice.", "alice/", "../etc", "alice@host"):
+            self.assertIsNotNone(validate_username(bad),
+                                 f"should reject {bad!r}")
+
+    def test_length_bounds(self):
+        # Below min
+        self.assertIsNotNone(validate_username("ab"))
+        # At min
+        self.assertIsNone(validate_username("a" * USERNAME_MIN_LEN))
+        # At max
+        self.assertIsNone(validate_username("a" * USERNAME_MAX_LEN))
+        # Above max
+        self.assertIsNotNone(validate_username("a" * (USERNAME_MAX_LEN + 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_signup_endpoint.py
+++ b/tests/test_signup_endpoint.py
@@ -1,0 +1,253 @@
+"""W4 P1-B — POST /signup/ endpoint contract.
+
+Verifies the HTTP shape and the enumeration-defense property that the
+unit tests in ``test_password_policy`` cannot see:
+
+  - Success and duplicate share one response body (200, same message)
+    so an anonymous caller cannot probe which usernames exist.
+  - Policy violations get a distinct 400 with the rule text.
+  - The DB row created by a successful signup has ``active=0`` and
+    ``role=external`` — i.e. unable to log in until an admin approves.
+  - A duplicate attempt does NOT overwrite the pre-existing row.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-signup-endpoint-32chars-min",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core import auth as auth_mod  # noqa: E402
+
+
+def _seed_users_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _row(path: str, username: str) -> dict | None:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        r = conn.execute(
+            "SELECT username, password_hash, role, active "
+            "FROM users WHERE username = ?",
+            (username,),
+        ).fetchone()
+        return dict(r) if r else None
+    finally:
+        conn.close()
+
+
+_ACCEPTED_MSG = "가입 요청이 접수되었습니다. 관리자 승인 후 사용 가능합니다."
+
+
+class SignupEndpointTests(unittest.TestCase):
+    """Black-box HTTP contract via FastAPI TestClient."""
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db_path = self._tmp.name
+        _seed_users_schema(self.db_path)
+        # Point core.auth at our temp DB for the duration of the test.
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db_path
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db_path).unlink(missing_ok=True)
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    # ─── success path ───────────────────────────────────────────────
+    def test_new_signup_returns_200_with_accepted_message(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice",
+            "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["message"], _ACCEPTED_MSG)
+
+    def test_new_signup_persists_pending_row(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice",
+            "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 200)
+
+        row = _row(self.db_path, "alice")
+        self.assertIsNotNone(row)
+        self.assertEqual(row["role"], "external")
+        # active=0 ⇒ login() will return None (verified in test_password_bcrypt).
+        self.assertEqual(row["active"], 0)
+        # Hash must be bcrypt-format (W4 P1-A invariant).
+        self.assertTrue(row["password_hash"].startswith("bcrypt$"))
+
+    # ─── enumeration defense ────────────────────────────────────────
+    def test_duplicate_signup_returns_same_200_body_as_success(self):
+        client = self._client()
+        first = client.post("/signup/", json={
+            "username": "alice", "password": "alice1234",
+        })
+        self.assertEqual(first.status_code, 200)
+
+        second = client.post("/signup/", json={
+            "username": "alice", "password": "different_pw_42",
+        })
+        self.assertEqual(second.status_code, 200)
+        # Bodies must be byte-identical so a probing caller cannot
+        # distinguish "registered" from "already exists".
+        self.assertEqual(first.json(), second.json())
+
+    def test_duplicate_does_not_overwrite_existing_row(self):
+        client = self._client()
+        client.post("/signup/", json={
+            "username": "alice", "password": "alice1234",
+        })
+        before = _row(self.db_path, "alice")
+        self.assertIsNotNone(before)
+
+        # Attempt to take over the account with a new password.
+        client.post("/signup/", json={
+            "username": "alice", "password": "takeover42attempt",
+        })
+        after = _row(self.db_path, "alice")
+        self.assertEqual(before, after,
+                         "duplicate signup must NOT alter the existing row")
+
+    # ─── policy rejection ───────────────────────────────────────────
+    def test_short_password_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice", "password": "ab1",
+        })
+        self.assertEqual(r.status_code, 400)
+        body = r.json()
+        # FastAPI HTTPException body shape: {"detail": <message>}
+        self.assertIn("8", body["detail"])
+
+    def test_password_without_digit_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice", "password": "alphaonly",
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("숫자", r.json()["detail"])
+
+    def test_password_without_letter_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice", "password": "12345678",
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("영문", r.json()["detail"])
+
+    def test_oversize_password_returns_400(self):
+        # 73 chars — past the bcrypt 72-byte window.
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice", "password": "a" * 71 + "12",
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("72", r.json()["detail"])
+
+    def test_uppercase_username_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "Alice", "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 400)
+
+    def test_special_char_username_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "alice@host", "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 400)
+
+    def test_korean_username_returns_400(self):
+        client = self._client()
+        r = client.post("/signup/", json={
+            "username": "앨리스", "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 400)
+
+    # ─── side-effect: rejected signup leaves DB clean ──────────────
+    def test_policy_violation_does_not_create_row(self):
+        client = self._client()
+        client.post("/signup/", json={
+            "username": "bob", "password": "tooshort",
+        })
+        self.assertIsNone(_row(self.db_path, "bob"))
+
+
+class SignupEndsUpInaccessibleTests(unittest.TestCase):
+    """A pending account must not be able to log in. This couples
+    P1-B to the existing P1-A authenticate() behavior (active=0 ⇒
+    None) and would fail loudly if a future refactor removed the
+    active-flag check."""
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db_path = self._tmp.name
+        _seed_users_schema(self.db_path)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db_path
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db_path).unlink(missing_ok=True)
+
+    def test_pending_user_cannot_authenticate(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        client = TestClient(srv.app)
+
+        r = client.post("/signup/", json={
+            "username": "alice", "password": "alice1234",
+        })
+        self.assertEqual(r.status_code, 200)
+
+        # Direct authenticate() returns None for an active=0 row.
+        self.assertIsNone(auth_mod.authenticate("alice", "alice1234"))
+
+        # The HTTP login route reflects the same — 401, not 200.
+        login = client.post("/login/", json={
+            "username": "alice", "password": "alice1234", "api_key": "",
+        })
+        self.assertEqual(login.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Self-service account creation, gated by an admin approval step (W4 P2, upcoming). The endpoint never reveals whether a username exists: success and duplicate share one 200 body so an anonymous caller cannot enumerate users. Only policy violations get a distinct 400.

### Trust zone change (ARCHITECTURE.md §5.1)

Authentication now has three identity states with explicit, auditable transitions:

\`\`\`
anonymous (no token)
   │  POST /signup/
   ▼
pending (DB row, active=0, role=external)
   │  admin approval + role assignment (P2)
   ▼
authenticated (active=1, role assigned)
\`\`\`

A pending account cannot log in — \`authenticate()\` already returned None for \`active=0\` rows since Phase 4, so no new check is needed. \`/login/\` returns 401 regardless of whether the row is missing or just pending, so probing /login/ does not leak account existence either.

## What changed

**core/auth.py**
- \`validate_password_policy(pw)\` — 8..72 chars (72 = bcrypt input window, hard reject not silent truncation), must include at least one letter and one digit. 한글 등 unicode letters count.
- \`validate_username(name)\` — 3..32 chars, \`[a-z0-9_-]\`. Lowercase enforced so \`Admin\` and \`admin\` can never coexist.
- \`signup(username, password) -> SignupResult\` — bcrypt hash (W4 P1-A), inserts \`active=0\` / \`role=external\`, treats duplicates as a no-op (does NOT overwrite existing rows even on race — IntegrityError caught).

**server_llmwiki.py**
- \`POST /signup/\` — public, rate-limited (same 30/60s IP window as /login/, /query/, /upload/).
- Audit log distinguishes \`signup_pending\` / \`signup_rejected_duplicate\` / \`signup_rejected_policy\`; the response body does not.

**docs/ARCHITECTURE.md §5.1** — new "Account states" section with four invariants.

**SECURITY.md** — bcrypt + transparent migration noted in Authentication; new "Account creation (W4 P1-B)" subsection.

**tests/test_password_policy.py (new)** — 16 tests covering policy validators.

**tests/test_signup_endpoint.py (new)** — 13 tests via FastAPI TestClient:
- Success: 200, message, row persisted with \`active=0\`/\`role=external\`, \`bcrypt\$\` envelope.
- Enumeration defense: duplicate returns byte-identical response body, does NOT overwrite existing row (takeover attempt fails).
- Policy rejection: 400 for short / digit-less / letter-less / oversize passwords; 400 for uppercase / special-char / korean usernames; rejected signup does not create a row.
- Cross-PR invariant: a pending row cannot authenticate (direct \`authenticate()\` returns None; /login/ returns 401).

## Verification

\`\`\`
python -m unittest discover tests
Ran 1160 tests in 15.258s
OK
\`\`\`

## Out of scope

- Admin pending-user approval UI — **W4 P2** (next PR). Until P2 lands, admins approve via CLI: query users WHERE active=0, UPDATE active=1 + role=<chosen>.
- Self-service password reset — **W4 P2** will reuse the same admin flow.
- API key rotation — **W4 P3**.

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — does not touch \`core/retrieval\`, \`core/graph\`, or \`core/reasoning\`. \`core/auth.py\` + endpoint only.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) ✅ — ARCHITECTURE.md updated in same PR with the new account-state transition. No new module, no removal of a non-goal.
- Rule 5 (file size) ✅ — core/auth.py ~340 lines, well below 20 KB.