### PR TITLE
feat(auth): password change + admin-issued reset tokens (W4 P2-B-1, backend only)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,8 @@ JAMES implements defense-in-depth across the RAG pipeline.
   digests are accepted on input only and rewritten to bcrypt on the
   next successful login (transparent migration).
 - Rate limiting: 30 requests / 60 seconds per IP across
-  `/query/`, `/upload/`, `/login/`, `/signup/`
+  `/query/`, `/upload/`, `/login/`, `/signup/`,
+  `/password/reset/confirm`
 - Full audit log in SQLite (every request, decision, denial)
 
 ### Account creation (W4 P1-B)
@@ -74,6 +75,21 @@ JAMES implements defense-in-depth across the RAG pipeline.
 - Username policy: 3..32 characters, lowercase + digits + `_-` only.
   Case-folding collisions (`Admin` vs `admin`) are blocked at signup,
   not at login.
+
+### Credential rotation (W4 P2-B)
+
+- `POST /password/change` lets a logged-in user rotate their own
+  password. Identity comes from the JWT subject claim — the request
+  body never names a user.
+- `POST /admin/users/issue-reset-token` lets an admin mint a one-shot
+  reset token for a target user. The plaintext token is returned
+  once; only SHA256(token) is persisted. 1-hour TTL. Issuing a new
+  token revokes any prior unused token for the same user.
+- `POST /password/reset/confirm` accepts `{username, token,
+  new_password}`. Replay is blocked by a `used_at` flag written in
+  the same transaction as the password UPDATE. Token-validity
+  errors (unknown / expired / wrong username / already used) all
+  collapse to a single 401 so anonymous callers cannot enumerate.
 
 ---
 

--- a/core/auth.py
+++ b/core/auth.py
@@ -277,6 +277,16 @@ def reject_user(username: str) -> bool:
         conn.close()
 
 
+# W4 P2-B password change + admin reset-token workflow lives in a
+# sibling module, ``core/auth_reset.py``. It needs the SQLite-helpers
+# below (``_get_conn``, ``_get_user``, ``hash_password``,
+# ``verify_password``, ``validate_password_policy``) which are why it
+# is a sibling and not a separate package — keeping the cyclic-risk
+# surface to one well-known direction (auth → auth_reset, never back).
+# Splitting was forced by the 20 KB module-size gate in CLAUDE.md
+# rule 5; consolidating here would push auth.py over the line.
+
+
 # ─── W4 P1-B: self-service signup + policy validation ─────────
 
 # Hard upper bound chosen to match bcrypt's native 72-byte input window.

--- a/core/auth_reset.py
+++ b/core/auth_reset.py
@@ -1,0 +1,206 @@
+"""W4 P2-B — self-service password change + admin-issued reset tokens.
+
+Why this is a sibling module (not part of core/auth.py):
+  CLAUDE.md rule 5 keeps every file under core/ at <20 KB. After
+  P1-A/P1-B/P2-A, auth.py crossed that line. The reset workflow has
+  no upstream callers inside auth.py, so moving it out costs nothing
+  at the call sites and respects the gate.
+
+Dependencies are unidirectional: this module imports auth's helpers;
+auth never imports back.
+
+Public surface:
+  - RESET_TOKEN_TTL_SEC                  — 1 hour, exposed for tests
+  - change_password(user, old, new) -> str       — logged-in flow
+  - issue_reset_token(username) -> Optional[str] — admin-issued
+  - consume_reset_token(user, tok, new) -> str   — public confirm
+
+Persistence:
+  ``password_reset_tokens`` table, created lazily on import. Stores
+  SHA256(token) — never the raw token — so a DB read does not yield
+  usable reset credentials.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from typing import Optional
+
+from core.auth import (
+    _get_conn,
+    _get_user,
+    hash_password,
+    verify_password,
+    validate_password_policy,
+)
+
+
+# 1 hour. Long enough that an admin can hand the token to a user
+# out-of-band (phone, in-person, internal chat) without rushing;
+# short enough that an intercepted token has bounded value.
+RESET_TOKEN_TTL_SEC = 3600
+
+
+def _init_reset_token_table() -> None:
+    """Create the password_reset_tokens table if missing.
+
+    The token itself is 32 random URL-safe bytes — well above SHA256's
+    pre-image difficulty — so the one-way hash here is purely "don't
+    leak the credential at rest", not collision resistance.
+    """
+    conn = _get_conn()
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS password_reset_tokens (
+                token_hash  TEXT PRIMARY KEY,
+                username    TEXT NOT NULL,
+                created_at  INTEGER NOT NULL,
+                expires_at  INTEGER NOT NULL,
+                used_at     INTEGER
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_init_reset_token_table()
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def change_password(username: str, old_password: str, new_password: str) -> str:
+    """Self-service password change for an authenticated user.
+
+    Returns one of:
+      - "ok"             — password updated
+      - "invalid_old"    — current password didn't verify
+      - "policy:<msg>"   — new password failed validate_password_policy
+      - "no_user"        — username does not exist or is inactive
+
+    Side effects on success: bcrypt-rehashes the new password and writes
+    one UPDATE. No audit log here — the endpoint handler writes that
+    so the caller's IP is captured.
+    """
+    user = _get_user(username)
+    if not user or not user.get("active"):
+        return "no_user"
+    if not verify_password(old_password, user["password_hash"]):
+        return "invalid_old"
+    err = validate_password_policy(new_password)
+    if err is not None:
+        return f"policy:{err}"
+
+    new_hash = hash_password(new_password)
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?",
+            (new_hash, username),
+        )
+        conn.commit()
+        return "ok"
+    finally:
+        conn.close()
+
+
+def issue_reset_token(username: str) -> Optional[str]:
+    """Admin-issued password-reset token.
+
+    The plaintext token is returned exactly once — only the hash is
+    persisted, so the caller MUST relay the token out-of-band before
+    discarding the response. Returns None if the user is unknown or
+    inactive (admins should not issue resets for pending or removed
+    accounts — those have other workflows).
+
+    Any prior unused tokens for the same username are revoked (DELETE)
+    so a previously-issued-but-undelivered token cannot silently
+    coexist with a fresh one.
+    """
+    user = _get_user(username)
+    if not user or not user.get("active"):
+        return None
+
+    token = secrets.token_urlsafe(32)
+    now   = int(time.time())
+    exp   = now + RESET_TOKEN_TTL_SEC
+
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "DELETE FROM password_reset_tokens "
+            "WHERE username = ? AND used_at IS NULL",
+            (username,),
+        )
+        conn.execute(
+            "INSERT INTO password_reset_tokens "
+            "(token_hash, username, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?)",
+            (_token_hash(token), username, now, exp),
+        )
+        conn.commit()
+        return token
+    finally:
+        conn.close()
+
+
+def consume_reset_token(username: str, token: str, new_password: str) -> str:
+    """One-shot reset using a token from ``issue_reset_token``.
+
+    Returns one of:
+      - "ok"                — password updated, token marked used
+      - "invalid_token"     — unknown hash, wrong username, or expired
+      - "already_used"      — token was previously consumed
+      - "policy:<msg>"      — new password failed validation
+      - "no_user"           — token was valid but the user row vanished
+                              between issue and consume (race / delete)
+
+    The token check + password UPDATE + used_at UPDATE happen under one
+    connection, so a concurrent second consume can't succeed: the
+    second caller observes used_at != NULL.
+    """
+    err = validate_password_policy(new_password)
+    if err is not None:
+        return f"policy:{err}"
+
+    h    = _token_hash(token)
+    now  = int(time.time())
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT username, expires_at, used_at "
+            "FROM password_reset_tokens WHERE token_hash = ?",
+            (h,),
+        ).fetchone()
+        if row is None:
+            return "invalid_token"
+        if row["username"] != username:
+            # Same hash, different user — only possible under a 256-bit
+            # collision, but reject defensively anyway.
+            return "invalid_token"
+        if row["used_at"] is not None:
+            return "already_used"
+        if row["expires_at"] < now:
+            return "invalid_token"
+
+        user = conn.execute(
+            "SELECT active FROM users WHERE username = ?", (username,)
+        ).fetchone()
+        if user is None or not user["active"]:
+            return "no_user"
+
+        conn.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?",
+            (hash_password(new_password), username),
+        )
+        conn.execute(
+            "UPDATE password_reset_tokens SET used_at = ? WHERE token_hash = ?",
+            (now, h),
+        )
+        conn.commit()
+        return "ok"
+    finally:
+        conn.close()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,30 @@ Invariants:
   signer requested. Role assignment happens in the admin approval
   flow, never at signup time.
 
+### 5.2 Credential change paths (W4 P2-B, 2026-05-11)
+
+Once a user is authenticated, two credential-rotation paths exist.
+Both run through `core/auth_reset.py` (a sibling of `core/auth.py`
+kept separate only to honor the 20 KB module-size gate):
+
+- **Self-service change** (`POST /password/change`): the caller
+  supplies the old password plus a new one; the username is read
+  from the JWT subject claim, never from the request body. A body
+  `username` field, if smuggled in, is ignored — the JWT is the only
+  source of identity here.
+- **Admin-issued reset** (`POST /admin/users/issue-reset-token`):
+  the admin requests a one-shot token for a target user. The
+  plaintext token is returned exactly once; the database stores only
+  SHA256(token). Tokens expire after 1 hour and are revoked
+  automatically if a new token is issued for the same username.
+  The user redeems via `POST /password/reset/confirm` with the
+  token, their username, and a new password — replay is rejected by
+  a `used_at` column updated in the same transaction as the password
+  UPDATE.
+
+Both paths apply `validate_password_policy()` from W4 P1-B and
+re-hash through `hash_password()` (bcrypt) from W4 P1-A.
+
 ---
 
 ## 5.5 PolicyEngine (single source of policy decisions)

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -42,6 +42,13 @@ from core.auth import (
     approve_user as _auth_approve_user,
     reject_user as _auth_reject_user,
     deactivate_user as _auth_deactivate_user,
+    verify_token as _auth_verify_token,
+)
+from core.auth_reset import (
+    change_password    as _auth_change_password,
+    issue_reset_token  as _auth_issue_reset_token,
+    consume_reset_token as _auth_consume_reset_token,
+    RESET_TOKEN_TTL_SEC,
 )
 from core.policy_engine import default_engine
 from processors.file_processor import FileProcessor
@@ -459,9 +466,10 @@ async def rate_limit_middleware(request: Request, call_next):
     ip = get_client_ip(request)
     endpoint = request.url.path
 
-    # 체크 필요한 엔드포인트만. /signup/ 도 unauthenticated 표적이라
-    # 같은 IP-window 로 brute-force 시도를 차단한다.
-    if endpoint in ("/query/", "/upload/", "/login/", "/signup/"):
+    # 체크 필요한 엔드포인트만. /signup/ + /password/reset/confirm 도
+    # unauthenticated 표적이라 같은 IP-window 로 brute-force 차단.
+    if endpoint in ("/query/", "/upload/", "/login/", "/signup/",
+                    "/password/reset/confirm"):
         if not _rate_limiter.check(ip, endpoint):
             remaining = _rate_limiter.remaining(ip)
             _write_audit(
@@ -2615,6 +2623,157 @@ async def admin_users_deactivate(
     _write_audit(role, "/admin/users/deactivate", query=data.username,
                  security_event="deactivated", ip_address=ip)
     return {"ok": True, "username": data.username}
+
+
+# ─── W4 P2-B: password change + reset-token workflow ────────────
+
+def _bearer_username(request: Request) -> Optional[str]:
+    """Pull `sub` (username) out of the Bearer JWT, or None.
+
+    The endpoints below need the caller's username to scope the
+    operation to their own account. We use the JWT subject claim
+    rather than a body field so the client cannot self-impersonate.
+    """
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    payload = _auth_verify_token(auth_header[7:].strip())
+    return (payload or {}).get("sub") if payload else None
+
+
+class PasswordChangeRequest(BaseModel):
+    old_password: str
+    new_password: str
+
+@app.post("/password/change",
+          summary="비밀번호 변경 (로그인된 사용자 — W4 P2-B)")
+async def password_change(data: PasswordChangeRequest, request: Request):
+    """Self-service password change. JWT-authenticated; the request
+    body MUST NOT include username — the subject is taken from the
+    JWT so an attacker holding only a stolen body can't pivot.
+
+    Response codes:
+      200 — password updated
+      400 — new password fails the policy (rule shown verbatim)
+      401 — JWT missing/invalid OR old_password didn't verify
+            (same status so an attacker can't distinguish the two
+             after the JWT slot is filled)
+    """
+    ip = get_client_ip(request)
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="인증이 필요합니다.")
+
+    result = _auth_change_password(username, data.old_password, data.new_password)
+    if result == "ok":
+        _write_audit("authenticated", "/password/change", query=username,
+                     security_event="password_change_success", ip_address=ip)
+        return {"ok": True}
+    if result.startswith("policy:"):
+        msg = result.split(":", 1)[1]
+        _write_audit("authenticated", "/password/change", query=username,
+                     security_event=f"password_change_rejected_policy",
+                     ip_address=ip)
+        raise HTTPException(status_code=400, detail=msg)
+    # invalid_old / no_user → collapse to 401. The audit log still
+    # distinguishes for the operator.
+    _write_audit("authenticated", "/password/change", query=username,
+                 security_event=f"password_change_failed_{result}",
+                 ip_address=ip)
+    raise HTTPException(
+        status_code=401,
+        detail="현재 비밀번호가 일치하지 않거나 계정이 비활성 상태입니다.",
+    )
+
+
+class AdminIssueResetTokenRequest(BaseModel):
+    username: str
+
+@app.post("/admin/users/issue-reset-token",
+          summary="비밀번호 재설정 토큰 발급 (admin 전용 — W4 P2-B)")
+async def admin_issue_reset_token(
+    data:    AdminIssueResetTokenRequest,
+    request: Request,
+    api_key: str = "",
+    role:    str = Depends(get_role_from_request),
+):
+    """Admin issues a one-shot reset token. Token is returned in
+    plaintext exactly once — admin must relay it out-of-band (phone,
+    in-person, internal chat). Server only stores SHA256(token).
+
+    Returns 404 if the user is unknown or inactive — admins should not
+    issue resets for pending or removed accounts (use approve/reject).
+    """
+    _require_admin(api_key, role)
+    ip = get_client_ip(request)
+
+    token = _auth_issue_reset_token(data.username)
+    if token is None:
+        _write_audit(role, "/admin/users/issue-reset-token",
+                     query=data.username,
+                     security_event="reset_token_issue_failed (unknown or inactive)",
+                     ip_address=ip)
+        raise HTTPException(
+            status_code=404,
+            detail="활성 사용자가 아닙니다.",
+        )
+    _write_audit(role, "/admin/users/issue-reset-token",
+                 query=data.username,
+                 security_event="reset_token_issued",
+                 ip_address=ip)
+    return {
+        "ok": True,
+        "username":           data.username,
+        "token":              token,
+        "expires_in_seconds": RESET_TOKEN_TTL_SEC,
+    }
+
+
+class PasswordResetConfirmRequest(BaseModel):
+    username:     str
+    token:        str
+    new_password: str
+
+@app.post("/password/reset/confirm",
+          summary="비밀번호 재설정 (토큰 + 새 비번 — W4 P2-B)")
+async def password_reset_confirm(
+    data:    PasswordResetConfirmRequest,
+    request: Request,
+):
+    """Public endpoint — the caller is anonymous and presents an
+    admin-issued token. Rate-limited at the IP layer to keep token
+    brute-force bounded.
+
+    Response codes:
+      200 — password reset
+      400 — new_password fails the policy (rule shown verbatim)
+      401 — token invalid / expired / already used / no such user
+            (one unified message; the audit log distinguishes for
+            the operator)
+    """
+    ip = get_client_ip(request)
+    result = _auth_consume_reset_token(data.username, data.token,
+                                       data.new_password)
+    if result == "ok":
+        _write_audit("anonymous", "/password/reset/confirm",
+                     query=data.username,
+                     security_event="password_reset_completed",
+                     ip_address=ip)
+        return {"ok": True}
+    if result.startswith("policy:"):
+        _write_audit("anonymous", "/password/reset/confirm",
+                     query=data.username,
+                     security_event="password_reset_rejected_policy",
+                     ip_address=ip)
+        raise HTTPException(status_code=400, detail=result.split(":", 1)[1])
+    _write_audit("anonymous", "/password/reset/confirm",
+                 query=data.username,
+                 security_event=f"password_reset_failed_{result}",
+                 ip_address=ip)
+    raise HTTPException(
+        status_code=401,
+        detail="토큰이 유효하지 않거나 만료되었습니다.",
+    )
 
 
 @app.get("/admin/entities", summary="Entity 현황 — search + paging [item #1]")

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -1,0 +1,232 @@
+"""W4 P2-B — self-service password change (logged-in user).
+
+Coverage:
+  - core.auth_reset.change_password — pure DB helper, all four return
+    codes ("ok", "invalid_old", "policy:...", "no_user").
+  - POST /password/change endpoint — JWT-scoped, status codes 200 /
+    400 / 401, and the audit-log invariant that the username comes
+    from the JWT `sub` (not the body).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-password-change-suite-32chars",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core import auth as auth_mod  # noqa: E402
+from core import auth_reset as reset_mod  # noqa: E402
+
+
+def _seed_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS password_reset_tokens (
+            token_hash  TEXT PRIMARY KEY,
+            username    TEXT NOT NULL,
+            created_at  INTEGER NOT NULL,
+            expires_at  INTEGER NOT NULL,
+            used_at     INTEGER
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _insert_active(path: str, username: str, password: str,
+                   role: str = "employee", active: int = 1) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO users (username, password_hash, role, active) "
+        "VALUES (?, ?, ?, ?)",
+        (username, auth_mod.hash_password(password), role, active),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _verify_login_works(path: str, username: str, password: str) -> bool:
+    auth_mod._DB_PATH_saved = auth_mod._DB_PATH
+    auth_mod._DB_PATH = path
+    try:
+        return auth_mod.authenticate(username, password) is not None
+    finally:
+        auth_mod._DB_PATH = auth_mod._DB_PATH_saved
+
+
+class ChangePasswordHelperTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_ok_changes_password_and_old_no_longer_works(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = reset_mod.change_password("alice", "old_pw_42", "new_pw_99")
+        self.assertEqual(r, "ok")
+        # Direct authenticate() probe — old fails, new works.
+        self.assertIsNone(auth_mod.authenticate("alice", "old_pw_42"))
+        self.assertIsNotNone(auth_mod.authenticate("alice", "new_pw_99"))
+
+    def test_invalid_old_password(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = reset_mod.change_password("alice", "wrong", "new_pw_99")
+        self.assertEqual(r, "invalid_old")
+        # Original still works.
+        self.assertIsNotNone(auth_mod.authenticate("alice", "old_pw_42"))
+
+    def test_policy_rejection_returned_with_message(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        # too short
+        r = reset_mod.change_password("alice", "old_pw_42", "ab1")
+        self.assertTrue(r.startswith("policy:"),
+                        f"expected 'policy:...', got {r!r}")
+        # Old still works — failed policy must not mutate the row.
+        self.assertIsNotNone(auth_mod.authenticate("alice", "old_pw_42"))
+
+    def test_no_user_for_unknown_username(self):
+        r = reset_mod.change_password("ghost", "any", "new_pw_99")
+        self.assertEqual(r, "no_user")
+
+    def test_no_user_for_inactive_account(self):
+        _insert_active(self.db, "pending", "old_pw_42", active=0)
+        # Even with the correct old password, an inactive account
+        # cannot self-change — they have no business being logged in.
+        r = reset_mod.change_password("pending", "old_pw_42", "new_pw_99")
+        self.assertEqual(r, "no_user")
+
+
+class ChangePasswordEndpointTests(unittest.TestCase):
+    """HTTP-level: JWT scoping, status codes, body-username defense."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = cls._read_api_key()
+
+    @staticmethod
+    def _read_api_key() -> str:
+        env_v = os.environ.get("JAMES_API_KEY")
+        if env_v:
+            return env_v.strip()
+        env_path = Path(__file__).resolve().parent.parent / ".env"
+        if env_path.exists():
+            for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+                if line.startswith("JAMES_API_KEY="):
+                    return line.split("=", 1)[1].strip()
+        return ""
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _jwt_for(self, username: str, role: str = "employee") -> str:
+        return auth_mod.create_token(username, role)
+
+    def test_ok_returns_200_and_updates_password(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = self._client().post(
+            "/password/change",
+            json={"old_password": "old_pw_42", "new_password": "new_pw_99"},
+            headers={"Authorization": f"Bearer {self._jwt_for('alice')}"},
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertIsNotNone(auth_mod.authenticate("alice", "new_pw_99"))
+
+    def test_missing_jwt_returns_401(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = self._client().post(
+            "/password/change",
+            json={"old_password": "old_pw_42", "new_password": "new_pw_99"},
+        )
+        self.assertEqual(r.status_code, 401)
+        # Row unchanged.
+        self.assertIsNotNone(auth_mod.authenticate("alice", "old_pw_42"))
+
+    def test_wrong_old_password_returns_401(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = self._client().post(
+            "/password/change",
+            json={"old_password": "wrong", "new_password": "new_pw_99"},
+            headers={"Authorization": f"Bearer {self._jwt_for('alice')}"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_short_new_password_returns_400(self):
+        _insert_active(self.db, "alice", "old_pw_42")
+        r = self._client().post(
+            "/password/change",
+            json={"old_password": "old_pw_42", "new_password": "ab1"},
+            headers={"Authorization": f"Bearer {self._jwt_for('alice')}"},
+        )
+        self.assertEqual(r.status_code, 400)
+        # Old still works.
+        self.assertIsNotNone(auth_mod.authenticate("alice", "old_pw_42"))
+
+    def test_jwt_scoping_body_username_field_is_ignored(self):
+        """The body has no username field by design. A caller cannot
+        target another account by adding one — we read from the JWT
+        only. This test wedges an extra `username` into the body to
+        confirm pydantic-extra-ignore does not accidentally route it.
+        """
+        _insert_active(self.db, "alice", "old_pw_42")
+        _insert_active(self.db, "bob",   "bob_pw_42")
+        r = self._client().post(
+            "/password/change",
+            json={
+                "old_password": "old_pw_42",
+                "new_password": "new_pw_99",
+                "username":     "bob",   # tries to target bob via body
+            },
+            headers={"Authorization": f"Bearer {self._jwt_for('alice')}"},
+        )
+        # alice changed, bob untouched.
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertIsNotNone(auth_mod.authenticate("alice", "new_pw_99"))
+        self.assertIsNotNone(auth_mod.authenticate("bob",   "bob_pw_42"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_password_reset_token.py
+++ b/tests/test_password_reset_token.py
@@ -1,0 +1,372 @@
+"""W4 P2-B — admin-issued reset token workflow.
+
+Coverage:
+  - issue_reset_token: returns plaintext once, persists hash, revokes
+    prior unused tokens, returns None for unknown/inactive users.
+  - consume_reset_token: all six return codes, two-call replay
+    rejected, expired token rejected, cross-username token rejected.
+  - HTTP endpoints: admin gate on issue, 404 on unknown user,
+    unified-401 on bad token (enumeration defense), 200 on valid
+    consume, audit semantics.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-reset-token-suite-32chars",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core import auth as auth_mod  # noqa: E402
+from core import auth_reset as reset_mod  # noqa: E402
+
+
+def _seed_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS password_reset_tokens (
+            token_hash  TEXT PRIMARY KEY,
+            username    TEXT NOT NULL,
+            created_at  INTEGER NOT NULL,
+            expires_at  INTEGER NOT NULL,
+            used_at     INTEGER
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _insert(path: str, username: str, role: str = "employee",
+            active: int = 1) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO users (username, password_hash, role, active) "
+        "VALUES (?, ?, ?, ?)",
+        (username, auth_mod.hash_password("original_pw_42"), role, active),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _count_tokens(path: str, username: str) -> int:
+    conn = sqlite3.connect(path)
+    try:
+        n = conn.execute(
+            "SELECT COUNT(*) FROM password_reset_tokens WHERE username = ?",
+            (username,),
+        ).fetchone()[0]
+        return n
+    finally:
+        conn.close()
+
+
+def _force_expired_token(path: str, token: str) -> None:
+    """Backdate the token so it appears expired."""
+    h = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "UPDATE password_reset_tokens SET expires_at = ? WHERE token_hash = ?",
+        (int(time.time()) - 60, h),
+    )
+    conn.commit()
+    conn.close()
+
+
+class IssueTokenTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_issue_returns_plaintext_token_and_persists_hash(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        self.assertIsNotNone(tok)
+        # token is URL-safe base64 of 32 bytes → at least 32 chars.
+        self.assertGreaterEqual(len(tok), 32)
+        # DB stores SHA256, NOT the plaintext.
+        conn = sqlite3.connect(self.db)
+        try:
+            row = conn.execute(
+                "SELECT token_hash FROM password_reset_tokens WHERE username = ?",
+                ("alice",),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertNotEqual(row[0], tok,
+                            "plaintext token must NOT appear in DB")
+        self.assertEqual(
+            row[0], hashlib.sha256(tok.encode()).hexdigest(),
+            "stored hash must be SHA256 of the plaintext token",
+        )
+
+    def test_issue_revokes_prior_unused_tokens(self):
+        _insert(self.db, "alice")
+        first  = reset_mod.issue_reset_token("alice")
+        second = reset_mod.issue_reset_token("alice")
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        # Only the freshest unused token survives — the first is gone.
+        self.assertEqual(_count_tokens(self.db, "alice"), 1)
+        # The old token no longer consumes (proves it was deleted).
+        self.assertEqual(
+            reset_mod.consume_reset_token("alice", first, "new_pw_99"),
+            "invalid_token",
+        )
+
+    def test_issue_returns_none_for_unknown_user(self):
+        self.assertIsNone(reset_mod.issue_reset_token("ghost"))
+
+    def test_issue_returns_none_for_inactive_user(self):
+        _insert(self.db, "pending", active=0)
+        self.assertIsNone(reset_mod.issue_reset_token("pending"))
+
+
+class ConsumeTokenTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_ok_updates_password_and_marks_token_used(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        r = reset_mod.consume_reset_token("alice", tok, "new_pw_99")
+        self.assertEqual(r, "ok")
+        # New password works, original no longer.
+        self.assertIsNotNone(auth_mod.authenticate("alice", "new_pw_99"))
+        self.assertIsNone(auth_mod.authenticate("alice", "original_pw_42"))
+
+    def test_replay_rejected_as_already_used(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        self.assertEqual(
+            reset_mod.consume_reset_token("alice", tok, "new_pw_99"), "ok",
+        )
+        # Second call with same token — must NOT silently succeed.
+        self.assertEqual(
+            reset_mod.consume_reset_token("alice", tok, "yet_another_99"),
+            "already_used",
+        )
+        # The yet_another password should NOT have taken effect.
+        self.assertIsNone(auth_mod.authenticate("alice", "yet_another_99"))
+
+    def test_expired_token_rejected(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        _force_expired_token(self.db, tok)
+        r = reset_mod.consume_reset_token("alice", tok, "new_pw_99")
+        self.assertEqual(r, "invalid_token")
+
+    def test_wrong_username_rejected(self):
+        _insert(self.db, "alice")
+        _insert(self.db, "bob")
+        tok = reset_mod.issue_reset_token("alice")
+        # Same token hash, claim it for bob — must fail.
+        r = reset_mod.consume_reset_token("bob", tok, "new_pw_99")
+        self.assertEqual(r, "invalid_token")
+        # alice's password is also unchanged (the bad consume didn't
+        # touch any row).
+        self.assertIsNotNone(auth_mod.authenticate("alice", "original_pw_42"))
+
+    def test_unknown_token_rejected(self):
+        _insert(self.db, "alice")
+        r = reset_mod.consume_reset_token("alice", "nonexistent-token-xyz",
+                                          "new_pw_99")
+        self.assertEqual(r, "invalid_token")
+
+    def test_policy_violation_returned_with_message(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        # Short new password — policy:... before token validation
+        # even fires. That's intentional: we don't want a successful
+        # token consume to be partially applied with a bad password.
+        r = reset_mod.consume_reset_token("alice", tok, "ab1")
+        self.assertTrue(r.startswith("policy:"), r)
+        # Token still valid for a second try (NOT consumed).
+        self.assertEqual(
+            reset_mod.consume_reset_token("alice", tok, "valid_pw_99"), "ok",
+        )
+
+    def test_inactive_user_rejected(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        # Admin deactivates between issue and consume.
+        auth_mod.deactivate_user("alice")
+        r = reset_mod.consume_reset_token("alice", tok, "new_pw_99")
+        self.assertEqual(r, "no_user")
+
+
+class EndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = cls._read_api_key()
+
+    @staticmethod
+    def _read_api_key() -> str:
+        env_v = os.environ.get("JAMES_API_KEY")
+        if env_v:
+            return env_v.strip()
+        env_path = Path(__file__).resolve().parent.parent / ".env"
+        if env_path.exists():
+            for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+                if line.startswith("JAMES_API_KEY="):
+                    return line.split("=", 1)[1].strip()
+        return ""
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _admin_headers(self) -> dict:
+        return {"Authorization": f"Bearer {auth_mod.create_token('admin', 'admin')}"}
+
+    def _user_headers(self) -> dict:
+        return {"Authorization": f"Bearer {auth_mod.create_token('employee', 'employee')}"}
+
+    # ── issue ──────────────────────────────────────────────────────
+    def test_issue_requires_admin(self):
+        _insert(self.db, "alice")
+        r = self._client().post(
+            "/admin/users/issue-reset-token",
+            params={"api_key": self._api_key},
+            json={"username": "alice"},
+            headers=self._user_headers(),  # employee, not admin
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_issue_returns_token_and_ttl(self):
+        _insert(self.db, "alice")
+        r = self._client().post(
+            "/admin/users/issue-reset-token",
+            params={"api_key": self._api_key},
+            json={"username": "alice"},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertTrue(body["ok"])
+        self.assertGreaterEqual(len(body["token"]), 32)
+        self.assertEqual(body["expires_in_seconds"],
+                         reset_mod.RESET_TOKEN_TTL_SEC)
+
+    def test_issue_404_for_unknown_user(self):
+        r = self._client().post(
+            "/admin/users/issue-reset-token",
+            params={"api_key": self._api_key},
+            json={"username": "ghost"},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_issue_404_for_inactive_user(self):
+        _insert(self.db, "pending", active=0)
+        r = self._client().post(
+            "/admin/users/issue-reset-token",
+            params={"api_key": self._api_key},
+            json={"username": "pending"},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 404)
+
+    # ── confirm ────────────────────────────────────────────────────
+    def test_confirm_happy_path_returns_200_and_changes_password(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        r = self._client().post(
+            "/password/reset/confirm",
+            json={"username": "alice", "token": tok,
+                  "new_password": "new_pw_99"},
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertIsNotNone(auth_mod.authenticate("alice", "new_pw_99"))
+
+    def test_confirm_bad_token_returns_401_unified(self):
+        # Wrong token AND wrong username — both must collapse to a
+        # single 401 so an anonymous caller can't enumerate users.
+        for body in [
+            {"username": "alice", "token": "bogus", "new_password": "new_pw_99"},
+            {"username": "ghost", "token": "bogus", "new_password": "new_pw_99"},
+        ]:
+            r = self._client().post("/password/reset/confirm", json=body)
+            self.assertEqual(r.status_code, 401, f"body={body}")
+
+    def test_confirm_policy_violation_returns_400(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        r = self._client().post(
+            "/password/reset/confirm",
+            json={"username": "alice", "token": tok, "new_password": "ab1"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_confirm_replay_returns_401(self):
+        _insert(self.db, "alice")
+        tok = reset_mod.issue_reset_token("alice")
+        self._client().post(
+            "/password/reset/confirm",
+            json={"username": "alice", "token": tok,
+                  "new_password": "new_pw_99"},
+        )
+        r = self._client().post(
+            "/password/reset/confirm",
+            json={"username": "alice", "token": tok,
+                  "new_password": "yet_another_99"},
+        )
+        self.assertEqual(r.status_code, 401)
+        self.assertIsNone(auth_mod.authenticate("alice", "yet_another_99"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Backend for the two missing credential-rotation paths. Logged-in users can rotate their own password without admin intervention, and admins can issue one-shot reset tokens for users who've lost access. UI for both flows lands in the follow-up (P2-B-2).

## Why a new sibling module

The reset workflow needs auth's existing primitives (\`_get_conn\`, \`_get_user\`, \`hash_password\`, \`verify_password\`, \`validate_password_policy\`). Folding it into \`core/auth.py\` would push the file past CLAUDE.md rule 5's 20 KB ceiling (auth.py was already at ~19.7 KB after P2-A). \`core/auth_reset.py\` is a sibling that imports from core.auth but is never imported back — dependency stays unidirectional, no package restructure needed.

## Endpoints

- **POST /password/change** — Authenticated. JWT subject is the only source of the username; body has no username field (test verifies a smuggled body \`username\` is ignored). \`invalid_old\` and \`no_user\` both collapse to **401** (audit log distinguishes).
- **POST /admin/users/issue-reset-token** — Admin only. Returns plaintext token exactly once; DB stores \`SHA256(token)\`. 1 hour TTL. Re-issuing revokes any prior unused token for the user.
- **POST /password/reset/confirm** — Public, rate-limited. Token-validity errors (unknown / expired / wrong username / already used) all collapse to a single **401** — anonymous callers cannot enumerate.

## Helpers (core/auth_reset.py)

- \`change_password(user, old, new) -> str\` — \`"ok" | "invalid_old" | "policy:<msg>" | "no_user"\`
- \`issue_reset_token(user) -> Optional[str]\` — plaintext, once
- \`consume_reset_token(user, token, new) -> str\` — six return codes; replay protection via \`used_at\` UPDATE in the same connection that verifies the token

## Schema

New table \`password_reset_tokens\`:
| col | type | note |
|---|---|---|
| \`token_hash\` | TEXT PRIMARY KEY | SHA256(plaintext), never the token |
| \`username\` | TEXT NOT NULL | |
| \`created_at\` | INTEGER | unix epoch |
| \`expires_at\` | INTEGER | unix epoch, +3600 from create |
| \`used_at\` | INTEGER NULL | non-null once consumed |

## Tests (29 new)

**test_password_change.py (10)** — core helper coverage (ok / invalid_old / policy / no_user / inactive); endpoint coverage (200 happy, 401 missing-JWT, 401 wrong-old, 400 short-new, JWT-scoping).

**test_password_reset_token.py (19)** — issue (plaintext-once + hash-persists, revokes prior, None on unknown / inactive); consume (ok / replay / expired / wrong-username / unknown / policy-before-token-check / inactive-user); endpoints (issue admin-gate, 200 + TTL, 404 unknown / inactive, confirm happy / unified-401 enum defense / 400 policy / 401 replay).

## Verification

\`\`\`
python -m unittest discover tests
Ran 1209 tests in 30.325s
OK
\`\`\`

## Out of scope (W4 P2-B-2)

- admin.html: 본인 비밀번호 변경 form
- 사용자 관리 page: per-user 토큰 발급 button
- Login screen: 비밀번호 찾기 flow

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — does not touch \`core/retrieval\`, \`core/graph\`, or \`core/reasoning\`.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) — new module \`core/auth_reset.py\` + new workflow in ARCHITECTURE.md §5.2 in the same PR.
- Rule 5 (file size) ✅ — core/auth.py 19.7 KB, core/auth_reset.py 6.7 KB, both under the 20 KB gate.