### PR TITLE
feat(auth): per-user API keys — issue / list / revoke backend (W4 P3-1)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,19 @@ JAMES implements defense-in-depth across the RAG pipeline.
   Case-folding collisions (`Admin` vs `admin`) are blocked at signup,
   not at login.
 
+### User API keys (W4 P3-1)
+
+- `POST /api-keys/issue` mints a long-lived `jms_<token>` for the
+  JWT-authenticated user. Plaintext is returned exactly once; only
+  `SHA256(token)` is persisted.
+- `GET /api-keys/list` returns the caller's keys by prefix, label,
+  timestamps, and revocation flag. Plaintext is never returned.
+- `POST /api-keys/revoke` revokes a key by its 12-character prefix.
+  Scope is enforced by the owning user — a caller cannot revoke
+  another user's key.
+- Revocation is one-way (no unrevoke). Rotation = revoke + issue.
+- Wiring into request authentication is W4 P3-2 (separate PR).
+
 ### Credential rotation (W4 P2-B)
 
 - `POST /password/change` lets a logged-in user rotate their own

--- a/core/api_keys.py
+++ b/core/api_keys.py
@@ -1,0 +1,229 @@
+"""W4 P3-1 — per-user API keys (long-lived) with rotation.
+
+Why this module exists (vs the system-wide JAMES_API_KEY)
+---------------------------------------------------------
+The legacy ``JAMES_API_KEY`` env var is a single shared secret used by
+the server operator for bring-up and admin scripts. It cannot be
+rotated without restarting the server, and it does not identify a
+user — every call authenticated by it is "the operator".
+
+For external integrations (CI scripts, internal tooling, third-party
+clients), users need their own credentials that:
+  - can be issued and rotated without operator help,
+  - identify *who* is calling so audit logs and policy gates have
+    a real subject,
+  - can be revoked individually if leaked.
+
+This module is the issuance / verification / revocation backbone.
+P3-2 wires it into the authentication middleware so that an
+``X-API-Key`` header on any endpoint resolves to a user identity.
+P3-1 lands the storage + management layer alone so the changeover
+in the middleware can land separately and be audited on its own.
+
+Token shape
+-----------
+  jms_<43-char-urlsafe>
+  └──┘└────────────────┘
+   ▲           ▲
+   │           └── 32 random bytes, URL-safe base64 (Mr. Robot's bcrypt
+   │               equivalent — only the SHA256 is stored)
+   └── "jms_" prefix tags the credential by source so a leaked grep
+       hit in a log is recognisable at a glance. The first 12 chars
+       (``jms_`` + 8 of the random body) form the *display prefix* —
+       the only fragment ever shown again after issuance, used as the
+       handle for revocation.
+
+DB row
+------
+``api_keys``:
+  key_hash      TEXT PRIMARY KEY    -- SHA256(plaintext), never the key
+  key_prefix    TEXT NOT NULL       -- 12 chars, indexed for revocation
+  username      TEXT NOT NULL       -- owner
+  label         TEXT                -- operator-supplied note (optional)
+  created_at    INTEGER NOT NULL    -- unix epoch
+  last_used_at  INTEGER             -- bumped on every successful verify
+  revoked_at    INTEGER             -- NULL = active
+
+No expiry column: long-lived credentials are the point. Rotation is
+explicit (revoke + re-issue), not silent. If a TTL becomes necessary
+later we add a column rather than reusing this one.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from typing import Optional, List, Tuple, Dict
+
+from core.auth import _get_conn, _get_user
+
+
+KEY_PREFIX_LEN = 12  # "jms_" + 8 chars
+TOKEN_BODY_BYTES = 32
+
+
+def _init_api_keys_table() -> None:
+    """Create ``api_keys`` if missing. Idempotent."""
+    conn = _get_conn()
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS api_keys (
+                key_hash      TEXT PRIMARY KEY,
+                key_prefix    TEXT NOT NULL,
+                username      TEXT NOT NULL,
+                label         TEXT,
+                created_at    INTEGER NOT NULL,
+                last_used_at  INTEGER,
+                revoked_at    INTEGER
+            )
+        """)
+        # The prefix gets queried on every revoke call; index keeps it
+        # fast even on a fleet of stale keys.
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_api_keys_prefix_user
+            ON api_keys (key_prefix, username)
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_init_api_keys_table()
+
+
+def _hash_key(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def _generate_token() -> Tuple[str, str]:
+    """Return (plaintext, prefix).
+
+    Plaintext is ``"jms_" + 43-char-urlsafe``. Prefix is the first
+    ``KEY_PREFIX_LEN`` characters of the plaintext — enough to identify
+    a specific key out of a user's list without revealing the body.
+    """
+    body  = secrets.token_urlsafe(TOKEN_BODY_BYTES)
+    plain = f"jms_{body}"
+    return plain, plain[:KEY_PREFIX_LEN]
+
+
+def issue_api_key(username: str, label: Optional[str] = None
+                  ) -> Optional[Tuple[str, str]]:
+    """Issue a new API key for an active user.
+
+    Returns ``(plaintext, prefix)`` exactly once. Only the SHA256 hash
+    is persisted; the plaintext cannot be recovered from the DB.
+    Returns None if the user is unknown or inactive — issuing keys
+    for pending/removed accounts is a misuse.
+    """
+    user = _get_user(username)
+    if not user or not user.get("active"):
+        return None
+
+    plain, prefix = _generate_token()
+    now = int(time.time())
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "INSERT INTO api_keys "
+            "(key_hash, key_prefix, username, label, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (_hash_key(plain), prefix, username, label, now),
+        )
+        conn.commit()
+        return plain, prefix
+    finally:
+        conn.close()
+
+
+def verify_api_key(plain: str) -> Optional[Dict]:
+    """Resolve a plaintext key to its owning user, or None.
+
+    Bumps ``last_used_at`` on every successful verify. A revoked key
+    (``revoked_at`` is not null) is rejected; the lookup still touches
+    the row but does not update the timestamp.
+
+    Returns:
+      None on miss / revocation / inactive owner.
+      {"username": ..., "role": ...} on success — role is read from
+      the users table so a role change takes effect on the next call.
+    """
+    if not plain or not plain.startswith("jms_"):
+        return None
+    h    = _hash_key(plain)
+    now  = int(time.time())
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT username, revoked_at FROM api_keys WHERE key_hash = ?",
+            (h,),
+        ).fetchone()
+        if row is None or row["revoked_at"] is not None:
+            return None
+        # Owner must still be an active user — revoking the account
+        # invalidates every key transitively.
+        user = conn.execute(
+            "SELECT role, active FROM users WHERE username = ?",
+            (row["username"],),
+        ).fetchone()
+        if user is None or not user["active"]:
+            return None
+
+        conn.execute(
+            "UPDATE api_keys SET last_used_at = ? WHERE key_hash = ?",
+            (now, h),
+        )
+        conn.commit()
+        return {"username": row["username"], "role": user["role"]}
+    finally:
+        conn.close()
+
+
+def revoke_api_key(username: str, key_prefix: str) -> bool:
+    """Mark a single key revoked. Only the owning user (or admin —
+    enforced at the endpoint, not here) may revoke their keys.
+
+    Idempotent: revoking an already-revoked key returns False rather
+    than re-stamping ``revoked_at``, so re-runs are visible to the
+    caller without rewriting history.
+    """
+    if not key_prefix:
+        return False
+    now  = int(time.time())
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "UPDATE api_keys SET revoked_at = ? "
+            "WHERE key_prefix = ? AND username = ? AND revoked_at IS NULL",
+            (now, key_prefix, username),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def list_api_keys(username: str) -> List[Dict]:
+    """Return one row per key the user owns.
+
+    Each row is keyed by ``key_prefix`` (the user-visible handle)
+    rather than the full hash. ``revoked`` is a boolean for the
+    caller's convenience; ``revoked_at`` is also included so an
+    operator can sort by it.
+    """
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT key_prefix, label, created_at, last_used_at, revoked_at "
+            "FROM api_keys WHERE username = ? "
+            "ORDER BY revoked_at IS NULL DESC, created_at DESC",
+            (username,),
+        ).fetchall()
+        out = []
+        for r in rows:
+            d = dict(r)
+            d["revoked"] = d["revoked_at"] is not None
+            out.append(d)
+        return out
+    finally:
+        conn.close()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,6 +167,33 @@ kept separate only to honor the 20 KB module-size gate):
 Both paths apply `validate_password_policy()` from W4 P1-B and
 re-hash through `hash_password()` (bcrypt) from W4 P1-A.
 
+### 5.3 User API keys (W4 P3-1, 2026-05-11)
+
+Long-lived credentials for external integrations (CI scripts,
+internal tooling). Distinct from the system-wide `JAMES_API_KEY`
+env var, which remains the operator's bootstrap secret.
+
+- `core/api_keys.py` (separate module to honor the 20 KB module-size
+  gate) issues `jms_<43-char-urlsafe>` tokens. Only SHA256(token) is
+  persisted in the `api_keys` table; the plaintext is returned
+  exactly once from `POST /api-keys/issue`.
+- The first 12 characters (`jms_` + 8 random) form the public
+  **prefix** — visible to the owner via `GET /api-keys/list` and
+  used as the handle for `POST /api-keys/revoke`. The prefix never
+  reveals the body and is not a credential.
+- `verify_api_key(plain)` returns the current `(username, role)` —
+  the role is read from the users table at call time, so a role
+  change on the user row takes effect on the next verify (keys do
+  not pin a stale role).
+- Revocation is one-way: a revoked key cannot be unrevoked. Issuing
+  a fresh key is the rotation path. The `username = ?` filter in
+  `revoke_api_key` prevents a caller from revoking another user's
+  key via guessed prefix.
+
+**Wiring into request authentication** lands separately in W4 P3-2.
+P3-1 only stands up storage + management; the endpoints below use
+JWT auth to reach the key-management surface itself.
+
 ---
 
 ## 5.5 PolicyEngine (single source of policy decisions)

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -50,6 +50,11 @@ from core.auth_reset import (
     consume_reset_token as _auth_consume_reset_token,
     RESET_TOKEN_TTL_SEC,
 )
+from core.api_keys import (
+    issue_api_key  as _api_key_issue,
+    revoke_api_key as _api_key_revoke,
+    list_api_keys  as _api_key_list,
+)
 from core.policy_engine import default_engine
 from processors.file_processor import FileProcessor
 
@@ -2774,6 +2779,94 @@ async def password_reset_confirm(
         status_code=401,
         detail="토큰이 유효하지 않거나 만료되었습니다.",
     )
+
+
+# ─── W4 P3-1: user API keys (issue / list / revoke) ─────────────
+
+class ApiKeyIssueRequest(BaseModel):
+    # Optional operator-supplied note ("ci-deploy", "laptop-2026-05"
+    # etc.) so a leaked key can be tied to a context. Plain string —
+    # rendered as text in the admin UI.
+    label: Optional[str] = None
+
+@app.post("/api-keys/issue",
+          summary="API 키 발급 (로그인된 사용자 자신용 — W4 P3-1)")
+async def api_keys_issue(data: ApiKeyIssueRequest, request: Request):
+    """Issue a new long-lived API key for the JWT-authenticated user.
+
+    The plaintext is returned **exactly once**. Only SHA256(token) is
+    persisted, so the value cannot be recovered later — the user must
+    capture it now. A revoked key cannot be unrevoked; issue a fresh
+    one instead.
+
+    Response codes:
+      200 — {token, prefix, label?}
+      401 — JWT missing/invalid
+      404 — JWT subject does not correspond to an active user (race
+            between token mint and account deactivation)
+    """
+    ip = get_client_ip(request)
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="인증이 필요합니다.")
+
+    pair = _api_key_issue(username, data.label)
+    if pair is None:
+        _write_audit("authenticated", "/api-keys/issue", query=username,
+                     security_event="api_key_issue_failed (inactive)",
+                     ip_address=ip)
+        raise HTTPException(status_code=404, detail="활성 사용자가 아닙니다.")
+    plain, prefix = pair
+    _write_audit("authenticated", "/api-keys/issue", query=username,
+                 security_event=f"api_key_issued prefix={prefix}",
+                 ip_address=ip)
+    return {"ok": True, "token": plain, "prefix": prefix,
+            "label": data.label}
+
+
+@app.get("/api-keys/list", summary="내 API 키 목록 (W4 P3-1)")
+async def api_keys_list(request: Request):
+    """List the caller's keys (active + revoked).
+
+    Plaintext is never returned. Each entry exposes the prefix (which
+    is the revocation handle), label, timestamps, and a ``revoked``
+    boolean. Sort: active first, then by created_at DESC.
+    """
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="인증이 필요합니다.")
+    return {"keys": _api_key_list(username)}
+
+
+class ApiKeyRevokeRequest(BaseModel):
+    key_prefix: str
+
+@app.post("/api-keys/revoke",
+          summary="API 키 회수 (로그인된 사용자 — 본인 키만 회수 가능, W4 P3-1)")
+async def api_keys_revoke(data: ApiKeyRevokeRequest, request: Request):
+    """Revoke one of the caller's keys by its prefix.
+
+    Scope is enforced in core.api_keys.revoke_api_key by the
+    ``username = ?`` filter — a caller cannot revoke another user's
+    key by guessing their prefix. Re-revoking an already-revoked key
+    returns 404 (rowcount=0) rather than re-stamping the timestamp.
+    """
+    ip = get_client_ip(request)
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="인증이 필요합니다.")
+
+    ok = _api_key_revoke(username, data.key_prefix)
+    if not ok:
+        _write_audit("authenticated", "/api-keys/revoke", query=username,
+                     security_event=f"api_key_revoke_failed prefix={data.key_prefix}",
+                     ip_address=ip)
+        raise HTTPException(status_code=404,
+                            detail="해당 키가 없거나 이미 회수되었습니다.")
+    _write_audit("authenticated", "/api-keys/revoke", query=username,
+                 security_event=f"api_key_revoked prefix={data.key_prefix}",
+                 ip_address=ip)
+    return {"ok": True, "prefix": data.key_prefix}
 
 
 @app.get("/admin/entities", summary="Entity 현황 — search + paging [item #1]")

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,334 @@
+"""W4 P3-1 — per-user API keys: issue / list / revoke.
+
+Coverage:
+  - core.api_keys helpers (issue / verify / revoke / list) — pure
+    DB semantics independent of the FastAPI layer.
+  - Endpoint contracts — JWT-scoped issue + list + revoke, plaintext-
+    once invariant, cross-user revocation blocked.
+
+Out of scope for THIS PR:
+  - The authentication middleware does NOT yet accept the issued
+    keys as a substitute for a JWT — that wiring is W4 P3-2. Tests
+    here verify that the key resolves through verify_api_key() to
+    the correct (username, role); the integration into request
+    handling is exercised by P3-2's tests.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-api-keys-suite-32chars",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core import auth as auth_mod  # noqa: E402
+from core import api_keys as ak_mod  # noqa: E402
+
+
+def _seed_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS api_keys (
+            key_hash      TEXT PRIMARY KEY,
+            key_prefix    TEXT NOT NULL,
+            username      TEXT NOT NULL,
+            label         TEXT,
+            created_at    INTEGER NOT NULL,
+            last_used_at  INTEGER,
+            revoked_at    INTEGER
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _insert_user(path: str, username: str, role: str = "employee",
+                 active: int = 1) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO users (username, password_hash, role, active) "
+        "VALUES (?, ?, ?, ?)",
+        (username, auth_mod.hash_password("placeholder_pw_42"),
+         role, active),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_key_row(path: str, prefix: str) -> dict | None:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        r = conn.execute(
+            "SELECT * FROM api_keys WHERE key_prefix = ?", (prefix,)
+        ).fetchone()
+        return dict(r) if r else None
+    finally:
+        conn.close()
+
+
+class IssueAndVerifyTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_issue_returns_jms_prefixed_plaintext_and_prefix(self):
+        _insert_user(self.db, "alice")
+        pair = ak_mod.issue_api_key("alice", label="ci")
+        self.assertIsNotNone(pair)
+        plain, prefix = pair
+        self.assertTrue(plain.startswith("jms_"))
+        self.assertEqual(prefix, plain[:ak_mod.KEY_PREFIX_LEN])
+        # Body is long enough to be brute-resistant.
+        self.assertGreater(len(plain), 32)
+
+    def test_issue_persists_hash_not_plaintext(self):
+        _insert_user(self.db, "alice")
+        plain, prefix = ak_mod.issue_api_key("alice")
+        row = _read_key_row(self.db, prefix)
+        self.assertIsNotNone(row)
+        self.assertNotEqual(row["key_hash"], plain,
+                            "plaintext token must NOT be stored")
+        self.assertEqual(
+            row["key_hash"],
+            hashlib.sha256(plain.encode("utf-8")).hexdigest(),
+            "stored hash must be SHA256(plaintext)",
+        )
+
+    def test_issue_rejects_unknown_user(self):
+        self.assertIsNone(ak_mod.issue_api_key("ghost"))
+
+    def test_issue_rejects_inactive_user(self):
+        _insert_user(self.db, "pending", active=0)
+        self.assertIsNone(ak_mod.issue_api_key("pending"))
+
+    def test_verify_returns_username_and_current_role(self):
+        _insert_user(self.db, "alice", role="employee")
+        plain, _ = ak_mod.issue_api_key("alice")
+        out = ak_mod.verify_api_key(plain)
+        self.assertEqual(out, {"username": "alice", "role": "employee"})
+
+    def test_verify_reflects_role_changes_on_user_row(self):
+        # If admin promotes alice via the users table, the next verify
+        # must see the new role — keys do NOT pin a stale role.
+        _insert_user(self.db, "alice", role="employee")
+        plain, _ = ak_mod.issue_api_key("alice")
+        # Promote alice.
+        conn = sqlite3.connect(self.db)
+        conn.execute("UPDATE users SET role = ? WHERE username = ?",
+                     ("manager", "alice"))
+        conn.commit()
+        conn.close()
+        out = ak_mod.verify_api_key(plain)
+        self.assertEqual(out["role"], "manager")
+
+    def test_verify_rejects_when_owner_inactive(self):
+        _insert_user(self.db, "alice")
+        plain, _ = ak_mod.issue_api_key("alice")
+        auth_mod.deactivate_user("alice")
+        self.assertIsNone(ak_mod.verify_api_key(plain))
+
+    def test_verify_rejects_garbage_and_wrong_prefix(self):
+        self.assertIsNone(ak_mod.verify_api_key(""))
+        self.assertIsNone(ak_mod.verify_api_key("not-a-key"))
+        # Right shape, never issued — must miss.
+        self.assertIsNone(ak_mod.verify_api_key("jms_unissued_xyz"))
+
+    def test_verify_bumps_last_used_at(self):
+        _insert_user(self.db, "alice")
+        plain, prefix = ak_mod.issue_api_key("alice")
+        before = _read_key_row(self.db, prefix)
+        self.assertIsNone(before["last_used_at"])
+        ak_mod.verify_api_key(plain)
+        after = _read_key_row(self.db, prefix)
+        self.assertIsNotNone(after["last_used_at"])
+
+
+class RevokeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_revoke_blocks_subsequent_verify(self):
+        _insert_user(self.db, "alice")
+        plain, prefix = ak_mod.issue_api_key("alice")
+        self.assertTrue(ak_mod.revoke_api_key("alice", prefix))
+        self.assertIsNone(ak_mod.verify_api_key(plain))
+
+    def test_revoke_cannot_target_other_users_key(self):
+        _insert_user(self.db, "alice")
+        _insert_user(self.db, "bob")
+        plain, prefix = ak_mod.issue_api_key("alice")
+        # Bob tries to revoke alice's key via her prefix — must fail.
+        self.assertFalse(ak_mod.revoke_api_key("bob", prefix))
+        # Key still verifies.
+        self.assertIsNotNone(ak_mod.verify_api_key(plain))
+
+    def test_revoke_idempotent_returns_false_second_time(self):
+        _insert_user(self.db, "alice")
+        _, prefix = ak_mod.issue_api_key("alice")
+        self.assertTrue(ak_mod.revoke_api_key("alice", prefix))
+        self.assertFalse(ak_mod.revoke_api_key("alice", prefix),
+                         "re-revoking must not silently re-stamp; "
+                         "history is informational")
+
+    def test_revoke_unknown_prefix_returns_false(self):
+        _insert_user(self.db, "alice")
+        self.assertFalse(ak_mod.revoke_api_key("alice", "jms_xxxxxxxx"))
+
+
+class ListTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_list_returns_only_owners_keys(self):
+        _insert_user(self.db, "alice")
+        _insert_user(self.db, "bob")
+        ak_mod.issue_api_key("alice", label="alice-key")
+        ak_mod.issue_api_key("bob",   label="bob-key")
+        keys = ak_mod.list_api_keys("alice")
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0]["label"], "alice-key")
+
+    def test_list_excludes_plaintext_includes_prefix_and_label(self):
+        _insert_user(self.db, "alice")
+        ak_mod.issue_api_key("alice", label="ci")
+        row = ak_mod.list_api_keys("alice")[0]
+        # No raw "key" or "plaintext" field — prefix is the handle.
+        self.assertNotIn("key", row)
+        self.assertNotIn("plaintext", row)
+        self.assertIn("key_prefix", row)
+        self.assertEqual(row["label"], "ci")
+        self.assertFalse(row["revoked"])
+
+    def test_list_sort_active_first_then_recent(self):
+        _insert_user(self.db, "alice")
+        _, p1 = ak_mod.issue_api_key("alice", label="first")
+        _, p2 = ak_mod.issue_api_key("alice", label="second")
+        ak_mod.revoke_api_key("alice", p1)
+        names = [r["label"] for r in ak_mod.list_api_keys("alice")]
+        # Active "second" comes before revoked "first".
+        self.assertEqual(names[0], "second")
+        self.assertEqual(names[1], "first")
+        self.assertTrue(ak_mod.list_api_keys("alice")[1]["revoked"])
+
+
+class EndpointTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+        _insert_user(self.db, "alice")
+        _insert_user(self.db, "bob")
+
+    def tearDown(self):
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _hdr(self, username: str, role: str = "employee") -> dict:
+        return {"Authorization": f"Bearer {auth_mod.create_token(username, role)}"}
+
+    def test_issue_requires_jwt(self):
+        r = self._client().post("/api-keys/issue", json={"label": "ci"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_issue_returns_plaintext_once_and_prefix(self):
+        r = self._client().post("/api-keys/issue",
+                                json={"label": "ci"},
+                                headers=self._hdr("alice"))
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertTrue(body["token"].startswith("jms_"))
+        self.assertEqual(body["prefix"], body["token"][:ak_mod.KEY_PREFIX_LEN])
+        self.assertEqual(body["label"], "ci")
+
+    def test_list_returns_only_callers_keys(self):
+        ak_mod.issue_api_key("alice", label="alice-key")
+        ak_mod.issue_api_key("bob",   label="bob-key")
+        r = self._client().get("/api-keys/list",
+                               headers=self._hdr("alice"))
+        self.assertEqual(r.status_code, 200, r.text)
+        labels = [k["label"] for k in r.json()["keys"]]
+        self.assertEqual(labels, ["alice-key"])
+
+    def test_revoke_happy_path(self):
+        _, prefix = ak_mod.issue_api_key("alice", label="ci")
+        r = self._client().post("/api-keys/revoke",
+                                json={"key_prefix": prefix},
+                                headers=self._hdr("alice"))
+        self.assertEqual(r.status_code, 200, r.text)
+        # Listing shows it as revoked.
+        rows = ak_mod.list_api_keys("alice")
+        self.assertTrue(rows[0]["revoked"])
+
+    def test_revoke_cross_user_returns_404(self):
+        _, prefix = ak_mod.issue_api_key("alice", label="ci")
+        # Bob tries to revoke alice's key.
+        r = self._client().post("/api-keys/revoke",
+                                json={"key_prefix": prefix},
+                                headers=self._hdr("bob"))
+        self.assertEqual(r.status_code, 404)
+
+    def test_revoke_unknown_prefix_returns_404(self):
+        r = self._client().post("/api-keys/revoke",
+                                json={"key_prefix": "jms_nonexist"},
+                                headers=self._hdr("alice"))
+        self.assertEqual(r.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Storage + management layer for long-lived per-user credentials. The authentication middleware does NOT yet accept these as a substitute for a JWT — that wiring is **W4 P3-2 (separate PR)**. Splitting lets the sensitive middleware change land independently and be reviewed on its own.

## Why a new module

The system-wide \`JAMES_API_KEY\` env var is an operator bootstrap secret that cannot be rotated without a restart and identifies no user. External integrations (CI, internal tooling, third-party clients) need credentials they can issue, rotate, and revoke on their own, that resolve to a real subject for audit/policy. \`core/api_keys.py\` is the storage + management layer; \`core/auth.py\` keeps the legacy semantics unchanged.

## Token shape

\`\`\`
jms_<43-char-urlsafe>
 ▲     ▲
 │     └── 32 random bytes, URL-safe base64
 └── "jms_" tag makes a leaked-in-logs key recognisable at a glance.
\`\`\`

First 12 chars (\`jms_\` + 8 random) form the public **prefix** — the only fragment shown after issuance, used as the handle for revocation. Not a credential.

## Public surface (core/api_keys.py)

- \`issue_api_key(username, label?) -> Optional[(plain, prefix)]\` — plaintext returned once. None on unknown/inactive user.
- \`verify_api_key(plain) -> Optional[{username, role}]\` — bumps \`last_used_at\` on success. Role read from users table at call time (no stale-role pinning). None on miss/revocation/inactive owner.
- \`revoke_api_key(username, prefix) -> bool\` — idempotent. Cross-user revocation impossible (username filter in WHERE clause, not a layer above).
- \`list_api_keys(username) -> List[Dict]\` — owner scope, active-first sort, no plaintext fields.

## Endpoints

- **POST /api-keys/issue** — \`{label?}\` → \`{token, prefix, label}\` (200). JWT subject is the only owner reference. 404 if subject is inactive.
- **GET /api-keys/list** — \`{keys:[...]}\` (200), caller only.
- **POST /api-keys/revoke** — \`{key_prefix}\` → \`{ok, prefix}\` (200) / 404 (unknown or cross-user).

## DB row (table \`api_keys\`)

| col | type | note |
|---|---|---|
| \`key_hash\` | TEXT PRIMARY KEY | SHA256(plaintext) |
| \`key_prefix\` | TEXT NOT NULL | indexed handle for revocation |
| \`username\` | TEXT NOT NULL | |
| \`label\` | TEXT | operator note |
| \`created_at\` | INTEGER | unix epoch |
| \`last_used_at\` | INTEGER | bumped on verify |
| \`revoked_at\` | INTEGER NULL | one-way |

No expiry column: long-lived is the point. Rotation = revoke + re-issue.

## Tests (22 new)

**Helpers (15)** — issue shape + hash-not-plaintext persists; verify round-trip + role-not-pinned + inactive owner rejected + last_used bumped; revoke blocks-verify + cross-user blocked + idempotent + unknown prefix; list owner-scoping + plaintext-excluded + active-first sort.

**Endpoints (6)** — issue 401 missing-JWT / 200 happy; list scoped to caller; revoke 200 happy / 404 cross-user / 404 unknown prefix.

## Verification

\`\`\`
python -m unittest discover tests
Ran 1231 tests in 35.729s
OK
\`\`\`

## Out of scope

- **W4 P3-2** — authentication middleware accepts \`X-API-Key\` / \`?api_key\` as a JWT substitute (security-sensitive; focused PR)
- **W4 P3-3** — frontend "내 API 키" management UI

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no \`core/retrieval\`, \`core/graph\`, or \`core/reasoning\` change.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) ✅ — new module + ARCHITECTURE.md §5.3 in same PR.
- Rule 5 (file size) ✅ — core/api_keys.py 7.9 KB, well under gate.