### PR TITLE
feat(policy): feature capability registry + can_use_feature backend (W4-Q1)

### DIFF
--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -1,0 +1,326 @@
+"""W4-Q1 — per-role feature capability registry.
+
+Before this module, every endpoint-level role check was hardcoded
+(`_require_admin` calls scattered across server_llmwiki.py, plus
+ad-hoc role comparisons inside handlers). Changing "manager can also
+upload" required a code edit + deploy.
+
+This module turns those hardcoded checks into a **catalog of named
+features** plus a small **override table**. Admins flip checkboxes in
+the UI; the runtime consults the same catalog through
+``PolicyEngine.can_use_feature(role, feature_id)``.
+
+Surface
+-------
+- ``FEATURES`` — immutable catalog (~15 entries). Adding a feature is
+  a code change on purpose: the operator UI exposes only what code
+  knows about, so a typo can't silently authorize anything.
+- ``get_override(feature_id, role) -> Optional[bool]`` — None = no
+  override, fall through to the feature's default_allowed set.
+- ``set_override(feature_id, role, allowed)`` — UPSERT one row.
+- ``clear_override(feature_id, role)`` — remove one row; the
+  feature falls back to its default.
+- ``clear_all_overrides_for(feature_id)`` — reset one feature
+  (used by the UI's "기본값 복원" action).
+- ``list_effective(roles)`` — catalog + current effective matrix
+  for the admin UI.
+
+Persistence
+-----------
+``feature_overrides`` table lives in the same SQLite DB as the users
+table (``james_users.db``). One row per (feature_id, role) that
+differs from the default. Empty table ⇒ the entire system runs on
+defaults, which is the pre-Q1 baseline.
+
+Wiring
+------
+Q1 (this PR) sets up storage + ``can_use_feature`` only. Q2 wires
+``_require_feature("upload.file", role)`` into the existing
+endpoints, and Q3 ships the admin matrix UI.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, FrozenSet, List
+
+from core.auth import _get_conn, ALLOWED_ROLES
+
+
+@dataclass(frozen=True)
+class Feature:
+    """One atomic capability the system knows how to gate.
+
+    Attributes:
+      id: canonical dotted id, e.g. "upload.file". Used in the
+          ``feature_overrides`` table and the ``applied_rule`` field
+          of every PolicyEngine decision for this feature.
+      description: short Korean label shown in the admin UI.
+      default_allowed: roles that have this feature out of the box.
+          A role NOT in this set is denied unless an admin adds an
+          override row. Stored as frozenset to prevent accidental
+          mutation.
+    """
+    id:               str
+    description:      str
+    default_allowed:  FrozenSet[str]
+
+
+def _f(fid: str, desc: str, allowed_roles: str) -> Feature:
+    """Compact constructor — `allowed_roles` is a comma-separated
+    list ('admin,manager,employee') so the catalog stays readable."""
+    roles = frozenset(r.strip() for r in allowed_roles.split(",") if r.strip())
+    # Defensive check at module load: every default role must exist in
+    # ALLOWED_ROLES. A typo here would silently produce a feature
+    # nobody can ever use.
+    unknown = roles - set(ALLOWED_ROLES)
+    if unknown:
+        raise RuntimeError(
+            f"feature_registry: feature {fid!r} has unknown role(s) "
+            f"in default_allowed: {sorted(unknown)}"
+        )
+    return Feature(id=fid, description=desc, default_allowed=roles)
+
+
+# Canonical feature catalog. Order matters only for the admin UI
+# (the grid renders top-to-bottom in this order).
+FEATURES: Dict[str, Feature] = {
+    # ── query / retrieval ───────────────────────────────────────
+    "query.basic": _f(
+        "query.basic",
+        "자메스 질의 (/query/)",
+        "admin,manager,employee,external",
+    ),
+    "query.web_search": _f(
+        "query.web_search",
+        "웹 검색 fallback",
+        "admin,manager",
+    ),
+    # ── upload / ingestion ──────────────────────────────────────
+    "upload.file": _f(
+        "upload.file",
+        "파일 업로드 (PDF/문서/이미지)",
+        "admin,manager",
+    ),
+    "upload.video": _f(
+        "upload.video",
+        "영상 업로드 (현재 거부, video-asr 대비 슬롯)",
+        "admin",
+    ),
+    # ── graph ──────────────────────────────────────────────────
+    "graph.view": _f(
+        "graph.view",
+        "그래프 페이지 진입",
+        "admin,manager,employee",
+    ),
+    "graph.explore_neighbor": _f(
+        "graph.explore_neighbor",
+        "노드 클릭 이웃 탐색",
+        "admin,manager",
+    ),
+    # ── self-service auth ──────────────────────────────────────
+    "password.change_self": _f(
+        "password.change_self",
+        "본인 비밀번호 변경",
+        "admin,manager,employee,external",
+    ),
+    "api_keys.issue_self": _f(
+        "api_keys.issue_self",
+        "본인 API 키 발급/조회/회수",
+        "admin,manager,employee",
+    ),
+    # ── admin surfaces ─────────────────────────────────────────
+    "admin.users": _f(
+        "admin.users",
+        "사용자 관리 (승인/거부/비활성화)",
+        "admin",
+    ),
+    "admin.audit_log": _f(
+        "admin.audit_log",
+        "감사 로그 조회",
+        "admin",
+    ),
+    "admin.evolution": _f(
+        "admin.evolution",
+        "self-evolution 제어 (제안/승인/롤백)",
+        "admin",
+    ),
+    "admin.policy_matrix": _f(
+        "admin.policy_matrix",
+        "권한 매트릭스 관리 (이 화면 자체)",
+        "admin",
+    ),
+    # ── workspace (W8 후속, 카탈로그 슬롯만 미리 등록) ─────────
+    "workspace.run_jobs": _f(
+        "workspace.run_jobs",
+        "(W8) 워크스페이스 job 실행",
+        "admin,manager",
+    ),
+    "workspace.schedule": _f(
+        "workspace.schedule",
+        "(W8) 워크스페이스 job 예약 (cron)",
+        "admin",
+    ),
+}
+
+
+# ───────────────────────────────────────────────────────────────
+# Storage helpers — ``feature_overrides`` table
+# ───────────────────────────────────────────────────────────────
+
+def _init_feature_overrides_table() -> None:
+    """Create the override table if missing. Idempotent — called on
+    module import so a fresh deployment has the schema before the
+    first admin write."""
+    conn = _get_conn()
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS feature_overrides (
+                feature_id  TEXT NOT NULL,
+                role        TEXT NOT NULL,
+                allowed     INTEGER NOT NULL,
+                updated_at  INTEGER NOT NULL,
+                updated_by  TEXT,
+                PRIMARY KEY (feature_id, role)
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_init_feature_overrides_table()
+
+
+def get_override(feature_id: str, role: str) -> Optional[bool]:
+    """Return ``True``/``False`` if an override exists for this pair,
+    else ``None`` (caller falls back to default)."""
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT allowed FROM feature_overrides "
+            "WHERE feature_id = ? AND role = ?",
+            (feature_id, role),
+        ).fetchone()
+        if row is None:
+            return None
+        return bool(row["allowed"])
+    finally:
+        conn.close()
+
+
+def set_override(feature_id: str, role: str, allowed: bool,
+                 updated_by: Optional[str] = None) -> bool:
+    """Upsert one override. Returns False if the feature_id is
+    unknown or the role is not in ``ALLOWED_ROLES`` — admins should
+    not be able to author rows that no runtime check will ever
+    consult.
+    """
+    if feature_id not in FEATURES:
+        return False
+    if role not in ALLOWED_ROLES:
+        return False
+    import time as _time
+    now = int(_time.time())
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "INSERT INTO feature_overrides "
+            "(feature_id, role, allowed, updated_at, updated_by) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(feature_id, role) DO UPDATE SET "
+            "allowed = excluded.allowed, "
+            "updated_at = excluded.updated_at, "
+            "updated_by = excluded.updated_by",
+            (feature_id, role, 1 if allowed else 0, now, updated_by),
+        )
+        conn.commit()
+        return True
+    finally:
+        conn.close()
+
+
+def clear_override(feature_id: str, role: str) -> bool:
+    """Remove a single override row. Returns True if a row was
+    deleted (the feature×role pair will now fall through to the
+    default)."""
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "DELETE FROM feature_overrides "
+            "WHERE feature_id = ? AND role = ?",
+            (feature_id, role),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def clear_all_overrides_for(feature_id: str) -> int:
+    """Reset one entire feature — all role overrides for it gone.
+    Returns the number of rows deleted. Used by the admin UI's
+    "기본값 복원" action."""
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "DELETE FROM feature_overrides WHERE feature_id = ?",
+            (feature_id,),
+        )
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+def list_effective(roles: Optional[List[str]] = None) -> List[Dict]:
+    """Return the catalog with the *currently effective* allowed set
+    for each feature × role. Shape per row:
+
+      {
+        "id": "upload.file",
+        "description": "파일 업로드 (PDF/문서/이미지)",
+        "default_allowed": ["admin", "manager"],
+        "effective": {
+          "admin":    {"allowed": True,  "source": "default"},
+          "manager":  {"allowed": True,  "source": "default"},
+          "employee": {"allowed": False, "source": "default"},
+          "external": {"allowed": True,  "source": "override"},  # if any
+        },
+      }
+
+    Used by the admin matrix UI — single round-trip captures both the
+    catalog (so the UI can render rows in code order) and the live
+    state (so checkboxes reflect any overrides).
+    """
+    roles = roles or list(ALLOWED_ROLES)
+
+    # One scan of feature_overrides; building a {(fid,role): allowed}
+    # dict keeps the per-feature lookup O(1).
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT feature_id, role, allowed FROM feature_overrides"
+        ).fetchall()
+    finally:
+        conn.close()
+    overrides = {(r["feature_id"], r["role"]): bool(r["allowed"]) for r in rows}
+
+    out: List[Dict] = []
+    for fid, feat in FEATURES.items():
+        effective = {}
+        for role in roles:
+            ov = overrides.get((fid, role))
+            if ov is None:
+                effective[role] = {
+                    "allowed": role in feat.default_allowed,
+                    "source":  "default",
+                }
+            else:
+                effective[role] = {"allowed": ov, "source": "override"}
+        out.append({
+            "id":               fid,
+            "description":      feat.description,
+            "default_allowed":  sorted(feat.default_allowed),
+            "effective":        effective,
+        })
+    return out

--- a/core/policy_engine.py
+++ b/core/policy_engine.py
@@ -317,6 +317,51 @@ class PolicyEngine:
             applied_rule="policy.emit.passthrough",
         )
 
+    def can_use_feature(self, role: str, feature_id: str) -> Decision:
+        """[W4-Q1] Endpoint-level feature gate.
+
+        Consults ``core.feature_registry``:
+          1. If the feature_id is unknown, deny (fail-closed — a typo
+             at a call site should fail loudly, not silently authorize).
+          2. If ``feature_overrides`` has a row for (feature_id, role),
+             honor it. The override is explicit operator intent and
+             takes precedence over the catalog's default_allowed.
+          3. Otherwise, allow iff ``role`` is in the feature's
+             ``default_allowed`` set.
+
+        The ``applied_rule`` of every returned Decision is
+        ``policy.feature.<feature_id>`` so audit-log search can find
+        "every check of this feature" with a single LIKE pattern.
+
+        Q1 ships this method; Q2 wires it into endpoints in place of
+        ad-hoc role comparisons; Q3 ships the admin matrix UI.
+        """
+        from core.feature_registry import FEATURES, get_override
+        feat = FEATURES.get(feature_id)
+        if feat is None:
+            return Decision(
+                allowed=False,
+                reason="unknown_feature",
+                applied_rule=f"policy.feature.{feature_id}",
+            )
+        override = get_override(feature_id, role)
+        if override is not None:
+            return Decision(
+                allowed=override,
+                reason=(
+                    "override.allow" if override else "override.deny"
+                ),
+                applied_rule=f"policy.feature.{feature_id}",
+            )
+        in_default = role in feat.default_allowed
+        return Decision(
+            allowed=in_default,
+            reason=(
+                "default.allow" if in_default else "default.deny"
+            ),
+            applied_rule=f"policy.feature.{feature_id}",
+        )
+
     def sanitize_for_ingestion(
         self,
         content: TrustedContent,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,10 +221,57 @@ and asks one of four typed methods:
 | `can_walk(role, entity) -> Decision`        | Graph DFS: may this role traverse to this entity? |
 | `can_call_tool(role, tool, args) -> Decision` | Tool execution: may this role invoke this tool? |
 | `can_emit(role, content) -> Decision`       | Output gate: may this role receive this content? |
+| `can_use_feature(role, feature_id) -> Decision` | Endpoint-level feature gate (W4-Q1, 2026-05-11). Catalog in `core/feature_registry.py`; admin overrides in `feature_overrides` table. |
 
 `Decision` is `(allowed: bool, reason: str, applied_rule: str)` —
 frozen dataclass; `applied_rule` is the canonical id used in audit-log
 correlation, e.g. `policy.retrieve.abac` or `policy.tool.admin_only`.
+
+### 5.5.1 Feature capability registry (W4-Q1, 2026-05-11)
+
+`core/feature_registry.py` is the catalog of all endpoint-level
+capability names the runtime knows about (`upload.file`,
+`admin.users`, `query.web_search`, etc.). Adding a feature is a
+**code change on purpose** — the operator UI only exposes feature
+ids the catalog knows about, so a typo can never silently authorize
+anything.
+
+Each `Feature` carries `id`, `description` (Korean label for the UI),
+and `default_allowed` (a frozenset of role names). The catalog is
+the source of truth at install time; admins override it through the
+small `feature_overrides` table:
+
+```
+feature_overrides (
+  feature_id  TEXT,
+  role        TEXT,
+  allowed     INTEGER 0|1,
+  updated_at  INTEGER,
+  updated_by  TEXT,
+  PRIMARY KEY (feature_id, role)
+)
+```
+
+Empty table ⇒ the entire system runs on the catalog's defaults, which
+is the pre-Q1 baseline.
+
+`PolicyEngine.can_use_feature(role, feature_id)` resolves a check as:
+1. **Unknown feature_id ⇒ deny** (fail-closed; a typo at a call site
+   should fail loudly, not silently authorize).
+2. **Override row present ⇒ honor it** (`reason="override.allow"` or
+   `"override.deny"`).
+3. **Otherwise** ⇒ allow iff `role ∈ feature.default_allowed`.
+
+The `applied_rule` of every decision is `policy.feature.<feature_id>`
+so audit-log search can find all checks of one feature with a single
+LIKE pattern.
+
+**W4-Q1 scope (this section)** — storage layer + the can_use_feature
+method + admin management endpoints (`/admin/features/list`,
+`/admin/features/override`, `/admin/features/reset`). The runtime
+*does not yet* consult these decisions on existing endpoints — that
+wiring is **W4-Q2** (separate PR; carries higher regression risk and
+warrants focused review). The admin UI is **W4-Q3**.
 
 **TrustedContent** is the wrapper every multimodal extractor (OCR,
 ASR, vision, web) returns instead of a raw string. Carries

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3672,6 +3672,131 @@ async def admin_audit_list(
             "limit": limit, "offset": offset}
 
 
+# ─── W4-Q1: feature capability matrix ──────────────────────────
+# Admin-only surface to inspect + adjust the per-role feature gate
+# (core/feature_registry.py + PolicyEngine.can_use_feature).
+# Q2 wires the runtime checks into existing endpoints; Q3 ships
+# the admin matrix UI. Q1 stands up only the management surface.
+
+@app.get("/admin/features/list", summary="권한 매트릭스 조회 (W4-Q1)")
+async def admin_features_list(
+    api_key: str,
+    role:    str = Depends(get_role_from_request),
+):
+    """Catalog + currently-effective allowed set per role.
+
+    Response shape:
+      {
+        "roles":    ["admin", "manager", "employee", "external"],
+        "features": [ {id, description, default_allowed, effective}, ... ]
+      }
+
+    The ``effective`` map per feature is keyed by role and carries
+    ``{allowed, source}`` where ``source ∈ {"default","override"}``
+    so the UI can render override rows distinctly.
+    """
+    _require_admin(api_key, role)
+    from core.feature_registry import list_effective
+    return {
+        "roles":    sorted(ALLOWED_ROLES),
+        "features": list_effective(),
+    }
+
+
+class FeatureOverrideRequest(BaseModel):
+    feature_id: str
+    role:       str
+    allowed:    bool
+
+@app.post("/admin/features/override",
+          summary="권한 매트릭스 override 설정 (W4-Q1)")
+async def admin_features_override(
+    data:    FeatureOverrideRequest,
+    request: Request,
+    api_key: str = "",
+    role:    str = Depends(get_role_from_request),
+):
+    """Set one (feature_id, role) override.
+
+    Validation lives inside ``set_override`` — unknown feature_id or
+    role returns False, surfaced here as 400. Idempotent: re-setting
+    the same value just updates the timestamp + updated_by.
+    """
+    _require_admin(api_key, role)
+    from core.feature_registry import set_override
+
+    # Read caller username from the JWT subject for audit-log
+    # attribution. Optional — if missing (DEV_MODE / X-Role), we
+    # still write the row but updated_by is None.
+    try:
+        from core.auth import verify_token
+        caller = None
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            caller = (verify_token(auth_header[7:].strip()) or {}).get("sub")
+    except Exception:
+        caller = None
+
+    ok = set_override(data.feature_id, data.role, data.allowed,
+                      updated_by=caller)
+    ip = get_client_ip(request)
+    if not ok:
+        _write_audit(role, "/admin/features/override",
+                     query=f"{data.feature_id}/{data.role}",
+                     security_event="override_failed (unknown feature or role)",
+                     ip_address=ip)
+        raise HTTPException(
+            status_code=400,
+            detail="알 수 없는 feature_id 또는 role 입니다.",
+        )
+    _write_audit(role, "/admin/features/override",
+                 query=f"{data.feature_id}/{data.role}",
+                 security_event=f"override_set allowed={data.allowed}",
+                 ip_address=ip)
+    return {"ok": True, "feature_id": data.feature_id,
+            "role": data.role, "allowed": data.allowed}
+
+
+class FeatureResetRequest(BaseModel):
+    feature_id: str
+    # role 이 명시되면 그 한 행만 reset, 비어있으면 feature 전체 reset
+    role:       Optional[str] = None
+
+@app.post("/admin/features/reset",
+          summary="권한 매트릭스 override 제거 → 기본값 복원 (W4-Q1)")
+async def admin_features_reset(
+    data:    FeatureResetRequest,
+    request: Request,
+    api_key: str = "",
+    role:    str = Depends(get_role_from_request),
+):
+    """Remove overrides for a feature.
+
+    Two modes:
+      - role specified  → delete that single override row.
+      - role omitted/empty → delete every override for the feature
+                              (full reset to default).
+
+    Returns the number of rows actually deleted, so the UI can show
+    "0개 reset" when the feature already used the defaults.
+    """
+    _require_admin(api_key, role)
+    from core.feature_registry import clear_override, clear_all_overrides_for
+
+    ip = get_client_ip(request)
+    if data.role:
+        deleted = 1 if clear_override(data.feature_id, data.role) else 0
+        scope_label = f"{data.feature_id}/{data.role}"
+    else:
+        deleted = clear_all_overrides_for(data.feature_id)
+        scope_label = data.feature_id
+    _write_audit(role, "/admin/features/reset",
+                 query=scope_label,
+                 security_event=f"override_cleared count={deleted}",
+                 ip_address=ip)
+    return {"ok": True, "deleted": deleted, "scope": scope_label}
+
+
 # ────────────────────────────────────────────────────────────────────
 # [#2 file management tab, 2026-05-09] /admin/files/* endpoints —
 # unified file inspection (tree + search + download). Upload + history

--- a/tests/test_feature_registry.py
+++ b/tests/test_feature_registry.py
@@ -1,0 +1,373 @@
+"""W4-Q1 — feature registry + PolicyEngine.can_use_feature + endpoints.
+
+Three layers:
+  1. core.feature_registry — pure DB roundtrip.
+  2. PolicyEngine.can_use_feature — override > default > fail-closed.
+  3. HTTP endpoints — /admin/features/{list,override,reset}.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-feature-registry-suite-32chars",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _seed_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS feature_overrides (
+            feature_id  TEXT NOT NULL,
+            role        TEXT NOT NULL,
+            allowed     INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            updated_by  TEXT,
+            PRIMARY KEY (feature_id, role)
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _api_key() -> str:
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+class _FixtureBase(unittest.TestCase):
+    def setUp(self):
+        from core import auth as auth_mod
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        from core import auth as auth_mod
+        auth_mod._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+
+class CatalogTests(unittest.TestCase):
+    """Module-import time validation."""
+
+    def test_every_default_role_is_in_allowed_roles(self):
+        # Constructor raises on unknown roles; if the module imported
+        # without error, every feature is well-formed.
+        from core.feature_registry import FEATURES
+        from core.auth import ALLOWED_ROLES
+        for fid, feat in FEATURES.items():
+            self.assertTrue(
+                feat.default_allowed.issubset(ALLOWED_ROLES),
+                f"{fid} has role not in ALLOWED_ROLES: "
+                f"{feat.default_allowed - set(ALLOWED_ROLES)}",
+            )
+
+    def test_admin_users_default_is_admin_only(self):
+        from core.feature_registry import FEATURES
+        self.assertEqual(FEATURES["admin.users"].default_allowed,
+                         frozenset({"admin"}))
+
+    def test_query_basic_open_to_everyone(self):
+        from core.feature_registry import FEATURES, ALLOWED_ROLES
+        self.assertEqual(FEATURES["query.basic"].default_allowed,
+                         frozenset(ALLOWED_ROLES))
+
+
+class StorageTests(_FixtureBase):
+    def test_get_override_returns_none_when_empty(self):
+        from core.feature_registry import get_override
+        self.assertIsNone(get_override("upload.file", "employee"))
+
+    def test_set_then_get_roundtrip(self):
+        from core.feature_registry import set_override, get_override
+        self.assertTrue(set_override("upload.file", "employee", True,
+                                     updated_by="test-admin"))
+        self.assertEqual(get_override("upload.file", "employee"), True)
+
+    def test_set_override_upserts(self):
+        from core.feature_registry import set_override, get_override
+        set_override("upload.file", "employee", True)
+        set_override("upload.file", "employee", False)
+        self.assertEqual(get_override("upload.file", "employee"), False)
+
+    def test_set_rejects_unknown_feature(self):
+        from core.feature_registry import set_override
+        self.assertFalse(set_override("nope.such.feature", "admin", True))
+
+    def test_set_rejects_unknown_role(self):
+        from core.feature_registry import set_override
+        self.assertFalse(set_override("upload.file", "wizard", True))
+
+    def test_clear_override_removes_row(self):
+        from core.feature_registry import (
+            set_override, clear_override, get_override,
+        )
+        set_override("upload.file", "employee", True)
+        self.assertTrue(clear_override("upload.file", "employee"))
+        self.assertIsNone(get_override("upload.file", "employee"))
+
+    def test_clear_returns_false_when_no_row(self):
+        from core.feature_registry import clear_override
+        self.assertFalse(clear_override("upload.file", "employee"))
+
+    def test_clear_all_overrides_for_feature(self):
+        from core.feature_registry import (
+            set_override, clear_all_overrides_for, get_override,
+        )
+        set_override("upload.file", "manager",  True)
+        set_override("upload.file", "employee", True)
+        set_override("graph.view",  "external", True)
+        n = clear_all_overrides_for("upload.file")
+        self.assertEqual(n, 2)
+        # Other feature untouched.
+        self.assertEqual(get_override("graph.view", "external"), True)
+        # upload.file rows gone.
+        self.assertIsNone(get_override("upload.file", "manager"))
+
+
+class PolicyEngineCanUseFeatureTests(_FixtureBase):
+    def test_default_allow(self):
+        from core.policy_engine import default_engine
+        d = default_engine.can_use_feature("admin", "admin.users")
+        self.assertTrue(d.allowed)
+        self.assertEqual(d.reason, "default.allow")
+        self.assertEqual(d.applied_rule, "policy.feature.admin.users")
+
+    def test_default_deny(self):
+        from core.policy_engine import default_engine
+        d = default_engine.can_use_feature("employee", "admin.users")
+        self.assertFalse(d.allowed)
+        self.assertEqual(d.reason, "default.deny")
+
+    def test_override_grants_role_outside_default_set(self):
+        from core.policy_engine import default_engine
+        from core.feature_registry import set_override
+        set_override("upload.file", "employee", True)
+        d = default_engine.can_use_feature("employee", "upload.file")
+        self.assertTrue(d.allowed)
+        self.assertEqual(d.reason, "override.allow")
+
+    def test_override_revokes_default_grant(self):
+        from core.policy_engine import default_engine
+        from core.feature_registry import set_override
+        set_override("query.basic", "external", False)
+        d = default_engine.can_use_feature("external", "query.basic")
+        self.assertFalse(d.allowed)
+        self.assertEqual(d.reason, "override.deny")
+
+    def test_unknown_feature_fails_closed(self):
+        from core.policy_engine import default_engine
+        d = default_engine.can_use_feature("admin", "totally.fake")
+        self.assertFalse(d.allowed,
+                         "fail-closed on unknown feature_id — typo at a "
+                         "call site must not silently authorize")
+        self.assertEqual(d.reason, "unknown_feature")
+
+
+class ListEffectiveTests(_FixtureBase):
+    def test_shape_with_no_overrides(self):
+        from core.feature_registry import list_effective
+        rows = list_effective()
+        # One row per feature in the catalog.
+        self.assertTrue(any(r["id"] == "upload.file" for r in rows))
+        upload = next(r for r in rows if r["id"] == "upload.file")
+        self.assertIn("admin",   upload["effective"])
+        self.assertEqual(upload["effective"]["admin"]["source"], "default")
+        self.assertEqual(upload["effective"]["external"]["allowed"], False)
+
+    def test_override_surfaces_with_source_override(self):
+        from core.feature_registry import set_override, list_effective
+        set_override("upload.file", "external", True)
+        rows = list_effective()
+        upload = next(r for r in rows if r["id"] == "upload.file")
+        self.assertEqual(upload["effective"]["external"]["source"], "override")
+        self.assertEqual(upload["effective"]["external"]["allowed"], True)
+
+
+class EndpointTests(_FixtureBase):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = _api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        super().setUp()
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _admin_hdr(self):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token('test-admin', 'admin')}"}
+
+    def _employee_hdr(self):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token('test-emp', 'employee')}"}
+
+    # ── admin gate ──────────────────────────────────────────────
+    def test_list_requires_admin(self):
+        r = self._client().get(
+            "/admin/features/list",
+            params={"api_key": self._api_key},
+            headers=self._employee_hdr(),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_override_requires_admin(self):
+        r = self._client().post(
+            "/admin/features/override",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file",
+                  "role": "manager", "allowed": True},
+            headers=self._employee_hdr(),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_reset_requires_admin(self):
+        r = self._client().post(
+            "/admin/features/reset",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file"},
+            headers=self._employee_hdr(),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    # ── list ────────────────────────────────────────────────────
+    def test_list_returns_catalog_with_roles(self):
+        r = self._client().get(
+            "/admin/features/list",
+            params={"api_key": self._api_key},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertIn("admin",    body["roles"])
+        self.assertIn("manager",  body["roles"])
+        self.assertIn("employee", body["roles"])
+        self.assertIn("external", body["roles"])
+        ids = [f["id"] for f in body["features"]]
+        self.assertIn("upload.file", ids)
+        self.assertIn("admin.users", ids)
+
+    def test_list_reflects_override_immediately(self):
+        from core.feature_registry import set_override
+        set_override("upload.file", "external", True)
+        r = self._client().get(
+            "/admin/features/list",
+            params={"api_key": self._api_key},
+            headers=self._admin_hdr(),
+        )
+        body = r.json()
+        upload = next(f for f in body["features"] if f["id"] == "upload.file")
+        self.assertEqual(upload["effective"]["external"]["source"], "override")
+        self.assertEqual(upload["effective"]["external"]["allowed"], True)
+
+    # ── override ────────────────────────────────────────────────
+    def test_override_happy_path(self):
+        r = self._client().post(
+            "/admin/features/override",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file",
+                  "role": "employee", "allowed": True},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        from core.feature_registry import get_override
+        self.assertEqual(get_override("upload.file", "employee"), True)
+
+    def test_override_unknown_feature_returns_400(self):
+        r = self._client().post(
+            "/admin/features/override",
+            params={"api_key": self._api_key},
+            json={"feature_id": "nope.fake",
+                  "role": "employee", "allowed": True},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_override_unknown_role_returns_400(self):
+        r = self._client().post(
+            "/admin/features/override",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file",
+                  "role": "wizard", "allowed": True},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 400)
+
+    # ── reset ───────────────────────────────────────────────────
+    def test_reset_single_role(self):
+        from core.feature_registry import set_override, get_override
+        set_override("upload.file", "employee", True)
+        r = self._client().post(
+            "/admin/features/reset",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file", "role": "employee"},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json()["deleted"], 1)
+        self.assertIsNone(get_override("upload.file", "employee"))
+
+    def test_reset_entire_feature(self):
+        from core.feature_registry import set_override, get_override
+        set_override("upload.file", "employee", True)
+        set_override("upload.file", "manager",  False)
+        r = self._client().post(
+            "/admin/features/reset",
+            params={"api_key": self._api_key},
+            json={"feature_id": "upload.file"},
+            headers=self._admin_hdr(),
+        )
+        body = r.json()
+        self.assertEqual(body["deleted"], 2)
+        self.assertIsNone(get_override("upload.file", "employee"))
+        self.assertIsNone(get_override("upload.file", "manager"))
+
+    def test_reset_returns_zero_when_no_overrides(self):
+        r = self._client().post(
+            "/admin/features/reset",
+            params={"api_key": self._api_key},
+            json={"feature_id": "graph.view"},
+            headers=self._admin_hdr(),
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["deleted"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First of three PRs that move endpoint-level role checks from hardcoded \`_require_admin\` calls and ad-hoc role comparisons onto a runtime-configurable matrix. This PR ships **storage layer + PolicyEngine method + admin management endpoints** — but does NOT yet wire runtime checks into existing endpoints. That wiring is **W4-Q2** (separate PR; higher regression risk, focused review).

## Why split Q1/Q2/Q3

Q2 will touch ~30 admin endpoints to replace explicit role comparisons with \`_require_feature("upload.file", role)\` calls. A single misalignment between the default catalog and the prior hardcoded behavior would silently authorize or deny live operators. Q1 lands the catalog + override storage + decision logic *independently* so Q2's diff is purely behavior-equivalent rewiring.

## What lands

**\`core/feature_registry.py\` (new, 11.8 KB)**
- \`FEATURES\` catalog — **14 atomic capability ids** covering query / upload / graph / self-service auth / admin surfaces / W8 workspace slots
- Constructor validates every default role at module import — typos crash at startup, not at first request
- Helpers: \`get/set/clear_override\`, \`clear_all_overrides_for\` (UI 기본값 복원), \`list_effective\`
- \`feature_overrides\` table created lazily

**\`core/policy_engine.py\`**
- New \`can_use_feature(role, feature_id) -> Decision\`
- Resolution: unknown → deny (fail-closed); override present → honor; else → \`role ∈ default_allowed\`
- \`applied_rule = policy.feature.<feature_id>\` for audit-log search

**\`server_llmwiki.py\`** — 3 new admin endpoints:
- \`GET /admin/features/list\` — catalog + effective matrix
- \`POST /admin/features/override\` — set one (feature_id, role) row
- \`POST /admin/features/reset\` — clear one row, or all rows for a feature

**\`docs/ARCHITECTURE.md §5.5 + §5.5.1\`** — new \`can_use_feature\` row in methods table + "Feature capability registry" subsection (catalog → override → default resolution, schema, Q1/Q2/Q3 staging).

**\`tests/test_feature_registry.py\` (new, 29 tests)** — catalog invariants / storage roundtrip / PolicyEngine resolution / list_effective shape / endpoint admin gate + happy paths + 400 on unknown feature·role.

## Defaults snapshot (matches pre-Q1 hardcoded behavior)

| role | feature ids |
|---|---|
| admin only | \`admin.users\`, \`admin.audit_log\`, \`admin.evolution\`, \`admin.policy_matrix\`, \`upload.video\`, \`workspace.schedule\` |
| admin + manager | \`upload.file\`, \`query.web_search\`, \`workspace.run_jobs\`, \`graph.explore_neighbor\` |
| admin + manager + employee | \`graph.view\`, \`api_keys.issue_self\` |
| all four | \`query.basic\`, \`password.change_self\` |

## Verification

\`\`\`
python -m unittest discover tests
Ran 1284 tests in 38.182s
OK
\`\`\`

## Out of scope

- **W4-Q2** — replace \`_require_admin\` + ad-hoc role checks at the ~30 existing endpoints with \`_require_feature(<id>, role)\`.
- **W4-Q3** — admin matrix UI (feature × role checkbox grid + "기본값 복원").

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅ — feature ids are generic.
- Rule 2 (bench paste) N/A — no core/retrieval, graph, reasoning change.
- Rule 3 (self-evolution untouched) ✅ — \`admin.evolution\` is a feature gate, not a policy change.
- Rule 4 (architecture): new module + new PolicyEngine method + ARCHITECTURE.md §5.5/§5.5.1 in the same PR. **architecture label appropriate** (trust-boundary surface extended).
- Rule 5 (file size) ✅ — feature_registry.py 11.8 KB, policy_engine.py 19.2 KB.