### PR TITLE
feat(chat): 파일 드래그·복붙 미니썸네일 + 사이드바 자동전환 (W6)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1174,10 +1174,18 @@
     </div>
 
     <div class="input-area">
+      <!-- W6: 챗 input 위 미니썸네일 row.
+           uploadQueue 가 비어있으면 display:none. 클릭 → 사이드바
+           업로드 모드 자동 전환 + expand. dragenter 단계에서도 미리
+           표시될 수 있게 chat.js 가 갱신한다. -->
+      <div id="chat-attachment-row"
+           style="display:none;flex-wrap:wrap;gap:6px;padding:6px 16px;
+                  border-bottom:1px solid var(--border-2);"></div>
       <div class="input-wrap">
         <textarea id="chat-input" placeholder="Type a message (Shift+Enter for new line)"
                   data-i18n-placeholder="chat.placeholder" rows="1"
-          oninput="autoResize(this)" onkeydown="handleKey(event)"></textarea>
+          oninput="autoResize(this)" onkeydown="handleKey(event)"
+          onpaste="handleChatPaste(event)"></textarea>
         <button class="send-btn" id="send-btn" onclick="sendMessage()">▲</button>
       </div>
     </div>

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -182,7 +182,15 @@ dropZone.addEventListener('drop', async e => {
     if (!e.dataTransfer.types.includes('Files')) return;
     e.preventDefault();
     dragDepth++;
-    if (dragDepth === 1) showOverlay();
+    if (dragDepth === 1) {
+      showOverlay();
+      // W6: switch sidebar to upload mode so the user sees the drop
+      // target before they release. switchSidebarMode 는 W5 의 공개
+      // entry point. 사이드바가 collapsed 상태면 expand 도 함께.
+      if (typeof switchSidebarMode === 'function') {
+        switchSidebarMode('upload');
+      }
+    }
   });
 
   window.addEventListener('dragover', e => {
@@ -209,15 +217,15 @@ dropZone.addEventListener('drop', async e => {
     if (files.length === 0) return;
 
     addFiles(files);
-    // 사이드바 자동 열기 — 큐 / 진행률 보이도록
-    if (typeof toggleSidebar === 'function') {
+    // W6: switchSidebarMode 가 expand 까지 처리 — 명시적으로 보장.
+    if (typeof switchSidebarMode === 'function') {
+      switchSidebarMode('upload');
+    } else if (typeof toggleSidebar === 'function') {
+      // Fallback for any host without W5 (e.g. older cached page).
       const sb = document.getElementById('sidebar');
-      if (sb && sb.classList.contains('collapsed')) {
-        toggleSidebar();
-      }
+      if (sb && sb.classList.contains('collapsed')) toggleSidebar();
     }
     if (typeof toast === 'function') {
-      // 폴더 드롭이면 내부 파일 다 펼쳐진 합계가 보임
       const folderHint = files.some(f => f.relPath && f.relPath.includes('/'))
                         ? ' (폴더 포함)' : '';
       toast(`파일 ${files.length}개 추가됨${folderHint}`, 'success');
@@ -262,7 +270,115 @@ function addFiles(files) {
     toast(msg, 'warn');
   }
   updateUploadBtn();
+  // W6: refresh the chat-input mini-thumbnails row.
+  if (typeof renderChatAttachmentRow === 'function') {
+    renderChatAttachmentRow();
+  }
 }
+
+
+/* ── W6: 챗 input 위 미니썸네일 row ──
+   사이드바 file-list 와 같은 uploadQueue 를 mirror 표시. 이미지는
+   FileReader 로 readAsDataURL 해서 base64 thumb, 그 외는 getFileIcon
+   이모지. 클릭 → 사이드바 업로드 모드 전환 + expand. 빈 큐 = 숨김.
+*/
+const _thumbDataCache = new Map(); // id → dataURL (이미지만)
+
+function _maybeLoadThumb(item) {
+  if (!item || !item.file) return;
+  if (_thumbDataCache.has(item.id)) return;
+  if (!/^image\//.test(item.file.type || '')) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    _thumbDataCache.set(item.id, reader.result);
+    // Re-render to swap the icon for the loaded thumb. Cheap — the
+    // row is only N items, and renderChatAttachmentRow is O(N).
+    renderChatAttachmentRow();
+  };
+  // No onerror handler — failure leaves the icon fallback in place.
+  try { reader.readAsDataURL(item.file); } catch (_) {}
+}
+
+function renderChatAttachmentRow() {
+  const row = document.getElementById('chat-attachment-row');
+  if (!row) return;
+  const queue = (typeof uploadQueue !== 'undefined') ? uploadQueue : [];
+  if (!queue.length) {
+    row.style.display = 'none';
+    row.innerHTML = '';
+    return;
+  }
+  row.style.display = 'flex';
+  row.innerHTML = queue.map(it => {
+    _maybeLoadThumb(it);
+    const isImg  = /^image\//.test(it.file.type || '');
+    const thumb  = isImg && _thumbDataCache.has(it.id)
+      ? `<img src="${_thumbDataCache.get(it.id)}" alt=""
+              style="width:100%;height:100%;object-fit:cover;border-radius:5px">`
+      : `<span style="font-size:18px">${
+          (typeof getFileIcon === 'function') ? getFileIcon(it.file.name) : '📄'
+        }</span>`;
+    const status = it.status === 'upload' ? '⬆️'
+                 : it.status === 'done'   ? '✅'
+                 : it.status === 'error'  ? '❌'
+                 : '';
+    // Truncate the display name — 16 chars + ext keeps the chip narrow.
+    const name = it.file.name.length > 22
+      ? it.file.name.slice(0, 16) + '…' + it.file.name.slice(-5)
+      : it.file.name;
+    return `
+      <div onclick="_chatAttachClick()"
+           title="${it.file.name.replace(/"/g, '&quot;')}"
+           style="display:flex;align-items:center;gap:6px;padding:4px 8px 4px 4px;
+                  background:var(--surface-2);border:1px solid var(--border);
+                  border-radius:8px;cursor:pointer;font-size:11px;color:var(--text-soft);
+                  max-width:200px;font-family:var(--font-ui)">
+        <span style="width:24px;height:24px;display:flex;align-items:center;
+                     justify-content:center;background:var(--bg);border-radius:5px;
+                     overflow:hidden;flex-shrink:0">${thumb}</span>
+        <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
+          ${name}
+        </span>
+        ${status ? `<span style="flex-shrink:0">${status}</span>` : ''}
+      </div>`;
+  }).join('');
+}
+
+// Single click target for the whole row — opens sidebar on the
+// upload mode so the user can inspect / remove / start the upload.
+window._chatAttachClick = function () {
+  if (typeof switchSidebarMode === 'function') {
+    switchSidebarMode('upload');
+  } else if (typeof toggleSidebar === 'function') {
+    const sb = document.getElementById('sidebar');
+    if (sb && sb.classList.contains('collapsed')) toggleSidebar();
+  }
+};
+
+
+/* ── W6: 챗 input 에 paste — 클립보드의 파일/이미지를 큐에 추가 ──
+   브라우저에서 이미지를 복사하면 ClipboardItem 으로 File-like 객체가
+   넘어옴. 텍스트 paste 는 무시하고 textarea 의 기본 동작 유지.
+*/
+window.handleChatPaste = function (e) {
+  if (!e.clipboardData || !e.clipboardData.items) return;
+  const files = [];
+  for (const item of e.clipboardData.items) {
+    if (item.kind === 'file') {
+      const f = item.getAsFile();
+      if (f) files.push(f);
+    }
+  }
+  if (!files.length) return;   // 일반 텍스트 paste 는 그대로
+  e.preventDefault();
+  addFiles(files);
+  if (typeof switchSidebarMode === 'function') {
+    switchSidebarMode('upload');
+  }
+  if (typeof toast === 'function') {
+    toast(`클립보드에서 파일 ${files.length}개 추가됨`, 'success');
+  }
+};
 
 /* ── 파일 제거 또는 진행 중 취소 ──
  *  Issue #14: when upload is in flight (item.status === 'upload' and xhr
@@ -280,6 +396,11 @@ function removeOrCancel(id) {
   const el = document.getElementById(`file-${id}`);
   if (el) el.remove();
   updateUploadBtn();
+  // W6: keep the chat-input mini-thumbnail row in sync.
+  if (typeof renderChatAttachmentRow === 'function') {
+    _thumbDataCache.delete(id);
+    renderChatAttachmentRow();
+  }
 }
 // Backwards-compat alias for any inline onclick that still calls removeFile
 function removeFile(id) { removeOrCancel(id); }
@@ -365,6 +486,11 @@ function setStatus(id, status, label) {
   // Per-file progress bar visible only during upload.
   const prog = document.getElementById(`progress-${id}`);
   if (prog) prog.style.display = (status === 'upload') ? '' : 'none';
+  // W6: keep the chat-input mini-thumbnail status indicator in sync
+  // (⬆️ / ✅ / ❌).
+  if (typeof renderChatAttachmentRow === 'function') {
+    renderChatAttachmentRow();
+  }
 }
 
 function setProgress(id, pct) {


### PR DESCRIPTION
## Summary

옵션 C 세 번째 사이클. **W5 의 \`switchSidebarMode\` 첫 사용자.** 챗 input 영역에서 파일 드래그·복붙·드롭 시:
- 사이드바를 \`upload\` 모드로 자동 전환 (W5)
- 챗 input 위에 미니썸네일 row 표시 (큐 mirror)
- paste (Ctrl+V) — 클립보드 이미지/파일도 큐에 추가

## What changed

**index.html**
- 챗 input 위에 \`#chat-attachment-row\` 컨테이너 (큐 비어있으면 display:none)
- \`<textarea>\` 에 \`onpaste="handleChatPaste(event)"\` wire

**static/upload.js**
- \`dragenter\` 핸들러에 \`switchSidebarMode('upload')\` 추가 — 사이드바가 \`recent\`/\`search\` 모드 + collapsed 상태였어도 release 전에 드롭존 노출
- \`drop\` 후에도 \`switchSidebarMode('upload')\` 명시 호출. Fallback 으로 구 캐시 환경 위해 \`toggleSidebar\` 경로 유지
- 신규 \`renderChatAttachmentRow()\` — uploadQueue 를 chip 형식으로 mirror. 이미지는 FileReader \`readAsDataURL\` base64 thumb, 그 외는 \`getFileIcon\` 이모지
- \`_thumbDataCache\` Map 으로 thumb 캐시 (같은 파일 두 번 read 안 함)
- \`addFiles\` / \`removeOrCancel\` / \`setStatus\` 가 각각 \`renderChatAttachmentRow\` 호출 → chip 상태 indicator (⬆️/✅/❌) 사이드바와 동기화
- 신규 \`handleChatPaste\` — clipboardData.items 에서 \`kind==='file'\` 만 추출. 일반 텍스트 paste 는 그대로 통과

## Defensive UX

- 영상 파일은 기존 \`_isVideoFile\` 필터로 addFiles 단계에서 차단 (paste 경로도 동일 검증)
- chip 파일명 22 자 초과 시 \`abcdefghij…lhwpx\` 단축. 전체 이름은 title attribute hover 표시
- chip max-width:200px → 챗 input 가로 폭 한도. 큐 많으면 flex-wrap 다음 줄

## Verification

\`\`\`
python -m unittest discover tests
Ran 1284 tests in 38.288s
OK
\`\`\`

**UI 라이브 검증:**
1. 챗 입력창에 파일 드래그 → 사이드바가 recent/search 모드였어도 upload 모드로 자동 전환 + expand → 드롭존 노출
2. 드롭 → 사이드바 큐 + 챗 input 위 미니썸네일 row 동시 표시
3. 이미지 복사 → 챗 input 에서 Ctrl+V → 클립보드 파일 큐에 추가 → 미니썸네일 즉시 표시
4. chip 클릭 → 사이드바 upload 모드 + expand
5. 업로드 시작 → chip 상태 ⬆️ → 완료 시 ✅
6. 사이드바에서 X 로 큐 제거 → chip 즉시 사라짐

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/* change.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) ✅ — 새 trust boundary 없음. paste 도 기존 upload 검증 거침.
- Rule 5 (file size) ✅ — frontend no per-file gate.

## 다음 (옵션 C)

**W4-Q2** — feature gate 와이어링 (회귀 위험 큰 작업, focused review).