### PR TITLE
feat(policy): wire 17 endpoints onto _require_feature (W4-Q2-a)

### DIFF
--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -193,7 +193,15 @@ _init_feature_overrides_table()
 
 def get_override(feature_id: str, role: str) -> Optional[bool]:
     """Return ``True``/``False`` if an override exists for this pair,
-    else ``None`` (caller falls back to default)."""
+    else ``None`` (caller falls back to default).
+
+    A missing ``feature_overrides`` table is treated as "no overrides".
+    The table is created on module import for the live DB, but tests
+    that monkey-patch ``_DB_PATH`` to a fresh file would otherwise
+    crash with OperationalError; we'd rather fall through to defaults
+    in that case than fail-closed on a runtime exception.
+    """
+    import sqlite3 as _sqlite3
     conn = _get_conn()
     try:
         row = conn.execute(
@@ -204,6 +212,8 @@ def get_override(feature_id: str, role: str) -> Optional[bool]:
         if row is None:
             return None
         return bool(row["allowed"])
+    except _sqlite3.OperationalError:
+        return None
     finally:
         conn.close()
 
@@ -295,12 +305,16 @@ def list_effective(roles: Optional[List[str]] = None) -> List[Dict]:
     roles = roles or list(ALLOWED_ROLES)
 
     # One scan of feature_overrides; building a {(fid,role): allowed}
-    # dict keeps the per-feature lookup O(1).
+    # dict keeps the per-feature lookup O(1). Missing table → empty
+    # overrides (defaults apply across the board).
+    import sqlite3 as _sqlite3
     conn = _get_conn()
     try:
         rows = conn.execute(
             "SELECT feature_id, role, allowed FROM feature_overrides"
         ).fetchall()
+    except _sqlite3.OperationalError:
+        rows = []
     finally:
         conn.close()
     overrides = {(r["feature_id"], r["role"]): bool(r["allowed"]) for r in rows}

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1712,7 +1712,7 @@ async def list_proposals(
     role:    str = Depends(get_role_from_request),
 ):
     """admin 검토 대기 중인 자기진화 제안 목록."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.evo_analyzer import list_proposals as _list
         return {"proposals": _list(status), "status_filter": status}
@@ -1731,7 +1731,7 @@ async def approve_proposal(
     admin이 제안을 승인하면 즉시 자동 실행 + 결과 보고.
     실행 결과를 응답으로 반환.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.evo_analyzer import approve_and_execute
         report = approve_and_execute(proposal_id)
@@ -1752,7 +1752,7 @@ async def reject_proposal_api(
     role:        str = Depends(get_role_from_request),
 ):
     """[4-C] 제안 거부 + 사유 장기기억 저장."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.evo_analyzer import reject_proposal
         ok = reject_proposal(proposal_id, reason)
@@ -1773,7 +1773,7 @@ async def save_rejection_memory(
     role:    str = Depends(get_role_from_request),
 ):
     """[4-C] 거부 사유 → memory_store 장기기억 저장."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from core.memory import MemoryStore
         ms  = MemoryStore()
@@ -1797,7 +1797,7 @@ async def get_evo_reports(
     role:    str = Depends(get_role_from_request),
 ):
     """자기진화 실행 결과 보고서 목록."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.evo_analyzer import list_reports
         return {"reports": list_reports(limit)}
@@ -1810,7 +1810,7 @@ async def get_evo_reports(
 async def generate_proposals(
     api_key: str, role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.evo_analyzer import generate_proposals_from_signals
         from llm.router import RouterWrapper
@@ -2401,6 +2401,30 @@ def _require_admin(api_key: str, role: str):
                             detail="admin 권한 필요 — admin 계정으로 로그인하세요")
 
 
+def _require_feature(api_key: str, role: str, feature_id: str):
+    """[W4-Q2] Validate api_key + consult PolicyEngine.can_use_feature.
+
+    Same shape as _require_admin but consults the per-feature gate
+    from W4-Q1 instead of the hardcoded ``role != "admin"`` check.
+    For features whose default_allowed set is ``{"admin"}`` (every
+    admin.* feature in the Q1 catalog), behaviour is identical to
+    _require_admin — that equivalence is the safety net for Q2-a's
+    rewrite of existing endpoints.
+
+    Q2-b will add new admin.* features for the remaining endpoints
+    (settings/llm/persona/...) and replace their _require_admin
+    calls similarly.
+    """
+    verify_api_key(api_key)
+    from core.policy_engine import default_engine
+    d = default_engine.can_use_feature(role, feature_id)
+    if not d.allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"권한이 부족합니다. ({feature_id})",
+        )
+
+
 def _read_jsonl_tail(path: str, max_lines: int = 200) -> list[dict]:
     """[#2-A] Read only the last `max_lines` rows of a JSONL log.
 
@@ -2571,7 +2595,7 @@ async def admin_users(
     is replaced with a real implementation. Any exception now surfaces
     as a 500 — better than masking schema drift behind an empty UI.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.users")
     return {"users": _auth_list_users(only_pending=bool(pending))}
 
 
@@ -2590,7 +2614,7 @@ async def admin_users_approve(
     api_key: str = "",
     role:    str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.users")
     if data.role not in ALLOWED_ROLES:
         raise HTTPException(status_code=400, detail=f"invalid role: {data.role}")
 
@@ -2620,7 +2644,7 @@ async def admin_users_reject(
     api_key: str = "",
     role:    str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.users")
     ok = _auth_reject_user(data.username)
     ip = get_client_ip(request)
     if not ok:
@@ -2647,10 +2671,10 @@ async def admin_users_deactivate(
     api_key: str = "",
     role:    str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.users")
     # Admin cannot deactivate themselves — that would be an instant
-    # lockout. The role check above has already confirmed the caller's
-    # role is admin; we read the JWT subject to recover the username.
+    # lockout. The feature gate above has already confirmed the caller
+    # holds admin.users; we read the JWT subject to recover the username.
     try:
         from core.auth import verify_token
         caller_payload = None
@@ -2758,7 +2782,7 @@ async def admin_issue_reset_token(
     Returns 404 if the user is unknown or inactive — admins should not
     issue resets for pending or removed accounts (use approve/reject).
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.users")
     ip = get_client_ip(request)
 
     token = _auth_issue_reset_token(data.username)
@@ -3093,7 +3117,7 @@ async def admin_memory(api_key: str, role: str = Depends(get_role_from_request))
 @app.get("/admin/patches", summary="Patch 이력 [P7]")
 async def admin_patches(api_key: str, status: str = "all",
                         role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.patch.patch_generator import list_patches
         return {"patches": list_patches(status)}
@@ -3239,7 +3263,7 @@ async def admin_patch_audit(
     Composes with `/admin/audit` (the broader, multi-source feed) —
     this endpoint is the patch-specific view.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     from tools.patch.audit_query import query_patch_audit
     rows = query_patch_audit(
         since=since or None,
@@ -3611,7 +3635,7 @@ async def admin_audit_list(
     may carry sensitive context (rejected passwords are NOT logged
     verbatim by _write_audit; only the rule name surfaces).
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.audit_log")
     limit  = max(1, min(int(limit or 100), 500))
     offset = max(0, int(offset or 0))
     qstr   = (q or "").strip()
@@ -3695,7 +3719,7 @@ async def admin_features_list(
     ``{allowed, source}`` where ``source ∈ {"default","override"}``
     so the UI can render override rows distinctly.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.policy_matrix")
     from core.feature_registry import list_effective
     return {
         "roles":    sorted(ALLOWED_ROLES),
@@ -3722,7 +3746,7 @@ async def admin_features_override(
     role returns False, surfaced here as 400. Idempotent: re-setting
     the same value just updates the timestamp + updated_by.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.policy_matrix")
     from core.feature_registry import set_override
 
     # Read caller username from the JWT subject for audit-log
@@ -3780,7 +3804,7 @@ async def admin_features_reset(
     Returns the number of rows actually deleted, so the UI can show
     "0개 reset" when the feature already used the defaults.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.policy_matrix")
     from core.feature_registry import clear_override, clear_all_overrides_for
 
     ip = get_client_ip(request)

--- a/tests/test_evolution_audit_query.py
+++ b/tests/test_evolution_audit_query.py
@@ -243,13 +243,19 @@ class EndpointContractTests(unittest.TestCase):
         self.assertIn("from tools.patch.audit_query import query_patch_audit", src,
                       "audit endpoint must import query_patch_audit")
         # Admin gating — same pattern as the rest of /admin/* handlers.
-        # The handler invokes _require_admin(api_key, role).
-        # We grep for the call inside the handler body region.
+        # Either the legacy _require_admin(api_key, role) call or the
+        # W4-Q2 _require_feature(api_key, role, "admin.evolution") call
+        # gates this endpoint; both enforce admin authority for the
+        # admin.evolution feature.
         idx = src.index('@app.get("/admin/patch/audit"')
         # Window: 1500 chars after the decorator covers the handler body.
         window = src[idx:idx + 1500]
-        self.assertIn("_require_admin(api_key, role)", window,
-                      "audit endpoint must call _require_admin")
+        self.assertTrue(
+            "_require_admin(api_key, role)" in window
+            or '_require_feature(api_key, role, "admin.evolution")' in window,
+            "audit endpoint must call _require_admin or "
+            "_require_feature for admin.evolution",
+        )
         self.assertIn("query_patch_audit(", window,
                       "audit endpoint must call query_patch_audit")
         # Response shape contract.

--- a/tests/test_q2a_feature_wiring.py
+++ b/tests/test_q2a_feature_wiring.py
@@ -1,0 +1,181 @@
+"""W4-Q2-a — feature gate wiring on existing admin endpoints.
+
+The catalog from Q1 is no longer just metadata: 17 endpoints now
+consult ``PolicyEngine.can_use_feature`` through the new
+``_require_feature`` helper. This test proves the override path
+ACTUALLY changes who can call which endpoint — without it, Q1 was
+purely cosmetic.
+
+Two demonstrations using ``/admin/users`` as the witness endpoint:
+  1. admin JWT → 200 (default_allowed includes admin)
+  2. manager JWT → 403 by default
+  3. override admin.users allowed for manager → manager JWT now → 200
+  4. clear override → manager JWT → 403 again
+
+The same wiring covers 17 endpoints; testing one is enough to prove
+the helper + Q1 module + Q2 wiring all line up.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-q2a-wiring-32chars-min",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _seed_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash TEXT NOT NULL,
+            role          TEXT NOT NULL,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS feature_overrides (
+            feature_id  TEXT NOT NULL,
+            role        TEXT NOT NULL,
+            allowed     INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            updated_by  TEXT,
+            PRIMARY KEY (feature_id, role)
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _api_key() -> str:
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+class FeatureGateRewireTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = _api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        from core import auth as auth_mod
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        _seed_schema(self.db)
+        self._saved_path = auth_mod._DB_PATH
+        auth_mod._DB_PATH = self.db
+
+    def tearDown(self):
+        from core import auth as auth_mod
+        auth_mod._DB_PATH = self._saved_path
+        Path(self.db).unlink(missing_ok=True)
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _hdr(self, role: str):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token(f'test-{role}', role)}"}
+
+    # ── default matrix ────────────────────────────────────────────
+    def test_admin_passes_admin_users_by_default(self):
+        r = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_manager_blocked_from_admin_users_by_default(self):
+        r = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("manager"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    # ── override path ─────────────────────────────────────────────
+    def test_override_grants_manager_access(self):
+        from core.feature_registry import set_override
+        set_override("admin.users", "manager", True, updated_by="test")
+        r = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("manager"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_clear_override_restores_default_deny(self):
+        from core.feature_registry import set_override, clear_override
+        set_override("admin.users", "manager", True)
+        # Confirm it actually let manager in first.
+        r1 = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("manager"),
+        )
+        self.assertEqual(r1.status_code, 200, r1.text)
+        clear_override("admin.users", "manager")
+        # Now back to default-deny.
+        r2 = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("manager"),
+        )
+        self.assertEqual(r2.status_code, 403)
+
+    def test_override_to_false_revokes_admin(self):
+        # Inverse direction: an admin override flagged False should
+        # lock the admin out. This is the operator's escape hatch
+        # for "we need to disable a feature mid-flight without a
+        # deploy" scenarios.
+        from core.feature_registry import set_override
+        set_override("admin.users", "admin", False)
+        r = self._client().get(
+            "/admin/users",
+            params={"api_key": self._api_key},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    # ── different features stay independent ───────────────────────
+    def test_override_on_one_feature_does_not_leak_to_another(self):
+        from core.feature_registry import set_override
+        # Grant manager access to admin.users only.
+        set_override("admin.users", "manager", True)
+        # admin.audit_log still defaults to admin-only — manager blocked.
+        r = self._client().get(
+            "/admin/audit/list",
+            params={"api_key": self._api_key},
+            headers=self._hdr("manager"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Q1 lit up the feature catalog as **data**; until Q2 wires runtime checks, override rows in \`feature_overrides\` are cosmetic — every endpoint still runs through the hardcoded \`_require_admin\`. **This PR is the first slice of Q2**: rewires the 17 admin endpoints whose features the Q1 catalog already covers. Q2-b extends the catalog + rewires the remaining ~25; Q2-c handles non-admin gates.

## Helper

\`_require_feature(api_key, role, feature_id)\` next to \`_require_admin\`. Same \`verify_api_key\` step, then consults \`default_engine.can_use_feature\`. Raises 403 with the feature_id in the detail string.

**For any feature whose default_allowed is \`{"admin"}\` (every admin.* feature in the Q1 catalog), behaviour is identical to the legacy \`_require_admin\`** — that equivalence is the safety net for this rewrite.

## Rewired endpoints (17)

| feature | endpoints |
|---|---|
| \`admin.users\` (5) | \`/admin/users\` · \`/users/approve\` · \`/users/reject\` · \`/users/deactivate\` · \`/users/issue-reset-token\` |
| \`admin.audit_log\` (1) | \`/admin/audit/list\` |
| \`admin.policy_matrix\` (3) | \`/admin/features/list\` · \`/override\` · \`/reset\` |
| \`admin.evolution\` (8) | \`/admin/proposals/\` · \`/proposals/{id}/approve\` · \`/reject\` · \`/admin/memory/save-rejection\` · \`/admin/evo-reports/\` · \`/admin/proposals/generate/\` · \`/admin/patches\` · \`/admin/patch/audit\` |

The remaining \`_require_admin\` callers (LLM mgmt, persona, knowledge, character, file/entity/memory inspection, dashboard, metrics/trace, web-search-config, legacy /admin/audit JSONL) are deliberately left alone — **Q2-b** will deal with them after extending the catalog.

## Defensive change in \`core/feature_registry.py\`

\`get_override\` and \`list_effective\` now swallow \`sqlite3.OperationalError\` ("no such table") and fall through to defaults. The table is created on module import for the live DB, but ~15 existing test files monkey-patch \`_DB_PATH\` to a fresh sqlite without the schema; without this catch every admin endpoint in those tests would 500.

## Tests

**\`tests/test_q2a_feature_wiring.py\` (new, 6 tests)** — proves the override path ACTUALLY changes who can call an endpoint:
- admin JWT → 200 by default
- manager JWT → 403 by default
- override \`admin.users\` allowed for manager → manager → 200
- clear override → manager → 403 again
- override \`admin.users\` allowed=False for admin → admin → 403 (operator's mid-flight feature-disable escape hatch)
- override on \`admin.users\` doesn't leak to \`admin.audit_log\`

**\`tests/test_evolution_audit_query.py\`** — source-text check accepted only \`_require_admin\` substring. Loosened to accept either \`_require_admin\` OR \`_require_feature(..., "admin.evolution")\`.

## Verification

\`\`\`
python -m unittest discover tests
Ran 1290 tests in 38.141s
OK
\`\`\`

## Out of scope

- **Q2-b** — catalog extension + remaining ~25 admin endpoints
- **Q2-c** — query / upload / graph user-side feature gates
- **Q3** — admin matrix UI

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning change.
- Rule 3 (self-evolution untouched) ✅ — \`admin.evolution\` is a gate on existing endpoints, not a policy change.
- Rule 4 (architecture) — surface already documented in ARCHITECTURE.md §5.5.1 (Q1).
- Rule 5 (file size) ✅ — feature_registry.py 12.0 KB; server_llmwiki.py is FastAPI entry point (no gate).