### PR TITLE
feat(policy): catalog extension + 38 remaining endpoints wired (W4-Q2-b)

### DIFF
--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -149,6 +149,40 @@ FEATURES: Dict[str, Feature] = {
         "권한 매트릭스 관리 (이 화면 자체)",
         "admin",
     ),
+    # Added in W4-Q2-b — features that cover the remaining admin
+    # endpoints. All admin-only by default; admins can grant subsets
+    # to manager (e.g. "manager can read metrics but not change LLM
+    # selection") via the matrix UI in W4-Q3.
+    "admin.settings": _f(
+        "admin.settings",
+        "시스템 설정 (LLM 모델 / persona / 웹 검색 / model selection)",
+        "admin",
+    ),
+    "admin.data": _f(
+        "admin.data",
+        "데이터 인스펙션 (entity / memory / files / 업로드 이력)",
+        "admin",
+    ),
+    "admin.metrics": _f(
+        "admin.metrics",
+        "메트릭·대시보드·trace 조회",
+        "admin",
+    ),
+    "admin.character": _f(
+        "admin.character",
+        "성향(character) 조회·설정",
+        "admin",
+    ),
+    "admin.knowledge": _f(
+        "admin.knowledge",
+        "능력 성장(knowledge) 조회·학습",
+        "admin",
+    ),
+    "admin.tools": _f(
+        "admin.tools",
+        "관리자 도구 (화면 캡처 분석 등)",
+        "admin",
+    ),
     # ── workspace (W8 후속, 카탈로그 슬롯만 미리 등록) ─────────
     "workspace.run_jobs": _f(
         "workspace.run_jobs",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,12 +266,29 @@ The `applied_rule` of every decision is `policy.feature.<feature_id>`
 so audit-log search can find all checks of one feature with a single
 LIKE pattern.
 
-**W4-Q1 scope (this section)** — storage layer + the can_use_feature
-method + admin management endpoints (`/admin/features/list`,
-`/admin/features/override`, `/admin/features/reset`). The runtime
-*does not yet* consult these decisions on existing endpoints — that
-wiring is **W4-Q2** (separate PR; carries higher regression risk and
-warrants focused review). The admin UI is **W4-Q3**.
+**W4-Q1 scope** — storage layer + the can_use_feature method + admin
+management endpoints (`/admin/features/list`, `/admin/features/override`,
+`/admin/features/reset`).
+
+**W4-Q2 status (2026-05-11)** — runtime wiring completed in two slices:
+- **Q2-a** rewired 17 admin endpoints whose features Q1 already
+  covered (admin.users / admin.audit_log / admin.policy_matrix /
+  admin.evolution).
+- **Q2-b** extended the catalog with 6 admin.* features
+  (admin.settings, admin.data, admin.metrics, admin.character,
+  admin.knowledge, admin.tools) and rewired the remaining 38
+  `_require_admin` call sites onto `_require_feature`. The
+  hardcoded `_require_admin` helper is preserved as a backward-
+  compat alias for any external caller, but no in-repo endpoint
+  uses it anymore.
+
+After Q2-b, the runtime consults the matrix on every admin endpoint.
+Setting `feature_overrides` rows in the DB (or via the admin UI in
+Q3) is the operator's only knob — no code change required to grant
+or revoke a feature for a role mid-flight.
+
+**W4-Q3** ships the admin matrix UI (feature × role checkbox grid
++ "기본값 복원").
 
 **TrustedContent** is the wrapper every multimodal extractor (OCR,
 ASR, vision, web) returns instead of a raw string. Carries

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1203,7 +1203,7 @@ async def llm_install(api_key: str, model: str,
     {percent, completed, total, status} to _install_progress[model],
     which the admin UI polls.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     ALLOWED_MODELS = _allowed_install_models() | {"llava:13b"}
     if model not in ALLOWED_MODELS:
         raise HTTPException(
@@ -1245,7 +1245,7 @@ async def llm_install_progress(api_key: str, model: str,
     Response shape:
       {status, percent, completed, total, done, error, model}
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     snap = _install_progress.get(model)
     if not snap:
         return {"model": model, "status": "idle",
@@ -1257,7 +1257,7 @@ async def llm_install_progress(api_key: str, model: str,
 @app.get("/admin/llm/installed", summary="설치된 Ollama 모델 목록 [4-B]")
 async def llm_installed(api_key: str, role: str = Depends(get_role_from_request)):
     """현재 Ollama에 설치된 모델 목록."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     try:
         import urllib.request, json as _json
         with urllib.request.urlopen("http://localhost:11434/api/tags", timeout=5) as r:
@@ -1293,7 +1293,7 @@ async def llm_resolution(api_key: str, role: str = Depends(get_role_from_request
        preference: {chat: [...], coding: [...]},
        ttl_s: 60}
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     from core.model_resolver import resolution_snapshot
     return resolution_snapshot()
 
@@ -1301,7 +1301,7 @@ async def llm_resolution(api_key: str, role: str = Depends(get_role_from_request
 @app.get("/admin/llm/recommend", summary="하드웨어 기반 LLM 추천 [4-B]")
 async def llm_recommend(api_key: str, role: str = Depends(get_role_from_request)):
     """현재 하드웨어 스펙에 맞는 LLM 모델 추천."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     try:
         from tools.system.hardware_inspector import get_hardware_specs, get_llm_recommendations
         specs = get_hardware_specs()
@@ -1326,7 +1326,7 @@ async def llm_pull(
     role: str = Depends(get_role_from_request),
 ):
     """Ollama 모델 pull (다운로드). 시간이 걸릴 수 있음."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     if not model or len(model) > 60:
         raise HTTPException(status_code=400, detail="model명 오류")
     # 보안: 허용 모델만
@@ -1358,7 +1358,7 @@ async def llm_delete(
     role: str = Depends(get_role_from_request),
 ):
     """Ollama 모델 삭제."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     try:
         import urllib.request, json as _json
         body = _json.dumps({"name": model}).encode()
@@ -1395,7 +1395,7 @@ async def get_web_search_config(api_key: str,
                         can render the right toast (TAVILY missing,
                         DDG fallback active, both missing, etc.)
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     from core.web_search_config import load
     from tools.web.web_searcher import get_search_engine_status
     cfg = load()
@@ -1419,7 +1419,7 @@ async def set_web_search_config(data: WebSearchConfigUpdate,
     Empty allowed_roles is rejected — silently disabling web search
     is rarely the intent and harder to debug later (operator can
     clear TAVILY_API_KEY instead if they really want it off)."""
-    _require_admin(data.api_key, role)
+    _require_feature(data.api_key, role, "admin.settings")
     from core.web_search_config import save, validate_update
     clean_roles, clean_threshold, err = validate_update(
         data.allowed_roles, data.threshold,
@@ -1452,7 +1452,7 @@ async def llm_selections_get(
     role: str = Depends(get_role_from_request),
 ):
     """현재 ``llm.selection`` 의 ``task_type → model`` 매핑 전체 반환."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     from llm.selection import get_all_selections
     return {"selections": get_all_selections()}
 
@@ -1465,7 +1465,7 @@ async def llm_select_set(
     role: str = Depends(get_role_from_request),
 ):
     """``task_type`` 의 추론에 사용할 model을 지정. ollama에 설치된 model만 허용."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     task_type = (task_type or "").strip()
     model     = (model or "").strip()
     if not task_type or len(task_type) > 32:
@@ -1493,7 +1493,7 @@ async def llm_select_remove(
     role: str = Depends(get_role_from_request),
 ):
     """``task_type`` 매핑 제거. 기본 model로 fallback."""
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     from llm.selection import remove_model_for_task
     removed = remove_model_for_task(task_type)
     _write_audit(role, "/admin/llm/select#delete", query=task_type, elapsed_sec=0)
@@ -1829,7 +1829,7 @@ async def generate_proposals(
 async def get_perf_metrics(
     api_key: str, role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.metrics")
     try:
         from tools.self.performance_evaluator import get_current_metrics
         from tools.self.importance_scorer import get_scorer_stats
@@ -1843,7 +1843,7 @@ async def get_perf_metrics(
 async def manual_evaluate(
     api_key: str, role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.performance_evaluator import run_evaluation
         return run_evaluation()
@@ -1856,7 +1856,7 @@ async def get_perf_history(
     api_key: str, limit: int = 20,
     role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.performance_evaluator import get_eval_history
         return {"history": get_eval_history(limit)}
@@ -1881,7 +1881,7 @@ async def learn_topic_api(
       4. wiki entity 저장 + vector 인덱싱
       5. domain 태그 자동 분류 + 지식 레벨 +5점
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.knowledge")
     if not topic:
         raise HTTPException(status_code=400, detail="topic 파라미터 필요")
     try:
@@ -1983,7 +1983,7 @@ async def learn_topic_api(
 async def learn_from_errors_api(
     api_key: str, role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.knowledge")
     try:
         from tools.self.self_learner import learn_from_errors
         results = learn_from_errors()
@@ -1999,7 +1999,7 @@ async def get_error_queries(
     api_key: str, min_count: int = 2,
     role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from tools.self.importance_scorer import get_repeated_errors
         return {"error_queries": get_repeated_errors(min_count)}
@@ -2033,7 +2033,7 @@ async def submit_feedback(
 async def get_feedback_stats_api(
     api_key: str, role: str = Depends(get_role_from_request),
 ):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.evolution")
     try:
         from core.feedback_engine import get_feedback_stats
         return get_feedback_stats()
@@ -2046,7 +2046,7 @@ async def get_feedback_stats_api(
 
 @app.get("/admin/character/", summary="성향 조회 [P7-EVO-D]")
 async def get_character(api_key: str, role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.character")
     try:
         # [P5c 2026-05-10] summary 필드 추가 — 16 trait 자연어 요약
         # (핵심/가치/스타일 3 라인). 프론트는 동일 룰의 JS 미러를 가지므로
@@ -2069,7 +2069,7 @@ class TraitUpdateRequest(BaseModel):
 @app.post("/admin/character/", summary="성향 설정 [P7-EVO-D]")
 async def set_character(data: TraitUpdateRequest,
                          role: str = Depends(get_role_from_request)):
-    _require_admin(data.api_key, role)
+    _require_feature(data.api_key, role, "admin.character")
     try:
         from core.character_profile import get_profile
         result = get_profile().set_trait(data.trait_id, data.value)
@@ -2089,7 +2089,7 @@ async def set_character(data: TraitUpdateRequest,
          summary="성향 상관관계 그래프 [P1 unified UX]")
 async def get_character_correlations(api_key: str,
                                       role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.character")
     try:
         from core.character_profile import CharacterProfile
         return {
@@ -2105,7 +2105,7 @@ async def get_character_correlations(api_key: str,
 
 @app.get("/admin/knowledge/", summary="능력 성장 현황 [P7-EVO-E]")
 async def get_knowledge(api_key: str, role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.knowledge")
     try:
         from core.knowledge_tracker import get_tracker
         t = get_tracker()
@@ -2215,7 +2215,7 @@ async def screen_analyze(
     role: str = Depends(get_role_from_request),
 ):
     """화면 캡처 → OCR → LLM 분석. admin 전용."""
-    _require_admin(data.api_key, role)
+    _require_feature(data.api_key, role, "admin.tools")
     try:
         from tools.screen.screen_agent import run_screen_analysis
         region = tuple(data.region) if data.region else None
@@ -2480,7 +2480,7 @@ def _read_jsonl_tail(path: str, max_lines: int = 200) -> list[dict]:
 
 @app.get("/admin/dashboard", summary="관리자 대시보드 [P7]")
 async def admin_dashboard(api_key: str, role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.metrics")
 
     # ── 기본 카운트 ──────────────────────────────────────────
     try:    entity_count = len(rag_engine.wiki_generator.entity_id_index)
@@ -2963,7 +2963,7 @@ async def admin_entities(
     so the operator always sees corpus-wide totals. `total` is the count
     AFTER filters are applied; `total_all` is the unfiltered count.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     from pathlib import Path
 
     # Clamp limit defensively — 500 covers any realistic v0.2 wiki.
@@ -3027,7 +3027,7 @@ async def admin_entity_detail(
     Used by the admin entities page click-to-expand modal so the
     operator can audit a wiki row without leaving the admin UI.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     from pathlib import Path
 
     fpath = rag_engine.wiki_generator.entity_id_index.get(entity_id)
@@ -3070,7 +3070,7 @@ async def admin_graph_snapshot(
     are dropped by default and require an explicit elevated role to
     surface (which v0.2 doesn't yet have — kept off for now).
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     from core.graph_snapshot import build_snapshot
 
     src = (source_type or "prod").strip().lower()
@@ -3100,7 +3100,7 @@ async def admin_graph_snapshot(
 
 @app.get("/admin/memory", summary="Memory 현황 [P7]")
 async def admin_memory(api_key: str, role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     try:
         from core.memory import MemoryStore
         from core.memory.store import _connect
@@ -3143,7 +3143,7 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
         `james_patch_log.jsonl` (visible via /admin/audit).
     """
     body = await request.json()
-    _require_admin(body.get("api_key",""), role)
+    _require_feature(body.get("api_key",""), role, "admin.evolution")
 
     # #48 phase 1 — opt-in gate.
     from config import EVOLUTION_ENABLED, APPROVER_ROLE
@@ -3286,7 +3286,7 @@ async def admin_patch_audit(
 @app.post("/admin/patch/reject", summary="Patch 거부 [P7]")
 async def admin_patch_reject(request: Request, role: str = Depends(get_role_from_request)):
     body = await request.json()
-    _require_admin(body.get("api_key",""), role)
+    _require_feature(body.get("api_key",""), role, "admin.evolution")
     patch_id = body.get("patch_id","")
     from pathlib import Path
     pf = Path(f"./workspace/patches/{patch_id}.json")
@@ -3372,7 +3372,7 @@ async def admin_trace_get(
     404 when no trace file exists for the (trace_id, day) pair.
     Stages are returned in the order they were written (chronological).
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.metrics")
     from core.observability import read_trace
     # Normalize the day arg: empty/whitespace → today (read_trace default).
     day_arg = (day or "").strip() or None
@@ -3415,7 +3415,7 @@ async def admin_metrics_get(
     See `core/trace_metrics.py::aggregate_metrics` for the latency
     derivation rationale (per-trace ts_ns deltas vs explicit fields).
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.metrics")
     from core.trace_metrics import aggregate_metrics
     stage_filter = (stage or "").strip() or None
     stats = aggregate_metrics(window_hours=window_hours,
@@ -3493,7 +3493,7 @@ async def export_answer(request: Request, role: str = Depends(get_role_from_requ
 @app.get("/admin/audit", summary="감사 로그 [P7]")
 async def admin_audit(api_key: str, limit: int = 100,
                       role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.audit_log")
     logs = []
     for lf in ["james_audit_db.jsonl","james_audit_tool.jsonl",
                "james_attack_log.jsonl","james_system_log.jsonl"]:
@@ -3529,7 +3529,7 @@ async def admin_uploads_history(
     Admin-gated; unrelated audit endpoints already exist for the wider
     log surface.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     # Hard cap to keep the JSON payload bounded and avoid the
     # browser locking up if an operator passes ?limit=999999.
     limit  = max(1, min(int(limit or 50), 500))
@@ -3900,7 +3900,7 @@ async def admin_files_tree(
     big wiki could be slow and produce a fat JSON, but we don't need
     deeper. `1` lists immediate children only.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     max_depth = max(1, min(int(max_depth or 3), 5))
     base = _resolve_under_root(root, path)
     if not base or not os.path.isdir(base):
@@ -3959,7 +3959,7 @@ async def admin_files_search(
     Returns a flat list (not nested). Capped at `limit` matches (default
     100, max 500) so a one-character query doesn't dump the whole tree.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     qstr  = (q or "").strip().lower()
     if not qstr:
         return {"q": "", "matches": [], "total": 0, "root": root}
@@ -4015,7 +4015,7 @@ async def admin_files_download(
     Uses FileResponse — FastAPI streams the file, doesn't load it into
     memory. Audit log records every download.
     """
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.data")
     if not (path or "").strip():
         raise HTTPException(status_code=400, detail="path required")
     full = _resolve_under_root(root, path)
@@ -4039,7 +4039,7 @@ async def admin_files_download(
 
 @app.get("/admin/settings", summary="설정 조회 [P7]")
 async def admin_settings_get(api_key: str, role: str = Depends(get_role_from_request)):
-    _require_admin(api_key, role)
+    _require_feature(api_key, role, "admin.settings")
     from config import GEMMA_MODEL
     try:
         from core.memory import MemoryStore
@@ -4110,7 +4110,7 @@ class AdminSettingsRequest(BaseModel):
 
 @app.post("/admin/settings", summary="설정 변경 [P7]")
 async def admin_settings_post(data: AdminSettingsRequest, role: str = Depends(get_role_from_request)):
-    _require_admin(data.api_key, role)
+    _require_feature(data.api_key, role, "admin.settings")
     if data.protected_files:
         os.environ["JAMES_PROTECTED_FILES"] = data.protected_files
     _write_audit(role, "/admin/settings", query=f"model={data.model}")

--- a/tests/test_admin_entities.py
+++ b/tests/test_admin_entities.py
@@ -45,7 +45,7 @@ class BackendEndpointContractTests(unittest.TestCase):
             self.assertIn(kw, window,
                           f"/admin/entities must accept {kw} query param")
         # Admin-gated.
-        self.assertIn("_require_admin(api_key, role)", window)
+        self.assertTrue("_require_admin(api_key, role)" in window or "_require_feature(api_key, role" in window)
         # Response shape contract — these keys must appear in the return dict.
         for shape_key in ('"entities"', '"type_counts"', '"total"',
                           '"total_all"', '"limit"', '"offset"', '"filters"'):
@@ -77,7 +77,7 @@ class BackendEndpointContractTests(unittest.TestCase):
         self.assertGreater(idx, 0,
                            "/admin/entities/{entity_id} detail endpoint missing")
         window = self.src[idx:idx + 1500]
-        self.assertIn("_require_admin(api_key, role)", window)
+        self.assertTrue("_require_admin(api_key, role)" in window or "_require_feature(api_key, role" in window)
         # Must 404 on missing entity (no silent empty response).
         self.assertIn("status_code=404", window,
                       "detail endpoint must 404 on missing entity")

--- a/tests/test_admin_metrics.py
+++ b/tests/test_admin_metrics.py
@@ -271,7 +271,7 @@ class AdminMetricsEndpointTests(unittest.TestCase):
         self.assertIn("from core.trace_metrics import aggregate_metrics", src)
         idx = src.index('@app.get("/admin/metrics"')
         window = src[idx:idx + 1500]
-        self.assertIn("_require_admin(api_key, role)", window)
+        self.assertTrue("_require_admin(api_key, role)" in window or "_require_feature(api_key, role" in window)
         self.assertIn("aggregate_metrics(", window)
         # Response shape contract.
         for key in ('"window_hours"', '"stage_filter"', '"stages"'):

--- a/tests/test_admin_trace_endpoint.py
+++ b/tests/test_admin_trace_endpoint.py
@@ -63,7 +63,7 @@ class EndpointContractTests(unittest.TestCase):
                       "trace endpoint must import read_trace")
         idx = src.index('@app.get("/admin/trace/{trace_id}"')
         window = src[idx:idx + 1500]
-        self.assertIn("_require_admin(api_key, role)", window,
+        self.assertTrue("_require_admin(api_key, role)" in window or "_require_feature(api_key, role" in window,
                       "trace endpoint must call _require_admin")
         self.assertIn("read_trace(trace_id, day=", window,
                       "trace endpoint must invoke read_trace with day param")

--- a/tests/test_file_mgmt_tab.py
+++ b/tests/test_file_mgmt_tab.py
@@ -72,7 +72,7 @@ class EndpointSourceTests(unittest.TestCase):
 
     def test_tree_admin_gated(self):
         body = self._endpoint_body('@app.get("/admin/files/tree"')
-        self.assertIn("_require_admin(api_key, role)", body,
+        self.assertTrue("_require_admin(api_key, role)" in body or "_require_feature(api_key, role" in body,
             "tree must enforce admin BEFORE listing")
 
     def test_tree_uses_resolver(self):
@@ -91,7 +91,7 @@ class EndpointSourceTests(unittest.TestCase):
 
     def test_search_admin_gated(self):
         body = self._endpoint_body('@app.get("/admin/files/search"')
-        self.assertIn("_require_admin(api_key, role)", body)
+        self.assertTrue("_require_admin(api_key, role)" in body or "_require_feature(api_key, role" in body)
 
     def test_search_uses_resolver(self):
         body = self._endpoint_body('@app.get("/admin/files/search"')
@@ -108,7 +108,7 @@ class EndpointSourceTests(unittest.TestCase):
 
     def test_download_admin_gated(self):
         body = self._endpoint_body('@app.get("/admin/files/download"')
-        self.assertIn("_require_admin(api_key, role)", body)
+        self.assertTrue("_require_admin(api_key, role)" in body or "_require_feature(api_key, role" in body)
 
     def test_download_uses_resolver(self):
         body = self._endpoint_body('@app.get("/admin/files/download"')

--- a/tests/test_graph_snapshot.py
+++ b/tests/test_graph_snapshot.py
@@ -265,7 +265,7 @@ class ServerRouteContractTests(unittest.TestCase):
                       "snapshot must accept source_type query param")
         self.assertIn("include_sensitive", window,
                       "snapshot must accept include_sensitive query param")
-        self.assertIn("_require_admin(api_key, role)", window,
+        self.assertTrue("_require_admin(api_key, role)" in window or "_require_feature(api_key, role" in window,
                       "snapshot endpoint must be admin-gated")
         self.assertIn("build_snapshot", window,
                       "snapshot must call build_snapshot helper")

--- a/tests/test_install_progress.py
+++ b/tests/test_install_progress.py
@@ -128,7 +128,7 @@ class ProgressEndpointTests(unittest.TestCase):
         m = re.search(r"\n@app\.", rest)
         end = idx + 1 + m.start() if m else idx + 3000
         body = self.src[idx:end]
-        self.assertIn("_require_admin", body,
+        self.assertTrue("_require_admin" in body or "_require_feature" in body,
             "progress endpoint must be admin-gated")
 
     def test_endpoint_returns_idle_for_unknown_model(self):

--- a/tests/test_model_names_install.py
+++ b/tests/test_model_names_install.py
@@ -106,7 +106,7 @@ class LlmInstallEndpointTests(unittest.TestCase):
 
     def test_admin_only(self):
         body = self._endpoint_body()
-        self.assertIn("_require_admin(api_key, role)", body,
+        self.assertTrue("_require_admin(api_key, role)" in body or "_require_feature(api_key, role" in body,
                       "install must be admin-gated — multi-GB downloads "
                       "shouldn't be exposed to chat users")
 

--- a/tests/test_upload_history.py
+++ b/tests/test_upload_history.py
@@ -51,7 +51,7 @@ class EndpointSourceTests(unittest.TestCase):
         idx = self.src.index('@app.get("/admin/uploads/history/"')
         end = self.src.index('@app.', idx + 10)
         body = self.src[idx:end]
-        self.assertIn("_require_admin(api_key, role)", body,
+        self.assertTrue("_require_admin(api_key, role)" in body or "_require_feature(api_key, role" in body,
                       "/admin/uploads/history/ must enforce admin role")
 
     def test_query_filters_to_upload_endpoint(self):

--- a/tests/test_web_search_admin_panel.py
+++ b/tests/test_web_search_admin_panel.py
@@ -194,7 +194,7 @@ class AdminEndpointTests(unittest.TestCase):
         )
         self.assertIsNotNone(m)
         body = m.group(0)
-        self.assertIn("_require_admin", body,
+        self.assertTrue("_require_admin" in body or "_require_feature" in body,
             "POST must call _require_admin")
 
     def test_post_validates_via_helper(self):


### PR DESCRIPTION
## Summary

Closes the runtime wiring track started in Q2-a. **6 new admin.* features** are added to the Q1 catalog, and **every remaining \`_require_admin\` call site (38 total)** is rewired onto \`_require_feature\`.

After this PR, **no in-repo endpoint uses the legacy hardcoded admin gate anymore**. The helper is preserved as a backward-compat alias, but the runtime consults the feature matrix on every admin endpoint. Setting \`feature_overrides\` rows (DB or upcoming Q3 UI) is the only knob.

## New catalog entries (admin-only by default)

| feature_id | scope |
|---|---|
| \`admin.settings\` | LLM 모델 / persona / 웹 검색 / model selection |
| \`admin.data\` | entity / memory / files / 업로드 이력 인스펙션 |
| \`admin.metrics\` | 메트릭·대시보드·trace 조회 |
| \`admin.character\` | 성향(character) 조회·설정 |
| \`admin.knowledge\` | 능력 성장(knowledge) 조회·학습 |
| \`admin.tools\` | 관리자 도구 (화면 캡처 분석 등) |

Catalog is now **20 features**. Every admin.* still defaults to \`{"admin"}\` → behavior invariant under the default matrix.

## Wired endpoints by group

| feature | endpoints | count |
|---|---|---|
| admin.settings | LLM mgmt (install/installed/resolution/recommend/pull/delete/selections), web-search-config, /admin/settings | **14** |
| admin.metrics | perf-metrics, dashboard, trace, metrics | **5** |
| admin.data | entities + entity detail, memory rows + list, files (tree/search/download), uploads/history | **10** |
| admin.character | character GET/POST + correlations | **3** |
| admin.knowledge | knowledge GET, knowledge/learn, learn-from-errors | **3** |
| admin.evolution (Q2-a + Q2-b) | proposals + patches + manual_evaluate + evolution-history + feedback + feedback_stats + patch/reject | **13** total |
| admin.tools | screen-capture/analyze | **1** |
| admin.audit_log | legacy /admin/audit JSONL | **1** |

Q2-a (17) + Q2-b (38) = **55 endpoint feature gates** running through the matrix.

## Source-grep test updates (9 files)

Tests that grep server source for \`_require_admin(api_key, role)\` as the admin-gate fingerprint are loosened to accept either the legacy form OR the new \`_require_feature(api_key, role\` form. Same intent ("this endpoint has an admin gate"), wider acceptance.

## Verification

\`\`\`
python -m unittest discover tests
Ran 1290 tests in 37.872s
OK
\`\`\`

The Q2-a behavioral suite (\`test_q2a_feature_wiring\`) already proves override semantics; the additional 38 endpoints inherit via the shared helper, so per-endpoint behavioral tests would be redundant.

## Docs

\`ARCHITECTURE.md §5.5.1\` updated — Q1's "upcoming W4-Q2" paragraph replaced with post-Q2-b reality.

## Out of scope

- **W4-Q2-c** — user-side feature gates (query.basic / upload.file / graph.view). Today those endpoints rely on \`verify_api_key\` (any valid key passes) without a feature check. Q2-c adds explicit gates so external/employee roles can be denied query/upload via the matrix.
- **W4-Q3** — admin matrix UI (feature × role checkbox grid).

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning change.
- Rule 3 (self-evolution untouched) ✅ — admin.evolution still gates the same surface; this PR is wiring, not policy.
- Rule 4 (architecture) — ARCHITECTURE.md §5.5.1 updated.
- Rule 5 (file size) ✅ — feature_registry.py 12.7 KB, well under gate.