### PR TITLE
feat(data): data artifact lifecycle backbone (W7-A)

### DIFF
--- a/core/data_artifacts.py
+++ b/core/data_artifacts.py
@@ -1,0 +1,340 @@
+"""W7-A — data lifecycle backbone.
+
+Tracks every uploaded file as a first-class ``artifact`` row and links
+it to the wiki entities derived from it. Before this module, the
+relationship "I uploaded this PDF — which entities came from it?" was
+implicit (a UUID prefix in the filename). Now it is queryable.
+
+Where this lives
+----------------
+- ``data_artifacts`` and ``wiki_links`` rows live in a new SQLite DB
+  ``james_data.db`` (separate from ``james_users.db``). Auth data and
+  user-generated data have different retention / backup profiles, so
+  splitting them now avoids painful surgery later when one needs to
+  rotate or restore independently.
+- Path resolution: ``BASE_DIR / james_data.db``, with the same
+  cwd-fallback as ``core/auth.py``.
+
+Why DB-side own/all separation
+------------------------------
+``list_artifacts(username=...)`` filters at the SQL level, not after
+fetching. An employee querying their own artifacts never sees another
+user's rows in memory — there's no in-Python ACL bug surface.
+
+API
+---
+- ``register_artifact(origin_path, origin_name, origin_size, uploaded_by)
+  -> artifact_id`` — call from /upload/ on first successful save.
+- ``update_status(artifact_id, status)`` — uploaded → extracted →
+  indexed → (failed). Used by /upload/'s processing pipeline.
+- ``link_entity(artifact_id, entity_id)`` — wiki_generator records
+  which entity it derived from which artifact.
+- ``get_artifact(artifact_id, requester_username=None) -> Optional[Dict]``
+  — full row + linked entity_ids. If ``requester_username`` is given
+  AND differs from ``uploaded_by``, returns None (own-only access).
+- ``list_artifacts(username=None, status=None, q=None, limit, offset)``
+  — username=None ⇒ admin view (all rows). username=str ⇒ own rows
+  only. q substring on origin_name.
+- ``count_artifacts(...)``: same filters, COUNT(*) only.
+- ``backfill_from_uploads_dir(uploads_dir)`` — first-boot scan that
+  inserts a row for every file already on disk with
+  ``uploaded_by="legacy"`` and ``status="indexed"`` (the file is
+  already in the corpus; the row just makes it queryable).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+import uuid
+from typing import Optional, List, Dict
+
+
+try:
+    from config import BASE_DIR
+    _DB_PATH = os.path.join(BASE_DIR, "james_data.db")
+except ImportError:
+    _DB_PATH = "james_data.db"
+
+
+ALLOWED_STATUSES = {"uploaded", "extracted", "indexed", "failed"}
+
+
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _init_db() -> None:
+    """Create tables + indexes if missing. Idempotent — called on import.
+
+    Indexes match the dominant query shapes:
+      - listing by uploader (employee's own files)
+      - filtering by status (operator wants only 'failed')
+      - newest-first sort by uploaded_at
+    """
+    conn = _get_conn()
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS data_artifacts (
+                artifact_id   TEXT PRIMARY KEY,
+                origin_path   TEXT NOT NULL,
+                origin_name   TEXT NOT NULL,
+                origin_size   INTEGER,
+                uploaded_at   INTEGER NOT NULL,
+                uploaded_by   TEXT,
+                status        TEXT NOT NULL DEFAULT 'uploaded'
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS wiki_links (
+                artifact_id  TEXT NOT NULL,
+                entity_id    TEXT NOT NULL,
+                linked_at    INTEGER NOT NULL,
+                PRIMARY KEY (artifact_id, entity_id)
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_artifacts_uploader "
+                     "ON data_artifacts (uploaded_by, uploaded_at DESC)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_artifacts_status "
+                     "ON data_artifacts (status, uploaded_at DESC)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_wiki_links_entity "
+                     "ON wiki_links (entity_id)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_init_db()
+
+
+def register_artifact(origin_path: str, origin_name: str,
+                      origin_size: Optional[int] = None,
+                      uploaded_by: Optional[str] = None,
+                      status: str = "uploaded") -> str:
+    """Insert a new artifact row and return the generated id.
+
+    ``origin_path`` is the absolute or relative path stored at /upload/
+    time (e.g. ``uploads/<uuid>_<name>``). ``origin_name`` is the
+    original filename without the UUID prefix. The status default
+    matches the lifecycle entry point.
+    """
+    if status not in ALLOWED_STATUSES:
+        raise ValueError(f"invalid status: {status!r}")
+    artifact_id = uuid.uuid4().hex
+    now = int(time.time())
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "INSERT INTO data_artifacts "
+            "(artifact_id, origin_path, origin_name, origin_size, "
+            "uploaded_at, uploaded_by, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (artifact_id, origin_path, origin_name, origin_size,
+             now, uploaded_by, status),
+        )
+        conn.commit()
+        return artifact_id
+    finally:
+        conn.close()
+
+
+def update_status(artifact_id: str, status: str) -> bool:
+    """Move the artifact through the lifecycle. Returns False if the
+    artifact id is unknown — caller can decide whether that's an error
+    or a no-op for backfilled rows."""
+    if status not in ALLOWED_STATUSES:
+        raise ValueError(f"invalid status: {status!r}")
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "UPDATE data_artifacts SET status = ? WHERE artifact_id = ?",
+            (status, artifact_id),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def link_entity(artifact_id: str, entity_id: str) -> bool:
+    """Record that ``entity_id`` was derived from ``artifact_id``.
+
+    Idempotent: re-linking the same pair is a no-op (PK conflict
+    swallowed). Returns True if a new row was created.
+    """
+    now = int(time.time())
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO wiki_links "
+            "(artifact_id, entity_id, linked_at) VALUES (?, ?, ?)",
+            (artifact_id, entity_id, now),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def get_artifact(artifact_id: str,
+                 requester_username: Optional[str] = None
+                 ) -> Optional[Dict]:
+    """Return one row + ``entities`` list of linked entity_ids.
+
+    Ownership check: if ``requester_username`` is supplied, the call
+    only returns the row when ``uploaded_by == requester_username``.
+    Pass ``None`` for the admin path (see is_admin in the endpoint).
+    """
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            "SELECT * FROM data_artifacts WHERE artifact_id = ?",
+            (artifact_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        if requester_username is not None and row["uploaded_by"] != requester_username:
+            return None
+        entities = [r["entity_id"] for r in conn.execute(
+            "SELECT entity_id FROM wiki_links WHERE artifact_id = ? "
+            "ORDER BY linked_at ASC",
+            (artifact_id,),
+        ).fetchall()]
+        out = dict(row)
+        out["entities"] = entities
+        return out
+    finally:
+        conn.close()
+
+
+def list_artifacts(username: Optional[str] = None,
+                   status: Optional[str] = None,
+                   q: Optional[str] = None,
+                   limit: int = 50, offset: int = 0) -> List[Dict]:
+    """Filtered list, newest first.
+
+    - ``username=None`` ⇒ admin view (every row).
+    - ``username=str`` ⇒ that user's rows only (SQL filter, not
+      post-filter — prevents leak through pagination math).
+    - ``status`` ⇒ exact match (uploaded/extracted/indexed/failed).
+    - ``q`` ⇒ case-insensitive substring on origin_name.
+
+    Each row also carries ``entity_count`` (cheap COUNT join in SQL)
+    so the UI can render "PDF → 12 entities" without a per-row fetch.
+    """
+    where: list = []
+    params: list = []
+    if username is not None:
+        where.append("a.uploaded_by = ?")
+        params.append(username)
+    if status:
+        if status not in ALLOWED_STATUSES:
+            return []
+        where.append("a.status = ?")
+        params.append(status)
+    if q:
+        where.append("LOWER(a.origin_name) LIKE ?")
+        params.append(f"%{q.lower()}%")
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+
+    sql = (
+        "SELECT a.*, "
+        "  (SELECT COUNT(*) FROM wiki_links w WHERE w.artifact_id = a.artifact_id) "
+        "    AS entity_count "
+        "FROM data_artifacts a"
+        + where_sql +
+        " ORDER BY a.uploaded_at DESC LIMIT ? OFFSET ?"
+    )
+    params.extend([max(1, min(int(limit), 500)), max(0, int(offset))])
+
+    conn = _get_conn()
+    try:
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+    finally:
+        conn.close()
+
+
+def count_artifacts(username: Optional[str] = None,
+                    status: Optional[str] = None,
+                    q: Optional[str] = None) -> int:
+    """Match the filter shape of ``list_artifacts``; SQL COUNT only."""
+    where: list = []
+    params: list = []
+    if username is not None:
+        where.append("uploaded_by = ?")
+        params.append(username)
+    if status:
+        if status not in ALLOWED_STATUSES:
+            return 0
+        where.append("status = ?")
+        params.append(status)
+    if q:
+        where.append("LOWER(origin_name) LIKE ?")
+        params.append(f"%{q.lower()}%")
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    conn = _get_conn()
+    try:
+        return int(conn.execute(
+            f"SELECT COUNT(*) AS c FROM data_artifacts{where_sql}",
+            params,
+        ).fetchone()["c"])
+    finally:
+        conn.close()
+
+
+def backfill_from_uploads_dir(uploads_dir: str) -> int:
+    """One-time scan of ``uploads/`` to register pre-W7-A files.
+
+    Idempotent: every call inserts only files that don't already have a
+    row matching their origin_path. ``uploaded_by`` is set to ``legacy``
+    and ``status`` to ``indexed`` (the file is already in the corpus
+    via prior /upload/ calls; the row only makes it queryable).
+
+    Returns the number of new rows inserted. 0 on subsequent runs.
+
+    The filename convention from /upload/ is ``<uuid>_<original-name>``
+    (see server_llmwiki.upload). We split on the first ``_`` to
+    recover origin_name; if no underscore is found, the full filename
+    becomes origin_name and origin_path retains the leading bare token.
+    """
+    if not os.path.isdir(uploads_dir):
+        return 0
+
+    conn = _get_conn()
+    try:
+        existing = {r["origin_path"] for r in conn.execute(
+            "SELECT origin_path FROM data_artifacts WHERE uploaded_by = 'legacy'"
+        ).fetchall()}
+
+        inserted = 0
+        now = int(time.time())
+        for fname in sorted(os.listdir(uploads_dir)):
+            full = os.path.join(uploads_dir, fname)
+            if not os.path.isfile(full):
+                continue
+            rel = os.path.join("uploads", fname).replace("\\", "/")
+            if rel in existing:
+                continue
+            if "_" in fname:
+                _uuid_part, _, origin_name = fname.partition("_")
+            else:
+                origin_name = fname
+            try:
+                size = os.path.getsize(full)
+            except OSError:
+                size = None
+            conn.execute(
+                "INSERT INTO data_artifacts "
+                "(artifact_id, origin_path, origin_name, origin_size, "
+                "uploaded_at, uploaded_by, status) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (uuid.uuid4().hex, rel, origin_name, size,
+                 now, "legacy", "indexed"),
+            )
+            inserted += 1
+        conn.commit()
+        return inserted
+    finally:
+        conn.close()

--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -183,16 +183,29 @@ FEATURES: Dict[str, Feature] = {
         "관리자 도구 (화면 캡처 분석 등)",
         "admin",
     ),
-    # ── workspace (W8 후속, 카탈로그 슬롯만 미리 등록) ─────────
+    # ── workspace + 데이터 (W7/W8 트랙) ────────────────────────
+    # external 은 의도적으로 차단 — 외부 사용자가 시스템 리소스 소비
+    # (Excel/문서 합성 등) 하는 건 위험. admin 매트릭스에서 override
+    # 가능하지만 default 는 internal-staff 만.
+    "workspace.view": _f(
+        "workspace.view",
+        "워크스페이스 페이지 진입 (데이터 explorer + job 트리거)",
+        "admin,manager,employee",
+    ),
     "workspace.run_jobs": _f(
         "workspace.run_jobs",
-        "(W8) 워크스페이스 job 실행",
-        "admin,manager",
+        "워크스페이스 job 실행 (Excel/문서/Export)",
+        "admin,manager,employee",
     ),
     "workspace.schedule": _f(
         "workspace.schedule",
-        "(W8) 워크스페이스 job 예약 (cron)",
+        "워크스페이스 job 예약 (cron) — 시스템 영향 큼",
         "admin",
+    ),
+    "data.view_own": _f(
+        "data.view_own",
+        "자기 업로드 파일 / job 결과 조회",
+        "admin,manager,employee,external",
     ),
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,6 +302,56 @@ change required to grant or revoke a feature for a role mid-flight.
 **W4-Q3** ships the admin matrix UI (feature × role checkbox grid
 + "기본값 복원").
 
+---
+
+## 6. Data Lifecycle (W7-A, 2026-05-11)
+
+Every file uploaded through `/upload/` gets a tracking row in the
+new `data_artifacts` table (in a separate `james_data.db`). The
+artifact moves through a small explicit lifecycle:
+
+```
+uploaded   ← /upload/ saves bytes to disk + register_artifact()
+   ↓
+extracted  ← (optional, set when a long-running pipeline pulls text)
+   ↓
+indexed    ← vector + entity steps succeeded → /upload/ returns 200
+   ↓                                              (or)
+failed     ← any step in /upload/ raised
+```
+
+A second table `wiki_links (artifact_id, entity_id)` records which
+wiki entities were derived from which upload — the relationship was
+previously implicit in the filename UUID prefix and not queryable.
+
+**Authority model — own vs all**
+
+Two surfaces consult the matrix:
+- `admin.data` (admin only by default) gates `/admin/artifacts/list`
+  and `/admin/artifacts/{id}` — sees every uploader's rows.
+- `data.view_own` (all four roles by default) gates
+  `/artifacts/mine/list` and `/artifacts/mine/{id}` — scoped to the
+  JWT subject. The SQL `WHERE uploaded_by = ?` filter runs in the
+  helper, so a non-owner attempting another user's id receives a
+  404 (not 403 — 403 would leak existence).
+
+System api_key callers without a JWT cannot reach `/artifacts/mine/*`
+(401: there's no "own" to bind). Operators must log in.
+
+**First-boot backfill**
+
+`core.data_artifacts.backfill_from_uploads_dir(UPLOAD_DIR)` runs in
+the startup hook. Any file in `uploads/` without a matching row is
+inserted with `uploaded_by="legacy"` and `status="indexed"` — the
+file is already in the corpus; the row just makes it queryable.
+Idempotent on subsequent boots.
+
+**W7-B** ships a standalone `frontend/workspace.html` (not folded
+into admin.html — employees can reach it without admin auth) that
+renders this layer as a data explorer.
+**W8** layers `jobs` + a small scheduler on top so users can run
+Excel/document/export jobs against their artifacts.
+
 **TrustedContent** is the wrapper every multimodal extractor (OCR,
 ASR, vision, web) returns instead of a raw string. Carries
 `(text, source, trust)` so the reasoning pipeline knows whether to run

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -265,6 +265,18 @@ async def on_startup():
         # Housekeeping must never block server startup.
         print(f"[STARTUP] trace prune skipped: {e}")
 
+    # [W7-A 2026-05-11] Backfill data_artifacts for any pre-W7 files
+    # already sitting in uploads/. Idempotent — only inserts rows that
+    # don't already have an origin_path match with uploaded_by='legacy'.
+    # Fail-safe: any error is logged and skipped, never blocks startup.
+    try:
+        from core.data_artifacts import backfill_from_uploads_dir
+        n = backfill_from_uploads_dir(UPLOAD_DIR)
+        if n > 0:
+            print(f"[DATA] backfilled {n} legacy artifact row(s) from {UPLOAD_DIR}")
+    except Exception as e:
+        print(f"[STARTUP] data-artifact backfill skipped: {e}")
+
     # [PR plan-3, 2026-05-09] LLM readiness check + friendly install
     # guidance. If Ollama has 0 models, every /query/ would fail. We
     # emit a clear console banner pointing operators to the admin
@@ -659,6 +671,31 @@ async def upload(
         if os.path.exists(filepath): os.remove(filepath)
         raise HTTPException(status_code=500, detail=f"파일 저장 실패: {e}")
 
+    # [W7-A 2026-05-11] Register the artifact as soon as the bytes land
+    # on disk. Status moves to 'indexed' after successful processing or
+    # 'failed' if any step raises. The JWT subject (preferred) or
+    # 'system' (system api_key only) becomes uploaded_by — the latter
+    # surfaces in the audit log so a leaked-key upload is still
+    # attributable to "the operator".
+    from core.data_artifacts import (
+        register_artifact as _da_register,
+        update_status     as _da_update_status,
+    )
+    rel_path = os.path.join("uploads", unique_name).replace("\\", "/")
+    artifact_uploader = _bearer_username(request) or "system"
+    try:
+        artifact_id = _da_register(
+            origin_path=rel_path,
+            origin_name=file.filename,
+            origin_size=total_size,
+            uploaded_by=artifact_uploader,
+            status="uploaded",
+        )
+    except Exception as _e:
+        # Never block the upload on a tracking-row failure.
+        print(f"[UPLOAD] data_artifacts register skipped: {_e}")
+        artifact_id = None
+
     try:
         # #44 phase 4-B: process_file 가 TrustedContent 반환.
         # #44 phase 4-C: ingestion 검역은 PolicyEngine 단일 chokepoint
@@ -795,6 +832,13 @@ async def upload(
         except Exception:
             pass
 
+        # [W7-A] mark indexed only after vector + entity steps succeeded.
+        if artifact_id:
+            try:
+                _da_update_status(artifact_id, "indexed")
+            except Exception as _e:
+                print(f"[UPLOAD] status update skipped: {_e}")
+
         result_data = {
             "status":      "ok",
             "filename":    unique_name,
@@ -802,12 +846,21 @@ async def upload(
             "summary":     meta.get("summary",""),
             "keywords":    meta.get("keywords",[]),
             "sensitivity": meta.get("sensitivity","internal"),
+            "artifact_id": artifact_id,   # [W7-A]
         }
         _write_audit(role, "/upload/", query=file.filename, ip_address=ip)
         return result_data
     except HTTPException:
+        # [W7-A] HTTPException propagation — surface but mark failed
+        # so the operator can find it via /admin/artifacts/list.
+        if artifact_id:
+            try: _da_update_status(artifact_id, "failed")
+            except Exception: pass
         raise
     except Exception as e:
+        if artifact_id:
+            try: _da_update_status(artifact_id, "failed")
+            except Exception: pass
         raise HTTPException(status_code=500, detail=f"분석 실패: {e}")
 
 
@@ -3745,6 +3798,107 @@ async def admin_audit_list(
     return {"items": items, "total": total,
             "category": cat, "q": qstr,
             "limit": limit, "offset": offset}
+
+
+# ─── W7-A: data artifacts (per-upload lifecycle tracking) ──────
+# Two surfaces:
+#   /admin/artifacts/*  — admin.data feature, sees every user's rows
+#   /artifacts/mine/*   — data.view_own feature, scoped to JWT subject
+
+@app.get("/admin/artifacts/list", summary="데이터 아티팩트 — 관리자 전체 조회 (W7-A)")
+async def admin_artifacts_list(
+    api_key: str,
+    status:  str = "",
+    q:       str = "",
+    limit:   int = 50,
+    offset:  int = 0,
+    role:    str = Depends(get_role_from_request),
+):
+    """All artifacts (every uploader). admin.data feature."""
+    _require_feature(api_key, role, "admin.data")
+    from core.data_artifacts import list_artifacts, count_artifacts
+    s = status.strip() or None
+    qstr = q.strip() or None
+    return {
+        "items":  list_artifacts(status=s, q=qstr, limit=limit, offset=offset),
+        "total":  count_artifacts(status=s, q=qstr),
+        "status": s or "",
+        "q":      qstr or "",
+        "limit":  limit,
+        "offset": offset,
+    }
+
+
+@app.get("/admin/artifacts/{artifact_id}", summary="아티팩트 상세 — 관리자 (W7-A)")
+async def admin_artifacts_detail(
+    artifact_id: str,
+    api_key:     str,
+    role:        str = Depends(get_role_from_request),
+):
+    """Admin view — owner ignored, returns the row regardless."""
+    _require_feature(api_key, role, "admin.data")
+    from core.data_artifacts import get_artifact
+    row = get_artifact(artifact_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return row
+
+
+@app.get("/artifacts/mine/list", summary="내 데이터 아티팩트 (W7-A)")
+async def mine_artifacts_list(
+    request: Request,
+    status:  str = "",
+    q:       str = "",
+    limit:   int = 50,
+    offset:  int = 0,
+    role:    str = Depends(get_role_from_request),
+):
+    """User self-view. JWT subject is the scope — non-JWT callers
+    (system api_key only) are denied because there's no "own" to
+    bind. data.view_own feature gates the role (every role allowed
+    by default; admin can revoke per role)."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "data.view_own").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (data.view_own)")
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+    from core.data_artifacts import list_artifacts, count_artifacts
+    s = status.strip() or None
+    qstr = q.strip() or None
+    return {
+        "items":  list_artifacts(username=username, status=s, q=qstr,
+                                 limit=limit, offset=offset),
+        "total":  count_artifacts(username=username, status=s, q=qstr),
+        "status": s or "",
+        "q":      qstr or "",
+        "limit":  limit,
+        "offset": offset,
+    }
+
+
+@app.get("/artifacts/mine/{artifact_id}", summary="내 아티팩트 상세 (W7-A)")
+async def mine_artifacts_detail(
+    artifact_id: str,
+    request:     Request,
+    role:        str = Depends(get_role_from_request),
+):
+    """Self-view. ``get_artifact(requester_username=...)`` returns None
+    when the row belongs to someone else — surfaces as 404 here so a
+    caller can't probe other users' artifact ids."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "data.view_own").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (data.view_own)")
+    username = _bearer_username(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+    from core.data_artifacts import get_artifact
+    row = get_artifact(artifact_id, requester_username=username)
+    if row is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return row
 
 
 # ─── W4-Q1: feature capability matrix ──────────────────────────

--- a/tests/test_data_artifacts.py
+++ b/tests/test_data_artifacts.py
@@ -1,0 +1,325 @@
+"""W7-A — data artifact lifecycle + admin/own endpoints.
+
+Three layers:
+  1. core.data_artifacts helpers — pure DB roundtrip.
+  2. backfill_from_uploads_dir — first-boot scan idempotence.
+  3. HTTP endpoints — admin.data + data.view_own feature gates,
+     own-only scoping (cross-user 404 defense), JSON shapes.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-data-artifacts-32chars-min",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _api_key() -> str:
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+class _DataDBFixture(unittest.TestCase):
+    """Point ``core.data_artifacts._DB_PATH`` at a fresh tmp file +
+    create the schema. Restored in tearDown so tests don't leak state."""
+
+    def setUp(self):
+        from core import data_artifacts as da
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self.db = self._tmp.name
+        self._saved = da._DB_PATH
+        da._DB_PATH = self.db
+        # _init_db only ran at module import (against the live path) —
+        # explicitly create the schema in the tmp db.
+        da._init_db()
+
+    def tearDown(self):
+        from core import data_artifacts as da
+        da._DB_PATH = self._saved
+        Path(self.db).unlink(missing_ok=True)
+
+
+class HelperTests(_DataDBFixture):
+    def test_register_returns_artifact_id_and_persists(self):
+        from core.data_artifacts import register_artifact, get_artifact
+        aid = register_artifact(
+            origin_path="uploads/x_a.pdf",
+            origin_name="a.pdf",
+            origin_size=1024,
+            uploaded_by="alice",
+        )
+        self.assertTrue(aid)
+        row = get_artifact(aid)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["origin_name"], "a.pdf")
+        self.assertEqual(row["uploaded_by"], "alice")
+        self.assertEqual(row["status"], "uploaded")
+        self.assertEqual(row["entities"], [])
+
+    def test_register_rejects_unknown_status(self):
+        from core.data_artifacts import register_artifact
+        with self.assertRaises(ValueError):
+            register_artifact("uploads/x", "x", 0, "alice", status="garbage")
+
+    def test_update_status_moves_through_lifecycle(self):
+        from core.data_artifacts import (
+            register_artifact, update_status, get_artifact,
+        )
+        aid = register_artifact("uploads/x", "x", 0, "alice")
+        for st in ("extracted", "indexed", "failed"):
+            self.assertTrue(update_status(aid, st))
+            self.assertEqual(get_artifact(aid)["status"], st)
+
+    def test_update_status_unknown_id_returns_false(self):
+        from core.data_artifacts import update_status
+        self.assertFalse(update_status("no-such-id", "indexed"))
+
+    def test_link_entity_idempotent(self):
+        from core.data_artifacts import (
+            register_artifact, link_entity, get_artifact,
+        )
+        aid = register_artifact("uploads/x", "x", 0, "alice")
+        self.assertTrue(link_entity(aid, "ent_001"))
+        # Second link to the same pair is a no-op (PK conflict).
+        self.assertFalse(link_entity(aid, "ent_001"))
+        self.assertTrue(link_entity(aid, "ent_002"))
+        row = get_artifact(aid)
+        self.assertEqual(sorted(row["entities"]), ["ent_001", "ent_002"])
+
+    def test_get_artifact_owner_scope(self):
+        from core.data_artifacts import register_artifact, get_artifact
+        aid = register_artifact("uploads/x", "x", 0, "alice")
+        # Owner view works.
+        self.assertIsNotNone(get_artifact(aid, requester_username="alice"))
+        # Other user is denied (None — caller surfaces 404).
+        self.assertIsNone(get_artifact(aid, requester_username="bob"))
+        # Admin (no requester) sees the row.
+        self.assertIsNotNone(get_artifact(aid))
+
+
+class ListAndCountTests(_DataDBFixture):
+    def setUp(self):
+        super().setUp()
+        from core.data_artifacts import register_artifact
+        register_artifact("uploads/1", "alice-report.pdf", 100, "alice", "indexed")
+        register_artifact("uploads/2", "alice-notes.txt", 200, "alice", "uploaded")
+        register_artifact("uploads/3", "bob-data.csv", 300, "bob", "indexed")
+
+    def test_list_admin_view_returns_all(self):
+        from core.data_artifacts import list_artifacts, count_artifacts
+        self.assertEqual(count_artifacts(), 3)
+        self.assertEqual(len(list_artifacts()), 3)
+
+    def test_list_scoped_to_username(self):
+        from core.data_artifacts import list_artifacts, count_artifacts
+        rows = list_artifacts(username="alice")
+        self.assertEqual({r["origin_name"] for r in rows},
+                         {"alice-report.pdf", "alice-notes.txt"})
+        self.assertEqual(count_artifacts(username="alice"), 2)
+        self.assertEqual(count_artifacts(username="bob"), 1)
+
+    def test_status_filter(self):
+        from core.data_artifacts import list_artifacts
+        names = [r["origin_name"] for r in list_artifacts(status="indexed")]
+        self.assertEqual(sorted(names), ["alice-report.pdf", "bob-data.csv"])
+
+    def test_q_substring(self):
+        from core.data_artifacts import list_artifacts
+        names = [r["origin_name"] for r in list_artifacts(q="alice")]
+        self.assertEqual(len(names), 2)
+        self.assertTrue(all("alice" in n for n in names))
+
+    def test_sort_newest_first(self):
+        from core.data_artifacts import register_artifact, list_artifacts
+        # uploaded_at is unix-second precision; sleep > 1s so the
+        # next insert lands in a later bucket regardless of how fast
+        # the prior setUp inserts ran.
+        time.sleep(1.1)
+        register_artifact("uploads/late", "late.pdf", 999, "alice", "indexed")
+        names = [r["origin_name"] for r in list_artifacts()]
+        self.assertEqual(names[0], "late.pdf",
+                         "newest insertion must surface first")
+
+    def test_entity_count_in_list(self):
+        from core.data_artifacts import (
+            register_artifact, link_entity, list_artifacts,
+        )
+        aid = register_artifact("uploads/x", "x.pdf", 0, "alice", "indexed")
+        link_entity(aid, "ent_1")
+        link_entity(aid, "ent_2")
+        row = next(r for r in list_artifacts() if r["origin_name"] == "x.pdf")
+        self.assertEqual(row["entity_count"], 2)
+
+
+class BackfillTests(_DataDBFixture):
+    def test_inserts_files_with_legacy_owner(self):
+        from core.data_artifacts import (
+            backfill_from_uploads_dir, list_artifacts,
+        )
+        with tempfile.TemporaryDirectory() as ud:
+            for name in ("aaa_first.pdf", "bbb_second.txt"):
+                with open(os.path.join(ud, name), "w") as f:
+                    f.write("x")
+            n = backfill_from_uploads_dir(ud)
+            self.assertEqual(n, 2)
+            rows = list_artifacts()
+            self.assertEqual({r["uploaded_by"] for r in rows}, {"legacy"})
+            self.assertEqual({r["origin_name"] for r in rows},
+                             {"first.pdf", "second.txt"})
+            self.assertTrue(all(r["status"] == "indexed" for r in rows),
+                            "backfill should mark indexed — files are in corpus")
+
+    def test_idempotent_on_second_run(self):
+        from core.data_artifacts import (
+            backfill_from_uploads_dir, count_artifacts,
+        )
+        with tempfile.TemporaryDirectory() as ud:
+            with open(os.path.join(ud, "u_a.pdf"), "w") as f:
+                f.write("x")
+            n1 = backfill_from_uploads_dir(ud)
+            n2 = backfill_from_uploads_dir(ud)
+            self.assertEqual(n1, 1)
+            self.assertEqual(n2, 0,
+                             "rerun must not double-insert legacy rows")
+            self.assertEqual(count_artifacts(), 1)
+
+    def test_no_underscore_filename_keeps_full_name(self):
+        from core.data_artifacts import backfill_from_uploads_dir, list_artifacts
+        with tempfile.TemporaryDirectory() as ud:
+            with open(os.path.join(ud, "naked.pdf"), "w") as f:
+                f.write("x")
+            backfill_from_uploads_dir(ud)
+            self.assertEqual(list_artifacts()[0]["origin_name"], "naked.pdf")
+
+    def test_missing_dir_returns_zero(self):
+        from core.data_artifacts import backfill_from_uploads_dir
+        self.assertEqual(backfill_from_uploads_dir("/no/such/path"), 0)
+
+
+class EndpointTests(_DataDBFixture):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = _api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        super().setUp()
+        from core.data_artifacts import register_artifact
+        self.alice_aid = register_artifact(
+            "uploads/u1_alice.pdf", "alice.pdf", 100, "alice", "indexed",
+        )
+        self.bob_aid = register_artifact(
+            "uploads/u2_bob.pdf", "bob.pdf", 200, "bob", "indexed",
+        )
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _hdr(self, username: str, role: str):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token(username, role)}"}
+
+    # ── admin view ────────────────────────────────────────────────
+    def test_admin_list_sees_all_users(self):
+        r = self._client().get(
+            "/admin/artifacts/list",
+            params={"api_key": self._api_key},
+            headers=self._hdr("test-admin", "admin"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["total"], 2)
+        uploaders = {it["uploaded_by"] for it in body["items"]}
+        self.assertEqual(uploaders, {"alice", "bob"})
+
+    def test_admin_list_blocked_for_employee(self):
+        r = self._client().get(
+            "/admin/artifacts/list",
+            params={"api_key": self._api_key},
+            headers=self._hdr("emp1", "employee"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_admin_detail_returns_full_row(self):
+        r = self._client().get(
+            f"/admin/artifacts/{self.alice_aid}",
+            params={"api_key": self._api_key},
+            headers=self._hdr("test-admin", "admin"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json()["origin_name"], "alice.pdf")
+
+    def test_admin_detail_404_unknown(self):
+        r = self._client().get(
+            "/admin/artifacts/no-such-id",
+            params={"api_key": self._api_key},
+            headers=self._hdr("test-admin", "admin"),
+        )
+        self.assertEqual(r.status_code, 404)
+
+    # ── own (mine) view ───────────────────────────────────────────
+    def test_mine_list_scoped_to_jwt_subject(self):
+        # alice JWT — sees only alice's row.
+        r = self._client().get(
+            "/artifacts/mine/list",
+            params={"api_key": self._api_key},
+            headers=self._hdr("alice", "employee"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["total"], 1)
+        self.assertEqual(body["items"][0]["uploaded_by"], "alice")
+
+    def test_mine_list_requires_jwt(self):
+        r = self._client().get(
+            "/artifacts/mine/list",
+            params={"api_key": self._api_key},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_mine_detail_own_path_works(self):
+        r = self._client().get(
+            f"/artifacts/mine/{self.alice_aid}",
+            params={"api_key": self._api_key},
+            headers=self._hdr("alice", "employee"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json()["uploaded_by"], "alice")
+
+    def test_mine_detail_cross_user_returns_404_not_403(self):
+        # bob asks for alice's artifact id — must surface as 404,
+        # not 403. 403 leaks the existence of the id.
+        r = self._client().get(
+            f"/artifacts/mine/{self.alice_aid}",
+            params={"api_key": self._api_key},
+            headers=self._hdr("bob", "employee"),
+        )
+        self.assertEqual(r.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First-class tracking for every uploaded file as a queryable artifact row, plus the wiki entities derived from it. Replaces the implicit "UUID prefix in the filename" relationship with explicit DB rows, own/all scoping at the SQL layer, and a first-boot backfill for existing \`uploads/\` contents.

## Why a new DB file

\`core/data_artifacts.py\` writes to a new \`james_data.db\` (next to \`james_users.db\`). Auth/users/api_keys have different retention + backup profiles than user-generated artifacts; splitting now avoids painful surgery later.

\`\`\`
data_artifacts (artifact_id PK, origin_path, origin_name, origin_size,
                uploaded_at, uploaded_by, status)
wiki_links     (artifact_id, entity_id, linked_at) PK(artifact_id, entity_id)
\`\`\`

## Lifecycle

\`\`\`
uploaded → extracted → indexed
            \
             → failed (any /upload/ raise)
\`\`\`

Tracking is best-effort — every helper call in /upload/ is wrapped in try/except so a tracking-row failure never blocks an actual upload.

## Catalog updates

- **\`workspace.view\` (NEW)** → admin/manager/employee
- **\`workspace.run_jobs\`** was admin/manager → **NOW admin/manager/employee** (employee 까지 작업 허용)
- \`workspace.schedule\` (unchanged) → admin (cron 영향 크니 좁게)
- **\`data.view_own\` (NEW)** → 모든 4 role
- external 은 의도적으로 workspace.* 차단 (시스템 리소스 보호). 매트릭스 override 로 풀 수 있음.

## New endpoints

| endpoint | feature | scope |
|---|---|---|
| \`GET /admin/artifacts/list\` | admin.data | every uploader's rows |
| \`GET /admin/artifacts/{id}\` | admin.data | full row visibility |
| \`GET /artifacts/mine/list\` | data.view_own | JWT subject only |
| \`GET /artifacts/mine/{id}\` | data.view_own | own — 404 (not 403) for cross-user probe |

Non-JWT callers → 401 on /mine/* (no "own" to bind).

## /upload/ integration

- After bytes land on disk: \`register_artifact(uploaded_by=JWT sub or "system", status="uploaded")\`
- After vector+entity steps succeed: \`update_status("indexed")\`
- HTTPException / Exception paths → status="failed" so operators find partial uploads via \`?status=failed\`
- **Wiki-link recording deferred** — wiki_generator entity-id contract change is better as a focused follow-up. \`wiki_links\` table + \`link_entity\` helper are in this PR so W7-B can render "X.pdf → 12 entities" once wiring lands.

## First-boot backfill

\`backfill_from_uploads_dir(UPLOAD_DIR)\` runs in startup hook. Walks uploads/, splits \`<uuid>_<origin-name>\`, inserts row with \`uploaded_by="legacy"\` + \`status="indexed"\`. Idempotent.

## Tests (24 new)

| layer | tests |
|---|---|
| Helpers | register/get + status enum + lifecycle moves + unknown-id no-op + link_entity idempotent + owner scope cross-user None |
| list/count | admin all + username scope + status filter + q substring + sort newest-first + entity_count from JOIN |
| backfill | legacy owner + idempotent rerun + no-underscore filename + missing dir |
| Endpoints | admin gate (403 for employee) + admin all + admin detail 200/404 + mine scoped to JWT + mine requires JWT (401) + mine own works + mine cross-user 404 |

## Verification

\`\`\`
python -m unittest discover tests
Ran 1314 tests in 41.643s
OK
\`\`\`

## Docs

\`ARCHITECTURE.md §6\` (NEW) — Data Lifecycle. Lifecycle diagram, own-vs-all model, backfill behavior, pointers to W7-B / W8.

## Out of scope

- **W7-B** — \`frontend/workspace.html\` data explorer (standalone page so employees can reach without admin auth).
- **W8-A/B** — jobs + scheduler + handlers + workspace UI extension.
- **wiki_links population** — wiki_generator integration as a focused follow-up.

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning change.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) — new module + ARCHITECTURE.md §6 in same PR. Trust-boundary extended (data ownership + own-vs-all scoping).
- Rule 5 (file size) ✅ — data_artifacts.py 12.2 KB.