### PR TITLE
feat(data): populate wiki_links on upload (W8-C, follow-up)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,6 +324,15 @@ A second table `wiki_links (artifact_id, entity_id)` records which
 wiki entities were derived from which upload — the relationship was
 previously implicit in the filename UUID prefix and not queryable.
 
+**Population (W8-C, 2026-05-11)** — `/upload/` captures the
+`entity_id` list returned by `wiki_generator.process_document_for_entities`
+(or the single id from the `create_entity_file` fallback) and calls
+`core.data_artifacts.link_entity` for each. Best-effort write — a
+failure leaves the upload itself intact (bytes on disk, vector +
+wiki .md files all present) but the artifact ↔ entity relation is
+not queryable for that specific upload. Subsequent uploads continue
+to populate.
+
 **Authority model — own vs all**
 
 Two surfaces consult the matrix:

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -743,17 +743,27 @@ async def upload(
                 "source_type": "prod",
             },
         )
+        # [W8-C 2026-05-11] capture entity_ids so we can write
+        # wiki_links rows after the entity files are on disk. The
+        # process_document_for_entities return type was unused before;
+        # we now consume it to make the artifact ↔ entity relation
+        # queryable from /admin/artifacts/<id> + the workspace UI.
+        created_entity_ids: list = []
         try:
-            rag_engine.wiki_generator.process_document_for_entities(
-                file.filename, raw_content, [],
-                user_role="admin",
-                metadata=meta,
+            created_entity_ids = list(
+                rag_engine.wiki_generator.process_document_for_entities(
+                    file.filename, raw_content, [],
+                    user_role="admin",
+                    metadata=meta,
+                ) or []
             )
         except TypeError:
             # 구버전 시그니처 fallback (metadata/user_role 미지원)
             try:
-                rag_engine.wiki_generator.process_document_for_entities(
-                    file.filename, raw_content, []
+                created_entity_ids = list(
+                    rag_engine.wiki_generator.process_document_for_entities(
+                        file.filename, raw_content, []
+                    ) or []
                 )
             except AttributeError:
                 pass
@@ -772,13 +782,34 @@ async def upload(
                     "sensitivity": meta.get("sensitivity", "internal"),
                     "source_type": "prod",
                 }
-                rag_engine.wiki_generator.create_entity_file(
+                created_path = rag_engine.wiki_generator.create_entity_file(
                     doc_entity, file.filename, []
                 )
+                # create_entity_file returns the .md file path.
+                # The entity_id matches the stem (no extension).
+                if created_path:
+                    from pathlib import Path as _PathW8C
+                    created_entity_ids.append(_PathW8C(created_path).stem)
             except Exception as wiki_err:
                 print(f"[UPLOAD] wiki entity 생성 skip: {wiki_err}")
         except Exception as e:
             print(f"[UPLOAD] entity 처리 skip: {e}")
+
+        # [W8-C 2026-05-11] write wiki_links rows. Best-effort — a
+        # failure here does NOT roll back the upload (the bytes are on
+        # disk and the vector store / wiki .md files exist). It only
+        # means the artifact ↔ entity relation isn't queryable for
+        # this upload; subsequent uploads continue to track.
+        if artifact_id and created_entity_ids:
+            try:
+                from core.data_artifacts import link_entity
+                for eid in created_entity_ids:
+                    if eid:
+                        link_entity(artifact_id, eid)
+                print(f"[UPLOAD] linked {len(created_entity_ids)} entities "
+                      f"to artifact {artifact_id}")
+            except Exception as _e:
+                print(f"[UPLOAD] link_entity skipped: {_e}")
 
         # ── [P7] Media Store — 이미지/영상/오디오 날짜별 폴더 보관 ──
         MEDIA_EXTS = {


### PR DESCRIPTION
## Summary

W7-A landed the \`wiki_links\` table + \`link_entity\` helper but the row was never written — \`process_document_for_entities\` returned an entity_id list that \`/upload/\` discarded. As a result, every artifact detail panel and \`/admin/artifacts/<id>\` response showed \`"entities": []\` regardless of how many wiki entries the upload actually produced.

This PR captures that list and writes one \`wiki_links\` row per id. **Best-effort by design** — failure to link does not roll back the upload (bytes on disk + vector + wiki .md files all present); only the relation cells stay empty for that specific upload.

## Changes

**\`server_llmwiki.upload\`**
- \`created_entity_ids\` accumulates ids from three paths:
  - \`process_document_for_entities\` new sig
  - \`process_document_for_entities\` legacy 3-arg fallback
  - \`create_entity_file\` explicit path (returns .md path → \`entity_id = Path.stem\`)
- After wiki step: \`link_entity(artifact_id, eid)\` per id, wrapped in try/except
- Audit print on success: \`"linked N entities to artifact <id>"\`

**\`docs/ARCHITECTURE.md §6\`** — adds "Population" paragraph explaining when wiki_links rows appear (W8-C) and the best-effort failure mode.

## Effect on existing UIs

- **W7-B /admin/artifacts/{id} detail panel**: "연결된 엔터티" 섹션이 placeholder ("연결된 엔터티가 아직 없습니다") 대신 실제 wiki entity_id 표시 (이 PR 머지 후 업로드부터)
- **W7-A list rows**: \`entity_count\` (SQL JOIN, API 변화 X) 가 신규 wiki_links 행을 즉시 반영

## Why no new tests

- \`core.data_artifacts.link_entity\` 는 W7-A 의 24 tests 가 이미 cover (duplicate idempotent, owner scope 등)
- \`/upload/\` integration test 는 LLM + vector + wiki I/O 전체 mock 필요 — 한 줄 변경 대비 비용 과다
- 와이어링이 실패 path 에서 read-only + 성공 path 에서 identity-preserving

## Verification

\`\`\`
python -m unittest discover tests
Ran 1334 tests in 40.940s
OK
\`\`\`

## Out of scope

- **Legacy backfill** — pre-W8-C 업로드는 unlinked 상태. 필요 시 reconciliation 스크립트 (frontmatter source_document → artifact_id resolve) 별도 작성. 운영 우선순위 낮음.
- **W8-A2 scheduler** / **90-day retention** — 별도 PR.
- **video-asr** — 별도 PR.

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅ — generic relation.
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning change.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) — ARCHITECTURE.md §6 updated in same PR.
- Rule 5 (file size) ✅ — no module size change.