### PR TITLE
fix(lint): F821 (undefined name) bugs + ruff baseline

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,61 @@
+# JAMES — ruff config
+#
+# Phase 1 (this commit, 2026-05-11): enforce F821 (undefined names) only.
+# Phase 2 (next cycle):   apply --fix for F401 (unused-import) and
+#                          F541 (f-string-missing-placeholders).
+#                          Both auto-fixable + safe.
+# Phase 3:                 address F841 (unused-variable) + F811
+#                          (redefined-while-unused) — manual review.
+# Phase 4:                 extend to E (pycodestyle), W, I (isort).
+#
+# Current Pyflakes inventory (snapshot at 2026-05-11):
+#   F821 — 0  ← enforced (was 4: server_llmwiki.py + 3× wiki_editor.py)
+#   F401 — 205 (auto-fixable)
+#   F541 — 96  (auto-fixable)
+#   F841 — 28  (auto-fixable)
+#   F811 — 4   (manual)
+#
+# Why F821 first
+# --------------
+# F821 catches genuine NameErrors — code that will raise at runtime as
+# soon as the affected branch executes. Before this commit, GET
+# /hardware/ in psutil-less environments raised NameError on the
+# fallback path (platform was used without import); after the fix the
+# default specs render. Style rules (E/W) and import hygiene (F401)
+# are cleanups, not correctness bugs — they wait until F-class is
+# clean.
+#
+# How to run
+# ----------
+#   ruff check .              # respects this file's [lint.select]
+#   ruff check --select F .   # full Pyflakes inventory (333 errors today)
+#   ruff check --fix .        # apply auto-fixable rules
+target-version = "py311"
+
+# Generated / vendored / runtime-data — never linted. ``exclude`` is
+# a top-level setting, not part of [lint].
+exclude = [
+    "venv/",
+    ".venv/",
+    "env/",
+    "ENV/",
+    "build/",
+    "dist/",
+    "models/",
+    "chroma_db/",
+    "wiki/",
+    "workspace/",
+    "uploads/",
+    "backups/",
+    "memory/",
+    "reports/",
+    "frontend/",       # JS/HTML/CSS, not Python
+    ".cache/",
+    "tmp/",
+    "temp/",
+    "*.pyc",
+    "__pycache__/",
+]
+
+[lint]
+select = ["F821"]

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1622,7 +1622,12 @@ async def hardware_info(
         specs = get_hardware_specs()
         return {"ok": True, "specs": specs}
     except Exception as e:
-        # psutil 없는 환경 — 기본값 반환
+        # psutil 없는 환경 — 기본값 반환. [F821 fix 2026-05-11]
+        # ``platform`` was referenced without import; before this fix
+        # the fallback path raised NameError → 500 instead of the
+        # friendly default specs. Imported locally so the happy path
+        # is not taxed with an unused module load.
+        import platform
         return {
             "ok": False,
             "specs": {

--- a/tools/wiki/wiki_editor.py
+++ b/tools/wiki/wiki_editor.py
@@ -77,7 +77,12 @@ def _resync_vector(name: str, content: str, source_type: str = "prod"):
                 from graph_rag_engine import RAGEngine    # 루트 fallback
             except ModuleNotFoundError:
                 import sys
-                sys.path.insert(0, str(BASE_PATH) if "BASE_PATH" in dir() else ".")
+                # [F821 fix 2026-05-11] previously referenced an
+                # undefined ``BASE_PATH``; the in-dir() guard made it
+                # silently fall through to ".". Use the module-level
+                # ``BASE_DIR`` imported at the top of this file —
+                # that's the intent.
+                sys.path.insert(0, str(BASE_DIR))
                 from core.graph_rag_engine import RAGEngine
         engine = RAGEngine(default_role="admin")
 
@@ -115,7 +120,12 @@ def _refresh_index():
                 from graph_rag_engine import RAGEngine    # 루트 fallback
             except ModuleNotFoundError:
                 import sys
-                sys.path.insert(0, str(BASE_PATH) if "BASE_PATH" in dir() else ".")
+                # [F821 fix 2026-05-11] previously referenced an
+                # undefined ``BASE_PATH``; the in-dir() guard made it
+                # silently fall through to ".". Use the module-level
+                # ``BASE_DIR`` imported at the top of this file —
+                # that's the intent.
+                sys.path.insert(0, str(BASE_DIR))
                 from core.graph_rag_engine import RAGEngine
         engine = RAGEngine(default_role="admin")
         engine.wiki_generator.refresh_entity_map()
@@ -259,7 +269,12 @@ def delete_entity(name: str, user_role: str = "admin") -> Tuple[bool, str]:
                 from graph_rag_engine import RAGEngine    # 루트 fallback
             except ModuleNotFoundError:
                 import sys
-                sys.path.insert(0, str(BASE_PATH) if "BASE_PATH" in dir() else ".")
+                # [F821 fix 2026-05-11] previously referenced an
+                # undefined ``BASE_PATH``; the in-dir() guard made it
+                # silently fall through to ".". Use the module-level
+                # ``BASE_DIR`` imported at the top of this file —
+                # that's the intent.
+                sys.path.insert(0, str(BASE_DIR))
                 from core.graph_rag_engine import RAGEngine
         RAGEngine(default_role="admin").vector_store.delete_by_source(path.name)
     except Exception:


### PR DESCRIPTION
## Summary

Closes **4 F821 violations** ruff caught — three were dead defensive code, **one was a real runtime bug** that would surface as a 500 in psutil-less deployments. Also adds \`ruff.toml\` as the project's lint baseline, currently enforcing F821 only with an explicit phased plan in the file's preamble.

## Bugs fixed

### 1. \`server_llmwiki.py\` — real bug
\`GET /hardware/\` fallback path used \`platform.processor()\` without an \`import platform\`. When the primary path (\`tools.system.hardware_inspector\`) raised — typically because psutil isn't installed — the exception handler itself raised \`NameError\` and the endpoint returned **500** instead of the friendly default specs. Imported \`platform\` locally inside the except block.

### 2. \`tools/wiki/wiki_editor.py:80/118/262\` — dead code
Three call sites used \`str(BASE_PATH) if "BASE_PATH" in dir() else "."\`. The \`dir()\` guard meant the \`BASE_PATH\` branch was never taken (it wasn't defined anywhere), so the code always fell through to \`"."\`. Replaced with the real intent: \`str(BASE_DIR)\`, the already-imported module-level constant from \`config\`.

## ruff.toml

- \`target-version\` = py311
- \`select = ["F821"]\` — only the genuine NameError detector is enforced today. **333 total Pyflakes errors** exist; phased plan in the file preamble:

| rule | count | phase |
|---|---|---|
| F821 | ~~4~~ **0** | **this PR** (enforced) |
| F401 unused-import | 205 | Phase 2 (auto-fix) |
| F541 empty f-string | 96 | Phase 2 (auto-fix) |
| F841 unused-var | 28 | Phase 3 (auto-fix) |
| F811 redefined | 4 | Phase 3 (manual) |

- \`exclude\` covers data dirs (wiki/, workspace/, uploads/, chroma_db/, memory/, reports/, backups/, models/), build artifacts, frontend (not Python), virtualenv layouts.

## Why not auto-fix everything in one pass

\`ruff check --fix .\` would clear 261/333 errors in one diff. Bundling that with a correctness fix is wrong because:
- **diff readability** — reviewers can't separate the NameError fix from i18n-touching f-string scrubs
- **regression surface** — auto-fix on F401 removes "unused" imports; if a module relied on the import's side effect (registering a handler at import time), the auto-fix bricks it silently

The phased plan schedules those for a focused follow-up.

## Verification

\`\`\`
ruff check --select F821 .   # All checks passed!
ruff check .                  # All checks passed! (F821 only today)
python -m unittest discover tests
Ran 1334 tests in 43.240s
OK
\`\`\`

## Branching

This is a **hotfix** branched off main, independent of the open W7-W8 PR #195 (W8-C wiki_links). Either can land first; merging this PR clears the F821 baseline, then #195 rebases trivially.

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning change.
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) — no new module, no trust-boundary change.
- Rule 5 (file size) ✅ — no module size change.