### PR TITLE
chore(lint): ruff Phase 3 — F401 noqa + F841 cleanup; baseline → 4 rules

### DIFF
--- a/core/memory/loom.py
+++ b/core/memory/loom.py
@@ -206,7 +206,6 @@ if __name__ == "__main__":
 
     def chk(name, ok, detail=""):
         global passed
-        passed_local = ok
         print(f"  {'✅' if ok else '❌'} {name}" + (f" → {detail}" if detail else ""))
         return ok
 

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -320,7 +320,7 @@ def handle_self_evolve(
     try:
         from tools.self.file_scanner import get_file_content
 
-        q_lower = safe_query.lower()
+        safe_query.lower()
 
         # [P2-9] 폴더 지정 분석 (예: "tools 폴더", "core/ 폴더")
         folder_match = re.search(

--- a/core/workspace.py
+++ b/core/workspace.py
@@ -399,7 +399,7 @@ def execute_job(job_id: str) -> Dict:
         fname = handler(input_refs, out_dir, options)
         rel = os.path.join("workspace", "results", job_id, fname).replace("\\", "/")
         _set_status(job_id, "done", output_path=rel)
-    except Exception as e:
+    except Exception:
         tb = traceback.format_exc()
         _set_status(job_id, "failed", error=tb[-4000:])  # cap traceback length
         # don't re-raise — the row + tests are the contract.

--- a/james_phase55_test.py
+++ b/james_phase55_test.py
@@ -57,7 +57,7 @@ def run_sandbox_tests():
 
     try:
         from tools.code.sandbox import (
-            validate_action, validate_path, validate_command,
+            validate_action, validate_path, validate_command,  # noqa: F401
             ALLOWED_PATHS, BLOCKED_COMMANDS, MAX_EXEC_TIME_SEC,
         )
     except ImportError as e:
@@ -343,7 +343,7 @@ def run_llm_tests():
     def t_no_multi_llm_router():
         """Multi-LLM 라우팅 없음 (GPU 전)"""
         try:
-            import llm.router
+            import llm.router  # noqa: F401
             return False, "router 존재 — Phase 6 이후 추가 예정"
         except ImportError:
             return True, "llm/router 없음 (GPU 이후 추가 예정)"
@@ -480,7 +480,6 @@ def run_audit_log_tests():
 
         # 임시 로그 파일로 테스트
         old_log = AUDIT_LOG_PATH
-        test_log = "james_audit_tool_test.jsonl"
 
         # 이벤트 발생
         validate_action("rm -rf /", "./workspace", "user")

--- a/james_phase5_test.py
+++ b/james_phase5_test.py
@@ -61,7 +61,7 @@ def run_jepa_tests():
     try:
         from core.jepa_adapter import (
             expand, JEPA_TOKEN_HARD_LIMIT, JEPA_TIMEOUT_SEC,
-            _tokenize_simple, _expand_keywords, _hard_truncate,
+            _tokenize_simple, _expand_keywords, _hard_truncate,  # noqa: F401
         )
     except ImportError as e:
         print(f"  ⚠️  import 실패: {e}"); return
@@ -345,7 +345,7 @@ def run_security_regression():
     print("="*55)
 
     try:
-        from core.security_layer import SecurityLayer, detect_attack, check_access
+        from core.security_layer import SecurityLayer, detect_attack, check_access  # noqa: F401
         from core.memory import MemoryLoom
     except ImportError as e:
         print(f"  ⚠️  import 실패: {e}"); return

--- a/james_phase6_gate.py
+++ b/james_phase6_gate.py
@@ -147,7 +147,6 @@ def run_retrieval_reliability():
         Orchestrator의 dedup 후 결과 수 ≥ single 결과 수.
         """
         from core.orchestrator import retrieve
-        call_results = []
         def mock_search(q, **kwargs):
             return [
                 {"text":f"관련문서:{q[:10]}","source":f"doc_{hash(q)%100}.md","score":0.85},

--- a/james_security_test.py
+++ b/james_security_test.py
@@ -54,7 +54,7 @@ def run_security_layer_tests():
 
     try:
         from core.security_layer import (
-            validate_input, detect_attack, filter_graph_by_abac,
+            validate_input, detect_attack, filter_graph_by_abac,  # noqa: F401
             mask_sensitive, SecurityLayer, check_access
         )
     except ImportError as e:
@@ -304,7 +304,7 @@ def run_sec_fix_tests():
     print("\n" + "="*55 + "\n  5. SEC-FIX 1,2,3 검증 [Phase 4]\n" + "="*55)
 
     try:
-        from core.security_layer import SecurityLayer, mask_sensitive
+        from core.security_layer import SecurityLayer, mask_sensitive  # noqa: F401
     except ImportError as e:
         print(f"  ⚠️  {e}"); return
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,23 +1,28 @@
 # JAMES — ruff config
 #
 # Phase 1 (2026-05-11): enforce F821 (undefined names) only.
-# Phase 2 (2026-05-11, this commit): auto-fix F541 (empty f-strings,
-#                          96 cleared, ENFORCED). F401 partially
-#                          auto-fixed (164 of 206 cleared); 42
-#                          remaining are intentional try-import
-#                          availability checks — Phase 3 will mark
-#                          them ``# noqa: F401`` and then enforce.
-# Phase 3:                 noqa-mark remaining F401, fix F841
-#                          unused-variable + F811 redefined-while-unused.
-# Phase 4:                 extend to E (pycodestyle), W, I (isort).
+# Phase 2 (2026-05-11): auto-fix F541 (96 cleared, ENFORCED).
+#                       F401 partially auto-fixed (164 of 206).
+# Phase 3 (2026-05-11, this commit):
+#   - Remaining 42 F401 marked with ``# noqa: F401`` — all sites are
+#     intentional try-import availability checks or __init__.py
+#     re-exports. F401 now ENFORCED so new unused imports get caught.
+#   - F841 unused-variable: 28 → 0. Auto-fix handled 2 safely; 24
+#     unsafe-fixes applied + verified by full test suite; the final
+#     pair (g_, b_) in test_graph_visual_rendering.py rewritten to
+#     ``_, _, _, a_`` (tuple unpacking). ENFORCED.
+#   - F811 redefined-while-unused: still 4 (all in
+#     core/memory/extractor.py — duplicate def blocks). Deferred to
+#     a focused PR; the dead first definitions need a deliberate
+#     deletion + behavioural test, not a one-liner.
+# Phase 4: extend to E (pycodestyle), W, I (isort).
 #
-# Current Pyflakes inventory (snapshot at 2026-05-11, post-Phase 2):
-#   F821 — 0   ← enforced (Phase 1)
-#   F541 — 0   ← enforced (Phase 2, was 96)
-#   F401 — 42  ← intentional try-import availability checks; Phase 3
-#                will noqa-mark + enforce. Was 206 before Phase 2.
-#   F841 — 28  (auto-fixable, Phase 3)
-#   F811 — 4   (manual, Phase 3)
+# Current Pyflakes inventory (post-Phase 3):
+#   F821 — 0  ← enforced (Phase 1)
+#   F541 — 0  ← enforced (Phase 2)
+#   F401 — 0  ← enforced (Phase 3, intentional sites noqa-marked)
+#   F841 — 0  ← enforced (Phase 3)
+#   F811 — 4  (deferred — core/memory/extractor.py)
 #
 # Why F821 first
 # --------------
@@ -62,5 +67,5 @@ exclude = [
 ]
 
 [lint]
-# Phase 1 + Phase 2 selectors.
-select = ["F821", "F541"]
+# Phase 1-3 selectors. F811 deferred (see preamble Phase 3 notes).
+select = ["F821", "F541", "F401", "F841"]

--- a/scripts/migrate_entity_hard_dedup.py
+++ b/scripts/migrate_entity_hard_dedup.py
@@ -352,7 +352,7 @@ def main() -> int:
         canon_fm["updated_at"]     = datetime.now(timezone.utc).isoformat()
         entries[canonical_path] = (canon_fm, canon_body)
 
-        added = [r for r in merged_relations
+        [r for r in merged_relations
                  if r not in (canon_fm.get("relations") or [])]
         print(f"    → relations: {len(merged_relations)}, "
               f"aliases: {len(merged_aliases)}, sources: {len(merged_sources)}")

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -2637,10 +2637,7 @@ async def admin_dashboard(api_key: str, role: str = Depends(get_role_from_reques
     # ── [3-A] audit_log 기반 실시간 통계 ────────────────────
     today_queries   = 0
     avg_elapsed     = 0.0
-    cache_hits      = 0
     blocked_count   = 0
-    score_sum       = 0.0
-    score_count     = 0
     elapsed_list    = []   # 응답 시간 그래프용
     recent_queries  = []   # 최근 쿼리 목록용
 

--- a/tests/test_character_interactive_radar.py
+++ b/tests/test_character_interactive_radar.py
@@ -315,7 +315,7 @@ class JsSliderTests(unittest.TestCase):
 
     def test_resetCharacter_includes_new_traits(self):
         idx = self.js.index("function resetCharacter")
-        nxt = self.js.index("\n", idx + 1)
+        self.js.index("\n", idx + 1)
         # Reset block has all defaults inline; expand to the closing brace.
         end = self.js.index("\n}", idx)
         body = self.js[idx:end]

--- a/tests/test_first_run_wizard.py
+++ b/tests/test_first_run_wizard.py
@@ -118,7 +118,7 @@ class FrontendJsTests(unittest.TestCase):
 
     def test_check_uses_resolution_endpoint(self):
         idx = self.js.index("async function firstRunCheck")
-        nxt = self.js.index("\n", self.js.index("}", idx + 200))
+        self.js.index("\n", self.js.index("}", idx + 200))
         body = self.js[idx:idx + 1500]
         self.assertIn("/admin/llm/resolution", body,
             "firstRunCheck must call /admin/llm/resolution")

--- a/tests/test_graph_camera_glow.py
+++ b/tests/test_graph_camera_glow.py
@@ -173,7 +173,7 @@ class NodeHaloTests(unittest.TestCase):
 
     def test_tick_uses_sine_pulse(self):
         idx = self.js.index("function tickNodeHalos")
-        nxt = self.js.index("\n  ", idx + 100)
+        self.js.index("\n  ", idx + 100)
         body = self.js[idx:idx + 1500]
         self.assertIn("Math.sin", body,
             "halo must pulse via sine for organic breathing feel")

--- a/tests/test_graph_explorer.py
+++ b/tests/test_graph_explorer.py
@@ -137,7 +137,7 @@ class NeighborPanelTests(unittest.TestCase):
 
     def test_render_function_uses_escapehtml(self):
         idx = self.js.index("function renderNeighborPanel")
-        nxt = self.js.index("\n  ", idx + 100)   # bound at next top-level
+        self.js.index("\n  ", idx + 100)   # bound at next top-level
         # Find a stable end: the closing of the function
         end = self.js.index("\n  window.onNeighborClick", idx)
         body = self.js[idx:end]

--- a/tests/test_graph_mobile_loop_search.py
+++ b/tests/test_graph_mobile_loop_search.py
@@ -100,7 +100,7 @@ class PulseLoopTests(unittest.TestCase):
 
     def test_stop_clears_interval(self):
         idx = self.js.index("function stopPulseLoop")
-        nxt = self.js.index("\n  ", idx + 100)
+        self.js.index("\n  ", idx + 100)
         body = self.js[idx:idx + 400]
         self.assertIn("clearInterval", body)
 
@@ -108,7 +108,7 @@ class PulseLoopTests(unittest.TestCase):
         # When the active path is cleared (new question, close panel),
         # the pulse loop must stop too.
         idx = self.js.index("function clearActivePath")
-        nxt = self.js.index("\n  ", idx + 50)
+        self.js.index("\n  ", idx + 50)
         body = self.js[idx:idx + 600]
         self.assertIn("stopPulseLoop", body,
             "clearActivePath must also stop the pulse loop so the next "
@@ -184,7 +184,7 @@ class SearchDrawerJsTests(unittest.TestCase):
 
     def test_render_uses_escapehtml(self):
         idx = self.js.index("function _renderSearchList")
-        nxt = self.js.index("\n  ", idx + 100)
+        self.js.index("\n  ", idx + 100)
         body = self.js[idx:idx + 2000]
         # Names + types come from the snapshot — XSS-escape both.
         self.assertGreaterEqual(body.count("escapeHtml"), 2,

--- a/tests/test_graph_visual_rendering.py
+++ b/tests/test_graph_visual_rendering.py
@@ -153,7 +153,8 @@ class LinkRenderingTests(unittest.TestCase):
         self.assertGreater(len(m), 0, "expected at least one rgba literal")
         # The non-hub baseline is the LAST rgba in the function body.
         baseline = m[-1]
-        r_, g_, b_, a_ = int(baseline[0]), int(baseline[1]), int(baseline[2]), float(baseline[3])
+        # G/B channels are not asserted on; only R + alpha gate visibility.
+        r_, _, _, a_ = int(baseline[0]), int(baseline[1]), int(baseline[2]), float(baseline[3])
         self.assertGreaterEqual(r_, 160,
             f"baseline R={r_} should be ≥160 for visibility (was 150)")
         self.assertGreaterEqual(a_, 0.35,

--- a/tests/test_mobile_responsive.py
+++ b/tests/test_mobile_responsive.py
@@ -83,7 +83,7 @@ class TouchTargetAndIosGuardTests(unittest.TestCase):
         # iOS zooms in on focus when input font-size < 16px. The
         # mobile.css rule for textarea/input must declare ≥16px.
         # We look inside the 768px block.
-        block_match = re.search(
+        re.search(
             r"@media\s*\(\s*max-width\s*:\s*768px\s*\)\s*\{(.+?)\n\}\s*\n\s*/\*",
             self.css, re.DOTALL,
         )

--- a/tests/test_model_catalog_per_mode.py
+++ b/tests/test_model_catalog_per_mode.py
@@ -70,7 +70,7 @@ class ModelCatalogTests(unittest.TestCase):
         # entry (default) is light for chat, heavy for coding.
         cat = self.srv._model_catalog()
         chat0 = cat["chat"][0]   # (tag, weight)
-        code0 = cat["coding"][0]
+        cat["coding"][0]
         # chat's default may be light or medium (env override possible)
         self.assertIn(chat0[1], ("light", "medium"),
             f"chat default should be light/medium, got {chat0[1]}")

--- a/tests/test_trace_prune.py
+++ b/tests/test_trace_prune.py
@@ -94,7 +94,7 @@ class PruneBasicTests(unittest.TestCase):
         self._make_day_dir(0)   # today — within any [1, 365] window
         self._make_day_dir(2)   # 2d ago — outside keep_days=1
         # keep_days=0 must clamp to 1, NOT wipe today.
-        result = prune_old_traces(keep_days=0)
+        prune_old_traces(keep_days=0)
         today = datetime.now().strftime("%Y-%m-%d")
         self.assertTrue((self.root / today).exists(),
                         "keep_days=0 must clamp to 1; today must survive")

--- a/tests/test_workspace_jobs.py
+++ b/tests/test_workspace_jobs.py
@@ -229,7 +229,7 @@ class HandlerTests(_JobsFixture):
     def test_entity_export_filters_by_category(self):
         from core.workspace import register_job, execute_job, _RESULT_DIR
         jid = register_job("entity_export", ["concept"], owner="alice")
-        row = execute_job(jid)
+        execute_job(jid)
         out_full = os.path.join(_RESULT_DIR, jid)
         files = [f for f in os.listdir(out_full) if f.endswith(".json")]
         data = json.loads(Path(os.path.join(out_full, files[0]))

--- a/tools/admin/__init__.py
+++ b/tools/admin/__init__.py
@@ -1,3 +1,3 @@
 """PROJECT JAMES — Admin tools (리셋, 시드, 데이터 정합성 검사)"""
 
-from tools.admin.seed_data import SEED_ENTITIES, write_seed_files
+from tools.admin.seed_data import SEED_ENTITIES, write_seed_files  # noqa: F401

--- a/tools/admin/wiki_reset.py
+++ b/tools/admin/wiki_reset.py
@@ -264,7 +264,7 @@ def create_seed_data():
     print(f"\n{C}  📦 시드 데이터 생성 중...{E}")
 
     try:
-        from tools.admin.seed_data import SEED_ENTITIES, write_seed_files
+        from tools.admin.seed_data import SEED_ENTITIES, write_seed_files  # noqa: F401
         count = write_seed_files()
         print(f"  {G}✅{E} 시드 entity {count}개 생성 완료")
     except ImportError:

--- a/tools/code/code_reader.py
+++ b/tools/code/code_reader.py
@@ -168,7 +168,7 @@ class CodeReader:
                         "size_kb":   round(f.stat().st_size / 1024, 2),
                         "lines":     None,   # 빠른 목록은 라인 수 생략
                     })
-        except Exception as e:
+        except Exception:
             return False, []
 
         print(f"[READER] 목록: {directory} → {len(files)}개 파일")

--- a/tools/patch/patch_applier.py
+++ b/tools/patch/patch_applier.py
@@ -105,7 +105,7 @@ def apply(patch: dict, validated: bool = False) -> Tuple[bool, str]:
                 return False, msg
         else:
             # 코드 블록 직접 쓰기
-            existing = p.read_text(encoding="utf-8") if p.exists() else ""
+            p.read_text(encoding="utf-8") if p.exists() else ""
             p.write_text(code, encoding="utf-8")
 
     except Exception as e:

--- a/tools/self/__init__.py
+++ b/tools/self/__init__.py
@@ -1,19 +1,19 @@
 from tools.self.file_scanner import (
-    auto_index_on_startup, scan_and_report, get_file_content,
+    auto_index_on_startup, scan_and_report, get_file_content,  # noqa: F401
 )
 from tools.self.evo_analyzer import (
-    observe_and_signal, generate_proposals_from_signals,
-    approve_and_execute, reject_proposal,
-    list_proposals, list_reports,
+    observe_and_signal, generate_proposals_from_signals,  # noqa: F401
+    approve_and_execute, reject_proposal,  # noqa: F401
+    list_proposals, list_reports,  # noqa: F401
 )
 from tools.self.importance_scorer import (
-    score_query, get_loom_threshold,
-    get_repeated_errors, get_scorer_stats,
+    score_query, get_loom_threshold,  # noqa: F401
+    get_repeated_errors, get_scorer_stats,  # noqa: F401
 )
 from tools.self.performance_evaluator import (
-    record_query, run_evaluation,
-    get_current_metrics, get_eval_history,
+    record_query, run_evaluation,  # noqa: F401
+    get_current_metrics, get_eval_history,  # noqa: F401
 )
 from tools.self.self_learner import (
-    learn_topic, learn_from_errors, continuous_learn,
+    learn_topic, learn_from_errors, continuous_learn,  # noqa: F401
 )

--- a/tools/self/self_learner.py
+++ b/tools/self/self_learner.py
@@ -227,7 +227,7 @@ class SelfLearner:
         """EvoAnalyzer 제안 생성."""
         try:
             from tools.self.evo_analyzer import _make_proposal, save_proposal
-            normalized = re.sub(r'[^\w가-힣]', '_', topic).strip('_')
+            re.sub(r'[^\w가-힣]', '_', topic).strip('_')
             p = _make_proposal(
                 prop_type   = "wiki_add",
                 title       = f"[자기학습] {topic}",

--- a/tools/web/web_searcher.py
+++ b/tools/web/web_searcher.py
@@ -154,11 +154,11 @@ def get_search_engine_status() -> Dict:
     # ── Tavily 설치 감지: TavilyClient import로 확인 (최상위 패키지 대신) ──
     tavily_installed = False
     try:
-        from tavily import TavilyClient  # 실제 사용하는 클래스로 감지
+        from tavily import TavilyClient  # 실제 사용하는 클래스로 감지  # noqa: F401
         tavily_installed = True
     except ImportError:
         try:
-            import tavily  # fallback
+            import tavily  # fallback  # noqa: F401
             tavily_installed = True
         except ImportError:
             tavily_installed = False
@@ -166,11 +166,11 @@ def get_search_engine_status() -> Dict:
     # ── DDG 설치 감지: DDGS 클래스로 확인 ──
     ddg_installed = False
     try:
-        from duckduckgo_search import DDGS  # 실제 사용하는 클래스로 감지
+        from duckduckgo_search import DDGS  # 실제 사용하는 클래스로 감지  # noqa: F401
         ddg_installed = True
     except ImportError:
         try:
-            import duckduckgo_search
+            import duckduckgo_search  # noqa: F401
             ddg_installed = True
         except ImportError:
             ddg_installed = False
@@ -547,7 +547,7 @@ def save_as_longterm(
         # entity 정보 구성
         topic    = _topic_key(query)
         sources  = [r["url"] for r in results if r.get("url")]
-        source_str = "\n".join(f"- {u}" for u in sources[:3])
+        "\n".join(f"- {u}" for u in sources[:3])
         now      = datetime.now().isoformat()
 
         entity = {
@@ -608,7 +608,6 @@ def update_knowledge_level(query: str, is_longterm: bool = False):
     try:
         from core.knowledge_tracker import KnowledgeTracker
         kt = KnowledgeTracker()
-        signal = "web_longterm" if is_longterm else "web_shortterm"
         domain = kt.classify_domain(query) if hasattr(kt, 'classify_domain') else "general"
         delta  = 5.0 if is_longterm else 2.0
 

--- a/tools/wiki/__init__.py
+++ b/tools/wiki/__init__.py
@@ -1,6 +1,6 @@
 from tools.wiki.wiki_editor import (
-    find_entity_file, read_entity,
-    update_entity, append_to_entity,
-    delete_entity, create_entity,
-    parse_edit_intent, list_entities,
+    find_entity_file, read_entity,  # noqa: F401
+    update_entity, append_to_entity,  # noqa: F401
+    delete_entity, create_entity,  # noqa: F401
+    parse_edit_intent, list_entities,  # noqa: F401
 )

--- a/tools/wiki/wiki_editor.py
+++ b/tools/wiki/wiki_editor.py
@@ -255,7 +255,7 @@ def delete_entity(name: str, user_role: str = "admin") -> Tuple[bool, str]:
         return False, "WIKI_DIR 범위 외 파일 접근 차단"
 
     backup = _backup(path)
-    content = path.read_text(encoding="utf-8")
+    path.read_text(encoding="utf-8")
 
     path.unlink()
     _audit("DELETE", path.name, f"삭제됨 (백업: {backup.name})", user_role)


### PR DESCRIPTION
## Summary

Closes 3 of the 4 remaining F-class violations and pulls them into the enforced \`ruff check .\` baseline. F811 is the lone holdout — 4 duplicate-def sites in \`core/memory/extractor.py\` that need a **focused deletion PR**, not a one-liner.

## Result

| rule | before | after | status |
|---|---|---|---|
| F821 undefined-name | 0 | 0 | enforced (Phase 1) |
| F541 empty f-string | 0 | 0 | enforced (Phase 2) |
| **F401 unused-import** | 42 | **0** | **enforced (this PR)** |
| **F841 unused-variable** | 28 | **0** | **enforced (this PR)** |
| F811 redefined-while-unused | 4 | 4 | deferred (separate PR) |

\`ruff.toml\` select now \`["F821", "F541", "F401", "F841"]\` — any new violation in those classes blocks \`ruff check .\` on subsequent PRs.

## What changed

### F401 noqa marking (25 lines / 8 files)
All remaining sites were intentional try-import availability checks or \`__init__.py\` re-exports. Examples:
\`\`\`python
# availability probe
try:
    import llm.router  # noqa: F401
    return False, "router 존재 — Phase 6 이후"
except ImportError:
    ...

# __init__.py re-export
from tools.self.evo_analyzer import (
    observe_and_signal,                 # noqa: F401
    generate_proposals_from_signals,    # noqa: F401
)
\`\`\`

\`noqa\` communicates intent + survives future refactors better than rewriting all 8 \`__init__.py\` with \`__all__\` + \`import as\` redundant aliases.

### F841 unused-variable cleanup (28 sites)
- 2 sites auto-fixed (safe path)
- 24 sites cleared by \`ruff check --select F841 --fix --unsafe-fixes\`
- 2 final sites — tuple unpacking in \`test_graph_visual_rendering.py:156\` — \`g_\`/\`b_\` were RGBA channels not asserted on. Rewritten to \`r_, _, _, a_ = ...\`

## Why F811 is deferred

\`core/memory/extractor.py\` defines \`extract_memory\` / \`validate_memory\` / \`get_stats\` / \`save_as_longterm\` **twice each** — the second def shadows the first. The second is the newer signature \`(query, response)\` used by callers; the first appears to be a pre-refactor leftover. Deleting the first set safely requires checking every caller's argument shape — a focused PR with behavioural smoke test, not a Phase 3 sweep.

## Verification

\`\`\`
ruff check .                # All checks passed!  (4 rule classes)
ruff check --select F .     # 4 errors  (F811 only, deferred)
python -m unittest discover tests
Ran 1351 tests in 43.255s
OK
\`\`\`

29 files; +69 / -70. No semantic change inside \`core/retrieval\` / \`core/graph\` / \`core/reasoning\`.

## Out of scope

- F811 in \`core/memory/extractor.py\` (4 hits) — separate focused PR
- Phase 4 (E / W / I rule classes) — later Tier 1 / 2

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — pure lint cleanup
- Rule 3 (self-evolution untouched) ✅
- Rule 4 (architecture) — no boundary change
- Rule 5 (file size) ✅