### PR TITLE
fix(memory,web): F811 dedup — extractor / store / web_searcher (includes latent bug fix)

### DIFF
--- a/core/memory/extractor.py
+++ b/core/memory/extractor.py
@@ -56,104 +56,16 @@ def repeated_pattern(query: str) -> bool:
     return list(_query_history).count(key) >= 2
 
 
-# ─── preference 파싱 (Step 1) ────────────────────────────────
-
-def _parse_preference(query: str) -> Optional[dict]:
-    rules = [
-        (r"(코드|code).*(상세|자세|간단|짧게|길게)", "code_detail_level"),
-        (r"(언어|language).*(한국어|영어|english)",   "response_language"),
-        (r"(답변|응답).*(짧게|간결|상세|자세)",        "response_style"),
-        (r"(먼저|first|우선).*(구조|architecture|설계)", "explain_style"),
-    ]
-    q = query.strip()
-    for pattern, key in rules:
-        if re.search(pattern, q, re.IGNORECASE):
-            return {"type":"preference","key":key,"value":q[:100],
-                    "raw":q,"confidence":0.85,"source":"trusted"}
-    return {"type":"preference","key":"general","value":q[:100],
-            "raw":q,"confidence":0.82,"source":"trusted"}
+# [F811 dedup 2026-05-11] First-pass definitions of _parse_preference /
+# _detect_pattern / _detect_goal / extract_memory / validate_memory
+# lived here. They were shadowed by the second-pass set below (lines
+# starting with the live ``_parse_preference``) and never executed.
+# Removed for clarity. The live behaviour is exactly what was already
+# running — Python uses the most recent definition, so the surviving
+# set produces byte-identical output to before this change.
 
 
-# ─── pattern 감지 (Step 2) ───────────────────────────────────
-
-def _detect_pattern(query: str) -> dict:
-    """
-    Step 2: 반복 행동 또는 명시적 패턴 선언.
-    예: "주로 아키텍처 설계부터 시작해"
-        "보통 코드 리뷰 먼저 요청함"
-    """
-    q = query.strip()
-
-    # 패턴 키워드 기반 파싱
-    rules = [
-        (r"(아키텍처|설계|구조).*(먼저|우선|시작)", "prefers_architecture_first"),
-        (r"(코드|code).*(리뷰|review)",             "prefers_code_review"),
-        (r"(테스트|test).*(먼저|우선)",              "prefers_test_first"),
-        (r"(요약|정리).*(먼저|우선|짧게)",           "prefers_summary_first"),
-    ]
-    for pattern, label in rules:
-        if re.search(pattern, q, re.IGNORECASE):
-            return {"type":"pattern","pattern":label,"raw":q,
-                    "confidence":0.82,"source":"trusted"}
-
-    return {"type":"pattern","pattern":q[:100],"raw":q,
-            "confidence":0.80,"source":"trusted"}
-
-
-# ─── goal 감지 (Step 3) ──────────────────────────────────────
-
-def _detect_goal(query: str) -> dict:
-    """
-    Step 3: 명시적 목표/계획 선언.
-    예: "보안이 강한 RAG 시스템 완성이 목표야"
-        "로컬 AI 엔진 구축하고 싶다"
-    """
-    q = query.strip()
-    return {"type":"goal","goal":q[:200],"raw":q,
-            "confidence":0.80,"source":"trusted"}
-
-
-# ─── 메인 API ────────────────────────────────────────────────
-
-def extract_memory(query: str, response: str) -> Optional[dict]:
-    """
-    질문에서 저장할 Memory 후보 추출.
-    Step 1(preference) → Step 2(pattern) → Step 3(goal) 순서.
-    """
-    if not query or not query.strip():
-        return None
-    q = query.strip()
-
-    # 너무 짧은 잡담 제외
-    if len(q) < 8:
-        return None
-
-    # Step 1: preference trigger
-    if any(k in q for k in TRIGGER_KEYWORDS):
-        return _parse_preference(q)
-
-    # Step 2: pattern trigger 또는 반복
-    if any(k in q for k in PATTERN_KEYWORDS):
-        return _detect_pattern(q)
-    if repeated_pattern(q):
-        return _detect_pattern(q)
-
-    # Step 3: goal trigger
-    if any(k in q for k in GOAL_KEYWORDS):
-        return _detect_goal(q)
-
-    return None
-
-
-def validate_memory(candidate: Optional[dict]) -> bool:
-    """추출된 후보 검증."""
-    if not candidate:
-        return False
-    if candidate.get("source") != "trusted":
-        return False
-    if float(candidate.get("confidence", 0)) < 0.8:
-        return False
-    return True
+# ─── preference 파싱 ─────────────────────────────────────────
 
 def _parse_preference(query: str) -> Optional[dict]:
     """

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -214,17 +214,12 @@ class MemoryStore:
 
         return "\n".join(lines) if lines else ""
 
-    def get_stats(self) -> dict:
-        try:
-            with _connect() as conn:
-                return {
-                    "preferences": conn.execute("SELECT COUNT(*) FROM preferences").fetchone()[0],
-                    "patterns":    conn.execute("SELECT COUNT(*) FROM patterns").fetchone()[0],
-                    "goals":       conn.execute("SELECT COUNT(*) FROM goals").fetchone()[0],
-                    "db_path":     DB_PATH,
-                }
-        except Exception:
-            return {"preferences": 0, "patterns": 0, "goals": 0}
+    # [F811 dedup 2026-05-11] First-pass ``get_stats`` (preferences /
+    # patterns / goals / db_path only) lived here. The second-pass
+    # definition further down adds conversations + session_summaries
+    # and was already shadowing this one — Python ignored this
+    # version at runtime. Removed for clarity; the live response
+    # shape does not change.
 
     def clear(self):
         """테스트용 전체 초기화"""

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,7 +22,23 @@
 #   F541 — 0  ← enforced (Phase 2)
 #   F401 — 0  ← enforced (Phase 3, intentional sites noqa-marked)
 #   F841 — 0  ← enforced (Phase 3)
-#   F811 — 4  (deferred — core/memory/extractor.py)
+#   F811 — 0  ← enforced (Phase 3-fixup, this commit)
+#
+# Phase 3 fixup (2026-05-11): F811 holdouts resolved.
+#   - core/memory/extractor.py: deleted first-pass set
+#     (_parse_preference / _detect_pattern / _detect_goal /
+#      extract_memory / validate_memory). The second-pass set
+#     was already shadowing them, so runtime behaviour is byte-
+#     identical.
+#   - core/memory/store.py: deleted older get_stats; newer (richer
+#     response with conversations + session_summaries) was already
+#     the active one.
+#   - tools/web/web_searcher.py: deleted OLDER save_as_longterm at
+#     line 524 that lacked the ``domain`` kwarg. This was a real
+#     bug — the U-1 improved version at line 401 was being shadowed,
+#     so callers passing ``domain=...`` (server_llmwiki.upload's
+#     /admin/proposals/approve handler) hit silent TypeError caught
+#     by an outer try/except.
 #
 # Why F821 first
 # --------------
@@ -67,5 +83,5 @@ exclude = [
 ]
 
 [lint]
-# Phase 1-3 selectors. F811 deferred (see preamble Phase 3 notes).
-select = ["F821", "F541", "F401", "F841"]
+# All Pyflakes correctness rules. Phase 4 will widen to E / W / I.
+select = ["F"]

--- a/tools/web/web_searcher.py
+++ b/tools/web/web_searcher.py
@@ -521,81 +521,15 @@ def should_promote_to_longterm(query: str) -> bool:
     return _search_history.get(key, 0) >= REPEAT_TH
 
 
-def save_as_longterm(
-    query: str,
-    results: List[Dict],
-    summary: str,
-    user_role: str = "admin",
-) -> Optional[str]:
-    """
-    [경로 A 장기 전환 / 경로 B 직접 저장]
-    웹 검색 결과 → wiki entity 생성 → vector 인덱싱.
-    반환: 생성된 wiki 파일 경로 (실패 시 None)
-    """
-    if not results or not summary:
-        return None
-
-    try:
-        try:
-            from core.graph_rag_engine import RAGEngine
-        except ModuleNotFoundError:
-            from graph_rag_engine import RAGEngine
-
-        engine   = RAGEngine(default_role=user_role)
-        wg       = engine.wiki_generator
-
-        # entity 정보 구성
-        topic    = _topic_key(query)
-        sources  = [r["url"] for r in results if r.get("url")]
-        "\n".join(f"- {u}" for u in sources[:3])
-        now      = datetime.now().isoformat()
-
-        entity = {
-            "name":        topic,
-            "entity_type": "concept",
-            "sensitivity": "internal",
-            "source_type": "prod",
-            "description": summary,
-            "attributes": {
-                "web_sources":   sources,
-                "learned_at":    now,
-                "learn_method":  "web_search",
-            },
-            "relations": [],
-        }
-
-        # wiki .md 파일 생성
-        path = wg.create_entity_file(
-            entity,
-            filename=f"web_{topic[:20]}_{int(time.time())}.md",
-            chunk_ids=[],
-            user_role=user_role,
-        )
-
-        # vector 인덱싱
-        content = Path(path).read_text(encoding="utf-8")
-        try:
-            from core.tokenizer import split_chunks
-        except ImportError:
-            def split_chunks(text, **kw):
-                return [text[i:i+500] for i in range(0, len(text), 500)]
-
-        chunks = split_chunks(content)
-        engine.vector_store.add_documents_with_meta(
-            texts=chunks,
-            source=Path(path).name,
-            metadata={"sensitivity": "internal", "source_type": "prod", "owner": "system"},
-        )
-
-        # entity_id_index 갱신
-        wg.refresh_entity_map()
-
-        print(f"[WEB→WIKI] 장기 저장 완료: {Path(path).name} ({len(chunks)} chunks)")
-        return path
-
-    except Exception as e:
-        print(f"[WEB→WIKI] 장기 저장 실패: {e}")
-        return None
+# [F811 dedup 2026-05-11] An older save_as_longterm without the
+# ``domain`` parameter lived here. Because Python honours the last
+# definition, this older version was the one actually executing —
+# the U-1 improved version at line 401 had no effect at runtime, and
+# the /admin/proposals/approve flow's ``domain=domain`` kwarg silently
+# raised TypeError that the caller's try/except swallowed (line 2072
+# in server_llmwiki.upload, around the /admin/proposals/* approval).
+# Removing this shadow restores the U-1 version + makes the
+# ``domain`` argument live.
 
 
 # ── KnowledgeTracker 연동 ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Final F-class cleanup. Three files had duplicate def blocks where the second def shadowed the first; ruff F811 flagged them but auto-fix was deliberately deferred from Phase 3 because deciding which duplicate to keep needs reading both bodies + the callers.

**Two were dead code** (byte-identical runtime after removal). **One was a real latent bug**.

## Files

### 1. \`core/memory/extractor.py\` — dead first-pass
Deleted first-pass def set (\`_parse_preference\`, \`_detect_pattern\`, \`_detect_goal\`, \`extract_memory\`, \`validate_memory\`). They were shadowed by the second-pass set; Python ran the second set already.

### 2. \`core/memory/store.py\` — dead older \`get_stats\`
Older version (preferences + patterns + goals + db_path) shadowed by the newer one (+ conversations + session_summaries) at line ~547.

### 3. ⚠️ \`tools/web/web_searcher.py\` — **REAL BUG**

The older 4-arg \`save_as_longterm\` (no \`domain\` kwarg) at line ~524 was shadowing the U-1 improved 5-arg version at line ~401. \`server_llmwiki.upload\`'s /admin/proposals/approve handler calls:

\`\`\`python
save_as_longterm(query=..., results=..., summary=..., user_role=..., domain=domain)
\`\`\`

The older signature would raise \`TypeError\` on the \`domain\` kwarg, which the caller's outer \`try/except Exception\` silently swallowed. **The wiki entity save was failing silently on every approval.** Removing the older shadow makes the U-1 version live and the \`domain\` argument start working.

## ruff.toml

\`select = ["F"]\` — all Pyflakes correctness rules. Snapshot now \`F821/F541/F401/F841/F811 = 0/0/0/0/0\`.

## Why focused PR (not under Phase 3)

Phase 3 was mechanical (auto-fix + noqa). F811 needs human judgement on **which** def is intended. For web_searcher the answer was "the other one, the one the caller's signature expects". Bundling under Phase 3's sweep risked deleting the wrong half or leaving the latent TypeError in place.

## Verification

\`\`\`
ruff check .                # All checks passed!  (F class entire)
ruff check --select F .     # All checks passed!  (= zero F-class)
python -m unittest discover tests
Ran 1351 tests in 42.605s
OK
\`\`\`

4 files; +42 / -185.

## Out of scope

- Phase 4 — extend ruff to E / W / I (style classes, not correctness)

## CLAUDE.md compliance

- Rule 1 (no domain features) ✅
- Rule 2 (bench paste) N/A — no core/retrieval/graph/reasoning semantic change
- Rule 3 (self-evolution untouched) ✅ — the /admin/proposals/ approval path now succeeds where it previously silently failed; the human-approval gate itself is unchanged
- Rule 4 (architecture) — no boundary change
- Rule 5 (file size) ✅ — files got smaller