### PR TITLE
feat(scheduler): W8-D follow-up — /admin/scheduler/status + /jobs/unschedule

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -186,6 +186,50 @@ def update_schedule(job_id: str, next_run_at: Optional[int]) -> bool:
         conn.close()
 
 
+def unschedule_job(job_id: str) -> bool:
+    """Convert a scheduled job back into a one-shot (W8-D follow-up).
+
+    Clears both ``schedule_cron`` and ``next_run_at`` so the row no
+    longer reappears in ``claim_due_scheduled_jobs``. The historical
+    output_path and status are preserved — the operator can still
+    inspect what the last firing produced.
+
+    Returns False if the row doesn't exist or was already a one-shot.
+    """
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "UPDATE jobs SET schedule_cron = NULL, next_run_at = NULL "
+            "WHERE job_id = ? AND schedule_cron IS NOT NULL",
+            (job_id,),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def list_upcoming_scheduled(limit: int = 20) -> List[Dict]:
+    """Scheduled rows ordered by ``next_run_at`` ASC.
+
+    Used by /admin/scheduler/status to show what fires next. Returns
+    a slim shape (job_id / job_type / owner / schedule_cron /
+    next_run_at) — the full row is available via /admin/jobs/{id}.
+    """
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT job_id, job_type, owner, schedule_cron, next_run_at "
+            "FROM jobs WHERE schedule_cron IS NOT NULL "
+            "ORDER BY (next_run_at IS NULL) DESC, next_run_at ASC "
+            "LIMIT ?",
+            (max(1, min(int(limit), 200)),),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
 # ───────────────────────────────────────────────────────────────
 # Retention sweep
 # ───────────────────────────────────────────────────────────────

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -4070,6 +4070,73 @@ async def jobs_schedule(
     }
 
 
+# ─── W8-D follow-up: unschedule + scheduler status ─────────────
+
+class JobUnscheduleRequest(BaseModel):
+    job_id: str
+
+
+@app.post("/jobs/unschedule",
+          summary="정기 실행 해제 (W8-D follow-up)")
+async def jobs_unschedule(
+    data:    JobUnscheduleRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    """Converts a scheduled row back into a one-shot. Mirror of
+    /jobs/schedule's authority surface — workspace.schedule
+    (admin-only default). 404 when the job doesn't exist or is
+    already a one-shot."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.schedule").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.schedule)")
+    from core.scheduler import unschedule_job
+    ok = unschedule_job(data.job_id)
+    ip = get_client_ip(request)
+    if not ok:
+        _write_audit(role, "/jobs/unschedule", query=data.job_id,
+                     security_event="unschedule_failed (unknown or one-shot)",
+                     ip_address=ip)
+        raise HTTPException(
+            status_code=404,
+            detail="해당 job 이 없거나 이미 정기실행이 아닙니다.",
+        )
+    _write_audit(role, "/jobs/unschedule", query=data.job_id,
+                 security_event="unscheduled", ip_address=ip)
+    return {"ok": True, "job_id": data.job_id}
+
+
+@app.get("/admin/scheduler/status",
+         summary="스케줄러 상태 + 다음 firing 목록 (W8-D follow-up)")
+async def admin_scheduler_status(
+    api_key: str,
+    limit:   int = 20,
+    role:    str = Depends(get_role_from_request),
+):
+    """Scheduler health snapshot.
+
+    Returns the live ``default_scheduler`` state (is_running,
+    poll_interval_sec, retention_days, last_retention) plus the next
+    N scheduled rows sorted by ``next_run_at``. Operator can spot
+    "scheduler stopped" (is_running=False), "retention never ran"
+    (last_retention=0), or "this job is stuck" (next_run_at in the
+    past) at a glance.
+
+    Gated by admin.metrics (matches /admin/metrics / dashboard).
+    """
+    _require_feature(api_key, role, "admin.metrics")
+    from core.scheduler import default_scheduler, list_upcoming_scheduled
+    return {
+        "is_running":         default_scheduler.is_running(),
+        "poll_interval_sec":  default_scheduler.poll_interval_sec,
+        "retention_days":     default_scheduler.retention_days,
+        "last_retention_at":  default_scheduler._last_retention,
+        "now":                int(time.time()),
+        "upcoming":           list_upcoming_scheduled(limit=limit),
+    }
+
+
 @app.get("/jobs/list", summary="내 job 목록 (W8-A)")
 async def jobs_list(
     request: Request,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -377,5 +377,204 @@ class ScheduleEndpointTests(_SchedulerFixture):
         self.assertIn(r.status_code, (401, 403))
 
 
+# ─── W8-D follow-up: unschedule + status ─────────────────────────
+
+class UnscheduleJobTests(_SchedulerFixture):
+    """``unschedule_job`` direct-call coverage — DB-only, no HTTP."""
+
+    def test_unschedule_converts_scheduled_to_one_shot(self):
+        from core.workspace import register_job, get_job
+        from core.scheduler import unschedule_job
+        jid = register_job("excel_build", [], owner="alice",
+                           schedule_cron="every:60",
+                           next_run_at=1_000_000)
+        self.assertTrue(unschedule_job(jid))
+        row = get_job(jid)
+        self.assertIsNone(row["schedule_cron"])
+        self.assertIsNone(row["next_run_at"])
+
+    def test_unschedule_returns_false_for_one_shot(self):
+        from core.workspace import register_job
+        from core.scheduler import unschedule_job
+        jid = register_job("excel_build", [], owner="alice")
+        self.assertFalse(unschedule_job(jid))
+
+    def test_unschedule_returns_false_for_unknown_job(self):
+        from core.scheduler import unschedule_job
+        self.assertFalse(unschedule_job("does-not-exist"))
+
+    def test_unscheduled_row_not_reclaimed(self):
+        # The contract that matters: once unscheduled, the scheduler
+        # must never pick the row up again.
+        from core.workspace import register_job
+        from core.scheduler import (
+            unschedule_job, claim_due_scheduled_jobs,
+        )
+        jid = register_job("excel_build", [], owner="alice",
+                           schedule_cron="every:60",
+                           next_run_at=1_000_000)
+        self.assertEqual(len(claim_due_scheduled_jobs(now=2_000_000)), 1)
+        unschedule_job(jid)
+        self.assertEqual(claim_due_scheduled_jobs(now=2_000_000), [])
+
+
+class ListUpcomingScheduledTests(_SchedulerFixture):
+    def test_orders_by_next_run_at_ascending(self):
+        from core.workspace import register_job
+        from core.scheduler import list_upcoming_scheduled
+        a = register_job("excel_build", [], owner="alice",
+                         schedule_cron="every:60", next_run_at=3_000_000)
+        b = register_job("excel_build", [], owner="alice",
+                         schedule_cron="every:60", next_run_at=1_000_000)
+        c = register_job("excel_build", [], owner="alice",
+                         schedule_cron="every:60", next_run_at=2_000_000)
+        rows = list_upcoming_scheduled(limit=20)
+        # NULL-first rule doesn't fire here — all three have integers.
+        ids = [r["job_id"] for r in rows if r["job_id"] in (a, b, c)]
+        self.assertEqual(ids, [b, c, a])
+
+    def test_skips_one_shot_rows(self):
+        from core.workspace import register_job
+        from core.scheduler import list_upcoming_scheduled
+        register_job("excel_build", [], owner="alice")  # one-shot
+        register_job("excel_build", [], owner="alice",
+                     schedule_cron="every:60", next_run_at=1_000_000)
+        rows = list_upcoming_scheduled(limit=20)
+        # Only the scheduled row should be present.
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["schedule_cron"], "every:60")
+
+    def test_limit_is_honored(self):
+        from core.workspace import register_job
+        from core.scheduler import list_upcoming_scheduled
+        for i in range(5):
+            register_job("excel_build", [], owner="alice",
+                         schedule_cron="every:60",
+                         next_run_at=1_000_000 + i)
+        rows = list_upcoming_scheduled(limit=3)
+        self.assertEqual(len(rows), 3)
+
+
+class UnscheduleEndpointTests(_SchedulerFixture):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = _api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        super().setUp()
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _hdr(self, role: str):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token('test-'+role, role)}"}
+
+    def _new_scheduled(self) -> str:
+        from core.workspace import register_job
+        return register_job("excel_build", [], owner="alice",
+                            schedule_cron="every:60",
+                            next_run_at=1_000_000)
+
+    def test_employee_blocked(self):
+        # workspace.schedule is admin-only by default — mirrors
+        # /jobs/schedule's gate.
+        jid = self._new_scheduled()
+        r = self._client().post(
+            "/jobs/unschedule",
+            params={"api_key": self._api_key},
+            json={"job_id": jid},
+            headers=self._hdr("employee"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_admin_happy_path(self):
+        from core.workspace import get_job
+        jid = self._new_scheduled()
+        r = self._client().post(
+            "/jobs/unschedule",
+            params={"api_key": self._api_key},
+            json={"job_id": jid},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertTrue(r.json()["ok"])
+        row = get_job(jid)
+        self.assertIsNone(row["schedule_cron"])
+
+    def test_one_shot_returns_404(self):
+        from core.workspace import register_job
+        jid = register_job("excel_build", [], owner="alice")
+        r = self._client().post(
+            "/jobs/unschedule",
+            params={"api_key": self._api_key},
+            json={"job_id": jid},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_unknown_job_returns_404(self):
+        r = self._client().post(
+            "/jobs/unschedule",
+            params={"api_key": self._api_key},
+            json={"job_id": "ghost-job"},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 404)
+
+
+class SchedulerStatusEndpointTests(_SchedulerFixture):
+    @classmethod
+    def setUpClass(cls):
+        cls._api_key = _api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing")
+        super().setUp()
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _hdr(self, role: str):
+        from core.auth import create_token
+        return {"Authorization": f"Bearer {create_token('test-'+role, role)}"}
+
+    def test_employee_blocked(self):
+        # admin.metrics is admin-only — employee → 403.
+        r = self._client().get(
+            "/admin/scheduler/status",
+            params={"api_key": self._api_key},
+            headers=self._hdr("employee"),
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_admin_status_shape(self):
+        from core.workspace import register_job
+        register_job("excel_build", [], owner="alice",
+                     schedule_cron="every:60",
+                     next_run_at=1_000_000)
+        r = self._client().get(
+            "/admin/scheduler/status",
+            params={"api_key": self._api_key, "limit": 10},
+            headers=self._hdr("admin"),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        for key in ("is_running", "poll_interval_sec", "retention_days",
+                    "last_retention_at", "now", "upcoming"):
+            self.assertIn(key, body)
+        self.assertIsInstance(body["upcoming"], list)
+        self.assertGreaterEqual(len(body["upcoming"]), 1)
+        # JAMES_DISABLE_SCHEDULER=1 in this test module → no thread.
+        self.assertFalse(body["is_running"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two operator-surface endpoints around the W8-D scheduler. Before this PR, inspecting *is the polling thread alive / what fires next / when did retention last run* meant tailing the log; cancelling a recurring job meant raw SQL.

- **GET /admin/scheduler/status** — `admin.metrics` gate. Returns `{is_running, poll_interval_sec, retention_days, last_retention_at, now, upcoming[]}`. Spot \"scheduler stopped\" / \"retention never ran\" / \"stuck row\" at a glance.
- **POST /jobs/unschedule** — `workspace.schedule` gate (mirrors /jobs/schedule's authority). Body: `{job_id}`. Converts a scheduled row back to one-shot (preserves status + output_path so the last firing stays inspectable). 404 on unknown / already one-shot.

Two supporting helpers in `core/scheduler.py`:
- `unschedule_job(job_id)` — clears `schedule_cron` + `next_run_at`. Returns False on unknown/one-shot.
- `list_upcoming_scheduled(limit)` — slim shape ordered by `next_run_at` ASC, NULL last. Limit capped at 200.

## Verification

`python -m unittest tests.test_scheduler -v` — **36 tests, all pass**. +13 new (was 23):
- UnscheduleJobTests x4 — convert / one-shot False / unknown False / row never reclaimed
- ListUpcomingScheduledTests x3 — ASC order / skips one-shot / limit honored
- UnscheduleEndpointTests x4 — employee 403 / admin happy / one-shot 404 / unknown 404
- SchedulerStatusEndpointTests x2 — employee 403 / admin response shape

- `core/scheduler.py` 15.3 KB (< 20 KB module gate).
- `ruff check core/scheduler.py server_llmwiki.py tests/test_scheduler.py` — All checks passed.

Audit log: both endpoints write to `james_audit.db` via `_write_audit`. `/jobs/unschedule` distinguishes `security_event=\"unscheduled\"` from `security_event=\"unschedule_failed (unknown or one-shot)\"` so failed cancel attempts are visible.

## Out of scope

- No bench paste — these endpoints touch `core/scheduler` (operator surface), not `core/retrieval` / `core/graph` / `core/reasoning`.
- Admin UI wiring (workspace.html status panel) — separate UI PR.
- Bulk reschedule / pause-all — single-row operator endpoints first; bulk waits for a real operator need.

Closes #N/A (Tier 1 follow-up after #201, no tracking issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)