### PR TITLE
chore(ci): GitHub Actions lint workflow — ruff on every PR + main push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: ruff (F-class enforced)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ruff
+        run: pip install ruff==0.15.8
+
+      - name: ruff check
+        run: ruff check . --output-format=github


### PR DESCRIPTION
## Summary

Adds `.github/workflows/lint.yml` — a GitHub Actions workflow that runs `ruff check .` on every PR targeting `main` and on every direct push to `main`.

- ruff version pinned to `0.15.8`
- Respects the project's existing `ruff.toml` (currently enforcing F821 + F541 + F401 + F841)
- Output uses `--output-format=github`, so any finding is surfaced as an inline annotation on the PR diff rather than buried in the action log
- `permissions: contents: read` only — no write tokens granted to the workflow

## Verification

- Local dry-run on this branch's HEAD:
  ```
  $ ruff check . --output-format=github
  All checks passed!     (exit 0)
  ```
- The branch is built directly on top of `main` (commit `c81865e`, ruff Phase 3), so the CI run on this PR will exercise the same codebase as the local run.

This PR touches CI config only — no changes under `core/{retrieval,graph,reasoning}`, so bench numbers are not applicable (CLAUDE.md rule 2).

## OpenSSF Best Practices impact

| Criterion | Before | After |
|---|---|---|
| `static_analysis_often` | Unmet (run on demand only) | **Met** (runs on every PR + main push) |
| `test_continuous_integration` | Unmet | Still Unmet — separate follow-up since the test suite needs Ollama and other heavy deps wired up first |

This flips one criterion in our recently-awarded passing badge from a documented Unmet to Met, and is the first step toward silver-level criteria.

## Out of scope

Tracked as follow-up PRs:

- **Test CI workflow** (`.github/workflows/test.yml`) — needs to pick which subset of `tests/` can run without Ollama / model downloads
- **Dependabot 2 high-severity advisories** — `vulnerabilities_fixed_60_days` separate fix
- **F811 cleanup** in `core/memory/extractor.py` — last F-class rule remaining, as called out in `ruff.toml`'s Phase 3 note

---

## 한국어 요약

GitHub Actions에 **ruff lint 워크플로**를 추가합니다. PR마다·main push마다 자동으로 `ruff check .` 실행. `ruff.toml`의 enforced 규칙(F821/F541/F401/F841) 전부 검증. 위반 시 PR diff에 인라인 annotation으로 표시됨. OpenSSF `static_analysis_often` 항목이 Unmet → Met로 전환됩니다 (passing 뱃지 silver 진입 1보).

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_