### PR TITLE
feat(audit): Phase 2 — mirror attack/system JSONL events to SQLite

### DIFF
--- a/core/audit_bridge.py
+++ b/core/audit_bridge.py
@@ -62,6 +62,8 @@ _RESERVED_KEYS = {
     # Identifier-ish fields are folded into ``query`` so the audit list
     # UI's free-text search hits them directly.
     "tool_used", "target_file", "path", "target",
+    # Explicit endpoint override (Phase 2 — attack/system streams).
+    "endpoint",
 }
 
 
@@ -87,11 +89,20 @@ def _resolve_query(entry: Dict[str, Any]) -> str:
 def _resolve_endpoint(entry: Dict[str, Any]) -> str:
     """Synthesise a category-friendly endpoint.
 
-    ``tool:<layer>:<event>`` — e.g. ``tool:router:TOOL_EXECUTED``,
-    ``tool:code_reader:FILE_READ``. Phase 3 of the migration adds a
-    category ``tools`` to ``/admin/audit/list`` that filters on
-    ``endpoint LIKE 'tool:%'``; this prefix is the join point.
+    Phase 1 (tool stream) auto-synthesises ``tool:<layer>:<event>`` —
+    e.g. ``tool:router:TOOL_EXECUTED``, ``tool:code_reader:FILE_READ``.
+
+    Phase 2 (attack/system streams) needs different prefixes
+    (``attack:``, ``system:``) so Phase 3 can route them to separate
+    /admin/audit/list categories. A writer signals the stream by
+    setting ``entry["endpoint"]`` explicitly; the bridge respects it.
+
+    Length-capped to 200 chars to avoid pathological writers from
+    bloating the column.
     """
+    explicit = entry.get("endpoint")
+    if explicit:
+        return str(explicit)[:200]
     layer = entry.get("layer") or "tool"
     event = entry.get("event") or "EVENT"
     return f"tool:{layer}:{event}"
@@ -161,3 +172,45 @@ def mirror_to_audit_db(entry: Dict[str, Any],
         return True
     except Exception:
         return False
+
+
+# ─── Phase 2 stream-specific helpers ────────────────────────────
+#
+# Wrap mirror_to_audit_db with the right ``endpoint`` prefix so the
+# 12 attack/system writer sites can call us with 1 line. Phase 3 will
+# filter on these prefixes — ``LIKE 'attack:%'`` and ``LIKE 'system:%'``.
+
+def mirror_attack_event(entry: Dict[str, Any],
+                        attack_type: str = "injection") -> bool:
+    """Mirror a ``log_attack`` JSONL entry to SQLite.
+
+    Attack events are inherently blocked (the system caught them before
+    serving), so ``blocked=True`` is forced regardless of the entry.
+    """
+    if not isinstance(entry, dict):
+        return False
+    return mirror_to_audit_db({
+        **entry,
+        "endpoint": f"attack:{attack_type}",
+        "event":    attack_type,
+        "blocked":  True,
+    })
+
+
+def mirror_system_event(entry: Dict[str, Any]) -> bool:
+    """Mirror a ``log_system_event`` JSONL entry to SQLite.
+
+    The legacy JSONL writers stamp their entries with ``level`` +
+    ``step`` (e.g. ``orchestrator.startup``). We use those for the
+    endpoint prefix: ``system:<level>:<step>``. Phase 3's category
+    ``system`` filters on ``LIKE 'system:%'``.
+    """
+    if not isinstance(entry, dict):
+        return False
+    level = entry.get("level") or "INFO"
+    step  = entry.get("step")  or "system"
+    return mirror_to_audit_db({
+        **entry,
+        "endpoint": f"system:{level}:{step}",
+        "event":    step,
+    })

--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -57,15 +57,21 @@ def is_cacheable_response(result: str) -> bool:
 
 def log_system_event(step: str, detail: str, level: str = "ERROR"):
     """시스템 이벤트 기록"""
+    entry = {
+        "time":   datetime.now().isoformat(),
+        "level":  level,
+        "step":   step,
+        "detail": str(detail)[:300],
+    }
     try:
-        entry = {
-            "time":   datetime.now().isoformat(),
-            "level":  level,
-            "step":   step,
-            "detail": str(detail)[:300],
-        }
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/core/graph_engine.py
+++ b/core/graph_engine.py
@@ -129,6 +129,12 @@ class GraphEngine:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except Exception:
             pass
+        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+        try:
+            from core.audit_bridge import mirror_system_event
+            mirror_system_event(entry)
+        except Exception:
+            pass
 
     # ─── Entity Map Snapshot ─────────────────────────────────
 

--- a/core/memory/loom.py
+++ b/core/memory/loom.py
@@ -32,11 +32,17 @@ CONFLICT_CONFIDENCE_DIFF = 0.3     # confidence 차이 이 이상이면 conflict
 
 
 def _log(step: str, detail: str, level: str = "INFO"):
+    entry = {"time": datetime.now().isoformat(), "level": level,
+             "step": f"memory_loom.{step}", "detail": detail[:300]}
     try:
-        entry = {"time": datetime.now().isoformat(), "level": level,
-                 "step": f"memory_loom.{step}", "detail": detail[:300]}
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/core/memory/trust.py
+++ b/core/memory/trust.py
@@ -246,6 +246,12 @@ class MemoryTrustScorer:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except Exception:
             pass
+        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+        try:
+            from core.audit_bridge import mirror_system_event
+            mirror_system_event(entry)
+        except Exception:
+            pass
         print(f"[TRUST] ⛔ write 거부: {entity.get('name','?')} score={score:.3f}")
 
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -22,11 +22,17 @@ SYSTEM_LOG_PATH = "james_system_log.jsonl"
 
 
 def _log(step: str, detail: str):
+    entry = {"time": datetime.now().isoformat(), "level": "INFO",
+             "step": f"orchestrator.{step}", "detail": detail[:200]}
     try:
-        entry = {"time": datetime.now().isoformat(), "level": "INFO",
-                 "step": f"orchestrator.{step}", "detail": detail[:200]}
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/core/query_expander.py
+++ b/core/query_expander.py
@@ -64,11 +64,17 @@ _STOPWORDS = {
 
 
 def _log(step: str, detail: str, level: str = "INFO"):
+    entry = {"time": datetime.now().isoformat(), "level": level,
+             "step": f"query_expand.{step}", "detail": detail[:200]}
     try:
-        entry = {"time": datetime.now().isoformat(), "level": level,
-                 "step": f"query_expand.{step}", "detail": detail[:200]}
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -75,6 +75,12 @@ class ReasoningEngine:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except Exception:
             pass
+        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+        try:
+            from core.audit_bridge import mirror_system_event
+            mirror_system_event(entry)
+        except Exception:
+            pass
 
     @staticmethod
     def _elapsed(t_start: float, label: str) -> float:

--- a/core/retrieval_engine.py
+++ b/core/retrieval_engine.py
@@ -52,6 +52,12 @@ class RetrievalEngine:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except Exception:
             pass
+        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+        try:
+            from core.audit_bridge import mirror_system_event
+            mirror_system_event(entry)
+        except Exception:
+            pass
 
     # ─── BM25 정규화 ─────────────────────────────────────────
 

--- a/core/security_layer.py
+++ b/core/security_layer.py
@@ -136,21 +136,33 @@ INSTRUCTION_INJECTION_PATTERNS = [
 # ─── 로그 ────────────────────────────────────────────────────
 
 def log_attack(query: str, role: str, attack_type: str = "injection"):
+    entry = {"time": datetime.now().isoformat(), "role": role,
+             "attack_type": attack_type, "query": query[:200]}
     try:
-        entry = {"time": datetime.now().isoformat(), "role": role,
-                 "attack_type": attack_type, "query": query[:200]}
         with open(ATTACK_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite audit_log (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_attack_event
+        mirror_attack_event(entry, attack_type=attack_type)
     except Exception:
         pass
 
 def log_system_event(step: str, detail: str, role: str = "unknown", level: str = "ERROR"):
     """[LOG-1] james_system_log.jsonl 영구 기록"""
+    entry = {"time": datetime.now().isoformat(), "level": level,
+             "step": step, "detail": str(detail)[:300], "role": role}
     try:
-        entry = {"time": datetime.now().isoformat(), "level": level,
-                 "step": step, "detail": str(detail)[:300], "role": role}
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite audit_log (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/llm/router.py
+++ b/llm/router.py
@@ -27,11 +27,17 @@ _llm_instances: Dict[str, BaseLLM] = {}
 
 
 def _log(step: str, detail: str):
+    entry = {"time": datetime.now().isoformat(), "level": "INFO",
+             "step": f"llm_router.{step}", "detail": detail[:200]}
     try:
-        entry = {"time": datetime.now().isoformat(), "level": "INFO",
-                 "step": f"llm_router.{step}", "detail": detail[:200]}
         with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
     except Exception:
         pass
 

--- a/tests/test_audit_bridge.py
+++ b/tests/test_audit_bridge.py
@@ -303,6 +303,110 @@ class BestEffortContractTests(unittest.TestCase):
         self.assertIsNone(_rows(self.db)[0]["answer"])
 
 
+class Phase2AttackEventTests(unittest.TestCase):
+    """``mirror_attack_event`` — attack stream prefix + forced blocked=1."""
+
+    def setUp(self):
+        self.db = _fresh_db()
+
+    def tearDown(self):
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_attack_endpoint_prefix(self):
+        from core.audit_bridge import mirror_attack_event
+        entry = {
+            "time": "2026-05-11T20:00:00",
+            "role": "external",
+            "attack_type": "injection",
+            "query": "ignore previous instructions",
+        }
+        # mirror_attack_event uses the module-level DB path; force the
+        # test DB via the underlying call.
+        from core import audit_bridge
+        original_db = audit_bridge._DEFAULT_AUDIT_DB
+        audit_bridge._DEFAULT_AUDIT_DB = self.db
+        try:
+            ok = mirror_attack_event(entry, attack_type="injection")
+        finally:
+            audit_bridge._DEFAULT_AUDIT_DB = original_db
+        self.assertTrue(ok)
+        r = _rows(self.db)[0]
+        self.assertEqual(r["endpoint"],       "attack:injection")
+        self.assertEqual(r["security_event"], "injection")
+        self.assertEqual(r["user_role"],      "external")
+        # Attacks are inherently blocked, regardless of input.
+        self.assertEqual(r["blocked"], 1)
+
+    def test_attack_blocked_forced_even_when_entry_says_false(self):
+        from core import audit_bridge
+        original_db = audit_bridge._DEFAULT_AUDIT_DB
+        audit_bridge._DEFAULT_AUDIT_DB = self.db
+        try:
+            audit_bridge.mirror_attack_event(
+                {"time": "t", "role": "x", "blocked": False, "query": "q"},
+                attack_type="risky_coding",
+            )
+        finally:
+            audit_bridge._DEFAULT_AUDIT_DB = original_db
+        self.assertEqual(_rows(self.db)[0]["blocked"], 1)
+        self.assertEqual(_rows(self.db)[0]["endpoint"], "attack:risky_coding")
+
+    def test_non_dict_returns_false(self):
+        from core.audit_bridge import mirror_attack_event
+        self.assertFalse(mirror_attack_event(None))
+        self.assertFalse(mirror_attack_event("string"))
+
+
+class Phase2SystemEventTests(unittest.TestCase):
+    """``mirror_system_event`` — system stream prefix + level/step join."""
+
+    def setUp(self):
+        self.db = _fresh_db()
+
+    def tearDown(self):
+        Path(self.db).unlink(missing_ok=True)
+
+    def _mirror(self, entry):
+        from core import audit_bridge
+        original_db = audit_bridge._DEFAULT_AUDIT_DB
+        audit_bridge._DEFAULT_AUDIT_DB = self.db
+        try:
+            return audit_bridge.mirror_system_event(entry)
+        finally:
+            audit_bridge._DEFAULT_AUDIT_DB = original_db
+
+    def test_system_endpoint_prefix(self):
+        ok = self._mirror({
+            "time":   "2026-05-11T21:00:00",
+            "level":  "ERROR",
+            "step":   "orchestrator.startup",
+            "detail": "boot failed",
+            "role":   "system",
+        })
+        self.assertTrue(ok)
+        r = _rows(self.db)[0]
+        self.assertEqual(r["endpoint"],       "system:ERROR:orchestrator.startup")
+        self.assertEqual(r["security_event"], "orchestrator.startup")
+        self.assertEqual(r["user_role"],      "system")
+        # System events are not blocked by themselves.
+        self.assertEqual(r["blocked"], 0)
+        # detail is packed into answer (not a reserved column).
+        ans = json.loads(r["answer"])
+        self.assertEqual(ans["detail"], "boot failed")
+
+    def test_missing_level_defaults_to_info(self):
+        self._mirror({"time": "t", "step": "x.y", "detail": "z"})
+        self.assertEqual(_rows(self.db)[0]["endpoint"], "system:INFO:x.y")
+
+    def test_missing_step_defaults_to_system(self):
+        self._mirror({"time": "t", "level": "WARN", "detail": "z"})
+        self.assertEqual(_rows(self.db)[0]["endpoint"], "system:WARN:system")
+
+    def test_non_dict_returns_false(self):
+        from core.audit_bridge import mirror_system_event
+        self.assertFalse(mirror_system_event(None))
+
+
 class EndpointPrefixContractTests(unittest.TestCase):
     """Phase 3 will add a category 'tools' filtering ``endpoint LIKE 'tool:%'``.
     Lock that prefix in so a future writer rename doesn't break the
@@ -324,6 +428,19 @@ class EndpointPrefixContractTests(unittest.TestCase):
         for r in _rows(self.db):
             self.assertTrue(r["endpoint"].startswith("tool:"),
                             f"endpoint={r['endpoint']} not prefixed")
+
+    def test_explicit_endpoint_overrides_synthesis(self):
+        # Phase 2 contract: an entry with ``endpoint`` set bypasses the
+        # tool:<layer>:<event> synthesis. Phase 3's category filter
+        # depends on this.
+        from core.audit_bridge import mirror_to_audit_db
+        mirror_to_audit_db(
+            {"event": "X", "role": "x", "layer": "y",
+             "endpoint": "custom:prefix:here"},
+            db_path=self.db,
+        )
+        self.assertEqual(_rows(self.db)[0]["endpoint"],
+                         "custom:prefix:here")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 2 of the 4-phase JSONL → SQLite audit migration (PR #206 was Phase 1, tool stream).

This PR adds dual-write for the remaining two streams the legacy `/admin/audit` endpoint surfaces:
- **Attack events** — `core/security_layer.log_attack` (one central writer)
- **System events** — `core/security_layer.log_system_event` + 9 module-local `_log_system` copies (llm/router, gemma_client, graph_engine, query_expander, orchestrator, retrieval_engine, memory/loom, memory/trust, reasoning/engine)

After this PR, `/admin/audit/list` (SQLite-backed) covers every event the legacy endpoint reads. Phase 3 will add the category filters that expose the new rows in the admin UI.

## Changes

- **`core/audit_bridge.py`** (8.0 KB)
  - `_resolve_endpoint` now respects an explicit `entry["endpoint"]` (length-capped 200) and falls back to Phase 1's `tool:<layer>:<event>` synthesis.
  - `endpoint` added to `_RESERVED_KEYS` so it doesn't leak into the answer JSON.
  - `mirror_attack_event(entry, attack_type)` — `endpoint=\"attack:<type>\"`, `blocked=True` forced (attacks are inherently blocked).
  - `mirror_system_event(entry)` — `endpoint=\"system:<level>:<step>\"`, fallbacks `INFO` / `\"system\"`.
- **11 writer sites wired** (entry dict hoisted out of try/except so the bridge sees the same dict JSONL receives — no divergence path).

## Rollback path

Delete the 11 mirror call blocks. JSONL files unchanged.

## Verification

`python -m unittest discover -s tests -t .` — **1385 tests OK** (+8 new).
- `Phase2AttackEventTests` (3) — endpoint prefix / blocked forced / non-dict
- `Phase2SystemEventTests` (4) — endpoint prefix / level fallback / step fallback / non-dict
- `EndpointPrefixContractTests` +1 — explicit endpoint overrides synthesis

- `core/audit_bridge.py` 8.0 KB (< 20 KB gate). `ruff check` clean on all 12 touched files.

## Out of scope

- Phase 3 — `/admin/audit/list` category filter (`tools` / `attack` / `system`) + admin.js dropdown. Separate PR.
- Phase 4 — JSONL writer removal + `/admin/audit` endpoint removal + `/admin/dashboard` / `/code/surface/` reader migration. Separate PR after operator parity check.
- i18n cleanup — independent track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)