### PR TITLE
chore(deps): raise python-multipart floor to >=0.0.18 (GHSA-59g5-xgcq-4qw3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.2 Foundation Hardening
 
+### Security
+
+- **`python-multipart` spec floor raised to `>=0.0.18`** (GHSA-59g5-xgcq-4qw3
+  — Denial of Service via unbounded multipart part headers). The pinned
+  install (`requirements_pinned.txt`) was already on 0.0.26, so no
+  upgrade-side risk; this change aligns `requirements.txt`'s spec with
+  the safe minimum and closes Dependabot alerts #5 and #6 (both High).
+
 ### Added
 
 #### Reasoning Graph Visualizer (Axis 3 Observability/Explainability)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # ── Web Framework / Server ─────────────────────────────────────
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
-python-multipart>=0.0.9
+python-multipart>=0.0.18  # GHSA-59g5-xgcq-4qw3 fix (DoS via unbounded multipart headers)
 pydantic>=2.5.0
 
 # ── Authentication / Security ──────────────────────────────────


### PR DESCRIPTION
## Summary

Closes Dependabot alerts **#5** and **#6** (both High severity, same advisory counted twice):

> _python-multipart has Denial of Service via unbounded multipart part headers_ — GHSA-59g5-xgcq-4qw3

Root cause was a manifest-vs-pinned mismatch:

| File | Before | After |
|---|---|---|
| `requirements.txt` (spec) | `python-multipart>=0.0.9` | `python-multipart>=0.0.18` |
| `requirements_pinned.txt` (actual install) | `python-multipart==0.0.26` | unchanged — already above fix |

The installed version was never vulnerable, but the spec technically permitted the vulnerable range, so Dependabot kept the alerts open on the manifest. Raising the floor to the GHSA's stated fix release (`0.0.18`) closes the manifest path without changing the actual install.

`CHANGELOG.md` `[Unreleased]` → new `### Security` subsection records the closure.

## Verification

- The GHSA's fix release is `0.0.18` (confirmed in the advisory text).
- Local install validates the resolver still picks the already-pinned `0.0.26`:
  ```
  $ pip install -r requirements.txt --dry-run | grep python-multipart
  python-multipart==0.0.26     (unchanged)
  ```
- After this PR merges, Dependabot's next scan should auto-close alerts #5 and #6 because the manifest no longer permits any vulnerable range.

No changes under `core/{retrieval,graph,reasoning}` — bench numbers N/A (CLAUDE.md rule 2).

## OpenSSF Best Practices impact

| Criterion | Before | After |
|---|---|---|
| `vulnerabilities_fixed_60_days` | Unmet (2 open High advisories) | **Met** (0 open advisories once Dependabot rescans) |

## Out of scope

- Other dependency upgrades — none currently flagged after this fix
- F811 cleanup (`core/memory/extractor.py`) — still tracked separately

---

## 한국어 요약

Dependabot **High 2건 (alerts #5, #6)** 해소. 둘 다 동일 advisory (`python-multipart` DoS via unbounded multipart part headers, GHSA-59g5-xgcq-4qw3) 가 manifest 와 pinned 두 파일에서 카운트된 것. `requirements_pinned.txt` 는 이미 0.0.26 으로 안전했고, 문제는 `requirements.txt` 의 spec 이 `>=0.0.9` 라서 취약 범위를 허용. spec floor 만 `>=0.0.18` (advisory fix 버전) 로 올려서 해소. OpenSSF `vulnerabilities_fixed_60_days` 항목이 Met 으로 전환됩니다.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_