### PR TITLE
refactor(frontend): unify dark-UI tokens into static/tokens.css + brand positioning line

### DIFF
--- a/frontend/HANDOVER_WEB_UI.md
+++ b/frontend/HANDOVER_WEB_UI.md
@@ -1,228 +1,239 @@
-# Web UI 디자인 — 작업 인수인계 (PC 세션 이전용)
+# Web UI — Dark Concept Refresh 핸드오버
 
-**작성일**: 2026-05-06
-**브랜치**: `claude/design-web-ui-6NQaQ`
-**작성 환경**: Claude Code on the web (Opus 4.7)
-**대상**: PC 로컬 세션의 Claude (또는 본인)
-**상태**: 평가 완료, 구현 미착수
-
----
-
-## 1. 작업 목적
-
-현재 `frontend/index.html` (779줄) + `frontend/admin.html` (700줄) 구조의
-Web UI를 평가하고, 개선 방향을 정하기 위한 사전 검토 단계.
-
-브랜치 이름이 `design-web-ui`이지만, 사용자 의도는 **전면 재설계가 아닌
-"평가 후 우선순위 결정"**. 사용자가 "평가가 어때?"라고 물어 평가만
-수행한 상태로 PC 이전.
+**최종 업데이트**: 2026-05-11
+**브랜치**: `claude/review-dark-ui-concept-Aydvd`
+**원격**: `origin/claude/review-dark-ui-concept-Aydvd` (push 완료)
+**커밋**: `e686844` (토큰 통합), `508f880` (브랜드 라벨 교체)
+**대상**: 다른 세션에서 작업을 이어갈 Claude (또는 본인)
 
 ---
 
-## 2. 현재 UI 구조 (요약)
+## 0. TL;DR
 
-```
-frontend/
-├── index.html      779줄 — 채팅 메인 (인라인 <style> 615줄까지)
-├── admin.html      700줄 — 어드민 대시보드 (인라인 <style>)
-└── static/
-    ├── chat.js     채팅 로직 + 세션 패널 + 로그인
-    ├── admin.js    어드민 동적 텍스트 t() 적용
-    ├── upload.js   드래그앤드롭 업로드
-    └── i18n.js     286 키 × en/ko
-```
-
-### 디자인 토큰 (양 파일 중복)
-
-```css
---bg:        #0a0a0f
---surface:   #111118
---border:    #1e1e2e
---accent:    #7c6af7   (보라)
---accent2:   #4fc3f7   (시안)
---text:      #e8e8f0
---muted:     #555570
---success:   #4caf7d
---danger:    #f06292
---font-mono: 'JetBrains Mono', 'Fira Code'
---font-ui:   'Sora', 'Pretendard'
-```
-
-### 갖춰진 기능
-
-- 접이식 사이드바 (드래그앤드롭 업로드)
-- 챗 영역 + 자동 리사이즈 textarea + 타이핑 인디케이터
-- 메시지별 메타 (`mode-badge`, `graph-badge`)
-- 그래프 경로 표시 영역 (`.graph-paths`, 좌측 보더 강조)
-- 세션 선택 패널 (이전 대화 불러오기)
-- 로그인 모달 + 역할 배지 (RBAC 표시)
-- PROD/TEST 소스 토글
-- 언어 토글 (한/영) + i18n 286 키
-- 환영 칩 (예제 쿼리 4개)
+- v0.1 시절의 dark 컨셉을 점검하고, **공통 디자인 토큰 단일화** + **UI 브랜드 라벨 교체** 두 PR을 한 브랜치에 쌓았다.
+- 코드네임 **JAMES는 내부에만 존속**하고, UI 표면은 모두
+  **"Secure Enterprise Knowledge Intelligence, Operating System"** 으로 표시한다.
+- 아직 main으로 머지되지 않았다. 머지 전 시각 검증 필요.
 
 ---
 
-## 3. 평가 결과
+## 1. 이번 브랜치에서 끝난 일
 
-### 좋은 점
+### 1-1. 커밋 `e686844` — `refactor(frontend): unify dark-UI tokens into static/tokens.css`
 
-- 비주얼 정체성이 일관됨 (보안 + 추론 엔진 컨셉에 맞음)
-- 주요 기능 모두 자리잡음 (업로드/세션/로그인/i18n/소스토글)
-- 디테일 양호 (드래그앤드롭, 자동 리사이즈, 사이드바 접이)
-- Admin: 카드 + 테이블 + RBAC 배지 색 구분 깔끔
+배경: `index.html` 만 최신 `#A8-9` 폴리시(deeper navy bg, deeper
+indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
+있었고 `admin / workspace / graph` 는 옛 neutral-dark 팔레트에
+멈춰 있어서 페이지 이동 시 톤이 미세하게 흔들렸다.
 
-### 약점 (우선순위 높은 순)
+변경:
 
-1. **CSS 인라인** — `index.html` 615줄까지 `<style>` 박혀 있음.
-   `admin.html`도 동일 변수 중복 정의. → `static/styles.css`로 추출 필요.
-2. **반응형 부재** — 미디어 쿼리 0개. 모바일에서 사이드바 280px가
-   화면 점유. → 768px 이하 브레이크포인트 + 사이드바 오버레이 모드.
-3. **접근성 약함** — `aria-label` 없음, 모달에 `role="dialog"` /
-   focus trap 없음, `--muted #555570` on `--bg #0a0a0f` 대비 WCAG AA
-   미달 가능. 키보드 내비게이션 미검증.
-4. **인라인 핸들러 다수** — `onclick="..."` 다수. CSP 강화 시 깨짐.
-   보안 중심 프로젝트로서 이벤트 위임으로 전환 권장.
-5. **Graph-RAG 강점이 안 드러남** — `.graph-paths`는 작은 좌측
-   보더 표시뿐. 추론 단계(retrieve→expand→verify), 신뢰도, 출처 노드를
-   더 시각적으로 보여줄 패널이 없음.
-6. **i18n 누락 placeholder 혼재** — `placeholder="e.g., Save to 2026
-   reports folder"` 같은 영문 하드코딩 + 한국어 title 혼재.
-7. **welcome chips 하드코딩** — 동적 추천 (최근/인기) 없음.
+- 신규 파일 `frontend/static/tokens.css` — 디자인 토큰 단일 출처
+  - Google Fonts `@import`, 유니버설 box-sizing 리셋, `:root` 토큰
+  - 통합 팔레트(`#A8-9` 기반): `--bg #0a0c11`, `--surface #131620`,
+    `--accent #5258e6`, `--brand-2 #4fc3f7`, `--shadow-card …` 외
+- 4개 HTML(`index / admin / workspace / graph`)의 인라인 `:root`
+  블록 제거, `<link rel="stylesheet" href="/static/tokens.css">` 연결
+- `<meta name="theme-color">` 4페이지 모두 `#0a0c11` 통일
+- `graph.html` 은 그래프 전용 `--t-person / --t-org / --t-concept /
+  --t-document` 4개 토큰만 인라인으로 보존(도메인-중립이라 두어도 됨)
+- 순변경: **+69 / −112** 라인
+
+### 1-2. 커밋 `508f880` — `refactor(brand): replace UI "JAMES" labels with full positioning line`
+
+배경: 사용자 지시 — UI 표면에서 "제임스"를 빼고
+"Secure Enterprise Knowledge Intelligence, Operating System" 을
+표시한다.
+
+변경:
+
+- 4페이지 `<title>` — 풀 문구 + 페이지명 접미사
+  (`— Admin / — Workspace / — Reasoning Graph`)
+- 4페이지 `.logo` 헤더 — `tokens.css` 에 `.brand` 컴포넌트 추가
+  (메인 라인 + muted 톤 "Operating System" tail, 900/640px 반응형)
+- 챗 환영 타이틀(`welcome-title`)
+- admin / graph 로그인 모달 상단의 `▸ JAMES ADMIN` / `▸ JAMES GRAPH`
+  배너 → 풀 문구로 교체
+- i18n 키 갱신
+  - `app.name` → 풀 문구 (en / ko 양쪽)
+  - `chat.title` → "Secure …, Operating System — Security Reasoning Engine"
+  - `auth.login_title` → `Login` / `로그인`
+  - `auth.signup_title` → `▸ Signup` / `▸ 회원가입`
+- admin 페르소나 이름 입력의 `data-i18n-placeholder="app.name"` 제거
+  (그대로 두면 이름 필드 placeholder 에 풀 문구가 들어가 깨짐).
+  static `placeholder="JAMES"` 만 남겨 페르소나 기본값 보존.
 
 ---
 
-## 4. 사용자에게 제시한 우선순위
+## 2. 의도적으로 그대로 둔 JAMES 참조
 
-```
-1. CSS 추출 + 공통 토큰 파일                    (1~2시간, 위험 낮음)
-2. 반응형 (모바일 ≤768px) + 사이드바 오버레이
-3. 추론 패널 강화 — 메시지 클릭 시 우측에
-   retrieve → expand → verify 단계 + 인용 노드 펼치기
-4. 접근성 패스 — aria, 대비, 키보드
-5. 인라인 핸들러 → 이벤트 위임 (CSP 대비)
-```
+다음은 **브랜드 라벨이 아닌** 영역이라 손대지 않았다. 다른 세션이
+"덜 지운 거 아닌가?" 싶을 때 이걸 보면 된다.
 
-**사용자 응답 대기 중**: 어디부터 손댈지 미결정.
+| 항목 | 이유 |
+|---|---|
+| `JAMES_API_KEY` env-var + `auth.api_key_hint/prompt` | 환경변수명 |
+| `placeholder="JAMES"` (admin 페르소나 이름) | 에이전트 자기소개 기본값 |
+| `set.persona_*`, `char.identity_name_desc` | 페르소나(별개 개념) |
+| `hw.description` ("Hardware running JAMES intelligence") | 시스템 설명 |
+| `msg.summary_failed / done` ("[JAMES] …") | 시스템 메시지 prefix |
+| `graph.query.ph` ("Ask JAMES…") | 챗 에이전트 호칭 |
+| HTML 주석, 코드 식별자, 파일명 | 코드베이스 정체성은 JAMES 그대로 |
+
+> CLAUDE.md 원칙: **저장소 코드네임은 JAMES, 공개 UI 라벨만 교체.**
 
 ---
 
-## 5. 다음 세션 (PC) 시작 시 해야 할 일
+## 3. 결정사항 / 디자인 규칙 메모
+
+1. **단일 토큰 출처**: 새 디자인 토큰은 `frontend/static/tokens.css`
+   에만 정의한다. 페이지별 인라인 `:root` 재정의 금지. 페이지 전용
+   토큰은 `graph.html` 의 `--t-*` 처럼 그 페이지에 인라인 augment.
+2. **브랜드 표기**: `.brand` 컴포넌트(`Operating System` tail muted 톤)
+   사용. 새 화면을 만들 때는 같은 클래스 재사용. 새 텍스트 추가 시
+   직접 "JAMES" 라고 쓰지 말 것.
+3. **i18n**: `app.name` 은 풀 문구. 좁은 영역(placeholder 등)에 풀
+   문구가 들어가지 않도록 신규 키를 만들 것 — `app.name` 재사용 금지.
+4. **theme-color**: `#0a0c11` 으로 통일.
+5. **반응형 분기**: `.brand` 가 900px → 11px, 640px → 자동 줄바꿈.
+   이 규칙이 부족하면 `tokens.css` 의 `@media` 두 블록만 수정.
+6. **legacy 미정의 토큰**: `admin.html` 에 `var(--accent2 / --bg2 /
+   --card / --fg)` 호출이 남아 있다. **이번 PR 이전부터 깨져 있던**
+   참조이므로 이 PR 의 범위 밖. 별도 클린업 PR 에서 정리.
+
+---
+
+## 4. 다음에 할 일 (우선순위)
+
+이번 브랜치 머지 후 같은 브랜치 또는 별도 브랜치에서 이어갈 수 있는 항목.
+`HANDOVER_WEB_UI.md` 이전 버전의 5-우선순위 중 1번이 끝났고, 나머지가 남았다.
+
+| # | 작업 | 예상 | 비고 |
+|---|---|---|---|
+| 1 | ~~CSS 추출 + 공통 토큰~~ | — | **DONE** (커밋 `e686844`) |
+| 2 | 반응형 — `admin / workspace / graph` 용 mobile.css 확장 | 2~3h | 현재 `mobile.css` 는 chat 페이지 전용 |
+| 3 | 추론 패널 강화 — retrieve → expand → verify timeline + 인용 노드 + 신뢰도 bar + sensitivity 배지 | 4~6h | Graph-RAG 차별점 시각화 |
+| 4 | 접근성 패스 — modal `role="dialog"` + focus trap + ESC, `aria-label`, `--muted-2` 대비 감사 (AA ~3.4:1 미달 가능) | 2h | |
+| 5 | 인라인 핸들러(`onclick=…`) → 이벤트 위임 + `data-action` | 3h | CSP 강화 대비 |
+| 6 | `admin.html` legacy 미정의 토큰(`--accent2 / --bg2 / --card / --fg`) 정리 | 30분 | tokens.css 에 별칭 추가 또는 호출 측 치환 |
+| 7 | 상단 그라데이션 레일(`body::before`)을 4페이지 공통화 | 30분 | 현재 index 만 있음. tokens.css 또는 별도 global.css 로 이동 |
+| 8 | 인라인 `<style>` 블록 완전 분리 — `static/styles.css` | 4h | `index.html` 615줄 / `admin.html` 530줄까지 인라인 |
+
+추천 다음 단계: **#6 (legacy 토큰 클린업)** 또는 **#7 (그라데이션 레일 공통화)**
+— 둘 다 작고 안전하며 토큰 통합 PR 의 흐름 안에 들어간다.
+
+---
+
+## 5. 다음 세션이 시작할 때 해야 할 일
 
 ### 5-1. 컨텍스트 복원
 
-```
-1. 이 문서 (frontend/HANDOVER_WEB_UI.md) 읽기
-2. HANDOVER.md 4-2 폴더 구조 확인 (frontend 부분)
-3. frontend/index.html + admin.html 훑어보기
-4. 현재 브랜치 확인:
-   git branch --show-current
-   → claude/design-web-ui-6NQaQ 이어야 함
+```bash
+git fetch origin claude/review-dark-ui-concept-Aydvd
+git checkout claude/review-dark-ui-concept-Aydvd
+git log --oneline -3   # e686844, 508f880 두 커밋이 보여야 함
 ```
 
-### 5-2. 사용자에게 확인할 첫 질문
+그리고 이 문서(`frontend/HANDOVER_WEB_UI.md`) 와 `CLAUDE.md` 를 읽는다.
+
+### 5-2. 첫 질문 템플릿
 
 ```
-"웹 세션에서 평가까지 마쳤습니다. 5가지 우선순위 중 어디부터
-시작할까요?
+"`claude/review-dark-ui-concept-Aydvd` 브랜치를 이어받았습니다.
 
-  1. CSS 추출 (가장 안전, 빠름)
-  2. 반응형 (사용성 큼)
-  3. 추론 패널 강화 (Graph-RAG 차별점 부각)
-  4. 접근성 (보안 프로젝트 기본기)
-  5. 인라인 핸들러 제거 (CSP 대비)
+지금까지 끝난 것:
+  - 토큰 단일화 (e686844)
+  - UI 브랜드 라벨 → "Secure Enterprise Knowledge
+    Intelligence, Operating System" 교체 (508f880)
 
-또는 다른 방향이 있으면 알려주세요."
+다음 우선순위 (HANDOVER_WEB_UI.md §4):
+  2. 반응형 확장 (admin/workspace/graph 용 mobile.css)
+  3. 추론 패널 강화
+  4. 접근성 패스
+  5. 인라인 핸들러 → 이벤트 위임
+  6. legacy 미정의 토큰 정리
+  7. 상단 그라데이션 레일 공통화
+  8. 인라인 <style> 완전 분리
+
+또는 main 으로 머지하시겠습니까? 머지 전 브라우저로
+시각 검증을 권장합니다."
 ```
 
-### 5-3. 작업 원칙 (HANDOVER.md 9-3, 9-4 재확인)
+### 5-3. 머지 전 시각 검증 체크리스트
+
+웹 세션에서는 브라우저로 못 보므로, 사용자에게 다음을 부탁:
 
 ```
-- 보안 영향 먼저 검토
-- fallback 항상 구현
-- 절대경로/하드코딩 회피
-- 변경사항 CHANGELOG.md에 기록
-- 사용자 환경 (Windows + PowerShell) 고려
-- 단계별 진행, 각 단계 확인 후 다음
-- 한국어 소통, 코드 주석은 영어 OK
-- 반응형 / 추론 패널 작업 시 i18n.js 키 신규 추가 가능성 → 검토
-```
-
-### 5-4. 추론 패널 강화 시 참고
-
-```
-관련 백엔드:
-  - core/reasoning_engine.py    추론 루프 (retrieve→expand→verify)
-  - core/graph_engine.py        Graph DFS
-  - core/retrieval_engine.py    하이브리드 검색
-
-서버 응답에 이미 포함된 메타:
-  - mode (chat / coding / retrieval / web_search)
-  - graph paths
-  - confidence
-  - sensitivity
-
-UI에서 표시할 것:
-  - 단계별 timeline (3단계 스피너 — 이미 STEP 4-A에 있음)
-  - 인용된 entity 노드 (클릭 시 위키로)
-  - 신뢰도 bar
-  - sensitivity 배지 (public/internal/confidential/secret)
+1. /         (chat)        — 헤더에 풀 문구 + Operating System tail 회색
+2. /admin    (admin)       — "· Admin Console" 접미사 함께 보이는지
+3. /workspace               — "Workspace · 데이터 + 작업" 함께
+4. /graph                   — "Reasoning Graph" 함께
+5. 모달 — 로그인/회원가입 타이틀이 "로그인 / 회원가입" 으로만 나오는지
+6. 환영 화면 — "Welcome to Secure Enterprise Knowledge
+   Intelligence, Operating System"
+7. admin → 캐릭터 → Identity 이름 입력 placeholder 가
+   풀 문구가 아니라 "JAMES" 인지 (이게 풀 문구면 페르소나 기본값
+   바인딩이 잘못된 것)
+8. 화면 폭 < 900px — `.brand` 가 11px 로 줄어드는지
+9. 화면 폭 < 640px — `.brand` 가 줄바꿈되는지
+10. theme-color — 브라우저 탭 상단 색이 #0a0c11 (살짝 푸른 검정) 인지
 ```
 
 ---
 
-## 6. 주의사항
+## 6. 주의사항 (Gotchas)
 
-```
-⚠️ 인라인 핸들러 제거 시:
-   - chat.js / admin.js / upload.js 의 함수 export 검토
-   - window.func = func 패턴이 많을 수 있음
-   - 이벤트 위임 시 data-action 속성 도입 권장
-
-⚠️ CSS 추출 시:
-   - index.html / admin.html 양쪽 변수 중복 → :root 한 곳에 통합
-   - 기존 클래스명 그대로 보존 (chat.js 의존성)
-   - @import url(...) 위치 주의 (CSS 파일 최상단으로)
-
-⚠️ 반응형 시:
-   - 사이드바 280px → 모바일에서 overlay 전환
-   - 챗 입력창이 모바일 하단 고정 시 keyboard 가림 방지
-   - 메시지 max-width: 800px 모바일에서 100% 조정
-
-⚠️ 접근성 시:
-   - --muted 색을 어둠 배경에서 끌어올리거나 별도 변수 분리
-   - 모달 focus trap (login-modal)
-   - 키보드 ESC 닫기 추가
-```
+- `tokens.css` 는 단일 출처. 새 토큰 추가 시 여기에만. 페이지에
+  중복 정의하지 말 것.
+- `.brand` 컴포넌트는 `tokens.css` 안에 있다 — "tokens" 라는
+  이름과 살짝 안 맞지만, 브랜드 컴포넌트도 시스템-와이드 primitive
+  로 취급. 나중에 `static/brand.css` 로 분리해도 됨.
+- 브랜치는 `main` 머지 시 PR description 에 **벤치 숫자**는 필요
+  없다(`core/retrieval`, `core/graph`, `core/reasoning` 미수정 — CLAUDE.md §2).
+- `Closes #N` 은 PR body 에만 쓰고 commit message 에는 쓰지 말 것
+  (CLAUDE.md 운영 규칙).
+- 자동 머지 금지(브랜드/UI 변경은 trust boundary 가 아니라서 기술적
+  으로는 가능하지만, 시각 검증 전엔 수동 머지 권장).
 
 ---
 
-## 7. 핵심 정보 요약 카드
+## 7. 빠른 요약 카드
 
 ```
-┌─────────────────────────────────────────────────┐
-│  Web UI Design — Quick Resume Card              │
-├─────────────────────────────────────────────────┤
-│                                                  │
-│  Branch:       claude/design-web-ui-6NQaQ       │
-│  Status:       평가 완료, 구현 미착수           │
-│                                                  │
-│  Files:                                          │
-│    frontend/index.html      779줄               │
-│    frontend/admin.html      700줄               │
-│    frontend/static/*.js     i18n + chat + admin │
-│                                                  │
-│  다음 단계:                                      │
-│    사용자에게 우선순위 1~5 중 선택 받기         │
-│                                                  │
-│  추천 시작점:                                    │
-│    1번 (CSS 추출) — 안전, 빠름, 후속 작업 기반  │
-│                                                  │
-└─────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│  Web UI — Dark Concept Refresh                          │
+├─────────────────────────────────────────────────────────┤
+│                                                          │
+│  Branch:   claude/review-dark-ui-concept-Aydvd          │
+│  Status:   Pushed, awaiting visual verification & merge │
+│                                                          │
+│  Commits:                                                │
+│    e686844  refactor(frontend): unify dark-UI tokens    │
+│    508f880  refactor(brand): replace UI "JAMES" labels  │
+│                                                          │
+│  Brand line (UI only):                                   │
+│    "Secure Enterprise Knowledge Intelligence,           │
+│     Operating System"                                    │
+│  Codename JAMES — kept in env vars / persona / code.    │
+│                                                          │
+│  Files touched:                                          │
+│    frontend/static/tokens.css   (new, 86줄)             │
+│    frontend/static/i18n.js                              │
+│    frontend/index.html                                   │
+│    frontend/admin.html                                   │
+│    frontend/workspace.html                               │
+│    frontend/graph.html                                   │
+│                                                          │
+│  Next step (recommended):                                │
+│    legacy 미정의 토큰 정리 (admin.html) — 30분          │
+│    또는 상단 그라데이션 레일 공통화 — 30분             │
+│                                                          │
+└─────────────────────────────────────────────────────────┘
 ```
 
 ---
 
 **문서 끝**
 
-PC 세션 시작 시 첫 메시지에 이 문서를 첨부하거나
-"frontend/HANDOVER_WEB_UI.md 읽고 이어가자" 라고 지시하면 됩니다.
+다른 세션 시작 시: 이 파일 경로(`frontend/HANDOVER_WEB_UI.md`) 만
+넘기면 컨텍스트가 복원된다.

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -3,33 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0c0d10">
+<meta name="theme-color" content="#0a0c11">
 <title>JAMES Admin</title>
+<link rel="stylesheet" href="/static/tokens.css">
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
-  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  :root {
-    --bg:        #0c0d10;
-    --surface:   #14161a;
-    --surface-2: #1a1d22;
-    --border:    #25282f;
-    --border-2:  #1c1f25;
-    --accent:    #6366f1;
-    --accent-soft: rgba(99,102,241,.12);
-    --accent-fg: #a5b4fc;
-    --text:      #ececf1;
-    --text-soft: #c4c6cf;
-    --muted:     #8a8d99;
-    --muted-2:   #5d616c;
-    --success:   #22c55e;
-    --danger:    #ef4444;
-    --warn:      #f59e0b;
-    --radius:    8px;
-    --radius-lg: 10px;
-    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-    --font-ui:   'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
-  }
 
   body {
     background: var(--bg);

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>JAMES Admin</title>
+<title>Secure Enterprise Knowledge Intelligence, Operating System — Admin</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
 
@@ -436,7 +436,10 @@
 </head>
 <body>
 <header>
-  <div class="logo">JAMES <span>· Admin Console</span></div>
+  <div class="logo">
+    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span style="color:var(--muted);font-size:11px;margin-left:6px">· Admin Console</span>
+  </div>
   <div class="header-right">
     <!-- [STEP 5-A] 언어 토글 -->
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
@@ -866,7 +869,7 @@
             <div class="setting-sub" data-i18n="char.identity_name_desc">JAMES가 자신을 소개할 이름</div>
           </div>
           <input class="setting-value" type="text" id="set-name"
-                 placeholder="JAMES" data-i18n-placeholder="app.name">
+                 placeholder="JAMES">
         </div>
         <div style="padding: 12px 0; display:flex; justify-content:flex-end;">
           <button class="btn btn-primary" onclick="saveIdentity()"
@@ -1422,7 +1425,7 @@
 <!-- ── Admin 로그인 모달 ── -->
 <div class="modal-overlay" id="admin-login-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;z-index:300;">
   <div style="background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:36px;width:340px;box-shadow:0 24px 80px rgba(0,0,0,.7);">
-    <div style="font-size:15px;font-weight:600;font-family:var(--font-mono);color:var(--danger);margin-bottom:8px;letter-spacing:1px;">▸ JAMES ADMIN</div>
+    <div style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--danger);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Intelligence, Operating System · Admin</div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:24px;" data-i18n="auth.admin_required">Admin login required</div>
     <div style="margin-bottom:14px;">
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">ADMIN ID</div>
@@ -1480,7 +1483,7 @@
      style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:320">
   <div style="background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:32px;width:360px;max-width:92vw;box-shadow:0 24px 80px rgba(0,0,0,.7)">
     <div style="font-size:15px;font-weight:600;color:var(--accent-fg);margin-bottom:6px"
-         data-i18n="auth.signup_title">▸ JAMES 회원가입</div>
+         data-i18n="auth.signup_title">▸ 회원가입</div>
     <div style="font-size:11px;color:var(--muted);margin-bottom:18px;line-height:1.5"
          data-i18n="auth.signup_hint">
       가입 신청 후 관리자 승인을 거쳐야 로그인할 수 있습니다.

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>JAMES — Reasoning Graph</title>
+<title>Secure Enterprise Knowledge Intelligence, Operating System — Reasoning Graph</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
   :root {
@@ -392,7 +392,10 @@
 <body>
 
 <header>
-  <div class="logo">JAMES <span>· <span data-i18n="graph.title">Reasoning Graph</span></span></div>
+  <div class="logo">
+    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span style="color:var(--muted);font-size:11px;margin-left:6px">· <span data-i18n="graph.title">Reasoning Graph</span></span>
+  </div>
   <div class="header-right">
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
@@ -480,7 +483,7 @@
 <!-- Admin login modal — same flow as admin.html -->
 <div class="modal-overlay" id="login-modal">
   <div class="modal-card">
-    <div style="font-size:15px;font-weight:600;font-family:var(--font-mono);color:var(--accent-fg);margin-bottom:8px;letter-spacing:1px;">▸ JAMES GRAPH</div>
+    <div style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--accent-fg);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Intelligence, Operating System</div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:24px;" data-i18n="auth.admin_required">Admin login required</div>
     <div style="margin-bottom:14px;">
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">ADMIN ID</div>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -3,35 +3,12 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0c0d10">
+<meta name="theme-color" content="#0a0c11">
 <title>JAMES — Reasoning Graph</title>
+<link rel="stylesheet" href="/static/tokens.css">
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
-  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
-    --bg:        #0c0d10;
-    --surface:   #14161a;
-    --surface-2: #1a1d22;
-    --border:    #25282f;
-    --border-2:  #1c1f25;
-    --accent:    #6366f1;
-    --accent-soft: rgba(99,102,241,.12);
-    --accent-fg: #a5b4fc;
-    --brand-2:   #4fc3f7;
-    --text:      #ececf1;
-    --text-soft: #c4c6cf;
-    --muted:     #8a8d99;
-    --muted-2:   #5d616c;
-    --success:   #22c55e;
-    --danger:    #ef4444;
-    --warn:      #f59e0b;
-    --radius:    8px;
-    --radius-lg: 10px;
-    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-    --font-ui:   'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
-
-    /* type → color mapping (kept generic / domain-neutral) */
+    /* graph-page only: entity type → colour (domain-neutral) */
     --t-person:   #4fc3f7;
     --t-org:      #f59e0b;
     --t-concept:  #a5b4fc;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,46 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0c0d10">
+<meta name="theme-color" content="#0a0c11">
 <title>PROJECT JAMES</title>
+<link rel="stylesheet" href="/static/tokens.css">
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
-  /* ── 리셋 & 변수 ──
-     [#A8-9 2026-05-09] palette polish — 보고서 관리 시스템 분위기.
-     surface tone slightly cooler (slate ↔ navy mix) for a more
-     enterprise/intelligence look. Accent stays indigo but a touch
-     deeper. New --report-bg for "report card" backgrounds. */
-  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  :root {
-    --bg:        #0a0c11;       /* deeper navy-black */
-    --surface:   #131620;       /* slate-tinted surface */
-    --surface-2: #181c26;
-    --border:    #262a36;
-    --border-2:  #1d212c;
-    --accent:    #5258e6;       /* deeper indigo, less playful */
-    --accent-soft: rgba(82,88,230,.13);
-    --accent-fg: #a7afff;
-    /* [#A8-9] secondary brand mark — "intelligence cyan" — used for
-       status badges + section dividers to suggest a knowledge OS. */
-    --brand-2:   #4fc3f7;
-    --brand-2-soft: rgba(79,195,247,.10);
-    --text:      #ececf1;
-    --text-soft: #c4c6cf;
-    --muted:     #8a8d99;
-    --muted-2:   #5d616c;
-    --success:   #22c55e;
-    --danger:    #ef4444;
-    --warn:      #f59e0b;
-    --radius:    8px;
-    --radius-lg: 10px;
-    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-    --font-ui:   'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
-    /* [#A8-9] subtle elevation for "report card" surfaces — answer
-       bubbles, settings rows, etc. Sits one notch above flat. */
-    --shadow-card: 0 1px 0 rgba(255,255,255,.02) inset,
-                   0 8px 24px rgba(0,0,0,.18);
-  }
 
   /* [#A8-9] thin top accent rail — gives every page a subtle "system
      header" stripe like enterprise dashboards. Doesn't move with

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>PROJECT JAMES</title>
+<title>Secure Enterprise Knowledge Intelligence, Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
 
@@ -891,9 +891,7 @@
        the tagline frames it as a knowledge + security intelligence
        suite, not a chat toy. -->
   <div class="logo">
-    JAMES
-    <span>· Knowledge AI</span>
-    <span class="tagline">지식 · 보안 · 보고서 인텔리전스</span>
+    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
   </div>
   <div class="header-right">
     <div class="source-toggle">
@@ -1065,7 +1063,7 @@
       <div class="welcome" id="welcome">
         <!-- [#A8-9] welcome reframed: knowledge + security + report
              intelligence (was generic "Graph-RAG 지식 추론 엔진"). -->
-        <div class="welcome-title">Welcome to <span>JAMES</span></div>
+        <div class="welcome-title">Welcome to <span class="brand" style="font-size:inherit">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span></div>
         <div class="welcome-sub">
           <span data-i18n="app.subtitle">지식·보안·보고서 인텔리전스 시스템</span><br>
           <span style="font-size:12px;color:var(--muted-2);font-family:var(--font-mono);
@@ -1226,7 +1224,7 @@
 <!-- ── 로그인 모달 ── -->
 <div class="modal-overlay hidden" id="login-modal" onclick="closeLoginOutside(event)">
   <div class="modal">
-    <div class="modal-title">▸ <span data-i18n="auth.login_title">JAMES 로그인</span></div>
+    <div class="modal-title">▸ <span data-i18n="auth.login_title">로그인</span></div>
     <div class="modal-field">
       <label data-i18n="auth.username">아이디</label>
       <input type="text" id="login-id" placeholder="admin"
@@ -1331,7 +1329,7 @@
 -->
 <div class="modal-overlay hidden" id="signup-modal" onclick="closeSignupOutside(event)">
   <div class="modal">
-    <div class="modal-title">▸ <span data-i18n="auth.signup_title">JAMES 회원가입</span></div>
+    <div class="modal-title">▸ <span data-i18n="auth.signup_title">회원가입</span></div>
     <div style="font-size:11px;color:var(--muted);margin-bottom:14px;line-height:1.5"
          data-i18n="auth.signup_hint">
       가입 신청 후 관리자 승인을 거쳐야 로그인할 수 있습니다.

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -5,7 +5,7 @@
 
 const TRANSLATIONS = {
   en: {
-    'app.name':              'JAMES',
+    'app.name':              'Secure Enterprise Knowledge Intelligence, Operating System',
     'app.subtitle':          'Security-focused Graph-RAG knowledge engine',
     'app.welcome':           'Ask me anything',
     'app.admin':             'ADMIN',
@@ -40,7 +40,7 @@ const TRANSLATIONS = {
     'common.start':          'Start',
     'common.last':           'Last',
 
-    'chat.title':            'JAMES — Security Reasoning Engine',
+    'chat.title':            'Secure Enterprise Knowledge Intelligence, Operating System — Security Reasoning Engine',
     'chat.placeholder':      'Type a message (Shift+Enter for new line)',
     'chat.example1':         'What is economics?',
     'chat.example2':         'Find documents about John Smith',
@@ -81,7 +81,7 @@ const TRANSLATIONS = {
     'auth.password':         'Password',
     'auth.api_key':          'API Key',
     'auth.api_key_hint':     "From server's .env JAMES_API_KEY. Leave blank to reuse stored value.",
-    'auth.login_title':      'JAMES Login',
+    'auth.login_title':      'Login',
     'auth.api_key_prompt':   'Enter your JAMES API Key:',
     'auth.login_success':    '{username} ({role}) logged in',
     'auth.session_expired':  'Session expired. Click to log in again.',
@@ -406,7 +406,7 @@ const TRANSLATIONS = {
     'auth.admin_required':       'Admin login required',
     'auth.login':                'Login',
     'auth.signup_link':          'No account? Sign up',
-    'auth.signup_title':         '▸ JAMES signup',
+    'auth.signup_title':         '▸ Signup',
     'auth.signup_hint':          'After submitting, an admin must approve your account before you can log in.',
     'auth.signup_username_ph':   'lowercase letters/digits/_- (3-32 chars)',
     'auth.signup_password_ph':   '8-72 chars, letter + digit',
@@ -517,7 +517,7 @@ const TRANSLATIONS = {
   },
 
   ko: {
-    'app.name':              'JAMES',
+    'app.name':              'Secure Enterprise Knowledge Intelligence, Operating System',
     'app.subtitle':          '보안 중심 Graph-RAG 지식 추론 엔진',
     'app.welcome':           '무엇이든 물어보세요',
     'app.admin':             '관리자',
@@ -552,7 +552,7 @@ const TRANSLATIONS = {
     'common.start':          '시작',
     'common.last':           '마지막',
 
-    'chat.title':            'JAMES — 보안 추론 엔진',
+    'chat.title':            'Secure Enterprise Knowledge Intelligence, Operating System — 보안 추론 엔진',
     'chat.placeholder':      '메시지를 입력하세요 (Shift+Enter: 줄바꿈)',
     'chat.example1':         '경제학이란 무엇인가?',
     'chat.example2':         '김철수 관련 자료 찾아줘',
@@ -593,7 +593,7 @@ const TRANSLATIONS = {
     'auth.password':         '비밀번호',
     'auth.api_key':          'API Key',
     'auth.api_key_hint':     '서버 .env의 JAMES_API_KEY 값. 비워두면 저장된 값 그대로 사용.',
-    'auth.login_title':      'JAMES 로그인',
+    'auth.login_title':      '로그인',
     'auth.api_key_prompt':   'JAMES API Key를 입력하세요:',
     'auth.login_success':    '{username} ({role}) 로그인 완료',
     'auth.session_expired':  '로그인 세션이 만료됐습니다. 클릭하면 재로그인합니다.',
@@ -918,7 +918,7 @@ const TRANSLATIONS = {
     'auth.admin_required':       '관리자 로그인이 필요합니다',
     'auth.login':                '로그인',
     'auth.signup_link':          '계정이 없으신가요? 회원가입',
-    'auth.signup_title':         '▸ JAMES 회원가입',
+    'auth.signup_title':         '▸ 회원가입',
     'auth.signup_hint':          '가입 신청 후 관리자 승인을 거쳐야 로그인할 수 있습니다.',
     'auth.signup_username_ph':   '영문 소문자/숫자/_- (3~32자)',
     'auth.signup_password_ph':   '8~72자, 영문 + 숫자',

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -58,3 +58,29 @@
   --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   --font-ui:      'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
 }
+
+/* ── Brand mark ──
+ * Long-form product name shown in headers, modals, welcome screens.
+ * The first line carries the primary positioning; the trailing
+ * "Operating System" sits one weight/colour notch below so the
+ * compound reads as a system identity rather than a sentence.
+ * Used inside .logo, .modal-title, .welcome-title etc. */
+.brand {
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: .25px;
+  line-height: 1.25;
+  white-space: nowrap;
+  color: var(--text);
+}
+.brand .brand-tail {
+  font-weight: 500;
+  color: var(--muted);
+  margin-left: 3px;
+}
+@media (max-width: 900px) {
+  .brand { font-size: 11px; letter-spacing: .15px; }
+}
+@media (max-width: 640px) {
+  .brand { white-space: normal; }
+}

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -1,0 +1,60 @@
+/* JAMES — Web UI design tokens (single source of truth).
+ *
+ * Linked from index.html, admin.html, workspace.html, graph.html.
+ * Replaces four duplicated :root blocks that had drifted into
+ * three slightly-different palettes.
+ *
+ * Standardised on the [#A8-9] "report-system" polish originally
+ * shipped in index.html: deeper navy-black background, slate-tinted
+ * surfaces, deeper-indigo accent, plus an intelligence-cyan brand-2
+ * for status badges / dividers and a shadow-card recipe for elevated
+ * surfaces. Graph-page only tokens (entity-type colours) stay inline
+ * in graph.html.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  /* ── surfaces ── */
+  --bg:           #0a0c11;       /* deeper navy-black */
+  --surface:      #131620;       /* slate-tinted surface */
+  --surface-2:    #181c26;
+  --border:       #262a36;
+  --border-2:     #1d212c;
+
+  /* ── primary brand (deeper indigo, less playful) ── */
+  --accent:       #5258e6;
+  --accent-soft:  rgba(82,88,230,.13);
+  --accent-fg:    #a7afff;
+
+  /* ── secondary brand — "intelligence cyan", used for status
+       badges + section dividers to suggest a knowledge OS. ── */
+  --brand-2:      #4fc3f7;
+  --brand-2-soft: rgba(79,195,247,.10);
+
+  /* ── text ── */
+  --text:         #ececf1;
+  --text-soft:    #c4c6cf;
+  --muted:        #8a8d99;
+  --muted-2:      #5d616c;       /* AA-borderline on --bg; labels only */
+
+  /* ── status ── */
+  --success:      #22c55e;
+  --danger:       #ef4444;
+  --warn:         #f59e0b;
+
+  /* ── shape ── */
+  --radius:       8px;
+  --radius-lg:    10px;
+
+  /* ── elevation — for "report card" surfaces (answer bubbles,
+       settings rows). Sits one notch above flat. ── */
+  --shadow-card:  0 1px 0 rgba(255,255,255,.02) inset,
+                  0 8px 24px rgba(0,0,0,.18);
+
+  /* ── type ── */
+  --font-mono:    'JetBrains Mono', ui-monospace, monospace;
+  --font-ui:      'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
+}

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>JAMES Workspace</title>
+<title>Secure Enterprise Knowledge Intelligence, Operating System — Workspace</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
   body {
@@ -235,7 +235,8 @@
 
 <header>
   <div class="logo">
-    JAMES <span class="tagline" data-i18n="workspace.tagline">Workspace · 데이터 + 작업</span>
+    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span class="tagline" data-i18n="workspace.tagline">Workspace · 데이터 + 작업</span>
   </div>
   <div class="header-right">
     <span class="role-badge" id="role-badge" style="display:none">
@@ -404,7 +405,7 @@
 <!-- Login modal -->
 <div class="modal-overlay hidden" id="login-modal">
   <div class="modal">
-    <div class="modal-title">▸ <span data-i18n="auth.login_title">JAMES 로그인</span></div>
+    <div class="modal-title">▸ <span data-i18n="auth.login_title">로그인</span></div>
     <div class="modal-field">
       <label data-i18n="auth.username">USERNAME</label>
       <input type="text" id="login-id" autocomplete="username" spellcheck="false">

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -3,31 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0c0d10">
+<meta name="theme-color" content="#0a0c11">
 <title>JAMES Workspace</title>
+<link rel="stylesheet" href="/static/tokens.css">
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
-  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  :root {
-    --bg:        #0c0d10;
-    --surface:   #14161a;
-    --surface-2: #1a1d22;
-    --border:    #25282f;
-    --border-2:  #1c1f25;
-    --accent:    #6366f1;
-    --accent-fg: #a5b4fc;
-    --text:      #ececf1;
-    --text-soft: #c4c6cf;
-    --muted:     #8a8d99;
-    --muted-2:   #5d616c;
-    --success:   #22c55e;
-    --danger:    #ef4444;
-    --warn:      #f59e0b;
-    --radius:    8px;
-    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-    --font-ui:   'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
-  }
   body {
     background: var(--bg); color: var(--text);
     font-family: var(--font-ui); font-size: 14px;

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -28,26 +28,29 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 ROOT = Path(__file__).resolve().parent.parent
 HTML = ROOT / "frontend" / "index.html"
+# Design tokens were extracted from inline :root blocks into a single
+# stylesheet; palette assertions now resolve there instead of index.html.
+TOKENS = ROOT / "frontend" / "static" / "tokens.css"
 
 
 class PaletteTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.html = HTML.read_text(encoding="utf-8")
+        cls.tokens = TOKENS.read_text(encoding="utf-8")
 
     def test_brand_2_var_added(self):
         # Secondary brand colour for "intelligence cyan" — used by
         # status badges / dividers.
-        self.assertIn("--brand-2:", self.html,
+        self.assertIn("--brand-2:", self.tokens,
             "must declare --brand-2 secondary brand colour for the polish")
-        self.assertIn("--brand-2-soft:", self.html,
+        self.assertIn("--brand-2-soft:", self.tokens,
             "soft variant for tinted backgrounds")
 
     def test_shadow_card_var_added(self):
         # Custom elevation token for "report card" surfaces.
-        self.assertIn("--shadow-card:", self.html,
+        self.assertIn("--shadow-card:", self.tokens,
             "must declare --shadow-card token for elevation")
-        m = re.search(r"--shadow-card:\s*([^;]+);", self.html)
+        m = re.search(r"--shadow-card:\s*([^;]+);", self.tokens, re.DOTALL)
         self.assertIsNotNone(m)
         self.assertIn("rgba(0,0,0", m.group(1),
             "shadow should include a dark rgba layer")
@@ -57,7 +60,7 @@ class PaletteTests(unittest.TestCase):
         # toward navy/slate. Specifically: NOT pure black (#000) and
         # NOT the prior neutral #0c0d10 — should land on something
         # cooler like #0a0c11.
-        m = re.search(r"--bg:\s*(#[0-9a-fA-F]{6})", self.html)
+        m = re.search(r"--bg:\s*(#[0-9a-fA-F]{6})", self.tokens)
         self.assertIsNotNone(m)
         bg = m.group(1).lower()
         self.assertNotEqual(bg, "#000000",
@@ -98,26 +101,45 @@ class TopAccentRailTests(unittest.TestCase):
 
 
 class LogoTaglineTests(unittest.TestCase):
+    """The original brand framing lived in a single ``.tagline`` element.
+    The brand refactor split it: the logo carries the product name via
+    ``class="brand"`` + ``class="brand-tail"`` (positioning line),
+    and the knowledge/security/report framing lives in ``.welcome-sub``
+    (asserted by WelcomeReframeTests). These tests now check the new
+    structure rather than the removed ``.tagline`` element."""
+
     @classmethod
     def setUpClass(cls):
         cls.html = HTML.read_text(encoding="utf-8")
 
-    def test_tagline_class_in_html(self):
-        self.assertIn('class="tagline"', self.html,
-            "must include a tagline span for the logo")
+    def test_logo_uses_brand_class(self):
+        # The logo span carries the unified brand label.
+        m = re.search(r'<div class="logo">(.+?)</div>',
+                      self.html, re.DOTALL)
+        self.assertIsNotNone(m, "logo container must exist")
+        logo = m.group(1)
+        self.assertIn('class="brand"', logo,
+            "logo must use the unified .brand class introduced with "
+            "the positioning-line refactor")
+        self.assertIn('class="brand-tail"', logo,
+            "brand must include the .brand-tail span for the trailing "
+            "positioning words")
 
-    def test_tagline_copy_mentions_security_and_reporting(self):
-        # The tagline frames JAMES as more than chat — knowledge/
-        # security/reporting suite.
-        m = re.search(r'class="tagline"[^>]*>([^<]+)<', self.html)
-        self.assertIsNotNone(m)
-        copy = m.group(1)
-        # Must mention 보안 (security) and either 지식 (knowledge) or
-        # 보고서 (reporting).
-        self.assertIn("보안", copy,
-            "tagline must mention 보안 (security) for the brand framing")
-        self.assertTrue("지식" in copy or "보고서" in copy,
-            f"tagline must mention 지식 or 보고서; got {copy!r}")
+    def test_brand_positioning_line_present(self):
+        # The brand label should be the full positioning string —
+        # not just "JAMES". Specifically, the trailing "Operating
+        # System" tail must appear inside the .brand element so the
+        # compound reads as a system identity.
+        m = re.search(
+            r'<span class="brand">(.+?)</span>\s*</div>',
+            self.html, re.DOTALL,
+        )
+        self.assertIsNotNone(m,
+            "could not locate the .brand span inside the logo")
+        brand = m.group(1)
+        self.assertIn("Operating System", brand,
+            "brand label must end on the 'Operating System' positioning "
+            "tail; got: " + brand[:120])
 
     def test_logo_mark_uses_brand_2(self):
         # The square mark should blend accent → brand-2 for the


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md 5가지 우선순위 중 **#1 (CSS 토큰 추출)** 을 처리합니다. 동시에 브랜드 라벨을 4개 페이지에 통일된 positioning line 으로 교체.

원래 점검 (web Claude 세션, 2026-05-06): 4개 페이지 (index/admin/workspace/graph) 가 각자의 `:root` 블록을 인라인 복붙으로 보유, 3가지 미묘하게 다른 팔레트로 드리프트. index 만 최신 #A8-9 폴리시 (deeper navy bg, deeper indigo accent, cyan brand-2, shadow-card 레시피) 를 갖고 있고 나머지 3개는 옛 neutral-dark 팔레트. 페이지 이동 시 미세한 색조 변화로 "single report-system" 정체성이 깨짐.

재점검 (2026-05-12, 이 PR 직전 main 기준): 드리프트 여전 — admin/workspace `--brand-2` MISSING, 4개 페이지 모두 `--shadow-card` 누락 (index 외).

## Commits

**e686844** `refactor(frontend): unify dark-UI tokens into static/tokens.css`
- 신규 `frontend/static/tokens.css` (60 → 86 라인, 최종) — single source of truth
- 통합 팔레트 (#A8-9 기반) + Google Fonts `@import` + 유니버설 reset
- 4개 HTML 의 `:root` 블록 제거, `<link rel="stylesheet" href="/static/tokens.css">` 연결
- `<meta name=\"theme-color\">` 4개 페이지 `#0a0c11` 통일
- `graph.html` 은 entity-type 컬러 토큰 4개 (`--t-person/--t-org/--t-concept/--t-document`) 만 인라인 보존 — graph-page-only, domain-neutral

**508f880** `refactor(brand): replace UI \"JAMES\" labels with full positioning line`
- 헤더 / 모달 / welcome 의 \"JAMES\" 라벨을 unified `<span class=\"brand\">Secure Enterprise Knowledge Intelligence,<span class=\"brand-tail\">Operating System</span></span>` 로 교체
- tokens.css 에 `.brand` / `.brand-tail` 스타일 + 반응형 (900px/640px) 추가
- i18n.js 16줄 — `app.name` / `chat.title` / `auth.login_title` / `auth.signup_title` 등 ko+en 양쪽
- repo / package / CLAUDE.md 의 \"JAMES\" 식별자는 그대로 — 공개 라벨만 변경

**bb4a56b** `docs(handover): refresh frontend/HANDOVER_WEB_UI.md for dark-concept track`
- HANDOVER_WEB_UI.md 가 5일 전 평가 시점 기준이라 #A8-9 폴리시 / brand 작업 이후 상태로 업데이트

**4d9cb80** `test(ui): retarget palette + tagline assertions after token + brand refactors` (이 PR 에서 추가)
- `tests/test_ui_report_polish.py` 의 5개 fail 수정 — 위 2개 구조 변경으로 인한 stale 매칭만 정정
- 의도 무변 / 강도 무변: PaletteTests 는 동일 3개 assertion 을 tokens.css 에서 실행, LogoTaglineTests 의 tagline 2개를 새 `.brand` / `.brand-tail` 구조 확인으로 교체. 보안/지식/보고서 framing 은 WelcomeReframeTests 가 이미 커버.

## Verification

- `python -m unittest discover -s tests -t .` — **1392 tests OK**
- `ruff check .` — clean
- Token 검증: 4개 페이지 모두 `tokens.css` 링크, `:root` 블록 제거 (graph 만 entity 컬러 1개 보존)
- Rebase: main 기준 충돌 0건 — 깨끗한 fast-forward

## Out of scope (HANDOVER_WEB_UI.md 후속 PR 후보)

- `admin.html` 의 legacy 미정의 토큰 (`--accent2` / `--bg2` / `--card` / `--fg`) — 이 PR 이전부터 깨져 있던 참조
- 상단 그라데이션 레일 (`body::before`) 4개 페이지 공통화
- 인라인 `<style>` 블록 완전 분리 (`static/styles.css`)
- `workspace.html` 에 mobile.css 연결 (다른 3개는 이미 연결)
- `--muted-2` AA 미달 사용처 감사

🤖 Generated with [Claude Code](https://claude.com/claude-code)