### PR TITLE
chore(frontend): link mobile.css from workspace.html + scope chat sidebar rules

### DIFF
--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -273,8 +273,11 @@
 
   /* ─────────────── chat 페이지 ─────────────── */
 
-  /* 사이드바 — 모바일에선 화면 가득, 닫혔을 때 0 */
-  .sidebar {
+  /* 사이드바 — 모바일에선 화면 가득, 닫혔을 때 0.
+   * Scoped to ``aside.sidebar`` so it doesn't clobber workspace.html's
+   * ``nav.sidebar`` (which is a flow-positioned 200/56px rail with
+   * its own inline @media at 700px). */
+  aside.sidebar {
     position: fixed;
     z-index: 50;
     inset: 0 auto 0 0;          /* top:0 right:auto bottom:0 left:0 */
@@ -282,7 +285,7 @@
     max-width: 360px;
     box-shadow: 4px 0 16px rgba(0, 0, 0, 0.4);
   }
-  .sidebar.collapsed { width: 0; box-shadow: none; }
+  aside.sidebar.collapsed { width: 0; box-shadow: none; }
   .sidebar-open-btn {
     width: 44px;
     height: 44px;

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -6,6 +6,12 @@
 <meta name="theme-color" content="#0a0c11">
 <title>Secure Enterprise Knowledge Intelligence, Operating System — Workspace</title>
 <link rel="stylesheet" href="/static/tokens.css">
+<!-- Shared mobile responsive overrides (touch targets, iOS font-size,
+     safe-area-inset, generic modal/table rules). Workspace-specific
+     mobile rules — sidebar collapse + detail-panel full-width — stay
+     inline below at the same 700px breakpoint. mobile.css's 768px
+     rules layer underneath. -->
+<link rel="stylesheet" href="/static/mobile.css">
 <style>
   body {
     background: var(--bg); color: var(--text);

--- a/tests/test_mobile_css_coverage.py
+++ b/tests/test_mobile_css_coverage.py
@@ -1,0 +1,87 @@
+"""mobile.css coverage — every full-page UI links the shared responsive
+overrides stylesheet, and the chat-only sidebar rules stay scoped so
+they don't clobber workspace.html's flow-positioned ``nav.sidebar``.
+
+Background: chat (index.html) + admin.html linked mobile.css from day
+one; workspace.html shipped without responsive rules other than its
+own inline ``@media (max-width: 700px)`` block (sidebar collapse +
+detail-panel full-width). That left mobile touch-target sizing,
+iOS font-size auto-zoom prevention, safe-area-inset handling and a
+few other generic mobile concerns unaddressed on the workspace page.
+
+graph.html intentionally does NOT link mobile.css — it implements its
+own page-specific @media block tuned to graph-canvas concerns (top
+search drawer, neighbor panel placement). That choice is preserved.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class MobileCssLinkPresentTests(unittest.TestCase):
+    """Pages that depend on shared mobile rules link the stylesheet."""
+
+    def _read(self, name: str) -> str:
+        return (ROOT / "frontend" / name).read_text(encoding="utf-8")
+
+    def test_chat_links_mobile_css(self):
+        self.assertIn('href="/static/mobile.css"', self._read("index.html"),
+            "index.html (chat) must link the shared mobile overrides")
+
+    def test_admin_links_mobile_css(self):
+        self.assertIn('href="/static/mobile.css"', self._read("admin.html"),
+            "admin.html must link the shared mobile overrides")
+
+    def test_workspace_links_mobile_css(self):
+        self.assertIn('href="/static/mobile.css"', self._read("workspace.html"),
+            "workspace.html must link mobile.css for touch-target + "
+            "iOS font-size + safe-area-inset rules")
+
+
+class ChatSidebarRuleScopedTests(unittest.TestCase):
+    """mobile.css's chat sidebar rules use ``aside.sidebar``, not the
+    bare ``.sidebar`` selector — so they don't collide with
+    workspace.html's ``<nav class="sidebar">``.
+
+    Why this matters: ``<nav class="sidebar">`` in workspace is a
+    flow-positioned 200px rail (56px at ≤700px). If mobile.css matched
+    it with the chat selector, workspace's sidebar would become
+    ``position: fixed`` at 88vw between 701-768px, breaking the page
+    layout entirely.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.css = (ROOT / "frontend" / "static" / "mobile.css"
+                   ).read_text(encoding="utf-8")
+
+    def test_bare_dot_sidebar_selector_not_used(self):
+        # The chat sidebar rule body has these distinctive properties
+        # — position:fixed + 88vw width. Confirm no rule with EXACTLY
+        # that body is keyed on the bare ``.sidebar`` selector.
+        bad = re.search(
+            r'(^|\s)\.sidebar\s*\{[^}]*position:\s*fixed[^}]*88vw',
+            self.css, re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNone(
+            bad,
+            "mobile.css chat sidebar rule must be scoped to "
+            "``aside.sidebar`` — bare ``.sidebar`` would match "
+            "workspace.html's <nav class=\"sidebar\">",
+        )
+
+    def test_aside_sidebar_selector_present(self):
+        self.assertIn("aside.sidebar", self.css,
+            "the scoped chat selector should be present in mobile.css")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md priority **#2 (모바일 반응형) 잔여** — chat 과 admin 은 day-one 부터 mobile.css 를 링크하고 있었지만 workspace.html 만 자체 inline `@media` 블록만 갖고 있어 mobile.css 가 처리하는 공통 모바일 사항이 누락되어 있었습니다:
- iOS 입력창 자동 확대 방지 (font-size ≥ 16px)
- `safe-area-inset-bottom` 패딩
- 터치 타겟 ≥ 36px (button / `.nav-item` / `.role-badge`)
- 헤더 wrap / 작은 패딩
- 테이블 셀 `word-break`

## 충돌 처리

`<aside class=\"sidebar\">` (chat) 과 `<nav class=\"sidebar\">` (workspace) 둘 다 `.sidebar` 클래스를 쓰지만 의도가 완전히 다릅니다:
- chat: 280px 접이식 off-canvas
- workspace: 200px / 56px flow-positioned rail

mobile.css 의 `.sidebar { position: fixed; width: 88vw }` 가 ≤ 768px 에서 workspace 의 nav 를 망가뜨릴 수 있어 `aside.sidebar` 로 scope. 701px ~ 768px 구간 (mobile.css 768px ↔ workspace inline 700px breakpoint gap) 에서 workspace nav 가 fixed-position 으로 변형되는 회귀를 차단합니다.

graph.html 은 mobile.css 링크 의도적 제외 — graph-canvas 전용 @media 블록 (top search drawer, neighbor panel placement) 이 이미 인라인으로 들어가 있어 page-specific concern 으로 유지.

## Changes

- `frontend/workspace.html` — `<link rel=\"stylesheet\" href=\"/static/mobile.css\">` 추가
- `frontend/static/mobile.css` — `.sidebar` / `.sidebar.collapsed` → `aside.sidebar` / `aside.sidebar.collapsed`

## Tests

`tests/test_mobile_css_coverage.py` (NEW, 5 tests):
- `MobileCssLinkPresentTests` x3 — chat / admin / workspace 모두 mobile.css 링크
- `ChatSidebarRuleScopedTests` x2 — bare `.sidebar` 가 chat 의 position:fixed 88vw 룰을 소유하지 않음, `aside.sidebar` 가 소유

`python -m unittest discover -s tests -t .` — **1397 tests OK** (+5). `ruff check .` clean.

## HANDOVER_WEB_UI.md 진행 현황

| # | 작업 | 상태 |
|---|------|------|
| 1 | CSS 토큰 추출 → tokens.css | ✅ #214 |
| **2** | **모바일 반응형 (사이드바 오버레이)** | ✅ **이 PR** |
| 3 | 추론 패널 강화 (Graph-RAG 차별점) | 🔜 |
| 4 | 접근성 패스 (aria/대비/focus trap) | 🔜 |
| 5 | 인라인 onclick 제거 (CSP) | 🔜 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)