### PR TITLE
feat(a11y): aria-label on icon-only and JS-populated buttons (4b)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -443,6 +443,7 @@
   <div class="header-right">
     <!-- [STEP 5-A] 언어 토글 -->
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+            aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <a href="/" class="nav-btn" data-i18n="admin.chat_link">← 챗으로</a>
   </div>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -398,6 +398,7 @@
   </div>
   <div class="header-right">
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+            aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <a href="/admin" class="nav-btn">← <span data-i18n="graph.back_admin">Admin</span></a>
     <a href="/" class="nav-btn">← <span data-i18n="graph.back_chat">Chat</span></a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -900,11 +900,14 @@
     </div>
     <!-- [STEP 5-A] 언어 토글 -->
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+            aria-label="언어 전환 / Toggle language"
             style="font-size:11px;font-weight:700;padding:4px 8px"></button>
-    <button class="nav-btn" onclick="clearHistory()" data-i18n-title="chat.clear_history" data-i18n-title="chat.clear_history" title="대화 초기화">🗑</button>
+    <button class="nav-btn" onclick="clearHistory()" data-i18n-title="chat.clear_history" title="대화 초기화"
+            aria-label="대화 기록 삭제">🗑</button>
     <!-- [P3-4] 세션 선택 버튼 -->
-    <button class="nav-btn" onclick="toggleSessionPanel()" data-i18n-title="chat.session_open" data-i18n-title="chat.session_open" title="이전 대화 불러오기"
-            id="session-btn" style="position:relative">
+    <button class="nav-btn" onclick="toggleSessionPanel()" data-i18n-title="chat.session_open" title="이전 대화 불러오기"
+            id="session-btn" aria-label="세션 패널 열기"
+            style="position:relative">
       💬
       <span id="session-count-badge"
             style="display:none;position:absolute;top:-2px;right:-2px;
@@ -939,6 +942,7 @@
         <span data-i18n="chat.new_session">+ 새 대화</span>
       </button>
       <button onclick="toggleSessionPanel()"
+              aria-label="세션 패널 닫기"
               style="background:none;border:none;color:var(--muted);
                      cursor:pointer;font-size:16px;padding:0 4px">✕</button>
     </div>
@@ -953,7 +957,8 @@
 
 <main style="position:relative">
   <button class="sidebar-open-btn" id="sidebar-open-btn"
-          onclick="toggleSidebar()" data-i18n-title="upload.open" title="업로드 열기">▶</button>
+          onclick="toggleSidebar()" data-i18n-title="upload.open" title="업로드 열기"
+          aria-label="사이드바 열기">▶</button>
   <!-- ── 사이드바 (W5: rail + panel split) ── -->
   <aside class="sidebar" id="sidebar">
     <!-- Left rail — mode icons. switchSidebarMode(id) flips both
@@ -980,7 +985,8 @@
     <div class="sidebar-panel">
       <div class="sidebar-header">
         <div class="sidebar-title" id="sidebar-title">▸ <span data-i18n="upload.title">파일 업로드</span></div>
-        <button class="sidebar-toggle" onclick="toggleSidebar()" data-i18n-title="common.close" title="닫기">◀</button>
+        <button class="sidebar-toggle" onclick="toggleSidebar()" data-i18n-title="common.close" title="닫기"
+                aria-label="사이드바 닫기">◀</button>
       </div>
 
       <!-- Mode: 파일 업로드 (default) -->
@@ -1107,6 +1113,7 @@
         </span>
         <button id="mode-install-btn"
                 onclick="triggerModelInstall()"
+                aria-label="LLM 모델 설치"
                 style="display:none;background:var(--accent-soft);
                        border:1px solid var(--accent);color:var(--accent-fg);
                        padding:4px 10px;border-radius:6px;font-size:11px;
@@ -1150,7 +1157,8 @@
                   data-i18n-placeholder="chat.placeholder" rows="1"
           oninput="autoResize(this)" onkeydown="handleKey(event)"
           onpaste="handleChatPaste(event)"></textarea>
-        <button class="send-btn" id="send-btn" onclick="sendMessage()">▲</button>
+        <button class="send-btn" id="send-btn" onclick="sendMessage()"
+                aria-label="메시지 전송">▲</button>
       </div>
     </div>
   </section>

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -249,7 +249,9 @@
       <span class="who" id="role-who"></span>
       <span id="role-name"></span>
     </span>
-    <button class="header-btn" data-lang-toggle onclick="toggleLang()" style="font-weight:700"></button>
+    <button class="header-btn" data-lang-toggle onclick="toggleLang()"
+            aria-label="언어 전환 / Toggle language"
+            style="font-weight:700"></button>
     <a href="/" class="header-btn" style="text-decoration:none" data-i18n="workspace.back_chat">챗</a>
     <button class="header-btn" id="login-btn"
             onclick="showLogin()" data-i18n="auth.login">로그인</button>
@@ -394,7 +396,7 @@
 
 <!-- Artifact detail panel -->
 <div class="detail-panel" id="detail-panel">
-  <button class="close" onclick="closeDetail()">×</button>
+  <button class="close" onclick="closeDetail()" aria-label="상세 패널 닫기">×</button>
   <h3 id="detail-title">—</h3>
   <div class="detail-row"><div class="label">ARTIFACT ID</div><div class="value" id="d-id"></div></div>
   <div class="detail-row"><div class="label">PATH</div><div class="value" id="d-path"></div></div>

--- a/tests/test_a11y_aria_labels.py
+++ b/tests/test_a11y_aria_labels.py
@@ -1,0 +1,149 @@
+"""Icon-only / empty buttons carry accessible names.
+
+HANDOVER_WEB_UI.md priority #4 subset 4b. Icon-only buttons
+(glyph characters like ✕ / × / ▲ / ◀ / 🗑) and empty buttons whose
+text content is set by JS at runtime (the ``data-lang-toggle``
+language switcher) must declare ``aria-label`` so screen-readers
+have a stable name regardless of current visual state.
+
+These tests guard against regression — once a button is wired with
+aria-label, a future refactor cannot silently strip it.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+FRONTEND = ROOT / "frontend"
+
+
+def _button_block_around(html: str, marker: str) -> str:
+    """Return the <button ...>...</button> block whose attribute or
+    inner text contains ``marker``. Used to assert per-button
+    attributes without hard-coding line numbers."""
+    # Locate all button blocks (DOTALL because multi-line buttons are
+    # common in this codebase).
+    for m in re.finditer(r'<button\b[^>]*>([\s\S]*?)</button>', html):
+        block = m.group(0)
+        if marker in block:
+            return block
+    return ""
+
+
+class LangToggleButtonsTests(unittest.TestCase):
+    """The ``data-lang-toggle`` button exists on all 4 pages. Its
+    visible text is JS-populated, so the static HTML body is empty;
+    aria-label is therefore the only stable accessible name."""
+
+    def _block(self, page: str) -> str:
+        html = (FRONTEND / page).read_text(encoding="utf-8")
+        # data-lang-toggle is unique per page
+        m = re.search(
+            r'<button[^>]*data-lang-toggle[^>]*>[^<]*</button>',
+            html, re.DOTALL,
+        )
+        return m.group(0) if m else ""
+
+    def _check(self, page: str) -> None:
+        block = self._block(page)
+        self.assertTrue(block, f"{page}: data-lang-toggle button not found")
+        self.assertIn("aria-label=", block,
+            f"{page}: lang-toggle must declare aria-label "
+            "(its visible text is JS-populated and unreliable for AT)")
+
+    def test_index(self):     self._check("index.html")
+    def test_admin(self):     self._check("admin.html")
+    def test_workspace(self): self._check("workspace.html")
+    def test_graph(self):     self._check("graph.html")
+
+
+class IconOnlyButtonsTests(unittest.TestCase):
+    """Specific high-value icon-only buttons that previously lacked
+    an accessible name."""
+
+    def setUp(self):
+        self.index = (FRONTEND / "index.html"
+                     ).read_text(encoding="utf-8")
+        self.admin = (FRONTEND / "admin.html"
+                     ).read_text(encoding="utf-8")
+        self.workspace = (FRONTEND / "workspace.html"
+                         ).read_text(encoding="utf-8")
+
+    def _assert_aria_on_button(self, html: str, locator: str,
+                               page: str) -> None:
+        """Find a button containing ``locator`` and assert it has
+        aria-label. ``locator`` should be a unique substring of the
+        button block (e.g. an onclick handler name)."""
+        block = _button_block_around(html, locator)
+        self.assertTrue(block,
+            f"{page}: button matching {locator!r} not found")
+        self.assertIn("aria-label=", block,
+            f"{page}: button {locator!r} must declare aria-label")
+
+    def test_index_session_open_button(self):
+        # The 💬 button in the header opens the session panel
+        # (id=session-btn).
+        self._assert_aria_on_button(
+            self.index, 'id="session-btn"', "index.html")
+
+    def test_index_session_close_button(self):
+        # The ✕ button INSIDE the session panel header closes it.
+        # The button HTML uses inline ``style="background:none;..."``
+        # — that string only exists on the close button.
+        self._assert_aria_on_button(
+            self.index, "background:none;border:none;color:var(--muted)",
+            "index.html")
+
+    def test_index_send_button(self):
+        # The ▲ submit button on the chat input.
+        self._assert_aria_on_button(
+            self.index, "sendMessage()", "index.html")
+
+    def test_index_model_install_button(self):
+        # mode-install-btn — empty button shown only when LLM is missing.
+        self._assert_aria_on_button(
+            self.index, "triggerModelInstall()", "index.html")
+
+    def test_index_clear_history_button(self):
+        # 🗑 button next to lang toggle.
+        self._assert_aria_on_button(
+            self.index, "clearHistory()", "index.html")
+
+    def test_index_sidebar_open_button(self):
+        # ▶ button shown when sidebar is collapsed (id=sidebar-open-btn).
+        self._assert_aria_on_button(
+            self.index, 'id="sidebar-open-btn"', "index.html")
+
+    def test_index_sidebar_close_button(self):
+        # ◀ button inside the upload sidebar header
+        # (class="sidebar-toggle").
+        self._assert_aria_on_button(
+            self.index, 'class="sidebar-toggle"', "index.html")
+
+    def test_admin_nav_toggle_button(self):
+        # ☰ hamburger on admin nav.
+        self._assert_aria_on_button(
+            self.admin, "toggleAdminNav()", "admin.html")
+
+    def test_admin_entity_detail_close_button(self):
+        # × button inside the entity-detail modal header.
+        self._assert_aria_on_button(
+            self.admin, "closeEntityDetail()", "admin.html")
+
+    def test_admin_session_turns_close_button(self):
+        self._assert_aria_on_button(
+            self.admin, "closeSessionTurns()", "admin.html")
+
+    def test_workspace_detail_close_button(self):
+        self._assert_aria_on_button(
+            self.workspace, "closeDetail()", "workspace.html")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md priority **#4 (접근성)** subset **4b**. Following 4a's modal dialog pattern (#216), every icon-only or runtime-populated button gets a stable accessible name. Screen-readers and voice-control users now have clear labels regardless of current visual state.

## Per-button changes (12 buttons, 4 pages)

**Language toggle** (data-lang-toggle — empty body, JS injects \"KO|EN\" at runtime):
- index.html / admin.html / workspace.html / graph.html — all 4 sites now declare `aria-label=\"언어 전환 / Toggle language\"`.

**index.html — chat-specific icon buttons**:
| Button | New aria-label |
|--------|----------------|
| 💬 `#session-btn` | 세션 패널 열기 |
| ✕ session close | 세션 패널 닫기 |
| 🗑 clear history | 대화 기록 삭제 |
| ▲ `#send-btn` | 메시지 전송 |
| ▶ `#sidebar-open-btn` | 사이드바 열기 |
| ◀ `.sidebar-toggle` | 사이드바 닫기 |
| `#mode-install-btn` (empty) | LLM 모델 설치 |

**workspace.html**: `× .close` button on detail panel → `aria-label=\"상세 패널 닫기\"`.

## Side cleanups

- `index.html` L905: removed duplicate `data-i18n-title=\"chat.clear_history\"` attribute (repeated twice).
- `index.html` L908: removed duplicate `data-i18n-title=\"chat.session_open\"` attribute.

## Tests

`tests/test_a11y_aria_labels.py` (NEW, 15 tests):
- `LangToggleButtonsTests` x4 — every page's data-lang-toggle has aria-label
- `IconOnlyButtonsTests` x11 — each high-value icon button has aria-label (located by unique handler or id, not line numbers)

`python -m unittest discover -s tests -t .` — **1421 tests OK** (+15 from 1406). `ruff check .` clean.

## HANDOVER_WEB_UI.md #4 진행

| Sub | Status |
|-----|--------|
| 4a — modal role/dialog + focus trap + ESC | ✅ #216 |
| **4b — aria-label on icon-only buttons** | ✅ **this PR** |
| 4c — WCAG AA contrast audit (--muted-2 ≈ 3.4:1) | 🔜 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)