### PR TITLE
refactor(brand): shorten label + boost header visibility

### DIFF
--- a/frontend/HANDOVER_WEB_UI.md
+++ b/frontend/HANDOVER_WEB_UI.md
@@ -12,7 +12,7 @@
 
 - v0.1 시절의 dark 컨셉을 점검하고, **공통 디자인 토큰 단일화** + **UI 브랜드 라벨 교체** 두 PR을 한 브랜치에 쌓았다.
 - 코드네임 **JAMES는 내부에만 존속**하고, UI 표면은 모두
-  **"Secure Enterprise Knowledge Intelligence, Operating System"** 으로 표시한다.
+  **"Secure Enterprise Knowledge Operating System"** 으로 표시한다.
 - 아직 main으로 머지되지 않았다. 머지 전 시각 검증 필요.
 
 ---
@@ -42,7 +42,7 @@ indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
 ### 1-2. 커밋 `508f880` — `refactor(brand): replace UI "JAMES" labels with full positioning line`
 
 배경: 사용자 지시 — UI 표면에서 "제임스"를 빼고
-"Secure Enterprise Knowledge Intelligence, Operating System" 을
+"Secure Enterprise Knowledge Operating System" 을
 표시한다.
 
 변경:
@@ -144,7 +144,7 @@ git log --oneline -3   # e686844, 508f880 두 커밋이 보여야 함
 지금까지 끝난 것:
   - 토큰 단일화 (e686844)
   - UI 브랜드 라벨 → "Secure Enterprise Knowledge
-    Intelligence, Operating System" 교체 (508f880)
+    Operating System" 교체 (508f880, 이후 "Intelligence," 제거 단축)
 
 다음 우선순위 (HANDOVER_WEB_UI.md §4):
   2. 반응형 확장 (admin/workspace/graph 용 mobile.css)
@@ -170,7 +170,7 @@ git log --oneline -3   # e686844, 508f880 두 커밋이 보여야 함
 4. /graph                   — "Reasoning Graph" 함께
 5. 모달 — 로그인/회원가입 타이틀이 "로그인 / 회원가입" 으로만 나오는지
 6. 환영 화면 — "Welcome to Secure Enterprise Knowledge
-   Intelligence, Operating System"
+   Operating System"
 7. admin → 캐릭터 → Identity 이름 입력 placeholder 가
    풀 문구가 아니라 "JAMES" 인지 (이게 풀 문구면 페르소나 기본값
    바인딩이 잘못된 것)
@@ -212,8 +212,7 @@ git log --oneline -3   # e686844, 508f880 두 커밋이 보여야 함
 │    508f880  refactor(brand): replace UI "JAMES" labels  │
 │                                                          │
 │  Brand line (UI only):                                   │
-│    "Secure Enterprise Knowledge Intelligence,           │
-│     Operating System"                                    │
+│    "Secure Enterprise Knowledge Operating System"        │
 │  Codename JAMES — kept in env vars / persona / code.    │
 │                                                          │
 │  Files touched:                                          │

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>Secure Enterprise Knowledge Intelligence, Operating System — Admin</title>
+<title>Secure Enterprise Knowledge Operating System — Admin</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
 
@@ -437,7 +437,7 @@
 <body>
 <header>
   <div class="logo">
-    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span style="color:var(--muted);font-size:11px;margin-left:6px">· Admin Console</span>
   </div>
   <div class="header-right">
@@ -1436,7 +1436,7 @@
      aria-labelledby="admin-login-modal-title"
      style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;z-index:300;">
   <div style="background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:36px;width:340px;box-shadow:0 24px 80px rgba(0,0,0,.7);">
-    <div id="admin-login-modal-title" style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--danger);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Intelligence, Operating System · Admin</div>
+    <div id="admin-login-modal-title" style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--danger);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Operating System · Admin</div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:24px;" data-i18n="auth.admin_required">Admin login required</div>
     <div style="margin-bottom:14px;">
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">ADMIN ID</div>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>Secure Enterprise Knowledge Intelligence, Operating System — Reasoning Graph</title>
+<title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
   :root {
@@ -393,7 +393,7 @@
 
 <header>
   <div class="logo">
-    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span style="color:var(--muted);font-size:11px;margin-left:6px">· <span data-i18n="graph.title">Reasoning Graph</span></span>
   </div>
   <div class="header-right">
@@ -486,7 +486,7 @@
      role="dialog" aria-modal="true"
      aria-labelledby="login-modal-title">
   <div class="modal-card">
-    <div id="login-modal-title" style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--accent-fg);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Intelligence, Operating System</div>
+    <div id="login-modal-title" style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--accent-fg);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Operating System</div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:24px;" data-i18n="auth.admin_required">Admin login required</div>
     <div style="margin-bottom:14px;">
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">ADMIN ID</div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>Secure Enterprise Knowledge Intelligence, Operating System</title>
+<title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
 
@@ -891,7 +891,7 @@
        the tagline frames it as a knowledge + security intelligence
        suite, not a chat toy. -->
   <div class="logo">
-    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
   </div>
   <div class="header-right">
     <div class="source-toggle">
@@ -1069,7 +1069,7 @@
       <div class="welcome" id="welcome">
         <!-- [#A8-9] welcome reframed: knowledge + security + report
              intelligence (was generic "Graph-RAG 지식 추론 엔진"). -->
-        <div class="welcome-title">Welcome to <span class="brand" style="font-size:inherit">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span></div>
+        <div class="welcome-title">Welcome to <span class="brand" style="font-size:inherit">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span></div>
         <div class="welcome-sub">
           <span data-i18n="app.subtitle">지식·보안·보고서 인텔리전스 시스템</span><br>
           <span style="font-size:12px;color:var(--muted-2);font-family:var(--font-mono);

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -5,7 +5,7 @@
 
 const TRANSLATIONS = {
   en: {
-    'app.name':              'Secure Enterprise Knowledge Intelligence, Operating System',
+    'app.name':              'Secure Enterprise Knowledge Operating System',
     'app.subtitle':          'Security-focused Graph-RAG knowledge engine',
     'app.welcome':           'Ask me anything',
     'app.admin':             'ADMIN',
@@ -40,7 +40,7 @@ const TRANSLATIONS = {
     'common.start':          'Start',
     'common.last':           'Last',
 
-    'chat.title':            'Secure Enterprise Knowledge Intelligence, Operating System — Security Reasoning Engine',
+    'chat.title':            'Secure Enterprise Knowledge Operating System — Security Reasoning Engine',
     'chat.placeholder':      'Type a message (Shift+Enter for new line)',
     'chat.example1':         'What is economics?',
     'chat.example2':         'Find documents about John Smith',
@@ -517,7 +517,7 @@ const TRANSLATIONS = {
   },
 
   ko: {
-    'app.name':              'Secure Enterprise Knowledge Intelligence, Operating System',
+    'app.name':              'Secure Enterprise Knowledge Operating System',
     'app.subtitle':          '보안 중심 Graph-RAG 지식 추론 엔진',
     'app.welcome':           '무엇이든 물어보세요',
     'app.admin':             '관리자',
@@ -552,7 +552,7 @@ const TRANSLATIONS = {
     'common.start':          '시작',
     'common.last':           '마지막',
 
-    'chat.title':            'Secure Enterprise Knowledge Intelligence, Operating System — 보안 추론 엔진',
+    'chat.title':            'Secure Enterprise Knowledge Operating System — 보안 추론 엔진',
     'chat.placeholder':      '메시지를 입력하세요 (Shift+Enter: 줄바꿈)',
     'chat.example1':         '경제학이란 무엇인가?',
     'chat.example2':         '김철수 관련 자료 찾아줘',

--- a/frontend/static/preview-cyber.html
+++ b/frontend/static/preview-cyber.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#04060a">
+<title>Cyber concept preview — JAMES (minimal mono)</title>
+<style>
+/* ── Minimal-mono cyber palette ────────────────────────────────
+ * 단일 액센트(민트-시안)만으로 모든 인터랙티브 / 상태 표현을 처리.
+ * indigo / green / multi-color status 는 의도적으로 제거.
+ * 빨강은 오류 경고에만 한정 (semantic distinct).
+ */
+:root {
+  /* 깊은 검정 — 모니터 사진의 톤에 맞춘 #04060a (현재 --bg #0a0c11 보다 한 단계 더 진함) */
+  --bg:           #04060a;
+  --surface:      #07090e;        /* 거의 bg 와 동일 — 카드는 outline 으로만 구분 */
+  --surface-2:    #0b0e14;
+
+  /* 단일 액센트 — 민트-시안 */
+  --accent:       #6be7d0;
+  --accent-soft:  rgba(107,231,208,.10);
+  --accent-dim:   rgba(107,231,208,.35);
+  --accent-line:  rgba(107,231,208,.55);
+
+  /* 텍스트는 흰색 / 흐린 흰색 / 액센트색 3단계만 */
+  --text:         #f1f5f3;
+  --text-soft:    #b9c2bf;
+  --muted:        #6a716e;
+
+  /* 경고 빨강만 보존 — 의미 구분 위해 */
+  --danger:       #ef4444;
+
+  --font-mono:    'JetBrains Mono', ui-monospace, monospace;
+  --font-ui:      'Inter', 'Pretendard', system-ui, sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  min-height: 100vh;
+  padding: 32px 24px 96px;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* ── 6a: 배경 분위기 — 그리드 + 단색 라디얼 (cyan 하나만) ── */
+body.bg-on::before {
+  content: "";
+  position: fixed; inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(70vw 55vh at 92% 0%,
+                    rgba(107,231,208,.05), transparent 60%),
+    radial-gradient(55vw 45vh at 8% 100%,
+                    rgba(107,231,208,.04), transparent 65%),
+    repeating-linear-gradient(0deg,
+                              rgba(107,231,208,.020) 0 1px,
+                              transparent 1px 36px),
+    repeating-linear-gradient(90deg,
+                              rgba(107,231,208,.020) 0 1px,
+                              transparent 1px 36px);
+  z-index: 0;
+}
+.wrap { position: relative; z-index: 1; max-width: 1100px; margin: 0 auto; }
+
+h1 {
+  font-size: 18px; font-weight: 600; letter-spacing: .3px;
+}
+.sub {
+  color: var(--muted); font-family: var(--font-mono);
+  font-size: 11px; margin: 4px 0 24px;
+}
+.toggle-bar {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 28px; padding: 12px;
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  border-radius: 8px;
+}
+.toggle-bar label {
+  font-size: 12px; cursor: pointer;
+  padding: 5px 10px; border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--text-soft);
+  user-select: none;
+}
+.toggle-bar input { accent-color: var(--accent); }
+
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media (max-width: 800px) { .row { grid-template-columns: 1fr; } }
+
+.demo {
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  border-radius: 10px;
+  padding: 20px;
+  position: relative;
+}
+.demo h3 {
+  font-size: 13px; font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--text);
+}
+.demo .tag {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--accent); margin-bottom: 16px;
+  letter-spacing: .5px;
+}
+.demo p { font-size: 12px; color: var(--text-soft); line-height: 1.55; margin-bottom: 14px; }
+.demo .row-btn { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+
+/* ── 6b: 단색 outline 버튼 + glow ───────────────────────────── */
+.btn {
+  background: transparent;
+  border: 1px solid var(--accent-line);
+  color: var(--text); padding: 7px 16px;
+  border-radius: 7px; font-size: 12px;
+  font-family: var(--font-ui); cursor: pointer;
+  transition: box-shadow .25s ease, color .2s, border-color .2s;
+  letter-spacing: .3px;
+}
+.btn:hover { color: var(--accent); }
+.btn.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+body.glow-on .btn {
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.10),
+    0 0 14px rgba(107,231,208,.18);
+}
+body.glow-on .btn.primary {
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.30),
+    0 0 22px rgba(107,231,208,.32);
+}
+.icon-btn {
+  width: 32px; height: 32px;
+  border: 1px solid var(--accent-line);
+  background: transparent;
+  border-radius: 7px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--accent);
+  cursor: pointer;
+}
+body.glow-on .icon-btn {
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.15),
+    0 0 14px rgba(107,231,208,.20);
+}
+
+/* 단색 role badge — dot 도 cyan, 글자도 cyan */
+.role-badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 11px;
+  padding: 6px 12px; border-radius: 6px;
+  background: transparent; border: 1px solid var(--accent-line);
+  color: var(--accent);
+  letter-spacing: .5px;
+}
+.role-badge .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+}
+body.glow-on .role-badge {
+  box-shadow: 0 0 14px rgba(107,231,208,.18);
+}
+body.glow-on .role-badge .dot {
+  box-shadow: 0 0 6px var(--accent);
+}
+
+/* ── 6c: 단색 glassmorphism ────────────────────────────────── */
+.modal-overlay {
+  position: fixed; inset: 0; z-index: 50;
+  display: none; align-items: center; justify-content: center;
+  background: rgba(0,0,0,.55);
+}
+body.glass-on .modal-overlay {
+  background: rgba(4,6,10,.35);
+  backdrop-filter: blur(12px) saturate(125%);
+  -webkit-backdrop-filter: blur(12px) saturate(125%);
+}
+.modal-overlay.open { display: flex; }
+.modal {
+  background: rgba(7,9,14,.92);
+  border: 1px solid var(--accent-dim);
+  border-radius: 12px;
+  padding: 28px;
+  width: 360px; max-width: 92vw;
+}
+body.glass-on .modal {
+  background: rgba(7,9,14,.55);
+  backdrop-filter: blur(20px) saturate(135%);
+  -webkit-backdrop-filter: blur(20px) saturate(135%);
+  border: 1px solid var(--accent-line);
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.06) inset,
+    0 24px 80px rgba(0,0,0,.6),
+    0 0 28px rgba(107,231,208,.12);
+}
+.modal h3 { font-size: 14px; margin-bottom: 10px; color: var(--accent); letter-spacing: .3px; }
+.modal p  { font-size: 12px; color: var(--text-soft); margin-bottom: 18px; line-height: 1.55; }
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+/* ── 6d: 단색 live indicator ───────────────────────────────── */
+@keyframes cyber-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(107,231,208,.55); }
+  60%      { box-shadow: 0 0 0 8px rgba(107,231,208,0); }
+}
+.live-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); display: inline-block;
+}
+body.live-on .live-dot {
+  animation: cyber-pulse 1.6s ease-out infinite;
+}
+.live-label {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--accent); letter-spacing: 1.5px;
+}
+
+.src-toggle {
+  display: inline-flex; border: 1px solid var(--accent-line);
+  border-radius: 7px; overflow: hidden;
+}
+.src-toggle button {
+  background: transparent; border: 0; color: var(--muted);
+  padding: 6px 14px; cursor: pointer; font-size: 11px;
+  font-family: var(--font-mono); position: relative;
+  letter-spacing: .5px;
+}
+.src-toggle button.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+body.live-on .src-toggle button.active::after {
+  content: "";
+  position: absolute; left: 0; right: 0; bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  animation: scan 1.8s linear infinite;
+}
+@keyframes scan {
+  0%   { transform: translateX(-100%); opacity: .2; }
+  50%  { opacity: 1; }
+  100% { transform: translateX(100%); opacity: .2; }
+}
+
+/* ── Top-bar replica — 첨부 이미지 그대로 재현 ──────────────── */
+.topbar {
+  display: flex; gap: 12px; align-items: center;
+  padding: 16px 12px;
+  margin: 28px 0;
+  border: 1px solid var(--accent-dim);
+  border-radius: 10px;
+  flex-wrap: wrap;
+}
+.topbar-label {
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--accent); letter-spacing: .5px;
+  flex-basis: 100%;
+  margin-bottom: 4px;
+}
+.tb-btn {
+  background: transparent;
+  border: 1px solid var(--accent-line);
+  color: var(--accent);
+  padding: 8px 18px;
+  border-radius: 9px;
+  font-family: var(--font-mono); font-size: 13px;
+  letter-spacing: .5px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+body.glow-on .tb-btn {
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.12),
+    0 0 16px rgba(107,231,208,.18);
+}
+.tb-btn .pipe { color: var(--text-soft); }
+.tb-icon { width: 14px; height: 14px; }
+
+footer.note {
+  margin-top: 24px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--muted);
+  line-height: 1.7;
+  border-top: 1px solid var(--accent-dim); padding-top: 12px;
+}
+footer.note code { color: var(--accent); }
+</style>
+</head>
+<body class="bg-on glow-on glass-on live-on">
+
+<div class="wrap">
+  <h1>Cyber concept preview — minimal mono</h1>
+  <div class="sub">SINGLE ACCENT · #6BE7D0 MINT-CYAN · NO INDIGO / GREEN / MULTI-COLOR STATUS</div>
+
+  <div class="toggle-bar">
+    <label><input type="checkbox" id="t6a" checked> 6a 배경 텍스처</label>
+    <label><input type="checkbox" id="t6b" checked> 6b Glow</label>
+    <label><input type="checkbox" id="t6c" checked> 6c Glassmorphism</label>
+    <label><input type="checkbox" id="t6d" checked> 6d Live indicator</label>
+  </div>
+
+  <!-- 첨부 이미지의 상단 바 그대로 재현 -->
+  <div class="topbar">
+    <div class="topbar-label">▸ TOP BAR — replica of reference image</div>
+    <button class="tb-btn"><span class="pipe">|</span>EN</button>
+    <button class="tb-btn" aria-label="삭제">
+      <svg class="tb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+    </button>
+    <button class="tb-btn" aria-label="채팅">
+      <svg class="tb-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8l-4 4V6a2 2 0 0 1 2-2z"/></svg>
+    </button>
+    <button class="tb-btn">ADMIN ×</button>
+    <button class="tb-btn">
+      <svg class="tb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 7H4v5h16V7zM4 12v8a1 1 0 0 0 1 1h6V12M20 12v8a1 1 0 0 1-1 1h-6V12M12 7V3M12 7a3 3 0 1 1-3-3M12 7a3 3 0 1 0 3-3"/></svg>
+      Workspace
+    </button>
+  </div>
+
+  <div class="row">
+
+    <!-- 6a -->
+    <div class="demo">
+      <h3>6a — 배경 분위기</h3>
+      <div class="tag">SUBTLE TEXTURE · MONO</div>
+      <p>그리드도 라디얼 글로우도 <strong>액센트 한 색조</strong>로만 (이전: cyan + indigo 두 색조). 노이즈 한계 5% 이하. 화면 전체에 반영됨 — 체크박스로 끄고 비교.</p>
+    </div>
+
+    <!-- 6b -->
+    <div class="demo">
+      <h3>6b — Outline + glow</h3>
+      <div class="tag">SINGLE ACCENT</div>
+      <p>모든 버튼이 동일 outline + 동일 glow. \"채워진 버튼\" 없음 — 첨부 이미지와 동일.</p>
+      <div class="row-btn">
+        <button class="btn primary">분석 실행</button>
+        <button class="btn">취소</button>
+        <button class="icon-btn">★</button>
+      </div>
+      <div style="margin-top:14px">
+        <span class="role-badge"><span class="dot"></span> ADMIN@JAMES</span>
+      </div>
+    </div>
+
+    <!-- 6c -->
+    <div class="demo">
+      <h3>6c — Glassmorphism</h3>
+      <div class="tag">backdrop-filter · MONO border</div>
+      <p>모달 배경 frosted + 액센트 한 색조의 outline + 미세 glow. \"공간에 떠있는 단색 유리 패널\".</p>
+      <div class="row-btn">
+        <button class="btn primary" onclick="document.getElementById('demo-modal').classList.add('open')">모달 열기</button>
+      </div>
+    </div>
+
+    <!-- 6d -->
+    <div class="demo">
+      <h3>6d — Live indicators</h3>
+      <div class="tag">PULSE · SCAN · MONO</div>
+      <p>상태 색이 cyan 하나 — green/yellow/red 다색 라이브 LED 제거. 빨강은 오류 시만 등장.</p>
+      <div class="row-btn">
+        <span class="live-label"><span class="live-dot"></span> LIVE</span>
+        <div class="src-toggle">
+          <button class="active">PROD</button>
+          <button>TEST</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <footer class="note">
+    팔레트 단일화: <code>--accent #6be7d0</code> (민트-시안) 만으로 outline / icon / status dot / live pulse / scan line 모두 처리.<br>
+    검정 한 단계 더 진한 <code>--bg #04060a</code>. 인디고/그린/멀티컬러 상태 제거. 빨강 <code>--danger</code> 은 오류 표시에만 한정.<br>
+    상단 체크박스로 4 효과 끄고 비교. 첨부 이미지의 상단 바 6 버튼을 재현했습니다.
+  </footer>
+</div>
+
+<div class="modal-overlay" id="demo-modal" onclick="if(event.target.id==='demo-modal') this.classList.remove('open')">
+  <div class="modal">
+    <h3>▸ MONO PREVIEW</h3>
+    <p>단색 액센트 outline · backdrop blur · 미세 glow. 6c 토글을 끄면 평면 dim 비교 가능.</p>
+    <div class="modal-actions">
+      <button class="btn" onclick="document.getElementById('demo-modal').classList.remove('open')">CLOSE</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const map = { t6a: 'bg-on', t6b: 'glow-on', t6c: 'glass-on', t6d: 'live-on' };
+for (const id of Object.keys(map)) {
+  document.getElementById(id).addEventListener('change', (e) => {
+    document.body.classList.toggle(map[id], e.target.checked);
+  });
+}
+</script>
+</body>
+</html>

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -61,25 +61,33 @@
 
 /* ── Brand mark ──
  * Long-form product name shown in headers, modals, welcome screens.
- * The first line carries the primary positioning; the trailing
- * "Operating System" sits one weight/colour notch below so the
- * compound reads as a system identity rather than a sentence.
- * Used inside .logo, .modal-title, .welcome-title etc. */
+ * The first line ("Secure Enterprise Knowledge") carries the primary
+ * positioning; the trailing "Operating System" sits one weight notch
+ * below but on the same colour band so the full compound stays
+ * readable at a glance. Both halves use --text-soft or stronger —
+ * --muted is intentionally avoided here because the brand line is
+ * load-bearing identity, not metadata.
+ * Used inside .logo, .modal-title, .welcome-title etc.
+ *
+ * Visibility tuning (2026-05-12):
+ *   - 12px → 14px : header readable without leaning in
+ *   - brand-tail --muted → --text-soft (5.92:1 → 11.48:1 on --bg)
+ *   - weight 500 → 550 on tail for slight emphasis lift */
 .brand {
   font-weight: 600;
-  font-size: 12px;
+  font-size: 14px;
   letter-spacing: .25px;
   line-height: 1.25;
   white-space: nowrap;
   color: var(--text);
 }
 .brand .brand-tail {
-  font-weight: 500;
-  color: var(--muted);
-  margin-left: 3px;
+  font-weight: 550;
+  color: var(--text-soft);
+  margin-left: 4px;
 }
 @media (max-width: 900px) {
-  .brand { font-size: 11px; letter-spacing: .15px; }
+  .brand { font-size: 12px; letter-spacing: .15px; }
 }
 @media (max-width: 640px) {
   .brand { white-space: normal; }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#0a0c11">
-<title>Secure Enterprise Knowledge Intelligence, Operating System — Workspace</title>
+<title>Secure Enterprise Knowledge Operating System — Workspace</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <!-- Shared mobile responsive overrides (touch targets, iOS font-size,
      safe-area-inset, generic modal/table rules). Workspace-specific
@@ -241,7 +241,7 @@
 
 <header>
   <div class="logo">
-    <span class="brand">Secure Enterprise Knowledge Intelligence,<span class="brand-tail">Operating System</span></span>
+    <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span class="tagline" data-i18n="workspace.tagline">Workspace · 데이터 + 작업</span>
   </div>
   <div class="header-right">


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md `Intelligence,` 토큰 제거 + 헤더 시인성 향상 1차.

- Brand line: `Secure Enterprise Knowledge Intelligence, Operating System` → **`Secure Enterprise Knowledge Operating System`**
- `.brand` 12→**14px** (모바일 11→12px) + `.brand-tail` color `--muted`→`--text-soft` (3.16:1 미달 회피, 5.92:1 → **11.48:1**) + weight 500→550
- `preview-cyber.html` 추가 — 모노 mint-cyan 컨셉 레퍼런스 (라이브 페이지 아님, `/static/preview-cyber.html` 정적 자산)

## Why

- 사용자 피드백: "Intelligence," 가 헤더에서 한 줄을 넘기고 시각적으로 무겁다 → 단축
- `--muted-2`/`--muted` 가 작은 텍스트(11~12px)에서 가독성 저하 → 헤더 식별성 회복 필요
- #218 에서 `--muted-2` 자체는 4.67:1 으로 끌어올렸지만, brand-tail 은 `--muted` 사용 중 → 동일 흐름으로 한 단계 더 강한 `--text-soft` 채택

## Verification

- `python -m unittest discover -s tests -t .` → **1430 tests OK** (변동 없음, 프론트 only)
- `ruff check .` clean
- WCAG: `.brand-tail` 11.48:1 (AA normal 4.5 통과, AAA 7.0 통과)
- 시각 검증 사용자 체크리스트 (HANDOVER_WEB_UI §5-3):
  - [ ] `/` `/admin` `/workspace` `/graph` 헤더 — 한 줄 풀 라벨 + Operating System tail 살짝 약함
  - [ ] 로그인/회원가입 모달 타이틀
  - [ ] welcome 화면
  - [ ] `<900px` 12px / `<640px` 줄바꿈
  - [ ] theme-color `#0a0c11`

## Out of scope

- 인라인 핸들러 → 이벤트 위임 (HANDOVER §4 #5)
- admin.html legacy 미정의 토큰 정리 (#6)
- 상단 그라데이션 레일 공통화 (#7)
- `preview-cyber.html` 의 mint-cyan 컨셉을 실제 페이지에 반영하는 작업 — 별도 결정 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)