### PR TITLE
refactor(frontend): drop legacy CSS token aliases

### DIFF
--- a/frontend/HANDOVER_WEB_UI.md
+++ b/frontend/HANDOVER_WEB_UI.md
@@ -97,9 +97,11 @@ indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
 4. **theme-color**: `#0a0c11` 으로 통일.
 5. **반응형 분기**: `.brand` 가 900px → 11px, 640px → 자동 줄바꿈.
    이 규칙이 부족하면 `tokens.css` 의 `@media` 두 블록만 수정.
-6. **legacy 미정의 토큰**: `admin.html` 에 `var(--accent2 / --bg2 /
-   --card / --fg)` 호출이 남아 있다. **이번 PR 이전부터 깨져 있던**
-   참조이므로 이 PR 의 범위 밖. 별도 클린업 PR 에서 정리.
+6. ~~**legacy 미정의 토큰**: `admin.html` 에 `var(--accent2 / --bg2 /
+   --card / --fg)` 호출이 남아 있다.~~ **DONE** (브랜치
+   `chore/v0.2-legacy-tokens` 에서 `--accent2 → --brand-2`,
+   `--fg → --text`, `--bg2 → --surface-2`, `--card → --surface-2`
+   로 일괄 치환).
 
 ---
 
@@ -115,12 +117,12 @@ indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
 | 3 | 추론 패널 강화 — retrieve → expand → verify timeline + 인용 노드 + 신뢰도 bar + sensitivity 배지 | 4~6h | Graph-RAG 차별점 시각화 |
 | 4 | 접근성 패스 — modal `role="dialog"` + focus trap + ESC, `aria-label`, `--muted-2` 대비 감사 (AA ~3.4:1 미달 가능) | 2h | |
 | 5 | 인라인 핸들러(`onclick=…`) → 이벤트 위임 + `data-action` | 3h | CSP 강화 대비 |
-| 6 | `admin.html` legacy 미정의 토큰(`--accent2 / --bg2 / --card / --fg`) 정리 | 30분 | tokens.css 에 별칭 추가 또는 호출 측 치환 |
+| 6 | ~~`admin.html` legacy 미정의 토큰(`--accent2 / --bg2 / --card / --fg`) 정리~~ | — | **DONE** (브랜치 `chore/v0.2-legacy-tokens`) |
 | 7 | 상단 그라데이션 레일(`body::before`)을 4페이지 공통화 | 30분 | 현재 index 만 있음. tokens.css 또는 별도 global.css 로 이동 |
 | 8 | 인라인 `<style>` 블록 완전 분리 — `static/styles.css` | 4h | `index.html` 615줄 / `admin.html` 530줄까지 인라인 |
 
-추천 다음 단계: **#6 (legacy 토큰 클린업)** 또는 **#7 (그라데이션 레일 공통화)**
-— 둘 다 작고 안전하며 토큰 통합 PR 의 흐름 안에 들어간다.
+추천 다음 단계: **#7 (그라데이션 레일 공통화)** —
+작고 안전하며 토큰 통합 PR 의 흐름 안에 들어간다.
 
 ---
 

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -571,11 +571,11 @@
         <input id="mypw-old" type="password"
                data-i18n-placeholder="users.mypw_old_ph" placeholder="현재 비밀번호"
                autocomplete="current-password"
-               style="flex:1;min-width:160px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);font-size:13px">
+               style="flex:1;min-width:160px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px">
         <input id="mypw-new" type="password"
                data-i18n-placeholder="users.mypw_new_ph" placeholder="새 비밀번호 (8~72자, 영문+숫자)"
                autocomplete="new-password"
-               style="flex:2;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);font-size:13px">
+               style="flex:2;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px">
         <button onclick="changeMyPassword()"
                 style="padding:8px 14px;background:#1e7a3e;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px"
                 data-i18n="users.mypw_submit">변경</button>
@@ -590,7 +590,7 @@
                  data-i18n-placeholder="users.mykey_label_ph"
                  placeholder="라벨 (선택, 예: ci-deploy)"
                  maxlength="64"
-                 style="flex:1;min-width:160px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);font-size:12px">
+                 style="flex:1;min-width:160px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
           <button onclick="issueMyApiKey()"
                   style="padding:7px 12px;background:#1e5a7a;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:12px"
                   data-i18n="users.mykey_issue">키 발급</button>
@@ -671,13 +671,13 @@
                placeholder="이름 / id 검색 (substring)"
                style="flex:1;min-width:200px;padding:8px 12px;
                       background:var(--bg);border:1px solid var(--border);
-                      border-radius:6px;color:var(--fg);font-size:13px"
+                      border-radius:6px;color:var(--text);font-size:13px"
                oninput="onEntitiesSearchInput()">
         <select id="entities-etype-filter"
                 onchange="loadEntities()"
                 style="padding:8px 12px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
-                       color:var(--fg);font-size:13px">
+                       color:var(--text);font-size:13px">
           <option value="">모든 타입</option>
         </select>
         <span id="entities-counter"
@@ -697,13 +697,13 @@
         <button onclick="entitiesPage(-1)" id="entities-prev"
                 style="padding:6px 14px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
-                       color:var(--fg);cursor:pointer">← 이전</button>
+                       color:var(--text);cursor:pointer">← 이전</button>
         <span id="entities-page-label"
               style="align-self:center;font-size:12px;color:var(--muted);font-family:var(--font-mono)">page 1</span>
         <button onclick="entitiesPage(1)" id="entities-next"
                 style="padding:6px 14px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
-                       color:var(--fg);cursor:pointer">다음 →</button>
+                       color:var(--text);cursor:pointer">다음 →</button>
       </div>
 
       <!-- Detail modal -->
@@ -714,7 +714,7 @@
                   z-index:9999;align-items:flex-start;justify-content:center;
                   overflow-y:auto;padding:40px 16px"
            onclick="closeEntityDetail(event)">
-        <div style="background:var(--card,#1e1e2e);border:1px solid var(--border);
+        <div style="background:var(--surface-2);border:1px solid var(--border);
                     border-radius:8px;padding:20px;max-width:720px;width:100%;
                     max-height:85vh;overflow-y:auto" onclick="event.stopPropagation()">
           <div style="display:flex;justify-content:space-between;align-items:center;
@@ -769,7 +769,7 @@
                   z-index:9999;align-items:flex-start;justify-content:center;
                   overflow-y:auto;padding:40px 16px"
            onclick="closeSessionTurns(event)">
-        <div style="background:var(--card,#1e1e2e);border:1px solid var(--border);
+        <div style="background:var(--surface-2);border:1px solid var(--border);
                     border-radius:8px;padding:20px;max-width:820px;width:100%;
                     max-height:85vh;overflow-y:auto" onclick="event.stopPropagation()">
           <div style="display:flex;justify-content:space-between;align-items:center;
@@ -1076,7 +1076,7 @@
       <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
         <select id="audit-category"
                 onchange="audit_reload()"
-                style="padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);font-size:12px">
+                style="padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
           <option value="all"        data-i18n="audit.cat_all">전체</option>
           <option value="user_mgmt"  data-i18n="audit.cat_user_mgmt">사용자 관리</option>
           <option value="password"   data-i18n="audit.cat_password">비밀번호/가입</option>
@@ -1091,7 +1091,7 @@
                data-i18n-placeholder="audit.search_ph"
                placeholder="이벤트 / username / 키 prefix 검색"
                oninput="audit_searchInput()"
-               style="flex:1;min-width:200px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);font-size:12px">
+               style="flex:1;min-width:200px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
         <span id="audit-counter"
               style="font-size:11px;color:var(--muted);font-family:var(--font-mono)"></span>
       </div>
@@ -1111,12 +1111,12 @@
       <div style="display:flex;gap:8px;justify-content:center;margin-top:12px">
         <button onclick="audit_page(-1)"
                 id="audit-prev"
-                style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer">← 이전</button>
+                style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer">← 이전</button>
         <span id="audit-page-label"
               style="align-self:center;font-size:12px;color:var(--muted);font-family:var(--font-mono)">page 1</span>
         <button onclick="audit_page(1)"
                 id="audit-next"
-                style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer">다음 →</button>
+                style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer">다음 →</button>
       </div>
     </div>
 
@@ -1326,9 +1326,9 @@
             </div>
             <div style="display:flex;gap:4px">
               <span style="font-size:11px;padding:2px 7px;border-radius:4px;
-                           background:var(--bg2);color:var(--muted)" data-i18n="set.speed_fast">1=fast</span>
+                           background:var(--surface-2);color:var(--muted)" data-i18n="set.speed_fast">1=fast</span>
               <span style="font-size:11px;padding:2px 7px;border-radius:4px;
-                           background:var(--bg2);color:var(--muted)" data-i18n="set.speed_precise">5=precise</span>
+                           background:var(--surface-2);color:var(--muted)" data-i18n="set.speed_precise">5=precise</span>
             </div>
           </div>
         </div>
@@ -1411,9 +1411,9 @@
                    oninput="applyWsThresholdLabel(this.value)">
             <div style="display:flex;gap:4px">
               <span style="font-size:11px;padding:2px 7px;border-radius:4px;
-                           background:var(--bg2);color:var(--muted)">안함</span>
+                           background:var(--surface-2);color:var(--muted)">안함</span>
               <span style="font-size:11px;padding:2px 7px;border-radius:4px;
-                           background:var(--bg2);color:var(--muted)">강력</span>
+                           background:var(--surface-2);color:var(--muted)">강력</span>
             </div>
           </div>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -538,7 +538,7 @@
   }
   .file-progress-fill {
     height: 100%; width: 0;
-    background: linear-gradient(90deg, var(--accent2), var(--accent));
+    background: linear-gradient(90deg, var(--brand-2), var(--accent));
     transition: width .15s ease;
   }
   .file-progress-pct {
@@ -552,7 +552,7 @@
     border-radius: 6px;
     font-size: 11px; font-family: var(--font-mono);
   }
-  .queue-progress-text { color: var(--accent2); margin-bottom: 4px; word-break: break-all; }
+  .queue-progress-text { color: var(--brand-2); margin-bottom: 4px; word-break: break-all; }
   .queue-progress-bar  {
     height: 2px; background: rgba(255,255,255,.06);
     border-radius: 1px; overflow: hidden;

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -605,7 +605,7 @@ async function loadUsers() {
           <tr>
             <td class="mono">${u.username}</td>
             <td class="mono">${u.created_at?.slice(0,10) || '-'}</td>
-            <td><select id="approve-role-${safeName}" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--fg)">${opts}</select></td>
+            <td><select id="approve-role-${safeName}" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)">${opts}</select></td>
             <td>
               <button onclick="approveUser('${u.username}')" style="padding:4px 10px;margin-right:4px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.approve')}</button>
               <button onclick="rejectUser('${u.username}')" style="padding:4px 10px;background:#7a1e1e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.reject')}</button>
@@ -1500,7 +1500,7 @@ async function loadAudit() {
       const isBlock = it.blocked
         || /fail|rejected|blocked|denied|invalid/i.test(ev);
       const evCell = ev
-        ? `<span style="${isBlock ? 'color:#d97a7a' : 'color:var(--fg)'}">${_auditEscapeHtml(ev)}</span>`
+        ? `<span style="${isBlock ? 'color:#d97a7a' : 'color:var(--text)'}">${_auditEscapeHtml(ev)}</span>`
         : '<span style="color:var(--muted)">—</span>';
       return `
         <tr>
@@ -2276,7 +2276,7 @@ async function loadPerformance() {
     const perf = data.performance || {};
     const imp  = data.importance  || {};
 
-    const gradeColor = { A:'var(--success)', B:'var(--accent2)',
+    const gradeColor = { A:'var(--success)', B:'var(--brand-2)',
                          C:'var(--warn)', D:'var(--danger)', 'N/A':'var(--muted)' };
     const last = await api('/admin/performance/history/?limit=1');
     const lastGrade = last.history?.[0]?.grade || 'N/A';
@@ -2307,7 +2307,7 @@ async function loadPerfHistory() {
   try {
     const data  = await api('/admin/performance/history/?limit=10');
     const tbody = document.getElementById('perf-history-body');
-    const gradeColor = { A:'var(--success)', B:'var(--accent2)',
+    const gradeColor = { A:'var(--success)', B:'var(--brand-2)',
                          C:'var(--warn)', D:'var(--danger)' };
     tbody.innerHTML = (data.history || []).map(h => `
       <tr>

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1822,7 +1822,7 @@ function formatAnswer(text) {
     return `\x00CODE${idx}\x00`;
   });
   text = escHtml(text);
-  text = text.replace(/^###\s+(.+)$/gm, '<strong style="font-size:13px;color:var(--accent2)">$1</strong>');
+  text = text.replace(/^###\s+(.+)$/gm, '<strong style="font-size:13px;color:var(--brand-2)">$1</strong>');
   text = text.replace(/^##\s+(.+)$/gm,  '<strong style="font-size:14px;color:var(--accent)">$1</strong>');
   text = text.replace(/^#\s+(.+)$/gm,   '<strong style="font-size:15px;color:var(--accent)">$1</strong>');
   text = text.replace(/^---+$/gm, '<hr style="border:none;border-top:1px solid var(--border);margin:6px 0">');


### PR DESCRIPTION
## Summary

- Replaces 4 undefined CSS token names that survived the tokens.css consolidation in PR #214.
- `--accent2` → `--brand-2`, `--fg` → `--text`, `--bg2` → `--surface-2`, `--card` → `--surface-2`.
- 4 frontend files touched (admin.html, index.html, admin.js, chat.js) + handover doc.

## Why

All four legacy names were never defined in tokens.css, so the call sites silently fell back to `initial`, or to the hard-coded fallback colour (`var(--card,#1e1e2e)`). The drift was tracked as item #6 of the HANDOVER_WEB_UI.md cleanup queue and explicitly deferred out of PR #214.

## Verification

- Grep confirms zero `var(--accent2|--fg|--bg2|--card)` references remain under `frontend/` (only the now-resolved HANDOVER doc entry mentions them as DONE).
- No test refers to the legacy names — CSS-only rename. CI will run the suite.
- HANDOVER_WEB_UI.md item #6 marked **DONE**; "next steps" recommendation reduced to item #7.

## Out of scope

- Cyber palette migration (Task #22 — pending, separate track).
- Inline `<style>` block extraction (HANDOVER item #8 — separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)