### PR TITLE
feat(frontend): lift top accent rail into tokens.css

### DIFF
--- a/frontend/HANDOVER_WEB_UI.md
+++ b/frontend/HANDOVER_WEB_UI.md
@@ -118,11 +118,13 @@ indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
 | 4 | 접근성 패스 — modal `role="dialog"` + focus trap + ESC, `aria-label`, `--muted-2` 대비 감사 (AA ~3.4:1 미달 가능) | 2h | |
 | 5 | 인라인 핸들러(`onclick=…`) → 이벤트 위임 + `data-action` | 3h | CSP 강화 대비 |
 | 6 | ~~`admin.html` legacy 미정의 토큰(`--accent2 / --bg2 / --card / --fg`) 정리~~ | — | **DONE** (브랜치 `chore/v0.2-legacy-tokens`) |
-| 7 | 상단 그라데이션 레일(`body::before`)을 4페이지 공통화 | 30분 | 현재 index 만 있음. tokens.css 또는 별도 global.css 로 이동 |
+| 7 | ~~상단 그라데이션 레일(`body::before`)을 4페이지 공통화~~ | — | **DONE** (브랜치 `feat/v0.2-gradient-rail-common`) |
 | 8 | 인라인 `<style>` 블록 완전 분리 — `static/styles.css` | 4h | `index.html` 615줄 / `admin.html` 530줄까지 인라인 |
 
-추천 다음 단계: **#7 (그라데이션 레일 공통화)** —
-작고 안전하며 토큰 통합 PR 의 흐름 안에 들어간다.
+추천 다음 단계: **#3 (추론 패널 강화)** 또는
+**#5 (인라인 onclick 제거)** — 둘 다 mid-risk, 4~6h.
+가벼운 작업이 더 필요하면 **#8 (인라인 `<style>` 블록 분리)**
+부분 착수.
 
 ---
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,19 +8,6 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
 
-  /* [#A8-9] thin top accent rail — gives every page a subtle "system
-     header" stripe like enterprise dashboards. Doesn't move with
-     scroll, doesn't intrude on layout (1px high). */
-  body::before {
-    content: '';
-    position: fixed; top: 0; left: 0; right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, var(--accent) 0%, var(--brand-2) 100%);
-    opacity: .9;
-    z-index: 999;
-    pointer-events: none;
-  }
-
   body {
     background: var(--bg);
     color: var(--text);

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -92,3 +92,19 @@
 @media (max-width: 640px) {
   .brand { white-space: normal; }
 }
+
+/* ── Top accent rail ──
+ * Thin 2px stripe along the very top of every page — gives the app
+ * a subtle "system header" feel like enterprise dashboards. Fixed
+ * position so it survives scroll, pointer-events:none so it never
+ * blocks clicks. Originally inline in index.html only; lifted here
+ * so admin/workspace/graph inherit the same rail. */
+body::before {
+  content: '';
+  position: fixed; top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--brand-2) 100%);
+  opacity: .9;
+  z-index: 999;
+  pointer-events: none;
+}

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -71,15 +71,21 @@ class PaletteTests(unittest.TestCase):
 
 
 class TopAccentRailTests(unittest.TestCase):
+    """Top stripe was lifted from inline index.html style into tokens.css
+    so admin/workspace/graph inherit the same rail. Assertions now resolve
+    in the tokens file; index.html must NOT redeclare it."""
+
     @classmethod
     def setUpClass(cls):
-        cls.html = HTML.read_text(encoding="utf-8")
+        cls.tokens = TOKENS.read_text(encoding="utf-8")
+        cls.index_html = HTML.read_text(encoding="utf-8")
 
     def test_body_before_pseudo_present(self):
         # Subtle "system header" stripe at the top of every page.
-        self.assertIn("body::before", self.html,
-            "must add ::before stripe on body for system-header look")
-        m = re.search(r"body::before\s*\{([^}]+)\}", self.html)
+        self.assertIn("body::before", self.tokens,
+            "tokens.css must declare ::before stripe on body so all 4 "
+            "pages inherit the system-header look")
+        m = re.search(r"body::before\s*\{([^}]+)\}", self.tokens)
         self.assertIsNotNone(m)
         block = m.group(1)
         self.assertIn("position: fixed", block,
@@ -93,11 +99,18 @@ class TopAccentRailTests(unittest.TestCase):
 
     def test_stripe_is_thin(self):
         # Should be visually subtle — 1-3px tall, not a thick band.
-        m = re.search(r"body::before\s*\{[^}]*height:\s*(\d+)px", self.html)
+        m = re.search(r"body::before\s*\{[^}]*height:\s*(\d+)px", self.tokens)
         self.assertIsNotNone(m, "couldn't extract stripe height")
         height = int(m.group(1))
         self.assertLessEqual(height, 4,
             f"stripe height {height}px too thick — must be ≤ 4px")
+
+    def test_index_html_does_not_redeclare_rail(self):
+        # Guard against drift back to inline declaration — the rule
+        # belongs to tokens.css from now on.
+        self.assertNotIn("body::before", self.index_html,
+            "index.html must not redeclare body::before — it now lives "
+            "in tokens.css for all 4 pages")
 
 
 class LogoTaglineTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Moves `body::before` 2px gradient stripe from inline `<style>` in `index.html` into `tokens.css`.
- All four pages (index/admin/workspace/graph) now inherit the same system-header rail.
- TopAccentRailTests rewritten to read from `tokens.css`; new guardrail test fails if `index.html` re-introduces the inline declaration.

## Why

Only `index.html` had the rail because the rule was inline. Admin / workspace / graph looked subtly different at the top. Folding the rule into the shared `tokens.css` (already linked by every page since PR #214) is the smallest viable fix.

## Verification

- `git diff frontend/index.html` shows the inline `body::before` block removed, surrounding `<style>` intact.
- `tokens.css` now carries the rule with the same `var(--accent) → var(--brand-2)` gradient and 2px height.
- Tests updated:
  - `test_body_before_pseudo_present` now asserts on `tokens.css`.
  - `test_stripe_is_thin` now asserts on `tokens.css`.
  - New `test_index_html_does_not_redeclare_rail` guards against drift.
- HANDOVER_WEB_UI.md item #7 marked **DONE**.

## Out of scope

- Cyber palette migration (Task #22 — separate track).
- Inline `<style>` block extraction (HANDOVER #8 — separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)