### PR TITLE
feat(frontend): mono-cyber palette migration (Task #22 precursor)

### DIFF
--- a/frontend/HANDOVER_WEB_UI.md
+++ b/frontend/HANDOVER_WEB_UI.md
@@ -94,7 +94,7 @@ indigo accent, intelligence-cyan brand-2, shadow-card)를 가지고
    직접 "JAMES" 라고 쓰지 말 것.
 3. **i18n**: `app.name` 은 풀 문구. 좁은 영역(placeholder 등)에 풀
    문구가 들어가지 않도록 신규 키를 만들 것 — `app.name` 재사용 금지.
-4. **theme-color**: `#0a0c11` 으로 통일.
+4. **theme-color**: `#04060a` 으로 통일 (Task #22 mono-cyber bg).
 5. **반응형 분기**: `.brand` 가 900px → 11px, 640px → 자동 줄바꿈.
    이 규칙이 부족하면 `tokens.css` 의 `@media` 두 블록만 수정.
 6. ~~**legacy 미정의 토큰**: `admin.html` 에 `var(--accent2 / --bg2 /
@@ -180,7 +180,7 @@ git log --oneline -3   # e686844, 508f880 두 커밋이 보여야 함
    바인딩이 잘못된 것)
 8. 화면 폭 < 900px — `.brand` 가 11px 로 줄어드는지
 9. 화면 폭 < 640px — `.brand` 가 줄바꿈되는지
-10. theme-color — 브라우저 탭 상단 색이 #0a0c11 (살짝 푸른 검정) 인지
+10. theme-color — 브라우저 탭 상단 색이 #04060a (mono cyber bg) 인지
 ```
 
 ---

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0a0c11">
+<meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
@@ -165,8 +165,8 @@
   .btn-approve:hover { background: rgba(34,197,94,.2); }
   .btn-reject  { background: rgba(239,68,68,.12); color: var(--danger); border: 1px solid rgba(239,68,68,.3); }
   .btn-reject:hover { background: rgba(239,68,68,.2); }
-  .btn-primary { background: var(--accent); color: #fff; }
-  .btn-primary:hover { background: #5258e6; }
+  .btn-primary { background: var(--accent); color: var(--on-accent); }
+  .btn-primary:hover { background: var(--accent-hover); }
 
   /* ── 로그 영역 ── */
   .log-box {
@@ -1134,7 +1134,7 @@
                       border-radius:8px;color:var(--text);font-size:13px"
                onkeydown="if(event.key==='Enter') loadUploads()">
         <button onclick="loadUploads()" style="padding:8px 16px;
-                background:var(--accent);color:#fff;border:0;border-radius:8px;
+                background:var(--accent);color:var(--on-accent);border:0;border-radius:8px;
                 cursor:pointer;font-size:13px;font-weight:600">
           <span data-i18n="common.search">검색</span>
         </button>
@@ -1175,7 +1175,7 @@
                       border-radius:8px;color:var(--text);font-size:13px"
                onkeydown="if(event.key==='Enter') searchFiles()">
         <button onclick="searchFiles()" style="padding:8px 16px;
-                background:var(--accent);color:#fff;border:0;border-radius:8px;
+                background:var(--accent);color:var(--on-accent);border:0;border-radius:8px;
                 cursor:pointer;font-size:13px;font-weight:600">
           <span data-i18n="common.search">검색</span>
         </button>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0a0c11">
+<meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
@@ -513,7 +513,7 @@
     </div>
     <div id="login-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:12px;font-family:var(--font-mono);"></div>
     <button onclick="doLogin()"
-            style="width:100%;padding:11px;background:var(--accent);border:none;border-radius:8px;color:#fff;font-size:14px;font-weight:600;cursor:pointer;"
+            style="width:100%;padding:11px;background:var(--accent);border:none;border-radius:8px;color:var(--on-accent);font-size:14px;font-weight:600;cursor:pointer;"
             data-i18n="auth.login">
       Login
     </button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0a0c11">
+<meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <style>
@@ -41,16 +41,18 @@
     align-items: center;
     gap: 10px;
   }
-  /* [#A8-9] logo mark — gradient now blends accent (indigo) into
-     brand-2 (intelligence cyan) for a knowledge/security feel. Thin
-     inner shine via box-shadow inset adds depth without ostentation. */
+  /* [#A8-9] logo mark — gradient over the mono mint-cyan accent.
+     Pre-Task-#22 this blended indigo→cyan; the mono migration
+     unifies both stops on --accent so the gradient is a tonal
+     wash rather than a hue shift. Thin inner shine via box-shadow
+     inset adds depth without ostentation. */
   .logo::before {
     content: '';
     width: 22px; height: 22px;
     border-radius: 6px;
     background: linear-gradient(135deg, var(--accent) 0%, var(--brand-2) 100%);
     box-shadow: 0 0 0 1px rgba(255,255,255,.04) inset,
-                0 2px 6px rgba(82,88,230,.30);
+                0 2px 6px rgba(107,231,208,.30);
   }
   /* [#A8-9] tagline shim — "지식·보안 인텔리전스" appears beside the
      logo on wide screens, hides on phones. Tells visitors what JAMES
@@ -195,8 +197,8 @@
     font-weight: 500; cursor: pointer;
     transition: all .15s;
   }
-  .modal-btn.primary { background: var(--accent); color: #fff; }
-  .modal-btn.primary:hover { background: #5258e6; }
+  .modal-btn.primary { background: var(--accent); color: var(--on-accent); }
+  .modal-btn.primary:hover { background: var(--accent-hover); }
   .modal-btn.cancel  { background: transparent; border: 1px solid var(--border); color: var(--text-soft); }
   .modal-btn.cancel:hover { background: var(--surface-2); color: var(--text); }
 
@@ -563,7 +565,7 @@
     cursor: pointer;
     transition: background .15s;
   }
-  .upload-btn:hover { background: #5258e6; }
+  .upload-btn:hover { background: var(--accent-hover); }
   .upload-btn:disabled { background: var(--surface-2); color: var(--muted); cursor: default; }
 
   /* ── 챗 영역 ── */
@@ -814,7 +816,7 @@
     flex-shrink: 0;
     display: flex; align-items: center; justify-content: center;
   }
-  .send-btn:hover { background: #5258e6; }
+  .send-btn:hover { background: var(--accent-hover); }
   .send-btn:disabled { background: var(--surface-2); color: var(--muted); cursor: default; }
 
   /* ── 그래프 경로 ── */
@@ -898,7 +900,7 @@
       💬
       <span id="session-count-badge"
             style="display:none;position:absolute;top:-2px;right:-2px;
-                   background:var(--accent);color:#fff;border-radius:9px;
+                   background:var(--accent);color:var(--on-accent);border-radius:9px;
                    font-size:10px;padding:1px 6px;font-weight:600;line-height:1.4">
       </span>
     </button>
@@ -924,7 +926,7 @@
     <div style="font-weight:600;font-size:13px;color:var(--text)"><span data-i18n="chat.previous">이전 대화</span></div>
     <div style="display:flex;gap:6px">
       <button onclick="newSession()"
-              style="background:var(--accent);color:#fff;border:none;
+              style="background:var(--accent);color:var(--on-accent);border:none;
                      border-radius:6px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500">
         <span data-i18n="chat.new_session">+ 새 대화</span>
       </button>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -254,7 +254,7 @@ function _firstRunRow(r, primary) {
       </div>
     </div>
     <button onclick="firstRunInstall('${tag.replace(/'/g, "\\'")}')"
-            style="padding:7px 14px;background:var(--accent);color:#fff;
+            style="padding:7px 14px;background:var(--accent);color:var(--on-accent);
                    border:0;border-radius:6px;cursor:pointer;font-size:12px;
                    font-weight:600;flex-shrink:0">
       📦 설치
@@ -2408,7 +2408,7 @@ async function webLearnTopic() {
         .join('<br>');
 
       const domainBadge = r.domain
-        ? `<span style="background:var(--accent);color:#fff;border-radius:4px;
+        ? `<span style="background:var(--accent);color:var(--on-accent);border-radius:4px;
                         padding:2px 8px;font-size:10px">${r.domain}</span>`
         : '';
 

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -1,15 +1,23 @@
 /* JAMES — Web UI design tokens (single source of truth).
  *
  * Linked from index.html, admin.html, workspace.html, graph.html.
- * Replaces four duplicated :root blocks that had drifted into
- * three slightly-different palettes.
  *
- * Standardised on the [#A8-9] "report-system" polish originally
- * shipped in index.html: deeper navy-black background, slate-tinted
- * surfaces, deeper-indigo accent, plus an intelligence-cyan brand-2
- * for status badges / dividers and a shadow-card recipe for elevated
- * surfaces. Graph-page only tokens (entity-type colours) stay inline
- * in graph.html.
+ * Mono-cyber palette (2026-05-12 migration, Task #22):
+ *   Single mint-cyan accent (#6be7d0) carries every interactive
+ *   surface — buttons, links, status, dividers, gradient rail.
+ *   The prior indigo (--accent #5258e6) + intelligence-cyan
+ *   (--brand-2 #4fc3f7) duo is collapsed: --brand-2 is now an
+ *   *alias* of --accent so existing call sites keep resolving,
+ *   but they paint the same single colour. This gives the
+ *   minimal-mono cyber aesthetic locked in preview-cyber.html
+ *   without requiring a multi-file token-rename PR.
+ *
+ *   Red (--danger) is preserved — it carries semantic meaning
+ *   (errors, attack-blocked, dangerous actions) that the mono
+ *   accent cannot.
+ *
+ * Graph-page only tokens (entity-type colours) stay inline in
+ * graph.html.
  */
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
@@ -18,27 +26,36 @@
 
 :root {
   /* ── surfaces ── */
-  --bg:           #0a0c11;       /* deeper navy-black */
-  --surface:      #131620;       /* slate-tinted surface */
-  --surface-2:    #181c26;
-  --border:       #262a36;
-  --border-2:     #1d212c;
+  --bg:           #04060a;       /* deeper near-black, monitor-tone */
+  --surface:      #07090e;       /* nearly bg — cards differ by outline only */
+  --surface-2:    #0b0e14;
+  --border:       #1a1f28;
+  --border-2:     #14181f;
 
-  /* ── primary brand (deeper indigo, less playful) ── */
-  --accent:       #5258e6;
-  --accent-soft:  rgba(82,88,230,.13);
-  --accent-fg:    #a7afff;
+  /* ── primary accent — single mint-cyan, mono cyber ── */
+  --accent:       #6be7d0;
+  --accent-soft:  rgba(107,231,208,.10);
+  --accent-fg:    #a8f3e0;       /* brighter shade for prominent text */
+  --accent-hover: #56b9a7;       /* slightly darker shade for :hover */
+  --on-accent:    #04060a;       /* foreground on solid-accent fills.
+                                    Previously buttons used #fff which
+                                    fails WCAG on the mint-cyan accent
+                                    (~1.5:1) — inverse-mono is needed. */
 
-  /* ── secondary brand — "intelligence cyan", used for status
-       badges + section dividers to suggest a knowledge OS. ── */
-  --brand-2:      #4fc3f7;
-  --brand-2-soft: rgba(79,195,247,.10);
+  /* ── --brand-2 retained as an alias of --accent ──
+       Pre-migration this was an "intelligence cyan" distinct from
+       the indigo accent. The mono migration folds it into accent
+       so single-source call sites (gradient rail, file-progress,
+       formatAnswer ### headers, perf grade-B colour) keep working
+       while painting the same colour. ── */
+  --brand-2:      #6be7d0;
+  --brand-2-soft: rgba(107,231,208,.10);
 
   /* ── text ── */
-  --text:         #ececf1;
-  --text-soft:    #c4c6cf;
-  --muted:        #8a8d99;
-  --muted-2:      #787c84;       /* 4.67:1 on --bg — WCAG AA pass */
+  --text:         #f1f5f3;       /* cooler white, mono-friendly */
+  --text-soft:    #c8d0cd;
+  --muted:        #8a8d99;       /* 6.14:1 on --bg — WCAG AA pass */
+  --muted-2:      #787c84;       /* 4.83:1 on --bg — WCAG AA pass */
 
   /* ── status ── */
   --success:      #22c55e;

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#0a0c11">
+<meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <!-- Shared mobile responsive overrides (touch targets, iOS font-size,
@@ -72,7 +72,7 @@
   }
   .page-title .badge {
     font-size: 10px; padding: 2px 8px; border-radius: 4px;
-    background: var(--accent); color: #fff; font-weight: 600;
+    background: var(--accent); color: var(--on-accent); font-weight: 600;
     letter-spacing: 1px;
   }
   .hint {
@@ -207,7 +207,7 @@
     color: var(--muted);
   }
   .modal-btn.primary {
-    background: var(--accent); color: #fff; font-weight: 600;
+    background: var(--accent); color: var(--on-accent); font-weight: 600;
   }
   .modal-link {
     text-align: center; margin-top: 14px; font-size: 12px;
@@ -351,7 +351,7 @@
           </div>
           <div>
             <button onclick="runJob()" id="run-job-btn"
-                    style="padding:9px 16px;background:var(--accent);color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600"
+                    style="padding:9px 16px;background:var(--accent);color:var(--on-accent);border:0;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600"
                     data-i18n="workspace.run">실행</button>
           </div>
         </div>

--- a/tests/test_a11y_contrast.py
+++ b/tests/test_a11y_contrast.py
@@ -1,17 +1,18 @@
 """WCAG AA contrast contract on the dark-UI design tokens.
 
-HANDOVER_WEB_UI.md priority #4 subset 4c. The audit found
-``--muted-2`` was #5d616c which gave only ~3.16:1 on --bg (#0a0c11)
-— **below the WCAG AA 4.5:1 threshold** for normal-sized body text.
-4 small-text use sites (10-12 px) inherited that failure.
+HANDOVER_WEB_UI.md priority #4 subset 4c. The original audit caught
+``--muted-2`` at #5d616c giving only ~3.16:1 on --bg — below the
+WCAG AA 4.5:1 threshold for normal-sized body text. 4 small-text
+use sites (10-12 px) inherited that failure.
 
 This test parses tokens.css, extracts the colour tokens, and computes
 the relative-luminance contrast ratio between every text colour and
 ``--bg``. Each must pass the appropriate WCAG AA threshold (4.5:1 for
 normal text, 3:1 for large/decorative).
 
-If a future change darkens ``--muted-2`` (or any text token) below
-threshold, this test fails loudly so the regression doesn't ship.
+The palette migrated to the mono-cyber palette in Task #22 (deeper
+``--bg #04060a``, single mint-cyan ``--accent``); contrast ratios were
+re-verified at that point and all current text tokens still pass.
 """
 from __future__ import annotations
 
@@ -101,9 +102,10 @@ class WcagAaContrastTests(unittest.TestCase):
         self._assert_ratio("--muted", 4.5, "normal text")
 
     def test_muted_2_passes_aa_normal(self):
-        # --muted-2 is the borderline secondary muted. Pre-fix value
-        # was #5d616c at 3.16:1 — failed AA. Post-fix #787c84 sits
-        # at ~4.67:1, just above threshold.
+        # --muted-2 is the borderline secondary muted. Original pre-4c
+        # value was #5d616c at 3.16:1 — failed AA. Post-4c #787c84
+        # sat at ~4.67:1 on --bg #0a0c11; on the new mono-cyber
+        # --bg #04060a it lands at ~4.83:1 — still above threshold.
         self._assert_ratio("--muted-2", 4.5, "normal text")
 
     def test_accent_fg_passes_aa_normal(self):
@@ -113,9 +115,11 @@ class WcagAaContrastTests(unittest.TestCase):
         self._assert_ratio("--accent-fg", 4.5, "normal text")
 
     def test_brand_2_passes_aa_large(self):
-        # --brand-2 (intelligence cyan) is reserved for divider lines
-        # / status dots / large badges — large-text/UI threshold
-        # applies (3:1).
+        # --brand-2 was originally a distinct "intelligence cyan"
+        # paired with the indigo accent. Post Task #22 mono migration
+        # it is an *alias* of --accent (same mint-cyan), still
+        # reserved for divider lines / status dots / large badges.
+        # Large-text/UI threshold applies (3:1).
         self._assert_ratio("--brand-2", 3.0, "large text / UI")
 
 

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -56,16 +56,15 @@ class PaletteTests(unittest.TestCase):
             "shadow should include a dark rgba layer")
 
     def test_palette_cooler_tones(self):
-        # The base bg should still be near-black but slightly tinted
-        # toward navy/slate. Specifically: NOT pure black (#000) and
-        # NOT the prior neutral #0c0d10 — should land on something
-        # cooler like #0a0c11.
+        # The base bg should be a tinted near-black (slate / cyber)
+        # rather than pure black or the legacy neutral #0c0d10.
+        # Post Task #22 mono migration lands on #04060a (deeper) —
+        # earlier passes used #0a0c11. Both are acceptable here.
         m = re.search(r"--bg:\s*(#[0-9a-fA-F]{6})", self.tokens)
         self.assertIsNotNone(m)
         bg = m.group(1).lower()
         self.assertNotEqual(bg, "#000000",
             "pure black is too aggressive — keep slight tint")
-        # New value should be different from the prior #0c0d10 baseline.
         self.assertNotEqual(bg, "#0c0d10",
             "palette polish should refresh the bg tint")
 


### PR DESCRIPTION
## Summary

Folds the prior **indigo accent (`#5258e6`) + intelligence-cyan brand-2 (`#4fc3f7`)** duo into a **single mint-cyan accent (`#6be7d0`)** on a deeper near-black background (`#04060a`). This matches the locked design in `frontend/static/preview-cyber.html` and unblocks the four Cyber sub-tasks (#18-21).

## What

**Tokens (`tokens.css`)**
- `--bg / --surface / --surface-2` → deeper near-blacks
- `--border / --border-2` → tightened, mono-friendly
- `--accent / --accent-soft / --accent-fg` → mint-cyan family
- `--accent-hover` (new) — `:hover` state, replaces 4 hard-coded indigo `#5258e6` hovers
- `--on-accent` (new) — foreground colour for solid-accent fills (was `#fff` in 12 sites, **fails WCAG ~1.5:1** on mint)
- `--brand-2` retained as **alias of `--accent`** — zero rename churn for gradient rail, file-progress, formatAnswer `###` headers, perf grade-B colour, etc.
- `--text / --text-soft` → cooler whites
- `--danger` preserved (semantic red)

**Call-site updates**
- 12 sites: `background:var(--accent);color:#fff` → `…color:var(--on-accent)` across 5 files (admin/index/workspace/graph + admin.js)
- 4 sites: hard-coded `#5258e6` hovers → `var(--accent-hover)`
- `theme-color` meta on 4 pages: `#0a0c11` → `#04060a`
- index.html logo box-shadow rgba retinted to mint

## Verification

**WCAG contrast (verified, all on new `--bg #04060a`):**

| Token | Ratio | Threshold |
|---|---|---|
| `--text` | 18.43:1 | AA normal ≥ 4.5 ✅ |
| `--text-soft` | 13.13:1 | AA normal ≥ 4.5 ✅ |
| `--muted` | 6.14:1 | AA normal ≥ 4.5 ✅ |
| `--muted-2` | 4.83:1 | AA normal ≥ 4.5 ✅ |
| `--accent-fg` | 15.98:1 | AA normal ≥ 4.5 ✅ |
| `--brand-2` | 13.54:1 | AA large/UI ≥ 3.0 ✅ |

`test_a11y_contrast.py` re-runs against the new tokens — threshold assertions unchanged.

## Out of scope

- **Per-feature cyber effects** (Tasks #18-21: grid texture, glow accent, glassmorphism on modals, live status indicators) layer on top of this palette in follow-up PRs.
- **Domain-specific hard-coded `#4fc3f7` callouts** (chat web-search block, sensitivity badge, graph entity-type colours) — these are semantic markings, not "the accent", left untouched for the precursor.
- **Inline `<style>` block extraction** (HANDOVER #8) — separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)