### PR TITLE
feat(frontend): cyber 6a background texture (grid + corner radials)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -9,7 +9,7 @@
 <style>
 
   body {
-    background: var(--bg);
+    background-color: var(--bg);
     color: var(--text);
     font-family: var(--font-ui);
     font-size: 14px;

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -17,7 +17,7 @@
 
   html, body { height: 100%; }
   body {
-    background: var(--bg);
+    background-color: var(--bg);
     color: var(--text);
     font-family: var(--font-ui);
     font-size: 14px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
 <style>
 
   body {
-    background: var(--bg);
+    background-color: var(--bg);
     color: var(--text);
     font-family: var(--font-ui);
     font-size: 14px;

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -110,6 +110,31 @@
   .brand { white-space: normal; }
 }
 
+/* ── Cyber background texture (Task #22 — 6a) ──
+ * Two soft mint-cyan radials anchored to top-right and bottom-left
+ * viewport corners + a 36px square grid at .02 opacity. Layered as
+ * the body's background-image so it sits behind all content without
+ * touching the stacking context. background-attachment:fixed keeps
+ * the radials viewport-anchored across scroll.
+ *
+ * Pages must declare `background-color: var(--bg);` (NOT the
+ * `background:` shorthand, which would reset background-image to
+ * none and erase the texture). */
+body {
+  background-image:
+    radial-gradient(70vw 55vh at 92% 0%,
+                    rgba(107,231,208,.05), transparent 60%),
+    radial-gradient(55vw 45vh at 8% 100%,
+                    rgba(107,231,208,.04), transparent 65%),
+    repeating-linear-gradient(0deg,
+                              rgba(107,231,208,.020) 0 1px,
+                              transparent 1px 36px),
+    repeating-linear-gradient(90deg,
+                              rgba(107,231,208,.020) 0 1px,
+                              transparent 1px 36px);
+  background-attachment: fixed;
+}
+
 /* ── Top accent rail ──
  * Thin 2px stripe along the very top of every page — gives the app
  * a subtle "system header" feel like enterprise dashboards. Fixed

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/static/mobile.css">
 <style>
   body {
-    background: var(--bg); color: var(--text);
+    background-color: var(--bg); color: var(--text);
     font-family: var(--font-ui); font-size: 14px;
     min-height: 100dvh; display: flex; flex-direction: column;
     -webkit-font-smoothing: antialiased;

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -221,5 +221,61 @@ class WelcomeReframeTests(unittest.TestCase):
             "Knowledge + Security for enterprise framing")
 
 
+class CyberBackgroundTextureTests(unittest.TestCase):
+    """Cyber 6a — body background carries a mint-cyan grid + radial
+    overlay so the four app surfaces share a subtle "system" backdrop.
+    Layered as background-image on body in tokens.css. Pages must use
+    `background-color: var(--bg)` (NOT the `background:` shorthand,
+    which would reset background-image and erase the texture)."""
+
+    PAGES = ("index.html", "admin.html", "workspace.html", "graph.html")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokens = TOKENS.read_text(encoding="utf-8")
+        cls.pages = {
+            name: (ROOT / "frontend" / name).read_text(encoding="utf-8")
+            for name in cls.PAGES
+        }
+
+    def _body_block(self, css: str) -> str | None:
+        # Match top-level `body { ... }` rules, skipping `body::before`
+        # and other selectors. Returns the first body-only block found.
+        for m in re.finditer(r"(^|\n)\s*body\s*\{([^}]+)\}", css):
+            return m.group(2)
+        return None
+
+    def test_tokens_declares_cyber_texture(self):
+        body = self._body_block(self.tokens)
+        self.assertIsNotNone(body, "tokens.css must declare a body rule "
+            "for the cyber 6a texture")
+        self.assertIn("background-image", body,
+            "body rule must carry a background-image with the 6a layers")
+        # Mint-cyan rgba — same family as --accent #6be7d0.
+        self.assertIn("rgba(107,231,208", body,
+            "texture should use the mint-cyan accent (107,231,208)")
+        # Two radial corner glows + two repeating-linear grids.
+        self.assertGreaterEqual(body.count("radial-gradient("), 2,
+            "expected two corner radial glows in the 6a texture")
+        self.assertGreaterEqual(body.count("repeating-linear-gradient("), 2,
+            "expected horizontal + vertical grid lines (2 layers)")
+        self.assertIn("background-attachment: fixed", body,
+            "texture must be viewport-anchored so it doesn't scroll")
+
+    def test_pages_use_background_color_not_shorthand(self):
+        # The `background:` shorthand resets background-image to none —
+        # which would erase the texture layered in tokens.css. Each page
+        # must use `background-color: var(--bg)` instead.
+        for name, html in self.pages.items():
+            body = self._body_block(html)
+            self.assertIsNotNone(body, f"{name}: body rule must exist")
+            self.assertNotRegex(body, r"\bbackground:\s*var\(--bg\)",
+                f"{name}: body must use `background-color: var(--bg)` "
+                "(the shorthand resets background-image and erases "
+                "the cyber 6a texture from tokens.css)")
+            self.assertIn("background-color: var(--bg)", body,
+                f"{name}: body must declare `background-color: var(--bg)`")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Layers the **mint-cyan grid + corner-radial overlay** from the locked design (`preview-cyber.html` §6a) onto `body` via `tokens.css`. This is the **first of four post-precursor cyber sub-tasks** (#222 unblocked 6a–d).

The texture is viewport-anchored (`background-attachment: fixed`) so it stays put during scroll. Two radials peek out at top-right (.05α) and bottom-left (.04α); a 36px square grid sits at .02α across the whole surface. Everything keys off the existing `--accent` mint-cyan — no new tokens.

## What

**`frontend/static/tokens.css`** — new `body { background-image: …; background-attachment: fixed; }` rule with four layered gradients:

| Layer | Geometry | Opacity |
|---|---|---|
| radial-gradient | 70vw × 55vh @ 92% 0% (top-right) | .05 |
| radial-gradient | 55vw × 45vh @ 8% 100% (bottom-left) | .04 |
| repeating-linear-gradient 0° | 1px / 36px | .02 |
| repeating-linear-gradient 90° | 1px / 36px | .02 |

**`frontend/{index,admin,workspace,graph}.html`** — body rule moves from the `background:` shorthand to `background-color: var(--bg);`. The shorthand resets `background-image` to none, which would erase the cyber texture; using the longhand keeps it.

**`tests/test_ui_report_polish.py`** — new `CyberBackgroundTextureTests` class with two contract tests:

1. `test_tokens_declares_cyber_texture` — tokens.css has 2 radials + 2 repeating grids in mint-cyan rgba, with `background-attachment: fixed`.
2. `test_pages_use_background_color_not_shorthand` — each of the 4 page body rules uses `background-color: var(--bg)` and **not** the shorthand. Guards against a future refactor silently re-introducing the shorthand and erasing the texture.

## Verification

- `python -m unittest discover tests` → **1433 tests OK** (48 UI/a11y subset run separately too — all pass).
- `ruff check tests/test_ui_report_polish.py` → clean.
- No token values changed, so the WCAG contrast suite (`test_a11y_contrast`) is unaffected.

## Out of scope

- **6b — single-accent glow on buttons / icon-buttons / role badges** (`box-shadow` rings).
- **6c — glassmorphism on modal overlays** (`backdrop-filter: blur`).
- **6d — live status indicators** (pulsing mint dot, source-toggle active scan line).
- **HANDOVER #3 — reasoning panel timeline / sensitivity badges** — separate track.
- **HANDOVER #5 — inline `onclick` → event delegation** — separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)