### PR TITLE
feat(frontend): cyber 6b single-accent glow on primary surfaces

### DIFF
--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -135,6 +135,35 @@ body {
   background-attachment: fixed;
 }
 
+/* ── Cyber 6b — single-accent glow on primary surfaces ──
+ * Adds a soft mint-cyan halo to the elements that fill with --accent
+ * or carry mint-cyan branding (primary action buttons + status
+ * badge). Same opacity envelope as preview-cyber.html §6b, always-on
+ * (no toggle class — the look is the default now).
+ *
+ * Targets only the live call sites that actually paint with --accent
+ * — generic / semantic-coloured buttons (`.btn-approve`, `.btn-reject`,
+ * neutral `.btn`) are left alone so red/green/neutral cues stay
+ * distinct from the mint accent halo.
+ *
+ * Disabled primary buttons drop the glow so they don't read as
+ * "active". The `.role-badge .dot` keeps its semantic colour
+ * (grey / --success) without a halo — only the badge perimeter
+ * gets the soft ring. */
+.btn-primary,
+.send-btn {
+  box-shadow:
+    0 0 0 1px rgba(107,231,208,.30),
+    0 0 22px rgba(107,231,208,.32);
+}
+.btn-primary:disabled,
+.send-btn:disabled {
+  box-shadow: none;
+}
+.role-badge {
+  box-shadow: 0 0 14px rgba(107,231,208,.18);
+}
+
 /* ── Top accent rail ──
  * Thin 2px stripe along the very top of every page — gives the app
  * a subtle "system header" feel like enterprise dashboards. Fixed

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -221,6 +221,56 @@ class WelcomeReframeTests(unittest.TestCase):
             "Knowledge + Security for enterprise framing")
 
 
+class CyberGlowTests(unittest.TestCase):
+    """Cyber 6b — single-accent glow halos. tokens.css adds an
+    always-on mint-cyan `box-shadow` to elements that fill with the
+    accent (primary buttons, status badge). Disabled primary buttons
+    must drop the glow so they don't read as active. Semantic
+    `.btn-approve` / `.btn-reject` are intentionally untouched —
+    green / red cues stay distinct from the mint halo."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokens = TOKENS.read_text(encoding="utf-8")
+
+    def _block_after(self, marker: str) -> str:
+        # Return the rule body that follows `marker` (a selector list)
+        # up to the next closing brace.
+        idx = self.tokens.find(marker)
+        self.assertGreaterEqual(idx, 0, f"expected selector `{marker}`")
+        close = self.tokens.find("}", idx)
+        self.assertGreater(close, idx)
+        return self.tokens[idx:close]
+
+    def test_primary_buttons_get_strong_glow(self):
+        # Selectors must list both .btn-primary (admin) and .send-btn
+        # (index) so admin save / issue and chat send all halo.
+        block = self._block_after(".btn-primary,")
+        self.assertIn(".send-btn", block,
+            "primary glow rule must list both .btn-primary and .send-btn")
+        self.assertIn("box-shadow", block)
+        # Mint-cyan rgba (107,231,208) at strong opacity (~.30 / .32).
+        self.assertIn("rgba(107,231,208,.30)", block)
+        self.assertIn("rgba(107,231,208,.32)", block)
+
+    def test_disabled_primaries_drop_glow(self):
+        # `:disabled` primaries must override to `box-shadow: none` —
+        # otherwise a greyed-out send-btn would still halo as if active.
+        block = self._block_after(".btn-primary:disabled,")
+        self.assertIn(".send-btn:disabled", block,
+            "disabled override must cover both primary classes")
+        self.assertIn("box-shadow: none", block)
+
+    def test_role_badge_gets_subtle_glow(self):
+        # Login-state badge wraps in a soft ring. The inner .dot keeps
+        # its grey / --success colour without an explicit halo.
+        block = self._block_after(".role-badge {")
+        self.assertIn("box-shadow", block,
+            ".role-badge must carry the subtle perimeter glow")
+        # Subtle ~.18 opacity, single 14px blur.
+        self.assertIn("rgba(107,231,208,.18)", block)
+
+
 class CyberBackgroundTextureTests(unittest.TestCase):
     """Cyber 6a — body background carries a mint-cyan grid + radial
     overlay so the four app surfaces share a subtle "system" backdrop.


### PR DESCRIPTION
## Summary

Second of four post-precursor cyber sub-tasks (6a merged in #223, this is **6b**). Adds **always-on mint-cyan halos** to the elements that already paint with `--accent`:

- `.btn-primary` (admin save / issue / learn / character / settings — 8 sites)
- `.send-btn` (chat send button)
- `.role-badge` (login-state perimeter — chat + workspace headers)

Strong ring on primary buttons (~.30 / .32 opacity, 22px blur). Subtle wrap on the badge (~.18 opacity, 14px blur). Same envelope as `preview-cyber.html` §6b.

## What

**`frontend/static/tokens.css`** — three new rules:

```css
.btn-primary, .send-btn {
  box-shadow:
    0 0 0 1px rgba(107,231,208,.30),
    0 0 22px rgba(107,231,208,.32);
}
.btn-primary:disabled, .send-btn:disabled {
  box-shadow: none;
}
.role-badge {
  box-shadow: 0 0 14px rgba(107,231,208,.18);
}
```

**`tests/test_ui_report_polish.py`** — new `CyberGlowTests` class with three contract tests:

1. `test_primary_buttons_get_strong_glow` — selector list includes both `.btn-primary` + `.send-btn` and carries mint-cyan rgba at `.30` / `.32`.
2. `test_disabled_primaries_drop_glow` — `:disabled` override resolves to `box-shadow: none` so greyed-out sends don't halo.
3. `test_role_badge_gets_subtle_glow` — `.role-badge` carries the perimeter ring at `.18` opacity.

## Scope decisions

- **Semantic buttons left alone**: `.btn-approve` (green) and `.btn-reject` (red) intentionally **don't** get the mint glow — the colour cue carries meaning and a mint halo would dilute it.
- **Neutral `.btn` left alone**: generic admin buttons (no `--accent` fill) stay flat. Glow without a matching accent surface reads as noise.
- **`.role-badge .dot` left alone**: keeps its grey (logged-out) / `--success` (logged-in) semantic. Only the badge perimeter rings.

## Verification

- `python -m unittest discover tests` → **1436 tests OK** (was 1433; +3 new contract tests).
- `ruff check tests/test_ui_report_polish.py` → clean.
- No token values changed, contrast suite unaffected.

## Out of scope

- **6c — glassmorphism on modal overlays** (`backdrop-filter: blur`).
- **6d — live status indicators** (pulsing mint dot, scan line on active toggles).
- **`.send-btn { color: #fff }` → `var(--on-accent)`** — leftover from precursor (#222) "12 sites" list; tracked separately if needed (icon colour, not text, so WCAG 3:1 surface is the relevant threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
