### PR TITLE
feat(frontend): cyber 6d live indicators (pulse dot + scan line)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,8 +91,8 @@
   }
   .source-toggle button:hover { color: var(--text-soft); }
   .source-toggle button.active {
-    background: var(--accent);
-    color: #fff;
+    background: var(--accent-soft);
+    color: var(--accent);
   }
   .nav-btn {
     padding: 6px 12px;
@@ -879,6 +879,7 @@
        suite, not a chat toy. -->
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
+    <span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
   </div>
   <div class="header-right">
     <div class="source-toggle">

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -189,6 +189,52 @@ body {
   }
 }
 
+/* ── Cyber 6d — live indicators ──
+ * Pulsing mint dot (`.live-dot`) for "system live" cues and a 1px
+ * scan line under the active source-toggle button. Both animations
+ * are gated behind `prefers-reduced-motion: no-preference` — users
+ * who request reduced motion get the static surfaces (dot + bottom
+ * line) without the pulse / sweep, so the visual cue still carries
+ * without the movement.
+ *
+ * `.source-toggle button` gets `position: relative` so the scan
+ * `::after` anchors to the button's box. */
+.live-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent);
+  display: inline-block;
+  vertical-align: middle;
+}
+.source-toggle button { position: relative; }
+.source-toggle button.active::after {
+  content: "";
+  position: absolute; left: 0; right: 0; bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg,
+                              transparent,
+                              var(--accent-fg),
+                              transparent);
+  opacity: .2;
+  pointer-events: none;
+}
+@keyframes cyber-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(107,231,208,.55); }
+  60%      { box-shadow: 0 0 0 8px rgba(107,231,208,0); }
+}
+@keyframes cyber-scan {
+  0%   { transform: translateX(-100%); opacity: .2; }
+  50%  { opacity: 1; }
+  100% { transform: translateX(100%); opacity: .2; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .live-dot {
+    animation: cyber-pulse 1.6s ease-out infinite;
+  }
+  .source-toggle button.active::after {
+    animation: cyber-scan 1.8s linear infinite;
+  }
+}
+
 /* ── Top accent rail ──
  * Thin 2px stripe along the very top of every page — gives the app
  * a subtle "system header" feel like enterprise dashboards. Fixed

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -333,6 +333,113 @@ class CyberGlassmorphismTests(unittest.TestCase):
             "expected mint outer halo layer in the 3-layer box-shadow")
 
 
+class CyberLiveIndicatorTests(unittest.TestCase):
+    """Cyber 6d — pulsing mint `.live-dot` + 1px scan line under
+    active `.source-toggle button`. Animations are wrapped in
+    `@media (prefers-reduced-motion: no-preference)` so reduced-
+    motion users still see the static surfaces (dot + bottom line)
+    without the pulse / sweep."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokens = TOKENS.read_text(encoding="utf-8")
+        cls.index_html = HTML.read_text(encoding="utf-8")
+
+    def test_keyframes_defined(self):
+        # Both animations declared. Names are namespaced (`cyber-`)
+        # so they don't collide with other keyframes the app might
+        # ship later.
+        self.assertIn("@keyframes cyber-pulse", self.tokens,
+            "expected @keyframes cyber-pulse")
+        self.assertIn("@keyframes cyber-scan", self.tokens,
+            "expected @keyframes cyber-scan")
+
+    def test_animations_gated_by_reduced_motion(self):
+        # `animation:` properties must live inside
+        # `@media (prefers-reduced-motion: no-preference)` so reduced-
+        # motion users get the static dot + static bottom line.
+        m = re.search(
+            r"@media\s*\(\s*prefers-reduced-motion:\s*no-preference\s*\)\s*\{(.+?)\n\}",
+            self.tokens, re.DOTALL,
+        )
+        self.assertIsNotNone(m,
+            "6d animations must be wrapped in @media "
+            "(prefers-reduced-motion: no-preference)")
+        block = m.group(1)
+        self.assertIn("animation: cyber-pulse", block,
+            ".live-dot pulse animation must live inside the "
+            "reduced-motion guard")
+        self.assertIn("animation: cyber-scan", block,
+            ".source-toggle scan animation must live inside the "
+            "reduced-motion guard")
+
+    def test_live_dot_static_styles_outside_guard(self):
+        # Static dot styling (size, colour, shape) must apply even
+        # under reduced motion — only the animation should drop.
+        m = re.search(r"\.live-dot\s*\{([^}]+)\}", self.tokens)
+        self.assertIsNotNone(m,
+            "tokens.css must declare a base .live-dot rule outside "
+            "the reduced-motion guard")
+        block = m.group(1)
+        self.assertIn("border-radius: 50%", block)
+        self.assertIn("var(--accent)", block,
+            "dot must paint with the mint accent")
+
+    def test_scan_line_uses_accent_gradient(self):
+        # The ::after carries a transparent → accent-fg → transparent
+        # gradient so the streak shows over the soft-tinted active
+        # button bg. accent-fg (a brighter mint shade) is used here
+        # because plain --accent would blend into --accent-soft.
+        m = re.search(
+            r"\.source-toggle button\.active::after\s*\{([^}]+)\}",
+            self.tokens,
+        )
+        self.assertIsNotNone(m,
+            "tokens.css must declare the scan line ::after")
+        block = m.group(1)
+        self.assertIn("linear-gradient", block)
+        self.assertIn("var(--accent-fg)", block,
+            "scan line must use --accent-fg (brighter mint) so it "
+            "shows over the --accent-soft active background")
+
+    def test_active_toggle_uses_soft_tint(self):
+        # The active source-toggle button background was migrated
+        # from the solid `var(--accent)` fill to the soft-tinted
+        # `var(--accent-soft)` so the scan line is visible.
+        m = re.search(
+            r"\.source-toggle button\.active\s*\{([^}]+)\}",
+            self.index_html,
+        )
+        self.assertIsNotNone(m,
+            "index.html must declare .source-toggle button.active rule")
+        block = m.group(1)
+        self.assertIn("var(--accent-soft)", block,
+            "active toggle background must be --accent-soft (not solid "
+            "--accent) so the scan line shows through")
+        self.assertNotIn("color: #fff", block,
+            "active toggle text colour must migrate from #fff to "
+            "var(--accent) (mono-cyber outline+tint pattern)")
+
+    def test_chat_header_has_live_dot(self):
+        # Concrete placement of the live-dot utility — sits inside
+        # `.logo` next to the brand line so the system-online cue is
+        # paired with product identity.
+        m = re.search(
+            r'<div class="logo">(.+?)</div>',
+            self.index_html, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        logo = m.group(1)
+        self.assertIn('class="live-dot"', logo,
+            "chat header .logo must include a .live-dot indicator "
+            "as the exemplar placement of the 6d utility")
+        # aria-hidden because the dot is decorative — the system
+        # status it represents isn't surfaced to screen readers
+        # from this element alone.
+        self.assertIn("aria-hidden", logo,
+            "live-dot is decorative; must carry aria-hidden")
+
+
 class CyberBackgroundTextureTests(unittest.TestCase):
     """Cyber 6a — body background carries a mint-cyan grid + radial
     overlay so the four app surfaces share a subtle "system" backdrop.


### PR DESCRIPTION
## Summary

Closes the four-step mono-cyber rollout (6a #223, 6b #224, 6c #225, this is **6d**). Adds two **live-state cues** keyed off the mint accent:

- **`.live-dot`** — 8px mint dot with `cyber-pulse` keyframe (expanding ring that fades from `rgba(107,231,208,.55)` to 0 over 1.6s). Placed in `.logo` of `index.html` as a "system live" cue next to the brand line.
- **`.source-toggle button.active::after`** — 1px scan line at the button's bottom, `cyber-scan` keyframe sweeping `transparent → accent-fg → transparent` across 1.8s. Auto-applies to the chat header's PROD / TEST toggle.

Both animations are gated behind `@media (prefers-reduced-motion: no-preference)` so reduced-motion users get the static surfaces (dot + bottom line) without the pulse / sweep — the visual cue still carries without the movement.

## What

**`frontend/static/tokens.css`** — new 6d block:

```css
.live-dot {
  width: 8px; height: 8px; border-radius: 50%;
  background: var(--accent);
  display: inline-block; vertical-align: middle;
}
.source-toggle button { position: relative; }
.source-toggle button.active::after {
  content: "";
  position: absolute; left: 0; right: 0; bottom: 0;
  height: 1px;
  background: linear-gradient(90deg, transparent, var(--accent-fg), transparent);
  opacity: .2; pointer-events: none;
}
@keyframes cyber-pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(107,231,208,.55); } 60% { box-shadow: 0 0 0 8px rgba(107,231,208,0); } }
@keyframes cyber-scan  { 0% { transform: translateX(-100%); opacity: .2; } 50% { opacity: 1; } 100% { transform: translateX(100%); opacity: .2; } }
@media (prefers-reduced-motion: no-preference) {
  .live-dot { animation: cyber-pulse 1.6s ease-out infinite; }
  .source-toggle button.active::after { animation: cyber-scan 1.8s linear infinite; }
}
```

**`frontend/index.html`**
- `.source-toggle button.active` — solid `var(--accent)` + `color: #fff` → `var(--accent-soft)` + `color: var(--accent)`. Matches the mono-cyber outline+tint pattern locked in `preview-cyber.html` §6d and lets the scan-line `--accent-fg` gradient show through (a brighter mint streak on the soft mint wash).
- `.logo` — adds `<span class="live-dot" aria-hidden="true" title="System live"></span>` next to the brand. `aria-hidden` because the dot is decorative.

**`tests/test_ui_report_polish.py`** — new `CyberLiveIndicatorTests` with six contract tests:

1. `test_keyframes_defined` — both `cyber-pulse` + `cyber-scan` declared.
2. `test_animations_gated_by_reduced_motion` — both `animation:` properties live inside the `prefers-reduced-motion` guard.
3. `test_live_dot_static_styles_outside_guard` — base `.live-dot` (size, mint, round) applies even under reduced motion.
4. `test_scan_line_uses_accent_gradient` — scan `::after` uses `--accent-fg` (not `--accent`) so the streak shows over `--accent-soft`.
5. `test_active_toggle_uses_soft_tint` — `index.html` toggle migrated from solid + `#fff` to `--accent-soft` + `--accent`.
6. `test_chat_header_has_live_dot` — `.logo` contains the live-dot with `aria-hidden`.

## Verification

- `python -m unittest discover tests` → **1445 tests OK** (was 1439; +6 new contract tests).
- `ruff check tests/test_ui_report_polish.py` → clean.
- Animations namespaced (`cyber-` prefix) so they don't collide with future keyframes.
- No token values changed, contrast suite unaffected.

## Out of scope

- **Cross-page live-dot rollout** — admin/workspace/graph headers can adopt the same `.logo > .live-dot` pattern if desired; left for a follow-up so this PR'svisible surface is single-page (chat).
- **HANDOVER §3 reasoning panel** — confidence bar, sensitivity badge, retrieve→expand→verify timeline.
- **HANDOVER §5 inline `onclick` → event delegation** (CSP hardening).
- **HANDOVER §8 admin inline-style modal extraction** — would let 6c apply fully to admin modal inner cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
