### PR TITLE
refactor(frontend): lift admin modal cards into class=modal

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -168,6 +168,19 @@
   .btn-primary { background: var(--accent); color: var(--on-accent); }
   .btn-primary:hover { background: var(--accent-hover); }
 
+  /* ── Modal card base ──
+   * Class-extracted from the per-modal inline styles so the cyber 6c
+   * glass treatment (backdrop-filter + mint 3-layer box-shadow in
+   * tokens.css) applies to admin modal inner cards. Per-modal
+   * dimensions (width / padding / max-height) stay inline since they
+   * vary between the login modal (340px) and the firstrun wizard
+   * (560px, scrollable). */
+  .modal {
+    background: rgba(7,9,14,.55);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+  }
+
   /* ── 로그 영역 ── */
   .log-box {
     background: var(--surface);
@@ -1435,7 +1448,7 @@
      role="dialog" aria-modal="true"
      aria-labelledby="admin-login-modal-title"
      style="display:none;position:fixed;inset:0;background:rgba(4,6,10,.35);display:flex;align-items:center;justify-content:center;z-index:300;">
-  <div style="background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:36px;width:340px;box-shadow:0 24px 80px rgba(0,0,0,.7);">
+  <div class="modal" style="padding:36px;width:340px;">
     <div id="admin-login-modal-title" style="font-size:13px;font-weight:600;font-family:var(--font-mono);color:var(--danger);margin-bottom:8px;letter-spacing:.5px;">▸ Secure Enterprise Knowledge Operating System · Admin</div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:24px;" data-i18n="auth.admin_required">Admin login required</div>
     <div style="margin-bottom:14px;">
@@ -1651,9 +1664,8 @@
      aria-labelledby="firstrun-wizard-modal-title"
      style="display:none;position:fixed;inset:0;background:rgba(4,6,10,.35);
             align-items:center;justify-content:center;z-index:400;">
-  <div style="background:var(--surface);border:1px solid var(--border);
-              border-radius:14px;padding:36px;width:560px;max-width:92vw;
-              box-shadow:0 24px 80px rgba(0,0,0,.8);max-height:88vh;overflow-y:auto;">
+  <div class="modal" style="padding:36px;width:560px;max-width:92vw;
+              max-height:88vh;overflow-y:auto;">
     <div id="firstrun-wizard-modal-title" style="font-size:18px;font-weight:600;color:var(--accent-fg);
                 margin-bottom:8px;letter-spacing:.3px;">
       🎯 처음 실행 — LLM 모델 설치 필요

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -333,6 +333,80 @@ class CyberGlassmorphismTests(unittest.TestCase):
             "expected mint outer halo layer in the 3-layer box-shadow")
 
 
+class AdminModalClassExtractionTests(unittest.TestCase):
+    """HANDOVER §8 follow-up — admin modal inner cards were lifted
+    from inline `style="background:var(--surface);border:...;
+    box-shadow:..."` into `class="modal"`. With the class in place,
+    the cyber 6c glass treatment from tokens.css applies fully
+    (backdrop-filter blur + mint 3-layer box-shadow), no longer
+    just the overlay-side blur.
+
+    Per-modal dimensions (width, padding, max-height, overflow)
+    stay inline because the two modals differ — login is 340px,
+    firstrun wizard is 560px and scrollable."""
+
+    ADMIN = ROOT / "frontend" / "admin.html"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = cls.ADMIN.read_text(encoding="utf-8")
+
+    def test_modal_class_rule_declared(self):
+        # Admin must declare a base `.modal` rule so tokens.css 6c
+        # has a surface to layer on. Bg must be translucent (alpha
+        # ≤ .55) so the backdrop-filter blur is visible through it.
+        m = re.search(r"\.modal\s*\{([^}]+)\}", self.html)
+        self.assertIsNotNone(m,
+            "admin.html must declare `.modal` so the cyber 6c glass "
+            "treatment applies to its modal inner cards")
+        block = m.group(1)
+        self.assertIn("rgba(7,9,14,.55)", block,
+            "admin .modal bg must be the translucent surface "
+            "(alpha .55) so backdrop-filter blur shows through")
+        self.assertIn("border", block)
+        self.assertIn("border-radius", block)
+
+    def test_login_modal_uses_class(self):
+        # The login modal inner card must carry `class="modal"` and
+        # have shed the inline bg / border / box-shadow.
+        m = re.search(
+            r'id="admin-login-modal".+?<div\s+([^>]*)>',
+            self.html, re.DOTALL,
+        )
+        self.assertIsNotNone(m, "admin-login-modal inner div must exist")
+        inner = m.group(1)
+        self.assertIn('class="modal"', inner,
+            "admin-login-modal inner div must carry class=\"modal\"")
+        # Bg / border / box-shadow must have moved out of inline style —
+        # owned by the .modal rule + tokens.css 6c.
+        self.assertNotIn("background:var(--surface)", inner,
+            "inline `background:var(--surface)` must move to the "
+            ".modal class rule")
+        self.assertNotIn("box-shadow:", inner,
+            "inline box-shadow must drop — tokens.css 6c owns it")
+
+    def test_firstrun_modal_uses_class(self):
+        m = re.search(
+            r'id="firstrun-wizard-modal".+?<div\s+([^>]*)>',
+            self.html, re.DOTALL,
+        )
+        self.assertIsNotNone(m,
+            "firstrun-wizard-modal inner div must exist")
+        inner = m.group(1)
+        self.assertIn('class="modal"', inner,
+            "firstrun-wizard-modal inner div must carry class=\"modal\"")
+        self.assertNotIn("background:var(--surface)", inner,
+            "inline `background:var(--surface)` must move to the "
+            ".modal class rule")
+        self.assertNotIn("box-shadow:", inner,
+            "inline box-shadow must drop — tokens.css 6c owns it")
+        # Per-modal customisation stays inline — firstrun is
+        # scrollable and wider than the login modal.
+        self.assertIn("max-height:88vh", inner,
+            "firstrun wizard remains scrollable (max-height + overflow)")
+        self.assertIn("overflow-y:auto", inner)
+
+
 class CyberLiveIndicatorTests(unittest.TestCase):
     """Cyber 6d — pulsing mint `.live-dot` + 1px scan line under
     active `.source-toggle button`. Animations are wrapped in


### PR DESCRIPTION
## Summary

HANDOVER §8 follow-up. Lifts admin's two modal inner cards (`admin-login-modal`, `firstrun-wizard-modal`) from **inline-styled divs** into **`class="modal"`** so the cyber 6c glass treatment from `tokens.css` (backdrop-filter blur + mint 3-layer box-shadow) applies fully. Previously only the overlay-side blur landed because the inner cards were inline-only.

## What

**`frontend/admin.html`** — new `.modal` rule in the `<style>` block:

```css
.modal {
  background: rgba(7,9,14,.55);
  border: 1px solid var(--border);
  border-radius: 14px;
}
```

- **Login modal inner div** (340px): adds `class="modal"`, drops inline `background:var(--surface)` / `border` / `border-radius` / `box-shadow`. Keeps `padding:36px; width:340px;` inline (per-modal dimensions, not shared).
- **Firstrun-wizard inner div** (560px, scrollable): same shape but keeps `width:560px; max-width:92vw; max-height:88vh; overflow-y:auto;` inline.

**`tests/test_ui_report_polish.py`** — new `AdminModalClassExtractionTests` with three contract tests:

1. `test_modal_class_rule_declared` — admin declares `.modal` with translucent bg (rgba alpha .55) + border + border-radius.
2. `test_login_modal_uses_class` — login modal inner div carries `class="modal"` and has shed inline bg / box-shadow.
3. `test_firstrun_modal_uses_class` — firstrun inner div carries `class="modal"`, kept scrollable (`max-height:88vh` + `overflow-y:auto` stay inline).

## Verification

- `python -m unittest discover tests` → **1448 tests OK** (was 1445; +3 new contract tests).
- `ruff check tests/test_ui_report_polish.py` → clean.
- Admin `role="dialog"` / `aria-modal` attributes preserved (a11y modal test suite still passes).

## Result

Admin login + firstrun wizard now show the **full cyber 6c effect**: blurred dashboard behind, mint-edged glass card on top, with the inset glow halo on the card. Same visual language as index / workspace / graph modals.

## Out of scope

- **Admin overlay class extraction** — the `.modal-overlay` element still uses inline `style="display:none;position:fixed;..."` for positioning + display toggling. The 6c overlay blur already works (the class is on the element), so this is purely a cosmetic refactor saved for later.
- **HANDOVER §3 reasoning panel** — timeline + confidence bar + sensitivity badge.
- **HANDOVER §5 inline `onclick` → event delegation** — CSP hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
