### PR TITLE
feat(frontend): roll cyber 6d live-dot across all 4 pages

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -452,6 +452,7 @@
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span style="color:var(--muted);font-size:11px;margin-left:6px">· Admin Console</span>
+    <span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
   </div>
   <div class="header-right">
     <!-- [STEP 5-A] 언어 토글 -->

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -394,6 +394,7 @@
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span style="color:var(--muted);font-size:11px;margin-left:6px">· <span data-i18n="graph.title">Reasoning Graph</span></span>
+    <span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
   </div>
   <div class="header-right">
     <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -242,6 +242,7 @@
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
     <span class="tagline" data-i18n="workspace.tagline">Workspace · 데이터 + 작업</span>
+    <span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
   </div>
   <div class="header-right">
     <span class="role-badge" id="role-badge" style="display:none">

--- a/tests/test_ui_report_polish.py
+++ b/tests/test_ui_report_polish.py
@@ -494,24 +494,22 @@ class CyberLiveIndicatorTests(unittest.TestCase):
             "active toggle text colour must migrate from #fff to "
             "var(--accent) (mono-cyber outline+tint pattern)")
 
-    def test_chat_header_has_live_dot(self):
-        # Concrete placement of the live-dot utility — sits inside
-        # `.logo` next to the brand line so the system-online cue is
-        # paired with product identity.
-        m = re.search(
-            r'<div class="logo">(.+?)</div>',
-            self.index_html, re.DOTALL,
-        )
-        self.assertIsNotNone(m)
-        logo = m.group(1)
-        self.assertIn('class="live-dot"', logo,
-            "chat header .logo must include a .live-dot indicator "
-            "as the exemplar placement of the 6d utility")
+    def test_all_page_headers_have_live_dot(self):
+        # All four pages carry the live-dot inside `.logo` so the
+        # "system live" cue is consistent across the app surface.
         # aria-hidden because the dot is decorative — the system
         # status it represents isn't surfaced to screen readers
         # from this element alone.
-        self.assertIn("aria-hidden", logo,
-            "live-dot is decorative; must carry aria-hidden")
+        for name in ("index.html", "admin.html",
+                     "workspace.html", "graph.html"):
+            html = (ROOT / "frontend" / name).read_text(encoding="utf-8")
+            m = re.search(r'<div class="logo">(.+?)</div>', html, re.DOTALL)
+            self.assertIsNotNone(m, f"{name}: .logo block must exist")
+            logo = m.group(1)
+            self.assertIn('class="live-dot"', logo,
+                f"{name}: .logo must include the live-dot indicator")
+            self.assertIn('aria-hidden', logo,
+                f"{name}: live-dot must carry aria-hidden (decorative)")
 
 
 class CyberBackgroundTextureTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Cyber 6d (#226) added `.live-dot` to the chat header as the exemplar placement. This PR rolls it out to **admin / workspace / graph** so the "system live" cue is consistent across every app surface. The pulse animation and `prefers-reduced-motion` guard already live in `tokens.css` from 6d — this is HTML-only.

## What

Each page inserts the dot **after** its existing page-name tag so it lands as the rightmost element inside `.logo`:

- `admin.html` — after `· Admin Console`
- `workspace.html` — after `Workspace · 데이터 + 작업`
- `graph.html` — after `· Reasoning Graph`

```html
<span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
```

`aria-hidden` because the dot is decorative — the system status it represents isn't surfaced to screen readers from this element alone.

## Tests

`test_chat_header_has_live_dot` (1 page) is replaced with `test_all_page_headers_have_live_dot` (4 pages, looped). Asserts (a) `class="live-dot"` is present inside each page's `.logo`, (b) `aria-hidden` is carried.

## Verification

- `python -m unittest discover tests` → **1448 tests OK** (test count unchanged; 1 test broadened to cover 4 pages instead of just index).
- No CSS changes (animations + reduced-motion guard already in `tokens.css` from #226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
