### PR TITLE
feat(frontend): render graph_paths as mint citation chips

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -838,6 +838,30 @@
     margin-bottom: 4px;
     font-family: var(--font-ui);
   }
+  /* HANDOVER §3 — citation nodes rendered as mint-outlined chips so
+   * the graph traversal is scannable at a glance instead of a plain
+   * "→ A → B → C" run-on. */
+  .graph-paths .path-row {
+    display: flex; flex-wrap: wrap; gap: 4px;
+    align-items: center;
+    margin: 3px 0;
+  }
+  .graph-paths .path-node {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 4px;
+    border: 1px solid rgba(107,231,208,.35);
+    background: rgba(107,231,208,.05);
+    color: var(--accent-fg);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.6;
+  }
+  .graph-paths .path-arrow {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
 
   /* ── 스크롤바 ── */
   ::-webkit-scrollbar { width: 8px; height: 8px; }

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1176,10 +1176,27 @@ function appendJamesMsg(data) {
   // item #5-B: graph paths는 기본 hidden — 사용자가 "그래프 보기"
   // 토글 클릭 시 펼침. 답변 가시성을 해치는 큰 paths 리스트 (최대
   // 50개)가 매번 깔리던 문제 해결.
+  //
+  // HANDOVER §3 follow-up — paths are rendered as mint-outlined
+  // node chips instead of plain "→ A → B → C" text. Each path is
+  // a string like "Entity → Entity → Entity"; split on the arrow,
+  // wrap each node in `.path-node` (chip) and each separator in
+  // `.path-arrow` (muted). Empty / malformed splits fall back to
+  // a single chip carrying the whole string so we never lose data.
+  const renderPathRow = (p) => {
+    const nodes = String(p).split('→').map(n => n.trim()).filter(Boolean);
+    if (nodes.length === 0) return '';
+    const inner = nodes.map((n, i) =>
+      (i > 0 ? '<span class="path-arrow">→</span>' : '') +
+      `<span class="path-node">${escHtml(n)}</span>`
+    ).join('');
+    return `<div class="path-row">${inner}</div>`;
+  };
+
   let pathsHtml = '';
   if (paths.length > 0) {
     const pathsId = 'gp_' + Math.random().toString(36).slice(2, 9);
-    const list = paths.map(p => `<div>→ ${escHtml(p)}</div>`).join('');
+    const list = paths.map(renderPathRow).join('');
     pathsHtml = `
       <details class="graph-paths-details" style="margin-top:6px">
         <summary class="graph-paths-toggle"

--- a/tests/test_graph_path_toggle.py
+++ b/tests/test_graph_path_toggle.py
@@ -82,5 +82,73 @@ class GraphPathToggleTests(unittest.TestCase):
                       "must guard rendering on non-empty paths array")
 
 
+class GraphPathChipRenderTests(unittest.TestCase):
+    """HANDOVER §3 follow-up — each graph path renders as mint-
+    outlined node chips with muted arrow separators instead of a
+    plain text run. Existing `<details>` toggle wrapper is
+    preserved (see GraphPathToggleTests above)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = JS.read_text(encoding="utf-8")
+        cls.index_html = (Path(__file__).resolve().parent.parent
+                          / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_render_helper_splits_on_arrow(self):
+        # A renderer helper must split each path string on the
+        # arrow glyph and render the segments individually — not
+        # just dump the raw `→ A → B → C` text into a div.
+        self.assertIn("renderPathRow", self.js,
+            "expected a `renderPathRow` helper that turns a path "
+            "string into chip markup")
+        # The split character must be the actual arrow glyph.
+        m = re.search(r"renderPathRow\s*=.*?\}", self.js, re.DOTALL)
+        self.assertIsNotNone(m, "renderPathRow body must be findable")
+        body = m.group(0)
+        self.assertIn("split('→')", body,
+            "renderPathRow must split path strings on the '→' glyph")
+        # Each node wrapped in .path-node, separators in .path-arrow.
+        self.assertIn('class="path-node"', body,
+            "each split segment must be wrapped in <span class=\"path-node\">")
+        self.assertIn('class="path-arrow"', body,
+            "arrow separators must be wrapped in <span class=\"path-arrow\">")
+        # Empty / malformed splits must fall back gracefully —
+        # the helper checks `nodes.length === 0` and returns ''
+        # so a bogus path doesn't render an empty `.path-row`.
+        self.assertIn("nodes.length === 0", body,
+            "renderPathRow must guard against empty splits")
+
+    def test_chip_css_in_index_html(self):
+        # `.path-node` chips must be styled with the mint accent
+        # palette so they read as Graph-RAG citations, not generic
+        # text. Look inside the `.graph-paths .path-node` rule.
+        m = re.search(
+            r"\.graph-paths\s+\.path-node\s*\{([^}]+)\}",
+            self.index_html,
+        )
+        self.assertIsNotNone(m,
+            "index.html must declare `.graph-paths .path-node` chip styling")
+        block = m.group(1)
+        self.assertIn("rgba(107,231,208", block,
+            "chip must use the mint-cyan accent rgba family")
+        self.assertIn("border", block)
+        self.assertIn("border-radius", block,
+            "chip must have rounded corners")
+
+    def test_arrow_separator_styled_muted(self):
+        # The arrow separators sit between chips and should be
+        # visually quieter so the chips are the foreground reading.
+        m = re.search(
+            r"\.graph-paths\s+\.path-arrow\s*\{([^}]+)\}",
+            self.index_html,
+        )
+        self.assertIsNotNone(m,
+            "index.html must declare `.graph-paths .path-arrow` separator styling")
+        block = m.group(1)
+        self.assertIn("var(--muted)", block,
+            "arrow separator should use --muted so chips read as the "
+            "foreground content")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

**HANDOVER §3 first slice** — Graph-RAG citation trail (`graph_paths`) renders as **mint-outlined node chips** with muted arrow separators instead of the previous plain text run. The chat answer surfaces *which* entities the engine traversed at a glance, not as a wall of arrows.

Backend unchanged — pure UI parse + layout of existing `graph_paths` data.

## What

**`frontend/static/chat.js`** — adds `renderPathRow` helper:

```js
const renderPathRow = (p) => {
  const nodes = String(p).split('→').map(n => n.trim()).filter(Boolean);
  if (nodes.length === 0) return '';
  const inner = nodes.map((n, i) =>
    (i > 0 ? '<span class="path-arrow">→</span>' : '') +
    `<span class="path-node">${escHtml(n)}</span>`
  ).join('');
  return `<div class="path-row">${inner}</div>`;
};
```

Empty / malformed splits fall back to `''` so a bogus path doesn't render an empty `.path-row`. The existing `<details>` toggle wrapper, summary label (`🕸️ 그래프 경로 N개 보기`), and `class="graph-paths"` container are all preserved — only the inner per-path markup becomes chips.

**`frontend/index.html`** — three new rules inside the existing `.graph-paths` block:

```css
.graph-paths .path-row   { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin: 3px 0; }
.graph-paths .path-node  { /* mint outline pill on .05 soft wash, accent-fg text, JetBrains Mono */ }
.graph-paths .path-arrow { color: var(--muted); /* JetBrains Mono */ }
```

**`tests/test_graph_path_toggle.py`** — new `GraphPathChipRenderTests` with three contract tests:

1. `test_render_helper_splits_on_arrow` — `renderPathRow` exists, splits on `'→'`, wraps in `.path-node` + `.path-arrow`, guards against empty splits.
2. `test_chip_css_in_index_html` — `.graph-paths .path-node` uses mint-cyan rgba family + border + border-radius.
3. `test_arrow_separator_styled_muted` — `.graph-paths .path-arrow` uses `var(--muted)`.

The four existing `GraphPathToggleTests` still pass — `<details>` wrapper, summary label, default-closed, and `class="graph-paths"` container are all preserved.

## Verification

- `python -m unittest discover tests` → **1451 tests OK** (was 1448; +3 new tests).
- Pure-frontend change — `/query/` response shape unchanged.

## Out of scope (remaining §3 items)

- **Sensitivity 배지** — would need backend wiring (engine returns per-source sensitivity, server aggregates, response adds field).
- **Retrieve → Expand → Verify timeline** — would need per-stage timings surfaced from observability JSONL into `QueryResponse`.

(신뢰도 bar already exists in `chat.js` at line 1154+, rendering `data.unified_score` as a 3-tone semantic bar.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
