### PR TITLE
refactor(frontend): graph page — inline handlers → data-action delegation (§5 PR-A)

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -397,7 +397,7 @@
     <span class="live-dot" aria-hidden="true" title="System live" style="margin-left:10px"></span>
   </div>
   <div class="header-right">
-    <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+    <button class="nav-btn" data-lang-toggle data-action="toggle-lang" title="Language / 언어"
             aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <a href="/admin" class="nav-btn">← <span data-i18n="graph.back_admin">Admin</span></a>
@@ -458,7 +458,7 @@
          Replaces the side aside's node-search on phones (where aside
          is hidden) and gives desktop users a faster way to jump to
          any entity. Toggle tab is always visible. -->
-    <div class="tsd-toggle" id="tsd-toggle" onclick="toggleSearchDrawer()"
+    <div class="tsd-toggle" id="tsd-toggle" data-action="toggle-search-drawer"
          title="엔티티 검색 (Esc로 닫기)">
       🔎 검색 ▾
     </div>
@@ -468,8 +468,7 @@
                id="tsd-search"
                class="tsd-search"
                placeholder="엔티티 이름 검색…"
-               autocomplete="off"
-               onkeydown="if(event.key==='Escape') hideSearchDrawer()">
+               autocomplete="off">
         <div class="tsd-list" id="tsd-list"></div>
       </div>
     </div>
@@ -498,7 +497,6 @@
       <div style="font-size:10px;color:var(--muted);letter-spacing:1px;font-family:var(--font-mono);margin-bottom:6px;">PASSWORD</div>
       <input id="login-pw" type="password" placeholder="••••••••"
              autocomplete="new-password"
-             onkeydown="if(event.key==='Enter') doLogin()"
              style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:10px 14px;color:var(--text);font-size:14px;outline:none;">
     </div>
     <div style="margin-bottom:14px;">
@@ -508,11 +506,10 @@
       </div>
       <input id="login-apikey" type="password" placeholder="JAMES_API_KEY"
              autocomplete="off" spellcheck="false"
-             onkeydown="if(event.key==='Enter') doLogin()"
              style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:10px 14px;color:var(--text);font-size:14px;outline:none;">
     </div>
     <div id="login-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:12px;font-family:var(--font-mono);"></div>
-    <button onclick="doLogin()"
+    <button data-action="do-login"
             style="width:100%;padding:11px;background:var(--accent);border:none;border-radius:8px;color:var(--on-accent);font-size:14px;font-weight:600;cursor:pointer;"
             data-i18n="auth.login">
       Login

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -1136,7 +1136,41 @@
     loadAndRender(src.value);
   }
 
+  // ─── Inline-handler migration (CSP-friendly delegation) ───────
+  // graph.html no longer uses ``onclick=`` / ``onkeydown=`` inline
+  // attributes. Instead, buttons set ``data-action="…"`` and the
+  // routing happens here. Key shortcuts (Enter on login fields,
+  // Escape on the search drawer input) are also delegated through
+  // the document so they keep working without inline handlers.
+  function _bindFrontendEvents() {
+    document.addEventListener('click', function (e) {
+      var t = e.target.closest && e.target.closest('[data-action]');
+      if (!t) return;
+      switch (t.getAttribute('data-action')) {
+        case 'toggle-lang':
+          if (typeof window.toggleLang === 'function') window.toggleLang();
+          break;
+        case 'toggle-search-drawer':
+          if (typeof window.toggleSearchDrawer === 'function') window.toggleSearchDrawer();
+          break;
+        case 'do-login':
+          if (typeof window.doLogin === 'function') window.doLogin();
+          break;
+      }
+    });
+    document.addEventListener('keydown', function (e) {
+      var id = e.target && e.target.id;
+      if (!id) return;
+      if (e.key === 'Enter' && (id === 'login-pw' || id === 'login-apikey')) {
+        if (typeof window.doLogin === 'function') window.doLogin();
+      } else if (e.key === 'Escape' && id === 'tsd-search') {
+        if (typeof window.hideSearchDrawer === 'function') window.hideSearchDrawer();
+      }
+    });
+  }
+
   function start() {
+    _bindFrontendEvents();
     if (!apiKey || !token) { showLogin(); return; }
     // Probe with a tiny admin request to see if our token still proves admin.
     fetch(API + '/admin/graph/snapshot?source_type=prod&api_key=' +

--- a/tests/test_frontend_event_delegation.py
+++ b/tests/test_frontend_event_delegation.py
@@ -1,0 +1,147 @@
+"""Frontend §5 — inline event handlers → ``data-action`` + delegation.
+
+CSP-friendly migration (HANDOVER_WEB_UI.md §4 priority 5).
+
+Every page-level HTML file in ``frontend/`` must be free of inline
+``onclick=``, ``onchange=``, ``onkeydown=``, ``onkeyup=``,
+``onsubmit=``, ``oninput=``, ``onfocus=``, ``onblur=`` handler
+attributes. The matching JS file installs a single document-level
+delegated handler that routes by ``data-action`` (clicks) and by
+``e.target.id`` + ``e.key`` (keyboard shortcuts).
+
+This contract is rolled out **page by page**. Each PR flips one
+page's assertions on. Pages still using inline handlers stay on the
+known-bad list (``_LEGACY_INLINE_PAGES``) and graduate as their PR
+lands.
+
+Run:
+    python -m unittest tests.test_frontend_event_delegation
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+FRONTEND = ROOT / "frontend"
+STATIC = FRONTEND / "static"
+
+# Inline handler attributes the migration removes. Mirrors the
+# common DOM event-attribute surface; if a new one appears in HTML,
+# add it here so the contract catches it.
+_INLINE_ATTR_RE = re.compile(
+    r"\son(?:click|change|submit|input|keydown|keyup|keypress"
+    r"|focus|blur|mouseover|mouseout|mouseenter|mouseleave"
+    r"|mousedown|mouseup)\s*=",
+    re.IGNORECASE,
+)
+
+# Pages already migrated to delegation. Each PR adds a name here.
+_MIGRATED_PAGES = {
+    "graph.html",
+}
+
+# Pages still using inline handlers. Will shrink to empty by PR-D.
+_LEGACY_INLINE_PAGES = {
+    "index.html",
+    "admin.html",
+    "workspace.html",
+}
+
+
+class NoInlineHandlersTests(unittest.TestCase):
+    """Migrated pages must have zero inline event-handler attributes."""
+
+    def test_migrated_pages_have_no_inline_handlers(self):
+        for name in sorted(_MIGRATED_PAGES):
+            with self.subTest(page=name):
+                src = (FRONTEND / name).read_text(encoding="utf-8")
+                hits = _INLINE_ATTR_RE.findall(src)
+                self.assertEqual(
+                    hits, [],
+                    name + " still has inline handler attributes: "
+                    + ", ".join(sorted(set(h.strip() for h in hits))),
+                )
+
+    def test_legacy_pages_still_known(self):
+        # Guardrail: if a legacy page silently becomes clean, promote
+        # it to _MIGRATED_PAGES so the contract starts protecting it.
+        for name in sorted(_LEGACY_INLINE_PAGES):
+            with self.subTest(page=name):
+                src = (FRONTEND / name).read_text(encoding="utf-8")
+                self.assertRegex(
+                    src, _INLINE_ATTR_RE,
+                    name + " is now free of inline handlers — please "
+                    "move it from _LEGACY_INLINE_PAGES to "
+                    "_MIGRATED_PAGES in this test.",
+                )
+
+
+class GraphPageDelegationTests(unittest.TestCase):
+    """PR-A — graph.html now routes via data-action; graph.js installs
+    a single document click delegate plus a keydown delegate for
+    Enter (login submit) and Escape (search drawer close)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (FRONTEND / "graph.html").read_text(encoding="utf-8")
+        cls.js   = (STATIC / "graph.js").read_text(encoding="utf-8")
+
+    def test_html_uses_data_action_for_lang_toggle(self):
+        self.assertRegex(
+            self.html,
+            r'data-lang-toggle\s+data-action="toggle-lang"',
+            "language toggle button must carry data-action=toggle-lang",
+        )
+
+    def test_html_uses_data_action_for_drawer_toggle(self):
+        self.assertIn(
+            'data-action="toggle-search-drawer"', self.html,
+            "search drawer toggle must carry data-action=toggle-search-drawer",
+        )
+
+    def test_html_uses_data_action_for_login_button(self):
+        self.assertIn(
+            'data-action="do-login"', self.html,
+            "login button must carry data-action=do-login",
+        )
+
+    def test_html_drops_inline_login_submit_keys(self):
+        # The two login modal inputs used to fire doLogin() on Enter
+        # via inline onkeydown. After §5 migration they're plain
+        # <input>s — the JS keydown delegate watches them by id.
+        self.assertNotRegex(
+            self.html,
+            r'id="login-(pw|apikey)"[^>]*onkeydown',
+            "login inputs must not carry inline onkeydown",
+        )
+
+    def test_js_installs_click_delegation(self):
+        # Single document-level click listener, switch by data-action.
+        self.assertRegex(
+            self.js,
+            r"document\.addEventListener\(\s*['\"]click['\"]",
+            "graph.js must install a document-level click delegate",
+        )
+        self.assertIn("data-action", self.js,
+            "graph.js must read data-action in its delegate")
+
+    def test_js_installs_keydown_delegation(self):
+        self.assertRegex(
+            self.js,
+            r"document\.addEventListener\(\s*['\"]keydown['\"]",
+            "graph.js must install a document-level keydown delegate",
+        )
+        # Enter on login fields and Escape on tsd-search must be routed.
+        self.assertIn("login-pw", self.js)
+        self.assertIn("login-apikey", self.js)
+        self.assertIn("tsd-search", self.js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph_mobile_loop_search.py
+++ b/tests/test_graph_mobile_loop_search.py
@@ -139,7 +139,9 @@ class SearchDrawerHtmlTests(unittest.TestCase):
 
     def test_toggle_tab_present(self):
         self.assertIn('id="tsd-toggle"', self.html)
-        self.assertIn('onclick="toggleSearchDrawer()"', self.html)
+        # [§5 migration] inline onclick replaced by data-action +
+        # document-level click delegate in graph.js.
+        self.assertIn('data-action="toggle-search-drawer"', self.html)
 
     def test_search_input_present(self):
         self.assertIn('id="tsd-search"', self.html)
@@ -149,11 +151,19 @@ class SearchDrawerHtmlTests(unittest.TestCase):
         self.assertIn('id="tsd-list"', self.html)
 
     def test_escape_key_closes(self):
-        # Input has onkeydown="if(event.key==='Escape')" handler.
-        idx = self.html.index('id="tsd-search"')
-        body = self.html[idx:idx + 600]
-        self.assertIn("Escape", body,
-            "input must have ESC-to-close handler for keyboard users")
+        # [§5 migration] ESC-to-close handler moved from inline
+        # onkeydown on the input to a document-level keydown delegate
+        # in graph.js that routes on (e.target.id, e.key).
+        js = (ROOT / "frontend" / "static" / "graph.js").read_text(encoding="utf-8")
+        self.assertRegex(
+            js,
+            r"document\.addEventListener\(\s*['\"]keydown['\"]",
+            "graph.js must install a document-level keydown delegate",
+        )
+        self.assertIn("tsd-search", js,
+            "keydown delegate must route ESC on the search input")
+        self.assertIn("Escape", js,
+            "keydown delegate must recognise the ESC key")
 
     def test_drawer_open_class_styling(self):
         # CSS rule for .tsd-open must define max-height (slide-in).


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md §4 priority 5 — **phase 1 of 4** (graph → workspace → chat → admin).
CSP-prep: remove inline `onclick=` / `onkeydown=` attributes so we
can eventually drop `'unsafe-inline'` from `script-src`.

- `graph.html` — 6 inline handlers removed:
  - `onclick="toggleLang()"` → `data-action="toggle-lang"`
  - `onclick="toggleSearchDrawer()"` → `data-action="toggle-search-drawer"`
  - `onclick="doLogin()"` → `data-action="do-login"`
  - `onkeydown="…doLogin()"` (2 inputs) → JS keydown delegate by `e.target.id`
  - `onkeydown="…hideSearchDrawer()"` → JS keydown delegate
- `graph.js` — two document-level delegates installed in `_bindFrontendEvents()`,
  called from `start()` so they bind before the auth probe (login button must
  work pre-auth).
- `tests/test_frontend_event_delegation.py` (new, 8 tests) — `_MIGRATED_PAGES`
  guardrail forbids inline event attrs on migrated pages; `_LEGACY_INLINE_PAGES`
  marks index/admin/workspace as known-bad pending PR-B/C/D.
- `test_graph_mobile_loop_search.py` — 2 assertions that pinned the inline
  pattern updated to the new `data-action` + JS keydown-delegate shape.

## Verification

- `python -m unittest discover -s tests -p "test_*.py"` — **1459 tests OK**
  (+8 new vs. main's 1451).
- `ruff check tests/test_frontend_event_delegation.py` — clean.
- No `core/retrieval` / `core/graph` / `core/reasoning` touched → no bench
  numbers required (CLAUDE.md §2).

## Out of scope

- index.html / admin.html / workspace.html migration → PR-B/C/D.
- `a11y-modal.js:148` ESC fallback (`button[onclick*="close" i]`) — survives
  on graph.html because the cancel button selector takes precedence; full
  removal in a follow-up after PR-D.
- Visual / behaviour parity check (lang toggle, drawer toggle, Enter-submit
  login) — please verify in browser before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)