### PR TITLE
refactor(frontend): workspace page — inline handlers → data-action delegation (§5 PR-B)

### DIFF
--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -293,7 +293,7 @@ async function reloadData() {
       const uploaderCell = adminPath
         ? `<td class="mono">${_esc(it.uploaded_by || '-')}</td>`
         : '';
-      return `<tr onclick="openDetail('${it.artifact_id}')">
+      return `<tr data-action="open-detail" data-artifact-id="${_esc(it.artifact_id)}" style="cursor:pointer">
         <td>${_esc(it.origin_name || '')}
             <span style="color:var(--muted);font-size:10px;display:block;font-family:var(--font-mono)">${_fmtBytes(it.origin_size)}</span>
         </td>
@@ -438,10 +438,10 @@ async function reloadJobs() {
         ? `<span class="mono" style="font-size:10px;color:var(--muted)">${_esc(j.output_path.split('/').pop())}</span>`
         : '<span style="color:var(--muted)">—</span>';
       const dlBtn = (j.status === 'done' && j.output_path)
-        ? `<button onclick="downloadJob('${j.job_id}', ${adminPath ? 'true' : 'false'})"
+        ? `<button data-action="download-job" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
                    style="padding:4px 10px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer;font-size:11px">다운로드</button>`
         : (j.status === 'failed'
-            ? `<button onclick="showJobError('${j.job_id}', ${adminPath ? 'true' : 'false'})"
+            ? `<button data-action="show-job-error" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
                        style="padding:4px 10px;background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;cursor:pointer;font-size:11px">에러 보기</button>`
             : '<span style="color:var(--muted)">—</span>');
       return `<tr>
@@ -510,8 +510,70 @@ function toggleLang() {
   location.reload();
 }
 
+/* ── Inline-handler migration (CSP-friendly delegation) ──
+ * workspace.html no longer uses ``onclick=`` / ``onchange=`` /
+ * ``oninput=`` / ``onkeydown=`` / ``href="javascript:…"`` inline
+ * attributes. Static elements carry ``data-action`` and the
+ * document-level click delegate routes by name. Stable inputs
+ * (search, status select, job type select, login modal fields)
+ * are wired directly by id since they live for the lifetime of
+ * the page and don't appear in any innerHTML template. */
+function _bindFrontendEvents() {
+  document.addEventListener('click', (e) => {
+    const t = e.target.closest && e.target.closest('[data-action]');
+    if (!t) return;
+    const action = t.getAttribute('data-action');
+    switch (action) {
+      case 'toggle-lang':      toggleLang(); break;
+      case 'show-login':       showLogin(); break;
+      case 'do-logout':        doLogout(); break;
+      case 'select-tab':       selectTab(t.getAttribute('data-tab')); break;
+      case 'data-page-prev':   dataPage(-1); break;
+      case 'data-page-next':   dataPage(1); break;
+      case 'run-job':          runJob(); break;
+      case 'reload-jobs':      reloadJobs(); break;
+      case 'close-detail':     closeDetail(); break;
+      case 'close-login':      closeLogin(); break;
+      case 'do-login':         doLogin(); break;
+      case 'open-forgot':      e.preventDefault(); openForgot(); break;
+      case 'open-detail':      openDetail(t.getAttribute('data-artifact-id')); break;
+      case 'download-job':
+        downloadJob(
+          t.getAttribute('data-job-id'),
+          t.getAttribute('data-admin') === 'true',
+        );
+        break;
+      case 'show-job-error':
+        showJobError(
+          t.getAttribute('data-job-id'),
+          t.getAttribute('data-admin') === 'true',
+        );
+        break;
+    }
+  });
+}
+
+function _bindStableInputs() {
+  const dq = document.getElementById('data-q');
+  if (dq) dq.addEventListener('input', () => onDataSearchInput());
+  const dstat = document.getElementById('data-status');
+  if (dstat) dstat.addEventListener('change', () => reloadData());
+  const jt = document.getElementById('job-type');
+  if (jt) jt.addEventListener('change', () => onJobTypeChange());
+  const lpw = document.getElementById('login-pw');
+  if (lpw) lpw.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') doLogin();
+  });
+  const lkey = document.getElementById('login-apikey');
+  if (lkey) lkey.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') doLogin();
+  });
+}
+
 /* ── boot ── */
 window.addEventListener('DOMContentLoaded', () => {
+  _bindFrontendEvents();
+  _bindStableInputs();
   _loadStored();
   updateRoleBadge();
   if (!_token) {

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -249,28 +249,28 @@
       <span class="who" id="role-who"></span>
       <span id="role-name"></span>
     </span>
-    <button class="header-btn" data-lang-toggle onclick="toggleLang()"
+    <button class="header-btn" data-lang-toggle data-action="toggle-lang"
             aria-label="언어 전환 / Toggle language"
             style="font-weight:700"></button>
     <a href="/" class="header-btn" style="text-decoration:none" data-i18n="workspace.back_chat">챗</a>
     <button class="header-btn" id="login-btn"
-            onclick="showLogin()" data-i18n="auth.login">로그인</button>
+            data-action="show-login" data-i18n="auth.login">로그인</button>
     <button class="header-btn" id="logout-btn"
-            onclick="doLogout()" style="display:none" data-i18n="auth.logout">로그아웃</button>
+            data-action="do-logout" style="display:none" data-i18n="auth.logout">로그아웃</button>
   </div>
 </header>
 
 <main>
   <nav class="sidebar">
-    <div class="nav-item active" data-tab="data" onclick="selectTab('data')">
+    <div class="nav-item active" data-tab="data" data-action="select-tab">
       <span class="nav-icon">📦</span>
       <span data-i18n="workspace.tab_data">내 데이터</span>
     </div>
-    <div class="nav-item" data-tab="jobs" onclick="selectTab('jobs')">
+    <div class="nav-item" data-tab="jobs" data-action="select-tab">
       <span class="nav-icon">🛠</span>
       <span data-i18n="workspace.tab_jobs">작업</span>
     </div>
-    <div class="nav-item" data-tab="search" onclick="selectTab('search')">
+    <div class="nav-item" data-tab="search" data-action="select-tab">
       <span class="nav-icon">🔍</span>
       <span data-i18n="workspace.tab_search">검색</span>
     </div>
@@ -289,9 +289,8 @@
       <div class="toolbar">
         <input id="data-q" type="text"
                data-i18n-placeholder="workspace.search_ph"
-               placeholder="파일명 검색"
-               oninput="onDataSearchInput()">
-        <select id="data-status" onchange="reloadData()">
+               placeholder="파일명 검색">
+        <select id="data-status">
           <option value="" data-i18n="workspace.status_all">전체 상태</option>
           <option value="uploaded">uploaded</option>
           <option value="extracted">extracted</option>
@@ -313,9 +312,9 @@
         </tbody>
       </table>
       <div class="pager">
-        <button id="data-prev" onclick="dataPage(-1)" data-i18n="common.prev">← 이전</button>
+        <button id="data-prev" data-action="data-page-prev" data-i18n="common.prev">← 이전</button>
         <span class="pageinfo" id="data-pageinfo">page 1</span>
-        <button id="data-next" onclick="dataPage(1)" data-i18n="common.next">다음 →</button>
+        <button id="data-next" data-action="data-page-next" data-i18n="common.next">다음 →</button>
       </div>
     </div>
 
@@ -334,7 +333,7 @@
         <div style="display:grid;grid-template-columns:auto 1fr auto;gap:8px;align-items:end">
           <div>
             <label style="font-size:10px;color:var(--muted);letter-spacing:.5px;font-family:var(--font-mono);display:block;margin-bottom:4px">JOB TYPE</label>
-            <select id="job-type" onchange="onJobTypeChange()" style="padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
+            <select id="job-type" style="padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
               <option value="excel_build" data-i18n="workspace.jt_excel">excel_build · 엔티티 → .xlsx</option>
               <option value="doc_combine" data-i18n="workspace.jt_doc">doc_combine · 엔티티 → .md</option>
               <option value="entity_export" data-i18n="workspace.jt_export">entity_export · 카테고리 → .json</option>
@@ -350,7 +349,7 @@
                    style="width:100%;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px;font-family:var(--font-mono)">
           </div>
           <div>
-            <button onclick="runJob()" id="run-job-btn"
+            <button data-action="run-job" id="run-job-btn"
                     style="padding:9px 16px;background:var(--accent);color:var(--on-accent);border:0;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600"
                     data-i18n="workspace.run">실행</button>
           </div>
@@ -365,7 +364,7 @@
       <!-- Toolbar + table -->
       <div class="toolbar">
         <span class="counter" id="jobs-counter"></span>
-        <button class="header-btn" onclick="reloadJobs()" style="margin-left:auto"
+        <button class="header-btn" data-action="reload-jobs" style="margin-left:auto"
                 data-i18n="workspace.refresh">새로고침</button>
       </div>
       <table>
@@ -396,7 +395,7 @@
 
 <!-- Artifact detail panel -->
 <div class="detail-panel" id="detail-panel">
-  <button class="close" onclick="closeDetail()" aria-label="상세 패널 닫기">×</button>
+  <button class="close" data-action="close-detail" aria-label="상세 패널 닫기">×</button>
   <h3 id="detail-title">—</h3>
   <div class="detail-row"><div class="label">ARTIFACT ID</div><div class="value" id="d-id"></div></div>
   <div class="detail-row"><div class="label">PATH</div><div class="value" id="d-path"></div></div>
@@ -422,21 +421,19 @@
     </div>
     <div class="modal-field">
       <label data-i18n="auth.password">PASSWORD</label>
-      <input type="password" id="login-pw" autocomplete="current-password"
-             onkeydown="if(event.key==='Enter') doLogin()">
+      <input type="password" id="login-pw" autocomplete="current-password">
     </div>
     <div class="modal-field">
       <label data-i18n="auth.api_key">API KEY</label>
-      <input type="password" id="login-apikey" autocomplete="off"
-             onkeydown="if(event.key==='Enter') doLogin()">
+      <input type="password" id="login-apikey" autocomplete="off">
     </div>
     <div class="modal-error" id="login-error"></div>
     <div class="modal-actions">
-      <button class="modal-btn cancel" onclick="closeLogin()" data-i18n="common.cancel">취소</button>
-      <button class="modal-btn primary" onclick="doLogin()" data-i18n="auth.login">로그인</button>
+      <button class="modal-btn cancel" data-action="close-login" data-i18n="common.cancel">취소</button>
+      <button class="modal-btn primary" data-action="do-login" data-i18n="auth.login">로그인</button>
     </div>
     <div class="modal-link">
-      <a href="javascript:openForgot()" data-i18n="auth.forgot_password">비밀번호를 잊으셨나요?</a>
+      <a href="#" data-action="open-forgot" data-i18n="auth.forgot_password">비밀번호를 잊으셨나요?</a>
     </div>
   </div>
 </div>

--- a/tests/test_a11y_aria_labels.py
+++ b/tests/test_a11y_aria_labels.py
@@ -141,8 +141,10 @@ class IconOnlyButtonsTests(unittest.TestCase):
             self.admin, "closeSessionTurns()", "admin.html")
 
     def test_workspace_detail_close_button(self):
+        # [§5 migration] inline onclick="closeDetail()" replaced by
+        # data-action="close-detail" — locator follows.
         self._assert_aria_on_button(
-            self.workspace, "closeDetail()", "workspace.html")
+            self.workspace, 'data-action="close-detail"', "workspace.html")
 
 
 if __name__ == "__main__":

--- a/tests/test_frontend_event_delegation.py
+++ b/tests/test_frontend_event_delegation.py
@@ -44,13 +44,13 @@ _INLINE_ATTR_RE = re.compile(
 # Pages already migrated to delegation. Each PR adds a name here.
 _MIGRATED_PAGES = {
     "graph.html",
+    "workspace.html",
 }
 
 # Pages still using inline handlers. Will shrink to empty by PR-D.
 _LEGACY_INLINE_PAGES = {
     "index.html",
     "admin.html",
-    "workspace.html",
 }
 
 
@@ -141,6 +141,108 @@ class GraphPageDelegationTests(unittest.TestCase):
         self.assertIn("login-pw", self.js)
         self.assertIn("login-apikey", self.js)
         self.assertIn("tsd-search", self.js)
+
+
+class WorkspacePageDelegationTests(unittest.TestCase):
+    """PR-B — workspace.html and workspace.js route every click via
+    ``data-action``; static inputs are bound by id at DOMContentLoaded.
+
+    workspace.js dynamically renders <tr> rows and job-action buttons
+    through innerHTML; those templates must also emit ``data-action``
+    rather than inline ``onclick``."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (FRONTEND / "workspace.html").read_text(encoding="utf-8")
+        cls.js   = (STATIC / "workspace.js").read_text(encoding="utf-8")
+
+    # ─── HTML ──────────────────────────────────────────────────────
+    def test_html_uses_data_action_for_header_buttons(self):
+        for action in (
+            "toggle-lang", "show-login", "do-logout",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_uses_data_action_for_tab_nav(self):
+        # All three sidebar tabs route through one 'select-tab' action,
+        # with the tab name pulled from the existing data-tab attribute.
+        self.assertEqual(
+            self.html.count('data-action="select-tab"'), 3,
+            "all three nav-item tabs must carry data-action=select-tab",
+        )
+        for tab in ("data", "jobs", "search"):
+            self.assertRegex(
+                self.html,
+                r'data-tab="' + tab + r'"[^>]*data-action="select-tab"',
+                f'nav-item[data-tab={tab}] must carry data-action=select-tab',
+            )
+
+    def test_html_uses_data_action_for_pager_and_jobs(self):
+        for action in (
+            "data-page-prev", "data-page-next",
+            "run-job", "reload-jobs",
+            "close-detail", "close-login", "do-login",
+            "open-forgot",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_drops_inline_login_submit_keys(self):
+        # login-pw / login-apikey used to fire doLogin() on Enter via
+        # inline onkeydown — now handled by direct addEventListener on
+        # those stable ids in _bindStableInputs.
+        self.assertNotRegex(
+            self.html,
+            r'id="login-(pw|apikey)"[^>]*onkeydown',
+        )
+
+    def test_html_drops_javascript_href(self):
+        # ``href="javascript:openForgot()"`` (CSP-hostile) replaced by
+        # ``href="#" data-action="open-forgot"``; the click delegate
+        # calls preventDefault before invoking the action.
+        self.assertNotIn('href="javascript:', self.html)
+
+    def test_html_forgot_link_carries_data_action(self):
+        self.assertRegex(
+            self.html,
+            r'<a\s+href="#"\s+data-action="open-forgot"',
+        )
+
+    # ─── JS ────────────────────────────────────────────────────────
+    def test_js_installs_click_delegation(self):
+        self.assertRegex(
+            self.js,
+            r"document\.addEventListener\(\s*['\"]click['\"]",
+            "workspace.js must install a document-level click delegate",
+        )
+        self.assertIn("data-action", self.js)
+
+    def test_js_binds_stable_inputs(self):
+        # Helper must exist and DOMContentLoaded must call it. Without
+        # this binding the search, status select and login-Enter
+        # shortcuts silently stop working.
+        self.assertIn("_bindStableInputs", self.js)
+        self.assertRegex(
+            self.js,
+            r"DOMContentLoaded[\s\S]*?_bindStableInputs\(\)",
+        )
+
+    def test_js_dynamic_rows_use_data_action(self):
+        # The artifact-row <tr> template (reloadData) and job action
+        # buttons (reloadJobs) must emit data-action attributes,
+        # not inline onclick=.
+        self.assertIn('data-action="open-detail"', self.js)
+        self.assertIn('data-artifact-id', self.js)
+        self.assertIn('data-action="download-job"', self.js)
+        self.assertIn('data-action="show-job-error"', self.js)
+        self.assertIn('data-job-id', self.js)
+        # And the templates must not regress to inline onclick.
+        self.assertNotRegex(
+            self.js,
+            r'<(?:tr|button)[^>]*\sonclick=',
+            "no innerHTML template in workspace.js may emit inline onclick",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md §4 priority 5 — **phase 2 of 4**. Stacked on PR-A
(#230). Targets `workspace.html` (18 handlers) and the 3 dynamic
templates in `workspace.js`.

### `workspace.html` — 14 distinct actions

`toggle-lang`, `show-login`, `do-logout`, `select-tab` (×3 via
`data-tab`), `data-page-prev`, `data-page-next`, `run-job`,
`reload-jobs`, `close-detail`, `close-login`, `do-login`,
`open-forgot`.

`href="javascript:openForgot()"` → `href="#" data-action="open-forgot"`.
The click delegate calls `e.preventDefault()` before invoking the
action (CSP-friendlier than `javascript:` URIs).

### `workspace.js`

- Artifact row template: `data-action="open-detail" data-artifact-id="…"`
- Job action buttons: `data-action="download-job"` / `show-job-error`
  with `data-job-id` + `data-admin` data attributes.
- New `_bindFrontendEvents()` + `_bindStableInputs()`, both called
  from DOMContentLoaded.
- Stable inputs wired by id (`#data-q` input, `#data-status` change,
  `#job-type` change, `#login-pw` / `#login-apikey` Enter).

### Tests

- `tests/test_frontend_event_delegation.py`: `workspace.html` moves
  from `_LEGACY_INLINE_PAGES` to `_MIGRATED_PAGES`; **9 new tests**
  for header / tab nav / pager / login modal / forgot anchor /
  dynamic-row data-action emission.
- `tests/test_a11y_aria_labels.py`: `workspace_detail_close_button`
  locator updated to `data-action="close-detail"`.

## Verification

- `python -m unittest discover` — **1468 tests OK** (+9 vs PR-A).
- No `core/retrieval` / `core/graph` / `core/reasoning` touched → no
  bench numbers required.
- Visual / behaviour parity (lang, tabs, pager, data search, job
  trigger, download, login Enter, forgot link) — please verify in
  browser before merge.

## Out of scope

- `index.html` / `chat.js` / `upload.js` → PR-C
- `admin.html` / `admin.js` → PR-D
- `a11y-modal.js:148` ESC fallback removal → follow-up after PR-D

## Stacking

Branched off `chore/v0.2-frontend-event-delegation` (PR-A's branch).
After PR-A merges, please rebase this branch onto `main` and force-push
before merge — or merge PR-A first and then change this PR's base to
`main` via GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)