### PR TITLE
refactor(frontend): chat page — inline handlers → data-action delegation (§5 PR-C)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -907,17 +907,17 @@
   </div>
   <div class="header-right">
     <div class="source-toggle">
-      <button class="active" onclick="setSource('prod', this)">PROD</button>
-      <button onclick="setSource('test', this)">TEST</button>
+      <button class="active" data-action="set-source" data-source="prod">PROD</button>
+      <button data-action="set-source" data-source="test">TEST</button>
     </div>
     <!-- [STEP 5-A] 언어 토글 -->
-    <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+    <button class="nav-btn" data-lang-toggle data-action="toggle-lang" title="Language / 언어"
             aria-label="언어 전환 / Toggle language"
             style="font-size:11px;font-weight:700;padding:4px 8px"></button>
-    <button class="nav-btn" onclick="clearHistory()" data-i18n-title="chat.clear_history" title="대화 초기화"
+    <button class="nav-btn" data-action="clear-history" data-i18n-title="chat.clear_history" title="대화 초기화"
             aria-label="대화 기록 삭제">🗑</button>
     <!-- [P3-4] 세션 선택 버튼 -->
-    <button class="nav-btn" onclick="toggleSessionPanel()" data-i18n-title="chat.session_open" title="이전 대화 불러오기"
+    <button class="nav-btn" data-action="toggle-session-panel" data-i18n-title="chat.session_open" title="이전 대화 불러오기"
             id="session-btn" aria-label="세션 패널 열기"
             style="position:relative">
       💬
@@ -927,7 +927,7 @@
                    font-size:10px;padding:1px 6px;font-weight:600;line-height:1.4">
       </span>
     </button>
-    <div class="role-badge" id="role-badge" onclick="showLogin()">
+    <div class="role-badge" id="role-badge" data-action="show-login">
       <span class="dot"></span>
       <span class="role-name" id="role-name" data-i18n="auth.login">로그인</span>
     </div>
@@ -948,12 +948,12 @@
               margin-bottom:12px">
     <div style="font-weight:600;font-size:13px;color:var(--text)"><span data-i18n="chat.previous">이전 대화</span></div>
     <div style="display:flex;gap:6px">
-      <button onclick="newSession()"
+      <button data-action="new-session"
               style="background:var(--accent);color:var(--on-accent);border:none;
                      border-radius:6px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500">
         <span data-i18n="chat.new_session">+ 새 대화</span>
       </button>
-      <button onclick="toggleSessionPanel()"
+      <button data-action="toggle-session-panel"
               aria-label="세션 패널 닫기"
               style="background:none;border:none;color:var(--muted);
                      cursor:pointer;font-size:16px;padding:0 4px">✕</button>
@@ -969,7 +969,7 @@
 
 <main style="position:relative">
   <button class="sidebar-open-btn" id="sidebar-open-btn"
-          onclick="toggleSidebar()" data-i18n-title="upload.open" title="업로드 열기"
+          data-action="toggle-sidebar" data-i18n-title="upload.open" title="업로드 열기"
           aria-label="사이드바 열기">▶</button>
   <!-- ── 사이드바 (W5: rail + panel split) ── -->
   <aside class="sidebar" id="sidebar">
@@ -977,17 +977,17 @@
          .active on the matching rail item and the matching panel. -->
     <div class="sidebar-rail">
       <div class="sidebar-rail-item active" data-mode="upload"
-           onclick="switchSidebarMode('upload')">
+           data-action="switch-sidebar-mode">
         📂
         <span class="sidebar-rail-tip" data-i18n="sidebar.mode_upload">파일 업로드</span>
       </div>
       <div class="sidebar-rail-item" data-mode="recent"
-           onclick="switchSidebarMode('recent')">
+           data-action="switch-sidebar-mode">
         🕘
         <span class="sidebar-rail-tip" data-i18n="sidebar.mode_recent">최근 챗</span>
       </div>
       <div class="sidebar-rail-item" data-mode="search"
-           onclick="switchSidebarMode('search')">
+           data-action="switch-sidebar-mode">
         🔍
         <span class="sidebar-rail-tip" data-i18n="sidebar.mode_search">검색</span>
       </div>
@@ -997,13 +997,13 @@
     <div class="sidebar-panel">
       <div class="sidebar-header">
         <div class="sidebar-title" id="sidebar-title">▸ <span data-i18n="upload.title">파일 업로드</span></div>
-        <button class="sidebar-toggle" onclick="toggleSidebar()" data-i18n-title="common.close" title="닫기"
+        <button class="sidebar-toggle" data-action="toggle-sidebar" data-i18n-title="common.close" title="닫기"
                 aria-label="사이드바 닫기">◀</button>
       </div>
 
       <!-- Mode: 파일 업로드 (default) -->
       <div class="sidebar-panel-mode active" data-mode="upload">
-        <div class="drop-zone" id="drop-zone" onclick="document.getElementById('file-input').click()">
+        <div class="drop-zone" id="drop-zone" data-action="trigger-file-input">
           <input type="file" id="file-input" multiple
                  accept="image/*,audio/*,video/*,.pdf,.txt,.md,.json,.docx,.xlsx,.pptx,.hwp,.hwpx">
           <!-- item #8: 폴더 통째 선택용 hidden input. webkitdirectory 사용 시
@@ -1021,7 +1021,7 @@
         </div>
         <!-- item #8: 폴더 선택 버튼 (드래그 외 클릭 경로) -->
         <button type="button"
-                onclick="event.stopPropagation(); document.getElementById('folder-input').click()"
+                data-action="trigger-folder-input"
                 style="margin:0 12px;padding:8px;
                        background:var(--surface-2);border:1px solid var(--border);
                        border-radius:6px;color:var(--text-soft);font-size:12px;
@@ -1044,7 +1044,7 @@
           <div class="queue-progress-bar"><div class="queue-progress-fill" id="queue-progress-fill"></div></div>
         </div>
 
-        <button class="upload-btn" id="upload-btn" onclick="uploadFiles()" disabled>
+        <button class="upload-btn" id="upload-btn" data-action="upload-files" disabled>
           <span data-i18n="upload.btn_default">업로드 및 분석</span>
         </button>
       </div>
@@ -1094,10 +1094,10 @@
           </span>
         </div>
         <div class="welcome-chips">
-          <span class="chip" onclick="useChip(this)" data-i18n="chat.example1">경제학이란 무엇인가?</span>
-          <span class="chip" onclick="useChip(this)" data-i18n="chat.example3">업로드된 문서 요약해줘</span>
-          <span class="chip" onclick="useChip(this)" data-i18n="chat.example_code">파이썬 함수 작성해줘</span>
-          <span class="chip" onclick="useChip(this)" data-i18n="chat.example2">김철수 관련 자료 찾아줘</span>
+          <span class="chip" data-action="use-chip" data-i18n="chat.example1">경제학이란 무엇인가?</span>
+          <span class="chip" data-action="use-chip" data-i18n="chat.example3">업로드된 문서 요약해줘</span>
+          <span class="chip" data-action="use-chip" data-i18n="chat.example_code">파이썬 함수 작성해줘</span>
+          <span class="chip" data-action="use-chip" data-i18n="chat.example2">김철수 관련 자료 찾아줘</span>
         </div>
       </div>
     </div>
@@ -1108,7 +1108,6 @@
                                       padding:4px 16px;font-size:11px;flex-wrap:wrap">
       <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
         <select id="mode-picker"
-                onchange="onModePickerChange()"
                 style="background:var(--surface);border:1px solid var(--border);
                        color:var(--text);padding:4px 10px;border-radius:6px;
                        font-size:11px;cursor:pointer">
@@ -1118,13 +1117,12 @@
               style="display:none;align-items:center;gap:4px"
               title="이 모드에서 사용할 모델 선택">
           <select id="model-picker"
-                  onchange="onModelPickerChange()"
                   style="background:var(--surface);border:1px solid var(--border);
                          color:var(--text);padding:4px 10px;border-radius:6px;
                          font-size:11px;cursor:pointer"></select>
         </span>
         <button id="mode-install-btn"
-                onclick="triggerModelInstall()"
+                data-action="trigger-model-install"
                 aria-label="LLM 모델 설치"
                 style="display:none;background:var(--accent-soft);
                        border:1px solid var(--accent);color:var(--accent-fg);
@@ -1146,10 +1144,10 @@
               style="display:none;font-size:11px;color:var(--accent-fg);
                      padding:2px 8px;border:1px solid var(--accent-fg);
                      border-radius:6px;cursor:pointer"
-              onclick="acceptModeRecommend()"
+              data-action="accept-mode-recommend"
               title="권장 모드로 전환"></span>
       </div>
-      <button onclick="copyConversation()"
+      <button data-action="copy-conversation"
               style="background:none;border:1px solid var(--border);
                      border-radius:6px;padding:4px 10px;cursor:pointer;
                      color:var(--muted);font-size:11px;transition:all .15s"
@@ -1166,10 +1164,8 @@
                   border-bottom:1px solid var(--border-2);"></div>
       <div class="input-wrap">
         <textarea id="chat-input" placeholder="Type a message (Shift+Enter for new line)"
-                  data-i18n-placeholder="chat.placeholder" rows="1"
-          oninput="autoResize(this)" onkeydown="handleKey(event)"
-          onpaste="handleChatPaste(event)"></textarea>
-        <button class="send-btn" id="send-btn" onclick="sendMessage()"
+                  data-i18n-placeholder="chat.placeholder" rows="1"></textarea>
+        <button class="send-btn" id="send-btn" data-action="send-message"
                 aria-label="메시지 전송">▲</button>
       </div>
     </div>
@@ -1245,8 +1241,7 @@
 <!-- ── 로그인 모달 ── -->
 <div class="modal-overlay hidden" id="login-modal"
      role="dialog" aria-modal="true"
-     aria-labelledby="login-modal-title"
-     onclick="closeLoginOutside(event)">
+     aria-labelledby="login-modal-title">
   <div class="modal">
     <div class="modal-title" id="login-modal-title">▸ <span data-i18n="auth.login_title">로그인</span></div>
     <div class="modal-field">
@@ -1257,8 +1252,7 @@
     <div class="modal-field">
       <label data-i18n="auth.password">비밀번호</label>
       <input type="password" id="login-pw" placeholder="••••••••"
-             autocomplete="new-password"
-             onkeydown="if(event.key==='Enter') doLogin()">
+             autocomplete="new-password">
     </div>
     <!-- [#1-C] API Key — visible field instead of one-shot prompt().
          Pre-filled from localStorage on showLogin. Eye toggle reveals
@@ -1269,11 +1263,10 @@
       <div style="position:relative">
         <input type="password" id="login-api-key" placeholder="sk-..."
                autocomplete="off" spellcheck="false"
-               style="padding-right:40px"
-               onkeydown="if(event.key==='Enter') doLogin()">
+               style="padding-right:40px">
         <button type="button"
                 id="login-api-key-toggle"
-                onclick="toggleApiKeyVisibility()"
+                data-action="toggle-api-key-visibility"
                 aria-label="show/hide api key"
                 title="API Key 보기/숨기기"
                 style="position:absolute;right:8px;top:50%;
@@ -1286,18 +1279,18 @@
     </div>
     <div class="modal-error" id="login-error"></div>
     <div class="modal-actions">
-      <button class="modal-btn cancel" onclick="closeLogin()" data-i18n="common.cancel">취소</button>
-      <button class="modal-btn primary" onclick="doLogin()" data-i18n="auth.login">로그인</button>
+      <button class="modal-btn cancel" data-action="close-login" data-i18n="common.cancel">취소</button>
+      <button class="modal-btn primary" data-action="do-login" data-i18n="auth.login">로그인</button>
     </div>
     <!-- W4 P5: forgot-password link -->
     <div style="margin-top:14px;text-align:center;font-size:12px">
-      <a href="javascript:openForgotPasswordModal()"
+      <a href="#" data-action="open-forgot-password-modal"
          style="color:var(--muted);text-decoration:underline;cursor:pointer"
          data-i18n="auth.forgot_password">비밀번호를 잊으셨나요?</a>
     </div>
     <!-- W4 P4: signup link beneath login -->
     <div style="margin-top:8px;text-align:center;font-size:12px">
-      <a href="javascript:openSignupModal()"
+      <a href="#" data-action="open-signup-modal"
          style="color:var(--muted);text-decoration:underline;cursor:pointer"
          data-i18n="auth.signup_link">계정이 없으신가요? 회원가입</a>
     </div>
@@ -1313,8 +1306,7 @@
 -->
 <div class="modal-overlay hidden" id="forgot-password-modal"
      role="dialog" aria-modal="true"
-     aria-labelledby="forgot-password-modal-title"
-     onclick="closeForgotPasswordOutside(event)">
+     aria-labelledby="forgot-password-modal-title">
   <div class="modal">
     <div class="modal-title" id="forgot-password-modal-title">▸ <span data-i18n="auth.reset_password_title">비밀번호 재설정</span></div>
     <div style="font-size:12px;color:var(--muted);margin-bottom:14px;line-height:1.5"
@@ -1337,13 +1329,12 @@
     </div>
     <div class="modal-field">
       <label data-i18n="auth.password">새 비밀번호</label>
-      <input type="password" id="reset-new-pw" autocomplete="new-password"
-             onkeydown="if(event.key==='Enter') submitPasswordReset()">
+      <input type="password" id="reset-new-pw" autocomplete="new-password">
     </div>
     <div class="modal-error" id="reset-error"></div>
     <div class="modal-actions">
-      <button class="modal-btn cancel" onclick="closeForgotPasswordModal()" data-i18n="common.cancel">취소</button>
-      <button class="modal-btn primary" onclick="submitPasswordReset()" data-i18n="auth.reset_submit">재설정</button>
+      <button class="modal-btn cancel" data-action="close-forgot-password-modal" data-i18n="common.cancel">취소</button>
+      <button class="modal-btn primary" data-action="submit-password-reset" data-i18n="auth.reset_submit">재설정</button>
     </div>
   </div>
 </div>
@@ -1356,8 +1347,7 @@
 -->
 <div class="modal-overlay hidden" id="signup-modal"
      role="dialog" aria-modal="true"
-     aria-labelledby="signup-modal-title"
-     onclick="closeSignupOutside(event)">
+     aria-labelledby="signup-modal-title">
   <div class="modal">
     <div class="modal-title" id="signup-modal-title">▸ <span data-i18n="auth.signup_title">회원가입</span></div>
     <div style="font-size:11px;color:var(--muted);margin-bottom:14px;line-height:1.5"
@@ -1374,14 +1364,13 @@
       <label data-i18n="auth.password">비밀번호</label>
       <input type="password" id="signup-pw" autocomplete="new-password"
              data-i18n-placeholder="auth.signup_password_ph"
-             placeholder="8~72자, 영문 + 숫자"
-             onkeydown="if(event.key==='Enter') doSignup()">
+             placeholder="8~72자, 영문 + 숫자">
     </div>
     <div class="modal-error" id="signup-error"></div>
     <div class="modal-info" id="signup-success" style="display:none;color:#1e7a3e;font-size:12px;margin-bottom:8px"></div>
     <div class="modal-actions">
-      <button class="modal-btn cancel" onclick="closeSignup()" data-i18n="common.cancel">취소</button>
-      <button class="modal-btn primary" onclick="doSignup()" data-i18n="auth.signup_submit">가입 신청</button>
+      <button class="modal-btn cancel" data-action="close-signup" data-i18n="common.cancel">취소</button>
+      <button class="modal-btn primary" data-action="do-signup" data-i18n="auth.signup_submit">가입 신청</button>
     </div>
   </div>
 </div>

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -90,6 +90,131 @@ function checkTokenExpiry() {
 // 5분마다 만료 확인
 setInterval(checkTokenExpiry, 5 * 60 * 1000);
 
+/* ── §5 인라인 핸들러 위임 (CSP-친화) ──
+ * index.html / chat.js / upload.js 에는 더 이상 ``onclick=`` /
+ * ``onkeydown=`` / ``oninput=`` 같은 인라인 핸들러가 없다. 정적
+ * 요소는 ``data-action`` 을 가지며 document 단의 click 위임이
+ * 라우팅한다. ``oninput`` 은 ``data-input-action`` 으로 분리해
+ * 별도 input 위임이 처리한다. 안정적 id 를 가진 요소
+ * (#chat-input textarea, login/forgot/signup 모달 overlay) 는
+ * DOMContentLoaded 시점에 id 로 직접 바인딩한다 — innerHTML 로
+ * 다시 그려지지 않는 요소들이기 때문. */
+function _bindFrontendEvents() {
+  document.addEventListener('click', (e) => {
+    const t = e.target.closest && e.target.closest('[data-action]');
+    if (!t) return;
+    const action = t.getAttribute('data-action');
+    switch (action) {
+      // Header / source toggle
+      case 'set-source':                setSource(t.getAttribute('data-source'), t); break;
+      case 'toggle-lang':               toggleLang(); break;
+      case 'clear-history':             clearHistory(); break;
+      case 'toggle-session-panel':      toggleSessionPanel(); break;
+      case 'show-login':                showLogin(); break;
+      case 'new-session':               newSession(); break;
+      // Sidebar
+      case 'toggle-sidebar':            toggleSidebar(); break;
+      case 'switch-sidebar-mode':       switchSidebarMode(t.getAttribute('data-mode')); break;
+      case 'trigger-file-input':
+        document.getElementById('file-input').click();
+        break;
+      case 'trigger-folder-input':
+        e.stopPropagation();
+        document.getElementById('folder-input').click();
+        break;
+      case 'upload-files':              uploadFiles(); break;
+      // Welcome chips
+      case 'use-chip':                  useChip(t); break;
+      // Mode/model
+      case 'trigger-model-install':     triggerModelInstall(); break;
+      case 'accept-mode-recommend':     acceptModeRecommend(); break;
+      case 'copy-conversation':         copyConversation(); break;
+      // Send + login
+      case 'send-message':              sendMessage(); break;
+      case 'toggle-api-key-visibility': toggleApiKeyVisibility(); break;
+      case 'close-login':               closeLogin(); break;
+      case 'do-login':                  doLogin(); break;
+      case 'open-forgot-password-modal':
+        e.preventDefault(); openForgotPasswordModal(); break;
+      case 'close-forgot-password-modal':
+        closeForgotPasswordModal(); break;
+      case 'submit-password-reset':     submitPasswordReset(); break;
+      case 'open-signup-modal':
+        e.preventDefault(); openSignupModal(); break;
+      case 'close-signup':              closeSignup(); break;
+      case 'do-signup':                 doSignup(); break;
+      // Dynamic answer-card buttons
+      case 'logout':                    logout(); break;
+      case 'approve-wiki-save':         approveWikiSave(t); break;
+      case 'ask-with-force-web':        askWithForceWeb(t); break;
+      case 'export-answer':
+        exportAnswer(t, t.getAttribute('data-format'));
+        break;
+      case 'send-feedback':
+        sendFeedback(
+          t.getAttribute('data-dir-id'),
+          t.getAttribute('data-signal'),
+          t,
+        );
+        break;
+      case 'copy-answer-text':          copyAnswerText(t); break;
+      case 'ask-suggestion':
+        askSuggestion(parseInt(t.getAttribute('data-index'), 10), t);
+        break;
+      // Session-panel rows
+      case 'switch-session':            switchSession(t.getAttribute('data-sid')); break;
+      case 'rename-session':            renameSession(t.getAttribute('data-sid'), e); break;
+      case 'delete-session':            deleteSession(t.getAttribute('data-sid'), e); break;
+      // upload.js mini-thumbnails
+      case 'chat-attach-click':         _chatAttachClick(); break;
+      case 'remove-or-cancel':          removeOrCancel(t.getAttribute('data-item-id')); break;
+    }
+  });
+
+  // Per-input updates (upload.js folder-input rows). Registering at
+  // module load is safe — events only fire once the inputs exist.
+  document.addEventListener('input', (e) => {
+    const t = e.target.closest && e.target.closest('[data-input-action]');
+    if (!t) return;
+    if (t.getAttribute('data-input-action') === 'update-instruction') {
+      updateInstruction(t.getAttribute('data-item-id'), t.value);
+    }
+  });
+}
+
+function _bindStableInputs() {
+  const ci = document.getElementById('chat-input');
+  if (ci) {
+    ci.addEventListener('input',   () => autoResize(ci));
+    ci.addEventListener('keydown', (e) => handleKey(e));
+    ci.addEventListener('paste',   (e) => handleChatPaste(e));
+  }
+  const lpw = document.getElementById('login-pw');
+  if (lpw) lpw.addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
+  const lk = document.getElementById('login-api-key');
+  if (lk)  lk.addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
+  const rn = document.getElementById('reset-new-pw');
+  if (rn)  rn.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitPasswordReset(); });
+  const su = document.getElementById('signup-pw');
+  if (su)  su.addEventListener('keydown', (e) => { if (e.key === 'Enter') doSignup(); });
+  const mp = document.getElementById('mode-picker');
+  if (mp)  mp.addEventListener('change', () => onModePickerChange());
+  const mdp = document.getElementById('model-picker');
+  if (mdp) mdp.addEventListener('change', () => onModelPickerChange());
+  // Modal-overlay click-outside → close. Each overlay's existing
+  // close*Outside fn already checks ``e.target === overlay`` so we
+  // forward the event unchanged.
+  const lm = document.getElementById('login-modal');
+  if (lm)  lm.addEventListener('click', (e) => closeLoginOutside(e));
+  const fm = document.getElementById('forgot-password-modal');
+  if (fm)  fm.addEventListener('click', (e) => closeForgotPasswordOutside(e));
+  const sm = document.getElementById('signup-modal');
+  if (sm)  sm.addEventListener('click', (e) => closeSignupOutside(e));
+}
+
+_bindFrontendEvents();
+window.addEventListener('DOMContentLoaded', _bindStableInputs);
+
 /* ── 초기화 ── */
 window.addEventListener('DOMContentLoaded', () => {
   // [#1-C] API key는 더 이상 native prompt()로 묻지 않는다 — 폰에서
@@ -855,7 +980,7 @@ function updateRoleBadge() {
 
     roleText.innerHTML = `
       <span style="color:${roleColor};font-weight:600">${userRole.toUpperCase()}</span>
-      <button class="logout-btn" onclick="logout()" title="로그아웃">✕</button>
+      <button class="logout-btn" data-action="logout" title="로그아웃">✕</button>
     `;
   } else {
     badge.classList.remove('logged-in');
@@ -1081,7 +1206,7 @@ function appendJamesMsg(data) {
     saveWikiChip = `
       <div style="margin-top:6px">
         <button class="next-action-chip save-wiki-btn"
-                onclick="approveWikiSave(this)"
+                data-action="approve-wiki-save"
                 data-proposal-id="${escHtml(data.pending_save_proposal_id)}"
                 style="text-align:left;background:rgba(76,175,125,.10);
                        border:1px solid rgba(76,175,125,.45);border-radius:8px;
@@ -1137,7 +1262,7 @@ function appendJamesMsg(data) {
       forceWebChip = `
         <div style="margin-top:8px">
           <button class="next-action-chip force-web-btn"
-                  onclick="askWithForceWeb(this)"
+                  data-action="ask-with-force-web"
                   data-question="${encodeURIComponent(q)}"
                   style="text-align:left;background:rgba(79,195,247,.10);
                          border:1px solid rgba(79,195,247,.45);border-radius:8px;
@@ -1232,27 +1357,28 @@ function appendJamesMsg(data) {
   const answerEscapedAttr = encodeURIComponent(answer);
   const _expBtnStyle = "background:none;border:1px solid var(--border);border-radius:6px;padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;transition:all .15s";
   const pyExportBtn = hasCodeBlock ? `
-      <button class="fb-btn export-btn" onclick="exportAnswer(this, 'py')" data-content="${answerEscapedAttr}"
+      <button class="fb-btn export-btn" data-action="export-answer" data-format="py" data-content="${answerEscapedAttr}"
         style="${_expBtnStyle}" title=".py 다운로드 (코드 블록만 추출)">📥 .py</button>` : '';
   const exportButtons = showExportBtns ? `
-      <button class="fb-btn export-btn" onclick="exportAnswer(this, 'md')" data-content="${answerEscapedAttr}"
+      <button class="fb-btn export-btn" data-action="export-answer" data-format="md" data-content="${answerEscapedAttr}"
         style="${_expBtnStyle}" title=".md 다운로드">📥 .md</button>
-      <button class="fb-btn export-btn" onclick="exportAnswer(this, 'docx')" data-content="${answerEscapedAttr}"
+      <button class="fb-btn export-btn" data-action="export-answer" data-format="docx" data-content="${answerEscapedAttr}"
         style="${_expBtnStyle}" title=".docx 다운로드 (Word)">📥 .docx</button>
-      <button class="fb-btn export-btn" onclick="exportAnswer(this, 'txt')" data-content="${answerEscapedAttr}"
+      <button class="fb-btn export-btn" data-action="export-answer" data-format="txt" data-content="${answerEscapedAttr}"
         style="${_expBtnStyle}" title=".txt 다운로드 (Notepad)">📥 .txt</button>${pyExportBtn}`
     : pyExportBtn;
+  const dirIdEsc = dirId ? escHtml(dirId) : '';
   const fbHtml = dirId ? `
     <div class="feedback-btns" style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap">
-      <button class="fb-btn" onclick="sendFeedback('${dirId}', 'explicit_positive', this)"
+      <button class="fb-btn" data-action="send-feedback" data-dir-id="${dirIdEsc}" data-signal="explicit_positive"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
                transition:all .15s" title="좋아요">👍</button>
-      <button class="fb-btn" onclick="sendFeedback('${dirId}', 'explicit_negative', this)"
+      <button class="fb-btn" data-action="send-feedback" data-dir-id="${dirIdEsc}" data-signal="explicit_negative"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
                transition:all .15s" title="별로예요">👎</button>
-      <button class="fb-btn" onclick="copyAnswerText(this)" data-content="${answerEscapedAttr}"
+      <button class="fb-btn" data-action="copy-answer-text" data-content="${answerEscapedAttr}"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
                transition:all .15s" title="이 답변 복사">📋 복사</button>
@@ -1270,7 +1396,8 @@ function appendJamesMsg(data) {
                                        margin-top:8px">
         ${suggestions.map((s, i) => `
           <button class="next-action-chip"
-                  onclick="askSuggestion(${i}, this)"
+                  data-action="ask-suggestion"
+                  data-index="${i}"
                   data-suggestion="${encodeURIComponent(s.text)}"
                   style="text-align:left;background:var(--surface-2);
                          border:1px solid var(--border);border-radius:8px;
@@ -1919,7 +2046,7 @@ function formatAnswerWithParagraphs(text) {
     return `<div class="paragraph">
       <div class="paragraph-content">${formatAnswer(restored)}</div>
       <button class="paragraph-copy-btn"
-              onclick="copyAnswerText(this)"
+              data-action="copy-answer-text"
               data-content="${escapedAttr}"
               title="이 문단 복사"
               aria-label="이 문단 복사">📋</button>
@@ -2011,13 +2138,14 @@ async function loadSessionList() {
       const sidEsc    = s.session_id.replace(/'/g, "\\'");
       const titleEsc  = titleText.replace(/'/g, "\\'").replace(/"/g, '&quot;');
 
+      const sidAttr = escHtml(s.session_id);
       return `
-        <div data-sid="${s.session_id}"
+        <div data-sid="${sidAttr}"
              style="padding:10px;margin-bottom:6px;border-radius:8px;
                     border:1px solid ${isCurrent ? 'var(--accent,#7c6af7)' : 'var(--border,#333)'};
                     background:${isCurrent ? 'rgba(124,106,247,.1)' : 'var(--bg,#161616)'};
                     transition:all .15s">
-          <div onclick="switchSession('${sidEsc}')" style="cursor:pointer">
+          <div data-action="switch-session" data-sid="${sidAttr}" style="cursor:pointer">
             <div style="display:flex;align-items:center;gap:6px;margin-bottom:3px">
               ${s.name ? '<span style="font-size:11px">📌</span>' : ''}
               <div style="flex:1;font-size:13px;font-weight:600;
@@ -2035,12 +2163,12 @@ async function loadSessionList() {
           <!-- [3-D] 액션 버튼 -->
           <div style="display:flex;gap:4px;margin-top:6px;
                       padding-top:6px;border-top:1px solid var(--border,#333)">
-            <button onclick="renameSession('${sidEsc}', event)"
+            <button data-action="rename-session" data-sid="${sidAttr}"
                     style="flex:1;background:none;border:1px solid var(--border,#333);
                            border-radius:4px;padding:3px 6px;font-size:10px;
                            cursor:pointer;color:var(--muted,#888)"
                     title="이름 변경">✏️ 이름</button>
-            <button onclick="deleteSession('${sidEsc}', event)"
+            <button data-action="delete-session" data-sid="${sidAttr}"
                     style="flex:1;background:none;border:1px solid var(--border,#333);
                            border-radius:4px;padding:3px 6px;font-size:10px;
                            cursor:pointer;color:#f06292"

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -310,7 +310,7 @@ function renderChatAttachmentRow() {
       ? it.file.name.slice(0, 16) + '…' + it.file.name.slice(-5)
       : it.file.name;
     return `
-      <div onclick="_chatAttachClick()"
+      <div data-action="chat-attach-click"
            title="${it.file.name.replace(/"/g, '&quot;')}"
            style="display:flex;align-items:center;gap:6px;padding:4px 8px 4px 4px;
                   background:var(--surface-2);border:1px solid var(--border);
@@ -428,7 +428,7 @@ function renderFileItem(item) {
         <div class="file-size">${formatSize(item.file.size)}</div>
       </div>
       <span class="file-status status-ready" id="status-${item.id}">대기</span>
-      <button class="remove-btn" id="action-${item.id}" onclick="removeOrCancel('${item.id}')" title="제거">✕</button>
+      <button class="remove-btn" id="action-${item.id}" data-action="remove-or-cancel" data-item-id="${escHtml(item.id)}" title="제거">✕</button>
     </div>
     <div class="file-progress-row" id="progress-${item.id}" style="display:none;">
       <div class="file-progress-bar"><div class="file-progress-fill" id="progress-fill-${item.id}"></div></div>
@@ -441,7 +441,8 @@ function renderFileItem(item) {
         class="folder-input"
         id="folder-${item.id}"
         placeholder="저장 폴더 (예: 김철수 폴더에 | 기본: 날짜 자동)"
-        oninput="updateInstruction('${item.id}', this.value)"
+        data-input-action="update-instruction"
+        data-item-id="${escHtml(item.id)}"
       >
     </div>
   `;

--- a/tests/test_a11y_aria_labels.py
+++ b/tests/test_a11y_aria_labels.py
@@ -102,18 +102,21 @@ class IconOnlyButtonsTests(unittest.TestCase):
 
     def test_index_send_button(self):
         # The ▲ submit button on the chat input.
+        # [§5 migration] sendMessage() → data-action="send-message".
         self._assert_aria_on_button(
-            self.index, "sendMessage()", "index.html")
+            self.index, 'data-action="send-message"', "index.html")
 
     def test_index_model_install_button(self):
         # mode-install-btn — empty button shown only when LLM is missing.
+        # [§5 migration] triggerModelInstall() → data-action.
         self._assert_aria_on_button(
-            self.index, "triggerModelInstall()", "index.html")
+            self.index, 'data-action="trigger-model-install"', "index.html")
 
     def test_index_clear_history_button(self):
         # 🗑 button next to lang toggle.
+        # [§5 migration] clearHistory() → data-action="clear-history".
         self._assert_aria_on_button(
-            self.index, "clearHistory()", "index.html")
+            self.index, 'data-action="clear-history"', "index.html")
 
     def test_index_sidebar_open_button(self):
         # ▶ button shown when sidebar is collapsed (id=sidebar-open-btn).

--- a/tests/test_chat_mode_picker.py
+++ b/tests/test_chat_mode_picker.py
@@ -170,12 +170,18 @@ class FrontendChatHtmlTests(unittest.TestCase):
     def test_mode_picker_select_present(self):
         self.assertIn('id="mode-picker"', self.html,
                       "<select id='mode-picker'> missing in chat HTML")
-        self.assertIn('onchange="onModePickerChange()"', self.html)
+        # [§5 migration] inline onchange replaced by id-bound listener
+        # registered in _bindStableInputs (chat.js).
+        chat = (ROOT / "frontend" / "static" / "chat.js").read_text(
+            encoding="utf-8")
+        self.assertIn("onModePickerChange", chat,
+            "chat.js must wire onModePickerChange via _bindStableInputs")
 
     def test_recommend_badge_present(self):
         self.assertIn('id="mode-recommend"', self.html,
                       "recommendation badge element missing")
-        self.assertIn('onclick="acceptModeRecommend()"', self.html)
+        # [§5 migration] inline onclick replaced by data-action.
+        self.assertIn('data-action="accept-mode-recommend"', self.html)
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_wiki_save.py
+++ b/tests/test_chat_wiki_save.py
@@ -113,8 +113,11 @@ class FrontendChipTests(unittest.TestCase):
             "must inspect pending_save_proposal_id")
         self.assertIn("userRole === 'admin'", body,
             "chip must be admin-only (server also rejects non-admin)")
-        self.assertIn("approveWikiSave(this)", body,
-            "chip onclick must call approveWikiSave")
+        # [§5 migration] inline onclick replaced by data-action;
+        # delegate in chat.js calls approveWikiSave(button) so the
+        # function still reads dataset.proposalId from the element.
+        self.assertIn('data-action="approve-wiki-save"', body,
+            "chip must carry data-action=approve-wiki-save")
         self.assertIn("data-proposal-id", body,
             "chip must carry proposal id via data attr")
         self.assertIn("${saveWikiChip}", body,

--- a/tests/test_copy_and_conditional_download.py
+++ b/tests/test_copy_and_conditional_download.py
@@ -43,7 +43,8 @@ class FullCopyButtonTests(unittest.TestCase):
         cls.js   = JS.read_text(encoding="utf-8")
 
     def test_html_has_full_copy_button(self):
-        self.assertIn('onclick="copyConversation()"', self.html,
+        # [§5 migration] copyConversation() → data-action.
+        self.assertIn('data-action="copy-conversation"', self.html,
                       "전체 대화 복사 버튼 missing")
         self.assertIn("대화 전체 복사", self.html,
                       "user-visible label '대화 전체 복사' missing")
@@ -81,7 +82,9 @@ class PerMessageCopyTests(unittest.TestCase):
         m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
         end = idx + 1 + m.start() if m else idx + 8000
         body = self.js[idx:end]
-        self.assertIn('onclick="copyAnswerText(this)"', body,
+        # [§5 migration] copyAnswerText(this) → data-action; delegate
+        # passes the element to the underlying function.
+        self.assertIn('data-action="copy-answer-text"', body,
                       "appendJamesMsg must include a per-answer copy button")
         self.assertIn("📋 복사", body)
 

--- a/tests/test_folder_upload.py
+++ b/tests/test_folder_upload.py
@@ -122,9 +122,19 @@ class HtmlFolderInputTests(unittest.TestCase):
     def test_folder_select_button_present(self):
         # Visible "폴더 선택" button.
         self.assertIn("폴더 선택", self.html)
-        # Triggering folder-input click via JS onclick.
-        self.assertIn("folder-input').click()", self.html,
-                      "polder button must trigger folder-input.click()")
+        # [§5 migration] inline `onclick="...folder-input.click()"` is
+        # replaced by `data-action="trigger-folder-input"`. The click
+        # delegate in chat.js calls e.stopPropagation() (drop-zone
+        # parent has its own data-action="trigger-file-input") and
+        # then `document.getElementById('folder-input').click()`.
+        self.assertIn('data-action="trigger-folder-input"', self.html,
+                      "folder button must carry data-action=trigger-folder-input")
+        chat_js = (ROOT / "frontend" / "static" / "chat.js").read_text(
+            encoding="utf-8")
+        self.assertIn("folder-input", chat_js,
+                      "chat.js delegate must reference #folder-input")
+        self.assertIn("trigger-folder-input", chat_js,
+                      "chat.js delegate must register trigger-folder-input action")
 
     def test_dropzone_label_mentions_folder_support(self):
         # Affordance text — user should know folder-drop works too.

--- a/tests/test_force_web_chip.py
+++ b/tests/test_force_web_chip.py
@@ -153,8 +153,11 @@ class FrontendChipTests(unittest.TestCase):
             "must check web_used before rendering chip")
         self.assertIn("score < 0.50", body,
             "must gate on score threshold")
-        self.assertIn("askWithForceWeb(this)", body,
-            "chip onclick must call askWithForceWeb")
+        # [§5 migration] inline onclick replaced by data-action;
+        # delegate forwards the element to askWithForceWeb so dataset
+        # is still readable.
+        self.assertIn('data-action="ask-with-force-web"', body,
+            "chip must carry data-action=ask-with-force-web")
         self.assertIn("data-question", body,
             "chip must carry the question via data attribute")
         self.assertIn("${forceWebChip}", body,

--- a/tests/test_frontend_event_delegation.py
+++ b/tests/test_frontend_event_delegation.py
@@ -36,7 +36,8 @@ STATIC = FRONTEND / "static"
 # add it here so the contract catches it.
 _INLINE_ATTR_RE = re.compile(
     r"\son(?:click|change|submit|input|keydown|keyup|keypress"
-    r"|focus|blur|mouseover|mouseout|mouseenter|mouseleave"
+    r"|focus|blur|paste|drag(?:start|enter|over|leave|end)?|drop"
+    r"|mouseover|mouseout|mouseenter|mouseleave"
     r"|mousedown|mouseup)\s*=",
     re.IGNORECASE,
 )
@@ -45,11 +46,11 @@ _INLINE_ATTR_RE = re.compile(
 _MIGRATED_PAGES = {
     "graph.html",
     "workspace.html",
+    "index.html",
 }
 
 # Pages still using inline handlers. Will shrink to empty by PR-D.
 _LEGACY_INLINE_PAGES = {
-    "index.html",
     "admin.html",
 }
 
@@ -243,6 +244,162 @@ class WorkspacePageDelegationTests(unittest.TestCase):
             r'<(?:tr|button)[^>]*\sonclick=',
             "no innerHTML template in workspace.js may emit inline onclick",
         )
+
+
+class ChatPageDelegationTests(unittest.TestCase):
+    """PR-C — index.html / chat.js / upload.js route every click via
+    ``data-action``; ``oninput`` is split into a separate
+    ``data-input-action`` delegate so dynamic upload-row inputs can be
+    re-rendered through innerHTML without losing wiring; stable inputs
+    (chat textarea, login/forgot/signup modals, mode/model pickers)
+    are bound by id at DOMContentLoaded."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html   = (FRONTEND / "index.html").read_text(encoding="utf-8")
+        cls.chat   = (STATIC / "chat.js").read_text(encoding="utf-8")
+        cls.upload = (STATIC / "upload.js").read_text(encoding="utf-8")
+
+    # ─── HTML — static actions ────────────────────────────────────
+    def test_html_uses_data_action_for_header(self):
+        for action in (
+            "set-source", "toggle-lang", "clear-history",
+            "toggle-session-panel", "show-login",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_uses_data_action_for_sidebar(self):
+        for action in (
+            "toggle-sidebar", "switch-sidebar-mode",
+            "trigger-file-input", "trigger-folder-input",
+            "upload-files",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_uses_data_action_for_chat_actions(self):
+        for action in (
+            "use-chip", "trigger-model-install", "accept-mode-recommend",
+            "copy-conversation", "send-message", "new-session",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_uses_data_action_for_login_modal(self):
+        for action in (
+            "toggle-api-key-visibility", "close-login", "do-login",
+            "open-forgot-password-modal", "open-signup-modal",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_drops_javascript_href(self):
+        # ``href="javascript:openForgotPasswordModal()"`` and
+        # ``href="javascript:openSignupModal()"`` replaced by
+        # ``href="#" data-action="open-…-modal"``; click delegate calls
+        # preventDefault before invoking the action.
+        self.assertNotIn('href="javascript:', self.html)
+
+    # ─── chat.js dynamic templates ────────────────────────────────
+    def test_chat_js_dynamic_buttons_use_data_action(self):
+        for action in (
+            "logout", "approve-wiki-save", "ask-with-force-web",
+            "export-answer", "send-feedback", "copy-answer-text",
+            "ask-suggestion",
+            "switch-session", "rename-session", "delete-session",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.chat)
+
+    def test_chat_js_export_buttons_carry_format_data(self):
+        # The four export buttons share one action and pass the format
+        # via ``data-format`` so the delegate only registers one entry.
+        for fmt in ("py", "md", "docx", "txt"):
+            with self.subTest(format=fmt):
+                self.assertRegex(
+                    self.chat,
+                    r'data-action="export-answer"[^`]*?data-format="' + fmt + r'"',
+                )
+
+    def test_chat_js_feedback_buttons_carry_dir_and_signal(self):
+        # sendFeedback was called as fn(dirId, signal, btn); migration
+        # encodes (dirId, signal) into data attributes so the delegate
+        # can rebuild the call.
+        for signal in ("explicit_positive", "explicit_negative"):
+            with self.subTest(signal=signal):
+                self.assertRegex(
+                    self.chat,
+                    r'data-action="send-feedback"[^`]*?data-signal="' + signal + r'"',
+                )
+        self.assertIn('data-dir-id="', self.chat,
+            "feedback button must carry data-dir-id")
+
+    def test_chat_js_session_rows_carry_sid(self):
+        # The three session-panel actions (switch/rename/delete) read
+        # the session id from data-sid (HTML-escaped via escHtml) —
+        # safer than the prior JS string-injection pattern.
+        self.assertRegex(
+            self.chat,
+            r'data-action="switch-session"\s+data-sid=',
+        )
+        self.assertRegex(
+            self.chat,
+            r'data-action="rename-session"\s+data-sid=',
+        )
+        self.assertRegex(
+            self.chat,
+            r'data-action="delete-session"\s+data-sid=',
+        )
+
+    # ─── upload.js dynamic templates ──────────────────────────────
+    def test_upload_js_uses_data_action(self):
+        self.assertIn('data-action="chat-attach-click"', self.upload)
+        self.assertIn('data-action="remove-or-cancel"', self.upload)
+        # And the folder-input per-row oninput moves to a separate
+        # input-delegate attribute so the click delegate doesn't see it.
+        self.assertIn('data-input-action="update-instruction"', self.upload)
+
+    def test_upload_js_no_inline_handlers(self):
+        hits = _INLINE_ATTR_RE.findall(self.upload)
+        self.assertEqual(
+            hits, [],
+            "upload.js innerHTML templates may not emit inline handlers",
+        )
+
+    # ─── Delegation infrastructure ────────────────────────────────
+    def test_chat_js_installs_click_delegation(self):
+        self.assertRegex(
+            self.chat,
+            r"document\.addEventListener\(\s*['\"]click['\"]",
+            "chat.js must install a document-level click delegate",
+        )
+        self.assertIn("data-action", self.chat)
+
+    def test_chat_js_installs_input_delegation(self):
+        # The folder-input oninput in upload.js routes through this
+        # separate input delegate so re-rendered rows keep working.
+        self.assertRegex(
+            self.chat,
+            r"document\.addEventListener\(\s*['\"]input['\"]",
+            "chat.js must install a document-level input delegate",
+        )
+        self.assertIn("data-input-action", self.chat)
+
+    def test_chat_js_binds_stable_inputs_on_dom_ready(self):
+        self.assertIn("_bindStableInputs", self.chat)
+        self.assertRegex(
+            self.chat,
+            r"DOMContentLoaded[\s\S]{0,80}?_bindStableInputs",
+        )
+
+    def test_chat_js_binds_modal_overlay_close(self):
+        # The three modal overlay click-outside handlers are bound by
+        # id in _bindStableInputs (closeLoginOutside / Forgot / Signup
+        # each check e.target === overlay so we forward the event).
+        self.assertIn("closeLoginOutside", self.chat)
+        self.assertIn("closeForgotPasswordOutside", self.chat)
+        self.assertIn("closeSignupOutside", self.chat)
 
 
 if __name__ == "__main__":

--- a/tests/test_login_api_key_field.py
+++ b/tests/test_login_api_key_field.py
@@ -59,13 +59,22 @@ class HtmlFieldTests(unittest.TestCase):
     def test_visibility_toggle_button_present(self):
         self.assertIn('id="login-api-key-toggle"', self.html,
             "missing 👁️ visibility-toggle button")
-        self.assertIn('toggleApiKeyVisibility()', self.html,
-            "toggle button must wire to toggleApiKeyVisibility()")
+        # [§5 migration] inline onclick → data-action.
+        self.assertIn('data-action="toggle-api-key-visibility"', self.html,
+            "toggle button must carry data-action=toggle-api-key-visibility")
 
     def test_enter_key_submits_login(self):
-        m = re.search(r'id="login-api-key"[^>]*', self.html)
-        self.assertIn("if(event.key==='Enter') doLogin()", m.group(0),
-            "Enter on api-key field must submit login (parity with pw field)")
+        # [§5 migration] inline onkeydown removed; chat.js
+        # _bindStableInputs binds an Enter handler to #login-api-key
+        # that calls doLogin() (parity with the password field).
+        chat = JS.read_text(encoding="utf-8")
+        self.assertIn("login-api-key", chat,
+            "chat.js must wire #login-api-key for Enter submit")
+        self.assertRegex(
+            chat,
+            r"login-api-key[\s\S]{0,400}?Enter[\s\S]{0,200}?doLogin",
+            "Enter on #login-api-key must submit login via JS-bound handler",
+        )
 
     def test_hint_text_present(self):
         # Subtle hint pointing to .env JAMES_API_KEY so users know

--- a/tests/test_model_catalog_per_mode.py
+++ b/tests/test_model_catalog_per_mode.py
@@ -166,7 +166,10 @@ class FrontendSecondaryPickerTests(unittest.TestCase):
                       "secondary <select id='model-picker'> missing")
         self.assertIn('id="model-picker-wrap"', self.html,
                       "wrapper for hide/show needed")
-        self.assertIn('onchange="onModelPickerChange()"', self.html)
+        # [§5 migration] inline onchange replaced by id-bound listener
+        # registered in _bindStableInputs (chat.js).
+        self.assertIn("onModelPickerChange", self.js,
+            "chat.js must wire onModelPickerChange via _bindStableInputs")
 
     def test_refresh_model_picker_function(self):
         self.assertIn("function refreshModelPicker", self.js,

--- a/tests/test_model_names_install.py
+++ b/tests/test_model_names_install.py
@@ -144,7 +144,8 @@ class FrontendInstallButtonTests(unittest.TestCase):
     def test_install_button_in_html(self):
         self.assertIn('id="mode-install-btn"', self.html,
                       "install button missing from index.html")
-        self.assertIn('onclick="triggerModelInstall()"', self.html)
+        # [§5 migration] inline onclick → data-action.
+        self.assertIn('data-action="trigger-model-install"', self.html)
 
     def test_picker_options_show_model_tag_and_status(self):
         # loadModePickerOptions builds option labels with model tag +

--- a/tests/test_paragraph_copy.py
+++ b/tests/test_paragraph_copy.py
@@ -92,8 +92,11 @@ class JsContractTests(unittest.TestCase):
         body = self.js[idx:idx + 2500]
         self.assertIn('class="paragraph"', body)
         self.assertIn('class="paragraph-copy-btn"', body)
-        self.assertIn('onclick="copyAnswerText(this)"', body,
-                      "must reuse copyAnswerText for paragraph copy")
+        # [§5 migration] inline onclick → data-action; delegate
+        # forwards the element to copyAnswerText so dataset.content
+        # remains the data path.
+        self.assertIn('data-action="copy-answer-text"', body,
+                      "paragraph copy button must carry data-action=copy-answer-text")
         self.assertIn("encodeURIComponent(restored)", body,
                       "paragraph content must be URI-encoded for data attr")
         self.assertIn("paragraph-content", body,

--- a/tests/test_py_export.py
+++ b/tests/test_py_export.py
@@ -143,8 +143,14 @@ class FrontendPyButtonTests(unittest.TestCase):
         m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
         end = idx + 1 + m.start() if m else idx + 8000
         body = self.js[idx:end]
-        self.assertIn("exportAnswer(this, 'py')", body,
-                      ".py export button missing")
+        # [§5 migration] inline onclick replaced by
+        # ``data-action="export-answer" data-format="py"`` — the
+        # delegate calls exportAnswer(btn, 'py') from the data attr.
+        self.assertRegex(
+            body,
+            r'data-action="export-answer"[\s\S]{0,80}?data-format="py"',
+            ".py export button must carry data-action=export-answer + data-format=py",
+        )
         self.assertIn("hasCodeBlock", body,
                       "must detect code blocks before showing .py button")
         self.assertIn("```", body,

--- a/tests/test_suggestion_click.py
+++ b/tests/test_suggestion_click.py
@@ -209,8 +209,12 @@ class JsContractTests(unittest.TestCase):
         body = self.js[idx:end]
         self.assertIn("next-action-chip", body,
                       "chip class missing from rendered HTML")
-        self.assertIn('onclick="askSuggestion(', body,
-                      "chip must be wired to askSuggestion")
+        # [§5 migration] inline onclick → data-action; delegate parses
+        # data-index and forwards (index, button) to askSuggestion.
+        self.assertIn('data-action="ask-suggestion"', body,
+                      "chip must carry data-action=ask-suggestion")
+        self.assertIn("data-index=", body,
+                      "chip must carry data-index for delegate to forward")
         self.assertIn("data-suggestion=", body,
                       "chip must carry data-suggestion attribute")
 


### PR DESCRIPTION
## Summary

HANDOVER_WEB_UI.md §4 priority 5 — **phase 3 of 4**. Stacked on PR-B (#231).
Targets `index.html` (41), `chat.js` (15 in innerHTML templates) and
`upload.js` (3, including per-row `oninput`).

### `index.html` — 26 distinct actions

Header / source toggle / sidebar (rail + panel) / welcome chips /
mode-recommend / copy-conversation / send / login + forgot + signup
modals. Two `href=\"javascript:…\"` anchors → `href=\"#\" data-action=…`.

### `chat.js` innerHTML templates — safer dynamic markup

Every dynamic button now emits `data-action` + data-* params (formats,
dir-ids, indices, session ids) instead of JS-injecting them into an
attribute string. The session-row migration removes the JS escape path
entirely (`sidEsc = id.replace(/'/g, \"\\'\")` is no longer needed —
`escHtml(id)` lands in `data-sid`).

Actions: `logout`, `approve-wiki-save`, `ask-with-force-web`,
`export-answer` (+`data-format`), `send-feedback` (+`data-dir-id`,
`data-signal`), `copy-answer-text`, `ask-suggestion` (+`data-index`),
`switch-session` / `rename-session` / `delete-session` (+`data-sid`).

### `upload.js` — `data-input-action` for the oninput case

Per-file remove button + folder-input `oninput` migrated. A separate
**document-level input delegate** routes by `data-input-action` so
upload rows can be re-rendered through innerHTML without losing wiring.

### Delegation infrastructure (chat.js)

- `_bindFrontendEvents()` — click + input delegates, registered at
  module load (events fire after DOM exists).
- `_bindStableInputs()` — runs at DOMContentLoaded; wires by id:
  chat textarea (autoResize / handleKey / handleChatPaste), three
  modal-Enter keys, two pickers (mode/model change), three modal-overlay
  click-outside listeners.

### Tests

- `tests/test_frontend_event_delegation.py`:
  - `index.html` moves to `_MIGRATED_PAGES`
  - inline-attr regex extended (`onpaste`, `ondrag*`, `ondrop`)
  - **15 new `ChatPageDelegationTests`**
- 12 existing chat-frontend tests had inline-handler locators
  updated to `data-action` equivalents.

## Verification

- `python -m unittest discover` — **1483 tests OK** (+15 vs PR-B).
- No `core/retrieval` / `core/graph` / `core/reasoning` touched.
- Visual / behaviour parity (welcome chips, send, sidebar mode flip,
  drag-drop, login/forgot/signup Enter, copy/export, feedback, session
  switch/rename/delete) — please verify in browser before merge.

## Out of scope

- `admin.html` / `admin.js` → PR-D
- `a11y-modal.js:148` ESC fallback removal → follow-up after PR-D
- Adding a CSP header → separate cycle once PR-D lands and we've run
  the site in a real browser to catch anything the contract test missed

## Stacking

Branched off `chore/v0.2-frontend-event-delegation-b` (PR-B's branch),
which is branched off PR-A. Recommended merge order: PR-A → PR-B → PR-C.
Each branch rebases onto `main` after the prior PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)