### PR TITLE
refactor(frontend): admin page — inline handlers → data-action delegation (§5 PR-D)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -456,7 +456,7 @@
   </div>
   <div class="header-right">
     <!-- [STEP 5-A] 언어 토글 -->
-    <button class="nav-btn" data-lang-toggle onclick="toggleLang()" title="Language / 언어"
+    <button class="nav-btn" data-lang-toggle data-action="toggle-lang" title="Language / 언어"
             aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <a href="/" class="nav-btn" data-i18n="admin.chat_link">← 챗으로</a>
@@ -466,7 +466,7 @@
 <div class="admin-layout">
   <!-- 모바일에서 사이드메뉴 토글 — item #2 -->
   <button id="admin-nav-toggle"
-          onclick="toggleAdminNav()"
+          data-action="toggle-admin-nav"
           aria-label="메뉴 토글"
           style="display:none;position:fixed;top:8px;left:8px;z-index:60;
                  width:44px;height:44px;border:1px solid var(--border);
@@ -475,47 +475,47 @@
 
   <!-- ── 사이드 메뉴 (폴더블 섹션) ── -->
   <nav id="admin-nav">
-    <div class="nav-section nav-foldable" onclick="toggleNavSection(this)">
+    <div class="nav-section nav-foldable" data-action="toggle-nav-section">
       <span class="nav-fold-icon">▾</span> OVERVIEW
     </div>
     <div class="nav-group">
-      <div class="nav-item active" onclick="showPage('dashboard', this)">
+      <div class="nav-item active" data-action="show-page" data-page="dashboard">
         <span class="nav-icon">📊</span> <span data-i18n="admin.dashboard">대시보드</span>
       </div>
     </div>
 
-    <div class="nav-section nav-foldable" onclick="toggleNavSection(this)">
+    <div class="nav-section nav-foldable" data-action="toggle-nav-section">
       <span class="nav-fold-icon">▾</span> <span data-i18n="admin.section_manage">관리</span>
     </div>
     <div class="nav-group">
-      <div class="nav-item" onclick="showPage('users', this)">
+      <div class="nav-item" data-action="show-page" data-page="users">
         <span class="nav-icon">👥</span> <span data-i18n="admin.users">사용자</span>
       </div>
-      <div class="nav-item" onclick="showPage('policy', this)">
+      <div class="nav-item" data-action="show-page" data-page="policy">
         <span class="nav-icon">🛡️</span> <span data-i18n="admin.policy">권한 매트릭스</span>
       </div>
-      <div class="nav-item" onclick="showPage('entities', this)">
+      <div class="nav-item" data-action="show-page" data-page="entities">
         <span class="nav-icon">🕸</span> Entity
       </div>
-      <div class="nav-item" onclick="showPage('memory', this)">
+      <div class="nav-item" data-action="show-page" data-page="memory">
         <span class="nav-icon">🧠</span> Memory
       </div>
-      <div class="nav-item" onclick="showPage('patches', this)">
+      <div class="nav-item" data-action="show-page" data-page="patches">
         <span class="nav-icon">🔧</span> Patches
       </div>
-      <div class="nav-item" onclick="showPage('uploads', this)">
+      <div class="nav-item" data-action="show-page" data-page="uploads">
         <span class="nav-icon">📥</span> <span data-i18n="admin.upload_history">업로드 이력</span>
       </div>
-      <div class="nav-item" onclick="showPage('files', this)">
+      <div class="nav-item" data-action="show-page" data-page="files">
         <span class="nav-icon">📁</span> <span data-i18n="admin.file_mgmt">파일 관리</span>
       </div>
     </div>
 
-    <div class="nav-section nav-foldable" onclick="toggleNavSection(this)">
+    <div class="nav-section nav-foldable" data-action="toggle-nav-section">
       <span class="nav-fold-icon">▾</span> <span data-i18n="admin.section_security">보안</span>
     </div>
     <div class="nav-group">
-      <div class="nav-item" onclick="showPage('audit', this)">
+      <div class="nav-item" data-action="show-page" data-page="audit">
         <span class="nav-icon">📋</span> <span data-i18n="admin.audit_log">감사 로그</span>
       </div>
       <a class="nav-item" href="/admin/graph" style="text-decoration:none">
@@ -523,38 +523,38 @@
       </a>
     </div>
 
-    <div class="nav-section nav-foldable" onclick="toggleNavSection(this)">
+    <div class="nav-section nav-foldable" data-action="toggle-nav-section">
       <span class="nav-fold-icon">▾</span> <span data-i18n="admin.section_evolution">자기진화</span>
     </div>
     <div class="nav-group">
-      <div class="nav-item" onclick="showPage('proposals', this)">
+      <div class="nav-item" data-action="show-page" data-page="proposals">
         <span class="nav-icon">🧬</span> <span data-i18n="admin.proposal_review">제안 검토</span>
       </div>
-      <div class="nav-item" onclick="showPage('evo-reports', this)">
+      <div class="nav-item" data-action="show-page" data-page="evo-reports">
         <span class="nav-icon">📈</span> <span data-i18n="admin.evo_report">진화 보고서</span>
       </div>
-      <div class="nav-item" onclick="showPage('character', this)">
+      <div class="nav-item" data-action="show-page" data-page="character">
         <span class="nav-icon">🎭</span> <span data-i18n="admin.character">성향 캐릭터</span>
       </div>
-      <div class="nav-item" onclick="showPage('knowledge', this)">
+      <div class="nav-item" data-action="show-page" data-page="knowledge">
         <span class="nav-icon">🏆</span> <span data-i18n="admin.growth">능력 성장</span>
       </div>
-      <div class="nav-item" onclick="showPage('performance', this)">
+      <div class="nav-item" data-action="show-page" data-page="performance">
         <span class="nav-icon">📊</span> <span data-i18n="admin.performance">성능 평가</span>
       </div>
-      <div class="nav-item" onclick="showPage('learning', this)">
+      <div class="nav-item" data-action="show-page" data-page="learning">
         <span class="nav-icon">🎓</span> <span data-i18n="admin.learning">자기학습</span>
       </div>
     </div>
 
-    <div class="nav-section nav-foldable" onclick="toggleNavSection(this)">
+    <div class="nav-section nav-foldable" data-action="toggle-nav-section">
       <span class="nav-fold-icon">▾</span> <span data-i18n="admin.section_system">시스템</span>
     </div>
     <div class="nav-group">
-      <div class="nav-item" onclick="showPage('hardware', this)">
+      <div class="nav-item" data-action="show-page" data-page="hardware">
         <span class="nav-icon">🛠️</span> <span data-i18n="admin.hardware">장비 현황</span>
       </div>
-      <div class="nav-item" onclick="showPage('settings', this)">
+      <div class="nav-item" data-action="show-page" data-page="settings">
         <span class="nav-icon">⚙️</span> <span data-i18n="admin.settings">설정</span>
       </div>
     </div>
@@ -590,7 +590,7 @@
                data-i18n-placeholder="users.mypw_new_ph" placeholder="새 비밀번호 (8~72자, 영문+숫자)"
                autocomplete="new-password"
                style="flex:2;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px">
-        <button onclick="changeMyPassword()"
+        <button data-action="change-my-password"
                 style="padding:8px 14px;background:#1e7a3e;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px"
                 data-i18n="users.mypw_submit">변경</button>
         <div id="mypw-msg" style="flex-basis:100%;font-size:12px;color:var(--muted);font-family:var(--font-mono);min-height:16px"></div>
@@ -605,7 +605,7 @@
                  placeholder="라벨 (선택, 예: ci-deploy)"
                  maxlength="64"
                  style="flex:1;min-width:160px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
-          <button onclick="issueMyApiKey()"
+          <button data-action="issue-my-api-key"
                   style="padding:7px 12px;background:#1e5a7a;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:12px"
                   data-i18n="users.mykey_issue">키 발급</button>
         </div>
@@ -685,10 +685,8 @@
                placeholder="이름 / id 검색 (substring)"
                style="flex:1;min-width:200px;padding:8px 12px;
                       background:var(--bg);border:1px solid var(--border);
-                      border-radius:6px;color:var(--text);font-size:13px"
-               oninput="onEntitiesSearchInput()">
+                      border-radius:6px;color:var(--text);font-size:13px">
         <select id="entities-etype-filter"
-                onchange="loadEntities()"
                 style="padding:8px 12px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
                        color:var(--text);font-size:13px">
@@ -708,13 +706,13 @@
 
       <!-- Paging buttons -->
       <div style="display:flex;gap:8px;justify-content:center;margin-top:12px">
-        <button onclick="entitiesPage(-1)" id="entities-prev"
+        <button data-action="entities-page" data-delta="-1" id="entities-prev"
                 style="padding:6px 14px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
                        color:var(--text);cursor:pointer">← 이전</button>
         <span id="entities-page-label"
               style="align-self:center;font-size:12px;color:var(--muted);font-family:var(--font-mono)">page 1</span>
-        <button onclick="entitiesPage(1)" id="entities-next"
+        <button data-action="entities-page" data-delta="1" id="entities-next"
                 style="padding:6px 14px;background:var(--bg);
                        border:1px solid var(--border);border-radius:6px;
                        color:var(--text);cursor:pointer">다음 →</button>
@@ -727,16 +725,16 @@
            style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);
                   z-index:9999;align-items:flex-start;justify-content:center;
                   overflow-y:auto;padding:40px 16px"
-           onclick="closeEntityDetail(event)">
+           data-overlay-action="close-entity-detail">
         <div style="background:var(--surface-2);border:1px solid var(--border);
                     border-radius:8px;padding:20px;max-width:720px;width:100%;
-                    max-height:85vh;overflow-y:auto" onclick="event.stopPropagation()">
+                    max-height:85vh;overflow-y:auto">
           <div style="display:flex;justify-content:space-between;align-items:center;
                       margin-bottom:12px;border-bottom:1px solid var(--border);
                       padding-bottom:8px">
             <div id="entity-detail-title"
                  style="font-size:16px;font-weight:600"></div>
-            <button onclick="closeEntityDetail()"
+            <button data-action="close-entity-detail"
                     aria-label="닫기"
                     style="background:transparent;border:0;color:var(--muted);
                            cursor:pointer;font-size:20px">×</button>
@@ -782,16 +780,16 @@
            style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);
                   z-index:9999;align-items:flex-start;justify-content:center;
                   overflow-y:auto;padding:40px 16px"
-           onclick="closeSessionTurns(event)">
+           data-overlay-action="close-session-turns">
         <div style="background:var(--surface-2);border:1px solid var(--border);
                     border-radius:8px;padding:20px;max-width:820px;width:100%;
-                    max-height:85vh;overflow-y:auto" onclick="event.stopPropagation()">
+                    max-height:85vh;overflow-y:auto">
           <div style="display:flex;justify-content:space-between;align-items:center;
                       margin-bottom:12px;border-bottom:1px solid var(--border);
                       padding-bottom:8px">
             <div id="session-turns-title"
                  style="font-size:16px;font-weight:600">세션 원본 대화</div>
-            <button onclick="closeSessionTurns()"
+            <button data-action="close-session-turns"
                     aria-label="닫기"
                     style="background:transparent;border:0;color:var(--muted);
                            cursor:pointer;font-size:20px">×</button>
@@ -826,7 +824,7 @@
     <div class="page" id="page-proposals">
       <div class="page-title"><span data-i18n="prop.page_title">🧬 자기진화 제안 검토</span>
         <button class="btn btn-primary" style="font-size:12px;margin-left:12px"
-          onclick="generateProposals()" data-i18n="prop.generate">📡 Analyze Signals → Generate Proposals</button>
+          data-action="generate-proposals" data-i18n="prop.generate">📡 Analyze Signals → Generate Proposals</button>
       </div>
       <div class="section-title">▸ <span data-i18n="prop.title">대기 중인 제안</span></div>
       <div class="table-wrap">
@@ -893,7 +891,7 @@
                  placeholder="JAMES">
         </div>
         <div style="padding: 12px 0; display:flex; justify-content:flex-end;">
-          <button class="btn btn-primary" onclick="saveIdentity()"
+          <button class="btn btn-primary" data-action="save-identity"
                   data-i18n="char.identity_save">💾 이름 저장</button>
         </div>
       </div>
@@ -964,10 +962,10 @@
           </div>
 
           <div style="margin-top:20px;display:flex;gap:8px;flex-wrap:wrap">
-            <button class="btn btn-primary" onclick="saveCharacter()"
+            <button class="btn btn-primary" data-action="save-character"
                     data-i18n="char.save">💾 저장</button>
             <button class="btn" style="background:var(--surface);border:1px solid var(--border);color:var(--muted)"
-                    onclick="resetCharacter()">
+                    data-action="reset-character">
               <span data-i18n="set.reset_default">↩ 기본값</span>
             </button>
           </div>
@@ -1004,7 +1002,7 @@
     <div class="page" id="page-performance">
       <div class="page-title"><span data-i18n="perf.page_title">📊 성능 평가</span>
         <button class="btn btn-primary" style="font-size:12px;margin-left:12px"
-          onclick="runEvaluation()" data-i18n="perf.run_now">🏃 Run Evaluation</button>
+          data-action="run-evaluation" data-i18n="perf.run_now">🏃 Run Evaluation</button>
       </div>
       <div class="cards" id="perf-cards"></div>
       <div class="section-title"><span data-i18n="perf.history">▸ Evaluation History</span></div>
@@ -1045,9 +1043,8 @@
           <div style="display:flex;flex-direction:column;gap:8px;min-width:260px">
             <div style="display:flex;gap:8px">
               <input class="setting-value" type="text" id="web-learn-input"
-                     placeholder="e.g., quantum computing, generative AI" data-i18n-placeholder="learn.web_placeholder"
-                     onkeydown="if(event.key==='Enter') webLearnTopic()">
-              <button class="btn btn-primary" onclick="webLearnTopic()" data-i18n="learn.web_btn">🌐 Search &amp; Learn</button>
+                     placeholder="e.g., quantum computing, generative AI" data-i18n-placeholder="learn.web_placeholder">
+              <button class="btn btn-primary" data-action="web-learn-topic" data-i18n="learn.web_btn">🌐 Search &amp; Learn</button>
             </div>
             <div style="font-size:11px;color:var(--muted)">
               <span data-i18n="learn.web_hint">💡 Tip: Asking the same topic twice in chat triggers auto long-term conversion</span>
@@ -1069,11 +1066,11 @@
           <div style="display:flex;gap:8px">
             <input class="setting-value" type="text" id="learn-topic-input"
                    placeholder="e.g., quantum computing, blockchain" data-i18n-placeholder="learn.topic_placeholder">
-            <button class="btn btn-primary" onclick="learnTopic()" data-i18n="learn.btn">Learn</button>
+            <button class="btn btn-primary" data-action="learn-topic" data-i18n="learn.btn">Learn</button>
           </div>
         </div>
         <div style="padding:12px 0">
-          <button class="btn btn-approve" onclick="learnFromErrors()" data-i18n="learn.from_errors">🔄 Auto-learn from errors</button>
+          <button class="btn btn-approve" data-action="learn-from-errors" data-i18n="learn.from_errors">🔄 Auto-learn from errors</button>
         </div>
         <div id="learn-result" style="font-size:12px;font-family:var(--font-mono);
              color:var(--muted);min-height:20px"></div>
@@ -1089,7 +1086,6 @@
       </div>
       <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
         <select id="audit-category"
-                onchange="audit_reload()"
                 style="padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
           <option value="all"        data-i18n="audit.cat_all">전체</option>
           <option value="user_mgmt"  data-i18n="audit.cat_user_mgmt">사용자 관리</option>
@@ -1104,7 +1100,6 @@
         <input id="audit-q" type="text"
                data-i18n-placeholder="audit.search_ph"
                placeholder="이벤트 / username / 키 prefix 검색"
-               oninput="audit_searchInput()"
                style="flex:1;min-width:200px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px">
         <span id="audit-counter"
               style="font-size:11px;color:var(--muted);font-family:var(--font-mono)"></span>
@@ -1123,12 +1118,12 @@
         </table>
       </div>
       <div style="display:flex;gap:8px;justify-content:center;margin-top:12px">
-        <button onclick="audit_page(-1)"
+        <button data-action="audit-page" data-delta="-1"
                 id="audit-prev"
                 style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer">← 이전</button>
         <span id="audit-page-label"
               style="align-self:center;font-size:12px;color:var(--muted);font-family:var(--font-mono)">page 1</span>
-        <button onclick="audit_page(1)"
+        <button data-action="audit-page" data-delta="1"
                 id="audit-next"
                 style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer">다음 →</button>
       </div>
@@ -1145,9 +1140,8 @@
                data-i18n-placeholder="uploads.search_placeholder"
                style="flex:1;min-width:200px;padding:8px 12px;
                       background:var(--surface-2);border:1px solid var(--border);
-                      border-radius:8px;color:var(--text);font-size:13px"
-               onkeydown="if(event.key==='Enter') loadUploads()">
-        <button onclick="loadUploads()" style="padding:8px 16px;
+                      border-radius:8px;color:var(--text);font-size:13px">
+        <button data-action="load-uploads" style="padding:8px 16px;
                 background:var(--accent);color:var(--on-accent);border:0;border-radius:8px;
                 cursor:pointer;font-size:13px;font-weight:600">
           <span data-i18n="common.search">검색</span>
@@ -1173,7 +1167,6 @@
       <!-- 검색/루트 선택 행 -->
       <div style="display:flex;gap:10px;margin-bottom:14px;align-items:center;flex-wrap:wrap">
         <select id="files-root"
-                onchange="onFilesRootChange()"
                 style="background:var(--surface-2);border:1px solid var(--border);
                        border-radius:8px;color:var(--text);font-size:13px;
                        padding:8px 12px;cursor:pointer">
@@ -1186,14 +1179,13 @@
                data-i18n-placeholder="files.search_placeholder"
                style="flex:1;min-width:200px;padding:8px 12px;
                       background:var(--surface-2);border:1px solid var(--border);
-                      border-radius:8px;color:var(--text);font-size:13px"
-               onkeydown="if(event.key==='Enter') searchFiles()">
-        <button onclick="searchFiles()" style="padding:8px 16px;
+                      border-radius:8px;color:var(--text);font-size:13px">
+        <button data-action="search-files" style="padding:8px 16px;
                 background:var(--accent);color:var(--on-accent);border:0;border-radius:8px;
                 cursor:pointer;font-size:13px;font-weight:600">
           <span data-i18n="common.search">검색</span>
         </button>
-        <button onclick="loadFiles()" style="padding:8px 12px;
+        <button data-action="load-files" style="padding:8px 12px;
                 background:var(--surface-2);border:1px solid var(--border);
                 color:var(--muted);border-radius:8px;cursor:pointer;font-size:12px"
                 title="검색 초기화 + 트리 다시 불러오기">
@@ -1217,8 +1209,7 @@
         💡 새 파일 업로드는 <a href="/" style="color:var(--accent-fg);
            text-decoration:none">Chat 페이지</a>에서 진행됩니다.
         업로드 직후 이 트리에 반영되며, 자세한 내역은
-        <a href="javascript:showPage('uploads', document.querySelector(
-          '.nav-item[onclick*=uploads]'))"
+        <a href="#" data-action="show-page" data-page="uploads"
           style="color:var(--accent-fg);text-decoration:none">📥 업로드 이력</a> 탭 참조.
       </div>
     </div>
@@ -1273,7 +1264,7 @@
              data-i18n="common.loading">
           Loading...
         </div>
-        <button class="btn btn-secondary" onclick="loadHardware()"
+        <button class="btn btn-secondary" data-action="load-hardware"
                 style="margin-top:12px;font-size:12px">
           <span data-i18n="hw.remeasure">🔄 다시 측정</span>
         </button>
@@ -1294,7 +1285,6 @@
           <div><div class="setting-label" data-i18n="set.answer_lang">Response Language</div>
                <div class="setting-sub" data-i18n="set.answer_lang_desc">Default response language (includes UI)</div></div>
           <select class="setting-value" id="set-language"
-                  onchange="onLanguageChange(this.value)"
                   style="cursor:pointer">
             <option value="한국어" data-i18n="set.lang_ko">🇰🇷 Korean</option>
             <option value="한국어/영어" data-i18n="set.lang_both">🌐 Korean + English (bilingual)</option>
@@ -1332,8 +1322,7 @@
           </div>
           <div style="display:flex;align-items:center;gap:10px;min-width:220px">
             <input type="range" id="set-loop" min="1" max="5" value="2" step="1"
-                   style="flex:1;accent-color:var(--accent)"
-                   oninput="document.getElementById('set-loop-val').textContent=this.value">
+                   style="flex:1;accent-color:var(--accent)">
             <div style="display:flex;justify-content:space-between;
                         font-size:10px;color:var(--muted);width:100%;position:absolute;
                         margin-top:24px;pointer-events:none">
@@ -1357,7 +1346,7 @@
           </div>
         </div>
         <div style="padding: 16px 0; display:flex; justify-content:flex-end;">
-          <button class="btn btn-primary" onclick="saveSettings()" data-i18n="set.save_server">Save Server Settings</button>
+          <button class="btn btn-primary" data-action="save-settings" data-i18n="set.save_server">Save Server Settings</button>
         </div>
       </div>
 
@@ -1421,8 +1410,7 @@
           <div style="display:flex;align-items:center;gap:10px;min-width:260px">
             <input type="range" id="ws-threshold" min="0.05" max="0.80" step="0.05"
                    value="0.30"
-                   style="flex:1;accent-color:var(--accent)"
-                   oninput="applyWsThresholdLabel(this.value)">
+                   style="flex:1;accent-color:var(--accent)">
             <div style="display:flex;gap:4px">
               <span style="font-size:11px;padding:2px 7px;border-radius:4px;
                            background:var(--surface-2);color:var(--muted)">안함</span>
@@ -1432,7 +1420,7 @@
           </div>
         </div>
         <div style="padding: 16px 0; display:flex; justify-content:flex-end;">
-          <button class="btn btn-primary" onclick="saveWebSearchConfig()">Save Web Search Settings</button>
+          <button class="btn btn-primary" data-action="save-web-search-config">Save Web Search Settings</button>
         </div>
       </div>
     </div>
@@ -1464,11 +1452,10 @@
       <div style="position:relative">
         <input id="admin-login-pw" type="password" placeholder="••••••••"
                autocomplete="new-password"
-               onkeydown="if(event.key==='Enter') doAdminLogin()"
                style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:7px;padding:10px 40px 10px 14px;color:var(--text);font-size:14px;outline:none;">
         <button type="button"
                 id="admin-login-pw-toggle"
-                onclick="toggleAdminPwVisibility()"
+                data-action="toggle-admin-pw-visibility"
                 aria-label="show/hide password"
                 title="비밀번호 보기/숨기기"
                 style="position:absolute;right:8px;top:50%;
@@ -1478,20 +1465,20 @@
       </div>
     </div>
     <div id="admin-login-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:12px;font-family:var(--font-mono);"></div>
-    <button onclick="doAdminLogin()"
+    <button data-action="do-admin-login"
             style="width:100%;padding:11px;background:var(--danger);border:none;border-radius:8px;color:#fff;font-size:14px;font-weight:600;cursor:pointer;"
             data-i18n="auth.login">
       Login
     </button>
     <!-- W4 P2-B-2: forgot-password link -->
     <div style="margin-top:14px;text-align:center;">
-      <a href="javascript:openForgotPasswordModal()"
+      <a href="#" data-action="open-forgot-password-modal"
          style="font-size:12px;color:var(--muted);text-decoration:underline;cursor:pointer"
          data-i18n="auth.forgot_password">비밀번호를 잊으셨나요?</a>
     </div>
     <!-- W4 P4: signup link -->
     <div style="margin-top:8px;text-align:center;">
-      <a href="javascript:openSignupModal()"
+      <a href="#" data-action="open-signup-modal"
          style="font-size:12px;color:var(--muted);text-decoration:underline;cursor:pointer"
          data-i18n="auth.signup_link">계정이 없으신가요? 회원가입</a>
     </div>
@@ -1532,10 +1519,10 @@
     <div id="signup-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:6px;font-family:var(--font-mono)"></div>
     <div id="signup-success" style="display:none;font-size:12px;color:#1e7a3e;margin-bottom:10px;line-height:1.5"></div>
     <div style="display:flex;gap:8px">
-      <button onclick="closeSignupModal()"
+      <button data-action="close-signup-modal"
               style="flex:1;padding:10px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer"
               data-i18n="common.cancel">취소</button>
-      <button onclick="submitSignup()"
+      <button data-action="submit-signup"
               style="flex:2;padding:10px;background:#1e5a7a;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer"
               data-i18n="auth.signup_submit">가입 신청</button>
     </div>
@@ -1577,10 +1564,10 @@
     </div>
     <div id="reset-error" style="font-size:12px;color:var(--danger);min-height:18px;margin-bottom:10px;font-family:var(--font-mono)"></div>
     <div style="display:flex;gap:8px">
-      <button onclick="closeForgotPasswordModal()"
+      <button data-action="close-forgot-password-modal"
               style="flex:1;padding:10px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer"
               data-i18n="common.cancel">취소</button>
-      <button onclick="submitPasswordReset()"
+      <button data-action="submit-password-reset"
               style="flex:2;padding:10px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer"
               data-i18n="auth.reset_submit">재설정</button>
     </div>
@@ -1610,10 +1597,10 @@
     <div style="font-size:11px;color:var(--muted);margin-bottom:14px;font-family:var(--font-mono)"
          id="mykey-display-prefix"></div>
     <div style="display:flex;gap:8px">
-      <button onclick="copyMyApiKey()"
+      <button data-action="copy-my-api-key"
               style="flex:2;padding:9px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;cursor:pointer"
               data-i18n="users.mykey_copy">키 복사</button>
-      <button onclick="closeMyApiKeyModal()"
+      <button data-action="close-my-api-key-modal"
               style="flex:1;padding:9px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer"
               data-i18n="common.close">닫기</button>
     </div>
@@ -1644,10 +1631,10 @@
     <div style="font-size:11px;color:var(--muted);margin-bottom:14px;font-family:var(--font-mono)"
          id="token-display-ttl"></div>
     <div style="display:flex;gap:8px">
-      <button onclick="copyResetToken()"
+      <button data-action="copy-reset-token"
               style="flex:2;padding:9px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;cursor:pointer"
               data-i18n="users.token_copy">토큰 복사</button>
-      <button onclick="closeResetTokenModal()"
+      <button data-action="close-reset-token-modal"
               style="flex:1;padding:9px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer"
               data-i18n="common.close">닫기</button>
     </div>
@@ -1711,14 +1698,14 @@
 
     <div style="display:flex;gap:10px;margin-top:18px">
       <button id="firstrun-later-btn"
-              onclick="firstRunDismiss()"
+              data-action="first-run-dismiss"
               style="flex:1;padding:11px;background:var(--surface-2);
                      border:1px solid var(--border);border-radius:8px;
                      color:var(--muted);font-size:13px;cursor:pointer;">
         나중에 (이 세션 동안 다시 안 띄움)
       </button>
       <button id="firstrun-refresh-btn"
-              onclick="firstRunCheck()"
+              data-action="first-run-check"
               style="padding:11px 16px;background:var(--surface-2);
                      border:1px solid var(--border);border-radius:8px;
                      color:var(--muted);font-size:13px;cursor:pointer;"

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -34,8 +34,227 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+/* ── §5 PR-D: inline-handler migration (CSP-friendly delegation) ──
+ * admin.html no longer carries any ``onclick=`` / ``onchange=`` /
+ * ``oninput=`` / ``onkeydown=`` attributes; admin.js innerHTML
+ * templates likewise emit ``data-action`` (+ supporting ``data-*``)
+ * instead of inline handlers. One document-level click delegate
+ * routes by ``data-action`` name; a parallel change-delegate routes
+ * the dynamic policy-toggle checkboxes; an ``data-overlay-action``
+ * fast-path handles the two modal overlays whose previous
+ * ``onclick="closeXyz(event)"`` used ``stopPropagation`` on the
+ * inner content. Stable inputs that live for the page lifetime
+ * (search boxes, sliders, login fields) wire up by id at
+ * DOMContentLoaded — they don't appear in any innerHTML template
+ * so direct binding is safe and avoids per-keystroke delegate work. */
+function _bindFrontendEvents() {
+  document.addEventListener('click', (e) => {
+    // Modal-overlay close: only the overlay itself (e.target === el)
+    // should close. Clicks on inner content bubble up but e.target
+    // is the descendant, so the equality check filters them out —
+    // this replaces the old stopPropagation-on-inner-content trick.
+    const overlay = e.target.closest && e.target.closest('[data-overlay-action]');
+    if (overlay && overlay === e.target) {
+      const oa = overlay.getAttribute('data-overlay-action');
+      if (oa === 'close-entity-detail') { closeEntityDetail(); return; }
+      if (oa === 'close-session-turns') { closeSessionTurns(); return; }
+    }
+
+    const t = e.target.closest && e.target.closest('[data-action]');
+    if (!t) return;
+    const action = t.getAttribute('data-action');
+    switch (action) {
+      /* ── header / nav (static) ────────────────────────────────── */
+      case 'toggle-lang':         toggleLang(); break;
+      case 'toggle-admin-nav':    toggleAdminNav(); break;
+      case 'toggle-nav-section':  toggleNavSection(t); break;
+      case 'show-page': {
+        // Anchor variant uses href="#" — stop the navigation.
+        if (t.tagName === 'A') e.preventDefault();
+        const page = t.getAttribute('data-page');
+        // showPage(id, el) marks `el` as active; if the click came
+        // from a non-nav-item (the in-page anchor link to "uploads"),
+        // locate the matching nav-item so the sidebar still updates.
+        const navItem = t.classList.contains('nav-item')
+          ? t
+          : document.querySelector('.nav-item[data-page="' + page + '"]');
+        showPage(page, navItem || t);
+        break;
+      }
+
+      /* ── users page (static) ──────────────────────────────────── */
+      case 'change-my-password':  changeMyPassword(); break;
+      case 'issue-my-api-key':    issueMyApiKey(); break;
+
+      /* ── entities page (static) ───────────────────────────────── */
+      case 'entities-page':
+        entitiesPage(parseInt(t.getAttribute('data-delta'), 10) || 0);
+        break;
+      case 'close-entity-detail': closeEntityDetail(); break;
+      case 'close-session-turns': closeSessionTurns(); break;
+
+      /* ── proposals / character / performance / learning ───────── */
+      case 'generate-proposals':  generateProposals(); break;
+      case 'save-identity':       saveIdentity(); break;
+      case 'save-character':      saveCharacter(); break;
+      case 'reset-character':     resetCharacter(); break;
+      case 'run-evaluation':      runEvaluation(); break;
+      case 'web-learn-topic':     webLearnTopic(); break;
+      case 'learn-topic':         learnTopic(); break;
+      case 'learn-from-errors':   learnFromErrors(); break;
+
+      /* ── audit / uploads / files / hardware / settings ────────── */
+      case 'audit-page':
+        audit_page(parseInt(t.getAttribute('data-delta'), 10) || 0);
+        break;
+      case 'load-uploads':        loadUploads(); break;
+      case 'search-files':        searchFiles(); break;
+      case 'load-files':          loadFiles(); break;
+      case 'load-hardware':       loadHardware(); break;
+      case 'save-settings':       saveSettings(); break;
+      case 'save-web-search-config': saveWebSearchConfig(); break;
+
+      /* ── login modal + signup/forgot anchors ──────────────────── */
+      case 'toggle-admin-pw-visibility': toggleAdminPwVisibility(); break;
+      case 'do-admin-login':      doAdminLogin(); break;
+      case 'open-forgot-password-modal':
+        e.preventDefault(); openForgotPasswordModal(); break;
+      case 'open-signup-modal':
+        e.preventDefault(); openSignupModal(); break;
+      case 'close-signup-modal':  closeSignupModal(); break;
+      case 'submit-signup':       submitSignup(); break;
+      case 'close-forgot-password-modal': closeForgotPasswordModal(); break;
+      case 'submit-password-reset': submitPasswordReset(); break;
+      case 'copy-my-api-key':     copyMyApiKey(); break;
+      case 'close-my-api-key-modal': closeMyApiKeyModal(); break;
+      case 'copy-reset-token':    copyResetToken(); break;
+      case 'close-reset-token-modal': closeResetTokenModal(); break;
+
+      /* ── first-run wizard ─────────────────────────────────────── */
+      case 'first-run-dismiss':   firstRunDismiss(); break;
+      case 'first-run-check':     firstRunCheck(); break;
+      case 'first-run-install':   firstRunInstall(t.getAttribute('data-tag')); break;
+
+      /* ── dynamic templates (admin.js innerHTML) ───────────────── */
+      case 'approve-user':        approveUser(t.getAttribute('data-username')); break;
+      case 'reject-user':         rejectUser(t.getAttribute('data-username')); break;
+      case 'issue-reset-token-for':
+        issueResetTokenFor(t.getAttribute('data-username')); break;
+      case 'deactivate-user':     deactivateUser(t.getAttribute('data-username')); break;
+      case 'revoke-my-api-key':   revokeMyApiKey(t.getAttribute('data-prefix')); break;
+      case 'reset-policy-feature':
+        resetPolicyFeature(t.getAttribute('data-feature-id')); break;
+      case 'open-entity-detail':
+        openEntityDetail(t.getAttribute('data-entity-id')); break;
+      case 'open-session-turns':
+        openSessionTurns(
+          t.getAttribute('data-sid'),
+          t.getAttribute('data-title') || '',
+        );
+        break;
+      case 'summarize-and-delete':
+        summarizeAndDelete(t.getAttribute('data-sid')); break;
+      case 'patch-action':
+        patchAction(
+          t.getAttribute('data-patch-id'),
+          t.getAttribute('data-decision'),
+        );
+        break;
+      case 'uploads-prev':        _uploadsPrev(); break;
+      case 'uploads-next':        _uploadsNext(); break;
+      case 'show-proposal-detail': {
+        // The Detail button used to inline-pass title + truncated body;
+        // we now look the proposal up in the loadProposals() cache so
+        // long text doesn't have to round-trip through HTML attrs.
+        const pid = t.getAttribute('data-proposal-id');
+        const p = _proposalsById.get(pid);
+        if (!p) return;
+        const title = escAdm(p.title);
+        const body  = escAdm(p.description) + '\\n\\n' + escAdm((p.content || '').slice(0, 600));
+        showProposalDetail(pid, title, body);
+        break;
+      }
+      case 'execute-web-learn-proposal':
+        executeWebLearnProposal(
+          t.getAttribute('data-proposal-id'),
+          t.getAttribute('data-topic') || '',
+          t,
+        );
+        break;
+      case 'approve-proposal':
+        approveProposal(t.getAttribute('data-proposal-id')); break;
+      case 'reject-proposal-by-id':
+        rejectProposalById(t.getAttribute('data-proposal-id')); break;
+      case 'learn-single-topic':
+        learnSingleTopic(t.getAttribute('data-query') || ''); break;
+      case 'install-llm':
+        installLLM(t.getAttribute('data-model-name'), t); break;
+    }
+  });
+
+  // Policy-matrix checkboxes are re-rendered by loadPolicy() through
+  // innerHTML, so a per-row addEventListener would lose binding on
+  // every reload. A single delegated 'change' listener keyed by
+  // data-change-action survives renders.
+  document.addEventListener('change', (e) => {
+    const t = e.target.closest && e.target.closest('[data-change-action]');
+    if (!t) return;
+    if (t.getAttribute('data-change-action') === 'policy-toggle') {
+      onPolicyToggle(t, t.getAttribute('data-feature-id'), t.getAttribute('data-role'));
+    }
+  });
+}
+
+function _bindStableInputs() {
+  // Always-present inputs that don't appear in any innerHTML template.
+  // (Anything inside a dynamically re-rendered <tbody> must use the
+  //  delegated path above instead.)
+  const ent = document.getElementById('entities-search');
+  if (ent) ent.addEventListener('input', () => onEntitiesSearchInput());
+  const eft = document.getElementById('entities-etype-filter');
+  if (eft) eft.addEventListener('change', () => loadEntities());
+
+  const ac = document.getElementById('audit-category');
+  if (ac) ac.addEventListener('change', () => audit_reload());
+  const aq = document.getElementById('audit-q');
+  if (aq) aq.addEventListener('input', () => audit_searchInput());
+
+  const us = document.getElementById('uploads-search');
+  if (us) us.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') loadUploads();
+  });
+
+  const fr = document.getElementById('files-root');
+  if (fr) fr.addEventListener('change', () => onFilesRootChange());
+  const fs = document.getElementById('files-search');
+  if (fs) fs.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') searchFiles();
+  });
+
+  const sl = document.getElementById('set-language');
+  if (sl) sl.addEventListener('change', (e) => onLanguageChange(e.target.value));
+  const loop = document.getElementById('set-loop');
+  if (loop) loop.addEventListener('input', (e) => {
+    const lv = document.getElementById('set-loop-val');
+    if (lv) lv.textContent = e.target.value;
+  });
+  const wsth = document.getElementById('ws-threshold');
+  if (wsth) wsth.addEventListener('input', (e) => applyWsThresholdLabel(e.target.value));
+
+  const wli = document.getElementById('web-learn-input');
+  if (wli) wli.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') webLearnTopic();
+  });
+  const apw = document.getElementById('admin-login-pw');
+  if (apw) apw.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') doAdminLogin();
+  });
+}
+
 /* ── 초기화 ── */
 window.addEventListener('DOMContentLoaded', async () => {
+  _bindFrontendEvents();
+  _bindStableInputs();
   if (!apiKey) {
     apiKey = prompt('JAMES API Key:') || '';
     localStorage.setItem('james_api_key', apiKey);
@@ -253,7 +472,7 @@ function _firstRunRow(r, primary) {
         ${desc}${sizeGB ? ' · ' + sizeGB : ''}
       </div>
     </div>
-    <button onclick="firstRunInstall('${tag.replace(/'/g, "\\'")}')"
+    <button data-action="first-run-install" data-tag="${tag}"
             style="padding:7px 14px;background:var(--accent);color:var(--on-accent);
                    border:0;border-radius:6px;cursor:pointer;font-size:12px;
                    font-weight:600;flex-shrink:0">
@@ -607,8 +826,8 @@ async function loadUsers() {
             <td class="mono">${u.created_at?.slice(0,10) || '-'}</td>
             <td><select id="approve-role-${safeName}" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)">${opts}</select></td>
             <td>
-              <button onclick="approveUser('${u.username}')" style="padding:4px 10px;margin-right:4px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.approve')}</button>
-              <button onclick="rejectUser('${u.username}')" style="padding:4px 10px;background:#7a1e1e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.reject')}</button>
+              <button data-action="approve-user" data-username="${u.username}" style="padding:4px 10px;margin-right:4px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.approve')}</button>
+              <button data-action="reject-user" data-username="${u.username}" style="padding:4px 10px;background:#7a1e1e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.reject')}</button>
             </td>
           </tr>`;
       }).join('') || `<tr><td colspan='4' class='empty'>${t('users.empty_pending')}</td></tr>`;
@@ -632,10 +851,10 @@ async function loadUsers() {
       //   - deactivate (hidden on caller's own row, server enforces
       //     anyway with a 400)
       const tokenBtn = u.active
-        ? `<button onclick="issueResetTokenFor('${u.username}')" style="padding:4px 10px;margin-right:4px;background:#1e5a7a;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.issue_token')}</button>`
+        ? `<button data-action="issue-reset-token-for" data-username="${u.username}" style="padding:4px 10px;margin-right:4px;background:#1e5a7a;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.issue_token')}</button>`
         : '';
       const deactivateBtn = (u.active && u.username !== selfUser)
-        ? `<button onclick="deactivateUser('${u.username}')" style="padding:4px 10px;background:#444;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.deactivate')}</button>`
+        ? `<button data-action="deactivate-user" data-username="${u.username}" style="padding:4px 10px;background:#444;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.deactivate')}</button>`
         : '';
       const action = (tokenBtn || deactivateBtn)
         ? `${tokenBtn}${deactivateBtn}`
@@ -682,7 +901,7 @@ function _renderMyApiKeys(keys) {
       : `<span class="badge" style="background:#1e7a3e;color:#fff">${t('users.status_active')}</span>`;
     const action = k.revoked
       ? '<span style="color:var(--muted)">—</span>'
-      : `<button onclick="revokeMyApiKey('${k.key_prefix}')" style="padding:4px 10px;background:#7a1e1e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.mykey_revoke')}</button>`;
+      : `<button data-action="revoke-my-api-key" data-prefix="${k.key_prefix}" style="padding:4px 10px;background:#7a1e1e;color:#fff;border:0;border-radius:4px;cursor:pointer">${t('users.mykey_revoke')}</button>`;
     return `
       <tr>
         <td class="mono">${k.key_prefix}…</td>
@@ -806,7 +1025,8 @@ async function loadPolicy() {
         return `<td style="text-align:center">
           <label style="display:inline-flex;align-items:center;gap:2px;cursor:pointer">
             <input type="checkbox" ${eff.allowed ? 'checked' : ''}
-                   onchange="onPolicyToggle(this, '${f.id}', '${r}')"
+                   data-change-action="policy-toggle"
+                   data-feature-id="${f.id}" data-role="${r}"
                    style="cursor:pointer;width:16px;height:16px;accent-color:#1e7a3e">
             ${dot}
           </label>
@@ -819,7 +1039,7 @@ async function loadPolicy() {
         </td>
         ${cells}
         <td style="text-align:center">
-          <button onclick="resetPolicyFeature('${f.id}')"
+          <button data-action="reset-policy-feature" data-feature-id="${f.id}"
                   style="padding:4px 8px;background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--muted);font-size:11px;cursor:pointer">
             ${t('policy.reset_default')}
           </button>
@@ -1144,7 +1364,7 @@ async function loadEntities() {
     // 테이블 — 행 클릭 → 상세
     const tbody = document.getElementById('entities-body');
     tbody.innerHTML = (data.entities || []).map(e => `
-      <tr style="cursor:pointer" onclick="openEntityDetail('${e.entity_id}')">
+      <tr style="cursor:pointer" data-action="open-entity-detail" data-entity-id="${escapeHtml(e.entity_id)}">
         <td>${escapeHtml(e.name) || `<em style="color:var(--muted)">${e.entity_id}</em>`}</td>
         <td class="mono">${e.entity_type}</td>
         <td><span class="badge-status">${e.sensitivity || '-'}</span></td>
@@ -1265,13 +1485,12 @@ async function loadLongTerm() {
       // item #3-b: row click → original turns modal. session_id is
       // present in the API response (memory/store.py:492).
       const sid = s.session_id || '';
-      const onclick = sid
-        ? `onclick="openSessionTurns('${escapeHtml(sid)}', '${escapeHtml((s.topic || '').slice(0, 40))}')"`
+      const attrs = sid
+        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml((s.topic || '').slice(0, 40))}" style="cursor:pointer"`
         : '';
-      const cursor = sid ? 'cursor:pointer' : '';
       const hint   = sid ? '' : ' <em style="color:var(--muted);font-size:10px">(no session_id)</em>';
       return `
-        <tr style="${cursor}" ${onclick}>
+        <tr ${attrs}>
           <td class="mono">${s.saved_at?.slice(0,10) || '-'}</td>
           <td>${escapeHtml(s.topic || '-')}${hint}</td>
           <td style="max-width:400px;font-size:12px">${escapeHtml((s.summary || '').slice(0,120) || '-')}</td>
@@ -1295,7 +1514,7 @@ async function loadSessions() {
       // (액션 버튼은 그대로 두고 행 일부만 클릭 가능하게 — 실수로
       // summarize&delete 버튼 누르는 사고 방지)
       const expandable = sid
-        ? `onclick="openSessionTurns('${escapeHtml(sid)}', '${escapeHtml(sid.slice(0,20))}')" style="cursor:pointer"`
+        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml(sid.slice(0,20))}" style="cursor:pointer"`
         : '';
       return `
         <tr>
@@ -1305,7 +1524,7 @@ async function loadSessions() {
           <td class="mono">${s.last?.slice(0,16) || '-'}</td>
           <td>
             <button class="btn btn-approve" style="font-size:10px"
-              onclick="summarizeAndDelete('${escapeHtml(sid)}')" data-i18n='mem.summarize_delete'>Summarize & Delete</button>
+              data-action="summarize-and-delete" data-sid="${escapeHtml(sid)}" data-i18n='mem.summarize_delete'>Summarize & Delete</button>
           </td>
         </tr>
       `;
@@ -1407,8 +1626,8 @@ async function loadPatches() {
         <td class="mono">${p.confidence != null ? (p.confidence*100).toFixed(0)+'%' : '-'}</td>
         <td class="mono">${p.created_at?.slice(0,16) || '-'}</td>
         <td>${p.status === 'PENDING_APPROVAL' ? `
-          <button class="btn btn-approve" onclick="patchAction('${p.patch_id}','approve')" data-i18n='prop.approve'>Approve</button>
-          <button class="btn btn-reject"  onclick="patchAction('${p.patch_id}','reject')" data-i18n='prop.reject'>Reject</button>
+          <button class="btn btn-approve" data-action="patch-action" data-patch-id="${p.patch_id}" data-decision="approve" data-i18n='prop.approve'>Approve</button>
+          <button class="btn btn-reject"  data-action="patch-action" data-patch-id="${p.patch_id}" data-decision="reject"  data-i18n='prop.reject'>Reject</button>
         ` : '-'}</td>
       </tr>
     `).join('') || `<tr><td colspan='6' class='empty'>${t('patch.no_patches')}</td></tr>`;
@@ -1599,14 +1818,14 @@ async function loadUploads(resetOffset = true) {
       const hasPrev = _uploadsOffset > 0;
       const hasNext = (_uploadsOffset + items.length) < total;
       pager.innerHTML = `
-        <button onclick="_uploadsPrev()" ${hasPrev ? '' : 'disabled'}
+        <button data-action="uploads-prev" ${hasPrev ? '' : 'disabled'}
                 style="padding:6px 14px;background:var(--surface-2);
                        border:1px solid var(--border);border-radius:6px;
                        color:var(--text);cursor:${hasPrev ? 'pointer' : 'not-allowed'};
                        opacity:${hasPrev ? '1' : '0.4'};font-size:12px">
           ‹ 이전
         </button>
-        <button onclick="_uploadsNext()" ${hasNext ? '' : 'disabled'}
+        <button data-action="uploads-next" ${hasNext ? '' : 'disabled'}
                 style="padding:6px 14px;background:var(--surface-2);
                        border:1px solid var(--border);border-radius:6px;
                        color:var(--text);cursor:${hasNext ? 'pointer' : 'not-allowed'};
@@ -2081,12 +2300,18 @@ async function saveWebSearchConfig() {
 /* ── 자기진화 제안 ── */
 
 let _currentProposalId = null;
+// PR-D delegation: cache proposals by id so the "Detail" data-action
+// handler can rebuild the (id, title, content) tuple without packing
+// long text into HTML data-* attributes (which would need extra escape).
+const _proposalsById = new Map();
 
 async function loadProposals() {
   try {
     const data = await api('/admin/proposals/?status=pending');
     const tbody = document.getElementById('proposals-body');
     const proposals = data.proposals || [];
+    _proposalsById.clear();
+    for (const p of proposals) _proposalsById.set(p.proposal_id, p);
 
     if (!proposals.length) {
       tbody.innerHTML = `<tr><td colspan='5' class='empty'>${t('prop.no_pending')}</td></tr>`;
@@ -2100,15 +2325,16 @@ async function loadProposals() {
       const topic = p.metadata?.topic || '';
       const actionBtns = isWebLearn
         ? `<button class="btn btn-approve" style="font-size:10px;background:#4fc3f7"
-             onclick="executeWebLearnProposal('${p.proposal_id}','${topic}',this)">
+             data-action="execute-web-learn-proposal"
+             data-proposal-id="${p.proposal_id}" data-topic="${escAdm(topic)}">
              ${t('prop.web_search')}
            </button>
            <button class="btn btn-reject" style="font-size:10px"
-             onclick="rejectProposalById('${p.proposal_id}')">❌ Reject</button>`
+             data-action="reject-proposal-by-id" data-proposal-id="${p.proposal_id}">❌ Reject</button>`
         : `<button class="btn btn-approve" style="font-size:10px"
-             onclick="approveProposal('${p.proposal_id}')">✅ Approve</button>
+             data-action="approve-proposal" data-proposal-id="${p.proposal_id}">✅ Approve</button>
            <button class="btn btn-reject" style="font-size:10px"
-             onclick="rejectProposalById('${p.proposal_id}')">❌ Reject</button>`;
+             data-action="reject-proposal-by-id" data-proposal-id="${p.proposal_id}">❌ Reject</button>`;
 
       return `<tr>
         <td><span class="mono" style="font-size:10px">${p.type}</span></td>
@@ -2119,7 +2345,8 @@ async function loadProposals() {
         <td style="display:flex;gap:4px;flex-wrap:wrap">
           <button class="btn" style="font-size:10px;background:var(--surface);
             border:1px solid var(--border);color:var(--text)"
-            onclick="showProposalDetail('${p.proposal_id}',\`${escAdm(p.title)}\`,\`${escAdm(p.description)}\n\n${escAdm(p.content?.slice(0,600))}\`)">
+            data-action="show-proposal-detail"
+            data-proposal-id="${p.proposal_id}">
             ${t('prop.detail')}
           </button>
           ${actionBtns}
@@ -2356,7 +2583,7 @@ async function loadLearning() {
         <td class="mono">${q.last?.slice(0,10)||'-'}</td>
         <td>
           <button class="btn btn-approve" style="font-size:10px"
-            onclick="learnSingleTopic('${(q.query||'').replace(/'/g,"\\'")}')">
+            data-action="learn-single-topic" data-query="${escapeHtml(q.query || '')}">
             Learn</button>
         </td>
       </tr>`).join('')
@@ -3335,7 +3562,7 @@ async function loadLLMRecommend() {
         <div style="font-size:11px;color:var(--muted);text-align:right;min-width:60px">
           ${m.size_gb}GB
         </div>
-        <button onclick="installLLM('${m.name}', this)"
+        <button data-action="install-llm" data-model-name="${escapeHtml(m.name)}"
                 style="border:none;border-radius:6px;padding:5px 12px;
                        font-size:11px;font-weight:600;color:#fff;
                        ${btnStyle}" ${isInstalled?'disabled':''}>

--- a/tests/test_a11y_aria_labels.py
+++ b/tests/test_a11y_aria_labels.py
@@ -131,17 +131,21 @@ class IconOnlyButtonsTests(unittest.TestCase):
 
     def test_admin_nav_toggle_button(self):
         # ☰ hamburger on admin nav.
+        # [§5 PR-D] inline onclick="toggleAdminNav()" replaced by
+        # data-action="toggle-admin-nav".
         self._assert_aria_on_button(
-            self.admin, "toggleAdminNav()", "admin.html")
+            self.admin, 'data-action="toggle-admin-nav"', "admin.html")
 
     def test_admin_entity_detail_close_button(self):
         # × button inside the entity-detail modal header.
+        # [§5 PR-D] now identified by data-action.
         self._assert_aria_on_button(
-            self.admin, "closeEntityDetail()", "admin.html")
+            self.admin, 'data-action="close-entity-detail"', "admin.html")
 
     def test_admin_session_turns_close_button(self):
+        # [§5 PR-D] now identified by data-action.
         self._assert_aria_on_button(
-            self.admin, "closeSessionTurns()", "admin.html")
+            self.admin, 'data-action="close-session-turns"', "admin.html")
 
     def test_workspace_detail_close_button(self):
         # [§5 migration] inline onclick="closeDetail()" replaced by

--- a/tests/test_admin_entities.py
+++ b/tests/test_admin_entities.py
@@ -100,17 +100,36 @@ class FrontendAdminContractTests(unittest.TestCase):
         cls.js   = (root / "static" / "admin.js").read_text(encoding="utf-8")
 
     def test_html_has_search_input(self):
+        # [§5 PR-D] inline oninput="onEntitiesSearchInput()" replaced
+        # by direct id-binding in admin.js _bindStableInputs().
         self.assertIn('id="entities-search"', self.html)
-        self.assertIn('oninput="onEntitiesSearchInput()"', self.html,
-                      "search input must wire to the debounced handler")
+        self.assertIn(
+            "document.getElementById('entities-search')", self.js,
+            "search input must be bound by id in _bindStableInputs",
+        )
+        self.assertIn("onEntitiesSearchInput", self.js,
+            "the debounced search handler must still exist")
 
     def test_html_has_etype_filter(self):
+        # [§5 PR-D] inline onchange="loadEntities()" replaced by
+        # direct id-binding in admin.js _bindStableInputs().
         self.assertIn('id="entities-etype-filter"', self.html)
-        self.assertIn('onchange="loadEntities()"', self.html)
+        self.assertIn(
+            "document.getElementById('entities-etype-filter')", self.js,
+            "etype filter must be bound by id in _bindStableInputs",
+        )
 
     def test_html_has_paging_buttons(self):
-        self.assertIn('onclick="entitiesPage(-1)"', self.html)
-        self.assertIn('onclick="entitiesPage(1)"', self.html)
+        # [§5 PR-D] inline onclick="entitiesPage(±1)" replaced by
+        # data-action="entities-page" with a signed data-delta.
+        self.assertRegex(
+            self.html,
+            r'data-action="entities-page"\s+data-delta="-1"',
+        )
+        self.assertRegex(
+            self.html,
+            r'data-action="entities-page"\s+data-delta="1"',
+        )
         self.assertIn('id="entities-page-label"', self.html)
 
     def test_html_has_detail_modal(self):

--- a/tests/test_admin_foldable_tech.py
+++ b/tests/test_admin_foldable_tech.py
@@ -111,9 +111,12 @@ class FoldableNavHtmlTests(unittest.TestCase):
         cls.html = ADMIN_HTML.read_text(encoding="utf-8")
 
     def test_hamburger_toggle_button_present(self):
+        # [§5 PR-D] inline onclick="toggleAdminNav()" replaced by
+        # data-action="toggle-admin-nav" routed through the document
+        # click delegate.
         self.assertIn('id="admin-nav-toggle"', self.html,
                       "hamburger toggle button missing")
-        self.assertIn('onclick="toggleAdminNav()"', self.html)
+        self.assertIn('data-action="toggle-admin-nav"', self.html)
 
     def test_nav_sections_have_foldable_class(self):
         # All section headers should be foldable.

--- a/tests/test_admin_history_expand.py
+++ b/tests/test_admin_history_expand.py
@@ -45,11 +45,13 @@ class HtmlContractTests(unittest.TestCase):
                           f"modal placeholder {el} missing")
 
     def test_close_handler_present(self):
-        # Backdrop click handler + explicit X button handler both wire
-        # to closeSessionTurns.
-        self.assertIn('onclick="closeSessionTurns(event)"', self.html,
+        # [§5 PR-D] Backdrop close moves to data-overlay-action (fires
+        # only when e.target === overlay; replaces the prior
+        # onclick="closeSessionTurns(event)" + inner stopPropagation
+        # pattern). X button uses data-action="close-session-turns".
+        self.assertIn('data-overlay-action="close-session-turns"', self.html,
                       "backdrop click handler missing")
-        self.assertIn('onclick="closeSessionTurns()"', self.html,
+        self.assertIn('data-action="close-session-turns"', self.html,
                       "X button handler missing")
 
     def test_long_term_table_advertises_clickable_rows(self):
@@ -82,31 +84,40 @@ class JsContractTests(unittest.TestCase):
                       "closeSessionTurns missing")
 
     def test_long_term_row_uses_session_id_when_available(self):
+        # [§5 PR-D] The row template now emits
+        # data-action="open-session-turns" data-sid=… data-title=…
+        # instead of inline onclick="openSessionTurns(…)".
         idx = self.js.index("async function loadLongTerm")
         body = self.js[idx:idx + 1500]
-        self.assertIn("openSessionTurns(", body,
-                      "loadLongTerm rows must wire to openSessionTurns")
-        # Conditional: only attach onclick when session_id present.
+        self.assertIn('data-action="open-session-turns"', body,
+                      "loadLongTerm rows must wire to open-session-turns "
+                      "via the click delegate")
+        self.assertIn('data-sid=', body,
+                      "row must carry data-sid for the delegate to read")
+        # Conditional: only attach the action when session_id is present.
         self.assertIn("s.session_id", body,
                       "loadLongTerm must read session_id from each summary")
 
     def test_sessions_action_button_not_overridden(self):
-        # Sanity: the summarize&delete button must NOT call
-        # openSessionTurns by accident — operators expect distinct
-        # behaviors for "expand" vs "delete".
+        # Sanity: the summarize&delete button must NOT also fire the
+        # expand action by accident — operators expect distinct
+        # behaviors for "expand" vs "delete". The row's expand-on-
+        # click moved to data-action="open-session-turns" on the
+        # session-id and turn-count cells only; the action <button>
+        # cell uses data-action="summarize-and-delete".
         idx = self.js.index("async function loadSessions")
         body = self.js[idx:idx + 1800]
-        self.assertIn("summarizeAndDelete(", body,
-                      "summarize&delete button must remain functional")
-        # The button itself must not also be wired to expand.
-        # Look for the <button ... onclick="summarizeAndDelete..."> region
-        # and assert it doesn't contain openSessionTurns inside the button tag.
+        self.assertIn('data-action="summarize-and-delete"', body,
+                      "summarize&delete button must remain functional "
+                      "via the click delegate")
+        # Find the summarize button tag and assert it doesn't also
+        # carry the expand action.
         m = re.search(
-            r'<button[^>]*summarizeAndDelete[^>]*>',
+            r'<button[^>]*data-action="summarize-and-delete"[^>]*>',
             body,
         )
         self.assertIsNotNone(m, "summarize button regex missing")
-        self.assertNotIn("openSessionTurns", m.group(),
+        self.assertNotIn("open-session-turns", m.group(),
                          "the summarize button must not also be wired "
                          "to expand — operators get confused if a single "
                          "click does two things")

--- a/tests/test_admin_pw_eye.py
+++ b/tests/test_admin_pw_eye.py
@@ -28,10 +28,13 @@ class HtmlTests(unittest.TestCase):
         cls.html = HTML.read_text(encoding="utf-8")
 
     def test_toggle_button_present(self):
+        # [§5 PR-D] inline onclick="toggleAdminPwVisibility()" replaced
+        # by data-action="toggle-admin-pw-visibility".
         self.assertIn('id="admin-login-pw-toggle"', self.html,
             "admin login pw toggle button missing")
-        self.assertIn('toggleAdminPwVisibility()', self.html,
-            "toggle button must wire to toggleAdminPwVisibility()")
+        self.assertIn('data-action="toggle-admin-pw-visibility"', self.html,
+            "toggle button must wire to toggle-admin-pw-visibility "
+            "(routed through the click delegate)")
 
     def test_default_emoji(self):
         m = re.search(

--- a/tests/test_character_interactive_radar.py
+++ b/tests/test_character_interactive_radar.py
@@ -88,8 +88,11 @@ class HtmlStructureTests(unittest.TestCase):
                 f"legend i18n key {key} must be present in HTML")
 
     def test_buttons_preserved(self):
-        self.assertIn("saveCharacter()", self.html)
-        self.assertIn("resetCharacter()", self.html)
+        # [§5 PR-D] inline onclick="saveCharacter()" / "resetCharacter()"
+        # replaced by data-action variants routed through the click
+        # delegate.
+        self.assertIn('data-action="save-character"', self.html)
+        self.assertIn('data-action="reset-character"', self.html)
 
 
 # ─── 2. CSS — radar visuals + ripple animations ───────────────────

--- a/tests/test_character_remove_text_persona.py
+++ b/tests/test_character_remove_text_persona.py
@@ -132,9 +132,14 @@ class CharacterPageIdentityTests(unittest.TestCase):
             "이름 입력(set-name) 은 character 페이지로 이전되어야 함")
 
     def test_save_identity_button_present(self):
+        # [§5 PR-D] inline onclick="saveIdentity()" replaced by
+        # data-action="save-identity" routed through the click delegate.
+        # The handler must still call saveIdentity (not savePersona)
+        # — verified by the JS suite's saveIdentity-posts-only-name test.
         block = self._character_page()
-        self.assertIn("saveIdentity()", block,
-            "Identity 섹션의 저장 버튼은 saveIdentity() 호출 — savePersona X")
+        self.assertIn('data-action="save-identity"', block,
+            "Identity 섹션의 저장 버튼은 data-action='save-identity' — "
+            "save-character / save-persona 가 아님")
 
     def test_identity_label_keys(self):
         block = self._character_page()

--- a/tests/test_file_mgmt_tab.py
+++ b/tests/test_file_mgmt_tab.py
@@ -220,8 +220,14 @@ class FrontendNavAndPageTests(unittest.TestCase):
         cls.html = (ROOT / "frontend" / "admin.html").read_text(encoding="utf-8")
 
     def test_nav_item_present(self):
-        self.assertIn("showPage('files'", self.html,
-            "sidebar must have a clickable entry for the files tab")
+        # [§5 PR-D] inline onclick="showPage('files', this)" replaced
+        # by data-action="show-page" data-page="files" routed through
+        # the document click delegate.
+        self.assertRegex(
+            self.html,
+            r'data-action="show-page"\s+data-page="files"',
+            "sidebar must have a clickable entry for the files tab",
+        )
         self.assertIn("admin.file_mgmt", self.html,
             "i18n key admin.file_mgmt must be wired in")
 
@@ -235,7 +241,21 @@ class FrontendNavAndPageTests(unittest.TestCase):
             "search input must exist")
 
     def test_search_uses_enter_key(self):
-        self.assertIn("if(event.key==='Enter') searchFiles()", self.html)
+        # [§5 PR-D] inline onkeydown="if(event.key==='Enter') searchFiles()"
+        # replaced by direct id-binding in admin.js _bindStableInputs()
+        # — that listener watches the 'keydown' event on #files-search
+        # and triggers searchFiles() when the Enter key fires.
+        js = (ROOT / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+        self.assertIn("document.getElementById('files-search')", js,
+            "#files-search must be bound by id in _bindStableInputs")
+        # The bound listener must call searchFiles on Enter.
+        bind_block = js[js.index("_bindStableInputs"):]
+        bind_block = bind_block[:3000]
+        self.assertRegex(
+            bind_block,
+            r"'files-search'[\s\S]*?Enter[\s\S]*?searchFiles\(\)",
+            "the files-search Enter handler must still call searchFiles()",
+        )
 
     def test_root_select_options_match_backend_allowlist(self):
         # The 3 root options must match the server's _file_mgmt_roots keys.

--- a/tests/test_first_run_wizard.py
+++ b/tests/test_first_run_wizard.py
@@ -96,10 +96,14 @@ class FrontendModalTests(unittest.TestCase):
                 f"modal must contain element with id={elem_id}")
 
     def test_dismiss_button_calls_firstRunDismiss(self):
-        self.assertIn("onclick=\"firstRunDismiss()\"", self.html)
+        # [§5 PR-D] inline onclick="firstRunDismiss()" replaced by
+        # data-action="first-run-dismiss" routed through the click delegate.
+        self.assertIn('data-action="first-run-dismiss"', self.html)
 
     def test_refresh_button_calls_firstRunCheck(self):
-        self.assertIn("onclick=\"firstRunCheck()\"", self.html)
+        # [§5 PR-D] inline onclick="firstRunCheck()" replaced by
+        # data-action="first-run-check".
+        self.assertIn('data-action="first-run-check"', self.html)
 
 
 class FrontendJsTests(unittest.TestCase):

--- a/tests/test_frontend_event_delegation.py
+++ b/tests/test_frontend_event_delegation.py
@@ -47,12 +47,13 @@ _MIGRATED_PAGES = {
     "graph.html",
     "workspace.html",
     "index.html",
-}
-
-# Pages still using inline handlers. Will shrink to empty by PR-D.
-_LEGACY_INLINE_PAGES = {
     "admin.html",
 }
+
+# Pages still using inline handlers. With PR-D landing, this is empty
+# and the rollout contract becomes a closed gate: any new page-level
+# HTML file added under ``frontend/`` is migrated by default.
+_LEGACY_INLINE_PAGES: set[str] = set()
 
 
 class NoInlineHandlersTests(unittest.TestCase):
@@ -81,6 +82,35 @@ class NoInlineHandlersTests(unittest.TestCase):
                     "move it from _LEGACY_INLINE_PAGES to "
                     "_MIGRATED_PAGES in this test.",
                 )
+
+    def test_no_inline_javascript_href(self):
+        # ``href="javascript:foo()"`` is CSP-hostile in the same way
+        # as inline ``onclick`` — once the four core pages graduate,
+        # they must stay clean.
+        for name in sorted(_MIGRATED_PAGES):
+            with self.subTest(page=name):
+                src = (FRONTEND / name).read_text(encoding="utf-8")
+                self.assertNotIn(
+                    'href="javascript:', src,
+                    name + " still has href=\"javascript:…\" links",
+                )
+
+    def test_rollout_complete(self):
+        # PR-D closes the migration: every page-level *.html in
+        # frontend/ must be listed in _MIGRATED_PAGES. New pages added
+        # later will trip this guard until they're added to the set
+        # (and themselves migrated). Excludes preview/static fixtures.
+        top_level = {
+            p.name for p in FRONTEND.glob("*.html")
+            if p.is_file()
+        }
+        unaccounted = top_level - _MIGRATED_PAGES - _LEGACY_INLINE_PAGES
+        self.assertEqual(
+            unaccounted, set(),
+            "new top-level page(s) in frontend/ are missing from "
+            "_MIGRATED_PAGES or _LEGACY_INLINE_PAGES: "
+            + ", ".join(sorted(unaccounted)),
+        )
 
 
 class GraphPageDelegationTests(unittest.TestCase):
@@ -400,6 +430,189 @@ class ChatPageDelegationTests(unittest.TestCase):
         self.assertIn("closeLoginOutside", self.chat)
         self.assertIn("closeForgotPasswordOutside", self.chat)
         self.assertIn("closeSignupOutside", self.chat)
+
+
+class AdminPageDelegationTests(unittest.TestCase):
+    """PR-D — admin.html + admin.js. The largest page in the bunch
+    (~62 inline HTML handlers + ~22 dynamic-template handlers, plus
+    two modal-overlay close patterns and a checkbox change handler).
+
+    Beyond the static actions, the admin page exercises three
+    delegation patterns the prior PRs didn't need:
+
+      1. ``data-overlay-action`` for the entity-detail and
+         session-turns modals — the old onclick="event.stopPropagation()"
+         on the inner content is replaced by an equality check
+         (``e.target === overlay``) in the click delegate.
+      2. A separate ``change`` delegate keyed by ``data-change-action``
+         for the policy-matrix checkboxes, which are dynamically
+         re-rendered by loadPolicy().
+      3. The proposal-detail button only carries the proposal id;
+         the title + body are looked up from a module-level
+         ``_proposalsById`` cache populated by loadProposals(). This
+         avoids round-tripping long, newline-bearing strings through
+         HTML data-* attributes (which would need extra escaping)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (FRONTEND / "admin.html").read_text(encoding="utf-8")
+        cls.js   = (STATIC / "admin.js").read_text(encoding="utf-8")
+
+    # ─── HTML ──────────────────────────────────────────────────────
+    def test_html_uses_data_action_for_header(self):
+        for action in (
+            "toggle-lang", "toggle-admin-nav",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    def test_html_uses_data_action_for_nav_sections(self):
+        # All five foldable section headers share one action.
+        self.assertGreaterEqual(
+            self.html.count('data-action="toggle-nav-section"'), 5,
+            "all nav-section headers must carry data-action=toggle-nav-section",
+        )
+
+    def test_html_uses_data_action_for_show_page(self):
+        # 17 distinct pages, each carrying data-action=show-page with
+        # the page name on data-page. The footer anchor in the files
+        # section adds one more (jumping to the uploads page).
+        for page in (
+            "dashboard", "users", "policy", "entities", "memory",
+            "patches", "uploads", "files", "audit",
+            "proposals", "evo-reports", "character", "knowledge",
+            "performance", "learning", "hardware", "settings",
+        ):
+            with self.subTest(page=page):
+                self.assertRegex(
+                    self.html,
+                    r'data-action="show-page"\s+data-page="' + page + r'"',
+                    f'nav entry for page={page} missing',
+                )
+
+    def test_html_uses_data_action_for_paging_buttons(self):
+        # Entities + audit each have prev/next pager with a signed delta.
+        self.assertRegex(
+            self.html,
+            r'data-action="entities-page"\s+data-delta="-1"',
+        )
+        self.assertRegex(
+            self.html,
+            r'data-action="entities-page"\s+data-delta="1"',
+        )
+        self.assertRegex(
+            self.html,
+            r'data-action="audit-page"\s+data-delta="-1"',
+        )
+        self.assertRegex(
+            self.html,
+            r'data-action="audit-page"\s+data-delta="1"',
+        )
+
+    def test_html_uses_data_overlay_action_for_modals(self):
+        # The two big modals (entity detail / session turns) used to
+        # rely on onclick="closeXyz(event)" on the overlay and
+        # onclick="event.stopPropagation()" on the inner content. The
+        # delegate now treats data-overlay-action as "only fires when
+        # the click target is the overlay itself".
+        self.assertIn('data-overlay-action="close-entity-detail"', self.html)
+        self.assertIn('data-overlay-action="close-session-turns"', self.html)
+
+    def test_html_uses_data_action_for_login_modal(self):
+        for action in (
+            "toggle-admin-pw-visibility", "do-admin-login",
+            "open-forgot-password-modal", "open-signup-modal",
+            "close-signup-modal", "submit-signup",
+            "close-forgot-password-modal", "submit-password-reset",
+            "copy-my-api-key", "close-my-api-key-modal",
+            "copy-reset-token", "close-reset-token-modal",
+            "first-run-dismiss", "first-run-check",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.html)
+
+    # ─── admin.js dynamic templates ────────────────────────────────
+    def test_js_dynamic_buttons_use_data_action(self):
+        for action in (
+            "first-run-install",
+            "approve-user", "reject-user",
+            "issue-reset-token-for", "deactivate-user",
+            "revoke-my-api-key", "reset-policy-feature",
+            "open-entity-detail",
+            "open-session-turns", "summarize-and-delete",
+            "patch-action",
+            "uploads-prev", "uploads-next",
+            "show-proposal-detail", "execute-web-learn-proposal",
+            "approve-proposal", "reject-proposal-by-id",
+            "learn-single-topic", "install-llm",
+        ):
+            with self.subTest(action=action):
+                self.assertIn(f'data-action="{action}"', self.js)
+
+    def test_js_policy_toggle_uses_change_action(self):
+        # The policy-matrix is re-rendered by innerHTML; per-checkbox
+        # addEventListener would lose binding on every reload, so a
+        # delegated change handler is required.
+        self.assertIn('data-change-action="policy-toggle"', self.js)
+        self.assertIn('data-feature-id', self.js)
+        self.assertIn('data-role', self.js)
+
+    def test_js_patch_action_carries_decision(self):
+        # Approve and Reject share one action; the decision is on
+        # data-decision so the delegate registers a single entry.
+        for decision in ("approve", "reject"):
+            with self.subTest(decision=decision):
+                self.assertRegex(
+                    self.js,
+                    r'data-action="patch-action"[^`]*?data-decision="' + decision + r'"',
+                )
+
+    def test_js_no_inline_handlers_in_templates(self):
+        # Mirrors the contract for upload.js: no innerHTML template
+        # may regress to emitting inline ``onclick=`` etc. JS property
+        # access (``.onclick = …``) is allowed — only the leading-
+        # whitespace HTML-attr form is flagged by _INLINE_ATTR_RE.
+        hits = _INLINE_ATTR_RE.findall(self.js)
+        self.assertEqual(
+            hits, [],
+            "admin.js innerHTML templates may not emit inline handlers",
+        )
+
+    # ─── Delegation infrastructure ────────────────────────────────
+    def test_js_installs_click_delegation(self):
+        self.assertRegex(
+            self.js,
+            r"document\.addEventListener\(\s*['\"]click['\"]",
+            "admin.js must install a document-level click delegate",
+        )
+        self.assertIn("data-action", self.js)
+
+    def test_js_installs_change_delegation(self):
+        # Used for the dynamic policy-toggle checkboxes.
+        self.assertRegex(
+            self.js,
+            r"document\.addEventListener\(\s*['\"]change['\"]",
+            "admin.js must install a document-level change delegate",
+        )
+        self.assertIn("data-change-action", self.js)
+
+    def test_js_binds_stable_inputs_on_dom_ready(self):
+        self.assertIn("_bindStableInputs", self.js)
+        self.assertRegex(
+            self.js,
+            r"DOMContentLoaded[\s\S]{0,200}?_bindStableInputs",
+        )
+
+    def test_js_proposals_cache_supports_detail(self):
+        # The Detail button only carries data-proposal-id; the
+        # delegate looks the proposal up here so long content avoids
+        # round-tripping through HTML attributes.
+        self.assertIn("_proposalsById", self.js)
+        self.assertRegex(
+            self.js,
+            r"_proposalsById\.set\(",
+            "loadProposals must populate _proposalsById",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_threshold_labels.py
+++ b/tests/test_threshold_labels.py
@@ -39,16 +39,26 @@ class HtmlElementsTests(unittest.TestCase):
             "must add a span#ws-threshold-label that JS updates")
 
     def test_slider_oninput_uses_helper(self):
-        # The slider should call applyWsThresholdLabel(this.value),
-        # not raw textContent assignment, so the label updates too.
-        m = re.search(
-            r'<input[^>]*id="ws-threshold"[^>]*oninput="([^"]+)"',
+        # [§5 PR-D] inline oninput="applyWsThresholdLabel(this.value)"
+        # replaced by direct id-binding in admin.js _bindStableInputs().
+        # Contract: the slider input must still exist, and the helper
+        # must still be called from the live input listener.
+        self.assertRegex(
             self.html,
+            r'<input[^>]*id="ws-threshold"',
+            "couldn't locate slider element",
         )
-        self.assertIsNotNone(m, "couldn't locate slider element")
-        oninput = m.group(1)
-        self.assertIn("applyWsThresholdLabel", oninput,
-            "slider oninput must call applyWsThresholdLabel for live label")
+        js = JS.read_text(encoding="utf-8")
+        self.assertIn(
+            "document.getElementById('ws-threshold')", js,
+            "slider must be bound by id in _bindStableInputs",
+        )
+        # The binding handler invokes applyWsThresholdLabel for live label.
+        bind_block = js[js.index("_bindStableInputs"):]
+        bind_block = bind_block[:2000]
+        self.assertIn("applyWsThresholdLabel", bind_block,
+            "id-bound input listener must call applyWsThresholdLabel "
+            "for the live label")
 
     def test_track_endpoints_use_korean_labels(self):
         # Min/max badges next to slider should say 안함 / 강력 instead

--- a/tests/test_upload_history.py
+++ b/tests/test_upload_history.py
@@ -216,9 +216,14 @@ class FrontendAdminHtmlTests(unittest.TestCase):
         cls.html = (ROOT / "frontend" / "admin.html").read_text(encoding="utf-8")
 
     def test_nav_item_present(self):
-        # Sidebar must have a clickable entry that calls showPage('uploads', ...).
-        self.assertIn("showPage('uploads'", self.html,
-                      "sidebar must register a nav-item linking to uploads page")
+        # [§5 PR-D] inline onclick="showPage('uploads', this)" replaced
+        # by data-action="show-page" data-page="uploads" routed through
+        # the document click delegate.
+        self.assertRegex(
+            self.html,
+            r'data-action="show-page"\s+data-page="uploads"',
+            "sidebar must register a nav-item linking to uploads page",
+        )
         self.assertIn('admin.upload_history', self.html,
                       "i18n key admin.upload_history must be wired in")
 
@@ -233,8 +238,19 @@ class FrontendAdminHtmlTests(unittest.TestCase):
                       "pagination container must exist")
 
     def test_search_uses_enter_key(self):
-        # Ergonomic: pressing Enter triggers loadUploads.
-        self.assertIn("if(event.key==='Enter') loadUploads()", self.html)
+        # [§5 PR-D] inline onkeydown="if(event.key==='Enter') loadUploads()"
+        # replaced by direct id-binding in admin.js _bindStableInputs()
+        # — that listener watches keydown on #uploads-search.
+        js = (ROOT / "frontend" / "static" / "admin.js").read_text(encoding="utf-8")
+        self.assertIn("document.getElementById('uploads-search')", js,
+            "#uploads-search must be bound by id in _bindStableInputs")
+        bind_block = js[js.index("_bindStableInputs"):]
+        bind_block = bind_block[:3000]
+        self.assertRegex(
+            bind_block,
+            r"'uploads-search'[\s\S]*?Enter[\s\S]*?loadUploads\(\)",
+            "the uploads-search Enter handler must still call loadUploads()",
+        )
 
 
 class I18nKeysTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Final phase of the §5 inline-handler → ``data-action`` delegation rollout. Closes the migration: ``_LEGACY_INLINE_PAGES`` is now empty and every page-level ``*.html`` in ``frontend/`` is in ``_MIGRATED_PAGES`` (enforced by a new ``test_rollout_complete`` guard).

Stacked on #232 (PR-C). Merge order: #230 → #231 → #232 → this.

## Scope

- ``admin.html`` (1733 lines): 62 inline handlers + 2 ``href=\"javascript:…\"`` links migrated.
- ``admin.js`` (3404 → ~3580 lines): 22 ``onclick=`` occurrences in innerHTML templates rewritten to emit ``data-action`` + ``data-*``. One document-level click delegate + one ``change`` delegate + one ``_bindStableInputs()`` for the page-lifetime inputs.

## Patterns this PR introduced (not needed in PR-A/B/C)

1. **Sidebar nav** — 17 nav-items collapse to one action with a payload: ``data-action=\"show-page\" data-page=\"<name>\"``. The delegate locates the matching nav-item to mark active so the in-page anchor (``href=\"#\" data-page=\"uploads\"``) still updates the sidebar.

2. **Modal overlays** — entity-detail and session-turns modals used to wire ``onclick=\"closeXyz(event)\"`` on the overlay + ``stopPropagation`` on the inner content. Replaced by ``data-overlay-action`` plus an ``e.target === overlay`` equality check in the delegate.

3. **Dynamic checkboxes** — the policy-matrix is re-rendered by ``loadPolicy()`` through innerHTML, so per-row ``addEventListener`` would lose binding on every reload. A separate document-level ``change`` delegate keyed by ``data-change-action`` survives renders.

4. **Long detail body** — the proposal \"Detail\" button only carries ``data-proposal-id``; ``loadProposals()`` populates a module-level ``_proposalsById`` cache so long, newline-bearing description+content strings don't have to round-trip through HTML attributes (which would need extra escape).

## Verification

- ``tests/test_frontend_event_delegation.py`` — admin.html moves to ``_MIGRATED_PAGES``; legacy set closed; 14 new contract tests under ``AdminPageDelegationTests``; new ``test_no_inline_javascript_href`` and ``test_rollout_complete`` guards.
- 11 adjacent tests updated from inline-handler substring matches to ``data-action`` / id-binding contracts: ``test_a11y_aria_labels``, ``test_admin_entities``, ``test_admin_foldable_tech``, ``test_admin_history_expand``, ``test_admin_pw_eye``, ``test_character_interactive_radar``, ``test_character_remove_text_persona``, ``test_file_mgmt_tab``, ``test_first_run_wizard``, ``test_threshold_labels``, ``test_upload_history``.

**1499 tests OK, ruff clean.**

## Test plan

- [x] Full suite green: ``python -m unittest discover -s tests -t . `` → 1499/1499 OK
- [x] ``python -m ruff check tests/ frontend/`` → all checks passed
- [x] CSP-friendly: zero inline ``on*=`` attributes across all four page-level HTML files (graph, workspace, index, admin)
- [x] No ``href=\"javascript:…\"`` links anywhere in migrated pages

## Out of scope

- Not removing the named functions (``saveCharacter``, ``firstRunInstall``, ``approveUser``, etc.); they remain as module-level callables invoked from the delegate.
- No behavior changes to any admin action — purely a wiring refactor.
- Static fixture pages under ``frontend/static/*.html`` (preview-cyber.html etc.) are not page-level templates and are not part of the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)