### PR TITLE
docs(architecture): v0.2.x Change Request track — handover + §5.6 trust zone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 | Business track (current cycle) | `docs/handovers/v0.2.1-business-track.md` |
 | v0.3 license / CLA / plugin API session | `docs/handovers/session-2026-05-09-license-infrastructure.md` |
 | License long-term plan + trigger monitoring | `docs/LICENSE_PLAN.md` |
+| **Change Request primitive (v0.2.x cycle)** | `docs/handovers/v0.2.x-cr-track.md` + `docs/ARCHITECTURE.md §5.6` |
 | Open issues by priority | `gh issue list --label priority:high` |
 | STEP 7 regression baseline | `eval/regression/step7_queries.json` (or `scripts/step7_query_test.py`) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,6 +155,27 @@ The following moved to v0.3 to keep v0.2 focused:
 
 ### Deferred follow-ups (recheck before v0.3)
 
+- **Change Request primitive — generalise the approver_username
+  pattern.** v0.1 hard-coded approver tracking for self-evolution
+  alone (Axis 5). Every other write — wiki edits, workspace job
+  runs, ontology patches, config saves — lands with no proposal,
+  no review, no diff, no rollback. v0.2.x adds `core/change_request.py`
+  as a single primitive owning the propose → review → merge →
+  audit cycle, with two target types (`wiki_entity` first,
+  `run_jobs` second) and the existing self-evolution gate folded
+  on top in the same cycle. Spans Axis 4 (security boundary
+  generalisation) + Axis 5 (controlled write authorisation
+  generalised beyond self-evolution).
+  - Trust zone documented in `docs/ARCHITECTURE.md §5.6`.
+  - Cycle plan + frozen schema + invariants in
+    `docs/handovers/v0.2.x-cr-track.md`.
+  - Deliberately closed enum for `target_type` — the registration
+    API surface is the v0.3 plugin contract.
+  - Multi-approver, team / project / department, external
+    notification routing → all deferred to v0.3.
+  - Done-when: every audit row carrying an `approver_username`
+    today goes through `core/change_request.py`.
+
 - **Audit Phase 4b-2 — remove 16 JSONL writer sites.** The
   JSONL → SQLite migration completed every reader path
   (PRs #206 / #207 / #208 / #210 / #211): the legacy `/admin/audit`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -463,6 +463,91 @@ become a regression.
 
 ---
 
+## 5.6 Change Request primitive (v0.2.x, in progress)
+
+`core/change_request.py` is the single primitive for governing
+**write actions** — wiki edits, workspace job runs, ontology
+patches, config saves. It generalises the `approver_username`
+pattern that v0.1 hard-coded for self-evolution alone: every
+write becomes a proposal first, every merge requires an approver,
+every transition writes one row to `audit_bridge`.
+
+```
+proposer (any authenticated user)
+   │ POST /admin/cr/        (target_type + target_id + proposed_diff + base_hash)
+   ▼
+change_requests row, status='open'
+   │ POST /admin/cr/{id}/review     ← any authenticated user; cr_reviews row
+   │ POST /admin/cr/{id}/approve    ← admin only
+   ▼
+apply() under SQLite transaction:
+   ├─ target-specific apply (mutates wiki / runs job / ...)
+   ├─ change_requests row → status='merged'
+   └─ audit_bridge row recording the transition
+```
+
+Three properties make this the right shape for the mother platform:
+
+1. **Domain-neutral**. The proposal / review / merge / audit cycle
+   is universal — the same object makes sense for clause edits,
+   nutrition labels, or single-operator notes. Domain coupling
+   enters only at v1.0 (CLAUDE.md rule #1, `docs/PLATFORM_READINESS`).
+2. **Append-only audit is the source of truth**. The
+   `change_requests` table itself can be reconstructed from
+   `audit_bridge` rows. The audit-bridge invariant from §4
+   (auditability over performance) extends to the CR primitive.
+3. **No external `target_type` registration before v0.3**. The
+   dispatcher is a closed enum on purpose — the registration API is
+   exactly the v0.3 plugin contract surface and locking it before
+   then would force a breaking change later.
+
+### Trust zone
+
+| Edge | Default trust | Hardening |
+|---|---|---|
+| proposer | **low** | `_require_auth` only; proposal is inert until merged |
+| reviewer (comment / request_changes) | **low** | same as proposer |
+| reviewer (approve / reject) | requires admin role | `_require_admin` at the endpoint |
+| approver ≠ proposer | invariant | enforced at merge time; no self-approval |
+
+### Invariants
+
+1. `merged_at` / `merged_by` NOT NULL ⇔ `status='merged'`.
+2. approver ≠ proposer.
+3. `base_hash` mismatch at merge → 409 + `status='superseded'`
+   (proposal is now stale; user must rebase).
+4. merge is a single SQLite transaction across (a) the row update,
+   (b) target apply, (c) the audit_bridge insert. apply() raising
+   rolls back all three.
+5. apply() failure leaves `status='open'`. A reject is an explicit
+   reviewer decision, never an apply-side accident.
+6. `target_type` unknown to the dispatcher → 400 at propose time
+   (fail closed — matches the PolicyEngine `can_use_feature` pattern
+   for typos).
+7. Every state transition writes one `audit_bridge` row.
+
+### v0.2.x scope
+
+Two target types ship: `wiki_entity` (markdown edits with
+`base_hash` conflict detection) and `run_jobs` (gating workspace
+job execution). The existing self-evolution gate is folded onto
+the same primitive in the same cycle — the `approver_username` /
+`approver_role` / `before_metrics` / `after_metrics` fields that
+v0.1 introduced for patches become per-CR fields on a CR with
+`target_type='self_evolution_patch'`. Behaviour is byte-identical;
+the storage and audit shape become uniform.
+
+**Done-when criterion**: every write that today calls
+`audit_bridge.write_event(action='approved')` with an approver
+field goes through `core/change_request.py`. The bespoke
+`/admin/proposals/...` endpoints become thin wrappers over
+`/admin/cr/...`.
+
+The full cycle plan lives in
+`docs/handovers/v0.2.x-cr-track.md`.
+
+---
+
 ## 6. Evolution Boundaries
 
 Self-evolution is **disabled by default**. To enable:
@@ -470,6 +555,13 @@ Self-evolution is **disabled by default**. To enable:
 1. Set `JAMES_ENABLE_EVOLUTION=1` (explicit opt-in)
 2. Configure `JAMES_EVOLUTION_APPROVER_ROLE` (default: `admin`)
 3. Patches flow: `feedback → candidate → 4-gate eval → approval → deploy → rollback-ready`
+
+> **v0.2.x note**: in the Change Request track (§5.6), the
+> self-evolution flow is being **wrapped** by the generalised CR
+> primitive — the approver field, the eval gate, and the audit-log
+> writes preserve byte-for-byte behaviour. CLAUDE.md rule #3
+> remains in force; the deploy step still rejects without an
+> approver.
 
 A patch reaches `deploy` only after a human with the approver role
 explicitly approves it. Auto-approval is a bug, not a feature.

--- a/docs/handovers/v0.2.x-cr-track.md
+++ b/docs/handovers/v0.2.x-cr-track.md
@@ -1,0 +1,233 @@
+# v0.2.x — Change Request track (cycle handover)
+
+> 2026-05-12. A v0.2.x hardening cycle — does **not** open a new
+> minor version. Lives alongside the open frontend stack (#230–#235)
+> and the v0.2 → v0.3 platform-readiness gate.
+>
+> Read order: `CLAUDE.md` → this file → `docs/ARCHITECTURE.md §5.6`
+> (the trust zone) → `ROADMAP.md` v0.2.x section.
+
+---
+
+## 1. Problem
+
+Every write inside JAMES today follows one of two shapes:
+
+| Shape | Example | Governance today |
+|---|---|---|
+| Self-evolution | `/admin/proposals/{id}/approve` | ✅ `approver_username` recorded, audit-bridged, eval-gated |
+| Everything else | wiki edit, workspace job run, ontology patch, config save | ❌ **none** — the write lands as soon as the call returns |
+
+The first row exists because v0.1 already learned a hard rule: a
+self-modifying system without a human approver is a bug, not a
+feature (CLAUDE.md rule #3). The second row is the rest of the
+system — and most user-visible "collaboration" friction comes from
+its absence: there is no proposal, no review, no diff, no rollback,
+no shared timeline.
+
+**This cycle generalises the approver_username pattern into a single
+primitive — the Change Request — and routes one new write through
+it (wiki entity edits) so the pattern is real before we make it
+universal.**
+
+The primitive is deliberately **domain-neutral**: the same CR object
+makes sense for a legal corp doing clause edits, a food retailer
+editing nutrition labels, or a single operator editing their own
+notes. Domain coupling enters the picture only at v1.0, per
+`docs/PLATFORM_READINESS.md` and CLAUDE.md rule #1.
+
+---
+
+## 2. Scope (frozen for v0.2.x)
+
+### In scope
+- A new `core/change_request.py` module owning the CR lifecycle
+- Two SQLite tables — `change_requests` + `cr_reviews`
+- Admin endpoints (`/admin/cr/...`) for propose / list / detail /
+  approve / reject / review
+- One `target_type=wiki_entity` apply path (markdown file edit with
+  `base_hash` conflict detection)
+- One follow-up `target_type=run_jobs` apply path (same cycle)
+- Workspace UI panel that lists CRs and lets admins approve/reject
+- Integration of the existing self-evolution gate (audit-recorded,
+  but currently bespoke) onto the same CR object
+
+### Out of scope (deferred to v0.3 plugin contract)
+- External `target_type` registration API (today's `target_type` is
+  a closed enum; new entries require a code change — on purpose)
+- Multi-approver workflows ("2 of 3 admins must approve")
+- Team / project / department scoping
+- Hierarchical labels (flat `labels` CSV column today; v0.3 may
+  migrate to a proper tag table)
+- Status-machine extensions for domain-specific phases
+  (Draft → Review → Published per-domain)
+- External notification routing (Slack / e-mail on CR events)
+
+Anything in the second list, if asked for during this cycle, gets a
+flat **no** with a pointer back to this section.
+
+---
+
+## 3. Trust zone (single sentence)
+
+`proposer (any authenticated user) → CR row inert in
+change_requests → admin reviewer → apply() under transaction →
+audit_bridge row`. Nothing else writes to the target.
+
+The full statement lives in `docs/ARCHITECTURE.md §5.6` (the
+architecture PR that ships **with** this handover).
+
+### Invariants (will be enforced by tests in PR-CR-B)
+
+1. `merged_at` / `merged_by` are NOT NULL iff `status='merged'`.
+2. Approver MUST differ from proposer (no self-approval).
+3. `base_hash` mismatch at merge time → 409 + `status='superseded'`.
+4. Merge is a single SQLite transaction across (a) `change_requests`
+   row update, (b) target apply call, (c) `audit_bridge` row insert.
+   apply() raising rolls all three back.
+5. apply() failure leaves `status='open'` (NOT `rejected`). A
+   reject is an explicit reviewer decision, never an apply-side
+   accident.
+6. `target_type` unknown to the apply dispatcher → 400 at propose
+   time (fail closed; matches the PolicyEngine `can_use_feature`
+   pattern).
+7. Every state transition writes one row to `audit_bridge` so the
+   CR table can be reconstructed from the audit log even if the
+   `change_requests` table itself is lost.
+
+---
+
+## 4. Tables (frozen schema)
+
+```sql
+CREATE TABLE change_requests (
+  cr_id          TEXT PRIMARY KEY,         -- ULID-like sortable id
+  target_type    TEXT NOT NULL,            -- 'wiki_entity' | 'run_jobs'
+  target_id      TEXT NOT NULL,            -- e.g., entity_id or job spec hash
+  title          TEXT NOT NULL,
+  description    TEXT,
+  proposed_diff  TEXT NOT NULL,            -- JSON; structure is target_type-specific
+  base_hash      TEXT NOT NULL,            -- sha256 of target state at propose time
+  proposer       TEXT NOT NULL,
+  status         TEXT NOT NULL,            -- 'open' | 'merged' | 'rejected' | 'superseded'
+  labels         TEXT,                     -- CSV; FLAT (v0.3 may migrate to a tag table)
+  created_at     INTEGER NOT NULL,         -- unix epoch
+  updated_at     INTEGER NOT NULL,
+  merged_at      INTEGER,                  -- NULL until merged
+  merged_by      TEXT,                     -- approver_username; NULL until merged
+  reject_reason  TEXT                      -- NULL unless status='rejected'
+);
+CREATE INDEX idx_cr_status_target ON change_requests(status, target_type, target_id);
+CREATE INDEX idx_cr_proposer ON change_requests(proposer, status);
+
+CREATE TABLE cr_reviews (
+  review_id   TEXT PRIMARY KEY,
+  cr_id       TEXT NOT NULL REFERENCES change_requests(cr_id) ON DELETE CASCADE,
+  reviewer    TEXT NOT NULL,
+  decision    TEXT NOT NULL,               -- 'approve' | 'request_changes' | 'comment'
+  body        TEXT,
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX idx_cr_reviews_cr ON cr_reviews(cr_id, created_at);
+```
+
+This schema is **frozen for v0.2.x**. Migrations belong to v0.3 if
+the plugin contract requires them.
+
+---
+
+## 5. PR sequence
+
+| PR | Branch | Scope | Depends on | Gate |
+|---|---|---|---|---|
+| CR-A (this) | `docs/v0.2-cr-track` | This file + ARCHITECTURE.md §5.6 + ROADMAP entry + doc-presence test | — | `architecture` label, 1500+ tests still green |
+| CR-B | `feat/v0.2-cr-backend` | `core/change_request.py` + apply for `wiki_entity` + 5 endpoints + table migration + invariants tests | CR-A merged | Bench numbers if `core/retrieval/graph/reasoning` touched (they should not be) |
+| CR-C | `feat/v0.2-cr-ui` | Workspace UI panel + JS delegation reuse | CR-B merged | A11y + event-delegation tests still green |
+| CR-D | `feat/v0.2-cr-jobs-and-evo` | `run_jobs` apply path + self-evolution gate re-routes via CR | CR-C merged | All self-evolution tests still pass byte-identical (CLAUDE.md rule #3) |
+
+Each PR creates its own handover update under
+`docs/handovers/v0.2.x-cr-*.md` if non-trivial decisions are made
+during implementation.
+
+---
+
+## 6. What this cycle deliberately does NOT do
+
+- Touch `core/retrieval` / `core/graph` / `core/reasoning` (CLAUDE.md
+  rule #2 — would require bench numbers in every PR; this cycle is
+  governance, not reasoning).
+- Modify `docs/PLATFORM_READINESS.md` (the gate definitions stay).
+- Disable or auto-approve the self-evolution path. CR-D **wraps**
+  the existing gate; the approver field, the eval gate, and the
+  audit_bridge writes are preserved byte-for-byte.
+- Expose any `target_type` registration API to plugins. The closed
+  enum is the v0.3 contract surface — locking it now would force a
+  breaking change later (per `docs/PLATFORM_READINESS.md` v0.3 gate).
+- Land any UI element that implies a team / project / department
+  model. Flat `labels` only.
+
+If a reviewer requests any of these in the cycle, the answer is
+**defer to v0.3**, not "let's just add it quickly".
+
+---
+
+## 7. Files this cycle touches
+
+Predicted (will sharpen during CR-B implementation):
+
+```
+core/change_request.py                    # NEW, ≤ 15 KB target (CLAUDE.md rule #5)
+core/change_request_apply.py              # NEW, target-specific dispatcher
+server_llmwiki.py                         # +~200 lines for the 6 endpoints
+frontend/workspace.html                   # CR tab
+frontend/static/workspace.js              # CR list + detail
+docs/ARCHITECTURE.md                      # §5.6 (this PR)
+docs/handovers/v0.2.x-cr-track.md         # this file
+ROADMAP.md                                # one v0.2.x bullet
+tests/test_change_request_core.py         # state machine + invariants
+tests/test_change_request_wiki_apply.py   # wiki target apply path
+tests/test_change_request_jobs_apply.py   # run_jobs target apply path (CR-D)
+tests/test_change_request_audit.py        # audit_bridge integration
+tests/test_workspace_cr_panel.py          # UI contract (CR-C)
+tests/test_cr_docs_presence.py            # this PR: keeps the docs load-bearing
+```
+
+`core/change_request.py` budget: 15 KB. If apply dispatcher growth
+pushes it over, split as `core/change_request/__init__.py` + apply
+sub-package — same pattern as `core/memory/`.
+
+---
+
+## 8. Decision log
+
+- **First `target_type` = `wiki_entity`** (not `run_jobs`) because
+  wiki edits currently have zero governance and the data value is
+  immediately visible. `run_jobs` is the second target in the same
+  cycle (CR-D) — pattern reuse, ~80 lines.
+- **`base_hash` over optimistic locking version numbers** because
+  wiki entries are markdown files on disk. SHA256(file bytes) at
+  propose time is the natural "what I was looking at" anchor.
+- **`labels` is a CSV column** (not a tag table) because hierarchical
+  scoping (team / project / department) is exactly the v0.3 plugin
+  contract surface — locking it now would force a breaking change.
+- **No external `target_type` registration API** for the same reason.
+- **Approver ≠ proposer** is the only baked-in workflow rule.
+  Multi-approver flows belong to v0.3.
+- **Self-evolution stays untouched until CR-D** so that the
+  approval / eval / rollback chain (`tests/test_self_evolution_gate.py`,
+  `tests/test_evolution_bench_gate.py`, `tests/test_evolution_rollback.py`)
+  has zero behavioural drift across CR-A/B/C.
+
+---
+
+## 9. 한국어 요약
+
+자메스 안에서 쓰기 작업에 대한 **결재·감사·롤백 사이클**을 단일
+원시(Change Request)로 모은다. 지금은 자가-진화만 결재 게이트가
+있고 위키 편집 / 잡 실행 / 온톨로지 변경은 전부 무관문 통과 중.
+
+v0.2.x 범위: `core/change_request.py` 신규 + `wiki_entity` /
+`run_jobs` 두 타깃 + 워크스페이스 UI + 자가-진화 게이트 통합.
+다중 결재자 · 팀/부서 · 외부 `target_type` 등록 API 는 v0.3
+플러그인 계약과 함께. 도메인 가정은 들이지 않는다 (CLAUDE.md
+규칙 #1).

--- a/tests/test_cr_docs_presence.py
+++ b/tests/test_cr_docs_presence.py
@@ -1,0 +1,215 @@
+"""[PR-CR-A, 2026-05-12] Change Request track — docs-presence contract.
+
+Step A of the v0.2.x CR cycle is doc-only: a handover under
+``docs/handovers/v0.2.x-cr-track.md``, a new trust-zone section
+``§5.6 Change Request primitive`` in ``docs/ARCHITECTURE.md``, and
+a ``ROADMAP.md`` entry that points to both. CLAUDE.md rule #4
+explicitly requires an architecture-labelled PR for new modules /
+new trust zones — this test makes the docs load-bearing so a
+later PR cannot quietly skip them.
+
+Mirrors the rollout-gate pattern from
+``tests/test_frontend_event_delegation.py`` and
+``tests/test_mobile_css_coverage.py``: the documents themselves
+are the contract, and a contract test names the load-bearing
+substrings so silent drift becomes a CI failure.
+
+Out of scope for this test:
+- The actual ``core/change_request.py`` module (PR-CR-B).
+- The ``change_requests`` / ``cr_reviews`` SQLite tables (PR-CR-B).
+- Any UI element (PR-CR-C).
+
+Run:
+    python -m unittest tests.test_cr_docs_presence
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+HANDOVER = ROOT / "docs" / "handovers" / "v0.2.x-cr-track.md"
+ARCHITECTURE = ROOT / "docs" / "ARCHITECTURE.md"
+ROADMAP = ROOT / "ROADMAP.md"
+CLAUDE_MD = ROOT / "CLAUDE.md"
+
+
+class HandoverPresenceTests(unittest.TestCase):
+    """The v0.2.x CR handover doc must exist with the load-bearing
+    sections subsequent PRs will reference."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.assertTrue = unittest.TestCase().assertTrue  # for setUpClass usage
+        cls.text = HANDOVER.read_text(encoding="utf-8") if HANDOVER.exists() else ""
+
+    def test_handover_file_exists(self):
+        self.assertTrue(
+            HANDOVER.exists(),
+            f"missing {HANDOVER.relative_to(ROOT)} — PR-CR-A must create it",
+        )
+
+    def test_handover_freezes_scope(self):
+        # PR-CR-B/C/D will all reference 'frozen for v0.2.x' to refuse
+        # scope creep — if this phrase disappears, the cycle plan is
+        # silently broken.
+        self.assertIn(
+            "frozen for v0.2.x", self.text,
+            "handover must declare its scope as 'frozen for v0.2.x' "
+            "so subsequent PRs can refuse scope creep with a doc cite",
+        )
+
+    def test_handover_names_both_target_types(self):
+        # wiki_entity ships in CR-B; run_jobs in CR-D. Both must be
+        # in the handover so the dispatcher contract test in CR-B can
+        # cross-reference.
+        self.assertIn("wiki_entity", self.text)
+        self.assertIn("run_jobs", self.text)
+
+    def test_handover_lists_invariants(self):
+        # The seven invariants (approver != proposer, base_hash
+        # mismatch → superseded, etc.) are the contract that
+        # tests/test_change_request_core.py (PR-CR-B) will enforce.
+        self.assertIn("Invariants", self.text)
+        for phrase in (
+            "approver",         # invariant 2
+            "base_hash",        # invariant 3
+            "transaction",      # invariant 4
+            "audit_bridge",     # invariant 7
+        ):
+            with self.subTest(invariant_token=phrase):
+                self.assertIn(phrase, self.text,
+                    f"handover invariant section must mention {phrase!r}")
+
+    def test_handover_lists_deferred_v03_items(self):
+        # The cycle deliberately punts five items to v0.3 — multi-
+        # approver, team/project/department, hierarchical labels,
+        # external target_type API, domain-specific status machines.
+        # Naming them in the handover is what lets reviewers refuse
+        # scope creep without re-litigating.
+        for deferred in (
+            "Multi-approver",
+            "Team",
+            "Hierarchical",
+            "registration API",
+        ):
+            with self.subTest(deferred=deferred):
+                self.assertIn(deferred, self.text,
+                    f"handover must list {deferred!r} among deferred-"
+                    "to-v0.3 items so scope creep is refusable")
+
+    def test_handover_names_pr_sequence(self):
+        # CR-A through CR-D are the only PRs that should land in this
+        # cycle. Naming them keeps the sequence visible.
+        for pr in ("CR-A", "CR-B", "CR-C", "CR-D"):
+            with self.subTest(pr=pr):
+                self.assertIn(pr, self.text,
+                    f"handover must name {pr} in the PR sequence")
+
+
+class ArchitectureSectionTests(unittest.TestCase):
+    """ARCHITECTURE.md must declare the new trust zone — CLAUDE.md
+    rule #4 requires an architecture-labelled PR for new trust
+    zones, and this test pins the load-bearing tokens."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = ARCHITECTURE.read_text(encoding="utf-8")
+
+    def test_change_request_section_present(self):
+        # §5.6 sits between PolicyEngine (5.5) and Evolution
+        # Boundaries (§6) — both governance primitives.
+        self.assertIn("5.6 Change Request primitive", self.text,
+            "ARCHITECTURE.md must declare §5.6 — the new trust zone "
+            "(CLAUDE.md rule #4)")
+
+    def test_section_states_audit_bridge_as_source_of_truth(self):
+        # The invariant that lets the CR table be reconstructed from
+        # audit_bridge is what makes the primitive recoverable.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("audit_bridge", section,
+            "§5.6 must name audit_bridge as the source of truth")
+        self.assertIn("append-only", section.lower() + section)
+
+    def test_section_states_closed_enum_for_target_type(self):
+        # The reason we don't expose external target_type registration
+        # before v0.3 — it's exactly the plugin contract surface.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("closed enum", section.lower(),
+            "§5.6 must state target_type is a closed enum until v0.3 — "
+            "the registration API surface is the plugin contract")
+        self.assertIn("v0.3", section)
+
+    def test_section_states_approver_neq_proposer(self):
+        # The only baked-in workflow rule.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("approver", section.lower())
+        self.assertIn("proposer", section.lower())
+
+    def test_evolution_section_references_cr_wrapping(self):
+        # §6 (Evolution Boundaries) must note that the self-
+        # evolution gate is being wrapped by CR in CR-D so the
+        # CLAUDE.md rule #3 invariant (approver_username present)
+        # is visibly preserved.
+        idx = self.text.index("## 6. Evolution Boundaries")
+        section = self.text[idx:idx + 2000]
+        # Either "Change Request" or "CR primitive" — both signal the
+        # wrapping. Refuse the section if neither is mentioned.
+        self.assertTrue(
+            ("Change Request" in section) or ("§5.6" in section),
+            "§6 must reference the §5.6 CR primitive so the wrap "
+            "decision is visible from the evolution-gate doc surface",
+        )
+
+
+class RoadmapEntryTests(unittest.TestCase):
+    """ROADMAP.md must point to the CR track from the v0.2 deferred-
+    follow-ups section so future-self knows it's a cycle in flight."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = ROADMAP.read_text(encoding="utf-8")
+
+    def test_change_request_entry_present(self):
+        self.assertIn("Change Request primitive", self.text,
+            "ROADMAP must reference the CR track")
+
+    def test_entry_points_to_handover(self):
+        # Forward references must remain valid — if a CR-B reviewer
+        # follows the ROADMAP link they should land in the handover.
+        self.assertIn("v0.2.x-cr-track.md", self.text,
+            "ROADMAP entry must point to the handover doc by path")
+        self.assertIn("ARCHITECTURE.md §5.6", self.text,
+            "ROADMAP entry must point to the architecture section")
+
+    def test_entry_names_done_when(self):
+        # Every roadmap item carries a done-when criterion.
+        idx = self.text.index("Change Request primitive")
+        nxt_dash = self.text.index("- **", idx + 1)
+        block = self.text[idx:nxt_dash]
+        self.assertIn("Done-when", block.replace("done-when", "Done-when"))
+
+
+class ClaudeMdEntryTests(unittest.TestCase):
+    """CLAUDE.md's 'Where to look next' table must list the CR track
+    so any future session that loads only CLAUDE.md finds it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = CLAUDE_MD.read_text(encoding="utf-8")
+
+    def test_cr_track_listed(self):
+        self.assertIn("v0.2.x-cr-track.md", self.text,
+            "CLAUDE.md 'Where to look next' table must list the CR "
+            "track handover so future sessions discover it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Step A (docs-only) of the v0.2.x CR cycle. **CLAUDE.md rule #4** requires an architecture-labelled PR for new modules / new trust zones — this is that PR. Code lands in **PR-CR-B** onward.

### Rationale

Every write inside JAMES today follows one of two shapes:

| Shape | Example | Governance today |
|---|---|---|
| Self-evolution | ``/admin/proposals/{id}/approve`` | ✅ ``approver_username``, audit-bridged, eval-gated |
| Everything else | wiki edit, workspace job run, ontology patch, config save | ❌ **none** — write lands as soon as the call returns |

The first row exists because CLAUDE.md rule #3 makes it non-negotiable. The second row is the rest of the system, and most user-visible \"collaboration\" friction comes from its absence — no proposal, no review, no diff, no rollback, no shared timeline.

The Change Request primitive generalises the approver pattern into a single object that owns the propose → review → merge → audit cycle for every write. **Deliberately domain-neutral** — the same CR object makes sense for a legal corp doing clause edits, a food retailer editing nutrition labels, or a single operator editing their notes. Domain coupling enters only at v1.0 per CLAUDE.md rule #1 and ``docs/PLATFORM_READINESS.md``.

## What's in this PR

- **``docs/handovers/v0.2.x-cr-track.md``** — cycle handover. Problem statement, in-scope targets (``wiki_entity`` → CR-B; ``run_jobs`` → CR-D), frozen SQLite schema, seven invariants, PR sequence, explicit deferred-to-v0.3 list (multi-approver, team / project / department, hierarchical labels, external ``target_type`` registration API).
- **``docs/ARCHITECTURE.md §5.6``** — new section between PolicyEngine (§5.5) and Evolution Boundaries (§6). Declares the proposer / reviewer / approver trust zone, names ``audit_bridge`` as single source of truth, states the closed-enum ``target_type`` until v0.3, and updates §6 to note that CLAUDE.md rule #3's ``approver_username`` invariant is preserved byte-for-byte when CR-D wraps the self-evolution gate.
- **``ROADMAP.md``** — entry under \"Deferred follow-ups (recheck before v0.3)\" with done-when criterion and pointers to both docs.
- **``CLAUDE.md``** — \"Where to look next\" table adds the CR track so any session loading only CLAUDE.md discovers it.
- **``tests/test_cr_docs_presence.py``** — 15 tests pin the load-bearing sections so CR-B/C/D cannot quietly drift past the architecture decisions.

## PR sequence (cycle plan)

| PR | Scope |
|---|---|
| **CR-A (this)** | Docs + architecture trust zone + presence test |
| CR-B | ``core/change_request.py`` + ``wiki_entity`` apply + 6 endpoints + table migration + invariants tests |
| CR-C | Workspace UI panel (reuses §5 event-delegation pattern) |
| CR-D | ``run_jobs`` apply path + self-evolution gate re-routes via CR |

## Deferred to v0.3 (explicitly refused for this cycle)

- External ``target_type`` registration API (the v0.3 plugin contract surface)
- Multi-approver workflows
- Team / project / department scoping
- Hierarchical labels (flat CSV ``labels`` column today)
- Domain-specific status machines (Draft → Review → Published per-domain)
- External notification routing (Slack / e-mail)

If a reviewer requests any of these during this cycle, the answer is **defer to v0.3** per the handover doc § 6.

## Verification

**1466 tests OK, ruff clean.**

- ``tests/test_cr_docs_presence.py`` (15 tests) pins:
  - handover file exists with frozen scope, both target types, seven invariants section, deferred-to-v0.3 list, PR sequence
  - ARCHITECTURE.md §5.6 present, names ``audit_bridge`` as source of truth, declares ``closed enum`` for ``target_type``, names approver ≠ proposer
  - ARCHITECTURE.md §6 references §5.6 so the wrap decision is visible from the evolution-gate doc surface
  - ROADMAP.md entry exists with done-when criterion and forward links
  - CLAUDE.md \"Where to look next\" table includes the CR track

## Test plan

- [x] ``python -m unittest discover -s tests -t . `` → 1466 OK
- [x] ``python -m ruff check tests/`` → clean
- [x] CLAUDE.md rule #4 (architecture label) satisfied — label applied at PR creation
- [x] No code changes; no bench numbers needed (CLAUDE.md rule #2)
- [x] No ``core/retrieval`` / ``core/graph`` / ``core/reasoning`` touched

## Out of scope

- No backend code (CR-B).
- No UI (CR-C).
- No self-evolution rewiring (CR-D).
- ``docs/PLATFORM_READINESS.md`` untouched — gate definitions stay (handover § 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)