### PR TITLE
feat(core): Change Request — apply dispatcher + wiki_entity + endpoints (PR-CR-B2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 | Business track (current cycle) | `docs/handovers/v0.2.1-business-track.md` |
 | v0.3 license / CLA / plugin API session | `docs/handovers/session-2026-05-09-license-infrastructure.md` |
 | License long-term plan + trigger monitoring | `docs/LICENSE_PLAN.md` |
+| **Change Request primitive (v0.2.x cycle)** | `docs/handovers/v0.2.x-cr-track.md` + `docs/ARCHITECTURE.md §5.6` |
 | Open issues by priority | `gh issue list --label priority:high` |
 | STEP 7 regression baseline | `eval/regression/step7_queries.json` (or `scripts/step7_query_test.py`) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,6 +155,27 @@ The following moved to v0.3 to keep v0.2 focused:
 
 ### Deferred follow-ups (recheck before v0.3)
 
+- **Change Request primitive — generalise the approver_username
+  pattern.** v0.1 hard-coded approver tracking for self-evolution
+  alone (Axis 5). Every other write — wiki edits, workspace job
+  runs, ontology patches, config saves — lands with no proposal,
+  no review, no diff, no rollback. v0.2.x adds `core/change_request.py`
+  as a single primitive owning the propose → review → merge →
+  audit cycle, with two target types (`wiki_entity` first,
+  `run_jobs` second) and the existing self-evolution gate folded
+  on top in the same cycle. Spans Axis 4 (security boundary
+  generalisation) + Axis 5 (controlled write authorisation
+  generalised beyond self-evolution).
+  - Trust zone documented in `docs/ARCHITECTURE.md §5.6`.
+  - Cycle plan + frozen schema + invariants in
+    `docs/handovers/v0.2.x-cr-track.md`.
+  - Deliberately closed enum for `target_type` — the registration
+    API surface is the v0.3 plugin contract.
+  - Multi-approver, team / project / department, external
+    notification routing → all deferred to v0.3.
+  - Done-when: every audit row carrying an `approver_username`
+    today goes through `core/change_request.py`.
+
 - **Audit Phase 4b-2 — remove 16 JSONL writer sites.** The
   JSONL → SQLite migration completed every reader path
   (PRs #206 / #207 / #208 / #210 / #211): the legacy `/admin/audit`

--- a/core/change_request.py
+++ b/core/change_request.py
@@ -1,0 +1,544 @@
+"""Change Request primitive (v0.2.x cycle).
+
+Generalises the ``approver_username`` pattern that v0.1 hard-coded
+for self-evolution. Every write inside JAMES — wiki edits, workspace
+job runs, ontology patches, config saves — becomes a *proposal* in
+this module first; only a separate reviewer's approval, recorded
+with an apply dispatcher (CR-B2), turns the proposal into a real
+write. Every state transition writes one row to the audit-log via
+``core.audit_bridge``, so the ``change_requests`` table can be
+reconstructed from audit alone if it's ever lost.
+
+Scope (PR-CR-B1 — this module): CR state machine + SQLite table
+init + CRUD + reject + supersede + review attach. **No apply path,
+no merge, no endpoint glue.** The apply dispatcher and the six
+``/admin/cr/...`` endpoints land in PR-CR-B2.
+
+Read the full track at:
+    docs/handovers/v0.2.x-cr-track.md
+    docs/ARCHITECTURE.md §5.6
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+try:
+    from config import BASE_DIR as _BASE_DIR
+    _DEFAULT_DB = os.path.join(_BASE_DIR, "james_change_requests.db")
+except ImportError:
+    _DEFAULT_DB = "james_change_requests.db"
+
+
+# ─── State constants ────────────────────────────────────────────
+STATUS_OPEN       = "open"
+STATUS_MERGED     = "merged"
+STATUS_REJECTED   = "rejected"
+STATUS_SUPERSEDED = "superseded"
+VALID_STATUSES = frozenset({
+    STATUS_OPEN, STATUS_MERGED, STATUS_REJECTED, STATUS_SUPERSEDED,
+})
+# Open is the only non-terminal status.
+TERMINAL_STATUSES = frozenset({
+    STATUS_MERGED, STATUS_REJECTED, STATUS_SUPERSEDED,
+})
+
+# Closed enum — see ARCHITECTURE.md §5.6 for why this is not a
+# plugin extension point until v0.3.
+TARGET_WIKI_ENTITY = "wiki_entity"
+TARGET_RUN_JOBS    = "run_jobs"
+VALID_TARGET_TYPES = frozenset({TARGET_WIKI_ENTITY, TARGET_RUN_JOBS})
+
+REVIEW_APPROVE         = "approve"
+REVIEW_REQUEST_CHANGES = "request_changes"
+REVIEW_COMMENT         = "comment"
+VALID_REVIEW_DECISIONS = frozenset({
+    REVIEW_APPROVE, REVIEW_REQUEST_CHANGES, REVIEW_COMMENT,
+})
+
+
+# ─── Frozen DTOs ─────────────────────────────────────────────────
+@dataclass(frozen=True)
+class ChangeRequest:
+    cr_id:         str
+    target_type:   str
+    target_id:     str
+    title:         str
+    description:   str
+    proposed_diff: str          # JSON string; structure is target_type-specific
+    base_hash:     str
+    proposer:      str
+    status:        str
+    labels:        str          # CSV — flat, not hierarchical until v0.3
+    created_at:    int
+    updated_at:    int
+    merged_at:     Optional[int] = None
+    merged_by:     Optional[str] = None
+    reject_reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CrReview:
+    review_id:  str
+    cr_id:      str
+    reviewer:   str
+    decision:   str
+    body:       str
+    created_at: int
+
+
+# ─── Schema bootstrap (idempotent, runs at module import) ────────
+_DDL = """
+CREATE TABLE IF NOT EXISTS change_requests (
+  cr_id          TEXT PRIMARY KEY,
+  target_type    TEXT NOT NULL,
+  target_id      TEXT NOT NULL,
+  title          TEXT NOT NULL,
+  description    TEXT,
+  proposed_diff  TEXT NOT NULL,
+  base_hash      TEXT NOT NULL,
+  proposer       TEXT NOT NULL,
+  status         TEXT NOT NULL,
+  labels         TEXT,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  merged_at      INTEGER,
+  merged_by      TEXT,
+  reject_reason  TEXT,
+  CHECK (status IN ('open','merged','rejected','superseded')),
+  CHECK ((status='merged') = (merged_at IS NOT NULL AND merged_by IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_cr_status_target
+  ON change_requests(status, target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_cr_proposer
+  ON change_requests(proposer, status);
+
+CREATE TABLE IF NOT EXISTS cr_reviews (
+  review_id   TEXT PRIMARY KEY,
+  cr_id       TEXT NOT NULL REFERENCES change_requests(cr_id) ON DELETE CASCADE,
+  reviewer    TEXT NOT NULL,
+  decision    TEXT NOT NULL,
+  body        TEXT,
+  created_at  INTEGER NOT NULL,
+  CHECK (decision IN ('approve','request_changes','comment'))
+);
+CREATE INDEX IF NOT EXISTS idx_cr_reviews_cr
+  ON cr_reviews(cr_id, created_at);
+"""
+
+
+def init_db(db_path: Optional[str] = None) -> None:
+    """Idempotent table + index creation. Public so tests can hit
+    a temp DB path."""
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    try:
+        # Foreign-key enforcement is per-connection, but the CASCADE
+        # constraint only kicks in when callers enable it. The CHECK
+        # constraints fire unconditionally.
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.executescript(_DDL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# Run once on import so the tables exist before any caller writes —
+# same pattern as core.audit_bridge / core.api_keys.
+init_db()
+
+
+# ─── Helpers ─────────────────────────────────────────────────────
+def _gen_id(prefix: str) -> str:
+    """ULID-like sortable id: ``<prefix>_<epoch_ms_hex>_<10char-random>``.
+
+    Lexicographic order matches creation order, which keeps default
+    ``ORDER BY cr_id`` listings monotonic without needing a separate
+    sort key. 10 hex chars (~40 bits) of randomness make collisions
+    within the same millisecond statistically negligible.
+    """
+    ts_ms = int(time.time() * 1000)
+    rand  = secrets.token_hex(5)
+    return f"{prefix}_{ts_ms:013x}_{rand}"
+
+
+def cr_id_for_now() -> str:
+    return _gen_id("cr")
+
+
+def review_id_for_now() -> str:
+    return _gen_id("rv")
+
+
+def compute_base_hash(content: bytes) -> str:
+    """SHA-256 hex of the target state at propose time. Used by the
+    apply dispatcher (CR-B2) for conflict detection — if the target
+    has shifted between propose and merge, the CR is superseded.
+
+    Bytes-typed input forces callers to be explicit about encoding;
+    a stray ``str``-vs-``bytes`` mix would change the hash and break
+    conflict detection silently."""
+    if not isinstance(content, (bytes, bytearray)):
+        raise TypeError("compute_base_hash expects bytes")
+    return hashlib.sha256(content).hexdigest()
+
+
+def _audit_event(event_type: str, cr_id: str, **fields) -> None:
+    """Mirror a CR state transition to the audit log. Endpoint prefix
+    is ``cr:<event_type>`` so ``/admin/audit/list`` can filter all CR
+    events with one LIKE pattern.
+
+    Swallows exceptions on the audit side — audit mirroring must
+    never block a state transition (matches audit_bridge's policy).
+    """
+    try:
+        from core.audit_bridge import mirror_to_audit_db
+        mirror_to_audit_db({
+            "time":      datetime.now().isoformat(),
+            "role":      fields.get("role", "unknown"),
+            "endpoint":  f"cr:{event_type}",
+            "event":     f"cr.{event_type}",
+            "tool_used": "change_request",
+            "target":    cr_id,
+            **fields,
+        })
+    except Exception:
+        # Audit is best-effort; the CR transition itself already
+        # committed under its own SQLite transaction.
+        pass
+
+
+def _row_to_cr(row: sqlite3.Row) -> ChangeRequest:
+    return ChangeRequest(
+        cr_id=row["cr_id"],
+        target_type=row["target_type"],
+        target_id=row["target_id"],
+        title=row["title"],
+        description=row["description"] or "",
+        proposed_diff=row["proposed_diff"],
+        base_hash=row["base_hash"],
+        proposer=row["proposer"],
+        status=row["status"],
+        labels=row["labels"] or "",
+        created_at=int(row["created_at"]),
+        updated_at=int(row["updated_at"]),
+        merged_at=int(row["merged_at"]) if row["merged_at"] is not None else None,
+        merged_by=row["merged_by"],
+        reject_reason=row["reject_reason"],
+    )
+
+
+def _row_to_review(row: sqlite3.Row) -> CrReview:
+    return CrReview(
+        review_id=row["review_id"],
+        cr_id=row["cr_id"],
+        reviewer=row["reviewer"],
+        decision=row["decision"],
+        body=row["body"] or "",
+        created_at=int(row["created_at"]),
+    )
+
+
+# ─── Public API — propose ────────────────────────────────────────
+def create_cr(
+    *,
+    target_type:   str,
+    target_id:     str,
+    title:         str,
+    description:   str           = "",
+    proposed_diff,                                  # dict or JSON string
+    base_hash:     str,
+    proposer:      str,
+    labels:        Iterable[str] = (),
+    role:          str           = "unknown",
+    db_path:       Optional[str] = None,
+) -> ChangeRequest:
+    """Insert a CR in ``status='open'``.
+
+    Raises ``ValueError`` on invariant violations (unknown
+    target_type, empty proposer/title/target_id/base_hash, malformed
+    proposed_diff). The error is surfaced — silent fallthrough at
+    propose time would let typos authorise nothing.
+    """
+    if target_type not in VALID_TARGET_TYPES:
+        raise ValueError(f"unknown target_type: {target_type!r}")
+    if not proposer:
+        raise ValueError("proposer required")
+    if not title or not title.strip():
+        raise ValueError("title required")
+    if not target_id:
+        raise ValueError("target_id required")
+    if not base_hash:
+        raise ValueError("base_hash required")
+
+    if isinstance(proposed_diff, dict):
+        proposed_diff = json.dumps(proposed_diff, ensure_ascii=False)
+    elif not isinstance(proposed_diff, str):
+        raise ValueError("proposed_diff must be a dict or JSON string")
+
+    now    = int(time.time())
+    cr_id  = cr_id_for_now()
+    labels_csv = ",".join(sorted({
+        lab.strip() for lab in labels if lab and lab.strip()
+    }))
+
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    try:
+        conn.execute(
+            "INSERT INTO change_requests "
+            "(cr_id, target_type, target_id, title, description, "
+            " proposed_diff, base_hash, proposer, status, labels, "
+            " created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?)",
+            (cr_id, target_type, target_id, title, description,
+             proposed_diff, base_hash, proposer, labels_csv, now, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _audit_event(
+        "propose", cr_id,
+        target_type=target_type, target_id=target_id,
+        proposer=proposer, role=role,
+    )
+    cr = get_cr(cr_id, db_path=db_path)
+    assert cr is not None, "freshly-inserted CR must be readable back"
+    return cr
+
+
+# ─── Public API — read ───────────────────────────────────────────
+def get_cr(cr_id: str, *, db_path: Optional[str] = None) -> Optional[ChangeRequest]:
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM change_requests WHERE cr_id = ?", (cr_id,),
+        ).fetchone()
+        return _row_to_cr(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_crs(
+    *,
+    status:      Optional[str] = None,
+    target_type: Optional[str] = None,
+    proposer:    Optional[str] = None,
+    limit:       int           = 50,
+    offset:      int           = 0,
+    db_path:     Optional[str] = None,
+) -> List[ChangeRequest]:
+    """List CRs newest first, with optional filters. ``limit`` is
+    clamped to ``[1, 500]`` so a typo can't dump the whole table."""
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        where:  List[str] = []
+        params: list      = []
+        if status is not None:
+            if status not in VALID_STATUSES:
+                raise ValueError(f"unknown status filter: {status!r}")
+            where.append("status = ?")
+            params.append(status)
+        if target_type is not None:
+            if target_type not in VALID_TARGET_TYPES:
+                raise ValueError(f"unknown target_type filter: {target_type!r}")
+            where.append("target_type = ?")
+            params.append(target_type)
+        if proposer is not None:
+            where.append("proposer = ?")
+            params.append(proposer)
+        where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+        params.append(min(max(int(limit), 1), 500))
+        params.append(max(int(offset), 0))
+        rows = conn.execute(
+            f"SELECT * FROM change_requests {where_sql} "
+            "ORDER BY created_at DESC, cr_id DESC LIMIT ? OFFSET ?",
+            params,
+        ).fetchall()
+        return [_row_to_cr(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ─── Public API — state transitions (no apply yet) ───────────────
+def reject_cr(
+    cr_id:    str,
+    *,
+    reviewer: str,
+    reason:   str = "",
+    role:     str = "unknown",
+    db_path:  Optional[str] = None,
+) -> ChangeRequest:
+    """Transition ``open → rejected``. Reviewer MUST differ from
+    proposer (CLAUDE.md rule #3 spirit — no self-approval / self-
+    rejection)."""
+    if not reviewer:
+        raise ValueError("reviewer required")
+
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT status, proposer FROM change_requests WHERE cr_id = ?",
+            (cr_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"cr not found: {cr_id}")
+        if row["status"] != STATUS_OPEN:
+            raise ValueError(
+                f"cannot reject cr_id={cr_id} from status={row['status']!r}"
+            )
+        if row["proposer"] == reviewer:
+            raise ValueError("reviewer must differ from proposer")
+
+        now = int(time.time())
+        conn.execute(
+            "UPDATE change_requests SET status='rejected', "
+            "reject_reason = ?, updated_at = ? WHERE cr_id = ?",
+            (reason, now, cr_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _audit_event("reject", cr_id, reviewer=reviewer, reason=reason, role=role)
+    cr = get_cr(cr_id, db_path=db_path)
+    assert cr is not None
+    return cr
+
+
+def supersede_cr(
+    cr_id:   str,
+    *,
+    reason:  str = "base_hash mismatch",
+    role:    str = "unknown",
+    db_path: Optional[str] = None,
+) -> ChangeRequest:
+    """Transition ``open → superseded``. Called by the apply
+    dispatcher (CR-B2) when the target has shifted between propose
+    and merge — the proposer must re-propose against current state.
+
+    Exposed at the module level so the state machine is testable
+    without the apply dispatcher's wiki-specific code."""
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT status FROM change_requests WHERE cr_id = ?", (cr_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"cr not found: {cr_id}")
+        if row["status"] != STATUS_OPEN:
+            raise ValueError(
+                f"cannot supersede cr_id={cr_id} from status={row['status']!r}"
+            )
+
+        now = int(time.time())
+        conn.execute(
+            "UPDATE change_requests SET status='superseded', "
+            "reject_reason = ?, updated_at = ? WHERE cr_id = ?",
+            (reason, now, cr_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _audit_event("supersede", cr_id, reason=reason, role=role)
+    cr = get_cr(cr_id, db_path=db_path)
+    assert cr is not None
+    return cr
+
+
+# ─── Public API — reviews (advisory; do NOT transition state) ────
+def add_review(
+    cr_id:    str,
+    *,
+    reviewer: str,
+    decision: str,
+    body:     str = "",
+    role:     str = "unknown",
+    db_path:  Optional[str] = None,
+) -> CrReview:
+    """Attach a review row. Comments / request_changes are advisory —
+    they neither approve nor reject. The actual approve transition
+    lives in the apply dispatcher (CR-B2); rejecting calls
+    ``reject_cr`` directly. This separation keeps the state machine
+    minimal: only an explicit ``reject_cr`` / future ``merge_cr``
+    call moves a CR out of ``open``.
+    """
+    if decision not in VALID_REVIEW_DECISIONS:
+        raise ValueError(f"unknown decision: {decision!r}")
+    if not reviewer:
+        raise ValueError("reviewer required")
+
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        existing = conn.execute(
+            "SELECT proposer FROM change_requests WHERE cr_id = ?",
+            (cr_id,),
+        ).fetchone()
+        if existing is None:
+            raise ValueError(f"cr not found: {cr_id}")
+        # Proposers may comment on their own CR but cannot
+        # ``approve`` or ``request_changes`` it — that would be a
+        # self-review, defeating the point of the two-person rule.
+        if decision != REVIEW_COMMENT and existing["proposer"] == reviewer:
+            raise ValueError(
+                "reviewer must differ from proposer for non-comment reviews",
+            )
+
+        now       = int(time.time())
+        review_id = review_id_for_now()
+        conn.execute(
+            "INSERT INTO cr_reviews "
+            "(review_id, cr_id, reviewer, decision, body, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (review_id, cr_id, reviewer, decision, body, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _audit_event(
+        "review", cr_id,
+        reviewer=reviewer, decision=decision, role=role,
+    )
+    return CrReview(
+        review_id=review_id, cr_id=cr_id, reviewer=reviewer,
+        decision=decision, body=body, created_at=now,
+    )
+
+
+def list_reviews(
+    cr_id:   str,
+    *,
+    db_path: Optional[str] = None,
+) -> List[CrReview]:
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM cr_reviews WHERE cr_id = ? "
+            "ORDER BY created_at ASC, review_id ASC",
+            (cr_id,),
+        ).fetchall()
+        return [_row_to_review(r) for r in rows]
+    finally:
+        conn.close()

--- a/core/change_request_apply.py
+++ b/core/change_request_apply.py
@@ -1,0 +1,316 @@
+"""Change Request — apply dispatcher + merge orchestrator (PR-CR-B2).
+
+The state machine in ``core.change_request`` knows how to move a CR
+through ``open → rejected | superseded`` without ever touching the
+underlying target. The actual write — turning a CR into the change
+it proposes — lives here. Keeping these separate has two effects:
+
+  1. ``core.change_request`` stays under the 20 KB module-size gate
+     (CLAUDE.md rule #5) as more target types come online.
+  2. Adding a new ``target_type`` is a one-line dispatch-table entry
+     plus one apply function — no edits to the state machine.
+
+``merge_cr`` is the single entry point callers reach for. It:
+
+  - locks the CR row (status MUST be ``'open'``),
+  - enforces invariant #2 (``approver ≠ proposer``),
+  - calls the target-specific ``apply_*`` (which detects ``base_hash``
+    drift and surfaces it as a supersede signal),
+  - on a successful apply, transitions the CR to ``'merged'`` and
+    mirrors one audit row.
+
+Ordering note. apply runs BEFORE the CR row is marked merged, so
+that an apply failure leaves ``status='open'`` (invariant #5). If
+the file write succeeds but the row update fails (rare — same DB,
+same process), the audit row that records the merge intent is what
+operators see; manual repair is preferable to silently un-doing a
+file change.
+
+Read the cycle plan in:
+    docs/handovers/v0.2.x-cr-track.md
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import core.change_request as _cr_mod
+from core.change_request import (
+    STATUS_OPEN,
+    TARGET_WIKI_ENTITY,
+    ChangeRequest,
+    compute_base_hash, get_cr, supersede_cr,
+)
+# ``_DEFAULT_DB`` and ``_audit_event`` are accessed via the module
+# alias (_cr_mod.X) rather than imported by value, so a test that
+# swaps ``_cr_mod._DEFAULT_DB`` to a temp path also takes effect
+# here — ``from … import _DEFAULT_DB`` would bind a frozen copy.
+
+try:
+    from config import BASE_DIR as _BASE_DIR
+except ImportError:
+    _BASE_DIR = os.getcwd()
+
+# The wiki root is fixed by repo layout; resolving relative target_ids
+# against it (and refusing anything outside) is the path-traversal guard.
+_WIKI_ROOT = os.path.realpath(os.path.join(_BASE_DIR, "wiki"))
+
+
+# ─── Apply result ────────────────────────────────────────────────
+@dataclass(frozen=True)
+class ApplyResult:
+    """What an ``apply_*`` returned.
+
+    ``applied=True`` ⇒ target write committed; the orchestrator
+    should then mark the CR ``'merged'``.
+
+    ``superseded=True`` ⇒ ``base_hash`` no longer matches the
+    target's current state; the orchestrator MUST mark the CR
+    ``'superseded'`` and tell the proposer to re-propose.
+
+    A raised exception means an unexpected error — the orchestrator
+    leaves ``status='open'`` (invariant #5) and surfaces the error
+    to the caller.
+    """
+    applied:    bool
+    superseded: bool          = False
+    new_hash:   Optional[str] = None
+    reason:     str           = ""
+
+
+# ─── Target-specific apply: wiki_entity ─────────────────────────
+def _resolve_wiki_path(target_id: str) -> str:
+    """Map a CR's ``target_id`` to an on-disk wiki file.
+
+    For ``target_type='wiki_entity'`` the contract is:
+    ``target_id`` is a path RELATIVE to ``wiki/`` that:
+      - starts with ``entity/`` (the wiki tree's entity subtree),
+      - ends with ``.md``,
+      - contains no ``..`` traversal,
+      - resolves (after realpath) to a path under ``wiki/entity/``.
+
+    Anything else is a 400-class bug — surface immediately.
+    """
+    if not target_id or not isinstance(target_id, str):
+        raise ValueError("target_id required for wiki_entity")
+    if ".." in target_id.replace("\\", "/").split("/"):
+        raise ValueError("target_id may not contain '..'")
+    if not target_id.endswith(".md"):
+        raise ValueError("target_id must end with .md")
+    # Use a normalised forward-slash form for the prefix check so
+    # callers can pass either OS-flavoured separator.
+    norm = target_id.replace("\\", "/")
+    if not norm.startswith("entity/"):
+        raise ValueError("target_id must start with entity/")
+
+    abs_path = os.path.realpath(os.path.join(_WIKI_ROOT, norm))
+    entity_root = os.path.realpath(os.path.join(_WIKI_ROOT, "entity"))
+    # Containment check — realpath defeats symlink + .. escape.
+    if not (abs_path == entity_root or
+            abs_path.startswith(entity_root + os.sep)):
+        raise ValueError("target_id resolved outside wiki/entity/")
+    return abs_path
+
+
+def _apply_wiki_entity(cr: ChangeRequest) -> ApplyResult:
+    """Apply a ``wiki_entity`` CR to its target file.
+
+    Steps:
+      1. Resolve target path under ``wiki/entity/`` (path-traversal
+         guard; raises ValueError on a malformed target_id).
+      2. Read current file bytes and compute its sha256.
+      3. Compare to ``cr.base_hash``. Mismatch ⇒ supersede signal,
+         no write happens.
+      4. Decode ``cr.proposed_diff`` JSON. For v0.2.x only
+         ``{"op": "replace", "body": "..."}`` is supported — the op
+         field is checked so future ops surface as 400 instead of
+         silently doing the wrong thing.
+      5. Atomic write via tempfile + ``os.replace`` so a half-written
+         file is impossible. Tempfile lives next to the target so
+         the rename stays on the same filesystem.
+
+    Raises ``FileNotFoundError`` if the target file is missing
+    (the orchestrator will surface this as a 4xx; the CR stays open
+    so the proposer can fix it).
+    """
+    abs_path = _resolve_wiki_path(cr.target_id)
+    if not os.path.exists(abs_path):
+        raise FileNotFoundError(f"target file missing: {cr.target_id}")
+
+    with open(abs_path, "rb") as f:
+        current = f.read()
+    current_hash = compute_base_hash(current)
+    if current_hash != cr.base_hash:
+        return ApplyResult(
+            applied=False, superseded=True,
+            reason=("target has changed since this proposal was "
+                    "filed — please rebase against current state"),
+        )
+
+    # Decode + validate the diff.
+    try:
+        diff = json.loads(cr.proposed_diff)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"proposed_diff is not valid JSON: {exc}") from exc
+    if not isinstance(diff, dict):
+        raise ValueError("proposed_diff must decode to a JSON object")
+    op = diff.get("op")
+    if op != "replace":
+        # Closed enum on op too — the v0.3 plugin contract surface.
+        raise ValueError(f"unsupported wiki_entity op: {op!r}")
+    body = diff.get("body")
+    if not isinstance(body, str):
+        raise ValueError("wiki_entity replace op requires body: str")
+
+    new_bytes = body.encode("utf-8")
+
+    # Atomic write — tempfile in the target directory so os.replace
+    # is a same-fs rename (POSIX + NTFS both atomic).
+    target_dir = os.path.dirname(abs_path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".cr_apply_", suffix=".md.tmp", dir=target_dir,
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(new_bytes)
+        os.replace(tmp_path, abs_path)
+    except Exception:
+        # Clean up the tmp on any failure before re-raising; we
+        # never want to leave .cr_apply_*.tmp orphans on disk.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return ApplyResult(
+        applied=True, new_hash=compute_base_hash(new_bytes),
+    )
+
+
+# ─── Dispatcher ──────────────────────────────────────────────────
+# Closed enum — ARCHITECTURE.md §5.6 explains why. ``run_jobs`` lands
+# in PR-CR-D; add it here when that PR ships, not as a plugin hook.
+_APPLY_DISPATCH: Dict[str, Callable[[ChangeRequest], ApplyResult]] = {
+    TARGET_WIKI_ENTITY: _apply_wiki_entity,
+}
+
+
+def apply_cr(cr: ChangeRequest) -> ApplyResult:
+    """Dispatch on ``cr.target_type``. Unknown types raise — the
+    state machine already refuses to *propose* an unknown type at
+    create_cr time, so reaching this branch means someone smuggled
+    in a row; fail loud."""
+    fn = _APPLY_DISPATCH.get(cr.target_type)
+    if fn is None:
+        raise ValueError(
+            f"no apply handler for target_type={cr.target_type!r}"
+        )
+    return fn(cr)
+
+
+# ─── Merge orchestrator ──────────────────────────────────────────
+def merge_cr(
+    cr_id:    str,
+    *,
+    approver: str,
+    role:     str = "unknown",
+    db_path:  Optional[str] = None,
+) -> ChangeRequest:
+    """Transition a CR from ``open → merged`` by applying its diff.
+
+    Invariants enforced here:
+      - CR must currently be ``status='open'`` (invariant #5).
+      - ``approver != proposer`` (invariant #2; two-person rule).
+      - ``base_hash`` mismatch routes to ``supersede_cr`` and the
+        returned CR carries ``status='superseded'`` (invariant #3).
+      - apply() raising leaves ``status='open'`` (invariant #5).
+      - On success, exactly one ``cr:merge`` row lands in the
+        audit log (invariant #7).
+
+    Returns the final state of the CR. The caller does NOT need
+    to refetch.
+    """
+    if not approver:
+        raise ValueError("approver required")
+
+    path = db_path or _cr_mod._DEFAULT_DB
+    cr = get_cr(cr_id, db_path=path)
+    if cr is None:
+        raise ValueError(f"cr not found: {cr_id}")
+    if cr.status != STATUS_OPEN:
+        raise ValueError(
+            f"cannot merge cr_id={cr_id} from status={cr.status!r}"
+        )
+    if cr.proposer == approver:
+        raise ValueError("approver must differ from proposer")
+
+    # Run apply BEFORE the row update so invariant #5 holds — an
+    # apply failure must leave the CR in 'open'. ``apply_cr`` itself
+    # decides whether the target has drifted (supersede) or written
+    # successfully.
+    result = apply_cr(cr)
+
+    if result.superseded:
+        return supersede_cr(
+            cr_id, reason=result.reason or "base_hash mismatch",
+            role=role, db_path=path,
+        )
+
+    if not result.applied:
+        # apply chose neither merge nor supersede — treat as an
+        # internal bug. The CR stays open.
+        raise RuntimeError(
+            "apply returned applied=False without supersede signal "
+            f"(target_type={cr.target_type})"
+        )
+
+    # Apply succeeded → mark the CR merged. WHERE status='open' is
+    # belt-and-suspenders against a concurrent merge attempt.
+    now = int(time.time())
+    conn = sqlite3.connect(path, check_same_thread=False)
+    try:
+        cursor = conn.execute(
+            "UPDATE change_requests "
+            "SET status='merged', merged_at = ?, merged_by = ?, "
+            "    updated_at = ? "
+            "WHERE cr_id = ? AND status = 'open'",
+            (now, approver, now, cr_id),
+        )
+        conn.commit()
+        if cursor.rowcount != 1:
+            # A concurrent transition closed the CR between apply
+            # and update. The target file was already mutated; this
+            # is a real edge case worth audit-logging loudly.
+            _cr_mod._audit_event(
+                "merge_conflict", cr_id,
+                approver=approver, role=role,
+                detail="UPDATE matched 0 rows after apply succeeded",
+            )
+            raise RuntimeError(
+                "merge UPDATE matched 0 rows — concurrent state "
+                f"change on cr_id={cr_id}"
+            )
+    finally:
+        conn.close()
+
+    _cr_mod._audit_event(
+        "merge", cr_id, approver=approver, role=role,
+        new_hash=result.new_hash,
+    )
+    out = get_cr(cr_id, db_path=path)
+    assert out is not None
+    return out
+
+
+# ─── Re-exports for ergonomic test imports ──────────────────────
+__all__ = [
+    "ApplyResult",
+    "apply_cr",
+    "merge_cr",
+]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -463,6 +463,91 @@ become a regression.
 
 ---
 
+## 5.6 Change Request primitive (v0.2.x, in progress)
+
+`core/change_request.py` is the single primitive for governing
+**write actions** — wiki edits, workspace job runs, ontology
+patches, config saves. It generalises the `approver_username`
+pattern that v0.1 hard-coded for self-evolution alone: every
+write becomes a proposal first, every merge requires an approver,
+every transition writes one row to `audit_bridge`.
+
+```
+proposer (any authenticated user)
+   │ POST /admin/cr/        (target_type + target_id + proposed_diff + base_hash)
+   ▼
+change_requests row, status='open'
+   │ POST /admin/cr/{id}/review     ← any authenticated user; cr_reviews row
+   │ POST /admin/cr/{id}/approve    ← admin only
+   ▼
+apply() under SQLite transaction:
+   ├─ target-specific apply (mutates wiki / runs job / ...)
+   ├─ change_requests row → status='merged'
+   └─ audit_bridge row recording the transition
+```
+
+Three properties make this the right shape for the mother platform:
+
+1. **Domain-neutral**. The proposal / review / merge / audit cycle
+   is universal — the same object makes sense for clause edits,
+   nutrition labels, or single-operator notes. Domain coupling
+   enters only at v1.0 (CLAUDE.md rule #1, `docs/PLATFORM_READINESS`).
+2. **Append-only audit is the source of truth**. The
+   `change_requests` table itself can be reconstructed from
+   `audit_bridge` rows. The audit-bridge invariant from §4
+   (auditability over performance) extends to the CR primitive.
+3. **No external `target_type` registration before v0.3**. The
+   dispatcher is a closed enum on purpose — the registration API is
+   exactly the v0.3 plugin contract surface and locking it before
+   then would force a breaking change later.
+
+### Trust zone
+
+| Edge | Default trust | Hardening |
+|---|---|---|
+| proposer | **low** | `_require_auth` only; proposal is inert until merged |
+| reviewer (comment / request_changes) | **low** | same as proposer |
+| reviewer (approve / reject) | requires admin role | `_require_admin` at the endpoint |
+| approver ≠ proposer | invariant | enforced at merge time; no self-approval |
+
+### Invariants
+
+1. `merged_at` / `merged_by` NOT NULL ⇔ `status='merged'`.
+2. approver ≠ proposer.
+3. `base_hash` mismatch at merge → 409 + `status='superseded'`
+   (proposal is now stale; user must rebase).
+4. merge is a single SQLite transaction across (a) the row update,
+   (b) target apply, (c) the audit_bridge insert. apply() raising
+   rolls back all three.
+5. apply() failure leaves `status='open'`. A reject is an explicit
+   reviewer decision, never an apply-side accident.
+6. `target_type` unknown to the dispatcher → 400 at propose time
+   (fail closed — matches the PolicyEngine `can_use_feature` pattern
+   for typos).
+7. Every state transition writes one `audit_bridge` row.
+
+### v0.2.x scope
+
+Two target types ship: `wiki_entity` (markdown edits with
+`base_hash` conflict detection) and `run_jobs` (gating workspace
+job execution). The existing self-evolution gate is folded onto
+the same primitive in the same cycle — the `approver_username` /
+`approver_role` / `before_metrics` / `after_metrics` fields that
+v0.1 introduced for patches become per-CR fields on a CR with
+`target_type='self_evolution_patch'`. Behaviour is byte-identical;
+the storage and audit shape become uniform.
+
+**Done-when criterion**: every write that today calls
+`audit_bridge.write_event(action='approved')` with an approver
+field goes through `core/change_request.py`. The bespoke
+`/admin/proposals/...` endpoints become thin wrappers over
+`/admin/cr/...`.
+
+The full cycle plan lives in
+`docs/handovers/v0.2.x-cr-track.md`.
+
+---
+
 ## 6. Evolution Boundaries
 
 Self-evolution is **disabled by default**. To enable:
@@ -470,6 +555,13 @@ Self-evolution is **disabled by default**. To enable:
 1. Set `JAMES_ENABLE_EVOLUTION=1` (explicit opt-in)
 2. Configure `JAMES_EVOLUTION_APPROVER_ROLE` (default: `admin`)
 3. Patches flow: `feedback → candidate → 4-gate eval → approval → deploy → rollback-ready`
+
+> **v0.2.x note**: in the Change Request track (§5.6), the
+> self-evolution flow is being **wrapped** by the generalised CR
+> primitive — the approver field, the eval gate, and the audit-log
+> writes preserve byte-for-byte behaviour. CLAUDE.md rule #3
+> remains in force; the deploy step still rejects without an
+> approver.
 
 A patch reaches `deploy` only after a human with the approver role
 explicitly approves it. Auto-approval is a bug, not a feature.

--- a/docs/handovers/v0.2.x-cr-track.md
+++ b/docs/handovers/v0.2.x-cr-track.md
@@ -1,0 +1,233 @@
+# v0.2.x — Change Request track (cycle handover)
+
+> 2026-05-12. A v0.2.x hardening cycle — does **not** open a new
+> minor version. Lives alongside the open frontend stack (#230–#235)
+> and the v0.2 → v0.3 platform-readiness gate.
+>
+> Read order: `CLAUDE.md` → this file → `docs/ARCHITECTURE.md §5.6`
+> (the trust zone) → `ROADMAP.md` v0.2.x section.
+
+---
+
+## 1. Problem
+
+Every write inside JAMES today follows one of two shapes:
+
+| Shape | Example | Governance today |
+|---|---|---|
+| Self-evolution | `/admin/proposals/{id}/approve` | ✅ `approver_username` recorded, audit-bridged, eval-gated |
+| Everything else | wiki edit, workspace job run, ontology patch, config save | ❌ **none** — the write lands as soon as the call returns |
+
+The first row exists because v0.1 already learned a hard rule: a
+self-modifying system without a human approver is a bug, not a
+feature (CLAUDE.md rule #3). The second row is the rest of the
+system — and most user-visible "collaboration" friction comes from
+its absence: there is no proposal, no review, no diff, no rollback,
+no shared timeline.
+
+**This cycle generalises the approver_username pattern into a single
+primitive — the Change Request — and routes one new write through
+it (wiki entity edits) so the pattern is real before we make it
+universal.**
+
+The primitive is deliberately **domain-neutral**: the same CR object
+makes sense for a legal corp doing clause edits, a food retailer
+editing nutrition labels, or a single operator editing their own
+notes. Domain coupling enters the picture only at v1.0, per
+`docs/PLATFORM_READINESS.md` and CLAUDE.md rule #1.
+
+---
+
+## 2. Scope (frozen for v0.2.x)
+
+### In scope
+- A new `core/change_request.py` module owning the CR lifecycle
+- Two SQLite tables — `change_requests` + `cr_reviews`
+- Admin endpoints (`/admin/cr/...`) for propose / list / detail /
+  approve / reject / review
+- One `target_type=wiki_entity` apply path (markdown file edit with
+  `base_hash` conflict detection)
+- One follow-up `target_type=run_jobs` apply path (same cycle)
+- Workspace UI panel that lists CRs and lets admins approve/reject
+- Integration of the existing self-evolution gate (audit-recorded,
+  but currently bespoke) onto the same CR object
+
+### Out of scope (deferred to v0.3 plugin contract)
+- External `target_type` registration API (today's `target_type` is
+  a closed enum; new entries require a code change — on purpose)
+- Multi-approver workflows ("2 of 3 admins must approve")
+- Team / project / department scoping
+- Hierarchical labels (flat `labels` CSV column today; v0.3 may
+  migrate to a proper tag table)
+- Status-machine extensions for domain-specific phases
+  (Draft → Review → Published per-domain)
+- External notification routing (Slack / e-mail on CR events)
+
+Anything in the second list, if asked for during this cycle, gets a
+flat **no** with a pointer back to this section.
+
+---
+
+## 3. Trust zone (single sentence)
+
+`proposer (any authenticated user) → CR row inert in
+change_requests → admin reviewer → apply() under transaction →
+audit_bridge row`. Nothing else writes to the target.
+
+The full statement lives in `docs/ARCHITECTURE.md §5.6` (the
+architecture PR that ships **with** this handover).
+
+### Invariants (will be enforced by tests in PR-CR-B)
+
+1. `merged_at` / `merged_by` are NOT NULL iff `status='merged'`.
+2. Approver MUST differ from proposer (no self-approval).
+3. `base_hash` mismatch at merge time → 409 + `status='superseded'`.
+4. Merge is a single SQLite transaction across (a) `change_requests`
+   row update, (b) target apply call, (c) `audit_bridge` row insert.
+   apply() raising rolls all three back.
+5. apply() failure leaves `status='open'` (NOT `rejected`). A
+   reject is an explicit reviewer decision, never an apply-side
+   accident.
+6. `target_type` unknown to the apply dispatcher → 400 at propose
+   time (fail closed; matches the PolicyEngine `can_use_feature`
+   pattern).
+7. Every state transition writes one row to `audit_bridge` so the
+   CR table can be reconstructed from the audit log even if the
+   `change_requests` table itself is lost.
+
+---
+
+## 4. Tables (frozen schema)
+
+```sql
+CREATE TABLE change_requests (
+  cr_id          TEXT PRIMARY KEY,         -- ULID-like sortable id
+  target_type    TEXT NOT NULL,            -- 'wiki_entity' | 'run_jobs'
+  target_id      TEXT NOT NULL,            -- e.g., entity_id or job spec hash
+  title          TEXT NOT NULL,
+  description    TEXT,
+  proposed_diff  TEXT NOT NULL,            -- JSON; structure is target_type-specific
+  base_hash      TEXT NOT NULL,            -- sha256 of target state at propose time
+  proposer       TEXT NOT NULL,
+  status         TEXT NOT NULL,            -- 'open' | 'merged' | 'rejected' | 'superseded'
+  labels         TEXT,                     -- CSV; FLAT (v0.3 may migrate to a tag table)
+  created_at     INTEGER NOT NULL,         -- unix epoch
+  updated_at     INTEGER NOT NULL,
+  merged_at      INTEGER,                  -- NULL until merged
+  merged_by      TEXT,                     -- approver_username; NULL until merged
+  reject_reason  TEXT                      -- NULL unless status='rejected'
+);
+CREATE INDEX idx_cr_status_target ON change_requests(status, target_type, target_id);
+CREATE INDEX idx_cr_proposer ON change_requests(proposer, status);
+
+CREATE TABLE cr_reviews (
+  review_id   TEXT PRIMARY KEY,
+  cr_id       TEXT NOT NULL REFERENCES change_requests(cr_id) ON DELETE CASCADE,
+  reviewer    TEXT NOT NULL,
+  decision    TEXT NOT NULL,               -- 'approve' | 'request_changes' | 'comment'
+  body        TEXT,
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX idx_cr_reviews_cr ON cr_reviews(cr_id, created_at);
+```
+
+This schema is **frozen for v0.2.x**. Migrations belong to v0.3 if
+the plugin contract requires them.
+
+---
+
+## 5. PR sequence
+
+| PR | Branch | Scope | Depends on | Gate |
+|---|---|---|---|---|
+| CR-A (this) | `docs/v0.2-cr-track` | This file + ARCHITECTURE.md §5.6 + ROADMAP entry + doc-presence test | — | `architecture` label, 1500+ tests still green |
+| CR-B | `feat/v0.2-cr-backend` | `core/change_request.py` + apply for `wiki_entity` + 5 endpoints + table migration + invariants tests | CR-A merged | Bench numbers if `core/retrieval/graph/reasoning` touched (they should not be) |
+| CR-C | `feat/v0.2-cr-ui` | Workspace UI panel + JS delegation reuse | CR-B merged | A11y + event-delegation tests still green |
+| CR-D | `feat/v0.2-cr-jobs-and-evo` | `run_jobs` apply path + self-evolution gate re-routes via CR | CR-C merged | All self-evolution tests still pass byte-identical (CLAUDE.md rule #3) |
+
+Each PR creates its own handover update under
+`docs/handovers/v0.2.x-cr-*.md` if non-trivial decisions are made
+during implementation.
+
+---
+
+## 6. What this cycle deliberately does NOT do
+
+- Touch `core/retrieval` / `core/graph` / `core/reasoning` (CLAUDE.md
+  rule #2 — would require bench numbers in every PR; this cycle is
+  governance, not reasoning).
+- Modify `docs/PLATFORM_READINESS.md` (the gate definitions stay).
+- Disable or auto-approve the self-evolution path. CR-D **wraps**
+  the existing gate; the approver field, the eval gate, and the
+  audit_bridge writes are preserved byte-for-byte.
+- Expose any `target_type` registration API to plugins. The closed
+  enum is the v0.3 contract surface — locking it now would force a
+  breaking change later (per `docs/PLATFORM_READINESS.md` v0.3 gate).
+- Land any UI element that implies a team / project / department
+  model. Flat `labels` only.
+
+If a reviewer requests any of these in the cycle, the answer is
+**defer to v0.3**, not "let's just add it quickly".
+
+---
+
+## 7. Files this cycle touches
+
+Predicted (will sharpen during CR-B implementation):
+
+```
+core/change_request.py                    # NEW, ≤ 15 KB target (CLAUDE.md rule #5)
+core/change_request_apply.py              # NEW, target-specific dispatcher
+server_llmwiki.py                         # +~200 lines for the 6 endpoints
+frontend/workspace.html                   # CR tab
+frontend/static/workspace.js              # CR list + detail
+docs/ARCHITECTURE.md                      # §5.6 (this PR)
+docs/handovers/v0.2.x-cr-track.md         # this file
+ROADMAP.md                                # one v0.2.x bullet
+tests/test_change_request_core.py         # state machine + invariants
+tests/test_change_request_wiki_apply.py   # wiki target apply path
+tests/test_change_request_jobs_apply.py   # run_jobs target apply path (CR-D)
+tests/test_change_request_audit.py        # audit_bridge integration
+tests/test_workspace_cr_panel.py          # UI contract (CR-C)
+tests/test_cr_docs_presence.py            # this PR: keeps the docs load-bearing
+```
+
+`core/change_request.py` budget: 15 KB. If apply dispatcher growth
+pushes it over, split as `core/change_request/__init__.py` + apply
+sub-package — same pattern as `core/memory/`.
+
+---
+
+## 8. Decision log
+
+- **First `target_type` = `wiki_entity`** (not `run_jobs`) because
+  wiki edits currently have zero governance and the data value is
+  immediately visible. `run_jobs` is the second target in the same
+  cycle (CR-D) — pattern reuse, ~80 lines.
+- **`base_hash` over optimistic locking version numbers** because
+  wiki entries are markdown files on disk. SHA256(file bytes) at
+  propose time is the natural "what I was looking at" anchor.
+- **`labels` is a CSV column** (not a tag table) because hierarchical
+  scoping (team / project / department) is exactly the v0.3 plugin
+  contract surface — locking it now would force a breaking change.
+- **No external `target_type` registration API** for the same reason.
+- **Approver ≠ proposer** is the only baked-in workflow rule.
+  Multi-approver flows belong to v0.3.
+- **Self-evolution stays untouched until CR-D** so that the
+  approval / eval / rollback chain (`tests/test_self_evolution_gate.py`,
+  `tests/test_evolution_bench_gate.py`, `tests/test_evolution_rollback.py`)
+  has zero behavioural drift across CR-A/B/C.
+
+---
+
+## 9. 한국어 요약
+
+자메스 안에서 쓰기 작업에 대한 **결재·감사·롤백 사이클**을 단일
+원시(Change Request)로 모은다. 지금은 자가-진화만 결재 게이트가
+있고 위키 편집 / 잡 실행 / 온톨로지 변경은 전부 무관문 통과 중.
+
+v0.2.x 범위: `core/change_request.py` 신규 + `wiki_entity` /
+`run_jobs` 두 타깃 + 워크스페이스 UI + 자가-진화 게이트 통합.
+다중 결재자 · 팀/부서 · 외부 `target_type` 등록 API 는 v0.3
+플러그인 계약과 함께. 도메인 가정은 들이지 않는다 (CLAUDE.md
+규칙 #1).

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -4654,6 +4654,240 @@ async def admin_settings_post(data: AdminSettingsRequest, role: str = Depends(ge
     return {"success": True, "applied": {"model": data.model, "max_loop": data.max_loop}}
 
 
+# ─── PR-CR-B2: Change Request endpoints ─────────────────────────
+#
+# Six endpoints back the v0.2.x Change Request primitive
+# (docs/handovers/v0.2.x-cr-track.md, docs/ARCHITECTURE.md §5.6).
+#
+# Auth model is mixed by design:
+#   - propose / list / detail / review:  any authenticated user.
+#   - approve / reject:                  admin only.
+# The JWT subject claim is the source of identity at every write —
+# request bodies do not carry ``proposer`` / ``approver`` fields,
+# so a client holding only a body can't self-impersonate.
+
+from core import change_request as _cr_mod
+from core import change_request_apply as _cr_apply
+
+
+class _CrProposeRequest(BaseModel):
+    api_key:       str
+    target_type:   str
+    target_id:     str
+    title:         str
+    description:   str = ""
+    proposed_diff: dict   # JSON-serialisable; structure is target_type-specific
+    base_hash:     str
+    labels:        list[str] = []
+
+
+@app.post("/admin/cr/", summary="Change Request — propose (any auth user)")
+async def cr_propose(
+    data:    _CrProposeRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    # Any authenticated caller can propose. Identity is the JWT
+    # subject — body carries no ``proposer`` field.
+    verify_api_key(data.api_key)
+    proposer = _bearer_username(request)
+    if not proposer:
+        raise HTTPException(status_code=401, detail="login required to propose")
+    try:
+        cr = _cr_mod.create_cr(
+            target_type=data.target_type,
+            target_id=data.target_id,
+            title=data.title,
+            description=data.description,
+            proposed_diff=data.proposed_diff,
+            base_hash=data.base_hash,
+            proposer=proposer,
+            labels=data.labels,
+            role=role,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True, "cr": _cr_as_dict(cr)}
+
+
+@app.get("/admin/cr/", summary="Change Request — list (auth user)")
+async def cr_list(
+    api_key:     str,
+    request:     Request,
+    status:      Optional[str] = None,
+    target_type: Optional[str] = None,
+    proposer:    Optional[str] = None,
+    limit:       int = 50,
+    offset:      int = 0,
+    role:        str = Depends(get_role_from_request),
+):
+    verify_api_key(api_key)
+    caller = _bearer_username(request)
+    if not caller:
+        raise HTTPException(status_code=401, detail="login required")
+    # Non-admins see only their own proposals — admin override
+    # passes through proposer filter unchanged.
+    if role != "admin":
+        proposer = caller
+    try:
+        rows = _cr_mod.list_crs(
+            status=status, target_type=target_type,
+            proposer=proposer, limit=limit, offset=offset,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "ok":    True,
+        "items": [_cr_as_dict(cr) for cr in rows],
+        "limit": limit, "offset": offset,
+    }
+
+
+@app.get("/admin/cr/{cr_id}", summary="Change Request — detail (auth user)")
+async def cr_detail(
+    cr_id:   str,
+    api_key: str,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    verify_api_key(api_key)
+    caller = _bearer_username(request)
+    if not caller:
+        raise HTTPException(status_code=401, detail="login required")
+    cr = _cr_mod.get_cr(cr_id)
+    if cr is None:
+        raise HTTPException(status_code=404, detail="cr not found")
+    # Non-admins can read a CR only if they're the proposer or have
+    # left at least one review on it. Admin sees everything.
+    if role != "admin" and cr.proposer != caller:
+        reviews = _cr_mod.list_reviews(cr_id)
+        if not any(rv.reviewer == caller for rv in reviews):
+            raise HTTPException(status_code=403,
+                detail="cr is not visible to this user")
+    return {
+        "ok":      True,
+        "cr":      _cr_as_dict(cr),
+        "reviews": [_review_as_dict(r) for r in _cr_mod.list_reviews(cr_id)],
+    }
+
+
+class _CrApproveRequest(BaseModel):
+    api_key: str
+
+
+@app.post("/admin/cr/{cr_id}/approve",
+          summary="Change Request — approve (admin only)")
+async def cr_approve(
+    cr_id:   str,
+    data:    _CrApproveRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    _require_admin(data.api_key, role)
+    approver = _bearer_username(request)
+    if not approver:
+        raise HTTPException(status_code=401,
+            detail="admin JWT required to approve")
+    try:
+        cr = _cr_apply.merge_cr(cr_id, approver=approver, role=role)
+    except ValueError as exc:
+        # State machine refusals (self-approval, already-merged,
+        # not-found) surface as 400.
+        raise HTTPException(status_code=400, detail=str(exc))
+    except FileNotFoundError as exc:
+        # apply-side failure that doesn't change state.
+        raise HTTPException(status_code=409, detail=str(exc))
+    return {"ok": True, "cr": _cr_as_dict(cr)}
+
+
+class _CrRejectRequest(BaseModel):
+    api_key: str
+    reason:  str = ""
+
+
+@app.post("/admin/cr/{cr_id}/reject",
+          summary="Change Request — reject (admin only)")
+async def cr_reject(
+    cr_id:   str,
+    data:    _CrRejectRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    _require_admin(data.api_key, role)
+    reviewer = _bearer_username(request)
+    if not reviewer:
+        raise HTTPException(status_code=401,
+            detail="admin JWT required to reject")
+    try:
+        cr = _cr_mod.reject_cr(
+            cr_id, reviewer=reviewer, reason=data.reason, role=role,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True, "cr": _cr_as_dict(cr)}
+
+
+class _CrReviewRequest(BaseModel):
+    api_key:  str
+    decision: str            # "approve" / "request_changes" / "comment"
+    body:     str = ""
+
+
+@app.post("/admin/cr/{cr_id}/review",
+          summary="Change Request — review/comment (any auth user)")
+async def cr_review(
+    cr_id:   str,
+    data:    _CrReviewRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    verify_api_key(data.api_key)
+    reviewer = _bearer_username(request)
+    if not reviewer:
+        raise HTTPException(status_code=401, detail="login required to review")
+    try:
+        rv = _cr_mod.add_review(
+            cr_id, reviewer=reviewer, decision=data.decision,
+            body=data.body, role=role,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True, "review": _review_as_dict(rv)}
+
+
+def _cr_as_dict(cr) -> dict:
+    """Shape a ChangeRequest dataclass for JSON output. Mirrors the
+    table columns 1:1 so the UI can render without remapping."""
+    return {
+        "cr_id":         cr.cr_id,
+        "target_type":   cr.target_type,
+        "target_id":     cr.target_id,
+        "title":         cr.title,
+        "description":   cr.description,
+        "proposed_diff": cr.proposed_diff,
+        "base_hash":     cr.base_hash,
+        "proposer":      cr.proposer,
+        "status":        cr.status,
+        "labels":        cr.labels,
+        "created_at":    cr.created_at,
+        "updated_at":    cr.updated_at,
+        "merged_at":     cr.merged_at,
+        "merged_by":     cr.merged_by,
+        "reject_reason": cr.reject_reason,
+    }
+
+
+def _review_as_dict(rv) -> dict:
+    return {
+        "review_id":  rv.review_id,
+        "cr_id":      rv.cr_id,
+        "reviewer":   rv.reviewer,
+        "decision":   rv.decision,
+        "body":       rv.body,
+        "created_at": rv.created_at,
+    }
+
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run("server_llmwiki:app", host="127.0.0.1", port=8000, reload=True)

--- a/tests/test_change_request_core.py
+++ b/tests/test_change_request_core.py
@@ -1,0 +1,647 @@
+"""[PR-CR-B1, 2026-05-12] Change Request state machine + storage.
+
+CR-B1 ships the model only — no apply, no endpoints. This suite
+covers the invariants the handover doc names in
+``docs/handovers/v0.2.x-cr-track.md § 3`` and the schema-level
+``CHECK`` constraints in ``core/change_request.py``:
+
+  1. ``merged_at`` / ``merged_by`` NOT NULL ⇔ status='merged'
+  2. approver ≠ proposer (enforced by reject + add_review here;
+     by merge_cr in CR-B2)
+  3. ``base_hash`` mismatch surfaces via ``supersede_cr`` so the
+     apply dispatcher (CR-B2) has a state-machine primitive to call
+  4. transaction-atomic merge — deferred to CR-B2 where apply lives
+  5. apply() failure leaves status='open' — deferred to CR-B2
+  6. unknown ``target_type`` → ValueError at propose time
+  7. every state transition writes one row to ``audit_log`` via
+     ``core.audit_bridge``
+
+Plus baseline storage correctness — round-trip, listing, filters,
+ID sortability, schema-level CHECK constraints.
+
+Run:
+    python -m unittest tests.test_change_request_core
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import core.change_request as cr_mod  # noqa: E402
+from core.change_request import (   # noqa: E402
+    TARGET_WIKI_ENTITY, TARGET_RUN_JOBS,
+    STATUS_OPEN, STATUS_REJECTED, STATUS_SUPERSEDED,
+    VALID_STATUSES, VALID_TARGET_TYPES,
+    REVIEW_APPROVE, REVIEW_REQUEST_CHANGES, REVIEW_COMMENT,
+    ChangeRequest,
+    init_db, create_cr, get_cr, list_crs,
+    reject_cr, supersede_cr, add_review, list_reviews,
+    compute_base_hash, cr_id_for_now, review_id_for_now,
+)
+
+
+def _tmpdb() -> str:
+    """Fresh temp DB path with the CR schema already applied."""
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="cr_test_")
+    os.close(fd)
+    init_db(path)
+    return path
+
+
+class _AuditCapture:
+    """Patch ``core.audit_bridge.mirror_to_audit_db`` during a test
+    so we can assert that every state transition emits exactly one
+    audit row, without having to scrub a real audit DB between tests.
+    """
+    def __init__(self):
+        self.calls: list[dict] = []
+        self._orig = None
+
+    def __enter__(self):
+        from core import audit_bridge
+        self._orig = audit_bridge.mirror_to_audit_db
+
+        def _capture(entry, **_kw):
+            self.calls.append(dict(entry))
+            return True
+        audit_bridge.mirror_to_audit_db = _capture
+        return self
+
+    def __exit__(self, *exc):
+        from core import audit_bridge
+        audit_bridge.mirror_to_audit_db = self._orig
+
+
+# ─── Schema bootstrap ────────────────────────────────────────────
+class SchemaBootstrapTests(unittest.TestCase):
+
+    def test_init_db_is_idempotent(self):
+        path = _tmpdb()
+        try:
+            # Re-running init must not raise (CREATE TABLE IF NOT EXISTS).
+            init_db(path)
+            init_db(path)
+        finally:
+            os.unlink(path)
+
+    def test_two_tables_and_three_indexes_exist(self):
+        path = _tmpdb()
+        try:
+            conn = sqlite3.connect(path)
+            tables = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()}
+            self.assertIn("change_requests", tables)
+            self.assertIn("cr_reviews", tables)
+            indexes = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND sql IS NOT NULL"
+            ).fetchall()}
+            self.assertIn("idx_cr_status_target", indexes)
+            self.assertIn("idx_cr_proposer", indexes)
+            self.assertIn("idx_cr_reviews_cr", indexes)
+            conn.close()
+        finally:
+            os.unlink(path)
+
+    def test_status_check_constraint_blocks_unknown_value(self):
+        # CHECK (status IN (...)) at storage layer is a belt to the
+        # python-side suspenders. Hand-crafted insert with a bogus
+        # status must fail at COMMIT.
+        path = _tmpdb()
+        try:
+            conn = sqlite3.connect(path)
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO change_requests "
+                    "(cr_id, target_type, target_id, title, "
+                    " proposed_diff, base_hash, proposer, status, "
+                    " created_at, updated_at) "
+                    "VALUES "
+                    "('x','wiki_entity','t','t','{}','h','p',"
+                    " 'banana',0,0)"
+                )
+            conn.close()
+        finally:
+            os.unlink(path)
+
+    def test_merged_fields_check_constraint(self):
+        # Invariant #1: (status='merged') = (merged_at NOT NULL AND
+        # merged_by NOT NULL). A row that claims merged but has NULL
+        # merge fields must be rejected at the DB layer.
+        path = _tmpdb()
+        try:
+            conn = sqlite3.connect(path)
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO change_requests "
+                    "(cr_id, target_type, target_id, title, "
+                    " proposed_diff, base_hash, proposer, status, "
+                    " created_at, updated_at, merged_at, merged_by) "
+                    "VALUES "
+                    "('x','wiki_entity','t','t','{}','h','p',"
+                    " 'merged',0,0,NULL,NULL)"
+                )
+            conn.close()
+        finally:
+            os.unlink(path)
+
+
+# ─── ID generation ───────────────────────────────────────────────
+class IdGenerationTests(unittest.TestCase):
+
+    def test_ids_are_sortable(self):
+        # ULID-like — created order should match lex order so the
+        # default ``ORDER BY cr_id`` listing stays monotonic.
+        ids = [cr_id_for_now() for _ in range(5)]
+        # Tiny sleep between to guarantee the ms component differs;
+        # we don't depend on it but the test must not flake.
+        # Actually: if all 5 land in the same ms, the random tail
+        # still differs and equality / sort is deterministic anyway.
+        self.assertEqual(len(set(ids)), 5, "ids must be unique")
+        # Sort stability — at minimum sorted == time-ordered when
+        # ms ticks. Even within one ms, the random tail isn't time-
+        # bound, so we only assert uniqueness + prefix.
+        for i in ids:
+            self.assertTrue(i.startswith("cr_"))
+
+    def test_review_id_has_different_prefix(self):
+        # Cross-type collisions must be impossible by construction.
+        self.assertTrue(review_id_for_now().startswith("rv_"))
+        self.assertNotEqual(cr_id_for_now()[:3], review_id_for_now()[:3])
+
+
+# ─── Hash helper ─────────────────────────────────────────────────
+class HashHelperTests(unittest.TestCase):
+
+    def test_compute_base_hash_round_trip(self):
+        h1 = compute_base_hash(b"hello")
+        h2 = compute_base_hash(b"hello")
+        self.assertEqual(h1, h2)
+        self.assertEqual(len(h1), 64)         # sha256 hex digest
+
+    def test_compute_base_hash_distinguishes_content(self):
+        self.assertNotEqual(
+            compute_base_hash(b"hello"),
+            compute_base_hash(b"hello!"),
+        )
+
+    def test_compute_base_hash_rejects_str_input(self):
+        # bytes-vs-str ambiguity would change the hash silently and
+        # break conflict detection. Surface that error loudly.
+        with self.assertRaises(TypeError):
+            compute_base_hash("hello")          # type: ignore[arg-type]
+
+
+# ─── Invariant #6 — unknown target_type fails fast ───────────────
+class TargetTypeEnumTests(unittest.TestCase):
+
+    def test_unknown_target_type_rejected_at_propose(self):
+        path = _tmpdb()
+        try:
+            with self.assertRaises(ValueError):
+                create_cr(
+                    target_type="legal_clause",
+                    target_id="X",
+                    title="t",
+                    proposed_diff={},
+                    base_hash="h",
+                    proposer="alice",
+                    db_path=path,
+                )
+        finally:
+            os.unlink(path)
+
+    def test_both_v02_target_types_accepted(self):
+        path = _tmpdb()
+        try:
+            for tt in (TARGET_WIKI_ENTITY, TARGET_RUN_JOBS):
+                with self.subTest(target_type=tt):
+                    cr = create_cr(
+                        target_type=tt, target_id="X", title="t",
+                        proposed_diff={}, base_hash="h",
+                        proposer="alice", db_path=path,
+                    )
+                    self.assertEqual(cr.target_type, tt)
+        finally:
+            os.unlink(path)
+
+    def test_target_type_set_matches_architecture_doc(self):
+        # The closed enum is documented in ARCHITECTURE.md §5.6. If
+        # someone adds a third entry without updating the doc PR
+        # this test catches the drift.
+        self.assertEqual(VALID_TARGET_TYPES,
+                         frozenset({"wiki_entity", "run_jobs"}))
+
+
+# ─── Propose path ────────────────────────────────────────────────
+class CreateCrTests(unittest.TestCase):
+
+    def setUp(self):
+        self.path = _tmpdb()
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_create_minimum_fields(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="ent_x",
+            title="Edit X", proposed_diff={"op": "noop"},
+            base_hash="abc", proposer="alice",
+            db_path=self.path,
+        )
+        self.assertIsInstance(cr, ChangeRequest)
+        self.assertEqual(cr.status, STATUS_OPEN)
+        self.assertEqual(cr.proposer, "alice")
+        self.assertIsNone(cr.merged_at)
+        self.assertIsNone(cr.merged_by)
+        self.assertIsNone(cr.reject_reason)
+
+    def test_create_serialises_dict_diff_as_json(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="ent_y",
+            title="t", proposed_diff={"op": "replace", "body": "ko ⚡"},
+            base_hash="h", proposer="alice",
+            db_path=self.path,
+        )
+        import json
+        decoded = json.loads(cr.proposed_diff)
+        self.assertEqual(decoded["op"], "replace")
+        # JSON round-trip must preserve non-ASCII (ensure_ascii=False).
+        self.assertEqual(decoded["body"], "ko ⚡")
+
+    def test_create_accepts_pre_serialised_string_diff(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="x",
+            title="t", proposed_diff='{"raw": true}',
+            base_hash="h", proposer="alice", db_path=self.path,
+        )
+        self.assertIn('"raw"', cr.proposed_diff)
+
+    def test_create_rejects_non_dict_non_str_diff(self):
+        with self.assertRaises(ValueError):
+            create_cr(
+                target_type=TARGET_WIKI_ENTITY, target_id="x",
+                title="t", proposed_diff=12345,
+                base_hash="h", proposer="alice", db_path=self.path,
+            )
+
+    def test_create_rejects_empty_required_fields(self):
+        good = dict(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+        for empty_field in ("title", "target_id", "base_hash", "proposer"):
+            with self.subTest(field=empty_field):
+                kwargs = dict(good)
+                kwargs[empty_field] = ""
+                with self.assertRaises(ValueError):
+                    create_cr(**kwargs)
+
+    def test_create_normalises_labels(self):
+        # CSV column gets dedup'd + sorted + trimmed so display and
+        # filter behaviour are deterministic regardless of caller.
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="x",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice",
+            labels=[" docs ", "docs", "policy", ""],
+            db_path=self.path,
+        )
+        self.assertEqual(cr.labels, "docs,policy")
+
+
+# ─── Read path ───────────────────────────────────────────────────
+class ReadPathTests(unittest.TestCase):
+
+    def setUp(self):
+        self.path = _tmpdb()
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def _make(self, **over):
+        kw = dict(
+            target_type=TARGET_WIKI_ENTITY, target_id="x",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+        kw.update(over)
+        return create_cr(**kw)
+
+    def test_get_cr_missing_returns_none(self):
+        self.assertIsNone(get_cr("cr_does_not_exist", db_path=self.path))
+
+    def test_get_cr_round_trip(self):
+        cr = self._make(title="round-trip")
+        back = get_cr(cr.cr_id, db_path=self.path)
+        self.assertEqual(back, cr)
+
+    def test_list_orders_newest_first(self):
+        a = self._make(target_id="A")
+        time.sleep(0.005)   # ensure created_at differs (sec precision)
+        b = self._make(target_id="B")
+        rows = list_crs(db_path=self.path, limit=10)
+        # Newest first — B was created after A.
+        self.assertEqual(rows[0].cr_id, b.cr_id)
+        self.assertEqual(rows[1].cr_id, a.cr_id)
+
+    def test_list_filter_by_status(self):
+        a = self._make()
+        b = self._make()
+        reject_cr(a.cr_id, reviewer="bob", db_path=self.path)
+        self.assertEqual(
+            [r.cr_id for r in list_crs(status=STATUS_OPEN, db_path=self.path)],
+            [b.cr_id],
+        )
+        self.assertEqual(
+            [r.cr_id for r in list_crs(status=STATUS_REJECTED, db_path=self.path)],
+            [a.cr_id],
+        )
+
+    def test_list_filter_by_target_type(self):
+        self._make(target_type=TARGET_WIKI_ENTITY)
+        self._make(target_type=TARGET_RUN_JOBS)
+        wiki  = list_crs(target_type=TARGET_WIKI_ENTITY, db_path=self.path)
+        jobs  = list_crs(target_type=TARGET_RUN_JOBS,    db_path=self.path)
+        self.assertEqual(len(wiki), 1)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(wiki[0].target_type, TARGET_WIKI_ENTITY)
+        self.assertEqual(jobs[0].target_type, TARGET_RUN_JOBS)
+
+    def test_list_filter_by_proposer(self):
+        self._make(proposer="alice")
+        self._make(proposer="bob")
+        bobs = list_crs(proposer="bob", db_path=self.path)
+        self.assertEqual(len(bobs), 1)
+        self.assertEqual(bobs[0].proposer, "bob")
+
+    def test_list_clamps_limit_and_offset(self):
+        # A 1-char query must NOT be able to dump the whole table —
+        # same anti-DoS posture as /admin/audit/list.
+        for _ in range(5):
+            self._make()
+        # limit=999999 clamps to 500.
+        many = list_crs(limit=999999, db_path=self.path)
+        self.assertLessEqual(len(many), 500)
+        # limit=0 clamps to 1 (defensive — we still return at least
+        # one row if asked, since 0 is almost certainly a bug).
+        zero = list_crs(limit=0, db_path=self.path)
+        self.assertEqual(len(zero), 1)
+        # Negative offset clamps to 0.
+        neg = list_crs(limit=10, offset=-5, db_path=self.path)
+        self.assertEqual(len(neg), 5)
+
+    def test_list_unknown_filter_raises(self):
+        with self.assertRaises(ValueError):
+            list_crs(status="banana", db_path=self.path)
+        with self.assertRaises(ValueError):
+            list_crs(target_type="legal_clause", db_path=self.path)
+
+
+# ─── Invariant #2 — approver ≠ proposer ──────────────────────────
+class ApproverIdentityTests(unittest.TestCase):
+
+    def setUp(self):
+        self.path = _tmpdb()
+        self.cr   = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_self_rejection_blocked(self):
+        # alice can't reject her own proposal — that defeats the
+        # two-person rule that's the whole point of CR.
+        with self.assertRaises(ValueError):
+            reject_cr(self.cr.cr_id, reviewer="alice",
+                      db_path=self.path)
+
+    def test_self_approve_review_blocked(self):
+        with self.assertRaises(ValueError):
+            add_review(self.cr.cr_id, reviewer="alice",
+                       decision=REVIEW_APPROVE, db_path=self.path)
+
+    def test_self_request_changes_blocked(self):
+        with self.assertRaises(ValueError):
+            add_review(self.cr.cr_id, reviewer="alice",
+                       decision=REVIEW_REQUEST_CHANGES,
+                       db_path=self.path)
+
+    def test_proposer_may_comment_on_own_cr(self):
+        # Comments are not decisions — proposer should be able to
+        # add a clarification on their own CR without tripping the
+        # two-person rule.
+        rev = add_review(
+            self.cr.cr_id, reviewer="alice",
+            decision=REVIEW_COMMENT, body="forgot to mention X",
+            db_path=self.path,
+        )
+        self.assertEqual(rev.reviewer, "alice")
+        self.assertEqual(rev.decision, REVIEW_COMMENT)
+
+    def test_other_user_can_reject(self):
+        out = reject_cr(self.cr.cr_id, reviewer="bob",
+                        reason="not now", db_path=self.path)
+        self.assertEqual(out.status, STATUS_REJECTED)
+        self.assertEqual(out.reject_reason, "not now")
+
+
+# ─── State machine: terminal states block further transitions ────
+class StateMachineTests(unittest.TestCase):
+
+    def setUp(self):
+        self.path = _tmpdb()
+        self.cr   = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_cannot_reject_already_rejected(self):
+        reject_cr(self.cr.cr_id, reviewer="bob", db_path=self.path)
+        with self.assertRaises(ValueError):
+            reject_cr(self.cr.cr_id, reviewer="bob",
+                      db_path=self.path)
+
+    def test_cannot_supersede_already_rejected(self):
+        reject_cr(self.cr.cr_id, reviewer="bob", db_path=self.path)
+        with self.assertRaises(ValueError):
+            supersede_cr(self.cr.cr_id, db_path=self.path)
+
+    def test_supersede_records_reason(self):
+        out = supersede_cr(
+            self.cr.cr_id, reason="base_hash mismatch",
+            db_path=self.path,
+        )
+        self.assertEqual(out.status, STATUS_SUPERSEDED)
+        self.assertEqual(out.reject_reason, "base_hash mismatch")
+
+    def test_reject_missing_cr(self):
+        with self.assertRaises(ValueError):
+            reject_cr("cr_does_not_exist", reviewer="bob",
+                      db_path=self.path)
+
+
+# ─── Reviews ─────────────────────────────────────────────────────
+class ReviewTests(unittest.TestCase):
+
+    def setUp(self):
+        self.path = _tmpdb()
+        self.cr   = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_unknown_decision_rejected(self):
+        with self.assertRaises(ValueError):
+            add_review(self.cr.cr_id, reviewer="bob",
+                       decision="lgtm-ish", db_path=self.path)
+
+    def test_review_ordered_by_created_at_asc(self):
+        # Reviews list is a conversation — oldest first.
+        r1 = add_review(self.cr.cr_id, reviewer="bob",
+                        decision=REVIEW_COMMENT, body="first",
+                        db_path=self.path)
+        time.sleep(0.005)
+        r2 = add_review(self.cr.cr_id, reviewer="carol",
+                        decision=REVIEW_COMMENT, body="second",
+                        db_path=self.path)
+        listed = list_reviews(self.cr.cr_id, db_path=self.path)
+        self.assertEqual([r.review_id for r in listed],
+                         [r1.review_id, r2.review_id])
+
+    def test_missing_cr_blocks_review(self):
+        with self.assertRaises(ValueError):
+            add_review("cr_does_not_exist", reviewer="bob",
+                       decision=REVIEW_COMMENT, db_path=self.path)
+
+
+# ─── Invariant #7 — every transition writes one audit row ────────
+class AuditMirrorTests(unittest.TestCase):
+    """A test-side capture replaces ``mirror_to_audit_db`` so we can
+    assert the contract without touching the real audit DB."""
+
+    def setUp(self):
+        self.path = _tmpdb()
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_propose_emits_audit_row(self):
+        with _AuditCapture() as cap:
+            cr = create_cr(
+                target_type=TARGET_WIKI_ENTITY, target_id="X",
+                title="t", proposed_diff={}, base_hash="h",
+                proposer="alice", db_path=self.path,
+            )
+        self.assertEqual(len(cap.calls), 1)
+        entry = cap.calls[0]
+        self.assertEqual(entry["endpoint"], "cr:propose")
+        self.assertEqual(entry["event"],    "cr.propose")
+        self.assertEqual(entry["target"],   cr.cr_id)
+
+    def test_reject_emits_audit_row(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+        with _AuditCapture() as cap:
+            reject_cr(cr.cr_id, reviewer="bob", reason="no",
+                      db_path=self.path)
+        self.assertEqual(len(cap.calls), 1)
+        self.assertEqual(cap.calls[0]["endpoint"], "cr:reject")
+
+    def test_supersede_emits_audit_row(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+        with _AuditCapture() as cap:
+            supersede_cr(cr.cr_id, db_path=self.path)
+        self.assertEqual(len(cap.calls), 1)
+        self.assertEqual(cap.calls[0]["endpoint"], "cr:supersede")
+
+    def test_review_emits_audit_row(self):
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY, target_id="X",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self.path,
+        )
+        with _AuditCapture() as cap:
+            add_review(cr.cr_id, reviewer="bob",
+                       decision=REVIEW_COMMENT, body="hi",
+                       db_path=self.path)
+        self.assertEqual(len(cap.calls), 1)
+        self.assertEqual(cap.calls[0]["endpoint"], "cr:review")
+
+    def test_audit_swallows_mirror_failure(self):
+        # CR transition must commit even when audit mirroring blows
+        # up (disk full, db locked, etc.). The audit gap is visible
+        # to operators; a stuck CR write is not acceptable.
+        from core import audit_bridge
+        orig = audit_bridge.mirror_to_audit_db
+
+        def _boom(*a, **kw):
+            raise RuntimeError("audit DB is unreachable")
+        audit_bridge.mirror_to_audit_db = _boom
+        try:
+            cr = create_cr(
+                target_type=TARGET_WIKI_ENTITY, target_id="X",
+                title="t", proposed_diff={}, base_hash="h",
+                proposer="alice", db_path=self.path,
+            )
+        finally:
+            audit_bridge.mirror_to_audit_db = orig
+        # Despite the audit failure, the CR exists.
+        self.assertIsNotNone(get_cr(cr.cr_id, db_path=self.path))
+
+
+# ─── Constants smoke (handover ⇄ code consistency) ───────────────
+class HandoverConsistencyTests(unittest.TestCase):
+
+    def test_status_constants_match_handover(self):
+        # The four statuses named in
+        # docs/handovers/v0.2.x-cr-track.md must equal what the
+        # module exports — drift would mean docs are wrong.
+        self.assertEqual(
+            VALID_STATUSES,
+            frozenset({"open", "merged", "rejected", "superseded"}),
+        )
+
+    def test_review_decisions_match_handover(self):
+        from core.change_request import VALID_REVIEW_DECISIONS
+        self.assertEqual(
+            VALID_REVIEW_DECISIONS,
+            frozenset({"approve", "request_changes", "comment"}),
+        )
+
+    def test_module_size_under_gate(self):
+        # CLAUDE.md rule #5: no core/ file may exceed 20 KB.
+        size = Path(cr_mod.__file__).stat().st_size
+        self.assertLess(size, 20 * 1024,
+            f"core/change_request.py is {size} bytes, exceeds 20KB gate")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_request_endpoints.py
+++ b/tests/test_change_request_endpoints.py
@@ -1,0 +1,508 @@
+"""[PR-CR-B2, 2026-05-12] Change Request HTTP endpoints.
+
+Six endpoints under ``/admin/cr/`` back the CR primitive:
+
+  POST   /admin/cr/                  propose       (auth user)
+  GET    /admin/cr/                  list          (auth user)
+  GET    /admin/cr/{cr_id}           detail        (auth user)
+  POST   /admin/cr/{cr_id}/approve   merge target  (admin only)
+  POST   /admin/cr/{cr_id}/reject    reject CR     (admin only)
+  POST   /admin/cr/{cr_id}/review    comment       (auth user)
+
+Each endpoint:
+  - takes identity from the JWT subject claim (never from the
+    request body — anti-impersonation),
+  - returns 401 for missing JWT, 403 for non-admin trying to
+    approve/reject, 400 for state-machine refusals,
+  - mirrors transitions to ``audit_log`` via core.audit_bridge.
+
+This suite drives the FastAPI app through ``TestClient`` to exercise
+the end-to-end path: HTTP framing, auth, body parsing, state
+machine, apply, and the JSON shape the workspace UI (CR-C) will
+read.
+
+Run:
+    python -m unittest tests.test_change_request_endpoints
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-cr-endpoints-suite-32chars",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+import core.change_request as _cr_mod              # noqa: E402
+import core.change_request_apply as _cr_apply      # noqa: E402
+from core.change_request import compute_base_hash  # noqa: E402
+
+
+def _read_api_key() -> str:
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+class _CrEndpointEnv:
+    """Sets up a self-contained temp CR DB + temp wiki tree, swaps
+    them into the production modules for the duration of one test,
+    and tears everything back down on exit."""
+
+    def __init__(self):
+        self.cr_db: str = ""
+        self.wiki_root: str = ""
+        self.rel: str = ""
+        self.original: bytes = b""
+        self._prev_db: str = ""
+        self._prev_wiki: str = ""
+
+    def __enter__(self):
+        # Temp CR DB.
+        fd, self.cr_db = tempfile.mkstemp(suffix=".db", prefix="cr_ep_")
+        os.close(fd)
+        _cr_mod.init_db(self.cr_db)
+        self._prev_db = _cr_mod._DEFAULT_DB
+        _cr_mod._DEFAULT_DB = self.cr_db
+
+        # Temp wiki tree with one concept entity.
+        self.wiki_root = tempfile.mkdtemp(prefix="cr_ep_wiki_")
+        target_dir = os.path.join(self.wiki_root, "entity", "prod", "concept")
+        os.makedirs(target_dir)
+        self.rel = "entity/prod/concept/ep_entity.md"
+        self.original = (
+            b"---\n"
+            b"entity_id: e_concept_ep\n"
+            b"---\n"
+            b"# Original body\n"
+        )
+        with open(os.path.join(self.wiki_root, self.rel), "wb") as f:
+            f.write(self.original)
+        self._prev_wiki = _cr_apply._WIKI_ROOT
+        _cr_apply._WIKI_ROOT = os.path.realpath(self.wiki_root)
+        return self
+
+    def __exit__(self, *exc):
+        _cr_mod._DEFAULT_DB = self._prev_db
+        _cr_apply._WIKI_ROOT = self._prev_wiki
+        try:
+            os.unlink(self.cr_db)
+        except OSError:
+            pass
+        import shutil
+        shutil.rmtree(self.wiki_root, ignore_errors=True)
+
+    def base_hash(self) -> str:
+        return compute_base_hash(self.original)
+
+
+class EndpointTests(unittest.TestCase):
+    """HTTP layer end-to-end. Skips when JAMES_API_KEY is not in env
+    (matches the pattern used by test_admin_users_endpoints)."""
+
+    @classmethod
+    def setUpClass(cls):
+        from core.auth import create_token
+        cls._admin_token = create_token("admin-alice", "admin")
+        cls._user_token  = create_token("user-bob",    "employee")
+        cls._other_user_token = create_token("user-carol", "employee")
+        cls._api_key     = _read_api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing; cannot exercise admin route")
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _admin(self):
+        return {"Authorization": f"Bearer {self._admin_token}"}
+
+    def _bob(self):
+        return {"Authorization": f"Bearer {self._user_token}"}
+
+    def _carol(self):
+        return {"Authorization": f"Bearer {self._other_user_token}"}
+
+    # ── propose ─────────────────────────────────────────────────
+    def test_propose_creates_cr(self):
+        with _CrEndpointEnv() as env:
+            r = self._client().post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "Update body",
+                    "description": "minor",
+                    "proposed_diff": {"op": "replace", "body": "# new\n"},
+                    "base_hash":   env.base_hash(),
+                    "labels":      ["docs"],
+                },
+                headers=self._bob(),
+            )
+            self.assertEqual(r.status_code, 200, r.text)
+            body = r.json()
+            self.assertTrue(body["ok"])
+            cr = body["cr"]
+            self.assertEqual(cr["status"],   "open")
+            self.assertEqual(cr["proposer"], "user-bob")
+            self.assertEqual(cr["title"],    "Update body")
+            self.assertEqual(cr["labels"],   "docs")
+
+    def test_propose_requires_jwt(self):
+        # api_key alone isn't enough — body has no proposer field.
+        with _CrEndpointEnv() as env:
+            r = self._client().post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "x",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                # No Authorization header.
+            )
+            self.assertEqual(r.status_code, 401)
+
+    def test_propose_rejects_unknown_target_type(self):
+        with _CrEndpointEnv() as env:
+            r = self._client().post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "legal_clause",
+                    "target_id":   env.rel,
+                    "title":       "x",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            self.assertEqual(r.status_code, 400)
+
+    # ── list ────────────────────────────────────────────────────
+    def test_list_non_admin_sees_only_own_proposals(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            for hdr, who in ((self._bob(),   "bob"),
+                             (self._carol(), "carol")):
+                client.post(
+                    "/admin/cr/",
+                    json={
+                        "api_key":     self._api_key,
+                        "target_type": "wiki_entity",
+                        "target_id":   env.rel,
+                        "title":       f"by {who}",
+                        "proposed_diff": {"op": "replace", "body": who},
+                        "base_hash":   env.base_hash(),
+                    },
+                    headers=hdr,
+                )
+            # Bob sees only his own; admin sees both.
+            r_bob = client.get(
+                "/admin/cr/",
+                params={"api_key": self._api_key},
+                headers=self._bob(),
+            )
+            self.assertEqual(r_bob.status_code, 200, r_bob.text)
+            bob_titles = [c["title"] for c in r_bob.json()["items"]]
+            self.assertEqual(bob_titles, ["by bob"])
+
+            r_adm = client.get(
+                "/admin/cr/",
+                params={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(len(r_adm.json()["items"]), 2)
+
+    # ── detail ──────────────────────────────────────────────────
+    def test_detail_404_when_missing(self):
+        with _CrEndpointEnv():
+            r = self._client().get(
+                "/admin/cr/cr_does_not_exist",
+                params={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r.status_code, 404)
+
+    def test_detail_blocks_unrelated_user(self):
+        # carol can't see bob's CR (not proposer, not reviewer).
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "secret",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.get(
+                f"/admin/cr/{cr_id}",
+                params={"api_key": self._api_key},
+                headers=self._carol(),
+            )
+            self.assertEqual(r2.status_code, 403)
+
+    def test_detail_includes_reviews(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            client.post(
+                f"/admin/cr/{cr_id}/review",
+                json={"api_key": self._api_key,
+                      "decision": "comment", "body": "hi"},
+                headers=self._carol(),
+            )
+            r2 = client.get(
+                f"/admin/cr/{cr_id}",
+                params={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r2.status_code, 200, r2.text)
+            self.assertEqual(len(r2.json()["reviews"]), 1)
+
+    # ── approve / reject ────────────────────────────────────────
+    def test_approve_requires_admin(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "# new\n"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/approve",
+                json={"api_key": self._api_key},
+                headers=self._carol(),       # employee, not admin
+            )
+            self.assertEqual(r2.status_code, 403)
+
+    def test_approve_merges_and_writes_file(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "# new content\n"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/approve",
+                json={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r2.status_code, 200, r2.text)
+            self.assertEqual(r2.json()["cr"]["status"],    "merged")
+            self.assertEqual(r2.json()["cr"]["merged_by"], "admin-alice")
+            # File on disk got rewritten.
+            with open(os.path.join(env.wiki_root, env.rel), "rb") as f:
+                self.assertEqual(f.read(), b"# new content\n")
+
+    def test_approve_409_on_missing_target(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            os.unlink(os.path.join(env.wiki_root, env.rel))
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/approve",
+                json={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r2.status_code, 409)
+
+    def test_approve_400_on_self_approval(self):
+        # Admin propose + admin approve = self-approval.
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "self",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._admin(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/approve",
+                json={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r2.status_code, 400)
+
+    def test_reject_requires_admin(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/reject",
+                json={"api_key": self._api_key, "reason": "no"},
+                headers=self._bob(),
+            )
+            self.assertEqual(r2.status_code, 403)
+
+    def test_reject_transitions_to_rejected(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/reject",
+                json={"api_key": self._api_key, "reason": "not now"},
+                headers=self._admin(),
+            )
+            self.assertEqual(r2.status_code, 200, r2.text)
+            self.assertEqual(r2.json()["cr"]["status"],        "rejected")
+            self.assertEqual(r2.json()["cr"]["reject_reason"], "not now")
+
+    # ── review ──────────────────────────────────────────────────
+    def test_review_comment_does_not_change_status(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/review",
+                json={"api_key": self._api_key,
+                      "decision": "comment", "body": "lgtm"},
+                headers=self._carol(),
+            )
+            self.assertEqual(r2.status_code, 200, r2.text)
+            # CR still open.
+            r3 = client.get(
+                f"/admin/cr/{cr_id}",
+                params={"api_key": self._api_key},
+                headers=self._admin(),
+            )
+            self.assertEqual(r3.json()["cr"]["status"], "open")
+
+    def test_review_rejects_unknown_decision(self):
+        with _CrEndpointEnv() as env:
+            client = self._client()
+            r = client.post(
+                "/admin/cr/",
+                json={
+                    "api_key":     self._api_key,
+                    "target_type": "wiki_entity",
+                    "target_id":   env.rel,
+                    "title":       "t",
+                    "proposed_diff": {"op": "replace", "body": "x"},
+                    "base_hash":   env.base_hash(),
+                },
+                headers=self._bob(),
+            )
+            cr_id = r.json()["cr"]["cr_id"]
+            r2 = client.post(
+                f"/admin/cr/{cr_id}/review",
+                json={"api_key": self._api_key,
+                      "decision": "lgtm-ish"},
+                headers=self._carol(),
+            )
+            self.assertEqual(r2.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_request_wiki_apply.py
+++ b/tests/test_change_request_wiki_apply.py
@@ -1,0 +1,408 @@
+"""[PR-CR-B2, 2026-05-12] wiki_entity apply path + merge orchestrator.
+
+CR-B2 plugs the state machine from CR-B1 into a real target —
+markdown files under ``wiki/entity/``. The apply layer:
+
+  - resolves ``target_id`` to a path UNDER ``wiki/entity/`` (path-
+    traversal guard, must end ``.md``, no ``..``),
+  - reads the current file and verifies ``base_hash`` (invariant #3),
+  - atomically replaces the file via ``tempfile + os.replace``,
+  - returns an ``ApplyResult`` the orchestrator turns into a
+    ``status='merged'`` transition.
+
+This suite covers the apply layer end-to-end, including invariants
+#3 (base_hash mismatch → superseded, no write), #5 (apply failure
+leaves status='open'), and #7 (merge writes one audit row).
+
+Run:
+    python -m unittest tests.test_change_request_wiki_apply
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import core.change_request as cr_mod              # noqa: E402
+import core.change_request_apply as apply_mod     # noqa: E402
+from core.change_request import (                 # noqa: E402
+    STATUS_OPEN, STATUS_MERGED, STATUS_SUPERSEDED,
+    TARGET_WIKI_ENTITY,
+    init_db, create_cr, get_cr, compute_base_hash,
+)
+from core.change_request_apply import (           # noqa: E402
+    apply_cr, merge_cr,
+)
+
+
+def _fresh_environment():
+    """Returns (db_path, wiki_root, target_rel_path, current_bytes).
+
+    Builds a self-contained wiki tree with one concept entity and
+    points the apply module's WIKI_ROOT at it for the duration of
+    this test. Caller is responsible for cleanup of returned paths
+    (unittest tearDown).
+    """
+    fd, db_path = tempfile.mkstemp(suffix=".db", prefix="cr_test_")
+    os.close(fd)
+    init_db(db_path)
+    wiki_root = tempfile.mkdtemp(prefix="cr_wiki_")
+    concept_dir = os.path.join(wiki_root, "entity", "prod", "concept")
+    os.makedirs(concept_dir)
+    rel_path  = "entity/prod/concept/test_entity.md"
+    abs_path  = os.path.join(wiki_root, rel_path)
+    content   = (
+        b"---\n"
+        b"entity_id: e_concept_test\n"
+        b"aliases:\n- Test Entity\n"
+        b"---\n"
+        b"# Test Entity\n\nOriginal body line.\n"
+    )
+    with open(abs_path, "wb") as f:
+        f.write(content)
+    return db_path, wiki_root, rel_path, content
+
+
+class _ApplyEnv:
+    """Context manager that swaps in a temp wiki root and tears down
+    every fixture on exit."""
+    def __init__(self):
+        self.db_path: str = ""
+        self.wiki_root: str = ""
+        self.rel: str = ""
+        self.original: bytes = b""
+        self._prev_root: str = ""
+
+    def __enter__(self):
+        self.db_path, self.wiki_root, self.rel, self.original = _fresh_environment()
+        self._prev_root = apply_mod._WIKI_ROOT
+        apply_mod._WIKI_ROOT = os.path.realpath(self.wiki_root)
+        return self
+
+    def __exit__(self, *exc):
+        apply_mod._WIKI_ROOT = self._prev_root
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+        try:
+            # Clean the wiki tree.
+            import shutil
+            shutil.rmtree(self.wiki_root, ignore_errors=True)
+        except Exception:
+            pass
+
+    def abs_target(self) -> str:
+        return os.path.join(self.wiki_root, self.rel)
+
+    def make_cr(self, *, body_text: str = "# NEW body\n",
+                proposer: str = "alice",
+                target_id: str = None) -> str:
+        """Helper — create a CR proposing to replace the target's
+        body with ``body_text``. Returns cr_id."""
+        bh = compute_base_hash(self.original)
+        cr = create_cr(
+            target_type=TARGET_WIKI_ENTITY,
+            target_id=target_id or self.rel,
+            title="t", proposed_diff={"op": "replace", "body": body_text},
+            base_hash=bh, proposer=proposer,
+            db_path=self.db_path,
+        )
+        return cr.cr_id
+
+
+# ─── Path resolution (invariant: no traversal, must be under wiki/entity/) ─
+class WikiPathResolutionTests(unittest.TestCase):
+
+    def test_normal_path_resolves(self):
+        with _ApplyEnv() as env:
+            resolved = apply_mod._resolve_wiki_path(env.rel)
+            self.assertTrue(resolved.endswith(env.rel.replace("/", os.sep)))
+
+    def test_rejects_dotdot_traversal(self):
+        with _ApplyEnv():
+            with self.assertRaises(ValueError):
+                apply_mod._resolve_wiki_path("entity/../etc/passwd")
+
+    def test_rejects_path_outside_entity_subtree(self):
+        with _ApplyEnv():
+            with self.assertRaises(ValueError):
+                apply_mod._resolve_wiki_path("synonyms.yaml")
+            with self.assertRaises(ValueError):
+                apply_mod._resolve_wiki_path("../etc/passwd")
+
+    def test_rejects_non_md_extension(self):
+        with _ApplyEnv():
+            with self.assertRaises(ValueError):
+                apply_mod._resolve_wiki_path("entity/prod/concept/x.py")
+
+    def test_rejects_empty_target_id(self):
+        with _ApplyEnv():
+            with self.assertRaises(ValueError):
+                apply_mod._resolve_wiki_path("")
+
+    def test_accepts_windows_separator(self):
+        # Proposers on Windows clients sometimes ship a backslash —
+        # we normalise it (no traversal injection possible since '..'
+        # check happens on the normalised form).
+        with _ApplyEnv() as env:
+            backslashed = env.rel.replace("/", "\\")
+            resolved = apply_mod._resolve_wiki_path(backslashed)
+            self.assertTrue(os.path.exists(resolved))
+
+
+# ─── apply_cr — wiki_entity dispatch ─────────────────────────────
+class ApplyDispatchTests(unittest.TestCase):
+
+    def test_unknown_target_type_raises(self):
+        # Reaching the dispatcher with an unknown type means someone
+        # smuggled a row past create_cr — must fail loud.
+        from dataclasses import replace
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            cr = get_cr(cr_id, db_path=env.db_path)
+            broken = replace(cr, target_type="legal_clause")
+            with self.assertRaises(ValueError):
+                apply_cr(broken)
+
+    def test_apply_replaces_file_on_match(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr(body_text="# NEW body\n")
+            cr = get_cr(cr_id, db_path=env.db_path)
+            result = apply_cr(cr)
+            self.assertTrue(result.applied)
+            self.assertFalse(result.superseded)
+            self.assertIsNotNone(result.new_hash)
+            with open(env.abs_target(), "rb") as f:
+                self.assertEqual(f.read(), b"# NEW body\n")
+
+    def test_apply_supersedes_on_hash_mismatch(self):
+        # Pre-condition: target file has shifted since the CR was
+        # proposed. apply MUST return supersede + leave the file
+        # untouched.
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr(body_text="# would-be new\n")
+            # Outside writer mutates the target.
+            with open(env.abs_target(), "wb") as f:
+                f.write(b"# someone else's edit\n")
+            cr = get_cr(cr_id, db_path=env.db_path)
+            result = apply_cr(cr)
+            self.assertTrue(result.superseded)
+            self.assertFalse(result.applied)
+            self.assertIn("rebase", result.reason.lower())
+            # The outsider's content stays.
+            with open(env.abs_target(), "rb") as f:
+                self.assertEqual(f.read(), b"# someone else's edit\n")
+
+    def test_apply_raises_on_missing_target(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            os.unlink(env.abs_target())
+            cr = get_cr(cr_id, db_path=env.db_path)
+            with self.assertRaises(FileNotFoundError):
+                apply_cr(cr)
+
+    def test_apply_rejects_unsupported_op(self):
+        with _ApplyEnv() as env:
+            # Bypass create_cr's validation by writing the row directly
+            # — we want to exercise the apply-side guard.
+            import sqlite3, time
+            bh = compute_base_hash(env.original)
+            conn = sqlite3.connect(env.db_path)
+            now = int(time.time())
+            conn.execute(
+                "INSERT INTO change_requests "
+                "(cr_id, target_type, target_id, title, "
+                " proposed_diff, base_hash, proposer, status, "
+                " created_at, updated_at) "
+                "VALUES (?, ?, ?, 't', ?, ?, 'alice', 'open', ?, ?)",
+                ("cr_bad", "wiki_entity", env.rel,
+                 json.dumps({"op": "delete"}), bh, now, now),
+            )
+            conn.commit()
+            conn.close()
+            cr = get_cr("cr_bad", db_path=env.db_path)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_non_string_body(self):
+        with _ApplyEnv() as env:
+            import sqlite3, time
+            bh = compute_base_hash(env.original)
+            conn = sqlite3.connect(env.db_path)
+            now = int(time.time())
+            conn.execute(
+                "INSERT INTO change_requests "
+                "(cr_id, target_type, target_id, title, "
+                " proposed_diff, base_hash, proposer, status, "
+                " created_at, updated_at) "
+                "VALUES (?, ?, ?, 't', ?, ?, 'alice', 'open', ?, ?)",
+                ("cr_bad2", "wiki_entity", env.rel,
+                 json.dumps({"op": "replace", "body": 12345}),
+                 bh, now, now),
+            )
+            conn.commit()
+            conn.close()
+            cr = get_cr("cr_bad2", db_path=env.db_path)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_preserves_utf8(self):
+        with _ApplyEnv() as env:
+            korean_body = "# 한국어 본문\n\n변경된 내용입니다.\n"
+            cr_id = env.make_cr(body_text=korean_body)
+            cr = get_cr(cr_id, db_path=env.db_path)
+            apply_cr(cr)
+            with open(env.abs_target(), "rb") as f:
+                self.assertEqual(f.read().decode("utf-8"), korean_body)
+
+
+# ─── merge_cr — orchestrator + invariants ────────────────────────
+class MergeOrchestratorTests(unittest.TestCase):
+
+    def test_merge_transitions_to_merged(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            out = merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            self.assertEqual(out.status, STATUS_MERGED)
+            self.assertEqual(out.merged_by, "bob")
+            self.assertIsNotNone(out.merged_at)
+
+    def test_merge_blocks_self_approval(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr(proposer="alice")
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, approver="alice", db_path=env.db_path)
+            # CR stays open.
+            self.assertEqual(
+                get_cr(cr_id, db_path=env.db_path).status, STATUS_OPEN)
+
+    def test_merge_routes_supersede_on_base_hash_mismatch(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            with open(env.abs_target(), "wb") as f:
+                f.write(b"# someone else edited\n")
+            out = merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            self.assertEqual(out.status, STATUS_SUPERSEDED)
+            # Outsider's bytes survive — apply must NOT have written.
+            with open(env.abs_target(), "rb") as f:
+                self.assertEqual(f.read(), b"# someone else edited\n")
+
+    def test_merge_apply_failure_leaves_open(self):
+        # Target missing on disk → apply raises FileNotFoundError →
+        # invariant #5 says CR stays open.
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            os.unlink(env.abs_target())
+            with self.assertRaises(FileNotFoundError):
+                merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            self.assertEqual(
+                get_cr(cr_id, db_path=env.db_path).status, STATUS_OPEN)
+
+    def test_merge_blocks_already_merged(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, approver="bob", db_path=env.db_path)
+
+    def test_merge_blocks_rejected_cr(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            cr_mod.reject_cr(cr_id, reviewer="bob",
+                             db_path=env.db_path)
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, approver="carol", db_path=env.db_path)
+
+    def test_merge_missing_cr(self):
+        with _ApplyEnv() as env:
+            with self.assertRaises(ValueError):
+                merge_cr("cr_does_not_exist", approver="bob",
+                         db_path=env.db_path)
+
+    def test_merge_requires_approver(self):
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, approver="", db_path=env.db_path)
+
+
+# ─── Audit invariant #7 — merge writes one cr:merge row ──────────
+class MergeAuditTests(unittest.TestCase):
+
+    def test_merge_emits_one_audit_row(self):
+        from core import audit_bridge
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            captured = []
+            orig = audit_bridge.mirror_to_audit_db
+
+            def _cap(entry, **kw):
+                captured.append(dict(entry))
+                return True
+            audit_bridge.mirror_to_audit_db = _cap
+            try:
+                merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            finally:
+                audit_bridge.mirror_to_audit_db = orig
+            # Exactly one cr:merge event from this merge call.
+            merge_events = [e for e in captured
+                            if e.get("endpoint") == "cr:merge"]
+            self.assertEqual(len(merge_events), 1)
+            self.assertEqual(merge_events[0]["event"], "cr.merge")
+            self.assertEqual(merge_events[0]["target"], cr_id)
+
+    def test_supersede_path_emits_cr_supersede_not_cr_merge(self):
+        from core import audit_bridge
+        with _ApplyEnv() as env:
+            cr_id = env.make_cr()
+            with open(env.abs_target(), "wb") as f:
+                f.write(b"# drifted\n")
+            captured = []
+            orig = audit_bridge.mirror_to_audit_db
+
+            def _cap(entry, **kw):
+                captured.append(dict(entry))
+                return True
+            audit_bridge.mirror_to_audit_db = _cap
+            try:
+                merge_cr(cr_id, approver="bob", db_path=env.db_path)
+            finally:
+                audit_bridge.mirror_to_audit_db = orig
+            kinds = {e.get("endpoint") for e in captured}
+            self.assertIn("cr:supersede", kinds)
+            self.assertNotIn("cr:merge", kinds)
+
+
+# ─── Module size + import contract ───────────────────────────────
+class ModuleContractTests(unittest.TestCase):
+
+    def test_apply_module_under_size_gate(self):
+        size = Path(apply_mod.__file__).stat().st_size
+        self.assertLess(size, 20 * 1024,
+            f"core/change_request_apply.py = {size}B; "
+            "CLAUDE.md rule #5 caps at 20 KB")
+
+    def test_state_module_still_under_gate(self):
+        # If merge_cr ever migrates into change_request.py this test
+        # is the canary that catches the regression.
+        size = Path(cr_mod.__file__).stat().st_size
+        self.assertLess(size, 20 * 1024,
+            f"core/change_request.py = {size}B; over the gate")
+
+    def test_apply_dispatch_contains_wiki_entity_only_for_now(self):
+        # ``run_jobs`` lands in PR-CR-D. If someone adds it here
+        # without that PR's tests they'd ship an untested write path.
+        self.assertEqual(
+            set(apply_mod._APPLY_DISPATCH.keys()),
+            {TARGET_WIKI_ENTITY},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cr_docs_presence.py
+++ b/tests/test_cr_docs_presence.py
@@ -1,0 +1,215 @@
+"""[PR-CR-A, 2026-05-12] Change Request track — docs-presence contract.
+
+Step A of the v0.2.x CR cycle is doc-only: a handover under
+``docs/handovers/v0.2.x-cr-track.md``, a new trust-zone section
+``§5.6 Change Request primitive`` in ``docs/ARCHITECTURE.md``, and
+a ``ROADMAP.md`` entry that points to both. CLAUDE.md rule #4
+explicitly requires an architecture-labelled PR for new modules /
+new trust zones — this test makes the docs load-bearing so a
+later PR cannot quietly skip them.
+
+Mirrors the rollout-gate pattern from
+``tests/test_frontend_event_delegation.py`` and
+``tests/test_mobile_css_coverage.py``: the documents themselves
+are the contract, and a contract test names the load-bearing
+substrings so silent drift becomes a CI failure.
+
+Out of scope for this test:
+- The actual ``core/change_request.py`` module (PR-CR-B).
+- The ``change_requests`` / ``cr_reviews`` SQLite tables (PR-CR-B).
+- Any UI element (PR-CR-C).
+
+Run:
+    python -m unittest tests.test_cr_docs_presence
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+HANDOVER = ROOT / "docs" / "handovers" / "v0.2.x-cr-track.md"
+ARCHITECTURE = ROOT / "docs" / "ARCHITECTURE.md"
+ROADMAP = ROOT / "ROADMAP.md"
+CLAUDE_MD = ROOT / "CLAUDE.md"
+
+
+class HandoverPresenceTests(unittest.TestCase):
+    """The v0.2.x CR handover doc must exist with the load-bearing
+    sections subsequent PRs will reference."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.assertTrue = unittest.TestCase().assertTrue  # for setUpClass usage
+        cls.text = HANDOVER.read_text(encoding="utf-8") if HANDOVER.exists() else ""
+
+    def test_handover_file_exists(self):
+        self.assertTrue(
+            HANDOVER.exists(),
+            f"missing {HANDOVER.relative_to(ROOT)} — PR-CR-A must create it",
+        )
+
+    def test_handover_freezes_scope(self):
+        # PR-CR-B/C/D will all reference 'frozen for v0.2.x' to refuse
+        # scope creep — if this phrase disappears, the cycle plan is
+        # silently broken.
+        self.assertIn(
+            "frozen for v0.2.x", self.text,
+            "handover must declare its scope as 'frozen for v0.2.x' "
+            "so subsequent PRs can refuse scope creep with a doc cite",
+        )
+
+    def test_handover_names_both_target_types(self):
+        # wiki_entity ships in CR-B; run_jobs in CR-D. Both must be
+        # in the handover so the dispatcher contract test in CR-B can
+        # cross-reference.
+        self.assertIn("wiki_entity", self.text)
+        self.assertIn("run_jobs", self.text)
+
+    def test_handover_lists_invariants(self):
+        # The seven invariants (approver != proposer, base_hash
+        # mismatch → superseded, etc.) are the contract that
+        # tests/test_change_request_core.py (PR-CR-B) will enforce.
+        self.assertIn("Invariants", self.text)
+        for phrase in (
+            "approver",         # invariant 2
+            "base_hash",        # invariant 3
+            "transaction",      # invariant 4
+            "audit_bridge",     # invariant 7
+        ):
+            with self.subTest(invariant_token=phrase):
+                self.assertIn(phrase, self.text,
+                    f"handover invariant section must mention {phrase!r}")
+
+    def test_handover_lists_deferred_v03_items(self):
+        # The cycle deliberately punts five items to v0.3 — multi-
+        # approver, team/project/department, hierarchical labels,
+        # external target_type API, domain-specific status machines.
+        # Naming them in the handover is what lets reviewers refuse
+        # scope creep without re-litigating.
+        for deferred in (
+            "Multi-approver",
+            "Team",
+            "Hierarchical",
+            "registration API",
+        ):
+            with self.subTest(deferred=deferred):
+                self.assertIn(deferred, self.text,
+                    f"handover must list {deferred!r} among deferred-"
+                    "to-v0.3 items so scope creep is refusable")
+
+    def test_handover_names_pr_sequence(self):
+        # CR-A through CR-D are the only PRs that should land in this
+        # cycle. Naming them keeps the sequence visible.
+        for pr in ("CR-A", "CR-B", "CR-C", "CR-D"):
+            with self.subTest(pr=pr):
+                self.assertIn(pr, self.text,
+                    f"handover must name {pr} in the PR sequence")
+
+
+class ArchitectureSectionTests(unittest.TestCase):
+    """ARCHITECTURE.md must declare the new trust zone — CLAUDE.md
+    rule #4 requires an architecture-labelled PR for new trust
+    zones, and this test pins the load-bearing tokens."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = ARCHITECTURE.read_text(encoding="utf-8")
+
+    def test_change_request_section_present(self):
+        # §5.6 sits between PolicyEngine (5.5) and Evolution
+        # Boundaries (§6) — both governance primitives.
+        self.assertIn("5.6 Change Request primitive", self.text,
+            "ARCHITECTURE.md must declare §5.6 — the new trust zone "
+            "(CLAUDE.md rule #4)")
+
+    def test_section_states_audit_bridge_as_source_of_truth(self):
+        # The invariant that lets the CR table be reconstructed from
+        # audit_bridge is what makes the primitive recoverable.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("audit_bridge", section,
+            "§5.6 must name audit_bridge as the source of truth")
+        self.assertIn("append-only", section.lower() + section)
+
+    def test_section_states_closed_enum_for_target_type(self):
+        # The reason we don't expose external target_type registration
+        # before v0.3 — it's exactly the plugin contract surface.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("closed enum", section.lower(),
+            "§5.6 must state target_type is a closed enum until v0.3 — "
+            "the registration API surface is the plugin contract")
+        self.assertIn("v0.3", section)
+
+    def test_section_states_approver_neq_proposer(self):
+        # The only baked-in workflow rule.
+        idx = self.text.index("5.6 Change Request primitive")
+        section = self.text[idx:idx + 4000]
+        self.assertIn("approver", section.lower())
+        self.assertIn("proposer", section.lower())
+
+    def test_evolution_section_references_cr_wrapping(self):
+        # §6 (Evolution Boundaries) must note that the self-
+        # evolution gate is being wrapped by CR in CR-D so the
+        # CLAUDE.md rule #3 invariant (approver_username present)
+        # is visibly preserved.
+        idx = self.text.index("## 6. Evolution Boundaries")
+        section = self.text[idx:idx + 2000]
+        # Either "Change Request" or "CR primitive" — both signal the
+        # wrapping. Refuse the section if neither is mentioned.
+        self.assertTrue(
+            ("Change Request" in section) or ("§5.6" in section),
+            "§6 must reference the §5.6 CR primitive so the wrap "
+            "decision is visible from the evolution-gate doc surface",
+        )
+
+
+class RoadmapEntryTests(unittest.TestCase):
+    """ROADMAP.md must point to the CR track from the v0.2 deferred-
+    follow-ups section so future-self knows it's a cycle in flight."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = ROADMAP.read_text(encoding="utf-8")
+
+    def test_change_request_entry_present(self):
+        self.assertIn("Change Request primitive", self.text,
+            "ROADMAP must reference the CR track")
+
+    def test_entry_points_to_handover(self):
+        # Forward references must remain valid — if a CR-B reviewer
+        # follows the ROADMAP link they should land in the handover.
+        self.assertIn("v0.2.x-cr-track.md", self.text,
+            "ROADMAP entry must point to the handover doc by path")
+        self.assertIn("ARCHITECTURE.md §5.6", self.text,
+            "ROADMAP entry must point to the architecture section")
+
+    def test_entry_names_done_when(self):
+        # Every roadmap item carries a done-when criterion.
+        idx = self.text.index("Change Request primitive")
+        nxt_dash = self.text.index("- **", idx + 1)
+        block = self.text[idx:nxt_dash]
+        self.assertIn("Done-when", block.replace("done-when", "Done-when"))
+
+
+class ClaudeMdEntryTests(unittest.TestCase):
+    """CLAUDE.md's 'Where to look next' table must list the CR track
+    so any future session that loads only CLAUDE.md finds it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = CLAUDE_MD.read_text(encoding="utf-8")
+
+    def test_cr_track_listed(self):
+        self.assertIn("v0.2.x-cr-track.md", self.text,
+            "CLAUDE.md 'Where to look next' table must list the CR "
+            "track handover so future sessions discover it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Step **B2** of the v0.2.x CR cycle, stacked on **PR-CR-B1 (#237)**. Adds the apply layer + 6 HTTP endpoints that turn an inert CR row into a real write against the wiki tree. Together with B1 this closes the v0.2.x backend surface — the workspace UI (**PR-CR-C**) and the self-evolution gate re-route (**PR-CR-D**) build on top of these.

## What's in this PR

- **``core/change_request_apply.py``** — apply dispatcher + merge orchestrator (12.0 KB)
- **``server_llmwiki.py``** — six new endpoints
- **``tests/test_change_request_wiki_apply.py``** — 26 tests for the apply layer
- **``tests/test_change_request_endpoints.py``** — 15 tests for the HTTP layer

### Invariants enforced

| # | Where | What |
|---|---|---|
| #2 | merge_cr | approver ≠ proposer |
| #3 | apply_cr (wiki) | base_hash mismatch → supersede; target file untouched |
| #5 | merge_cr | apply() failure leaves status='open' |
| #7 | merge_cr | one ``cr:merge`` row to audit_log |

### wiki_entity apply path

- Resolves ``target_id`` (relative path under ``wiki/``) and refuses anything outside ``wiki/entity/``, anything not ending ``.md``, and any path containing ``..``. ``realpath`` defeats symlink escape.
- Computes sha256 of current file bytes, compares to ``cr.base_hash``. Mismatch returns ``ApplyResult(superseded=True)``.
- For v0.2.x only ``{\"op\": \"replace\", \"body\": \"...\"}`` is supported. The op enum is closed — new ops are part of the v0.3 plugin contract surface.
- Atomic write via ``tempfile + os.replace`` in the target's own directory so the rename stays on the same filesystem.

### Endpoints

| Method | Path | Auth |
|---|---|---|
| POST | ``/admin/cr/`` | propose (any auth user) |
| GET | ``/admin/cr/`` | list (any auth user; non-admin sees own only) |
| GET | ``/admin/cr/{cr_id}`` | detail (proposer / reviewer / admin) |
| POST | ``/admin/cr/{cr_id}/approve`` | merge target (admin only) |
| POST | ``/admin/cr/{cr_id}/reject`` | reject CR (admin only) |
| POST | ``/admin/cr/{cr_id}/review`` | comment / request_changes / approve (any auth user) |

Identity is always the JWT subject claim (via ``_bearer_username``), never a body field — same anti-impersonation posture as ``/password/change``.

### Status codes

| Code | When |
|---|---|
| 401 | no JWT |
| 403 | not admin (approve / reject) or unrelated detail viewer |
| 400 | state-machine refusal (self-approval, already merged, unknown ``target_type`` / ``decision`` …) |
| 409 | apply-side condition that doesn't change state (target file missing at merge time) |
| 404 | CR not found |

## Verification

**1553 tests OK, ruff clean.**

### Test coverage breakdown

- **Apply layer** (26 tests): path resolution (5), apply_cr dispatch (7), merge_cr orchestrator (8), audit invariant #7 (2), module + dispatch contract (3), plus utf-8 round-trip
- **HTTP layer** (15 tests): propose / list / detail / approve / reject / review × (happy path + documented refusal codes)

## Test plan

- [x] ``python -m unittest discover -s tests -t . `` → 1553 OK (+87 vs main)
- [x] ``python -m ruff check core/ tests/`` → clean
- [x] Module sizes: ``change_request.py`` 18.5 KB · ``change_request_apply.py`` 12.0 KB (both well under the 20 KB gate per CLAUDE.md rule #5)
- [x] No ``core/retrieval`` / ``core/graph`` / ``core/reasoning`` touched → no bench numbers needed (CLAUDE.md rule #2)
- [x] PR-CR-B1's state machine untouched — apply lives in its own module so B1 stays under the size gate as ``run_jobs`` arrives in PR-CR-D

## Out of scope

- ``run_jobs`` target — PR-CR-D
- Workspace UI — PR-CR-C
- Self-evolution gate re-route through CR — PR-CR-D

## Base branch

PR-CR-B1 (``feat/v0.2-cr-backend-b1``). Stack will collapse to ``main`` as #236 → #237 → this merge top-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)