### PR TITLE
feat(core): Change Request — run_jobs apply path (PR-CR-D)

### DIFF
--- a/core/change_request_apply.py
+++ b/core/change_request_apply.py
@@ -42,7 +42,7 @@ from typing import Callable, Dict, Optional
 import core.change_request as _cr_mod
 from core.change_request import (
     STATUS_OPEN,
-    TARGET_WIKI_ENTITY,
+    TARGET_WIKI_ENTITY, TARGET_RUN_JOBS,
     ChangeRequest,
     compute_base_hash, get_cr, supersede_cr,
 )
@@ -193,11 +193,96 @@ def _apply_wiki_entity(cr: ChangeRequest) -> ApplyResult:
     )
 
 
+# ─── Target-specific apply: run_jobs (PR-CR-D) ──────────────────
+def _apply_run_jobs(cr: ChangeRequest) -> ApplyResult:
+    """Apply a ``run_jobs`` CR by registering and executing a
+    workspace job under the proposer's name.
+
+    Diff shape (closed for v0.2.x — same plugin-contract reasoning
+    as the wiki op enum):
+
+        {"op":         "run",
+         "job_type":   "excel_build" | "doc_combine" | "entity_export",
+         "input_refs": [ "...", ... ],
+         "options":    {...}                   # optional
+        }
+
+    Unlike ``wiki_entity``, ``run_jobs`` is a *trigger* — the CR's
+    ``base_hash`` is informational only (no current "state" of the
+    target to compare against). The proposer typically computes it
+    as ``sha256(json.dumps({job_type, input_refs}, sort_keys=True))``
+    so duplicate proposals can be spotted by id; the apply does
+    not enforce a comparison.
+
+    Returns ``ApplyResult(applied=True, new_hash=job_id)`` — the
+    job_id is the merge artifact a reviewer can trace via the
+    workspace Jobs tab.
+    """
+    # Decode + validate the diff.
+    try:
+        diff = json.loads(cr.proposed_diff)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"proposed_diff is not valid JSON: {exc}") from exc
+    if not isinstance(diff, dict):
+        raise ValueError("proposed_diff must decode to a JSON object")
+    if diff.get("op") != "run":
+        raise ValueError(f"unsupported run_jobs op: {diff.get('op')!r}")
+
+    job_type = diff.get("job_type")
+    if not isinstance(job_type, str) or not job_type:
+        raise ValueError("run_jobs requires a non-empty job_type string")
+
+    input_refs = diff.get("input_refs")
+    if not isinstance(input_refs, list):
+        raise ValueError("run_jobs requires input_refs as a list")
+    if not all(isinstance(r, str) for r in input_refs):
+        raise ValueError("run_jobs input_refs must be a list of strings")
+
+    options = diff.get("options")
+    if options is not None and not isinstance(options, dict):
+        raise ValueError("run_jobs options must be a JSON object or null")
+
+    # Import lazily so the CR module stays importable on installs
+    # without the workspace job tables (e.g., test fixtures).
+    from core import workspace as _ws
+
+    # HANDLERS is the canonical allowlist of job_types — same enum
+    # the /jobs/run endpoint consults.
+    if job_type not in _ws.HANDLERS:
+        raise ValueError(
+            f"unknown job_type: {job_type!r} "
+            f"(known: {sorted(_ws.HANDLERS.keys())})"
+        )
+
+    # Register under the proposer's name — the job becomes visible
+    # in their /jobs/list view (admin sees it in /admin/jobs/list).
+    # The approver is recorded in the CR row + audit, NOT on the
+    # job, to keep workspace.jobs schema unchanged.
+    job_id = _ws.register_job(
+        job_type=job_type,
+        input_refs=input_refs,
+        owner=cr.proposer,
+        options=options,
+    )
+    try:
+        _ws.execute_job(job_id)
+    except Exception as exc:
+        # The job row exists at this point (status='failed' or 'pending'
+        # depending on where execute_job blew up). Surface to caller so
+        # merge_cr raises and CR stays open — invariant #5.
+        raise RuntimeError(
+            f"run_jobs execution failed for job_id={job_id}: {exc}"
+        ) from exc
+
+    return ApplyResult(applied=True, new_hash=job_id)
+
+
 # ─── Dispatcher ──────────────────────────────────────────────────
-# Closed enum — ARCHITECTURE.md §5.6 explains why. ``run_jobs`` lands
-# in PR-CR-D; add it here when that PR ships, not as a plugin hook.
+# Closed enum — ARCHITECTURE.md §5.6 explains why. Plugin-style
+# external registration is the v0.3 contract surface, not now.
 _APPLY_DISPATCH: Dict[str, Callable[[ChangeRequest], ApplyResult]] = {
     TARGET_WIKI_ENTITY: _apply_wiki_entity,
+    TARGET_RUN_JOBS:    _apply_run_jobs,
 }
 
 

--- a/docs/handovers/v0.2.x-cr-track.md
+++ b/docs/handovers/v0.2.x-cr-track.md
@@ -42,17 +42,21 @@ notes. Domain coupling enters the picture only at v1.0, per
 
 ### In scope
 - A new `core/change_request.py` module owning the CR lifecycle
+- A new `core/change_request_apply.py` module owning the target-
+  specific apply dispatcher + merge orchestrator
 - Two SQLite tables — `change_requests` + `cr_reviews`
 - Admin endpoints (`/admin/cr/...`) for propose / list / detail /
   approve / reject / review
 - One `target_type=wiki_entity` apply path (markdown file edit with
   `base_hash` conflict detection)
-- One follow-up `target_type=run_jobs` apply path (same cycle)
+- One follow-up `target_type=run_jobs` apply path (same cycle —
+  shipped in CR-D)
 - Workspace UI panel that lists CRs and lets admins approve/reject
-- Integration of the existing self-evolution gate (audit-recorded,
-  but currently bespoke) onto the same CR object
 
-### Out of scope (deferred to v0.3 plugin contract)
+### Out of scope (deferred follow-ups)
+- **Self-evolution gate wrap onto CR** — descoped from this cycle
+  (see § 5). The existing approver_username / eval-gate / rollback
+  path stays as-is for v0.2.x. Re-routes into CR in CR-E or v0.3.
 - External `target_type` registration API (today's `target_type` is
   a closed enum; new entries require a code change — on purpose)
 - Multi-approver workflows ("2 of 3 admins must approve")
@@ -140,10 +144,33 @@ the plugin contract requires them.
 
 | PR | Branch | Scope | Depends on | Gate |
 |---|---|---|---|---|
-| CR-A (this) | `docs/v0.2-cr-track` | This file + ARCHITECTURE.md §5.6 + ROADMAP entry + doc-presence test | — | `architecture` label, 1500+ tests still green |
-| CR-B | `feat/v0.2-cr-backend` | `core/change_request.py` + apply for `wiki_entity` + 5 endpoints + table migration + invariants tests | CR-A merged | Bench numbers if `core/retrieval/graph/reasoning` touched (they should not be) |
-| CR-C | `feat/v0.2-cr-ui` | Workspace UI panel + JS delegation reuse | CR-B merged | A11y + event-delegation tests still green |
-| CR-D | `feat/v0.2-cr-jobs-and-evo` | `run_jobs` apply path + self-evolution gate re-routes via CR | CR-C merged | All self-evolution tests still pass byte-identical (CLAUDE.md rule #3) |
+| CR-A | `docs/v0.2-cr-track` | This file + ARCHITECTURE.md §5.6 + ROADMAP entry + doc-presence test | — | `architecture` label, 1500+ tests still green |
+| CR-B1 | `feat/v0.2-cr-backend-b1` | `core/change_request.py` model + state machine + audit + invariants tests | CR-A merged | Bench numbers if `core/retrieval/graph/reasoning` touched (they should not be) |
+| CR-B2 | `feat/v0.2-cr-backend-b2` | `core/change_request_apply.py` apply dispatcher + `wiki_entity` apply + 6 `/admin/cr/...` endpoints + integration tests | CR-B1 merged | Same — purely additive on top of B1 |
+| CR-C | `feat/v0.2-cr-ui` | Workspace UI panel + i18n keys | CR-B2 merged | A11y + event-delegation tests still green |
+| CR-D | `feat/v0.2-cr-jobs` | `run_jobs` apply path (second target_type) | CR-C merged | Workspace jobs DB schema untouched |
+
+**Scope decision (2026-05-12)** — the original plan bundled
+self-evolution gate re-routing into CR-D ("run_jobs + self-
+evolution gate re-routes via CR"). After implementation experience
+in CR-B/C/D-jobs, the self-evolution wrap is too large to land in
+the same cycle without risking the byte-identical regression that
+CLAUDE.md rule #3 forbids:
+
+  - 3 endpoints (`/admin/patch/approve`, `/admin/proposals/{id}/approve`,
+    `/admin/proposals/{id}/reject`),
+  - 4 test files locked to specific JSONL shapes
+    (`test_self_evolution_gate.py`, `test_evolution_bench_gate.py`,
+    `test_evolution_rollback.py`, `test_evolution_audit_query.py`),
+  - the eval gate + rollback path that v0.1 hardened over multiple
+    PRs (#69 / #77 / #78 / #79).
+
+A shadow-CR row that records each self-evolution approval
+alongside the existing flow is the obvious wrap shape, but
+implementing it correctly without altering the eval-gate or
+rollback semantics is a cycle in itself. **Deferred to a follow-up
+PR (CR-E) or, more likely, the v0.3 plugin-contract cycle** where
+the unified audit shape becomes part of the platform contract.
 
 Each PR creates its own handover update under
 `docs/handovers/v0.2.x-cr-*.md` if non-trivial decisions are made

--- a/tests/test_change_request_jobs_apply.py
+++ b/tests/test_change_request_jobs_apply.py
@@ -1,0 +1,344 @@
+"""[PR-CR-D, 2026-05-12] run_jobs apply path.
+
+Second target_type in the CR apply dispatcher. Unlike wiki_entity
+(which mutates a markdown file under wiki/), a ``run_jobs`` CR is a
+trigger — approving the CR fires a workspace job under the
+proposer's name. The job_id becomes the merge artifact (returned as
+``ApplyResult.new_hash``) so reviewers can trace back from the CR
+to the job row in the workspace Jobs tab.
+
+This suite exercises the apply layer + merge orchestrator path for
+run_jobs targets. Tests mock workspace.register_job / execute_job
+so the suite doesn't depend on the workspace jobs DB schema being
+in a particular state — the apply layer's concern is "did we
+dispatch the right args", not "did workspace's executor work".
+
+Run:
+    python -m unittest tests.test_change_request_jobs_apply
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import core.change_request as _cr_mod          # noqa: E402
+import core.change_request_apply as apply_mod  # noqa: E402
+from core.change_request import (              # noqa: E402
+    STATUS_OPEN, STATUS_MERGED,
+    TARGET_RUN_JOBS,
+    init_db, create_cr, get_cr,
+)
+from core.change_request_apply import (        # noqa: E402
+    apply_cr, merge_cr,
+)
+
+
+class _JobsApplyEnv:
+    """Sets up a temp CR DB and patches workspace.register_job +
+    execute_job so the apply layer's behaviour is exercised
+    without depending on the workspace SQLite schema.
+
+    The recorder is a list of ``("register"/"execute", payload)``
+    tuples — tests assert against this to verify arg passing."""
+
+    def __init__(self, *, execute_raises: Exception | None = None,
+                 register_returns: str = "job_xyz"):
+        self.db: str = ""
+        self._prev_db: str = ""
+        self.calls: list[tuple] = []
+        self._exec_raises = execute_raises
+        self._register_returns = register_returns
+        self._orig_register = None
+        self._orig_execute = None
+
+    def __enter__(self):
+        fd, self.db = tempfile.mkstemp(suffix=".db", prefix="cr_jobs_")
+        os.close(fd)
+        init_db(self.db)
+        self._prev_db = _cr_mod._DEFAULT_DB
+        _cr_mod._DEFAULT_DB = self.db
+
+        from core import workspace as ws
+        self._orig_register = ws.register_job
+        self._orig_execute  = ws.execute_job
+
+        def _fake_register(*, job_type, input_refs, owner=None,
+                           options=None, **_kw):
+            self.calls.append((
+                "register",
+                {"job_type": job_type, "input_refs": list(input_refs),
+                 "owner": owner, "options": options},
+            ))
+            return self._register_returns
+
+        def _fake_execute(job_id):
+            self.calls.append(("execute", {"job_id": job_id}))
+            if self._exec_raises is not None:
+                raise self._exec_raises
+            return {"job_id": job_id, "status": "done"}
+
+        ws.register_job = _fake_register
+        ws.execute_job  = _fake_execute
+        return self
+
+    def __exit__(self, *exc):
+        from core import workspace as ws
+        ws.register_job = self._orig_register
+        ws.execute_job  = self._orig_execute
+        _cr_mod._DEFAULT_DB = self._prev_db
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+
+def _propose_run(env: _JobsApplyEnv, *, diff: dict,
+                 proposer: str = "alice",
+                 base_hash: str = "deadbeef") -> str:
+    cr = create_cr(
+        target_type=TARGET_RUN_JOBS,
+        target_id="excel_build:ent_001+ent_042",
+        title="Build the weekly excel",
+        proposed_diff=diff,
+        base_hash=base_hash,
+        proposer=proposer,
+        db_path=env.db,
+    )
+    return cr.cr_id
+
+
+# ─── Diff shape validation ───────────────────────────────────────
+class DiffValidationTests(unittest.TestCase):
+
+    def test_apply_rejects_non_run_op(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "delete", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_missing_job_type(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "input_refs": ["ent_001"],
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_input_refs_not_list(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": "ent_001,ent_002",
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_non_string_input_ref(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001", 42, "ent_003"],
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_non_dict_options(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+                "options": "not-a-dict",
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+    def test_apply_rejects_unknown_job_type(self):
+        # workspace.HANDLERS is the allowlist — same enum the
+        # /jobs/run endpoint consults.
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "legal_clause_render",
+                "input_refs": ["ent_001"],
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+            # Nothing was registered.
+            self.assertEqual(env.calls, [])
+
+    def test_apply_rejects_invalid_json_diff(self):
+        with _JobsApplyEnv() as env:
+            # Bypass create_cr's serialisation by writing a row directly
+            # with malformed JSON in proposed_diff.
+            import sqlite3, time
+            now = int(time.time())
+            conn = sqlite3.connect(env.db)
+            conn.execute(
+                "INSERT INTO change_requests "
+                "(cr_id, target_type, target_id, title, "
+                " proposed_diff, base_hash, proposer, status, "
+                " created_at, updated_at) "
+                "VALUES (?, ?, ?, 't', ?, ?, 'alice', 'open', ?, ?)",
+                ("cr_bad_json", "run_jobs", "x",
+                 "{not-json", "h", now, now),
+            )
+            conn.commit()
+            conn.close()
+            cr = get_cr("cr_bad_json", db_path=env.db)
+            with self.assertRaises(ValueError):
+                apply_cr(cr)
+
+
+# ─── Happy path ──────────────────────────────────────────────────
+class HappyPathTests(unittest.TestCase):
+
+    def test_apply_routes_through_register_and_execute(self):
+        with _JobsApplyEnv(register_returns="job_xyz") as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001", "ent_042"],
+                "options": {"format": "xlsx"},
+            }, proposer="alice")
+            cr = get_cr(cr_id, db_path=env.db)
+            result = apply_cr(cr)
+            self.assertTrue(result.applied)
+            self.assertFalse(result.superseded)
+            self.assertEqual(result.new_hash, "job_xyz")
+
+            # Order matters — register must precede execute.
+            self.assertEqual(
+                [k for (k, _) in env.calls],
+                ["register", "execute"],
+            )
+            reg = env.calls[0][1]
+            self.assertEqual(reg["job_type"],   "excel_build")
+            self.assertEqual(reg["input_refs"], ["ent_001", "ent_042"])
+            # Owner MUST be the proposer — not the approver. The
+            # approver's identity lives on the CR row + audit.
+            self.assertEqual(reg["owner"],   "alice")
+            self.assertEqual(reg["options"], {"format": "xlsx"})
+            self.assertEqual(env.calls[1][1]["job_id"], "job_xyz")
+
+    def test_apply_works_without_options(self):
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "doc_combine",
+                "input_refs": ["ent_001"],
+            })
+            cr = get_cr(cr_id, db_path=env.db)
+            apply_cr(cr)
+            self.assertIsNone(env.calls[0][1]["options"])
+
+    def test_base_hash_is_informational_for_run_jobs(self):
+        # Unlike wiki_entity, run_jobs apply doesn't compare
+        # base_hash to anything — the same base_hash that would
+        # cause a wiki_entity to supersede is fine here.
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            }, base_hash="any-string-at-all")
+            cr = get_cr(cr_id, db_path=env.db)
+            result = apply_cr(cr)
+            self.assertTrue(result.applied)
+
+
+# ─── Merge orchestrator integration ─────────────────────────────
+class MergeIntegrationTests(unittest.TestCase):
+
+    def test_merge_transitions_run_jobs_cr_to_merged(self):
+        with _JobsApplyEnv(register_returns="job_aaa") as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            })
+            out = merge_cr(cr_id, approver="bob", db_path=env.db)
+            self.assertEqual(out.status, STATUS_MERGED)
+            self.assertEqual(out.merged_by, "bob")
+
+    def test_execute_failure_leaves_cr_open(self):
+        # Apply-time exception → invariant #5 (status stays 'open').
+        with _JobsApplyEnv(execute_raises=RuntimeError("disk full")) as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            })
+            with self.assertRaises(RuntimeError):
+                merge_cr(cr_id, approver="bob", db_path=env.db)
+            self.assertEqual(
+                get_cr(cr_id, db_path=env.db).status, STATUS_OPEN)
+
+    def test_merge_blocks_self_approval_on_run_jobs(self):
+        # Two-person rule fires regardless of target_type.
+        with _JobsApplyEnv() as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            }, proposer="alice")
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, approver="alice", db_path=env.db)
+            # And nothing was registered — we refuse BEFORE the
+            # apply path runs.
+            self.assertEqual(env.calls, [])
+
+
+# ─── Audit invariant #7 — merge writes one cr:merge row ─────────
+class AuditTests(unittest.TestCase):
+
+    def test_run_jobs_merge_emits_one_cr_merge_audit_row(self):
+        from core import audit_bridge
+        with _JobsApplyEnv(register_returns="job_zzz") as env:
+            cr_id = _propose_run(env, diff={
+                "op": "run", "job_type": "excel_build",
+                "input_refs": ["ent_001"],
+            })
+            captured = []
+            orig = audit_bridge.mirror_to_audit_db
+
+            def _cap(entry, **kw):
+                captured.append(dict(entry))
+                return True
+            audit_bridge.mirror_to_audit_db = _cap
+            try:
+                merge_cr(cr_id, approver="bob", db_path=env.db)
+            finally:
+                audit_bridge.mirror_to_audit_db = orig
+            merge_events = [e for e in captured
+                            if e.get("endpoint") == "cr:merge"]
+            self.assertEqual(len(merge_events), 1)
+            # job_id is on the audit row so post-hoc traceability
+            # works (find the CR that triggered a given job).
+            self.assertEqual(merge_events[0].get("new_hash"), "job_zzz")
+
+
+# ─── Dispatch table contract ────────────────────────────────────
+class DispatchContractTests(unittest.TestCase):
+
+    def test_run_jobs_now_in_dispatch_table(self):
+        self.assertIn(TARGET_RUN_JOBS, apply_mod._APPLY_DISPATCH)
+
+    def test_dispatch_table_covers_every_valid_target_type(self):
+        from core.change_request import VALID_TARGET_TYPES
+        self.assertEqual(
+            set(apply_mod._APPLY_DISPATCH.keys()),
+            set(VALID_TARGET_TYPES),
+            "every target_type the CR schema accepts must have an "
+            "apply handler — otherwise proposers can file CRs that "
+            "can never merge",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_change_request_wiki_apply.py
+++ b/tests/test_change_request_wiki_apply.py
@@ -395,12 +395,17 @@ class ModuleContractTests(unittest.TestCase):
         self.assertLess(size, 20 * 1024,
             f"core/change_request.py = {size}B; over the gate")
 
-    def test_apply_dispatch_contains_wiki_entity_only_for_now(self):
-        # ``run_jobs`` lands in PR-CR-D. If someone adds it here
-        # without that PR's tests they'd ship an untested write path.
+    def test_apply_dispatch_matches_valid_target_types(self):
+        # The dispatch table must cover every v0.2.x target_type
+        # the schema allows — adding a target_type without an apply
+        # handler would let proposers file CRs that can never merge.
+        # ``run_jobs`` joined in PR-CR-D; see
+        # tests/test_change_request_jobs_apply.py for that target's
+        # behaviour suite.
+        from core.change_request import VALID_TARGET_TYPES
         self.assertEqual(
             set(apply_mod._APPLY_DISPATCH.keys()),
-            {TARGET_WIKI_ENTITY},
+            set(VALID_TARGET_TYPES),
         )
 
 


### PR DESCRIPTION
## Summary

Final PR of the v0.2.x CR cycle, stacked on **PR-CR-C (#239)**. Adds the second ``target_type`` to the apply dispatcher — running a workspace job through the CR review/approval gate.

## What's in this PR

- **``core/change_request_apply.py``** — new ``_apply_run_jobs`` handler (~80 lines)
- **``tests/test_change_request_jobs_apply.py``** — 16 tests
- **``tests/test_change_request_wiki_apply.py``** — dispatch-table contract test rewritten as a generic "every ``VALID_TARGET_TYPES`` has a dispatcher" check
- **``docs/handovers/v0.2.x-cr-track.md``** — scoping decision recorded (self-evolution wrap descoped — see below)

## Diff shape

Closed enum for v0.2.x, same plugin-contract reasoning as ``wiki_entity``:

```json
{
  \"op\":         \"run\",
  \"job_type\":   \"excel_build\" | \"doc_combine\" | \"entity_export\",
  \"input_refs\": [\"ent_001\", \"ent_042\", \"...\"],
  \"options\":    {}                    // optional
}
```

``job_type`` MUST be in ``core.workspace.HANDLERS`` (the same allowlist ``/jobs/run`` consults). ``input_refs`` MUST be a list of strings. ``options`` when present MUST be a JSON object.

## Behaviour

Unlike ``wiki_entity``, ``run_jobs`` is a **trigger** — the CR's ``base_hash`` is informational only (no current state to compare). The apply layer registers the job under the **proposer's** name (not the approver's) so the resulting job shows up in the proposer's ``/jobs/list``; the approver lives on the CR row + audit, never on the job.

Approve → ``register_job`` → ``execute_job`` in order; the ``job_id`` becomes the CR's ``new_hash`` so reviewers can trace back from ``/admin/cr/{id}`` to the resulting workspace job row.

| Dispatch table | After this PR |
|---|---|
| ``wiki_entity`` | ``_apply_wiki_entity`` |
| ``run_jobs`` | ``_apply_run_jobs`` |

**Invariant**: ``VALID_TARGET_TYPES == set(dispatch.keys())`` — enforced by a new contract test so adding a target_type without an apply handler trips CI.

## Scope decision — self-evolution wrap descoped

The original CR-D plan in the handover doc bundled the self-evolution gate re-route (\"approver_username on patches becomes a shadow CR row\") with run_jobs. After implementing CR-B/C/D-jobs, the wrap is **too large to land in the same cycle** without risking byte-identical regression across:

- 3 endpoints (``/admin/patch/approve``, ``/admin/proposals/{id}/approve``, ``/admin/proposals/{id}/reject``)
- 4 locked test files (``test_self_evolution_gate.py``, ``test_evolution_bench_gate.py``, ``test_evolution_rollback.py``, ``test_evolution_audit_query.py``)
- the eval-gate + rollback path that v0.1 hardened over multiple PRs (#69, #77, #78, #79)

**CLAUDE.md rule #3** forbids that risk, so the wrap is deferred to a follow-up PR (CR-E) or, more likely, the **v0.3 plugin-contract cycle** where the unified audit shape becomes part of the platform contract. ``docs/handovers/v0.2.x-cr-track.md`` § 5 records the decision; the \"Out of scope\" list now carries it as a deferred item.

## Verification

**1584 tests OK, ruff clean.**

The 16 new tests cover:

- **Diff shape validation** (7 tests) — rejects non-``run`` op, missing ``job_type``, non-list ``input_refs``, non-string ref element, non-dict options, unknown ``job_type``, malformed JSON
- **Happy path** (3 tests) — ``register_job`` + ``execute_job`` called in order with the proposer as owner; works without options; ``base_hash`` is informational
- **Merge orchestrator** (3 tests) — run_jobs CR → ``status='merged'``; execute failure leaves ``status='open'`` (invariant #5); self-approval blocked before apply runs
- **Audit** (1 test, invariant #7) — one ``cr:merge`` row with ``new_hash=job_id``
- **Dispatch contract** (2 tests) — ``run_jobs`` in dispatch; dispatch keys == ``VALID_TARGET_TYPES``

## Test plan

- [x] ``python -m unittest discover -s tests -t . `` → 1584 OK (+16 vs CR-C)
- [x] ``python -m ruff check`` → clean
- [x] Module sizes: ``change_request.py`` 18.5 KB · ``change_request_apply.py`` 15.7 KB (both well under the 20 KB CLAUDE.md rule #5 gate)
- [x] ``core/retrieval`` / ``core/graph`` / ``core/reasoning`` untouched — no bench numbers needed (CLAUDE.md rule #2)
- [x] ``core/workspace`` schema untouched — ``register_job`` / ``execute_job`` signatures preserved
- [x] Self-evolution endpoints / tests untouched — byte-identical to ``main`` (CLAUDE.md rule #3)

## Out of scope

- **Self-evolution wrap** → deferred (see § Scope decision above)
- ``data-action`` delegation sweep for workspace.html's CR tab → §5 PR-B
- UI hint to show the resulting ``job_id`` after approval → trivial polish; can land in any follow-up

## Base branch

PR-CR-C (``feat/v0.2-cr-ui``). Stack collapses to ``main`` as #236 → #237 → #238 → #239 → this merge top-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)