### PR TITLE
docs(promo): dev.to blog post draft + launch tracker

### DIFF
--- a/reports/promo-assets/devto-post.md
+++ b/reports/promo-assets/devto-post.md
@@ -1,0 +1,200 @@
+---
+title: "Building a Mini Palantir: A Local Graph-RAG Engine with Ontology, Security, and Self-Evolution (Alpha)"
+published: false
+description: "How I built PROJECT JAMES — a security-focused, locally-runnable Graph-RAG knowledge engine in Python, MIT-licensed. Inspired by Palantir's ontology approach, but 100% local and open source."
+tags: rag, llm, python, opensource
+cover_image:
+canonical_url:
+---
+
+> **TL;DR**
+> [PROJECT JAMES](https://github.com/Hashevolution/James-RAG-Evol) is a security-focused, locally-runnable Graph-RAG knowledge engine in Python. It combines an explicit 12-type ontology, 3-stage access control (RBAC + ABAC + instruction isolation), a self-evolution scaffold with audit log, and 100% local execution via Ollama. MIT-licensed, alpha v0.2.0, [OpenSSF Best Practices passing](https://www.bestpractices.dev/projects/12806).
+
+## Why I built this
+
+If you've ever wanted to point a local LLM at your own wiki, codebase, or document store, you've probably hit the same three walls I did:
+
+1. **Cloud RAG services** want everything in their cloud — fine for prototypes, painful for anything sensitive.
+2. **Self-hosted RAG frameworks** are usually one of: (a) too much infrastructure (Kubernetes-shaped), or (b) too few security primitives (no role separation, no audit trail).
+3. **Most Graph-RAG implementations** treat the graph as a side feature on top of vectors. The graph rarely *participates* in the security boundary or the reasoning path.
+
+I wanted something closer to **Palantir Foundry's mental model** — an explicit ontology, capability-token security, a full audit log — but compressed into something one person can run on a laptop, under MIT, without a cloud account.
+
+That's what PROJECT JAMES is.
+
+> Palantir® is a registered trademark of Palantir Technologies Inc. PROJECT JAMES is not affiliated with or endorsed by Palantir. "Mini Palantir" here is a descriptive comparison of the ontology-and-audit-log design pattern, not a product claim.
+
+## What's in the box
+
+Five things that rarely show up in the same Python repo:
+
+| # | Capability | What it does |
+|---|---|---|
+| 1 | **Graph-RAG with ontology** | 12 relation types; relations carry semantic meaning beyond vector similarity |
+| 2 | **3-stage security** | RBAC + ABAC + Instruction Isolation, applied at vector → graph → output |
+| 3 | **Self-evolution scaffold** | feedback signals → patch proposals → 4-Gate validation → auto-rollback on bench regression, all with `approver_username` audit |
+| 4 | **100% local** | Ollama-based, no cloud LLM dependency. Gemma `gemma2:2b` works on a laptop |
+| 5 | **Explicit reasoning paths** | Every response surfaces the traversed graph paths so you can see *why* it answered that way |
+
+## Architecture at a glance
+
+```
+[User query]
+     ↓
+[Security filter]      ← 31+ injection patterns + risky-coding hard-refuse
+     ↓
+[Query router]         ← chat / coding / retrieval / web_search
+     ↓
+[Hybrid search]        ← Vector(60%) + BM25(20%) + keyword(10%) + name(10%)
+     ↓
+[Graph engine]         ← DFS traversal + confidence pruning + sensitivity gating
+     ↓
+[Reasoning loop]       ← retrieve → expand → verify
+     ↓
+[Output filter]        ← PII masking + role-based content filter
+     ↓
+[Answer + reasoning path]
+```
+
+The graph is not a side index. Every retrieval that reaches the graph engine is gated by the user's role, the entity's sensitivity, and the ontology relation type. Removing the graph would break the security model — they're the same pipeline, not two pipelines glued together.
+
+## A typical query lifecycle
+
+```python
+# Pseudocode for what happens behind /query/
+def answer(query: str, user: User) -> Response:
+    # 1. Pre-check: 31+ injection patterns, risky-coding hard-refuse
+    if security_layer.pre_check(query) == BLOCK:
+        return RESPONSE_BLOCKED  # byte-identical block message
+
+    # 2. Hybrid retrieval — vector + BM25 + keyword + name match
+    candidates = hybrid_search(query, top_k=10)
+
+    # 3. Graph expansion — only visit entities the user can read
+    paths = graph_engine.expand(
+        seed_entities=candidates,
+        role=user.role,                # RBAC
+        sensitivity_ceiling=user.tier, # ABAC
+        max_depth=3,
+    )
+
+    # 4. Reason over retrieved context (LLM call via router)
+    answer, reasoning_trace = llm.reason(query, paths)
+
+    # 5. Output filter — PII mask, role-based redact
+    return output_filter.apply(answer, user.role)
+```
+
+The interesting part is step 3: **the graph traversal itself is access-controlled**, not just the final output. A `confidential` entity is never even *traversed* for an `employee` user, so the model never sees it. This means no jailbreak prompt can talk the LLM into leaking content it never had in the context.
+
+## Security in depth
+
+A few specific behaviors worth calling out:
+
+### Hard-refuse for destructive commands
+
+Queries that ask the model to produce filesystem-wide deletion, SQL `DROP DATABASE`, `git reset --hard`, etc. trigger a **byte-identical block message** *before* the LLM is ever called. The block message is the same string as the prompt-injection block, so an audit consumer cannot distinguish the two externally.
+
+Patterns live in `core/security_layer.py::RISKY_CODING_REGEX`. Korean scope markers (`전체`, `모든`) are recognized too.
+
+### Bcrypt password storage with transparent migration
+
+Passwords are stored as `bcrypt$<hash>`. Pre-bcrypt SHA-256 hex digests from older deployments are accepted on input only and **rewritten to bcrypt on the next successful login** — no manual migration needed.
+
+### Audit log everywhere
+
+Every approved self-evolution patch is recorded with `approver_username`, `approver_role`, `approved_at`, and `approval_method` in the patch lifecycle JSONL. There is no auto-deploy path that bypasses this — if you bypass it, your fork stops being JAMES.
+
+## Self-evolution scaffold
+
+This is the part that scares people most when I describe it, so let me be precise about what it does and doesn't do:
+
+**What it does:**
+
+1. Collects feedback signals from `/query/` responses (thumbs-up/down, latency, hallucination flags)
+2. Generates a candidate patch proposal (LLM-assisted)
+3. Validates it through a 4-Gate pipeline:
+   - **Gate 1**: Syntactic — parses, imports, no obvious explosions
+   - **Gate 2**: Test suite — existing tests still pass
+   - **Gate 3**: Bench eval — STEP 7 regression suite stays within tolerance
+   - **Gate 4**: Human approval — `approver_username` required
+4. Applies the patch with a known-good backup
+5. **Auto-rollback** if Gate 3 detects a post-deploy regression
+
+**What it does NOT do:**
+
+- It does not auto-deploy without `approver_username`. If you set `JAMES_AUTO_APPROVE=1`, the server refuses to start unless `JAMES_DEV_MODE=1` is also set.
+- It does not modify trust boundaries (auth, policy, sandbox) without an explicit `architecture` PR label.
+- It does not touch security-critical files inside `core/security_layer.py` or `core/policy_engine.py` automatically.
+
+The default deployment ships with `JAMES_ENABLE_EVOLUTION=0`. You have to opt in.
+
+## What it's NOT — honest limitations
+
+PROJECT JAMES is alpha. Here's what doesn't work yet:
+
+- **Real-data validation is the v0.2 → v0.3 gate.** The internal STEP 7 suite passes (13 queries, security-block invariants, graph-paths bands), but the next gate is *a second user running the bench end-to-end on their own corpus*. That's a recruitment problem, not a coding problem, and I'm honest about it.
+- **Multimodal retrieval is v0.3.** Video-ASR (Whisper) and image OCR (Tesseract, EasyOCR) are wired and work as ingestion paths, but multimodal retrieval as a first-class graph citizen is the next milestone.
+- **Self-evolution is verified single-user.** It works on my machine. It has not been adversarially probed by a second user yet. Don't enable it in production.
+- **Plugin API is v0.3.** Domain packs (legal, food, retail, travel) are deliberately blocked until v1.0 — see `docs/PLATFORM_READINESS.md` for the gate definitions.
+
+## Trust signals
+
+External validation that matters more than my self-assessment:
+
+- **[OpenSSF Best Practices passing badge](https://www.bestpractices.dev/projects/12806)** (Tiered 111%, awarded 2026-05-11)
+- **7 published GitHub Releases** through v0.2.0 (Foundation Hardening)
+- **Static analysis** — ruff F-class rules (F821 + F541 + F401 + F841) enforced on every PR via GitHub Actions
+- **Security tests** — 83-item adversarial regression suite (`james_security_test.py`) covering injection, path traversal, prompt injection, unsafe deserialization; 17-item password regression suite (`tests/test_password_bcrypt.py`)
+- **Vulnerability disclosure** — GitHub Private Vulnerability Reporting enabled; backup channel documented in `SECURITY.md`
+- **MIT-licensed**, with `CONTRIBUTING.md` test-policy gate
+
+## Try it
+
+```bash
+git clone https://github.com/Hashevolution/James-RAG-Evol
+cd James-RAG-Evol
+
+# Configure
+cp .env.example .env
+# Edit .env — set JAMES_API_KEY, JAMES_JWT_SECRET (32-char random)
+
+# Install (Python 3.11+)
+pip install -r requirements.txt
+
+# Pull a model
+ollama pull gemma2:2b   # 1.6 GB, runs on a laptop
+
+# Start
+python server_llmwiki.py
+```
+
+Then `http://localhost:8000`.
+
+## Where this is going
+
+Short-term roadmap:
+
+- **v0.2.1**: Recruitment for the second-user real-data validation gate
+- **v0.3.0**: Plugin API skeleton — `core/plugins/base.py` with 4 plugin interfaces, `JAMES_PLUGINS` loader, `packs/general/` dogfood, multi-instance `JAMES_WORKSPACE`
+- **v1.0**: Production hardening + first domain packs (legal, retail, etc. only after this gate)
+
+The bigger frame is in `docs/PLATFORM_READINESS.md`: PROJECT JAMES is a *mother platform* until v1.0. Domain forks happen after, not before. That's the discipline of the project.
+
+## Feedback welcome
+
+I'm specifically looking for:
+
+1. **Adversarial review of the security model** — the boundary, the audit log, the hard-refuse policy. If you can break the role separation, please open a private advisory.
+2. **A second-user corpus**. If you've got a wiki/document store you can point this at and run `scripts/bench.py --suite=step7 --check` on, I want to know what breaks.
+3. **Critiques of the self-evolution scaffold** — particularly whether the 4-Gate is *enough* gating, or whether it needs another stage before Gate 4.
+
+Repo: https://github.com/Hashevolution/James-RAG-Evol
+Discussions: GitHub Issues
+Security: GitHub Private Vulnerability Reporting (preferred), `karu-7@hanmail.net` (backup)
+
+If you build something on top of it, I'd love to hear about it.
+
+---
+
+🤖 Honest disclosure: this article was drafted with AI assistance and edited by the author. The codebase, design decisions, and limitations described here are real and verifiable in the linked repository.

--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -1,0 +1,127 @@
+# Launch tracker — v0.2.0 promotion-readiness cycle
+
+> Active monitoring log for the v0.2.0 promotion cycle. PR URLs, tweet URLs,
+> external badges, and channel D-Days live here.
+> Update this file whenever a PR is merged, a tweet posts, or a channel goes live.
+
+---
+
+## Status snapshot
+
+| Date | Milestone | Outcome |
+|---|---|---|
+| 2026-05-11 | OpenSSF Best Practices passing badge | ✅ Awarded (Tiered 111%) |
+| 2026-05-11 | python-multipart security fix (PR #213) | ✅ Merged into main |
+| 2026-05-11 | GitHub Actions lint workflow (PR #205) | ✅ Merged into main |
+| 2026-05-11 | OpenSSF badge + promo asset pack (PR #202) | ✅ Merged into main |
+| 2026-05-11 | License / CLA / v0.3 plugin handover (PR #203) | ✅ Merged into main |
+| 2026-05-11 | awesome-llm-apps PR #804 | ⏳ Open, awaiting curator |
+| 2026-05-12 | Awesome-GraphRAG PR #27 | ⏳ Open, awaiting curator |
+| 2026-05-12 | Awesome-LLM PR #563 | ⏳ Open, awaiting curator |
+| 2026-05-12 | Twitter/X English thread | ✅ Posted |
+| 2026-05-12 | Twitter/X Korean thread | ✅ Posted |
+| 2026-05-12 | GitHub Topics + Description refresh | ✅ Applied |
+| 2026-05-12 | GeekNews account created | ✅ (D-Day lockout 7 days) |
+
+---
+
+## External validation badges
+
+| Badge | URL | Status |
+|---|---|---|
+| OpenSSF Best Practices **passing** | https://www.bestpractices.dev/projects/12806 | Active (Tiered 111%, 2026-05-11) |
+
+---
+
+## Open external PRs (awesome-list submissions)
+
+Three independent curators, three independent review pipelines. One acceptance is sufficient to start drawing traffic.
+
+| Repo | PR | Stars (approx) | Curator | Posted | Notes |
+|---|---|---|---|---|---|
+| [Shubhamsaboo/awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) | [#804](https://github.com/Shubhamsaboo/awesome-llm-apps/pull/804) | 50k+ | Shubhamsaboo | 2026-05-11 | Listed in 📀 RAG section as `external` |
+| [DEEP-PolyU/Awesome-GraphRAG](https://github.com/DEEP-PolyU/Awesome-GraphRAG) | [#27](https://github.com/DEEP-PolyU/Awesome-GraphRAG/pull/27) | 1k+ | DEEP-PolyU | 2026-05-12 | 💻 Open-source Project section |
+| [Hannibal046/Awesome-LLM](https://github.com/Hannibal046/Awesome-LLM) | [#563](https://github.com/Hannibal046/Awesome-LLM/pull/563) | 25k+ | Hannibal046 | 2026-05-12 | LLM Applications section. Title has minor wording issue (Visualized capitalization) — curator may request rewording |
+
+---
+
+## Social posts
+
+| Channel | URL | Audience | Posted |
+|---|---|---|---|
+| Twitter/X (English) | https://x.com/i/status/2054094082067386690 | Global EN | 2026-05-12 |
+| Twitter/X (Korean) | _(TBD — fill after posting)_ | KR | 2026-05-12 |
+
+Monitoring rule: respond to substantive replies within 1-2 hours during the first 24 hours; longer-form responses (e.g. quote threads) get hour-of-day discretion.
+
+---
+
+## GitHub repo metadata refresh
+
+Applied via the About panel (⚙️) on 2026-05-12:
+
+- **Description**: `🔐 Local-first Graph-RAG with ontology, 3-stage security, self-evolution scaffold. 100% Ollama. MIT.`
+- **Website**: `https://www.bestpractices.dev/projects/12806`
+- **Topics (10)**: `rag`, `graph-rag`, `ontology`, `ollama`, `local-llm`, `llm`, `python`, `security`, `knowledge-graph`, `retrieval-augmented-generation`
+
+---
+
+## Upcoming channel D-Days
+
+| Channel | D-Day | Lock reason | Asset ready |
+|---|---|---|---|
+| **GeekNews** | 2026-05-19 (D+7 from account creation) | New-account post lockout | `reports/promo-assets/geeknews-post.md` ✅ |
+| **dev.to blog post** | Any time | None | `reports/promo-assets/devto-post.md` ✅ |
+| **Show HN** | 2026-05-26 (GeekNews +7) | Stagger to avoid same-week saturation | `reports/promo-assets/hackernews-show-hn.md` ✅ |
+| **r/LocalLLaMA** | 2026-06-02 (Show HN +7) | Same | `reports/promo-assets/reddit-locallama.md` ✅ |
+
+Recommended hours:
+- GeekNews — KST weekday 09–11 or 20–22
+- Show HN — US Pacific 06:00–09:00 (front-page algorithm window)
+- r/LocalLLaMA — US Eastern 09:00–11:00
+
+---
+
+## OpenSSF criterion auto-promotions (post-merge)
+
+These three criteria flipped from Unmet → Met as a side effect of merges that landed on 2026-05-11:
+
+| Criterion | Trigger | Effect |
+|---|---|---|
+| `static_analysis_often` | PR #205 (`.github/workflows/lint.yml`) | Lint runs on every PR + every push to main |
+| `vulnerabilities_fixed_60_days` | PR #213 (python-multipart spec floor) | Dependabot alerts #5/#6 auto-close on next rescan |
+| `static_analysis_fixed` | PR #196 (already in baseline, reinforced by ruff Phase 2/3) | F-class enforcement at 0 violations |
+
+**User action remaining**: update the two criteria above to Met on the bestpractices.dev form. Tiered % expected to climb above 111% — first step toward `silver` tier.
+
+---
+
+## Phase 5 monitoring rule
+
+If the next 7 days (2026-05-12 → 2026-05-19) show no acceptance on any of the three awesome PRs:
+
+1. Check for curator comments — usually a small wording/position request, respond within 24 hours
+2. If no comments and PRs sit untouched for 7+ days, ping the curator politely (single comment, no follow-up)
+3. After 14 days idle, expand to one additional awesome-list (awesome-self-hosted, awesome-rag, etc.)
+
+If at least one awesome PR merges before 2026-05-19:
+
+- Mention the merge in the GeekNews post body ("Listed in awesome-X")
+- Mention in the Show HN post body (D+14)
+- Drop a one-line acknowledgement in the next CHANGELOG entry
+
+---
+
+## Cycle close criteria
+
+This launch tracker file is considered complete when all of the following are true:
+
+- [ ] At least one awesome PR is merged
+- [ ] GeekNews post is published and URL recorded
+- [ ] Show HN post is published and URL recorded
+- [ ] r/LocalLLaMA post is published and URL recorded
+- [ ] dev.to post is published and URL recorded
+- [ ] OpenSSF Tiered % updated post-merge (target ≥ 115%)
+- [ ] Second-user real-data corpus volunteer engaged (v0.2 → v0.3 gate)
+
+Append a final "Phase 5 outcomes" section once the above are satisfied, then archive this file under `reports/promo-assets/archive/v0.2.0-launch-tracker.md` and reset for v0.3 cycle.


### PR DESCRIPTION
## Summary

Two new files under `reports/promo-assets/`:

### 1. `devto-post.md` — full dev.to blog draft (~1,800 words)

Ready for the author to review and publish at any time. Frontmatter is `published: false` so the post can be previewed on dev.to before flipping to true.

**Article structure**:
- TL;DR (1 paragraph)
- Why I built this (problem framing — 3 walls every self-hosted RAG hits)
- What's in the box (5-capability table)
- Architecture at a glance (ASCII diagram of the 7-stage pipeline)
- A typical query lifecycle (Python pseudocode of `/query/`)
- Security in depth (hard-refuse, bcrypt migration, audit log)
- Self-evolution scaffold (do / don't list, 4-Gate, auto-rollback)
- Honest limitations (real-data gate, multimodal retrieval, plugin API)
- Trust signals (OpenSSF passing, 7 releases, ruff F-class, 83+17 regression tests)
- Install snippet + roadmap + feedback channels

Suggested tags: `rag`, `llm`, `python`, `opensource`.

### 2. `launch-tracker.md` — single source of truth for the v0.2.0 promotion cycle

Working document that captures:

- **Status snapshot** — 12 dated milestones from 2026-05-11 onwards
- **External validation badges** — OpenSSF Best Practices passing
- **3 open awesome-list PRs** — #804 (awesome-llm-apps), #27 (Awesome-GraphRAG), #563 (Awesome-LLM) with curator, stars, notes
- **2 social posts** — Twitter/X English thread (URL recorded), Korean thread (TBD slot)
- **GitHub Topics + Description** refresh applied 2026-05-12
- **4 upcoming channel D-Days** — GeekNews 2026-05-19, dev.to anytime, Show HN 2026-05-26, r/LocalLLaMA 2026-06-02; recommended hours per channel
- **3 OpenSSF criterion auto-promotions** — `static_analysis_often`, `vulnerabilities_fixed_60_days`, `static_analysis_fixed` flipped Unmet → Met thanks to PR #205 / #213 / #196; user action remaining to update on bestpractices.dev
- **Monitoring rule** for curator silence
- **Cycle close criteria** — defines when to archive this tracker and reset for v0.3

## Verification

- No code touched — pure docs/promo addition. CLAUDE.md rule 2 (bench numbers on `core/{retrieval,graph,reasoning}`) does not apply.
- Both files are markdown, no syntactic checks needed beyond reader review.

## Out of scope

- Actually publishing the dev.to post (author action; `published: false` until then)
- GeekNews / Show HN / r/LocalLLaMA channel publication (tracked by `launch-tracker.md`)
- bestpractices.dev form update for the three flipped OpenSSF criteria (5-minute user action, called out in tracker)

---

## 한국어 요약

dev.to 블로그 글 본문(약 1,800단어) + v0.2.0 홍보 사이클 launch tracker 두 파일 추가. dev.to 글은 `published: false`로 저장되어 작성자가 검토 후 게시 가능. tracker는 awesome PR 3개·트윗 2개·GitHub Topics 갱신·OpenSSF 후속 작업·다음 채널 D-Day까지 single-source-of-truth로 정리. 코드 변경 없음.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_