### PR TITLE
chore(deps): urllib3 ≥ 2.7.0 + python-multipart ≥ 0.0.27 — close 6 dependabot high-severity alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # ── Web Framework / Server ─────────────────────────────────────
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
-python-multipart>=0.0.18  # GHSA-59g5-xgcq-4qw3 fix (DoS via unbounded multipart headers)
+python-multipart>=0.0.27  # GHSA / Dependabot alerts #5,#6 (DoS via unbounded multipart headers; 0.0.27 raises the floor past the newer disclosure)
 pydantic>=2.5.0
 
 # ── Authentication / Security ──────────────────────────────────
@@ -16,6 +16,13 @@ python-dotenv>=1.0.0
 
 # ── HTTP / Networking ──────────────────────────────────────────
 requests>=2.31.0
+# Dependabot alerts #7-#10 — urllib3 must be ≥ 2.7.0 to close both
+# the decompression-bomb bypass in the streaming API and the
+# sensitive-header leak across origins in proxied low-level
+# redirects. Pinning the floor here even though urllib3 is also
+# a transitive of requests, so a fresh install with a stale wheel
+# cache cannot regress us.
+urllib3>=2.7.0
 
 # ── Vector DB / Embeddings / Search ────────────────────────────
 chromadb>=0.4.22

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -104,7 +104,7 @@ pytesseract==0.3.13
 python-bidi==0.6.7
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-python-multipart==0.0.26
+python-multipart==0.0.27
 PyYAML==6.0.3
 rank-bm25==0.2.2
 referencing==0.37.0
@@ -141,7 +141,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 ultralytics==8.4.33
 ultralytics-thop==2.0.18
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.44.0
 watchfiles==1.1.1
 websocket-client==1.9.0


### PR DESCRIPTION
## Summary

Six open dependabot alerts (all high severity). Bumps to the patched versions per the GitHub Security Advisory database:

| Package | Old | New | Alerts | CVE family |
|---|---|---|---|---|
| ``urllib3`` | 2.6.3 | **2.7.0** | #7, #8, #9, #10 | (1) Sensitive headers forwarded across origins in proxied low-level redirects · (2) Decompression-bomb safeguards bypassed in the streaming API |
| ``python-multipart`` | 0.0.26 | **0.0.27** | #5, #6 | DoS via unbounded multipart part headers (newer disclosure; prior floor 0.0.18 from #213 closed the earlier disclosure) |

## What changed

- **``requirements.txt``** — floor pins on both packages. ``urllib3`` is pinned explicitly here even though it's also transitive of ``requests``, so a fresh install with a stale wheel cache cannot regress us. Each line carries a comment trail pointing back at the alert numbers.
- **``requirements_pinned.txt``** — exact pins bumped: ``python-multipart 0.0.26 → 0.0.27``, ``urllib3 2.6.3 → 2.7.0``.

## Verification

**1656 tests OK** with the upgraded packages installed locally:

```
pip install 'urllib3>=2.7.0' 'python-multipart>=0.0.27'
# → urllib3-2.7.0, python-multipart-0.0.27
python -m unittest discover -s tests -t .
# → Ran 1656 tests in 49.575s · OK
```

## Test plan

- [x] ``python -m unittest discover -s tests -t .`` → 1656 OK against urllib3 2.7.0 + python-multipart 0.0.27
- [ ] After merge: ``gh api repos/Hashevolution/James-RAG-Evol/dependabot/alerts`` should report 0 open alerts (or only the ones not covered here)

## Out of scope

- Pip auto-upgrade itself ("A new release of pip is available 26.1 → 26.1.1") — unrelated, deferred
- Any other transitive bumps surfaced by ``pip-compile`` — this PR keeps the diff minimal to the two packages dependabot called out

🤖 Generated with [Claude Code](https://claude.com/claude-code)