### PR TITLE
docs(promo): record dev.to publication + secondary Dependabot bump in tracker

### DIFF
--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -22,6 +22,9 @@
 | 2026-05-12 | Twitter/X Korean thread | ✅ Posted |
 | 2026-05-12 | GitHub Topics + Description refresh | ✅ Applied |
 | 2026-05-12 | GeekNews account created | ✅ (D-Day lockout 7 days) |
+| 2026-05-12 | dev.to article published | ✅ Live ([URL](https://dev.to/hashevolution/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-1914)) |
+| 2026-05-12 | dev.to draft + launch tracker (PR #242) | ✅ Merged into main |
+| 2026-05-12 | urllib3 + python-multipart secondary advisory bumps (Dependabot #7-#10) | ✅ Merged into main (separate session — `urllib3>=2.7.0`, `python-multipart>=0.0.27`) |
 
 ---
 
@@ -50,7 +53,8 @@ Three independent curators, three independent review pipelines. One acceptance i
 | Channel | URL | Audience | Posted |
 |---|---|---|---|
 | Twitter/X (English) | https://x.com/i/status/2054094082067386690 | Global EN | 2026-05-12 |
-| Twitter/X (Korean) | _(TBD — fill after posting)_ | KR | 2026-05-12 |
+| Twitter/X (Korean) | _(URL pending — author to record)_ | KR | 2026-05-12 |
+| dev.to article | https://dev.to/hashevolution/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-1914 | Global EN (technical) | 2026-05-12 |
 
 Monitoring rule: respond to substantive replies within 1-2 hours during the first 24 hours; longer-form responses (e.g. quote threads) get hour-of-day discretion.
 
@@ -70,8 +74,8 @@ Applied via the About panel (⚙️) on 2026-05-12:
 
 | Channel | D-Day | Lock reason | Asset ready |
 |---|---|---|---|
+| **dev.to blog post** | ✅ Published 2026-05-12 | None | `reports/promo-assets/devto-post.md` ✅ |
 | **GeekNews** | 2026-05-19 (D+7 from account creation) | New-account post lockout | `reports/promo-assets/geeknews-post.md` ✅ |
-| **dev.to blog post** | Any time | None | `reports/promo-assets/devto-post.md` ✅ |
 | **Show HN** | 2026-05-26 (GeekNews +7) | Stagger to avoid same-week saturation | `reports/promo-assets/hackernews-show-hn.md` ✅ |
 | **r/LocalLLaMA** | 2026-06-02 (Show HN +7) | Same | `reports/promo-assets/reddit-locallama.md` ✅ |
 
@@ -120,7 +124,7 @@ This launch tracker file is considered complete when all of the following are tr
 - [ ] GeekNews post is published and URL recorded
 - [ ] Show HN post is published and URL recorded
 - [ ] r/LocalLLaMA post is published and URL recorded
-- [ ] dev.to post is published and URL recorded
+- [x] dev.to post is published and URL recorded (2026-05-12)
 - [ ] OpenSSF Tiered % updated post-merge (target ≥ 115%)
 - [ ] Second-user real-data corpus volunteer engaged (v0.2 → v0.3 gate)
 


### PR DESCRIPTION
## Summary

Updates `reports/promo-assets/launch-tracker.md` to reflect:

1. **dev.to article published** (2026-05-12)
   URL: https://dev.to/hashevolution/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-1914
   - Added to Status snapshot, Social posts table, and Cycle close criteria
   - dev.to row in the channel D-Days table flips from "Any time" to "✅ Published 2026-05-12"

2. **Secondary Dependabot bump** that landed on main between the PR #213 merge and now (separate session):
   - `urllib3>=2.7.0` (alerts #7-#10 — decompression-bomb bypass + sensitive-header leak)
   - `python-multipart>=0.0.27` (floor raised again past the newer disclosure)
   - Recorded in Status snapshot so the tracker stays the single source of truth

3. **PR #242 merge** (dev.to draft + tracker scaffold) recorded.

## Verification

- Pure docs change. CLAUDE.md rule 2 (bench numbers on `core/{retrieval,graph,reasoning}`) does not apply.
- The dev.to URL has been confirmed by the author (WebFetch returns 403 due to dev.to bot blocking, but the author published from their own account).

## Out of scope

- Korean Twitter/X URL still pending — author to record when convenient
- bestpractices.dev form Met-flip for `static_analysis_often` and `vulnerabilities_fixed_60_days` — still queued as a 5-minute user action

---

## 한국어 요약

dev.to 글 게시 URL과 다른 세션에서 처리한 urllib3 + python-multipart 후속 보안 bump를 launch tracker에 기록.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_