### PR TITLE
docs(handover): refresh v0.2 platform track for post-CR-cycle state

### DIFF
--- a/docs/handovers/v0.2.0-platform-track.md
+++ b/docs/handovers/v0.2.0-platform-track.md
@@ -24,51 +24,75 @@ This frame is documented in `docs/PLATFORM_READINESS.md`. Read that
 file before proposing any work that touches a domain (legal clauses,
 food labels, POS connectors, etc.).
 
-## 2. Where v0.2 stands today
+## 2. Where v0.2 stands today (updated 2026-05-12)
 
-- **Axis 1 (Architecture Separation)** — substantially done:
-  - `core/memory_*` consolidated into `core/memory/` package (PR #35)
-  - `core/reasoning_engine.py` split into `engine.py` (16 KB),
-    `modes.py`, `pipeline.py` (PRs #37, #38, #39)
-  - All `core/` files now < 20 KB except `memory/store.py` (21 KB,
-    follow-up issue exists)
-- **Axis 2 (Eval Harness)** — not started
-- **Axis 3 (Observability)** — not started
-- **Axis 4 (Security Boundary)** — not started; `PolicyEngine`
-  extraction is next
-- **Axis 5 (Controlled Evolution)** — not started; opt-in flag
-  + approval gate
-- **Axis 6 (Real-Data Validation)** — partially done via STEP 7
+The six axes are **engineering-complete**. Live status per ROADMAP:
+
+| Axis | Status | Done-when |
+|---|---|---|
+| 1 Architecture Separation | ✅ | `import` graph acyclic; every `core/` file < 20 KB |
+| 2 Evaluation Harness | ✅ | PR cannot land without bench numbers |
+| 3 Observability / Tracing | ✅ | Hallucination report diagnosable by trace_id alone |
+| 4 Security Boundary | ✅ | Removing PolicyEngine breaks ≥ 6 modules |
+| 5 Controlled Evolution | ✅ | Deploy without `approver_username` is rejected |
+| 6 Real-Data Validation | 🟡 | **Second-user end-to-end bench run** (recruitment task, not code) |
+
+Axis 6 is the only one blocking the v0.2 → v0.3 gate, and it's an
+**adoption task**, not an engineering task. From here, v0.2.x is
+"polish + governance follow-ups" while we recruit the second user.
+
+### v0.2.x cycles that landed on top of the six axes
+
+- **Frontend dark UI** — token unification, mobile.css extraction,
+  inline `<style>` extraction (PR #246), reasoning panel phase
+  grouping (PR #235), event-delegation rollout (§5, PRs #230 #241
+  #232 #233), workspace CR panel (PR #239). HANDOVER_WEB_UI.md §4
+  rollout list now fully closed except for #2 (already done) and
+  #8 (just landed); workspace + graph inline-style follow-up
+  (#8b) deliberately deferred.
+- **Change Request primitive** — `core/change_request.py` +
+  `core/change_request_apply.py` + 6 endpoints + workspace UI.
+  Two `target_type`s land: `wiki_entity` (PR #243) and
+  `run_jobs` (PR #240). Trust zone documented in
+  `docs/ARCHITECTURE.md §5.6`. The self-evolution gate wrap is
+  **deferred** — see `docs/handovers/v0.2.x-cr-track.md § 5` for
+  the scoping decision.
+- **Security** — dependabot 6 high-severity alerts closed
+  (urllib3 ≥ 2.7.0 + python-multipart ≥ 0.0.27, PR #244).
 
 ## 3. Next session's recommended priorities
 
-In order. Do not jump ahead unless an issue is blocked.
+The six axes are done. Three live tracks pull at the next session:
 
-### P0 — Axis 4 PolicyEngine extraction
-- Create `core/policy_engine.py` as the single source of policy
-  decisions
-- Replace direct `check_access` imports across retrieval / graph /
-  output / tools with `PolicyEngine` calls
-- Verification: removing the engine breaks ≥ 4 modules
+### P0 — Second-user adoption (Axis 6, blocks v0.3 gate)
+Not code — a recruitment + onboarding task. Do not start v0.3
+work until this lands or the gate is explicitly re-scoped in
+`docs/PLATFORM_READINESS.md`.
 
-### P0 — Axis 2 RAGAS integration
-- Add `ragas>=0.2.0` to `requirements.txt`
-- New harness `eval/ragas/run_ragas.py`
-- PR contract: any change to `core/retrieval/` or `core/reasoning/`
-  must paste bench summary
+### P1 — Workspace.html + graph.html inline-style extraction (§4 #8b)
+Mirror PR #246's pattern for the two remaining pages:
+add `static/workspace.css` and `static/graph.css`, link them
+between tokens.css and mobile.css, flip the entries in
+`tests/test_inline_style_extraction.py::_EXTRACTED`. Low risk,
+~2 h. Closes the inline-style rollout entirely.
 
-### P1 — Axis 3 trace_id propagation
-- `trace_id = uuid7()` at API edge, propagated via contextvar
-- Structured stage logs: `query → retrieve → rerank → graph → tool → answer`
-- `GET /admin/trace/{id}` returns full pipeline replay
+### P1 — CR-E: self-evolution gate wrap onto Change Request
+Deferred from v0.2.x cycle (see
+`docs/handovers/v0.2.x-cr-track.md § 5`). High risk — byte-
+identical regression in 3 endpoints + 4 locked test files is
+the bar. Almost certainly a v0.3 cycle item, paired with the
+plugin contract.
 
-### P1 — Lock STEP 7 as committed regression
-- Move `scripts/step7_query_test.py` queries into
-  `eval/regression/step7_queries.json`
-- Add `scripts/bench.py --suite=step7`
+### P2 — v0.3 preparation (license / CLA / plugin contract)
+Existing handover: `docs/handovers/session-2026-05-09-license-infrastructure.md`.
+License decision + CLA mechanics + plugin-contract sketch.
+**Do not freeze the plugin API before Axis 6 lands** — the
+contract surface is exactly what the second user will stress-
+test.
 
-### P2 — Module size cleanup (#29 follow-up)
-- Split `core/memory/store.py` (21 KB) along algorithm boundaries
+### P3 — Module size cleanup (#29 follow-up)
+`core/memory/store.py` is 21 KB (1 KB over the gate). Split
+along algorithm boundaries when its blast radius is small.
 
 ## 4. Open issues snapshot
 


### PR DESCRIPTION
## Summary

Closeout for v0.2.x. The platform-track handover dated to the start of the v0.2 cycle, when none of the six axes had work landed yet. Every axis is now engineering-complete; Axis 6 is the only remaining gate and it's a recruitment task.

## What changed

**§2 rewritten** — table form, one row per axis with current status and done-when criterion:

| Axis | Status |
|---|---|
| 1 Architecture Separation | ✅ |
| 2 Evaluation Harness | ✅ |
| 3 Observability / Tracing | ✅ |
| 4 Security Boundary | ✅ |
| 5 Controlled Evolution | ✅ |
| 6 Real-Data Validation | 🟡 (second-user adoption) |

Added a subsection listing the v0.2.x cycles that landed on top of the six axes (frontend dark UI rollout, Change Request primitive, security closeout) with PR references.

**§3 priorities re-ordered** for the next session:

- **P0** — Second-user adoption (Axis 6, blocks v0.3 gate). Not code.
- **P1** — Workspace + graph inline-style extraction (§4 #8b). Mirror PR #246. ~2 h.
- **P1** — CR-E: self-evolution gate wrap onto Change Request. Deferred from v0.2.x cycle (see ``docs/handovers/v0.2.x-cr-track.md § 5``).
- **P2** — v0.3 preparation (license / CLA / plugin contract). **Do not freeze plugin API before Axis 6 lands.**
- **P3** — ``core/memory/store.py`` size split (1 KB over the 20 KB gate).

§4 (open issues) and §5 (deliberate non-goals) preserved — neither has changed and both remain enforceable.

## Verification

- [x] ``python -m unittest discover -s tests -t .`` → 1663 OK (docs-only change should be a no-op)
- [x] Forward references in the new §2 (``ARCHITECTURE.md §5.6``, ``v0.2.x-cr-track.md § 5``, ``session-2026-05-09-license-infrastructure.md``) all resolve

## Out of scope

- No code changes
- No ROADMAP.md changes (the deferred-follow-ups section already names the CR track + inline-style extraction)
- No CLAUDE.md changes (its "Where to look next" table was updated when the CR track docs landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)