### PR TITLE
feat(chat): clean answer + dual web-search chip — Axis 6 user-feedback items 2 + 3

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1251,26 +1251,55 @@ function appendJamesMsg(data) {
   // [3-B] unified_score는 web chip + confidence badge 모두 참조 — 한 번만 읽기.
   const score = data.unified_score;
 
-  // [#A8-6] 자료 부족 + 웹 검색 미사용일 때 "웹으로 더 조사" chip.
-  //   - web_used=false (이미 웹 자료 받았으면 다시 보낼 필요 없음)
-  //   - unified_score < 0.50 (확신 낮은 답변 — internal-only로는 부족)
-  //   - 사용자 자체 질문은 lastUserQuestion에 보관 → 클릭 시 force flag로 재전송.
+  // [#A8-6 + Axis 6, 2026-05-12] Web-search chip — two variants
+  // keyed on confidence.
+  //   score < 0.50  → "자료 수집" framing (internal evidence is
+  //                   thin; the user needs more raw material).
+  //   score ≥ 0.70  → "최신 정보 보완" framing (answer is well-
+  //                   supported by internal sources; the user may
+  //                   still want to check for newer info on the web).
+  //   0.50 ≤ score < 0.70 → no chip (the mid band is the "neither
+  //                   convincing nor desperate" zone where a chip
+  //                   would feel like nagging).
+  // web_used=true skips the chip entirely (already pulled in web).
+  // The action is identical in both variants; copy + color differ.
   let forceWebChip = '';
-  if (!data.web_used && (score == null || score < 0.50)) {
+  if (!data.web_used) {
     const q = lastUserQuestion || '';
-    if (q.trim()) {
+    const HIGH_CONF = 0.70;
+    const LOW_CONF  = 0.50;
+    const isLow  = (score == null || score < LOW_CONF);
+    const isHigh = (score != null && score >= HIGH_CONF);
+    if (q.trim() && (isLow || isHigh)) {
+      const variant = isHigh
+        ? {
+            cls:    'force-web-btn web-refresh-btn',
+            bg:     'rgba(107,231,208,.10)',
+            border: 'rgba(107,231,208,.45)',
+            color:  '#6be7d0',
+            icon:   '✨',
+            label:  t('chat.web_chip_high'),
+          }
+        : {
+            cls:    'force-web-btn web-collect-btn',
+            bg:     'rgba(79,195,247,.10)',
+            border: 'rgba(79,195,247,.45)',
+            color:  '#4fc3f7',
+            icon:   '🌐',
+            label:  t('chat.web_chip_low'),
+          };
       forceWebChip = `
         <div style="margin-top:8px">
-          <button class="next-action-chip force-web-btn"
+          <button class="next-action-chip ${variant.cls}"
                   data-action="ask-with-force-web"
                   data-question="${encodeURIComponent(q)}"
-                  style="text-align:left;background:rgba(79,195,247,.10);
-                         border:1px solid rgba(79,195,247,.45);border-radius:8px;
+                  style="text-align:left;background:${variant.bg};
+                         border:1px solid ${variant.border};border-radius:8px;
                          padding:8px 12px;cursor:pointer;color:var(--text);
                          font-size:12px;width:100%;font-family:inherit;
                          transition:all .15s">
-            <span style="color:#4fc3f7;font-weight:600;margin-right:6px">🌐</span>
-            <span>웹 검색으로 더 자세히 조사하기</span>
+            <span style="color:${variant.color};font-weight:600;margin-right:6px">${variant.icon}</span>
+            <span>${escHtml(variant.label)}</span>
           </button>
         </div>`;
     }
@@ -1388,7 +1417,11 @@ function appendJamesMsg(data) {
   // item #1-B: 답변 끝의 "(1) ... (2) ... (3) ..." 다음-행동 제안을
   // 클릭 가능한 chip으로 변환. 클릭 → 입력창에 그 제안 텍스트 채움 +
   // 자동 전송 (사용자가 다음 차례를 한 클릭으로 진행).
-  const suggestions = extractNextActionSuggestions(answer);
+  // [Axis 6, 2026-05-12] cleanAnswer 는 본문에서 제안 블록을
+  // 잘라낸 버전 — bubble 은 cleanAnswer 만 렌더해서 같은 텍스트가
+  // chip + 본문에 두 번 보이는 문제 (실사용자 피드백) 해결.
+  const { suggestions, cleanAnswer } =
+    extractNextActionSuggestions(answer);
   let suggestionsHtml = '';
   if (suggestions.length > 0) {
     suggestionsHtml = `
@@ -1414,7 +1447,7 @@ function appendJamesMsg(data) {
   div.innerHTML = `
     <div class="avatar james">🧠</div>
     <div>
-      <div class="bubble">${formatAnswerWithParagraphs(answer)}${pathsHtml}</div>
+      <div class="bubble">${formatAnswerWithParagraphs(cleanAnswer)}${pathsHtml}</div>
       ${webBadge}
       ${saveWikiChip}
       ${confidenceBadge}
@@ -1450,15 +1483,26 @@ const SUGGESTION_PATTERNS = [
 ];
 
 function extractNextActionSuggestions(answerText) {
-  if (!answerText) return [];
+  /* [Axis 6 user feedback, 2026-05-12] — return both the parsed
+   * suggestions AND a copy of the answer with the suggestion block
+   * stripped off the tail. The bubble renders ``cleanAnswer`` so
+   * the same text doesn't appear twice (once as prose, once as
+   * chips). Falls back to the original ``answerText`` when no
+   * pattern reaches the ≥2-suggestion threshold.
+   */
+  const empty = { suggestions: [], cleanAnswer: answerText || '' };
+  if (!answerText) return empty;
   const tail = answerText.length > 600
              ? answerText.slice(-600)
              : answerText;
+  const tailStartInOriginal = answerText.length - tail.length;
   for (const re of SUGGESTION_PATTERNS) {
     re.lastIndex = 0;
     const out = [];
+    let firstMatchOffset = -1;
     let m;
     while ((m = re.exec(tail)) !== null) {
+      if (firstMatchOffset < 0) firstMatchOffset = m.index;
       const text = m[2].trim().replace(/[\.。]+$/, '');
       if (text.length >= 4 && text.length <= 200) {
         // 동일 텍스트 중복 제거 (예: "1. X" 다음 "1) X" 둘 다 매칭 방지)
@@ -1469,9 +1513,22 @@ function extractNextActionSuggestions(answerText) {
       if (out.length >= 5) break;
     }
     // 최소 2개 — 단일 매칭은 본문 잔재(예: "1단계: ...")일 가능성.
-    if (out.length >= 2) return out;
+    if (out.length >= 2) {
+      // Cut the answer at the first match offset, then drop any
+      // dangling colon-introducer line ("다음을 시도해보실 수 있습니다:")
+      // that the LLM put right before the list and that would
+      // otherwise hang at the bottom of the bubble.
+      const cutStart = tailStartInOriginal + firstMatchOffset;
+      let cleanAnswer = answerText.slice(0, cutStart)
+                                  .replace(/[\s　]+$/, '');
+      cleanAnswer = cleanAnswer.replace(
+        /(?:^|\n)[^\n]{0,80}[:：]\s*$/,
+        '',
+      ).replace(/[\s　]+$/, '');
+      return { suggestions: out, cleanAnswer };
+    }
   }
-  return [];
+  return empty;
 }
 
 /* [#A8-7] "📥 위키 저장" chip 클릭 핸들러.

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -71,6 +71,10 @@ const TRANSLATIONS = {
     'badge.inference_warn':  'Insufficient internal data — answer based on LLM inference. Use as reference only.',
 
     'toast.web_augmented':   'Answer enhanced via web search',
+    // [Axis 6, 2026-05-12] Web-search chip — dual variant per
+    // confidence score. See chat.js appendJamesMsg.
+    'chat.web_chip_low':     'Search the web for more material',
+    'chat.web_chip_high':    'Check the web for newer information',
     'toast.longterm_saved':  'Saved to long-term memory',
     'toast.level_up':        'Knowledge +{delta} [{domain}]',
     'toast.no_internal':     'No internal data — inference-based answer',
@@ -627,6 +631,10 @@ const TRANSLATIONS = {
     'badge.inference_warn':  '내부 자료가 부족해 LLM 추론으로 답변. 참고용으로만 활용하세요.',
 
     'toast.web_augmented':   '웹 검색으로 보완된 답변',
+    // [Axis 6, 2026-05-12] 신뢰도 분기 chip — chat.js 참조.
+    // 아이콘은 chat.js variant.icon 으로 별도 prepend.
+    'chat.web_chip_low':     '웹 검색으로 자료 수집',
+    'chat.web_chip_high':    '최신 정보로 보완 검색해볼까요?',
     'toast.longterm_saved':  '장기 기억으로 저장됨',
     'toast.level_up':        '지식 레벨 +{delta} [{domain}]',
     'toast.no_internal':     '내부 자료 없음 — 추론 기반 답변',

--- a/tests/test_force_web_chip.py
+++ b/tests/test_force_web_chip.py
@@ -151,8 +151,6 @@ class FrontendChipTests(unittest.TestCase):
             "chip class missing")
         self.assertIn("data.web_used", body,
             "must check web_used before rendering chip")
-        self.assertIn("score < 0.50", body,
-            "must gate on score threshold")
         # [§5 migration] inline onclick replaced by data-action;
         # delegate forwards the element to askWithForceWeb so dataset
         # is still readable.
@@ -169,6 +167,61 @@ class FrontendChipTests(unittest.TestCase):
         # Default empty + the conditional excludes web_used=true.
         self.assertIn("!data.web_used", body,
             "must skip chip when web search already happened")
+
+    # ─── Axis 6 (2026-05-12) — dual-variant chip ─────────────────
+    # The chip used to only fire on low confidence (score < 0.50).
+    # User feedback: high-confidence answers should also offer a
+    # web option — "check for newer information" — instead of
+    # silently hiding the chip when the answer is well-supported.
+    # The two thresholds split the score line into three bands:
+    #   < 0.50  → "자료 수집" framing
+    #   ≥ 0.70  → "최신 정보 보완" framing
+    #   between → no chip (deliberate quiet zone)
+    # Same data-action / data-question shape — the delegate doesn't
+    # care which variant fired.
+
+    def test_two_distinct_thresholds_declared(self):
+        idx = self.js.index("let forceWebChip")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("0.70", body,
+            "HIGH-confidence threshold (0.70) missing")
+        self.assertIn("0.50", body,
+            "LOW-confidence threshold (0.50) missing")
+
+    def test_high_variant_uses_i18n_key(self):
+        idx = self.js.index("let forceWebChip")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("'chat.web_chip_high'", body,
+            "high-confidence variant must source its label from "
+            "the chat.web_chip_high i18n key, not a literal string")
+
+    def test_low_variant_uses_i18n_key(self):
+        idx = self.js.index("let forceWebChip")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("'chat.web_chip_low'", body,
+            "low-confidence variant must source its label from "
+            "the chat.web_chip_low i18n key")
+
+    def test_i18n_keys_present_both_locales(self):
+        i18n = (Path(__file__).resolve().parent.parent
+                / "frontend" / "static" / "i18n.js"
+                ).read_text(encoding="utf-8")
+        for key in ("chat.web_chip_low", "chat.web_chip_high"):
+            with self.subTest(key=key):
+                count = len(re.findall(
+                    r"'" + re.escape(key) + r"'\s*:", i18n))
+                self.assertGreaterEqual(count, 2,
+                    f"i18n key {key!r} must be declared in both en + ko")
+
+    def test_variants_use_distinct_classes(self):
+        # web-collect-btn (low) vs web-refresh-btn (high) so future
+        # CSS / analytics can tell the two apart without parsing copy.
+        idx = self.js.index("let forceWebChip")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("web-collect-btn", body,
+            "low-confidence variant must carry the web-collect-btn class")
+        self.assertIn("web-refresh-btn", body,
+            "high-confidence variant must carry the web-refresh-btn class")
 
 
 if __name__ == "__main__":

--- a/tests/test_paragraph_copy.py
+++ b/tests/test_paragraph_copy.py
@@ -48,14 +48,20 @@ class JsContractTests(unittest.TestCase):
                       "must define formatAnswerWithParagraphs")
 
     def test_used_by_appendJamesMsg(self):
+        # [Axis 6, 2026-05-12] bubble now renders ``cleanAnswer``
+        # (answer with the suggestion tail stripped) instead of the
+        # raw answer, so users don't see the same (1)/(2)/(3) text
+        # both in the prose and as chips. The paragraph splitter is
+        # still applied — only the argument changed.
         idx = self.js.index("function appendJamesMsg")
         m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
         end = idx + 1 + m.start() if m else idx + 8000
         body = self.js[idx:end]
-        self.assertIn("formatAnswerWithParagraphs(answer)", body,
-                      "appendJamesMsg should render via the paragraph splitter")
+        self.assertIn("formatAnswerWithParagraphs(cleanAnswer)", body,
+                      "appendJamesMsg should render via the paragraph splitter "
+                      "with cleanAnswer (suggestion-stripped)")
         self.assertNotIn("formatAnswer(answer)", body.replace(
-            "formatAnswerWithParagraphs(answer)", ""),
+            "formatAnswerWithParagraphs(cleanAnswer)", ""),
             "must NOT call formatAnswer(answer) directly anymore")
 
     def test_function_handles_code_blocks(self):

--- a/tests/test_suggestion_click.py
+++ b/tests/test_suggestion_click.py
@@ -222,6 +222,66 @@ class JsContractTests(unittest.TestCase):
         self.assertIn("slice(-600)", self.js,
                       "extraction must restrict to answer tail (600 chars)")
 
+    # ─── Axis 6 (2026-05-12) — return-shape upgrade ──────────────
+    # The extractor used to return a plain list of suggestions; the
+    # bubble then rendered the FULL ``answer`` text alongside the
+    # chips, so users saw "(1) X (2) Y (3) Z" twice. The new
+    # contract returns {suggestions, cleanAnswer}, and the bubble
+    # renders cleanAnswer so the suggestion block appears as chips
+    # only. Tests below pin that contract.
+
+    def test_extract_returns_clean_answer_object(self):
+        # Function must return an object with both fields so the
+        # bubble can render ``cleanAnswer`` instead of the original.
+        idx = self.js.index("function extractNextActionSuggestions")
+        body = self.js[idx:idx + 2400]
+        self.assertIn("suggestions:", body,
+            "extractNextActionSuggestions must return {suggestions, …}")
+        self.assertIn("cleanAnswer", body,
+            "extractNextActionSuggestions must return {…, cleanAnswer}")
+
+    def test_extract_fallback_returns_original_answer(self):
+        # When no pattern reaches the ≥2 threshold, ``cleanAnswer``
+        # MUST be the original answer text — otherwise the bubble
+        # would render an empty string on every short reply.
+        idx = self.js.index("function extractNextActionSuggestions")
+        body = self.js[idx:idx + 2400]
+        # The early-return falls back to ``answerText`` (or empty
+        # string sentinel for missing input).
+        self.assertRegex(
+            body,
+            r"cleanAnswer:\s*answerText",
+            "fallback path must hand back the original answer text",
+        )
+
+    def test_bubble_renders_clean_answer(self):
+        # The bubble must call formatAnswerWithParagraphs on
+        # cleanAnswer (not the raw answer) so the suggestion tail
+        # is stripped from the visible prose.
+        idx = self.js.index("function appendJamesMsg")
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 12000
+        body = self.js[idx:end]
+        self.assertIn(
+            "formatAnswerWithParagraphs(cleanAnswer)", body,
+            "bubble must render formatAnswerWithParagraphs(cleanAnswer) — "
+            "not the raw answer — so suggestion text doesn't duplicate",
+        )
+
+    def test_caller_destructures_both_fields(self):
+        # The one caller (appendJamesMsg) must destructure both
+        # so we don't accidentally re-introduce the list form.
+        idx = self.js.index("function appendJamesMsg")
+        m = re.search(r"\nfunction\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 12000
+        body = self.js[idx:end]
+        self.assertRegex(
+            body,
+            r"\{\s*suggestions\s*,\s*cleanAnswer\s*\}\s*=\s*"
+            r"extractNextActionSuggestions",
+            "appendJamesMsg must destructure both fields",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two related chat-UX items from the v0.2.x → v0.3 **second-user adoption track** (handover §3 P0). Frontend-only PR — no backend / reasoning changes, so no bench numbers required per CLAUDE.md rule #2.

### Item 2 — bubble no longer duplicates the suggestion text

**Before**: when the LLM ended its answer with ``(1) X (2) Y (3) Z`` (or one of the four formats the existing extractor knows), the bubble rendered the full answer (with the list inside) AND showed clickable chips for the same three items beneath it. Users saw the suggestions twice.

**After**: ``extractNextActionSuggestions`` now returns ``{suggestions, cleanAnswer}`` — ``cleanAnswer`` is the answer with the matched suggestion block (plus any dangling colon-intro line like ``다음을 시도해보실 수 있습니다:``) stripped from the tail. ``appendJamesMsg`` renders the bubble via ``formatAnswerWithParagraphs(cleanAnswer)``; the chips still render below from the ``suggestions`` list.

**Fallback**: when no pattern reaches the ≥ 2-suggestion threshold, ``cleanAnswer === answerText`` so short replies are unaffected.

### Item 3 — web-search chip splits into HIGH / LOW variants

**Before**: chip only appeared at ``score < 0.50``. High-confidence answers had no path to *"let me also check the web"* — the chip was silently hidden.

**After**: three bands keyed on ``unified_score``:

| Score | Variant | Copy | Color |
|---|---|---|---|
| < 0.50 | 🌐 collect | ``웹 검색으로 자료 수집`` | mint cyan #4fc3f7 |
| ≥ 0.70 | ✨ refresh | ``최신 정보로 보완 검색해볼까요?`` | mint accent #6be7d0 |
| 0.50–0.70 | — | (deliberate quiet band) | — |

Same ``data-action=\"ask-with-force-web\"`` + ``data-question`` on both variants — the delegate doesn't care which fired. Variants carry distinct CSS classes (``.web-collect-btn`` / ``.web-refresh-btn``) so future styling or analytics can tell them apart without parsing copy.

### i18n

Two new keys, each in **en + ko**:

```
chat.web_chip_low   →  Search the web for more material / 웹 검색으로 자료 수집
chat.web_chip_high  →  Check the web for newer information / 최신 정보로 보완 검색해볼까요?
```

Icons live in ``chat.js`` ``variant.icon`` and are NOT in the i18n string, so a future copy edit can't double-stamp them.

## Verification

**1672 tests OK, ruff clean.**

| Suite | Δ tests | What's pinned |
|---|---|---|
| ``test_suggestion_click`` | +4 | new return shape (suggestions + cleanAnswer), fallback path, bubble uses cleanAnswer, caller destructures both |
| ``test_force_web_chip`` | +5 | dual thresholds (0.50 + 0.70), both variants use i18n keys, both i18n keys present in en + ko, two distinct CSS classes |
| ``test_paragraph_copy`` | (1 updated) | contract that ``formatAnswerWithParagraphs(answer)`` is now ``…(cleanAnswer)`` |

## Test plan

- [x] ``python -m unittest discover -s tests -t . `` → 1672 OK
- [x] ``python -m ruff check tests/`` → clean
- [ ] Visual smoke (browser):
  - Ask a question whose answer includes a numbered suggestion tail → bubble should NOT contain ``(1)…(2)…(3)…`` text; chips below should show the three options
  - Ask a high-internal-confidence question (e.g., a fact from the wiki the agent knows well) → mint ✨ chip ``최신 정보로 보완 검색해볼까요?`` appears
  - Ask a low-confidence question → existing 🌐 cyan chip ``웹 검색으로 자료 수집`` appears

## Out of scope

- **Item 1 (conversation continuity, backend)** — separate PR-B; the backend prompt + memory-history changes need STEP 7 bench numbers per CLAUDE.md rule #2 and shouldn't share a PR with these UI tweaks
- Per-page CSS for the new variant classes — current inline ``background`` / ``border`` values are enough; promoting to chat.css can land in a polish PR
- Analytics events for which chip variant the user clicked — out of v0.2.x scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)