### PR TITLE
fix(wiki): 2-pass UNRESOLVED target_id resolution after every ingest

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -467,12 +467,32 @@ class WikiGenerator:
         self.index_path.write_text("\n".join(lines), encoding="utf-8")
 
     # =========================
-    # RESOLVE (SAFE YAML 방식)
+    # RESOLVE — frontmatter `relations:` 의 UNRESOLVED 재매칭
     # =========================
 
-    def resolve_pending_relations(self):
+    def resolve_pending_relations(self) -> int:
+        """
+        frontmatter `relations:` 키의 `target_id == "UNRESOLVED"` 항목을
+        현재 entity 인덱스로 재매칭하여 채워준다.
 
-        resolved = 0
+        Why frontmatter only:
+          create_entity_file 이 권위로 사용하는 위치는 frontmatter
+          `relations:` 키이다. body 의 `## 관계` 섹션은 사람-읽기용
+          미러(예: `- 관련: FAA (conf=0.90)`)일 뿐 entity_id 를 노출하지
+          않으므로 매칭과 무관 — 그대로 둔다.
+
+        Why call this:
+          create_entity_file 시점에 target entity 가 아직 ingest 되지
+          않았으면 UNRESOLVED 로 남는다 (다른 PDF 가 늦게 들어오거나,
+          같은 PDF 의 다른 entity 가 뒤에서 만들어지는 케이스). 본
+          메서드를 entity_map refresh 직후 호출하면 그 시점까지 알려진
+          모든 entity 와 매칭이 완성된다.
+
+        Returns:
+            갱신된 relation 항목의 누적 개수.
+        """
+        files_changed = 0
+        relations_fixed = 0
 
         for t in self.entity_types:
             d = self.entity_path / t
@@ -480,60 +500,62 @@ class WikiGenerator:
                 continue
 
             for f in d.glob("*.md"):
-
                 content = f.read_text(encoding="utf-8")
-
-                if "UNRESOLVED" not in content:
+                if not content.startswith("---"):
+                    continue
+                end = content.find("---", 3)
+                if end < 0:
                     continue
 
-                end = content.find("---", 3)
-                fm = yaml.safe_load(content[3:end])
-                body = content[end+4:]
-
                 try:
-                    parts = body.split("## 관계")
-                    if len(parts) < 2:
-                        continue
-
-                    rel_yaml = parts[1]
-                    relations = yaml.safe_load(rel_yaml)
-
-                    changed = False
-
-                    for r in relations:
-                        if r.get("target_id") == "UNRESOLVED":
-
-                            found = self._find_existing_entity_id(
-                                r["target"],
-                                r["target_type"]
-                            )
-
-                            if not found:
-                                found = self._find_existing_entity_id(r["target"], None)
-
-                            if found:
-                                r["target_id"] = found
-                                changed = True
-
-                    if changed:
-                        new_body = "## 관계\n" + yaml.dump(relations, allow_unicode=True)
-
-                        new_content = (
-                            "---\n"
-                            + yaml.dump(fm, allow_unicode=True)
-                            + "---\n\n"
-                            + parts[0]
-                            + new_body
-                        )
-
-                        f.write_text(new_content, encoding="utf-8")
-                        resolved += 1
-
+                    fm = yaml.safe_load(content[3:end]) or {}
                 except Exception as e:
-                    print("[RESOLVE ERROR]", e)
+                    print(f"[RESOLVE] YAML parse fail {f.name}: {e}")
+                    continue
 
-        print(f"[RESOLVE] {resolved} fixed")
-        return resolved
+                body_tail = content[end + 3:]
+                relations = fm.get("relations")
+                if not isinstance(relations, list) or not relations:
+                    continue
+
+                file_changed = False
+                for r in relations:
+                    if not isinstance(r, dict):
+                        continue
+                    if r.get("target_id") != "UNRESOLVED":
+                        continue
+                    target = (r.get("target") or "").strip()
+                    if not target:
+                        continue
+                    ttype = r.get("target_type")
+                    # 정확 target_type 매칭 → 전체 타입 fallback
+                    found = (
+                        self._find_existing_entity_id(target, ttype)
+                        or self._find_existing_entity_id(target, None)
+                    )
+                    if found:
+                        r["target_id"] = found
+                        file_changed = True
+                        relations_fixed += 1
+
+                if file_changed:
+                    new_content = (
+                        "---\n"
+                        + yaml.dump(
+                            fm,
+                            allow_unicode    = True,
+                            default_flow_style = False,
+                            sort_keys        = True,
+                        )
+                        + "---"
+                        + body_tail
+                    )
+                    f.write_text(new_content, encoding="utf-8")
+                    files_changed += 1
+
+        print(f"[RESOLVE] {files_changed} files updated, "
+              f"{relations_fixed} relations resolved")
+        return relations_fixed
 
     # =========================
     # STATS
@@ -652,6 +674,14 @@ class WikiGenerator:
             self.refresh_entity_map()
         except Exception:
             self._build_entity_id_index()
+
+        # 이 ingest 로 새 entity 가 들어왔다 → 이전 ingest 가 UNRESOLVED 로
+        # 남겨둔 relation 들이 매칭될 수 있다. entity_map refresh 직후 2-pass
+        # 재매칭을 돌려 그래프 edge 가 새로 늘어나는 효과를 즉시 반영한다.
+        try:
+            self.resolve_pending_relations()
+        except Exception as e:
+            print(f"[ENTITY-EXTRACT] resolve_pending_relations fail (무시): {e}")
 
         print(f"[ENTITY-EXTRACT] {filename} -> {len(created_ids)} entities created "
               f"(extracted {len(name_to_id)} + 1 document)")

--- a/tests/test_wiki_resolve_unresolved.py
+++ b/tests/test_wiki_resolve_unresolved.py
@@ -1,0 +1,351 @@
+"""resolve_pending_relations contract — frontmatter UNRESOLVED 재매칭 (2026-05-13).
+
+Diagnostic context (user session): joby.md 등 PDF 추출 노드들의 frontmatter
+relations 가 `target_id: UNRESOLVED` 로 남아있어 그래프 엔진이 두 노드
+사이 edge 를 못 그림. wiki/entity/prod/org/faa.md 같은 target entity 가
+이미 존재하지만 create_entity_file 호출 시점에는 아직 ingest 되지
+않았던 케이스.
+
+Fix in `core/wiki_generator.WikiGenerator`:
+  - resolve_pending_relations 가 이전엔 body 의 `## 관계` 섹션만 yaml.load
+    하려 했고 (실제 body 는 사람-읽기용 글머리표라 load 실패), frontmatter
+    relations 키는 건드리지 않아 실질 동작 안 함.
+  - 재작성 후 frontmatter `relations:` 의 UNRESOLVED target_id 를
+    _find_existing_entity_id (alias 매칭 포함) 로 재매칭하여 채움.
+  - process_document_for_entities 가 refresh_entity_map 직후 자동 호출
+    하므로 매 ingest 마다 누적 UNRESOLVED 가 함께 해소됨.
+
+Run:
+  python -m unittest tests.test_wiki_resolve_unresolved
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ── 1. Functional contract (round-trip with synthetic wiki) ─────────
+
+def _write_entity(path: Path, fm: dict, body: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = (
+        "---\n"
+        + yaml.dump(fm, allow_unicode=True, default_flow_style=False, sort_keys=True)
+        + "---\n"
+        + body
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+class ResolvePendingRelationsTests(unittest.TestCase):
+    """frontmatter relations 의 UNRESOLVED 가 다음 sweep 에서 채워지는지."""
+
+    def setUp(self):
+        from core.wiki_generator import WikiGenerator
+        self.WG = WikiGenerator
+
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.entity_path = self.tmpdir / "entity"
+
+        # 4 표준 type 디렉토리
+        self.entity_types = ["person", "concept", "org", "document"]
+        for t in self.entity_types:
+            (self.entity_path / t).mkdir(parents=True)
+
+    def _stub(self):
+        """WikiGenerator 인스턴스 무거우므로 필요한 attr/method 만 가진 stub."""
+        stub = SimpleNamespace(
+            entity_types = self.entity_types,
+            entity_path  = self.entity_path,
+        )
+        # _find_existing_entity_id 와 _normalize_name 도 같은 정의를 흉내
+        from core.wiki_generator import WikiGenerator
+        stub._find_existing_entity_id = WikiGenerator._find_existing_entity_id.__get__(stub)
+        stub._normalize_name          = WikiGenerator._normalize_name.__get__(stub)
+        stub._read_frontmatter        = WikiGenerator._read_frontmatter.__get__(stub)
+        return stub
+
+    def test_resolves_when_target_entity_exists(self):
+        # 시나리오: joby.md 는 FAA 를 RELATED_TO 로 가리키지만 UNRESOLVED.
+        # faa.md (org) 가 wiki 에 이미 존재 → resolve 가 채워줘야.
+        _write_entity(
+            self.entity_path / "org" / "faa.md",
+            fm={
+                "name":        "FAA",
+                "normalized_name": "faa",
+                "entity_id":   "e_org_aaa11111",
+                "entity_type": "org",
+                "aliases":     [],
+                "relations":   [],
+            },
+        )
+        _write_entity(
+            self.entity_path / "org" / "joby.md",
+            fm={
+                "name":        "Joby",
+                "normalized_name": "joby",
+                "entity_id":   "e_org_bbb22222",
+                "entity_type": "org",
+                "aliases":     [],
+                "relations": [
+                    {
+                        "target":      "FAA",
+                        "target_id":   "UNRESOLVED",
+                        "target_type": "org",
+                        "label":       "관련",
+                        "confidence":  0.9,
+                    }
+                ],
+            },
+        )
+
+        stub = self._stub()
+        fixed = self.WG.resolve_pending_relations(stub)
+
+        self.assertEqual(fixed, 1,
+            "exactly one UNRESOLVED relation should be filled")
+
+        joby_after = yaml.safe_load(
+            (self.entity_path / "org" / "joby.md").read_text(encoding="utf-8")
+            .split("---", 2)[1]
+        )
+        self.assertEqual(joby_after["relations"][0]["target_id"],
+                         "e_org_aaa11111",
+            "joby's relation should now resolve to FAA's entity_id")
+
+    def test_falls_back_to_other_types_when_target_type_wrong(self):
+        # joby.md 가 eVTOL 을 target_type=concept 으로 가리킴.
+        # 만약 eVTOL 이 실제로는 다른 type 에 있다면 None fallback 으로 매칭.
+        _write_entity(
+            self.entity_path / "concept" / "evtol.md",
+            fm={
+                "name":            "eVTOL",
+                "normalized_name": "evtol",
+                "entity_id":       "e_concept_ccc33333",
+                "entity_type":     "concept",
+                "aliases":         [],
+                "relations":       [],
+            },
+        )
+        _write_entity(
+            self.entity_path / "org" / "joby.md",
+            fm={
+                "name":            "Joby",
+                "normalized_name": "joby",
+                "entity_id":       "e_org_bbb22222",
+                "entity_type":     "org",
+                "aliases":         [],
+                "relations": [
+                    {
+                        "target":      "eVTOL",
+                        "target_id":   "UNRESOLVED",
+                        "target_type": "org",   # 의도적으로 잘못된 타입
+                        "label":       "생산",
+                        "confidence":  0.9,
+                    }
+                ],
+            },
+        )
+
+        stub = self._stub()
+        fixed = self.WG.resolve_pending_relations(stub)
+        # 정확 타입(org) 매칭 실패 → None fallback 으로 concept 에서 발견
+        self.assertEqual(fixed, 1)
+
+        joby_after = yaml.safe_load(
+            (self.entity_path / "org" / "joby.md").read_text(encoding="utf-8")
+            .split("---", 2)[1]
+        )
+        self.assertEqual(joby_after["relations"][0]["target_id"],
+                         "e_concept_ccc33333")
+
+    def test_alias_match(self):
+        # entity 이름이 alias 로만 매칭되는 케이스 — _find_existing_entity_id
+        # 가 alias 도 본다는 사실에 의존.
+        _write_entity(
+            self.entity_path / "org" / "nvidia.md",
+            fm={
+                "name":            "NVIDIA",
+                "normalized_name": "nvidia",
+                "entity_id":       "e_org_ddd44444",
+                "entity_type":     "org",
+                "aliases":         ["엔비디아"],
+                "relations":       [],
+            },
+        )
+        _write_entity(
+            self.entity_path / "concept" / "topic.md",
+            fm={
+                "name":            "topic",
+                "normalized_name": "topic",
+                "entity_id":       "e_concept_eee55555",
+                "entity_type":     "concept",
+                "aliases":         [],
+                "relations": [
+                    {
+                        "target":      "엔비디아",     # alias
+                        "target_id":   "UNRESOLVED",
+                        "target_type": "org",
+                        "label":       "관련",
+                        "confidence":  0.7,
+                    }
+                ],
+            },
+        )
+
+        stub = self._stub()
+        fixed = self.WG.resolve_pending_relations(stub)
+        self.assertEqual(fixed, 1)
+
+        topic_after = yaml.safe_load(
+            (self.entity_path / "concept" / "topic.md").read_text(encoding="utf-8")
+            .split("---", 2)[1]
+        )
+        self.assertEqual(topic_after["relations"][0]["target_id"],
+                         "e_org_ddd44444",
+            "alias-only match should still fill target_id")
+
+    def test_no_target_keeps_unresolved(self):
+        # 매칭되는 target 이 wiki 에 없으면 UNRESOLVED 유지.
+        _write_entity(
+            self.entity_path / "org" / "joby.md",
+            fm={
+                "name":            "Joby",
+                "normalized_name": "joby",
+                "entity_id":       "e_org_bbb22222",
+                "entity_type":     "org",
+                "aliases":         [],
+                "relations": [
+                    {
+                        "target":      "Nonexistent",
+                        "target_id":   "UNRESOLVED",
+                        "target_type": "concept",
+                        "label":       "관련",
+                        "confidence":  0.7,
+                    }
+                ],
+            },
+        )
+
+        stub = self._stub()
+        fixed = self.WG.resolve_pending_relations(stub)
+        self.assertEqual(fixed, 0)
+
+        joby_after = yaml.safe_load(
+            (self.entity_path / "org" / "joby.md").read_text(encoding="utf-8")
+            .split("---", 2)[1]
+        )
+        self.assertEqual(joby_after["relations"][0]["target_id"], "UNRESOLVED")
+
+    def test_preserves_other_frontmatter_and_body(self):
+        # frontmatter 의 다른 키 + body 보존 검증.
+        _write_entity(
+            self.entity_path / "org" / "faa.md",
+            fm={
+                "name":            "FAA",
+                "normalized_name": "faa",
+                "entity_id":       "e_org_aaa11111",
+                "entity_type":     "org",
+                "aliases":         [],
+                "relations":       [],
+            },
+        )
+        _write_entity(
+            self.entity_path / "org" / "joby.md",
+            fm={
+                "name":            "Joby",
+                "normalized_name": "joby",
+                "entity_id":       "e_org_bbb22222",
+                "entity_type":     "org",
+                "aliases":         ["JOBY", "조비"],
+                "attributes":      {"summary": "eVTOL maker", "country": "US"},
+                "confidence":      1.0,
+                "sensitivity":     "internal",
+                "relations": [
+                    {
+                        "target":      "FAA",
+                        "target_id":   "UNRESOLVED",
+                        "target_type": "org",
+                        "label":       "관련",
+                        "confidence":  0.9,
+                    }
+                ],
+            },
+            body=(
+                "## 요약\n"
+                "전기 항공 회사\n\n"
+                "## 관계\n"
+                "- 관련: FAA (conf=0.90)\n"
+            ),
+        )
+
+        stub = self._stub()
+        self.WG.resolve_pending_relations(stub)
+
+        text = (self.entity_path / "org" / "joby.md").read_text(encoding="utf-8")
+        end = text.find("---", 3)
+        fm_after = yaml.safe_load(text[3:end])
+
+        self.assertEqual(fm_after["aliases"], ["JOBY", "조비"])
+        self.assertEqual(fm_after["attributes"]["country"], "US")
+        self.assertEqual(fm_after["sensitivity"], "internal")
+        # body 보존
+        self.assertIn("## 요약\n전기 항공 회사", text)
+        self.assertIn("- 관련: FAA (conf=0.90)", text)
+
+    def test_skips_files_without_unresolved(self):
+        # 모두 매칭 완료된 파일은 다시 쓰지 않는다 (mtime 변경 없음 검증
+        # 까지는 안 가도, fixed=0 + 파일 내용 동일).
+        _write_entity(
+            self.entity_path / "org" / "anthropic.md",
+            fm={
+                "name":            "Anthropic",
+                "normalized_name": "anthropic",
+                "entity_id":       "e_org_fff66666",
+                "entity_type":     "org",
+                "aliases":         [],
+                "relations": [
+                    {"target": "Claude", "target_id": "e_concept_xxx",
+                     "target_type": "concept", "label": "생산", "confidence": 0.9}
+                ],
+            },
+        )
+
+        path = self.entity_path / "org" / "anthropic.md"
+        before = path.read_text(encoding="utf-8")
+
+        stub = self._stub()
+        fixed = self.WG.resolve_pending_relations(stub)
+
+        self.assertEqual(fixed, 0)
+        self.assertEqual(path.read_text(encoding="utf-8"), before,
+            "files with no UNRESOLVED should not be rewritten")
+
+
+# ── 2. Static contract — process_document_for_entities 자동 호출 ────
+
+class AutoResolveOnIngestTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from core.wiki_generator import WikiGenerator
+        cls.src = inspect.getsource(WikiGenerator.process_document_for_entities)
+
+    def test_process_doc_invokes_resolve_pending_relations(self):
+        self.assertIn("resolve_pending_relations", self.src,
+            "process_document_for_entities must call resolve_pending_relations "
+            "after refresh_entity_map so every ingest cycle settles previously "
+            "UNRESOLVED relations against the newly-added entities")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continuation of #252 (user-session diagnostic). PDF 추출 노드들의
frontmatter `relations` 에 `target_id: UNRESOLVED` 가 광범위 — 예를
들어 `wiki/entity/prod/org/joby.md` 의 FAA / eVTOL relation 은 target
entity (`faa.md`, `evtol.md`) 가 실제 wiki 에 존재함에도 UNRESOLVED
로 남아 추론 그래프가 두 노드 사이 edge 를 못 그림.

**Root cause** — 기존 `resolve_pending_relations()` 는:
- (a) body 의 `## 관계` 섹션만 `yaml.load` 시도, body 가 사람-읽기용
  글머리표(`- 관련: FAA (conf=0.90)`)라 load 자체가 실패
- (b) frontmatter `relations:` 키는 아예 안 봄
- (c) 호출되는 곳이 `test/build_test_wiki.py` 1곳뿐 → 운영 경로에서
  실질 동작 X

**Fix**:
- `resolve_pending_relations` 를 frontmatter-aware 로 재작성. 각 entity
  파일의 frontmatter `relations:` 항목 중 `target_id == "UNRESOLVED"`
  를 `_find_existing_entity_id` (alias 매칭 포함) 로 재매칭. 정확
  target_type 매칭 → None fallback 으로 다른 타입에서도 찾음.
- `process_document_for_entities` 의 `refresh_entity_map` 직후 자동
  호출 → 매 ingest 마다 누적 UNRESOLVED 들이 새로 추가된 entity 와
  함께 해소됨. 운영 자동화.
- body 의 `## 관계` 섹션은 사람-읽기용 미러라 entity_id 노출 없음 —
  그대로 둠.

## Verification

- New `tests/test_wiki_resolve_unresolved.py` — **7 tests**:
  1. target entity 존재 시 정확 타입 매칭으로 UNRESOLVED 해소
  2. 잘못된 target_type 도 None fallback 으로 매칭
  3. alias-only 매칭 (NVIDIA ← 엔비디아)
  4. target 없으면 UNRESOLVED 유지
  5. 다른 frontmatter 키 + body 보존
  6. UNRESOLVED 없는 파일은 다시 쓰지 않음 (idempotent)
  7. `process_document_for_entities` 자동 호출 contract
- **Full suite: 1697 tests OK** (1690 + 7 new)
- `core/wiki_generator.py` 만 수정 — `core/retrieval` / `core/graph` /
  `core/reasoning` 미접촉 → CLAUDE.md rule #2 bench 게이트 무관
- 변화 방향이 graph edge **추가** only (제거 X) 이므로 STEP 7
  regression 가능성 낮음

## Out of scope (후속 PR)

- **기존 잘못된 concept 노드 청소** — `learn_method=web_search` +
  `relations=[]` + 질문문 패턴(예: `엔비디아와_조비와_관계.md`,
  `엔비디아_대해_묻고_있데_.md`) 인 노드 제거/재추출 스크립트 (정공법 3단)
- **그래프 시각화 즉시 재빌드** — 본 PR 머지 후 다음 ingest 시
  자동 해소되지만, 운영자가 지금 wiki 의 모든 누적 UNRESOLVED 를 한
  번에 정리하고 싶다면 `/admin/wiki/resolve-relations` endpoint 추가
  (별도 PR 가치)