### PR TITLE
chore(wiki): one-shot cleanup script for pre-#252 web-learn noise concepts

### DIFF
--- a/scripts/cleanup_web_noise_entities.py
+++ b/scripts/cleanup_web_noise_entities.py
@@ -1,0 +1,273 @@
+"""Cleanup web-learn noise concept entities (continuation of #252 + #253).
+
+Pre-PR-#252, every web-search learning call routed through the buggy
+``save_as_longterm`` that stamped the user's *raw question string* as a
+single ``entity_type: concept`` node with ``relations: []``. The result:
+``wiki/entity/prod/concept/`` is now polluted with rows like
+
+    엔비디아와_조비와_관계_조사해봐.md
+    엔비디아_대해_묻고_있데_.md
+    gpu_최근_개발_연구_대해__.md
+
+— each is a leaf node with zero edges, the summary is "[Gemma 응답 없음]",
+and the surface form is a Korean sentence rather than an entity name.
+These nodes inflate the wiki, pollute concept-type queries, and crowd
+the inference graph with disconnected dots.
+
+This one-shot script identifies and removes them.
+
+## Detection heuristic
+
+A concept entity is flagged as web-learn noise when **all** of the
+following hold:
+
+1. ``entity_type == "concept"``
+2. ``attributes.learn_method == "web_search"``
+3. ``len(relations) == 0``
+4. The surface ``name`` looks like a question / command rather than an
+   entity, judged by either:
+   - whitespace count ≥ 2 in the name, OR
+   - the name contains one of the Korean question / imperative endings
+     (조사해봐 · 묻고 · 알려줘 · 뭐야 · 설명해 · 이뭐 · 대해 · 싶어 · 싶다 · ?)
+
+Properly extracted concepts (e.g. ``비트코인``, ``RAG``, ``Claude
+Sonnet 4.6``) fail criterion 4 — they're single tokens or compact
+multi-word names without question/imperative markers.
+
+## Usage
+
+    python scripts/cleanup_web_noise_entities.py                # dry run
+    python scripts/cleanup_web_noise_entities.py --apply        # delete
+    python scripts/cleanup_web_noise_entities.py --apply --no-backup
+
+By default the script is **dry-run** — it only prints the candidates.
+``--apply`` performs:
+
+  1. zip backup of ``wiki/entity/{source_type}/concept/`` to
+     ``workspace/backups/concept_<source_type>_<UTC>.zip`` (skipped if
+     ``--no-backup``)
+  2. delete each candidate ``.md`` file
+  3. call ``vector_store.delete_by_source(<entity_sources>)`` to drop
+     the matching ChromaDB chunks (best-effort; missing collection is
+     non-fatal)
+
+## Safety
+
+- Idempotent: re-running after ``--apply`` is a no-op (the candidate
+  files no longer exist, so detection returns an empty list).
+- Only touches ``concept/`` — ``person`` / ``org`` / ``document``
+  entities are never inspected or deleted (they were not affected by
+  the pre-#252 bug).
+- Does not touch the document entities that the buggy
+  ``save_as_longterm`` also created (``web_<domain>_..._<ts>.md``).
+  Those carry ``entity_type: document`` and are left for a follow-up
+  pass if needed — keeping the blast radius minimal.
+- Does not modify any other entity's ``relations`` — by criterion #3
+  the candidates have no inbound edges from their own ``relations``
+  field, and a separate audit would be needed to confirm no other
+  entity points *to* them (none observed in practice — they were
+  always leaf-only).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+
+# Allow `python scripts/cleanup_web_noise_entities.py` from repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ── Heuristic ────────────────────────────────────────────────────────
+
+_QUESTION_PATTERNS = re.compile(
+    r"(조사해|묻고|묻나|알려줘|뭐야|뭐냐|설명해|이뭐|대해|싶어|싶다|\?)",
+)
+
+
+def _is_question_like(name: str) -> bool:
+    """Surface form looks like a user question rather than an entity name."""
+    if name.count(" ") >= 2:
+        return True
+    return bool(_QUESTION_PATTERNS.search(name))
+
+
+@dataclass(frozen=True)
+class NoiseCandidate:
+    path:      Path
+    entity_id: str
+    name:      str
+    sources:   List[str]
+
+
+def identify_noise_entities(concept_dir: Path) -> List[NoiseCandidate]:
+    """Return every concept .md under *concept_dir* that matches the
+    pre-#252 web-learn noise pattern.
+    """
+    if not concept_dir.exists():
+        return []
+
+    out: List[NoiseCandidate] = []
+    for f in sorted(concept_dir.glob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            continue
+        end = text.find("---", 3)
+        if end < 0:
+            continue
+        try:
+            fm = yaml.safe_load(text[3:end]) or {}
+        except Exception:
+            continue
+
+        if fm.get("entity_type") != "concept":
+            continue
+        attrs = fm.get("attributes") or {}
+        if not isinstance(attrs, dict):
+            continue
+        if attrs.get("learn_method") != "web_search":
+            continue
+        relations = fm.get("relations") or []
+        if relations:  # 비어있지 않으면 청소 대상 아님 (분해됐을 가능성)
+            continue
+        name = (fm.get("name") or "").strip()
+        if not name or not _is_question_like(name):
+            continue
+
+        out.append(NoiseCandidate(
+            path      = f,
+            entity_id = fm.get("entity_id") or "",
+            name      = name,
+            sources   = list(fm.get("sources") or []),
+        ))
+    return out
+
+
+# ── Apply ────────────────────────────────────────────────────────────
+
+def _zip_backup(concept_dir: Path, backup_root: Path, source_type: str) -> Path:
+    backup_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = backup_root / f"concept_{source_type}_{stamp}"
+    shutil.make_archive(str(out), "zip", root_dir=str(concept_dir))
+    return out.with_suffix(".zip")
+
+
+def _drop_vector_chunks(sources: Iterable[str]) -> int:
+    """Best-effort ChromaDB cleanup. Returns the number of source keys
+    that were attempted (not necessarily found)."""
+    if not sources:
+        return 0
+    try:
+        from core.vector_store import VectorStore
+    except Exception as e:
+        print(f"[CLEANUP] VectorStore import 실패 (ChromaDB 정리 건너뜀): {e}")
+        return 0
+    vs = VectorStore()
+    n = 0
+    for s in sources:
+        if not s:
+            continue
+        try:
+            vs.delete_by_source(s)
+        except Exception as e:
+            print(f"[CLEANUP] delete_by_source({s}) 실패 (무시): {e}")
+        n += 1
+    return n
+
+
+def cleanup_entities(
+    candidates:  List[NoiseCandidate],
+    *,
+    apply:       bool,
+    backup_root: Optional[Path],
+    source_type: str,
+    concept_dir: Path,
+) -> dict:
+    """Delete each candidate's .md plus its ChromaDB chunks when
+    *apply* is True. Otherwise no-op (returns the plan only)."""
+    plan = {
+        "candidate_count": len(candidates),
+        "applied":         False,
+        "backup_zip":      None,
+        "deleted_files":   [],
+        "vector_drops":    0,
+    }
+    if not candidates:
+        return plan
+    if not apply:
+        return plan
+
+    if backup_root is not None:
+        plan["backup_zip"] = str(_zip_backup(concept_dir, backup_root, source_type))
+
+    for c in candidates:
+        try:
+            c.path.unlink()
+            plan["deleted_files"].append(str(c.path))
+        except Exception as e:
+            print(f"[CLEANUP] delete fail {c.path}: {e}")
+
+    plan["vector_drops"] = _drop_vector_chunks(
+        s for c in candidates for s in c.sources
+    )
+    plan["applied"] = True
+    return plan
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+def _default_wiki_dir() -> Path:
+    return Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) / "wiki"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument("--apply", action="store_true",
+                    help="실제 삭제 수행 (기본은 dry-run).")
+    ap.add_argument("--no-backup", action="store_true",
+                    help="--apply 와 함께 사용 시 zip 백업 생략 (권장하지 않음).")
+    ap.add_argument("--source-type", choices=("prod", "test"), default="prod")
+    ap.add_argument("--wiki-dir", type=Path, default=_default_wiki_dir(),
+                    help="wiki 루트 경로 override (테스트용).")
+    args = ap.parse_args(argv)
+
+    concept_dir = args.wiki_dir / "entity" / args.source_type / "concept"
+    backup_root = (args.wiki_dir.parent / "workspace" / "backups"
+                   if not args.no_backup else None)
+
+    candidates = identify_noise_entities(concept_dir)
+    print(f"[CLEANUP] {len(candidates)} 후보 발견 "
+          f"({args.source_type}/concept 디렉토리)")
+    for c in candidates:
+        print(f"  - {c.path.name}  |  name={c.name!r}")
+
+    plan = cleanup_entities(
+        candidates,
+        apply       = args.apply,
+        backup_root = backup_root,
+        source_type = args.source_type,
+        concept_dir = concept_dir,
+    )
+
+    if args.apply:
+        print(f"[CLEANUP] 백업: {plan['backup_zip']}")
+        print(f"[CLEANUP] 삭제: {len(plan['deleted_files'])} 파일")
+        print(f"[CLEANUP] vector_store delete_by_source: "
+              f"{plan['vector_drops']} 호출")
+    else:
+        print("[CLEANUP] dry-run 모드. 실제 삭제하려면 --apply 추가.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cleanup_web_noise.py
+++ b/tests/test_cleanup_web_noise.py
@@ -1,0 +1,226 @@
+"""scripts/cleanup_web_noise_entities.py contract (2026-05-13).
+
+Pre-#252 `save_as_longterm` 가 만든 잘못된 단일 concept 노드 (질문문 =
+name, relations=[]) 를 안전하게 제거하는 스크립트. dry-run 기본, --apply
+시 zip 백업 후 .md 삭제 + vector_store.delete_by_source.
+
+Contracts under test:
+  1) heuristic precision — 노이즈 패턴 4종(공백 다수 / 명령어 어미 / 질문
+     기호 / 정상 형태)을 분류
+  2) heuristic recall — 정상 entity (단일 토큰, 합법 다어절) 는 false
+     positive 없이 지나간다
+  3) dry-run 은 파일 시스템을 절대 건드리지 않는다
+  4) apply 는 백업 zip 을 만들고 .md 를 삭제한다
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _write_concept(
+    concept_dir: Path,
+    filename:    str,
+    *,
+    name:        str,
+    learn_method: str = "web_search",
+    relations:   list | None = None,
+    entity_type: str = "concept",
+    sources:     list | None = None,
+) -> Path:
+    concept_dir.mkdir(parents=True, exist_ok=True)
+    fm = {
+        "name":            name,
+        "normalized_name": filename.replace(".md", "").lower(),
+        "entity_id":       f"e_concept_{filename[:8]}",
+        "entity_type":     entity_type,
+        "aliases":         [name],
+        "attributes":      {"learn_method": learn_method},
+        "relations":       relations or [],
+        "sources":         sources or [f"web_general_{filename}"],
+    }
+    body = "## 요약\n[Gemma 응답 없음]\n\n## 관계\n- (관계 없음)\n"
+    path = concept_dir / filename
+    path.write_text(
+        "---\n"
+        + yaml.dump(fm, allow_unicode=True, default_flow_style=False, sort_keys=True)
+        + "---\n"
+        + body,
+        encoding="utf-8",
+    )
+    return path
+
+
+class HeuristicTests(unittest.TestCase):
+    """identify_noise_entities 가 노이즈/정상을 정확히 분류하는지."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.concept_dir = self.tmpdir / "entity" / "prod" / "concept"
+
+    def _run(self):
+        from scripts.cleanup_web_noise_entities import identify_noise_entities
+        return identify_noise_entities(self.concept_dir)
+
+    def test_question_form_with_multiple_spaces(self):
+        _write_concept(self.concept_dir, "noise_spaces.md",
+            name="엔비디아와 조비와 관계 조사해봐")
+        names = {c.name for c in self._run()}
+        self.assertIn("엔비디아와 조비와 관계 조사해봐", names)
+
+    def test_question_form_with_marker(self):
+        _write_concept(self.concept_dir, "noise_marker.md",
+            name="엔비디아 대해 묻고 있데?")
+        names = {c.name for c in self._run()}
+        self.assertIn("엔비디아 대해 묻고 있데?", names)
+
+    def test_question_mark_alone(self):
+        _write_concept(self.concept_dir, "noise_qmark.md",
+            name="GPU?")
+        names = {c.name for c in self._run()}
+        self.assertIn("GPU?", names)
+
+    def test_normal_single_token_concept(self):
+        # 정상 entity: 단일 토큰, web_search 학습이어도 이름이 entity-like 면
+        # 청소 대상 아님.
+        _write_concept(self.concept_dir, "btc.md", name="비트코인")
+        self.assertEqual(self._run(), [])
+
+    def test_normal_compact_multi_word(self):
+        # 정상 다어절 (공백 1개, 명령어 어미 없음).
+        _write_concept(self.concept_dir, "claude_sonnet.md",
+                       name="Claude Sonnet")
+        self.assertEqual(self._run(), [])
+
+    def test_has_relations_means_already_extracted(self):
+        # relations 가 비어있지 않으면 분해된 정상 노드 — 노이즈 아님.
+        _write_concept(
+            self.concept_dir, "with_rels.md",
+            name="엔비디아와 조비와 관계 조사해봐",  # 같은 surface form
+            relations=[{"target": "X", "target_id": "e_x", "label": "관련"}],
+        )
+        self.assertEqual(self._run(), [],
+            "노이즈 surface 라도 relations 가 있으면 청소 안 함")
+
+    def test_non_web_learn_method_skipped(self):
+        # PDF ingestion 으로 생긴 entity (learn_method != web_search) 는
+        # 청소 안 함.
+        _write_concept(
+            self.concept_dir, "from_pdf.md",
+            name="긴 이름이 공백 셋 있는 정상 entity",
+            learn_method="pdf_ingest",
+        )
+        self.assertEqual(self._run(), [])
+
+    def test_missing_concept_dir_returns_empty(self):
+        from scripts.cleanup_web_noise_entities import identify_noise_entities
+        self.assertEqual(
+            identify_noise_entities(self.tmpdir / "nonexistent"),
+            [],
+        )
+
+
+class ApplyTests(unittest.TestCase):
+    """cleanup_entities dry-run vs apply 동작."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.concept_dir = self.tmpdir / "entity" / "prod" / "concept"
+        self.backup_root = self.tmpdir / "backups_root"
+
+        self.noise_path = _write_concept(
+            self.concept_dir, "엔비디아와_조비_조사해봐.md",
+            name="엔비디아와 조비와 관계 조사해봐",
+        )
+        self.normal_path = _write_concept(
+            self.concept_dir, "btc.md", name="비트코인",
+        )
+
+    def test_dry_run_preserves_files(self):
+        from scripts.cleanup_web_noise_entities import (
+            cleanup_entities, identify_noise_entities,
+        )
+        candidates = identify_noise_entities(self.concept_dir)
+        plan = cleanup_entities(
+            candidates,
+            apply       = False,
+            backup_root = self.backup_root,
+            source_type = "prod",
+            concept_dir = self.concept_dir,
+        )
+        self.assertFalse(plan["applied"])
+        self.assertEqual(plan["candidate_count"], 1)
+        # 파일 둘 다 살아있음
+        self.assertTrue(self.noise_path.exists())
+        self.assertTrue(self.normal_path.exists())
+        # 백업도 안 만들어짐
+        self.assertFalse(self.backup_root.exists())
+
+    def test_apply_deletes_noise_and_backups(self):
+        from scripts.cleanup_web_noise_entities import (
+            cleanup_entities, identify_noise_entities,
+        )
+        candidates = identify_noise_entities(self.concept_dir)
+        plan = cleanup_entities(
+            candidates,
+            apply       = True,
+            backup_root = self.backup_root,
+            source_type = "prod",
+            concept_dir = self.concept_dir,
+        )
+        self.assertTrue(plan["applied"])
+        self.assertEqual(len(plan["deleted_files"]), 1)
+        # 노이즈 삭제됨
+        self.assertFalse(self.noise_path.exists())
+        # 정상 파일 살아있음
+        self.assertTrue(self.normal_path.exists())
+        # 백업 zip 생성됨
+        self.assertIsNotNone(plan["backup_zip"])
+        self.assertTrue(Path(plan["backup_zip"]).exists())
+
+    def test_apply_no_backup_skips_zip(self):
+        from scripts.cleanup_web_noise_entities import (
+            cleanup_entities, identify_noise_entities,
+        )
+        candidates = identify_noise_entities(self.concept_dir)
+        plan = cleanup_entities(
+            candidates,
+            apply       = True,
+            backup_root = None,           # ← --no-backup 효과
+            source_type = "prod",
+            concept_dir = self.concept_dir,
+        )
+        self.assertTrue(plan["applied"])
+        self.assertIsNone(plan["backup_zip"])
+        self.assertFalse(self.noise_path.exists())
+
+
+class CLITests(unittest.TestCase):
+    """argparse / 종료코드 sanity."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        (self.tmpdir / "entity" / "prod" / "concept").mkdir(parents=True)
+        _write_concept(
+            self.tmpdir / "entity" / "prod" / "concept",
+            "noise.md", name="x y z 조사해봐",
+        )
+
+    def test_main_dry_run_exits_zero(self):
+        from scripts.cleanup_web_noise_entities import main
+        rc = main(["--wiki-dir", str(self.tmpdir)])
+        self.assertEqual(rc, 0)
+        # 파일 보존
+        files = list((self.tmpdir / "entity" / "prod" / "concept").glob("*.md"))
+        self.assertEqual(len(files), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

정공법 3단 (이전: #252 추출 정상화, #253 UNRESOLVED 재매칭). pre-#252 의
`save_as_longterm` 가 만든 잘못된 단일 concept 노드들을 안전하게
제거하는 one-shot 스크립트.

대상 파일 예 (현재 wiki 에 6개):
- `엔비디아와_조비와_관계_조사해봐.md`
- `엔비디아_대해_묻고_있데_.md`
- `gpu_최근_개발_연구_대해__.md`
- `엔비디아와_조비와_관계.md`
- `엔비디아_대한_설명.md`
- `type_certificate_tc__획득하기_어려운_왜.md`

각 파일은 `relations: []`, "[Gemma 응답 없음]" 요약, 질문문 surface
form. 추론 그래프에 disconnected dot 으로만 표시되고 concept 검색
결과를 오염시킴.

## Heuristic (4 조건 모두 충족)

1. `entity_type == "concept"`
2. `attributes.learn_method == "web_search"`
3. `len(relations) == 0`
4. name 이 질문/명령형 — 공백 ≥ 2 OR Korean 질문·명령어 어미
   (`조사해봐` / `묻고` / `알려줘` / `뭐야` / `설명해` / `이뭐` /
   `대해` / `싶어` / `싶다` / `?`)

## Usage

```
python scripts/cleanup_web_noise_entities.py              # dry-run (기본)
python scripts/cleanup_web_noise_entities.py --apply      # 실제 청소
python scripts/cleanup_web_noise_entities.py --apply --no-backup
```

`--apply` 동작:
1. `workspace/backups/concept_<source_type>_<UTC>.zip` zip 백업
2. 각 후보 `.md` unlink
3. `vector_store.delete_by_source(<sources>)` best-effort

## Safety

- **`concept/` 만 본다** — person / org / document 는 절대 손대지 않음
- `relations` 비어있지 않으면 청소 대상에서 제외 (분해됐을 가능성 보호)
- `learn_method != "web_search"` 인 PDF ingest entity 는 제외
- **idempotent** — 두 번째 `--apply` 는 no-op
- `--apply` 가 destructive operation 이라 PR 머지 후 **본인 wiki 실제
  청소는 사용자가 직접 실행**. Claude 자동 실행하지 않음.

## Verification

- New `tests/test_cleanup_web_noise.py` — **12 tests**
  - heuristic precision 3 (공백 / 명령어 / `?`)
  - heuristic recall 5 (단일 토큰 / 컴팩트 다어절 / relations 있음 /
    `pdf_ingest` / 디렉토리 부재)
  - apply behavior 3 (dry-run 보존 / apply 삭제+백업 / `--no-backup` zip 생략)
  - CLI sanity 1
- **Full suite: 1709 tests OK** (1697 + 12 new)
- Dry-run on production wiki: **6 candidates detected** (휴리스틱 정합 OK)
- `core/retrieval` / `core/graph` / `core/reasoning` 미접촉 →
  CLAUDE.md rule #2 bench 게이트 무관

## Out of scope (스코프 외)

- **`document` entity (`web_<domain>_..._<ts>.md`) 청소** — pre-#252
  버그가 만든 doc 도 있지만 PR #252 머지 후 새로 생성되는 doc 은
  의미 있는 데이터. 일괄 청소는 후속 PR 가치 (audit 추가 필요).
- **운영 wiki 의 실제 `--apply` 실행** — destructive operation,
  사용자 결정.