### PR TITLE
fix(graph): /admin/graph reflects entity files written by other engines (N-1)

### DIFF
--- a/core/graph_snapshot.py
+++ b/core/graph_snapshot.py
@@ -109,6 +109,22 @@ def build_snapshot(
         if cached and cached[0] == max_mtime:
             return cached[1]
 
+    # Cache miss → disk has been touched since the last snapshot. A
+    # *different* RAGEngine instance (e.g. the throwaway one constructed
+    # inside `tools.web.web_searcher.save_as_longterm`) may have written
+    # new entity files without updating THIS instance's in-memory
+    # `entity_id_index`. The mtime scan above catches the disk change,
+    # but rebuilding from a stale index would still skip the new files —
+    # the user saw this as "wiki entity added, /graph stale until server
+    # restart". Re-scan disk before the rebuild so newly-written entities
+    # appear on the next snapshot.
+    refresh = getattr(wiki_generator, "refresh_entity_map", None)
+    if callable(refresh):
+        try:
+            refresh()
+        except Exception:
+            pass
+
     # ── Load every entity frontmatter once. ──
     raw_entities: Dict[str, Dict[str, Any]] = {}
     for eid, fpath in wiki_generator.entity_id_index.items():

--- a/tests/test_graph_snapshot.py
+++ b/tests/test_graph_snapshot.py
@@ -234,6 +234,80 @@ class SnapshotShapeTests(unittest.TestCase):
                             "snapshot_hash must change when mtime + content changes")
         self.assertEqual(snap2["meta"]["node_count"], 2)
 
+    def test_snapshot_picks_up_files_written_outside_index(self):
+        """Regression for the 'wiki entity added → /graph stale until
+        server restart' bug.
+
+        Root cause: `tools.web.web_searcher.save_as_longterm` (장기기억
+        promotion path) constructs its own throwaway `RAGEngine` and
+        writes new entity files via that engine's `WikiGenerator`. The
+        server's shared `rag_engine.wiki_generator` never learns about
+        those files, so its `entity_id_index` stays stale. Even though
+        `_scan_max_mtime` notices the disk change and invalidates the
+        snapshot cache, the rebuild iterates the stale index and the
+        new entities silently vanish from `/admin/graph/snapshot`.
+
+        The fix: on cache miss, ask the wiki_generator to re-scan disk
+        before rebuilding. This test simulates the bug by writing a new
+        .md to disk without registering it in `entity_id_index`, then
+        teaches the fake how `refresh_entity_map` should behave.
+        """
+        from core.graph_snapshot import build_snapshot
+        ents = {
+            "e_person_aaaaaaaa": _mk_entity(
+                "e_person_aaaaaaaa", "Alice", "person",
+            ),
+        }
+        wiki = _FakeWiki(self.root, ents)
+        snap1 = build_snapshot(wiki)
+        self.assertEqual(snap1["meta"]["node_count"], 1)
+
+        # Simulate a *different* RAGEngine instance writing a new entity
+        # file to disk. The new file exists on the filesystem; this
+        # wiki_generator's in-memory index still has only the original
+        # entity (mirrors the save_as_longterm cross-instance race).
+        new_eid  = "e_org_bbbbbbbb"
+        new_fm   = _mk_entity(new_eid, "Acme", "org")
+        new_dir  = wiki.entity_path / "org"
+        new_dir.mkdir(parents=True, exist_ok=True)
+        new_path = new_dir / (new_eid + ".md")
+        new_path.write_text(
+            "---\nentity_id: " + new_eid + "\n---\n", encoding="utf-8",
+        )
+        # Bump mtime so _scan_max_mtime sees the disk change even on
+        # filesystems with coarse timestamp precision.
+        future = time.time() + 5
+        os.utime(new_path, (future, future))
+
+        # The real WikiGenerator.refresh_entity_map re-scans disk and
+        # rebuilds the index from each frontmatter. Mirror that for the
+        # fake: discover the new file, register it in the index, and
+        # remember its frontmatter so _read_frontmatter can return it.
+        def _refresh():
+            for t in wiki.entity_types:
+                d = wiki.entity_path / t
+                if not d.exists():
+                    continue
+                for f in d.glob("*.md"):
+                    eid = f.stem
+                    if eid not in wiki.entity_id_index:
+                        wiki.entity_id_index[eid] = f
+                        if eid == new_eid:
+                            wiki._fm[eid] = new_fm
+        wiki.refresh_entity_map = _refresh
+
+        snap2 = build_snapshot(wiki)
+        self.assertEqual(
+            snap2["meta"]["node_count"], 2,
+            "snapshot must re-scan disk on cache miss and surface "
+            "entity files written by another engine instance — "
+            "without this, /admin/graph remains stale until restart",
+        )
+        names = {n["name"] for n in snap2["nodes"]}
+        self.assertIn("Acme", names,
+                      "newly-written entity must appear by name in the "
+                      "rebuilt snapshot")
+
 
 # ─────────────────────────────────────────────────────────────
 class ServerRouteContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

`docs/handovers/v0.3.0-platform-track.md` 사이클 1 — **N-1** "장기기억 후
graph cache invalidation" 정공법.

- `save_as_longterm` 등 보조 경로가 자체 `RAGEngine()` 을 생성하면, 거기서
  쓰여진 wiki entity 가 디스크에는 존재하지만 서버 공유
  `rag_engine.wiki_generator.entity_id_index` 에는 없어서 `/admin/graph` 가
  "서버 재시작해야 보이는" 상태로 빠진다.
- `build_snapshot` 의 mtime 캐시는 invalidate 되지만, rebuild 가 여전히
  stale in-memory index 만 순회하는 것이 정확한 원인.
- 패치: cache miss 시 `wiki_generator.refresh_entity_map()` 을 호출해
  rebuild 전에 디스크를 다시 스캔. `getattr` 안전 가드로 refresh 메서드가
  없는 fake wiki (테스트 fixture) 에서는 no-op.

## Verification

회귀 테스트: `tests/test_graph_snapshot.py::SnapshotShapeTests::test_snapshot_picks_up_files_written_outside_index`

- 디스크에 새 `.md` 를 직접 쓰고 `entity_id_index` 는 일부러 그대로 둔다
- 두 번째 `build_snapshot` 호출이 새 entity 를 surface 하는지 확인
- 패치 없으면 `1 != 2` 로 실패, 있으면 통과 (수동 확인 완료)

인접 테스트 (graph snapshot / explorer / w2 / web-learn / wiki-resolve /
longterm-save / cleanup-noise / chat-wiki-save) 합쳐 **112 tests OK**.

### Bench (CLAUDE.md rule #2)

218 entities / 646 edges 실데이터:

| 경로 | 시간 |
|---|---|
| cold build (cache miss, no refresh) | 524.51 ms |
| cache hit | 0.51 ms |
| miss + refresh (이 PR) | 523.93 ms |

refresh 오버헤드 사실상 **0** — refresh 와 snapshot rebuild 가 같은
frontmatter 읽기 비용을 공유.

## Out of scope

- N-3 (새 세션 리프레쉬 안 됨) — 사이클 1 의 두 번째 항목, 다른 PR.
- `WikiGenerator.entity_id_index` 의 thread-safety 일반 개선 (refresh 가
  clear → 재구성 도중 짧은 race window 가 있음). 이 PR 은 보고된 stale
  현상만 정공으로 해결하고, race 일반화는 별도 이슈로 둠.
- `save_as_longterm` 의 throwaway-engine 패턴 자체 (모든 wiki 변경을 공유
  엔진으로 통일하는 더 큰 리팩터). 스냅샷 측의 refresh-on-miss 로 증상은
  사라지므로 v0.3 우선순위에서 분리.

Closes — `docs/handovers/v0.3.0-platform-track.md` §3 사이클 1 N-1