### PR TITLE
fix(reasoning): new-session greeting + cross-session leak (N-3)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -133,6 +133,12 @@ class ReasoningEngine:
         # ── Memory context + 대화 히스토리 주입 ─────────────
         memory_context = ""
         system_prompt  = ""
+        # [N-3 2026-05-13] hist_ctx 는 *현재* 세션의 prior turn 만 담는다.
+        # 새 세션에서는 빈 문자열 — long_ctx (다른 세션 요약) 나 prefs 가
+        # 있더라도 그것만으로 "대화 연속" 으로 취급해서는 안 된다.
+        # 모드 핸들러가 continuity directive 발동 여부를 정확히 판단할
+        # 수 있도록 try 바깥에서 미리 초기화.
+        hist_ctx = ""
         try:
             from core.memory import MemoryStore
             store         = MemoryStore()
@@ -288,7 +294,7 @@ class ReasoningEngine:
 
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":
-            return handle_chat(self, safe_query, system_prompt, memory_context, user_role, t_start, response_style=response_style, selected_model=picked_model)
+            return handle_chat(self, safe_query, system_prompt, memory_context, user_role, t_start, response_style=response_style, selected_model=picked_model, hist_ctx=hist_ctx)
         if mode == "meta":
             return handle_meta(self, safe_query, system_prompt, user_role, t_start)
         if mode == "wiki_edit":

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -54,6 +54,7 @@ def handle_chat(
     t_start: float,
     response_style: str = "",
     selected_model: str = "",   # [#A2 phase 2] catalog-validated user pick
+    hist_ctx: str = "",         # [N-3 2026-05-13] current-session prior turns only
 ) -> Dict[str, Any]:
     from core.response_style import resolve_style
     style = resolve_style(response_style)
@@ -68,16 +69,23 @@ def handle_chat(
     try:
         # system_prompt + memory_context + flow guide 주입
         sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-        # [Axis 6 user feedback, 2026-05-12] When prior turns exist
-        # in memory_context, prepend a continuity directive so the
-        # model (a) skips greeting / self-introduction preambles
-        # and (b) resolves anaphora ("이것", "위와 관련", "그것")
-        # against the most recent turn instead of starting fresh.
-        # Empty memory_context ⇒ no directive ⇒ first-turn replies
-        # keep their introductory tone.
-        if memory_context:
+        # [N-3 2026-05-13] Gate the continuity directive on
+        # ``hist_ctx`` — the *current* session's prior turns — not on
+        # the union ``memory_context`` which also blends long-term
+        # session summaries and stored preferences. Previously a brand-
+        # new session with prior-session summaries would still fire
+        # the directive: greetings were suppressed and the LLM resolved
+        # "위/이것/그것" against other sessions' content, surfacing
+        # as "새 세션인데 일상 인사가 안 됨 + 이전 세션 답변이 새 세션
+        # 에서 나오는 현상" (handover §3 사이클 1 N-3).
+        # ``memory_context`` is still passed into the prompt below —
+        # long-term summaries remain useful background — but only an
+        # actual current-session continuation activates the rule.
+        if hist_ctx:
             continuity_rule = CONTINUITY_DIRECTIVE_KO if is_ko else CONTINUITY_DIRECTIVE_EN
             mem_prefix = f"{continuity_rule}\n\n{memory_context}\n\n"
+        elif memory_context:
+            mem_prefix = f"{memory_context}\n\n"
         else:
             mem_prefix = ""
         raw_answer = engine.llm.call_gemma(

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -150,19 +150,154 @@ class ContinuityDirectiveTests(unittest.TestCase):
             r"this|that|above|anaphora",
             "EN directive must name English anaphora patterns")
 
-    def test_handle_chat_injects_directive_only_when_memory_present(self):
-        # Source-level assertion: the directive prepend lives inside
-        # an ``if memory_context:`` branch so a first-turn request
-        # (empty memory) is unchanged.
+    def test_handle_chat_gates_directive_on_current_session_history(self):
+        # [N-3 2026-05-13] The directive used to gate on
+        # ``memory_context`` (long_ctx ∪ hist_ctx ∪ prefs) — but a
+        # brand-new session with prior-session summaries in long_ctx
+        # would still fire the rule and (a) suppress the greeting and
+        # (b) push the LLM to resolve "위/이것/그것" against other
+        # sessions' content. The gate now lives on ``hist_ctx`` — the
+        # *current* session's prior turns — so only an actual
+        # continuation activates the rule. New session → no directive
+        # → "안녕하세요" greeting returns + no cross-session leakage.
         chat_idx = self.src.index("def handle_chat(")
         body = self.src[chat_idx:chat_idx + 4000]
-        self.assertIn("if memory_context:", body,
-            "handle_chat must gate the directive on memory_context "
-            "presence so first-turn replies keep their introductory tone")
+        self.assertIn("if hist_ctx:", body,
+            "handle_chat must gate the directive on hist_ctx — the "
+            "current session's prior turns — not on memory_context, "
+            "which blends in cross-session summaries and prefs")
         self.assertIn("CONTINUITY_DIRECTIVE_KO", body,
             "handle_chat must consume the KO directive constant")
         self.assertIn("CONTINUITY_DIRECTIVE_EN", body,
             "handle_chat must consume the EN directive constant")
+
+    def test_handle_chat_accepts_hist_ctx_kwarg(self):
+        # The new signature must accept hist_ctx as a keyword arg with
+        # an empty-string default, so callers that haven't been
+        # updated yet (and stateless test queries) continue to behave
+        # like first-turn cold starts.
+        sig = inspect.signature(self.modes.handle_chat)
+        self.assertIn("hist_ctx", sig.parameters,
+            "handle_chat must accept hist_ctx so the engine can pass "
+            "the current-session history separately from memory_context")
+        self.assertEqual(
+            sig.parameters["hist_ctx"].default, "",
+            "hist_ctx must default to '' — cold-start callers and "
+            "stateless STEP 7 queries should not trigger the directive")
+
+    def test_directive_not_injected_when_only_longterm_memory_exists(self):
+        """[N-3 regression] On a brand-new session, ``hist_ctx`` is
+        empty but ``memory_context`` can still carry long-term session
+        summaries or stored prefs. Before this fix the directive
+        fired anyway, suppressing 'safety net' greetings and pushing
+        the LLM to resolve anaphora against other sessions' content.
+        This test captures the prompt that handle_chat actually
+        constructs and asserts the directive is absent in that case.
+        """
+        from types import SimpleNamespace
+        from core.reasoning import modes as _modes
+
+        captured = {}
+        def _fake_gemma(prompt, **_kw):
+            captured["prompt"] = prompt
+            return "안녕하세요. 자메스입니다. 무엇을 도와드릴까요?"
+
+        fake_engine = SimpleNamespace(
+            llm = SimpleNamespace(call_gemma=_fake_gemma),
+            _log = lambda *a, **kw: None,
+            _LLM_ERROR_PREFIXES = ("[Gemma",),
+            _elapsed = lambda *a, **kw: None,
+        )
+
+        # New session: long-term summary in memory_context but no
+        # current-session turns. Greeting should be allowed; the
+        # continuity directive must NOT appear in the prompt.
+        long_only_memory = "[장기 기억] 사용자는 이전 세션에서 RAG 에 대해 질문했음."
+        _modes.handle_chat(
+            engine         = fake_engine,
+            safe_query     = "안녕",
+            system_prompt  = "",
+            memory_context = long_only_memory,
+            user_role      = "external",
+            t_start        = 0.0,
+            hist_ctx       = "",  # ← new session — no current history
+        )
+        self.assertIn("prompt", captured, "handle_chat must call the LLM")
+        prompt = captured["prompt"]
+        self.assertNotIn(
+            _modes.CONTINUITY_DIRECTIVE_KO, prompt,
+            "Continuity directive must NOT fire when the only memory "
+            "is cross-session — new session greetings would otherwise "
+            "be suppressed (N-3)",
+        )
+        self.assertNotIn(
+            _modes.CONTINUITY_DIRECTIVE_EN, prompt,
+            "Continuity directive (EN) must also stay out in this case",
+        )
+        # The memory_context itself can still be included as
+        # background, but without the "this is a continuation" framing.
+        self.assertIn(long_only_memory, prompt,
+            "Long-term memory may still appear in the prompt as "
+            "background — it just must not be framed as a continuation")
+
+    def test_directive_injected_when_current_session_history_exists(self):
+        """[N-3 regression] When the user *is* mid-conversation —
+        hist_ctx non-empty — the directive must still fire so the
+        PR #249 anaphora-resolution / greeting-suppression behaviour
+        survives. This is the path the original PR #249 was designed
+        for and must keep working."""
+        from types import SimpleNamespace
+        from core.reasoning import modes as _modes
+
+        captured = {}
+        def _fake_gemma(prompt, **_kw):
+            captured["prompt"] = prompt
+            return "(continuation reply)"
+
+        fake_engine = SimpleNamespace(
+            llm = SimpleNamespace(call_gemma=_fake_gemma),
+            _log = lambda *a, **kw: None,
+            _LLM_ERROR_PREFIXES = ("[Gemma",),
+            _elapsed = lambda *a, **kw: None,
+        )
+
+        live_history = "[이전 대화] user: RAG 알려줘\nassistant: RAG 는 ..."
+        _modes.handle_chat(
+            engine         = fake_engine,
+            safe_query     = "위 내용 더 자세히",
+            system_prompt  = "",
+            memory_context = live_history,
+            user_role      = "external",
+            t_start        = 0.0,
+            hist_ctx       = live_history,
+        )
+        prompt = captured.get("prompt", "")
+        self.assertIn(
+            _modes.CONTINUITY_DIRECTIVE_KO, prompt,
+            "Continuity directive must fire when current-session "
+            "history exists — that is the original PR #249 path",
+        )
+
+    def test_engine_threads_hist_ctx_to_handle_chat(self):
+        # The engine builds hist_ctx separately from memory_context
+        # and must forward it to handle_chat by name so the gate
+        # above can see "current session has prior turns" exactly.
+        from core.reasoning import engine as _engine
+        src = inspect.getsource(_engine)
+        self.assertIn("hist_ctx=hist_ctx", src,
+            "engine.query must forward hist_ctx to handle_chat by "
+            "keyword so the new-session greeting path is restored")
+        # hist_ctx must be initialised before the memory try/except
+        # — otherwise a memory store error leaves it undefined when
+        # the dispatch tries to forward it.
+        hist_init_idx = src.find('hist_ctx = ""')
+        try_idx       = src.find("from core.memory import MemoryStore")
+        self.assertGreater(hist_init_idx, 0,
+            "engine must initialise hist_ctx = '' before the memory "
+            "try block so a memory error still yields a cold-start "
+            "greeting instead of a NameError")
+        self.assertLess(hist_init_idx, try_idx,
+            "hist_ctx init must precede the memory try block")
 
     def test_directive_uses_korean_or_english_per_query(self):
         # The is_ko flag is computed at the top of handle_chat for


### PR DESCRIPTION
## Summary

`docs/handovers/v0.3.0-platform-track.md` 사이클 1 — **N-3** "새 세션
리프레쉬 안 됨" 정공법.

증상 (사용자 보고):
- 새 세션에서 "안녕" 같은 인사를 보내도 자메스가 인사 없이 시작
- 이전 세션 답변 내용이 새 세션에서 surfacing

### Root cause

PR #249 의 continuity directive 가 `if memory_context:` 로 게이트되어
있었는데, `memory_context` 는 다음 셋의 union 이다:

| 출처 | 내용 |
|---|---|
| `long_ctx` | 다른 세션 요약 (최근 2개) |
| `hist_ctx` | **현재** 세션의 prior turn (limit=5) |
| `pref_context` | 유저 preferences |

새 세션이라도 `long_ctx` 나 `pref_context` 가 있으면 directive 발동 →
(a) "안녕하세요/자메스입니다" 인사 LLM 측에서 강제 생략 + (b) LLM 이
"위/이것/그것" 을 다른 세션 요약에서 해석 → 사용자가 본 적 없는 이전
세션 답변이 새 세션에 등장.

### 정공법

continuity directive 게이트를 `hist_ctx` (현재 세션 prior turn 만) 로
좁힌다. `memory_context` 자체는 여전히 prompt 에 배경 정보로 들어가지만,
"이전 대화가 이어지고 있다" framing 은 hist_ctx 가 비면 씌우지 않는다.

**변경**
- `core/reasoning/modes.py:handle_chat` — `hist_ctx` kw arg 추가, 게이트
  `if memory_context:` → `if hist_ctx:` (+ `elif memory_context:` 으로
  memory 만 있을 때는 background 만 주입, framing 제거)
- `core/reasoning/engine.py` — `hist_ctx = \"\"` 를 try 바깥에 미리 초기화
  하고 chat 모드 dispatch 에 keyword 로 전달. 메모리 store 에러시에도
  cold-start 동작 보장.

## Verification

### Tests (총 14, 신규 4)

| 테스트 | 검증 |
|---|---|
| `test_handle_chat_gates_directive_on_current_session_history` | 소스 — `if hist_ctx:` 게이트 |
| `test_handle_chat_accepts_hist_ctx_kwarg` | signature — `hist_ctx=\"\"` 기본값 |
| `test_engine_threads_hist_ctx_to_handle_chat` | engine 에서 forward + try 바깥 init |
| `test_directive_not_injected_when_only_longterm_memory_exists` | **행동** — fake LLM 으로 prompt 캡처, long_ctx-only 시 directive 부재 검증 |
| `test_directive_injected_when_current_session_history_exists` | **행동** — hist_ctx 있을 때 directive 부재 검증 (PR #249 path 보존) |

마지막 두 개는 source-level 검증만으로는 잡지 못하는 행동 회귀를 차단.

### CLAUDE.md rule #2 — STEP 7 bench

STEP 7 (13 queries: 12 retrieve + 1 meta) — chat 모드 query 가 0개라
`handle_chat` 가 호출되지 않음. 따라서 이 PR 의 변경 surface 와 bench
surface 가 disjoint (PR #249 도 같은 근거).

| Run | 결과 |
|---|---|
| 1차 | `q1 graph_paths=0 outside band [15, 15]±2` — flake (retrieve 모드, handle_chat 미경유) |
| 2차 | **OK — within step7 baseline tolerances** (250.6s) |

## Out of scope

- N-3 이 우회한 표면적 증상 (UI 측 새 세션 인식) 는 chat.js `getSessionId()`
  + `clearHistory()` 만으로 충분. PR 은 모델 입력 prompt 게이트만 수정.
- `handle_meta` / `handle_coding` 등 다른 mode 의 continuity directive — N-3
  보고가 chat 모드 한정이라 같은 fix 를 다른 핸들러로 확산하는 것은
  별도 PR (modes.py 의 `CONTINUITY_DIRECTIVE_*` 상수는 이미 module-level
  로 재사용 가능).
- N-1 (graph cache invalidation) — PR #256 으로 별도 머지됨.

Closes — `docs/handovers/v0.3.0-platform-track.md` §3 사이클 1 N-3