### PR TITLE
feat(admin): POST /admin/wiki/resolve-relations — UNRESOLVED grand sweep

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3213,6 +3213,42 @@ async def admin_entity_detail(
     }
 
 
+@app.post("/admin/wiki/resolve-relations",
+          summary="Wiki UNRESOLVED relation grand sweep [v0.3 사이클 6]")
+async def admin_wiki_resolve_relations(
+    api_key:     str,
+    source_type: str = "prod",
+    role:        str = Depends(get_role_from_request),
+):
+    """Run WikiGenerator.resolve_pending_relations() across the wiki to
+    fill in any leftover ``target_id: UNRESOLVED`` rows in frontmatter
+    relations. PR #253 wires the resolver into every ingest path; this
+    endpoint exposes the same primitive as a manual grand sweep for
+    operators after migrations, bulk imports, or hand edits to wiki
+    files that introduce new entities the existing relations could now
+    point at. Returns the count of resolved relations (0 if everything
+    was already linked).
+    """
+    _require_feature(api_key, role, "admin.data")
+
+    src = (source_type or "prod").strip().lower()
+    if src not in ("prod", "test"):
+        src = "prod"
+
+    if src == rag_engine.wiki_generator.source_type:
+        gen = rag_engine.wiki_generator
+    else:
+        from core.wiki_generator import WikiGenerator
+        gen = WikiGenerator(source_type=src)
+
+    relations_fixed = gen.resolve_pending_relations()
+
+    return {
+        "resolved":    relations_fixed,
+        "source_type": src,
+    }
+
+
 @app.get("/admin/graph/snapshot", summary="Reasoning graph snapshot — nodes + edges [v0.2 Axis 3]")
 async def admin_graph_snapshot(
     api_key:           str,

--- a/tests/test_admin_wiki_resolve_relations.py
+++ b/tests/test_admin_wiki_resolve_relations.py
@@ -1,0 +1,100 @@
+"""POST /admin/wiki/resolve-relations — manual UNRESOLVED grand sweep.
+
+Context: PR #253 wired `WikiGenerator.resolve_pending_relations()` into
+every ingest so each new document's relations get filled in against the
+post-ingest entity index. This endpoint exposes the same primitive as
+an on-demand admin action — used after migrations, bulk imports, or
+hand edits to wiki files that introduce new entities that existing
+UNRESOLVED relations could now point at.
+
+The functional contract of `resolve_pending_relations()` itself is
+covered by `tests/test_wiki_resolve_unresolved.py`. This file pins
+only the endpoint wiring: route signature, admin gate, source_type
+guard, and the response shape callers can rely on.
+
+Run:
+  python -m unittest tests.test_admin_wiki_resolve_relations
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class EndpointWiringTests(unittest.TestCase):
+    """Route is registered as POST, admin-gated, calls the resolver,
+    returns the documented shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv)
+
+    def _window(self) -> str:
+        idx = self.src.index('@app.post("/admin/wiki/resolve-relations"')
+        # The next decorator (admin_graph_snapshot) bounds the handler.
+        end = self.src.index("@app.", idx + 1)
+        return self.src[idx:end]
+
+    def test_route_is_registered_as_post(self):
+        # POST because the endpoint mutates wiki files (writes back
+        # resolved target_id to frontmatter). A GET would be misleading
+        # and would let intermediaries cache or replay the call.
+        self.assertIn('@app.post("/admin/wiki/resolve-relations"', self.src,
+            "endpoint must be registered as POST so admins can trigger "
+            "the grand sweep explicitly and intermediaries don't cache it")
+
+    def test_handler_is_admin_gated(self):
+        win = self._window()
+        self.assertIn('_require_feature(api_key, role, "admin.data")', win,
+            "handler must gate on admin.data — the same feature flag the "
+            "neighbouring /admin/wiki and /admin/graph endpoints use")
+
+    def test_handler_accepts_source_type_query_param(self):
+        win = self._window()
+        self.assertIn("source_type:", win,
+            "handler must accept source_type so operators can sweep the "
+            "test wiki in isolation from prod")
+        # source_type guarded to {prod, test}.
+        self.assertIn('"prod"', win)
+        self.assertIn('"test"', win)
+
+    def test_handler_calls_resolve_pending_relations(self):
+        win = self._window()
+        self.assertIn("resolve_pending_relations()", win,
+            "handler must invoke WikiGenerator.resolve_pending_relations() "
+            "— that is the whole point of the endpoint")
+
+    def test_handler_returns_resolved_count_and_source_type(self):
+        win = self._window()
+        # Caller contract: {"resolved": <int>, "source_type": "prod"|"test"}.
+        # Anything wider would surface internal WikiGenerator state to the
+        # admin UI prematurely.
+        self.assertIn('"resolved"', win,
+            "response must expose the count of relations resolved so the "
+            "admin UI can show 'N relations linked' feedback")
+        self.assertIn('"source_type"', win,
+            "response must echo source_type so the UI can label whether "
+            "prod or test was swept")
+
+    def test_handler_reuses_shared_wiki_generator_when_possible(self):
+        # When source_type matches the live engine's bound source, reuse
+        # `rag_engine.wiki_generator` so the running engine's
+        # entity_id_index reflects the sweep without restart. Only
+        # cross-source sweeps construct a fresh generator.
+        win = self._window()
+        self.assertIn("rag_engine.wiki_generator", win,
+            "handler must reuse the shared engine generator when "
+            "source_type matches so the running engine sees the sweep "
+            "immediately (no restart needed)")
+        self.assertIn("from core.wiki_generator import WikiGenerator", win,
+            "handler must still construct a scoped WikiGenerator for "
+            "cross-source sweeps so test/prod stay isolated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR #253 가 \`WikiGenerator.resolve_pending_relations()\` 를 매 ingest 마다
자동 호출하도록 정공법으로 묶었지만, **이미 누적된 UNRESOLVED 관계는 다음 ingest 가 올 때까지 그대로 남는다.** 본 엔드포인트는 같은 resolver 를 admin 이 on-demand 로 트리거해서 wiki 전체를 한 번에 sweep 하는 운영 도구.

## 사용 시점

- 마이그레이션 직후 (예: \`scripts/migrate_inverse_relations.py\`)
- 대량 import 후 (다른 PDF 들을 동시 학습하면서 cross-reference 가 뒤늦게 알려지는 경우)
- wiki 파일을 손으로 편집해서 새 entity 가 생긴 경우

## 설계 결정

| 항목 | 선택 | 이유 |
|---|---|---|
| HTTP method | **POST** | wiki 파일 mutating. GET 이면 intermediary 가 캐싱 |
| Auth | \`admin.data\` feature gate | 기존 \`/admin/wiki\` \`/admin/graph\` 와 동일 |
| 파라미터 | \`source_type=prod\|test\` | test wiki 격리 sweep 가능 |
| 동시성 | shared generator reuse | source 가 live engine 과 같으면 \`rag_engine.wiki_generator\` 재사용 → 서버 재시작 없이 \`entity_id_index\` 즉시 반영 |
| 응답 | \`{"resolved": <int>, "source_type": "prod"\|"test"}\` | UI 가 "N relations linked" 피드백 표시 가능 |

## Verification

- [x] \`python -m pytest tests/\` → **1720 passed, 0 failed** (6 신규)
- [x] 새 테스트 6건 (POST 메서드 / admin gate / source_type 가드 / resolver 호출 / 응답 shape / shared generator reuse) — 모두 source introspection
- [x] resolver 본체의 기능 contract 는 \`tests/test_wiki_resolve_unresolved.py\` 가 이미 cover
- [x] core/retrieval | graph | reasoning 미접촉 → bench numbers 불필요

## Out of scope

- 프론트엔드 admin UI 버튼 (별도 PR — UI 정책상 사이클 5 챗 UX 묶음과 분리)
- 결과 진단 로깅 (현재 stdout 으로만 출력; \`workspace/jobs/\` 같은 영구 기록은 \`/admin/scheduler/status\` 사이클에서 일관 처리)

docs/handovers/v0.3.0-platform-track.md §3 사이클 6 첫 항목.

🤖 Generated with [Claude Code](https://claude.com/claude-code)