### PR TITLE
docs(handover): mark v0.3 사이클 6 closed + flag stale items

### DIFF
--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -67,11 +67,22 @@
 - N-5 부분 추론에서도 웹검색 옵션 (#N-4 와 묶음 가능)
 - N-6 장기기억 저장 모달 6c glass + mint 적용
 
-### 🟢 사이클 6 — 운영 도구 + v0.2.x 청소
-- `/admin/wiki/resolve-relations` endpoint (정공법 #253 grand sweep)
-- `core/memory/store.py` 21 KB → 분할 (CLAUDE.md rule #5)
-- `/admin/scheduler/status` + `/jobs/unschedule`
-- ruff Phase 2 — F401 / F541 auto-fix
+### 🟢 사이클 6 — 운영 도구 + v0.2.x 청소 (2026-05-13 마감)
+- [x] **PR #260** `core/memory/store.py` 24 KB → 12 KB. 자연 경계 분할
+  (db / conversation / summaries / store-facade). 공개 API 보존. 1714 OK.
+- [x] **PR #261** `POST /admin/wiki/resolve-relations` (정공법 #253 grand sweep
+  수동 트리거). admin.data gate + source_type=prod|test + shared generator
+  reuse. 1720 OK.
+- [x] **이미 구현 완료** (사이클 6 항목으로 잘못 적혀 있던 stale 항목):
+  - `/admin/scheduler/status` GET (`server_llmwiki.py:4128`,
+    `admin.metrics` gate, `is_running` / `last_retention_at` / `upcoming[]` 반환)
+  - `/jobs/unschedule` POST (`server_llmwiki.py:4097`,
+    `workspace.schedule` gate, `core.scheduler.unschedule_job` 위임,
+    감사로그 기록)
+  - 두 endpoint 모두 `tests/test_scheduler.py` 가 단위 + HTTP wiring cover.
+- [x] **이미 완료** ruff Phase 2 (2026-05-11 PR). 헤더 참조: `ruff.toml`
+  §"Current Pyflakes inventory" — F541 / F401 / F841 / F811 / F821 모두 0,
+  ENFORCED. 현재 `ruff check .` → All checks passed!.
 
 ### 🟠 사이클 7 — Plugin API skeleton (Track C, 대규모)
 - C-1~C-2 `core/plugins/base.py` 4 인터페이스 + 디렉토리


### PR DESCRIPTION
## Summary

v0.3 platform-track 핸드오버의 사이클 6 섹션을 현재 상태로 동기화.

**실제 작업** (이번 사이클에서 새로 진행):
- [x] **PR #260** \`core/memory/store.py\` 24 KB → 12 KB 분할 (rule #5 해소)
- [x] **PR #261** \`POST /admin/wiki/resolve-relations\` 신규 endpoint

**Stale 발견** (핸드오버에 미완료처럼 적혀 있었지만 실제론 이미 구현됨):
- \`/admin/scheduler/status\` GET (\`server_llmwiki.py:4128\`)
- \`/jobs/unschedule\` POST (\`server_llmwiki.py:4097\`)
- 두 endpoint 모두 \`tests/test_scheduler.py\` 가 cover (W8-D follow-up PR)
- ruff Phase 2 (F401 / F541) — 2026-05-11 PR 에서 완료. \`ruff check .\` → \`All checks passed!\`. \`ruff.toml\` 헤더에 history 보존

## Why this matters

v0.3 진입 직전(2026-05-13) 신규 작성된 핸드오버 문서가 v0.2.x 마지막 며칠간 머지된 작업을 반영 못한 자연 오차. 다음 세션이 사이클 6 을 새로 열거나 중복 작업을 시작하지 않도록 closed 표시 + stale 항목 출처 명시.

## Verification

- [x] \`/admin/scheduler/status\` 라인 확인: \`grep -n /admin/scheduler/status server_llmwiki.py\` → L4128
- [x] \`/jobs/unschedule\` 라인 확인: L4097
- [x] \`ruff check .\` → \`All checks passed!\`
- [x] 문서 단독 변경 — bench numbers / 코드 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)