### PR TITLE
feat(chat): N-4 suggestion chip header + N-5 mid-band web chip (사이클 5)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1251,18 +1251,22 @@ function appendJamesMsg(data) {
   // [3-B] unified_score는 web chip + confidence badge 모두 참조 — 한 번만 읽기.
   const score = data.unified_score;
 
-  // [#A8-6 + Axis 6, 2026-05-12] Web-search chip — two variants
-  // keyed on confidence.
-  //   score < 0.50  → "자료 수집" framing (internal evidence is
-  //                   thin; the user needs more raw material).
-  //   score ≥ 0.70  → "최신 정보 보완" framing (answer is well-
-  //                   supported by internal sources; the user may
-  //                   still want to check for newer info on the web).
-  //   0.50 ≤ score < 0.70 → no chip (the mid band is the "neither
-  //                   convincing nor desperate" zone where a chip
-  //                   would feel like nagging).
+  // [#A8-6 + Axis 6, 2026-05-12 + N-5, 2026-05-13] Web-search chip —
+  // three variants keyed on confidence.
+  //   score < 0.50           → "자료 수집" framing (internal evidence is
+  //                            thin; the user needs more raw material).
+  //   0.50 ≤ score < 0.70    → "부분 답변 보완" framing (partial-inference
+  //                            zone — user reported the mid-band was the
+  //                            most common case where the chip was missing
+  //                            and the LLM said "검색해 볼까요?" in prose
+  //                            with no clickable button. Cycle 5 N-5 fix:
+  //                            chip now fires in this band with a softer,
+  //                            non-nagging tone).
+  //   score ≥ 0.70           → "최신 정보 보완" framing (answer is well-
+  //                            supported by internal sources; the user may
+  //                            still want to check for newer info on the web).
   // web_used=true skips the chip entirely (already pulled in web).
-  // The action is identical in both variants; copy + color differ.
+  // The action is identical in all variants; copy + color differ.
   let forceWebChip = '';
   if (!data.web_used) {
     const q = lastUserQuestion || '';
@@ -1270,24 +1274,40 @@ function appendJamesMsg(data) {
     const LOW_CONF  = 0.50;
     const isLow  = (score == null || score < LOW_CONF);
     const isHigh = (score != null && score >= HIGH_CONF);
-    if (q.trim() && (isLow || isHigh)) {
-      const variant = isHigh
-        ? {
-            cls:    'force-web-btn web-refresh-btn',
-            bg:     'rgba(107,231,208,.10)',
-            border: 'rgba(107,231,208,.45)',
-            color:  '#6be7d0',
-            icon:   '✨',
-            label:  t('chat.web_chip_high'),
-          }
-        : {
-            cls:    'force-web-btn web-collect-btn',
-            bg:     'rgba(79,195,247,.10)',
-            border: 'rgba(79,195,247,.45)',
-            color:  '#4fc3f7',
-            icon:   '🌐',
-            label:  t('chat.web_chip_low'),
-          };
+    const isMid  = (score != null && score >= LOW_CONF && score < HIGH_CONF);
+    if (q.trim() && (isLow || isMid || isHigh)) {
+      let variant;
+      if (isHigh) {
+        variant = {
+          cls:    'force-web-btn web-refresh-btn',
+          bg:     'rgba(107,231,208,.10)',
+          border: 'rgba(107,231,208,.45)',
+          color:  '#6be7d0',
+          icon:   '✨',
+          label:  t('chat.web_chip_high'),
+        };
+      } else if (isMid) {
+        // [N-5] mid-band: warm amber, distinct from low (cyan) /
+        // high (mint) so the user can read confidence from color
+        // before reading the label.
+        variant = {
+          cls:    'force-web-btn web-supplement-btn',
+          bg:     'rgba(255,183,77,.10)',
+          border: 'rgba(255,183,77,.45)',
+          color:  '#ffb74d',
+          icon:   '🔍',
+          label:  t('chat.web_chip_mid'),
+        };
+      } else {
+        variant = {
+          cls:    'force-web-btn web-collect-btn',
+          bg:     'rgba(79,195,247,.10)',
+          border: 'rgba(79,195,247,.45)',
+          color:  '#4fc3f7',
+          icon:   '🌐',
+          label:  t('chat.web_chip_low'),
+        };
+      }
       forceWebChip = `
         <div style="margin-top:8px">
           <button class="next-action-chip ${variant.cls}"
@@ -1424,16 +1444,28 @@ function appendJamesMsg(data) {
     extractNextActionSuggestions(answer);
   let suggestionsHtml = '';
   if (suggestions.length > 0) {
+    // [N-4, 2026-05-13] Cluster header — "✨ 제안" with mint accent so
+    // the user reads "these are clickable next-step suggestions" at a
+    // glance, not "more inline prose". Pre-N-4 the chips appeared bare
+    // and users reported missing them entirely on long answers.
     suggestionsHtml = `
       <div class="next-actions" style="display:flex;flex-direction:column;gap:6px;
-                                       margin-top:8px">
+                                       margin-top:10px">
+        <div class="next-actions-header"
+             style="display:flex;align-items:center;gap:6px;
+                    font-size:11px;color:var(--accent);font-weight:700;
+                    letter-spacing:.4px;text-transform:uppercase">
+          <span style="font-size:14px">✨</span>
+          <span>${escHtml(t('chat.suggestions_label'))}</span>
+        </div>
         ${suggestions.map((s, i) => `
           <button class="next-action-chip"
                   data-action="ask-suggestion"
                   data-index="${i}"
                   data-suggestion="${encodeURIComponent(s.text)}"
                   style="text-align:left;background:var(--surface-2);
-                         border:1px solid var(--border);border-radius:8px;
+                         border:1px solid var(--accent-soft, rgba(107,231,208,.30));
+                         border-radius:8px;
                          padding:8px 12px;cursor:pointer;color:var(--text);
                          font-size:13px;transition:all .15s;width:100%;
                          font-family:inherit">

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -71,10 +71,15 @@ const TRANSLATIONS = {
     'badge.inference_warn':  'Insufficient internal data — answer based on LLM inference. Use as reference only.',
 
     'toast.web_augmented':   'Answer enhanced via web search',
-    // [Axis 6, 2026-05-12] Web-search chip — dual variant per
-    // confidence score. See chat.js appendJamesMsg.
+    // [Axis 6, 2026-05-12 + N-5, 2026-05-13] Web-search chip —
+    // three-variant copy per confidence score. See chat.js
+    // appendJamesMsg.
     'chat.web_chip_low':     'Search the web for more material',
+    'chat.web_chip_mid':     'Partial answer — supplement from the web?',
     'chat.web_chip_high':    'Check the web for newer information',
+    // [N-4, 2026-05-13] Header above next-action suggestion chips
+    // so the cluster reads as clickable, not as inline prose.
+    'chat.suggestions_label': 'Suggestions',
     'toast.longterm_saved':  'Saved to long-term memory',
     'toast.level_up':        'Knowledge +{delta} [{domain}]',
     'toast.no_internal':     'No internal data — inference-based answer',
@@ -631,10 +636,14 @@ const TRANSLATIONS = {
     'badge.inference_warn':  '내부 자료가 부족해 LLM 추론으로 답변. 참고용으로만 활용하세요.',
 
     'toast.web_augmented':   '웹 검색으로 보완된 답변',
-    // [Axis 6, 2026-05-12] 신뢰도 분기 chip — chat.js 참조.
-    // 아이콘은 chat.js variant.icon 으로 별도 prepend.
+    // [Axis 6, 2026-05-12 + N-5, 2026-05-13] 신뢰도 3분기 chip —
+    // chat.js 참조. 아이콘은 chat.js variant.icon 으로 별도 prepend.
     'chat.web_chip_low':     '웹 검색으로 자료 수집',
+    'chat.web_chip_mid':     '부분 답변 — 웹에서 보완할까요?',
     'chat.web_chip_high':    '최신 정보로 보완 검색해볼까요?',
+    // [N-4, 2026-05-13] 다음-행동 제안 chip 클러스터의 헤더 —
+    // 본문 산문과 시각적으로 분리해서 클릭 가능 신호를 강화.
+    'chat.suggestions_label': '제안',
     'toast.longterm_saved':  '장기 기억으로 저장됨',
     'toast.level_up':        '지식 레벨 +{delta} [{domain}]',
     'toast.no_internal':     '내부 자료 없음 — 추론 기반 답변',

--- a/tests/test_chat_ux_n4_n5.py
+++ b/tests/test_chat_ux_n4_n5.py
@@ -1,0 +1,175 @@
+"""Chat UX 사이클 5 — suggestion chip header (N-4) + mid-band web chip (N-5).
+
+User feedback (Axis 6 follow-up, 2026-05-13):
+
+  > 챗 페이지에서 대화창에 다음 중 어떤걸 원하시나요 등 2~3가지 제안시,
+  > 클릭 선택 버튼 형성이 안되기도 함 (최신 정보로 보완 검색해 볼까요?
+  > 떴을때). 클릭할수 있는 제안시 **제안 ** 별 모양을 좀더 가시적으로 개선
+  >
+  > 부분 추론의 경우에서도 제안에서 웹검색 가능 여부 선택할 수 있게끔
+  > 개선, 제안 사항이 클릭버튼 선택 형태로 안나오는 것같은데 확인후 개선
+
+Root cause:
+  - "최신 정보로 보완 검색해 볼까요?" 는 `chat.web_chip_high` i18n 라벨
+    문자열. 답변 confidence 가 mid-band (0.50 ≤ score < 0.70) 에 들면
+    chip 자체가 안 뜸 (사이클 5 이전 설계 = 미band 에서는 chip 없음).
+    LLM 이 답변 본문에 같은 문구를 prose 로 적어도 클릭 가능한 형태가
+    아니라 사용자는 "버튼이 안 나옴" 으로 인식.
+  - 제안 chip 자체는 떴어도 "→ 텍스트" 만 보여 inline prose 와 시각적
+    구분이 약함. 사용자가 "버튼이 아니다" 라고 인식.
+
+Fixes:
+  - **N-5**: forceWebChip 의 mid-band 변종 추가 (amber #ffb74d, icon 🔍,
+    web-supplement-btn class). low (cyan) / mid (amber) / high (mint)
+    삼분기 시각 구별.
+  - **N-4**: suggestion chip 클러스터 위에 "✨ 제안" 헤더 추가.
+    i18n key `chat.suggestions_label` 신설 (ko=제안 / en=Suggestions).
+    클릭 가능 신호를 명시.
+
+Run:
+  python -m unittest tests.test_chat_ux_n4_n5
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS   = ROOT / "frontend" / "static" / "chat.js"
+I18N = ROOT / "frontend" / "static" / "i18n.js"
+
+
+# ─── N-5 — mid-band web chip variant ───────────────────────────
+class MidBandWebChipTests(unittest.TestCase):
+    """Partial-inference confidence (0.50 ≤ score < 0.70) must now
+    surface a force-web chip. Before N-5 this band rendered nothing."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+
+    def test_isMid_flag_present(self):
+        # The mid-band predicate must be computed alongside isLow/isHigh.
+        self.assertRegex(
+            self.src,
+            r"const\s+isMid\s*=.*score\s*>=\s*LOW_CONF.*score\s*<\s*HIGH_CONF",
+            "isMid predicate must guard the new mid-band branch",
+        )
+
+    def test_mid_band_fires_chip(self):
+        # The gate must include isMid in addition to isLow/isHigh.
+        self.assertIn("isLow || isMid || isHigh", self.src,
+            "force-web chip must fire in the mid band too — was the "
+            "'no chip' zone before N-5 and that's where users reported "
+            "the missing button")
+
+    def test_mid_variant_uses_web_supplement_class(self):
+        # The new variant gets its own CSS hook so admin/theme tweaks
+        # can style it distinctly from low/high.
+        self.assertIn("web-supplement-btn", self.src,
+            "mid-band variant must carry a dedicated class")
+
+    def test_mid_variant_uses_web_chip_mid_i18n(self):
+        # Don't hard-code the label — go through i18n so ko/en both work.
+        self.assertIn("t('chat.web_chip_mid')", self.src,
+            "mid-band variant must pull its label from i18n")
+
+
+class WebChipMidI18nTests(unittest.TestCase):
+    """i18n keys for the new mid-band variant exist in both locales."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = I18N.read_text(encoding="utf-8")
+
+    def test_ko_mid_key_present(self):
+        # Korean strings live around line 633; just assert the key is
+        # there with a non-empty value.
+        m = re.search(r"'chat\.web_chip_mid':\s*'([^']+)'", self.src)
+        self.assertIsNotNone(m, "i18n must define chat.web_chip_mid")
+        # Both locales declare this key — collect all occurrences.
+        all_vals = re.findall(r"'chat\.web_chip_mid':\s*'([^']+)'", self.src)
+        self.assertEqual(len(all_vals), 2,
+            "chat.web_chip_mid must be defined exactly twice (en + ko)")
+        # Verify each non-empty.
+        for v in all_vals:
+            self.assertTrue(v.strip(),
+                "chat.web_chip_mid label must be non-empty in both locales")
+
+
+# ─── N-4 — suggestion chip cluster header ───────────────────────
+class SuggestionClusterHeaderTests(unittest.TestCase):
+    """Suggestion chips now sit under a ✨ 제안 header so the cluster
+    reads as clickable. Bare chips were getting mistaken for inline
+    prose."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+
+    def test_cluster_header_emits_when_suggestions_exist(self):
+        # The next-actions-header DOM node must appear in the chip
+        # rendering branch. Anchor on the rendering site so the test
+        # doesn't drift if the styling changes. 2500 chars covers the
+        # full conditional render block now that the header was added.
+        idx = self.src.index("if (suggestions.length > 0)")
+        block = self.src[idx:idx + 2500]
+        self.assertIn("next-actions-header", block,
+            "the suggestion render block must include a cluster header")
+        self.assertIn("✨", block,
+            "header must surface the ✨ star icon — user feedback "
+            "explicitly asked for 별 모양 visibility")
+        self.assertIn("t('chat.suggestions_label')", block,
+            "header must pull its label from i18n")
+
+    def test_individual_chip_keeps_arrow_indicator(self):
+        # The "→" prefix on each chip is the click affordance; even with
+        # the new header, individual chips must keep their arrow.
+        idx = self.src.index("if (suggestions.length > 0)")
+        block = self.src[idx:idx + 2500]
+        self.assertIn("→", block,
+            "each suggestion chip must keep its '→' click indicator")
+        self.assertIn("data-action=\"ask-suggestion\"", block,
+            "chip event hook must be preserved (event delegation handler "
+            "in chat.js still listens for ask-suggestion)")
+
+
+class SuggestionsLabelI18nTests(unittest.TestCase):
+    """i18n keys for the new cluster header exist in both locales."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = I18N.read_text(encoding="utf-8")
+
+    def test_label_defined_twice(self):
+        vals = re.findall(r"'chat\.suggestions_label':\s*'([^']+)'", self.src)
+        self.assertEqual(len(vals), 2,
+            "chat.suggestions_label must exist exactly twice (en + ko)")
+        for v in vals:
+            self.assertTrue(v.strip())
+
+
+# ─── Regression — existing low/high variants still wired ────────
+class LowHighVariantsStillPresentTests(unittest.TestCase):
+    """N-5 must not regress the original two-variant behaviour."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+
+    def test_low_variant_intact(self):
+        self.assertIn("web-collect-btn", self.src)
+        self.assertIn("t('chat.web_chip_low')", self.src)
+
+    def test_high_variant_intact(self):
+        self.assertIn("web-refresh-btn", self.src)
+        self.assertIn("t('chat.web_chip_high')", self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

사용자 피드백 (Axis 6 follow-up, 2026-05-13) 두 항목 동시 해결:

> 챗 페이지에서 대화창에 다음 중 어떤걸 원하시나요 등 2~3가지 제안시, 클릭 선택 버튼 형성이 안되기도 함 (최신 정보로 보완 검색해 볼까요? 떴을때). 클릭할수 있는 제안시 **제안 ** 별 모양을 좀더 가시적으로 개선
>
> 부분 추론의 경우에서도 제안에서 웹검색 가능 여부 선택할 수 있게끔 개선

## Root cause

- \"최신 정보로 보완 검색해 볼까요?\" 는 \`chat.web_chip_high\` i18n 라벨 자체. 답변 confidence 가 mid-band (0.50 ≤ score < 0.70) 에 들면 chip 자체가 안 떠서 LLM 이 본문에 같은 문구를 산문으로 적어도 클릭 가능한 형태가 아니라 사용자는 \"버튼 안 나옴\" 으로 인식.
- 제안 chip 자체는 떠도 \"→ 텍스트\" 만 보여 inline prose 와 시각적 구분 약함.

## Fixes

### N-5 — mid-band web chip 변종 추가
- isLow / **isMid (NEW)** / isHigh 삼분기. 게이트: \`isLow || isMid || isHigh\`
- mid 변종: amber #ffb74d, icon 🔍, \`web-supplement-btn\` class
- 신뢰도 색상 구분:
  - **low** (\`<0.50\`) — cyan #4fc3f7, 🌐 \"웹 검색으로 자료 수집\"
  - **mid** (\`0.50–0.69\`) — amber #ffb74d, 🔍 \"부분 답변 — 웹에서 보완할까요?\"
  - **high** (\`≥0.70\`) — mint #6be7d0, ✨ \"최신 정보로 보완 검색해볼까요?\"

### N-4 — 제안 chip 클러스터 헤더
- \`<div class=\"next-actions-header\">\` 신설: ✨ + \"제안\" / \"Suggestions\" (i18n)
- mint accent + uppercase letter-spacing 으로 클릭 가능 신호 강화
- 개별 chip: \`→\` 인디케이터 유지, 테두리도 mint soft 로 (\`var(--accent-soft, rgba(107,231,208,.30))\`)

### i18n keys 신설
| key | en | ko |
|---|---|---|
| \`chat.web_chip_mid\` | Partial answer — supplement from the web? | 부분 답변 — 웹에서 보완할까요? |
| \`chat.suggestions_label\` | Suggestions | 제안 |

## Verification

- [x] \`python -m pytest tests/\` → **1730 passed, 0 failed** (10 신규)
- [x] 신규 테스트 (\`tests/test_chat_ux_n4_n5.py\`):
  - mid-band wiring (isMid + 게이트 + class + i18n)
  - 헤더 (next-actions-header + ✨ + i18n)
  - 회귀 (low/high 변종 + → 화살표 + data-action)
- [x] core/retrieval | graph | reasoning 미접촉 → bench numbers 불필요
- [x] frontend 변경만 → 모듈 size gate 무영향

## Out of scope

- **N-6** (장기기억 저장 모달 6c glass + mint) — 별도 PR
- 단일 제안 (\`out.length < 2\`) 케이스의 chip 화 — 보수적으로 보류. 본 PR 은 사용자 보고 케이스 (mid-band 진입 직후 chip 누락) 만 정통.

docs/handovers/v0.3.0-platform-track.md §3 사이클 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)