### PR TITLE
feat(chat): N-6 in-page 장기기억 저장 모달 (6c glass + mint, 사이클 5)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1539,7 +1539,18 @@ async function approveWikiSave(btn) {
   if (!btn || btn.disabled) return;
   const id = btn.dataset.proposalId || '';
   if (!id) return;
-  if (!confirm('이 검색 결과를 wiki entity로 영구 저장합니다.\n저장 후 retrieval에 활용됩니다.\n계속하시겠습니까?')) return;
+  // [N-6, 2026-05-13] Native confirm() replaced with in-page modal so
+  // the prompt inherits the cyber 6c glass + mint look (tokens.css) and
+  // doesn't break the chat surface's typography on Windows / Linux
+  // where the OS dialog font diverges from the page.
+  const ok = await jamesConfirm({
+    title:       '장기 기억으로 저장',
+    message:     '이 검색 결과를 wiki entity로 영구 저장합니다.\n'
+               + '저장 후 retrieval에 활용됩니다.',
+    confirmText: '저장',
+    cancelText:  '취소',
+  });
+  if (!ok) return;
   btn.disabled = true;
   btn.style.opacity = '0.55';
   const labelEl = btn.querySelector('span:last-child');
@@ -2150,6 +2161,81 @@ function toast(msg, type = 'success') {
   t.textContent = msg;
   document.body.appendChild(t);
   setTimeout(() => t.remove(), 3000);
+}
+
+/* ── [N-6, 2026-05-13] In-page confirmation modal ──
+   Replaces native browser confirm() for long-term-save flows so the
+   prompt picks up the cyber 6c glass + mint treatment from
+   tokens.css (.modal-overlay backdrop-blur + .modal mint inset glow).
+
+   Usage:
+     const ok = await jamesConfirm({
+       title:       '위키에 저장',
+       message:     '이 검색 결과를 wiki entity로 영구 저장합니다.\n'
+                   + '저장 후 retrieval에 활용됩니다.',
+       confirmText: '저장',
+       cancelText:  '취소',
+       danger:      false,         // true → confirm button uses --danger
+     });
+     if (!ok) return;
+
+   Returns Promise<boolean> (true=confirm; false=cancel/Escape/backdrop).
+   The DOM is built lazily on first call and reused thereafter.
+   a11y-modal.js auto-traps focus + Escape-closes via the
+   .modal-btn.cancel click. */
+let _jamesConfirmEl = null;
+function _ensureJamesConfirmEl() {
+  if (_jamesConfirmEl) return _jamesConfirmEl;
+  const overlay = document.createElement('div');
+  overlay.id        = 'james-confirm-modal';
+  overlay.className = 'modal-overlay hidden';
+  overlay.setAttribute('role',            'dialog');
+  overlay.setAttribute('aria-modal',      'true');
+  overlay.setAttribute('aria-labelledby', 'james-confirm-title');
+  overlay.innerHTML = `
+    <div class="modal">
+      <div class="modal-title" id="james-confirm-title">▸ <span data-jc="title"></span></div>
+      <div data-jc="message"
+           style="font-size:13px;color:var(--text);
+                  white-space:pre-line;line-height:1.55;
+                  margin-bottom:18px"></div>
+      <div class="modal-actions">
+        <button class="modal-btn cancel"  data-jc="cancel"></button>
+        <button class="modal-btn primary" data-jc="confirm"></button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+  _jamesConfirmEl = overlay;
+  return overlay;
+}
+function jamesConfirm(opts) {
+  const o          = opts || {};
+  const overlay    = _ensureJamesConfirmEl();
+  const titleEl    = overlay.querySelector('[data-jc="title"]');
+  const msgEl      = overlay.querySelector('[data-jc="message"]');
+  const cancelBtn  = overlay.querySelector('[data-jc="cancel"]');
+  const confirmBtn = overlay.querySelector('[data-jc="confirm"]');
+  titleEl.textContent    = o.title       || '확인';
+  msgEl.textContent      = o.message     || '';
+  cancelBtn.textContent  = o.cancelText  || '취소';
+  confirmBtn.textContent = o.confirmText || '확인';
+  // Destructive confirms get the danger color on the primary button so
+  // the operator's eye registers the asymmetry before reading the label.
+  confirmBtn.style.background = o.danger ? 'var(--danger)' : '';
+  return new Promise((resolve) => {
+    const close = (val) => {
+      overlay.classList.add('hidden');
+      cancelBtn.onclick  = null;
+      confirmBtn.onclick = null;
+      overlay.onclick    = null;
+      resolve(val);
+    };
+    cancelBtn.onclick  = () => close(false);
+    confirmBtn.onclick = () => close(true);
+    // Backdrop click cancels — mirrors Escape via a11y-modal.js.
+    overlay.onclick = (e) => { if (e.target === overlay) close(false); };
+    overlay.classList.remove('hidden');
+  });
 }
 
 /* ── [P3-4] 세션 선택 ── */

--- a/tests/test_longterm_save_modal_n6.py
+++ b/tests/test_longterm_save_modal_n6.py
@@ -1,0 +1,158 @@
+"""Long-term save modal — replace native confirm() with 6c-glass dialog (N-6).
+
+User feedback (Axis 6 follow-up, 2026-05-13):
+
+  > 장기기억으로 저장할까요? 묻는 창이 뜨는것 ui 개선
+
+The "위키 저장 (장기 기억화)" chip in chat.js (approveWikiSave) used to
+pop the native browser ``confirm()`` dialog — which breaks the cyber
+surface's typography on Windows/Linux and never picks up the cyber 6c
+glassmorphism (backdrop-filter + mint inset glow) from tokens.css.
+
+Fix:
+  - New ``jamesConfirm(opts)`` helper in chat.js returns Promise<boolean>
+    and builds a ``.modal-overlay`` + ``.modal`` DOM tree that tokens.css
+    automatically picks up via ``@supports (backdrop-filter)``.
+  - ``approveWikiSave`` switches from ``confirm(...)`` to
+    ``await jamesConfirm({...})``.
+  - The dialog has the ARIA shape (``role=dialog`` / ``aria-modal=true``
+    / ``aria-labelledby``) and the ``.modal-btn.cancel`` button that
+    a11y-modal.js relies on for focus trap + Escape close.
+
+Out of scope: session-reset confirm at chat.js L588 (different flow —
+""현재 대화를 초기화할까요?", not the long-term-save question).
+
+Run:
+  python -m unittest tests.test_longterm_save_modal_n6
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+JS   = ROOT / "frontend" / "static" / "chat.js"
+
+
+class JamesConfirmHelperTests(unittest.TestCase):
+    """The new in-page confirm helper exists, returns a Promise, builds
+    a .modal-overlay / .modal DOM that tokens.css can decorate, and
+    carries the ARIA shape a11y-modal.js needs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+
+    def test_jamesConfirm_function_defined(self):
+        self.assertRegex(
+            self.src,
+            r"function\s+jamesConfirm\s*\(\s*opts\s*\)",
+            "jamesConfirm(opts) must be defined as a top-level function",
+        )
+
+    def test_jamesConfirm_returns_promise(self):
+        # Implementation must wrap resolve in a Promise so callers can
+        # await — the whole point of replacing native confirm().
+        body = self._helper_body()
+        self.assertIn("return new Promise", body,
+            "jamesConfirm must return new Promise so callers can await it")
+
+    def _helper_body(self) -> str:
+        idx = self.src.index("function jamesConfirm")
+        # Find the matching close brace by counting — but a flat 3000-char
+        # window is enough for the helper itself.
+        return self.src[idx:idx + 3000]
+
+    def test_modal_uses_canonical_classes(self):
+        # tokens.css's @supports (backdrop-filter) block targets
+        # exactly ``.modal-overlay`` and ``.modal`` — using those class
+        # names is what makes the 6c glass + mint pickup automatic.
+        body = self._helper_body() + self._ensure_body()
+        self.assertIn("modal-overlay", body,
+            "modal must use class 'modal-overlay' so tokens.css "
+            "backdrop-filter rule applies")
+        self.assertIn('class="modal"', body,
+            "inner card must use class 'modal' so tokens.css "
+            "mint inset glow + heavier blur applies")
+
+    def _ensure_body(self) -> str:
+        idx = self.src.index("function _ensureJamesConfirmEl")
+        return self.src[idx:idx + 2500]
+
+    def test_modal_carries_aria_attributes(self):
+        body = self._ensure_body()
+        # WCAG dialog pattern + what a11y-modal.js's [role="dialog"]
+        # observer relies on.
+        for attr in ('role',
+                     'aria-modal',
+                     'aria-labelledby'):
+            self.assertIn(attr, body,
+                f"modal must declare {attr} so a11y-modal.js traps focus "
+                "and Escape-closes correctly")
+
+    def test_cancel_button_has_modal_btn_cancel_class(self):
+        # a11y-modal.js fires Escape close by clicking
+        # ``.modal-btn.cancel`` — without this class Escape won't close
+        # the dialog.
+        body = self._ensure_body()
+        self.assertIn('class="modal-btn cancel"', body,
+            "Cancel button must carry class 'modal-btn cancel' so "
+            "a11y-modal.js Escape handler can find it")
+
+    def test_helper_resolves_false_on_cancel_and_backdrop(self):
+        body = self._helper_body()
+        # The contract: cancel and backdrop both resolve(false); only
+        # the confirm button resolves(true). Hard to assert directly,
+        # but we can pin the close(false) calls.
+        self.assertGreaterEqual(
+            body.count("close(false)"), 2,
+            "Cancel button click AND backdrop click must both resolve "
+            "false — they are the two non-confirm exit paths")
+        self.assertIn("close(true)", body,
+            "Confirm button click must resolve true")
+
+
+class ApproveWikiSaveCallsiteTests(unittest.TestCase):
+    """approveWikiSave now uses jamesConfirm instead of native confirm()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+
+    def _approveWikiSave_body(self) -> str:
+        idx = self.src.index("async function approveWikiSave")
+        end = self.src.index("\nfunction ", idx + 1)
+        return self.src[idx:end]
+
+    def test_native_confirm_gone(self):
+        # The native call used to be:
+        #   if (!confirm('이 검색 결과를 wiki entity로 ...')) return;
+        body = self._approveWikiSave_body()
+        self.assertNotIn(
+            "confirm('이 검색 결과를 wiki entity",
+            body,
+            "approveWikiSave must no longer use native confirm() — N-6 "
+            "replaces it with the in-page jamesConfirm modal")
+
+    def test_uses_jamesConfirm_with_await(self):
+        body = self._approveWikiSave_body()
+        self.assertIn("await jamesConfirm(", body,
+            "approveWikiSave must await jamesConfirm so the user's "
+            "choice gates the network call")
+
+    def test_modal_message_mentions_longterm_save(self):
+        # The user-facing string still has to say 장기 기억 / wiki / 영구
+        # so the operator understands what they're approving — same
+        # information that the old confirm() carried.
+        body = self._approveWikiSave_body()
+        self.assertRegex(body, r"장기 기억|wiki|영구",
+            "modal message must still describe what's being saved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

사용자 피드백 (Axis 6 follow-up, 2026-05-13):

> 장기기억으로 저장할까요? 묻는 창이 뜨는것 ui 개선

\`approveWikiSave\` (chat-side \"이 자료를 위키로 저장 (장기 기억화)\" chip) 가 native browser \`confirm()\` 을 호출하고 있어 OS 다이얼로그 폰트로 뜸 → cyber 6c glass + mint 표면과 어긋남.

## Fix

### 새 헬퍼 — \`jamesConfirm(opts)\`

\`\`\`js
const ok = await jamesConfirm({
  title:       '장기 기억으로 저장',
  message:     '이 검색 결과를 wiki entity로 영구 저장합니다.\n'
             + '저장 후 retrieval에 활용됩니다.',
  confirmText: '저장',
  cancelText:  '취소',
});
\`\`\`

- Promise<boolean> 반환 — true=confirm, false=cancel/Escape/backdrop
- \`.modal-overlay\` + \`.modal\` DOM 으로 tokens.css 의 \`@supports (backdrop-filter)\` 블록이 자동 6c glass + mint inset glow 적용
- DOM lazy build (\`_ensureJamesConfirmEl\`) — 첫 호출 1회 생성, 이후 재사용
- WCAG dialog ARIA (\`role=dialog\` / \`aria-modal=true\` / \`aria-labelledby\`) + \`.modal-btn cancel\` class 로 a11y-modal.js 의 focus trap + Escape 핸들러 정합
- backdrop 클릭도 cancel 처리 (Esc 와 동일 의미)
- \`danger:true\` 옵션으로 destructive confirm 시 \`--danger\` 색 prim 버튼

### approveWikiSave 호출 교체

native \`confirm(...)\` → \`await jamesConfirm({...})\`.

## Scope

- **approveWikiSave 만** (사용자 보고 \"장기기억으로 저장할까요?\" 일치 케이스)
- chat.js L588 의 세션 reset confirm (\"현재 대화를 초기화할까요?\") 은 다른 flow → 별도 PR

## Verification

- [x] \`python -m pytest tests/\` → **1729 passed, 0 failed** (9 신규)
- [x] 신규 테스트 (\`tests/test_longterm_save_modal_n6.py\`, 9 cases):
  - \`jamesConfirm\` 함수 정의 + Promise 반환 + close(false)/close(true) 양 분기
  - canonical classes (\`modal-overlay\` / \`modal\`) — tokens.css pickup
  - ARIA 3종 + \`.modal-btn cancel\` class — a11y-modal.js 정합
  - approveWikiSave: 옛 \`confirm()\` 사라짐 + \`await jamesConfirm\` + 메시지에 장기 기억 / wiki / 영구 키워드 보존
- [x] core/retrieval | graph | reasoning 미접촉 → bench numbers 불필요
- [x] frontend 변경만 → 모듈 size gate 무영향

## Out of scope

- 세션 reset confirm (chat.js:588) — 다른 flow, 다른 PR
- 다른 페이지 (admin / workspace / graph) 의 confirm() — 본 PR 은 chat 표면만

docs/handovers/v0.3.0-platform-track.md §3 사이클 5 마지막 항목 (N-6). 사이클 5 closure 는 PR #263 (N-4/N-5) + 본 PR 머지 후 별도 doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)