### PR TITLE
docs(handover): record Phase A migration applied + remaining queue

### DIFF
--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -103,11 +103,21 @@
   게이트 자동화
 
 ### 🟣 사이클 8 — Knowledge Cascade (5 PR)
-- Phase A 스키마 마이그레이션 (`sources: [{doc_id, weight, role, ts}]`)
-- Phase B 인제스션 경로
-- Phase C 삭제 cascade
-- Phase D 수정 cascade
-- Phase E 그래프 에디터 (= 사용자 요청 N-7)
+- [x] **Phase A — PR #266 머지 + 마이그레이션 적용 (2026-05-13)**
+  - `core/relations_schema.py` (4 source roles + 헬퍼 3) — 호출 site 0, Phase B 부터 사용
+  - `scripts/migrate_phase_a_sources.py` + `scripts/rollback_phase_a_sources.py`
+  - **production wiki 마이그레이션 실행됨**: 213 entity files / 656 relations
+    back-fill. 백업: `wiki.pre-v03-migration/` (사용자 최종 검증 후 수동 삭제)
+  - 멱등 확인 (재실행 시 mutated=0, already_migrated=656)
+  - 1764 tests pass (25 신규)
+  - **사용자 최종 검증 대기**: `python scripts/bench.py --suite=step7 --check` +
+    실사용 시나리오. 문제 시 `python scripts/rollback_phase_a_sources.py`
+- [ ] Phase B 인제스션 경로 — Phase A 검증 완료 후 진입.
+  `process_document_for_entities` 가 `confidence` 만 쓰던 것을 `sources:
+  [{doc_id, weight, role: "extract"}]` 에 직접 쓰고 confidence 는 derived 로
+- [ ] Phase C 파일 삭제 cascade (`DELETE /admin/files/...` endpoint)
+- [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint)
+- [ ] Phase E 그래프 에디터 (= 사용자 요청 N-7) — Phase B 끝나면 C/D 와 병렬 가능
 
 ### 🟣 사이클 9 — CR-E (self-evolution → CR 래핑)
 - 디퍼된 v0.2.x §5 항목. 4 locked JSONL test 파일 + eval gate +


### PR DESCRIPTION
## Summary

사이클 8 Phase A 완료 표시. PR #266 머지 + production wiki 마이그레이션 적용 결과 기록.

## 마이그레이션 결과
- 213 entity files / 656 relations back-fill
- 백업: \`wiki.pre-v03-migration/\` (사용자 최종 검증 후 수동 삭제)
- 멱등 확인 (재실행 mutated=0)
- 1764 tests pass

## 사용자 최종 검증 대기
\`python scripts/bench.py --suite=step7 --check\` + 실사용 시나리오 확인. 문제 시 \`python scripts/rollback_phase_a_sources.py\`.

## 남은 Phase 큐 (검증 완료 후 진입)
Phase B → C/D/E (B 끝나면 C/D/E 병렬 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)