### PR TITLE
chore(gitignore): exclude Phase A migration snapshot dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,12 @@ wiki/media/prod/
 !wiki/entity/prod/**/index.md
 !wiki/entity/prod/**/.gitkeep
 
+# Knowledge Cascade Phase A 마이그레이션 백업 (2026-05-13) — 운영자가
+# 최종 검증 후 수동 삭제. repo 에 들어가면 wiki/ 와 같은 개인 데이터
+# 누수 위험.
+wiki.pre-v03-migration/
+wiki.rollback-trash/
+
 # 운영자 튜닝 가능한 런타임 설정 (web search role/threshold 등).
 # 코드 안에 안전한 기본값 존재 — 운영자별 오버라이드는 로컬에만.
 web_search_config.json


### PR DESCRIPTION
## Summary

\`wiki.pre-v03-migration/\` + \`wiki.rollback-trash/\` 는 Phase A 마이그레이션 / rollback 시 만드는 일회성 백업. \`wiki/\` 와 같은 사용자 PDF 추출물을 mirror 하므로 repo 에 커밋되면 개인 데이터 누수.

사용자 최종 검증 후 수동 삭제 예정 (스크립트가 자동으로 안 지움 — 안전).

🤖 Generated with [Claude Code](https://claude.com/claude-code)