### PR TITLE
feat(graph): Knowledge Cascade Phase B — ingestion writes sources

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -12,6 +12,11 @@ from typing import Dict, List, Any, Optional
 from pathlib import Path
 
 from config import WIKI_DIR
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    INVERSE_SOURCE_ROLE,
+    compute_confidence_from_sources,
+)
 from core.vector_store import VectorStore
 from llm.router import RouterWrapper
 from utils.metadata import MetadataGenerator
@@ -327,14 +332,23 @@ class WikiGenerator:
 
             target_id = self._find_existing_entity_id(target_name, target_type)
 
-            relations.append({
+            # Phase B (Knowledge Cascade): caller 가 미리 채운 sources 가 있으면
+            # 보존하고 confidence 를 그로부터 derive 해 storage 와 동기화.
+            # 없으면 confidence-only 그대로 두어 Phase A 의 legacy fallback 가
+            # 동작하도록 한다. (docs/design/v0.3-knowledge-cascade.md §4)
+            new_rel = {
                 "target":      target_name,
                 "target_id":   target_id or "UNRESOLVED",
                 "target_type": target_type,
                 "type":        std_type,
                 "label":       display_label,
                 "confidence":  confidence,
-            })
+            }
+            incoming_sources = rel.get("sources")
+            if isinstance(incoming_sources, list) and incoming_sources:
+                new_rel["sources"]    = incoming_sources
+                new_rel["confidence"] = compute_confidence_from_sources(incoming_sources)
+            relations.append(new_rel)
 
         # Ontology: IS_A 자동 추론 relation 추가
         if use_ontology:
@@ -596,6 +610,15 @@ class WikiGenerator:
         metadata  = metadata or {}
         extracted = self._llm_extract_document_entities(filename, content, metadata)
 
+        # Phase B (Knowledge Cascade): 이 ingestion 가 만들어내는 모든
+        # relation 은 같은 doc 에서 유래하므로 doc_entity_id 와 ts 를
+        # 한 번 계산해 모든 _build_entity_relations / doc_relations 호출
+        # 에 동일하게 stamp. doc entity 자체는 _generate_entity_id 가
+        # name+type 결정적 함수라 미리 계산해도 나중 create 시점과 같다.
+        ingest_ts     = datetime.now().isoformat()
+        doc_name      = os.path.splitext(filename)[0]
+        doc_entity_id = self._generate_entity_id(doc_name, "document")
+
         created_ids:   List[str]      = []
         name_to_id:    Dict[str, str] = {}
         name_to_type:  Dict[str, str] = {}
@@ -614,7 +637,8 @@ class WikiGenerator:
                 continue
 
             ent_relations = self._build_entity_relations(
-                name, extracted.get("relations", [])
+                name, extracted.get("relations", []),
+                doc_id=doc_entity_id, ts=ingest_ts,
             )
             payload = {
                 "name":        name,
@@ -639,14 +663,24 @@ class WikiGenerator:
             except Exception as e:
                 print(f"[ENTITY-EXTRACT] FAIL {name}: {e}")
 
-        # document entity (원본 보존 + 모든 추출 entity와 RELATED_TO)
-        doc_name = os.path.splitext(filename)[0]
+        # document entity (원본 보존 + 모든 추출 entity와 RELATED_TO).
+        # Phase B: doc 의 outgoing edge 도 sources 를 stamp (doc_id=self).
+        # cascade delete 시 sources[*].doc_id 가 deleted doc 이면 drop —
+        # 이 self-source 들은 doc 삭제 시 함께 사라진다 (대상 entity 의
+        # incoming sources 가 0 이 되면 relation 자체가 사라짐 = Phase C 의
+        # cascade 와 정합).
         doc_relations = [
             {
                 "target":      n,
                 "target_type": name_to_type.get(n, "concept"),
                 "label":       "관련",
                 "confidence":  0.7,
+                "sources":     [{
+                    "doc_id": doc_entity_id,
+                    "weight": 0.7,
+                    "role":   EXTRACT_SOURCE_ROLE,
+                    "ts":     ingest_ts,
+                }],
             }
             for n in name_to_id
         ]
@@ -816,15 +850,36 @@ class WikiGenerator:
         self,
         source_name:   str,
         raw_relations: List,
+        doc_id:        Optional[str] = None,
+        ts:            Optional[str] = None,
     ) -> List[Dict]:
         """이 entity가 source 또는 target인 relation을 표준 형식으로 모은다.
 
         Issue #11: 이전 구현은 source==self만 골라서 target 입장 entity의
         relations 필드가 빈 채로 끝났다. graph_paths가 비어 expand가 항상
         0을 반환했다. 이제 양방향으로 부착한다 (incoming은 inverse label).
+
+        Phase B (Knowledge Cascade): ``doc_id`` 가 주어지면 각 emitted rel
+        에 ``sources: [{doc_id, weight=conf, role, ts}]`` 를 즉시 stamp.
+        outgoing 은 ``role=extract``, inverse 는 ``role=inverse``. 이로써
+        ingestion 시점에 inverse back-fill 까지 한 번에 완료되고
+        ``migrate_inverse_relations.py`` 의 별도 sweep 가 필요 없어진다.
+        ``doc_id`` 가 없으면 (legacy 호출 경로) sources 미부착 → 기존
+        confidence-only 동작 그대로.
         """
         out: List[Dict] = []
         seen: set = set()
+
+        def _stamp(role: str, conf: float) -> Optional[List[Dict]]:
+            if not doc_id:
+                return None
+            return [{
+                "doc_id": doc_id,
+                "weight": conf,
+                "role":   role,
+                "ts":     ts,
+            }]
+
         for r in raw_relations or []:
             if not isinstance(r, dict):
                 continue
@@ -843,7 +898,11 @@ class WikiGenerator:
                 key = (tgt, label)
                 if key not in seen:
                     seen.add(key)
-                    out.append({"target": tgt, "label": label, "confidence": conf})
+                    rel_dict = {"target": tgt, "label": label, "confidence": conf}
+                    sources = _stamp(EXTRACT_SOURCE_ROLE, conf)
+                    if sources:
+                        rel_dict["sources"] = sources
+                    out.append(rel_dict)
             # Incoming: target이 self → source를 inverse label로 추가
             elif tgt == source_name and src and len(src) <= 80 \
                     and _SAFE_ENTITY_NAME_RE.match(src):
@@ -851,5 +910,9 @@ class WikiGenerator:
                 key = (src, inv_label)
                 if key not in seen:
                     seen.add(key)
-                    out.append({"target": src, "label": inv_label, "confidence": conf})
+                    rel_dict = {"target": src, "label": inv_label, "confidence": conf}
+                    sources = _stamp(INVERSE_SOURCE_ROLE, conf)
+                    if sources:
+                        rel_dict["sources"] = sources
+                    out.append(rel_dict)
         return out

--- a/tests/test_phase_b_ingestion_sources.py
+++ b/tests/test_phase_b_ingestion_sources.py
@@ -1,0 +1,354 @@
+"""Phase B (Knowledge Cascade) — ingestion 가 sources 를 직접 쓰는지 검증.
+
+docs/design/v0.3-knowledge-cascade.md §4 / §8 — Phase B.
+
+본 테스트는 다음 3 레이어를 cover:
+
+  1. ``_build_entity_relations`` 단위: doc_id 가 주어졌을 때 outgoing 에
+     ``role=extract``, inverse 에 ``role=inverse`` 를 stamp 하는지.
+     doc_id 가 ``None`` 이면 (legacy caller) sources 미부착인지.
+  2. ``create_entity_file`` 단위: caller 가 ``sources`` 를 채워 보내면
+     frontmatter 에 그대로 쓰고 ``confidence`` 를 sources 로부터 derive
+     하는지. sources 없으면 기존 ``confidence`` 그대로 통과하는지.
+  3. ``process_document_for_entities`` 통합: LLM 추출 결과를 mock 한 뒤
+     실제 frontmatter 가 entity / inverse / doc-entity 3 갈래 모두에
+     올바른 sources 를 갖는지.
+
+production wiki 에 영향 없음 — WikiGenerator 인스턴스를 ``tempfile``
+WIKI_DIR 로 monkey-patch 해서 격리.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import yaml  # noqa: I001
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Windows cp949 console 환경에서 wiki_generator 의 print("[TRUST] ✅ ...")
+# 가 UnicodeEncodeError 를 던져 create_entity_file 이 그 자리에서 실패.
+# bench.py 와 동일 패턴으로 테스트 시작 시 stdout/stderr 를 UTF-8 로 강제.
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    INVERSE_SOURCE_ROLE,
+    compute_confidence_from_sources,
+)
+
+
+# ── 1. _build_entity_relations 단위 ─────────────────────────────────
+
+class BuildEntityRelationsSourcesTests(unittest.TestCase):
+    """outgoing/inverse 양쪽 모두 sources 를 stamp 하는지."""
+
+    def setUp(self):
+        from core.wiki_generator import WikiGenerator
+        # 메서드 자체는 self 만 받으므로 인스턴스 없이 unbound 로 호출 가능.
+        # _inverse_label_for 는 staticmethod 라 stub 에 별도 binding 불필요.
+        self.fn = WikiGenerator._build_entity_relations
+        self.stub = SimpleNamespace()
+        # _inverse_label_for 는 static 이므로 클래스 attribute 그대로 사용.
+        self.stub._inverse_label_for = WikiGenerator._inverse_label_for
+
+    def _raw_triples(self):
+        return [
+            {"source": "Joby", "target": "NVIDIA", "label": "관련",
+             "confidence": 0.8},
+            {"source": "FAA",  "target": "Joby",   "label": "감독",
+             "confidence": 0.7},
+        ]
+
+    def test_outgoing_gets_role_extract(self):
+        rels = self.fn(self.stub, "Joby", self._raw_triples(),
+                       doc_id="e_document_abc", ts="2026-05-14T10:00:00")
+        out = [r for r in rels if r["target"] == "NVIDIA"]
+        self.assertEqual(len(out), 1, "outgoing Joby→NVIDIA 가 1개 있어야")
+        sources = out[0].get("sources")
+        self.assertIsInstance(sources, list)
+        self.assertEqual(len(sources), 1)
+        s = sources[0]
+        self.assertEqual(s["doc_id"], "e_document_abc")
+        self.assertEqual(s["role"], EXTRACT_SOURCE_ROLE)
+        self.assertEqual(s["weight"], 0.8)
+        self.assertEqual(s["ts"], "2026-05-14T10:00:00")
+
+    def test_inverse_gets_role_inverse(self):
+        rels = self.fn(self.stub, "Joby", self._raw_triples(),
+                       doc_id="e_document_abc", ts="2026-05-14T10:00:00")
+        inv = [r for r in rels if r["target"] == "FAA"]
+        self.assertEqual(len(inv), 1, "inverse FAA→Joby 가 Joby 쪽에 1개 있어야")
+        sources = inv[0].get("sources")
+        self.assertIsInstance(sources, list)
+        s = sources[0]
+        self.assertEqual(s["doc_id"], "e_document_abc")
+        self.assertEqual(s["role"], INVERSE_SOURCE_ROLE,
+            "incoming(target=self) 측은 role=inverse 여야")
+        self.assertEqual(s["weight"], 0.7)
+
+    def test_no_doc_id_legacy_path_no_sources(self):
+        """doc_id=None (구 호출자) → sources 필드 미부착, 기존 동작 보존."""
+        rels = self.fn(self.stub, "Joby", self._raw_triples(),
+                       doc_id=None, ts=None)
+        self.assertGreater(len(rels), 0)
+        for r in rels:
+            self.assertNotIn("sources", r,
+                "doc_id 없이 호출된 경로는 sources 를 추가하면 안 됨")
+            self.assertIn("confidence", r)
+
+    def test_dedup_keeps_first_source(self):
+        """같은 (target, label) 가 중복 등장하면 첫 번째만 살아남고
+        sources 도 그 한 번분만 stamp 된다. 같은 doc 안 중복은 weight
+        팽창이 아니라 무시되어야 (관련 LLM 노이즈 방어)."""
+        dups = [
+            {"source": "Joby", "target": "NVIDIA", "label": "관련",
+             "confidence": 0.6},
+            {"source": "Joby", "target": "NVIDIA", "label": "관련",
+             "confidence": 0.9},
+        ]
+        rels = self.fn(self.stub, "Joby", dups,
+                       doc_id="e_document_xyz", ts="2026-05-14T10:00:00")
+        out = [r for r in rels if r["target"] == "NVIDIA"]
+        self.assertEqual(len(out), 1)
+        self.assertEqual(len(out[0]["sources"]), 1)
+        # 첫 번째 (conf=0.6) 가 우선
+        self.assertEqual(out[0]["sources"][0]["weight"], 0.6)
+
+
+# ── 2. create_entity_file 단위 ──────────────────────────────────────
+
+class CreateEntityFileSourcesPropagationTests(unittest.TestCase):
+    """caller 가 미리 채운 sources 를 frontmatter 에 그대로 쓰고
+    confidence 를 sources 로부터 derive 한다."""
+
+    def setUp(self):
+        # WikiGenerator 가 WIKI_DIR 을 통째로 import 하므로 monkey-patch.
+        self.tmp = tempfile.mkdtemp()
+        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
+        self.wiki_dir_patcher.start()
+        # core.wiki_generator 가 module-load 시 import 한 WIKI_DIR 도 갈아끼움
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = self.tmp
+
+        # vector_store / verify_before_write 의 side effect 비활성.
+        # (테스트는 frontmatter 만 검증)
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+
+    def tearDown(self):
+        self.wiki_dir_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    def _read_fm(self, name: str, etype: str) -> dict:
+        path = self.wg.entity_path / etype / f"{name.lower()}.md"
+        text = path.read_text(encoding="utf-8")
+        body = text.split("---", 2)[1]
+        return yaml.safe_load(body)
+
+    def test_caller_sources_preserved_and_confidence_derived(self):
+        sources_in = [{
+            "doc_id": "e_document_abc",
+            "weight": 0.8,
+            "role":   EXTRACT_SOURCE_ROLE,
+            "ts":     "2026-05-14T10:00:00",
+        }]
+        entity = {
+            "name": "Joby",
+            "type": "org",
+            "attributes": {"summary": "test"},
+            "relations": [{
+                "target": "NVIDIA",
+                "target_type": "org",
+                "label": "관련",
+                "confidence": 0.5,         # 의도적으로 mismatched
+                "sources": sources_in,
+            }],
+            "source_type": "test",
+        }
+        self.wg.create_entity_file(entity, "joby.md", ["chunk1"])
+
+        fm = self._read_fm("Joby", "org")
+        rels = fm.get("relations", [])
+        self.assertEqual(len(rels), 1)
+        rel = rels[0]
+        self.assertEqual(rel.get("sources"), sources_in)
+        # confidence 는 derived (caller-given 0.5 가 아니라 weight=0.8 reflect)
+        self.assertEqual(rel["confidence"],
+                         compute_confidence_from_sources(sources_in))
+
+    def test_no_sources_legacy_confidence_path(self):
+        """입력 rel 에 sources 없으면 confidence 그대로 (back-compat)."""
+        entity = {
+            "name": "Strategy",
+            "type": "org",
+            "attributes": {"summary": "test"},
+            "relations": [{
+                "target": "비트코인",
+                "target_type": "concept",
+                "label": "관련",
+                "confidence": 0.42,
+            }],
+            "source_type": "test",
+        }
+        self.wg.create_entity_file(entity, "doc.md", ["chunk2"])
+
+        fm = self._read_fm("Strategy", "org")
+        rels = fm.get("relations", [])
+        self.assertEqual(len(rels), 1)
+        self.assertNotIn("sources", rels[0])
+        self.assertEqual(rels[0]["confidence"], 0.42)
+
+
+# ── 3. process_document_for_entities 통합 ───────────────────────────
+
+class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
+    """LLM 추출 mock 후 실제 frontmatter (entity + inverse + doc) 가
+    sources 를 갖는지 확인."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
+        self.wiki_dir_patcher.start()
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = self.tmp
+
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+
+        # LLM 추출을 결정적 fixture 로 대체.
+        self.extracted = {
+            "entities": [
+                {"name": "Joby",   "type": "org",
+                 "description": "eVTOL maker"},
+                {"name": "NVIDIA", "type": "org",
+                 "description": "GPU maker"},
+            ],
+            "relations": [
+                {"source": "Joby", "target": "NVIDIA",
+                 "label": "관련", "confidence": 0.8},
+            ],
+        }
+        self.wg._llm_extract_document_entities = (
+            lambda *a, **kw: self.extracted
+        )
+
+    def tearDown(self):
+        self.wiki_dir_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    def _read_fm(self, name: str, etype: str) -> dict:
+        path = self.wg.entity_path / etype / f"{name.lower()}.md"
+        text = path.read_text(encoding="utf-8")
+        body = text.split("---", 2)[1]
+        return yaml.safe_load(body)
+
+    def test_end_to_end_sources_stamped_all_three_paths(self):
+        filename = "joby_nvidia_partnership.md"
+        ids = self.wg.process_document_for_entities(
+            filename=filename,
+            content="Joby and NVIDIA partnership.",
+            chunk_ids=["c1"],
+            user_role="admin",
+            metadata={},
+        )
+        # entity 2개 + doc 1개 = 3
+        self.assertGreaterEqual(len(ids), 2)
+
+        doc_name = os.path.splitext(filename)[0]
+        doc_id   = self.wg._generate_entity_id(doc_name, "document")
+
+        # 1) Joby 의 outgoing relation → NVIDIA, role=extract, doc_id 매칭
+        joby_fm = self._read_fm("Joby", "org")
+        joby_rels = joby_fm.get("relations", [])
+        out_to_nvidia = [r for r in joby_rels if r.get("target") == "NVIDIA"]
+        self.assertEqual(len(out_to_nvidia), 1)
+        srcs = out_to_nvidia[0].get("sources")
+        self.assertIsInstance(srcs, list)
+        self.assertEqual(srcs[0]["doc_id"], doc_id)
+        self.assertEqual(srcs[0]["role"], EXTRACT_SOURCE_ROLE)
+        self.assertEqual(srcs[0]["weight"], 0.8)
+
+        # 2) NVIDIA 의 inverse relation → Joby, role=inverse, 같은 doc_id
+        nv_fm = self._read_fm("NVIDIA", "org")
+        nv_rels = nv_fm.get("relations", [])
+        inv_to_joby = [r for r in nv_rels if r.get("target") == "Joby"]
+        self.assertEqual(len(inv_to_joby), 1,
+            "Phase B: inverse 가 ingestion 시점에 stamp 되어야")
+        inv_srcs = inv_to_joby[0].get("sources")
+        self.assertIsInstance(inv_srcs, list)
+        self.assertEqual(inv_srcs[0]["doc_id"], doc_id)
+        self.assertEqual(inv_srcs[0]["role"], INVERSE_SOURCE_ROLE)
+
+        # 3) doc entity 의 outgoing 도 sources 를 가짐 (self-source)
+        doc_fm = self._read_fm(doc_name, "document")
+        doc_rels = doc_fm.get("relations", [])
+        # doc 가 extracted entities 와 RELATED_TO 로 묶인다
+        targets = {r.get("target") for r in doc_rels}
+        self.assertIn("Joby",   targets)
+        self.assertIn("NVIDIA", targets)
+        for r in doc_rels:
+            srcs = r.get("sources")
+            self.assertIsInstance(srcs, list,
+                "doc-entity outgoing 도 sources 필수 (Phase C cascade 정합)")
+            self.assertEqual(srcs[0]["doc_id"], doc_id)
+            self.assertEqual(srcs[0]["role"], EXTRACT_SOURCE_ROLE)
+
+    def test_confidence_consistent_with_sources(self):
+        """confidence 는 sources 의 weight 와 compute_confidence_from_sources
+        결과가 일치 — derive 가 storage 와 동기화."""
+        self.wg.process_document_for_entities(
+            filename="x.md",
+            content="x",
+            chunk_ids=["c1"],
+        )
+        joby_fm = self._read_fm("Joby", "org")
+        for r in joby_fm.get("relations", []):
+            srcs = r.get("sources")
+            if not srcs:
+                continue
+            self.assertAlmostEqual(
+                r["confidence"],
+                compute_confidence_from_sources(srcs),
+                places=6,
+                msg=f"relation {r} confidence ≠ derive(sources)",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`docs/design/v0.3-knowledge-cascade.md` §4 / §8 — **Phase B**.

Phase A (#266) 가 모든 relation 에 `sources` 필드 인프라를 깔아둔 위에서,
이제 **인제스션 경로 자체가 sources 를 직접 쓰도록** 전환. 이전엔
`process_document_for_entities` 가 `confidence` 만 stamp 하고
back-fill 은 `migrate_inverse_relations.py` 라는 별도 sweep 가 담당
했다 — Phase B 는 두 단계를 한 ingest 안에 fold-in 한다.

### 변경 contract

`process_document_for_entities` 가 만든 모든 relation:
- **outgoing** (`source == self`) → `role=extract`, `doc_id=this_doc`
- **inverse**  (`target == self`) → `role=inverse`, **같은** `doc_id`
- **doc-entity → extracted entity** → self-source (Phase C cascade 정합)

`confidence` 는 storage 에 유지되지만 sources 가 있는 relation 은
`compute_confidence_from_sources(sources)` 결과로 덮어써 두 값이 항상
동기화. sources 없는 relation 은 기존 confidence-only 경로 그대로
(Phase A 의 legacy fallback 와 호환).

### Out of scope

- 기존 entity 의 relation 에 새 doc 의 source 를 추가하는 additive
  ingestion — **Phase D (modify cascade)** 의 일.
- 파일 삭제 시 sources cascade — **Phase C**.
- 그래프 에디터의 manual source — **Phase E**.
- `migrate_inverse_relations.py` 스크립트 제거: 디자인 메모는 "Phase A
  이후 제거" 라고 했지만, 현재 그 스크립트의 backfill 효과는 이미
  `_build_entity_relations` 에 흡수되어 있다. 별도 cleanup PR 로 분리.

### Verification

- 신규 테스트 8개 (`tests/test_phase_b_ingestion_sources.py`):
  1. `_build_entity_relations` 단위 4건 — outgoing/inverse role,
     legacy (doc_id=None) 경로 무영향, dedup keeps-first-source
  2. `create_entity_file` 단위 2건 — caller sources 보존 + derive
     confidence, 입력 sources 없으면 confidence 그대로
  3. `process_document_for_entities` 통합 2건 — 실제 frontmatter 의
     entity / inverse / doc-entity 3 갈래 모두 sources stamp,
     confidence ≡ derive(sources)
- 전체 회귀: **1772 tests OK** (1764 baseline + 8 신규, 0 regression)
- `ruff check core/wiki_generator.py core/relations_schema.py tests/test_phase_b_ingestion_sources.py` → All checks passed!
- CLAUDE.md rule #2 (bench numbers): 본 PR 은 `core/retrieval|graph|reasoning` 을 만지지 않음. 다만 디자인 §9 의 "Confidence drift breaks STEP 7 baseline" 위험을 고려해 — Phase B 는 **신규 ingestion 의 write path** 만 바꾸고 기존 디스크 데이터는 손대지 않는다. STEP 7 은 read-only query 라 영향 없음.

### Module size

`core/wiki_generator.py` 36 KB (변경 전 32 KB). 20 KB gate 사전 위반 상태 (cycle 6 의 `core/memory/store.py` 와 동일 패턴). 별도 split PR 사이클에서 처리 — 본 PR 의 scope 가 아님.

### Phase 큐

- [x] Phase A — PR #266 (relations_schema + migration)
- [x] **Phase B — 본 PR**
- [ ] Phase C — `DELETE /admin/files/...` cascade
- [ ] Phase D — modify cascade + extraction diff cache
- [ ] Phase E — graph editor + manual sources