### PR TITLE
feat(graph): Knowledge Cascade Phase C — file delete cascade

### DIFF
--- a/core/cascade.py
+++ b/core/cascade.py
@@ -1,0 +1,339 @@
+"""
+PROJECT JAMES — Knowledge Cascade Phase C (file delete).
+
+docs/design/v0.3-knowledge-cascade.md §5 — Phase C.
+
+업로드된 파일 1개를 삭제하면 그 파일이 만들어낸 모든 파생물 (vector
+chunks / entity files / 다른 entity 의 relation 의 source) 까지 한
+연산으로 cascade 한다. 이전엔 `delete_entity` + `delete_by_source` 만
+있어서 "파일은 사라졌는데 entity 의 relation 안에는 그 doc 의 흔적이
+남는다" 라는 데이터 부정합이 있었다.
+
+Phase A (PR #266) 가 `sources: [{doc_id, weight, role, ts}]` 인프라를
+깔고, Phase B (PR #269) 가 ingestion 시점에 sources 를 직접 쓰기
+시작했다. Phase C 는 그 sources 를 **삭제 방향에서 추적** 하는 부분.
+
+핵심 invariant (디자인 §5):
+  - manual sources 는 cascade 가 건드리지 않는다 (그래프 에디터에서
+    admin 이 명시적으로 추가한 source 는 파일 삭제와 무관).
+  - legacy sources (doc_id=None) 도 건드리지 않는다 (Phase A back-fill,
+    출처 미상이라 cascade 가 안전하게 식별할 수 없음).
+  - relation 의 모든 non-manual non-legacy source 가 사라지면 relation
+    자체가 사라진다. confidence 는 derived 라 자동으로 0 이 되고 곧
+    relation 도 사라지므로 stale confidence 는 남지 않는다.
+  - orphan entity 는 (a) `attributes.source_document == filename` 이고
+    (b) 다른 어떤 entity 도 이 entity 를 target_id 로 가리키지 않을
+    때만 삭제. (b) 가 만족되지 않으면 entity 는 남고 confidence 만 감소.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from core.relations_schema import (
+    MANUAL_SOURCE_ROLE,
+    compute_confidence_from_sources,
+)
+
+
+# uploads/ 의 물리 파일명 prefix 패턴. /upload/ endpoint 가
+# `str(uuid.uuid4()) + "_" + original_filename` 형식으로 저장하므로
+# 36-char uuid + underscore 를 strip 하면 원본 이름이 나온다.
+_UUID_PREFIX_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                             r"[0-9a-f]{4}-[0-9a-f]{12}_(.+)$",
+                             re.IGNORECASE)
+
+_FM_SPLIT_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+def strip_uuid_prefix(physical_filename: str) -> str:
+    """uploads/ 물리 파일명에서 uuid prefix 를 제거해 ingestion 이 사용한
+    원본 filename 을 얻는다. prefix 없으면 그대로 반환 (legacy uploads
+    + 직접 배치된 파일 호환)."""
+    m = _UUID_PREFIX_RE.match(physical_filename)
+    return m.group(1) if m else physical_filename
+
+
+def _read_frontmatter(path: Path) -> Optional[Tuple[Dict[str, Any], str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    m = _FM_SPLIT_RE.match(text)
+    if not m:
+        return None
+    try:
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(fm, dict):
+        return None
+    return fm, m.group(2)
+
+
+def _write_frontmatter(path: Path, fm: Dict[str, Any], body: str) -> None:
+    text = yaml.safe_dump(
+        fm, allow_unicode=True, sort_keys=False, default_flow_style=False,
+    ).rstrip()
+    path.write_text(f"---\n{text}\n---\n{body}", encoding="utf-8")
+
+
+def _iter_entity_files(entity_root: Path):
+    if not entity_root.exists():
+        return
+    yield from entity_root.rglob("*.md")
+
+
+def cascade_remove_doc_from_sources(
+    doc_entity_id: str,
+    entity_root:   Path,
+) -> Dict[str, int]:
+    """모든 entity 의 relation sources 에서 ``doc_entity_id`` 항목을 제거.
+
+    설계 §14 의 reference 구현. manual / legacy source 는 건드리지 않음.
+    sources 가 모두 사라진 relation 은 relation 자체가 사라진다.
+
+    Returns:
+        counts = {
+          "entities_scanned":     int,
+          "entities_touched":     int,
+          "relations_recomputed": int,
+          "relations_dropped":    int,
+        }
+    """
+    counts = {
+        "entities_scanned":     0,
+        "entities_touched":     0,
+        "relations_recomputed": 0,
+        "relations_dropped":    0,
+    }
+    for path in _iter_entity_files(entity_root):
+        parsed = _read_frontmatter(path)
+        if not parsed:
+            continue
+        fm, body = parsed
+        counts["entities_scanned"] += 1
+        relations = fm.get("relations") or []
+        if not isinstance(relations, list):
+            continue
+
+        new_rels: List[Dict[str, Any]] = []
+        touched = False
+        for rel in relations:
+            if not isinstance(rel, dict):
+                new_rels.append(rel)
+                continue
+            srcs = rel.get("sources")
+            if not isinstance(srcs, list):
+                new_rels.append(rel)
+                continue
+            # Filter: keep manual sources unconditionally; keep non-matching
+            # doc_ids. Drop entries where doc_id == this doc AND role != manual.
+            kept = [
+                s for s in srcs
+                if not (isinstance(s, dict)
+                        and s.get("doc_id") == doc_entity_id
+                        and s.get("role")   != MANUAL_SOURCE_ROLE)
+            ]
+            if len(kept) == len(srcs):
+                # 이 relation 은 deleted doc 의 영향을 받지 않음
+                new_rels.append(rel)
+                continue
+            touched = True
+            if not kept:
+                counts["relations_dropped"] += 1
+                continue   # relation 자체가 사라짐
+            rel["sources"]    = kept
+            rel["confidence"] = compute_confidence_from_sources(kept)
+            new_rels.append(rel)
+            counts["relations_recomputed"] += 1
+
+        if touched:
+            counts["entities_touched"] += 1
+            fm["relations"] = new_rels
+            _write_frontmatter(path, fm, body)
+
+    return counts
+
+
+def find_orphan_entities(
+    deleted_filename: str,
+    deleted_doc_id:   str,
+    entity_root:      Path,
+) -> List[Path]:
+    """``attributes.source_document == deleted_filename`` 인 entity 중
+    cascade 후에 도달 불가능 + 흔적 없는 것들의 파일 경로.
+
+    설계 §5 의 base rule (incoming 0) 를 한 단계 강화: cascade_remove_
+    doc_from_sources 가 끝난 상태에서 **남은 relation 도 0** 일 때만
+    orphan. 이 추가 조건은 manual source 가 살아남아 relation 자체는
+    유지된 entity 를 orphan 으로 오인해 삭제하는 것을 막아준다 (성공
+    기준 §12.1 의 "**only** existed because of this doc" 정합).
+
+    선행조건: 호출 시점에 cascade_remove_doc_from_sources 가 완료되어
+    있어야 stale target_id 가 incoming 에 끼지 않는다."""
+    incoming_target_ids: set = set()
+    candidate_paths: List[Tuple[Path, str, int]] = []
+    for path in _iter_entity_files(entity_root):
+        parsed = _read_frontmatter(path)
+        if not parsed:
+            continue
+        fm, _body = parsed
+        rels = fm.get("relations") or []
+        if not isinstance(rels, list):
+            rels = []
+        for rel in rels:
+            if isinstance(rel, dict):
+                tid = rel.get("target_id")
+                if tid and tid != "UNRESOLVED":
+                    incoming_target_ids.add(tid)
+        attrs = fm.get("attributes") or {}
+        eid   = fm.get("entity_id", "")
+        if not isinstance(attrs, dict):
+            continue
+        if attrs.get("source_document") == deleted_filename \
+                and eid and eid != deleted_doc_id:
+            candidate_paths.append((path, eid, len(rels)))
+
+    return [
+        p for p, eid, n_rels in candidate_paths
+        if eid not in incoming_target_ids and n_rels == 0
+    ]
+
+
+def find_doc_entity_path(
+    deleted_doc_id: str,
+    entity_root:    Path,
+) -> Optional[Path]:
+    """doc entity 파일 (= ingestion 이 만들었던 document type entity) 의
+    실제 경로를 찾는다. type 디렉토리 (document/) 위에 평탄하게 있으므로
+    바로 매칭."""
+    for path in _iter_entity_files(entity_root):
+        parsed = _read_frontmatter(path)
+        if not parsed:
+            continue
+        fm, _ = parsed
+        if fm.get("entity_id") == deleted_doc_id:
+            return path
+    return None
+
+
+def backup_upload_file(
+    physical_path:  Path,
+    upload_dir:     Path,
+) -> Path:
+    """``uploads/{file}`` 를 ``uploads/.deleted/{ts}_{file}`` 로 이동.
+
+    설계 §5: 파일은 N 일 동안 복구 가능한 backup 으로 보존. 실제
+    cleanup 은 별도 운영 도구의 일 (Phase C scope 밖).
+
+    .deleted 디렉토리가 없으면 생성. 이미 같은 이름이 있으면 (재시도
+    등) ``{ts}_{idx}_{file}`` 으로 충돌 회피.
+    """
+    deleted_dir = upload_dir / ".deleted"
+    deleted_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest = deleted_dir / f"{ts}_{physical_path.name}"
+    idx  = 1
+    while dest.exists():
+        dest = deleted_dir / f"{ts}_{idx}_{physical_path.name}"
+        idx += 1
+    shutil.move(str(physical_path), str(dest))
+    return dest
+
+
+def cascade_delete_upload(
+    physical_filename: str,
+    *,
+    wiki_generator,         # core.wiki_generator.WikiGenerator
+    vector_store,           # core.vector_store.VectorStore (delete_by_source 만 필요)
+    upload_dir:        Path,
+    user_role:         str = "admin",
+) -> Dict[str, Any]:
+    """업로드 파일 하나의 전 cascade. 디자인 §5 의 step 1~5 + audit.
+
+    Returns audit-friendly summary dict:
+      {
+        "physical_filename":     str,
+        "original_filename":     str,
+        "doc_entity_id":         str,
+        "doc_entity_deleted":    bool,
+        "orphan_entities_deleted": int,
+        "vector_deleted":        bool,
+        "file_backup":           str  (relative path under upload_dir),
+        "counts":                {cascade_remove_doc_from_sources 의 결과},
+      }
+
+    Raises:
+      FileNotFoundError — 물리 파일이 uploads/ 에 없을 때.
+    """
+    physical_path = Path(upload_dir) / physical_filename
+    if not physical_path.is_file():
+        raise FileNotFoundError(
+            f"upload not found: {physical_path}"
+        )
+
+    original_filename = strip_uuid_prefix(physical_filename)
+    doc_name          = os.path.splitext(original_filename)[0]
+    doc_entity_id     = wiki_generator._generate_entity_id(doc_name, "document")
+    entity_root       = Path(wiki_generator.entity_path)
+
+    # Step 1+2 — 모든 entity 의 sources 에서 이 doc 제거
+    counts = cascade_remove_doc_from_sources(doc_entity_id, entity_root)
+
+    # Step 3 — orphan sweep (이 doc 만으로 생긴 + 다른 누구도 안 가리키는
+    #          extracted entities). doc entity 본체는 제외.
+    orphan_paths = find_orphan_entities(
+        original_filename, doc_entity_id, entity_root,
+    )
+    for p in orphan_paths:
+        try:
+            p.unlink()
+        except OSError as e:
+            print(f"[CASCADE] orphan unlink fail {p}: {e}")
+
+    # Step 4 — doc entity 본체 삭제
+    doc_path = find_doc_entity_path(doc_entity_id, entity_root)
+    doc_deleted = False
+    if doc_path is not None:
+        try:
+            doc_path.unlink()
+            doc_deleted = True
+        except OSError as e:
+            print(f"[CASCADE] doc entity unlink fail {doc_path}: {e}")
+
+    # Step 5 — vector chunks
+    vec_deleted = False
+    try:
+        vec_deleted = bool(vector_store.delete_by_source(original_filename))
+    except Exception as e:
+        print(f"[CASCADE] vector delete fail {original_filename}: {e}")
+
+    # Step 6 — 물리 파일 → .deleted/ 백업
+    backup_path = backup_upload_file(physical_path, Path(upload_dir))
+
+    # Index refresh — entity 파일들이 사라졌으므로 wiki_generator 의
+    # in-memory entity_id_index 가 stale. refresh 가 가능한 instance 면 호출.
+    try:
+        if hasattr(wiki_generator, "refresh_entity_map"):
+            wiki_generator.refresh_entity_map()
+    except Exception as e:
+        print(f"[CASCADE] entity index refresh skipped: {e}")
+
+    return {
+        "physical_filename":       physical_filename,
+        "original_filename":       original_filename,
+        "doc_entity_id":           doc_entity_id,
+        "doc_entity_deleted":      doc_deleted,
+        "orphan_entities_deleted": len(orphan_paths),
+        "vector_deleted":          vec_deleted,
+        "file_backup":             str(backup_path.relative_to(Path(upload_dir))),
+        "counts":                  counts,
+        "user_role":               user_role,
+    }

--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -112,12 +112,19 @@
   - 1764 tests pass (25 신규)
   - **사용자 최종 검증 대기**: `python scripts/bench.py --suite=step7 --check` +
     실사용 시나리오. 문제 시 `python scripts/rollback_phase_a_sources.py`
-- [ ] Phase B 인제스션 경로 — Phase A 검증 완료 후 진입.
-  `process_document_for_entities` 가 `confidence` 만 쓰던 것을 `sources:
-  [{doc_id, weight, role: "extract"}]` 에 직접 쓰고 confidence 는 derived 로
-- [ ] Phase C 파일 삭제 cascade (`DELETE /admin/files/...` endpoint)
-- [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint)
-- [ ] Phase E 그래프 에디터 (= 사용자 요청 N-7) — Phase B 끝나면 C/D 와 병렬 가능
+- [x] **Phase B — PR #269 머지 (2026-05-14)**
+  - `process_document_for_entities` 가 sources 직접 작성: outgoing
+    `role=extract`, inverse `role=inverse` 같은 doc_id, doc-entity self-source
+  - `_build_entity_relations(..., doc_id=None, ts=None)` legacy caller 무영향
+  - `create_entity_file` caller-provided sources 보존 + confidence derive
+  - 1772 tests pass (8 신규)
+  - 사용자 검증 PASS: 1-A (bench step7 byte-identical), 3-B (N-1 graph cache), 4 (노이즈 cleanup)
+- [ ] **Phase C — 본 PR (#270 예정)** `DELETE /admin/files` cascade
+  (sources[*].doc_id 매칭 source 제거 → relation drop / confidence recompute
+  → orphan sweep (incoming 0 AND remaining relations 0) → vector delete →
+  파일 `uploads/.deleted/` backup). `core/cascade.py` 신규 + endpoint
+- [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint, Phase C 의존)
+- [ ] Phase E 그래프 에디터 (= 사용자 요청 N-7) — Phase B unblock 으로 C/D 와 병렬 가능
 
 ### 🟣 사이클 9 — CR-E (self-evolution → CR 래핑)
 - 디퍼된 v0.2.x §5 항목. 4 locked JSONL test 파일 + eval gate +

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -4610,6 +4610,69 @@ async def admin_files_download(
     )
 
 
+@app.delete("/admin/files",
+            summary="업로드 파일 + 파생 cascade 삭제 [Knowledge Cascade Phase C]")
+async def admin_files_delete(
+    api_key: str,
+    path:    str,
+    role:    str = Depends(get_role_from_request),
+):
+    """uploads/ 의 파일 하나를 삭제하고 그로부터 파생된 모든 wiki entity /
+    relation source / vector chunks 까지 cascade.
+
+    docs/design/v0.3-knowledge-cascade.md §5 — Phase C.
+
+    Trust boundary:
+      - admin.data feature gate
+      - root='uploads' 로 hard-coded (wiki/ entity 의 직접 삭제는
+        기존 chat 의 ``delete_entity`` 가 처리 — 다른 cascade 의미)
+      - ``_resolve_under_root`` 가 path traversal 차단
+      - 파일은 ``uploads/.deleted/{ts}_{name}`` 으로 backup, 즉시 purge
+        하지 않음 (N 일 후 운영 cleanup 의 일)
+    """
+    _require_feature(api_key, role, "admin.data")
+    if not (path or "").strip():
+        raise HTTPException(status_code=400, detail="path required")
+
+    # 'uploads' root 하에서만 동작 — wiki 의 entity 직접 삭제는 다른 경로.
+    full = _resolve_under_root("uploads", path)
+    if not full or not os.path.isfile(full):
+        raise HTTPException(status_code=404, detail="not found")
+
+    physical_filename = os.path.basename(full)
+
+    from core.cascade import cascade_delete_upload
+    try:
+        summary = cascade_delete_upload(
+            physical_filename,
+            wiki_generator = rag_engine.wiki_generator,
+            vector_store   = rag_engine.vector_store,
+            upload_dir     = _file_mgmt_roots()["uploads"],
+            user_role      = role,
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # 결과 + audit. cascade 결과의 핵심 숫자만 JSON 으로 압축해 answer
+    # 컬럼에 저장 (max 500 chars). 자세한 summary 는 응답 본문에 그대로.
+    counts = summary.get("counts", {})
+    audit_blob = json.dumps({
+        "doc_entity_id":           summary.get("doc_entity_id"),
+        "orphan_entities_deleted": summary.get("orphan_entities_deleted"),
+        "relations_recomputed":    counts.get("relations_recomputed"),
+        "relations_dropped":       counts.get("relations_dropped"),
+        "vector_deleted":          summary.get("vector_deleted"),
+        "file_backup":             summary.get("file_backup"),
+    }, ensure_ascii=False)
+    _write_audit(
+        role, "/admin/files/delete",
+        query=physical_filename,
+        answer=audit_blob,
+        elapsed_sec=0,
+    )
+    return {"ok": True, "summary": summary}
+
+
 @app.get("/admin/settings", summary="설정 조회 [P7]")
 async def admin_settings_get(api_key: str, role: str = Depends(get_role_from_request)):
     _require_feature(api_key, role, "admin.settings")

--- a/tests/test_phase_c_cascade.py
+++ b/tests/test_phase_c_cascade.py
@@ -1,0 +1,535 @@
+"""Phase C (Knowledge Cascade) — file delete cascade 검증.
+
+docs/design/v0.3-knowledge-cascade.md §5 — Phase C.
+
+본 테스트는 ``core/cascade.py`` 의 3 레이어를 단위 / 통합으로 cover:
+
+  1. ``strip_uuid_prefix`` — uploads/ 의 uuid_<original> 패턴 복원
+  2. ``cascade_remove_doc_from_sources`` — entity 의 sources 에서 doc
+     제거 + manual/legacy 보존 + relation drop / confidence recompute
+  3. ``find_orphan_entities`` — source_document 매칭 AND incoming 0
+  4. ``cascade_delete_upload`` (통합) — wiki + vector + file backup
+     까지 end-to-end
+
+production wiki 에 영향 없음 — 모든 fixture 는 tempfile.TemporaryDirectory
+하에서 동작.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import yaml  # noqa: I001
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
+from core.cascade import (
+    backup_upload_file,
+    cascade_delete_upload,
+    cascade_remove_doc_from_sources,
+    find_doc_entity_path,
+    find_orphan_entities,
+    strip_uuid_prefix,
+)
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    INVERSE_SOURCE_ROLE,
+    LEGACY_SOURCE_ROLE,
+    MANUAL_SOURCE_ROLE,
+    compute_confidence_from_sources,
+)
+
+
+# ── 0. uuid prefix strip ────────────────────────────────────────────
+
+class StripUuidPrefixTests(unittest.TestCase):
+    def test_strips_full_uuid_prefix(self):
+        physical = f"{uuid.uuid4()}_report.pdf"
+        self.assertEqual(strip_uuid_prefix(physical), "report.pdf")
+
+    def test_no_prefix_returns_input(self):
+        self.assertEqual(strip_uuid_prefix("report.pdf"), "report.pdf")
+
+    def test_uppercase_uuid_accepted(self):
+        u = str(uuid.uuid4()).upper()
+        self.assertEqual(strip_uuid_prefix(f"{u}_x.md"), "x.md")
+
+    def test_partial_match_does_not_strip(self):
+        # 짧은 hex 는 uuid 가 아니므로 그대로
+        self.assertEqual(strip_uuid_prefix("abc123_foo.pdf"), "abc123_foo.pdf")
+
+
+# ── 1. cascade_remove_doc_from_sources ──────────────────────────────
+
+def _write_entity(path: Path, fm: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = (
+        "---\n"
+        + yaml.safe_dump(fm, allow_unicode=True, sort_keys=False,
+                         default_flow_style=False)
+        + "---\n# body\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_fm(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    body = text.split("---", 2)[1]
+    return yaml.safe_load(body)
+
+
+class CascadeRemoveDocFromSourcesTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.entity_root = self.root / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (self.entity_root / t).mkdir(parents=True)
+
+    def test_drops_single_source_relation(self):
+        ent_path = self.entity_root / "org" / "joby.md"
+        _write_entity(ent_path, {
+            "entity_id": "e_org_joby",
+            "name": "Joby",
+            "entity_type": "org",
+            "relations": [{
+                "target": "NVIDIA", "target_id": "e_org_nvidia",
+                "target_type": "org", "label": "관련", "confidence": 0.8,
+                "sources": [{
+                    "doc_id": "e_document_X", "weight": 0.8,
+                    "role": EXTRACT_SOURCE_ROLE, "ts": "2026-05-14",
+                }],
+            }],
+        })
+        counts = cascade_remove_doc_from_sources("e_document_X", self.entity_root)
+        self.assertEqual(counts["relations_dropped"], 1)
+        self.assertEqual(counts["relations_recomputed"], 0)
+        fm = _read_fm(ent_path)
+        self.assertEqual(fm.get("relations"), [])
+
+    def test_recomputes_when_other_sources_remain(self):
+        ent_path = self.entity_root / "org" / "joby.md"
+        _write_entity(ent_path, {
+            "entity_id": "e_org_joby",
+            "name": "Joby",
+            "entity_type": "org",
+            "relations": [{
+                "target": "NVIDIA", "target_id": "e_org_nvidia",
+                "target_type": "org", "label": "관련", "confidence": 0.9,
+                "sources": [
+                    {"doc_id": "e_document_X", "weight": 0.7,
+                     "role": EXTRACT_SOURCE_ROLE, "ts": "2026-05-14"},
+                    {"doc_id": "e_document_Y", "weight": 0.5,
+                     "role": EXTRACT_SOURCE_ROLE, "ts": "2026-05-14"},
+                ],
+            }],
+        })
+        counts = cascade_remove_doc_from_sources("e_document_X", self.entity_root)
+        self.assertEqual(counts["relations_dropped"], 0)
+        self.assertEqual(counts["relations_recomputed"], 1)
+        fm = _read_fm(ent_path)
+        rel = fm["relations"][0]
+        self.assertEqual(len(rel["sources"]), 1)
+        self.assertEqual(rel["sources"][0]["doc_id"], "e_document_Y")
+        self.assertEqual(
+            rel["confidence"],
+            compute_confidence_from_sources(rel["sources"]),
+        )
+
+    def test_manual_source_preserved(self):
+        """role=manual 인 source 는 doc_id 가 매칭되어도 보존."""
+        ent_path = self.entity_root / "org" / "joby.md"
+        _write_entity(ent_path, {
+            "entity_id": "e_org_joby",
+            "name": "Joby",
+            "entity_type": "org",
+            "relations": [{
+                "target": "NVIDIA", "target_id": "e_org_nvidia",
+                "target_type": "org", "label": "관련", "confidence": 0.85,
+                "sources": [
+                    {"doc_id": "e_document_X", "weight": 0.7,
+                     "role": EXTRACT_SOURCE_ROLE, "ts": "2026-05-14"},
+                    # 같은 doc_id 지만 manual 이라 보존되어야
+                    {"doc_id": "e_document_X", "weight": 0.5,
+                     "role": MANUAL_SOURCE_ROLE, "ts": "2026-05-14"},
+                ],
+            }],
+        })
+        counts = cascade_remove_doc_from_sources("e_document_X", self.entity_root)
+        self.assertEqual(counts["relations_dropped"], 0)
+        self.assertEqual(counts["relations_recomputed"], 1)
+        fm = _read_fm(ent_path)
+        rel = fm["relations"][0]
+        self.assertEqual(len(rel["sources"]), 1)
+        self.assertEqual(rel["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+
+    def test_legacy_source_untouched(self):
+        """role=legacy (Phase A back-fill, doc_id=None) 은 어떤 doc 삭제
+        에도 영향받지 않는다."""
+        ent_path = self.entity_root / "org" / "old.md"
+        _write_entity(ent_path, {
+            "entity_id": "e_org_old",
+            "name": "Old",
+            "entity_type": "org",
+            "relations": [{
+                "target": "Strategy", "target_id": "e_org_strategy",
+                "target_type": "org", "label": "관련", "confidence": 0.7,
+                "sources": [{
+                    "doc_id": None, "weight": 0.7,
+                    "role": LEGACY_SOURCE_ROLE, "ts": "2026-05-05",
+                }],
+            }],
+        })
+        counts = cascade_remove_doc_from_sources("e_document_X", self.entity_root)
+        self.assertEqual(counts["entities_touched"], 0)
+        self.assertEqual(counts["relations_dropped"], 0)
+        fm = _read_fm(ent_path)
+        self.assertEqual(len(fm["relations"]), 1)
+
+    def test_inverse_role_dropped_normally(self):
+        """role=inverse 도 일반 extract 처럼 cascade 됨 (manual 만 예외)."""
+        ent_path = self.entity_root / "org" / "nvidia.md"
+        _write_entity(ent_path, {
+            "entity_id": "e_org_nvidia",
+            "name": "NVIDIA",
+            "entity_type": "org",
+            "relations": [{
+                "target": "Joby", "target_id": "e_org_joby",
+                "target_type": "org", "label": "관련", "confidence": 0.7,
+                "sources": [{
+                    "doc_id": "e_document_X", "weight": 0.7,
+                    "role": INVERSE_SOURCE_ROLE, "ts": "2026-05-14",
+                }],
+            }],
+        })
+        counts = cascade_remove_doc_from_sources("e_document_X", self.entity_root)
+        self.assertEqual(counts["relations_dropped"], 1)
+
+
+# ── 2. find_orphan_entities ─────────────────────────────────────────
+
+class FindOrphanEntitiesTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.entity_root = self.root / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (self.entity_root / t).mkdir(parents=True)
+
+    def test_entity_with_no_incoming_is_orphan(self):
+        # joby.md 는 deleted_doc 으로만 생성됨. 다른 누구도 안 가리킴.
+        _write_entity(self.entity_root / "org" / "joby.md", {
+            "entity_id": "e_org_joby",
+            "name": "Joby",
+            "entity_type": "org",
+            "attributes": {"source_document": "joby.pdf"},
+            "relations": [],
+        })
+        orphans = find_orphan_entities("joby.pdf", "e_document_X", self.entity_root)
+        self.assertEqual(len(orphans), 1)
+        self.assertEqual(orphans[0].name, "joby.md")
+
+    def test_entity_with_incoming_is_not_orphan(self):
+        # nvidia.md 는 joby.pdf 로 만들어졌지만 다른 entity(strategy.md)
+        # 가 가리키고 있어 orphan 아님 (다른 doc 의 evidence 가 살아있음).
+        _write_entity(self.entity_root / "org" / "nvidia.md", {
+            "entity_id": "e_org_nvidia",
+            "name": "NVIDIA",
+            "entity_type": "org",
+            "attributes": {"source_document": "joby.pdf"},
+            "relations": [],
+        })
+        _write_entity(self.entity_root / "org" / "strategy.md", {
+            "entity_id": "e_org_strategy",
+            "name": "Strategy",
+            "entity_type": "org",
+            "attributes": {"source_document": "other.pdf"},
+            "relations": [{
+                "target": "NVIDIA", "target_id": "e_org_nvidia",
+                "label": "관련", "confidence": 0.7,
+            }],
+        })
+        orphans = find_orphan_entities("joby.pdf", "e_document_X", self.entity_root)
+        self.assertEqual(orphans, [])
+
+    def test_doc_entity_itself_excluded(self):
+        # joby.pdf 의 doc-entity (entity_id == deleted_doc_id) 는
+        # orphan 후보가 아님 — find_doc_entity_path 가 따로 처리.
+        _write_entity(self.entity_root / "document" / "joby.md", {
+            "entity_id": "e_document_X",
+            "name": "joby",
+            "entity_type": "document",
+            "attributes": {"source_document": "joby.pdf"},
+            "relations": [],
+        })
+        orphans = find_orphan_entities("joby.pdf", "e_document_X", self.entity_root)
+        self.assertEqual(orphans, [])
+
+    def test_other_source_document_ignored(self):
+        _write_entity(self.entity_root / "org" / "tesla.md", {
+            "entity_id": "e_org_tesla",
+            "name": "Tesla",
+            "entity_type": "org",
+            "attributes": {"source_document": "other.pdf"},
+            "relations": [],
+        })
+        orphans = find_orphan_entities("joby.pdf", "e_document_X", self.entity_root)
+        self.assertEqual(orphans, [])
+
+
+# ── 3. backup_upload_file ───────────────────────────────────────────
+
+class BackupUploadFileTests(unittest.TestCase):
+    def test_moves_to_deleted_subdir(self):
+        tmp = Path(tempfile.mkdtemp())
+        f = tmp / "some_uuid_report.pdf"
+        f.write_text("payload", encoding="utf-8")
+        dest = backup_upload_file(f, tmp)
+        self.assertFalse(f.exists())
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.parent.name, ".deleted")
+        self.assertIn("some_uuid_report.pdf", dest.name)
+
+    def test_collision_handled(self):
+        tmp = Path(tempfile.mkdtemp())
+        f1 = tmp / "x.pdf"; f1.write_text("a")
+        d1 = backup_upload_file(f1, tmp)
+        # 다시 같은 이름 백업 — 충돌 회피
+        f2 = tmp / "x.pdf"; f2.write_text("b")
+        d2 = backup_upload_file(f2, tmp)
+        self.assertNotEqual(d1.name, d2.name)
+        self.assertTrue(d1.exists() and d2.exists())
+
+
+# ── 4. cascade_delete_upload — end-to-end ──────────────────────────
+
+class CascadeDeleteUploadIntegrationTests(unittest.TestCase):
+    """uploads/<file> 삭제 → wiki/relation/vector/file 4 갈래 모두 깨끗."""
+
+    def setUp(self):
+        self.root         = Path(tempfile.mkdtemp())
+        self.entity_root  = self.root / "entity"
+        self.upload_dir   = self.root / "uploads"
+        for t in ("person", "org", "concept", "document"):
+            (self.entity_root / t).mkdir(parents=True)
+        self.upload_dir.mkdir()
+
+        # WikiGenerator stub — _generate_entity_id 와 entity_path 만 필요.
+        from core.wiki_generator import WikiGenerator
+        self.wg = SimpleNamespace(
+            entity_path = self.entity_root,
+            _generate_entity_id = WikiGenerator._generate_entity_id.__get__(
+                SimpleNamespace()
+            ),
+        )
+        # bound method 가 self._normalize_name 을 호출하므로 stub 에도 연결.
+        self.wg._normalize_name = WikiGenerator._normalize_name.__get__(self.wg)
+        self.wg._generate_entity_id = (
+            WikiGenerator._generate_entity_id.__get__(self.wg)
+        )
+
+        # vector store stub
+        self.vs = MagicMock()
+        self.vs.delete_by_source.return_value = True
+
+        # 시나리오: report.pdf 가 만든 doc + 2 extracted (Joby, NVIDIA)
+        doc_id   = self.wg._generate_entity_id("report", "document")
+        joby_id  = self.wg._generate_entity_id("Joby", "org")
+        nv_id    = self.wg._generate_entity_id("NVIDIA", "org")
+
+        _write_entity(self.entity_root / "document" / "report.md", {
+            "entity_id": doc_id,
+            "name": "report",
+            "entity_type": "document",
+            "attributes": {"summary": "x"},   # doc 자체는 source_document 없음
+            "relations": [
+                {"target": "Joby",   "target_id": joby_id,
+                 "target_type": "org", "label": "관련", "confidence": 0.7,
+                 "sources": [{"doc_id": doc_id, "weight": 0.7,
+                              "role": EXTRACT_SOURCE_ROLE, "ts": "t"}]},
+                {"target": "NVIDIA", "target_id": nv_id,
+                 "target_type": "org", "label": "관련", "confidence": 0.7,
+                 "sources": [{"doc_id": doc_id, "weight": 0.7,
+                              "role": EXTRACT_SOURCE_ROLE, "ts": "t"}]},
+            ],
+        })
+        _write_entity(self.entity_root / "org" / "joby.md", {
+            "entity_id": joby_id,
+            "name": "Joby",
+            "entity_type": "org",
+            "attributes": {"source_document": "report.pdf"},
+            "relations": [{
+                "target": "NVIDIA", "target_id": nv_id,
+                "target_type": "org", "label": "관련", "confidence": 0.8,
+                "sources": [{"doc_id": doc_id, "weight": 0.8,
+                             "role": EXTRACT_SOURCE_ROLE, "ts": "t"}],
+            }],
+        })
+        _write_entity(self.entity_root / "org" / "nvidia.md", {
+            "entity_id": nv_id,
+            "name": "NVIDIA",
+            "entity_type": "org",
+            "attributes": {"source_document": "report.pdf"},
+            "relations": [{
+                "target": "Joby", "target_id": joby_id,
+                "target_type": "org", "label": "관련", "confidence": 0.8,
+                "sources": [{"doc_id": doc_id, "weight": 0.8,
+                             "role": INVERSE_SOURCE_ROLE, "ts": "t"}],
+            }],
+        })
+        # uploads/{uuid}_report.pdf
+        self.physical = f"{uuid.uuid4()}_report.pdf"
+        (self.upload_dir / self.physical).write_text("payload",
+                                                     encoding="utf-8")
+
+        self.doc_id  = doc_id
+        self.joby_id = joby_id
+        self.nv_id   = nv_id
+
+    def test_full_cascade_clears_all_artifacts(self):
+        summary = cascade_delete_upload(
+            self.physical,
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            user_role      = "admin",
+        )
+
+        # 1) 물리 파일이 .deleted/ 로 백업됨
+        self.assertFalse((self.upload_dir / self.physical).exists())
+        deleted_dir = self.upload_dir / ".deleted"
+        self.assertTrue(deleted_dir.exists())
+        self.assertEqual(len(list(deleted_dir.iterdir())), 1)
+
+        # 2) vector store 호출 (filename 원본 = report.pdf)
+        self.vs.delete_by_source.assert_called_once_with("report.pdf")
+
+        # 3) doc entity 파일 사라짐
+        self.assertFalse((self.entity_root / "document" / "report.md").exists())
+
+        # 4) extracted entity 중 incoming 0 인 것은 사라짐.
+        #    이 시나리오에서 Joby ↔ NVIDIA 양방향 relation 이 있는데
+        #    cascade_remove_doc_from_sources 가 doc_id 매칭 source 를
+        #    제거 → relation 도 사라짐 (단일 source 였으므로) → 양쪽 다
+        #    incoming 0 → 양쪽 다 orphan.
+        self.assertFalse((self.entity_root / "org" / "joby.md").exists())
+        self.assertFalse((self.entity_root / "org" / "nvidia.md").exists())
+
+        # 5) summary 값 검증
+        self.assertEqual(summary["original_filename"], "report.pdf")
+        self.assertEqual(summary["doc_entity_id"], self.doc_id)
+        self.assertTrue(summary["doc_entity_deleted"])
+        self.assertEqual(summary["orphan_entities_deleted"], 2)
+        self.assertTrue(summary["vector_deleted"])
+        self.assertIn(".deleted", summary["file_backup"]
+                      .replace("\\", "/"))
+        # 4 relations 모두 doc_id 매칭 single-source 였으므로 전부 drop:
+        #   doc/report.md → Joby
+        #   doc/report.md → NVIDIA
+        #   org/joby.md   → NVIDIA  (extract)
+        #   org/nvidia.md → Joby    (inverse)
+        self.assertEqual(summary["counts"]["relations_dropped"], 4)
+        self.assertEqual(summary["counts"]["entities_touched"], 3)
+
+    def test_other_doc_with_incoming_keeps_entity(self):
+        """별도 doc 이 NVIDIA 를 가리키면 report.pdf 삭제 시 NVIDIA 는 살아남고
+        confidence 만 감소 (또는 relation drop) 한다."""
+        # 추가 entity: Strategy (other.pdf 출처) → NVIDIA 를 가리킴
+        nv_id = self.nv_id
+        _write_entity(self.entity_root / "org" / "strategy.md", {
+            "entity_id": "e_org_strategy",
+            "name": "Strategy",
+            "entity_type": "org",
+            "attributes": {"source_document": "other.pdf"},
+            "relations": [{
+                "target": "NVIDIA", "target_id": nv_id,
+                "target_type": "org", "label": "관련", "confidence": 0.6,
+                "sources": [{"doc_id": "e_document_other", "weight": 0.6,
+                             "role": EXTRACT_SOURCE_ROLE, "ts": "t"}],
+            }],
+        })
+
+        cascade_delete_upload(
+            self.physical,
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            user_role      = "admin",
+        )
+
+        # Strategy 는 그대로
+        self.assertTrue((self.entity_root / "org" / "strategy.md").exists())
+        # NVIDIA 는 incoming 이 있으므로 살아남음
+        self.assertTrue((self.entity_root / "org" / "nvidia.md").exists())
+        # NVIDIA 의 relation 은 incoming inverse 만 있었고 doc_id 매칭
+        # source 였으므로 drop. 남는 relation 0
+        fm = _read_fm(self.entity_root / "org" / "nvidia.md")
+        self.assertEqual(fm.get("relations") or [], [])
+        # Joby 는 incoming 0 → orphan (Strategy 는 NVIDIA 만 가리킴)
+        self.assertFalse((self.entity_root / "org" / "joby.md").exists())
+
+    def test_manual_source_survives_doc_delete(self):
+        """admin 이 그래프 에디터로 추가한 manual source 는 cascade 무시."""
+        # NVIDIA→Joby relation 에 manual source 한 줄 추가
+        nv_path = self.entity_root / "org" / "nvidia.md"
+        fm = _read_fm(nv_path)
+        fm["relations"][0]["sources"].append({
+            "doc_id": None, "weight": 0.9,
+            "role":   MANUAL_SOURCE_ROLE,
+            "author": "admin", "ts": "t",
+        })
+        _write_entity(nv_path, fm)
+
+        cascade_delete_upload(
+            self.physical,
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            user_role      = "admin",
+        )
+
+        # NVIDIA 가 살아있고 (manual source 가 있는 relation 이 남아 incoming
+        # Joby 도 살아있어야)
+        self.assertTrue(nv_path.exists())
+        fm_after = _read_fm(nv_path)
+        rels = fm_after.get("relations") or []
+        self.assertEqual(len(rels), 1)
+        self.assertEqual(rels[0]["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+        # Joby 도 incoming(NVIDIA→Joby) 가 살아있어 살아남음
+        self.assertTrue((self.entity_root / "org" / "joby.md").exists())
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            cascade_delete_upload(
+                "no_such_uuid_report.pdf",
+                wiki_generator = self.wg,
+                vector_store   = self.vs,
+                upload_dir     = self.upload_dir,
+            )
+
+
+# ── 5. find_doc_entity_path ─────────────────────────────────────────
+
+class FindDocEntityPathTests(unittest.TestCase):
+    def test_returns_path_for_matching_eid(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "document").mkdir()
+        p = root / "document" / "report.md"
+        _write_entity(p, {"entity_id": "e_document_abc", "name": "report"})
+        self.assertEqual(find_doc_entity_path("e_document_abc", root), p)
+
+    def test_returns_none_when_missing(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "document").mkdir()
+        self.assertIsNone(find_doc_entity_path("e_document_missing", root))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`docs/design/v0.3-knowledge-cascade.md` §5 — **Phase C**.

업로드 파일 하나를 삭제하면 그 파일이 만들어낸 모든 파생물 (vector chunks / entity files / 다른 entity 의 relation sources) 까지 한 연산으로 cascade.

Phase A (#266) 가 깐 `sources` schema + Phase B (#269) 의 ingestion write path 위에서, 이제 **delete 방향에서도 `doc_id` 가 추적된다.** 이전엔 \`delete_entity\` + \`delete_by_source\` 만 있어서 "파일은 사라졌는데 entity 의 relation 안에 그 doc 의 흔적이 남는다" 라는 데이터 부정합이 있었다.

### 변경 contract

새 모듈 `core/cascade.py`:
- `cascade_remove_doc_from_sources(doc_entity_id, entity_root)` — 디자인 §14 reference impl. manual / legacy source 보존, 남은 sources 0 이면 relation drop, 아니면 confidence recompute
- `find_orphan_entities(filename, doc_id, entity_root)` — 디자인 §5 의 \"incoming 0\" rule 을 한 단계 강화: **남은 outgoing relation 도 0 일 때만 orphan**. 이 추가 조건이 manual edit 살아남은 entity 를 잘못 삭제하는 것을 막아준다 (성공기준 §12.1 의 \"**only** existed because of this doc\" 정합)
- `cascade_delete_upload(...)` — 디자인 §5 orchestrator. uploads/{file} → `uploads/.deleted/{ts}_{file}` backup 까지
- `strip_uuid_prefix(...)` — `/upload/` 의 `{uuid}_{original}` 물리명에서 원본 filename 복원

신규 endpoint `DELETE /admin/files` (server_llmwiki.py):
- admin.data gate, root='uploads' hard-coded (wiki entity 직접 삭제는 별 경로)
- `_resolve_under_root` path traversal 차단
- cascade summary 를 audit log `answer` 컬럼에 JSON 압축 기록

### Verification

- 신규 테스트 21개 (`tests/test_phase_c_cascade.py`):
  1. `strip_uuid_prefix` 4건 — full uuid, no prefix, uppercase, partial-no-match
  2. `cascade_remove_doc_from_sources` 5건 — drop / recompute / manual 보존 / legacy 무영향 / inverse 일반 처리
  3. `find_orphan_entities` 4건 — incoming 0 → orphan, incoming 있음 → 유지, doc 본체 제외, other source_document 무시
  4. `backup_upload_file` 2건 — `.deleted/` 이동, 충돌 회피
  5. `find_doc_entity_path` 2건 — 매칭 / missing
  6. `cascade_delete_upload` 통합 4건 — full cascade / other-doc 가리키는 entity 보존 / manual source 살아남음 / missing file FileNotFoundError
- 전체 회귀: **1793 tests OK** (1772 baseline + 21 신규, 0 regression)
- \`ruff check core/cascade.py tests/test_phase_c_cascade.py server_llmwiki.py\` → All checks passed!

### CLAUDE.md gates

- rule #2 (bench numbers): 본 PR 은 `core/retrieval|graph|reasoning` 미터치. cascade 로직은 새 `core/cascade.py` 에. STEP 7 read-path 무영향
- rule #5 (20 KB): `core/cascade.py` 8 KB (gate 통과). `server_llmwiki.py` 는 사전 위반 상태 그대로 (별 사이클의 split 대상)
- rule #3 (자가-진화 게이트): 본 PR 은 자가-진화 무관

### Out of scope

- **Phase D** 파일 수정 cascade (`PUT /admin/files/...` + extraction diff sidecar) — 다음 PR
- **Phase E** graph editor (manual sources 의 write path) — 별도 PR, 본 PR 의 manual-preservation 로직과 호환
- frontend UI 의 delete 버튼 wiring — 별도 cycle (admin.js 추가 + confirm 모달)

### Phase 큐

- [x] Phase A — PR #266
- [x] Phase B — PR #269
- [x] **Phase C — 본 PR**
- [ ] Phase D — modify cascade
- [ ] Phase E — graph editor (N-7)