### PR TITLE
feat(graph): Knowledge Cascade Phase E — graph editor backend (N-7)

### DIFF
--- a/core/graph_editor.py
+++ b/core/graph_editor.py
@@ -1,0 +1,463 @@
+"""
+PROJECT JAMES — Knowledge Cascade Phase E (graph editor backend).
+
+docs/design/v0.3-knowledge-cascade.md §7 — Phase E.
+
+`/admin/graph` 의 admin 이 edge 별 sources 를 직접 수정할 수 있게 하는
+3 endpoint 의 코어 로직. UI 가 클릭한 edge 의 source list / weight /
+role 을 받아 양방향 entity 파일의 frontmatter relation 의 ``sources``
+배열을 갱신한다.
+
+Phase B (PR #269) 가 ingestion 시점에 `sources` 를 stamp 하고
+Phase C (PR #270) 가 cascade 가 manual source 를 보존하도록 만들었기
+때문에, Phase E 의 manual source write 는 자연스럽게 cascade-안전:
+admin 이 추가한 ``role=manual`` source 는 doc 파일 삭제 시에도
+유지된다.
+
+Trust model (§7):
+  - admin 만 호출 가능 (server endpoint 에서 admin.data feature gate
+    + ``JAMES_GRAPH_EDIT=1`` env flag opt-in).
+  - 모든 write 는 양쪽 (forward + inverse) entity 파일에 동시 반영.
+  - audit log 에 before+after sources 배열 차이 기록.
+  - 두 admin 의 동시 PUT 은 last-writer-wins. POST (append) 는 commutative.
+"""
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from core.relations_schema import (
+    MANUAL_SOURCE_ROLE,
+    VALID_SOURCE_ROLES,
+    compute_confidence_from_sources,
+)
+
+
+_FM_SPLIT_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+# ─────────────────────────────────────────────────────────────────
+# entity 파일 I/O (cascade.py 의 helper 와 동일 패턴이지만 dedup 안 함
+# — 두 모듈은 독립 lifecycle 이라 미세 결합 회피)
+# ─────────────────────────────────────────────────────────────────
+
+def _read_entity(path: Path) -> Optional[Tuple[Dict[str, Any], str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    m = _FM_SPLIT_RE.match(text)
+    if not m:
+        return None
+    try:
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(fm, dict):
+        return None
+    return fm, m.group(2)
+
+
+def _write_entity(path: Path, fm: Dict[str, Any], body: str) -> None:
+    text = yaml.safe_dump(
+        fm, allow_unicode=True, sort_keys=False, default_flow_style=False,
+    ).rstrip()
+    path.write_text(f"---\n{text}\n---\n{body}", encoding="utf-8")
+
+
+def _load_entity_by_id(
+    entity_id: str,
+    wiki_generator,
+) -> Tuple[Path, Dict[str, Any], str]:
+    """entity_id → (path, frontmatter, body). 없으면 ValueError."""
+    idx = getattr(wiki_generator, "entity_id_index", {}) or {}
+    path = idx.get(entity_id)
+    if not path:
+        # 인덱스 미스 — fresh rebuild 한 번 시도
+        try:
+            wiki_generator.refresh_entity_map()
+            path = wiki_generator.entity_id_index.get(entity_id)
+        except Exception:
+            path = None
+    if not path:
+        raise ValueError(f"entity_id not found: {entity_id}")
+    parsed = _read_entity(Path(path))
+    if not parsed:
+        raise ValueError(f"entity file unreadable: {path}")
+    fm, body = parsed
+    return Path(path), fm, body
+
+
+# ─────────────────────────────────────────────────────────────────
+# ontology — forward/inverse type pair 도출
+# ─────────────────────────────────────────────────────────────────
+
+def _inverse_type(forward_type: str) -> str:
+    """ontology 가 정의한 inverse type 을 반환. 미정의면 자신 (대칭).
+
+    RELATED_TO 같은 대칭 relation 은 inverse 가 자신과 같다. 비대칭
+    (BELONGS_TO ↔ HAS_MEMBER) 은 명시적 mapping. 정의 부재 시 안전한
+    fallback 으로 forward 와 같은 type 반환.
+    """
+    try:
+        from core.ontology import RELATION_TYPES, normalize_relation
+    except ImportError:
+        return forward_type
+    std = normalize_relation(forward_type)
+    info = RELATION_TYPES.get(std, {})
+    inv = info.get("inverse")
+    return inv or std
+
+
+def _label_for_type(rel_type: str) -> str:
+    try:
+        from core.ontology import RELATION_TYPES, get_relation_label
+    except ImportError:
+        return rel_type
+    info = RELATION_TYPES.get(rel_type, {})
+    if info.get("label"):
+        return info["label"]
+    return get_relation_label(rel_type) or rel_type
+
+
+# ─────────────────────────────────────────────────────────────────
+# relation 매칭 + sources 합성
+# ─────────────────────────────────────────────────────────────────
+
+def _find_relation_index(
+    relations: List[Dict[str, Any]],
+    target_id: str,
+    rel_type:  str,
+) -> Optional[int]:
+    """frontmatter 의 ``relations`` 배열에서 (target_id, type) 매칭
+    relation 의 index 반환. 같은 (target_id, type) 가 여러 개 있으면
+    첫 번째. None 이면 매칭 없음."""
+    for i, rel in enumerate(relations):
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("target_id") == target_id and rel.get("type") == rel_type:
+            return i
+    return None
+
+
+def _validate_sources(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """클라이언트가 보낸 sources 배열을 정규화 + 검증.
+
+    - dict 가 아닌 항목은 drop.
+    - weight 는 [0.0, 1.0] 으로 clamp.
+    - role 은 VALID_SOURCE_ROLES 중 하나여야 함 (외 → 예외).
+    - manual / extract 등 모든 role 허용 — 보안 결정은 endpoint 에서
+      (admin 만 호출 가능).
+    - ts 가 없으면 now() 로 채움.
+    """
+    out: List[Dict[str, Any]] = []
+    now_iso = datetime.now().isoformat()
+    for s in sources or []:
+        if not isinstance(s, dict):
+            continue
+        role = s.get("role")
+        if role not in VALID_SOURCE_ROLES:
+            raise ValueError(f"invalid source role: {role!r}")
+        try:
+            w = float(s.get("weight", 0.0))
+        except (TypeError, ValueError):
+            w = 0.0
+        w = max(0.0, min(1.0, w))
+        entry: Dict[str, Any] = {
+            "doc_id": s.get("doc_id"),
+            "weight": w,
+            "role":   role,
+            "ts":     s.get("ts") or now_iso,
+        }
+        # optional metadata for manual sources
+        if role == MANUAL_SOURCE_ROLE:
+            if s.get("author"):
+                entry["author"] = str(s["author"])[:80]
+            if s.get("note"):
+                entry["note"] = str(s["note"])[:300]
+        out.append(entry)
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────
+# Public API — 3 mutation operations
+# ─────────────────────────────────────────────────────────────────
+
+def replace_relation_sources(
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    new_sources:   List[Dict[str, Any]],
+    *,
+    wiki_generator,
+    sync_inverse:  bool = True,
+) -> Dict[str, Any]:
+    """PUT semantics — forward + inverse 양쪽 relation 의 sources 를
+    전부 ``new_sources`` 로 교체. confidence 는 자동 derive. 매칭
+    relation 이 없으면 새로 만든다.
+
+    Returns audit-friendly diff:
+      {
+        "forward": {"before": [...], "after": [...]},
+        "inverse": {"before": [...], "after": [...]} | None,
+        "src_entity_id": ..., "tgt_entity_id": ...,
+        "relation_type": ..., "inverse_type": ...,
+      }
+    """
+    sources = _validate_sources(new_sources)
+    if not sources:
+        raise ValueError("new_sources must not be empty for PUT — use DELETE instead")
+
+    src_path, src_fm, src_body = _load_entity_by_id(src_entity_id, wiki_generator)
+    inv_type = _inverse_type(relation_type)
+
+    src_rels = list(src_fm.get("relations") or [])
+    fwd_idx = _find_relation_index(src_rels, tgt_entity_id, relation_type)
+    fwd_before = list(src_rels[fwd_idx].get("sources", [])) \
+                 if fwd_idx is not None else []
+
+    fwd_rel = src_rels[fwd_idx] if fwd_idx is not None else {
+        "target":      None,    # 채워짐 (tgt entity load 후)
+        "target_id":   tgt_entity_id,
+        "target_type": None,
+        "type":        relation_type,
+        "label":       _label_for_type(relation_type),
+    }
+    fwd_rel["sources"]    = sources
+    fwd_rel["confidence"] = compute_confidence_from_sources(sources)
+
+    inv_diff = None
+    inv_path = inv_fm = inv_body = None
+    if sync_inverse:
+        try:
+            inv_path, inv_fm, inv_body = _load_entity_by_id(
+                tgt_entity_id, wiki_generator,
+            )
+        except ValueError:
+            # target entity 가 없으면 inverse 동기화 skip (forward 만 반영).
+            # admin 이 의도적으로 dangling edge 를 만들 수도 있으므로 에러
+            # 가 아닌 부분-성공으로 처리.
+            inv_path = None
+
+    if inv_path is not None:
+        # forward 의 target 이름/타입을 inverse 의 self 로 사용.
+        # source entity 의 name 으로 채워야 함.
+        src_name = src_fm.get("name") or ""
+        src_type = src_fm.get("entity_type") or ""
+        # forward rel 의 target_name 도 inverse 의 self 이름과 일치해야 자연
+        if fwd_rel.get("target") is None:
+            fwd_rel["target"] = inv_fm.get("name", tgt_entity_id)
+        if fwd_rel.get("target_type") is None:
+            fwd_rel["target_type"] = inv_fm.get("entity_type", "concept")
+
+        inv_rels = list(inv_fm.get("relations") or [])
+        inv_idx = _find_relation_index(inv_rels, src_entity_id, inv_type)
+        inv_before = list(inv_rels[inv_idx].get("sources", [])) \
+                     if inv_idx is not None else []
+        inv_rel = inv_rels[inv_idx] if inv_idx is not None else {
+            "target":      src_name,
+            "target_id":   src_entity_id,
+            "target_type": src_type,
+            "type":        inv_type,
+            "label":       _label_for_type(inv_type),
+        }
+        inv_rel["sources"]    = sources
+        inv_rel["confidence"] = compute_confidence_from_sources(sources)
+        if inv_idx is None:
+            inv_rels.append(inv_rel)
+        else:
+            inv_rels[inv_idx] = inv_rel
+        inv_fm["relations"] = inv_rels
+        _write_entity(inv_path, inv_fm, inv_body)
+        inv_diff = {"before": inv_before, "after": list(sources)}
+
+    if fwd_idx is None:
+        src_rels.append(fwd_rel)
+    else:
+        src_rels[fwd_idx] = fwd_rel
+    src_fm["relations"] = src_rels
+    _write_entity(src_path, src_fm, src_body)
+
+    return {
+        "forward":        {"before": fwd_before, "after": list(sources)},
+        "inverse":        inv_diff,
+        "src_entity_id":  src_entity_id,
+        "tgt_entity_id":  tgt_entity_id,
+        "relation_type":  relation_type,
+        "inverse_type":   inv_type,
+    }
+
+
+def append_relation_source(
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    source:        Dict[str, Any],
+    *,
+    wiki_generator,
+    sync_inverse:  bool = True,
+) -> Dict[str, Any]:
+    """POST semantics — 단일 source 를 forward + inverse 양쪽 relation
+    의 sources 배열 끝에 append. 매칭 relation 이 없으면 새로 만든다.
+
+    동시 호출 시 commutative (append 만 하므로). 같은 source 가 두 번
+    append 되면 두 row 가 모두 보존 — dedup 은 admin 의 일.
+    """
+    src_norm = _validate_sources([source])
+    if not src_norm:
+        raise ValueError("source must be a valid sources entry")
+    one = src_norm[0]
+
+    src_path, src_fm, src_body = _load_entity_by_id(src_entity_id, wiki_generator)
+    inv_type = _inverse_type(relation_type)
+
+    src_rels = list(src_fm.get("relations") or [])
+    fwd_idx = _find_relation_index(src_rels, tgt_entity_id, relation_type)
+    if fwd_idx is None:
+        # forward relation 신규 생성
+        # target 이름/타입은 inverse load 가능하면 거기서 / 아니면 placeholder
+        tgt_name = tgt_entity_id
+        tgt_type = "concept"
+        try:
+            _, inv_fm_peek, _ = _load_entity_by_id(tgt_entity_id, wiki_generator)
+            tgt_name = inv_fm_peek.get("name", tgt_entity_id)
+            tgt_type = inv_fm_peek.get("entity_type", "concept")
+        except ValueError:
+            pass
+        new_rel = {
+            "target":      tgt_name,
+            "target_id":   tgt_entity_id,
+            "target_type": tgt_type,
+            "type":        relation_type,
+            "label":       _label_for_type(relation_type),
+            "confidence":  0.0,
+            "sources":     [],
+        }
+        src_rels.append(new_rel)
+        fwd_idx = len(src_rels) - 1
+
+    fwd_before = list(src_rels[fwd_idx].get("sources", []))
+    new_fwd_sources = list(fwd_before) + [one]
+    src_rels[fwd_idx]["sources"]    = new_fwd_sources
+    src_rels[fwd_idx]["confidence"] = compute_confidence_from_sources(
+        new_fwd_sources
+    )
+    src_fm["relations"] = src_rels
+    _write_entity(src_path, src_fm, src_body)
+
+    inv_diff = None
+    if sync_inverse:
+        try:
+            inv_path, inv_fm, inv_body = _load_entity_by_id(
+                tgt_entity_id, wiki_generator,
+            )
+        except ValueError:
+            inv_path = None
+
+        if inv_path is not None:
+            inv_rels = list(inv_fm.get("relations") or [])
+            inv_idx = _find_relation_index(inv_rels, src_entity_id, inv_type)
+            if inv_idx is None:
+                inv_rels.append({
+                    "target":      src_fm.get("name", src_entity_id),
+                    "target_id":   src_entity_id,
+                    "target_type": src_fm.get("entity_type", "concept"),
+                    "type":        inv_type,
+                    "label":       _label_for_type(inv_type),
+                    "confidence":  0.0,
+                    "sources":     [],
+                })
+                inv_idx = len(inv_rels) - 1
+            inv_before = list(inv_rels[inv_idx].get("sources", []))
+            new_inv_sources = list(inv_before) + [one]
+            inv_rels[inv_idx]["sources"]    = new_inv_sources
+            inv_rels[inv_idx]["confidence"] = compute_confidence_from_sources(
+                new_inv_sources
+            )
+            inv_fm["relations"] = inv_rels
+            _write_entity(inv_path, inv_fm, inv_body)
+            inv_diff = {"before": inv_before, "after": new_inv_sources}
+
+    return {
+        "forward":       {"before": fwd_before, "after": new_fwd_sources},
+        "inverse":       inv_diff,
+        "src_entity_id": src_entity_id,
+        "tgt_entity_id": tgt_entity_id,
+        "relation_type": relation_type,
+        "inverse_type":  inv_type,
+    }
+
+
+def delete_relation(
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    *,
+    wiki_generator,
+    sync_inverse:  bool = True,
+) -> Dict[str, Any]:
+    """DELETE semantics — forward + inverse 양쪽 relation 자체를 제거.
+
+    매칭 relation 이 없으면 no-op (해당 측 ``removed`` False 반환).
+    """
+    src_path, src_fm, src_body = _load_entity_by_id(src_entity_id, wiki_generator)
+    inv_type = _inverse_type(relation_type)
+
+    src_rels = list(src_fm.get("relations") or [])
+    fwd_idx = _find_relation_index(src_rels, tgt_entity_id, relation_type)
+    fwd_before = None
+    fwd_removed = False
+    if fwd_idx is not None:
+        fwd_before = list(src_rels[fwd_idx].get("sources", []))
+        src_rels.pop(fwd_idx)
+        src_fm["relations"] = src_rels
+        _write_entity(src_path, src_fm, src_body)
+        fwd_removed = True
+
+    inv_removed = False
+    inv_before = None
+    if sync_inverse:
+        try:
+            inv_path, inv_fm, inv_body = _load_entity_by_id(
+                tgt_entity_id, wiki_generator,
+            )
+        except ValueError:
+            inv_path = None
+        if inv_path is not None:
+            inv_rels = list(inv_fm.get("relations") or [])
+            inv_idx = _find_relation_index(inv_rels, src_entity_id, inv_type)
+            if inv_idx is not None:
+                inv_before = list(inv_rels[inv_idx].get("sources", []))
+                inv_rels.pop(inv_idx)
+                inv_fm["relations"] = inv_rels
+                _write_entity(inv_path, inv_fm, inv_body)
+                inv_removed = True
+
+    return {
+        "forward":       {"removed": fwd_removed, "before": fwd_before},
+        "inverse":       {"removed": inv_removed, "before": inv_before},
+        "src_entity_id": src_entity_id,
+        "tgt_entity_id": tgt_entity_id,
+        "relation_type": relation_type,
+        "inverse_type":  inv_type,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Env flag helper (디자인 §7 — JAMES_GRAPH_EDIT=1 opt-in)
+# ─────────────────────────────────────────────────────────────────
+
+def graph_edit_enabled() -> bool:
+    """``JAMES_GRAPH_EDIT=1`` 이면 그래프 에디터 endpoint 사용 가능.
+
+    디자인 §7 의 graceful degradation: 첫 release cycle 동안 admin 이
+    명시적으로 켜야 한다. 기본 off — 운영자가 의도하지 않은 mutation
+    을 실수로 invoke 할 수 없게.
+    """
+    v = os.environ.get("JAMES_GRAPH_EDIT", "").strip()
+    return v in ("1", "true", "TRUE", "yes", "on")

--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -119,12 +119,16 @@
   - `create_entity_file` caller-provided sources 보존 + confidence derive
   - 1772 tests pass (8 신규)
   - 사용자 검증 PASS: 1-A (bench step7 byte-identical), 3-B (N-1 graph cache), 4 (노이즈 cleanup)
-- [ ] **Phase C — 본 PR (#270 예정)** `DELETE /admin/files` cascade
-  (sources[*].doc_id 매칭 source 제거 → relation drop / confidence recompute
-  → orphan sweep (incoming 0 AND remaining relations 0) → vector delete →
-  파일 `uploads/.deleted/` backup). `core/cascade.py` 신규 + endpoint
+- [x] **Phase C — PR #270 머지 (2026-05-14)** `DELETE /admin/files` cascade.
+  `core/cascade.py` (cascade_remove_doc_from_sources / find_orphan_entities
+  강화 룰 / cascade_delete_upload / strip_uuid_prefix / backup_upload_file)
+  + endpoint. 21 신규 tests → 1793 OK
 - [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint, Phase C 의존)
-- [ ] Phase E 그래프 에디터 (= 사용자 요청 N-7) — Phase B unblock 으로 C/D 와 병렬 가능
+- [ ] **Phase E — 본 PR (backend only)** graph editor (= 사용자 요청 N-7).
+  `core/graph_editor.py` (replace / append / delete + 양방향 동기화 +
+  manual metadata) + 3 endpoint (`PUT/POST/DELETE /admin/graph/relation`)
+  + `JAMES_GRAPH_EDIT=1` opt-in flag. 16 신규 tests → 1809 OK.
+  **frontend UI wiring 은 follow-up PR**
 
 ### 🟣 사이클 9 — CR-E (self-evolution → CR 래핑)
 - 디퍼된 v0.2.x §5 항목. 4 locked JSONL test 파일 + eval gate +

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3289,6 +3289,195 @@ async def admin_graph_snapshot(
     )
 
 
+# ─── /admin/graph/relation — Phase E graph editor (write path) ───
+#
+# docs/design/v0.3-knowledge-cascade.md §7. admin 이 `/admin/graph`
+# 의 edge 별 sources / weight / role 을 직접 수정할 수 있게 하는 3
+# endpoint. JAMES_GRAPH_EDIT=1 env flag 가 켜진 경우에만 활성화 —
+# 의도치 않은 mutation 방지 (graceful degradation).
+# ────────────────────────────────────────────────────────────────
+
+def _require_graph_edit_enabled() -> None:
+    from core.graph_editor import graph_edit_enabled
+    if not graph_edit_enabled():
+        raise HTTPException(
+            status_code=403,
+            detail="graph_edit_disabled: set JAMES_GRAPH_EDIT=1 to enable",
+        )
+
+
+def _truncate_audit_blob(d: dict, cap: int = 500) -> str:
+    """audit log 의 query/answer 컬럼은 500 chars cap. sources before/
+    after 가 길어질 수 있으므로 JSON dump 후 잘림."""
+    s = json.dumps(d, ensure_ascii=False)
+    return s if len(s) <= cap else s[:cap - 3] + "..."
+
+
+@app.put("/admin/graph/relation",
+         summary="relation 의 sources 전체 교체 [Knowledge Cascade Phase E]")
+async def admin_graph_relation_put(request: Request,
+                                   role: str = Depends(get_role_from_request)):
+    """forward + inverse 양쪽 relation 의 sources 배열을 body 의 값으로
+    교체. confidence 는 자동 derive. relation 이 없으면 새로 생성.
+
+    Body JSON:
+      {
+        "api_key":       "...",
+        "src_entity_id": "e_org_joby",
+        "tgt_entity_id": "e_org_nvidia",
+        "relation_type": "RELATED_TO",
+        "sources": [
+          {"doc_id": null, "weight": 0.9, "role": "manual",
+           "author": "admin", "note": "..."}
+        ]
+      }
+    """
+    _require_graph_edit_enabled()
+    body = await request.json()
+    _require_feature(body.get("api_key", ""), role, "admin.data")
+
+    src_id = (body.get("src_entity_id") or "").strip()
+    tgt_id = (body.get("tgt_entity_id") or "").strip()
+    rtype  = (body.get("relation_type") or "").strip()
+    if not (src_id and tgt_id and rtype):
+        raise HTTPException(
+            status_code=400,
+            detail="src_entity_id / tgt_entity_id / relation_type required",
+        )
+    sources = body.get("sources") or []
+    if not isinstance(sources, list) or not sources:
+        raise HTTPException(
+            status_code=400,
+            detail="sources (non-empty list) required — use DELETE to drop",
+        )
+
+    from core.graph_editor import replace_relation_sources
+    try:
+        result = replace_relation_sources(
+            src_id, tgt_id, rtype, sources,
+            wiki_generator=rag_engine.wiki_generator,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    _write_audit(
+        role, "/admin/graph/relation [PUT]",
+        query=_truncate_audit_blob({
+            "src": src_id, "tgt": tgt_id, "type": rtype,
+        }),
+        answer=_truncate_audit_blob({
+            "fwd_before_n": len(result["forward"]["before"]),
+            "fwd_after_n":  len(result["forward"]["after"]),
+            "inv_synced":   result["inverse"] is not None,
+        }),
+    )
+    return {"ok": True, "result": result}
+
+
+@app.post("/admin/graph/relation/source",
+          summary="relation 의 sources 에 한 줄 append [Knowledge Cascade Phase E]")
+async def admin_graph_relation_append(request: Request,
+                                      role: str = Depends(get_role_from_request)):
+    """단일 source 를 forward + inverse 양쪽 relation 의 sources 배열에
+    append. 다른 admin 의 PUT 과 commutative — 같은 source 를 두 번
+    append 하면 두 row 모두 남는다 (dedup 은 admin 의 일).
+
+    Body JSON:
+      {
+        "api_key":       "...",
+        "src_entity_id": "...",
+        "tgt_entity_id": "...",
+        "relation_type": "RELATED_TO",
+        "source": {"doc_id": null, "weight": 0.7, "role": "manual",
+                   "note": "..."}
+      }
+    """
+    _require_graph_edit_enabled()
+    body = await request.json()
+    _require_feature(body.get("api_key", ""), role, "admin.data")
+
+    src_id = (body.get("src_entity_id") or "").strip()
+    tgt_id = (body.get("tgt_entity_id") or "").strip()
+    rtype  = (body.get("relation_type") or "").strip()
+    source = body.get("source")
+    if not (src_id and tgt_id and rtype and isinstance(source, dict)):
+        raise HTTPException(
+            status_code=400,
+            detail="src_entity_id / tgt_entity_id / relation_type / source required",
+        )
+
+    from core.graph_editor import append_relation_source
+    try:
+        result = append_relation_source(
+            src_id, tgt_id, rtype, source,
+            wiki_generator=rag_engine.wiki_generator,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    _write_audit(
+        role, "/admin/graph/relation/source [POST]",
+        query=_truncate_audit_blob({
+            "src": src_id, "tgt": tgt_id, "type": rtype,
+            "role": source.get("role"),
+        }),
+        answer=_truncate_audit_blob({
+            "fwd_after_n": len(result["forward"]["after"]),
+            "inv_synced": result["inverse"] is not None,
+        }),
+    )
+    return {"ok": True, "result": result}
+
+
+@app.delete("/admin/graph/relation",
+            summary="relation 자체 제거 [Knowledge Cascade Phase E]")
+async def admin_graph_relation_delete(request: Request,
+                                      role: str = Depends(get_role_from_request)):
+    """forward + inverse 양쪽 relation 을 frontmatter 에서 제거.
+
+    Body JSON:
+      {
+        "api_key":       "...",
+        "src_entity_id": "...",
+        "tgt_entity_id": "...",
+        "relation_type": "RELATED_TO"
+      }
+    """
+    _require_graph_edit_enabled()
+    body = await request.json()
+    _require_feature(body.get("api_key", ""), role, "admin.data")
+
+    src_id = (body.get("src_entity_id") or "").strip()
+    tgt_id = (body.get("tgt_entity_id") or "").strip()
+    rtype  = (body.get("relation_type") or "").strip()
+    if not (src_id and tgt_id and rtype):
+        raise HTTPException(
+            status_code=400,
+            detail="src_entity_id / tgt_entity_id / relation_type required",
+        )
+
+    from core.graph_editor import delete_relation
+    try:
+        result = delete_relation(
+            src_id, tgt_id, rtype,
+            wiki_generator=rag_engine.wiki_generator,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    _write_audit(
+        role, "/admin/graph/relation [DELETE]",
+        query=_truncate_audit_blob({
+            "src": src_id, "tgt": tgt_id, "type": rtype,
+        }),
+        answer=_truncate_audit_blob({
+            "fwd_removed": result["forward"]["removed"],
+            "inv_removed": result["inverse"]["removed"],
+        }),
+    )
+    return {"ok": True, "result": result}
+
+
 @app.get("/admin/memory", summary="Memory 현황 [P7]")
 async def admin_memory(api_key: str, role: str = Depends(get_role_from_request)):
     _require_feature(api_key, role, "admin.data")

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -1,0 +1,400 @@
+"""Phase E (Knowledge Cascade) — graph editor backend 검증.
+
+docs/design/v0.3-knowledge-cascade.md §7 — Phase E.
+
+본 테스트는 ``core/graph_editor.py`` 의 3 mutation API 와 env flag
+helper 를 cover. UI 는 별도 PR 이라 frontend wiring 은 검증 대상 아님.
+
+검증 시나리오:
+  1. replace_relation_sources (PUT)
+     - 기존 relation 의 sources 교체 + confidence derive
+     - 양방향 동기화 (forward + inverse)
+     - 매칭 relation 없을 때 신규 생성
+     - target entity 없을 때 forward 만 반영
+     - 빈 sources → ValueError (use DELETE)
+  2. append_relation_source (POST)
+     - 한 줄 append, 기존 sources 보존
+     - 양쪽 동시 append
+     - 신규 relation 자동 생성
+     - manual role 의 author/note 보존
+  3. delete_relation (DELETE)
+     - 양쪽 relation 제거
+     - 없으면 no-op
+  4. graph_edit_enabled — env flag 기본 off, "1"/"true"/"on" 등 허용
+  5. cascade(Phase C) 와의 정합: PUT 으로 추가한 manual source 가
+     cascade_remove_doc_from_sources 후에도 살아남아 entity 가
+     orphan 으로 잘못 분류되지 않음
+
+production wiki 무영향 — tempfile 격리.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml  # noqa: I001
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
+from core.graph_editor import (
+    append_relation_source,
+    delete_relation,
+    graph_edit_enabled,
+    replace_relation_sources,
+)
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    MANUAL_SOURCE_ROLE,
+    compute_confidence_from_sources,
+)
+
+
+# ── 0. fixture helpers ─────────────────────────────────────────────
+
+def _write_entity(path: Path, fm: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = (
+        "---\n"
+        + yaml.safe_dump(fm, allow_unicode=True, sort_keys=False,
+                         default_flow_style=False)
+        + "---\n# body\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_fm(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    body = text.split("---", 2)[1]
+    return yaml.safe_load(body)
+
+
+class _WgStub:
+    """WikiGenerator 의 entity_id_index + refresh_entity_map 만 모의."""
+    def __init__(self, entity_id_index: dict):
+        self.entity_id_index = entity_id_index
+
+    def refresh_entity_map(self):
+        pass
+
+
+def _two_entities_with_relation(role: str = EXTRACT_SOURCE_ROLE):
+    """Joby (org) ↔ NVIDIA (org) 1 relation 시나리오. 양쪽 다 sources
+    1 항목 보유. 반환: (root, wg_stub, joby_path, nv_path, ids)"""
+    root = Path(tempfile.mkdtemp()) / "entity"
+    for t in ("person", "org", "concept", "document"):
+        (root / t).mkdir(parents=True)
+    joby_id = "e_org_joby"
+    nv_id   = "e_org_nvidia"
+    joby_p = root / "org" / "joby.md"
+    nv_p   = root / "org" / "nvidia.md"
+    _write_entity(joby_p, {
+        "entity_id":   joby_id,
+        "name":        "Joby",
+        "entity_type": "org",
+        "relations": [{
+            "target": "NVIDIA", "target_id": nv_id,
+            "target_type": "org", "type": "RELATED_TO", "label": "관련",
+            "confidence": 0.7,
+            "sources": [{"doc_id": "e_doc_old", "weight": 0.7,
+                         "role": role, "ts": "2026-05-14"}],
+        }],
+    })
+    _write_entity(nv_p, {
+        "entity_id":   nv_id,
+        "name":        "NVIDIA",
+        "entity_type": "org",
+        "relations": [{
+            "target": "Joby", "target_id": joby_id,
+            "target_type": "org", "type": "RELATED_TO", "label": "관련",
+            "confidence": 0.7,
+            "sources": [{"doc_id": "e_doc_old", "weight": 0.7,
+                         "role": role, "ts": "2026-05-14"}],
+        }],
+    })
+    wg = _WgStub({joby_id: joby_p, nv_id: nv_p})
+    return root, wg, joby_p, nv_p, (joby_id, nv_id)
+
+
+# ── 1. replace_relation_sources (PUT) ──────────────────────────────
+
+class ReplaceRelationSourcesTests(unittest.TestCase):
+    def test_replaces_both_sides_and_derives_confidence(self):
+        _, wg, joby_p, nv_p, (joby_id, nv_id) = _two_entities_with_relation()
+        new_sources = [
+            {"doc_id": None, "weight": 0.9, "role": MANUAL_SOURCE_ROLE,
+             "author": "admin", "note": "verified manually"},
+        ]
+        result = replace_relation_sources(
+            joby_id, nv_id, "RELATED_TO", new_sources,
+            wiki_generator=wg,
+        )
+
+        # forward
+        fm = _read_fm(joby_p)
+        rel = fm["relations"][0]
+        self.assertEqual(len(rel["sources"]), 1)
+        self.assertEqual(rel["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+        self.assertEqual(rel["sources"][0]["author"], "admin")
+        self.assertEqual(rel["sources"][0]["note"], "verified manually")
+        self.assertEqual(rel["confidence"],
+                         compute_confidence_from_sources(rel["sources"]))
+
+        # inverse
+        fm_inv = _read_fm(nv_p)
+        rel_inv = fm_inv["relations"][0]
+        self.assertEqual(len(rel_inv["sources"]), 1)
+        self.assertEqual(rel_inv["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+        self.assertEqual(rel_inv["confidence"], rel["confidence"])
+
+        self.assertEqual(result["forward"]["after"][0]["role"],
+                         MANUAL_SOURCE_ROLE)
+        self.assertIsNotNone(result["inverse"])
+
+    def test_creates_relation_if_missing(self):
+        root = Path(tempfile.mkdtemp()) / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (root / t).mkdir(parents=True)
+        a_id, b_id = "e_org_a", "e_org_b"
+        a_p = root / "org" / "a.md"
+        b_p = root / "org" / "b.md"
+        _write_entity(a_p, {"entity_id": a_id, "name": "A",
+                            "entity_type": "org", "relations": []})
+        _write_entity(b_p, {"entity_id": b_id, "name": "B",
+                            "entity_type": "org", "relations": []})
+        wg = _WgStub({a_id: a_p, b_id: b_p})
+
+        replace_relation_sources(
+            a_id, b_id, "RELATED_TO",
+            [{"doc_id": None, "weight": 0.5, "role": MANUAL_SOURCE_ROLE}],
+            wiki_generator=wg,
+        )
+        fm_a = _read_fm(a_p)
+        self.assertEqual(len(fm_a["relations"]), 1)
+        self.assertEqual(fm_a["relations"][0]["target_id"], b_id)
+        self.assertEqual(fm_a["relations"][0]["target"], "B")
+        self.assertEqual(fm_a["relations"][0]["target_type"], "org")
+        fm_b = _read_fm(b_p)
+        self.assertEqual(len(fm_b["relations"]), 1)
+        self.assertEqual(fm_b["relations"][0]["target_id"], a_id)
+
+    def test_inverse_skipped_when_target_missing(self):
+        root = Path(tempfile.mkdtemp()) / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (root / t).mkdir(parents=True)
+        a_id = "e_org_a"
+        a_p = root / "org" / "a.md"
+        _write_entity(a_p, {"entity_id": a_id, "name": "A",
+                            "entity_type": "org", "relations": []})
+        wg = _WgStub({a_id: a_p})
+        result = replace_relation_sources(
+            a_id, "e_org_missing", "RELATED_TO",
+            [{"doc_id": None, "weight": 0.5, "role": MANUAL_SOURCE_ROLE}],
+            wiki_generator=wg,
+        )
+        fm = _read_fm(a_p)
+        self.assertEqual(len(fm["relations"]), 1)
+        self.assertIsNone(result["inverse"])
+
+    def test_empty_sources_raises(self):
+        _, wg, _, _, (joby_id, nv_id) = _two_entities_with_relation()
+        with self.assertRaises(ValueError):
+            replace_relation_sources(
+                joby_id, nv_id, "RELATED_TO", [],
+                wiki_generator=wg,
+            )
+
+    def test_invalid_role_raises(self):
+        _, wg, _, _, (joby_id, nv_id) = _two_entities_with_relation()
+        with self.assertRaises(ValueError):
+            replace_relation_sources(
+                joby_id, nv_id, "RELATED_TO",
+                [{"doc_id": None, "weight": 0.5, "role": "bogus_role"}],
+                wiki_generator=wg,
+            )
+
+    def test_src_entity_missing_raises(self):
+        _, wg, _, _, (_, nv_id) = _two_entities_with_relation()
+        with self.assertRaises(ValueError):
+            replace_relation_sources(
+                "e_org_nonexistent", nv_id, "RELATED_TO",
+                [{"doc_id": None, "weight": 0.5, "role": MANUAL_SOURCE_ROLE}],
+                wiki_generator=wg,
+            )
+
+
+# ── 2. append_relation_source (POST) ───────────────────────────────
+
+class AppendRelationSourceTests(unittest.TestCase):
+    def test_appends_to_both_sides_preserving_existing(self):
+        _, wg, joby_p, nv_p, (joby_id, nv_id) = _two_entities_with_relation()
+        result = append_relation_source(
+            joby_id, nv_id, "RELATED_TO",
+            {"doc_id": None, "weight": 0.5, "role": MANUAL_SOURCE_ROLE,
+             "note": "additional evidence"},
+            wiki_generator=wg,
+        )
+        fm = _read_fm(joby_p)
+        rel = fm["relations"][0]
+        self.assertEqual(len(rel["sources"]), 2)
+        # 첫 번째는 기존 extract source 보존
+        self.assertEqual(rel["sources"][0]["role"], EXTRACT_SOURCE_ROLE)
+        self.assertEqual(rel["sources"][1]["role"], MANUAL_SOURCE_ROLE)
+        # confidence 는 두 source 의 weight 합
+        self.assertEqual(rel["confidence"],
+                         compute_confidence_from_sources(rel["sources"]))
+
+        fm_inv = _read_fm(nv_p)
+        self.assertEqual(len(fm_inv["relations"][0]["sources"]), 2)
+        self.assertIsNotNone(result["inverse"])
+
+    def test_creates_relation_when_missing(self):
+        root = Path(tempfile.mkdtemp()) / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (root / t).mkdir(parents=True)
+        a_id, b_id = "e_org_a", "e_org_b"
+        a_p = root / "org" / "a.md"
+        b_p = root / "org" / "b.md"
+        _write_entity(a_p, {"entity_id": a_id, "name": "A",
+                            "entity_type": "org", "relations": []})
+        _write_entity(b_p, {"entity_id": b_id, "name": "B",
+                            "entity_type": "org", "relations": []})
+        wg = _WgStub({a_id: a_p, b_id: b_p})
+
+        append_relation_source(
+            a_id, b_id, "RELATED_TO",
+            {"doc_id": None, "weight": 0.6, "role": MANUAL_SOURCE_ROLE},
+            wiki_generator=wg,
+        )
+        fm_a = _read_fm(a_p)
+        fm_b = _read_fm(b_p)
+        self.assertEqual(len(fm_a["relations"]), 1)
+        self.assertEqual(len(fm_b["relations"]), 1)
+        self.assertEqual(fm_a["relations"][0]["sources"][0]["role"],
+                         MANUAL_SOURCE_ROLE)
+
+    def test_manual_metadata_preserved(self):
+        _, wg, joby_p, _, (joby_id, nv_id) = _two_entities_with_relation()
+        append_relation_source(
+            joby_id, nv_id, "RELATED_TO",
+            {"doc_id": None, "weight": 0.7, "role": MANUAL_SOURCE_ROLE,
+             "author": "alice", "note": "x" * 500},   # over-cap note
+            wiki_generator=wg,
+        )
+        fm = _read_fm(joby_p)
+        s = fm["relations"][0]["sources"][-1]
+        self.assertEqual(s["author"], "alice")
+        self.assertEqual(len(s["note"]), 300)   # truncated
+
+
+# ── 3. delete_relation (DELETE) ────────────────────────────────────
+
+class DeleteRelationTests(unittest.TestCase):
+    def test_removes_both_sides(self):
+        _, wg, joby_p, nv_p, (joby_id, nv_id) = _two_entities_with_relation()
+        result = delete_relation(
+            joby_id, nv_id, "RELATED_TO",
+            wiki_generator=wg,
+        )
+        self.assertTrue(result["forward"]["removed"])
+        self.assertTrue(result["inverse"]["removed"])
+        self.assertEqual(_read_fm(joby_p).get("relations") or [], [])
+        self.assertEqual(_read_fm(nv_p).get("relations") or [], [])
+
+    def test_noop_when_relation_missing(self):
+        root = Path(tempfile.mkdtemp()) / "entity"
+        for t in ("person", "org", "concept", "document"):
+            (root / t).mkdir(parents=True)
+        a_id, b_id = "e_org_a", "e_org_b"
+        a_p = root / "org" / "a.md"
+        b_p = root / "org" / "b.md"
+        _write_entity(a_p, {"entity_id": a_id, "name": "A",
+                            "entity_type": "org", "relations": []})
+        _write_entity(b_p, {"entity_id": b_id, "name": "B",
+                            "entity_type": "org", "relations": []})
+        wg = _WgStub({a_id: a_p, b_id: b_p})
+        result = delete_relation(
+            a_id, b_id, "RELATED_TO",
+            wiki_generator=wg,
+        )
+        self.assertFalse(result["forward"]["removed"])
+        self.assertFalse(result["inverse"]["removed"])
+
+
+# ── 4. env flag ────────────────────────────────────────────────────
+
+class GraphEditEnabledTests(unittest.TestCase):
+    def test_default_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JAMES_GRAPH_EDIT", None)
+            self.assertFalse(graph_edit_enabled())
+
+    def test_one_enables(self):
+        with patch.dict(os.environ, {"JAMES_GRAPH_EDIT": "1"}):
+            self.assertTrue(graph_edit_enabled())
+
+    def test_other_truthy_values(self):
+        for v in ("true", "TRUE", "yes", "on"):
+            with patch.dict(os.environ, {"JAMES_GRAPH_EDIT": v}):
+                self.assertTrue(graph_edit_enabled(), f"value {v!r}")
+
+    def test_falsy_values(self):
+        for v in ("0", "false", "no", "off", "", "random"):
+            with patch.dict(os.environ, {"JAMES_GRAPH_EDIT": v}):
+                self.assertFalse(graph_edit_enabled(), f"value {v!r}")
+
+
+# ── 5. Phase C cascade 와의 정합 ───────────────────────────────────
+
+class PhaseC_CascadeIntegrationTests(unittest.TestCase):
+    """그래프 에디터로 추가한 manual source 가 doc 삭제 cascade 후에도
+    살아남아 entity 가 orphan 으로 잘못 분류되지 않는지."""
+
+    def test_manual_source_survives_cascade(self):
+        from core.cascade import (
+            cascade_remove_doc_from_sources,
+            find_orphan_entities,
+        )
+        _, wg, joby_p, nv_p, (joby_id, nv_id) = _two_entities_with_relation()
+        # 시작 sources 는 doc=e_doc_old, role=extract.
+        # 그래프 에디터로 manual 한 줄 append.
+        append_relation_source(
+            joby_id, nv_id, "RELATED_TO",
+            {"doc_id": None, "weight": 0.9, "role": MANUAL_SOURCE_ROLE,
+             "author": "admin"},
+            wiki_generator=wg,
+        )
+        # joby/nvidia 둘 다 source_document=old.pdf 라고 마킹 (orphan
+        # 후보가 되도록).
+        for p in (joby_p, nv_p):
+            fm = _read_fm(p)
+            fm["attributes"] = {"source_document": "old.pdf"}
+            _write_entity(p, fm)
+
+        # cascade — e_doc_old 의 source 제거
+        counts = cascade_remove_doc_from_sources(
+            "e_doc_old", joby_p.parent.parent,
+        )
+        # extract source 만 사라지고 manual 은 남아 relation 유지
+        self.assertEqual(counts["relations_dropped"], 0)
+        self.assertEqual(counts["relations_recomputed"], 2)
+        fm_after = _read_fm(joby_p)
+        rel = fm_after["relations"][0]
+        self.assertEqual(len(rel["sources"]), 1)
+        self.assertEqual(rel["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+
+        # orphan sweep — manual relation 살아있어 둘 다 orphan 아님
+        orphans = find_orphan_entities(
+            "old.pdf", "e_doc_old", joby_p.parent.parent,
+        )
+        self.assertEqual(orphans, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`docs/design/v0.3-knowledge-cascade.md` §7 — **Phase E**. 사용자 요청 N-7 (그래프 에디터) 의 backend.

`/admin/graph` 의 admin 이 edge 별 sources 를 직접 편집할 수 있게 하는 backend. Phase B (#269) 의 sources schema + Phase C (#270) 의 manual-source-aware cascade 가 깐 위에서 **manual source 의 write path** 가 들어온다. **UI 는 별도 follow-up PR**.

### 변경 contract

새 모듈 `core/graph_editor.py`:
- `replace_relation_sources(...)` — PUT semantics. forward + inverse relation 의 sources 를 전부 교체, confidence 자동 derive, 매칭 relation 없으면 신규 생성, target entity 없으면 forward 만 반영
- `append_relation_source(...)` — POST semantics. 단일 source 양쪽 append (**commutative**). manual role 의 author/note metadata 보존, note 300 char cap
- `delete_relation(...)` — DELETE semantics. 양쪽 relation 자체 제거. 없으면 no-op
- `graph_edit_enabled()` — `JAMES_GRAPH_EDIT=1` opt-in env flag (디자인 §7 graceful degradation)

신규 endpoint 3 (server_llmwiki.py):
- `PUT    /admin/graph/relation`           — body: src_entity_id, tgt_entity_id, relation_type, sources[]
- `POST   /admin/graph/relation/source`    — body: src/tgt/type + source(dict)
- `DELETE /admin/graph/relation`           — body: src/tgt/type

모두 **admin.data** feature gate + `graph_edit_enabled()` 게이트. audit log 에 before/after sources 개수 + inverse 동기화 여부 기록 (raw sources 배열은 500-char audit cap 에 truncate; UI 에서 diff 보려면 endpoint 응답을 사용).

### Trust model (§7)

- admin 만 호출 (server-side gate, UI 만 의존하지 않음)
- 모든 mutation audit log 에 기록 (before+after count + inverse 동기화)
- manual sources 는 **Phase C cascade 에서 자동 보존** (#270 의 룰이 이미 처리 — 신규 cascade 분기 없음)
- 동시 PUT 은 last-writer-wins. POST (append) 는 commutative — 충돌 불가

### Phase C 정합 (end-to-end 검증됨)

테스트 `PhaseC_CascadeIntegrationTests::test_manual_source_survives_cascade` 가 다음을 round-trip 검증:
1. POST 로 manual source append
2. 원본 doc 의 source 를 cascade_remove_doc_from_sources 로 제거
3. manual source 가 살아남아 relation 유지 + entity 가 orphan 으로 분류되지 않음

### Verification

- 신규 테스트 16개 (`tests/test_phase_e_graph_editor.py`):
  - replace_relation_sources 6 — 양방향 교체 / 매칭 없으면 생성 / inverse 미존재 시 forward 만 / 빈 sources ValueError / invalid role / src missing
  - append_relation_source 3 — append preserving / 매칭 없으면 생성 / manual metadata (author + note cap)
  - delete_relation 2 — 양쪽 제거 / no-op
  - graph_edit_enabled 4 — default off / "1" / 기타 truthy / falsy
  - Phase C 정합 1 — end-to-end manual survives cascade
- 전체 회귀: **1809 tests OK** (1793 → 1809, +16 신규, 0 regression)
- \`ruff check core/graph_editor.py tests/test_phase_e_graph_editor.py server_llmwiki.py\` → All checks passed!

### CLAUDE.md gates

- rule #2 (bench numbers): 본 PR 은 read path 무영향. write path 는 admin-only opt-in 이라 STEP 7 baseline 에 미영향
- rule #3 (자가-진화): 본 PR 은 자가-진화 무관
- rule #5 (20 KB): `core/graph_editor.py` 13 KB (gate 통과)

### Out of scope (follow-up PR)

- **frontend UI**: `/admin/graph` 의 edit-mode toggle 버튼, edge 클릭 → modal, sources list 렌더, weight/role 폼, add-manual-source 폼, 우클릭 context menu
- **Phase D** modify cascade (`PUT /admin/files` + extraction diff sidecar) — 별 사이클
- bulk operations (여러 relation 한 번에 편집) — 필요 시 별 endpoint

### 활성화 방법

```bash
export JAMES_GRAPH_EDIT=1   # 또는 set on Windows
python server_llmwiki.py
```

env flag 없이 호출 시 endpoint 는 403 `graph_edit_disabled` 반환.

### Phase 큐

- [x] Phase A — PR #266
- [x] Phase B — PR #269
- [x] Phase C — PR #270
- [ ] Phase D — modify cascade (다음 사이클)
- [x] **Phase E (backend) — 본 PR**
- [ ] Phase E (frontend UI) — follow-up PR