### PR TITLE
docs(promo): record Hashnode cross-post in tracker

### DIFF
--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -26,6 +26,7 @@
 | 2026-05-12 | dev.to draft + launch tracker (PR #242) | ✅ Merged into main |
 | 2026-05-12 | urllib3 + python-multipart secondary advisory bumps (Dependabot #7-#10) | ✅ Merged into main (separate session — `urllib3>=2.7.0`, `python-multipart>=0.0.27`) |
 | 2026-05-12 | **Gemma 4 Challenge submission published (Build with Gemma 4 track)** | ✅ Live ([URL](https://dev.to/hashevolution/building-a-mini-palantir-on-gemma4e4b-128k-context-lets-the-graph-actually-be-graph-rag-33fk)) |
+| 2026-05-13 | Hashnode cross-post of intro article (`ragllm.hashnode.dev`) | ✅ Live ([URL](https://ragllm.hashnode.dev/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-alpha)) |
 
 ---
 
@@ -57,6 +58,7 @@ Three independent curators, three independent review pipelines. One acceptance i
 | Twitter/X (Korean) | _(URL pending — author to record)_ | KR | 2026-05-12 |
 | dev.to article (intro) | https://dev.to/hashevolution/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-1914 | Global EN (technical) | 2026-05-12 |
 | dev.to article (Gemma 4 Challenge submission) | https://dev.to/hashevolution/building-a-mini-palantir-on-gemma4e4b-128k-context-lets-the-graph-actually-be-graph-rag-33fk | Global EN (Gemma 4 contestants + judges) | 2026-05-12 |
+| Hashnode cross-post (intro article) | https://ragllm.hashnode.dev/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-alpha | Global EN (Hashnode algorithm + Google search) | 2026-05-13 |
 
 Monitoring rule: respond to substantive replies within 1-2 hours during the first 24 hours; longer-form responses (e.g. quote threads) get hour-of-day discretion.
 


### PR DESCRIPTION
## Summary

Records the Hashnode cross-post of the intro Mini-Palantir article in `launch-tracker.md`.

- Status snapshot: new row for 2026-05-13 Hashnode publication
- Social posts: new row pointing to `ragllm.hashnode.dev/building-a-mini-palantir-...` and labelling the audience as "Hashnode algorithm + Google search" (distinct from the dev.to original because the search-index path is independent)

The cross-post mirrors the **intro article**, not the Gemma 4 Challenge submission. Canonical URL on the Hashnode side should point back to the dev.to original to avoid Google duplicate-content penalty — author to confirm.

## Verification

Pure docs/promo addition. No code touched.

WebFetch returned 403 on the Hashnode URL due to bot blocking, but the URL was supplied by the author who published it.

## Out of scope

- Author confirmation of canonical URL setting on the Hashnode editor (5-minute manual check)
- Cross-posting the Gemma 4 Challenge submission to Hashnode as well (separate decision)
- The X/Twitter quote-reply linking the Hashnode URL — author may schedule for a different time-zone window than the dev.to quote-reply

---

## 한국어 요약

Hashnode intro 글 cross-post URL 을 launch tracker 에 기록. canonical URL 이 dev.to 원본으로 설정되어야 SEO 중복 회피 — 작성자 확인 필요.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_