### PR TITLE
feat(graph): Knowledge Cascade Phase E UI — edge edit modal (N-7)

### DIFF
--- a/core/graph_editor.py
+++ b/core/graph_editor.py
@@ -145,6 +145,34 @@ def _find_relation_index(
     return None
 
 
+def read_relation(
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    *,
+    wiki_generator,
+) -> Optional[Dict[str, Any]]:
+    """forward 측 entity 의 frontmatter 에서 매칭 relation dict 를 그대로
+    반환 (sources 배열 포함). 없으면 None.
+
+    UI 의 edit modal 이 edge 클릭 시 sources 를 fresh load 하기 위한
+    read path. snapshot endpoint 에 sources 를 넣지 않은 이유는 213
+    entity × N relation × N source 면 wire payload 가 폭증하기 때문 —
+    on-demand fetch 로 격리.
+    """
+    src_path, src_fm, _body = _load_entity_by_id(src_entity_id, wiki_generator)
+    _ = src_path   # unused
+    rels = src_fm.get("relations") or []
+    idx = _find_relation_index(rels, tgt_entity_id, relation_type)
+    if idx is None:
+        return None
+    rel = rels[idx]
+    # 안전한 복사본 — caller 가 변형해도 frontmatter 무영향
+    if isinstance(rel, dict):
+        return dict(rel)
+    return None
+
+
 def _validate_sources(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """클라이언트가 보낸 sources 배열을 정규화 + 검증.
 

--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -124,11 +124,15 @@
   강화 룰 / cascade_delete_upload / strip_uuid_prefix / backup_upload_file)
   + endpoint. 21 신규 tests → 1793 OK
 - [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint, Phase C 의존)
-- [ ] **Phase E — 본 PR (backend only)** graph editor (= 사용자 요청 N-7).
+- [x] **Phase E backend — PR #271 머지 (2026-05-14)** graph editor (= 사용자 요청 N-7).
   `core/graph_editor.py` (replace / append / delete + 양방향 동기화 +
   manual metadata) + 3 endpoint (`PUT/POST/DELETE /admin/graph/relation`)
-  + `JAMES_GRAPH_EDIT=1` opt-in flag. 16 신규 tests → 1809 OK.
-  **frontend UI wiring 은 follow-up PR**
+  + `JAMES_GRAPH_EDIT=1` opt-in flag. 16 신규 tests → 1809 OK
+- [ ] **Phase E frontend UI — 본 PR** `/admin/graph` 의 edit-mode 토글 +
+  edge 클릭 modal (sources 표시 + manual append + delete relation).
+  새 GET `/admin/graph/relation` (sources read path) + read_relation
+  helper + 3 read tests. frontend: `graph_editor.js` 신규, graph.html
+  + graph.js 의 hook. 1812 OK
 
 ### 🟣 사이클 9 — CR-E (self-evolution → CR 래핑)
 - 디퍼된 v0.2.x §5 항목. 4 locked JSONL test 파일 + eval gate +

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -68,6 +68,23 @@
         <div data-i18n="graph.tip.click">click node — focus</div>
       </div>
     </div>
+
+    <!-- [Knowledge Cascade Phase E UI] admin edit-mode toggle. JS hides
+         the wrapper if not admin / server has JAMES_GRAPH_EDIT off. -->
+    <div id="graph-edit-wrap" style="display:none">
+      <div class="panel-title" style="margin-bottom:8px">Edit mode</div>
+      <button id="graph-edit-toggle" type="button"
+              style="width:100%;padding:9px 12px;background:var(--surface-2);
+                     border:1px solid var(--border);border-radius:7px;
+                     color:var(--text-soft);font-size:12px;cursor:pointer;
+                     font-family:var(--font-mono);letter-spacing:.4px">
+        🔒 Edit mode: OFF
+      </button>
+      <div id="graph-edit-hint" class="stat"
+           style="margin-top:8px;line-height:1.6;font-size:11px;display:none">
+        edit ON — click any edge to view + edit its sources
+      </div>
+    </div>
   </aside>
 
   <div class="stage">
@@ -145,8 +162,87 @@
 <script src="https://unpkg.com/3d-force-graph@1.73.4/dist/3d-force-graph.min.js"></script>
 <script src="https://unpkg.com/d3-force-3d@3.0.5/dist/d3-force-3d.min.js"></script>
 
+<!-- [Knowledge Cascade Phase E UI] edge edit modal. Hidden by default.
+     a11y-modal.js handles focus trap + Escape; the .show class toggles
+     visibility (same pattern as #login-modal above). -->
+<div class="modal-overlay" id="edge-edit-modal"
+     role="dialog" aria-modal="true"
+     aria-labelledby="edge-edit-title">
+  <div class="modal-card" style="max-width:520px;width:92%;max-height:80vh;overflow-y:auto">
+    <div id="edge-edit-title"
+         style="font-size:13px;font-weight:600;font-family:var(--font-mono);
+                color:var(--accent-fg);margin-bottom:6px;letter-spacing:.5px">
+      ▸ <span id="edge-edit-src">—</span>
+      <span style="color:var(--muted);font-weight:400"> → </span>
+      <span id="edge-edit-tgt">—</span>
+    </div>
+    <div style="font-size:11px;color:var(--muted);margin-bottom:14px;
+                font-family:var(--font-mono)">
+      <span id="edge-edit-type">—</span>
+      <span style="margin-left:10px">conf: <span id="edge-edit-conf">—</span></span>
+    </div>
+
+    <div style="font-size:10px;color:var(--muted);letter-spacing:1px;
+                font-family:var(--font-mono);margin-bottom:6px">SOURCES</div>
+    <div id="edge-edit-sources"
+         style="border:1px solid var(--border);border-radius:7px;
+                background:var(--bg);padding:8px;margin-bottom:18px;
+                font-size:12px;max-height:30vh;overflow-y:auto">
+      <!-- JS fills rows -->
+    </div>
+
+    <div style="font-size:10px;color:var(--muted);letter-spacing:1px;
+                font-family:var(--font-mono);margin-bottom:6px">
+      ADD MANUAL SOURCE
+    </div>
+    <div style="display:flex;gap:8px;margin-bottom:8px">
+      <input id="edge-edit-weight" type="number" step="0.1" min="0" max="1"
+             value="0.8" placeholder="weight"
+             style="flex:0 0 80px;background:var(--bg);
+                    border:1px solid var(--border);border-radius:6px;
+                    padding:7px 9px;color:var(--text);font-size:12px;outline:none">
+      <input id="edge-edit-note" type="text" maxlength="300"
+             placeholder="note (optional)"
+             style="flex:1;background:var(--bg);border:1px solid var(--border);
+                    border-radius:6px;padding:7px 9px;color:var(--text);
+                    font-size:12px;outline:none">
+    </div>
+    <button id="edge-edit-append"
+            style="width:100%;padding:9px;background:var(--accent);
+                   border:none;border-radius:7px;color:var(--on-accent);
+                   font-size:12px;font-weight:600;cursor:pointer;
+                   font-family:var(--font-mono);letter-spacing:.4px;margin-bottom:18px">
+      + Add manual source
+    </button>
+
+    <div id="edge-edit-error"
+         style="font-size:11px;color:var(--danger);min-height:14px;
+                margin-bottom:8px;font-family:var(--font-mono)"></div>
+
+    <div style="display:flex;gap:8px">
+      <button id="edge-edit-delete-relation"
+              style="flex:1;padding:9px;background:transparent;
+                     border:1px solid var(--danger);border-radius:7px;
+                     color:var(--danger);font-size:11px;font-weight:600;
+                     cursor:pointer;font-family:var(--font-mono);
+                     letter-spacing:.4px">
+        Delete entire relation
+      </button>
+      <button id="edge-edit-close"
+              style="flex:1;padding:9px;background:var(--surface-2);
+                     border:1px solid var(--border);border-radius:7px;
+                     color:var(--text-soft);font-size:11px;font-weight:600;
+                     cursor:pointer;font-family:var(--font-mono);
+                     letter-spacing:.4px">
+        Close
+      </button>
+    </div>
+  </div>
+</div>
+
 <script src="/static/i18n.js"></script>
 <script src="/static/graph.js"></script>
+<script src="/static/graph_editor.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 </body>
 </html>

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -341,6 +341,14 @@
       if (!graph) initGraph();
       graph.graphData(data);
 
+      // [Knowledge Cascade Phase E UI] graph editor 가 본 instance 에
+      // linkClick 핸들러를 attach 할 수 있게 hook. graph_editor.js 는
+      // 본 graph.js 이후에 로드되므로 window.GraphEditor 가 이미 정의돼 있다.
+      if (window.GraphEditor && typeof window.GraphEditor.onSnapshotLoaded === 'function') {
+        try { window.GraphEditor.onSnapshotLoaded(graph, data, { apiKey: apiKey, token: token }); }
+        catch (_e) { /* never block graph render */ }
+      }
+
       var meta = snap.meta || {};
       var statBox = document.getElementById('stat-box');
       if (statBox) {

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -1,0 +1,373 @@
+/**
+ * PROJECT JAMES — Knowledge Cascade Phase E (frontend UI).
+ *
+ * docs/design/v0.3-knowledge-cascade.md §7. Backend (PR #271) 가 깐
+ * 3 mutation endpoint + 1 read endpoint 위에서 동작하는 admin 전용
+ * edge 편집 UI.
+ *
+ * Activation:
+ *   1) admin 으로 로그인 (login-modal 의 정상 flow)
+ *   2) 사이드바의 "Edit mode" 토글 클릭 → 서버의 JAMES_GRAPH_EDIT=1
+ *      여부 확인. flag off 면 alert + 토글 OFF 유지.
+ *   3) flag on 인 경우 ForceGraph3D 의 link 클릭이 본 모듈의 modal 을
+ *      열도록 wired.
+ *
+ * Backend dependencies:
+ *   GET    /admin/graph/relation                   (read sources)
+ *   POST   /admin/graph/relation/source            (append manual source)
+ *   DELETE /admin/graph/relation                   (drop relation 전체)
+ *   PUT    /admin/graph/relation                   (지금은 미사용 — per-source
+ *                                                   editor 는 follow-up)
+ *
+ * No bundler — same vanilla pattern as graph.js (IIFE, window 노출).
+ */
+(function () {
+  'use strict';
+
+  var API = '';
+  var graphInstance = null;
+  var snapshotData  = null;
+  var apiKey        = '';
+  var token         = '';
+
+  var editEnabled       = false;          // 토글 상태 (client side)
+  var editFlagChecked   = false;          // 서버 flag 확인 했는지
+  var currentEdge       = null;           // 모달에 표시 중인 edge
+
+  // ──────────────────────────────────────────────────────────────
+  // DOM refs (graph.html 에 정의)
+  // ──────────────────────────────────────────────────────────────
+  function $(id) { return document.getElementById(id); }
+
+  function authHeaders() {
+    return { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' };
+  }
+  function withKey(url) {
+    return url + (url.indexOf('?') < 0 ? '?' : '&') + 'api_key=' + encodeURIComponent(apiKey);
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // 서버 flag probe — JAMES_GRAPH_EDIT 가 켜져 있는지 확인.
+  // GET /admin/graph/relation 에 일부러 매칭 안 되는 dummy 를 보내 본다:
+  //   - 403 graph_edit_disabled → flag off
+  //   - 404 relation not found  → flag on, gate 통과
+  //   - 401  → 토큰 무효 (로그인 다시)
+  // ──────────────────────────────────────────────────────────────
+  async function probeEditFlag() {
+    try {
+      var url = withKey(API + '/admin/graph/relation') +
+                '&src_entity_id=__probe__&tgt_entity_id=__probe__' +
+                '&relation_type=RELATED_TO';
+      var r = await fetch(url, { headers: authHeaders() });
+      if (r.status === 403) {
+        var j = await r.json().catch(function () { return {}; });
+        if (String(j.detail || '').indexOf('graph_edit_disabled') >= 0) {
+          return { ok: false, reason: 'disabled' };
+        }
+        return { ok: false, reason: 'forbidden' };
+      }
+      if (r.status === 401) return { ok: false, reason: 'auth' };
+      // 200 또는 404 모두 flag on → gate 통과
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, reason: 'network' };
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // edge → src/tgt/type 정규화. graph.js 가 만들어둔 link dict 는
+  // {source: node_ref|id, target: node_ref|id, type, weight, conf} 형식.
+  // ──────────────────────────────────────────────────────────────
+  function linkSrcId(l) {
+    return typeof l.source === 'object' ? l.source.id : l.source;
+  }
+  function linkTgtId(l) {
+    return typeof l.target === 'object' ? l.target.id : l.target;
+  }
+  function nodeName(id) {
+    if (!snapshotData) return id;
+    for (var i = 0; i < snapshotData.nodes.length; i++) {
+      if (snapshotData.nodes[i].id === id) return snapshotData.nodes[i].name;
+    }
+    return id;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Modal lifecycle
+  // ──────────────────────────────────────────────────────────────
+  function openModal(edge) {
+    currentEdge = edge;
+    var modal = $('edge-edit-modal');
+    if (!modal) return;
+    $('edge-edit-src').textContent  = nodeName(linkSrcId(edge));
+    $('edge-edit-tgt').textContent  = nodeName(linkTgtId(edge));
+    $('edge-edit-type').textContent = edge.type || 'RELATED_TO';
+    $('edge-edit-conf').textContent = (edge.conf != null) ? String(edge.conf) : '—';
+    $('edge-edit-error').textContent = '';
+    $('edge-edit-sources').innerHTML =
+      '<div style="color:var(--muted);font-family:var(--font-mono);font-size:11px">Loading sources...</div>';
+    modal.classList.add('show');
+    refreshSources();
+  }
+
+  function closeModal() {
+    var modal = $('edge-edit-modal');
+    if (modal) modal.classList.remove('show');
+    currentEdge = null;
+  }
+
+  function setError(msg) {
+    var el = $('edge-edit-error');
+    if (el) el.textContent = msg || '';
+  }
+
+  function roleBadge(role) {
+    var color = 'var(--muted)';
+    if (role === 'manual')  color = 'var(--accent)';
+    if (role === 'extract') color = '#a5b4fc';
+    if (role === 'inverse') color = '#94a3b8';
+    if (role === 'legacy')  color = '#f59e0b';
+    return '<span style="display:inline-block;padding:1px 6px;border-radius:4px;' +
+           'background:rgba(255,255,255,.05);border:1px solid ' + color + ';' +
+           'color:' + color + ';font-size:10px;font-family:var(--font-mono);' +
+           'letter-spacing:.5px">' + role + '</span>';
+  }
+
+  function renderSourceRow(s, idx) {
+    var doc = s.doc_id ? String(s.doc_id) : '<span style="color:var(--muted)">(none)</span>';
+    var w   = (typeof s.weight === 'number') ? s.weight.toFixed(2) : '?';
+    var ts  = s.ts ? String(s.ts).slice(0, 19) : '';
+    var meta = '';
+    if (s.author) meta += '<div style="color:var(--muted);font-size:10px">author: ' + escapeHtml(s.author) + '</div>';
+    if (s.note)   meta += '<div style="color:var(--muted);font-size:10px;margin-top:2px">note: ' + escapeHtml(s.note) + '</div>';
+    return '' +
+      '<div data-src-idx="' + idx + '" style="display:flex;align-items:flex-start;' +
+         'gap:8px;padding:6px 0;border-bottom:1px solid var(--border)">' +
+        '<div style="flex:1;min-width:0">' +
+          '<div style="display:flex;gap:6px;align-items:center;font-family:var(--font-mono);font-size:11px">' +
+            roleBadge(s.role || '?') +
+            '<span style="color:var(--text-soft)">w=' + w + '</span>' +
+            (ts ? '<span style="color:var(--muted);font-size:10px">' + ts + '</span>' : '') +
+          '</div>' +
+          '<div style="margin-top:2px;color:var(--text-soft);font-family:var(--font-mono);' +
+                'font-size:10px;word-break:break-all">' + doc + '</div>' +
+          meta +
+        '</div>' +
+      '</div>';
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c];
+    });
+  }
+
+  async function refreshSources() {
+    if (!currentEdge) return;
+    var box = $('edge-edit-sources');
+    try {
+      var url = withKey(API + '/admin/graph/relation') +
+                '&src_entity_id=' + encodeURIComponent(linkSrcId(currentEdge)) +
+                '&tgt_entity_id=' + encodeURIComponent(linkTgtId(currentEdge)) +
+                '&relation_type=' + encodeURIComponent(currentEdge.type || 'RELATED_TO');
+      var r = await fetch(url, { headers: authHeaders() });
+      if (!r.ok) {
+        var j = await r.json().catch(function () { return {}; });
+        box.innerHTML = '<div style="color:var(--danger);font-size:11px">' +
+                        escapeHtml(j.detail || ('error ' + r.status)) + '</div>';
+        return;
+      }
+      var data = await r.json();
+      var rel  = (data && data.relation) || {};
+      var srcs = rel.sources || [];
+      if (!srcs.length) {
+        box.innerHTML = '<div style="color:var(--muted);font-size:11px">No sources (legacy or unmigrated relation).</div>';
+        return;
+      }
+      box.innerHTML = srcs.map(function (s, i) { return renderSourceRow(s, i); }).join('');
+      if (rel.confidence != null) {
+        $('edge-edit-conf').textContent = String(rel.confidence);
+      }
+    } catch (e) {
+      box.innerHTML = '<div style="color:var(--danger);font-size:11px">' +
+                      escapeHtml(String(e)) + '</div>';
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Mutation handlers
+  // ──────────────────────────────────────────────────────────────
+  async function appendManualSource() {
+    if (!currentEdge) return;
+    setError('');
+    var wEl = $('edge-edit-weight');
+    var nEl = $('edge-edit-note');
+    var w   = parseFloat(wEl.value);
+    if (!isFinite(w) || w < 0 || w > 1) {
+      setError('weight must be a number in [0, 1]'); return;
+    }
+    var body = {
+      api_key:       apiKey,
+      src_entity_id: linkSrcId(currentEdge),
+      tgt_entity_id: linkTgtId(currentEdge),
+      relation_type: currentEdge.type || 'RELATED_TO',
+      source: {
+        doc_id: null,
+        weight: w,
+        role:   'manual',
+        author: 'admin',
+        note:   (nEl.value || '').trim(),
+      },
+    };
+    try {
+      var r = await fetch(API + '/admin/graph/relation/source', {
+        method: 'POST', headers: authHeaders(), body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        var j = await r.json().catch(function () { return {}; });
+        setError(j.detail || ('error ' + r.status)); return;
+      }
+      nEl.value = '';
+      await refreshSources();
+      reloadSnapshot();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function deleteRelation() {
+    if (!currentEdge) return;
+    var ok = window.confirm(
+      'Delete the entire ' + (currentEdge.type || 'RELATED_TO') +
+      ' relation between ' + nodeName(linkSrcId(currentEdge)) +
+      ' and ' + nodeName(linkTgtId(currentEdge)) + '?'
+    );
+    if (!ok) return;
+    setError('');
+    var body = {
+      api_key:       apiKey,
+      src_entity_id: linkSrcId(currentEdge),
+      tgt_entity_id: linkTgtId(currentEdge),
+      relation_type: currentEdge.type || 'RELATED_TO',
+    };
+    try {
+      var r = await fetch(API + '/admin/graph/relation', {
+        method: 'DELETE', headers: authHeaders(), body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        var j = await r.json().catch(function () { return {}; });
+        setError(j.detail || ('error ' + r.status)); return;
+      }
+      closeModal();
+      reloadSnapshot();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  function reloadSnapshot() {
+    // graph.js 가 노출한 reload 가 있으면 호출, 아니면 src-select change
+    // 이벤트를 강제로 fire — 동일 source 면 재페치 한다.
+    if (typeof window.reloadGraphSnapshot === 'function') {
+      try { window.reloadGraphSnapshot(); return; }
+      catch (_e) { /* fall through */ }
+    }
+    var sel = document.getElementById('src-select');
+    if (sel) sel.dispatchEvent(new Event('change'));
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Toggle behavior
+  // ──────────────────────────────────────────────────────────────
+  async function onToggleClick() {
+    var btn = $('graph-edit-toggle');
+    var hint = $('graph-edit-hint');
+    if (!btn) return;
+
+    if (editEnabled) {
+      editEnabled = false;
+      btn.textContent = '🔒 Edit mode: OFF';
+      if (hint) hint.style.display = 'none';
+      return;
+    }
+
+    if (!editFlagChecked) {
+      btn.disabled = true;
+      var probe = await probeEditFlag();
+      btn.disabled = false;
+      editFlagChecked = true;
+      if (!probe.ok) {
+        var msg = 'Edit mode unavailable';
+        if (probe.reason === 'disabled') {
+          msg = 'Server has JAMES_GRAPH_EDIT off. Set JAMES_GRAPH_EDIT=1 + restart.';
+        } else if (probe.reason === 'auth') {
+          msg = 'Auth expired — please re-login.';
+        }
+        window.alert(msg);
+        return;
+      }
+    }
+    editEnabled = true;
+    btn.textContent = '🔓 Edit mode: ON';
+    if (hint) hint.style.display = 'block';
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Public hooks
+  // ──────────────────────────────────────────────────────────────
+  window.GraphEditor = {
+    /** graph.js 가 snapshot load 직후 호출. */
+    onSnapshotLoaded: function (g, d, auth) {
+      graphInstance = g;
+      snapshotData  = d;
+      apiKey        = (auth && auth.apiKey) || apiKey;
+      token         = (auth && auth.token)  || token;
+
+      // 토글 wrapper 노출 (admin 토큰이 있으면). server flag 는 토글
+      // 누를 때 lazy probe — 페이지 로드마다 probe 보내지 않음.
+      if (token) {
+        var wrap = $('graph-edit-wrap');
+        if (wrap) wrap.style.display = '';
+      }
+
+      // ForceGraph3D 의 link click → modal. 본 핸들러는 항상 등록되어
+      // 있고, edit 모드가 OFF 면 no-op.
+      if (g && typeof g.onLinkClick === 'function') {
+        g.onLinkClick(function (link) {
+          if (!editEnabled || !link) return;
+          openModal(link);
+        });
+      }
+    },
+  };
+
+  // ──────────────────────────────────────────────────────────────
+  // wiring (DOMContentLoaded 후 1 회)
+  // ──────────────────────────────────────────────────────────────
+  function wire() {
+    var btn = $('graph-edit-toggle');
+    if (btn) btn.addEventListener('click', onToggleClick);
+
+    var closeBtn = $('edge-edit-close');
+    if (closeBtn) closeBtn.addEventListener('click', closeModal);
+
+    var appendBtn = $('edge-edit-append');
+    if (appendBtn) appendBtn.addEventListener('click', appendManualSource);
+
+    var delBtn = $('edge-edit-delete-relation');
+    if (delBtn) delBtn.addEventListener('click', deleteRelation);
+
+    // overlay 클릭 닫기
+    var overlay = $('edge-edit-modal');
+    if (overlay) {
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) closeModal();
+      });
+    }
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wire);
+  } else {
+    wire();
+  }
+})();

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3313,6 +3313,34 @@ def _truncate_audit_blob(d: dict, cap: int = 500) -> str:
     return s if len(s) <= cap else s[:cap - 3] + "..."
 
 
+@app.get("/admin/graph/relation",
+         summary="relation 의 sources 조회 [Knowledge Cascade Phase E]")
+async def admin_graph_relation_get(
+    api_key:       str,
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    role:          str = Depends(get_role_from_request),
+):
+    """UI 의 edit modal 이 edge 클릭 시 호출. forward 측 relation 의
+    sources 배열 + 기본 메타 반환. 없으면 404.
+    Snapshot 에 sources 를 안 넣은 이유와 동기: payload 격리."""
+    _require_graph_edit_enabled()
+    _require_feature(api_key, role, "admin.data")
+
+    from core.graph_editor import read_relation
+    try:
+        rel = read_relation(
+            src_entity_id, tgt_entity_id, relation_type,
+            wiki_generator=rag_engine.wiki_generator,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    if rel is None:
+        raise HTTPException(status_code=404, detail="relation not found")
+    return {"ok": True, "relation": rel}
+
+
 @app.put("/admin/graph/relation",
          summary="relation 의 sources 전체 교체 [Knowledge Cascade Phase E]")
 async def admin_graph_relation_put(request: Request,

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -47,6 +47,7 @@ from core.graph_editor import (
     append_relation_source,
     delete_relation,
     graph_edit_enabled,
+    read_relation,
     replace_relation_sources,
 )
 from core.relations_schema import (
@@ -348,6 +349,33 @@ class GraphEditEnabledTests(unittest.TestCase):
         for v in ("0", "false", "no", "off", "", "random"):
             with patch.dict(os.environ, {"JAMES_GRAPH_EDIT": v}):
                 self.assertFalse(graph_edit_enabled(), f"value {v!r}")
+
+
+# ── 4b. read_relation (GET) ────────────────────────────────────────
+
+class ReadRelationTests(unittest.TestCase):
+    def test_returns_relation_with_sources(self):
+        _, wg, _, _, (joby_id, nv_id) = _two_entities_with_relation()
+        rel = read_relation(joby_id, nv_id, "RELATED_TO", wiki_generator=wg)
+        self.assertIsNotNone(rel)
+        self.assertEqual(rel["target_id"], nv_id)
+        self.assertEqual(len(rel["sources"]), 1)
+        self.assertEqual(rel["sources"][0]["role"], EXTRACT_SOURCE_ROLE)
+
+    def test_missing_relation_returns_none(self):
+        _, wg, _, _, (joby_id, _) = _two_entities_with_relation()
+        self.assertIsNone(read_relation(
+            joby_id, "e_org_nonexistent", "RELATED_TO",
+            wiki_generator=wg,
+        ))
+
+    def test_missing_src_entity_raises(self):
+        _, wg, _, _, (_, nv_id) = _two_entities_with_relation()
+        with self.assertRaises(ValueError):
+            read_relation(
+                "e_org_nonexistent", nv_id, "RELATED_TO",
+                wiki_generator=wg,
+            )
 
 
 # ── 5. Phase C cascade 와의 정합 ───────────────────────────────────


### PR DESCRIPTION
## Summary

`docs/design/v0.3-knowledge-cascade.md` §7 — **Phase E frontend**. 사용자 요청 N-7 (그래프에서 edge 클릭 → sources 보기 + 편집) 의 첫 가시화.

Phase E backend (PR #271) 위에서 동작하는 admin 전용 그래프 에디터 UI. **최소 viable scope**: edit-mode toggle + edge 클릭 modal + manual source append + delete entire relation. UI 의 per-source 편집 / node 편집 / 우클릭 context 는 follow-up.

### 변경 contract

**새 endpoint** (server_llmwiki.py):
- `GET /admin/graph/relation?src_entity_id=&tgt_entity_id=&relation_type=` — UI 가 edge 클릭 시 fresh sources 를 on-demand fetch. snapshot 에 sources 를 안 넣은 이유와 동기: payload 격리 (213 entity × N relation × N source 의 폭증 회피). 403 graph_edit_disabled / 404 not found / 200 {relation: {...}}

**새 helper** (`core/graph_editor.py`):
- `read_relation(src, tgt, type, *, wiki_generator)` — 매칭 relation dict 의 안전한 복사본 반환, 없으면 None

**UI** (`frontend/`):
- `graph.html` — aside 에 edit-mode 토글 wrapper (admin 토큰 없으면 숨김). 페이지 맨 아래에 `edge-edit-modal` (sources list + add manual source 폼 + delete relation 버튼). tokens.css cyber 6c 패턴 일관
- `graph_editor.js` (NEW) — IIFE, `window.GraphEditor` namespace 노출. `onSnapshotLoaded` hook 으로 graph.js 가 build 한 ForceGraph3D instance 에 `onLinkClick` 등록. 토글 첫 클릭 시 GET 으로 server flag probe (`JAMES_GRAPH_EDIT` off → alert)
- `graph.js` — snapshot load 직후 `window.GraphEditor.onSnapshotLoaded` 호출 hook 8 줄 추가. defensive guard

### UX flow

1. admin login (기존 login-modal)
2. 사이드바 "Edit mode" 토글 클릭 → server flag probe → ON
3. 그래프의 edge (link) 클릭 → modal 열림
4. modal 표시:
   - 헤더: src → tgt, relation_type, confidence
   - sources list: doc_id / role badge / weight / ts / (manual 인 경우 author + note)
   - "Add manual source" 폼: weight + note → POST `/admin/graph/relation/source`
   - "Delete entire relation" → confirm → DELETE `/admin/graph/relation`
5. 변경 후 snapshot 자동 reload (src-select change 이벤트로 trigger)

### Verification

- 신규 테스트 3 (`tests/test_phase_e_graph_editor.py` 의 ReadRelationTests):
  - 매칭 relation 반환 + sources 포함
  - 매칭 없음 → None
  - src entity 없음 → ValueError
- 전체 회귀: **1812 tests OK** (1809 baseline + 3 신규, regression 0)
- \`ruff check core/graph_editor.py server_llmwiki.py\` → All checks passed!
- JS unit test 미작성 — Python 백엔드는 cover, JS 는 사용자 라이브 검증 (아래)

### 사용자 라이브 검증 가이드

```powershell
# 1) flag 켜고 서버 기동
$env:JAMES_GRAPH_EDIT="1"
python server_llmwiki.py

# 2) http://127.0.0.1:8000/admin/graph 접속, admin 로그인
# 3) 사이드바 "Edit mode" 토글 클릭
#    → 🔓 Edit mode: ON 으로 바뀌고 hint 메시지 표시
# 4) 그래프의 edge 한 개 클릭 → modal 열림
# 5) sources list 확인 (Phase A back-fill 한 entity 면 role=legacy 1줄,
#    Phase B 이후 ingest 한 entity 면 role=extract 또는 inverse)
# 6) "Add manual source" 폼 → weight=0.8, note 입력 → 클릭
#    → modal 의 sources list refresh + 그래프 snapshot 재로드
# 7) "Delete entire relation" → confirm → modal 닫힘 + 그래프 edge 사라짐

# 끄려면: 토글 다시 클릭하거나 페이지 리프레시
```

### CLAUDE.md gates

- rule #2 (bench numbers): read path 무영향. write path 는 opt-in
- rule #3 (자가-진화): 무관
- rule #5 (20 KB): `graph_editor.js` 13 KB / `core/graph_editor.py` 15 KB → 둘 다 gate 통과

### Out of scope (follow-up PR)

- **per-source 편집/삭제** — 현재는 sources read-only 표시 + 전체 relation delete + manual append 만
- **node 편집 modal** — attributes 수정, 신규 relation 추가
- **우클릭 context menu** — 디자인 §7 의 right-click flow
- **JS unit tests** — 라이브 검증으로 갈음

### Phase 큐 (사이클 8 Knowledge Cascade)

- [x] Phase A — PR #266
- [x] Phase B — PR #269
- [x] Phase C — PR #270
- [x] Phase E backend — PR #271
- [x] **Phase E frontend — 본 PR**
- [ ] Phase D — modify cascade (별 사이클)
- [ ] Phase E follow-up — per-source editor / node 편집 / context menu