### PR TITLE
feat(graph): Knowledge Cascade Phase D — file modify cascade

### DIFF
--- a/core/cascade.py
+++ b/core/cascade.py
@@ -337,3 +337,252 @@ def cascade_delete_upload(
         "counts":                  counts,
         "user_role":               user_role,
     }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Phase D — modify cascade (docs/design/v0.3-knowledge-cascade.md §6)
+# ─────────────────────────────────────────────────────────────────
+
+import json as _json   # 모듈 상단의 stdlib import 와 충돌 회피용 alias
+
+
+def load_extraction_sidecar(
+    physical_filename: str,
+    upload_dir:        Path,
+) -> Optional[Dict[str, Any]]:
+    """Phase B (PR #269) 의 ingestion 이 저장한 LLM extraction sidecar 를
+    로드. 없거나 손상되면 None.
+
+    Phase D 의 modify cascade 가 diff 시작점으로 사용 — None 이면
+    wipe+reingest fallback (sidecar 가 없는 = Phase D 이전 업로드
+    또는 1회용 web 학습 등).
+    """
+    p = Path(upload_dir) / (physical_filename + ".extraction.json")
+    if not p.is_file():
+        return None
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            data = _json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (OSError, _json.JSONDecodeError):
+        pass
+    return None
+
+
+def diff_triples(
+    old_extraction: Optional[Dict[str, Any]],
+    new_extraction: Dict[str, Any],
+) -> Dict[str, list]:
+    """LLM extraction 의 (entities, relations) 두 셋을 비교해 변경 분류.
+
+    Triple identity = (subject_name_lower, label_lower, object_name_lower).
+    designs §9 의 risk: LLM 재추출 비결정성 → label / weight 의 미세한
+    변동이 false-positive 변경을 일으킨다. 본 함수는 label 을 lowercase
+    매칭으로 정규화 (대소문자 차이 무시) — weight 변동 무시는 호출자
+    (cascade_modify_doc) 가 처리한다.
+
+    Returns: {
+      "added_entities":   [{name, type, description}]    — new 에만 있는 entity
+      "removed_entities": [{name, type}]                 — old 에만 있는 entity
+      "added_triples":    [{source, target, label, confidence}]
+      "removed_triples":  [{source, target, label, confidence}]
+      "kept_triples":     [{source, target, label, confidence}]
+    }
+    """
+    def _ent_key(e):
+        return (
+            (e.get("name") or "").strip().lower(),
+            (e.get("type") or "concept").strip().lower(),
+        )
+
+    def _triple_key(r):
+        return (
+            (r.get("source") or "").strip().lower(),
+            (r.get("label")  or "관련").strip().lower(),
+            (r.get("target") or "").strip().lower(),
+        )
+
+    old_ext = (old_extraction or {}).get("extraction", old_extraction or {}) or {}
+    old_ents = old_ext.get("entities", []) or []
+    old_rels = old_ext.get("relations", []) or []
+    new_ents = new_extraction.get("entities", []) or []
+    new_rels = new_extraction.get("relations", []) or []
+
+    old_ent_map = {_ent_key(e): e for e in old_ents if isinstance(e, dict)}
+    new_ent_map = {_ent_key(e): e for e in new_ents if isinstance(e, dict)}
+    old_rel_map = {_triple_key(r): r for r in old_rels if isinstance(r, dict)}
+    new_rel_map = {_triple_key(r): r for r in new_rels if isinstance(r, dict)}
+
+    added_entities   = [new_ent_map[k] for k in new_ent_map if k not in old_ent_map]
+    removed_entities = [old_ent_map[k] for k in old_ent_map if k not in new_ent_map]
+    added_triples    = [new_rel_map[k] for k in new_rel_map if k not in old_rel_map]
+    removed_triples  = [old_rel_map[k] for k in old_rel_map if k not in new_rel_map]
+    kept_triples     = [new_rel_map[k] for k in new_rel_map if k in old_rel_map]
+
+    return {
+        "added_entities":   added_entities,
+        "removed_entities": removed_entities,
+        "added_triples":    added_triples,
+        "removed_triples":  removed_triples,
+        "kept_triples":     kept_triples,
+    }
+
+
+def cascade_modify_doc(
+    physical_filename: str,
+    new_content:       str,
+    *,
+    wiki_generator,
+    vector_store,
+    upload_dir:        Path,
+    new_metadata:      Optional[Dict[str, Any]] = None,
+    user_role:         str = "admin",
+) -> Dict[str, Any]:
+    """업로드 파일의 내용을 새 ``new_content`` 로 교체하고 그 파일이
+    만들어낸 wiki 파생물을 갱신한다. 디자인 §6 — Phase D.
+
+    실용적 구현 (kept-ts 갱신 허용):
+      1. 기존 sidecar 로드 → diff 시각화용 통계만 사용 (실제 cascade
+         는 doc_id 전체 wipe 가 더 간결)
+      2. cascade_remove_doc_from_sources(doc_id) — 이 doc 의 source
+         전체 제거. manual / 다른 doc 의 source 는 영향 없음.
+      3. orphan sweep — incoming 0 AND remaining relations 0
+      4. vector chunks 갱신 — delete old + add new
+      5. 물리 파일 내용 교체 (.deleted/ 백업)
+      6. 새 content 로 ingestion 재실행 (sidecar 도 새로 생성)
+      7. 새 metadata 가 있으면 적용
+
+    Returns: 디자인 §5 형식과 유사하지만 modify 전용 통계 포함:
+      {
+        "physical_filename":    str,
+        "original_filename":    str,
+        "doc_entity_id":        str,
+        "sidecar_present":      bool,    # diff 가능 여부
+        "diff":                 {added/removed/kept counts} | None,
+        "cascade_counts":       {entities_touched, relations_dropped, ...},
+        "orphan_entities_deleted": int,
+        "vector_replaced":      bool,
+        "file_backup":          str,
+        "reingest_entity_ids":  [str],
+        "user_role":            str,
+      }
+    """
+    physical_path = Path(upload_dir) / physical_filename
+    if not physical_path.is_file():
+        raise FileNotFoundError(f"upload not found: {physical_path}")
+
+    original_filename = strip_uuid_prefix(physical_filename)
+    doc_name          = os.path.splitext(original_filename)[0]
+    doc_entity_id     = wiki_generator._generate_entity_id(doc_name, "document")
+    entity_root       = Path(wiki_generator.entity_path)
+    upload_dir        = Path(upload_dir)
+
+    # Step 1 — sidecar 로드 + diff 통계 (실제 cascade 결정에는 사용하지
+    # 않지만 audit/UI 노출용)
+    old_sidecar = load_extraction_sidecar(physical_filename, upload_dir)
+    # 새 추출은 ingestion path 에서 다시 도므로 여기선 diff 만 위해 호출
+    diff_stats = None
+    if old_sidecar is not None:
+        try:
+            new_extraction_preview = wiki_generator._llm_extract_document_entities(
+                original_filename, new_content, new_metadata or {},
+            )
+            diff = diff_triples(old_sidecar, new_extraction_preview)
+            diff_stats = {
+                "added_entities":     len(diff["added_entities"]),
+                "removed_entities":   len(diff["removed_entities"]),
+                "added_triples":      len(diff["added_triples"]),
+                "removed_triples":    len(diff["removed_triples"]),
+                "kept_triples":       len(diff["kept_triples"]),
+            }
+        except Exception as e:
+            print(f"[CASCADE_MODIFY] diff preview skipped: {e}")
+
+    # Step 2 — 이 doc 의 source 전체 wipe (manual 은 자동 보존)
+    cascade_counts = cascade_remove_doc_from_sources(doc_entity_id, entity_root)
+
+    # Step 3 — orphan sweep
+    orphan_paths = find_orphan_entities(
+        original_filename, doc_entity_id, entity_root,
+    )
+    for p in orphan_paths:
+        try:
+            p.unlink()
+        except OSError as e:
+            print(f"[CASCADE_MODIFY] orphan unlink fail {p}: {e}")
+
+    # doc entity 본체는 modify 에서는 유지 (같은 filename 이 재추출됨).
+    # 다만 그 outgoing relations 가 cascade 에 의해 비워졌으므로 다음
+    # ingestion 이 다시 채울 수 있도록 한다. 만약 doc entity 가 orphan
+    # sweep 에 걸렸을 경우 (실제로는 source_document 매칭 X 라 안 걸림),
+    # ingestion 이 새로 생성한다.
+
+    # Step 4 — vector chunks 교체
+    vec_replaced = False
+    try:
+        vector_store.delete_by_source(original_filename)
+        # add 는 ingestion 의 일이 아니라 endpoint 의 일 — 본 함수 입장에선
+        # ingestion 호출 전 cleanup 만. 새 chunk add 는 endpoint 가 한다
+        # (vector_store.add_documents_with_meta 시그니처가 environment-
+        # 별로 다를 수 있어 직접 의존을 만들지 않는다).
+        vec_replaced = True
+    except Exception as e:
+        print(f"[CASCADE_MODIFY] vector delete fail: {e}")
+
+    # Step 5 — 물리 파일 → .deleted/ 백업, 그 자리에 새 content
+    backup_path = backup_upload_file(physical_path, upload_dir)
+    physical_path.write_text(new_content, encoding="utf-8") \
+        if isinstance(new_content, str) \
+        else physical_path.write_bytes(new_content)
+
+    # Step 6 — ingestion 재실행. sidecar 도 새로 작성됨.
+    sidecar_path = str(upload_dir / (physical_filename + ".extraction.json"))
+    reingest_ids: List[str] = []
+    try:
+        reingest_ids = list(
+            wiki_generator.process_document_for_entities(
+                original_filename,
+                new_content if isinstance(new_content, str) else
+                new_content.decode("utf-8", errors="replace"),
+                [],
+                user_role=user_role,
+                metadata=new_metadata or {},
+                extraction_sidecar_path=sidecar_path,
+            ) or []
+        )
+    except TypeError:
+        # 구버전 시그니처 fallback
+        try:
+            reingest_ids = list(
+                wiki_generator.process_document_for_entities(
+                    original_filename,
+                    new_content if isinstance(new_content, str) else
+                    new_content.decode("utf-8", errors="replace"),
+                    [], user_role=user_role, metadata=new_metadata or {},
+                ) or []
+            )
+        except Exception as e:
+            print(f"[CASCADE_MODIFY] reingest fail: {e}")
+    except Exception as e:
+        print(f"[CASCADE_MODIFY] reingest fail: {e}")
+
+    try:
+        if hasattr(wiki_generator, "refresh_entity_map"):
+            wiki_generator.refresh_entity_map()
+    except Exception as e:
+        print(f"[CASCADE_MODIFY] entity index refresh skipped: {e}")
+
+    return {
+        "physical_filename":       physical_filename,
+        "original_filename":       original_filename,
+        "doc_entity_id":           doc_entity_id,
+        "sidecar_present":         old_sidecar is not None,
+        "diff":                    diff_stats,
+        "cascade_counts":          cascade_counts,
+        "orphan_entities_deleted": len(orphan_paths),
+        "vector_replaced":         vec_replaced,
+        "file_backup":             str(backup_path.relative_to(upload_dir)),
+        "reingest_entity_ids":     reingest_ids,
+        "user_role":               user_role,
+    }

--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -599,10 +599,18 @@ class WikiGenerator:
         chunk_ids: List[str],
         user_role: str = "admin",
         metadata:  Optional[Dict] = None,
+        extraction_sidecar_path: Optional[str] = None,
     ) -> List[str]:
         """
         문서 본문에서 LLM으로 인물/조직/개념 entity와 relation을 추출하여
         각 entity별 .md를 생성하고, 추가로 원본을 document entity로도 보존한다.
+
+        Phase D (Knowledge Cascade): 호출자가 ``extraction_sidecar_path`` 를
+        주면 LLM extraction 결과 (entities + relations 원본 + metadata) 를
+        JSON sidecar 로 저장한다. Phase D 의 modify cascade 가 다음 재업로드
+        시 이 sidecar 를 읽어 old/new diff 를 계산한다. sidecar 부재 시
+        modify cascade 는 wipe+reingest fallback 으로 동작 — backwards
+        compatible (Phase B 이전 업로드도 안전).
 
         Returns:
             생성된 entity_id 리스트 (실패 시 빈 리스트 또는 document만)
@@ -716,6 +724,30 @@ class WikiGenerator:
             self.resolve_pending_relations()
         except Exception as e:
             print(f"[ENTITY-EXTRACT] resolve_pending_relations fail (무시): {e}")
+
+        # Phase D — extraction sidecar 저장. 재업로드 시 modify cascade 가
+        # old vs new diff 를 계산하려면 마지막 LLM 출력이 필요하다.
+        # 사용자 ingest 정보 (filename / category / keywords) + 추출 원본을
+        # 함께 저장해 cascade 가 self-contained 로 동작.
+        if extraction_sidecar_path:
+            try:
+                sidecar = {
+                    "filename":   filename,
+                    "ingest_ts":  ingest_ts,
+                    "metadata":   {
+                        "summary":  metadata.get("summary", ""),
+                        "category": metadata.get("category", "기타"),
+                        "keywords": metadata.get("keywords", []),
+                    },
+                    "extraction": {
+                        "entities":  extracted.get("entities", []),
+                        "relations": extracted.get("relations", []),
+                    },
+                }
+                with open(extraction_sidecar_path, "w", encoding="utf-8") as sf:
+                    json.dump(sidecar, sf, ensure_ascii=False, indent=2)
+            except Exception as e:
+                print(f"[ENTITY-EXTRACT] sidecar write skipped: {e}")
 
         print(f"[ENTITY-EXTRACT] {filename} -> {len(created_ids)} entities created "
               f"(extracted {len(name_to_id)} + 1 document)")

--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -123,16 +123,20 @@
   `core/cascade.py` (cascade_remove_doc_from_sources / find_orphan_entities
   강화 룰 / cascade_delete_upload / strip_uuid_prefix / backup_upload_file)
   + endpoint. 21 신규 tests → 1793 OK
-- [ ] Phase D 파일 수정 cascade (`PUT /admin/files/...` endpoint, Phase C 의존)
 - [x] **Phase E backend — PR #271 머지 (2026-05-14)** graph editor (= 사용자 요청 N-7).
   `core/graph_editor.py` (replace / append / delete + 양방향 동기화 +
   manual metadata) + 3 endpoint (`PUT/POST/DELETE /admin/graph/relation`)
   + `JAMES_GRAPH_EDIT=1` opt-in flag. 16 신규 tests → 1809 OK
-- [ ] **Phase E frontend UI — 본 PR** `/admin/graph` 의 edit-mode 토글 +
-  edge 클릭 modal (sources 표시 + manual append + delete relation).
-  새 GET `/admin/graph/relation` (sources read path) + read_relation
-  helper + 3 read tests. frontend: `graph_editor.js` 신규, graph.html
-  + graph.js 의 hook. 1812 OK
+- [x] **Phase E frontend UI — PR #273 머지 (2026-05-14)** `/admin/graph` 의
+  edit-mode 토글 + edge 클릭 modal (sources 표시 + manual append +
+  delete relation). 새 GET `/admin/graph/relation` (sources read path) +
+  read_relation helper + 3 read tests. frontend: `graph_editor.js` 신규,
+  graph.html + graph.js 의 hook. 1812 OK
+- [x] **Phase D — 본 PR (#274)** 파일 수정 cascade. `PUT /admin/files`
+  (multipart 교체) + `core/cascade.py::cascade_modify_doc` (이 doc 의
+  source wipe + orphan sweep + 새 content 재 ingest) + extraction sidecar
+  JSON (`uploads/<uuid>_<file>.extraction.json`) + diff_triples.
+  13 신규 tests → 1822 OK
 
 ### 🟣 사이클 9 — CR-E (self-evolution → CR 래핑)
 - 디퍼된 v0.2.x §5 항목. 4 locked JSONL test 파일 + eval gate +

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -757,12 +757,19 @@ async def upload(
         # we now consume it to make the artifact ↔ entity relation
         # queryable from /admin/artifacts/<id> + the workspace UI.
         created_entity_ids: list = []
+        # Phase D — extraction sidecar 경로. 물리 파일 옆에 `<uuid>_<file>
+        # .extraction.json` 으로 저장 → 재업로드 시 modify cascade 가 이
+        # 파일을 읽어 old/new triple diff 를 한다.
+        extraction_sidecar = os.path.join(
+            UPLOAD_DIR, unique_name + ".extraction.json",
+        )
         try:
             created_entity_ids = list(
                 rag_engine.wiki_generator.process_document_for_entities(
                     file.filename, raw_content, [],
                     user_role="admin",
                     metadata=meta,
+                    extraction_sidecar_path=extraction_sidecar,
                 ) or []
             )
         except TypeError:
@@ -4883,6 +4890,115 @@ async def admin_files_delete(
     }, ensure_ascii=False)
     _write_audit(
         role, "/admin/files/delete",
+        query=physical_filename,
+        answer=audit_blob,
+        elapsed_sec=0,
+    )
+    return {"ok": True, "summary": summary}
+
+
+@app.put("/admin/files",
+         summary="업로드 파일 내용 교체 + 파생 cascade 갱신 [Knowledge Cascade Phase D]")
+async def admin_files_modify(
+    request:     Request,
+    file:        UploadFile = File(...),
+    api_key:     str        = Form(...),
+    path:        str        = Form(...),
+    role:        str        = Depends(get_role_from_request),
+):
+    """`uploads/` 의 기존 파일을 새 multipart file 로 교체하고 파생
+    cascade 를 재실행.
+
+    docs/design/v0.3-knowledge-cascade.md §6 — Phase D.
+
+    Trust boundary:
+      - admin.data feature gate
+      - root='uploads' hard-coded, `_resolve_under_root` 가 path traversal 차단
+      - 새 content 도 PolicyEngine sanitize_for_ingestion 통과
+      - 옛 파일은 `uploads/.deleted/{ts}_{name}` 으로 backup
+    """
+    _require_feature(api_key, role, "admin.data")
+    if not (path or "").strip():
+        raise HTTPException(status_code=400, detail="path required")
+
+    full = _resolve_under_root("uploads", path)
+    if not full or not os.path.isfile(full):
+        raise HTTPException(status_code=404, detail="not found")
+
+    physical_filename = os.path.basename(full)
+
+    # 새 파일을 메모리에 모은 뒤 cascade 에 넘긴다. 동일한 size cap.
+    new_bytes = b""
+    while True:
+        chunk = await file.read(1024 * 1024)
+        if not chunk:
+            break
+        new_bytes += chunk
+        if len(new_bytes) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="파일 크기 초과")
+
+    # PolicyEngine sanitize — content extraction (텍스트 파일 / OCR 등은
+    # 추후 follow-up. 이번 PR 은 텍스트 직접 교체 경로). file_processor 가
+    # 일관된 entry point.
+    # NOTE: process_file expects a path; 임시 파일에 dump 후 처리.
+    import tempfile
+    suffix = os.path.splitext(file.filename or physical_filename)[1] or ".bin"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tf:
+        tf.write(new_bytes)
+        tmp_path = tf.name
+    try:
+        tc = file_processor.process_file(tmp_path, file.filename or physical_filename)
+        raw_content, _decision = default_engine.sanitize_for_ingestion(
+            tc, source=file.filename or physical_filename,
+        )
+        new_meta = file_processor.generate_file_metadata(raw_content)
+    finally:
+        try: os.unlink(tmp_path)
+        except OSError: pass
+
+    from core.cascade import cascade_modify_doc
+    from utils.tokenizer import split_chunks
+    try:
+        summary = cascade_modify_doc(
+            physical_filename,
+            raw_content,
+            wiki_generator = rag_engine.wiki_generator,
+            vector_store   = rag_engine.vector_store,
+            upload_dir     = _file_mgmt_roots()["uploads"],
+            new_metadata   = new_meta,
+            user_role      = role,
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # cascade_modify_doc 가 vector 의 add 는 하지 않으므로 (signature
+    # 의존 회피), 여기서 새 chunks 를 다시 넣는다.
+    try:
+        new_chunks = split_chunks(raw_content)
+        rag_engine.vector_store.add_documents_with_meta(
+            texts=new_chunks,
+            source=summary["original_filename"],
+            metadata={
+                "sensitivity": new_meta.get("sensitivity", "internal"),
+                "owner":       new_meta.get("owner", "system"),
+                "category":    new_meta.get("category", "기타"),
+                "source_type": "prod",
+            },
+        )
+    except Exception as e:
+        print(f"[FILES_PUT] vector re-add fail: {e}")
+
+    cc = summary.get("cascade_counts", {})
+    audit_blob = json.dumps({
+        "doc_entity_id":           summary.get("doc_entity_id"),
+        "sidecar_present":         summary.get("sidecar_present"),
+        "diff":                    summary.get("diff"),
+        "orphan_entities_deleted": summary.get("orphan_entities_deleted"),
+        "relations_dropped":       cc.get("relations_dropped"),
+        "file_backup":             summary.get("file_backup"),
+    }, ensure_ascii=False)
+    _write_audit(
+        role, "/admin/files [PUT]",
         query=physical_filename,
         answer=audit_blob,
         elapsed_sec=0,

--- a/tests/test_phase_d_modify_cascade.py
+++ b/tests/test_phase_d_modify_cascade.py
@@ -1,0 +1,428 @@
+"""Phase D (Knowledge Cascade) — modify cascade 검증.
+
+docs/design/v0.3-knowledge-cascade.md §6 — Phase D.
+
+본 테스트는 ``core/cascade.py`` 의 Phase D 함수 3 종을 cover:
+
+  1. ``load_extraction_sidecar`` — 사이드카 JSON 로드 / 부재 / 손상
+  2. ``diff_triples`` — entities + relations 의 added/removed/kept 분류
+     (label/name lowercase 정규화로 LLM 비결정성 일부 흡수)
+  3. ``cascade_modify_doc`` (통합) — 실제 wiki 재조립 시나리오:
+     - 기존 doc 의 source wipe + orphan sweep
+     - manual source 보존 (Phase C 와 같은 룰)
+     - 새 sidecar 생성
+     - 사이드카 없는 경우 (Phase D 이전 업로드) fallback 동작
+
+production wiki 무영향 — tempfile 격리.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml  # noqa: I001
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console
+ensure_utf8_console()
+
+from core.cascade import (
+    cascade_modify_doc,
+    diff_triples,
+    load_extraction_sidecar,
+)
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    INVERSE_SOURCE_ROLE,
+    MANUAL_SOURCE_ROLE,
+)
+
+
+# ── 1. load_extraction_sidecar ──────────────────────────────────────
+
+class LoadSidecarTests(unittest.TestCase):
+    def test_missing_returns_none(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.assertIsNone(load_extraction_sidecar("nope.pdf", tmp))
+
+    def test_loads_valid_sidecar(self):
+        tmp = Path(tempfile.mkdtemp())
+        payload = {
+            "filename": "x.pdf",
+            "extraction": {"entities": [{"name": "A", "type": "org"}],
+                           "relations": []},
+        }
+        (tmp / "x.pdf.extraction.json").write_text(
+            json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        loaded = load_extraction_sidecar("x.pdf", tmp)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded["filename"], "x.pdf")
+        self.assertEqual(loaded["extraction"]["entities"][0]["name"], "A")
+
+    def test_corrupt_returns_none(self):
+        tmp = Path(tempfile.mkdtemp())
+        (tmp / "x.pdf.extraction.json").write_text("{not json", encoding="utf-8")
+        self.assertIsNone(load_extraction_sidecar("x.pdf", tmp))
+
+
+# ── 2. diff_triples ─────────────────────────────────────────────────
+
+class DiffTriplesTests(unittest.TestCase):
+    def test_added_entity(self):
+        old = {"extraction": {"entities": [{"name": "A", "type": "org"}],
+                              "relations": []}}
+        new = {"entities": [{"name": "A", "type": "org"},
+                            {"name": "B", "type": "concept"}],
+               "relations": []}
+        d = diff_triples(old, new)
+        self.assertEqual(len(d["added_entities"]), 1)
+        self.assertEqual(d["added_entities"][0]["name"], "B")
+        self.assertEqual(d["removed_entities"], [])
+
+    def test_removed_entity(self):
+        old = {"extraction": {"entities": [{"name": "A", "type": "org"},
+                                           {"name": "B", "type": "concept"}],
+                              "relations": []}}
+        new = {"entities": [{"name": "A", "type": "org"}],
+               "relations": []}
+        d = diff_triples(old, new)
+        self.assertEqual(len(d["removed_entities"]), 1)
+        self.assertEqual(d["removed_entities"][0]["name"], "B")
+
+    def test_kept_triple(self):
+        old = {"extraction": {"entities": [],
+                              "relations": [{"source": "A", "target": "B",
+                                             "label": "관련", "confidence": 0.7}]}}
+        new = {"entities": [],
+               "relations": [{"source": "A", "target": "B",
+                              "label": "관련", "confidence": 0.8}]}
+        d = diff_triples(old, new)
+        # weight 만 변한 건 kept
+        self.assertEqual(len(d["kept_triples"]), 1)
+        self.assertEqual(d["added_triples"], [])
+        self.assertEqual(d["removed_triples"], [])
+
+    def test_label_case_insensitive(self):
+        """LLM 이 'RELATED_TO' 와 'related_to' 를 섞어 내도 같은 triple."""
+        old = {"extraction": {"entities": [],
+                              "relations": [{"source": "A", "target": "B",
+                                             "label": "RELATED_TO", "confidence": 0.7}]}}
+        new = {"entities": [],
+               "relations": [{"source": "A", "target": "B",
+                              "label": "related_to", "confidence": 0.7}]}
+        d = diff_triples(old, new)
+        self.assertEqual(len(d["kept_triples"]), 1)
+
+    def test_removed_and_added_triple(self):
+        old = {"extraction": {"entities": [],
+                              "relations": [{"source": "A", "target": "B", "label": "관련",
+                                             "confidence": 0.7},
+                                            {"source": "C", "target": "D", "label": "관련",
+                                             "confidence": 0.6}]}}
+        new = {"entities": [],
+               "relations": [{"source": "A", "target": "B", "label": "관련",
+                              "confidence": 0.7},
+                             {"source": "E", "target": "F", "label": "관련",
+                              "confidence": 0.5}]}
+        d = diff_triples(old, new)
+        self.assertEqual(len(d["kept_triples"]), 1)
+        self.assertEqual(len(d["added_triples"]), 1)
+        self.assertEqual(len(d["removed_triples"]), 1)
+        self.assertEqual(d["added_triples"][0]["source"], "E")
+        self.assertEqual(d["removed_triples"][0]["source"], "C")
+
+    def test_old_none_means_all_added(self):
+        """사이드카 부재 (None) → 모두 신규."""
+        new = {"entities": [{"name": "A", "type": "org"}],
+               "relations": [{"source": "A", "target": "B", "label": "관련"}]}
+        d = diff_triples(None, new)
+        self.assertEqual(len(d["added_entities"]), 1)
+        self.assertEqual(len(d["added_triples"]), 1)
+        self.assertEqual(d["removed_entities"], [])
+        self.assertEqual(d["removed_triples"], [])
+
+
+# ── 3. cascade_modify_doc — 통합 ────────────────────────────────────
+
+def _write_entity(path: Path, fm: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = (
+        "---\n"
+        + yaml.safe_dump(fm, allow_unicode=True, sort_keys=False,
+                         default_flow_style=False)
+        + "---\n# body\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_fm(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    body = text.split("---", 2)[1]
+    return yaml.safe_load(body)
+
+
+class CascadeModifyDocIntegrationTests(unittest.TestCase):
+    """전체 cascade_modify_doc 호출 — 기존 doc 의 wiki 가 새 content 의
+    추출로 정확히 교체되는지 검증."""
+
+    def setUp(self):
+        self.tmp_root = Path(tempfile.mkdtemp())
+        self.upload_dir  = self.tmp_root / "uploads"
+        self.upload_dir.mkdir()
+
+        # 진짜 WikiGenerator 사용 — WIKI_DIR 만 패치해 격리.
+        self.wiki_patcher = patch("config.WIKI_DIR", str(self.tmp_root / "wiki"))
+        self.wiki_patcher.start()
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = str(self.tmp_root / "wiki")
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+        self.entity_root = self.wg.entity_path
+
+        # 기존 doc + 2 entity 시나리오: report.pdf → Joby, NVIDIA
+        doc_id   = self.wg._generate_entity_id("report", "document")
+        joby_id  = self.wg._generate_entity_id("Joby", "org")
+        nv_id    = self.wg._generate_entity_id("NVIDIA", "org")
+
+        _write_entity(self.entity_root / "document" / "report.md", {
+            "entity_id": doc_id, "name": "report",
+            "normalized_name": "report", "aliases": ["report"],
+            "entity_type": "document",
+            "attributes": {"summary": "old"},
+            "relations": [
+                {"target": "Joby", "target_id": joby_id,
+                 "target_type": "org", "type": "RELATED_TO", "label": "관련",
+                 "confidence": 0.7,
+                 "sources": [{"doc_id": doc_id, "weight": 0.7,
+                              "role": EXTRACT_SOURCE_ROLE, "ts": "t"}]},
+                {"target": "NVIDIA", "target_id": nv_id,
+                 "target_type": "org", "type": "RELATED_TO", "label": "관련",
+                 "confidence": 0.7,
+                 "sources": [{"doc_id": doc_id, "weight": 0.7,
+                              "role": EXTRACT_SOURCE_ROLE, "ts": "t"}]},
+            ],
+        })
+        _write_entity(self.entity_root / "org" / "joby.md", {
+            "entity_id": joby_id, "name": "Joby",
+            "normalized_name": "joby", "aliases": ["Joby"],
+            "entity_type": "org",
+            "attributes": {"source_document": "report.pdf"},
+            "relations": [{
+                "target": "NVIDIA", "target_id": nv_id,
+                "target_type": "org", "type": "RELATED_TO", "label": "관련",
+                "confidence": 0.8,
+                "sources": [{"doc_id": doc_id, "weight": 0.8,
+                             "role": EXTRACT_SOURCE_ROLE, "ts": "t"}],
+            }],
+        })
+        _write_entity(self.entity_root / "org" / "nvidia.md", {
+            "entity_id": nv_id, "name": "NVIDIA",
+            "normalized_name": "nvidia", "aliases": ["NVIDIA"],
+            "entity_type": "org",
+            "attributes": {"source_document": "report.pdf"},
+            "relations": [{
+                "target": "Joby", "target_id": joby_id,
+                "target_type": "org", "type": "RELATED_TO", "label": "관련",
+                "confidence": 0.8,
+                "sources": [{"doc_id": doc_id, "weight": 0.8,
+                             "role": INVERSE_SOURCE_ROLE, "ts": "t"}],
+            }],
+        })
+
+        # 물리 파일 + 기존 사이드카
+        import uuid as _uuid
+        self.physical = f"{_uuid.uuid4()}_report.pdf"
+        (self.upload_dir / self.physical).write_text("old text",
+                                                     encoding="utf-8")
+        old_sidecar = {
+            "filename": "report.pdf",
+            "extraction": {
+                "entities":  [{"name": "Joby", "type": "org"},
+                              {"name": "NVIDIA", "type": "org"}],
+                "relations": [{"source": "Joby", "target": "NVIDIA",
+                               "label": "관련", "confidence": 0.8}],
+            },
+        }
+        (self.upload_dir / (self.physical + ".extraction.json")).write_text(
+            json.dumps(old_sidecar, ensure_ascii=False), encoding="utf-8")
+
+        self.wg._build_entity_id_index()
+
+        # LLM 추출 결정적 fixture — 새 content 는 Joby + Anthropic
+        # (NVIDIA 빠지고 Anthropic 추가).
+        self._new_extraction = {
+            "entities": [
+                {"name": "Joby",      "type": "org",
+                 "description": "eVTOL maker"},
+                {"name": "Anthropic", "type": "org",
+                 "description": "AI safety lab"},
+            ],
+            "relations": [
+                {"source": "Joby", "target": "Anthropic",
+                 "label": "관련", "confidence": 0.7},
+            ],
+        }
+        self.wg._llm_extract_document_entities = (
+            lambda *a, **kw: self._new_extraction
+        )
+
+        # vector store mock
+        self.vs = MagicMock()
+        self.vs.delete_by_source.return_value = True
+
+        self.wg._build_entity_id_index()
+
+        self.doc_id  = doc_id
+        self.joby_id = joby_id
+        self.nv_id   = nv_id
+
+    def tearDown(self):
+        self.wiki_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    @patch("core.memory.verify_before_write",
+           return_value=(True, "ok", 0.99))
+    def test_modify_replaces_doc_sources_and_writes_new_sidecar(self, _mock):
+        summary = cascade_modify_doc(
+            self.physical,
+            "new text — Joby x Anthropic",
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            new_metadata   = {},
+            user_role      = "admin",
+        )
+
+        # 1) 물리 파일 = 새 content + .deleted/ 백업 1개
+        physical_path = self.upload_dir / self.physical
+        self.assertTrue(physical_path.exists())
+        self.assertEqual(physical_path.read_text(encoding="utf-8"),
+                         "new text — Joby x Anthropic")
+        deleted_dir = self.upload_dir / ".deleted"
+        self.assertEqual(len(list(deleted_dir.iterdir())), 1)
+
+        # 2) 새 sidecar 가 작성됨 (Anthropic 포함)
+        new_sidecar = json.loads(
+            (self.upload_dir / (self.physical + ".extraction.json"))
+            .read_text(encoding="utf-8")
+        )
+        names = [e["name"] for e in new_sidecar["extraction"]["entities"]]
+        self.assertIn("Anthropic", names)
+
+        # 3) NVIDIA entity 는 orphan 으로 사라짐 (다른 incoming 없음)
+        self.assertFalse((self.entity_root / "org" / "nvidia.md").exists())
+
+        # 4) Joby entity 는 살아있고 새 relation (→ Anthropic) 보유
+        joby_fm = _read_fm(self.entity_root / "org" / "joby.md")
+        joby_rels = joby_fm.get("relations") or []
+        targets = [r.get("target") for r in joby_rels]
+        self.assertIn("Anthropic", targets)
+        # NVIDIA 향한 relation 은 사라져야
+        self.assertNotIn("NVIDIA", targets)
+
+        # 5) Anthropic 새 entity 생성됨
+        self.assertTrue((self.entity_root / "org" / "anthropic.md").exists())
+
+        # 6) summary 검증
+        self.assertEqual(summary["original_filename"], "report.pdf")
+        self.assertTrue(summary["sidecar_present"])
+        self.assertTrue(summary["vector_replaced"])
+        self.assertGreater(summary["orphan_entities_deleted"], 0)
+        self.assertEqual(summary["doc_entity_id"], self.doc_id)
+
+        # 7) vector store: delete_by_source 호출 1회
+        self.vs.delete_by_source.assert_called_with("report.pdf")
+
+    @patch("core.memory.verify_before_write",
+           return_value=(True, "ok", 0.99))
+    def test_manual_source_survives_modify(self, _mock):
+        """그래프 에디터로 추가한 manual source 가 modify cascade 후에도
+        살아남는지 (Phase C 의 cascade_remove 룰 정합)."""
+        # Joby → NVIDIA 의 source 에 manual 한 줄 추가
+        joby_path = self.entity_root / "org" / "joby.md"
+        fm = _read_fm(joby_path)
+        fm["relations"][0]["sources"].append({
+            "doc_id": None, "weight": 0.9, "role": MANUAL_SOURCE_ROLE,
+            "author": "admin", "ts": "t",
+        })
+        _write_entity(joby_path, fm)
+
+        cascade_modify_doc(
+            self.physical,
+            "new text",
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            new_metadata   = {},
+            user_role      = "admin",
+        )
+
+        # Joby 는 살아있고 NVIDIA 향한 relation 도 manual 덕에 유지.
+        # NVIDIA entity 도 incoming 이 있어 orphan 아님 → 유지.
+        self.assertTrue((self.entity_root / "org" / "joby.md").exists())
+        self.assertTrue((self.entity_root / "org" / "nvidia.md").exists())
+        joby_rels = (_read_fm(joby_path).get("relations") or [])
+        nv_targets = [r.get("target") for r in joby_rels]
+        self.assertIn("NVIDIA", nv_targets)
+
+    @patch("core.memory.verify_before_write",
+           return_value=(True, "ok", 0.99))
+    def test_no_sidecar_fallback(self, _mock):
+        """사이드카 없는 (Phase D 이전) 업로드도 wipe+reingest 로 동작."""
+        # 사이드카 파일 삭제
+        (self.upload_dir / (self.physical + ".extraction.json")).unlink()
+
+        summary = cascade_modify_doc(
+            self.physical,
+            "new text",
+            wiki_generator = self.wg,
+            vector_store   = self.vs,
+            upload_dir     = self.upload_dir,
+            new_metadata   = {},
+            user_role      = "admin",
+        )
+
+        self.assertFalse(summary["sidecar_present"])
+        # diff 정보는 None (계산하지 않음)
+        self.assertIsNone(summary["diff"])
+        # cascade 자체는 정상 수행 — Anthropic 새 entity 만들어짐
+        self.assertTrue((self.entity_root / "org" / "anthropic.md").exists())
+        # 새 sidecar 는 생성됨 (Phase D 이후 정합)
+        self.assertTrue(
+            (self.upload_dir / (self.physical + ".extraction.json")).exists()
+        )
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            cascade_modify_doc(
+                "no_such_uuid_x.pdf",
+                "new text",
+                wiki_generator = self.wg,
+                vector_store   = self.vs,
+                upload_dir     = self.upload_dir,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`docs/design/v0.3-knowledge-cascade.md` §6 — **Phase D**.

업로드 파일의 내용을 새 multipart 로 교체하고 그 파일이 만들어낸 wiki 파생물 (entity / relation sources / vector chunks) 을 새 LLM 추출에 맞춰 갱신.

Phase B (#269) 의 sources stamp + Phase C (#270) 의 manual-aware cascade 를 그대로 재사용 — **manual edits 는 자동 보존**, 다른 doc 의 corroborating source 도 영향 없음.

### 변경 contract

**extraction sidecar JSON** (Phase B 의 ingestion path 에 부착):
- `process_document_for_entities(..., extraction_sidecar_path=None)` 이 호출자 지정 경로에 LLM 출력 (entities + relations + metadata) 를 JSON 으로 저장. None 이면 skip (**back-compat**)
- `/upload/` 가 `uploads/<uuid>_<file>.extraction.json` 으로 자동 저장 → 미래 modify 의 diff 시작점

**`core/cascade.py` 신규**:
- `load_extraction_sidecar(physical_filename, upload_dir)` — 없거나 손상이면 None
- `diff_triples(old_extraction, new_extraction)` — entities + relations 의 added/removed/kept 분류. label/name lowercase 정규화로 LLM 비결정성 일부 흡수 (디자인 §9 risk #5 대응)
- `cascade_modify_doc(physical_filename, new_content, ...)` — orchestrator. **실용적 접근**: 이 doc 의 source 전체 wipe + orphan sweep + 새 content 로 ingestion 재실행. 사이드카 부재 시도 fallback 으로 동일하게 동작 (Phase D 이전 업로드 호환). kept-triples 의 ts 갱신은 허용 — 디자인 §6 strict surgical (kept 손대지 않기) 은 follow-up

**신규 endpoint `PUT /admin/files`** (server_llmwiki.py):
- admin.data feature gate, root='uploads' hard-coded
- multipart file 받아 PolicyEngine `sanitize_for_ingestion` 통과시킨 후 cascade
- cascade summary (sidecar present / diff counts / orphans) 를 audit log answer 컬럼에 JSON 압축 기록

### Verification

- 신규 테스트 13 (`tests/test_phase_d_modify_cascade.py`):
  - `load_extraction_sidecar` 3 — missing / valid / corrupt
  - `diff_triples` 6 — added entity / removed entity / kept triple / label case insensitive / removed+added / sidecar None → all added
  - `cascade_modify_doc` 통합 4 — full cascade + 새 sidecar / manual source 보존 / 사이드카 없는 fallback / missing file
- 전체 회귀: **1822 tests OK** (1809 baseline + 13 신규, regression 0)
- \`ruff check core/cascade.py core/wiki_generator.py server_llmwiki.py tests/test_phase_d_modify_cascade.py\` → All checks passed!

### CLAUDE.md gates

- rule #2 (bench numbers): read path 무영향. write path 는 admin opt-in
- rule #3 (자가-진화): 무관
- rule #5 (20 KB): `core/cascade.py` 17 KB (gate 통과). `core/wiki_generator.py` 는 +25 lines 가지만 사전 위반 상태 그대로

### Out of scope

- **Surgical triple-level cascade** (디자인 §6 strict): kept-triples 의 ts 도 보존하는 surgical 구현. 현재는 wipe+reingest 가 같은 outcome 을 더 간결히 달성 (단지 ts 만 churn). 별 PR
- **UI for `/admin/files [PUT]`** — 본 PR backend 만. follow-up: 사용자가 admin UI 에서 "이 파일 교체" 버튼 + 파일 picker
- **Weight delta cap** (디자인 §9 mitigation #5): `diff_triples` 가 weight 무시. 추후 |delta| < 0.1 ignore 옵션 가능

### 사용자 라이브 검증 가이드 (머지 후)

```powershell
$env:JAMES_API_KEY = "..."
python server_llmwiki.py

# 1) /upload/ 로 새 파일 한 개 (post Phase D 시점이라 사이드카 자동 생성)
# 2) curl -X PUT http://127.0.0.1:8000/admin/files \
#      -F "api_key=$env:JAMES_API_KEY" \
#      -F "path=<uuid>_<filename>" \
#      -F "file=@<new_local_file>" \
#      -H "Authorization: Bearer <jwt>"
# 3) 응답의 summary.diff 에 added/removed/kept counts 확인
# 4) wiki/entity/<type>/<entity>.md 에서 새 content 의 entity 들이 생겼는지
# 5) uploads/.deleted/{ts}_<file> 에 옛 파일 backup 존재 확인
# 6) audit log: SELECT * FROM audit_log WHERE endpoint='/admin/files [PUT]'
```

### Phase 큐 (사이클 8 Knowledge Cascade)

- [x] Phase A — PR #266
- [x] Phase B — PR #269
- [x] Phase C — PR #270
- [x] Phase E backend — PR #271
- [ ] Phase E frontend UI — PR #273 (open, awaiting merge)
- [x] **Phase D — 본 PR**