### PR TITLE
fix(graph): 노드 클릭 403 — Authorization 헤더 추가 (PR-O1)

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -582,7 +582,13 @@
     var key = encodeURIComponent(apiKey || '');
     var url = API + '/admin/entities/' + encodeURIComponent(node.id) +
               '?api_key=' + key;
-    fetch(url, { credentials: 'same-origin' })
+    // [PR-O1, 2026-05-15] /admin/entities/<id> 는 admin.data 게이트라
+    // Bearer JWT 필수. snapshot fetch (fetchSnapshot) 와 동일 패턴.
+    // 헤더 누락 시 항상 403 — "요약 불러오지 못했습니다 403" 라이브 차단.
+    fetch(url, {
+      credentials: 'same-origin',
+      headers: { 'Authorization': 'Bearer ' + token },
+    })
       .then(function (r) {
         if (!r.ok) throw new Error('HTTP ' + r.status);
         return r.json();


### PR DESCRIPTION
## Summary

라이브 사용 중 그래프 노드 클릭 시 `요약 불러오지 못했습니다 — HTTP 403`
이 항상 재현. 사이클 12 (Operational UX, #276) 의 첫 PR-O1.

- `frontend/static/graph.js` `fetchAndRenderEntitySummary` 의 fetch 가
  `Authorization: Bearer <token>` 헤더 누락 → `/admin/entities/<id>` 의
  `admin.data` feature gate 가 거부.
- 같은 파일 `fetchSnapshot` (line 151) / `start` probe (line 1184) 는
  이미 동일 헤더를 보냄. 이 호출만 누락이었음.
- 7-line diff (헤더 1줄 + 주석 3줄 + 객체 리터럴 형태 변경 3줄).

## Verification

- `python -m pytest tests/test_graph_w2_node_summary.py -q` → **33 OK**
  (호출 패턴/헬퍼 정의 검사. Authorization 헤더 유무는 비검사 영역이라
  기존 컨트랙트와 충돌 없음)
- `python -m pytest tests/test_admin_entities.py -q` → **11 OK**
  (`/admin/entities/<id>` 백엔드 인증 경로 — 회귀 0)
- 라이브 검증: 사용자가 admin 로그인 상태에서 그래프 노드 클릭 시
  요약 패널이 정상 렌더되는지 확인 필요.

## Out of scope

- 사이클 12 의 PR-O2 (제안 칩 정규식), PR-O3 (저장 spinner) 등 다른
  항목은 별 PR.
- bench 불필요: UI fix, `core/retrieval` / `core/graph` / `core/reasoning`
  변경 없음 (CLAUDE.md rule #2 면제).

cycle 12 / spec: docs/handovers/v0.3-operational-ux-track.md §4 PR-O1