### PR TITLE
chore(lint): main의 ruff F541/F401 5건 청소 (CI 그린 회복)

### DIFF
--- a/scripts/rollback_phase_a_sources.py
+++ b/scripts/rollback_phase_a_sources.py
@@ -32,7 +32,7 @@ def rollback(wiki_root: Path, force: bool = False) -> int:
               "로 실행됐거나 이미 rollback 됐을 수 있음)", file=sys.stderr)
         return 2
 
-    print(f"[ROLLBACK] stop the server before continuing.")
+    print("[ROLLBACK] stop the server before continuing.")
     if not wiki_root.exists():
         print(f"[ROLLBACK] {wiki_root} 가 없음 — snapshot 으로 바로 이동")
         snap.rename(wiki_root)
@@ -53,7 +53,7 @@ def rollback(wiki_root: Path, force: bool = False) -> int:
     wiki_root.rename(trash)
     print(f"[ROLLBACK] move {snap} → {wiki_root}")
     snap.rename(wiki_root)
-    print(f"[ROLLBACK] done.")
+    print("[ROLLBACK] done.")
     print(f"           trash kept at {trash} for manual inspection. "
           f"remove when confident.")
     return 0

--- a/tests/test_longterm_save_modal_n6.py
+++ b/tests/test_longterm_save_modal_n6.py
@@ -28,7 +28,6 @@ Run:
 from __future__ import annotations
 
 import os
-import re
 import sys
 import unittest
 from pathlib import Path

--- a/tests/test_phase_a_migration.py
+++ b/tests/test_phase_a_migration.py
@@ -21,13 +21,10 @@ from __future__ import annotations
 
 import importlib.util
 import os
-import shutil
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-
-import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
## Summary

main HEAD `c82fd8c` 시점에서 GitHub Actions `ruff (F-class enforced)`
가 5회 연속 실패 상태. 모두 Phase A 잔재:

- `scripts/rollback_phase_a_sources.py:35,56` — F541 f-string without
  placeholders (placeholder 없는 `print` 의 `f` prefix 2건)
- `tests/test_longterm_save_modal_n6.py:31` — F401 unused `import re`
- `tests/test_phase_a_migration.py:24,30` — F401 unused `shutil`, `yaml`

5건 모두 사용처 전무 (`Grep` 으로 `shutil.` / `yaml.` / `re.` 0건 확인).
동작 변경 없음.

## Verification

- `ruff check . --output-format=concise` → **All checks passed!**
- `pytest tests/test_phase_a_migration.py tests/test_longterm_save_modal_n6.py -q`
  → **18 OK**

## Out of scope

- 코드 동작 변경 없음 (lint-only).
- 다른 ruff 카테고리 (E/W class 등) 는 CI 가 enforce 하지 않으므로 미손댐.
- 사이클 12 PR-O1 (#277) 은 본 PR 머지 후 rebase 해서 그린 CI 위에서 재실행.

## CLAUDE.md gate

- Rule #1 (도메인 분화): 무관
- Rule #2 (bench): UI/Python lint 만, retrieval/graph/reasoning 무변경 → 면제
- Rule #5 (20 KB 모듈): 무관