### PR TITLE
feat(chat): 제안 칩 자연어 패턴 + threshold ≥1 (PR-O2)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1498,12 +1498,22 @@ function appendJamesMsg(data) {
    "① X" 같은 변형으로 답하면 chip이 안 나오는 간헐 누락 발생
    (사용자 보고 2026-05-08).
 
-   v2는 SUGGESTION_PATTERNS 배열을 순서대로 시도. 첫 번째로 ≥2개를
-   찾는 패턴의 결과를 채택. 패턴 우선순위:
-     ① "(1) X (2) Y (3) Z"   — strict, 우리가 권장하는 포맷
-     ② "1) X 2) Y 3) Z"      — 우괄호만
-     ③ "1. X\n2. Y\n3. Z"    — 다행 번호 목록
-     ④ "① X ② Y ③ Z"          — 원문자
+   v2는 SUGGESTION_PATTERNS 배열을 순서대로 시도. 첫 번째로 매칭이
+   잡힌 패턴의 결과를 채택. 패턴 우선순위:
+     ① "(1) X (2) Y (3) Z"        — strict, 권장 포맷
+     ② "1) X 2) Y 3) Z"           — 우괄호만
+     ③ "1. X\n2. Y\n3. Z"         — 다행 번호 목록
+     ④ "① X ② Y ③ Z"               — 원문자
+     ⑤ "혹시 X 궁금하신가요?"     — [PR-O2] 자연어 invite
+     ⑥ "X에 대해 더 알고 싶으시면" — [PR-O2] 자연어 invite
+     ⑦ "관련 질문(으로는)?: X"    — [PR-O2] 자연어 invite
+
+   [PR-O2, 2026-05-15] 사이클 12 사용자 피드백:
+     - "혹시 ~궁금하신가요?" 같은 자연어 제안은 ①~④ 어디에도 안 잡힘
+       → ⑤⑥⑦ 패턴 추가 (group 2 = chip 텍스트로 통일)
+     - threshold ≥2 → ≥1 (단일 매칭도 chip 화)
+       → 그러나 ⑤⑥⑦ 은 매우 구체적 phrasing 이라 false positive 낮고,
+         ①~④ 의 "1단계: ..." 류 본문 잔재는 길이/tail 제한으로 차단.
 
    답변 끝 600자만 검사 — 본문 중간 "(1) 첫째" 등을 제안으로
    오해하지 않도록 tail 제한. */
@@ -1512,6 +1522,14 @@ const SUGGESTION_PATTERNS = [
   /(?:^|[\s\n])(\d)\)\s+([^\n)]+?)(?=\s+\d\)|\n|$)/g,
   /(?:^|\n)\s*(\d)\.\s+([^\n]+)/g,
   /([①②③④⑤⑥⑦⑧⑨])\s+([^\n①-⑨]+?)(?=\s*[①-⑨]|$)/g,
+  // ⑤ "혹시 X 궁금하신가요?" / "혹시 X 알고 싶으세요?" — 한 LLM follow-up
+  //    group 1 = 앵커("혹시"), group 2 = chip 텍스트
+  /(혹시)\s+([^?？\n]{6,200}?)[\?？]/g,
+  // ⑥ "X에 대해 더 알고 싶으시면 …" — X 가 chip 텍스트. 시작 경계는
+  //    공백/줄바꿈/문장 시작으로 좁혀서 본문 중간 단어 침범 방지.
+  /(^|[\s\n。\.])([^\s.,()\n][^.,()\n]{4,200}?)에\s*(?:대해|관해)\s*더\s*알고\s*싶[으어]/g,
+  // ⑦ "관련 질문(으로는)?: X" / "관련된 문의: X"
+  /(관련(?:된|해서?)?\s*(?:질문|문의)(?:으로는?|은|이)?[:：])\s*([^\n]{4,200})/g,
 ];
 
 function extractNextActionSuggestions(answerText) {
@@ -1544,8 +1562,9 @@ function extractNextActionSuggestions(answerText) {
       }
       if (out.length >= 5) break;
     }
-    // 최소 2개 — 단일 매칭은 본문 잔재(예: "1단계: ...")일 가능성.
-    if (out.length >= 2) {
+    // [PR-O2, 2026-05-15] threshold ≥1. 단일 매칭도 chip 화.
+    // 본문 잔재 위험은 tail 600자 + length 4-200 + 중복 제거로 차단.
+    if (out.length >= 1) {
       // Cut the answer at the first match offset, then drop any
       // dangling colon-introducer line ("다음을 시도해보실 수 있습니다:")
       // that the LLM put right before the list and that would

--- a/tests/test_chat_ux_n4_n5.py
+++ b/tests/test_chat_ux_n4_n5.py
@@ -171,5 +171,100 @@ class LowHighVariantsStillPresentTests(unittest.TestCase):
         self.assertIn("t('chat.web_chip_high')", self.src)
 
 
+# ─── PR-O2 (2026-05-15) — 자연어 제안 패턴 + threshold ≥1 ───────
+class SuggestionPatternsPrO2Tests(unittest.TestCase):
+    """사이클 12 PR-O2: SUGGESTION_PATTERNS 에 자연어 invite 3 패턴 추가
+    + 단일 매칭 (≥1) 도 chip 화.
+
+    User feedback (2026-05-14):
+      > 못 잡는 케이스: 자연어 제안 ("혹시 ~궁금하신가요?"), 1개만 매칭
+
+    NL 패턴 ⑤⑥⑦ 은 매우 구체적 phrasing → false positive 낮음. 기존 ①~④
+    numbered list 도 threshold 완화 이득. tail 600자 + length 4-200 +
+    중복 제거가 본문 잔재 차단 layer.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+        # SUGGESTION_PATTERNS 배열 본문만 잘라 옴 — 다른 정규식 정의가
+        # 같은 파일에 있으니 윈도우 좁히기.
+        m_open = re.search(
+            r"const\s+SUGGESTION_PATTERNS\s*=\s*\[", cls.src,
+        )
+        assert m_open, "SUGGESTION_PATTERNS 배열 정의를 찾을 수 없음"
+        body_start = m_open.end()
+        m_close = re.search(r"\n\];", cls.src[body_start:])
+        assert m_close, "SUGGESTION_PATTERNS 배열의 ']' 닫힘을 찾을 수 없음"
+        cls.array_body = cls.src[body_start:body_start + m_close.start()]
+
+    def test_pattern_natural_language_hokshi(self):
+        # ⑤ "혹시 X 궁금하신가요?" — anchor 가 한글 '혹시' 로 시작.
+        self.assertIn("/(혹시)", self.array_body,
+            "자연어 패턴 ⑤ '혹시 X 궁금하신가요?' 누락")
+
+    def test_pattern_natural_language_more_info(self):
+        # ⑥ "X에 대해 더 알고 싶으시면" — '더\s*알고\s*싶' 시그니처.
+        self.assertRegex(self.array_body, r"더\\s\*알고\\s\*싶",
+            "자연어 패턴 ⑥ 'X에 대해 더 알고 싶으시면' 누락")
+
+    def test_pattern_natural_language_related_question(self):
+        # ⑦ "관련 질문(으로는)?: X" — '관련' + '질문|문의' + ':'.
+        self.assertIn("관련(?:된|해서?)?", self.array_body,
+            "자연어 패턴 ⑦ '관련된 질문: X' 누락")
+        # '질문|문의' alternation 시그니처 (non-capturing group `(?:...)` 내).
+        self.assertIn("질문|문의", self.array_body,
+            "자연어 패턴 ⑦ 의 '질문|문의' alternation 누락")
+
+    def test_threshold_lowered_to_one(self):
+        # 기존 `out.length >= 2` → `>= 1`.
+        self.assertIn("out.length >= 1", self.src,
+            "threshold 가 ≥1 로 완화되지 않음")
+        # 기존 `>= 2` 게이트가 더 이상 extractNextActionSuggestions 안에
+        # 남아 있으면 안 됨 (다른 함수의 `>= 2` 는 무관).
+        m_fn = re.search(
+            r"function\s+extractNextActionSuggestions\s*\("
+            r"[\s\S]+?\n\}\n",
+            self.src,
+        )
+        self.assertIsNotNone(m_fn, "extractNextActionSuggestions 본문을 찾을 수 없음")
+        self.assertNotIn("out.length >= 2", m_fn.group(0),
+            "extractNextActionSuggestions 안에 옛 ≥2 게이트가 남아있음")
+
+    def test_existing_numbered_patterns_intact(self):
+        # 회귀: ①~④ 정규식 시그니처 그대로 남아 있는지.
+        self.assertIn(r"\((\d)\)", self.array_body,
+            "① '(1) X (2) Y' 패턴 누락")
+        self.assertIn(r"(\d)\)\s+", self.array_body,
+            "② '1) X 2) Y' 패턴 누락")
+        self.assertIn(r"(\d)\.\s+", self.array_body,
+            "③ '1. X 2. Y' 패턴 누락")
+        self.assertIn("①②③④⑤⑥⑦⑧⑨", self.array_body,
+            "④ '① X ② Y' 원문자 패턴 누락")
+
+    def test_capture_group_2_convention_maintained(self):
+        # 모든 패턴이 group 2 = chip 텍스트 컨벤션을 따라야 함
+        # (extractNextActionSuggestions 의 `m[2]` 접근).
+        # 핵심 NL 패턴 (혹시 / 더 알고 / 관련 질문) 의 group 2 자리에
+        # 길이 상한 capture 시그니처 ([^...]{N,M}) 가 있는지 직접 확인.
+        # 정확한 group counting 은 JS regex 파서 없이 어려우므로
+        # 시그니처 단위 검사.
+        self.assertRegex(
+            self.array_body,
+            r"혹시[\)\s].*\[\^\?？\\n\]\{6,200\}",
+            "⑤ 혹시 패턴의 group 2 capture 시그니처 (길이 6-200) 누락",
+        )
+        self.assertRegex(
+            self.array_body,
+            r"\[\^\.\,\(\)\\n\]\{4,200\}\?\)에",
+            "⑥ '더 알고' 패턴의 group 2 capture 시그니처 (길이 4-200) 누락",
+        )
+        self.assertRegex(
+            self.array_body,
+            r"\[:：\]\)\\s\*\(\[\^\\n\]\{4,200\}\)",
+            "⑦ '관련 질문' 패턴의 ':' 뒤 group 2 capture 누락",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_suggestion_click.py
+++ b/tests/test_suggestion_click.py
@@ -181,13 +181,19 @@ class JsContractTests(unittest.TestCase):
     def test_function_iterates_patterns(self):
         idx = self.js.index("function extractNextActionSuggestions")
         body = self.js[idx:idx + 1500]
-        # Must loop through patterns and return early on first ≥2 hit.
+        # Must loop through patterns and return early on first ≥1 hit.
+        # [PR-O2, 2026-05-15] 사이클 12: threshold ≥2 → ≥1 (단일 매칭도
+        # chip 화). 본문 잔재 위험은 tail 600자 + length 4-200 + 중복
+        # 제거 가 담당.
         self.assertIn("for (const re of SUGGESTION_PATTERNS", body,
             "must iterate patterns")
         self.assertIn("re.lastIndex = 0", body,
             "must reset lastIndex (regex with /g flag is stateful)")
-        self.assertIn(">= 2", body,
-            "must require ≥2 to accept a pattern's result")
+        self.assertIn(">= 1", body,
+            "must require ≥1 to accept a pattern's result")
+        # 옛 ≥2 게이트 잔재 차단 (PR-O2 의도된 완화).
+        self.assertNotIn("out.length >= 2", body,
+            "옛 ≥2 게이트가 남아있음 — PR-O2 가 ≥1 로 완화함")
 
     def test_ask_suggestion_function(self):
         self.assertIn("function askSuggestion", self.js)


### PR DESCRIPTION
## Summary

라이브 사용 중 LLM 답변의 **자연어 follow-up invite** ("혹시 ~궁금하신가요?",
"~에 대해 더 알고 싶으시면", "관련 질문: ~") 가 기존 SUGGESTION_PATTERNS
①~④ 에 안 잡혀서 chip 미생성. 단일 매칭 (≥1) 케이스도 chip 화 안 됨
(`out.length >= 2` 게이트).

사이클 12 PR-O2 (handovers/v0.3-operational-ux-track.md §4):

- **NL 패턴 3 개 추가** — group 2 = chip 텍스트 컨벤션 유지:
  - ⑤ `/(혹시)\s+([^?？\n]{6,200}?)[\?？]/g`
  - ⑥ `/(^|[\s\n。\.])([^\s.,()\n][^.,()\n]{4,200}?)에\s*(?:대해|관해)\s*더\s*알고\s*싶[으어]/g`
  - ⑦ `/(관련(?:된|해서?)?\s*(?:질문|문의)(?:으로는?|은|이)?[:：])\s*([^\n]{4,200})/g`
- **threshold ≥2 → ≥1** (단일 매칭도 chip 화)

본문 잔재 false positive 차단 layer (기존 + 신규):
- tail 600자 (본문 중간 침범 방지)
- length 4-200 (단답/장문 제외)
- 중복 제거
- NL 패턴 자체가 매우 구체적 phrasing

## Verification

- `pytest tests/test_chat_ux_n4_n5.py -q` → **16 OK** (6 신규
  `SuggestionPatternsPrO2Tests`, 기존 N-4/N-5 회귀 0)
- `pytest tests/test_suggestion_click.py -q` → **18 OK** (옛 `>= 2`
  assertion 을 `>= 1` 로 갱신 — PR-O2 의도된 변경)
- `pytest tests/ -k 'chat or suggestion or n_3..6 or chip'` → **150/150**
  (회귀 0)
- `ruff check .` → All checks passed
- Node.js sanity parse OK

## Out of scope

- PR-O3 (장기기억 저장 spinner) 별 PR
- server-side suggestion (Fix-B) 는 사이클 11 Cog Phase 2 로 이관
- bench 불필요: UI fix, `core/retrieval` / `core/graph` /
  `core/reasoning` 무변경 → CLAUDE.md rule #2 면제

## CLAUDE.md gate

- Rule #1 (도메인 분화): 무관 (platform layer)
- Rule #2 (bench): 면제
- Rule #5 (20 KB): chat.js 는 이미 가장 큰 frontend 파일이지만 본 PR 은
  순수 추가 +20 line — 별도 분할 사이클은 follow-up.