### PR TITLE
docs(arch): §5.7.2 reasoning backends + trace_schema 단락 추가 (Pre-L0)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,6 +373,17 @@ the reverse.
 | Verification → CR-E | enforced | a verifier flagging a self-modifying outcome (memory write, ontology edit, evolution patch) must route through `core/change_request.py` — direct apply is a CLAUDE.md rule #3 violation |
 | Reflection state | working memory only | not persisted by default; episodic memory captures only the **final** verified answer trace |
 
+#### Reasoning backends + trace schema
+
+LLM 호출은 `core/reasoning/backends/` 의 명명된 어댑터
+(`claude_code_cli`, `ollama_local`, …) 를 통해서만 발생한다. 미들웨어는
+모델 SDK 를 직접 import 하지 않는다. 모든 백엔드는 동일 row 형태로
+`audit_bridge` 에 기록하며, 그 형태는 `core/reasoning/trace_schema.py`
+의 frozen dataclass (`stage`, `parent_step_id`, `backend_id`,
+`inputs_hash`, `output_summary`, `applied_rule`) 로 고정된다. 새 백엔드는
+**registry 만** 확장하고 **schema 는** 확장하지 않는다 — replay 도구는
+transport 와 무관하게 한 가지 row 형태만 읽는다.
+
 #### Trace replay invariant
 
 Every reasoning step — planner decisions, reranker scores, reflection


### PR DESCRIPTION
## Summary

Cognitive Layer Phase 0 의 **L0 PR** (`core/reasoning/backends/` +
`core/reasoning/trace_schema.py` MVP) 가 박히기 전에, 두 primitive 의
trust zone 합의를 ARCHITECTURE.md 에 먼저 박는다. CLAUDE.md rule #4
(architecture 변경은 사전 PR + `architecture` 라벨) 정합.

`docs/ARCHITECTURE.md §5.7.2` trust zone 표 직후, `#### Trace replay
invariant` 소제목 앞에 한 단락 추가:

- LLM 호출은 `core/reasoning/backends/` 의 명명된 어댑터를 통해서만
  발생 — 미들웨어는 모델 SDK 직접 import 금지
- 모든 백엔드는 `core/reasoning/trace_schema.py` 의 frozen dataclass
  로 정의된 6 필드 (`stage`, `parent_step_id`, `backend_id`,
  `inputs_hash`, `output_summary`, `applied_rule`) 형태로 `audit_bridge`
  에 기록
- 새 백엔드는 **registry 만** 확장, **schema 는** 확장 안 함 — replay
  도구는 transport 무관 한 가지 row 형태만 읽음

## Verification

- diff: `+11 LOC` to `docs/ARCHITECTURE.md` only
- 코드 변경 0 → bench 면제 (CLAUDE.md rule #2 적용 안 됨)
- 테스트 변경 0
- 모듈 size 게이트 영향 없음 (ARCHITECTURE.md 는 core 파일 아님)

## Out of scope

- 실제 코드 (`core/reasoning/backends/__init__.py`,
  `claude_code_cli.py`, `ollama_local.py`, `trace_schema.py`) — **L0
  PR** 에서 처리
- `pipeline.py` / `modes.py` wiring (`engine.llm.call_gemma` → backend
  registry) — **L1 PR** 에서 처리
- replay 도구 (`scripts/replay_trace.py`) — **L2 PR** 에서 처리

## Cross-check at L0

L0 PR 머지 전에 본 단락의 6 필드와 `TraceStep` dataclass 정의가
정확히 일치하는지 cross-check 한다 — doc drift 회피.

## CLAUDE.md gate

| Rule | 본 PR 의 적용 |
|---|---|
| #1 도메인 분화 금지 | 무관 (platform layer) |
| #2 bench numbers | 면제 (코드 무변경) |
| #3 self-evolution 게이트 | 무관 |
| #4 architecture 변경 | **본 PR** + `architecture` 라벨 |
| #5 20 KB 모듈 | 무관 (docs) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
