### PR TITLE
feat(reasoning): claude_code_cli backend + trace_schema MVP (L0)

### DIFF
--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -1,0 +1,135 @@
+"""Backend registry for the cognitive middleware layer (L0 MVP).
+
+ARCHITECTURE.md §5.7.2 contract: LLM 호출은 명명된 어댑터를 통해서만
+발생, 미들웨어는 모델 SDK 직접 import 금지. 새 백엔드는 registry 만
+확장, schema (core/reasoning/trace_schema.TraceStep) 는 확장 안 함.
+
+Two adapters ship with L0:
+
+  - ``ollama_local``     — wraps the existing RouterWrapper.call_gemma
+                           path; byte-identical to v0.3.0 behavior.
+                           Always registered.
+  - ``claude_code_cli``  — spawns the `claude` CLI as a subprocess.
+                           Registered only when the operator opts in via
+                           ``JAMES_ENABLE_CLAUDE_BACKEND=1`` — off by
+                           default so a stock JAMES install never reaches
+                           an external CLI without explicit consent.
+
+L0 is wiring-free — the registry exists but core/reasoning/pipeline.py
+still calls ``engine.llm.call_gemma(...)`` directly. L1 swaps those call
+sites onto ``get_backend(name).complete(...)`` + emit_trace_step.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    """One backend's response. Backends never raise on the user-facing
+    path — they return ``error="..."`` and let the caller decide. This
+    matches RouterWrapper's existing "_LLM_ERROR_PREFIXES" pattern in
+    core/reasoning/engine.py.
+    """
+    text: str
+    backend_id: str
+    model: str = ""
+    latency_ms: int = 0
+    error: str = ""
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """Every backend exposes one method. Optional kwargs (system,
+    max_tokens, timeout) match the shape pipeline.py already passes to
+    ``call_gemma`` — L1's wiring stays mechanical.
+    """
+    backend_id: str
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_tokens: int = 1024,
+        timeout: float = 60.0,
+        **opts,
+    ) -> CompletionResult: ...
+
+
+_REGISTRY: Dict[str, Backend] = {}
+
+
+def register_backend(name: str, backend: Backend) -> None:
+    """Add a backend to the registry. Idempotent re-registration with
+    the same instance is allowed (re-imports under test runners); a
+    different instance under the same name raises so we don't silently
+    overwrite an in-flight backend.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError("backend name must be a non-empty str")
+    if not isinstance(backend, Backend):
+        raise TypeError(
+            f"object registered as {name!r} does not satisfy the "
+            f"Backend protocol (missing .complete or .backend_id)"
+        )
+    existing = _REGISTRY.get(name)
+    if existing is not None and existing is not backend:
+        raise ValueError(
+            f"backend {name!r} already registered with a different instance"
+        )
+    _REGISTRY[name] = backend
+
+
+def get_backend(name: str) -> Backend:
+    """Look a backend up. Unknown name → KeyError; the opt-in pattern
+    is intentional — a caller asking for ``claude_code_cli`` when the
+    operator hasn't enabled it gets a loud failure, not silent fallback.
+    """
+    try:
+        return _REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"no backend registered for {name!r}; "
+            f"known: {sorted(_REGISTRY)}"
+        ) from None
+
+
+def list_backends() -> Dict[str, Backend]:
+    """Shallow copy of the registry — tests inspect this; production
+    code goes through get_backend.
+    """
+    return dict(_REGISTRY)
+
+
+def _clear_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    _REGISTRY.clear()
+
+
+# ─── auto-registration ─────────────────────────────────────────────
+# ollama_local is always registered — it wraps RouterWrapper which is
+# the v0.3.0 default path. claude_code_cli is opt-in via env so a stock
+# install can't accidentally route prompts to an external CLI.
+
+def _autoregister() -> None:
+    from core.reasoning.backends.ollama_local import OllamaLocalBackend
+    register_backend("ollama_local", OllamaLocalBackend())
+
+    if os.environ.get("JAMES_ENABLE_CLAUDE_BACKEND") == "1":
+        from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
+        register_backend("claude_code_cli", ClaudeCodeCliBackend())
+
+
+_autoregister()
+
+
+__all__ = [
+    "Backend",
+    "CompletionResult",
+    "register_backend",
+    "get_backend",
+    "list_backends",
+]

--- a/core/reasoning/backends/claude_code_cli.py
+++ b/core/reasoning/backends/claude_code_cli.py
@@ -1,0 +1,177 @@
+"""Adapter that spawns the ``claude`` CLI as a subprocess.
+
+Opt-in only. Registration in ``core/reasoning/backends/__init__.py``
+checks ``JAMES_ENABLE_CLAUDE_BACKEND=1`` so a stock JAMES install never
+reaches an external CLI without explicit operator consent.
+
+Security posture (L0 MVP):
+
+  1. Prompt is delivered via **stdin**, never as a CLI argument. A
+     prompt containing shell metacharacters (`;`, `|`, `$()`) cannot
+     reach the subprocess argv.
+  2. Argv is a fixed list — `[cli_path, "-p", "--output-format", "text"]`.
+     No user-controlled string ever joins argv.
+  3. Environment passed to the child is a **whitelist** — PATH, HOME,
+     and the explicit ``ANTHROPIC_API_KEY`` / ``CLAUDE_CONFIG_DIR``
+     forwards. os.environ is not handed over wholesale.
+  4. Output is size-capped (1 MiB) and the child is killed on timeout.
+  5. Cli path can be overridden via ``JAMES_CLAUDE_CLI_PATH`` (defaults
+     to looking up ``claude`` on PATH); a missing CLI surfaces as
+     ``error="cli not found"`` rather than a crash.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import List, Optional
+
+from core.reasoning.backends import CompletionResult
+
+
+_MAX_OUTPUT_BYTES = 1 * 1024 * 1024   # 1 MiB
+_ENV_WHITELIST = ("PATH", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CONFIG_DIR")
+
+
+def _resolve_cli_path() -> Optional[str]:
+    """Honor JAMES_CLAUDE_CLI_PATH if set, otherwise look up ``claude``
+    on PATH. Returns None if the binary is not findable — caller turns
+    that into ``error="cli not found"``.
+    """
+    explicit = os.environ.get("JAMES_CLAUDE_CLI_PATH", "").strip()
+    if explicit:
+        return explicit if os.path.exists(explicit) else None
+    return shutil.which("claude")
+
+
+def _build_env() -> dict:
+    """Whitelist os.environ. Empty values are dropped so the child does
+    not inherit cleared sentinels.
+    """
+    return {
+        k: os.environ[k]
+        for k in _ENV_WHITELIST
+        if os.environ.get(k)
+    }
+
+
+class ClaudeCodeCliBackend:
+    """``claude -p`` non-interactive driver.
+
+    The CLI's `-p` flag enters print mode: it reads the prompt from
+    stdin (when no positional argument is given), runs one turn, prints
+    the answer to stdout, exits. Output format is forced to ``text`` so
+    the result is the bare answer string.
+    """
+
+    backend_id = "claude_code_cli"
+
+    def __init__(self, cli_path: Optional[str] = None) -> None:
+        # Constructor-time path resolution is a snapshot; auto-registered
+        # instances pin whatever the operator's environment had at boot.
+        # Tests pass an explicit cli_path to override.
+        self._explicit_cli = cli_path
+
+    def _cli_path(self) -> Optional[str]:
+        return self._explicit_cli or _resolve_cli_path()
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_tokens: int = 1024,   # advisory — claude CLI does not surface a flag
+        timeout: float = 60.0,
+        model: Optional[str] = None,
+        **opts,
+    ) -> CompletionResult:
+        t0 = time.time()
+        path = self._cli_path()
+        if not path:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=model or "",
+                latency_ms=0, error="cli not found",
+            )
+
+        argv: List[str] = [path, "-p", "--output-format", "text"]
+        if model:
+            # validated by the CLI itself — we don't try to enumerate
+            # the model catalog client-side
+            argv.extend(["--model", str(model)])
+
+        composed = f"{system}\n\n{prompt}" if system else prompt
+        # bound the prompt at the same 1 MiB the output is bounded at —
+        # avoids handing a pathological prompt to the subprocess
+        composed = composed[: _MAX_OUTPUT_BYTES]
+
+        try:
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=_build_env(),
+                # text mode with utf-8 to match JAMES's encoding convention
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except (OSError, FileNotFoundError) as e:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=model or "",
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"spawn failed: {type(e).__name__}: {str(e)[:120]}",
+            )
+
+        try:
+            stdout, stderr = proc.communicate(input=composed, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.communicate(timeout=2.0)
+            except Exception:
+                pass
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=model or "",
+                latency_ms=int((time.time() - t0) * 1000),
+                error="timeout",
+            )
+        except Exception as e:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=model or "",
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"communicate failed: {type(e).__name__}: {str(e)[:120]}",
+            )
+
+        latency_ms = int((time.time() - t0) * 1000)
+
+        if proc.returncode != 0:
+            err = (stderr or "")[:200].strip() or f"exit code {proc.returncode}"
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=model or "",
+                latency_ms=latency_ms, error=err,
+            )
+
+        text = stdout or ""
+        truncated = False
+        if len(text.encode("utf-8", errors="replace")) > _MAX_OUTPUT_BYTES:
+            # Cut by characters so we don't split a UTF-8 sequence; the
+            # byte bound is a defense-in-depth check, not the primary cut.
+            text = text[: _MAX_OUTPUT_BYTES]
+            truncated = True
+
+        return CompletionResult(
+            text=text.rstrip("\n"),
+            backend_id=self.backend_id,
+            model=model or "",
+            latency_ms=latency_ms,
+            error="output truncated" if truncated else "",
+        )
+
+
+__all__ = ["ClaudeCodeCliBackend"]

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -1,0 +1,85 @@
+"""Adapter around RouterWrapper.call_gemma — the v0.3.0 default LLM path.
+
+Byte-identical to existing core/reasoning/pipeline.py calls. L1's
+wiring step will swap ``engine.llm.call_gemma(prompt, ...)`` for
+``get_backend("ollama_local").complete(prompt, ...)`` without changing
+which model runs or what prompt format reaches it.
+"""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from core.reasoning.backends import CompletionResult
+
+
+class OllamaLocalBackend:
+    """Wrap RouterWrapper("general"). Lazy LLM instantiation — importing
+    this module must not spin up the LLM router (test isolation +
+    autoregistration in core/reasoning/backends/__init__.py).
+    """
+
+    backend_id = "ollama_local"
+
+    def __init__(self) -> None:
+        self._router = None   # constructed on first .complete()
+
+    def _llm(self):
+        if self._router is None:
+            from llm.router import RouterWrapper
+            self._router = RouterWrapper("general")
+        return self._router
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_tokens: int = 1024,
+        timeout: float = 60.0,
+        model: Optional[str] = None,
+        use_cache: bool = True,
+        **opts,
+    ) -> CompletionResult:
+        # RouterWrapper.call_gemma already absorbs system_prompt via the
+        # prompt body in JAMES's existing pattern (modes.py / pipeline.py
+        # both prepend "system_prompt\\n\\n" to the user prompt). To stay
+        # byte-identical with the v0.3.0 call path, the caller still
+        # prepends; we don't double-prepend here.
+        composed = f"{system}\n\n{prompt}" if system else prompt
+
+        t0 = time.time()
+        try:
+            text = self._llm().call_gemma(
+                composed,
+                timeout=timeout,
+                use_cache=use_cache,
+                max_tokens=max_tokens,
+                model=model or None,
+            )
+        except Exception as e:
+            return CompletionResult(
+                text="",
+                backend_id=self.backend_id,
+                model=model or "",
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"{type(e).__name__}: {str(e)[:200]}",
+            )
+
+        # RouterWrapper returns error strings rather than raising for the
+        # known Gemma failure modes — preserve that signal in `error` so
+        # downstream emit_trace_step marks the row blocked=True.
+        _ERR_PREFIXES = ("[Gemma 응답 없음]", "[Gemma 오류]",
+                         "LLM 응답 생성 중 오류")
+        is_err = bool(text) and any(text.startswith(p) for p in _ERR_PREFIXES)
+
+        return CompletionResult(
+            text=text or "",
+            backend_id=self.backend_id,
+            model=model or "",
+            latency_ms=int((time.time() - t0) * 1000),
+            error=("backend reported error string" if is_err else ""),
+        )
+
+
+__all__ = ["OllamaLocalBackend"]

--- a/core/reasoning/trace_schema.py
+++ b/core/reasoning/trace_schema.py
@@ -1,0 +1,170 @@
+"""Frozen trace-row schema for the cognitive middleware layer (L0 MVP).
+
+ARCHITECTURE.md §5.7.2 Reasoning backends + trace schema:
+
+    LLM 호출은 core/reasoning/backends/ 의 명명된 어댑터를 통해서만
+    발생한다. 모든 백엔드는 동일 row 형태로audit_bridge에 기록하며, 그
+    형태는 이 모듈의 frozen dataclass (stage, parent_step_id,
+    backend_id, inputs_hash, output_summary, applied_rule) 로 고정된다.
+    새 백엔드는 registry 만 확장, schema 는 확장 안 함 — replay 도구는
+    transport 와 무관하게 한 가지 row 형태만 읽는다.
+
+Row mapping onto the existing audit_log table (Audit Phase 1–4 pattern,
+no DB migration required):
+
+    endpoint        ← "reason:<stage>"            — Phase 3 LIKE filter
+    security_event  ← applied_rule
+    elapsed_sec     ← latency_ms / 1000
+    user_role       ← caller-supplied (default "system")
+    query           ← "<backend_id>:<inputs_hash>"
+    answer          ← compact JSON of {parent_step_id, output_summary,
+                       error?, plus any caller extras}
+
+L1 wires this into pipeline.py/modes.py; L2 ships scripts/replay_trace.py
+that reads audit_log rows back into TraceStep instances. The schema is
+the contract those two PRs both honor.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional, FrozenSet
+
+
+# Stage whitelist — adding a stage is a code change on purpose so a typo
+# at a call site fails loud (matches the PolicyEngine.can_use_feature
+# pattern from W4-Q1). The seven stages cover Phase 1–4 of the cognitive
+# layer track (docs/handovers/v0.3-cognitive-layer-track.md):
+#
+#   plan      — Planner decomposition (Phase 2 PR-7)
+#   retrieve  — Loop-0 retrieval (existing path)
+#   rerank    — Cross-encoder reranking (Phase 1 PR-1)
+#   reflect   — draft → critique → revised (Phase 2 PR-5)
+#   verify    — generator → critic → fact-checker chain (Phase 2 PR-6)
+#   tool      — Tool router dispatch (Phase 2 PR-8)
+#   synth     — Final synthesizer (existing LLM call site)
+ALLOWED_STAGES: FrozenSet[str] = frozenset({
+    "plan", "retrieve", "rerank", "reflect", "verify", "tool", "synth",
+})
+
+
+@dataclass(frozen=True)
+class TraceStep:
+    """One reasoning step. Six required fields exactly match
+    ARCHITECTURE.md §5.7.2; latency_ms / error are observability extras
+    that don't appear in the contract (consumers may ignore them).
+    """
+    stage: str
+    backend_id: str
+    parent_step_id: str
+    inputs_hash: str
+    output_summary: str
+    applied_rule: str
+    latency_ms: int = 0
+    error: str = ""
+
+    def __post_init__(self) -> None:
+        if self.stage not in ALLOWED_STAGES:
+            raise ValueError(
+                f"unknown reasoning stage {self.stage!r}; "
+                f"allowed: {sorted(ALLOWED_STAGES)}"
+            )
+        if not isinstance(self.backend_id, str):
+            raise TypeError("backend_id must be str")
+        if not isinstance(self.applied_rule, str) or not self.applied_rule:
+            raise ValueError("applied_rule must be a non-empty str")
+
+
+def compute_inputs_hash(prompt: str, system: str = "") -> str:
+    """sha256(system + "\\n" + prompt)[:16]. Stable across processes so
+    replay can detect "same inputs, different outcome" regressions.
+    """
+    h = hashlib.sha256()
+    h.update((system or "").encode("utf-8", errors="replace"))
+    h.update(b"\n")
+    h.update((prompt or "").encode("utf-8", errors="replace"))
+    return h.hexdigest()[:16]
+
+
+def truncate_summary(text: str, limit: int = 200) -> str:
+    if text is None:
+        return ""
+    s = str(text)
+    return s if len(s) <= limit else s[:limit]
+
+
+def emit_trace_step(
+    step: TraceStep,
+    *,
+    user_role: str = "system",
+    extras: Optional[Dict[str, Any]] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Mirror a TraceStep onto the existing audit_log table.
+
+    Routes through core.audit_bridge.mirror_to_audit_db with the
+    "reason:<stage>" endpoint prefix so Phase 3's category filter can
+    surface reasoning rows alongside tool / attack / system rows.
+
+    Returns the bridge's bool (True on insert, False on failure). Never
+    raises — audit emission must not block the reasoning path.
+    """
+    from core.audit_bridge import mirror_to_audit_db   # lazy: test isolation
+
+    # Build the entry by laying TraceStep fields out as top-level
+    # non-reserved keys. audit_bridge._resolve_answer folds every
+    # non-reserved key into the `answer` JSON column, so the final row
+    # carries them in one flat JSON blob:
+    #
+    #   answer = {"parent_step_id": "...", "output_summary": "...", ...}
+    #
+    # The reserved keys (time / role / endpoint / event / blocked /
+    # exec_time_sec / tool_used / target) map onto dedicated columns.
+    entry: Dict[str, Any] = {
+        # reserved → columns
+        "time":           None,                       # bridge falls back to now()
+        "role":           user_role,
+        "endpoint":       f"reason:{step.stage}",
+        "event":          step.applied_rule,
+        "exec_time_sec":  round(step.latency_ms / 1000.0, 6) if step.latency_ms else None,
+        # Pack backend_id:inputs_hash into the `query` column so Phase 3's
+        # free-text search can find all rows for one backend or one input
+        # fingerprint.
+        "tool_used":      step.backend_id or "orchestrator",
+        "target":         step.inputs_hash,
+        "blocked":        bool(step.error),
+        # non-reserved → folded into the answer JSON
+        "parent_step_id": step.parent_step_id,
+        "output_summary": step.output_summary,
+    }
+    if step.error:
+        entry["error"] = step.error
+    if extras:
+        for k, v in extras.items():
+            # don't let extras clobber the schema fields or the bridge's
+            # reserved keys
+            if k in entry or k in {
+                "time", "role", "layer", "event", "blocked",
+                "exec_time_sec", "elapsed_sec",
+                "tool_used", "target_file", "path", "target",
+                "endpoint",
+            }:
+                continue
+            entry[k] = v
+
+    return mirror_to_audit_db(entry, db_path=db_path)
+
+
+def trace_step_to_dict(step: TraceStep) -> Dict[str, Any]:
+    """Plain dict copy for tests / replay. asdict() respects frozen."""
+    return asdict(step)
+
+
+__all__ = [
+    "ALLOWED_STAGES",
+    "TraceStep",
+    "compute_inputs_hash",
+    "truncate_summary",
+    "emit_trace_step",
+    "trace_step_to_dict",
+]

--- a/tests/test_reasoning_backends.py
+++ b/tests/test_reasoning_backends.py
@@ -1,0 +1,276 @@
+"""L0 — Backend registry + claude_code_cli subprocess adapter.
+
+ARCHITECTURE.md §5.7.2: 미들웨어는 모델 SDK 직접 import 금지, 새 백엔드
+는 registry 만 확장. opt-in for the external CLI.
+
+Tests:
+  * registry round-trip + Protocol enforcement
+  * ollama_local always registered (no env)
+  * claude_code_cli NOT registered without JAMES_ENABLE_CLAUDE_BACKEND
+  * claude_code_cli registered WITH the opt-in env
+  * subprocess success / non-zero exit / timeout / missing CLI paths
+  * stdin delivery — a prompt with shell metacharacters never reaches argv
+  * env whitelist — non-whitelisted env vars do not leak to the child
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _reimport_backends(env_overrides=None):
+    """Re-import core.reasoning.backends with a fresh registry under the
+    given env. Returns the freshly loaded module.
+    """
+    import core.reasoning.backends as mod
+    # ensure the submodules cached in sys.modules don't carry stale
+    # auto-register state into the new import
+    for name in list(sys.modules):
+        if name.startswith("core.reasoning.backends"):
+            del sys.modules[name]
+    with patch.dict(os.environ, env_overrides or {}, clear=False):
+        mod = importlib.import_module("core.reasoning.backends")
+    return mod
+
+
+class RegistryProtocolTests(unittest.TestCase):
+
+    def test_ollama_local_always_registered(self):
+        from core.reasoning import backends
+        self.assertIn("ollama_local", backends.list_backends())
+
+    def test_get_backend_unknown_raises_keyerror(self):
+        from core.reasoning import backends
+        with self.assertRaises(KeyError) as ctx:
+            backends.get_backend("definitely_not_a_backend")
+        self.assertIn("no backend registered", str(ctx.exception))
+
+    def test_register_backend_rejects_non_protocol(self):
+        from core.reasoning import backends
+        class NotABackend:
+            pass
+        with self.assertRaises(TypeError):
+            backends.register_backend("broken", NotABackend())
+
+    def test_register_backend_idempotent_with_same_instance(self):
+        from core.reasoning import backends
+        b = backends.get_backend("ollama_local")
+        backends.register_backend("ollama_local", b)   # must not raise
+        self.assertIs(backends.get_backend("ollama_local"), b)
+
+    def test_register_backend_rejects_different_instance_same_name(self):
+        from core.reasoning import backends
+        from core.reasoning.backends.ollama_local import OllamaLocalBackend
+        with self.assertRaises(ValueError):
+            backends.register_backend("ollama_local", OllamaLocalBackend())
+
+
+class OptInGateTests(unittest.TestCase):
+    """JAMES_ENABLE_CLAUDE_BACKEND=1 controls auto-registration of the
+    external CLI backend. Default (env unset) → NOT registered.
+    """
+
+    def setUp(self):
+        # snapshot relevant env vars
+        self._saved = {k: os.environ.get(k) for k in
+                       ("JAMES_ENABLE_CLAUDE_BACKEND",
+                        "JAMES_CLAUDE_CLI_PATH")}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        # always restore a normal registry for downstream tests
+        _reimport_backends()
+
+    def test_claude_backend_absent_when_env_unset(self):
+        os.environ.pop("JAMES_ENABLE_CLAUDE_BACKEND", None)
+        mod = _reimport_backends()
+        self.assertNotIn("claude_code_cli", mod.list_backends())
+
+    def test_claude_backend_present_when_opted_in(self):
+        mod = _reimport_backends({"JAMES_ENABLE_CLAUDE_BACKEND": "1"})
+        self.assertIn("claude_code_cli", mod.list_backends())
+
+    def test_claude_backend_absent_when_env_is_zero(self):
+        mod = _reimport_backends({"JAMES_ENABLE_CLAUDE_BACKEND": "0"})
+        self.assertNotIn("claude_code_cli", mod.list_backends())
+
+
+class ClaudeCliSubprocessTests(unittest.TestCase):
+    """Mock subprocess.Popen to exercise the adapter without an actual
+    claude CLI on the test machine.
+    """
+
+    def _backend(self, cli_path="/fake/claude"):
+        from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
+        return ClaudeCodeCliBackend(cli_path=cli_path)
+
+    def _mock_popen(self, stdout="hello world\n", stderr="", returncode=0):
+        proc = MagicMock()
+        proc.communicate.return_value = (stdout, stderr)
+        proc.returncode = returncode
+        return proc
+
+    def test_missing_cli_returns_error_not_raise(self):
+        from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
+        # explicit non-existent path
+        b = ClaudeCodeCliBackend(cli_path="/nope/never/exists")
+        # since we passed cli_path explicitly, _cli_path returns it as-is
+        # and the subprocess.Popen call will fail FileNotFoundError →
+        # caught and turned into error="spawn failed: ..."
+        with patch("subprocess.Popen", side_effect=FileNotFoundError("no such file")):
+            res = b.complete("hi")
+        self.assertEqual(res.text, "")
+        self.assertTrue(res.error.startswith("spawn failed"))
+        self.assertEqual(res.backend_id, "claude_code_cli")
+
+    def test_resolved_cli_path_none_returns_cli_not_found(self):
+        from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
+        b = ClaudeCodeCliBackend(cli_path=None)
+        # patch the resolver to return None (the realistic case on a
+        # machine without claude installed)
+        with patch("core.reasoning.backends.claude_code_cli._resolve_cli_path",
+                   return_value=None):
+            res = b.complete("hi")
+        self.assertEqual(res.text, "")
+        self.assertEqual(res.error, "cli not found")
+
+    def test_happy_path_returns_text(self):
+        b = self._backend()
+        proc = self._mock_popen(stdout="42\n")
+        with patch("subprocess.Popen", return_value=proc):
+            res = b.complete("what is the answer", system="be brief")
+        self.assertEqual(res.text, "42")   # rstrip("\n") applied
+        self.assertEqual(res.error, "")
+        self.assertGreaterEqual(res.latency_ms, 0)
+
+    def test_non_zero_exit_returns_error(self):
+        b = self._backend()
+        proc = self._mock_popen(stdout="", stderr="auth failed", returncode=2)
+        with patch("subprocess.Popen", return_value=proc):
+            res = b.complete("x")
+        self.assertEqual(res.text, "")
+        self.assertIn("auth failed", res.error)
+
+    def test_timeout_kills_and_reports(self):
+        import subprocess as sp
+        b = self._backend()
+        proc = MagicMock()
+        proc.communicate.side_effect = sp.TimeoutExpired(cmd="claude", timeout=1.0)
+        with patch("subprocess.Popen", return_value=proc):
+            res = b.complete("slow prompt", timeout=0.001)
+        self.assertEqual(res.error, "timeout")
+        proc.kill.assert_called_once()
+
+    def test_prompt_with_shell_metachars_never_in_argv(self):
+        """SECURITY: a prompt containing `;`, `|`, `$()` etc. must reach
+        the subprocess via stdin, never via argv. If argv ever contains
+        the prompt the test fails — that would be a shell-injection
+        vector even with shell=False.
+        """
+        b = self._backend()
+        evil = "; rm -rf / && echo pwned $(whoami) `id`"
+        proc = self._mock_popen()
+        with patch("subprocess.Popen", return_value=proc) as p:
+            b.complete(evil)
+        # argv is the first positional arg to Popen
+        argv = p.call_args.args[0]
+        joined = " ".join(argv)
+        for fragment in ("rm -rf", "pwned", "whoami", "$(", "`id`"):
+            self.assertNotIn(fragment, joined,
+                             f"prompt fragment {fragment!r} leaked into argv")
+        # stdin must carry the evil prompt verbatim instead
+        kwargs = p.call_args.kwargs
+        self.assertTrue(kwargs.get("stdin"))
+        stdin_arg = proc.communicate.call_args.kwargs.get("input", "")
+        self.assertIn(evil, stdin_arg)
+
+    def test_env_whitelist_does_not_leak_secrets(self):
+        """SECURITY: only PATH / HOME / ANTHROPIC_API_KEY /
+        CLAUDE_CONFIG_DIR pass through. A secret stashed in some other
+        env var must NOT reach the child.
+        """
+        b = self._backend()
+        proc = self._mock_popen()
+        secret_env = {
+            "JAMES_API_KEY": "leak-me",
+            "AWS_SECRET_ACCESS_KEY": "also-leak",
+            "ANTHROPIC_API_KEY": "ok-to-forward",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        with patch.dict(os.environ, secret_env, clear=False), \
+             patch("subprocess.Popen", return_value=proc) as p:
+            b.complete("x")
+        env_passed = p.call_args.kwargs.get("env", {})
+        self.assertIn("ANTHROPIC_API_KEY", env_passed)
+        self.assertIn("PATH", env_passed)
+        self.assertNotIn("JAMES_API_KEY", env_passed)
+        self.assertNotIn("AWS_SECRET_ACCESS_KEY", env_passed)
+
+    def test_model_flag_passed_to_argv(self):
+        """User-selected model string DOES appear in argv (after the
+        --model flag) — this is the only field that can. CLI validates
+        the value itself, so we don't enumerate the catalog here.
+        """
+        b = self._backend()
+        proc = self._mock_popen()
+        with patch("subprocess.Popen", return_value=proc) as p:
+            b.complete("x", model="claude-sonnet-4-6")
+        argv = p.call_args.args[0]
+        self.assertIn("--model", argv)
+        self.assertIn("claude-sonnet-4-6", argv)
+
+
+class OllamaLocalAdapterTests(unittest.TestCase):
+    """ollama_local wraps RouterWrapper.call_gemma. Verify the wrapper
+    forwards arguments and surfaces error strings as `error`.
+    """
+
+    def test_complete_returns_router_text(self):
+        from core.reasoning.backends.ollama_local import OllamaLocalBackend
+        b = OllamaLocalBackend()
+        fake_router = MagicMock()
+        fake_router.call_gemma.return_value = "hello"
+        b._router = fake_router
+        res = b.complete("hi", system="be helpful", max_tokens=128)
+        self.assertEqual(res.text, "hello")
+        self.assertEqual(res.error, "")
+        fake_router.call_gemma.assert_called_once()
+        called_prompt = fake_router.call_gemma.call_args.args[0]
+        self.assertIn("be helpful", called_prompt)
+        self.assertIn("hi", called_prompt)
+
+    def test_complete_marks_router_error_string(self):
+        from core.reasoning.backends.ollama_local import OllamaLocalBackend
+        b = OllamaLocalBackend()
+        fake_router = MagicMock()
+        fake_router.call_gemma.return_value = "[Gemma 응답 없음]"
+        b._router = fake_router
+        res = b.complete("hi")
+        self.assertEqual(res.text, "[Gemma 응답 없음]")
+        self.assertNotEqual(res.error, "")
+
+    def test_complete_router_exception_returns_error_not_raise(self):
+        from core.reasoning.backends.ollama_local import OllamaLocalBackend
+        b = OllamaLocalBackend()
+        fake_router = MagicMock()
+        fake_router.call_gemma.side_effect = RuntimeError("ollama down")
+        b._router = fake_router
+        res = b.complete("hi")
+        self.assertEqual(res.text, "")
+        self.assertIn("RuntimeError", res.error)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()

--- a/tests/test_reasoning_trace_schema.py
+++ b/tests/test_reasoning_trace_schema.py
@@ -1,0 +1,280 @@
+"""L0 — Frozen TraceStep dataclass + audit_bridge emit round-trip.
+
+ARCHITECTURE.md §5.7.2 Reasoning backends + trace schema: every backend
+writes one row of a fixed shape to the existing audit_log table. These
+tests pin the shape so a future backend (Phase 1 PR-1 reranker, Phase
+2 PR-5/-6 reflect/verify) can never silently drift the schema.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _rows(db_path: str):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM audit_log ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+class TraceStepDataclassTests(unittest.TestCase):
+    """The 6 required fields exactly match the ARCHITECTURE.md
+    §5.7.2 paragraph. Adding a field is a contract change."""
+
+    def test_six_required_fields_present(self):
+        from core.reasoning.trace_schema import TraceStep
+        names = {f.name for f in dataclasses.fields(TraceStep)}
+        # 6 from the architecture paragraph + 2 observability extras
+        # (latency_ms, error) that don't appear in the contract.
+        for required in ("stage", "parent_step_id", "backend_id",
+                         "inputs_hash", "output_summary", "applied_rule"):
+            self.assertIn(required, names,
+                          f"required schema field {required!r} missing")
+
+    def test_is_frozen(self):
+        from core.reasoning.trace_schema import TraceStep
+        s = TraceStep(stage="reflect", backend_id="ollama_local",
+                      parent_step_id="", inputs_hash="abc",
+                      output_summary="ok", applied_rule="reasoning.reflect")
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            s.stage = "verify"   # type: ignore[misc]
+
+    def test_unknown_stage_rejected(self):
+        from core.reasoning.trace_schema import TraceStep
+        with self.assertRaises(ValueError) as ctx:
+            TraceStep(stage="hallucinate",
+                      backend_id="ollama_local",
+                      parent_step_id="", inputs_hash="x",
+                      output_summary="y",
+                      applied_rule="reasoning.x")
+        self.assertIn("unknown reasoning stage", str(ctx.exception))
+
+    def test_applied_rule_required_nonempty(self):
+        from core.reasoning.trace_schema import TraceStep
+        with self.assertRaises(ValueError):
+            TraceStep(stage="reflect", backend_id="ollama_local",
+                      parent_step_id="", inputs_hash="x",
+                      output_summary="y", applied_rule="")
+
+    def test_all_seven_stages_accepted(self):
+        from core.reasoning.trace_schema import TraceStep, ALLOWED_STAGES
+        # explicit list — if a future PR adds a stage, this test must
+        # update too (i.e., adding a stage requires a deliberate edit
+        # here, matching the "registry only" architecture rule).
+        self.assertEqual(
+            ALLOWED_STAGES,
+            frozenset({"plan", "retrieve", "rerank", "reflect",
+                       "verify", "tool", "synth"}),
+        )
+        for st in ALLOWED_STAGES:
+            TraceStep(stage=st, backend_id="ollama_local",
+                      parent_step_id="", inputs_hash="x",
+                      output_summary="y",
+                      applied_rule=f"reasoning.{st}")
+
+
+class HelperFunctionTests(unittest.TestCase):
+
+    def test_inputs_hash_deterministic_and_16_chars(self):
+        from core.reasoning.trace_schema import compute_inputs_hash
+        a = compute_inputs_hash("hello world", system="be helpful")
+        b = compute_inputs_hash("hello world", system="be helpful")
+        self.assertEqual(a, b)
+        self.assertEqual(len(a), 16)
+
+    def test_inputs_hash_changes_with_system_or_prompt(self):
+        from core.reasoning.trace_schema import compute_inputs_hash
+        base = compute_inputs_hash("x", system="s")
+        self.assertNotEqual(base, compute_inputs_hash("x", system="t"))
+        self.assertNotEqual(base, compute_inputs_hash("y", system="s"))
+
+    def test_truncate_summary(self):
+        from core.reasoning.trace_schema import truncate_summary
+        self.assertEqual(truncate_summary("abc", limit=10), "abc")
+        self.assertEqual(truncate_summary("a" * 250), "a" * 200)
+        self.assertEqual(truncate_summary(None), "")
+
+
+class EmitRoundTripTests(unittest.TestCase):
+    """emit_trace_step → mirror_to_audit_db → audit_log row.
+    Pin the column mapping so L1's wiring step (and L2's replay tool)
+    can rely on it.
+    """
+
+    def _emit(self, step_kwargs, **emit_kwargs):
+        from core.reasoning.trace_schema import TraceStep, emit_trace_step
+        db = _fresh_db()
+        step = TraceStep(**step_kwargs)
+        ok = emit_trace_step(step, db_path=db, **emit_kwargs)
+        self.assertTrue(ok, "emit_trace_step returned False")
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        return rows[0]
+
+    def test_endpoint_prefix_is_reason_stage(self):
+        row = self._emit(dict(
+            stage="reflect", backend_id="ollama_local",
+            parent_step_id="root", inputs_hash="abcd0123",
+            output_summary="revised", applied_rule="reasoning.reflect.revised",
+            latency_ms=42,
+        ))
+        self.assertEqual(row["endpoint"], "reason:reflect")
+        self.assertEqual(row["security_event"], "reasoning.reflect.revised")
+        # backend_id + inputs_hash packed into searchable query column
+        self.assertEqual(row["query"], "ollama_local: abcd0123")
+        # latency_ms → elapsed_sec
+        self.assertAlmostEqual(row["elapsed_sec"], 0.042, places=4)
+
+    def test_answer_blob_has_parent_and_summary(self):
+        row = self._emit(dict(
+            stage="verify", backend_id="claude_code_cli",
+            parent_step_id="step-42", inputs_hash="ffff",
+            output_summary="answer looks correct",
+            applied_rule="reasoning.verify.fact_checker",
+        ))
+        ans = json.loads(row["answer"])
+        self.assertEqual(ans["parent_step_id"], "step-42")
+        self.assertEqual(ans["output_summary"], "answer looks correct")
+        self.assertNotIn("error", ans)
+        self.assertFalse(row["blocked"])
+
+    def test_error_marks_blocked_and_appears_in_answer(self):
+        row = self._emit(dict(
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="abc",
+            output_summary="", applied_rule="reasoning.synth",
+            error="timeout",
+        ))
+        self.assertTrue(row["blocked"])
+        ans = json.loads(row["answer"])
+        self.assertEqual(ans["error"], "timeout")
+
+    def test_extras_folded_in_without_clobbering_schema(self):
+        # Use a non-empty parent_step_id so we can prove the original
+        # value survives (audit_bridge._resolve_answer drops empty
+        # strings; the schema field still wins when present).
+        row = self._emit(
+            dict(stage="plan", backend_id="ollama_local",
+                 parent_step_id="root", inputs_hash="x",
+                 output_summary="3 subtasks",
+                 applied_rule="reasoning.plan"),
+            extras={"subtasks": ["a", "b", "c"],
+                    # reserved field — must be ignored, not clobber column
+                    "endpoint": "evil",
+                    # schema field — must be ignored
+                    "parent_step_id": "FORGED"},
+        )
+        # endpoint column stays the synthesized one
+        self.assertEqual(row["endpoint"], "reason:plan")
+        ans = json.loads(row["answer"])
+        self.assertEqual(ans["parent_step_id"], "root")   # original wins
+        self.assertEqual(ans["subtasks"], ["a", "b", "c"])
+
+    def test_empty_parent_step_id_dropped_from_answer(self):
+        """Replay-tool contract: an absent parent_step_id field means
+        the step has no parent (root). audit_bridge._resolve_answer
+        drops empty strings, so the row carries no parent_step_id key
+        when the step is root.
+        """
+        row = self._emit(dict(
+            stage="plan", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="x",
+            output_summary="root subtask",
+            applied_rule="reasoning.plan",
+        ))
+        ans = json.loads(row["answer"])
+        self.assertNotIn("parent_step_id", ans)
+        self.assertEqual(ans["output_summary"], "root subtask")
+
+    def test_user_role_default_is_system(self):
+        row = self._emit(dict(
+            stage="rerank", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="x",
+            output_summary="reordered", applied_rule="reasoning.rerank",
+        ))
+        self.assertEqual(row["user_role"], "system")
+
+    def test_user_role_caller_supplied(self):
+        row = self._emit(dict(
+            stage="tool", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="x",
+            output_summary="", applied_rule="reasoning.tool.web_search",
+        ), user_role="employee")
+        self.assertEqual(row["user_role"], "employee")
+
+    def test_orchestrator_backend_id_default(self):
+        """Orchestrator-level steps (no LLM call) emit with empty
+        backend_id; the bridge query column shows 'orchestrator' so
+        replay can distinguish from a real backend named ''.
+        """
+        row = self._emit(dict(
+            stage="plan", backend_id="", parent_step_id="",
+            inputs_hash="x", output_summary="",
+            applied_rule="reasoning.plan",
+        ))
+        self.assertIn("orchestrator", row["query"])
+
+
+class TraceStepToDictTests(unittest.TestCase):
+
+    def test_round_trip(self):
+        from core.reasoning.trace_schema import (
+            TraceStep, trace_step_to_dict,
+        )
+        s = TraceStep(stage="verify", backend_id="ollama_local",
+                      parent_step_id="p1", inputs_hash="abcd",
+                      output_summary="ok",
+                      applied_rule="reasoning.verify",
+                      latency_ms=100, error="")
+        d = trace_step_to_dict(s)
+        self.assertEqual(d["stage"], "verify")
+        self.assertEqual(d["latency_ms"], 100)
+        # Replay tool will rebuild a TraceStep from this dict — must work.
+        s2 = TraceStep(**d)
+        self.assertEqual(s, s2)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
> Pairs with **Pre-L0 PR #282** (`docs(arch): §5.7.2 backends + trace_schema 단락`). Merge #282 first to keep the architecture commitment ahead of the code that honors it.

## Summary

Cognitive Layer **Phase 0** 의 두 primitive 박는 PR.

- `core/reasoning/trace_schema.py` — frozen `TraceStep` dataclass + `emit_trace_step()` helper that routes through `core/audit_bridge.mirror_to_audit_db` (no DB migration: row mapped onto existing `audit_log` columns with `endpoint = "reason:<stage>"` — same Audit Phase 1–4 pattern that ships `tool:` / `attack:` / `system:` rows today).
- `core/reasoning/backends/` — `Backend` Protocol + registry. Two adapters ship:
  - **`ollama_local`** — wraps the existing `RouterWrapper("general").call_gemma`; byte-identical to v0.3.0.
  - **`claude_code_cli`** — `claude -p` subprocess. **Opt-in only** via `JAMES_ENABLE_CLAUDE_BACKEND=1`.

**Wiring 0**: no existing module imports `trace_schema` or `backends`. `pipeline.py` / `modes.py` / `engine.py` / server **completely untouched**. L1 (separate PR) is what swaps the live LLM call sites onto `get_backend(name).complete(...)` + `emit_trace_step(...)`.

## Verification

- **Tests**: 36 new (`tests/test_reasoning_trace_schema.py` — 17, `tests/test_reasoning_backends.py` — 19). Full reasoning-tagged test slice 67/67 green.
- **Lint**: `ruff check core/reasoning/trace_schema.py core/reasoning/backends tests/test_reasoning_*.py` → `All checks passed!`
- **Module size**: all files < 20 KB (6.5 / 6.4 / 4.7 / 3 KB).
- **STEP 7 bench**: **mechanically byte-identical** — `git diff main -- core/reasoning/pipeline.py core/reasoning/modes.py core/reasoning/engine.py server_llmwiki.py` is empty. No live code path changed. (Bench cannot be run in CI without a live server; user spot-check `python scripts/bench.py --suite=step7 --check` after merging is the operational confirmation.)

## Security posture (claude_code_cli backend)

| Threat | Mitigation |
|---|---|
| Shell injection via prompt | Prompt delivered via **stdin only**, never argv. Test `test_prompt_with_shell_metachars_never_in_argv` enforces. |
| argv injection via flags | argv is a fixed list. Only the `--model` value can be user-supplied; CLI validates it. |
| Secret env-var leak (e.g., `JAMES_API_KEY`) | Env passed to child is a **whitelist** (`PATH`, `HOME`, `ANTHROPIC_API_KEY`, `CLAUDE_CONFIG_DIR`). Test `test_env_whitelist_does_not_leak_secrets` enforces. |
| Output flood | 1 MiB cap, error tagged `output truncated`. |
| Hung process | `subprocess.kill()` on timeout, error tagged `timeout`. |
| Surprise external CLI on stock install | **Off by default**. `JAMES_ENABLE_CLAUDE_BACKEND=1` required to auto-register. `get_backend("claude_code_cli")` returns `KeyError` until set. |

## Trace schema → audit_log mapping

```
TraceStep field      audit_log column / location
─────────────────────────────────────────────────────
stage                endpoint    = "reason:<stage>"
applied_rule         security_event
latency_ms           elapsed_sec = latency_ms / 1000
backend_id           query       = "<backend_id>:<inputs_hash>"
inputs_hash          query       (same column)
parent_step_id       answer (JSON)  — dropped when ""
output_summary       answer (JSON)
error (if non-empty) answer (JSON) + blocked = 1
```

Endpoint prefix `reason:` joins the existing `tool:` / `attack:` / `system:` family that `/admin/audit/list` already filters on — no admin UI changes needed at L0.

## Out of scope

- **L1** — swap `engine.llm.call_gemma(...)` call sites in `core/reasoning/pipeline.py` and `core/reasoning/modes.py` onto `get_backend("ollama_local").complete(...)` + `emit_trace_step(...)`. STEP 7 must stay byte-identical; new audit rows count gets recorded.
- **L2** — `scripts/replay_trace.py` reads `audit_log` `WHERE endpoint LIKE 'reason:%'` for one `question_id` and reproduces the reasoning tree.
- Phase 1 PR-1 Reranker / Phase 2 PR-5 Reflection / PR-6 Verification — build **on top of** the registry + emit_trace_step from this PR.

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Platform-only — zero domain code |
| #2 bench numbers | Wiring 0 → mechanically guaranteed byte-identical. User spot-check confirms |
| #3 self-evolution gate | Unrelated |
| #4 architecture | **Pre-L0 #282** carries the architecture commitment; merge that first |
| #5 20 KB module size | All new files well under (6.5 / 6.4 / 4.7 / 3 KB) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
