### PR TITLE
feat(reasoning): trace_synth_call wiring on 12 LLM call sites (L1)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -23,6 +23,7 @@ from core.retrieval_engine  import RetrievalEngine
 from core.security_layer    import (
     SecurityLayer,
 )
+from core.reasoning.trace_helpers import trace_synth_call
 from core.reasoning.modes import (
     handle_chat,
     handle_meta,
@@ -423,10 +424,18 @@ class ReasoningEngine:
                 )
 
         try:
-            answer = self.llm.call_gemma(
-                prompt, timeout=120, use_cache=True,
-                max_tokens=style.max_tokens,
-                model=selected_model or None,
+            # L1 wiring: trace_synth_call wraps so the canonical RAG
+            # synthesis emits one reasoning audit row. Behaviour is
+            # byte-identical — the helper forwards call_gemma's return
+            # value untouched.
+            answer = trace_synth_call(
+                lambda: self.llm.call_gemma(
+                    prompt, timeout=120, use_cache=True,
+                    max_tokens=style.max_tokens,
+                    model=selected_model or None,
+                ),
+                prompt,
+                applied_rule="reasoning.synth.rag",
             )
             if not answer or any(answer.startswith(p) for p in self._LLM_ERROR_PREFIXES):
                 return "답변 생성에 실패했습니다."

--- a/core/reasoning/modes.py
+++ b/core/reasoning/modes.py
@@ -21,6 +21,8 @@ import re
 import time
 from typing import Any, Dict
 
+from core.reasoning.trace_helpers import trace_synth_call
+
 
 # [Axis 6 user feedback, 2026-05-12] Prepended to the LLM prompt
 # whenever previous-turn context exists. Suppresses the canned
@@ -88,10 +90,16 @@ def handle_chat(
             mem_prefix = f"{memory_context}\n\n"
         else:
             mem_prefix = ""
-        raw_answer = engine.llm.call_gemma(
-            f"{sys_prefix}{mem_prefix}{rule_txt}\n질문: {safe_query}\n\n답변:",
-            use_cache=True, timeout=60, max_tokens=style.max_tokens,
-            model=selected_model or None,
+        _chat_prompt = f"{sys_prefix}{mem_prefix}{rule_txt}\n질문: {safe_query}\n\n답변:"
+        raw_answer = trace_synth_call(
+            lambda: engine.llm.call_gemma(
+                _chat_prompt,
+                use_cache=True, timeout=60, max_tokens=style.max_tokens,
+                model=selected_model or None,
+            ),
+            _chat_prompt,
+            applied_rule="reasoning.synth.chat",
+            user_role=user_role,
         )
         # Preserve paragraph breaks (\n\n) — user feedback wants
         # natural 문단 separation, not a single block of text.
@@ -248,8 +256,15 @@ def handle_wiki_edit(
             ' "entity_type": "person|org|concept|document"}\n\n'
             "JSON만 출력:"
         )
-        raw = engine.llm.call_gemma(parse_prompt, timeout=30, use_cache=False,
-                                    model=selected_model or None)
+        raw = trace_synth_call(
+            lambda: engine.llm.call_gemma(
+                parse_prompt, timeout=30, use_cache=False,
+                model=selected_model or None,
+            ),
+            parse_prompt,
+            applied_rule="reasoning.synth.wiki_edit_parse",
+            user_role=user_role,
+        )
 
         # JSON 파싱
         import json as _json
@@ -295,9 +310,14 @@ def handle_wiki_edit(
                     f"[현재 내용]\n{old_content[:1200]}\n\n"
                     "수정된 전체 내용만 출력 (frontmatter 포함):"
                 )
-                new_content = engine.llm.call_gemma(
-                    new_prompt, timeout=90, use_cache=False,
-                    model=selected_model or None,
+                new_content = trace_synth_call(
+                    lambda: engine.llm.call_gemma(
+                        new_prompt, timeout=90, use_cache=False,
+                        model=selected_model or None,
+                    ),
+                    new_prompt,
+                    applied_rule="reasoning.synth.wiki_edit_update",
+                    user_role=user_role,
                 )
                 if new_content:
                     ok, msg = update_entity(target, new_content, user_role)
@@ -411,11 +431,19 @@ def handle_self_evolve(
 
                 # LLM에 세부 분석 요청
                 sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-                analysis = engine.llm.call_gemma(
+                _folder_prompt = (
                     f"{sys_prefix}다음 폴더 구조를 보고 각 파일의 역할과 "
-                    f"전체 아키텍처를 설명해줘:\n\n{folder_report[:2000]}\n\n설명:",
-                    timeout=120, use_cache=False,
-                    model=selected_model or None,
+                    f"전체 아키텍처를 설명해줘:\n\n{folder_report[:2000]}\n\n설명:"
+                )
+                analysis = trace_synth_call(
+                    lambda: engine.llm.call_gemma(
+                        _folder_prompt,
+                        timeout=120, use_cache=False,
+                        model=selected_model or None,
+                    ),
+                    _folder_prompt,
+                    applied_rule="reasoning.synth.self_evolve_folder",
+                    user_role=user_role,
                 )
                 answer = folder_report
                 if analysis:
@@ -428,11 +456,19 @@ def handle_self_evolve(
             fname   = file_match.group(1)
             content = get_file_content(fname)
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-            analysis = engine.llm.call_gemma(
+            _file_prompt = (
                 f"{sys_prefix}아래 코드를 분석하고 개선점을 제안해줘:\n\n"
-                f"파일: {fname}\n```python\n{content[:2000]}\n```\n\n분석:",
-                timeout=120, use_cache=False,
-                model=selected_model or None,
+                f"파일: {fname}\n```python\n{content[:2000]}\n```\n\n분석:"
+            )
+            analysis = trace_synth_call(
+                lambda: engine.llm.call_gemma(
+                    _file_prompt,
+                    timeout=120, use_cache=False,
+                    model=selected_model or None,
+                ),
+                _file_prompt,
+                applied_rule="reasoning.synth.self_evolve_file",
+                user_role=user_role,
             )
             answer = (
                 f"📄 **{fname}** 분석\n\n"
@@ -466,11 +502,19 @@ def handle_self_evolve(
 
             if safe_query and ("개선" in safe_query or "분석" in safe_query):
                 sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-                extra = engine.llm.call_gemma(
+                _improve_prompt = (
                     f"{sys_prefix}PROJECT JAMES의 현재 구조를 바탕으로, "
-                    f"다음 관점에서 개선 제안을 해줘: {safe_query}\n\n제안:",
-                    timeout=90, use_cache=False,
-                    model=selected_model or None,
+                    f"다음 관점에서 개선 제안을 해줘: {safe_query}\n\n제안:"
+                )
+                extra = trace_synth_call(
+                    lambda: engine.llm.call_gemma(
+                        _improve_prompt,
+                        timeout=90, use_cache=False,
+                        model=selected_model or None,
+                    ),
+                    _improve_prompt,
+                    applied_rule="reasoning.synth.self_evolve_improve",
+                    user_role=user_role,
                 )
                 if extra:
                     answer += f"\n\n💡 **개선 제안:**\n{extra}"
@@ -536,10 +580,16 @@ def handle_coding(
                   query_len=len(safe_query))
         try:
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-            answer = engine.llm.call_gemma(
-                f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:",
-                use_cache=True, timeout=120,
-                model=selected_model,
+            _coding_user_prompt = f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:"
+            answer = trace_synth_call(
+                lambda: engine.llm.call_gemma(
+                    _coding_user_prompt,
+                    use_cache=True, timeout=120,
+                    model=selected_model,
+                ),
+                _coding_user_prompt,
+                applied_rule="reasoning.synth.coding_user_pick",
+                user_role=user_role,
             )
             log_stage("coding_user_pick_done",
                       latency_ms=int((time.time() - t_code) * 1000),
@@ -573,9 +623,15 @@ def handle_coding(
             # Fallback: default GEMMA_MODEL via the engine's RouterWrapper
             try:
                 sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
-                answer = engine.llm.call_gemma(
-                    f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:",
-                    use_cache=True, timeout=90,
+                _coding_fallback_prompt = f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:"
+                answer = trace_synth_call(
+                    lambda: engine.llm.call_gemma(
+                        _coding_fallback_prompt,
+                        use_cache=True, timeout=90,
+                    ),
+                    _coding_fallback_prompt,
+                    applied_rule="reasoning.synth.coding_fallback",
+                    user_role=user_role,
                 )
                 log_stage("coding_fallback_done",
                           latency_ms=int((time.time() - t_code) * 1000),

--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -23,6 +23,7 @@ import time
 from typing import Any, Dict
 
 from core.reasoning.engine import MAX_LOOP, LOOP_TIMEOUT, TIMING_TARGET_SEC
+from core.reasoning.trace_helpers import trace_synth_call
 from core.security_layer import filter_answer_by_role
 from core.observability import log_stage
 
@@ -328,8 +329,14 @@ def run_retrieval_pipeline(
                                     f"아래 검색 결과를 한국어로 200자 이내 핵심 요약:\n"
                                     f"{web_context[:1000]}\n\n요약:"
                                 )
-                                summary = engine.llm.call_gemma(
-                                    summary_prompt, timeout=30, use_cache=False, max_tokens=300
+                                # L1 wiring — one audit row per LLM round-trip
+                                summary = trace_synth_call(
+                                    lambda: engine.llm.call_gemma(
+                                        summary_prompt, timeout=30, use_cache=False, max_tokens=300,
+                                    ),
+                                    summary_prompt,
+                                    applied_rule="reasoning.synth.web_summary",
+                                    user_role=user_role,
                                 )
                                 if summary:
                                     from tools.self.evo_analyzer import (
@@ -388,20 +395,32 @@ def run_retrieval_pipeline(
             _korean = sum(1 for c in safe_query if "가" <= c <= "힣")
             _is_ko = _korean >= max(1, len(safe_query) * 0.2)
             _rule = _style.rule_text_ko if _is_ko else _style.rule_text_en
-            answer_raw = engine.llm.call_gemma(
-                f"{sys_prefix}"
-                f"{'[웹 검색 결과 포함]' if web_context else ''}"
-                f"\n{_rule}\n질문: {safe_query}\n\n답변:",
-                use_cache=(not web_context), timeout=90,
-                max_tokens=_style.max_tokens,
-                model=selected_model or None,
-            ) if not combined_context.strip() else engine._generate_answer(
-                safe_query,
-                combined_context,
-                system_prompt,
-                response_style=response_style,
-                selected_model=selected_model,
-            )
+            # Two-arm decision: no internal context → direct LLM with the
+            # web-fallback prompt; otherwise the canonical RAG path via
+            # _generate_answer (which itself emits a trace row).
+            if not combined_context.strip():
+                _web_fallback_prompt = (
+                    f"{sys_prefix}"
+                    f"{'[웹 검색 결과 포함]' if web_context else ''}"
+                    f"\n{_rule}\n질문: {safe_query}\n\n답변:"
+                )
+                answer_raw = trace_synth_call(
+                    lambda: engine.llm.call_gemma(
+                        _web_fallback_prompt,
+                        use_cache=(not web_context), timeout=90,
+                        max_tokens=_style.max_tokens,
+                        model=selected_model or None,
+                    ),
+                    _web_fallback_prompt,
+                    applied_rule="reasoning.synth.web_fallback",
+                    user_role=user_role,
+                )
+            else:
+                answer_raw = engine._generate_answer(
+                    safe_query, combined_context, system_prompt,
+                    response_style=response_style,
+                    selected_model=selected_model,
+                )
             answer_raw = answer_raw if answer_raw else ""
 
             if answer_raw and not any(
@@ -424,13 +443,21 @@ def run_retrieval_pipeline(
             _korean_r = sum(1 for c in safe_query if "가" <= c <= "힣")
             _is_ko_r = _korean_r >= max(1, len(safe_query) * 0.2)
             _rule_r = _style_retry.rule_text_ko if _is_ko_r else _style_retry.rule_text_en
-            retry = engine.llm.call_gemma(
+            _retry_prompt = (
                 f"{sys_prefix}{_rule_r}\n"
                 f"질문: {safe_query}\n\n"
                 "(내부 자료에는 직접 언급이 없습니다. "
-                "위 가이드를 따라 자연스럽게 답하세요.)\n답변:",
-                use_cache=False, timeout=60, max_tokens=_style_retry.max_tokens,
-                model=selected_model or None,
+                "위 가이드를 따라 자연스럽게 답하세요.)\n답변:"
+            )
+            retry = trace_synth_call(
+                lambda: engine.llm.call_gemma(
+                    _retry_prompt,
+                    use_cache=False, timeout=60, max_tokens=_style_retry.max_tokens,
+                    model=selected_model or None,
+                ),
+                _retry_prompt,
+                applied_rule="reasoning.synth.retry_no_info",
+                user_role=user_role,
             )
             if retry and not any(retry.startswith(p) for p in engine._LLM_ERROR_PREFIXES):
                 print("[ROUTER] post_check → 재시도 (persona 포함)")

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -1,0 +1,145 @@
+"""L1 wiring helper — wrap an LLM call so it emits one TraceStep row.
+
+L0 (PR #283) shipped TraceStep / emit_trace_step / Backend registry as
+infrastructure. L1 (this PR) wires the existing 12 ``call_gemma`` sites
+in pipeline.py / modes.py / engine.py to emit one ``audit_log`` row each,
+without changing what the LLM returns (STEP 7 must stay byte-identical).
+
+The helper exists to keep each call site small:
+
+    raw = trace_synth_call(
+        lambda: engine.llm.call_gemma(prompt, timeout=60, max_tokens=400),
+        prompt,
+        applied_rule="reasoning.synth.chat",
+        user_role=user_role,
+    )
+
+vs the inline alternative (8 lines per site × 12 sites = 96 LOC of
+boilerplate). Same byte-output, plus one audit row per LLM round-trip.
+
+Trace correlation: every emitted step carries the current Axis-3
+``trace_id`` (core/observability) under ``extras["trace_id"]`` so the
+future replay tool can ``WHERE answer LIKE '%"trace_id": "<id>"%'`` to
+gather every reasoning row for one question. Schema fields stay clean —
+``parent_step_id`` continues to mean step lineage (populated in Phase 2
+when reflection/verification stack steps).
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Optional
+
+from core.reasoning.trace_schema import (
+    TraceStep,
+    compute_inputs_hash,
+    emit_trace_step,
+    truncate_summary,
+)
+
+
+# Sentinel string used in error rows to mark a RouterWrapper-known
+# failure mode (callee returned an error string, not text). Mirrors the
+# OllamaLocalBackend convention so consumers see the same shape whether
+# they call the backend directly or via this helper.
+_ROUTER_ERROR_PREFIXES = (
+    "[Gemma 응답 없음]",
+    "[Gemma 오류]",
+    "LLM 응답 생성 중 오류",
+)
+
+
+def _current_trace_id() -> str:
+    """Read the Axis-3 trace_id ContextVar without imposing a hard
+    dependency on observability — tests / direct callers without an
+    HTTP edge get an empty string and the helper still works.
+    """
+    try:
+        from core.observability import get_trace_id
+        return get_trace_id() or ""
+    except Exception:
+        return ""
+
+
+def _is_router_error(text: Optional[str]) -> bool:
+    if not text:
+        return True   # empty result counts as a failure to emit text
+    return any(text.startswith(p) for p in _ROUTER_ERROR_PREFIXES)
+
+
+def trace_synth_call(
+    llm_call: Callable[[], Any],
+    prompt: str,
+    *,
+    applied_rule: str,
+    user_role: str = "system",
+    stage: str = "synth",
+    backend_id: str = "ollama_local",
+    parent_step_id: str = "",
+    system: str = "",
+    extras: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Call ``llm_call()``, emit one TraceStep, return the raw text.
+
+    Behaviour:
+      * Wraps the call in a try/except — exceptions are converted into
+        an ``error`` row and re-raised so the caller's existing
+        error-handling stays unchanged.
+      * On success, classifies RouterWrapper's known error strings
+        (`[Gemma 응답 없음]`, etc.) as ``error`` rows even though the
+        return type is a string — consumers can filter on ``blocked=1``.
+      * Returns the raw text unmodified — no truncation, no rewriting.
+        The audit row's ``output_summary`` is a truncated copy; the
+        caller's downstream logic sees the full text.
+
+    ``extras`` is merged with the auto-added ``trace_id`` (the latter
+    wins on key collision, matching emit_trace_step's "schema field
+    cannot be clobbered" invariant from L0).
+    """
+    t0 = time.time()
+    emit_extras: Dict[str, Any] = dict(extras or {})
+    trace_id = _current_trace_id()
+    if trace_id:
+        emit_extras["trace_id"] = trace_id
+
+    try:
+        text = llm_call()
+    except Exception as e:
+        emit_trace_step(
+            TraceStep(
+                stage=stage,
+                backend_id=backend_id,
+                parent_step_id=parent_step_id,
+                inputs_hash=compute_inputs_hash(prompt, system=system),
+                output_summary="",
+                applied_rule=applied_rule,
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"{type(e).__name__}: {str(e)[:200]}",
+            ),
+            user_role=user_role,
+            extras=emit_extras,
+        )
+        raise
+
+    text_str = text if isinstance(text, str) else (str(text) if text is not None else "")
+    err = ""
+    if _is_router_error(text_str):
+        err = "backend reported error string"
+
+    emit_trace_step(
+        TraceStep(
+            stage=stage,
+            backend_id=backend_id,
+            parent_step_id=parent_step_id,
+            inputs_hash=compute_inputs_hash(prompt, system=system),
+            output_summary=truncate_summary(text_str),
+            applied_rule=applied_rule,
+            latency_ms=int((time.time() - t0) * 1000),
+            error=err,
+        ),
+        user_role=user_role,
+        extras=emit_extras,
+    )
+    return text_str
+
+
+__all__ = ["trace_synth_call"]

--- a/tests/test_reasoning_trace_helpers.py
+++ b/tests/test_reasoning_trace_helpers.py
@@ -1,0 +1,204 @@
+"""L1 — trace_synth_call helper that wraps an LLM call with one emit.
+
+12 ``call_gemma`` sites in pipeline.py / modes.py / engine.py route
+through this helper. STEP 7 must stay byte-identical (no answer
+mutation, no prompt rewriting); the only observable change is one
+audit_log row per LLM round-trip.
+
+Tests:
+  * happy path: text forwarded unchanged, one row emitted, fields
+    populated correctly
+  * RouterWrapper error string (`[Gemma 응답 없음]` etc.): text still
+    forwarded, but row's `error` is non-empty and `blocked=1`
+  * exception in llm_call: emitted as error row, then re-raised
+  * empty / None text: forwarded as "", emitted as error row
+  * trace_id ContextVar propagation: when set, appears in answer JSON
+  * trace_id absent: helper still works, no trace_id key in row
+  * extras: caller-supplied extras land in answer JSON alongside
+    trace_id (without clobbering schema fields)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _rows(db_path: str):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM audit_log ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+class TraceSynthCallTests(unittest.TestCase):
+    """Each test points emit_trace_step at an isolated DB by patching
+    audit_bridge's default path resolution at module import time.
+    """
+
+    def _run(self, llm_call, *, applied_rule="reasoning.synth.test",
+             user_role="employee", extras=None, prompt="hello"):
+        from core.reasoning.trace_helpers import trace_synth_call
+        db = _fresh_db()
+        # Patch the audit_bridge default path so emit_trace_step writes
+        # to our isolated db. The helper does not accept a db_path
+        # parameter (production code never specifies one).
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            text = trace_synth_call(
+                llm_call, prompt,
+                applied_rule=applied_rule,
+                user_role=user_role,
+                extras=extras,
+            )
+        return text, _rows(db)
+
+    def test_happy_path_text_forwarded_unchanged(self):
+        text, rows = self._run(lambda: "the answer is 42")
+        self.assertEqual(text, "the answer is 42")
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["endpoint"], "reason:synth")
+        self.assertEqual(row["security_event"], "reasoning.synth.test")
+        self.assertEqual(row["user_role"], "employee")
+        self.assertFalse(row["blocked"])
+        ans = json.loads(row["answer"])
+        self.assertEqual(ans["output_summary"], "the answer is 42")
+
+    def test_router_error_string_marked_error_but_text_forwarded(self):
+        """Existing call sites check answer.startswith("[Gemma 응답 없음]")
+        to decide retry — the helper must NOT swallow that string.
+        Behaviour-preserving wrapping.
+        """
+        text, rows = self._run(lambda: "[Gemma 응답 없음] timeout")
+        self.assertTrue(text.startswith("[Gemma 응답 없음]"))   # forwarded as-is
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+        ans = json.loads(rows[0]["answer"])
+        self.assertIn("error", ans)
+
+    def test_exception_emits_error_row_then_reraises(self):
+        from core.reasoning.trace_helpers import trace_synth_call
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            with self.assertRaises(RuntimeError) as ctx:
+                trace_synth_call(
+                    lambda: (_ for _ in ()).throw(RuntimeError("ollama down")),
+                    "p",
+                    applied_rule="reasoning.synth.test",
+                    user_role="admin",
+                )
+        self.assertIn("ollama down", str(ctx.exception))
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+        ans = json.loads(rows[0]["answer"])
+        self.assertIn("RuntimeError", ans["error"])
+        self.assertIn("ollama down", ans["error"])
+
+    def test_empty_text_marked_error(self):
+        text, rows = self._run(lambda: "")
+        self.assertEqual(text, "")
+        self.assertTrue(rows[0]["blocked"])
+
+    def test_none_return_handled_as_empty(self):
+        text, rows = self._run(lambda: None)
+        self.assertEqual(text, "")
+        self.assertTrue(rows[0]["blocked"])
+
+    def test_trace_id_propagation(self):
+        from core.observability import current_trace_id
+        token = current_trace_id.set("test-trace-xyz")
+        try:
+            text, rows = self._run(lambda: "ok")
+        finally:
+            current_trace_id.reset(token)
+        ans = json.loads(rows[0]["answer"])
+        self.assertEqual(ans.get("trace_id"), "test-trace-xyz")
+
+    def test_no_trace_id_when_contextvar_unset(self):
+        from core.observability import current_trace_id
+        token = current_trace_id.set("")   # explicit empty
+        try:
+            text, rows = self._run(lambda: "ok")
+        finally:
+            current_trace_id.reset(token)
+        ans = json.loads(rows[0]["answer"])
+        self.assertNotIn("trace_id", ans)
+
+    def test_extras_folded_in_alongside_trace_id(self):
+        from core.observability import current_trace_id
+        token = current_trace_id.set("trace-extras")
+        try:
+            text, rows = self._run(
+                lambda: "ok",
+                extras={"loop_idx": 2, "selected_model": "gemma2:2b"},
+            )
+        finally:
+            current_trace_id.reset(token)
+        ans = json.loads(rows[0]["answer"])
+        self.assertEqual(ans.get("trace_id"), "trace-extras")
+        self.assertEqual(ans.get("loop_idx"), 2)
+        self.assertEqual(ans.get("selected_model"), "gemma2:2b")
+
+    def test_inputs_hash_uses_prompt_arg_not_call_result(self):
+        """The helper hashes the `prompt` argument so the row's
+        inputs_hash is the input fingerprint (not the LLM output).
+        Replay needs this to detect "same inputs, different outcome".
+        """
+        from core.reasoning.trace_schema import compute_inputs_hash
+        expected = compute_inputs_hash("the prompt", system="")
+        text, rows = self._run(lambda: "any response", prompt="the prompt")
+        self.assertIn(expected, rows[0]["query"])
+
+    def test_latency_recorded(self):
+        import time
+        def slow():
+            time.sleep(0.02)
+            return "done"
+        text, rows = self._run(slow)
+        # latency_ms / 1000 → elapsed_sec; allow generous lower bound
+        self.assertGreaterEqual(rows[0]["elapsed_sec"], 0.015)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

L0 (#283) shipped TraceStep / `emit_trace_step` / Backend registry as **wiring-free** infrastructure. **L1 wires the existing 12 `call_gemma` sites** in `pipeline.py` / `modes.py` / `engine.py` so each LLM round-trip emits one `audit_log` row tagged with the cognitive-stage `applied_rule`.

**STEP 7 contract: byte-identical.** The `trace_synth_call` helper forwards the LLM's return value unmodified — same model, same prompt, same answer. The only new observable behavior is the audit emission.

## New module

`core/reasoning/trace_helpers.py` (~150 LOC):

```python
text = trace_synth_call(
    lambda: engine.llm.call_gemma(prompt, timeout=60, max_tokens=400),
    prompt,
    applied_rule="reasoning.synth.chat",
    user_role=user_role,
)
```

Behaviour:
- Wraps the call in try/except — **exceptions emit an error row then re-raise** (existing call sites' error-handling stays unchanged).
- On success, forwards text unchanged; classifies RouterWrapper error strings (`[Gemma 응답 없음]`, `[Gemma 오류]`, `LLM 응답 생성 중 오류`) as error rows (`blocked=1`).
- Pulls the current `trace_id` from `core.observability` ContextVar into `extras` so all reasoning rows for one HTTP request can be gathered with one `WHERE answer LIKE '%"trace_id": "<id>"%'`.

## 12 wired call sites

| File | Line | Applied rule |
|---|---|---|
| `core/reasoning/engine.py` | `_generate_answer` (~426) | `reasoning.synth.rag` |
| `core/reasoning/pipeline.py` | web summary proposal (~331) | `reasoning.synth.web_summary` |
| `core/reasoning/pipeline.py` | web fallback answer (~391) | `reasoning.synth.web_fallback` |
| `core/reasoning/pipeline.py` | retry on "no info" (~427) | `reasoning.synth.retry_no_info` |
| `core/reasoning/modes.py` | `handle_chat` (~91) | `reasoning.synth.chat` |
| `core/reasoning/modes.py` | `handle_wiki_edit` JSON parse (~251) | `reasoning.synth.wiki_edit_parse` |
| `core/reasoning/modes.py` | `handle_wiki_edit` content (~298) | `reasoning.synth.wiki_edit_update` |
| `core/reasoning/modes.py` | `handle_self_evolve` folder (~421) | `reasoning.synth.self_evolve_folder` |
| `core/reasoning/modes.py` | `handle_self_evolve` file (~438) | `reasoning.synth.self_evolve_file` |
| `core/reasoning/modes.py` | `handle_self_evolve` improve (~476) | `reasoning.synth.self_evolve_improve` |
| `core/reasoning/modes.py` | `handle_coding` user-pick (~546) | `reasoning.synth.coding_user_pick` |
| `core/reasoning/modes.py` | `handle_coding` fallback (~583) | `reasoning.synth.coding_fallback` |

`handle_meta` has zero LLM calls (filesystem-only) — no wrapping needed.

## Audit row shape (Audit Phase 1–4 pattern, no DB migration)

```
endpoint       = "reason:synth"
security_event = "reasoning.synth.<scope>"
query          = "ollama_local:<inputs_hash>"
elapsed_sec    = latency_ms / 1000
answer (JSON)  = {
    "parent_step_id": "",                # populated in Phase 2 when
                                          # reflection/verification stacks
    "output_summary": "<200 chars>",
    "trace_id": "<axis-3 uuid>",         # only when ContextVar is set
    "error": "<reason>"                  # only when non-empty
}
blocked = 1 iff error non-empty
```

`reason:synth` joins the existing `tool:` / `attack:` / `system:` endpoint families that `/admin/audit/list` already filters on — no admin UI changes needed.

## Verification

- **Tests**: 10 new (`tests/test_reasoning_trace_helpers.py`). Full reasoning-touching slice **249/249 green** (covers `test_reasoning_*`, `test_conversation_continuity`, `test_force_web_chip`, `test_chat_wiki_save`, `test_chat_mode_picker`, `test_web_search_admin_panel`, `test_source_files_first`, `test_query_include_contexts`, `test_policy_quarantine`, `test_longterm_save_admin_confirm`, `test_web_used_badge`, `test_response_style`, `test_observability`, `test_meta_mode`, `test_max_tokens_relax`, `test_force_web_overrides_mode`, `test_coding_mode`, `test_a2_phase2_selected_model`).
- **Lint**: `ruff check core/reasoning tests/test_reasoning_*.py` → `All checks passed!`
- **STEP 7 bench**: byte-identical contract held in test environment (helper unit tests verify text forwarding). User spot-check needed against live server post-merge: `python scripts/bench.py --suite=step7 --check`.

## Module size note (CLAUDE.md rule #5)

| File | Pre-L0 / main | After L1 | Delta |
|---|---|---|---|
| `pipeline.py` | 27.7 KB | 29.0 KB | +1.3 KB |
| `modes.py` | 27.9 KB | 30.0 KB | +2.1 KB |
| `engine.py` | 21.3 KB | 21.8 KB | +0.4 KB |

All three were **already over 20 KB on main HEAD `412ef21`** — pre-existing rule #5 debt. L1 adds modest bytes. **Splits remain deferred as a separate PR** broader than L1 scope (would require splitting `handle_self_evolve` and the loop body, both unrelated to L1's wiring concern).

## Out of scope

- **L2** — `scripts/replay_trace.py` that reads `audit_log WHERE endpoint LIKE 'reason:%'` and reproduces the reasoning tree from `trace_id` correlation.
- Phase 1 PR-1 Reranker / Phase 2 PR-5 Reflection / PR-6 Verification — build on top of `trace_synth_call`.
- Module splits for `pipeline.py` / `modes.py` / `engine.py` — separate cleanup PR.

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Platform-only — `applied_rule` strings encode reasoning scope, not domain |
| #2 bench numbers | Helper forwards text unchanged → byte-identical contract; emit-only side effect. Live-server spot-check after merge |
| #3 self-evolution gate | `applied_rule="reasoning.synth.self_evolve_*"` are observability tags; no behaviour change to `/admin/patch/approve` |
| #4 architecture | §5.7.2 TraceStep fields land via `emit_trace_step`. Trace-replay invariant honored — every LLM call now in `audit_bridge` |
| #5 module size | 3 files were already > 20 KB on main; L1 adds modest bytes; splits remain a separate PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
