### PR TITLE
chore(reasoning): replay_trace.py — reconstruct reasoning from audit_log (L2)

### DIFF
--- a/scripts/replay_trace.py
+++ b/scripts/replay_trace.py
@@ -1,0 +1,329 @@
+"""L2 — reconstruct one question's reasoning trace from audit_log.
+
+ARCHITECTURE.md §5.7.2 trace-replay invariant:
+
+    "The full reasoning trace must be reconstructable from audit_bridge
+    rows alone. No ephemeral in-memory state may carry decision
+    rationale that audit cannot replay."
+
+L1 wired 12 call_gemma sites to emit one TraceStep row each. Each row
+carries the request-level ``trace_id`` (from Axis-3 ContextVar) packed
+into the answer JSON blob. This script unpacks those rows for one
+``trace_id`` and prints the reasoning sequence — the proof that the
+invariant holds for v0.3.0 onwards.
+
+Usage:
+
+  python scripts/replay_trace.py <trace_id>
+      Pretty-print the reasoning steps in chronological order.
+
+  python scripts/replay_trace.py <trace_id> --json
+      Same data as JSON list (one object per row) for programmatic use.
+
+  python scripts/replay_trace.py --recent [--limit N]
+      List the N most recent trace_ids that have reason:* rows. Handy
+      for finding a trace_id to inspect when the operator forgets which
+      question they asked.
+
+  python scripts/replay_trace.py <trace_id> --db PATH
+      Override the default james_audit.db path (resolved relative to
+      core.audit_bridge._DEFAULT_AUDIT_DB).
+
+Exit codes:
+  0 — found ≥ 1 row (or --recent listed ≥ 0 ids)
+  1 — trace_id has no rows / DB unreachable / bad args
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# UTF-8 console — output includes Korean output_summary strings.
+try:
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except Exception:
+    pass
+
+from core.reasoning.trace_schema import TraceStep, ALLOWED_STAGES   # noqa: E402
+
+
+def _resolve_db_path(override: Optional[str]) -> str:
+    if override:
+        return override
+    try:
+        from core.audit_bridge import _DEFAULT_AUDIT_DB
+        return _DEFAULT_AUDIT_DB
+    except ImportError:
+        return "james_audit.db"
+
+
+def _row_to_trace_step(row: sqlite3.Row) -> Optional[TraceStep]:
+    """Reverse the emit_trace_step mapping (trace_schema.py).
+
+    Returns None when the row cannot be parsed — replay is best-effort
+    (the row stays in audit_log either way, available to manual SQL).
+    """
+    endpoint = row["endpoint"] or ""
+    if not endpoint.startswith("reason:"):
+        return None
+    stage = endpoint[len("reason:"):]
+    if stage not in ALLOWED_STAGES:
+        return None
+
+    query_field = row["query"] or ""
+    backend_id, _, inputs_hash = query_field.partition(":")
+    # _resolve_query strips the ": " separator; we accept "<bid>:<hash>"
+    # or "<bid>: <hash>" (the bridge formats with a space when both halves
+    # are non-empty).
+    inputs_hash = inputs_hash.lstrip()
+
+    answer_blob: Dict[str, Any] = {}
+    if row["answer"]:
+        try:
+            answer_blob = json.loads(row["answer"])
+        except json.JSONDecodeError:
+            answer_blob = {}
+
+    parent_step_id = str(answer_blob.get("parent_step_id", ""))
+    output_summary = str(answer_blob.get("output_summary", ""))
+    error_msg = str(answer_blob.get("error", ""))
+
+    elapsed = row["elapsed_sec"]
+    latency_ms = int(round(elapsed * 1000)) if elapsed else 0
+
+    try:
+        return TraceStep(
+            stage=stage,
+            backend_id=backend_id or "orchestrator",
+            parent_step_id=parent_step_id,
+            inputs_hash=inputs_hash,
+            output_summary=output_summary,
+            applied_rule=row["security_event"] or f"reasoning.{stage}",
+            latency_ms=latency_ms,
+            error=error_msg,
+        )
+    except (ValueError, TypeError):
+        return None
+
+
+def replay(
+    trace_id: str,
+    *,
+    db_path: Optional[str] = None,
+    include_extras: bool = False,
+) -> List[Dict[str, Any]]:
+    """Return reason:* rows for one trace_id as a list of dicts.
+
+    Each dict has the TraceStep fields plus ``timestamp``, ``user_role``,
+    and (when ``include_extras=True``) the full unparsed ``answer`` JSON.
+
+    Chronological order by audit_log.id (insertion order ≈ wall-clock).
+    Empty list = no rows for this trace_id.
+    """
+    if not trace_id:
+        return []
+
+    path = _resolve_db_path(db_path)
+    if not os.path.exists(path):
+        return []
+
+    # Trace correlation lives in the answer JSON blob. SQLite's LIKE
+    # against the JSON text is fine for the v0.3 row volume; if a future
+    # production ever grows past hundreds of MB of audit rows we'd
+    # promote trace_id to its own indexed column (separate PR).
+    needle = f'"trace_id": "{trace_id}"'
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, timestamp, user_role, endpoint, query, answer,
+                   blocked, security_event, elapsed_sec
+            FROM   audit_log
+            WHERE  endpoint LIKE 'reason:%' AND answer LIKE ?
+            ORDER  BY id ASC
+            """,
+            (f"%{needle}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        step = _row_to_trace_step(row)
+        if step is None:
+            continue
+        record: Dict[str, Any] = {
+            **asdict(step),
+            "timestamp":  row["timestamp"],
+            "user_role":  row["user_role"],
+            "blocked":    bool(row["blocked"]),
+        }
+        if include_extras and row["answer"]:
+            try:
+                blob = json.loads(row["answer"])
+                # surface anything not already in TraceStep
+                extras = {
+                    k: v for k, v in blob.items()
+                    if k not in {"parent_step_id", "output_summary", "error"}
+                }
+                if extras:
+                    record["extras"] = extras
+            except json.JSONDecodeError:
+                pass
+        out.append(record)
+    return out
+
+
+def list_recent_trace_ids(
+    limit: int = 20,
+    *,
+    db_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """List the ``limit`` most-recent trace_ids that have reason:* rows.
+
+    Returned dicts: {trace_id, first_seen, last_seen, step_count}.
+    Ordered by most-recent ``last_seen`` first.
+    """
+    path = _resolve_db_path(db_path)
+    if not os.path.exists(path):
+        return []
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        # Pull every reason:* row and bucket client-side. The volume is
+        # bounded (one row per LLM call ≤ ~12 per query) so a scan is
+        # cheap. SQLite's JSON1 extension would be cleaner but it's
+        # optional in default builds; staying on plain Python keeps the
+        # script portable.
+        rows = conn.execute(
+            """
+            SELECT timestamp, answer
+            FROM   audit_log
+            WHERE  endpoint LIKE 'reason:%'
+            ORDER  BY id ASC
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    buckets: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        if not row["answer"]:
+            continue
+        try:
+            blob = json.loads(row["answer"])
+        except json.JSONDecodeError:
+            continue
+        tid = blob.get("trace_id")
+        if not tid:
+            continue
+        ts = row["timestamp"] or ""
+        b = buckets.get(tid)
+        if b is None:
+            buckets[tid] = {
+                "trace_id":   tid,
+                "first_seen": ts,
+                "last_seen":  ts,
+                "step_count": 1,
+            }
+        else:
+            b["last_seen"]  = ts
+            b["step_count"] += 1
+
+    ordered = sorted(buckets.values(), key=lambda b: b["last_seen"], reverse=True)
+    return ordered[:limit]
+
+
+def _format_text(steps: List[Dict[str, Any]], trace_id: str) -> str:
+    if not steps:
+        return f"trace_id: {trace_id}\n(no reasoning rows found)"
+    lines = [f"trace_id: {trace_id}",
+             f"{'=' * (10 + len(trace_id))}"]
+    for i, step in enumerate(steps, start=1):
+        latency_s = step["latency_ms"] / 1000.0
+        marker = "  X" if step["blocked"] else f"  {i:>2}"
+        lines.append(
+            f"\n[{marker}] {step['applied_rule']:<40} "
+            f"{step['backend_id']:<14} {latency_s:>6.2f}s  "
+            f"{step['timestamp']}"
+        )
+        if step["parent_step_id"]:
+            lines.append(f"        parent: {step['parent_step_id']}")
+        lines.append(f"        input:  {step['inputs_hash']}")
+        if step["output_summary"]:
+            lines.append(f"        output: {step['output_summary'][:120]}")
+        if step["error"]:
+            lines.append(f"        error:  {step['error']}")
+        if step.get("extras"):
+            extras_str = ", ".join(f"{k}={v}" for k, v in step["extras"].items())
+            lines.append(f"        extras: {extras_str}")
+    lines.append("")
+    lines.append(f"{len(steps)} reasoning step(s)")
+    return "\n".join(lines)
+
+
+def _format_recent_text(buckets: List[Dict[str, Any]]) -> str:
+    if not buckets:
+        return "(no recent reasoning traces in audit_log)"
+    lines = [f"{'trace_id':<34} {'step_count':>10}  {'last_seen':<26}",
+             "-" * 75]
+    for b in buckets:
+        lines.append(
+            f"{b['trace_id']:<34} {b['step_count']:>10}  {b['last_seen']:<26}"
+        )
+    return "\n".join(lines)
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Replay one reasoning trace from audit_log",
+    )
+    ap.add_argument("trace_id", nargs="?",
+                    help="trace_id to replay (omit when using --recent)")
+    ap.add_argument("--recent", action="store_true",
+                    help="list recent trace_ids instead of replaying one")
+    ap.add_argument("--limit", type=int, default=20,
+                    help="cap for --recent (default 20)")
+    ap.add_argument("--json", action="store_true",
+                    help="emit JSON instead of human-readable text")
+    ap.add_argument("--extras", action="store_true",
+                    help="include non-schema answer JSON fields per row")
+    ap.add_argument("--db", default=None,
+                    help="override audit DB path (default: core.audit_bridge resolution)")
+    args = ap.parse_args(argv)
+
+    if args.recent:
+        buckets = list_recent_trace_ids(limit=args.limit, db_path=args.db)
+        if args.json:
+            print(json.dumps(buckets, ensure_ascii=False, indent=2))
+        else:
+            print(_format_recent_text(buckets))
+        return 0
+
+    if not args.trace_id:
+        ap.error("trace_id is required unless --recent is given")
+
+    steps = replay(args.trace_id, db_path=args.db, include_extras=args.extras)
+    if args.json:
+        print(json.dumps(steps, ensure_ascii=False, indent=2))
+    else:
+        print(_format_text(steps, args.trace_id))
+    return 0 if steps else 1
+
+
+if __name__ == "__main__":   # pragma: no cover
+    raise SystemExit(_main())

--- a/tests/test_replay_trace.py
+++ b/tests/test_replay_trace.py
@@ -1,0 +1,309 @@
+"""L2 — replay_trace round-trip + trace_id isolation.
+
+ARCHITECTURE.md §5.7.2 trace-replay invariant: the full reasoning trace
+must be reconstructable from audit_log rows alone. This test pins that
+contract — emit_trace_step writes rows, replay() reads them back, and
+the dataclass field shape survives the round-trip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _emit_with_trace_id(db: str, trace_id: str, **step_kwargs):
+    """Helper: emit one TraceStep with extras={"trace_id": trace_id}.
+    Mirrors what trace_helpers.trace_synth_call does in production.
+    """
+    from core.reasoning.trace_schema import TraceStep, emit_trace_step
+    step = TraceStep(**step_kwargs)
+    extras = {"trace_id": trace_id} if trace_id else None
+    emit_trace_step(step, db_path=db, extras=extras)
+
+
+class ReplayRoundTripTests(unittest.TestCase):
+
+    def test_empty_db_returns_empty_list(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        self.assertEqual(replay("any-id", db_path=db), [])
+
+    def test_no_matching_trace_id_returns_empty_list(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-A",
+            stage="reflect", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="aaaa",
+            output_summary="ok", applied_rule="reasoning.reflect.test",
+        )
+        self.assertEqual(replay("trace-B", db_path=db), [])
+
+    def test_single_step_round_trip(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-x",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="hash01",
+            output_summary="hello world",
+            applied_rule="reasoning.synth.chat",
+            latency_ms=42,
+        )
+        steps = replay("trace-x", db_path=db)
+        self.assertEqual(len(steps), 1)
+        s = steps[0]
+        self.assertEqual(s["stage"], "synth")
+        self.assertEqual(s["backend_id"], "ollama_local")
+        self.assertEqual(s["inputs_hash"], "hash01")
+        self.assertEqual(s["output_summary"], "hello world")
+        self.assertEqual(s["applied_rule"], "reasoning.synth.chat")
+        self.assertEqual(s["latency_ms"], 42)
+        self.assertFalse(s["blocked"])
+        # extra columns merged from the row
+        self.assertIn("timestamp", s)
+        self.assertEqual(s["user_role"], "system")
+
+    def test_multiple_steps_chronological(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        for stage, summary in [
+            ("plan",    "decomposed 3 subtasks"),
+            ("retrieve", "8 docs"),
+            ("rerank",   "top 3 reranked"),
+            ("synth",    "final answer"),
+        ]:
+            _emit_with_trace_id(
+                db, "trace-multi",
+                stage=stage, backend_id="ollama_local",
+                parent_step_id="", inputs_hash=f"h-{stage}",
+                output_summary=summary,
+                applied_rule=f"reasoning.{stage}.test",
+            )
+        steps = replay("trace-multi", db_path=db)
+        self.assertEqual([s["stage"] for s in steps],
+                         ["plan", "retrieve", "rerank", "synth"])
+
+    def test_isolation_between_traces(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        for tid in ("trace-A", "trace-B", "trace-A", "trace-C"):
+            _emit_with_trace_id(
+                db, tid,
+                stage="synth", backend_id="ollama_local",
+                parent_step_id="", inputs_hash=f"h-{tid}",
+                output_summary="ok",
+                applied_rule="reasoning.synth.test",
+            )
+        a_steps = replay("trace-A", db_path=db)
+        b_steps = replay("trace-B", db_path=db)
+        c_steps = replay("trace-C", db_path=db)
+        self.assertEqual(len(a_steps), 2)
+        self.assertEqual(len(b_steps), 1)
+        self.assertEqual(len(c_steps), 1)
+
+    def test_error_row_marked_blocked(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-err",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="hf",
+            output_summary="", applied_rule="reasoning.synth.chat",
+            error="timeout",
+        )
+        steps = replay("trace-err", db_path=db)
+        self.assertEqual(len(steps), 1)
+        self.assertTrue(steps[0]["blocked"])
+        self.assertEqual(steps[0]["error"], "timeout")
+
+    def test_include_extras_surfaces_non_schema_fields(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        # Inject a row directly with custom fields in the answer JSON
+        # (trace_helpers.py supports caller-supplied extras via the
+        # same path).
+        from core.reasoning.trace_schema import TraceStep, emit_trace_step
+        step = TraceStep(
+            stage="reflect", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="hh",
+            output_summary="revised draft",
+            applied_rule="reasoning.reflect.revised",
+        )
+        emit_trace_step(step, db_path=db, extras={
+            "trace_id":   "trace-extras",
+            "loop_idx":   2,
+            "model":      "gemma2:2b",
+        })
+        steps = replay("trace-extras", db_path=db, include_extras=True)
+        self.assertEqual(len(steps), 1)
+        self.assertIn("extras", steps[0])
+        self.assertEqual(steps[0]["extras"]["loop_idx"], 2)
+        self.assertEqual(steps[0]["extras"]["model"], "gemma2:2b")
+        # trace_id is the correlation key — it surfaces via extras since
+        # it is not a schema field
+        self.assertEqual(steps[0]["extras"]["trace_id"], "trace-extras")
+
+    def test_extras_omitted_by_default(self):
+        from scripts.replay_trace import replay
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-no-extras",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="h",
+            output_summary="ok", applied_rule="reasoning.synth.chat",
+        )
+        steps = replay("trace-no-extras", db_path=db)
+        self.assertNotIn("extras", steps[0])
+
+    def test_non_reason_rows_ignored(self):
+        """audit_log carries tool: / attack: / system: rows alongside
+        reason:* — replay() must only return reasoning rows.
+        """
+        from scripts.replay_trace import replay
+        from core.audit_bridge import mirror_to_audit_db
+        db = _fresh_db()
+        # one reason row with trace-mix
+        _emit_with_trace_id(
+            db, "trace-mix",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="h",
+            output_summary="ok", applied_rule="reasoning.synth.chat",
+        )
+        # one tool row that ALSO mentions "trace_id" in its payload
+        mirror_to_audit_db({
+            "role": "admin", "layer": "router", "event": "TOOL_EXECUTED",
+            "tool_used": "web_search",
+            "trace_id": "trace-mix",   # deliberate noise
+        }, db_path=db)
+        steps = replay("trace-mix", db_path=db)
+        # only the reasoning row comes back
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0]["stage"], "synth")
+
+
+class RecentTraceListingTests(unittest.TestCase):
+
+    def test_empty_db_returns_empty(self):
+        from scripts.replay_trace import list_recent_trace_ids
+        db = _fresh_db()
+        self.assertEqual(list_recent_trace_ids(db_path=db), [])
+
+    def test_buckets_by_trace_id_with_counts(self):
+        from scripts.replay_trace import list_recent_trace_ids
+        db = _fresh_db()
+        for tid, count in [("trace-A", 3), ("trace-B", 1), ("trace-C", 2)]:
+            for _ in range(count):
+                _emit_with_trace_id(
+                    db, tid,
+                    stage="synth", backend_id="ollama_local",
+                    parent_step_id="", inputs_hash="h",
+                    output_summary="ok",
+                    applied_rule="reasoning.synth.test",
+                )
+        buckets = list_recent_trace_ids(db_path=db)
+        by_tid = {b["trace_id"]: b for b in buckets}
+        self.assertEqual(by_tid["trace-A"]["step_count"], 3)
+        self.assertEqual(by_tid["trace-B"]["step_count"], 1)
+        self.assertEqual(by_tid["trace-C"]["step_count"], 2)
+
+    def test_limit_applied(self):
+        from scripts.replay_trace import list_recent_trace_ids
+        db = _fresh_db()
+        for i in range(5):
+            _emit_with_trace_id(
+                db, f"trace-{i}",
+                stage="synth", backend_id="ollama_local",
+                parent_step_id="", inputs_hash="h",
+                output_summary="ok",
+                applied_rule="reasoning.synth.test",
+            )
+        self.assertEqual(len(list_recent_trace_ids(limit=2, db_path=db)), 2)
+
+
+class CliEntryPointTests(unittest.TestCase):
+    """End-to-end via _main; ensures exit codes + --json flag work."""
+
+    def test_main_exits_1_when_trace_not_found(self):
+        from scripts.replay_trace import _main
+        db = _fresh_db()
+        rc = _main(["nonexistent-trace", "--db", db])
+        self.assertEqual(rc, 1)
+
+    def test_main_exits_0_when_trace_found(self):
+        from scripts.replay_trace import _main
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-cli",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="h",
+            output_summary="ok",
+            applied_rule="reasoning.synth.test",
+        )
+        rc = _main(["trace-cli", "--db", db])
+        self.assertEqual(rc, 0)
+
+    def test_main_recent_exits_0_when_empty(self):
+        from scripts.replay_trace import _main
+        db = _fresh_db()
+        rc = _main(["--recent", "--db", db])
+        self.assertEqual(rc, 0)
+
+    def test_json_output_parses(self):
+        from scripts.replay_trace import _main
+        import io
+        db = _fresh_db()
+        _emit_with_trace_id(
+            db, "trace-json",
+            stage="synth", backend_id="ollama_local",
+            parent_step_id="", inputs_hash="h",
+            output_summary="ok",
+            applied_rule="reasoning.synth.test",
+        )
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            _main(["trace-json", "--json", "--db", db])
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["stage"], "synth")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 0 의 마지막 단계. ARCHITECTURE.md §5.7.2 trace-replay invariant — **"the full reasoning trace must be reconstructable from audit_bridge rows alone"** — 가 이제 코드로 testable + operator-facing.

L0 (#283) 가 schema 를 frozen 으로 박았고, L1 (#284) 가 12 LLM call site 에서 emit 시작. L2 가 reader 를 ship.

## 새 파일

| 파일 | 크기 | 역할 |
|---|---|---|
| `scripts/replay_trace.py` | 11 KB | `replay(trace_id)` + `list_recent_trace_ids()` + CLI |
| `tests/test_replay_trace.py` | 11.5 KB | 16 tests — round-trip / 격리 / extras / CLI exit codes |

## CLI

```bash
# 최근 trace_id 찾기 (operator 가 본인이 방금 query 한 거 찾을 때)
python scripts/replay_trace.py --recent --limit 10

# 특정 trace_id 의 reasoning sequence 출력
python scripts/replay_trace.py <trace_id>

# JSON 으로 (프로그래매틱)
python scripts/replay_trace.py <trace_id> --json

# extras 포함 (trace_id / loop_idx / 기타 caller-supplied 메타)
python scripts/replay_trace.py <trace_id> --extras

# DB path override
python scripts/replay_trace.py <trace_id> --db /path/to/james_audit.db
```

CLI 예시 출력 (unit test 에서 캡쳐):

```
trace_id: trace-cli
===================

[   1] reasoning.synth.test                ollama_local     0.00s
        input:  h
        output: ok

1 reasoning step(s)
```

## Row 매핑 (역방향)

```
audit_log column           → TraceStep field
─────────────────────────────────────────────
endpoint "reason:<stage>"  → stage
query    "<bid>:<hash>"    → backend_id + inputs_hash
security_event             → applied_rule
elapsed_sec                → latency_ms (× 1000)
answer JSON.parent_step_id → parent_step_id
answer JSON.output_summary → output_summary
answer JSON.error          → error (blocked = 1 동기)
answer JSON.trace_id       → 검색 키 (extras 에 surface)
```

알 수 없는 stage 의 row 는 silently skip — schema drift 가 replay 를 crash 시키지 않음 (defensive design).

## Verification

- **Tests**: 16 new (`tests/test_replay_trace.py`). L0+L1+L2 reasoning bundle **62/62 green**.
- **Lint**: `ruff check scripts/replay_trace.py tests/test_replay_trace.py` → `All checks passed!`
- **모듈 크기**: 11 / 11.5 KB (both well under 20 KB).
- **회귀 위험**: zero — read-only tooling, no production runtime path touched.

## 운영자 사용 예 (L1 + L2 통합)

```bash
# 1. 서버에서 query 1건 실행
# 2. 응답에 trace_id 포함 (Axis 3 v0.2 부터 모든 응답이 trace_id 반환)
# 3. 그 trace_id 로 reasoning sequence 확인
python scripts/replay_trace.py <trace_id>

# → 그 question 에서 LLM 이 어디서 몇 번 불렸는지, 각 단계 latency,
#    어떤 prompt fingerprint, 어떤 backend, error 여부 등 한눈에
```

이게 "왜 시스템이 X 라고 답했는가?" 가 post-hoc 답해질 수 있다는 §5.7.2 의 forensic reasoning differentiator 의 첫 작동 증거.

## Out of scope

- **Phase 1 PR-1 Reranker** — cross-encoder ms-marco-MiniLM 추가, retrieval precision 향상
- **Phase 2 PR-5/-6 Reflection / Verification** — 새 reasoning stage 추가; `replay_trace.py` 의 ALLOWED_STAGES 와 자연스럽게 호환
- **trace_id 를 indexed 컬럼으로 promote** — 현재 LIKE 쿼리는 v0.3 row volume 에서 빠름. audit_log 가 수백 MB 넘어가면 별도 PR
- **JSON1 extension 활용** — SQLite 빌드 의존성 회피, 현재 portable 한 plain Python 파싱 유지

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Tooling, 도메인 무관 |
| #2 bench | 적용 안 됨 — read-only tooling, LLM 호출 0 |
| #3 self-evolution | 무관 |
| #4 architecture | §5.7.2 trace-replay invariant 가 testable + operator-facing — Phase 0 closure |
| #5 모듈 크기 | 11 / 11.5 KB, 20 KB 게이트 안 |

## Phase 0 완료

```
Pre-L0  #282  → §5.7.2 단락
L0      #283  → trace_schema + backends MVP
L1      #284  → 12 call site wiring
L2      THIS  → replay tool
```

다음: **Phase 1 PR-1** (Reranker, cross-encoder ms-marco-MiniLM) 또는 **사이클 12 PR-O4** (N-3 long_ctx 격리) — 사용자 선택.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
