### PR TITLE
feat(retrieval): cross-encoder reranker — Phase 1 PR-1

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -92,7 +92,64 @@ def run_retrieval_pipeline(
                     user_role=user_role,
                     source_type=source_type,
                 )
-            docs = docs[:5]
+            # ── Phase 1 PR-1: cross-encoder rerank ─────────
+            # orchestrator returns 8 docs by vector score; the reranker
+            # scores each (query, doc.text) pair and reorders. The
+            # original [:5] truncation now happens *inside* rerank()
+            # so the top-5 reflects rerank order, not vector order.
+            #
+            # JAMES_DISABLE_RERANK=1 or model load failure → rerank()
+            # returns docs[:top_k] unchanged → byte-identical to v0.3.0.
+            t_rerank = time.time()
+            pre_rerank_count = len(docs)
+            try:
+                from core.retrieval.rerank import get_reranker
+                docs = get_reranker().rerank(safe_query, docs, top_k=5)
+            except Exception as e:
+                engine._log("loop0_rerank", e, user_role)
+                docs = docs[:5]
+            rerank_ms = int((time.time() - t_rerank) * 1000)
+
+            # Emit one trace step for the rerank stage so the replay
+            # tool sees the cognitive-layer step alongside synth rows.
+            try:
+                from core.reasoning.trace_schema import (
+                    TraceStep, compute_inputs_hash, truncate_summary,
+                    emit_trace_step,
+                )
+                top = docs[0] if docs else {}
+                top_summary = (
+                    f"top: {(top.get('source') or top.get('name') or '?')[:60]} "
+                    f"rerank={top.get('rerank_score', float('nan')):.3f}"
+                    if docs else "no docs"
+                )
+                trace_extras: Dict[str, Any] = {
+                    "pre_rerank_count": pre_rerank_count,
+                    "post_rerank_count": len(docs),
+                }
+                try:
+                    from core.observability import get_trace_id
+                    _tid = get_trace_id()
+                    if _tid:
+                        trace_extras["trace_id"] = _tid
+                except Exception:
+                    pass
+                emit_trace_step(
+                    TraceStep(
+                        stage="rerank",
+                        backend_id="cross_encoder",
+                        parent_step_id="",
+                        inputs_hash=compute_inputs_hash(safe_query),
+                        output_summary=truncate_summary(top_summary),
+                        applied_rule="reasoning.rerank.cross_encoder",
+                        latency_ms=rerank_ms,
+                    ),
+                    user_role=user_role,
+                    extras=trace_extras,
+                )
+            except Exception as e:
+                engine._log("loop0_rerank_trace", e, user_role)
+
             loop_state["docs"] = docs
             doc_ctx, avg_score = engine.retrieval.build_doc_context(
                 [d.get("text", "") for d in docs],

--- a/core/retrieval/__init__.py
+++ b/core/retrieval/__init__.py
@@ -1,0 +1,11 @@
+"""Retrieval-side cognitive layer modules (v0.3 Phase 1, 2026-05-17).
+
+ARCHITECTURE.md §5.7.1: this package is the home for query rewriter,
+reranker, and adaptive-retrieval primitives that sit between the
+existing `core/retrieval_engine.py` (vector + BM25) and the LLM
+synthesis step. New modules land here; the v0.2 retrieval engine
+stays at `core/retrieval_engine.py`.
+
+Phase 1 PR-1 ships `rerank.py` (cross-encoder reranking).
+Future PRs add `query_rewriter.py`, `hybrid.py`, `adaptive.py`.
+"""

--- a/core/retrieval/rerank.py
+++ b/core/retrieval/rerank.py
@@ -1,0 +1,182 @@
+"""Cross-encoder reranker — Cognitive Layer Phase 1 PR-1.
+
+ARCHITECTURE.md §5.7.1: "Reranker — cross-encoder reordering of
+vector-retrieved top-k". Lives between Loop-0 retrieval (orchestrator,
+top_k=8) and the existing top-5 truncation in pipeline.py.
+
+Default model: ``cross-encoder/ms-marco-MiniLM-L-6-v2`` (~80 MB, English-
+optimized, fast — chosen for the v0.3 local-first profile per the
+2026-05-14 user briefing). Operators with Korean-heavy corpora can
+swap to ``BAAI/bge-reranker-base`` (~278 MB, multilingual) via the
+``JAMES_RERANKER_MODEL`` env var.
+
+Operational knobs:
+  JAMES_DISABLE_RERANK=1
+      Skip reranking entirely. The pipeline falls back to vector-score
+      order (v0.3.0 baseline behavior). Useful for A/B comparison and
+      for environments without GPU / sentence-transformers extras.
+  JAMES_RERANKER_MODEL=<hf-id>
+      Override the default cross-encoder model id.
+
+Failure posture: best-effort. If the model fails to load (no
+sentence-transformers, no network for first-time download, GPU OOM),
+``rerank()`` logs the failure once and returns the input docs
+unchanged. STEP 7 baseline is preserved when reranking is unavailable.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+def _disabled() -> bool:
+    return os.environ.get("JAMES_DISABLE_RERANK") == "1"
+
+
+def _model_id() -> str:
+    return os.environ.get("JAMES_RERANKER_MODEL", "").strip() or DEFAULT_MODEL
+
+
+class Reranker:
+    """One CrossEncoder instance per process (lazy-loaded).
+
+    Thread-safe lazy init — the first call to ``rerank()`` triggers
+    model download (if needed) + GPU/CPU placement; subsequent calls
+    reuse the loaded model. Failures during load are sticky for the
+    lifetime of the instance so we don't retry on every query.
+    """
+
+    def __init__(self, model_id: Optional[str] = None) -> None:
+        self._model_id = model_id or _model_id()
+        self._model = None             # type: ignore[assignment]
+        self._load_failed = False
+        self._load_lock = threading.Lock()
+
+    def _ensure_loaded(self) -> bool:
+        if self._model is not None:
+            return True
+        if self._load_failed:
+            return False
+        with self._load_lock:
+            if self._model is not None:
+                return True
+            if self._load_failed:
+                return False
+            try:
+                from sentence_transformers import CrossEncoder
+                self._model = CrossEncoder(self._model_id)
+                print(f"[RERANK] model loaded: {self._model_id}")
+                return True
+            except Exception as e:
+                # Sticky failure — don't spam the log on every query.
+                self._load_failed = True
+                print(f"[RERANK] model load failed ({type(e).__name__}: "
+                      f"{str(e)[:120]}) — falling back to vector-score order")
+                return False
+
+    def score_pairs(self, query: str, docs: List[Dict[str, Any]]) -> List[float]:
+        """Return one cross-encoder score per doc, same order as input.
+
+        Empty doc list → empty list. If the model is unavailable, returns
+        the vector scores (caller's existing ranking key) so downstream
+        sort is a no-op.
+        """
+        if not docs:
+            return []
+        if not self._ensure_loaded():
+            return [float(d.get("score", 0.0)) for d in docs]
+
+        pairs = [(query, d.get("text", "") or "") for d in docs]
+        try:
+            scores = self._model.predict(pairs)   # type: ignore[union-attr]
+        except Exception as e:
+            print(f"[RERANK] predict failed ({type(e).__name__}: "
+                  f"{str(e)[:120]}) — falling back to vector-score order")
+            return [float(d.get("score", 0.0)) for d in docs]
+
+        # CrossEncoder returns a numpy array; coerce to plain floats so
+        # downstream JSON serialization (audit_log, trace replay) stays
+        # straightforward.
+        return [float(s) for s in scores]
+
+    def rerank(
+        self,
+        query: str,
+        docs: List[Dict[str, Any]],
+        top_k: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Reorder ``docs`` by cross-encoder score (desc), truncate to
+        top_k. Adds ``rerank_score`` to each returned dict for audit /
+        observability so the operator can see why the new order won.
+
+        Empty input → empty output.
+        Disabled / model-load failure / model.predict failure → original
+        docs truncated to top_k, **no annotation** (callers can branch
+        on ``"rerank_score" in d`` to distinguish a real rerank from a
+        fallback).
+        """
+        if not docs:
+            return []
+        if _disabled() or not self._ensure_loaded():
+            return docs[:top_k]
+
+        # Predict inline so a runtime failure can fall back cleanly
+        # without leaving partial annotations. ``score_pairs`` exists
+        # as a public API for callers that want raw scores (and accepts
+        # the "return vector scores on failure" contract — useful for
+        # downstream code that needs *some* score).
+        pairs = [(query, d.get("text", "") or "") for d in docs]
+        try:
+            raw_scores = self._model.predict(pairs)   # type: ignore[union-attr]
+        except Exception as e:
+            print(f"[RERANK] predict failed ({type(e).__name__}: "
+                  f"{str(e)[:120]}) — falling back to vector-score order")
+            return docs[:top_k]
+
+        scores = [float(s) for s in raw_scores]
+        if len(scores) != len(docs):
+            return docs[:top_k]
+
+        # Annotate + sort. Stable sort preserves the input order when
+        # cross-encoder ties happen (rare with float scores but possible).
+        annotated = [
+            {**d, "rerank_score": s, "vector_score": float(d.get("score", 0.0))}
+            for d, s in zip(docs, scores)
+        ]
+        annotated.sort(key=lambda d: d["rerank_score"], reverse=True)
+        return annotated[:top_k]
+
+
+# ─── module-level singleton ────────────────────────────────────────
+# Production callers go through get_reranker() so the model loads once
+# per process. Tests can either patch the singleton or construct a
+# fresh Reranker(model_id=...) for isolation.
+_SINGLETON: Optional[Reranker] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_reranker() -> Reranker:
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = Reranker()
+    return _SINGLETON
+
+
+def _clear_singleton_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None
+
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "Reranker",
+    "get_reranker",
+]

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,197 @@
+"""Phase 1 PR-1 — cross-encoder reranker unit tests.
+
+ARCHITECTURE.md §5.7.1 Reranker: cross-encoder reordering of top-k.
+These tests use a mocked CrossEncoder (no model download) so they
+run in CI without network or GPU. The real model is exercised by
+the user's STEP 7 spot-check after merge.
+
+Coverage:
+  * disabled via JAMES_DISABLE_RERANK=1 → identity (top_k truncation only)
+  * model load failure → identity, sticky (no retry)
+  * happy path: docs reorder by cross-encoder score (desc), top_k applied
+  * annotation: each returned doc gains rerank_score + vector_score
+  * empty input → empty output
+  * predict failure mid-call → fallback to vector-score order
+  * env override JAMES_RERANKER_MODEL respected at init time
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _docs(n=4):
+    """Build n docs with descending vector scores (0.9, 0.7, 0.5, 0.3)."""
+    return [
+        {"text": f"doc {i} text", "source": f"d{i}.md", "score": 0.9 - 0.2 * i}
+        for i in range(n)
+    ]
+
+
+class DisabledTests(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_DISABLE_RERANK")
+        os.environ["JAMES_DISABLE_RERANK"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_DISABLE_RERANK", None)
+        else:
+            os.environ["JAMES_DISABLE_RERANK"] = self._saved
+
+    def test_disabled_returns_input_truncated(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        docs = _docs(8)
+        out = r.rerank("query", docs, top_k=5)
+        self.assertEqual(len(out), 5)
+        # original order preserved (vector-score desc)
+        self.assertEqual([d["source"] for d in out],
+                         ["d0.md", "d1.md", "d2.md", "d3.md", "d4.md"])
+        # no rerank_score annotation when disabled
+        for d in out:
+            self.assertNotIn("rerank_score", d)
+
+
+class LoadFailureTests(unittest.TestCase):
+
+    def test_load_failure_returns_input_unchanged(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        # Force the lazy load to fail by making CrossEncoder unimportable.
+        with patch("sentence_transformers.CrossEncoder",
+                   side_effect=RuntimeError("oom")):
+            out = r.rerank("q", _docs(4), top_k=5)
+        self.assertEqual(len(out), 4)
+        self.assertTrue(r._load_failed)
+        # sticky: second call must not retry
+        with patch("sentence_transformers.CrossEncoder") as ce:
+            r.rerank("q", _docs(2), top_k=5)
+            ce.assert_not_called()
+
+
+class HappyPathTests(unittest.TestCase):
+    """Inject a fake model directly into the instance to skip the real
+    download. The fake returns scores in reverse-input order so we can
+    verify the sort runs.
+    """
+
+    def _backend_with_fake(self, scores):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        fake = MagicMock()
+        fake.predict.return_value = scores
+        r._model = fake
+        return r, fake
+
+    def test_reorders_by_cross_encoder_score(self):
+        # Inputs in vector-score order (d0 > d1 > d2 > d3).
+        # Cross-encoder says the reverse: d3 > d2 > d1 > d0.
+        r, fake = self._backend_with_fake([0.1, 0.4, 0.7, 0.95])
+        out = r.rerank("q", _docs(4), top_k=5)
+        self.assertEqual([d["source"] for d in out],
+                         ["d3.md", "d2.md", "d1.md", "d0.md"])
+
+    def test_top_k_truncation_applied(self):
+        r, fake = self._backend_with_fake([0.1, 0.4, 0.7, 0.95])
+        out = r.rerank("q", _docs(4), top_k=2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual([d["source"] for d in out], ["d3.md", "d2.md"])
+
+    def test_annotations_added(self):
+        r, fake = self._backend_with_fake([0.5, 0.9, 0.3])
+        out = r.rerank("q", _docs(3), top_k=5)
+        for d in out:
+            self.assertIn("rerank_score", d)
+            self.assertIn("vector_score", d)
+            # vector_score captures the v0.3.0 ordering signal so
+            # downstream code can still read the original ranking
+            self.assertIsInstance(d["vector_score"], float)
+
+    def test_empty_input_empty_output(self):
+        r, fake = self._backend_with_fake([])
+        self.assertEqual(r.rerank("q", [], top_k=5), [])
+        fake.predict.assert_not_called()
+
+    def test_predict_failure_falls_back_to_vector_order(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        fake = MagicMock()
+        fake.predict.side_effect = RuntimeError("gpu memory full")
+        r._model = fake
+        out = r.rerank("q", _docs(4), top_k=5)
+        # Fall back: original order kept, no annotation
+        self.assertEqual([d["source"] for d in out],
+                         ["d0.md", "d1.md", "d2.md", "d3.md"])
+        for d in out:
+            self.assertNotIn("rerank_score", d)
+
+
+class ScorePairsTests(unittest.TestCase):
+
+    def test_score_pairs_returns_one_score_per_doc(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        fake = MagicMock()
+        fake.predict.return_value = [0.5, 0.6, 0.7]
+        r._model = fake
+        scores = r.score_pairs("q", _docs(3))
+        self.assertEqual(len(scores), 3)
+        self.assertEqual(scores, [0.5, 0.6, 0.7])
+
+    def test_score_pairs_empty_docs(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        # model not even loaded — empty docs short-circuits
+        self.assertEqual(r.score_pairs("q", []), [])
+
+    def test_score_pairs_fallback_returns_vector_scores(self):
+        from core.retrieval.rerank import Reranker
+        r = Reranker()
+        with patch("sentence_transformers.CrossEncoder",
+                   side_effect=RuntimeError("no")):
+            scores = r.score_pairs("q", _docs(3))
+        self.assertEqual(scores, [0.9, 0.7, 0.5])
+
+
+class EnvOverrideTests(unittest.TestCase):
+
+    def test_model_id_default(self):
+        from core.retrieval.rerank import Reranker, DEFAULT_MODEL
+        os.environ.pop("JAMES_RERANKER_MODEL", None)
+        r = Reranker()
+        self.assertEqual(r._model_id, DEFAULT_MODEL)
+
+    def test_model_id_env_override(self):
+        from core.retrieval.rerank import Reranker
+        with patch.dict(os.environ, {"JAMES_RERANKER_MODEL": "BAAI/bge-reranker-base"}):
+            r = Reranker()
+        self.assertEqual(r._model_id, "BAAI/bge-reranker-base")
+
+    def test_constructor_arg_wins_over_env(self):
+        from core.retrieval.rerank import Reranker
+        with patch.dict(os.environ, {"JAMES_RERANKER_MODEL": "env-model"}):
+            r = Reranker(model_id="explicit-model")
+        self.assertEqual(r._model_id, "explicit-model")
+
+
+class SingletonTests(unittest.TestCase):
+
+    def test_get_reranker_returns_same_instance(self):
+        from core.retrieval.rerank import get_reranker, _clear_singleton_for_tests
+        _clear_singleton_for_tests()
+        a = get_reranker()
+        b = get_reranker()
+        self.assertIs(a, b)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Cognitive Layer Phase 1 PR-1** — cross-encoder reranking between Loop-0 retrieval and the existing top-5 truncation. Phase 0 (Pre-L0 / L0 / L1 / L2) shipped the trace infrastructure with zero quality impact; **this is the first PR that actually changes retrieval ranking**.

```
orch_retrieve(top_k=8)   # was 8
→ Reranker.rerank(top_k=5)  # NEW — cross-encoder reorders
→ docs[:5]                  # truncation now reflects rerank order
```

## Backwards compatibility (STEP 7 contract)

`JAMES_DISABLE_RERANK=1` skips reranking → **byte-identical to v0.3.0** baseline. Same fallback fires when:
- Model load fails (e.g., no network for first-download)
- `model.predict()` raises (e.g., GPU OOM)

When fallback fires, docs come back **without `rerank_score` annotation** — callers can branch on `"rerank_score" in d` to distinguish a real rerank from a degraded path.

## New files

| File | Size | Role |
|---|---|---|
| `core/retrieval/__init__.py` | 0.5 KB | Package introduction; future `query_rewriter.py` / `hybrid.py` / `adaptive.py` land here |
| `core/retrieval/rerank.py` | 6.8 KB | `Reranker` class + `get_reranker()` singleton |
| `tests/test_reranker.py` | 5 KB | 14 tests (mocked CrossEncoder, no model download in CI) |

## Model selection

- **Default**: `cross-encoder/ms-marco-MiniLM-L-6-v2` (~80 MB, English-optimized) — chosen per the 2026-05-14 user briefing for the v0.3 local-first profile.
- **Operator override**: `JAMES_RERANKER_MODEL=BAAI/bge-reranker-base` (~278 MB, multilingual) — recommended for Korean-heavy corpora if ms-marco shows precision drop on Korean STEP 7 queries.

Both flow through `sentence-transformers.CrossEncoder` (already a JAMES dependency for embeddings — no new pip floor needed).

## Pipeline wiring

`core/reasoning/pipeline.py` Loop 0:

```python
# after orch_retrieve / hybrid_search fallback returns 8 docs:
from core.retrieval.rerank import get_reranker
docs = get_reranker().rerank(safe_query, docs, top_k=5)

# one TraceStep for the rerank stage (Phase 0 L0/L1 contract):
emit_trace_step(TraceStep(
    stage="rerank",
    backend_id="cross_encoder",
    applied_rule="reasoning.rerank.cross_encoder",
    latency_ms=...,
    output_summary=f"top: <source> rerank=<score>",
), extras={"pre_rerank_count": 8, "post_rerank_count": 5, "trace_id": ...})
```

`scripts/replay_trace.py` (from L2) now surfaces both the rerank step and the downstream synth step for one `trace_id` — full reasoning sequence visible.

## Verification

- **Unit tests**: 14 new (`tests/test_reranker.py`) all green
- **Regression**: 184/184 across reranker + L0/L1/L2 + reasoning-touching slice (`test_reasoning_*`, `test_replay_trace`, `test_conversation_continuity`, `test_force_web_chip`, `test_chat_wiki_save`, `test_web_search_admin_panel`, `test_source_files_first`, `test_query_include_contexts`, `test_policy_quarantine`, `test_meta_mode`, `test_coding_mode`)
- **Lint**: `ruff check core/retrieval core/reasoning/pipeline.py tests/test_reranker.py` → All checks passed
- **Mock-encoder coverage**: disabled / load fail (sticky) / predict fail / annotations / top_k / empty input / env override / singleton

## Bench gate (CLAUDE.md rule #2) — user spot-check needed

This PR touches `core/retrieval` and `core/reasoning` per rule #2; mock tests verify the wiring but **the cross-encoder's quality impact requires a live STEP 7 run**:

```powershell
# After merge, with server up:
python scripts/bench.py --suite=step7 --check
```

**Expected outcome**:
- Precision improves on English-leaning queries (q1, q2 conceptual, q9 lang-mix `What is RAG?`)
- Flat-to-slight-drop on Korean-only queries (ms-marco-MiniLM is English-trained — if regression observed, swap via `JAMES_RERANKER_MODEL=BAAI/bge-reranker-base` is the natural follow-up)
- STEP 7 contract: `graph_paths` should not regress (reranker only touches doc order, not the graph stage)

**Disable for A/B comparison**:
```powershell
$env:JAMES_DISABLE_RERANK = "1"
python scripts/bench.py --suite=step7 --check
# byte-identical to v0.3.0 expected — confirms fallback path
```

## Operational notes

- **First-boot cost**: cross-encoder model auto-downloads from HuggingFace on first `rerank()` call (~80 MB). Subsequent server restarts reuse the cached weights. Air-gapped operators: pre-pull the model dir into `~/.cache/huggingface/hub/` before first server start.
- **Latency**: ~50-150 ms per query on CPU for 8 docs (one cross-encoder forward pass). Recorded in the `audit_log.elapsed_sec` column for the `reason:rerank` row.
- **Memory**: ~150 MB resident after model load (one-time per process).

## Out of scope

- **Phase 1 PR-2 Query Rewriter** — `core/retrieval/query_rewriter.py`, small LLM call to transform user intent into retrieval-optimized queries
- **Phase 1 PR-3 Hybrid search** — BM25 + vector combination via Whoosh / rank-bm25 (currently the orchestrator already does this; PR-3 would formalize the weighting)
- **Module split for `core/reasoning/pipeline.py`** — pre-existing > 20 KB; separate cleanup PR
- **Multilingual reranker as default** — only after STEP 7 spot-check confirms Korean precision impact

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Cross-encoder reranking is domain-neutral |
| #2 bench numbers | User-side STEP 7 spot-check after merge (rerank impacts retrieval quality) |
| #3 self-evolution gate | Unrelated |
| #4 architecture | §5.7.1 Reranker primitive lands; no §5.7.2 trace-schema contract change |
| #5 20 KB module size | `rerank.py` 6.8 KB ✓ · `pipeline.py` 31.7 KB pre-existing debt (documented in L1 #284) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
