### PR TITLE
feat(retrieval): LLM query rewriter — Phase 1 PR-2

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -39,14 +39,63 @@ def run_retrieval_pipeline(
     force_web_search: bool = False,   # [#A8-6] 사용자가 chip 클릭 시 True
     selected_model: str = "",         # [#A2 phase 2] catalog-validated user pick
 ) -> Dict[str, Any]:
-    # ── STEP 0.5b: query expansion [P5] ──────────────────
-    # core/query_expander.py (was core/jepa_adapter.py — 단순 동의어
-    # 사전, JEPA 메커니즘과 무관) 현재 비활성화 상태.
-    # → Phase 9에서 멀티모달 임베딩 확장 시 재활성화 예정
-    # → 현재는 원본 쿼리 그대로 사용 (0ms 오버헤드)
+    # ── STEP 0.5b: query rewrite (Phase 1 PR-2) ─────────
+    # Cognitive Layer §5.7.1 Query Rewriter. Replaces the historical
+    # no-op kept here since v0.1 (the slot was reserved for this).
+    # Opt-in via JAMES_ENABLE_QUERY_REWRITE=1 — default OFF so a stock
+    # JAMES install pays no extra LLM round-trip per query. When
+    # enabled, the rewriter goes through the Backend registry (L0)
+    # using the local Ollama path; failures fall back to the original
+    # query so the pipeline always proceeds.
     t_qexp = time.time()
-    expanded_query = safe_query   # 확장 없이 원본 사용
-    engine._elapsed(t_qexp, "STEP0.5 query_expand")
+    expanded_query = safe_query
+    rewrite_latency_ms = 0
+    try:
+        from core.retrieval.query_rewriter import get_query_rewriter
+        expanded_query, rewrite_latency_ms = get_query_rewriter().rewrite(safe_query)
+    except Exception as e:
+        engine._log("query_rewrite", e, user_role)
+    engine._elapsed(t_qexp, "STEP0.5 query_rewrite")
+
+    # Emit one trace step for the rewrite stage so the replay tool sees
+    # rewrite → retrieve → rerank → synth in chronological order. Use
+    # the existing "retrieve" stage with a descriptive applied_rule —
+    # adding a "rewrite" stage to ALLOWED_STAGES would require a §5.7.2
+    # schema change (architecture-labelled PR), which this PR avoids.
+    if expanded_query != safe_query:
+        try:
+            from core.reasoning.trace_schema import (
+                TraceStep, compute_inputs_hash, truncate_summary,
+                emit_trace_step,
+            )
+            _rewrite_extras: Dict[str, Any] = {
+                "original_query": safe_query[:200],
+                "rewritten_query": expanded_query[:200],
+            }
+            try:
+                from core.observability import get_trace_id
+                _tid = get_trace_id()
+                if _tid:
+                    _rewrite_extras["trace_id"] = _tid
+            except Exception:
+                pass
+            emit_trace_step(
+                TraceStep(
+                    stage="retrieve",
+                    backend_id="ollama_local",
+                    parent_step_id="",
+                    inputs_hash=compute_inputs_hash(safe_query),
+                    output_summary=truncate_summary(
+                        f"{safe_query} → {expanded_query}"
+                    ),
+                    applied_rule="reasoning.retrieve.query_rewrite",
+                    latency_ms=rewrite_latency_ms,
+                ),
+                user_role=user_role,
+                extras=_rewrite_extras,
+            )
+        except Exception as e:
+            engine._log("query_rewrite_trace", e, user_role)
 
     # ── Loop 상태 초기화 ─────────────────────────────────
     loop_state = {

--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -1,0 +1,221 @@
+"""Query rewriter — Cognitive Layer Phase 1 PR-2.
+
+ARCHITECTURE.md §5.7.1: "Query Rewriter — transform user intent into
+retrieval-optimized queries". Sits at STEP 0.5b in pipeline.py (the
+slot that has been a no-op since v0.1, reserved for this exact moment).
+
+Routes through the Backend registry (Phase 0 L0) so the same rewrite
+can use the local Ollama path or a future Claude CLI backend without
+this module changing. Default backend is ``ollama_local`` — the
+operator's standard local LLM.
+
+Posture:
+  * **Opt-in by default** (``JAMES_ENABLE_QUERY_REWRITE=1``). Adding a
+    rewrite means one extra LLM round-trip per query (~5–10 s on
+    CPU-only ollama setups) — operators choose when to pay that cost.
+    A future PR can flip the default once we measure quality impact
+    on the user's corpus.
+  * **Best-effort fallback**: any failure (disabled, backend error,
+    JSON parse failure, runaway length) returns the original query
+    untouched. The pipeline always proceeds with a usable string.
+  * **Language-aware prompt**: a Korean-heavy query gets a Korean
+    rewrite instruction; otherwise English. Detection threshold
+    matches the existing pipeline language heuristic
+    (≥ 20% Korean character ratio).
+
+Wire-up (pipeline.py STEP 0.5b):
+    rewriter = get_query_rewriter()
+    expanded_query, latency_ms = rewriter.rewrite(safe_query)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from typing import Optional, Tuple
+
+
+DEFAULT_BACKEND_ID = "ollama_local"
+DEFAULT_TIMEOUT_S = 10.0
+DEFAULT_MAX_TOKENS = 200
+# Reject rewrites that balloon the query — usually a sign the LLM
+# elaborated instead of rewriting (e.g., explaining what the query is
+# rather than rephrasing it). 3× length is a generous bound.
+MAX_EXPANSION_RATIO = 3.0
+
+
+REWRITE_PROMPT_KO = (
+    "다음 검색 질의를 retrieval 시스템에 최적화된 형태로 다시 작성하라.\n"
+    "원본 질의: {query}\n\n"
+    "규칙:\n"
+    "- 의미는 그대로 유지\n"
+    "- 핵심 키워드는 강화 (동의어 1-2개 병기 가능)\n"
+    "- 대명사 (이것/그것/위/그분 등) 는 구체적인 명사로 치환\n"
+    "- 부연 설명 없이 한 문장으로\n\n"
+    "JSON 으로만 응답하라:\n"
+    '{{"rewritten": "<재작성된 질의>"}}'
+)
+
+REWRITE_PROMPT_EN = (
+    "Rewrite this search query for optimal retrieval.\n"
+    "Original query: {query}\n\n"
+    "Rules:\n"
+    "- Preserve meaning exactly\n"
+    "- Strengthen keywords (1-2 synonyms in parentheses OK)\n"
+    "- Replace ambiguous pronouns (this/that/it/the above) with the noun\n"
+    "- One sentence, no explanation\n\n"
+    "Respond with JSON only:\n"
+    '{{"rewritten": "<rewritten query>"}}'
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get("JAMES_ENABLE_QUERY_REWRITE") == "1"
+
+
+def _is_korean(text: str) -> bool:
+    """≥ 20% Korean character ratio matches the existing pipeline
+    heuristic in core/reasoning/{engine,modes,pipeline}.py.
+    """
+    if not text:
+        return False
+    korean_chars = sum(1 for c in text if "가" <= c <= "힣")
+    return korean_chars >= max(1, int(len(text) * 0.2))
+
+
+# Capture JSON object spanning the response. The LLM may pad with
+# leading / trailing prose despite the "respond with JSON only"
+# instruction — find the first {...} block and parse from there.
+_JSON_OBJECT_RE = re.compile(r'\{[^{}]*"rewritten"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"', re.DOTALL)
+
+
+def _parse_rewritten(llm_text: str) -> Optional[str]:
+    """Return the rewritten string from the LLM response, or None.
+
+    Tolerates the model padding with prose around the JSON — we anchor
+    on the ``"rewritten"`` key rather than insisting the whole response
+    parses as JSON.
+    """
+    if not llm_text:
+        return None
+    # Fast path: direct JSON parse
+    try:
+        blob = json.loads(llm_text)
+        if isinstance(blob, dict):
+            val = blob.get("rewritten")
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Slower path: regex sniff
+    m = _JSON_OBJECT_RE.search(llm_text)
+    if m:
+        candidate = m.group(1).strip()
+        # Unescape the limited set of escapes the regex preserved
+        candidate = candidate.replace('\\"', '"').replace("\\\\", "\\")
+        if candidate:
+            return candidate
+    return None
+
+
+class QueryRewriter:
+    """Stateless wrapper around a Backend; the Backend caches the LLM
+    client across calls.
+    """
+
+    def __init__(
+        self,
+        backend_id: str = DEFAULT_BACKEND_ID,
+        *,
+        timeout: float = DEFAULT_TIMEOUT_S,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        self._backend_id = backend_id
+        self._timeout = timeout
+        self._max_tokens = max_tokens
+
+    def rewrite(
+        self,
+        query: str,
+        *,
+        force: bool = False,
+    ) -> Tuple[str, int]:
+        """Return ``(rewritten_query, latency_ms)``.
+
+        Falls back to ``(query, 0)`` when:
+          * the env opt-in flag is not set (and ``force`` is False)
+          * query is empty / shorter than 4 chars (rewrite adds noise)
+          * backend lookup fails (registry doesn't know the id)
+          * backend.complete() raises or returns an error string
+          * the response doesn't contain a valid ``"rewritten"`` value
+          * the rewritten string is empty or balloons past
+            ``MAX_EXPANSION_RATIO × len(original)``
+        """
+        if not query or len(query.strip()) < 4:
+            return (query, 0)
+        if not force and not _enabled():
+            return (query, 0)
+
+        try:
+            from core.reasoning.backends import get_backend
+            backend = get_backend(self._backend_id)
+        except Exception:
+            return (query, 0)
+
+        prompt_tmpl = REWRITE_PROMPT_KO if _is_korean(query) else REWRITE_PROMPT_EN
+        prompt = prompt_tmpl.format(query=query)
+
+        t0 = time.time()
+        try:
+            result = backend.complete(
+                prompt,
+                max_tokens=self._max_tokens,
+                timeout=self._timeout,
+            )
+        except Exception:
+            return (query, int((time.time() - t0) * 1000))
+        latency_ms = int((time.time() - t0) * 1000)
+
+        if getattr(result, "error", "") or not getattr(result, "text", ""):
+            return (query, latency_ms)
+
+        rewritten = _parse_rewritten(result.text)
+        if not rewritten:
+            return (query, latency_ms)
+
+        # Reject runaway expansions — usually the LLM explaining instead
+        # of rewriting. Keep the original; mark the latency we spent.
+        if len(rewritten) > len(query) * MAX_EXPANSION_RATIO:
+            return (query, latency_ms)
+
+        return (rewritten, latency_ms)
+
+
+# ─── module-level singleton ────────────────────────────────────────
+_SINGLETON: Optional[QueryRewriter] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_query_rewriter() -> QueryRewriter:
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = QueryRewriter()
+    return _SINGLETON
+
+
+def _clear_singleton_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None
+
+
+__all__ = [
+    "DEFAULT_BACKEND_ID",
+    "QueryRewriter",
+    "get_query_rewriter",
+]

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1,0 +1,299 @@
+"""Phase 1 PR-2 — query rewriter unit tests.
+
+ARCHITECTURE.md §5.7.1 Query Rewriter. Uses the Backend registry (Phase
+0 L0) so unit tests register a mock backend rather than hitting the
+live Ollama. The pipeline integration smoke test (rewriter actually
+called from STEP 0.5b) is verified by running the real-server STEP 7
+bench post-merge — see PR body.
+
+Coverage:
+  * opt-in gate: JAMES_ENABLE_QUERY_REWRITE unset → identity
+  * force flag: bypasses the env gate (for tests / debug)
+  * short / empty query → identity (rewrite would only add noise)
+  * backend lookup failure → identity
+  * backend.complete error → identity, latency still recorded
+  * malformed JSON → identity
+  * tolerant parser: pure JSON / JSON with leading prose / JSON with
+    trailing prose all yield the rewritten string
+  * runaway expansion (> 3× length) rejected → identity
+  * KO vs EN prompt template selection
+  * singleton get_query_rewriter() returns the same instance
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _completion(text="", error=""):
+    """Minimal stand-in for the CompletionResult dataclass."""
+    res = MagicMock()
+    res.text = text
+    res.error = error
+    return res
+
+
+def _make_rewriter_with_backend(mock_backend):
+    """Build a QueryRewriter pointing at our mock backend.
+
+    We patch ``core.reasoning.backends.get_backend`` so the rewriter's
+    lazy lookup returns our mock without touching the real registry.
+    """
+    from core.retrieval.query_rewriter import QueryRewriter
+    return QueryRewriter()   # backend resolved at .rewrite() time
+
+
+class OptInGateTests(unittest.TestCase):
+    """Default OFF — rewriter must not call the backend without an
+    explicit opt-in. Operators choosing not to pay the extra LLM
+    round-trip should see byte-identical behaviour to v0.3.0.
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_QUERY_REWRITE")
+        os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+        else:
+            os.environ["JAMES_ENABLE_QUERY_REWRITE"] = self._saved
+
+    def test_disabled_default_returns_identity_no_backend_call(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, latency = rw.rewrite("이것은 테스트 질의입니다")
+        self.assertEqual(out, "이것은 테스트 질의입니다")
+        self.assertEqual(latency, 0)
+        fake.complete.assert_not_called()
+
+    def test_force_bypasses_env_gate(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "테스트 질의 (시험 검사)"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, _ = rw.rewrite("이것은 테스트 질의입니다", force=True)
+        self.assertEqual(out, "테스트 질의 (시험 검사)")
+        fake.complete.assert_called_once()
+
+
+class ShortQueryTests(unittest.TestCase):
+
+    def test_empty_query_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        self.assertEqual(QueryRewriter().rewrite(""), ("", 0))
+
+    def test_whitespace_query_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        self.assertEqual(QueryRewriter().rewrite("   "), ("   ", 0))
+
+    def test_short_query_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        # 3-char query is below the rewrite threshold
+        self.assertEqual(QueryRewriter().rewrite("RAG"), ("RAG", 0))
+
+
+class BackendFailureTests(unittest.TestCase):
+    """Every failure mode (lookup miss, raise, error string, empty
+    response, bad JSON) must fall back to identity. The pipeline
+    cannot tolerate a None or exception here.
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_QUERY_REWRITE")
+        os.environ["JAMES_ENABLE_QUERY_REWRITE"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+        else:
+            os.environ["JAMES_ENABLE_QUERY_REWRITE"] = self._saved
+
+    def test_backend_lookup_missing_returns_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter(backend_id="definitely_not_registered")
+        out, _ = rw.rewrite("이것은 충분히 긴 질의입니다")
+        self.assertEqual(out, "이것은 충분히 긴 질의입니다")
+
+    def test_backend_raises_returns_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.side_effect = RuntimeError("ollama timeout")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, _ = rw.rewrite("긴 한국어 질의 입니다")
+        self.assertEqual(out, "긴 한국어 질의 입니다")
+
+    def test_backend_returns_error_string_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(error="backend reported error")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, _ = rw.rewrite("긴 한국어 질의 입니다")
+        self.assertEqual(out, "긴 한국어 질의 입니다")
+
+    def test_empty_text_returns_identity(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, _ = rw.rewrite("긴 한국어 질의 입니다")
+        self.assertEqual(out, "긴 한국어 질의 입니다")
+
+
+class JsonParseTests(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_QUERY_REWRITE")
+        os.environ["JAMES_ENABLE_QUERY_REWRITE"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+        else:
+            os.environ["JAMES_ENABLE_QUERY_REWRITE"] = self._saved
+
+    def _rewrite_with_text(self, llm_text, query="이것은 충분히 긴 한국어 질의입니다"):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text=llm_text)
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            return rw.rewrite(query)
+
+    def test_pure_json_response(self):
+        out, _ = self._rewrite_with_text('{"rewritten": "다시 작성된 질의"}')
+        self.assertEqual(out, "다시 작성된 질의")
+
+    def test_json_with_leading_prose(self):
+        # The LLM padded with prose before the JSON despite "JSON only"
+        out, _ = self._rewrite_with_text(
+            "여기 재작성된 질의입니다:\n{\"rewritten\": \"새 질의\"}"
+        )
+        self.assertEqual(out, "새 질의")
+
+    def test_json_with_trailing_prose(self):
+        out, _ = self._rewrite_with_text(
+            '{"rewritten": "새 질의"}\n위 형태로 다시 작성했습니다.'
+        )
+        self.assertEqual(out, "새 질의")
+
+    def test_malformed_json_identity(self):
+        out, _ = self._rewrite_with_text("not json at all, just prose")
+        self.assertEqual(out, "이것은 충분히 긴 한국어 질의입니다")
+
+    def test_missing_rewritten_key_identity(self):
+        out, _ = self._rewrite_with_text('{"other": "value"}')
+        self.assertEqual(out, "이것은 충분히 긴 한국어 질의입니다")
+
+    def test_empty_rewritten_value_identity(self):
+        out, _ = self._rewrite_with_text('{"rewritten": ""}')
+        self.assertEqual(out, "이것은 충분히 긴 한국어 질의입니다")
+
+    def test_runaway_expansion_rejected(self):
+        # A reply that's > 3× the original length is most likely the
+        # LLM explaining instead of rewriting — keep the original.
+        long_value = "x" * 200
+        out, _ = self._rewrite_with_text(
+            f'{{"rewritten": "{long_value}"}}',
+            query="짧은 질의",
+        )
+        self.assertEqual(out, "짧은 질의")
+
+
+class LanguageDetectionTests(unittest.TestCase):
+    """The rewriter picks Korean or English prompt based on character
+    ratio. We assert the backend received the right template by
+    inspecting the prompt argument.
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_QUERY_REWRITE")
+        os.environ["JAMES_ENABLE_QUERY_REWRITE"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+        else:
+            os.environ["JAMES_ENABLE_QUERY_REWRITE"] = self._saved
+
+    def _capture_prompt(self, query):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            rw.rewrite(query)
+        return fake.complete.call_args.args[0]
+
+    def test_korean_query_uses_korean_prompt(self):
+        prompt = self._capture_prompt("RAG가 무엇인지 설명해줘")
+        self.assertIn("원본 질의", prompt)
+        self.assertNotIn("Original query", prompt)
+
+    def test_english_query_uses_english_prompt(self):
+        prompt = self._capture_prompt("Explain what RAG is")
+        self.assertIn("Original query", prompt)
+        self.assertNotIn("원본 질의", prompt)
+
+
+class SingletonTests(unittest.TestCase):
+
+    def test_get_query_rewriter_returns_same_instance(self):
+        from core.retrieval.query_rewriter import (
+            get_query_rewriter, _clear_singleton_for_tests,
+        )
+        _clear_singleton_for_tests()
+        a = get_query_rewriter()
+        b = get_query_rewriter()
+        self.assertIs(a, b)
+
+
+class LatencyRecordedTests(unittest.TestCase):
+    """Even on failure the helper reports how long the backend took —
+    operators want to know what cost a fallback-to-identity path."""
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_QUERY_REWRITE")
+        os.environ["JAMES_ENABLE_QUERY_REWRITE"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_QUERY_REWRITE", None)
+        else:
+            os.environ["JAMES_ENABLE_QUERY_REWRITE"] = self._saved
+
+    def test_failure_latency_recorded(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+        rw = QueryRewriter()
+        fake = MagicMock()
+        # simulate a slow backend that ultimately errors
+        def slow_error(prompt, **kw):
+            import time
+            time.sleep(0.02)
+            return _completion(error="timeout")
+        fake.complete.side_effect = slow_error
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out, latency = rw.rewrite("이것은 충분히 긴 한국어 질의입니다")
+        self.assertEqual(out, "이것은 충분히 긴 한국어 질의입니다")
+        self.assertGreaterEqual(latency, 15)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Cognitive Layer Phase 1 PR-2** — LLM query rewriter. Replaces the historical no-op at `pipeline.py` STEP 0.5b that has been a placeholder since v0.1.

**Opt-in by default**: `JAMES_ENABLE_QUERY_REWRITE=1` enables it. Without the flag every query returns `(query, 0)` and the pipeline is byte-identical to v0.3.0. Operators choose when to pay the extra LLM round-trip (~5-10s on CPU ollama setups).

```
v0.3.0:    safe_query → orchestrator
PR-2 ON:   safe_query → rewriter (LLM) → expanded_query → orchestrator
```

## Why opt-in by default

- Rewrite adds **one extra LLM round-trip** per query before retrieval starts. On the user's CPU ollama setup, that's a ~5-10s tax per query — significant when STEP 7 already runs at ~25-50s per query.
- Quality impact is corpus-dependent (helps ambiguous / pronoun-heavy queries, neutral on already-explicit queries). The user's STEP 7 spot-check decides whether to flip the default in a follow-up PR.
- Matches the cautious pattern established by Phase 0 backends (`JAMES_ENABLE_CLAUDE_BACKEND=1`).

## Routes through the Backend registry

The rewriter calls `core.reasoning.backends.get_backend("ollama_local").complete(...)` — the L0 abstraction. A future backend (Claude CLI, remote model) becomes the rewriter LLM with **zero changes to this module**:

```python
QueryRewriter(backend_id="claude_code_cli").rewrite(query)
```

## New files

| File | Size | Role |
|---|---|---|
| `core/retrieval/query_rewriter.py` | 7.4 KB | `QueryRewriter` + `get_query_rewriter()` singleton |
| `tests/test_query_rewriter.py` | 7 KB | 20 tests (mocked backend, no LLM in CI) |

## Failure posture (best-effort)

Every failure path falls back to identity — the pipeline never crashes here:

| Failure | Behavior |
|---|---|
| Env opt-in unset | `(query, 0)` — no backend call |
| Empty / whitespace / < 4 char query | `(query, 0)` |
| Backend lookup miss | `(query, 0)` |
| `backend.complete()` raises | `(query, latency)` |
| Backend returns error string | `(query, latency)` |
| Empty text response | `(query, latency)` |
| Malformed / missing JSON | `(query, latency)` |
| Runaway expansion (> 3× length) | `(query, latency)` — LLM explained instead of rewriting |

## Tolerant JSON parser

Real-world LLMs pad with prose even when asked for "JSON only". The parser tries direct `json.loads()` first, then anchors on the `"rewritten": "..."` key via regex — catches all three observed shapes:

```
{"rewritten": "..."}                          # pure JSON
여기 재작성된 질의입니다: {"rewritten": "..."}  # leading prose
{"rewritten": "..."} 위와 같이 다시 작성       # trailing prose
```

## Pipeline wiring

`core/reasoning/pipeline.py` STEP 0.5b:

```python
expanded_query, rewrite_latency_ms = get_query_rewriter().rewrite(safe_query)

if expanded_query != safe_query:
    emit_trace_step(TraceStep(
        stage="retrieve",   # existing stage; "rewrite" not in ALLOWED_STAGES
        applied_rule="reasoning.retrieve.query_rewrite",
        ...
    ), extras={"original_query": ..., "rewritten_query": ..., "trace_id": ...})
```

No `audit_log` row when rewrite is a no-op (env disabled or identity fallback) — keeps audit noise down.

## Verification

- **Unit tests**: 20 new (`tests/test_query_rewriter.py`) green
- **Regression**: 204/204 across rewriter + reranker + L0/L1/L2 + reasoning-touching slice
- **Lint**: `ruff check core/retrieval core/reasoning/pipeline.py tests/test_query_rewriter.py` → All checks passed
- **Mock-backend coverage**: opt-in gate / force flag / short query / lookup miss / raise / error string / empty text / pure JSON / JSON+prose / malformed / missing key / runaway / KO+EN prompt selection / singleton / latency recording

## Bench (CLAUDE.md rule #2)

- **Default OFF** → STEP 7 unchanged
- **With opt-in**:
  ```powershell
  $env:JAMES_ENABLE_QUERY_REWRITE = "1"
  python scripts/bench.py --suite=step7 --check
  ```
  Expected: recall improves on ambiguous queries (q4 BlackRock-ETF관계, q5 multi-hop, q7 compare); flat-to-slight-improve on direct queries. Latency rises by ~5-10s per query.

## Module size (CLAUDE.md rule #5)

| File | Pre-L0 | After PR-1 | After PR-2 (this) |
|---|---|---|---|
| `core/reasoning/pipeline.py` | 27.7 KB | 31.7 KB | **33.7 KB** |

Each Phase 1 PR adds ~2 KB to `pipeline.py`. Pre-existing > 20 KB documented in L1 #284 and PR-1 #286. **A split PR is now overdue** — recommended after PR-3 / PR-4 (or before, if reviewer wants it sooner). `query_rewriter.py` itself is 7.4 KB ✓.

## Out of scope

- **Phase 1 PR-3 Hybrid search** — BM25 + vector formal weighting
- **Phase 1 PR-4 Adaptive retrieval** — task-complexity-aware top_k / depth
- **Module split for `core/reasoning/pipeline.py`** — pre-existing debt
- **Flipping default ON** — wait for STEP 7 spot-check data

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Rewrite primitive is domain-neutral |
| #2 bench numbers | Default OFF → no impact; opt-in user-side STEP 7 |
| #3 self-evolution gate | Unrelated |
| #4 architecture | §5.7.1 Query Rewriter primitive lands; no §5.7.2 change |
| #5 20 KB module size | `query_rewriter.py` 7.4 KB ✓ · `pipeline.py` 33.7 KB pre-existing debt |

## Phase 1 progress

```
PR-1 #286  Reranker (cross-encoder)        ✓ merged
PR-2 THIS  Query rewriter (opt-in)         ← this PR
PR-3       Hybrid search (optional)        pending
PR-4       Adaptive retrieval (optional)   pending
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
