### PR TITLE
feat(reasoning): reflection loop — Phase 2 PR-5

### DIFF
--- a/core/reasoning/pipeline_synth.py
+++ b/core/reasoning/pipeline_synth.py
@@ -260,6 +260,24 @@ def generate_answer(
         ),
     )
 
+    # Phase 2 PR-5 — optional reflection pass.
+    # ReflectionLoop is opt-in via JAMES_ENABLE_REFLECT=1; default OFF
+    # so a stock JAMES install pays no extra LLM round-trip per query.
+    # When enabled, the loop runs critique + revise on the final answer
+    # and returns the revised text; any failure falls back to ``answer``
+    # unchanged so the synth contract is preserved end-to-end.
+    try:
+        from core.reasoning.reflect import get_reflection_loop
+        reflected = get_reflection_loop().reflect(
+            safe_query, answer, user_role=user_role
+        )
+        if reflected and reflected != answer and not any(
+            reflected.startswith(p) for p in engine._LLM_ERROR_PREFIXES
+        ):
+            answer = reflected
+    except Exception as e:
+        engine._log("reflect_loop", e, user_role)
+
     out.answer = answer
     return out
 

--- a/core/reasoning/reflect.py
+++ b/core/reasoning/reflect.py
@@ -1,0 +1,347 @@
+"""Reflection loop — Cognitive Layer Phase 2 PR-5.
+
+ARCHITECTURE.md §5.7.1: "Reflection Engine — draft → self_critique →
+revised per subtask". Wraps an already-generated answer with a
+critique + revise pass to surface contradictions, missing evidence,
+and policy-relevant errors before the answer reaches the user.
+
+Posture: opt-in by default. JAMES_ENABLE_REFLECT=1 enables. Each
+invocation costs **two extra LLM round-trips** (critique + revise),
+roughly doubling the answer-stage latency. Operators choose when the
+quality gain justifies the cost.
+
+Routes through the Backend registry (Phase 0 L0) — default
+``ollama_local`` matches the rest of v0.3.0's local-first profile. A
+future Claude CLI swap is a constructor arg with no other changes:
+
+    ReflectionLoop(backend_id="claude_code_cli").reflect(...)
+
+Two trace rows emitted per successful pass (Phase 0 L1 contract via
+emit_trace_step):
+
+    stage="reflect" applied_rule="reasoning.reflect.critique"
+    stage="reflect" applied_rule="reasoning.reflect.revised"
+
+Failure rows (critique returned error string / revised failed / etc.)
+land with ``error`` non-empty and ``blocked=1``. The caller always gets
+SOMETHING back — either the revised text or the original draft.
+
+Wiring (pipeline_synth.py): after generate_answer determines the final
+answer, optionally route through reflect() before returning.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Optional
+
+from core.reasoning.trace_schema import (
+    TraceStep,
+    compute_inputs_hash,
+    emit_trace_step,
+    truncate_summary,
+)
+
+
+DEFAULT_BACKEND_ID = "ollama_local"
+# Critique + revise budgets — kept tight so reflection doesn't blow
+# past the 30s timing target in core/reasoning/engine.py.
+DEFAULT_CRITIQUE_TIMEOUT_S = 30.0
+DEFAULT_REVISE_TIMEOUT_S = 45.0
+DEFAULT_CRITIQUE_MAX_TOKENS = 400
+DEFAULT_REVISE_MAX_TOKENS = 1024
+# Reject runaway revised answers that ballooned far past the draft —
+# usually a sign the LLM added boilerplate apologies rather than fixing
+# substance. 2.5× draft length is a generous bound.
+MAX_REVISE_RATIO = 2.5
+
+
+CRITIQUE_PROMPT_KO = (
+    "아래 답변을 비판적으로 검토하라. 검토 목적은 사용자가 받기 전에 "
+    "결함을 잡아내는 것이다.\n\n"
+    "[원본 질문]\n{query}\n\n"
+    "[답변 초안]\n{draft}\n\n"
+    "다음 3 가지 측면만 점검 (각 1-2 줄):\n"
+    "1. 모순/사실 오류 — 답변 안에서 서로 어긋나는 부분이나 명백히 틀린 사실\n"
+    "2. 누락된 핵심 — 질문에 직접 답하지 않은 부분 또는 빠진 핵심 정보\n"
+    "3. 모호함 — 사용자가 오해할 가능성이 있는 표현\n\n"
+    "문제가 없으면 'NO_ISSUES' 한 줄만 출력.\n\n"
+    "검토:"
+)
+
+CRITIQUE_PROMPT_EN = (
+    "Critically review the draft answer below. The goal is to catch "
+    "defects before the user sees it.\n\n"
+    "[Original question]\n{query}\n\n"
+    "[Draft answer]\n{draft}\n\n"
+    "Check only these 3 dimensions (1-2 lines each):\n"
+    "1. Contradiction / factual error — anything inconsistent within "
+    "the answer or clearly wrong\n"
+    "2. Missing core — parts of the question not answered, or key "
+    "information omitted\n"
+    "3. Ambiguity — phrasings the user might misread\n\n"
+    "If nothing is wrong, output 'NO_ISSUES' on one line.\n\n"
+    "Review:"
+)
+
+
+REVISE_PROMPT_KO = (
+    "아래 검토를 반영해서 답변을 개정하라.\n\n"
+    "[원본 질문]\n{query}\n\n"
+    "[답변 초안]\n{draft}\n\n"
+    "[검토 결과]\n{critique}\n\n"
+    "개정 규칙:\n"
+    "- 검토에서 지적된 문제만 수정. 잘 된 부분은 그대로.\n"
+    "- 의미를 보존하고 새 사실을 만들지 마라.\n"
+    "- 사과 문구나 '재작성했습니다' 같은 메타-텍스트 없이 답변만.\n\n"
+    "개정된 답변:"
+)
+
+REVISE_PROMPT_EN = (
+    "Revise the draft to address the review.\n\n"
+    "[Original question]\n{query}\n\n"
+    "[Draft answer]\n{draft}\n\n"
+    "[Review]\n{critique}\n\n"
+    "Revision rules:\n"
+    "- Fix only the issues the review flagged. Leave good parts as-is.\n"
+    "- Preserve meaning; don't invent new facts.\n"
+    "- Output only the revised answer — no apologies or meta-text like "
+    "\"here is the revised version\".\n\n"
+    "Revised answer:"
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get("JAMES_ENABLE_REFLECT") == "1"
+
+
+def _is_korean(text: str) -> bool:
+    """≥ 20% Korean character ratio — same heuristic as the rest of
+    core/reasoning/{engine,modes,pipeline}.py.
+    """
+    if not text:
+        return False
+    korean_chars = sum(1 for c in text if "가" <= c <= "힣")
+    return korean_chars >= max(1, int(len(text) * 0.2))
+
+
+def _no_issues(critique_text: str) -> bool:
+    """Critique signalled the draft is fine — skip revision."""
+    if not critique_text:
+        return True
+    head = critique_text.strip().splitlines()[0] if critique_text.strip() else ""
+    return head.strip().upper().startswith("NO_ISSUES")
+
+
+class ReflectionLoop:
+    """Stateless wrapper around a Backend; the Backend itself caches
+    the underlying LLM client across calls so successive reflections
+    on the same backend share connection state.
+    """
+
+    def __init__(
+        self,
+        backend_id: str = DEFAULT_BACKEND_ID,
+        *,
+        critique_timeout: float = DEFAULT_CRITIQUE_TIMEOUT_S,
+        revise_timeout: float = DEFAULT_REVISE_TIMEOUT_S,
+        critique_max_tokens: int = DEFAULT_CRITIQUE_MAX_TOKENS,
+        revise_max_tokens: int = DEFAULT_REVISE_MAX_TOKENS,
+    ) -> None:
+        self._backend_id = backend_id
+        self._critique_timeout = critique_timeout
+        self._revise_timeout = revise_timeout
+        self._critique_max_tokens = critique_max_tokens
+        self._revise_max_tokens = revise_max_tokens
+
+    def reflect(
+        self,
+        query: str,
+        draft: str,
+        *,
+        user_role: str = "system",
+        force: bool = False,
+    ) -> str:
+        """Run critique → (optional) revise and return the final text.
+
+        Always returns SOMETHING — either the revised answer or the
+        original draft. Never raises.
+
+        Skips (returns draft unchanged) when:
+          * the env opt-in flag is not set (and ``force`` is False)
+          * draft is empty or short (< 30 chars — nothing meaningful
+            to critique)
+          * backend lookup fails
+          * critique returns an error or empty text
+          * critique says 'NO_ISSUES' (no revision needed)
+          * revise returns an error / empty text
+          * revised answer balloons past ``MAX_REVISE_RATIO × draft length``
+        """
+        if not draft or len(draft.strip()) < 30:
+            return draft
+        if not force and not _enabled():
+            return draft
+
+        try:
+            from core.reasoning.backends import get_backend
+            backend = get_backend(self._backend_id)
+        except Exception:
+            return draft
+
+        is_ko = _is_korean(query) or _is_korean(draft)
+        crit_tmpl = CRITIQUE_PROMPT_KO if is_ko else CRITIQUE_PROMPT_EN
+        rev_tmpl = REVISE_PROMPT_KO if is_ko else REVISE_PROMPT_EN
+
+        # ── critique pass ────────────────────────────────────
+        critique_prompt = crit_tmpl.format(query=query, draft=draft)
+        critique_text, critique_err = self._call(
+            backend,
+            critique_prompt,
+            timeout=self._critique_timeout,
+            max_tokens=self._critique_max_tokens,
+            applied_rule="reasoning.reflect.critique",
+            user_role=user_role,
+        )
+        if critique_err or not critique_text:
+            return draft
+        if _no_issues(critique_text):
+            return draft
+
+        # ── revise pass ──────────────────────────────────────
+        revise_prompt = rev_tmpl.format(
+            query=query, draft=draft, critique=critique_text
+        )
+        revised_text, revised_err = self._call(
+            backend,
+            revise_prompt,
+            timeout=self._revise_timeout,
+            max_tokens=self._revise_max_tokens,
+            applied_rule="reasoning.reflect.revised",
+            user_role=user_role,
+        )
+        if revised_err or not revised_text:
+            return draft
+
+        # Runaway-revision guard — if the revised text balloons past
+        # MAX_REVISE_RATIO × draft length, the LLM probably elaborated
+        # instead of fixing. Keep the draft.
+        if len(revised_text) > len(draft) * MAX_REVISE_RATIO:
+            return draft
+
+        return revised_text
+
+    def _call(
+        self,
+        backend,
+        prompt: str,
+        *,
+        timeout: float,
+        max_tokens: int,
+        applied_rule: str,
+        user_role: str,
+    ) -> tuple[str, str]:
+        """One backend round-trip + one TraceStep emission.
+
+        Returns ``(text, error)``. ``error`` non-empty means the caller
+        should fall back. Even on failure, an audit row lands (with
+        ``error`` set + ``blocked=1``) so the replay tool sees the
+        attempt.
+        """
+        t0 = time.time()
+        try:
+            result = backend.complete(
+                prompt, max_tokens=max_tokens, timeout=timeout
+            )
+        except Exception as e:
+            latency_ms = int((time.time() - t0) * 1000)
+            err = f"{type(e).__name__}: {str(e)[:200]}"
+            self._emit(
+                applied_rule=applied_rule,
+                prompt=prompt,
+                text="",
+                latency_ms=latency_ms,
+                error=err,
+                user_role=user_role,
+            )
+            return ("", err)
+
+        latency_ms = int((time.time() - t0) * 1000)
+        text = getattr(result, "text", "") or ""
+        err = getattr(result, "error", "") or ""
+
+        self._emit(
+            applied_rule=applied_rule,
+            prompt=prompt,
+            text=text,
+            latency_ms=latency_ms,
+            error=err,
+            user_role=user_role,
+        )
+        return (text, err)
+
+    def _emit(
+        self,
+        *,
+        applied_rule: str,
+        prompt: str,
+        text: str,
+        latency_ms: int,
+        error: str,
+        user_role: str,
+    ) -> None:
+        extras = {}
+        try:
+            from core.observability import get_trace_id
+            tid = get_trace_id()
+            if tid:
+                extras["trace_id"] = tid
+        except Exception:
+            pass
+        try:
+            emit_trace_step(
+                TraceStep(
+                    stage="reflect",
+                    backend_id=self._backend_id,
+                    parent_step_id="",
+                    inputs_hash=compute_inputs_hash(prompt),
+                    output_summary=truncate_summary(text),
+                    applied_rule=applied_rule,
+                    latency_ms=latency_ms,
+                    error=error,
+                ),
+                user_role=user_role,
+                extras=extras or None,
+            )
+        except Exception:
+            # Reflection trace emission is best-effort — never block the
+            # answer flow if audit_log is unavailable.
+            pass
+
+
+# ─── module-level singleton ────────────────────────────────────────
+_SINGLETON: Optional[ReflectionLoop] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_reflection_loop() -> ReflectionLoop:
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = ReflectionLoop()
+    return _SINGLETON
+
+
+def _clear_singleton_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None
+
+
+__all__ = [
+    "DEFAULT_BACKEND_ID",
+    "ReflectionLoop",
+    "get_reflection_loop",
+]

--- a/tests/test_reflection_loop.py
+++ b/tests/test_reflection_loop.py
@@ -1,0 +1,359 @@
+"""Phase 2 PR-5 — reflection loop unit tests.
+
+ARCHITECTURE.md §5.7.1 Reflection Engine. Uses the Backend registry
+(Phase 0 L0) so unit tests register a mock backend rather than hitting
+the live Ollama. Pipeline integration smoke is covered by the existing
+204-test reasoning slice — this file pins the reflect.py contract.
+
+Coverage:
+  * opt-in gate: JAMES_ENABLE_REFLECT unset → draft returned unchanged
+  * force flag: bypasses env gate (for tests / debug)
+  * short / empty draft → draft returned (nothing meaningful to reflect)
+  * backend lookup miss → draft returned
+  * critique returns 'NO_ISSUES' → skip revise, return draft
+  * critique raises → draft returned, audit row emitted with error
+  * critique error string → draft returned
+  * revise raises → draft returned
+  * revise empty / error → draft returned
+  * happy path: revised text returned
+  * runaway revision (> 2.5× draft) rejected → draft returned
+  * KO / EN prompt template selection
+  * trace_step rows emitted per pass (mocked audit DB)
+  * singleton: get_reflection_loop returns the same instance
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _completion(text="", error=""):
+    res = MagicMock()
+    res.text = text
+    res.error = error
+    return res
+
+
+# A long-enough draft so the < 30-char gate doesn't trip.
+DRAFT_KO = (
+    "RAG는 Retrieval-Augmented Generation 의 약자로, 검색을 통해 "
+    "외부 지식을 LLM 응답에 결합하는 기법입니다."
+)
+DRAFT_EN = (
+    "RAG stands for Retrieval-Augmented Generation, a technique that "
+    "combines external knowledge retrieval with LLM responses."
+)
+
+
+class OptInGateTests(unittest.TestCase):
+    """Default OFF — reflection must not call the backend without an
+    explicit opt-in. Byte-identical to pre-PR-5 behaviour at the call
+    site (synth path returns answer as-is).
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("JAMES_ENABLE_REFLECT")
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_REFLECT", None)
+        else:
+            os.environ["JAMES_ENABLE_REFLECT"] = self._saved
+
+    def test_disabled_default_returns_draft_no_backend_call(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out = r.reflect("Q?", DRAFT_KO)
+        self.assertEqual(out, DRAFT_KO)
+        fake.complete.assert_not_called()
+
+    def test_force_bypasses_env_gate(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        # First call: critique. Second call: revise.
+        fake.complete.side_effect = [
+            _completion(text="누락된 부분 있음."),
+            _completion(text="RAG 는 검색 증강 생성으로, 외부 지식을 결합합니다 (보강)."),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out = r.reflect("RAG가 뭐야?", DRAFT_KO, force=True)
+        self.assertIn("보강", out)
+        self.assertEqual(fake.complete.call_count, 2)
+
+
+class ShortDraftTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def test_empty_draft_returns_unchanged(self):
+        from core.reasoning.reflect import ReflectionLoop
+        self.assertEqual(ReflectionLoop().reflect("Q?", ""), "")
+
+    def test_short_draft_returns_unchanged(self):
+        from core.reasoning.reflect import ReflectionLoop
+        short = "Hi"
+        self.assertEqual(ReflectionLoop().reflect("Q?", short), short)
+
+
+class BackendFailureTests(unittest.TestCase):
+    """Every failure mode falls back to the original draft."""
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def test_backend_lookup_missing_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop(backend_id="definitely_not_registered")
+        self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+
+    def test_critique_raises_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.side_effect = RuntimeError("ollama down")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+        # critique call attempted; revise NOT called
+        self.assertEqual(fake.complete.call_count, 1)
+
+    def test_critique_error_string_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(error="backend error")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+        self.assertEqual(fake.complete.call_count, 1)
+
+    def test_critique_empty_text_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+
+    def test_no_issues_response_skips_revise_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="NO_ISSUES")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+        # only critique ran; revise never called
+        self.assertEqual(fake.complete.call_count, 1)
+
+    def test_revise_raises_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.side_effect = [
+            _completion(text="누락된 부분 있음."),
+            RuntimeError("revise crash"),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+        self.assertEqual(fake.complete.call_count, 2)
+
+    def test_revise_empty_text_returns_draft(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.side_effect = [
+            _completion(text="problem."),
+            _completion(text=""),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+
+    def test_runaway_revise_rejected(self):
+        """Revised text > 2.5× draft length → likely the model elaborated
+        instead of fixing. Keep the original."""
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        big = "X" * 1000   # 1000 chars vs ~100-char DRAFT_KO
+        fake = MagicMock()
+        fake.complete.side_effect = [
+            _completion(text="needs more detail."),
+            _completion(text=big),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            self.assertEqual(r.reflect("Q?", DRAFT_KO), DRAFT_KO)
+
+
+class HappyPathTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def test_critique_plus_revise_returns_revised(self):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        revised = (
+            "RAG 는 검색 증강 생성으로, 외부 지식을 결합합니다. "
+            "관련 출처를 인용해 환각 위험을 낮춥니다."
+        )
+        fake.complete.side_effect = [
+            _completion(text="2. 누락된 핵심: 출처 인용의 역할을 설명하지 않음."),
+            _completion(text=revised),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            out = r.reflect("RAG가 뭐야?", DRAFT_KO)
+        self.assertEqual(out, revised)
+        self.assertEqual(fake.complete.call_count, 2)
+
+
+class LanguageDetectionTests(unittest.TestCase):
+    """KO / EN prompt template selection. Check the prompt that reaches
+    the backend on the critique call (revise reuses the same heuristic).
+    """
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def _capture_first_prompt(self, query, draft):
+        from core.reasoning.reflect import ReflectionLoop
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="NO_ISSUES")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            r.reflect(query, draft)
+        return fake.complete.call_args.args[0]
+
+    def test_korean_query_uses_korean_prompt(self):
+        prompt = self._capture_first_prompt("RAG가 뭐야?", DRAFT_KO)
+        self.assertIn("비판적으로 검토하라", prompt)
+        self.assertNotIn("Critically review", prompt)
+
+    def test_english_query_uses_english_prompt(self):
+        prompt = self._capture_first_prompt(
+            "What is RAG?", DRAFT_EN,
+        )
+        self.assertIn("Critically review", prompt)
+        self.assertNotIn("비판적으로 검토하라", prompt)
+
+
+class TraceEmissionTests(unittest.TestCase):
+    """Each pass (critique / revise) emits one ``reason:reflect``
+    audit row. Verify by pointing audit_bridge at a fresh DB.
+    """
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_REFLECT", None)
+
+    def _rows(self, db_path):
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            return conn.execute(
+                "SELECT * FROM audit_log "
+                "WHERE endpoint LIKE 'reason:%' ORDER BY id ASC"
+            ).fetchall()
+        finally:
+            conn.close()
+
+    def test_two_rows_emitted_on_happy_path(self):
+        from core.reasoning.reflect import ReflectionLoop
+        db = _fresh_db()
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.side_effect = [
+            _completion(text="needs an example."),
+            _completion(text=DRAFT_EN + " For example, web search results can be retrieved."),
+        ]
+        with patch("core.reasoning.backends.get_backend", return_value=fake), \
+             patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            r.reflect("What is RAG?", DRAFT_EN)
+        rows = self._rows(db)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["endpoint"], "reason:reflect")
+        self.assertEqual(rows[1]["endpoint"], "reason:reflect")
+        self.assertEqual(rows[0]["security_event"], "reasoning.reflect.critique")
+        self.assertEqual(rows[1]["security_event"], "reasoning.reflect.revised")
+
+    def test_critique_failure_still_emits_row(self):
+        from core.reasoning.reflect import ReflectionLoop
+        db = _fresh_db()
+        r = ReflectionLoop()
+        fake = MagicMock()
+        fake.complete.side_effect = RuntimeError("ollama down")
+        with patch("core.reasoning.backends.get_backend", return_value=fake), \
+             patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            r.reflect("Q?", DRAFT_EN)
+        rows = self._rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+        self.assertEqual(rows[0]["security_event"], "reasoning.reflect.critique")
+
+
+class SingletonTests(unittest.TestCase):
+
+    def test_get_reflection_loop_returns_same_instance(self):
+        from core.reasoning.reflect import (
+            get_reflection_loop, _clear_singleton_for_tests,
+        )
+        _clear_singleton_for_tests()
+        a = get_reflection_loop()
+        b = get_reflection_loop()
+        self.assertIs(a, b)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Cognitive Layer Phase 2 PR-5** — the first reasoning-depth addition (vs Phase 1 which improved retrieval). Wraps the final generated answer with a **critique → revise** pass before the output filter.

```
generate_answer()  →  answer (draft)
                       ↓  [if JAMES_ENABLE_REFLECT=1]
                      critique  (LLM #1)
                       ↓  [unless "NO_ISSUES"]
                      revise    (LLM #2)
                       ↓
                      revised answer
```

**Opt-in by default**: `JAMES_ENABLE_REFLECT=1` enables. Without the flag, byte-identical to v0.3.0+PR1+PR2. Operators choose when the 2× LLM round-trip cost is worth it.

## Routes through the Backend registry

Like Phase 1 PR-2, this uses `core.reasoning.backends.get_backend("ollama_local")` — the L0 abstraction. Future Claude CLI swap:

```python
ReflectionLoop(backend_id="claude_code_cli").reflect(...)
```

## New files

| File | Size | Role |
|---|---|---|
| `core/reasoning/reflect.py` | 11.8 KB | `ReflectionLoop` + `get_reflection_loop()` singleton |
| `tests/test_reflection_loop.py` | ~12 KB | 18 tests (mocked backend, no LLM in CI) |

## Failure posture

Every failure path returns the original draft — synth never receives None or raises:

| Failure | Behavior |
|---|---|
| Env opt-in unset | draft, no backend call |
| Empty / short draft (< 30 chars) | draft, no backend call |
| Backend lookup miss | draft |
| `backend.complete()` raises (critique) | draft + audit row with `error` |
| Critique returns error string / empty | draft |
| Critique says `NO_ISSUES` | draft (skip revise — efficiency) |
| Revise raises / empty / error string | draft |
| Revised text > 2.5× draft length | draft (runaway guard) |

## Trace contract (Phase 0 L0/L1 invariant preserved)

Per `replay_trace.py` (L2), one `trace_id` worth of reflection now shows:

```
[N]   reasoning.reflect.critique           ollama_local   2.10s
        output: 2. 누락된 핵심: 출처 인용의 역할을 설명하지 않음.
[N+1] reasoning.reflect.revised            ollama_local   4.30s
        output: RAG는 검색 증강 생성으로... (보강된 답변)
```

Both rows tagged `endpoint=reason:reflect`, `security_event=reasoning.reflect.{critique,revised}`, latency_ms recorded separately, error+blocked=1 when applicable.

## Pipeline wiring

`core/reasoning/pipeline_synth.py` — at the very end of `generate_answer`, after the answer log_stage row:

```python
try:
    from core.reasoning.reflect import get_reflection_loop
    reflected = get_reflection_loop().reflect(
        safe_query, answer, user_role=user_role
    )
    if reflected and reflected != answer and not any(
        reflected.startswith(p) for p in engine._LLM_ERROR_PREFIXES
    ):
        answer = reflected
except Exception as e:
    engine._log("reflect_loop", e, user_role)
```

The env gate lives **inside** `reflect.py` — the call site is unconditional. This keeps `pipeline_synth.py` from growing an env check per future cognitive primitive.

## Verification

- **Unit tests**: 18 new (`tests/test_reflection_loop.py`) green
- **Regression**: 303/303 reasoning-touching slice green (covers reflection + Phase 1 PR-1/PR-2 + L0/L1/L2 + all integration tests)
- **Lint**: `ruff check core/reasoning/reflect.py core/reasoning/pipeline_synth.py tests/test_reflection_loop.py` → All checks passed
- **Module sizes** (rule #5): reflect.py 11.8 KB ✓ · pipeline_synth.py 14.3 KB ✓

## Bench (CLAUDE.md rule #2)

- **Default OFF** → STEP 7 unchanged
- **With opt-in**:
  ```powershell
  $env:JAMES_ENABLE_REFLECT = "1"
  python scripts/bench.py --suite=step7 --check
  ```
  Expected: quality improvement on partially-grounded or ambiguous answers (q4 BlackRock-ETF, q5 multi-hop, q7 compare). Latency rises by ~5-15s per query (critique ~30s timeout, revise ~45s timeout, but typical Korean responses on local ollama land at ~3-8s each).

## Cumulative cognitive layer status

```
Phase 0 — Infrastructure
  Pre-L0 #282  §5.7.2 arch                 ✓ merged
  L0     #283  backends + trace_schema     ✓ merged
  L1     #284  12 call_gemma wiring        ✓ merged
  L2     #285  replay_trace tool           ✓ merged

Phase 1 — Retrieval
  PR-1   #286  Reranker (cross-encoder)    ✓ merged
  PR-2   #287  Query rewriter (opt-in)     ✓ merged
  split  #288  pipeline.py 분할 cleanup    ✓ merged

Phase 2 — Reasoning depth (this PR begins)
  PR-5   THIS  Reflection (opt-in)         ← this PR
  PR-6         Verification + CR-E         pending
  PR-7         Planner (optional)          pending
  PR-8         Tool router (optional)      pending
```

## Out of scope

- **Phase 2 PR-6 Verification engine** (`core/reasoning/verify.py`) — chain of generator → critic → fact_checker → security_validator, with the verifier's output wrapped as a Change Request per CR-E
- **Default ON** — wait for STEP 7 spot-check data
- **Per-step parent_step_id correlation** — currently both critique + revise rows get `parent_step_id=""`. Phase 2 PR-6 introduces real lineage when the verification engine stacks steps.

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Reflection primitive is domain-neutral |
| #2 bench numbers | Default OFF → no impact; opt-in user-side STEP 7 |
| #3 self-evolution gate | Unrelated |
| #4 architecture | §5.7.1 Reflection Engine primitive lands; reuses "reflect" stage already in §5.7.2 ALLOWED_STAGES from L0 |
| #5 20 KB module size | reflect.py 11.8 KB ✓ · pipeline_synth.py 14.3 KB ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
