### PR TITLE
feat(policy): external isolation via query.internal_rag (PR-O5)

### DIFF
--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -95,6 +95,16 @@ FEATURES: Dict[str, Feature] = {
         "웹 검색 fallback",
         "admin,manager",
     ),
+    # ── PR-O5 (cycle 12) — internal RAG gate ───────────────────
+    # external (= guest / 비로그인) 는 일상 챗만 허용하고 내부 자료
+    # (vector + graph) 는 차단. 차단 시 engine 이 retrieval pipeline
+    # 대신 handle_chat 으로 우회한다. admin 이 매트릭스 UI에서
+    # override 하면 external 도 internal RAG 통과 가능.
+    "query.internal_rag": _f(
+        "query.internal_rag",
+        "내부 자료(vector+graph) 기반 답변",
+        "admin,manager,employee",
+    ),
     # ── upload / ingestion ──────────────────────────────────────
     "upload.file": _f(
         "upload.file",

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -316,6 +316,26 @@ class ReasoningEngine:
         if mode == "coding":
             return handle_coding(self, safe_query, system_prompt, user_role, t_start, selected_model=picked_model)
 
+        # ── PR-O5 (cycle 12) — internal RAG feature gate ──────────
+        # external (= guest / 비로그인) 는 일상 챗만 허용. internal
+        # RAG (vector + graph) 차단 시 handle_chat 으로 우회 →
+        # LLM 의 일반 지식 + system_prompt + memory_context 만으로
+        # 답변. admin 이 권한 매트릭스에서 query.internal_rag 를
+        # external 에 override 하면 정상적인 retrieval 경로 통과.
+        try:
+            from core.policy_engine import default_engine as _policy_engine
+            _rag_dec = _policy_engine.can_use_feature(user_role, "query.internal_rag")
+            if not _rag_dec.allowed:
+                print(f"[POLICY] {user_role} blocked from internal_rag "
+                      f"({_rag_dec.reason}) → chat-only fallback")
+                return handle_chat(
+                    self, safe_query, system_prompt, memory_context, user_role, t_start,
+                    response_style=response_style, selected_model=picked_model,
+                    hist_ctx=hist_ctx,
+                )
+        except Exception as e:
+            self._log("internal_rag_gate", e, user_role)
+
         # ── Retrieval → core/reasoning/pipeline.py (#29 phase 3) ──
         # Lazy import to avoid circular dependency (pipeline imports
         # MAX_LOOP / LOOP_TIMEOUT / TIMING_TARGET_SEC from this module).

--- a/tests/test_external_role_isolation.py
+++ b/tests/test_external_role_isolation.py
@@ -1,0 +1,217 @@
+"""PR-O5 (cycle 12) — external role isolation via query.internal_rag.
+
+Handover §3 item ④: 비로그인/external 사용자는 일상 챗만 허용하고 내부
+자료 (vector + graph) 는 차단한다. PR-O5 ships this via a new
+``query.internal_rag`` feature in the catalog plus an engine-level
+gate that re-routes denied requests to ``handle_chat`` instead of the
+full retrieval pipeline.
+
+Tests:
+  * Feature catalog entry exists with the correct default_allowed
+  * Default decision: admin/manager/employee allowed, external denied
+  * Admin override (set_override → external True) makes the engine
+    path through retrieval again
+  * Engine source contains the gate
+  * Engine source routes denied requests to handle_chat (not the
+    retrieval pipeline)
+  * Runtime: with default state, ReasoningEngine.query(user_role=
+    "external", mode_override="retrieval") never reaches
+    run_retrieval_pipeline; instead handle_chat fires
+  * Runtime: with default state + user_role="employee", the engine
+    DOES enter run_retrieval_pipeline (no regression for internal staff)
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+class FeatureCatalogTests(unittest.TestCase):
+
+    def test_query_internal_rag_exists_in_catalog(self):
+        from core.feature_registry import FEATURES
+        self.assertIn("query.internal_rag", FEATURES,
+            "PR-O5 must add query.internal_rag to the feature catalog")
+
+    def test_query_internal_rag_default_excludes_external(self):
+        from core.feature_registry import FEATURES
+        feat = FEATURES["query.internal_rag"]
+        self.assertIn("admin",    feat.default_allowed)
+        self.assertIn("manager",  feat.default_allowed)
+        self.assertIn("employee", feat.default_allowed)
+        self.assertNotIn("external", feat.default_allowed,
+            "external must be DENIED internal_rag by default — admin "
+            "matrix override is the only way to grant it")
+
+
+class PolicyEngineDecisionTests(unittest.TestCase):
+
+    def test_default_allows_employee(self):
+        from core.policy_engine import default_engine
+        dec = default_engine.can_use_feature("employee", "query.internal_rag")
+        self.assertTrue(dec.allowed)
+
+    def test_default_denies_external(self):
+        from core.policy_engine import default_engine
+        dec = default_engine.can_use_feature("external", "query.internal_rag")
+        self.assertFalse(dec.allowed)
+
+
+class EngineGateSourceTests(unittest.TestCase):
+    """Structural shape — the engine source contains the gate and
+    re-routes to handle_chat. Catches a future refactor that drops
+    the check.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from core.reasoning import engine as _engine
+        cls.src = inspect.getsource(_engine)
+
+    def test_gate_calls_can_use_feature_with_internal_rag(self):
+        # The gate must consult the catalog by id, not duplicate the
+        # role check inline.
+        self.assertIn(
+            'can_use_feature(user_role, "query.internal_rag")',
+            self.src,
+            "engine must consult the policy engine for query.internal_rag "
+            "rather than hard-coding role==external",
+        )
+
+    def test_gate_routes_denied_to_handle_chat(self):
+        # The denied path must invoke handle_chat (NOT
+        # run_retrieval_pipeline). Look at the block following the
+        # can_use_feature call.
+        gate_idx = self.src.index('can_use_feature(user_role, "query.internal_rag")')
+        block = self.src[gate_idx:gate_idx + 800]
+        self.assertIn("handle_chat(", block,
+            "denied path must re-route to handle_chat instead of "
+            "run_retrieval_pipeline so the answer is generated without "
+            "internal RAG context")
+
+    def test_gate_precedes_retrieval_dispatch(self):
+        gate_idx = self.src.index('can_use_feature(user_role, "query.internal_rag")')
+        retrieval_idx = self.src.index("from core.reasoning.pipeline import run_retrieval_pipeline")
+        self.assertLess(gate_idx, retrieval_idx,
+            "PR-O5 gate must run BEFORE the retrieval dispatch")
+
+
+class RuntimeRoutingTests(unittest.TestCase):
+    """Mock the heavy collaborators and verify that on default-state
+    external requests, run_retrieval_pipeline is not called; handle_chat
+    IS called instead. Employee requests still flow through the
+    pipeline (no regression).
+    """
+
+    def _make_engine(self):
+        """Build a ReasoningEngine with all heavyweight collaborators
+        stubbed out. Only the dispatch logic exercises real code.
+
+        Patches target the symbols inside the ``core.reasoning.engine``
+        namespace (where ``from X import Y`` resolved them) — patching
+        the original modules' attributes after engine.py imported them
+        would not change the bound names.
+        """
+        from core.reasoning.engine import ReasoningEngine
+
+        with patch("core.reasoning.engine.GraphEngine", return_value=MagicMock()), \
+             patch("core.reasoning.engine.RetrievalEngine", return_value=MagicMock()), \
+             patch("llm.router.RouterWrapper", return_value=MagicMock()), \
+             patch("core.reasoning.engine.SecurityLayer", return_value=MagicMock()):
+            eng = ReasoningEngine()
+        # The security pre/post check must let everything through so
+        # the dispatch path runs.
+        eng.security.pre_check.return_value = {"allowed": True, "query": "test query"}
+        eng.security.post_check.return_value = {"allowed": True, "context": ""}
+        eng.security.abac_consistency_check.return_value = {
+            "consistent": True, "violations": [],
+        }
+        return eng
+
+    def _run_query_capturing_handle_chat(self, user_role):
+        from core.reasoning import pipeline as _pipeline
+
+        # Stub both handle_chat (from inside engine.modes import) and
+        # run_retrieval_pipeline so we can see which one fired.
+        # The engine.py imports `from core.reasoning.modes import handle_chat`
+        # at module load, so patch on the engine module namespace.
+        from core.reasoning import engine as _engine
+
+        called = {"handle_chat": False, "run_retrieval_pipeline": False}
+
+        def _fake_chat(*a, **kw):
+            called["handle_chat"] = True
+            return {"answer": "chat-stub", "mode": "chat"}
+
+        def _fake_pipeline(*a, **kw):
+            called["run_retrieval_pipeline"] = True
+            return {"answer": "rag-stub", "mode": "retrieval"}
+
+        eng = self._make_engine()
+        with patch.object(_engine, "handle_chat", _fake_chat), \
+             patch.object(_pipeline, "run_retrieval_pipeline", _fake_pipeline), \
+             patch("core.memory.MemoryStore") as _store_cls, \
+             patch("core.query_router.QueryRouter") as _qr_cls, \
+             patch("core.character_profile.CharacterProfile") as _cp_cls:
+            # MemoryStore stub — return strings the engine expects
+            store = MagicMock()
+            store.get_system_prompt.return_value = ""
+            store.get_context.return_value = ""
+            store.get_history_context.return_value = ""
+            store.get_long_term_context.return_value = ""
+            _store_cls.return_value = store
+            # Force the router to pick "retrieval" so the gate is what
+            # matters (not the mode dispatch).
+            _qr_cls.return_value.route.return_value = "retrieval"
+            _cp_cls.return_value.get_prompt_modifiers.return_value = ""
+
+            eng.query("어떤 자료 있어?", user_role=user_role,
+                      source_type="prod", session_id="t1")
+
+        return called
+
+    def test_external_routes_to_handle_chat_not_pipeline(self):
+        called = self._run_query_capturing_handle_chat("external")
+        self.assertTrue(called["handle_chat"],
+            "external must fall back to handle_chat when "
+            "query.internal_rag is denied")
+        self.assertFalse(called["run_retrieval_pipeline"],
+            "external must NOT reach run_retrieval_pipeline by default")
+
+    def test_employee_still_uses_pipeline(self):
+        called = self._run_query_capturing_handle_chat("employee")
+        self.assertFalse(called["handle_chat"],
+            "employee retrieval queries must reach the pipeline "
+            "(no regression from PR-O5)")
+        self.assertTrue(called["run_retrieval_pipeline"],
+            "employee retrieval queries must reach run_retrieval_pipeline")
+
+    def test_admin_override_lets_external_through(self):
+        """When an admin grants external the query.internal_rag override,
+        the engine path through retrieval restores.
+        """
+        from core.feature_registry import set_override, clear_override
+        try:
+            self.assertTrue(
+                set_override("query.internal_rag", "external", True,
+                             updated_by="test")
+            )
+            called = self._run_query_capturing_handle_chat("external")
+            self.assertTrue(called["run_retrieval_pipeline"],
+                "admin override must let external through to the "
+                "retrieval pipeline")
+            self.assertFalse(called["handle_chat"])
+        finally:
+            clear_override("query.internal_rag", "external")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Cycle 12 PR-O5** — external (= 비로그인 / guest) users get chat-only behaviour. Internal vector + graph retrieval is denied so a guest cannot exfiltrate corpus content through cleverly framed queries.

3-line gate at the engine dispatch + one new feature in the catalog. Admin matrix UI can override.

```python
# core/reasoning/engine.py — right before retrieval dispatch
try:
    from core.policy_engine import default_engine as _policy_engine
    _rag_dec = _policy_engine.can_use_feature(user_role, "query.internal_rag")
    if not _rag_dec.allowed:
        return handle_chat(self, safe_query, system_prompt, memory_context,
                           user_role, t_start, ..., hist_ctx=hist_ctx)
except Exception as e:
    self._log("internal_rag_gate", e, user_role)

# Retrieval pipeline path (unchanged) follows
```

## New feature

| id | description | default_allowed |
|---|---|---|
| `query.internal_rag` | 내부 자료(vector+graph) 기반 답변 | `admin`, `manager`, `employee` |

`external` is **blocked by default**. Admin override via the W4-Q3 matrix UI grants it.

## Effect

| Role | v0.3.0+PR-O4 | After PR-O5 |
|---|---|---|
| admin / manager / employee | retrieval pipeline | unchanged |
| **external** | retrieval pipeline (could read internal docs) | **handle_chat fallback** (LLM general knowledge only) |
| external + admin override | (n/a) | retrieval pipeline restored |

## New tests

`tests/test_external_role_isolation.py` (10 tests):

| Test class | What it pins |
|---|---|
| `FeatureCatalogTests` | `query.internal_rag` exists with the right default_allowed |
| `PolicyEngineDecisionTests` | employee allowed / external denied per the default |
| `EngineGateSourceTests` | gate calls `can_use_feature`, routes to `handle_chat`, runs before retrieval import |
| `RuntimeRoutingTests` | mocked end-to-end: external → handle_chat fires; employee → run_retrieval_pipeline fires; admin override → external regains pipeline |

## Verification

- **Unit tests**: 10 new green
- **Regression**: 372/372 reasoning + policy slice green (feature_registry, q2a_feature_wiring, conversation_continuity, verifier, reflection, query_rewriter, reranker, reasoning_*, replay_trace, force_web_chip, chat_wiki_save, web_search_admin_panel, source_files_first, query_include_contexts, policy_quarantine, meta_mode, coding_mode, force_web_overrides_mode, web_used_badge, longterm_save_admin_confirm, max_tokens_relax, response_style, observability, a2_phase2_selected_model)
- **Lint**: `ruff check core/feature_registry.py core/reasoning/engine.py tests/test_external_role_isolation.py` → All checks passed

## Bench (CLAUDE.md rule #2)

STEP 7 runs with default role context (employee) — gate evaluates to allowed, retrieval path **byte-identical**. User spot-check for the external path:

1. `/query/` with `user_role=external` + a query that would normally trigger retrieval (e.g., "BlackRock ETF 관계")
2. Confirm answer comes from LLM general knowledge — no "[관련 자료 목록]" header, no graph_paths citations
3. Optional: admin overrides `query.internal_rag` for external in the W4-Q3 matrix UI; same query now flows through retrieval

## Out of scope (deferred)

- **Guest auth downgrade** ("system_api_key alone → external role") — requires changes in `core/api_key_middleware` with broader blast radius. Separate PR.
- **Friendly login suffix** — i18n key `chat.login_prompt_guest`. Separate frontend PR.
- **HTML page gates** — `/workspace`, `/admin/*` already block external via `workspace.view` / `admin.*` features.

## Module size (rule #5)

| File | Before | After |
|---|---|---|
| `core/feature_registry.py` | 13.5 KB | **14.7 KB** ✓ |
| `core/reasoning/engine.py` | 22.5 KB | **23.7 KB** (pre-existing >20 KB debt, documented in L1 #284 / PR-1 #286 / PR-O4 #291) |

## Cycle 12 progress

```
PR-O1 #277  Node-click 403 fix              ✓ merged
PR-O2 #279  Suggestion chip NL patterns     ✓ merged
PR-O3 #280  Save-chip spinner               ✓ merged
PR-O4 #291  N-3 long_ctx isolation          ✓ merged
PR-O5 THIS  External isolation              ← this PR
PR-O6       Node editing + Korean labels    pending
PR-O7       Drag + click-to-connect         deferred
```

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Security gate, no domain logic |
| #2 bench numbers | Employee path byte-identical; external path covered by runtime mock test + user spot-check |
| #3 self-evolution gate | Unrelated |
| #4 architecture | §5.7.6 memory scope spirit — guests get system/workspace scope only via persona; session-scoped retrieval blocked |
| #5 module size | engine.py 23.7 KB pre-existing >20 KB debt; separate cleanup PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
