### PR TITLE
feat(graph): node attribute editor — PUT /admin/graph/node (PR-O6)

### DIFF
--- a/core/graph_editor.py
+++ b/core/graph_editor.py
@@ -476,6 +476,12 @@ def delete_relation(
     }
 
 
+# Node-level attribute editor (PR-O6) lives in ``core/graph_node_editor.py``
+# so this module stays focused on edge-level mutations under the 20 KB
+# rule #5 gate. The two modules share the file I/O helpers above via
+# direct import.
+
+
 # ─────────────────────────────────────────────────────────────────
 # Env flag helper (디자인 §7 — JAMES_GRAPH_EDIT=1 opt-in)
 # ─────────────────────────────────────────────────────────────────

--- a/core/graph_node_editor.py
+++ b/core/graph_node_editor.py
@@ -1,0 +1,211 @@
+"""PROJECT JAMES — Node attribute editor (cycle 12 PR-O6).
+
+Companion to ``core/graph_editor.py``. Edge-level mutations
+(PUT/POST/DELETE relation) shipped in Knowledge Cascade Phase E
+(PR #271 / #273). PR-O6 adds the node-level path so admin can rename
+an entity, refine its summary, add aliases (matching surface), correct
+entity_type, or toggle sensitivity — all from the graph editor UI
+without dropping to chat-based wiki editing.
+
+The two modules live separately so each stays under the CLAUDE.md
+rule #5 20 KB gate; they share file-I/O helpers via direct import.
+
+Immutability rules (handover §3 항목 ⑥-b):
+  - ``entity_id`` NEVER changes. It's the wiki's stable key; relations
+    on other entities point at it. Admin who wants a "new entity"
+    creates a fresh file via the existing wiki-create surface, not by
+    repurposing an existing entity_id.
+  - relations / sources are edge-level; the relation API in
+    ``graph_editor.py`` mutates them. ``update_node_attributes``
+    silently ignores those keys to keep the blast radius bounded.
+
+Trust model:
+  - admin only (server endpoint applies ``admin.data`` feature gate
+    + ``JAMES_GRAPH_EDIT=1`` env flag opt-in).
+  - audit log captures before+after dicts for the changed_fields only.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+# Share the file-I/O helpers with the relation editor — both modules
+# read/write the same entity .md files via the same yaml frontmatter
+# convention. A second copy of these helpers would invite drift.
+from core.graph_editor import _load_entity_by_id, _write_entity
+
+
+# Allowlist of frontmatter fields ``update_node_attributes`` may touch.
+# Anything else in the patch payload is silently dropped — a typo at
+# the call site cannot accidentally write a new top-level field that
+# downstream code doesn't know about.
+NODE_EDITABLE_FIELDS = frozenset({
+    "name",          # human-facing label
+    "entity_type",   # one of NODE_ALLOWED_ENTITY_TYPES
+    "aliases",       # list[str] — alternative names for matching
+    "summary",       # description text shown in node-detail panel
+    "sensitivity",   # "normal" | "sensitive" (mask_sensitive gate)
+})
+
+NODE_ALLOWED_ENTITY_TYPES = frozenset({
+    "person", "org", "concept", "document",
+})
+
+NODE_ALLOWED_SENSITIVITY = frozenset({"normal", "sensitive"})
+
+# Per-field caps. Wide enough for realistic wiki use; tight enough that
+# a runaway client payload can't blow the frontmatter.
+_NAME_CAP    = 200
+_ALIAS_CAP   = 80     # per alias
+_ALIAS_LIMIT = 20     # max aliases per entity
+_SUMMARY_CAP = 4000
+
+
+def _normalize_aliases(raw) -> List[str]:
+    """Unique non-empty alias strings, each ≤ _ALIAS_CAP chars, bounded
+    to _ALIAS_LIMIT total. Preserves insertion order so admin controls
+    the UI display sequence.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: List[str] = []
+    seen: set = set()
+    for a in raw:
+        if not isinstance(a, str):
+            continue
+        s = a.strip()[:_ALIAS_CAP]
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+        if len(out) >= _ALIAS_LIMIT:
+            break
+    return out
+
+
+def update_node_attributes(
+    entity_id: str,
+    patch: Dict[str, Any],
+    *,
+    wiki_generator,
+) -> Dict[str, Any]:
+    """PUT-style node attribute update. Allowlisted fields only.
+
+    Returns audit-friendly diff::
+
+        {
+          "entity_id":      "...",
+          "path":           "wiki/.../foo.md",
+          "before":         {"name": "...", ...},   # only changed fields
+          "after":          {"name": "...", ...},
+          "changed_fields": ["name", "summary"],
+        }
+
+    Raises:
+      ValueError — entity_id unknown, patch contains an invalid
+                   entity_type / sensitivity value, or patch is empty
+                   after filtering.
+    """
+    if not isinstance(patch, dict) or not patch:
+        raise ValueError("patch must be a non-empty dict")
+
+    # Filter to allowlisted fields first so a malformed payload's other
+    # keys can't reach the validation layer.
+    filtered: Dict[str, Any] = {}
+    for k in NODE_EDITABLE_FIELDS:
+        if k in patch:
+            filtered[k] = patch[k]
+    if not filtered:
+        raise ValueError(
+            f"patch contains no editable fields; "
+            f"allowed: {sorted(NODE_EDITABLE_FIELDS)}"
+        )
+
+    # Per-field validation + normalisation. Validation errors raise
+    # ValueError so the endpoint can turn them into 400.
+    cleaned: Dict[str, Any] = {}
+    if "name" in filtered:
+        name = filtered["name"]
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("name must be a non-empty string")
+        cleaned["name"] = name.strip()[:_NAME_CAP]
+    if "entity_type" in filtered:
+        et = filtered["entity_type"]
+        if et not in NODE_ALLOWED_ENTITY_TYPES:
+            raise ValueError(
+                f"entity_type must be one of "
+                f"{sorted(NODE_ALLOWED_ENTITY_TYPES)}; got {et!r}"
+            )
+        cleaned["entity_type"] = et
+    if "aliases" in filtered:
+        cleaned["aliases"] = _normalize_aliases(filtered["aliases"])
+    if "summary" in filtered:
+        summary = filtered["summary"]
+        if summary is None:
+            cleaned["summary"] = ""
+        elif not isinstance(summary, str):
+            raise ValueError("summary must be a string (or null to clear)")
+        else:
+            cleaned["summary"] = summary[:_SUMMARY_CAP]
+    if "sensitivity" in filtered:
+        sv = filtered["sensitivity"]
+        if sv not in NODE_ALLOWED_SENSITIVITY:
+            raise ValueError(
+                f"sensitivity must be one of "
+                f"{sorted(NODE_ALLOWED_SENSITIVITY)}; got {sv!r}"
+            )
+        cleaned["sensitivity"] = sv
+
+    # Load + diff + write.
+    path, fm, body = _load_entity_by_id(entity_id, wiki_generator)
+
+    before: Dict[str, Any] = {}
+    after:  Dict[str, Any] = {}
+    changed: List[str] = []
+    for k, new_val in cleaned.items():
+        old_val = fm.get(k)
+        if old_val == new_val:
+            continue
+        before[k] = old_val
+        after[k] = new_val
+        fm[k] = new_val
+        changed.append(k)
+
+    if not changed:
+        # No-op write — return the diff shape with empty changed_fields
+        # so the audit log can record "admin clicked save with no edits".
+        return {
+            "entity_id":      entity_id,
+            "path":           str(path),
+            "before":         {},
+            "after":          {},
+            "changed_fields": [],
+        }
+
+    # Touch updated_at so cascade / monitoring picks up the change.
+    fm["updated_at"] = datetime.now().isoformat()
+    _write_entity(path, fm, body)
+
+    # Refresh wiki_generator index so subsequent reads see the new name.
+    # Best-effort — a refresh failure must not invalidate the on-disk
+    # write that already succeeded.
+    try:
+        wiki_generator.refresh_entity_map()
+    except Exception:
+        pass
+
+    return {
+        "entity_id":      entity_id,
+        "path":           str(path),
+        "before":         before,
+        "after":          after,
+        "changed_fields": changed,
+    }
+
+
+__all__ = [
+    "NODE_EDITABLE_FIELDS",
+    "NODE_ALLOWED_ENTITY_TYPES",
+    "NODE_ALLOWED_SENSITIVITY",
+    "update_node_attributes",
+]

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3464,6 +3464,69 @@ async def admin_graph_relation_append(request: Request,
     return {"ok": True, "result": result}
 
 
+@app.put("/admin/graph/node",
+         summary="node attribute 편집 [cycle 12 PR-O6]")
+async def admin_graph_node_put(request: Request,
+                               role: str = Depends(get_role_from_request)):
+    """admin 만 호출 가능. ``JAMES_GRAPH_EDIT=1`` env opt-in.
+
+    Body JSON::
+
+        {
+          "api_key":   "...",
+          "entity_id": "e_org_anthropic",
+          "patch": {
+            "name":        "Anthropic, PBC",
+            "entity_type": "org",
+            "aliases":     ["앤스로픽", "Anthropic AI"],
+            "summary":     "AI safety company...",
+            "sensitivity": "normal"
+          }
+        }
+
+    Allowlisted fields only (NODE_EDITABLE_FIELDS in graph_editor.py).
+    ``entity_id`` is immutable and must match the existing row — admin
+    cannot repurpose an id by patching it.
+    """
+    _require_graph_edit_enabled()
+    body = await request.json()
+    _require_feature(body.get("api_key", ""), role, "admin.data")
+
+    entity_id = (body.get("entity_id") or "").strip()
+    patch     = body.get("patch") or {}
+    if not entity_id:
+        raise HTTPException(status_code=400, detail="entity_id required")
+    if not isinstance(patch, dict) or not patch:
+        raise HTTPException(status_code=400, detail="patch must be a non-empty dict")
+
+    from core.graph_node_editor import update_node_attributes
+    try:
+        result = update_node_attributes(
+            entity_id, patch,
+            wiki_generator=rag_engine.wiki_generator,
+        )
+    except ValueError as e:
+        msg = str(e)
+        # entity_id-not-found vs validation-error: both surface 400 but
+        # the not-found case is more naturally 404.
+        if msg.startswith("entity_id not found") or msg.startswith("entity file unreadable"):
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+
+    _write_audit(
+        role, "/admin/graph/node [PUT]",
+        query=_truncate_audit_blob({
+            "entity_id":      entity_id,
+            "changed_fields": result["changed_fields"],
+        }),
+        answer=_truncate_audit_blob({
+            "path":           result["path"],
+            "changed_n":      len(result["changed_fields"]),
+        }),
+    )
+    return {"ok": True, "result": result}
+
+
 @app.delete("/admin/graph/relation",
             summary="relation 자체 제거 [Knowledge Cascade Phase E]")
 async def admin_graph_relation_delete(request: Request,

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -50,6 +50,12 @@ from core.graph_editor import (
     read_relation,
     replace_relation_sources,
 )
+from core.graph_node_editor import (
+    NODE_ALLOWED_ENTITY_TYPES,
+    NODE_ALLOWED_SENSITIVITY,
+    NODE_EDITABLE_FIELDS,
+    update_node_attributes,
+)
 from core.relations_schema import (
     EXTRACT_SOURCE_ROLE,
     MANUAL_SOURCE_ROLE,
@@ -422,6 +428,200 @@ class PhaseC_CascadeIntegrationTests(unittest.TestCase):
             "old.pdf", "e_doc_old", joby_p.parent.parent,
         )
         self.assertEqual(orphans, [])
+
+
+# ── 6. update_node_attributes (PR-O6 cycle 12) ────────────────────
+
+
+def _single_entity(entity_type: str = "org"):
+    """Build a single-entity fixture for node-attribute tests.
+    Returns (root, wg_stub, entity_path, entity_id)."""
+    root = Path(tempfile.mkdtemp()) / "entity"
+    for t in NODE_ALLOWED_ENTITY_TYPES:
+        (root / t).mkdir(parents=True)
+    eid = f"e_{entity_type}_anthropic"
+    p = root / entity_type / "anthropic.md"
+    _write_entity(p, {
+        "entity_id":   eid,
+        "name":        "Anthropic",
+        "entity_type": entity_type,
+        "aliases":     ["Anthropic PBC"],
+        "summary":     "AI lab",
+        "sensitivity": "normal",
+    })
+    return root, _WgStub({eid: p}), p, eid
+
+
+class UpdateNodeAttributesTests(unittest.TestCase):
+    """PR-O6 — node attribute editor.
+
+    Pins immutability + allowlist + per-field validation + audit-diff
+    shape. UI wiring is a separate concern (PR-O6b frontend).
+    """
+
+    def test_happy_path_updates_name_and_summary(self):
+        _, wg, p, eid = _single_entity()
+        result = update_node_attributes(
+            eid,
+            {"name": "Anthropic, PBC", "summary": "AI safety company"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["entity_id"], eid)
+        self.assertEqual(sorted(result["changed_fields"]),
+                         ["name", "summary"])
+        self.assertEqual(result["before"]["name"], "Anthropic")
+        self.assertEqual(result["after"]["name"], "Anthropic, PBC")
+        fm = _read_fm(p)
+        self.assertEqual(fm["name"], "Anthropic, PBC")
+        self.assertEqual(fm["summary"], "AI safety company")
+        self.assertIn("updated_at", fm,
+            "successful write must stamp updated_at")
+
+    def test_empty_patch_raises(self):
+        _, wg, _, eid = _single_entity()
+        with self.assertRaises(ValueError):
+            update_node_attributes(eid, {}, wiki_generator=wg)
+
+    def test_patch_with_only_unknown_fields_raises(self):
+        _, wg, _, eid = _single_entity()
+        with self.assertRaises(ValueError) as ctx:
+            update_node_attributes(
+                eid,
+                {"entity_id": "hacked", "relations": [], "random": 1},
+                wiki_generator=wg,
+            )
+        self.assertIn("no editable fields", str(ctx.exception))
+
+    def test_unknown_fields_silently_dropped_when_one_known_field_present(self):
+        # Mixed payload: a typo / smuggled relations key must NOT
+        # reach the frontmatter; the known field still writes.
+        _, wg, p, eid = _single_entity()
+        result = update_node_attributes(
+            eid,
+            {
+                "name":      "New Name",
+                "entity_id": "hacked-id",   # immutability invariant
+                "relations": [{"forged": True}],  # use relation API
+                "random":    "ignored",
+            },
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], ["name"])
+        fm = _read_fm(p)
+        self.assertEqual(fm["entity_id"], eid,
+            "entity_id must remain unchanged across patches")
+        # _single_entity fixture has no relations field; the forged
+        # payload must NOT cause one to appear.
+        self.assertNotIn("relations", fm,
+            "relations must not be added by node-attribute writes")
+
+    def test_invalid_entity_type_raises(self):
+        _, wg, _, eid = _single_entity()
+        with self.assertRaises(ValueError) as ctx:
+            update_node_attributes(
+                eid, {"entity_type": "alien"}, wiki_generator=wg,
+            )
+        self.assertIn("entity_type", str(ctx.exception))
+
+    def test_invalid_sensitivity_raises(self):
+        _, wg, _, eid = _single_entity()
+        with self.assertRaises(ValueError):
+            update_node_attributes(
+                eid, {"sensitivity": "ultra"}, wiki_generator=wg,
+            )
+        self.assertEqual(sorted(NODE_ALLOWED_SENSITIVITY),
+                         ["normal", "sensitive"])
+
+    def test_empty_name_raises(self):
+        _, wg, _, eid = _single_entity()
+        with self.assertRaises(ValueError):
+            update_node_attributes(
+                eid, {"name": "   "}, wiki_generator=wg,
+            )
+
+    def test_aliases_normalized(self):
+        """Whitespace, dedup, per-alias cap, total cap."""
+        _, wg, p, eid = _single_entity()
+        many = [f"alias-{i}" for i in range(30)]  # > limit 20
+        many.append("alias-0")                     # dup
+        many.append("  alias-extra  ")             # whitespace
+        many.append("")                             # empty
+        many.append(123)                            # type
+        update_node_attributes(
+            eid, {"aliases": many}, wiki_generator=wg,
+        )
+        fm = _read_fm(p)
+        aliases = fm["aliases"]
+        self.assertEqual(len(aliases), 20,
+            "alias list must be capped at 20 entries")
+        self.assertEqual(aliases[0], "alias-0")
+        self.assertNotIn("", aliases)
+        self.assertNotIn(123, aliases)
+        # alias-0 only once even though sent twice
+        self.assertEqual(aliases.count("alias-0"), 1)
+
+    def test_summary_truncated_at_4000(self):
+        _, wg, p, eid = _single_entity()
+        big = "x" * 5000
+        update_node_attributes(
+            eid, {"summary": big}, wiki_generator=wg,
+        )
+        fm = _read_fm(p)
+        self.assertEqual(len(fm["summary"]), 4000,
+            "summary must cap at 4000 chars")
+
+    def test_summary_null_clears(self):
+        _, wg, p, eid = _single_entity()
+        update_node_attributes(
+            eid, {"summary": None}, wiki_generator=wg,
+        )
+        fm = _read_fm(p)
+        self.assertEqual(fm["summary"], "")
+
+    def test_no_op_patch_returns_empty_changed_fields(self):
+        # Re-applying current values should yield no diff and no write
+        # — but the function still returns the expected shape for the
+        # audit log.
+        _, wg, _, eid = _single_entity()
+        result = update_node_attributes(
+            eid,
+            {"name": "Anthropic", "entity_type": "org"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], [])
+        self.assertEqual(result["before"], {})
+        self.assertEqual(result["after"], {})
+
+    def test_missing_entity_id_raises(self):
+        _, wg, _, _ = _single_entity()
+        with self.assertRaises(ValueError) as ctx:
+            update_node_attributes(
+                "e_org_nonexistent", {"name": "X"}, wiki_generator=wg,
+            )
+        self.assertIn("entity_id not found", str(ctx.exception))
+
+    def test_relations_array_preserved_across_patch(self):
+        # The handler must not nuke or rewrite the relations array even
+        # when the patch payload doesn't mention it.
+        _, wg, joby_p, _, (joby_id, _) = _two_entities_with_relation()
+        # Use the joby fixture for this — it has 1 relation.
+        update_node_attributes(
+            joby_id, {"summary": "Joby Aviation update"},
+            wiki_generator=wg,
+        )
+        fm = _read_fm(joby_p)
+        self.assertEqual(len(fm["relations"]), 1,
+            "node-attribute write must leave relations untouched")
+        self.assertEqual(fm["relations"][0]["target"], "NVIDIA")
+
+    def test_editable_field_allowlist_matches_doc(self):
+        # Pinned for future code reviewers: any change here must be
+        # paired with a doc/handover update because external callers
+        # (admin matrix UI) gate on this list.
+        self.assertEqual(
+            sorted(NODE_EDITABLE_FIELDS),
+            ["aliases", "entity_type", "name", "sensitivity", "summary"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Cycle 12 PR-O6 backend** — admin can now rename an entity, fix `entity_type`, add aliases (matching surface), edit summary, or toggle sensitivity from the graph editor without dropping to chat-based wiki editing. Edge-level mutations (PUT/POST/DELETE relation) shipped in Knowledge Cascade Phase E (#271 / #273); PR-O6 fills in the matching node-level path.

```
PUT /admin/graph/node
{
  "api_key": "...",
  "entity_id": "e_org_anthropic",
  "patch": {
    "name":        "Anthropic, PBC",
    "entity_type": "org",
    "aliases":     ["앤스로픽", "Anthropic AI"],
    "summary":     "AI safety company...",
    "sensitivity": "normal"
  }
}
```

## Two-file split (rule #5)

Initial implementation pushed `core/graph_editor.py` from 18.4 KB to 26.5 KB → over the 20 KB CLAUDE.md gate. Split into:

| File | Size | Role |
|---|---|---|
| `core/graph_editor.py` | 19.7 KB ✓ | Edge-level mutations (existing) |
| `core/graph_node_editor.py` | 7.2 KB ✓ | NEW — node-level attribute editor |

Both modules share the file-I/O helpers (`_load_entity_by_id`, `_write_entity`, `_read_entity`) via direct import — single source of truth, no helper drift between the two editors.

## Allowlist + caps

| Field | Validation |
|---|---|
| `name` | non-empty str, capped at 200 chars |
| `entity_type` | one of `person`/`org`/`concept`/`document` |
| `aliases` | list[str], stripped + deduped, ≤ 20 entries × 80 chars |
| `summary` | str (or null to clear), capped at 4000 chars |
| `sensitivity` | one of `normal`/`sensitive` |

Anything else in the patch payload (including `entity_id`, `relations`, `sources`) is **silently dropped** — a typo or smuggled key cannot reach the frontmatter.

## Immutability

- **`entity_id` NEVER changes**. It's the wiki's stable key; other entities' relations point at it. Admin who wants a "new entity" creates a fresh file via the existing wiki-create surface, not by repurposing an existing entity_id.
- **`relations` / `sources` are edge-level** — the relation API in `graph_editor.py` owns them. The node API leaves them untouched even when the payload tries to overwrite.

## Endpoint behaviour

```python
PUT /admin/graph/node
  _require_graph_edit_enabled()    # JAMES_GRAPH_EDIT=1 opt-in
  _require_feature(api_key, role, "admin.data")
  ValueError → 400 (validation) or 404 (entity not found)
  audit_log entry: action="/admin/graph/node [PUT]"
                   query={entity_id, changed_fields}
                   answer={path, changed_n}
```

On successful write:
- `updated_at` stamped (cascade / monitoring picks it up)
- `wiki_generator.refresh_entity_map()` called best-effort
- Audit-friendly diff returned (`before`/`after` populated only for changed fields)

## Tests (13 new)

`tests/test_phase_e_graph_editor.py` — `UpdateNodeAttributesTests`:

| Test | What it pins |
|---|---|
| `test_happy_path_updates_name_and_summary` | basic write + diff + `updated_at` stamp |
| `test_empty_patch_raises` | empty dict → ValueError |
| `test_patch_with_only_unknown_fields_raises` | typo-only payload → ValueError |
| `test_unknown_fields_silently_dropped_when_one_known_field_present` | mixed payload: known writes, entity_id stays, relations doesn't appear |
| `test_invalid_entity_type_raises` | scope check |
| `test_invalid_sensitivity_raises` | scope check |
| `test_empty_name_raises` | trim check |
| `test_aliases_normalized` | dedup + caps + type filter + total limit |
| `test_summary_truncated_at_4000` | char cap |
| `test_summary_null_clears` | null → empty string |
| `test_no_op_patch_returns_empty_changed_fields` | re-applying current values → no diff |
| `test_missing_entity_id_raises` | not-found path |
| `test_relations_array_preserved_across_patch` | edge data untouched by node-attr writes |
| `test_editable_field_allowlist_matches_doc` | catches future scope creep |

## Verification

- **Phase E**: 33/33 graph_editor tests green (20 existing + 13 new)
- **Regression**: 405/405 reasoning + policy + graph editor slice green
- **Lint**: `ruff check core/graph_editor.py core/graph_node_editor.py tests/test_phase_e_graph_editor.py` → All checks passed
- **Module sizes** (rule #5): both files < 20 KB ✓

## Bench (CLAUDE.md rule #2)

No retrieval / reasoning path touched. STEP 7 byte-identical.

## Out of scope (PR-O6b — frontend follow-up)

- **Graph editor UI** "Edit node" toggle on the existing edge modal (`frontend/static/graph_editor.js`) — same pattern as the relation edit modal
- **i18n strings** for KO entity-type labels (인물/조직/개념/문서) + modal vocabulary simplification ("관계 종류" / "출처 가중치" 등)
- **Hover tooltips** on the graph page

Separate PR-O6b keeps the UI changes reviewable and lets the user spot-check the backend independently first.

## Cycle 12 progress

```
PR-O1 #277  Node-click 403 fix              ✓ merged
PR-O2 #279  Suggestion chip NL patterns     ✓ merged
PR-O3 #280  Save-chip spinner               ✓ merged
PR-O4 #291  N-3 long_ctx isolation          ✓ merged
PR-O5 #292  External isolation              ✓ merged
PR-O6 THIS  Node editor (backend)           ← this PR
PR-O6b      Node editor (frontend + i18n)   pending
PR-O7       Drag + click-to-connect         deferred
```

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Generic admin surface |
| #2 bench numbers | No reasoning touch → STEP 7 byte-identical |
| #3 self-evolution gate | Unrelated — admin-direct write, not patch pipeline |
| #4 architecture | §7 Phase E scope; no §5.7.* change |
| #5 module size | **Split happened**; both files < 20 KB ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
