### PR TITLE
feat(reasoning): tool router — Phase 2 PR-8

### DIFF
--- a/core/reasoning/tool_router.py
+++ b/core/reasoning/tool_router.py
@@ -1,0 +1,398 @@
+"""Tool Router — Cognitive Layer Phase 2 PR-8.
+
+ARCHITECTURE.md §5.7.1: "Tool Router — select between chat / web
+search / wiki edit / graph editor / memory write". The MVP is
+infrastructure-only (wiring 0) — the registry + dispatch primitive
+exists for Phase 2 PR-7 Planner / future reflection-driven tool calls
+to consume.
+
+Two trust classes:
+
+  - **Read tools** (`is_write=False`) — web_search, wiki_read, etc.
+    dispatch_tool() executes the handler directly. Result lands in
+    the trace but does NOT touch the wiki.
+  - **Write tools** (`is_write=True`) — wiki_edit, graph_node_edit,
+    save_to_wiki, etc. dispatch_tool() **wraps the call as a Change
+    Request** via core.change_request.create_cr per CLAUDE.md rule #3
+    (self-modifying outcomes need human approval). The handler is
+    NOT executed at dispatch time; the CR sits in 'open' status
+    waiting for admin approval.
+
+Trace contract:
+
+  Every dispatch emits one TraceStep with stage="tool":
+    applied_rule = "reasoning.tool.<tool_name>"
+    backend_id   = "tool_router"
+    output_summary brief — full output lives in the tool's own audit
+    row (web_searcher's mirror_to_audit_db, wiki_editor's CR row, etc.)
+
+This is the L0 contract — every cognitive-layer step writes one row
+to ``audit_log``. replay_trace.py picks them up alongside synth /
+reflect / verify rows.
+
+Built-in tools registered at module import:
+
+  - ``web_search``  — read-only; wraps tools/web/web_searcher.search_web
+                      (admin role required per existing query.web_search
+                      gate; this dispatcher does not duplicate the gate
+                      because the underlying tool already enforces it
+                      at the role level).
+
+L0 backends were "wiring 0" infrastructure that L1 wired into 12
+call sites. PR-8's Tool Router is the analogous primitive for tool
+calls — the wiring step is **Phase 2 PR-7 (Planner)** or a future
+reflection-driven tool-call PR.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+from core.reasoning.trace_schema import (
+    TraceStep,
+    compute_inputs_hash,
+    emit_trace_step,
+    truncate_summary,
+)
+
+
+# ─── data shapes ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One named callable the cognitive layer may dispatch.
+
+    Fields:
+      name:        canonical id, e.g. "web_search", "wiki_edit".
+      description: short human-facing label (Korean OK).
+      is_write:    True ⇒ dispatch routes through Change Request
+                   (handler NOT executed; admin must approve first).
+                   False ⇒ handler runs immediately, output returned.
+      cr_target_type: when is_write=True, this is passed to
+                      change_request.create_cr as ``target_type``.
+                      Must be one of VALID_TARGET_TYPES.
+      handler:     callable(args: dict, *, user_role: str) -> Any.
+                   Free function; must NOT raise on user input —
+                   convert errors into a string-y return value.
+    """
+    name:           str
+    description:    str
+    is_write:       bool
+    handler:        Callable[..., Any]
+    cr_target_type: str = ""
+
+
+@dataclass
+class ToolResult:
+    """Returned to the dispatch caller. ``ok`` distinguishes
+    successful execution / successful CR creation from the various
+    failure modes (unknown tool, handler raise, CR create raise).
+    """
+    ok:        bool
+    tool_name: str
+    output:    str = ""
+    error:     str = ""
+    cr_id:     Optional[str] = None
+    extras:    Dict[str, Any] = field(default_factory=dict)
+
+
+# ─── registry ──────────────────────────────────────────────────────
+
+_REGISTRY: Dict[str, Tool] = {}
+_REGISTRY_LOCK = threading.Lock()
+
+
+def register_tool(tool: Tool) -> None:
+    """Add a tool to the registry. Idempotent re-registration with
+    the same Tool instance is allowed (re-imports under test runners);
+    a different instance under the same name raises so we don't
+    silently overwrite an in-flight tool.
+    """
+    if not isinstance(tool, Tool):
+        raise TypeError("register_tool expects a Tool instance")
+    if not tool.name:
+        raise ValueError("tool.name must be non-empty")
+    with _REGISTRY_LOCK:
+        existing = _REGISTRY.get(tool.name)
+        if existing is not None and existing is not tool:
+            raise ValueError(
+                f"tool {tool.name!r} already registered with a "
+                f"different instance"
+            )
+        _REGISTRY[tool.name] = tool
+
+
+def get_tool(name: str) -> Tool:
+    """Look up a tool by name. Unknown name → KeyError; the
+    opt-in pattern matches the backend registry (L0)."""
+    try:
+        return _REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"no tool registered for {name!r}; "
+            f"known: {sorted(_REGISTRY)}"
+        ) from None
+
+
+def list_tools() -> Dict[str, Tool]:
+    """Shallow copy of the registry — tests inspect this; production
+    code goes through ``get_tool``.
+    """
+    return dict(_REGISTRY)
+
+
+def _clear_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+
+
+# ─── dispatch ──────────────────────────────────────────────────────
+
+
+def dispatch_tool(
+    name: str,
+    args: Optional[Dict[str, Any]] = None,
+    *,
+    user_role: str = "system",
+    proposer: str = "",
+) -> ToolResult:
+    """Execute (read) or propose (write) the named tool.
+
+    Always returns a ToolResult. Never raises.
+
+    ``proposer`` is only consulted for write tools; defaults to
+    ``user_role`` if empty. The CR system audits every state change
+    with proposer+approver, so the caller should pass an authenticated
+    username here rather than relying on the role string.
+    """
+    args = args or {}
+    t0 = time.time()
+
+    # Lookup
+    try:
+        tool = get_tool(name)
+    except KeyError as e:
+        result = ToolResult(
+            ok=False, tool_name=name,
+            error=f"unknown tool: {name}",
+        )
+        _emit_trace(
+            tool_name=name,
+            applied_rule=f"reasoning.tool.{name}",
+            output_summary=str(e)[:200],
+            latency_ms=int((time.time() - t0) * 1000),
+            error="unknown tool",
+            user_role=user_role,
+        )
+        return result
+
+    # Write path — propose a Change Request, do NOT execute.
+    if tool.is_write:
+        return _dispatch_write(tool, args, user_role, proposer, t0)
+
+    # Read path — execute directly.
+    return _dispatch_read(tool, args, user_role, t0)
+
+
+def _dispatch_read(
+    tool: Tool,
+    args: Dict[str, Any],
+    user_role: str,
+    t0: float,
+) -> ToolResult:
+    try:
+        output = tool.handler(args, user_role=user_role)
+    except Exception as e:
+        err = f"{type(e).__name__}: {str(e)[:200]}"
+        _emit_trace(
+            tool_name=tool.name,
+            applied_rule=f"reasoning.tool.{tool.name}",
+            output_summary="",
+            latency_ms=int((time.time() - t0) * 1000),
+            error=err,
+            user_role=user_role,
+        )
+        return ToolResult(ok=False, tool_name=tool.name, error=err)
+
+    output_str = output if isinstance(output, str) else (
+        str(output) if output is not None else ""
+    )
+    _emit_trace(
+        tool_name=tool.name,
+        applied_rule=f"reasoning.tool.{tool.name}",
+        output_summary=truncate_summary(output_str),
+        latency_ms=int((time.time() - t0) * 1000),
+        error="",
+        user_role=user_role,
+    )
+    return ToolResult(ok=True, tool_name=tool.name, output=output_str)
+
+
+def _dispatch_write(
+    tool: Tool,
+    args: Dict[str, Any],
+    user_role: str,
+    proposer: str,
+    t0: float,
+) -> ToolResult:
+    """Wrap the write as a Change Request (CLAUDE.md rule #3 —
+    self-modifying outcomes need human approval). The tool's handler
+    is NOT called at dispatch time; admin runs it via the CR
+    approve flow.
+    """
+    if not tool.cr_target_type:
+        err = (
+            f"tool {tool.name!r} is_write=True but cr_target_type is "
+            f"empty — cannot propose Change Request"
+        )
+        _emit_trace(
+            tool_name=tool.name,
+            applied_rule=f"reasoning.tool.{tool.name}",
+            output_summary="",
+            latency_ms=int((time.time() - t0) * 1000),
+            error=err,
+            user_role=user_role,
+        )
+        return ToolResult(ok=False, tool_name=tool.name, error=err)
+
+    proposer = proposer or user_role or "system"
+    try:
+        from core.change_request import create_cr, compute_base_hash
+        # Caller may pass an explicit base_hash; otherwise derive
+        # from the proposed_diff so concurrent CRs against the same
+        # target stay distinguishable.
+        base_hash = args.get("base_hash") or compute_base_hash(
+            str(args.get("proposed_diff", "")).encode("utf-8")
+        )
+        cr = create_cr(
+            target_type=tool.cr_target_type,
+            target_id=args.get("target_id", ""),
+            title=args.get("title") or f"[tool] {tool.name}",
+            description=args.get("description", ""),
+            proposed_diff=args.get("proposed_diff", {}),
+            base_hash=base_hash,
+            proposer=proposer,
+            labels=args.get("labels", ()),
+            role=user_role,
+        )
+    except Exception as e:
+        err = f"{type(e).__name__}: {str(e)[:200]}"
+        _emit_trace(
+            tool_name=tool.name,
+            applied_rule=f"reasoning.tool.{tool.name}",
+            output_summary="",
+            latency_ms=int((time.time() - t0) * 1000),
+            error=err,
+            user_role=user_role,
+        )
+        return ToolResult(ok=False, tool_name=tool.name, error=err)
+
+    _emit_trace(
+        tool_name=tool.name,
+        applied_rule=f"reasoning.tool.{tool.name}",
+        output_summary=f"CR {cr.cr_id} proposed",
+        latency_ms=int((time.time() - t0) * 1000),
+        error="",
+        user_role=user_role,
+        extras={"cr_id": cr.cr_id, "cr_target_type": tool.cr_target_type},
+    )
+    return ToolResult(
+        ok=True, tool_name=tool.name,
+        output=f"CR {cr.cr_id} created",
+        cr_id=cr.cr_id,
+        extras={"cr_target_type": tool.cr_target_type},
+    )
+
+
+# ─── trace emit ────────────────────────────────────────────────────
+
+
+def _emit_trace(
+    *,
+    tool_name: str,
+    applied_rule: str,
+    output_summary: str,
+    latency_ms: int,
+    error: str,
+    user_role: str,
+    extras: Optional[Dict[str, Any]] = None,
+) -> None:
+    emit_extras: Dict[str, Any] = dict(extras or {})
+    emit_extras["tool"] = tool_name
+    try:
+        from core.observability import get_trace_id
+        tid = get_trace_id()
+        if tid:
+            emit_extras["trace_id"] = tid
+    except Exception:
+        pass
+
+    try:
+        emit_trace_step(
+            TraceStep(
+                stage="tool",
+                backend_id="tool_router",
+                parent_step_id="",
+                inputs_hash=compute_inputs_hash(tool_name),
+                output_summary=output_summary,
+                applied_rule=applied_rule,
+                latency_ms=latency_ms,
+                error=error,
+            ),
+            user_role=user_role,
+            extras=emit_extras,
+        )
+    except Exception:
+        # Trace emit is best-effort — never block tool dispatch on
+        # audit_log unavailability.
+        pass
+
+
+# ─── built-in tools ────────────────────────────────────────────────
+#
+# Module-level auto-registration matches the backend registry pattern
+# (core/reasoning/backends/__init__.py). Built-ins are kept tight —
+# new tools register from their own modules rather than ballooning
+# this file.
+
+def _autoregister_builtins() -> None:
+    # web_search: thin wrapper around tools.web.web_searcher so the
+    # cognitive layer can request a search without each caller
+    # learning the underlying module's call shape.
+    def _web_search(args: Dict[str, Any], *, user_role: str) -> str:
+        try:
+            from tools.web.web_searcher import search_web, format_search_results
+        except ImportError:
+            return "web_search unavailable: web_searcher module not importable"
+        query = (args.get("query") or "").strip()
+        if not query:
+            return "web_search error: query argument required"
+        max_results = int(args.get("max_results", 4))
+        results = search_web(query, max_results=max_results)
+        if not results:
+            return "no web results"
+        return format_search_results(results)
+
+    register_tool(Tool(
+        name="web_search",
+        description="외부 웹 검색 (Tavily / DDG fallback)",
+        is_write=False,
+        handler=_web_search,
+    ))
+
+
+_autoregister_builtins()
+
+
+__all__ = [
+    "Tool",
+    "ToolResult",
+    "register_tool",
+    "get_tool",
+    "list_tools",
+    "dispatch_tool",
+]

--- a/tests/test_tool_router.py
+++ b/tests/test_tool_router.py
@@ -1,0 +1,330 @@
+"""Phase 2 PR-8 — tool router unit tests.
+
+ARCHITECTURE.md §5.7.1 Tool Router. MVP is infrastructure-only (no
+pipeline wiring); these tests pin the registry + dispatch + trace
+emission + CR-E hook contract so a future planner / reflection-
+driven caller can rely on them.
+
+Coverage:
+  * Tool dataclass + ToolResult dataclass shape
+  * register_tool: rejects non-Tool / empty name / different instance
+                   under same name; idempotent for same instance
+  * get_tool: unknown → KeyError
+  * dispatch_tool (read path): handler called, output returned, trace
+                                row emitted, latency tracked
+  * dispatch_tool (read path): handler raises → ToolResult.ok=False
+                                + error row
+  * dispatch_tool (unknown tool): ToolResult.ok=False, no handler call
+  * dispatch_tool (write path): wraps as Change Request via
+                                 core.change_request.create_cr;
+                                 handler NOT called at dispatch time;
+                                 CR id surfaces in result.cr_id +
+                                 trace extras
+  * dispatch_tool (write path): missing cr_target_type → error
+  * Built-in: web_search registered automatically
+  * Trace emit: stage="tool", applied_rule="reasoning.tool.<name>",
+                extras carry tool name + (when CR) cr_id
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _rows(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM audit_log "
+            "WHERE endpoint = 'reason:tool' ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+class ToolDataclassTests(unittest.TestCase):
+
+    def test_tool_fields(self):
+        from core.reasoning.tool_router import Tool
+        t = Tool(name="x", description="d", is_write=False,
+                 handler=lambda a, **kw: "ok")
+        self.assertEqual(t.name, "x")
+        self.assertFalse(t.is_write)
+        self.assertEqual(t.cr_target_type, "")
+
+    def test_tool_result_default_shape(self):
+        from core.reasoning.tool_router import ToolResult
+        r = ToolResult(ok=True, tool_name="x")
+        self.assertEqual(r.output, "")
+        self.assertEqual(r.error, "")
+        self.assertIsNone(r.cr_id)
+        self.assertEqual(r.extras, {})
+
+
+class RegistryTests(unittest.TestCase):
+
+    def test_built_in_web_search_registered(self):
+        from core.reasoning.tool_router import list_tools
+        tools = list_tools()
+        self.assertIn("web_search", tools)
+        self.assertFalse(tools["web_search"].is_write)
+
+    def test_register_rejects_non_tool(self):
+        from core.reasoning.tool_router import register_tool
+        with self.assertRaises(TypeError):
+            register_tool("not-a-tool")   # type: ignore[arg-type]
+
+    def test_register_rejects_empty_name(self):
+        from core.reasoning.tool_router import Tool, register_tool
+        with self.assertRaises(ValueError):
+            register_tool(Tool(
+                name="", description="x", is_write=False,
+                handler=lambda a, **kw: "",
+            ))
+
+    def test_register_idempotent_same_instance(self):
+        from core.reasoning.tool_router import Tool, register_tool, get_tool
+        t = Tool(name="ping_test_idem",
+                 description="x", is_write=False,
+                 handler=lambda a, **kw: "")
+        register_tool(t)
+        register_tool(t)   # must not raise
+        self.assertIs(get_tool("ping_test_idem"), t)
+
+    def test_register_rejects_different_instance_same_name(self):
+        from core.reasoning.tool_router import Tool, register_tool
+        t1 = Tool(name="ping_test_collide", description="a",
+                  is_write=False, handler=lambda a, **kw: "")
+        t2 = Tool(name="ping_test_collide", description="b",
+                  is_write=False, handler=lambda a, **kw: "")
+        register_tool(t1)
+        with self.assertRaises(ValueError):
+            register_tool(t2)
+
+    def test_get_tool_unknown_raises_keyerror(self):
+        from core.reasoning.tool_router import get_tool
+        with self.assertRaises(KeyError):
+            get_tool("definitely_not_registered")
+
+
+class DispatchReadTests(unittest.TestCase):
+    """Read-path dispatch: handler executes, output returned, trace
+    row emitted, errors converted to ToolResult.ok=False.
+    """
+
+    def _register_tool(self, *, handler, name="ut_read_tool"):
+        from core.reasoning.tool_router import Tool, register_tool
+        try:
+            register_tool(Tool(name=name, description="ut",
+                               is_write=False, handler=handler))
+        except ValueError:
+            # already registered from a prior test — refresh
+            from core.reasoning.tool_router import _REGISTRY
+            _REGISTRY[name] = Tool(name=name, description="ut",
+                                    is_write=False, handler=handler)
+        return name
+
+    def test_happy_path_returns_output_and_emits_trace(self):
+        from core.reasoning.tool_router import dispatch_tool
+        called = {"n": 0, "role": ""}
+        def h(args, *, user_role):
+            called["n"] += 1
+            called["role"] = user_role
+            return f"hello {args.get('q', '')}"
+
+        name = self._register_tool(handler=h)
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            result = dispatch_tool(name, {"q": "world"},
+                                   user_role="employee")
+        self.assertTrue(result.ok)
+        self.assertEqual(result.output, "hello world")
+        self.assertEqual(called["n"], 1)
+        self.assertEqual(called["role"], "employee")
+
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["endpoint"], "reason:tool")
+        self.assertEqual(rows[0]["security_event"],
+                         f"reasoning.tool.{name}")
+        self.assertFalse(rows[0]["blocked"])
+
+    def test_handler_raises_returns_error_result_and_emits_blocked(self):
+        from core.reasoning.tool_router import dispatch_tool
+        def h(args, *, user_role):
+            raise RuntimeError("backend down")
+
+        name = self._register_tool(handler=h,
+                                    name="ut_read_tool_raises")
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            result = dispatch_tool(name, {}, user_role="admin")
+        self.assertFalse(result.ok)
+        self.assertIn("RuntimeError", result.error)
+        self.assertIn("backend down", result.error)
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+
+    def test_unknown_tool_returns_error_result(self):
+        from core.reasoning.tool_router import dispatch_tool
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            result = dispatch_tool("not_registered", {})
+        self.assertFalse(result.ok)
+        self.assertIn("unknown tool", result.error)
+        rows = _rows(db)
+        # the unknown-tool path still emits one trace row for audit
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+
+
+class DispatchWriteTests(unittest.TestCase):
+    """Write-path dispatch: handler NOT executed, CR proposed via
+    change_request.create_cr, cr_id surfaces in ToolResult.cr_id +
+    trace extras. The handler being unused is the whole point —
+    admin approves the CR, and admin-side apply runs the real handler.
+    """
+
+    def _register_write_tool(self, *, target_type="wiki_entity",
+                               name="ut_write_tool"):
+        from core.reasoning.tool_router import Tool, _REGISTRY
+        handler = MagicMock(side_effect=AssertionError(
+            "write tool handler must NOT execute at dispatch time"
+        ))
+        t = Tool(name=name, description="ut", is_write=True,
+                 handler=handler, cr_target_type=target_type)
+        _REGISTRY[name] = t   # bypass collision rejection between tests
+        return name, handler
+
+    def test_write_dispatch_creates_cr_does_not_call_handler(self):
+        from core.reasoning.tool_router import dispatch_tool
+        name, handler = self._register_write_tool()
+        fake_cr = MagicMock()
+        fake_cr.cr_id = "cr_test_001"
+
+        with patch("core.change_request.create_cr",
+                   return_value=fake_cr) as mock_create, \
+             patch("core.change_request.compute_base_hash",
+                   return_value="bh_abc"):
+            result = dispatch_tool(
+                name,
+                {"target_id": "e_concept_x",
+                 "proposed_diff": {"name": "new"},
+                 "title": "rename"},
+                user_role="admin", proposer="admin_user",
+            )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.cr_id, "cr_test_001")
+        handler.assert_not_called()
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        self.assertEqual(kwargs["target_type"], "wiki_entity")
+        self.assertEqual(kwargs["target_id"], "e_concept_x")
+        self.assertEqual(kwargs["proposer"], "admin_user")
+
+    def test_write_dispatch_missing_cr_target_type_errors(self):
+        from core.reasoning.tool_router import Tool, dispatch_tool, _REGISTRY
+        name = "ut_write_no_target"
+        _REGISTRY[name] = Tool(
+            name=name, description="ut", is_write=True,
+            handler=lambda a, **kw: "should never run",
+            cr_target_type="",   # ← missing
+        )
+        result = dispatch_tool(name, {}, user_role="admin")
+        self.assertFalse(result.ok)
+        self.assertIn("cr_target_type", result.error)
+
+    def test_write_create_cr_raises_returns_error_result(self):
+        from core.reasoning.tool_router import dispatch_tool
+        name, _ = self._register_write_tool(name="ut_write_cr_raises")
+        with patch("core.change_request.create_cr",
+                   side_effect=ValueError("unknown target_type")), \
+             patch("core.change_request.compute_base_hash",
+                   return_value="bh"):
+            result = dispatch_tool(
+                name, {"target_id": "e1", "title": "t"},
+                user_role="admin",
+            )
+        self.assertFalse(result.ok)
+        self.assertIn("unknown target_type", result.error)
+
+    def test_write_emits_trace_with_cr_id_in_extras(self):
+        from core.reasoning.tool_router import dispatch_tool
+        name, _ = self._register_write_tool(name="ut_write_trace_cr")
+        fake_cr = MagicMock()
+        fake_cr.cr_id = "cr_xyz"
+        db = _fresh_db()
+        with patch("core.change_request.create_cr", return_value=fake_cr), \
+             patch("core.change_request.compute_base_hash",
+                   return_value="bh"), \
+             patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            dispatch_tool(
+                name, {"target_id": "e1", "title": "t"},
+                user_role="admin", proposer="admin_user",
+            )
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        import json
+        ans = json.loads(rows[0]["answer"])
+        self.assertEqual(ans.get("cr_id"), "cr_xyz")
+        self.assertEqual(ans.get("tool"), name)
+
+
+class TraceExtrasTests(unittest.TestCase):
+
+    def test_tool_name_in_trace_extras(self):
+        from core.reasoning.tool_router import Tool, dispatch_tool, _REGISTRY
+        name = "ut_trace_extras"
+        _REGISTRY[name] = Tool(
+            name=name, description="ut", is_write=False,
+            handler=lambda a, **kw: "ok",
+        )
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            dispatch_tool(name, {}, user_role="employee")
+        rows = _rows(db)
+        import json
+        ans = json.loads(rows[0]["answer"])
+        self.assertEqual(ans.get("tool"), name)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Cognitive Layer Phase 2 PR-8 — Tool Router**. Infrastructure-only (wiring 0), L0-pattern: the registry + dispatch primitive exists for Phase 2 PR-7 Planner / future reflection-driven tool calls to consume.

```python
from core.reasoning.tool_router import dispatch_tool

# Read tool — handler runs inline:
result = dispatch_tool("web_search", {"query": "RAG"}, user_role="admin")
print(result.output)   # search results
print(result.cr_id)    # None

# Write tool — handler NOT called; CR proposed instead:
result = dispatch_tool("wiki_edit",
    {"target_id": "e_concept_x",
     "proposed_diff": {"name": "new"}, "title": "rename"},
    user_role="admin", proposer="admin_user")
print(result.cr_id)    # "cr_..." — admin approves via existing CR flow
```

Every dispatch emits **one TraceStep with `stage="tool"`** so replay_trace.py shows tool calls alongside synth / reflect / verify rows.

## Two trust classes

| Class | Example | Path |
|---|---|---|
| Read (`is_write=False`) | `web_search`, `wiki_read` | Handler executes directly |
| Write (`is_write=True`) | `wiki_edit`, `graph_node_edit` | Wraps as **Change Request** via `core.change_request.create_cr` — admin approves, no inline execution |

This is the architectural payoff of v0.2.x CR-E: any new write surface in the cognitive layer automatically inherits the proposal / review / approval flow without each call site reinventing governance.

## New files

| File | Size | Role |
|---|---|---|
| `core/reasoning/tool_router.py` | 13.3 KB | `Tool` + `ToolResult` + registry + `dispatch_tool` + built-in `web_search` |
| `tests/test_tool_router.py` | ~10 KB | 16 tests (mocked handlers + change_request) |

## Trace contract preserved

`scripts/replay_trace.py` (L2) now shows tool calls in the reasoning sequence:

```
[N]   reasoning.tool.web_search          tool_router    1.3s
        extras: {"tool": "web_search"}
[N+1] reasoning.tool.wiki_edit           tool_router    0.0s
        extras: {"tool": "wiki_edit", "cr_id": "cr_...",
                 "cr_target_type": "wiki_entity"}
```

§5.7.2 trace-replay invariant extends to the action surface.

## Verification

- **Unit tests**: 16 new (`tests/test_tool_router.py`) green
- **Regression**: **467/467** reasoning + policy + graph editor + change_request slice green (PR-8 + every prior cognitive layer + cycle 12 PR + CR primitive)
- **Lint**: `ruff check core/reasoning/tool_router.py tests/test_tool_router.py` → All checks passed

## Bench (CLAUDE.md rule #2)

**No retrieval / reasoning runtime path touched.** STEP 7 byte-identical. wiring 0 — `pipeline.py` / `modes.py` / `engine.py` unchanged.

## Out of scope

- **Pipeline wiring** — `loop_state["pending_actions"]` currently empty; Phase 2 PR-7 Planner or reflection-driven tool calls will populate it. Same L0-pattern: infrastructure first, wiring by a separate PR with bench numbers.
- **`modes.py` split** (pre-existing rule #5 debt). PR-8 does **not** absorb it — `modes.py` is a per-mode chat dispatcher; Tool Router is a per-tool action dispatcher. Different concerns. Separate chore PR for modes.py later.
- **New built-in write tools** (`wiki_edit`, `graph_node_edit`) — the CR-E hook works generically, but the existing wiki_edit / graph_node_edit code is invoked via different surfaces today. A follow-up wires them to the Tool Router so reflection / planner code can emit them uniformly.

## Cognitive Layer status after this PR

```
Phase 0 — Infrastructure (4 PR)
  Pre-L0 #282  §5.7.2 arch                ✓ merged
  L0     #283  backends + trace_schema    ✓ merged
  L1     #284  12 call_gemma wiring       ✓ merged
  L2     #285  replay_trace tool          ✓ merged

Phase 1 — Retrieval Intelligence (3 PR)
  PR-1   #286  Reranker                   ✓ merged
  PR-2   #287  Query rewriter (opt-in)    ✓ merged
  split  #288  pipeline.py 분할            ✓ merged

Phase 2 — Reasoning Depth (3 PR + wiring TBD)
  PR-5   #289  Reflection (opt-in)        ✓ merged
  PR-6   #290  Verification (opt-in)      ✓ merged
  PR-8   THIS  Tool Router (infra)        ← this PR
  PR-7         Planner (optional)         pending — will wire PR-8
```

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Domain-neutral primitive — tool registrations are per-feature, not per-domain |
| #2 bench numbers | Byte-identical (no live pipeline path touched) |
| #3 self-evolution gate | **Write tools route through change_request.py** — the L0/L1 backend pattern extended to the action surface; CLAUDE.md rule #3 enforced architecturally rather than per-call-site |
| #4 architecture | §5.7.1 Tool Router primitive lands; reuses "tool" stage already in §5.7.2 ALLOWED_STAGES from L0 |
| #5 module size | 13.3 KB ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
