### PR TITLE
feat(reasoning): planner — task decomposition (Phase 2 PR-7)

### DIFF
--- a/core/reasoning/pipeline_synth.py
+++ b/core/reasoning/pipeline_synth.py
@@ -61,6 +61,27 @@ def generate_answer(
     out = AnswerBlock()
     answer = ""
 
+    # Phase 2 PR-7 — optional planner decomposition.
+    # When JAMES_ENABLE_PLANNER=1, decompose the query into 2-5
+    # subtasks and prepend them to the system_prompt so the LLM
+    # follows the plan. MVP scope is "처음엔 단순 표시" — the plan
+    # informs synth phrasing, but does NOT yet drive retrieval / tool
+    # routing (future PR-7 follow-up). Trivial plans (1 subtask) are
+    # skipped to avoid prompt noise.
+    try:
+        from core.reasoning.planner import get_planner
+        _plan = get_planner().plan(safe_query, user_role=user_role)
+        if _plan and not _plan.is_trivial():
+            _steps = "\n".join(
+                f"{i + 1}. {s}" for i, s in enumerate(_plan.subtasks)
+            )
+            system_prompt = (
+                f"[추론 계획]\n{_steps}\n\n위 계획에 따라 단계별로 답변하라.\n\n"
+                + system_prompt
+            )
+    except Exception as e:
+        engine._log("planner", e, user_role)
+
     try:
         sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
 

--- a/core/reasoning/planner.py
+++ b/core/reasoning/planner.py
@@ -1,0 +1,345 @@
+"""Planner — Cognitive Layer Phase 2 PR-7.
+
+ARCHITECTURE.md §5.7.1: "Planner — decompose a question into ordered
+subtasks; choose retrieval depth". Per the cognitive-layer track
+handover, MVP scope is "처음엔 단순 표시, 추후 본격" — the planner
+emits a decomposition plan + audit trail, and the synth step
+optionally prepends the plan to the LLM prompt so the model follows
+it. Driving retrieval / tool routing from the plan lands in a future
+PR (PR-7 follow-up or new "plan-driven retrieval" cycle).
+
+Posture: opt-in via JAMES_ENABLE_PLANNER=1. Default OFF preserves
+v0.3.0+PR-1+PR-2+PR-5+PR-6+PR-8 byte-identical behaviour. When enabled,
+one extra LLM round-trip per query (~5-10s on CPU ollama).
+
+Routes through the Backend registry (Phase 0 L0). Trace emit uses
+stage="plan" — already in ALLOWED_STAGES, no §5.7.2 schema change.
+
+Failure posture: every failure path returns a single-subtask plan
+(the original query). Synth never sees None or raises here.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from core.reasoning.trace_schema import (
+    TraceStep,
+    compute_inputs_hash,
+    emit_trace_step,
+    truncate_summary,
+)
+
+
+DEFAULT_BACKEND_ID = "ollama_local"
+DEFAULT_TIMEOUT_S = 20.0
+DEFAULT_MAX_TOKENS = 400
+# Decomposition cap. More than 5 subtasks is usually the model
+# elaborating rather than decomposing — and the synth prompt only
+# benefits from a focused checklist, not a wall of bullet points.
+MAX_SUBTASKS = 5
+# Trivial query gate. 4-character queries ("RAG?") don't need
+# decomposition; trying to plan them invites hallucination.
+MIN_QUERY_LEN = 12
+
+
+@dataclass
+class Plan:
+    """Outcome of one planning pass.
+
+    ``subtasks`` is always non-empty — on failure it falls back to
+    ``[original_query]`` so downstream code never has to guard
+    against an empty list.
+    """
+    original_query: str
+    subtasks:       List[str] = field(default_factory=list)
+    rationale:      str = ""
+
+    def is_trivial(self) -> bool:
+        """A trivial plan (1 subtask == the original query) means
+        the planner either skipped or fell back. Callers can branch
+        on this to avoid prepending a useless single-line checklist
+        to the synth prompt.
+        """
+        return (
+            len(self.subtasks) <= 1
+            or (len(self.subtasks) == 1
+                and self.subtasks[0].strip() == self.original_query.strip())
+        )
+
+
+def _enabled() -> bool:
+    return os.environ.get("JAMES_ENABLE_PLANNER") == "1"
+
+
+def _is_korean(text: str) -> bool:
+    if not text:
+        return False
+    korean_chars = sum(1 for c in text if "가" <= c <= "힣")
+    return korean_chars >= max(1, int(len(text) * 0.2))
+
+
+PLAN_PROMPT_KO = (
+    "아래 질문에 답하기 위해 필요한 하위 작업 (subtask) 들을 순서대로 "
+    "2-5 개로 분해하라.\n\n"
+    "[질문]\n{query}\n\n"
+    "규칙:\n"
+    "- 각 subtask 는 한 줄, 짧고 명령형 ('NVIDIA 의 GPU 라인업 조사')\n"
+    "- 한 단계가 다음 단계의 입력이 되는 자연 순서\n"
+    "- 질문이 단순하면 (1-2 단계로 충분) 그만큼만 출력\n"
+    "- 의미를 보존하고 새 주제를 만들지 마라\n\n"
+    "JSON 으로만 응답:\n"
+    '{{"subtasks": ["...", "..."], "rationale": "한 줄 이유"}}'
+)
+
+PLAN_PROMPT_EN = (
+    "Decompose the question below into 2-5 ordered subtasks needed to "
+    "answer it.\n\n"
+    "[Question]\n{query}\n\n"
+    "Rules:\n"
+    "- One line per subtask, imperative form (e.g., 'Survey NVIDIA's GPU lineup')\n"
+    "- Natural order — each step's output feeds the next\n"
+    "- If the question is simple (1-2 steps suffice), output only that many\n"
+    "- Preserve meaning; do not introduce new topics\n\n"
+    "Respond with JSON only:\n"
+    '{{"subtasks": ["...", "..."], "rationale": "one-line reason"}}'
+)
+
+
+# Tolerant JSON sniff — accepts either pure JSON or JSON padded with
+# prose. We anchor on the ``"subtasks"`` key so a model that ignores
+# the "JSON only" instruction and adds a one-line explanation still
+# parses.
+_JSON_OBJ_RE = re.compile(
+    r'\{[^{}]*"subtasks"\s*:\s*\[[^\]]*\][^{}]*\}',
+    re.DOTALL,
+)
+
+
+def _parse_plan_response(text: str) -> Optional[Tuple[List[str], str]]:
+    """Return ``(subtasks, rationale)`` or ``None`` on parse failure."""
+    if not text:
+        return None
+    try:
+        blob = json.loads(text)
+        return _extract(blob)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    m = _JSON_OBJ_RE.search(text)
+    if m:
+        try:
+            blob = json.loads(m.group(0))
+            return _extract(blob)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def _extract(blob) -> Optional[Tuple[List[str], str]]:
+    if not isinstance(blob, dict):
+        return None
+    subs = blob.get("subtasks") or []
+    if not isinstance(subs, list):
+        return None
+    cleaned: List[str] = []
+    for s in subs:
+        if not isinstance(s, str):
+            continue
+        st = s.strip()
+        if not st:
+            continue
+        cleaned.append(st[:200])
+        if len(cleaned) >= MAX_SUBTASKS:
+            break
+    if not cleaned:
+        return None
+    rationale = blob.get("rationale", "")
+    if not isinstance(rationale, str):
+        rationale = ""
+    return cleaned, rationale.strip()[:300]
+
+
+class Planner:
+    """Stateless wrapper around a Backend.
+
+    The Backend caches the underlying LLM client across calls so
+    successive plans on the same backend share connection state.
+    """
+
+    def __init__(
+        self,
+        backend_id: str = DEFAULT_BACKEND_ID,
+        *,
+        timeout: float = DEFAULT_TIMEOUT_S,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        self._backend_id = backend_id
+        self._timeout = timeout
+        self._max_tokens = max_tokens
+
+    def plan(
+        self,
+        query: str,
+        *,
+        user_role: str = "system",
+        force: bool = False,
+    ) -> Plan:
+        """Return a Plan with 1-5 subtasks.
+
+        Falls back to ``Plan(query, [query], "...")`` when:
+          * env opt-in unset and ``force`` is False
+          * query empty / shorter than MIN_QUERY_LEN
+          * backend lookup fails / .complete() raises / error string /
+            empty response / malformed JSON / empty subtasks list
+        """
+        query = (query or "").strip()
+        identity = Plan(original_query=query, subtasks=[query],
+                        rationale="planner skipped")
+        if not query or len(query) < MIN_QUERY_LEN:
+            return identity
+        if not force and not _enabled():
+            return identity
+
+        try:
+            from core.reasoning.backends import get_backend
+            backend = get_backend(self._backend_id)
+        except Exception:
+            self._emit_skip(query, user_role, "backend_lookup_failed")
+            return identity
+
+        is_ko = _is_korean(query)
+        tmpl = PLAN_PROMPT_KO if is_ko else PLAN_PROMPT_EN
+        prompt = tmpl.format(query=query)
+
+        t0 = time.time()
+        try:
+            result = backend.complete(
+                prompt,
+                max_tokens=self._max_tokens,
+                timeout=self._timeout,
+            )
+        except Exception as e:
+            err = f"{type(e).__name__}: {str(e)[:200]}"
+            self._emit(
+                query=query, prompt=prompt, output="",
+                latency_ms=int((time.time() - t0) * 1000),
+                error=err, user_role=user_role,
+            )
+            return identity
+        latency_ms = int((time.time() - t0) * 1000)
+
+        text = getattr(result, "text", "") or ""
+        err = getattr(result, "error", "") or ""
+        if err or not text:
+            self._emit(
+                query=query, prompt=prompt, output=text,
+                latency_ms=latency_ms, error=err or "empty_response",
+                user_role=user_role,
+            )
+            return identity
+
+        parsed = _parse_plan_response(text)
+        if parsed is None:
+            self._emit(
+                query=query, prompt=prompt, output=text,
+                latency_ms=latency_ms, error="parse_failed",
+                user_role=user_role,
+            )
+            return identity
+
+        subtasks, rationale = parsed
+        self._emit(
+            query=query, prompt=prompt,
+            output=f"{len(subtasks)} subtasks: " + " / ".join(
+                s[:40] for s in subtasks[:3]
+            ),
+            latency_ms=latency_ms, error="", user_role=user_role,
+        )
+        return Plan(
+            original_query=query,
+            subtasks=subtasks,
+            rationale=rationale,
+        )
+
+    def _emit(
+        self,
+        *,
+        query: str,
+        prompt: str,
+        output: str,
+        latency_ms: int,
+        error: str,
+        user_role: str,
+    ) -> None:
+        extras = {"original_query": query[:200]}
+        try:
+            from core.observability import get_trace_id
+            tid = get_trace_id()
+            if tid:
+                extras["trace_id"] = tid
+        except Exception:
+            pass
+        try:
+            emit_trace_step(
+                TraceStep(
+                    stage="plan",
+                    backend_id=self._backend_id,
+                    parent_step_id="",
+                    inputs_hash=compute_inputs_hash(prompt),
+                    output_summary=truncate_summary(output),
+                    applied_rule="reasoning.plan.decompose",
+                    latency_ms=latency_ms,
+                    error=error,
+                ),
+                user_role=user_role,
+                extras=extras,
+            )
+        except Exception:
+            # Best-effort — never block the synth path on audit_log
+            # unavailability.
+            pass
+
+    def _emit_skip(self, query: str, user_role: str, reason: str) -> None:
+        """Skip cases (no opt-in, no backend) — still emit so the
+        replay tool can show "planner was asked but bypassed".
+        """
+        self._emit(
+            query=query, prompt=query, output="",
+            latency_ms=0, error=f"skipped: {reason}",
+            user_role=user_role,
+        )
+
+
+# ─── module-level singleton ────────────────────────────────────────
+_SINGLETON: Optional[Planner] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_planner() -> Planner:
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = Planner()
+    return _SINGLETON
+
+
+def _clear_singleton_for_tests() -> None:
+    """Test helper. Production code never calls this."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None
+
+
+__all__ = [
+    "DEFAULT_BACKEND_ID",
+    "MAX_SUBTASKS",
+    "Plan",
+    "Planner",
+    "get_planner",
+]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,345 @@
+"""Phase 2 PR-7 — planner unit tests.
+
+ARCHITECTURE.md §5.7.1 Planner. Uses mocked backend so unit tests
+don't hit live Ollama. Pipeline integration smoke is covered by
+the reasoning-touching slice.
+
+Coverage:
+  * opt-in gate (JAMES_ENABLE_PLANNER) — default OFF returns trivial
+  * force flag: bypasses env gate
+  * empty / too-short query → trivial plan
+  * backend lookup miss → trivial plan, "skipped: backend_lookup_failed"
+  * backend.complete raises → trivial plan + error trace
+  * backend returns error string / empty text → trivial plan
+  * malformed JSON → trivial plan
+  * runaway subtasks (> 5) → capped at MAX_SUBTASKS
+  * KO vs EN prompt template selection
+  * happy path: Plan(subtasks=[...], rationale="...") returned
+  * trivial-detection: 1 subtask same as query → is_trivial() True
+  * trace emit: stage="plan", applied_rule="reasoning.plan.decompose"
+  * singleton
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _rows(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM audit_log "
+            "WHERE endpoint = 'reason:plan' ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _completion(text="", error=""):
+    res = MagicMock()
+    res.text = text
+    res.error = error
+    return res
+
+
+LONG_KO = "비트코인 ETF 가 미국 시장에 미친 영향을 종합적으로 분석해줘"
+LONG_EN = "Analyze the impact of Bitcoin ETF approvals on the US market"
+
+
+class OptInGateTests(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("JAMES_ENABLE_PLANNER", None)
+        else:
+            os.environ["JAMES_ENABLE_PLANNER"] = self._saved
+
+    def test_disabled_default_returns_trivial_plan(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertEqual(plan.subtasks, [LONG_KO])
+        self.assertTrue(plan.is_trivial())
+        fake.complete.assert_not_called()
+
+    def test_force_bypasses_env_gate(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"subtasks": ["1단계", "2단계", "3단계"], "rationale": "분해함"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO, force=True)
+        self.assertEqual(plan.subtasks, ["1단계", "2단계", "3단계"])
+        self.assertFalse(plan.is_trivial())
+        fake.complete.assert_called_once()
+
+
+class ShortQueryTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def test_empty_query_trivial(self):
+        from core.reasoning.planner import Planner
+        plan = Planner().plan("")
+        self.assertTrue(plan.is_trivial())
+
+    def test_short_query_trivial_no_backend_call(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan("RAG?")   # 4 chars, below MIN_QUERY_LEN
+        self.assertTrue(plan.is_trivial())
+        fake.complete.assert_not_called()
+
+
+class BackendFailureTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def test_backend_lookup_miss_trivial(self):
+        from core.reasoning.planner import Planner
+        p = Planner(backend_id="definitely_not_registered")
+        plan = p.plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+    def test_backend_raises_trivial(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.side_effect = RuntimeError("ollama down")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+    def test_backend_error_string_trivial(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(error="backend error")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+    def test_empty_text_trivial(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+    def test_malformed_json_trivial(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text="not json at all")
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+    def test_missing_subtasks_key_trivial(self):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rationale": "no subtasks"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            plan = Planner().plan(LONG_KO)
+        self.assertTrue(plan.is_trivial())
+
+
+class JsonParseTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def _plan_with_text(self, llm_text, query=LONG_KO):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(text=llm_text)
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            return Planner().plan(query)
+
+    def test_pure_json_three_subtasks(self):
+        plan = self._plan_with_text(
+            '{"subtasks": ["A", "B", "C"], "rationale": "분해"}'
+        )
+        self.assertEqual(plan.subtasks, ["A", "B", "C"])
+        self.assertEqual(plan.rationale, "분해")
+
+    def test_json_with_leading_prose(self):
+        plan = self._plan_with_text(
+            '여기 분해 결과:\n{"subtasks": ["X", "Y"], "rationale": "r"}'
+        )
+        self.assertEqual(plan.subtasks, ["X", "Y"])
+
+    def test_runaway_subtasks_capped_at_max(self):
+        from core.reasoning.planner import MAX_SUBTASKS
+        subs = [f"step{i}" for i in range(MAX_SUBTASKS + 5)]
+        text = (
+            '{"subtasks": ['
+            + ", ".join(f'"{s}"' for s in subs)
+            + '], "rationale": "many"}'
+        )
+        plan = self._plan_with_text(text)
+        self.assertEqual(len(plan.subtasks), MAX_SUBTASKS)
+
+    def test_non_string_subtasks_filtered(self):
+        plan = self._plan_with_text(
+            '{"subtasks": ["valid", 123, "also valid", null, ""], "rationale": ""}'
+        )
+        self.assertEqual(plan.subtasks, ["valid", "also valid"])
+
+
+class LanguageDetectionTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def _capture_prompt(self, query):
+        from core.reasoning.planner import Planner
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"subtasks": ["s"], "rationale": ""}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            Planner().plan(query)
+        return fake.complete.call_args.args[0]
+
+    def test_korean_query_uses_korean_prompt(self):
+        prompt = self._capture_prompt(LONG_KO)
+        self.assertIn("하위 작업", prompt)
+        self.assertNotIn("Decompose the question", prompt)
+
+    def test_english_query_uses_english_prompt(self):
+        prompt = self._capture_prompt(LONG_EN)
+        self.assertIn("Decompose the question", prompt)
+
+
+class TraceEmissionTests(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JAMES_ENABLE_PLANNER", None)
+
+    def test_happy_path_emits_plan_row(self):
+        from core.reasoning.planner import Planner
+        db = _fresh_db()
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"subtasks": ["A", "B"], "rationale": "r"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake), \
+             patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            Planner().plan(LONG_KO)
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["security_event"],
+                         "reasoning.plan.decompose")
+        self.assertEqual(rows[0]["endpoint"], "reason:plan")
+        self.assertFalse(rows[0]["blocked"])
+
+    def test_backend_raise_still_emits_row_blocked(self):
+        from core.reasoning.planner import Planner
+        db = _fresh_db()
+        fake = MagicMock()
+        fake.complete.side_effect = RuntimeError("oom")
+        with patch("core.reasoning.backends.get_backend", return_value=fake), \
+             patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            Planner().plan(LONG_KO)
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+
+
+class TrivialDetectionTests(unittest.TestCase):
+
+    def test_empty_subtasks_is_trivial(self):
+        from core.reasoning.planner import Plan
+        self.assertTrue(Plan("q", []).is_trivial())
+
+    def test_single_subtask_matching_query_is_trivial(self):
+        from core.reasoning.planner import Plan
+        self.assertTrue(Plan("question?", ["question?"]).is_trivial())
+
+    def test_single_subtask_different_from_query_still_trivial(self):
+        from core.reasoning.planner import Plan
+        # 1 subtask total → trivial regardless of content (no real
+        # decomposition happened)
+        self.assertTrue(Plan("q", ["something else"]).is_trivial())
+
+    def test_two_or_more_subtasks_not_trivial(self):
+        from core.reasoning.planner import Plan
+        self.assertFalse(Plan("q", ["a", "b"]).is_trivial())
+
+
+class SingletonTests(unittest.TestCase):
+
+    def test_get_planner_returns_same_instance(self):
+        from core.reasoning.planner import (
+            get_planner, _clear_singleton_for_tests,
+        )
+        _clear_singleton_for_tests()
+        a = get_planner()
+        b = get_planner()
+        self.assertIs(a, b)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

**Phase 2 PR-7 Planner** — task decomposition into ordered subtasks. **Closes Phase 2** of the cognitive layer (PR-5 + PR-6 + PR-7 + PR-8 all merged).

Per the handover spec, MVP scope is **"처음엔 단순 표시, 추후 본격"** — the planner emits a Plan + audit trail, and synth prepends the plan to the LLM prompt so the model follows it. Plan-driven retrieval / tool routing is the follow-up.

```python
# When JAMES_ENABLE_PLANNER=1 + multi-aspect query:
generate_answer(safe_query="BlackRock 와 비트코인 ETF 의 관계를 분석해줘", ...)

# Planner emits:
Plan(
    original_query="BlackRock 와 비트코인 ETF의 관계를 분석해줘",
    subtasks=[
        "BlackRock 의 ETF 사업 현황 조사",
        "비트코인 ETF 승인 타임라인 정리",
        "BlackRock 의 BTC ETF 출시 영향 분석",
    ],
    rationale="3단계 분해"
)

# system_prompt 에 prepend:
# [추론 계획]
# 1. BlackRock 의 ETF 사업 현황 조사
# 2. 비트코인 ETF 승인 타임라인 정리
# 3. BlackRock 의 BTC ETF 출시 영향 분석
#
# 위 계획에 따라 단계별로 답변하라.
```

**Opt-in by default**: `JAMES_ENABLE_PLANNER=1` enables. Without env, byte-identical to PR-1+PR-2+PR-5+PR-6+PR-8.

## Failure posture (best-effort)

Every failure path returns a **trivial Plan** (1 subtask = original query) — synth never sees None or raises:

| Failure | Behavior |
|---|---|
| Env opt-in unset | Trivial, no backend call |
| Empty / short query (< 12 chars) | Trivial, no backend call |
| Backend lookup miss | Trivial + trace row `skipped: backend_lookup_failed` |
| `backend.complete()` raises | Trivial + trace row with error |
| Backend returns error string / empty | Trivial |
| Malformed JSON / missing `subtasks` key | Trivial |
| Runaway subtasks (> 5) | Capped at `MAX_SUBTASKS` |

`Plan.is_trivial()` returns True for any of the above; synth uses this to decide whether to prepend the plan to system_prompt (skipped if trivial — avoids prompt noise).

## New files

| File | Size | Role |
|---|---|---|
| `core/reasoning/planner.py` | 10.8 KB | `Planner` + `Plan` + `get_planner()` singleton |
| `tests/test_planner.py` | ~9 KB | 23 tests (mocked backend) |

## Trace contract preserved

Per `replay_trace.py` (L2), with all Phase 1+2 env ON the **9-step** cognitive sequence:

```
[1] reasoning.plan.decompose          ollama_local   3.2s   (PR-7 — NEW)
[2] reasoning.retrieve.query_rewrite  ollama_local   3.5s   (PR-2)
[3] reasoning.rerank.cross_encoder    cross_encoder  0.1s   (PR-1)
[4] reasoning.synth.rag               ollama_local   8.5s   (L1)
[5] reasoning.reflect.critique        ollama_local   2.1s   (PR-5)
[6] reasoning.reflect.revised         ollama_local   4.3s   (PR-5)
[7] reasoning.verify.security         —              0.0s   (PR-6)
[8] reasoning.verify.fact_check       ollama_local   3.7s   (PR-6)
[9] reasoning.verify.final            —              0.0s   (PR-6)
```

(Tool router `[N] reasoning.tool.<name>` 도 wiring 후 자연 삽입.)

## Pipeline wiring

`core/reasoning/pipeline_synth.py` at the start of `generate_answer`:

```python
try:
    from core.reasoning.planner import get_planner
    _plan = get_planner().plan(safe_query, user_role=user_role)
    if _plan and not _plan.is_trivial():
        _steps = "\n".join(f"{i+1}. {s}" for i, s in enumerate(_plan.subtasks))
        system_prompt = f"[추론 계획]\n{_steps}\n\n위 계획에 따라 단계별로 답변하라.\n\n" + system_prompt
except Exception as e:
    engine._log("planner", e, user_role)
```

The env gate lives **inside** `planner.py` — the call site is unconditional; trivial plans are no-op.

## Verification

- **Unit tests**: 23 new (`tests/test_planner.py`) green
- **Regression**: **444/444** reasoning + policy + graph editor + change_request slice green
- **Lint**: `ruff check core/reasoning/planner.py core/reasoning/pipeline_synth.py tests/test_planner.py` → All checks passed

## Bench (CLAUDE.md rule #2)

- **Default OFF** → STEP 7 unchanged
- **With opt-in**:
  ```powershell
  $env:JAMES_ENABLE_PLANNER = "1"
  python scripts/bench.py --suite=step7 --check
  ```
  Expected: quality improvement on multi-aspect queries (q5 multi-hop, q7 compare); ~5-10s latency tax per query.

## Cognitive Layer status after this PR

```
Phase 0  Infrastructure        ✅ 100%  (4/4 PR)
Phase 1  Retrieval Intelligence ✅  75%  (3 PR + 선택 2)
Phase 2  Reasoning Depth        ✅ 100%  (4/4 핵심 — PR-5/-6/-7/-8 ALL merged) ← 닫힘
Phase 3  Memory Expansion       ⏳   0%  (next candidate)
Phase 4  Controlled Multi-Agent ⏳   0%  (5-role cap 박힘)
```

## Out of scope

- **Plan-driven retrieval** — planner subtasks could feed multi-query retrieval per subtask. PR-7 follow-up.
- **Plan-driven tool routing** — subtasks tagged with tool_hint → tool_router dispatch. Combines PR-7 + PR-8.
- **Default ON** — wait for STEP 7 spot-check data.

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 도메인 분화 금지 | Domain-neutral primitive |
| #2 bench numbers | Default OFF; opt-in user-side STEP 7 |
| #3 self-evolution gate | Unrelated |
| #4 architecture | §5.7.1 Planner primitive lands; reuses "plan" stage already in §5.7.2 ALLOWED_STAGES from L0 |
| #5 module size | planner.py 10.8 KB ✓ · pipeline_synth.py 16.1 KB ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
