### PR TITLE
docs(promo): record Ali second-turn exchange + main v0.3.0 state in tracker

### DIFF
--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -29,7 +29,11 @@
 | 2026-05-13 | Hashnode cross-post of intro article (`ragllm.hashnode.dev`) | ✅ Live ([URL](https://ragllm.hashnode.dev/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-alpha)) |
 | 2026-05-16 | awesome-llm-apps PR #804 closed by curator | ❌ Closed (link-only PRs not accepted; full tutorial folder with self-contained runnable code required) |
 | 2026-05-16 | **First external technical exchange — Ali Afana (Provia founder, dev.to Featured)** | ✅ Two-way collaboration discussion: 83-item injection regression suite spin-out + v0.3 Gemma 4 variant benchmark (E4B / 26B MoE / 31B Dense on STEP 7 corpus) |
+| 2026-05-16 | LinkedIn DM second-turn reply to Ali | ✅ Sent — v0.3.0 release acknowledged, swap-as-benchmark commitment, 83-item suite spin-out task split, temperature-0.3 cap pushback (new ablation lead) |
+| 2026-05-16 | dev.to substantive comment on Ali's article (`/alimafana/...refused-1j18`) | ✅ Posted — Scenario 2 white-shirt counterfactual cited as cleanest evidence; typed graph_path framing positioned at the "no ambiguity to resolve" end of Ali's spectrum; cross-link to PROJECT JAMES GitHub |
 | 2026-05-17 | **v0.3.0 — Platform Skeleton released on main** | ✅ Axis 6 second-user gate cleared 2026-05-13. Knowledge Cascade Phase A→E + Cognitive Middleware Layer architecture. Plugin API slipped to v0.3.x or v0.4 (per CHANGELOG note) |
+| 2026-05-17 | Cognitive Middleware Layer Phase 2 already shipping post-v0.3.0 | ✅ Verification engine (PR #290), planner / task decomposition (PR #297), tool router (PR #295) merged on main. Layer is now code, not architecture-only |
+| 2026-05-17 | Author dev.to Gemma 4 article — self-reply with bidirectional cross-reference to Ali's article | 🟡 Comment body drafted (see archive note below); awaiting author publication |
 
 ---
 
@@ -108,6 +112,20 @@ Per-judge tie-break is by reaction count, so post-publication actions matter:
 
 Asset archive: `reports/promo-assets/devto-gemma4-challenge.md`
 
+### Pending author-publication actions
+
+The following items are drafted and waiting for the author to publish from
+their own account (not automatable from this session):
+
+- **Author-reply on the Gemma 4 dev.to article** (bidirectional cross-reference
+  to Ali's MoE-vs-Dense piece). Body cites Ali's hypothesis as a testable
+  prediction on Graph-RAG typed-path inputs; commits to running it once the
+  Plugin / LLM Provider API lands in v0.3.x. Drafted 2026-05-17.
+- **dev.to intro + Gemma 4 article body sweep** — "v0.2.0 alpha" lines could
+  be refreshed to "v0.3.0 released 2026-05-17, Cognitive Layer Phase 2 in
+  progress" for consistency with current main state. Optional polish, no
+  freshness penalty (dev.to does not down-rank edited posts).
+
 ---
 
 ## OpenSSF criterion auto-promotions (post-merge)
@@ -153,6 +171,8 @@ This launch tracker file is considered complete when all of the following are tr
 - [ ] OpenSSF Tiered % updated post-merge (target ≥ 115%)
 - [x] **Second-user real-data corpus volunteer engaged (v0.2 → v0.3 gate cleared 2026-05-13)**
 - [x] **First substantive external technical exchange (Ali Afana / Provia, 2026-05-16)**
+- [x] **Two-way exchange formalised (LinkedIn second turn + dev.to substantive comment, 2026-05-16)**
+- [ ] Author-reply on Gemma 4 article with bidirectional cross-reference (drafted, awaiting publish)
 - [ ] Gemma 4 Challenge result decided (2026-06-04)
 
 Append a final "Phase 5 outcomes" section once the above are satisfied, then archive this file under `reports/promo-assets/archive/v0.2.0-launch-tracker.md` and reset for v0.3 cycle.


### PR DESCRIPTION
## Summary

Three updates to `reports/promo-assets/launch-tracker.md` — closes the first external technical exchange cycle and records main's current state:

### 1. Ali Afana — second turn complete (2026-05-16)

- **LinkedIn DM reply** sent: acknowledged v0.3.0 release, committed to the swap-as-benchmark in v0.3.x, split the 83-item injection-suite spin-out task (he contributes Arabic e-commerce attack-surface cases; we contribute Korean + English baseline + JSON schema), and introduced a new ablation lead: the temperature-0.3 cap in his Round 2 may not be neutral across MoE and Dense, so a temperature sweep on the same prompt would help separate "architecture matters" from "thermostat + architecture matters."
- **dev.to substantive comment** posted on Ali's article — Scenario 2 white-shirt counterfactual cited as the cleanest piece of evidence for architecture-not-size; typed `graph_path` syntax positioned at the "no ambiguity to resolve" end of his spectrum; PROJECT JAMES GitHub cross-linked.

### 2. main current state recorded

- **v0.3.0 Platform Skeleton released 2026-05-17** (tag published).
- **Cognitive Middleware Layer is no longer architecture-only.** Phase 2 already shipping on main: verification engine (PR #290), planner / task decomposition (PR #297), tool router (PR #295).
- Plugin / LLM Provider API still slipped to v0.3.x or v0.4 per CHANGELOG note (rebalanced from "v0.3 single theme" after the 2026-05-14 user briefing).

### 3. Pending author-publication actions section

Captures items that need the author's account (cannot be automated from session):

- Bidirectional cross-reference comment on author's own Gemma 4 article (drafted in session; cites Ali's collapse-prediction as testable on Graph-RAG typed-path input).
- Optional dev.to body sweep refreshing "v0.2.0 alpha" → "v0.3.0 released 2026-05-17, Cognitive Layer Phase 2 in progress."

Cycle close criteria checkboxes:
- Two-way exchange formalised → ✅
- Author-reply on Gemma 4 article with bidirectional cross-reference → 🟡 drafted, awaiting publish

## Verification

Pure docs change. CLAUDE.md rule 2 (bench numbers on `core/{retrieval,graph,reasoning}`) does not apply.

## Out of scope

- Author publishing the bidirectional cross-reference comment (drafted in session, author action)
- Author dev.to body sweep for v0.2.0 → v0.3.0 (optional polish, author action)
- Ali's third turn — natural pause; he may reply to the dev.to comment or the LinkedIn DM. No nudge planned this cycle.
- v0.3.x Plugin / LLM Provider API landing — gates both collaboration leads, but is not in scope for the promo cycle.

---

## 한국어 요약

Ali 와의 두 번째 턴 (LinkedIn 답장 + dev.to substantive 댓글) 게시 완료 + main 현재 v0.3.0 release 상태 (Cognitive Layer Phase 2 코드 일부 머지) 기록. 작성자가 직접 게시할 두 항목 (Gemma 4 글에 양방향 댓글, dev.to 글 body sweep) 도 별도 섹션으로 명시. 코드 변경 없음.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_