### PR TITLE
fix(chat): N-3 regression — newSession/switchSession leak old SID

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -543,8 +543,22 @@ function getSessionId() {
   return sid;
 }
 
-const SESSION_ID = getSessionId();
-const HISTORY_KEY = `james_history_${SESSION_ID}`;
+// [N-3 fix, 2026-05-18] const → let. newSession() / switchSession() 가
+// localStorage 의 james_session 만 갱신하고 in-memory 상수는 안 바꾸는
+// 회귀가 있었음 — "+ 새 채팅" 직후 query 가 옛 SID 로 전송되어 backend 의
+// hist_ctx 가 비어있지 않게 되고, long_ctx (이전 세션 분석 요약) 가
+// 주입돼 인사 대신 분석 답변이 나왔음 (PR-O4 #291 의 백엔드 게이트는
+// 정상이었으나 frontend 가 새 SID 를 못 흘려보냄).
+let SESSION_ID = getSessionId();
+let HISTORY_KEY = `james_history_${SESSION_ID}`;
+
+// localStorage 의 james_session 값을 바꾼 직후 호출해서 두 in-memory
+// 상수를 재동기. getSessionId() 는 localStorage 미존재 시 새 SID 를
+// 생성 + 저장하므로 newSession() / switchSession() 양쪽에서 안전.
+function refreshSessionGlobals() {
+  SESSION_ID = getSessionId();
+  HISTORY_KEY = `james_history_${SESSION_ID}`;
+}
 // item #3-a: 50 → 200. 50턴은 ~25 사용자-자메스 페어로 모바일 사용 한 번이면
 // 금방 cap. 200이면 ~100 페어, 며칠치 대화 보존 가능. localStorage 5MB 한도
 // 안에 안전 (200턴 × 평균 1KB ≈ 200KB).
@@ -2461,6 +2475,8 @@ async function switchSession(sessionId) {
   }
   // 세션 전환: sessionStorage 업데이트 + 히스토리 로드
   localStorage.setItem('james_session', sessionId);
+  // [N-3 fix] in-memory SESSION_ID / HISTORY_KEY 동기 (newSession 과 동일).
+  refreshSessionGlobals();
   toggleSessionPanel();
 
   // 현재 메시지 초기화 후 해당 세션 히스토리 표시
@@ -2507,6 +2523,9 @@ function newSession() {
   // 새 세션 ID 생성
   const newSid = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2,8);
   localStorage.setItem('james_session', newSid);
+  // [N-3 fix] in-memory SESSION_ID / HISTORY_KEY 도 동기. 안 그러면
+  // 다음 query 가 옛 SID 로 전송되어 backend N-3 게이트가 못 풀림.
+  refreshSessionGlobals();
   toggleSessionPanel();
 
   // 화면 초기화

--- a/tests/test_chat_history_persistence.py
+++ b/tests/test_chat_history_persistence.py
@@ -112,5 +112,126 @@ class ChatHistoryContractTests(unittest.TestCase):
         )
 
 
+class SessionIdRefreshAfterMutationTests(unittest.TestCase):
+    """[N-3 회귀, 2026-05-18 user feedback]
+
+    PR-O4 #291 added the engine-side `hist_ctx == ""` gate that
+    prevents cross-session long_ctx leakage. But the frontend kept
+    `SESSION_ID` / `HISTORY_KEY` as `const`s evaluated at module
+    load — so newSession() / switchSession() updated localStorage
+    but never the in-memory constants. The next POST /query/ sent
+    `session_id=<old>`, the backend's hist_ctx was still populated
+    from the old session, the N-3 gate didn't fire, and prior-
+    session analyses came back in place of greetings.
+
+    These tests pin the fix: const → let + a refreshSessionGlobals()
+    helper called wherever localStorage['james_session'] is mutated.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        path = Path(__file__).resolve().parent.parent / "frontend" / "static" / "chat.js"
+        cls.src = path.read_text(encoding="utf-8")
+
+    def test_session_id_is_let_not_const(self):
+        # The bug was that const SESSION_ID couldn't be reassigned
+        # when localStorage changed. The fix declares it `let`.
+        import re
+        # Match the declaration of SESSION_ID.
+        # `const SESSION_ID = ...` (old, broken) must NOT appear.
+        self.assertFalse(
+            re.search(r"\bconst\s+SESSION_ID\b", self.src),
+            "SESSION_ID must be declared with `let` so newSession() / "
+            "switchSession() can keep it in sync with localStorage. "
+            "The previous `const` declaration caused N-3 regression — "
+            "in-memory SESSION_ID was frozen at module-load time.",
+        )
+        self.assertTrue(
+            re.search(r"\blet\s+SESSION_ID\b", self.src),
+            "SESSION_ID must exist and be declared with `let`.",
+        )
+
+    def test_history_key_is_let_not_const(self):
+        # HISTORY_KEY depends on SESSION_ID. If SESSION_ID can change
+        # at runtime, HISTORY_KEY must follow it or restoreHistory()
+        # / saveToLocal() write to the old session's localStorage slot.
+        import re
+        self.assertFalse(
+            re.search(r"\bconst\s+HISTORY_KEY\b", self.src),
+            "HISTORY_KEY must be declared with `let` for the same "
+            "reason as SESSION_ID — it has to track SESSION_ID across "
+            "session mutations or saveToLocal writes orphan history.",
+        )
+        self.assertTrue(
+            re.search(r"\blet\s+HISTORY_KEY\b", self.src),
+            "HISTORY_KEY must exist and be declared with `let`.",
+        )
+
+    def test_refresh_session_globals_helper_exists(self):
+        # A single helper is the right shape — call sites converge
+        # on one place that decides "now that localStorage changed,
+        # rebind the two in-memory constants".
+        self.assertIn(
+            "function refreshSessionGlobals(",
+            self.src,
+            "A refreshSessionGlobals() helper must exist so call "
+            "sites (newSession, switchSession, future ones) share "
+            "one re-sync path.",
+        )
+        # The body must reassign BOTH globals — half-fix would still
+        # leave restoreHistory() reading the wrong HISTORY_KEY.
+        idx = self.src.index("function refreshSessionGlobals(")
+        body = self.src[idx:idx + 400]
+        self.assertIn("SESSION_ID =", body,
+                      "refreshSessionGlobals must reassign SESSION_ID")
+        self.assertIn("HISTORY_KEY =", body,
+                      "refreshSessionGlobals must reassign HISTORY_KEY")
+
+    def test_new_session_calls_refresh_helper(self):
+        # newSession() is the most common path that hits the N-3
+        # regression (user clicks "+ 새 채팅"). It MUST call the
+        # helper after writing localStorage.
+        idx = self.src.index("function newSession(")
+        # Scan the function body — bounded by the next top-level
+        # `function ` (or end of file).
+        next_fn = self.src.find("\nfunction ", idx + 1)
+        body = self.src[idx:next_fn if next_fn > 0 else len(self.src)]
+        self.assertIn(
+            "localStorage.setItem('james_session'",
+            body,
+            "newSession should still persist the new SID to localStorage",
+        )
+        self.assertIn(
+            "refreshSessionGlobals()",
+            body,
+            "newSession MUST call refreshSessionGlobals() after the "
+            "localStorage.setItem — otherwise SESSION_ID stays at its "
+            "old value and the very next /query/ POST sends the wrong "
+            "session_id, defeating the PR-O4 #291 N-3 backend gate.",
+        )
+
+    def test_switch_session_calls_refresh_helper(self):
+        # switchSession() has the same shape — localStorage write,
+        # then in-memory constants must be re-synced.
+        idx = self.src.index("async function switchSession(")
+        next_fn = self.src.find("\nasync function ", idx + 1)
+        if next_fn < 0:
+            next_fn = self.src.find("\nfunction ", idx + 1)
+        body = self.src[idx:next_fn if next_fn > 0 else len(self.src)]
+        self.assertIn(
+            "localStorage.setItem('james_session'",
+            body,
+            "switchSession should persist the chosen SID to localStorage",
+        )
+        self.assertIn(
+            "refreshSessionGlobals()",
+            body,
+            "switchSession MUST call refreshSessionGlobals() — same "
+            "reason as newSession. Switching sessions and then sending "
+            "a query without re-syncing would route the query to the "
+            "OLD session's hist_ctx.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

**Live user-reported regression** (B-1 spot-check, 2026-05-18). Clicking **\"+ 새 채팅\"** then sending \"안녕\" returns a prior-session analysis answer instead of a greeting.

PR-O4 #291 added the engine-side `hist_ctx == \"\"` gate in `engine_memory.py` — that's correct. But the **frontend companion was missing**: `chat.js` held `SESSION_ID` and `HISTORY_KEY` as `const`s evaluated at module load. `newSession()` / `switchSession()` mutated localStorage but the in-memory constants stayed frozen, so the very next `POST /query/` shipped `session_id=<old SID>`. The backend's `get_history_context(<old SID>, limit=5)` returned the previous session's turns, `hist_ctx` was non-empty, the N-3 gate didn't fire, `long_ctx` joined `memory_context`, and the LLM resolved \"안녕\" against \"BlackRock 비트코인 ETF 분석\" — exactly the regression the user reported.

`clearHistory()` avoided the bug only because it followed up with `location.reload()`, which re-runs `getSessionId()`. `newSession()` and `switchSession()` are instant-UX paths that **don't reload** — they shipped the regression.

## Root cause (3 lines)

```javascript
// frontend/static/chat.js — pre-fix
const SESSION_ID = getSessionId();         // ← module-load only
const HISTORY_KEY = `james_history_${SESSION_ID}`;

function newSession() {
  localStorage.setItem('james_session', newSid);
  // SESSION_ID / HISTORY_KEY NEVER REASSIGNED — const, frozen.
}
```

## Fix

1. `SESSION_ID` / `HISTORY_KEY` declarations: `const` → `let`.
2. New `refreshSessionGlobals()` helper — single re-sync point for any current or future mutation site. Re-runs `getSessionId()` and re-derives `HISTORY_KEY`.
3. `newSession()` and `switchSession()` call the helper immediately after `localStorage.setItem`. `switchSession()` had the same shape of bug — clicking a different session in the picker would have sent the next query to the OLD session's `hist_ctx` until reload.

**Frontend-only fix.** The backend N-3 gate (`engine_memory.py:82-87`) is unchanged — it just couldn't work because the SID it was gating on never reached it.

## Tests added (5 new in `SessionIdRefreshAfterMutationTests`)

| Test | Pins |
|---|---|
| `test_session_id_is_let_not_const` | A future contributor can't revert to `const` without breaking CI |
| `test_history_key_is_let_not_const` | Same for `HISTORY_KEY` (depends on SESSION_ID) |
| `test_refresh_session_globals_helper_exists` | Helper exists AND reassigns BOTH globals (half-fix would leave `saveToLocal` / `restoreHistory` writing to the wrong slot) |
| `test_new_session_calls_refresh_helper` | `newSession()` calls the helper after the localStorage write |
| `test_switch_session_calls_refresh_helper` | `switchSession()` calls the helper after the localStorage write |

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 platform-only | Frontend session plumbing — no domain coupling |
| #2 bench numbers | `core/*` unchanged → STEP 7 byte-identical |
| #3 self-evolution | Unrelated |
| #4 architecture | No `§5.*` change |
| #5 module size | Frontend; `chat.js` unchanged in shape, just `const` → `let` on 2 declarations + a small helper |

## Verification

- **9/9** `tests/test_chat_history_persistence.py` green (4 existing + 5 new)
- **2047/2047** full suite green (minus 3 pre-existing character-test failures, confirmed on main with `git stash`)
- `node --check frontend/static/chat.js` clean

## Out of scope

- **C-2 query_rewrite trace visibility** — separate PR-B (also discovered in this spot-check sweep, fixes the diagnostic gap for the next round of verification but isn't a live-block regression)
- **User's live re-verification** — user will re-run B-1 after merge as part of the planned spot-check sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)