### PR TITLE
fix(chat): strip enumeration leftovers from body after suggestion chip emit (PR-O2b)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1590,6 +1590,37 @@ function extractNextActionSuggestions(answerText) {
         /(?:^|\n)[^\n]{0,80}[:：]\s*$/,
         '',
       ).replace(/[\s　]+$/, '');
+
+      // [PR-O2b 2026-05-18] 본문 잔재 추가 제거.
+      // tail 600자 cut 만으로는 본문 앞쪽에 enumeration ((1)/(2)/(3)/
+      // ①②③/1)/1.) 형식의 follow-up 잔재가 남는 케이스 차단 못함 —
+      // chip 으로 emit 된 텍스트가 본문 위쪽에 enumeration prefix 와
+      // 함께 또 있으면 사용자가 같은 정보를 두 번 본다.
+      //
+      // 매우 보수적 strip:
+      //   - chip 으로 emit 된 텍스트 (out[i].text) 와 *정확 일치*
+      //   - enumeration prefix 동반 ((n) / n) / n. / ①②③④⑤⑥⑦⑧⑨)
+      //   - 줄 시작/끝 boundary
+      //   - 잘못 매칭 시 본문 보존이 우선이라 try/catch 로 감쌈
+      try {
+        for (const sugg of out) {
+          const escaped = sugg.text.replace(
+            /[.*+?^${}()|[\]\\]/g, '\\$&'
+          );
+          const enumRe = new RegExp(
+            '(?:^|\\n)\\s*(?:\\(\\d\\)|\\d[\\.)]|[①②③④⑤⑥⑦⑧⑨])\\s*'
+            + escaped
+            + '[\\.。?？]?\\s*(?=\\n|$)',
+            'g'
+          );
+          cleanAnswer = cleanAnswer.replace(enumRe, '');
+        }
+        // 줄바꿈 3 개 이상 → 2 개로 정리 (strip 후 빈 줄 누적 방지)
+        cleanAnswer = cleanAnswer.replace(/\n{3,}/g, '\n\n').trim();
+      } catch (_e) {
+        // regex 빌드 실패 시 base cleanAnswer (위 cutStart strip) 유지
+      }
+
       return { suggestions: out, cleanAnswer };
     }
   }

--- a/tests/test_chat_ux_n4_n5.py
+++ b/tests/test_chat_ux_n4_n5.py
@@ -266,5 +266,86 @@ class SuggestionPatternsPrO2Tests(unittest.TestCase):
         )
 
 
+class CleanAnswerBodyStripPrO2bTests(unittest.TestCase):
+    """[PR-O2b 2026-05-18 user feedback]
+
+    PR-O2 의 cleanAnswer 가 tail 600자 안에서 첫 매칭 이후만 자른다.
+    그래서 LLM 답변이 길고 enumeration ((1)/(2)/(3)) 이 본문 앞쪽
+    (tail 600자 밖) 에 있고, 다른 follow-up phrase 가 본문 끝쪽
+    (tail 안) 에 있으면:
+
+      - tail 안의 phrase 가 chip 으로 emit 됨
+      - cutStart 가 tail 안의 첫 매칭 위치 → 그 이후만 strip
+      - 본문 앞쪽 enumeration 은 그대로 남음
+      - 사용자는 본문 (1)(2)(3) + 하단 chip 1개를 같이 봄 (중복)
+
+    이 PR 은 chip 으로 emit 된 각 텍스트를 본문에서 enumeration prefix
+    동반으로 정확 일치 검색해서 그 라인만 추가 제거. 안전성:
+      - 정확 일치 substring 만 (sugg.text)
+      - enumeration prefix 동반 ((n) / n) / n. / ①②③)
+      - 줄 시작/끝 boundary
+      - try/catch — regex 빌드 실패 시 base cleanAnswer 유지
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = JS.read_text(encoding="utf-8")
+        m = re.search(
+            r"function\s+extractNextActionSuggestions\s*\("
+            r"[\s\S]+?\n\}\n",
+            cls.src,
+        )
+        assert m, "extractNextActionSuggestions 본문을 찾을 수 없음"
+        cls.fn_body = m.group(0)
+
+    def test_extra_strip_loop_present(self):
+        # chip out[] 을 다시 순회하며 본문에서 제거하는 loop 가 존재.
+        self.assertRegex(
+            self.fn_body,
+            r"for\s*\(\s*const\s+sugg\s+of\s+out\s*\)",
+            "PR-O2b strip loop ('for sugg of out') 누락 — 본문 잔재가 "
+            "tail cut 한 번으로만 처리되어 enumeration 잔재가 남음",
+        )
+
+    def test_regex_escape_helper_inline(self):
+        # 매칭 텍스트의 regex meta-char 를 escape 해야 안전. inline
+        # replace 로 escape 패턴이 있는지 확인.
+        self.assertIn(
+            r"[.*+?^${}()|[\]\\]",
+            self.fn_body,
+            "regex special-char escape 누락 — sugg.text 안의 '?' 같은 "
+            "메타 문자가 escape 안 되면 잘못된 RegExp 빌드 → 본문 망가짐",
+        )
+
+    def test_enumeration_prefix_required(self):
+        # strip 은 enumeration prefix 동반 일치만 — 본문 임의 위치
+        # 우연 일치를 자르지 않게.
+        self.assertRegex(
+            self.fn_body,
+            r"\\\(\\\\d\\\)|\\d\[\\\\\.\)\]|①②③",
+            "enumeration prefix 조건 ((n)/n)/n./①②③) 누락 — "
+            "조건 없는 strip 은 본문 임의 substring 을 자를 위험",
+        )
+
+    def test_try_catch_protects_base_clean_answer(self):
+        # regex 빌드 실패 시 base cleanAnswer (위 cutStart strip) 가
+        # 보존되어야 함. try { ... } catch (_e) { ... } 형태 확인.
+        self.assertRegex(
+            self.fn_body,
+            r"try\s*\{[\s\S]+?\}\s*catch\s*\(\s*_e\s*\)",
+            "try/catch 보호 누락 — 잘못된 regex 빌드 시 cleanAnswer "
+            "전체가 망가져 답변 본문이 사라질 위험",
+        )
+
+    def test_excess_newlines_collapsed_after_strip(self):
+        # strip 후 빈 줄 3 개 이상 누적되지 않게 정리하는 step.
+        self.assertIn(
+            r"\n{3,}",
+            self.fn_body,
+            "strip 후 newline 정리 step 누락 — 본문에 빈 줄 3 개 이상 "
+            "누적되어 UI 가 어색함",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Live E-1 / E-2 spot-check (2026-05-18, user observation): the suggestion-chip path (#279 PR-O2) emits chips when a follow-up pattern matches the answer's tail, and `cleanAnswer` cuts the answer at the **first** tail match. But when the LLM packs an enumeration ((1)/(2)/(3)) into the body proper — typically right under an intro sentence like \"다음 중 어떤 내용을 더 자세히 알고 싶으신가요?\" — and a **different** follow-up phrase appears later in the same answer, the tail cut only handles the latter. The enumeration up top survives in the bubble while the extracted text re-appears as a chip below — **same information twice**.

User wording:
> 크게 문제되지는 않지만, 완결성에 있어 조금 신경쓰임

## Fix shape

One extra, very conservative strip pass inside `extractNextActionSuggestions`. For each chip already extracted into `out[]`, rebuild a small regex that finds the chip's own text in the answer body **but only with an enumeration prefix attached** (`(n)` / `n)` / `n.` / one of `①②③④⑤⑥⑦⑧⑨`) **on its own line**.

| Safety layer | What it prevents |
|---|---|
| Exact-substring match on `sugg.text` (escaped for regex meta-chars) | Accidental fuzzy hits |
| Line-anchored (`^\|\n` and trailing `\n\|$`) | Mid-line collateral |
| Enumeration prefix **mandatory** | Body prose can't ever match — no enum, no strip |
| `try { ... } catch (_e)` wrap | Malformed RegExp (escape bug / unicode edge) → base cleanAnswer preserved |
| Trailing `\n{3,}` collapse | Removed middle lines don't leave triple-blank craters |

## Public API unchanged

`extractNextActionSuggestions` still returns `{suggestions, cleanAnswer}` with the same types. Bubble render call sites untouched.

## Tests added (5 new in `CleanAnswerBodyStripPrO2bTests`)

Source-level pins so future regression breaks CI:

| Test | Pins |
|---|---|
| `test_extra_strip_loop_present` | The new `for (const sugg of out)` loop must exist |
| `test_regex_escape_helper_inline` | Inline escape literal must appear so chip texts containing `?` / `(` / etc. don't blow up RegExp build |
| `test_enumeration_prefix_required` | Strip regex must contain at least one enumeration prefix token — strip is bounded by construction |
| `test_try_catch_protects_base_clean_answer` | `try / catch (_e)` wrap pinned |
| `test_excess_newlines_collapsed_after_strip` | `\n{3,}` collapse pinned |

## Verification

- **22/22** `tests/test_chat_ux_n4_n5.py` green (17 existing + 5 new)
- **17/17** `tests/test_suggestion_click.py` green (PR-O2 threshold-1 contract intact — strip happens AFTER chip extraction, chip count unchanged)
- **Full repo: 2058/2058** green (minus 3 pre-existing character-test failures unrelated to this PR — reproducible on main)
- `node --check frontend/static/chat.js` clean

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 platform-only | Pure UX, no domain coupling |
| #2 bench numbers | Frontend-only, `core/*` unchanged → STEP 7 byte-identical |
| #3 self-evolution | Unrelated |
| #4 architecture | No `§5.*` change; extends existing PR-O2 strip path |
| #5 module size | `chat.js` already biggest frontend file; this is a ~22-line additive change inside one function. The big-file follow-up split is already on the operational UX backlog. |

## What this PR does NOT do

- Does **NOT** lower the chip-emit threshold further (still PR-O2's `>= 1`). The bug was duplication, not chip count.
- Does **NOT** touch `tail-600` in the original cleanAnswer cut. That knob is conservative for a reason — widening it would risk chopping mid-body prose. The new strip is targeted (exact text + prefix) and therefore safer to apply on the already-cleaned answer.
- Does **NOT** alter what the LLM sees. Backend prompts / retrieval / rerank / planner / reflect / verify all byte-identical. STEP 7 cannot move.

## Cycle 12 progress after this PR

```
PR-O1 #277  Node-click 403 fix              ✓
PR-O2 #279  Suggestion chip NL patterns     ✓
PR-O2b THIS Suggestion body strip cleanup   ← this PR (cosmetic follow-up)
PR-O3 #280  Save-chip spinner               ✓
PR-O4 #291  N-3 long_ctx isolation          ✓ (+ #302 frontend fix)
PR-O5 #292  External isolation              ✓
PR-O6 #294  Node editor (backend)           ✓
PR-O6b #299 Node editor (frontend + i18n)   ✓
PR-O7       Drag + click-to-connect         deferred
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)