### PR TITLE
docs(handover): bilingual promo track — KO ↔ EN balance correction plan

### DIFF
--- a/docs/handovers/v0.3.x-bilingual-promo-track.md
+++ b/docs/handovers/v0.3.x-bilingual-promo-track.md
@@ -1,0 +1,256 @@
+# v0.3.x — Bilingual Promo Track (KO ↔ EN balance correction)
+
+> Status: open (next-cycle plan, no work started)
+> Created: 2026-05-18 (end of the v0.2/v0.3 promotion cycle)
+> Trigger: end-of-cycle audit showed EN reach ≈ 8–10× KO reach despite KO being a native asset
+> Companion documents:
+>   - `reports/promo-assets/launch-tracker.md` (running log — the cycle this is a follow-up to)
+>   - `docs/handovers/v0.3.x-ali-collaboration-track.md` (parallel track — Ali collaboration)
+>   - `docs/handovers/v0.3.x-gemma4-feedback-track.md` (parallel track — feedback routing)
+>   - `reports/promo-assets/screenshots/README.md` (reusable visual library)
+
+## Purpose
+
+The v0.2 → v0.3 promotion cycle landed strong on the English side (X EN thread + 3 dev.to articles + Hashnode + LinkedIn ×2 + Ali Afana 4-turn collaboration + verified-account replies from @simplydt and @mfucek_) and weak on the Korean side (1 X KR thread, 0 organic Korean replies, GeekNews unpublished).
+
+This handover defines the next promotion cycle's **KO ↔ EN balance correction** so the next session can pick any channel from either side and start without re-deriving the strategy each time.
+
+Any session continuing this track should be able to read this single page and know:
+
+- which channels to publish to in which order
+- which existing asset (article / screenshot / framing) plugs into each channel
+- the calendar with D-Day pressure (GeekNews tomorrow; Gemma 4 Challenge deadline 6 days; Show HN / Reddit staggered after)
+
+## End-of-cycle balance audit
+
+| Region | Live channels at 2026-05-18 | Organic external reactions |
+|---|---|---|
+| 🇺🇸 **EN** | X English (thread + standalone + Gemma 4 quote + v0.3.0 visualizer with image) · dev.to ×3 (intro / Gemma 4 Build / Gemma 4 Write) · Hashnode (intro cross-post) · LinkedIn ×2 · 3 awesome PRs (1 closed, 2 open) · OpenSSF passing badge | Matija Fućek (verified) + David T Kramaley (verified) X replies · Ali Afana 4-turn LinkedIn DM + dev.to substantive comment · 8 reactions on Gemma 4 Write track post |
+| 🇰🇷 **KO** | X Korean thread ×1 (URL still missing from launch-tracker — author to record) · README.ko.md · GeekNews account created 2026-05-12 (post lockout cleared 2026-05-19) | 0 |
+
+Imbalance: EN reach approximately 8–10× KO reach by channel count, much wider by reaction count. The asymmetry is not necessary — KO assets (Korean RAG corpus, Korean ontology, Korean-language fixture coverage, Palantir analogy fluency in Korean IT) are first-class differentiators in Korean tech communities.
+
+## 🇰🇷 KO channel list (priority order)
+
+Track-1 priorities are the calendar-pressured ones; lower-priority channels are time-flexible but valuable.
+
+### Track K1 — GeekNews (D-Day 2026-05-19, *tomorrow*)
+
+**Why first**: account is already past its 7-day post lockout, the geeknews-post.md draft is already on main (`reports/promo-assets/geeknews-post.md`), Korean IT community's highest single-shot reach.
+
+**Asset to use**:
+- Body: `reports/promo-assets/geeknews-post.md` — refresh for v0.3.0 (the draft was written for v0.2.0; the Cognitive Layer Phase 2 + Ali collaboration + Mini Palantir + Gemma 4 Challenge narrative are the new pieces)
+- Image: `reports/promo-assets/screenshots/06-3d-graph.jpg` (hero) — primary
+- Image: `reports/promo-assets/screenshots/03-chat-graph-paths.jpg` — secondary (47 graph paths surfaced)
+
+**Time window**: KST weekday 09–11 or 20–22 (Korean tech reader peak)
+
+**Done when**: post live + URL recorded in launch-tracker
+
+### Track K2 — Korean LinkedIn post (KO version of the v0.3.0 EN post)
+
+**Why second**: LinkedIn KO and EN posts run on separate algorithm pipelines — cumulative reach roughly 2× a single-language post. The English v0.3.0 post is already live, KO version reaches the Korean IT manager / founder audience that doesn't read English LinkedIn.
+
+**Asset to use**:
+- Body: translate the EN v0.3.0 LinkedIn post (already in the conversation history; covers OpenSSF badge / Cognitive Layer Phase 2 / Ali collaboration / Mini Palantir frame)
+- Hashtags: 영문(`#GemmaChallenge #RAG #GraphRAG`) + 한국어(`#오픈소스 #자체호스팅 #온톨로지`) 혼합. Bilingual hashtag set is normal on Korean LinkedIn and reaches both feeds.
+- Image: `06-3d-graph.jpg`
+
+**Time window**: KST weekday 09–11 or 19–21
+
+### Track K3 — Korean X thread series (Day 1–7)
+
+**Why third**: the v0.2/v0.3 cycle posted only 1 Korean X thread vs 4+ English X posts. Closing the gap with a 5–7-tweet KO series spread across one week.
+
+**Suggested tweet shapes**:
+
+| # | Topic | Source asset |
+|---|---|---|
+| 1 | v0.3.0 release + Cognitive Layer Phase 2 announcement (KO) | EN v0.3.0 LinkedIn post |
+| 2 | "Mini Palantir" framing in Korean — why the analogy lands | dev.to intro article KO summary |
+| 3 | Gemma 4 Challenge 두 트랙 동시 도전 — 작가의 정직성 frame | both Gemma 4 dev.to articles |
+| 4 | E4B 의 5개 cognitive stage 빈 응답 발견 — fair-witness 보고서 | Write track dev.to article |
+| 5 | Ali Afana 와의 두 번째-사용자 검증 collaboration | LinkedIn DM exchange summary |
+| 6 | 시각 자산: 3D 온톨로지 그래프 영상 (no text, just the visual) | 06-3d-graph.jpg |
+| 7 | 한국어 사용자를 위한 한 줄 — "노트북에서 100% 로컬, MIT" CTA | landing page link |
+
+**Done when**: all 7 posted within 7 days, each URL added to launch-tracker
+
+### Track K4 — Velog cross-post (intro article KO)
+
+**Why**: Velog is Korea's dev.to-equivalent. Google KO SEO sends Korean RAG / LLM searches there ahead of dev.to. A canonical-URL'd cross-post of the intro article gives the same content a Korean SEO surface without splitting reader credit.
+
+**Asset to use**:
+- Body: KO translation of the intro article ("Building a Mini Palantir: A Local Graph-RAG Engine with Ontology, Security, and Self-Evolution"), drafted from `reports/promo-assets/devto-post.md`
+- Canonical URL: set to the dev.to original — avoids Google duplicate-content penalty, both posts continue to receive their own algorithm signal
+- Cover image: `06-3d-graph.jpg`
+
+**Done when**: published + canonical URL set + URL recorded in tracker
+
+### Track K5 — OKKY (1.4M+ Korean IT members)
+
+**Why**: largest serious Korean developer community. "프로젝트 공유" 게시판 is the right one (not "자유게시판"). Korean developer-to-developer audience.
+
+**Asset to use**:
+- Body: tightened KO version of the dev.to intro article (1500–2000 자 max, OKKY readers are time-pressed)
+- Lead with "v0.3.0 alpha, MIT, 100% 로컬" — Korean dev community values production-readiness signals over marketing tone
+- Image: `06-3d-graph.jpg`
+
+**Risk**: OKKY's self-promotion 9:1 rule is enforced. If the account has no other OKKY history, the post may be removed. Have a fallback ready: comment 3–5 times on other people's posts before publishing the project share.
+
+### Track K6 — Clien 자게 / DDIT
+
+**Why**: broader Korean IT-adjacent reach (less developer-pure than OKKY). Different audience overlap.
+
+**Asset to use**:
+- Body: shorter casual KO blurb (300–500 자) + GitHub URL + a single screenshot
+- No technical depth — the "노트북에서 100% 로컬, MIT" framing is what reaches general Korean tech readers
+
+### Track K7 — Tistory / Notion blog (permanent Korean SEO)
+
+**Why**: long-tail Korean Google searches for "로컬 LLM", "Graph-RAG 한국어", "온톨로지 RAG" should land somewhere we own. Tistory and Notion both index well on Naver and Google KO.
+
+**Asset to use**:
+- Tistory: KO translation of the intro article, posted to a Tistory blog (existing or new)
+- Notion: same content as a public Notion page — different SEO footprint
+- canonical URL not used here (different SEO strategy than Velog)
+
+### Track K8 — PyCon Korea / DEVIEW CFP
+
+**Why**: highest-credibility Korean tech speaker stage. Reach is small numerically but high in influence — one accepted talk converts to multi-year reputation.
+
+**When**: PyCon Korea CFP usually opens June–July for an October event; DEVIEW CFP varies. Both target v1.0-ready talks rather than v0.3-alpha. **Hold this for the v0.4 → v1.0 cycle**, but mark the CFP windows on the calendar early.
+
+## 🇺🇸 EN channel list (next-cycle additions)
+
+Channels already live during v0.2/v0.3 are not re-listed here. These are the gaps:
+
+### Track E1 — Show HN (D-Day 2026-05-26)
+
+**Why first in EN**: already scheduled in the prior cycle's calendar. Hacker News front page is the single highest-reach EN channel for technical infra projects.
+
+**Asset to use**:
+- Body: `reports/promo-assets/hackernews-show-hn.md` — refresh for v0.3.0 + Ali collaboration + Gemma 4 Challenge two-track narrative
+- Image: `06-3d-graph.jpg` (HN supports inline images via the post URL, but generally HN posts perform better when the URL itself is the demo — point at the GitHub repo, let the README hero image do the visual work)
+
+**Time window**: US Pacific 06:00–09:00 (HN front-page algorithm window)
+
+### Track E2 — r/LocalLLaMA (D-Day 2026-06-02)
+
+**Asset to use**: `reports/promo-assets/reddit-locallama.md` — refresh for v0.3.0 + Cognitive Layer + collaboration leads
+
+**Risk**: r/LocalLLaMA enforces account-history rules. Have 5+ comments on other community posts before publishing the share.
+
+### Track E3 — r/selfhosted / r/Python / r/MachineLearning
+
+**Why**: each subreddit has a different audience overlap with PROJECT JAMES. r/selfhosted picks up the "100% local, MIT, Ollama" angle; r/Python picks up the Python codebase quality; r/MachineLearning is the most technical.
+
+**Schedule**: stagger one per week post Track E2 to avoid cross-posting spam flags.
+
+### Track E4 — Discord direct outreach
+
+Three servers worth direct technical outreach (not blast posting):
+
+| Server | Why | Approach |
+|---|---|---|
+| Ollama Discord | Direct Ollama integration mention | post in #showcase or #projects, link the dev.to Gemma 4 Write-track article (it documents Ollama-specific behavior) |
+| LangChain Discord | RAG community overlap | post in #show-and-tell, lead with the typed-graph-paths-as-typed-schema angle (Ali collaboration framing) |
+| Hugging Face Discord | Gemma 4 user community | post in #general or model-specific channels, lead with the Gemma 4 Challenge submissions |
+
+**Risk**: Discord servers have varying self-promotion rules. Read the channel guidelines first. The angle should be technical contribution, not project launch.
+
+### Track E5 — English newsletters
+
+Pitching one of these is a single email with article links, no ongoing effort:
+
+| Newsletter | Audience | Pitch angle |
+|---|---|---|
+| **TheSequence** | ML researchers + engineers | "Two-author Gemma 4 controlled experiment — co-author piece coming in v0.3.x" |
+| **AlphaSignal** | AI engineers / tooling | "Local Graph-RAG with typed-schema retrieval-conditioning — open-source MIT" |
+| **Latent Space** | Practitioner-engineer overlap | "Self-evolution scaffold with audit log — OpenSSF passing alpha" |
+
+**When**: after Track E3 lands at least one Reddit thread (newsletters look for "this is already getting traction" signal).
+
+### Track E6 — YouTube 90-second video
+
+**Why**: re-usable across all KO and EN channels. A single 90-second walk-through plays inline on dev.to / Reddit / LinkedIn / X / Show HN comments — the highest single asset reuse ratio.
+
+**Format**:
+- 0:00–0:15 — `git clone` + `pip install -r requirements.txt` + `ollama pull gemma4:e4b`
+- 0:15–0:35 — `python server_llmwiki.py`, then a chat query in Korean ("RAG가 무엇인가요?") with English subtitles
+- 0:35–0:55 — `/admin/graph` showing the 3D visualizer rotating
+- 0:55–1:15 — `/admin/patch/audit` showing the self-evolution lifecycle JSONL
+- 1:15–1:30 — landing card with GitHub URL + OpenSSF badge + MIT license
+
+**Subtitles**: KO + EN simultaneous (YouTube auto-CC plus a manually-uploaded SRT for Korean).
+
+**Source assets**: the same screenshots library (`01–06.jpg`) — these are still frames of the same scenes the video walks through.
+
+### Track E7 — Indie Hackers
+
+Solo-dev community; product launches there move slowly but the audience is high-quality. Suitable for a v0.4 release post, not a v0.3-alpha share.
+
+### Track E8 — Bluesky / Mastodon
+
+X-alternative SNS, IT activist-heavy. Cross-post the X English thread with a one-line context tweet. Mostly free reach with minimal extra effort once the X thread is written.
+
+## 🗓️ Calendar (next-cycle Week 1–4)
+
+| Date | KO | EN |
+|---|---|---|
+| **2026-05-19 (D+1)** | 🇰🇷 **K1: GeekNews 발행** (잠금 해제) | 🇺🇸 Gemma 4 Challenge reaction 모니터링 시작 |
+| 2026-05-20 | K2: Korean LinkedIn post + K3 tweet #1 | — |
+| 2026-05-21–22 | K4: Velog cross-post | — |
+| 2026-05-23 | K3 tweet #2 (Mini Palantir KO framing) | — |
+| 2026-05-24 (D+6) | K3 tweet #3 (Gemma 4 두 트랙) | 🇺🇸 **Gemma 4 Challenge 마감** |
+| 2026-05-25 | K3 tweet #4 (E4B 5 empty responses KO) | — |
+| **2026-05-26 (D+8)** | K3 tweet #5 (Ali collaboration) | 🇺🇸 **E1: Show HN 발행** (US Pacific 06–09) |
+| 2026-05-28 | K3 tweet #6 (3D graph visual) | — |
+| 2026-05-30 | K3 tweet #7 (한 줄 CTA + landing) | — |
+| **2026-06-01** | K5: OKKY 게시 | 🇰🇷 Track 2 (Ali fixture) 회수 |
+| **2026-06-02 (D+15)** | K6: 클리앙 / DDIT | 🇺🇸 **E2: r/LocalLLaMA 발행** |
+| 2026-06-04 | — | 🇺🇸 **Gemma 4 Challenge 결과 발표** |
+| 2026-06-05–10 | K7: Tistory / Notion 영구 한국어 자산 | E3: r/selfhosted (one Reddit per week) |
+| **2026-06-15** | — | 🇺🇸 Track 1 Provider contract 코드 PR 마감 |
+| 2026-06-15+ | — | E4: Discord 직접 컨택 (Ollama / LangChain / HuggingFace) |
+| 2026-06-20+ | — | E5: English newsletter pitch (TheSequence / AlphaSignal / Latent Space) |
+| 2026-06-25+ | — | E6: YouTube 90초 영상 (re-usable across all channels) |
+| 2026-07+ | K8: PyCon Korea / DEVIEW CFP 모니터링 (v0.4 → v1.0 사이클 대비) | E7 / E8: Indie Hackers / Bluesky / Mastodon (low-effort cross-posts) |
+
+## Decision rules — which asset goes where
+
+These are the rules the prior cycle didn't have written down. Recording them now so the next session doesn't re-derive each channel-asset pairing.
+
+| Asset | Primary use | Secondary use | Do NOT use |
+|---|---|---|---|
+| `06-3d-graph.jpg` | README hero, dev.to cover (intro), GeekNews body image, X first tweet | Anywhere a single hero image is wanted | — |
+| `03-chat-graph-paths.jpg` | dev.to cover (Gemma 4 Build / Write tracks), "the model is doing real work" channel | Reddit body when responsiveness needs to be shown | — |
+| `01-memory-status.jpg` | dev.to "Trust signals" section, X follow-up tweet on data substrate | LinkedIn deep posts | hero image (too text-heavy) |
+| `04-personality-radar.jpg` | dev.to intro § Personality, LinkedIn follow-up | Reddit secondary image | hero (audience-specific) |
+| `05-knowledge-tracker.jpg` | dev.to Self-evolution section, X tweet on learning growth | LinkedIn follow-up | hero (one-shot context) |
+| `02-intent-engineering.jpg` | dev.to Architecture support, Reddit secondary | — | hero (single-entity focus is narrow) |
+| `geeknews-post.md` | GeekNews KO body | — | EN channels (KO-specific framing) |
+| `hackernews-show-hn.md` | Show HN body | — | KO channels |
+| `reddit-locallama.md` | r/LocalLLaMA body | r/selfhosted with mild edit | KO channels, GeekNews |
+| `devto-post.md` (intro) | dev.to intro article | Hashnode cross-post, Velog cross-post (KO translation) | X / LinkedIn (too long) |
+| `devto-gemma4-challenge.md` (Build track archive) | dev.to Build track post | — | other channels (challenge-specific) |
+| `devto-gemma4-write-track.md` (Write track archive) | dev.to Write track post | — | other channels |
+| Mini Palantir framing | KO channels (GeekNews / LinkedIn KO / X KO) | EN channels with disclaimer | technically anywhere — disclaimer about trademark is in our SECURITY/promo docs |
+| Ali collaboration narrative | EN dev.to articles + LinkedIn EN + X EN | KO X tweet #5 specifically | KO mass-channels (audience won't recognize Ali; mention briefly with context) |
+
+## How a future session uses this page
+
+1. **Pick a channel** from the priority order (K1, K2, K3 for KO / E1, E2, E3 for EN).
+2. **Look up the asset mapping** in the Decision rules table.
+3. **Check the calendar** to make sure the channel's D-Day hasn't slipped.
+4. **Write the post / publish / record URL in launch-tracker.md**.
+5. **Mark the row in this handover as done** once the post is live.
+
+If the session can only do one thing in a sitting, **Track K1 (GeekNews tomorrow) is the calendar-pressured one**. After that, K2 + K3 tweets #1–2 are the easiest reach extension (existing asset reuse, no new writing).
+
+## What this handover deliberately does *not* cover
+
+- Inbound reaction routing once posts go live — that's `docs/handovers/v0.3.x-gemma4-feedback-track.md`'s scope, applied per channel
+- Ali-specific collaboration tracks — those are `docs/handovers/v0.3.x-ali-collaboration-track.md`'s scope
+- The actual code that the Provider contract / fixture migration depends on — those are coding tracks, not promo
+- A second-language audit of bilingual disparity beyond Korean (i.e. Spanish, Japanese, German potential audiences) — out of scope this cycle; revisit at v1.0 when domain-specific traction patterns are clearer


### PR DESCRIPTION
## Summary

Closes the v0.2 → v0.3 promotion cycle with a **bilingual promo plan** for the next cycle. End-of-cycle audit showed EN reach ≈ 8–10× KO reach despite KO being a first-class asset (Korean RAG corpus, Korean ontology, Korean-language fixture coverage, "Mini Palantir" analogy fluency in Korean IT).

This handover converts the imbalance into a next-cycle plan with priority channels per region, asset → channel decision rules, and a 3–4 week calendar.

### What ships

**End-of-cycle balance audit** — table of live channels and organic reactions per region (🇺🇸 EN: X / dev.to ×3 / Hashnode / LinkedIn ×2 / Ali 4-turn collaboration / Matija + David verified replies / OpenSSF passing badge vs 🇰🇷 KO: 1 X thread / README.ko.md / unpublished GeekNews).

**🇰🇷 KO channel list (K1–K8, priority order)**:

| # | Channel | When |
|---|---|---|
| **K1** | **GeekNews 발행** | D-Day **2026-05-19 (tomorrow)** |
| K2 | Korean LinkedIn post (KO version of EN v0.3.0 post) | 5/20 |
| K3 | Korean X thread series (7 tweets) | 5/20–5/30 |
| K4 | Velog cross-post (intro article KO, canonical URL'd) | 5/21–22 |
| K5 | OKKY 1.4M+ Korean IT | 6/1 |
| K6 | Clien 자게 / DDIT | 6/2 |
| K7 | Tistory / Notion (permanent KO SEO) | 6/5–10 |
| K8 | PyCon Korea / DEVIEW CFP | deferred to v0.4 → v1.0 |

**🇺🇸 EN channel list (E1–E8 — gaps from prior cycle)**:

| # | Channel | When |
|---|---|---|
| **E1** | **Show HN** | D-Day **2026-05-26** |
| **E2** | **r/LocalLLaMA** | D-Day **2026-06-02** |
| E3 | r/selfhosted / r/Python / r/MachineLearning (staggered) | weekly post 6/2 |
| E4 | Discord direct (Ollama / LangChain / HuggingFace) | 6/15+ |
| E5 | English newsletter pitches (TheSequence / AlphaSignal / Latent Space) | 6/20+ |
| E6 | YouTube 90-second video (highest single asset reuse ratio) | 6/25+ |
| E7 | Indie Hackers | defer to v0.4 release |
| E8 | Bluesky / Mastodon | 7+ (low effort cross-post) |

**Calendar** with four hard deadlines (GeekNews 5/19 / Gemma 4 5/24 / Show HN 5/26 / r/LocalLLaMA 6/2 / Provider contract 6/15).

**Decision rules table** mapping every existing asset (6 screenshots + 4 channel-specific markdown bodies + Mini Palantir framing + Ali collaboration narrative) to primary / secondary / forbidden channels — so the next session does not re-derive the pairing.

**"How a future session uses this page"** — 5-step picking guide, with K1 (GeekNews tomorrow) called out as the single calendar-pressured item if only one channel fits a sitting.

### Why this handover now

The v0.2/v0.3 promotion cycle ended with all written commitments converted to coding tracks (PR #311 Ali Collaboration + Schema v0). The natural next session is the **GeekNews D-Day tomorrow**, and without this handover the next session would have to re-derive the bilingual strategy from the launch-tracker alone. This page replaces that derivation with a picked-and-ranked list.

## Verification

Pure handover addition. No code touched. CLAUDE.md rule 2 (bench numbers) does not apply.

Cross-references:
- `reports/promo-assets/launch-tracker.md` — the cycle this is a follow-up to
- `docs/handovers/v0.3.x-ali-collaboration-track.md` — parallel coding track
- `docs/handovers/v0.3.x-gemma4-feedback-track.md` — inbound reply routing
- `reports/promo-assets/screenshots/README.md` — visual library

## Out of scope

- Inbound reaction routing (`gemma4-feedback-track.md` already covers, just applied per channel)
- Ali-specific collaboration tracks (`ali-collaboration-track.md` separate)
- Coding work behind the Provider contract / fixture migration (those are coding tracks)
- Second-language expansion beyond Korean (revisit at v1.0)

---

## 한국어 요약

본 v0.2 → v0.3 promotion cycle 종결 + 다음 cycle 의 bilingual promo plan 핸드오버. 본 사이클 EN 도달이 KO 의 약 8–10배라는 불균형을 다음 사이클의 우선순위 / asset-to-channel mapping / 4-week calendar 로 보정. K1 GeekNews 내일 D-Day 부터 시작.

https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV

---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_