### PR TITLE
feat(auth): default fallback role employee → external (default-deny)

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -398,9 +398,13 @@ def resolve_api_key_principal(api_key: str) -> Optional[dict]:
     if api_key == API_KEY:
         # System key intentionally does NOT carry admin authority by
         # itself — pairing it with an admin JWT is still required for
-        # admin endpoints. Returning "employee" here keeps the
-        # pre-P3-2 behaviour identical for system-only callers.
-        return {"source": "system", "username": "system", "role": "employee"}
+        # admin endpoints. The role field here is currently NOT
+        # consumed (``get_role_from_request`` only honors
+        # ``source == "user"`` and falls through for "system"), but we
+        # keep it in sync with the fallback (external) so any future
+        # caller that does honor it gets the secure default.
+        # [default-deny fallback 2026-05-18] employee → external.
+        return {"source": "system", "username": "system", "role": "external"}
     return None
 
 
@@ -436,9 +440,20 @@ def get_role_from_request(
             print(f"[AUTH] X-Role 헤더 사용: {x_role} (개발 모드)")
             return x_role
 
-    # [P7-FIX] JWT 없어도 api_key 검증은 엔드포인트에서 수행됨
-    # 로컬 전용 시스템: api_key 통과 = 신뢰 사용자 → employee 수준 부여
-    return "employee"
+    # [default-deny fallback 2026-05-18] employee → external.
+    # Previously (single-local-user posture): "api_key 통과 = 신뢰
+    # 사용자 → employee 수준 부여" — convenient for solo operators but
+    # the implicit elevation undercut PR-O5 (cycle 12, #292) — the
+    # internal_rag gate is policy-attached to the external role, and
+    # an anonymous caller with only the system API key was silently
+    # promoted past that gate. Fallback is now external so the secure
+    # default actually fires: chat / meta still work for a bare key,
+    # retrieval / coding / admin paths require an explicit login.
+    # System operators who want the old behaviour can either (a) log
+    # in (gets their real role from JWT), (b) use a user API key in
+    # the jms_... format that maps to a specific role via
+    # ``resolve_api_key_principal``, or (c) set X-Role in DEV_MODE.
+    return "external"
 
 def get_client_ip(request: Request) -> str:
     forwarded = request.headers.get("X-Forwarded-For")

--- a/tests/test_api_key_middleware.py
+++ b/tests/test_api_key_middleware.py
@@ -9,7 +9,10 @@ Three coverage angles:
   2. verify_api_key — accepts system AND user keys, rejects garbage.
   3. End-to-end via TestClient — calling an admin endpoint with only
      a user API key for an admin user must succeed; with only a
-     system key it must NOT (system key is intentionally employee).
+     system key it must NOT (system key is intentionally external —
+     since the 2026-05-18 default-deny fallback change, both the
+     system principal's nominal role and the no-credentials fallback
+     are "external" so the secure default actually fires).
 """
 from __future__ import annotations
 
@@ -106,8 +109,15 @@ class PrincipalResolutionTests(unittest.TestCase):
         self.assertEqual(p, {"source": "user", "username": "alice",
                              "role": "manager"})
 
-    def test_system_key_resolves_to_employee_not_admin(self):
-        """System key intentionally does NOT carry admin authority."""
+    def test_system_key_resolves_to_external_not_admin(self):
+        """System key intentionally does NOT carry admin authority.
+
+        [default-deny fallback 2026-05-18] role was 'employee' before;
+        flipped to 'external' so that any future caller honoring this
+        field (today only the user-key branch consumes it, but the
+        contract is widening) gets the secure default. The pairing
+        with an admin JWT for admin endpoints is unchanged.
+        """
         import server_llmwiki as srv
         sys_key = _system_api_key()
         if not sys_key:
@@ -115,8 +125,9 @@ class PrincipalResolutionTests(unittest.TestCase):
         p = srv.resolve_api_key_principal(sys_key)
         self.assertIsNotNone(p)
         self.assertEqual(p["source"], "system")
-        self.assertEqual(p["role"], "employee",
-                         "system key must not self-elevate to admin")
+        self.assertEqual(p["role"], "external",
+                         "system key must default-deny (external), "
+                         "not silently elevate to employee/admin")
 
     def test_unknown_keys_return_none(self):
         import server_llmwiki as srv
@@ -170,6 +181,70 @@ class VerifyApiKeyTests(unittest.TestCase):
         with self.assertRaises(HTTPException) as cm:
             srv.verify_api_key(plain)
         self.assertEqual(cm.exception.status_code, 403)
+
+
+class DefaultFallbackRoleTests(unittest.TestCase):
+    """[default-deny fallback 2026-05-18]
+
+    ``get_role_from_request`` used to fall back to ``"employee"`` when
+    no JWT / user API key / X-Role header was present. That silently
+    promoted bare-system-key callers past the PR-O5 internal_rag gate
+    (the gate is keyed on the ``external`` role). The fallback is
+    now ``"external"`` so the default deny actually fires.
+
+    These tests pin the new contract at the source level (regex on
+    the function body) — source-level so they don't depend on the
+    FastAPI dependency-injection plumbing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import inspect
+        import server_llmwiki as srv
+        cls.src = inspect.getsource(srv.get_role_from_request)
+
+    def test_fallback_returns_external(self):
+        # The function body must end with `return "external"` —
+        # not "employee", not anything else.
+        import re
+        self.assertIsNotNone(
+            re.search(r'return\s+"external"\s*$', self.src.rstrip()),
+            "get_role_from_request must end with `return \"external\"` "
+            "— the default-deny fallback. Reverting to 'employee' "
+            "silently promotes anonymous callers past PR-O5.",
+        )
+
+    def test_no_employee_fallback_remains(self):
+        # Make sure nobody put a stray `return "employee"` somewhere
+        # in the function (e.g. inside an `if` branch).
+        import re
+        # `return "employee"` must NOT appear anywhere — the function
+        # routes elsewhere for employee-role principals (user API key
+        # branch returns principal["role"], not a literal).
+        self.assertIsNone(
+            re.search(r'return\s+"employee"', self.src),
+            "No literal `return \"employee\"` should remain in "
+            "get_role_from_request. employee role still reaches "
+            "callers through resolved user keys (jms_...) — only the "
+            "anonymous fallback changed.",
+        )
+
+    def test_system_principal_role_is_external(self):
+        # The system-key principal returned by resolve_api_key_principal
+        # must also carry "external", not "employee" — kept in sync so
+        # any future caller honoring `principal["role"]` for system
+        # keys gets the same secure default.
+        import server_llmwiki as srv
+        sys_key = _system_api_key()
+        if not sys_key:
+            self.skipTest("JAMES_API_KEY missing")
+        p = srv.resolve_api_key_principal(sys_key)
+        self.assertIsNotNone(p)
+        self.assertEqual(
+            p["role"], "external",
+            "system principal must carry the same default-deny role "
+            "as the anonymous fallback",
+        )
 
 
 class EndToEndTests(unittest.TestCase):

--- a/tests/test_workspace_jobs.py
+++ b/tests/test_workspace_jobs.py
@@ -292,9 +292,14 @@ class EndpointTests(_JobsFixture):
             params={"api_key": self._api_key},
             json={"job_type": "excel_build", "input_refs": []},
         )
-        # api_key is valid but no Bearer → role=employee, workspace.run_jobs
-        # default includes employee → passes gate, but no JWT subject → 401.
-        self.assertEqual(r.status_code, 401)
+        # [default-deny fallback 2026-05-18] api_key is valid but no
+        # Bearer → role=external (was 'employee' before the secure-
+        # default change). workspace.run_jobs default_allowed does NOT
+        # include external, so the feature gate stops the request at
+        # 403 — the JWT-subject check at 401 isn't reached. Either
+        # response code proves "anonymous caller cannot run jobs",
+        # which is what this test was originally pinning.
+        self.assertEqual(r.status_code, 403)
 
     def test_run_external_role_denied_by_default(self):
         # external is NOT in workspace.run_jobs default_allowed.


### PR DESCRIPTION
## Summary

E-3 spot-check (2026-05-18 user observation): logged out of the chat UI expecting `role=external`, but every subsequent request still resolved to `role=employee`. The `employee` fallback was written for the v0.1 single-local-user posture — *\"the system api_key is in the operator's .env, so anyone who can present it is the operator\"*. After cycle 12 PR-O5 #292 attached the `internal_rag` feature gate to the **external** role specifically, that implicit employee promotion **silently bypassed the gate**: anonymous callers holding only the system API key got full RAG access while the matching ABAC rule for \"external\" stayed dormant. E-3 could not be exercised at all from the live UI without a separate user-account workaround.

This PR flips the fallback so the default deny actually fires. Anonymous callers — defined as *\"no JWT, no `jms_...` user key, no DEV_MODE + X-Role header\"* — now resolve to `\"external\"`.

User decision: option **(A) — single 1-line change**, accepting the UX cost (more explicit logins) for the secure default.

## What changes

```python
# server_llmwiki.py:441
# BEFORE:
return \"employee\"
# AFTER:
return \"external\"
```

Plus a sibling tweak in `resolve_api_key_principal()` (system-key path) so the principal's nominal role stays in sync with the fallback. Today only the user-key branch consumes `principal[\"role\"]`, so the sibling change is a no-op at runtime — but it prevents a future caller that does read it from getting the elevated default by mistake.

## Three recovery paths for the old behavior (explicitly listed in the new comment)

1. **Log in** — JWT carries the real role.
2. **Use a user API key** (`jms_...`) bound to a role via `resolve_api_key_principal`.
3. **`X-Role` header in DEV_MODE** — for dev / curl flows.

## UX impact (intentional)

| Path | Before (employee fallback) | After (external fallback) |
|---|---|---|
| chat / meta (external-allowed by ROLE_ALLOWED) | ✓ | ✓ |
| retrieval / coding / wiki_edit / self_evolve | ✓ implicit elevation | **✗ — login required** |
| admin pages | ✗ (already required JWT) | ✗ unchanged |
| Solo local operator | no login needed | **must log in once per browser session** |

E-3 spot-check is now exercisable directly: **log out → `role=external` on the very next request → PR-O5's internal_rag gate fires → chat-only fallback visible in the trace**.

## Tests (3 new + 2 updated)

`tests/test_api_key_middleware.py`:
- `test_system_key_resolves_to_external_not_admin` — was `..._to_employee_...`; same assertion shape, expected role updated.
- NEW class **`DefaultFallbackRoleTests`** with 3 source-level pins:
  - `test_fallback_returns_external` — function must end with `return \"external\"` (regex anchored).
  - `test_no_employee_fallback_remains` — no stray `return \"employee\"` literal anywhere in the function body.
  - `test_system_principal_role_is_external` — runtime check that `resolve_api_key_principal()` keeps the system principal in sync.

`tests/test_workspace_jobs.py`:
- `test_run_requires_jwt` — was asserting 401 with a comment that explicitly relied on the old `employee` fallback (\"role=employee → passes feature gate → JWT-subject 401\"). With the new fallback, the feature gate (`workspace.run_jobs`) stops the request at **403 before the JWT-subject check runs**. Expected code flipped 401 → 403; comment rewritten. The intent (anonymous caller cannot run jobs) is preserved; the sibling `test_run_external_role_denied_by_default` still pins the explicit-external path.

## Verification

- `tests/test_api_key_middleware.py`: **14/14** green (11 existing updated + 3 new in `DefaultFallbackRoleTests`)
- `tests/test_workspace_jobs.py`: **20/20** green
- **Full repo: 2061/2061** green (minus 3 pre-existing character-test failures unrelated to this PR)
- `node --check` — JS unaffected

## CLAUDE.md gate

| Rule | Application |
|---|---|
| #1 platform-only | Security primitive — no domain coupling |
| #2 bench numbers | `core/retrieval`, `core/graph`, `core/reasoning` byte-identical → STEP 7 unaffected |
| #3 self-evolution | Unrelated |
| #4 architecture | No `§5.*` schema change. `ALLOWED_ROLES` / `ROLE_ALLOWED` / feature policies are all unchanged — we only changed which role the request maps to when **none** is explicitly presented |
| #5 module size | `server_llmwiki.py` already biggest non-frontend file; this is a one-line edit + comment expansion. The split is on a separate backlog cycle |

## Migration note (breaking change)

For any deployment that relied on bare-`api_key` callers being treated as employees, the three recovery paths above are explicitly listed in the new comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)