### PR TITLE
feat(reasoning): synth call-site backend wiring (Track 1 PR-A)

### DIFF
--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -15,9 +15,12 @@ Two adapters ship with L0:
                            default so a stock JAMES install never reaches
                            an external CLI without explicit consent.
 
-L0 is wiring-free — the registry exists but core/reasoning/pipeline.py
-still calls ``engine.llm.call_gemma(...)`` directly. L1 swaps those call
-sites onto ``get_backend(name).complete(...)`` + emit_trace_step.
+L1 (Track 1 PR-A, 2026-05-19) routes every synth call site through
+``trace_synth_call`` → ``resolve_backend_for_stage(...)`` →
+``get_backend(name).complete(...)``. ``engine.llm.call_gemma`` is no
+longer reached from the middleware layer. Per-stage env override
+(``JAMES_BACKEND_SYNTH`` …) retargets a single stage without touching
+call sites.
 """
 from __future__ import annotations
 
@@ -143,6 +146,58 @@ def get_default_backend_id() -> str:
     return "ollama_local"
 
 
+# Stage names accepted by resolve_backend_for_stage. Mirrors the call-site
+# taxonomy in docs/design/v0.3-llm-provider-contract.md §"Selection".
+# Stages without a JAMES_BACKEND_<STAGE> override fall through to the
+# JAMES_REASONING_BACKEND global default. Adding a stage here is purely
+# additive — existing operators see no behavior change.
+_KNOWN_STAGES = frozenset({
+    "auth", "retrieve", "graph", "synth",
+    "verify", "reflect", "plan", "rewrite",
+})
+
+
+def resolve_backend_for_stage(stage: str) -> str:
+    """Pick the backend name for one call-site stage.
+
+    Resolution order (per ``docs/design/v0.3-llm-provider-contract.md``):
+
+      1. ``JAMES_BACKEND_<STAGE>`` env (e.g. ``JAMES_BACKEND_SYNTH``)
+         — per-stage override. Used by the 3×3 Gemma 4 experiment to
+         pin one stage to a specific backend while leaving others free.
+      2. ``JAMES_REASONING_BACKEND`` env — global default (PR #305).
+      3. Hardcoded ``"ollama_local"`` — the L0 default, always
+         registered.
+
+    Unknown / unregistered requested backends fall through to the
+    next level (same forgiving pattern as ``get_default_backend_id``).
+    A typo in ``JAMES_BACKEND_SYNTH`` shouldn't break every other
+    stage — it should just log and degrade to the global default.
+
+    ``stage`` is validated against ``_KNOWN_STAGES`` so a typo at the
+    call site (e.g. ``stage="snyth"``) raises loudly during dev
+    instead of silently bypassing the per-stage override.
+    """
+    if not isinstance(stage, str) or stage not in _KNOWN_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; known stages: {sorted(_KNOWN_STAGES)}"
+        )
+    per_stage_env = f"JAMES_BACKEND_{stage.upper()}"
+    requested = os.environ.get(per_stage_env, "").strip()
+    if requested:
+        if requested in _REGISTRY:
+            return requested
+        # Same forgiving pattern as get_default_backend_id — a typo or
+        # opt-in mismatch (e.g. claude_code_cli requested without
+        # JAMES_ENABLE_CLAUDE_BACKEND=1) logs and falls through.
+        print(
+            f"[BACKEND] {per_stage_env}={requested!r} not registered "
+            f"(known: {sorted(_REGISTRY)}) → falling through to "
+            f"JAMES_REASONING_BACKEND."
+        )
+    return get_default_backend_id()
+
+
 # ─── auto-registration ─────────────────────────────────────────────
 # ollama_local is always registered — it wraps RouterWrapper which is
 # the v0.3.0 default path. claude_code_cli is opt-in via env so a stock
@@ -167,4 +222,5 @@ __all__ = [
     "get_backend",
     "list_backends",
     "get_default_backend_id",
+    "resolve_backend_for_stage",
 ]

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -1,9 +1,11 @@
 """Adapter around RouterWrapper.call_gemma — the v0.3.0 default LLM path.
 
-Byte-identical to existing core/reasoning/pipeline.py calls. L1's
-wiring step will swap ``engine.llm.call_gemma(prompt, ...)`` for
-``get_backend("ollama_local").complete(prompt, ...)`` without changing
-which model runs or what prompt format reaches it.
+After L1 wiring (Track 1 PR-A, 2026-05-19) every synth call site goes
+through ``get_backend("ollama_local").complete(...)`` rather than
+RouterWrapper directly. This adapter remains byte-identical to the
+v0.3.0 prompt path — the same prompt, the same model, the same
+RouterWrapper call — so JAMES with no env overrides behaves exactly
+as it did before the wiring.
 """
 from __future__ import annotations
 

--- a/core/reasoning/engine_synth.py
+++ b/core/reasoning/engine_synth.py
@@ -140,18 +140,17 @@ def generate_rag_answer(
             )
 
     try:
-        # L1 wiring: trace_synth_call wraps so the canonical RAG
-        # synthesis emits one reasoning audit row. Behaviour is
-        # byte-identical — the helper forwards call_gemma's return
-        # value untouched.
+        # L1 wiring (PR-A Track 1): synth goes through the registered
+        # backend rather than calling RouterWrapper directly. Default
+        # backend (ollama_local) is byte-identical to the v0.3.0 path;
+        # JAMES_BACKEND_SYNTH retargets without touching this code.
         answer = trace_synth_call(
-            lambda: engine.llm.call_gemma(
-                prompt, timeout=120, use_cache=True,
-                max_tokens=style.max_tokens,
-                model=selected_model or None,
-            ),
             prompt,
             applied_rule="reasoning.synth.rag",
+            timeout=120,
+            use_cache=True,
+            max_tokens=style.max_tokens,
+            model=selected_model or None,
         )
         if not answer or any(answer.startswith(p) for p in LLM_ERROR_PREFIXES):
             return "답변 생성에 실패했습니다."

--- a/core/reasoning/modes/chat.py
+++ b/core/reasoning/modes/chat.py
@@ -63,14 +63,13 @@ def handle_chat(
             mem_prefix = ""
         _chat_prompt = f"{sys_prefix}{mem_prefix}{rule_txt}\n질문: {safe_query}\n\n답변:"
         raw_answer = trace_synth_call(
-            lambda: engine.llm.call_gemma(
-                _chat_prompt,
-                use_cache=True, timeout=60, max_tokens=style.max_tokens,
-                model=selected_model or None,
-            ),
             _chat_prompt,
             applied_rule="reasoning.synth.chat",
             user_role=user_role,
+            use_cache=True,
+            timeout=60,
+            max_tokens=style.max_tokens,
+            model=selected_model or None,
         )
         # Preserve paragraph breaks (\n\n) — user feedback wants
         # natural 문단 separation, not a single block of text.

--- a/core/reasoning/modes/coding.py
+++ b/core/reasoning/modes/coding.py
@@ -55,14 +55,12 @@ def handle_coding(
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
             _coding_user_prompt = f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:"
             answer = trace_synth_call(
-                lambda: engine.llm.call_gemma(
-                    _coding_user_prompt,
-                    use_cache=True, timeout=120,
-                    model=selected_model,
-                ),
                 _coding_user_prompt,
                 applied_rule="reasoning.synth.coding_user_pick",
                 user_role=user_role,
+                use_cache=True,
+                timeout=120,
+                model=selected_model,
             )
             log_stage("coding_user_pick_done",
                       latency_ms=int((time.time() - t_code) * 1000),
@@ -98,13 +96,11 @@ def handle_coding(
                 sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
                 _coding_fallback_prompt = f"{sys_prefix}코딩 질문: {safe_query}\n\n답변:"
                 answer = trace_synth_call(
-                    lambda: engine.llm.call_gemma(
-                        _coding_fallback_prompt,
-                        use_cache=True, timeout=90,
-                    ),
                     _coding_fallback_prompt,
                     applied_rule="reasoning.synth.coding_fallback",
                     user_role=user_role,
+                    use_cache=True,
+                    timeout=90,
                 )
                 log_stage("coding_fallback_done",
                           latency_ms=int((time.time() - t_code) * 1000),

--- a/core/reasoning/modes/self_evolve.py
+++ b/core/reasoning/modes/self_evolve.py
@@ -87,14 +87,12 @@ def handle_self_evolve(
                     f"전체 아키텍처를 설명해줘:\n\n{folder_report[:2000]}\n\n설명:"
                 )
                 analysis = trace_synth_call(
-                    lambda: engine.llm.call_gemma(
-                        _folder_prompt,
-                        timeout=120, use_cache=False,
-                        model=selected_model or None,
-                    ),
                     _folder_prompt,
                     applied_rule="reasoning.synth.self_evolve_folder",
                     user_role=user_role,
+                    timeout=120,
+                    use_cache=False,
+                    model=selected_model or None,
                 )
                 answer = folder_report
                 if analysis:
@@ -112,14 +110,12 @@ def handle_self_evolve(
                 f"파일: {fname}\n```python\n{content[:2000]}\n```\n\n분석:"
             )
             analysis = trace_synth_call(
-                lambda: engine.llm.call_gemma(
-                    _file_prompt,
-                    timeout=120, use_cache=False,
-                    model=selected_model or None,
-                ),
                 _file_prompt,
                 applied_rule="reasoning.synth.self_evolve_file",
                 user_role=user_role,
+                timeout=120,
+                use_cache=False,
+                model=selected_model or None,
             )
             answer = (
                 f"📄 **{fname}** 분석\n\n"
@@ -158,14 +154,12 @@ def handle_self_evolve(
                     f"다음 관점에서 개선 제안을 해줘: {safe_query}\n\n제안:"
                 )
                 extra = trace_synth_call(
-                    lambda: engine.llm.call_gemma(
-                        _improve_prompt,
-                        timeout=90, use_cache=False,
-                        model=selected_model or None,
-                    ),
                     _improve_prompt,
                     applied_rule="reasoning.synth.self_evolve_improve",
                     user_role=user_role,
+                    timeout=90,
+                    use_cache=False,
+                    model=selected_model or None,
                 )
                 if extra:
                     answer += f"\n\n💡 **개선 제안:**\n{extra}"

--- a/core/reasoning/modes/wiki_edit.py
+++ b/core/reasoning/modes/wiki_edit.py
@@ -49,13 +49,12 @@ def handle_wiki_edit(
             "JSON만 출력:"
         )
         raw = trace_synth_call(
-            lambda: engine.llm.call_gemma(
-                parse_prompt, timeout=30, use_cache=False,
-                model=selected_model or None,
-            ),
             parse_prompt,
             applied_rule="reasoning.synth.wiki_edit_parse",
             user_role=user_role,
+            timeout=30,
+            use_cache=False,
+            model=selected_model or None,
         )
 
         # JSON 파싱
@@ -103,13 +102,12 @@ def handle_wiki_edit(
                     "수정된 전체 내용만 출력 (frontmatter 포함):"
                 )
                 new_content = trace_synth_call(
-                    lambda: engine.llm.call_gemma(
-                        new_prompt, timeout=90, use_cache=False,
-                        model=selected_model or None,
-                    ),
                     new_prompt,
                     applied_rule="reasoning.synth.wiki_edit_update",
                     user_role=user_role,
+                    timeout=90,
+                    use_cache=False,
+                    model=selected_model or None,
                 )
                 if new_content:
                     ok, msg = update_entity(target, new_content, user_role)

--- a/core/reasoning/pipeline_synth.py
+++ b/core/reasoning/pipeline_synth.py
@@ -133,12 +133,12 @@ def generate_answer(
                                 )
                                 # L1 wiring — one audit row per LLM round-trip
                                 summary = trace_synth_call(
-                                    lambda: engine.llm.call_gemma(
-                                        summary_prompt, timeout=30, use_cache=False, max_tokens=300,
-                                    ),
                                     summary_prompt,
                                     applied_rule="reasoning.synth.web_summary",
                                     user_role=user_role,
+                                    timeout=30,
+                                    use_cache=False,
+                                    max_tokens=300,
                                 )
                                 if summary:
                                     from tools.self.evo_analyzer import (
@@ -207,15 +207,13 @@ def generate_answer(
                     f"\n{_rule}\n질문: {safe_query}\n\n답변:"
                 )
                 answer_raw = trace_synth_call(
-                    lambda: engine.llm.call_gemma(
-                        _web_fallback_prompt,
-                        use_cache=(not web_context), timeout=90,
-                        max_tokens=_style.max_tokens,
-                        model=selected_model or None,
-                    ),
                     _web_fallback_prompt,
                     applied_rule="reasoning.synth.web_fallback",
                     user_role=user_role,
+                    use_cache=(not web_context),
+                    timeout=90,
+                    max_tokens=_style.max_tokens,
+                    model=selected_model or None,
                 )
             else:
                 answer_raw = engine._generate_answer(
@@ -252,14 +250,13 @@ def generate_answer(
                 "위 가이드를 따라 자연스럽게 답하세요.)\n답변:"
             )
             retry = trace_synth_call(
-                lambda: engine.llm.call_gemma(
-                    _retry_prompt,
-                    use_cache=False, timeout=60, max_tokens=_style_retry.max_tokens,
-                    model=selected_model or None,
-                ),
                 _retry_prompt,
                 applied_rule="reasoning.synth.retry_no_info",
                 user_role=user_role,
+                use_cache=False,
+                timeout=60,
+                max_tokens=_style_retry.max_tokens,
+                model=selected_model or None,
             )
             if retry and not any(retry.startswith(p) for p in engine._LLM_ERROR_PREFIXES):
                 print("[ROUTER] post_check → 재시도 (persona 포함)")

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -1,34 +1,51 @@
-"""L1 wiring helper — wrap an LLM call so it emits one TraceStep row.
+"""L1 wiring helper — call one backend, emit one TraceStep row.
 
 L0 (PR #283) shipped TraceStep / emit_trace_step / Backend registry as
-infrastructure. L1 (this PR) wires the existing 12 ``call_gemma`` sites
-in pipeline.py / modes.py / engine.py to emit one ``audit_log`` row each,
-without changing what the LLM returns (STEP 7 must stay byte-identical).
+infrastructure. L1 (PR-A of Track 1, this file) routes every synth call
+site through the registered backend instead of calling
+``engine.llm.call_gemma`` directly. The wiring stays byte-identical when
+the default backend (``ollama_local``) runs — that backend wraps
+``RouterWrapper.call_gemma`` with the same kwargs.
 
-The helper exists to keep each call site small:
+Call shape:
 
     raw = trace_synth_call(
-        lambda: engine.llm.call_gemma(prompt, timeout=60, max_tokens=400),
         prompt,
         applied_rule="reasoning.synth.chat",
         user_role=user_role,
+        timeout=60,
+        max_tokens=400,
+        model=selected_model or None,
     )
 
-vs the inline alternative (8 lines per site × 12 sites = 96 LOC of
-boilerplate). Same byte-output, plus one audit row per LLM round-trip.
+Compared to the previous lambda form, this helper:
+
+  * resolves the backend per stage via ``resolve_backend_for_stage`` —
+    a ``JAMES_BACKEND_SYNTH=claude_code_cli`` env now retargets the
+    whole synth layer to Claude without touching call sites.
+  * never imports ``llm.router`` from the middleware layer; the SDK
+    barrier (R5 in ``docs/design/v0.3-llm-provider-contract.md``)
+    becomes architecturally enforceable.
+  * preserves the trace_id correlation, error-string classification,
+    and ``output_summary`` truncation from the v0.3.0 helper — no
+    audit-log shape change.
 
 Trace correlation: every emitted step carries the current Axis-3
 ``trace_id`` (core/observability) under ``extras["trace_id"]`` so the
-future replay tool can ``WHERE answer LIKE '%"trace_id": "<id>"%'`` to
-gather every reasoning row for one question. Schema fields stay clean —
-``parent_step_id`` continues to mean step lineage (populated in Phase 2
-when reflection/verification stack steps).
+replay tool can ``WHERE answer LIKE '%"trace_id": "<id>"%'`` to
+gather every reasoning row for one question. Schema fields stay
+clean — ``parent_step_id`` continues to mean step lineage.
 """
 from __future__ import annotations
 
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 
+from core.reasoning.backends import (
+    CompletionResult,
+    get_backend,
+    resolve_backend_for_stage,
+)
 from core.reasoning.trace_schema import (
     TraceStep,
     compute_inputs_hash,
@@ -37,10 +54,10 @@ from core.reasoning.trace_schema import (
 )
 
 
-# Sentinel string used in error rows to mark a RouterWrapper-known
-# failure mode (callee returned an error string, not text). Mirrors the
-# OllamaLocalBackend convention so consumers see the same shape whether
-# they call the backend directly or via this helper.
+# Sentinel string used in error rows to mark a backend-reported failure
+# (the backend returned text matching RouterWrapper's known error strings
+# rather than a clean response). Mirrors the OllamaLocalBackend convention
+# so consumers see the same shape regardless of which backend ran.
 _ROUTER_ERROR_PREFIXES = (
     "[Gemma 응답 없음]",
     "[Gemma 오류]",
@@ -67,29 +84,42 @@ def _is_router_error(text: Optional[str]) -> bool:
 
 
 def trace_synth_call(
-    llm_call: Callable[[], Any],
     prompt: str,
     *,
     applied_rule: str,
     user_role: str = "system",
     stage: str = "synth",
-    backend_id: str = "ollama_local",
     parent_step_id: str = "",
     system: str = "",
+    timeout: float = 60.0,
+    max_tokens: int = 1024,
+    use_cache: bool = True,
+    model: Optional[str] = None,
     extras: Optional[Dict[str, Any]] = None,
+    **opts: Any,
 ) -> str:
-    """Call ``llm_call()``, emit one TraceStep, return the raw text.
+    """Run one synth call through the registered backend, emit one
+    TraceStep row, return the raw text.
+
+    The backend is resolved fresh on every call so that an operator
+    flipping ``JAMES_BACKEND_SYNTH`` takes effect without a server
+    restart for the synth layer (other stages still resolve at import
+    time — see planner.py / reflect.py / verify.py). The cost is one
+    dictionary lookup per call, dominated by the LLM round trip.
 
     Behaviour:
-      * Wraps the call in a try/except — exceptions are converted into
-        an ``error`` row and re-raised so the caller's existing
-        error-handling stays unchanged.
-      * On success, classifies RouterWrapper's known error strings
-        (`[Gemma 응답 없음]`, etc.) as ``error`` rows even though the
-        return type is a string — consumers can filter on ``blocked=1``.
-      * Returns the raw text unmodified — no truncation, no rewriting.
-        The audit row's ``output_summary`` is a truncated copy; the
-        caller's downstream logic sees the full text.
+      * Backend failures are surfaced as ``CompletionResult`` with
+        ``error`` populated — never as raised exceptions — and emitted
+        as an audit row with ``blocked=True`` semantics. The function
+        returns the empty string in that case so existing callers
+        keep their ``if not answer: …`` fallbacks.
+      * If the helper itself can't reach a backend (registry empty
+        during early init / import failure), it logs an error row and
+        returns ``""`` rather than raising — matches R1.
+      * On success, RouterWrapper-style error strings
+        (``[Gemma 응답 없음]`` …) are classified as ``error`` rows even
+        though they arrive as plain text — preserves the v0.3.0
+        signal where the caller checked ``answer.startswith(prefix)``.
 
     ``extras`` is merged with the auto-added ``trace_id`` (the latter
     wins on key collision, matching emit_trace_step's "schema field
@@ -101,44 +131,61 @@ def trace_synth_call(
     if trace_id:
         emit_extras["trace_id"] = trace_id
 
+    # Backend resolution: R1 says we don't raise on the user path, so a
+    # registry-level failure (no backends registered, unknown stage) is
+    # converted to an error row + empty return rather than an exception.
     try:
-        text = llm_call()
+        backend_id = resolve_backend_for_stage(stage)
+        backend = get_backend(backend_id)
     except Exception as e:
         emit_trace_step(
             TraceStep(
                 stage=stage,
-                backend_id=backend_id,
+                backend_id="<unresolved>",
                 parent_step_id=parent_step_id,
                 inputs_hash=compute_inputs_hash(prompt, system=system),
                 output_summary="",
                 applied_rule=applied_rule,
                 latency_ms=int((time.time() - t0) * 1000),
-                error=f"{type(e).__name__}: {str(e)[:200]}",
+                error=f"backend_resolution: {type(e).__name__}: {str(e)[:200]}",
             ),
             user_role=user_role,
             extras=emit_extras,
         )
-        raise
+        return ""
 
-    text_str = text if isinstance(text, str) else (str(text) if text is not None else "")
-    err = ""
-    if _is_router_error(text_str):
+    result: CompletionResult = backend.complete(
+        prompt,
+        system=system,
+        max_tokens=max_tokens,
+        timeout=timeout,
+        model=model,
+        use_cache=use_cache,
+        **opts,
+    )
+
+    text_str = result.text if isinstance(result.text, str) else ""
+    err = result.error or ""
+    if not err and _is_router_error(text_str):
         err = "backend reported error string"
 
     emit_trace_step(
         TraceStep(
             stage=stage,
-            backend_id=backend_id,
+            backend_id=result.backend_id or backend_id,
             parent_step_id=parent_step_id,
             inputs_hash=compute_inputs_hash(prompt, system=system),
             output_summary=truncate_summary(text_str),
             applied_rule=applied_rule,
-            latency_ms=int((time.time() - t0) * 1000),
+            latency_ms=result.latency_ms or int((time.time() - t0) * 1000),
             error=err,
         ),
         user_role=user_role,
         extras=emit_extras,
     )
+    # The caller's downstream logic (error-prefix checks, "" fallback)
+    # is unchanged — return text whether it's a clean response or one of
+    # RouterWrapper's known error strings.
     return text_str
 
 

--- a/tests/fixtures/injection/test_fixture_format.py
+++ b/tests/fixtures/injection/test_fixture_format.py
@@ -331,11 +331,11 @@ class SchemaV1EnforcementTests(unittest.TestCase):
                 notes = str(entry.get("notes") or "")
                 self.assertIn(
                     "byte_drift_expected", notes,
-                    f"prompt contains direction marks but NFKC "
-                    f"normalization changes the bytes. Either rewrite "
-                    f"the prompt to be NFKC-stable, or document the "
-                    f"intentional drift by adding the token "
-                    f"`byte_drift_expected` to the `notes` field.",
+                    "prompt contains direction marks but NFKC "
+                    "normalization changes the bytes. Either rewrite "
+                    "the prompt to be NFKC-stable, or document the "
+                    "intentional drift by adding the token "
+                    "`byte_drift_expected` to the `notes` field.",
                 )
 
     def test_schema_version_when_present_is_v1_or_greater(self):

--- a/tests/fixtures/injection/test_security_decisions.py
+++ b/tests/fixtures/injection/test_security_decisions.py
@@ -25,7 +25,6 @@ Run:
 """
 from __future__ import annotations
 
-import os
 import sys
 import unittest
 from pathlib import Path

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -123,6 +123,57 @@ class ContinuityDirectiveTests(unittest.TestCase):
         from core.reasoning.modes import chat as _chat_mod
         cls.src = inspect.getsource(_chat_mod)
 
+    def setUp(self):
+        # Snapshot the backend registry + JAMES_BACKEND_SYNTH env so a
+        # _register_capture_backend()-using test doesn't bleed into
+        # other tests in this file (some of which run the real engine).
+        import os as _os
+        from core.reasoning.backends import _REGISTRY
+        self._saved_registry = dict(_REGISTRY)
+        self._saved_synth_env = _os.environ.get("JAMES_BACKEND_SYNTH")
+
+    def tearDown(self):
+        import os as _os
+        from core.reasoning.backends import (
+            _REGISTRY, _clear_for_tests, register_backend,
+        )
+        _clear_for_tests()
+        for name, inst in self._saved_registry.items():
+            register_backend(name, inst)
+        if self._saved_synth_env is None:
+            _os.environ.pop("JAMES_BACKEND_SYNTH", None)
+        else:
+            _os.environ["JAMES_BACKEND_SYNTH"] = self._saved_synth_env
+
+    def _register_capture_backend(self, *, reply="안녕하세요. 자메스입니다."):
+        """Register a backend that records the prompt it receives, then
+        pin the synth stage to it via JAMES_BACKEND_SYNTH so
+        handle_chat's trace_synth_call → resolve_backend_for_stage path
+        lands on us. Returns the dict that will hold ``"prompt"``.
+        """
+        import os as _os
+        from core.reasoning.backends import (
+            CompletionResult, _clear_for_tests, register_backend,
+        )
+
+        captured: dict = {}
+
+        class _CaptureBackend:
+            backend_id = "test_continuity_capture"
+
+            def complete(self_inner, prompt, *, system="", max_tokens=1024,
+                         timeout=60.0, model=None, use_cache=True, **opts):
+                captured["prompt"] = prompt
+                return CompletionResult(
+                    text=reply,
+                    backend_id=self_inner.backend_id,
+                )
+
+        _clear_for_tests()
+        register_backend("test_continuity_capture", _CaptureBackend())
+        _os.environ["JAMES_BACKEND_SYNTH"] = "test_continuity_capture"
+        return captured
+
     def test_directives_declared_at_module_level(self):
         # Constants at the top of the file so a future caller (e.g.,
         # handle_meta, handle_coding) can re-use them without
@@ -207,17 +258,21 @@ class ContinuityDirectiveTests(unittest.TestCase):
         the LLM to resolve anaphora against other sessions' content.
         This test captures the prompt that handle_chat actually
         constructs and asserts the directive is absent in that case.
+
+        [Track 1 PR-A, 2026-05-19] After the call-site wiring, the
+        synth layer goes through ``trace_synth_call`` →
+        ``get_backend(...).complete(...)`` rather than calling
+        ``engine.llm.call_gemma`` directly. We capture the prompt by
+        registering a callback backend and pinning the synth stage to
+        it via ``JAMES_BACKEND_SYNTH``.
         """
         from types import SimpleNamespace
         from core.reasoning import modes as _modes
 
-        captured = {}
-        def _fake_gemma(prompt, **_kw):
-            captured["prompt"] = prompt
-            return "안녕하세요. 자메스입니다. 무엇을 도와드릴까요?"
+        captured = self._register_capture_backend()
 
         fake_engine = SimpleNamespace(
-            llm = SimpleNamespace(call_gemma=_fake_gemma),
+            llm = SimpleNamespace(call_gemma=lambda *a, **kw: ""),
             _log = lambda *a, **kw: None,
             _LLM_ERROR_PREFIXES = ("[Gemma",),
             _elapsed = lambda *a, **kw: None,
@@ -259,17 +314,18 @@ class ContinuityDirectiveTests(unittest.TestCase):
         hist_ctx non-empty — the directive must still fire so the
         PR #249 anaphora-resolution / greeting-suppression behaviour
         survives. This is the path the original PR #249 was designed
-        for and must keep working."""
+        for and must keep working.
+
+        Track-1 PR-A note: see sibling test for the backend-capture
+        mechanism — same shape.
+        """
         from types import SimpleNamespace
         from core.reasoning import modes as _modes
 
-        captured = {}
-        def _fake_gemma(prompt, **_kw):
-            captured["prompt"] = prompt
-            return "(continuation reply)"
+        captured = self._register_capture_backend(reply="(continuation reply)")
 
         fake_engine = SimpleNamespace(
-            llm = SimpleNamespace(call_gemma=_fake_gemma),
+            llm = SimpleNamespace(call_gemma=lambda *a, **kw: ""),
             _log = lambda *a, **kw: None,
             _LLM_ERROR_PREFIXES = ("[Gemma",),
             _elapsed = lambda *a, **kw: None,

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -134,9 +134,7 @@ class ContinuityDirectiveTests(unittest.TestCase):
 
     def tearDown(self):
         import os as _os
-        from core.reasoning.backends import (
-            _REGISTRY, _clear_for_tests, register_backend,
-        )
+        from core.reasoning.backends import _clear_for_tests, register_backend
         _clear_for_tests()
         for name, inst in self._saved_registry.items():
             register_backend(name, inst)

--- a/tests/test_reasoning_backends.py
+++ b/tests/test_reasoning_backends.py
@@ -371,5 +371,111 @@ class DefaultBackendResolutionTests(unittest.TestCase):
                 )
 
 
+class StageBackendResolutionTests(unittest.TestCase):
+    """[Track 1 PR-A, 2026-05-19]
+
+    ``resolve_backend_for_stage(stage)`` layers per-stage overrides on
+    top of the global ``JAMES_REASONING_BACKEND``:
+
+      1. ``JAMES_BACKEND_<STAGE>`` env (e.g. JAMES_BACKEND_SYNTH)
+      2. ``JAMES_REASONING_BACKEND`` env (global)
+      3. ``"ollama_local"`` (hardcoded default)
+
+    These tests pin every transition the docs design promises.
+    """
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in
+                       ("JAMES_REASONING_BACKEND",
+                        "JAMES_BACKEND_SYNTH",
+                        "JAMES_BACKEND_RETRIEVE",
+                        "JAMES_ENABLE_CLAUDE_BACKEND")}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _reimport_backends()
+
+    def test_unknown_stage_raises(self):
+        # Stage typo at the call site should fail loudly during dev
+        # — silent fallthrough would silently bypass the override.
+        from core.reasoning import backends
+        with self.assertRaises(ValueError):
+            backends.resolve_backend_for_stage("snyth")
+
+    def test_no_env_returns_ollama_local(self):
+        for k in ("JAMES_REASONING_BACKEND", "JAMES_BACKEND_SYNTH"):
+            os.environ.pop(k, None)
+        mod = _reimport_backends()
+        self.assertEqual(mod.resolve_backend_for_stage("synth"), "ollama_local")
+
+    def test_per_stage_env_overrides_global(self):
+        os.environ["JAMES_REASONING_BACKEND"] = "claude_code_cli"
+        os.environ["JAMES_BACKEND_SYNTH"] = "ollama_local"
+        os.environ["JAMES_ENABLE_CLAUDE_BACKEND"] = "1"
+        mod = _reimport_backends()
+        # Global says claude, but per-stage synth pins ollama_local.
+        self.assertEqual(mod.resolve_backend_for_stage("synth"),
+                         "ollama_local")
+        # Other stages still follow the global.
+        self.assertEqual(mod.resolve_backend_for_stage("verify"),
+                         "claude_code_cli")
+
+    def test_per_stage_typo_falls_through_to_global(self):
+        # Per-stage typo (or claude requested without opt-in) must not
+        # break the rest of the pipeline — fall through to global, not
+        # raise.
+        os.environ["JAMES_REASONING_BACKEND"] = "ollama_local"
+        os.environ["JAMES_BACKEND_SYNTH"] = "rm-rf-slash"
+        os.environ.pop("JAMES_ENABLE_CLAUDE_BACKEND", None)
+        mod = _reimport_backends()
+        self.assertEqual(mod.resolve_backend_for_stage("synth"),
+                         "ollama_local")
+
+    def test_per_stage_falls_through_to_global_when_global_set(self):
+        # Stage env unset → uses JAMES_REASONING_BACKEND directly.
+        os.environ.pop("JAMES_BACKEND_SYNTH", None)
+        os.environ["JAMES_REASONING_BACKEND"] = "claude_code_cli"
+        os.environ["JAMES_ENABLE_CLAUDE_BACKEND"] = "1"
+        mod = _reimport_backends()
+        self.assertEqual(mod.resolve_backend_for_stage("synth"),
+                         "claude_code_cli")
+
+
+class SynthCallSitesUseBackendHelperTests(unittest.TestCase):
+    """Architectural assertion: every synth call site must reach the
+    LLM through ``trace_synth_call`` rather than the legacy
+    ``engine.llm.call_gemma`` pattern. A future refactor that re-adds
+    a direct ``call_gemma`` invocation in the middleware should fail
+    here, not in production.
+    """
+
+    def test_no_direct_call_gemma_in_middleware(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        middleware_files = [
+            root / "core" / "reasoning" / "engine_synth.py",
+            root / "core" / "reasoning" / "pipeline_synth.py",
+            root / "core" / "reasoning" / "modes" / "chat.py",
+            root / "core" / "reasoning" / "modes" / "coding.py",
+            root / "core" / "reasoning" / "modes" / "self_evolve.py",
+            root / "core" / "reasoning" / "modes" / "wiki_edit.py",
+        ]
+        for f in middleware_files:
+            with self.subTest(file=f.name):
+                src = f.read_text(encoding="utf-8")
+                self.assertNotIn(
+                    "engine.llm.call_gemma",
+                    src,
+                    f"{f.name} still calls engine.llm.call_gemma "
+                    f"directly. After Track 1 PR-A, every synth call "
+                    f"site must route through trace_synth_call → "
+                    f"get_backend(...).complete(...).",
+                )
+
+
 if __name__ == "__main__":   # pragma: no cover
     unittest.main()

--- a/tests/test_reasoning_trace_helpers.py
+++ b/tests/test_reasoning_trace_helpers.py
@@ -1,21 +1,28 @@
 """L1 — trace_synth_call helper that wraps an LLM call with one emit.
 
-12 ``call_gemma`` sites in pipeline.py / modes.py / engine.py route
-through this helper. STEP 7 must stay byte-identical (no answer
-mutation, no prompt rewriting); the only observable change is one
-audit_log row per LLM round-trip.
+After Track 1 PR-A wiring (2026-05-19) every synth call site routes
+through this helper → ``resolve_backend_for_stage`` → backend registry
+rather than calling ``RouterWrapper.call_gemma`` directly. STEP 7 stays
+byte-identical when the default backend (``ollama_local``) runs; the
+only observable change is one audit_log row per LLM round-trip plus
+the ability to swap a backend via env at the per-stage level.
 
 Tests:
-  * happy path: text forwarded unchanged, one row emitted, fields
-    populated correctly
-  * RouterWrapper error string (`[Gemma 응답 없음]` etc.): text still
-    forwarded, but row's `error` is non-empty and `blocked=1`
-  * exception in llm_call: emitted as error row, then re-raised
-  * empty / None text: forwarded as "", emitted as error row
+  * happy path: backend text forwarded unchanged, one row emitted
+  * RouterWrapper-style error string (`[Gemma 응답 없음]` etc.) in the
+    backend's CompletionResult.text: still forwarded as text, but
+    row's `error` is non-empty and `blocked=1` (matches the existing
+    `answer.startswith("[Gemma 응답 없음]")` retry checks at call sites)
+  * backend returns CompletionResult(error="..."): emitted as error
+    row, helper returns the empty string (post-Track-1 R1 contract —
+    backends never raise; they signal failure via `error=`)
+  * empty / no-text result: forwarded as "", emitted as error row
   * trace_id ContextVar propagation: when set, appears in answer JSON
   * trace_id absent: helper still works, no trace_id key in row
   * extras: caller-supplied extras land in answer JSON alongside
     trace_id (without clobbering schema fields)
+  * registry-level failure (unknown stage / no backends registered):
+    emits an unresolved-backend error row and returns ""
 """
 from __future__ import annotations
 
@@ -25,12 +32,20 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from typing import Callable, Optional
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.console import ensure_utf8_console  # noqa: E402
 ensure_utf8_console()
+
+from core.reasoning.backends import (  # noqa: E402
+    CompletionResult,
+    _REGISTRY,
+    _clear_for_tests,
+    register_backend,
+)
 
 
 _AUDIT_SCHEMA = """
@@ -71,29 +86,93 @@ def _rows(db_path: str):
         conn.close()
 
 
-class TraceSynthCallTests(unittest.TestCase):
-    """Each test points emit_trace_step at an isolated DB by patching
-    audit_bridge's default path resolution at module import time.
+class _CallbackBackend:
+    """Test backend whose .complete() invokes a Python callable and
+    wraps the result. Lets each test express its scenario in one line
+    (``lambda: "the answer"``) while still going through the same
+    backend → CompletionResult → emit flow that production uses.
     """
 
-    def _run(self, llm_call, *, applied_rule="reasoning.synth.test",
+    backend_id = "test_synth_backend"
+
+    def __init__(self, callback: Callable[[], object]):
+        self._cb = callback
+        self.last_call_kwargs: Optional[dict] = None
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_tokens: int = 1024,
+        timeout: float = 60.0,
+        model=None,
+        use_cache: bool = True,
+        **opts,
+    ) -> CompletionResult:
+        self.last_call_kwargs = dict(
+            prompt=prompt, system=system, max_tokens=max_tokens,
+            timeout=timeout, model=model, use_cache=use_cache, **opts,
+        )
+        try:
+            raw = self._cb()
+        except Exception as e:
+            # R1: backends signal failure via error=, not by raising.
+            return CompletionResult(
+                text="",
+                backend_id=self.backend_id,
+                error=f"{type(e).__name__}: {str(e)[:200]}",
+            )
+        text = raw if isinstance(raw, str) else ("" if raw is None else str(raw))
+        return CompletionResult(text=text, backend_id=self.backend_id)
+
+
+class TraceSynthCallTests(unittest.TestCase):
+    """Each test points emit_trace_step at an isolated DB and registers
+    a callback-driven backend under the per-stage env override so the
+    helper resolves it deterministically.
+    """
+
+    def setUp(self):
+        # Stash the real registry so the test doesn't bleed into real
+        # ollama_local; restore in tearDown.
+        self._saved_registry = dict(_REGISTRY)
+        _clear_for_tests()
+        self._saved_synth_env = os.environ.get("JAMES_BACKEND_SYNTH")
+        os.environ["JAMES_BACKEND_SYNTH"] = "test_synth_backend"
+
+    def tearDown(self):
+        _clear_for_tests()
+        for name, inst in self._saved_registry.items():
+            register_backend(name, inst)
+        if self._saved_synth_env is None:
+            os.environ.pop("JAMES_BACKEND_SYNTH", None)
+        else:
+            os.environ["JAMES_BACKEND_SYNTH"] = self._saved_synth_env
+
+    def _run(self, callback, *, applied_rule="reasoning.synth.test",
              user_role="employee", extras=None, prompt="hello"):
+        """Register a callback backend and call trace_synth_call. The
+        callback's return value becomes the backend's text; exceptions
+        raised inside the callback are converted to an error result
+        (the production R1 contract — backends do not raise on the
+        user-facing path).
+        """
         from core.reasoning.trace_helpers import trace_synth_call
+        backend = _CallbackBackend(callback)
+        register_backend("test_synth_backend", backend)
         db = _fresh_db()
-        # Patch the audit_bridge default path so emit_trace_step writes
-        # to our isolated db. The helper does not accept a db_path
-        # parameter (production code never specifies one).
         with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
             text = trace_synth_call(
-                llm_call, prompt,
+                prompt,
                 applied_rule=applied_rule,
                 user_role=user_role,
                 extras=extras,
             )
-        return text, _rows(db)
+        return text, _rows(db), backend
 
     def test_happy_path_text_forwarded_unchanged(self):
-        text, rows = self._run(lambda: "the answer is 42")
+        text, rows, _ = self._run(lambda: "the answer is 42")
         self.assertEqual(text, "the answer is 42")
         self.assertEqual(len(rows), 1)
         row = rows[0]
@@ -103,32 +182,39 @@ class TraceSynthCallTests(unittest.TestCase):
         self.assertFalse(row["blocked"])
         ans = json.loads(row["answer"])
         self.assertEqual(ans["output_summary"], "the answer is 42")
+        # backend_id is encoded as the prefix of the `query` column
+        # (``"<backend_id>: <inputs_hash>"``) per audit_bridge's existing
+        # convention — see emit_trace_step's serialization.
+        self.assertTrue(row["query"].startswith("test_synth_backend:"))
 
     def test_router_error_string_marked_error_but_text_forwarded(self):
-        """Existing call sites check answer.startswith("[Gemma 응답 없음]")
-        to decide retry — the helper must NOT swallow that string.
-        Behaviour-preserving wrapping.
+        """Existing call sites still check answer.startswith("[Gemma 응답 없음]")
+        to decide retry — the helper must NOT swallow that string when
+        the backend chooses to surface it as plain text. The same string
+        on the CompletionResult.text path produces an error row.
         """
-        text, rows = self._run(lambda: "[Gemma 응답 없음] timeout")
+        text, rows, _ = self._run(lambda: "[Gemma 응답 없음] timeout")
         self.assertTrue(text.startswith("[Gemma 응답 없음]"))   # forwarded as-is
         self.assertEqual(len(rows), 1)
         self.assertTrue(rows[0]["blocked"])
         ans = json.loads(rows[0]["answer"])
         self.assertIn("error", ans)
 
-    def test_exception_emits_error_row_then_reraises(self):
-        from core.reasoning.trace_helpers import trace_synth_call
-        db = _fresh_db()
-        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
-            with self.assertRaises(RuntimeError) as ctx:
-                trace_synth_call(
-                    lambda: (_ for _ in ()).throw(RuntimeError("ollama down")),
-                    "p",
-                    applied_rule="reasoning.synth.test",
-                    user_role="admin",
-                )
-        self.assertIn("ollama down", str(ctx.exception))
-        rows = _rows(db)
+    def test_backend_exception_becomes_error_row_and_empty_return(self):
+        """R1 of the Provider contract: backends do not raise on the
+        user path. The callback backend converts a raised exception to
+        CompletionResult(error=..., text=""); the helper then emits
+        the error row and returns "" rather than re-raising.
+
+        Pre-Track-1 the helper itself re-raised; that was the lambda-based
+        contract. With the named-backend contract, the helper trusts R1
+        and the call sites' "if not answer: …" fallbacks pick up the
+        empty return.
+        """
+        text, rows, _ = self._run(
+            lambda: (_ for _ in ()).throw(RuntimeError("ollama down"))
+        )
+        self.assertEqual(text, "")
         self.assertEqual(len(rows), 1)
         self.assertTrue(rows[0]["blocked"])
         ans = json.loads(rows[0]["answer"])
@@ -136,12 +222,12 @@ class TraceSynthCallTests(unittest.TestCase):
         self.assertIn("ollama down", ans["error"])
 
     def test_empty_text_marked_error(self):
-        text, rows = self._run(lambda: "")
+        text, rows, _ = self._run(lambda: "")
         self.assertEqual(text, "")
         self.assertTrue(rows[0]["blocked"])
 
     def test_none_return_handled_as_empty(self):
-        text, rows = self._run(lambda: None)
+        text, rows, _ = self._run(lambda: None)
         self.assertEqual(text, "")
         self.assertTrue(rows[0]["blocked"])
 
@@ -149,7 +235,7 @@ class TraceSynthCallTests(unittest.TestCase):
         from core.observability import current_trace_id
         token = current_trace_id.set("test-trace-xyz")
         try:
-            text, rows = self._run(lambda: "ok")
+            text, rows, _ = self._run(lambda: "ok")
         finally:
             current_trace_id.reset(token)
         ans = json.loads(rows[0]["answer"])
@@ -159,7 +245,7 @@ class TraceSynthCallTests(unittest.TestCase):
         from core.observability import current_trace_id
         token = current_trace_id.set("")   # explicit empty
         try:
-            text, rows = self._run(lambda: "ok")
+            text, rows, _ = self._run(lambda: "ok")
         finally:
             current_trace_id.reset(token)
         ans = json.loads(rows[0]["answer"])
@@ -169,7 +255,7 @@ class TraceSynthCallTests(unittest.TestCase):
         from core.observability import current_trace_id
         token = current_trace_id.set("trace-extras")
         try:
-            text, rows = self._run(
+            text, rows, _ = self._run(
                 lambda: "ok",
                 extras={"loop_idx": 2, "selected_model": "gemma2:2b"},
             )
@@ -180,14 +266,14 @@ class TraceSynthCallTests(unittest.TestCase):
         self.assertEqual(ans.get("loop_idx"), 2)
         self.assertEqual(ans.get("selected_model"), "gemma2:2b")
 
-    def test_inputs_hash_uses_prompt_arg_not_call_result(self):
+    def test_inputs_hash_uses_prompt_arg(self):
         """The helper hashes the `prompt` argument so the row's
-        inputs_hash is the input fingerprint (not the LLM output).
-        Replay needs this to detect "same inputs, different outcome".
+        inputs_hash is the input fingerprint. Replay needs this to
+        detect "same inputs, different outcome".
         """
         from core.reasoning.trace_schema import compute_inputs_hash
         expected = compute_inputs_hash("the prompt", system="")
-        text, rows = self._run(lambda: "any response", prompt="the prompt")
+        text, rows, _ = self._run(lambda: "any response", prompt="the prompt")
         self.assertIn(expected, rows[0]["query"])
 
     def test_latency_recorded(self):
@@ -195,9 +281,62 @@ class TraceSynthCallTests(unittest.TestCase):
         def slow():
             time.sleep(0.02)
             return "done"
-        text, rows = self._run(slow)
-        # latency_ms / 1000 → elapsed_sec; allow generous lower bound
+        text, rows, _ = self._run(slow)
+        # The callback backend doesn't set latency_ms explicitly; the
+        # helper falls back to wall-clock measurement. Generous lower
+        # bound because the helper rounds to integer milliseconds and
+        # the audit_log column is REAL seconds.
         self.assertGreaterEqual(rows[0]["elapsed_sec"], 0.015)
+
+    def test_kwargs_forwarded_to_backend(self):
+        """The new signature accepts timeout / max_tokens / model /
+        use_cache as keyword arguments and forwards them to the
+        backend's .complete() — the call-site rewrite at PR-A relies
+        on this being byte-equivalent to the old lambda kwargs.
+        """
+        from core.reasoning.trace_helpers import trace_synth_call
+        backend = _CallbackBackend(lambda: "ok")
+        register_backend("test_synth_backend", backend)
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            trace_synth_call(
+                "p",
+                applied_rule="reasoning.synth.test",
+                user_role="employee",
+                timeout=120,
+                max_tokens=400,
+                model="gemma3:12b",
+                use_cache=False,
+            )
+        kwargs = backend.last_call_kwargs
+        self.assertEqual(kwargs["timeout"], 120)
+        self.assertEqual(kwargs["max_tokens"], 400)
+        self.assertEqual(kwargs["model"], "gemma3:12b")
+        self.assertEqual(kwargs["use_cache"], False)
+
+    def test_unresolved_backend_emits_error_row_returns_empty(self):
+        """Stage typo / empty registry → helper does not raise; it
+        emits one error row tagged backend_id='<unresolved>' and
+        returns "" so the caller's existing "if not answer:" fallback
+        kicks in. Matches R1 at the helper boundary.
+        """
+        from core.reasoning.trace_helpers import trace_synth_call
+        # Clear the registry so any stage resolution lands on KeyError.
+        _clear_for_tests()
+        db = _fresh_db()
+        with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+            text = trace_synth_call(
+                "p",
+                applied_rule="reasoning.synth.test",
+                user_role="employee",
+            )
+        self.assertEqual(text, "")
+        rows = _rows(db)
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["blocked"])
+        ans = json.loads(rows[0]["answer"])
+        self.assertTrue(rows[0]["query"].startswith("<unresolved>:"))
+        self.assertIn("backend_resolution", ans["error"])
 
 
 if __name__ == "__main__":   # pragma: no cover

--- a/tests/test_source_files_first.py
+++ b/tests/test_source_files_first.py
@@ -31,7 +31,6 @@ Run:
 """
 from __future__ import annotations
 
-import inspect
 import os
 import sys
 import unittest


### PR DESCRIPTION
## Summary

Track 1 PR-A — Provider Contract L1 wiring for the synth layer.

Routes the 12 synth-stage call sites that previously called
`engine.llm.call_gemma(...)` directly through the named-backend
registry instead. The default `ollama_local` backend keeps the v0.3.0
`RouterWrapper` path byte-identical; `JAMES_BACKEND_SYNTH` retargets
the whole synth layer without code changes.

**Adds**:

- `resolve_backend_for_stage(stage)` in `core/reasoning/backends/__init__.py`
  — per-stage env override (e.g. `JAMES_BACKEND_SYNTH`) layered on
  top of `JAMES_REASONING_BACKEND` (PR #305). Unknown stages raise
  (loud dev signal); per-stage typos / opt-in mismatches fall through
  to the global default (no pipeline takedown).
- `trace_synth_call` new signature — prompt + kwargs, no lambda. R1 of
  the Provider contract honored: backend errors and registry-level
  failures emit one error audit row and return `""` rather than
  raising into the caller. Existing call-site fallbacks
  (`if not answer: …`) pick up the empty return.
- Architectural guard (`SynthCallSitesUseBackendHelperTests`) so a
  future PR cannot silently re-add `engine.llm.call_gemma` in any
  middleware module.

**Call sites swapped**:

| File | Stages |
|---|---|
| `core/reasoning/engine_synth.py` | synth.rag |
| `core/reasoning/pipeline_synth.py` | web_summary, web_fallback, retry_no_info |
| `core/reasoning/modes/chat.py` | synth.chat |
| `core/reasoning/modes/coding.py` | user_pick, fallback |
| `core/reasoning/modes/self_evolve.py` | folder, file, improve |
| `core/reasoning/modes/wiki_edit.py` | parse, update |

12 sites total.

## Verification

- **`test_reasoning_backends.py`** — 35 passed (10 subtests).
  `StageBackendResolutionTests` pins the 5 priority transitions:
  no env → ollama_local; per-stage override wins over global;
  per-stage typo falls through to global; stage env unset uses
  global; unknown stage raises. `SynthCallSitesUseBackendHelperTests`
  is the architectural guard.
- **`test_reasoning_trace_helpers.py`** — 12 passed. Covers the new
  backend-based contract end-to-end: happy path, RouterWrapper error
  strings forwarded, backend errors → error row + empty return, empty
  text marked error, trace_id propagation, extras folding, kwargs
  forwarded to backend, unresolved-backend graceful failure.
- **`test_conversation_continuity.py`** — 18 passed. The
  `fake_engine.llm.call_gemma` mock pattern was swapped for a
  `CaptureBackend` registered under `JAMES_BACKEND_SYNTH` so the N-3
  directive gate test still sees the prompt through the new path.
- **Full sweep**: `2069 passed, 3 failed`. The 3 failures are
  pre-existing (`test_character_prompt_cleanup` × 2 +
  `test_character_remove_text_persona` × 1, fallout of the engine.py
  split in #293). No new regressions.

## Bench

Micro-bench of `trace_synth_call` (LLM + `emit_trace_step` mocked,
isolating registry + Protocol dispatch + dict-assembly cost only):

| Metric | Value |
|---|---|
| mean | 3.82 μs / call |
| median | 3.82 μs / call |
| min / max | 3.79 / 3.88 μs / call |
| N | 10,000 calls × 5 trials |

A single ollama round-trip is 2,000–15,000 ms (2–15 seconds), so the
wiring overhead is roughly **0.0001% of one LLM call** — functionally
invisible against I/O latency.

STEP 7 full bench is deferred to Track 1 PR-C closure — one bench
across the three wiring PRs is higher signal than three byte-identical
reruns.

## Out of scope

- Conformance test suite (R1–R6 checks) — Track 1 PR-B
- `tests/test_no_sdk_leakage.py` (R5 architectural rule) — Track 1 PR-B
- `JAMES_PLUGINS` env-var loader and `JAMES_LLM_TEMPERATURE` — Track 1 PR-C
- STEP 7 full bench — Track 1 PR-C closure

Per `docs/design/v0.3-llm-provider-contract.md` §"Selection".

Part of Track 1 from `docs/handovers/v0.3.x-ali-collaboration-track.md`
(open through 2026-06-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)