### PR TITLE
feat(reasoning): JAMES_PLUGINS loader + JAMES_LLM_TEMPERATURE env (Track 1 PR-C)

### DIFF
--- a/config.py
+++ b/config.py
@@ -144,6 +144,28 @@ GEMMA_MODEL    = os.environ.get("JAMES_LLM_MODEL", "gemma4:e4b")
 CODING_MODEL   = os.environ.get("JAMES_CODING_MODEL", "qwen2.5-coder:32b")
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
+# [Track 1 PR-C, 2026-05-19] LLM_TEMPERATURE — default sampling
+# temperature passed to the model. Reserved kwarg per the Provider
+# contract (docs/design/v0.3-llm-provider-contract.md §R4). The
+# Gemma 4 3×3 experiment sweeps this variable, so backends used
+# in that experiment must accept it.
+#
+# Default 0.2 preserves the byte-identical v0.3.0 behavior — that
+# was the hardcoded value inside RouterWrapper.call_gemma before
+# this PR. Override via JAMES_LLM_TEMPERATURE.
+try:
+    LLM_TEMPERATURE = float(os.environ.get("JAMES_LLM_TEMPERATURE", "0.2"))
+except ValueError:
+    # An unparseable env value (e.g. "high") falls back to 0.2 with
+    # a warning rather than a hard crash — same forgiving pattern as
+    # the rest of config.py. The operator sees the print at startup.
+    print(
+        f"[CONFIG] JAMES_LLM_TEMPERATURE="
+        f"{os.environ.get('JAMES_LLM_TEMPERATURE')!r} is not a float "
+        f"→ falling back to 0.2"
+    )
+    LLM_TEMPERATURE = 0.2
+
 # ────────────────────────────────────────────────────────────────
 #  ChromaDB
 # ────────────────────────────────────────────────────────────────

--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -163,6 +163,7 @@ class GemmaClient:
         use_cache: bool = True,
         max_tokens: int = 0,
         model: str = None,
+        temperature: float = None,
     ) -> str:
         """
         Gemma 모델 호출.
@@ -250,7 +251,17 @@ class GemmaClient:
                             # 더 길게 가능. -1 (무제한)도 옵션이지만 runaway
                             # LLM 방어 위해 hard ceiling 유지.
                             "num_predict": max_tokens if max_tokens > 0 else 8192,
-                            "temperature": 0.2,    # 결정성 강화
+                            # [Track 1 PR-C, 2026-05-19] caller-supplied
+                            # temperature wins; otherwise config.LLM_TEMPERATURE
+                            # (default 0.2 — preserves v0.3.0 byte-identical
+                            # determinism). Reserved kwarg per the Provider
+                            # contract §R4 — also the 3×3 experiment's
+                            # swept variable.
+                            "temperature": (
+                                temperature
+                                if temperature is not None
+                                else __import__("config").LLM_TEMPERATURE
+                            ),
                             "num_ctx":     8192,   # [#A8-5] 4096 → 8192 (긴 답변 토큰까지 수용)
                         },
                     },

--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -202,6 +202,41 @@ def resolve_backend_for_stage(stage: str) -> str:
 # ollama_local is always registered — it wraps RouterWrapper which is
 # the v0.3.0 default path. claude_code_cli is opt-in via env so a stock
 # install can't accidentally route prompts to an external CLI.
+# External plugin backends listed in JAMES_PLUGINS are imported last so
+# they can register themselves on top of the built-in pair.
+
+def _load_plugins() -> None:
+    """[Track 1 PR-C, 2026-05-19] Import each module listed in
+    ``JAMES_PLUGINS`` (comma-separated). A plugin module typically
+    calls ``register_backend(...)`` at import time; this loader just
+    triggers the import so that registration side-effect fires.
+
+    Failures are **fatal** — a plugin that fails to load shouldn't
+    silently degrade the server. The exception surfaces with a clear
+    "JAMES_PLUGINS" prefix so the operator immediately knows where to
+    look. Empty / unset env → no-op.
+
+    Per ``docs/design/v0.3-llm-provider-contract.md`` §"Registration".
+    """
+    raw = os.environ.get("JAMES_PLUGINS", "").strip()
+    if not raw:
+        return
+    import importlib
+    modules = [m.strip() for m in raw.split(",") if m.strip()]
+    for mod_path in modules:
+        try:
+            importlib.import_module(mod_path)
+        except Exception as e:
+            # Surface the original error class + message so the
+            # operator can debug. The wrapping RuntimeError attribution
+            # is so a stack-trace consumer can grep for "JAMES_PLUGINS"
+            # rather than chasing a vague "ModuleNotFoundError" with
+            # no context.
+            raise RuntimeError(
+                f"JAMES_PLUGINS: failed to import plugin {mod_path!r}: "
+                f"{type(e).__name__}: {e}"
+            ) from e
+
 
 def _autoregister() -> None:
     from core.reasoning.backends.ollama_local import OllamaLocalBackend
@@ -210,6 +245,12 @@ def _autoregister() -> None:
     if os.environ.get("JAMES_ENABLE_CLAUDE_BACKEND") == "1":
         from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
         register_backend("claude_code_cli", ClaudeCodeCliBackend())
+
+    # Plugin import is last so a plugin can choose to override or
+    # extend the built-in registrations. register_backend's
+    # idempotent-with-same-instance rule still applies — duplicate
+    # registration of ollama_local with a different instance raises.
+    _load_plugins()
 
 
 _autoregister()

--- a/core/reasoning/backends/claude_code_cli.py
+++ b/core/reasoning/backends/claude_code_cli.py
@@ -84,6 +84,7 @@ class ClaudeCodeCliBackend:
         max_tokens: int = 1024,   # advisory — claude CLI does not surface a flag
         timeout: float = 60.0,
         model: Optional[str] = None,
+        temperature: Optional[float] = None,   # accepted per R4, ignored — CLI no flag
         **opts,
     ) -> CompletionResult:
         t0 = time.time()

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -41,6 +41,7 @@ class OllamaLocalBackend:
         timeout: float = 60.0,
         model: Optional[str] = None,
         use_cache: bool = True,
+        temperature: Optional[float] = None,
         **opts,
     ) -> CompletionResult:
         # RouterWrapper.call_gemma already absorbs system_prompt via the
@@ -58,6 +59,11 @@ class OllamaLocalBackend:
                 use_cache=use_cache,
                 max_tokens=max_tokens,
                 model=model or None,
+                # [Track 1 PR-C, 2026-05-19] Reserved kwarg per the
+                # Provider contract §R4. None → call_gemma falls back
+                # to config.LLM_TEMPERATURE (default 0.2). Required
+                # for the Gemma 4 3×3 experiment which sweeps this.
+                temperature=temperature,
             )
         except Exception as e:
             return CompletionResult(

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -95,6 +95,7 @@ def trace_synth_call(
     max_tokens: int = 1024,
     use_cache: bool = True,
     model: Optional[str] = None,
+    temperature: Optional[float] = None,
     extras: Optional[Dict[str, Any]] = None,
     **opts: Any,
 ) -> str:
@@ -161,6 +162,7 @@ def trace_synth_call(
         timeout=timeout,
         model=model,
         use_cache=use_cache,
+        temperature=temperature,
         **opts,
     )
 

--- a/tests/test_backend_conformance.py
+++ b/tests/test_backend_conformance.py
@@ -195,8 +195,10 @@ class ReferenceBackendConformanceTests(unittest.TestCase):
     def test_r4_reserved_kwargs_accepted(self):
         """R4 — every reserved kwarg is accepted without raising.
         Backends may translate or ignore each, but they must not
-        refuse. ``temperature`` is checked only for backends that
-        opt into the 3×3 experiment (none do on main yet).
+        refuse. ``temperature`` is the swept variable for the Gemma
+        4 3×3 experiment, so both reference backends accept it on
+        main (ollama_local applies; claude_code_cli ignores — both
+        legal per R4).
         """
         reserved = dict(
             system="be helpful",
@@ -204,6 +206,7 @@ class ReferenceBackendConformanceTests(unittest.TestCase):
             timeout=10.0,
             model=None,
             use_cache=False,
+            temperature=0.7,
         )
         for name, harness in _enumerate_reference_backends():
             with self.subTest(backend=name):
@@ -218,6 +221,33 @@ class ReferenceBackendConformanceTests(unittest.TestCase):
                         b.complete("p", **reserved)
                 else:
                     b.complete("p", **reserved)
+
+    def test_r4_temperature_reaches_ollama_for_3x3_experiment(self):
+        """R4 sub-clause for the 3×3 experiment: ollama_local must
+        actually *apply* temperature rather than just accept it.
+        The variable that the experiment sweeps must propagate end
+        to end into the ollama HTTP options block.
+
+        We inspect the fake router's recorded call rather than the
+        outgoing HTTP request — the contract surface lives at
+        ``RouterWrapper.call_gemma``'s signature, which now takes a
+        ``temperature`` kwarg.
+        """
+        from core.reasoning.backends.ollama_local import OllamaLocalBackend
+        b = OllamaLocalBackend()
+        fake_router = MagicMock()
+        fake_router.call_gemma.return_value = "ok"
+        b._router = fake_router
+        b.complete("p", temperature=0.9)
+        # Capture the kwarg the router actually received.
+        call_kwargs = fake_router.call_gemma.call_args.kwargs
+        self.assertEqual(
+            call_kwargs.get("temperature"), 0.9,
+            "ollama_local must forward `temperature` into "
+            "RouterWrapper.call_gemma so the 3×3 experiment's swept "
+            "variable reaches the model. Saw kwargs: "
+            f"{sorted(call_kwargs.keys())}",
+        )
 
     def test_r4_arbitrary_extra_opts_tolerated(self):
         """R4 sub-clause — backends accept **opts without refusing

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,204 @@
+"""JAMES_PLUGINS env-var loader for external backends.
+
+Per ``docs/design/v0.3-llm-provider-contract.md`` §"Registration", the
+plugin loader reads a comma-separated list of module paths from
+``JAMES_PLUGINS`` and imports each at server startup. A plugin module
+typically calls ``register_backend(...)`` at top level; this loader
+just triggers the import so that registration side-effect fires.
+
+Failures during plugin import are **fatal**. A plugin that silently
+fails to load would leave the operator running an apparently-healthy
+server that's missing the backend they configured — far worse than
+loud failure at startup.
+
+Tests:
+  * empty / unset JAMES_PLUGINS → no-op, no error
+  * single-module path → module imported, side-effect register fires
+  * multi-module list → each module imported in order
+  * non-existent module → raises RuntimeError with "JAMES_PLUGINS"
+    prefix (operator-friendly attribution)
+  * plugin that throws on import → wrapped RuntimeError surfaces the
+    original error class / message
+  * whitespace around commas tolerated
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.reasoning.backends import (  # noqa: E402
+    _REGISTRY,
+    _clear_for_tests,
+    _load_plugins,
+    register_backend,
+)
+
+
+class JamesPluginsLoaderTests(unittest.TestCase):
+
+    def setUp(self):
+        # Snapshot the live registry + JAMES_PLUGINS env so failures
+        # mid-test don't pollute the next module to run.
+        self._saved_registry = dict(_REGISTRY)
+        self._saved_plugins = os.environ.get("JAMES_PLUGINS")
+        # Work inside a fresh sys.path entry that we tear down after.
+        self._plugin_dir = tempfile.mkdtemp(prefix="james_plugin_test_")
+        sys.path.insert(0, self._plugin_dir)
+        self._created_modules = []
+
+    def tearDown(self):
+        _clear_for_tests()
+        for name, inst in self._saved_registry.items():
+            register_backend(name, inst)
+        if self._saved_plugins is None:
+            os.environ.pop("JAMES_PLUGINS", None)
+        else:
+            os.environ["JAMES_PLUGINS"] = self._saved_plugins
+        if self._plugin_dir in sys.path:
+            sys.path.remove(self._plugin_dir)
+        # Drop the test modules from sys.modules so a re-import next
+        # test re-runs the registration side-effect.
+        for mod in self._created_modules:
+            sys.modules.pop(mod, None)
+        try:
+            import shutil
+            shutil.rmtree(self._plugin_dir, ignore_errors=True)
+        except Exception:
+            pass
+
+    def _write_plugin(self, name: str, body: str) -> None:
+        """Write a Python module under the temp plugin dir + remember
+        its dotted name so tearDown can pop it from sys.modules.
+        """
+        path = Path(self._plugin_dir) / f"{name}.py"
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+        self._created_modules.append(name)
+
+    def test_empty_env_is_noop(self):
+        os.environ.pop("JAMES_PLUGINS", None)
+        _load_plugins()   # must not raise, must not register anything
+
+    def test_whitespace_only_env_is_noop(self):
+        os.environ["JAMES_PLUGINS"] = "   "
+        _load_plugins()   # treat as effectively unset
+
+    def test_single_plugin_imported_and_registers(self):
+        self._write_plugin("james_test_plugin_one", """
+            from core.reasoning.backends import (
+                register_backend, CompletionResult,
+            )
+
+            class _Stub:
+                backend_id = "test_plugin_one"
+                def complete(self, prompt, *, system="", max_tokens=1024,
+                             timeout=60.0, model=None, use_cache=True,
+                             temperature=None, **opts):
+                    return CompletionResult(
+                        text="stub", backend_id=self.backend_id,
+                    )
+
+            register_backend("test_plugin_one", _Stub())
+        """)
+        os.environ["JAMES_PLUGINS"] = "james_test_plugin_one"
+        _load_plugins()
+        self.assertIn("test_plugin_one", _REGISTRY)
+
+    def test_multiple_plugins_imported_in_order(self):
+        for n in ("two_a", "two_b"):
+            self._write_plugin(f"james_test_plugin_{n}", f"""
+                from core.reasoning.backends import (
+                    register_backend, CompletionResult,
+                )
+
+                class _Stub:
+                    backend_id = "test_plugin_{n}"
+                    def complete(self, prompt, *, system="", max_tokens=1024,
+                                 timeout=60.0, model=None, use_cache=True,
+                                 temperature=None, **opts):
+                        return CompletionResult(
+                            text="", backend_id=self.backend_id,
+                        )
+
+                register_backend("test_plugin_{n}", _Stub())
+            """)
+        os.environ["JAMES_PLUGINS"] = (
+            "james_test_plugin_two_a,james_test_plugin_two_b"
+        )
+        _load_plugins()
+        self.assertIn("test_plugin_two_a", _REGISTRY)
+        self.assertIn("test_plugin_two_b", _REGISTRY)
+
+    def test_whitespace_around_commas_tolerated(self):
+        self._write_plugin("james_test_plugin_ws", """
+            from core.reasoning.backends import (
+                register_backend, CompletionResult,
+            )
+
+            class _Stub:
+                backend_id = "test_plugin_ws"
+                def complete(self, prompt, *, system="", max_tokens=1024,
+                             timeout=60.0, model=None, use_cache=True,
+                             temperature=None, **opts):
+                    return CompletionResult(
+                        text="", backend_id=self.backend_id,
+                    )
+
+            register_backend("test_plugin_ws", _Stub())
+        """)
+        # Pad with whitespace to mimic a sloppily-edited env file.
+        os.environ["JAMES_PLUGINS"] = "  james_test_plugin_ws ,   "
+        _load_plugins()
+        self.assertIn("test_plugin_ws", _REGISTRY)
+
+    def test_missing_module_is_fatal(self):
+        os.environ["JAMES_PLUGINS"] = "definitely_does_not_exist_jp_99"
+        with self.assertRaises(RuntimeError) as ctx:
+            _load_plugins()
+        self.assertIn("JAMES_PLUGINS", str(ctx.exception))
+        self.assertIn("definitely_does_not_exist_jp_99", str(ctx.exception))
+
+    def test_plugin_import_error_is_fatal(self):
+        self._write_plugin("james_test_plugin_throws", """
+            raise RuntimeError("plugin intentionally broken at import")
+        """)
+        os.environ["JAMES_PLUGINS"] = "james_test_plugin_throws"
+        with self.assertRaises(RuntimeError) as ctx:
+            _load_plugins()
+        msg = str(ctx.exception)
+        self.assertIn("JAMES_PLUGINS", msg)
+        # Original error class + message must surface for debugging.
+        self.assertIn("RuntimeError", msg)
+        self.assertIn("intentionally broken", msg)
+
+    def test_loader_does_not_register_if_plugin_skips_registration(self):
+        """A plugin that imports cleanly but forgets to call
+        register_backend is valid (it might register conditionally).
+        The loader must not invent a registration on the plugin's
+        behalf.
+        """
+        before = set(_REGISTRY)
+        self._write_plugin("james_test_plugin_silent", """
+            # Intentionally empty — no register_backend call.
+            VALUE = 1
+        """)
+        os.environ["JAMES_PLUGINS"] = "james_test_plugin_silent"
+        _load_plugins()
+        after = set(_REGISTRY)
+        self.assertEqual(
+            before, after,
+            "loader must not auto-register on the plugin's behalf — "
+            "registration is the plugin's responsibility.",
+        )
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Track 1 PR-C — closes the Provider contract's operator surface by
wiring the last two knobs the design doc promised.

### 1. `JAMES_LLM_TEMPERATURE` — reserved kwarg per R4

The Gemma 4 3×3 experiment's swept variable. End-to-end forwarding
so that flipping the env actually reaches the model:

- `config.LLM_TEMPERATURE` — new constant, default `0.2` (preserves
  the previously-hardcoded value inside `RouterWrapper.call_gemma`).
  Env-unset operators see byte-identical v0.3.0 behavior.
- `core/gemma_client.py::call_gemma()` — new `temperature` kwarg
  (`None` → `config.LLM_TEMPERATURE`). The ollama HTTP options block
  reads the resolved value instead of a hardcoded `0.2`.
- `core/reasoning/backends/ollama_local.py::complete()` — forwards
  `temperature` into `call_gemma`. The swept variable propagates.
- `core/reasoning/backends/claude_code_cli.py::complete()` — accepts
  `temperature` explicitly and ignores it (Claude CLI surfaces no
  flag). R4 permits ignore-on-unsupported.
- `core/reasoning/trace_helpers.py::trace_synth_call()` — new
  `temperature` kwarg that forwards. Call sites continue to omit it
  (default `None`) so synth answers stay deterministic at 0.2.

### 2. `JAMES_PLUGINS` — external backend loader

Comma-separated list of module paths imported at startup. A plugin
module calls `register_backend(...)` at import time; the loader just
triggers the import.

- `core/reasoning/backends/__init__.py::_load_plugins()` — added,
  called from `_autoregister()` after the built-in pair so a plugin
  can append or override.
- **Failures are FATAL** (per the design doc) — a plugin that
  silently fails to load would leave the operator running an
  apparently-healthy server missing the backend they configured.
  `RuntimeError` is raised with a `"JAMES_PLUGINS:"` prefix so the
  operator immediately knows where to look; the original error class
  + message is preserved in the chain for debugging.

## Verification

- **`tests/test_plugin_loader.py`** — 8 new tests covering: empty
  env no-op, whitespace tolerance, single plugin, multi-plugin order,
  missing module fatal, plugin-throws-on-import fatal, silent plugin
  (no `register_backend` call) does NOT auto-register on its behalf.
- **`tests/test_backend_conformance.py`** extended:
  - R4 reserved-kwarg list now includes `temperature` (both reference
    backends accept it — ollama_local applies, claude_code_cli
    ignores — both legal).
  - New R4 sub-clause `test_r4_temperature_reaches_ollama_for_3x3`
    pins that ollama_local **actually forwards** temperature into
    `RouterWrapper.call_gemma` so the 3×3 swept variable propagates
    end to end.
- **Full repo sweep**: 2097 passed, 3 pre-existing failures (character
  tests from #293 engine.py split — unrelated to Track 1).
- **Ruff**: `All checks passed!`

## Byte-identical guarantee for the default operator

- `JAMES_LLM_TEMPERATURE` unset → `config.LLM_TEMPERATURE = 0.2` →
  same value the hardcoded line used in v0.3.0 → same model output.
- `JAMES_PLUGINS` unset → `_load_plugins()` returns immediately →
  same registry shape as v0.3.0.

## Bench

The PR-A micro-bench established `trace_synth_call` overhead at
**3.82 μs/call** (10,000 calls × 5 trials). PR-C adds a single
kwarg pass-through (`temperature`) and one startup-time env read —
the per-call cost is unchanged.

STEP 7 full quantitative bench is intentionally deferred:

- The runner (`scripts/bench.py --suite=step7 --check`) needs a live
  ollama server, which is operator-machine state outside CI's scope.
- The changes are byte-identical for env-unset operators (see above),
  so the expected delta is exactly zero.
- Operators who want the comparison can run
  `python scripts/bench.py --suite=step7 --check` against the
  committed baseline at `eval/regression/step7_baseline.json`. A
  non-zero drift would itself be a bug worth a separate PR.

## Out of scope

- STEP 7 full bench — run after merge against a live server
- Plugin loader called from `server_llmwiki.py` at startup —
  already fires via `_autoregister()` at `backends/__init__.py`
  import time, which happens during the existing imports

Per `docs/design/v0.3-llm-provider-contract.md` §"Registration"
(JAMES_PLUGINS) and §R4 (temperature).

**Closes Track 1** from `docs/handovers/v0.3.x-ali-collaboration-track.md`
(open through 2026-06-15). PR-A (#324) wired the synth call sites;
PR-B (#325) added the conformance suite + SDK leakage guard; this
PR closes the loop with the operator-facing env knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)