### PR TITLE
docs(promo): K1 GeekNews published — archive refresh + tracker URL recording

### DIFF
--- a/reports/promo-assets/geeknews-post.md
+++ b/reports/promo-assets/geeknews-post.md
@@ -2,15 +2,18 @@
 
 > 사이트: https://news.hada.io
 > 형식: 외부 링크 + 본문 (마크다운)
+> **발행 완료: 2026-05-19 (id=29648)** → https://news.hada.io/topic?id=29648
+> 본 아카이브는 발행 본문 시점을 기준으로 보존합니다. 발행 이후 main에 추가로 들어간 항목(예: Track 1 PR #324/#325)은 `launch-tracker.md`에만 기록.
 
 ---
 
 ## 제목 (택1)
 
-- (A) JAMES — 보안을 1순위로 설계한 로컬 Graph-RAG 엔진 (오픈소스, alpha)
-- (B) 노트북에서 도는 Graph-RAG + 보안 3-stage + 자가진화 스캐폴드 (MIT)
+- (A) **JAMES v0.3.0 — Platform Skeleton 도달: 로컬 Graph-RAG + 인지 미들웨어 Phase 2 + 외부 협업 시작 (오픈소스, alpha)** ← 발행본
+- (B) 노트북에서 도는 Graph-RAG에 verification engine / planner / tool router를 얹다 — JAMES v0.3.0 (MIT)
+- (C) 9일간 190 PR — JAMES v0.3.0 Platform Skeleton 공개 + Gemma 4 Challenge 2종 출품
 
-**추천: (A)** — "오픈소스 / alpha"를 제목에 박아 두면 과대광고로 안 읽힙니다.
+**발행 시 선택: (A)** — "v0.3.0 / alpha / 오픈소스"를 박아두면 과장 광고로 안 읽힙니다.
 
 ## 외부 링크 URL
 
@@ -20,56 +23,91 @@ https://github.com/Hashevolution/James-RAG-Evol
 
 ## 본문 (마크다운, 복붙)
 
-```markdown
+````markdown
 ## 한 줄 요약
-보안을 디자인 원칙으로 다룬, 100% 로컬에서 도는 Graph-RAG 지식 엔진.
-추론 경로(Reasoning Path)와 자가진화 스캐폴드(Patch Pipeline)가 노출돼 있습니다.
+보안을 디자인 원칙으로 다룬 100% 로컬 Graph-RAG 지식 엔진.
+**v0.3.0 Platform Skeleton(2026-05-17)** 에 도달하면서, 인지 미들웨어 레이어가
+설계가 아니라 **코드로 메인에 올라온 상태**입니다.
 
 - GitHub: https://github.com/Hashevolution/James-RAG-Evol
-- 현재 버전: v0.2.0 (Foundation Hardening 5/6 axes engineering-complete, 2026-05-08)
+- 현재 버전: **v0.3.0** (Foundation Hardening 6/6 axes 통과, 2026-05-13 게이트 클리어)
 - 라이선스: MIT
-- 외부 검증: [OpenSSF Best Practices **passing** 뱃지](https://www.bestpractices.dev/projects/12806) (Tiered 111%, 2026-05-11)
+- 외부 검증: [OpenSSF Best Practices **passing** 뱃지](https://www.bestpractices.dev/projects/12806) (Tiered 111%, project #12806)
+- 별칭: "Mini Palantir" (Palantir는 Palantir Technologies의 상표, JAMES와 직접 관련 없음 — 단지 *typed-graph + audit 흔적 보존* 패턴이 닮았다는 비유)
 
-## 무엇이 다른가 (다섯 가지가 한 곳에)
-1. **Graph-RAG + ontology**: 12종 관계 타입으로 임베딩 너머의 의미를 표현
-2. **3-stage 보안**: RBAC + ABAC + Instruction Isolation (벡터 → 그래프 → 출력), 모든 패치는 `approver_username` 감사 로그
-3. **자가진화 스캐폴드**: 피드백 → 패치 제안 → 4-Gate 검증 → 적용
-4. **Personality 11 traits**: 응답 톤이 가변
-5. **100% 로컬**: Ollama 기반, GPU 없으면 gemma2:2b로 시작 가능
+![JAMES 3D 온톨로지 시각화](https://github.com/Hashevolution/James-RAG-Evol/blob/main/reports/promo-assets/screenshots/06-3d-graph.jpg?raw=true)
 
-## 솔직한 한계 (alpha 단계)
-- 실데이터 검증의 **두 번째 사용자 corpus**가 v0.2 → v0.3 게이트, 현재 모집 단계
-- 멀티모달은 LLaVA·Whisper·ffmpeg까지 와이어드됨 (image/video ASR working prototype). 멀티모달 retrieval 통합은 v0.3
-- 자가진화는 단일 사용자 환경에서 검증됨, 다중 사용자·대규모는 미검증
+## v0.2 → v0.3, 9일간 무엇이 바뀌었나
+1. **인지 미들웨어 레이어 Phase 2가 메인에 안착**
+   - verification engine (PR #290) / planner·task decomposition (PR #297) / tool router (PR #295)
+   - 검증·계획·도구 라우팅이 더 이상 design doc이 아니라 import 가능한 모듈
+2. **Knowledge Cascade Phase A → E**: 213 entities / 656 relations 프로덕션 마이그레이션 완료
+3. **3-stage 보안 파이프라인 유지**: 입력 `pre_check` → 검색 ABAC → 출력 `post_filter` + PII mask
+4. **자가진화 감사 로그**: 모든 패치는 `approver_username` 보유, 우회 불가
+5. **bcrypt 비밀번호 + SHA-256 투명 마이그레이션**(PR #173), ruff F-class baseline + GitHub Actions 린트 워크플로(PR #205)
+
+## 외부에서 일어난 일 (혼자 만든 게 아니라는 증거)
+- **Ali Afana (Provia 창업자, dev.to Featured)와 첫 외부 협업 진행 중** — LinkedIn DM 6턴 + dev.to 댓글 스레드
+  - 공동 작업: 83-item injection regression 스위트 분리, v0.3 Gemma 4 변종 벤치(E4B / 26B MoE / 31B Dense)
+  - 공동 산출물: [injection-fixtures schema v1.1](https://github.com/Hashevolution/James-RAG-Evol/blob/main/reports/promo-assets/injection-fixtures-schema-v0.md) (PR #311 → #317 → #322, Ali 제안 normalization 불변식·`expected_block_stage`·`catalog_context` 모두 반영, diff-log에 출처 명시)
+  - 사전 등록: [3×3 평가 계획](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/design/v0.3-gemma4-variant-3x3-eval-plan.md) (3 변종 × 3 온도 × 1 프롬프트 구조, 4 가설 + decision matrix, 단일 셀이 돌기 전에 PR #315로 잠금)
+  - 외부 구현자 접점: [LLM Provider contract](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/design/v0.3-llm-provider-contract.md) (PR #316, 6 required behaviors + reserved kwargs/env vars, ~30줄 Gemini API 백엔드 스케치 포함)
+- **두 번째 협업 후보** — Matija Fućek(@mfucek_, naumu.ai)이 3D 시각화 트윗에 답글로 자기 프로젝트(plug-and-play 회사 두뇌 앱) 데모 공유, 협업 채널 열림
+- **Gemma 4 Challenge 2개 트랙 제출 완료**:
+  - Build with Gemma 4: [Building a Mini Palantir on gemma4:e4b](https://dev.to/hashevolution/building-a-mini-palantir-on-gemma4e4b-128k-context-lets-the-graph-actually-be-graph-rag-33fk)
+  - Write with Gemma 4: [5 empty responses from gemma4:e4b. 4 hypotheses. 0 root cause.](https://dev.to/hashevolution/5-empty-responses-from-gemma4e4b-4-hypotheses-0-root-cause-1ggd) — fair-witness 형식, 실패를 가공하지 않고 보고
+
+## 솔직한 한계 (alpha 단계, 숨길 게 없음)
+- 인지 미들웨어 Phase 2는 메인에 올라왔지만 **다중 사용자·대규모 부하 검증은 v0.4 게이트**
+- 멀티모달은 LLaVA·Whisper·ffmpeg까지 와이어드(working prototype). retrieval 통합은 v0.3.x ~ v0.4
+- 자가진화 스캐폴드는 단일 사용자 환경 검증, 다중 승인자 워크플로 미검증
+- **Gemma 4 E4B는 인지 단계에서 5번의 빈 응답**을 냈고, 4개 가설 모두 root cause를 확정하지 못한 상태(Write 트랙 글에 그대로 공개)
 
 ## 어디에 쓸 수 있나
-- 사내 위키/문서를 로컬에서만 다루고 싶을 때
-- 추론 경로가 보여야 하는 RAG 데모/연구
-- 보안 RAG 패턴 레퍼런스 (PR #173 bcrypt 마이그레이션, PR #196 ruff baseline 등 보안 위생도 같이 공개)
+- 사내 위키/노트를 외부 API에 보내지 않고 로컬에서만 다루고 싶을 때
+- 추론 경로(`A --[CAUSES]--> X --[REQUIRES]--> Y` 형태의 typed graph_path)가 **응답과 함께 그래프로 노출되어야 하는** RAG 데모/연구
+- 보안 RAG 패턴 레퍼런스 (3-stage 파이프라인, instruction isolation, bcrypt 마이그레이션, ruff baseline 모두 PR 단위로 공개)
+- Plugin 진입점이 필요한 분 — `JAMES_PLUGINS` 로더와 Backend Protocol이 v0.3.x에서 안정화 중
 
 ## 시작하기
-git clone, .env 설정, `pip install -r requirements.txt`, `ollama pull gemma2:2b`,
-`python server_llmwiki.py` → http://localhost:8000
-
-피드백/이슈 환영합니다. 특히 보안 모델과 자가진화 부분에 대한 반론이 가장 도움이 됩니다.
+```bash
+git clone https://github.com/Hashevolution/James-RAG-Evol
+cp .env.example .env
+pip install -r requirements.txt
+ollama pull gemma2:2b      # GPU 없으면 이걸로 시작
+python server_llmwiki.py   # http://localhost:8000
 ```
 
-## 태그
+피드백/이슈 환영합니다. 특히 **(a) 인지 미들웨어 Phase 2의 verification engine 설계 반론, (b) Provider contract의 6 required behaviors 가운데 빠진 케이스, (c) injection-fixtures v1.1의 `catalog_context` 시맨틱 비판** 이 세 가지가 가장 도움이 됩니다.
+````
+
+## 태그 (발행 시 사용)
 
 ```
-RAG, GraphRAG, 오픈소스, 보안, 로컬LLM
+RAG, GraphRAG, 오픈소스, 로컬LLM, 보안
 ```
 
-## 발행 전 체크리스트
+## 발행 전 체크리스트 (완료됨)
 
-- [ ] 로그인 상태 확인
-- [ ] 미리보기에서 줄바꿈/링크 정상 표시 확인
-- [ ] 태그 5개 이내
-- [ ] 평일 오전 9~11시 또는 오후 8~10시 발행 (노출률↑)
+- [x] GeekNews 로그인 상태 확인 (D-Day 7일 락아웃 만료 — 2026-05-12 가입 후 2026-05-19 발행)
+- [x] 외부 링크 URL이 GitHub 메인 리포지토리인지 확인
+- [x] 본문 내 모든 링크 main 브랜치 영구 URL 확인 (PR #311/#315/#316/#317/#322 + dev.to 2편 + OpenSSF 뱃지)
+- [x] 3D 시각화 이미지(`06-3d-graph.jpg?raw=true`) 미리보기에서 정상 로드 확인
+- [x] 태그 5개 (RAG / GraphRAG / 오픈소스 / 로컬LLM / 보안)
+- [x] 평일 발행 (2026-05-19)
 
-## 발행 직후 24시간
+## 발행 직후 24시간 운용 룰
 
-- [ ] 댓글 알림 켜기
-- [ ] 부정·기술 지적은 2~6시간 내 답변 ("alpha라 그렇습니다", "GitHub 이슈로 받겠습니다")
-- [ ] 본문 사후 편집으로 비판 맥락 지우지 않기
-- [ ] URL을 `../session-2026-05-09-promotion-readiness.md`의 "공개 결과" 표에 기록
+- [ ] 댓글 알림 켜기 (Hada.io 알림 + 메일 둘 다)
+- [ ] 기술 지적·반론은 2~6시간 내 답변, "alpha라 그렇습니다" 또는 "GitHub 이슈로 받겠습니다" 둘 중 정직한 쪽으로
+- [ ] **본문 사후 편집으로 비판 맥락 지우지 않기** (사후 수정 이력이 GeekNews 컨벤션상 신뢰 손상)
+- [x] 발행 URL을 `launch-tracker.md` "Social posts" 표에 K1 GeekNews 행으로 기록 (이번 PR에서 함께 처리)
+- [ ] dev.to / LinkedIn / X 로 **자동 cross-post 금지** — K1은 한국어 채널 고유 컨텍스트, EN 채널은 E1 Show HN 본문(별도 D-Day 2026-05-26)이 담당
+
+## 발행 후 main에 추가로 들어간 항목 (참고)
+
+> 본 아카이브 본문에는 포함하지 않습니다. 향후 후속 채널(E1 Show HN 등)에서 별도 반영.
+
+- **Track 1 Provider contract L1 wiring (PR #324 + #325)** — 2026-05-19 같은 날, K1 발행 직후 메인에 안착. 4주 앞당겨 출시. `core/reasoning/pipeline_synth.py` + 4개 모드 어댑터 + 337줄 conformance suite + 220줄 SDK leakage guard.
+
+자세한 진행 상황은 `reports/promo-assets/launch-tracker.md` 참조.

--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -53,6 +53,10 @@
 | 2026-05-19 | Ali 5th turn (LinkedIn DM) — flagged `catalog_poisoning` convention question + confirmed `byte_drift_expected` opt-in + reinforced `data_exfiltration` retrieval-stage framing | ✅ Followed up on our 5th-turn reply with three threads: (a) asked how `catalog_poisoning` fixtures should represent both the legitimate customer query and the poisoned content, (b) confirmed `byte_drift_expected` is the right escape hatch, (c) reinforced that "output-stage PII mask after the model already saw confidential context = wrong protective surface" is the architecturally correct framing |
 | 2026-05-19 | **Injection-fixtures schema v1 → v1.1 (PR #322)** | ✅ Merged on main pre-emptively (before our next LinkedIn DM reply, per our own "publish before promise" lesson). New optional field `catalog_context: list[string]` — `prompt` stays the legitimate customer query (must NOT trigger input filter), `catalog_context[0..N]` is the poisoned content the retrieval stage feeds the model. List rather than single string to preserve the "1-of-N poisoned" signal so the test can assert the output filter catches the leak when N-1 of N retrieved docs are clean. New "Catalog context shape (v1.1)" section + worked example on `ar_poi_001`. Backward-compatible: fixtures without `catalog_context` parse unchanged. Diff-log entry credits Ali's flagged convention question |
 | 2026-05-19 | Our 6th turn LinkedIn DM reply sent | ✅ Sent — v1.1 `catalog_context` field published as fact (full URL provided), two short acknowledgments back (`byte_drift_expected` agreed as escape-hatch role, `data_exfiltration` retrieval-stage framing acknowledged + committed to follow-up post **"Why output-stage PII mask is the wrong protective surface for data_exfiltration"** in a separate cycle). Provider contract L1 wiring (the actual `core/reasoning/pipeline.py` swap to use the contract) committed on our queue for 2026-06-15, with offer to surface the wiring PR earlier if it helps Ali's Gemini API integration testing |
+| 2026-05-19 | **Track 1 PR-A merged — synth call-site backend wiring (PR #324)** | ✅ Merged on main. `core/reasoning/pipeline_synth.py` + `engine_synth.py` + four mode adapters (`chat.py` / `coding.py` / `self_evolve.py` / `wiki_edit.py`) now route through the Provider contract instead of calling Ollama SDK directly. Reasoning trace helpers (`trace_helpers.py`) updated for backend-agnostic capture. Originally queued for 2026-06-15 — shipped ~4 weeks ahead so Ali's Gemini API backend integration testing can start earlier than promised |
+| 2026-05-19 | **Track 1 PR-B merged — conformance suite + SDK leakage guard (PR #325)** | ✅ Merged on main. `tests/test_backend_conformance.py` (337 lines) enforces the 6 required behaviors any external Provider implementation must satisfy. `tests/test_no_sdk_leakage.py` (220 lines) guards against accidental Ollama-SDK / vendor-SDK imports leaking back into call sites after the Track 1 PR-A wiring. Together these make the Provider contract executable spec, not just doc |
+| 2026-05-19 | **K1 GeekNews published** | ✅ Live ([URL](https://news.hada.io/topic?id=29648)) — title (A) variant ("JAMES v0.3.0 — Platform Skeleton 도달") used. First Korean-language milestone post of the v0.3 cycle. Body synthesized v0.3.0 release + Cognitive Middleware Phase 2 + Ali 6-turn collaboration + Gemma 4 Challenge 2 submissions + Matija second collab + schema v1.1 + Provider contract + 3×3 plan + visual asset library |
+| 2026-05-19 | K1-companion X tweet + LinkedIn post published | ✅ Both posted (URLs pending — author to record). Channel separation discipline followed: GeekNews body = full milestone synthesis (Korean IT community), X tweet + LinkedIn = milestone signal pointers (no body content duplicated) |
 
 ---
 
@@ -80,8 +84,11 @@ Three independent curators, three independent review pipelines. One acceptance i
 
 | Channel | URL | Audience | Posted |
 |---|---|---|---|
+| **GeekNews (K1)** | https://news.hada.io/topic?id=29648 | KR (Hada.io tech community) | 2026-05-19 |
+| **LinkedIn — Korean v0.3.0 milestone post** | _(URL pending — author to record)_ | KR/Global professional | 2026-05-19 |
+| **Twitter/X (Korean — v0.3.0 K1-companion)** | _(URL pending — author to record)_ | KR | 2026-05-19 |
 | Twitter/X (English) | https://x.com/i/status/2054094082067386690 | Global EN | 2026-05-12 |
-| Twitter/X (Korean) | _(URL pending — author to record)_ | KR | 2026-05-12 |
+| Twitter/X (Korean — v0.2.0 cycle) | _(URL pending — author to record)_ | KR | 2026-05-12 |
 | dev.to article (intro) | https://dev.to/hashevolution/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-1914 | Global EN (technical) | 2026-05-12 |
 | dev.to article (Gemma 4 Challenge submission) | https://dev.to/hashevolution/building-a-mini-palantir-on-gemma4e4b-128k-context-lets-the-graph-actually-be-graph-rag-33fk | Global EN (Gemma 4 contestants + judges) | 2026-05-12 |
 | Hashnode cross-post (intro article) | https://ragllm.hashnode.dev/building-a-mini-palantir-a-local-graph-rag-engine-with-ontology-security-and-self-evolution-alpha | Global EN (Hashnode algorithm + Google search) | 2026-05-13 |
@@ -257,14 +264,14 @@ This launch tracker file is considered complete when all of the following are tr
 - [x] **Visual asset library shipped — 6 screenshots + README hero (PR #304, 2026-05-18)**
 - [x] **First image-bearing X post (2026-05-18, URL pending)**
 - [ ] dev.to two articles refreshed with cover images (planned, drag-drop from screenshots library)
-- [ ] GeekNews D-Day 2026-05-19 — body refresh + image embed + author publish
+- [x] **GeekNews D-Day 2026-05-19 — body refreshed for v0.3.0 + image embed + author publish complete** (id=29648, 3D ontology image attached, K1-companion X tweet + LinkedIn post sent same day)
 - [x] **First organic verified-account replies on X received and responded to (2026-05-18)**
 - [x] **Ali received the injection-fixtures schema URL via LinkedIn DM (Track 2 trigger)** — followed up with schema v1 refinements (2026-05-18); v1.1 `catalog_context` field added pre-emptively (2026-05-19, PR Track 2c) answering Ali's flagged convention question. Ali confirmed 2026-05-19: "byte_drift_expected is the right escape hatch", "data_exfiltration retrieval-stage insight is architecturally correct framing", `ar_ecommerce.yaml` authoring starts this week, **2026-06-01 deadline holds**.
 - [x] **Cross-experiment design (3×3 matrix) pre-registered on main with falsification criteria locked before any cell runs**
 - [x] **LLM Provider contract published on main 2–3 weeks ahead of schedule** — external implementers can wire backends now
 - [x] **Track 2 fixture migration in progress on main** — `baseline_kr_en.yaml` + harness shipped 2026-05-18 by a separate session picking up the Ali Collaboration Track handover
 - [x] **Second potential collaboration started — @mfucek_ / naumu_ai (X verified)** — independent of the Ali track, complementary skill domain (product/UX vs experimental/academic). Email transferred 2026-05-18
-- [ ] Track 1 — Provider contract **L1 wiring (code)** lands (deadline 2026-06-15)
+- [x] **Track 1 — Provider contract L1 wiring (code) landed 2026-05-19 (PR #324 PR-A + PR #325 PR-B)** — ~4 weeks ahead of the 2026-06-15 deadline; synth call-sites + conformance suite + SDK leakage guard all in. Remaining sub-tasks: trace-stage backend wiring (separate PR), retrieval-stage backend wiring (separate PR), public surface-the-wiring DM ping to Ali
 - [ ] Track 2 — Ali delivers `ar_ecommerce.yaml` (15–20 Arabic fixtures + ≥5 benign, deadline ~2026-06-01)
 - [ ] @mfucek_ DM follow-up — naumu_ai platform access + comparison signal
 - [ ] **`data_exfiltration` follow-up post — "Why output-stage PII mask is the wrong protective surface for data_exfiltration"** — committed to Ali in 2026-05-19 LinkedIn DM, separate cycle deliverable


### PR DESCRIPTION
## Summary

K1 GeekNews milestone published 2026-05-19 at https://news.hada.io/topic?id=29648 (title variant A: "JAMES v0.3.0 — Platform Skeleton 도달"). This PR brings the public archive and launch tracker in sync with what actually shipped on GeekNews + the X/LinkedIn companion posts that went out the same day.

- **`reports/promo-assets/geeknews-post.md`** — replaced the stale v0.2.0-era body with the v0.3.0 synthesis (Cognitive Middleware Phase 2 / Ali 6-turn collaboration / Gemma 4 Challenge 2 submissions / Matija second collab / schema v1.1 / Provider contract / 3×3 plan / visual asset library). Inner bash code-block wrapped in 4-backtick outer fence so it renders cleanly. Body frozen at publication moment — same-day post-publication main commits (Track 1 PR #324/#325) are noted in a footer reference, not folded back into the body.
- **`reports/promo-assets/launch-tracker.md`** — 5 new status snapshot rows: K1 publish, K1-companion X tweet + LinkedIn post (URLs pending author), Track 1 PR-A (#324) synth call-site backend wiring, Track 1 PR-B (#325) conformance suite + SDK leakage guard. Social posts table gains K1 GeekNews URL + 2 pending companion-post URL slots. Two cycle-close checkboxes flipped to done: GeekNews D-Day complete + Track 1 L1 wiring landed (~4 weeks ahead of 2026-06-15 deadline).

## Verification

- `grep -n '^\`\`\`\`\\|^\`\`\`' reports/promo-assets/geeknews-post.md` confirms code-fence balance (outer 4-tick at 26/82, inner 3-tick at 73/79 — no termination collision)
- Body matches text actually submitted to Hada.io 2026-05-19 (cross-checked against the title (A) line at top of archive)
- All embedded PR links in body (PR #311 / #315 / #316 / #317 / #322 + dev.to 2 + OpenSSF) resolve to merged main artifacts
- `wc -c`: geeknews-post.md = 8055 bytes, launch-tracker.md = 29069 bytes (no core/ touched, 20 KB module gate N/A)
- No `core/retrieval`, `core/graph`, or `core/reasoning` files touched — bench numbers requirement N/A

## Out of scope

- K1-companion X tweet URL + LinkedIn URL — author to fill into the two `(URL pending — author to record)` rows once the public URLs are surfaced
- E1 Show HN body refresh for D-Day 2026-05-26 — separate PR (`docs/v0.3-show-hn-body-refresh`)
- K3 Korean X 7-tweet series Days 2–7 — separate PR (`docs/v0.3-x-ko-7tweet-series`)
- `data_exfiltration` follow-up post committed to Ali in 6th-turn DM — separate cycle deliverable per the tracker


---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_