### PR TITLE
chore(tests): grep engine_source() — clear 3 pre-existing character failures

### DIFF
--- a/tests/test_character_prompt_cleanup.py
+++ b/tests/test_character_prompt_cleanup.py
@@ -163,16 +163,25 @@ class BehaviorTests(unittest.TestCase):
 class EngineIntegrationTests(unittest.TestCase):
     """엔진은 store.get_system_prompt 와 character_profile.get_prompt_modifiers
     두 곳에서 prompt 조각을 받아 합친다. P4 가 store 쪽만 손대므로 engine
-    경로 자체는 변하면 안됨."""
+    경로 자체는 변하면 안됨.
+
+    [chore 2026-05-19] After the #293 engine.py split (engine_memory.py
+    + engine_synth.py), the two calls live inside engine_memory.
+    These tests now grep the *concatenated* engine source via the
+    shared helper, so a future split that moves them again still
+    passes without rewriting the assertions.
+    """
 
     def test_engine_still_calls_get_system_prompt(self):
-        engine = (ROOT / "core" / "reasoning" / "engine.py").read_text(encoding="utf-8")
-        self.assertIn("get_system_prompt()", engine,
+        from tests._pipeline_src import engine_source
+        src = engine_source()
+        self.assertIn("get_system_prompt()", src,
             "engine 은 P4 후에도 store.get_system_prompt 를 계속 호출")
 
     def test_engine_still_calls_get_prompt_modifiers(self):
-        engine = (ROOT / "core" / "reasoning" / "engine.py").read_text(encoding="utf-8")
-        self.assertIn("get_prompt_modifiers", engine,
+        from tests._pipeline_src import engine_source
+        src = engine_source()
+        self.assertIn("get_prompt_modifiers", src,
             "engine 은 P4 후에도 character_profile 에서 trait directives 를 받음 "
             "— 성격 표현은 trait 에서, 이름/언어는 store 에서, 라는 분리가 핵심")
 

--- a/tests/test_character_remove_text_persona.py
+++ b/tests/test_character_remove_text_persona.py
@@ -252,11 +252,17 @@ class EnginePromptStillUsesProfileTests(unittest.TestCase):
     P3에서 free-text persona 를 끊었어도 trait-based directives 는 살아 있어야 함."""
 
     def test_engine_still_imports_character_profile(self):
-        engine = (ROOT / "core" / "reasoning" / "engine.py").read_text(encoding="utf-8")
-        self.assertIn("from core.character_profile import", engine,
+        # [chore 2026-05-19] After the #293 engine.py split, the
+        # character_profile import + get_prompt_modifiers call live
+        # inside engine_memory.py. Grep the concatenated engine source
+        # via the shared helper so a future split that moves them
+        # again still passes without rewriting the assertion.
+        from tests._pipeline_src import engine_source
+        src = engine_source()
+        self.assertIn("from core.character_profile import", src,
             "엔진은 P3 이후에도 character_profile 를 import 해서 trait "
             "directives 를 system_prompt 에 주입해야 함")
-        self.assertIn("get_prompt_modifiers", engine)
+        self.assertIn("get_prompt_modifiers", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Clears the three EngineIntegrationTests / EnginePromptStillUsesProfileTests
assertions that have been failing on main since PR #293 (`refactor(reasoning):
split engine.py — memory + synth modules`).

The tests grep `core/reasoning/engine.py` as raw text and look for
`get_system_prompt`, `get_prompt_modifiers`, and `from core.character_profile`
imports. #293 moved those three symbols into `engine_memory.py` without
updating the assertions, so the tests have been red ever since.

**Fix**: switch each assertion to the existing
`tests/_pipeline_src.engine_source()` helper, which concatenates
`engine.py` + `engine_memory.py` + `engine_synth.py`. That helper
was added in the #288 / #293 sweep precisely for this case —
structural tests that previously did `inspect.getsource(engine_mod)`
now inspect the split companions too.

A future split that moves these calls again will keep passing as
long as the new module is added to `engine_source()`.

## Failing → passing

| Test | Before | After |
|---|---|---|
| `EngineIntegrationTests::test_engine_still_calls_get_system_prompt` | FAIL | PASS |
| `EngineIntegrationTests::test_engine_still_calls_get_prompt_modifiers` | FAIL | PASS |
| `EnginePromptStillUsesProfileTests::test_engine_still_imports_character_profile` | FAIL | PASS |

## Verification

- `test_character_prompt_cleanup.py` — **11/11 passed**
- `test_character_remove_text_persona.py` — **22/22 passed**
- **Full repo sweep**: **2100 passed, 0 failed** (was 2097 passed + 3 pre-existing failed; this PR clears those 3 without introducing new ones).
- **Ruff**: `All checks passed!`

## Out of scope

- Renaming the test classes to reflect the post-split shape — left
  intact so a future reader can still trace P3/P4 history. Each
  class's docstring carries a 2026-05-19 note explaining the
  helper switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)