### PR TITLE
feat(memory): episodic store infra (Cognitive Phase 3 PR-9a)

### DIFF
--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -21,6 +21,16 @@ from core.memory.loom import (
     MEMORY_DEDUP_WINDOW,
 )
 from core.memory.trust import verify_before_write
+# [Cognitive Phase 3 PR-9a, 2026-05-19] session-scoped tier (§5.7.6).
+# Wiring lands in PR-9b; this re-export keeps consumers using
+# `from core.memory import EpisodicMemory` consistent with the
+# MemoryStore / MemoryLoom pattern.
+from core.memory.episodic import (
+    EpisodicEvent,
+    EpisodicMemory,
+    KNOWN_STAGES as EPISODIC_STAGES,
+    MAX_SUMMARY_CHARS as EPISODIC_MAX_SUMMARY_CHARS,
+)
 
 __all__ = [
     "MemoryStore",
@@ -35,4 +45,8 @@ __all__ = [
     "MEMORY_CONFIDENCE_TH",
     "MEMORY_DEDUP_WINDOW",
     "verify_before_write",
+    "EpisodicEvent",
+    "EpisodicMemory",
+    "EPISODIC_STAGES",
+    "EPISODIC_MAX_SUMMARY_CHARS",
 ]

--- a/core/memory/episodic.py
+++ b/core/memory/episodic.py
@@ -1,0 +1,367 @@
+"""Session-scoped event store — Cognitive Phase 3 PR-9a.
+
+The session tier of the ``docs/ARCHITECTURE.md §5.7.6`` scope hierarchy.
+Holds the intra-turn reasoning trail (plan / reflect / verify / synth /
+…) in a form the *next* turn in the same session can read online.
+
+This module ships infrastructure only — no call sites in the cognitive
+middleware reach ``EpisodicMemory.record`` yet. PR-9b adds the wiring.
+The split mirrors the L0 / L1 pattern the backends track used
+(PR #283 ships infra; PR #284 wires the call sites).
+
+Two invariants from §5.7.6:
+
+1. **Writes never escape upward.** Every read filters on
+   ``WHERE session_id = ?`` at the SQL layer. The store exposes no
+   "list all sessions" read on the user-facing path — that's an
+   admin-only API in PR-9b.
+2. **Session end clears.** A new ``session_id`` is a clean episodic
+   slate; ``clear_session`` removes exactly that session's rows.
+   ``prune_older_than`` is the retention sweep (default 7 days, matches
+   ``JAMES_TRACE_RETENTION_DAYS`` from Axis 3 PR #84).
+
+Design doc: ``docs/design/v0.3-episodic-memory.md``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ─── Stage taxonomy ────────────────────────────────────────────────
+# Validated at record() time so a typo at the wiring site (PR-9b)
+# fails loudly during dev rather than silently bypassing readers.
+# Mirrors the cognitive middleware stages in
+# docs/ARCHITECTURE.md §5.7.2.
+KNOWN_STAGES = frozenset({
+    "retrieve",
+    "plan",
+    "reflect",
+    "verify",
+    "synth",
+    "tool_call",
+    "error",
+})
+
+
+# ─── Summary truncation ────────────────────────────────────────────
+# Matches the audit_log's truncate_summary cap (240 chars). Long
+# reasoning summaries fall outside the episodic working set — the
+# forensic record in audit_log carries the full text.
+MAX_SUMMARY_CHARS = 240
+
+
+# ─── Default DB location ───────────────────────────────────────────
+# Separate file from james_data.db (workspace-scoped) and
+# james_audit.db (forensic, retained). Episodic prunes; mixing
+# retention policies in one file forces the wrong invariant to win.
+try:
+    from config import BASE_DIR
+    DEFAULT_EPISODIC_DB = os.path.join(BASE_DIR, "james_episodic.db")
+except ImportError:
+    DEFAULT_EPISODIC_DB = "./james_episodic.db"
+
+
+@dataclass(frozen=True)
+class EpisodicEvent:
+    """One reasoning event recorded inside a session.
+
+    Field shape matches docs/design/v0.3-episodic-memory.md §"Schema".
+    The frozen=True attribute pins the contract — consumers don't
+    mutate events after read; if reflection needs to revise a verdict
+    it appends a new event rather than editing the old one (mirrors
+    the append-only discipline of audit_log).
+    """
+
+    event_id: str
+    session_id: str
+    turn_id: str
+    ts: float
+    stage: str
+    summary: str
+    score: float = 0.0
+    extras: Dict[str, Any] = field(default_factory=dict)
+    trace_id: str = ""
+
+
+def _new_event_id() -> str:
+    """Sortable + globally-unique id. ULID-shaped (timestamp-prefix +
+    randomness) without pulling in an external dependency:
+
+      ``{millis:013d}-{hex16}``
+
+    The 13-digit zero-padded millisecond timestamp keeps the string
+    sortable through the year 2286, matching ULID's design horizon.
+    The 16-char random hex (64 bits) is enough collision-resistance
+    for the per-session event volume the design anticipates
+    (~20 events × ~10 turns × ~thousands of sessions ≈ 10^5 events
+    per workspace, well within 2^64).
+    """
+    return f"{int(time.time() * 1000):013d}-{secrets.token_hex(8)}"
+
+
+def _truncate(s: str) -> str:
+    """Cap summary at MAX_SUMMARY_CHARS. Non-strings coerced via str()
+    so a misuse at the call site doesn't crash the writer.
+    """
+    if not isinstance(s, str):
+        s = "" if s is None else str(s)
+    if len(s) <= MAX_SUMMARY_CHARS:
+        return s
+    return s[:MAX_SUMMARY_CHARS]
+
+
+class EpisodicMemory:
+    """One instance per process. Scoped reads/writes happen via
+    ``session_id`` arguments rather than per-session instances — same
+    pattern as ``MemoryStore`` in store.py, and the session_id stays
+    the only namespace key so a future v0.4 multi-process topology
+    remains forward-compatible.
+
+    Initialization is idempotent: re-running on an existing DB
+    creates no schema drift, opens the existing file.
+    """
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self._db_path = db_path or DEFAULT_EPISODIC_DB
+        Path(os.path.dirname(self._db_path) or ".").mkdir(
+            parents=True, exist_ok=True
+        )
+        self._init_schema()
+
+    # ─── lifecycle ──────────────────────────────────────────────
+
+    def _connect(self) -> sqlite3.Connection:
+        # WAL keeps concurrent reads safe with one writer — the v0.3
+        # single-process default. Multi-process topology (v0.4) needs
+        # a different store; the schema/API stay forward-compatible
+        # because session_id is the only namespace key.
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError:
+            # Some filesystems (network mounts) refuse WAL; the rest
+            # of the store still works under rollback-journal mode,
+            # so this is best-effort.
+            pass
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS episodic_events (
+                    event_id    TEXT PRIMARY KEY,
+                    session_id  TEXT NOT NULL,
+                    turn_id     TEXT NOT NULL,
+                    ts          REAL NOT NULL,
+                    stage       TEXT NOT NULL,
+                    summary     TEXT,
+                    score       REAL DEFAULT 0.0,
+                    extras_json TEXT,
+                    trace_id    TEXT NOT NULL DEFAULT ''
+                );
+                CREATE INDEX IF NOT EXISTS ix_episodic_session_ts
+                    ON episodic_events(session_id, ts DESC);
+                CREATE INDEX IF NOT EXISTS ix_episodic_turn
+                    ON episodic_events(session_id, turn_id);
+                CREATE INDEX IF NOT EXISTS ix_episodic_trace
+                    ON episodic_events(trace_id);
+                """
+            )
+
+    # ─── write ──────────────────────────────────────────────────
+
+    def record(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        stage: str,
+        summary: str,
+        score: float = 0.0,
+        extras: Optional[Dict[str, Any]] = None,
+        trace_id: str = "",
+    ) -> str:
+        """Append one event. Returns the assigned ``event_id``.
+
+        Validates ``stage`` against KNOWN_STAGES (typo → ValueError).
+        Truncates ``summary`` to MAX_SUMMARY_CHARS. Non-string
+        ``summary`` is coerced rather than rejected so a misused
+        wiring point doesn't crash the writer.
+        """
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty str")
+        if not isinstance(turn_id, str) or not turn_id:
+            raise ValueError("turn_id must be a non-empty str")
+        if stage not in KNOWN_STAGES:
+            raise ValueError(
+                f"unknown stage {stage!r}; "
+                f"known stages: {sorted(KNOWN_STAGES)}"
+            )
+
+        event_id = _new_event_id()
+        truncated = _truncate(summary)
+        extras_json = json.dumps(extras or {}, ensure_ascii=False)
+
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO episodic_events "
+                "(event_id, session_id, turn_id, ts, stage, summary, "
+                "score, extras_json, trace_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    event_id,
+                    session_id,
+                    turn_id,
+                    time.time(),
+                    stage,
+                    truncated,
+                    float(score),
+                    extras_json,
+                    trace_id or "",
+                ),
+            )
+        return event_id
+
+    # ─── read ───────────────────────────────────────────────────
+
+    def _row_to_event(self, row: sqlite3.Row) -> EpisodicEvent:
+        try:
+            extras = json.loads(row["extras_json"]) if row["extras_json"] else {}
+        except (json.JSONDecodeError, TypeError):
+            # A malformed extras_json row shouldn't take the reader
+            # down — the rest of the event is still useful for
+            # debugging. Surface as empty dict; the dev-time path
+            # has already passed JSON validation via json.dumps.
+            extras = {}
+        return EpisodicEvent(
+            event_id=row["event_id"],
+            session_id=row["session_id"],
+            turn_id=row["turn_id"],
+            ts=float(row["ts"]),
+            stage=row["stage"],
+            summary=row["summary"] or "",
+            score=float(row["score"] or 0.0),
+            extras=extras,
+            trace_id=row["trace_id"] or "",
+        )
+
+    def events_for_turn(
+        self,
+        session_id: str,
+        turn_id: str,
+    ) -> List[EpisodicEvent]:
+        """Every event in one turn, sorted chronologically by event_id
+        (the ULID-shaped id sorts by ts millis as a side-effect).
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM episodic_events "
+                "WHERE session_id = ? AND turn_id = ? "
+                "ORDER BY event_id ASC",
+                (session_id, turn_id),
+            ).fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    def recent_events(
+        self,
+        session_id: str,
+        *,
+        limit: int = 20,
+        stages: Tuple[str, ...] = (),
+    ) -> List[EpisodicEvent]:
+        """The last ``limit`` events in this session, optionally
+        filtered by stage. Default 20 ≈ 5 turns of reasoning. Returned
+        in chronological order (oldest first) so the next-turn cognitive
+        consumer sees the trail in the order it happened.
+        """
+        if limit <= 0:
+            return []
+
+        sql = (
+            "SELECT * FROM ("
+            "SELECT * FROM episodic_events WHERE session_id = ? "
+        )
+        params: List[Any] = [session_id]
+        if stages:
+            placeholders = ",".join("?" for _ in stages)
+            sql += f"AND stage IN ({placeholders}) "
+            params.extend(stages)
+        # Pull the most recent N rows in reverse-chrono via the index,
+        # then flip to chronological in the outer SELECT.
+        sql += (
+            "ORDER BY ts DESC LIMIT ?"
+            ") ORDER BY ts ASC"
+        )
+        params.append(limit)
+
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    def get_by_trace_id(
+        self,
+        session_id: str,
+        trace_id: str,
+    ) -> List[EpisodicEvent]:
+        """Look up every event written under one trace_id within this
+        session. Cross-session lookup deliberately disallowed — the
+        admin debugging endpoint in PR-9b crosses sessions through a
+        separate API that the PolicyEngine gates.
+        """
+        if not trace_id:
+            return []
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM episodic_events "
+                "WHERE session_id = ? AND trace_id = ? "
+                "ORDER BY event_id ASC",
+                (session_id, trace_id),
+            ).fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    # ─── lifecycle ──────────────────────────────────────────────
+
+    def clear_session(self, session_id: str) -> int:
+        """Delete every row for this session. Returns rows removed.
+        Called when the frontend cycles a session via ``newSession()``
+        (chat.js, PR #302) and as part of the retention sweep.
+        """
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM episodic_events WHERE session_id = ?",
+                (session_id,),
+            )
+            return cur.rowcount
+
+    def prune_older_than(self, *, max_age_days: int) -> int:
+        """Retention sweep. Default at the call site is 7 days,
+        matching ``JAMES_TRACE_RETENTION_DAYS`` (Axis 3 PR #84).
+        Returns rows removed.
+        """
+        if max_age_days <= 0:
+            raise ValueError("max_age_days must be > 0")
+        threshold = time.time() - (max_age_days * 86400)
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM episodic_events WHERE ts < ?",
+                (threshold,),
+            )
+            return cur.rowcount
+
+
+__all__ = [
+    "EpisodicEvent",
+    "EpisodicMemory",
+    "KNOWN_STAGES",
+    "MAX_SUMMARY_CHARS",
+    "DEFAULT_EPISODIC_DB",
+]

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,335 @@
+"""Tests for ``core/memory/episodic.py`` (Cognitive Phase 3 PR-9a).
+
+Covers the 10-item test plan in ``docs/design/v0.3-episodic-memory.md``
+§"Test plan". Every test uses a temp DB so the suite is hermetic and
+parallel-safe.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.memory.episodic import (  # noqa: E402
+    EpisodicEvent,
+    EpisodicMemory,
+    KNOWN_STAGES,
+    MAX_SUMMARY_CHARS,
+)
+
+
+def _fresh_store() -> EpisodicMemory:
+    """One EpisodicMemory pointing at a freshly-created temp DB."""
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    return EpisodicMemory(db_path=f.name)
+
+
+class RecordTests(unittest.TestCase):
+
+    def test_record_returns_sortable_id(self):
+        """Plan item 1 — event_id sorts chronologically by ts."""
+        em = _fresh_store()
+        ids = []
+        for i in range(5):
+            ids.append(em.record(
+                session_id="s1", turn_id="t1", stage="synth",
+                summary=f"event {i}",
+            ))
+            # Force a millisecond gap so the ts-prefix differs.
+            time.sleep(0.002)
+        self.assertEqual(ids, sorted(ids),
+            "event_ids must be sortable in chronological order — "
+            "the ULID-shaped ts-prefix is the guarantee replay relies on")
+
+    def test_record_validates_stage(self):
+        """Plan item 6 — unknown stage raises ValueError."""
+        em = _fresh_store()
+        with self.assertRaises(ValueError) as ctx:
+            em.record(session_id="s1", turn_id="t1",
+                      stage="snyth", summary="oops")
+        self.assertIn("unknown stage", str(ctx.exception))
+
+    def test_record_truncates_long_summary(self):
+        """Plan item 7 — summary > MAX_SUMMARY_CHARS lands truncated."""
+        em = _fresh_store()
+        big = "x" * 5000
+        eid = em.record(session_id="s1", turn_id="t1",
+                        stage="synth", summary=big)
+        events = em.events_for_turn("s1", "t1")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_id, eid)
+        self.assertEqual(len(events[0].summary), MAX_SUMMARY_CHARS)
+
+    def test_record_rejects_empty_session_id(self):
+        em = _fresh_store()
+        with self.assertRaises(ValueError):
+            em.record(session_id="", turn_id="t1",
+                      stage="synth", summary="x")
+
+    def test_record_rejects_empty_turn_id(self):
+        em = _fresh_store()
+        with self.assertRaises(ValueError):
+            em.record(session_id="s1", turn_id="",
+                      stage="synth", summary="x")
+
+    def test_record_accepts_extras_and_trace_id(self):
+        em = _fresh_store()
+        eid = em.record(
+            session_id="s1", turn_id="t1", stage="synth",
+            summary="ok", extras={"foo": 1, "bar": [1, 2]},
+            trace_id="abc-123",
+        )
+        events = em.events_for_turn("s1", "t1")
+        self.assertEqual(events[0].event_id, eid)
+        self.assertEqual(events[0].extras, {"foo": 1, "bar": [1, 2]})
+        self.assertEqual(events[0].trace_id, "abc-123")
+
+    def test_record_handles_non_string_summary_gracefully(self):
+        """A misused wiring point that passes a non-string summary
+        should land as a coerced empty/string row, not crash the writer.
+        """
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary=None)
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary=42)   # type: ignore[arg-type]
+        events = em.events_for_turn("s1", "t1")
+        self.assertEqual(len(events), 2)
+
+
+class ReadTests(unittest.TestCase):
+
+    def test_events_for_turn_returns_chronological(self):
+        """Plan item 2 — events_for_turn sorted by event_id ASC."""
+        em = _fresh_store()
+        recorded = []
+        for i in range(4):
+            recorded.append(em.record(
+                session_id="s1", turn_id="t1", stage="synth",
+                summary=f"event {i}",
+            ))
+            time.sleep(0.002)
+        events = em.events_for_turn("s1", "t1")
+        self.assertEqual([e.event_id for e in events], recorded)
+
+    def test_recent_events_respects_limit(self):
+        """Plan item 3 — recent_events honors `limit` and `stages`."""
+        em = _fresh_store()
+        for i in range(10):
+            em.record(session_id="s1", turn_id=f"t{i}",
+                      stage="synth", summary=f"e{i}")
+            time.sleep(0.001)
+        events = em.recent_events("s1", limit=3)
+        self.assertEqual(len(events), 3)
+        # The 3 most recent → events 7/8/9 (chronological order).
+        self.assertEqual([e.summary for e in events], ["e7", "e8", "e9"])
+
+    def test_recent_events_filters_by_stage(self):
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary="synth1")
+        em.record(session_id="s1", turn_id="t1",
+                  stage="plan", summary="plan1")
+        em.record(session_id="s1", turn_id="t2",
+                  stage="reflect", summary="reflect1")
+        em.record(session_id="s1", turn_id="t2",
+                  stage="plan", summary="plan2")
+        plans = em.recent_events("s1", limit=20, stages=("plan",))
+        self.assertEqual(len(plans), 2)
+        self.assertEqual({e.summary for e in plans}, {"plan1", "plan2"})
+
+    def test_recent_events_zero_limit_returns_empty(self):
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary="x")
+        self.assertEqual(em.recent_events("s1", limit=0), [])
+
+    def test_get_by_trace_id_within_session(self):
+        """Plan item 9 — record made with trace_id is retrievable."""
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1", stage="synth",
+                  summary="a", trace_id="trace-1")
+        em.record(session_id="s1", turn_id="t2", stage="reflect",
+                  summary="b", trace_id="trace-1")
+        em.record(session_id="s1", turn_id="t3", stage="verify",
+                  summary="c", trace_id="trace-2")
+        out = em.get_by_trace_id("s1", "trace-1")
+        self.assertEqual({e.summary for e in out}, {"a", "b"})
+
+    def test_get_by_trace_id_empty_returns_empty(self):
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1", stage="synth",
+                  summary="a", trace_id="trace-1")
+        self.assertEqual(em.get_by_trace_id("s1", ""), [])
+
+
+class SessionIsolationTests(unittest.TestCase):
+    """Plan item 5 — the §5.7.6 'writes never escape upward' invariant.
+    Every reader filters on session_id at the SQL layer; a session B
+    must never observe session A's rows.
+    """
+
+    def test_recent_events_isolated_per_session(self):
+        em = _fresh_store()
+        em.record(session_id="A", turn_id="t1",
+                  stage="synth", summary="from A")
+        em.record(session_id="B", turn_id="t1",
+                  stage="synth", summary="from B")
+        a_events = em.recent_events("A", limit=20)
+        b_events = em.recent_events("B", limit=20)
+        self.assertEqual(len(a_events), 1)
+        self.assertEqual(a_events[0].summary, "from A")
+        self.assertEqual(len(b_events), 1)
+        self.assertEqual(b_events[0].summary, "from B")
+
+    def test_events_for_turn_isolated_per_session(self):
+        em = _fresh_store()
+        em.record(session_id="A", turn_id="t1",
+                  stage="synth", summary="from A")
+        em.record(session_id="B", turn_id="t1",   # same turn_id!
+                  stage="synth", summary="from B")
+        a = em.events_for_turn("A", "t1")
+        b = em.events_for_turn("B", "t1")
+        self.assertEqual([e.summary for e in a], ["from A"])
+        self.assertEqual([e.summary for e in b], ["from B"])
+
+    def test_get_by_trace_id_isolated_per_session(self):
+        em = _fresh_store()
+        em.record(session_id="A", turn_id="t1", stage="synth",
+                  summary="from A", trace_id="shared-trace")
+        em.record(session_id="B", turn_id="t1", stage="synth",
+                  summary="from B", trace_id="shared-trace")
+        # Same trace_id in both sessions — must still isolate.
+        self.assertEqual(
+            [e.summary for e in em.get_by_trace_id("A", "shared-trace")],
+            ["from A"],
+        )
+        self.assertEqual(
+            [e.summary for e in em.get_by_trace_id("B", "shared-trace")],
+            ["from B"],
+        )
+
+    def test_clear_session_only_removes_targeted_session(self):
+        em = _fresh_store()
+        em.record(session_id="A", turn_id="t1",
+                  stage="synth", summary="from A")
+        em.record(session_id="B", turn_id="t1",
+                  stage="synth", summary="from B")
+        removed = em.clear_session("A")
+        self.assertEqual(removed, 1)
+        self.assertEqual(em.recent_events("A", limit=20), [])
+        # B's row survives.
+        self.assertEqual(len(em.recent_events("B", limit=20)), 1)
+
+
+class LifecycleTests(unittest.TestCase):
+
+    def test_clear_session_returns_rows_removed(self):
+        """Plan item 4 — clear_session removes exactly that session."""
+        em = _fresh_store()
+        for i in range(3):
+            em.record(session_id="A", turn_id=f"t{i}",
+                      stage="synth", summary=f"e{i}")
+        removed = em.clear_session("A")
+        self.assertEqual(removed, 3)
+        self.assertEqual(em.clear_session("A"), 0)   # idempotent
+
+    def test_prune_older_than_removes_old_rows(self):
+        """Plan item 10 — retention sweep deletes rows older than the
+        cutoff and keeps newer ones.
+        """
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary="recent")
+        # Backdate one row by 30 days. Direct SQL since record()
+        # always stamps with time.time(); the backdating is a test-
+        # only mutation to simulate the retention edge.
+        with em._connect() as conn:
+            conn.execute(
+                "INSERT INTO episodic_events "
+                "(event_id, session_id, turn_id, ts, stage, summary, "
+                "score, extras_json, trace_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "old-1",
+                    "s1", "t-old",
+                    time.time() - (30 * 86400),
+                    "synth", "old", 0.0, "{}", "",
+                ),
+            )
+        removed = em.prune_older_than(max_age_days=7)
+        self.assertEqual(removed, 1)
+        remaining = em.recent_events("s1", limit=20)
+        self.assertEqual([e.summary for e in remaining], ["recent"])
+
+    def test_prune_negative_or_zero_age_raises(self):
+        em = _fresh_store()
+        with self.assertRaises(ValueError):
+            em.prune_older_than(max_age_days=0)
+        with self.assertRaises(ValueError):
+            em.prune_older_than(max_age_days=-3)
+
+    def test_idempotent_schema_init(self):
+        """Plan item 8 — re-running __init__ on an existing DB is a no-op."""
+        f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        f.close()
+        em1 = EpisodicMemory(db_path=f.name)
+        em1.record(session_id="s1", turn_id="t1",
+                   stage="synth", summary="pre-reinit")
+        # Spinning up a second instance against the same file must
+        # not drop / recreate the table.
+        em2 = EpisodicMemory(db_path=f.name)
+        events = em2.recent_events("s1", limit=20)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].summary, "pre-reinit")
+
+
+class EventDataclassTests(unittest.TestCase):
+
+    def test_event_is_frozen(self):
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary="x")
+        ev = em.events_for_turn("s1", "t1")[0]
+        with self.assertRaises(Exception):
+            # frozen dataclass disallows attribute assignment
+            ev.summary = "tampered"   # type: ignore[misc]
+
+    def test_known_stages_non_empty(self):
+        # Guard against an accidental edit emptying the stage set
+        # and turning every record() validation into a no-op.
+        self.assertGreater(len(KNOWN_STAGES), 0)
+        # The cognitive middleware's named stages must all be present.
+        for stage in ("retrieve", "plan", "reflect",
+                      "verify", "synth", "tool_call", "error"):
+            self.assertIn(stage, KNOWN_STAGES)
+
+
+class EventDataclassFieldShapeTests(unittest.TestCase):
+    """Spot-checks for the EpisodicEvent surface — a future schema
+    change that drops one of these fields must update consumers
+    (PR-9b and the design doc) rather than land silently.
+    """
+
+    def test_required_fields_present(self):
+        em = _fresh_store()
+        em.record(session_id="s1", turn_id="t1",
+                  stage="synth", summary="x")
+        ev = em.events_for_turn("s1", "t1")[0]
+        self.assertIsInstance(ev, EpisodicEvent)
+        for attr in ("event_id", "session_id", "turn_id", "ts",
+                     "stage", "summary", "score", "extras", "trace_id"):
+            self.assertTrue(hasattr(ev, attr),
+                            f"EpisodicEvent missing attribute {attr!r}")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Lands the **session-scoped tier** of `docs/ARCHITECTURE.md` §5.7.6.
Infrastructure only — no call sites in the cognitive middleware
reach `EpisodicMemory.record` yet. **PR-9b adds the wiring.** The
split mirrors the L0 / L1 pattern the backends track used (PR #283
ships infra; PR #284 wired the call sites).

Design pre-registered in `docs/design/v0.3-episodic-memory.md` (#336).

## What this PR ships

### `core/memory/episodic.py` — new module under the memory package

- `EpisodicEvent` dataclass (frozen) — exact field shape the design
  named: `event_id` (ULID-shaped) + `session_id` + `turn_id` + `ts`
  + `stage` + `summary` + `score` + `extras` (dict) + `trace_id`
  back-link.
- `EpisodicMemory` class — API surface the design fixed: `record()`,
  `events_for_turn()`, `recent_events()` (with optional `stages`
  filter), `get_by_trace_id()` (session-scoped), `clear_session()`,
  `prune_older_than()` (retention sweep).
- **Separate SQLite file** (`james_episodic.db`) — not
  `james_data.db` (workspace-scoped) nor `james_audit.db` (forensic).
- WAL mode best-effort, falls back to rollback-journal on
  filesystems that refuse it.
- 3 indexes matching the three expected access patterns:
  `(session_id, ts DESC)`, `(session_id, turn_id)`, `(trace_id)`.
- **ULID-shaped `event_id` without an external dependency**:
  `f"{millis:013d}-{secrets.token_hex(8)}"`. Sortable through 2286
  + 64 bits of randomness.
- Stage validation against a closed `KNOWN_STAGES` set
  (`{retrieve, plan, reflect, verify, synth, tool_call, error}`) so
  a typo at the future PR-9b wiring site fails loudly during dev.
- Summary truncation at `MAX_SUMMARY_CHARS=240`, matching the
  `audit_log` truncate_summary cap.

### `core/memory/__init__.py` re-exports

`EpisodicEvent` / `EpisodicMemory` / `KNOWN_STAGES`
(as `EPISODIC_STAGES` to avoid collision with future cognitive-stage
taxonomies) / `MAX_SUMMARY_CHARS` — same pattern as the existing
`MemoryStore` / `MemoryLoom` exports.

### `tests/test_episodic_memory.py` — 24 tests

Covers the 10-item plan from the design doc + dataclass-shape guards:

- **Record validation**: stage typo raises, empty session_id /
  turn_id raises, non-string summary coerced, extras + trace_id
  round-trip.
- **Read ordering**: `events_for_turn` chronological,
  `recent_events` respects `limit`, stage filter works, `limit=0`
  returns empty, `get_by_trace_id` within session.
- **§5.7.6 session isolation invariant** — 4 dedicated tests prove
  session B never observes session A's rows for any reader:
  `recent_events`, `events_for_turn` (even with same `turn_id`),
  `get_by_trace_id` (even with same `trace_id`), `clear_session`
  (deleting A leaves B intact).
- **Lifecycle**: `clear_session` returns count + idempotent;
  `prune_older_than` removes old rows + raises on non-positive age;
  re-initing on existing DB is no-op.
- `EpisodicEvent.frozen=True` dataclass invariant.

## What PR-9 does NOT do

- **Wiring** — cognitive middleware does not yet call `record()`.
  Lands in **PR-9b** along with the admin debugging endpoint
  (`GET /admin/episodic/{session_id}`, gated by
  `admin.episodic.list`).
- **Working memory** (`core/memory/working.py`) — separate file, PR-10.
- **Graph evolution / event nodes** — PR-11, optional.

## Verification

- New `tests/test_episodic_memory.py` — **24 passed in 1.4s**.
- **Full repo sweep**: **2124 passed, 0 failed** (was 2100 passed,
  0 failed; +24 new).
- **Ruff**: `All checks passed!`
- Module size: `episodic.py` ~11 KB, well under the 20 KB CLAUDE.md
  rule #5 cap.

## Bench note

No bench numbers attached — this PR adds a new module under
`core/memory/` with no call sites in the synth or retrieval pipeline.
CLAUDE.md rule #2's bench gate targets `core/retrieval`, `core/graph`,
and `core/reasoning` regression; an unused storage primitive in
`core/memory/` does not move STEP 7 numbers. PR-9b (which wires the
cognitive stages to `record(...)`) will revisit.

Per `docs/design/v0.3-episodic-memory.md` §"PR sequence".

🤖 Generated with [Claude Code](https://claude.com/claude-code)