### PR TITLE
feat(legal): CLA infrastructure — B-2 / B-5 / B-7 / B-8 (Track B)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,53 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Required permissions for the CLA Assistant Action to:
+#   - update PR statuses ("CLA signed" check)
+#   - post the signature-request comment
+#   - read the PR body / author
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    # Trigger conditions: a real PR event, OR the human-typed
+    # "I have read the CLA..." comment, OR an admin-typed "recheck".
+    if: >-
+      github.event_name == 'pull_request_target'
+      || github.event.comment.body == 'recheck'
+      || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+    steps:
+      - name: "CLA Assistant"
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT scoped to the signature repo (see docs/handovers/
+          # session-2026-05-09-license-infrastructure.md §B-5
+          # "사용자 액션 — CLA_BOT_PAT 생성").
+          # Without this secret the workflow will fail at run time
+          # with a clear "missing PAT" error — the CLA itself does
+          # not gate, the secret does.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOT_PAT }}
+        with:
+          # Where signatures are recorded inside the remote repo.
+          path-to-signatures: 'signatures/version1/cla.json'
+          # The canonical CLA text the contributor signs against.
+          path-to-document: 'https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/legal/CLA.md'
+          # Signature commits land on this branch of the remote repo.
+          branch: 'main'
+          # Bot accounts that should never be asked to sign — they're
+          # not legal persons. Extend as new bots are added.
+          allowlist: dependabot[bot],github-actions[bot]
+          # Signature storage: separate private repo so the public
+          # source repo carries no PII (emails, GitHub IDs).
+          remote-organization-name: Hashevolution
+          remote-repository-name: james-rag-evol-cla

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,9 +307,37 @@ Don't be discouraged by review feedback — it's how we build a quality codebase
 
 ---
 
-## License
+## License & Contributor License Agreement (CLA)
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+PROJECT JAMES is **MIT-licensed** today. Your contributions are accepted
+under the same MIT terms.
+
+Because the project's license model may evolve over its lifetime (the
+conditions and procedure are tracked in
+[`docs/LICENSE_PLAN.md`](docs/LICENSE_PLAN.md)), every external contributor
+must sign the **[Individual Contributor License Agreement](docs/legal/CLA.md)**
+before their first pull request is merged.
+
+- The signing is automated. When you open your first PR, the **CLA
+  Assistant** bot will post a comment with a single-click sign link.
+- One signature covers **all your future contributions** to this project
+  unless the license model materially changes (see CLA §4-bis Relicensing
+  Grant).
+- The CLA confirms that:
+  1. You wrote (or have rights to) what you're contributing.
+  2. You grant Hashevolution a perpetual, irrevocable copyright and patent
+     license over your contribution.
+  3. You allow Hashevolution to **relicense** your contribution if a future
+     license-model change is necessary (CLA §4-bis). This clause is the
+     one that lets projects like MongoDB, Elastic, and Grafana evolve
+     their licenses without re-canvassing every past contributor — it's
+     decisive for project longevity even though it has zero effect under
+     MIT continuation.
+
+If you cannot or will not sign the CLA, you can still help in ways that
+don't require it — see [`docs/legal/non-cla-contributions.md`](docs/legal/non-cla-contributions.md)
+for alternatives (bug reports, discussion, derivative patchsets you
+publish on your own fork, etc.).
 
 ---
 

--- a/docs/legal/CLA.md
+++ b/docs/legal/CLA.md
@@ -1,0 +1,148 @@
+# PROJECT JAMES — Individual Contributor License Agreement (ICLA)
+
+> **Version**: v1.0 (2026-05-19)
+> **Project**: PROJECT JAMES (`hashevolution/james-rag-evol`)
+> **Maintainer**: Hashevolution
+
+Thank you for your interest in contributing to PROJECT JAMES (the "Project"),
+maintained by **Hashevolution** (the "Project Lead"). This Contributor License
+Agreement ("Agreement") clarifies the intellectual property license granted
+with Contributions from any individual ("You" or "Contributor").
+
+This Agreement is based on the **Apache Software Foundation Individual
+Contributor License Agreement v2.2**, adapted for PROJECT JAMES's licensing
+model. By signing this Agreement, you accept and agree to the following
+terms for Your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the individual copyright owner who Submits a
+Contribution to the Project. For purposes of this Agreement, "You" includes
+the entity by which You are employed if Your employer holds rights to
+intellectual property You create (see §4 below).
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Project for inclusion in, or documentation of, any
+of the products owned or managed by the Project. "Submitted" means any form
+of electronic, verbal, or written communication sent to the Project or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Project for the purpose of discussing
+and improving the Project, but excluding communication that is conspicuously
+marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+**Hashevolution** and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute Your Contributions and
+such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+**Hashevolution** and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Project, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of
+Your Contribution(s) with the Project to which such Contribution(s) was
+submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes
+direct or contributory patent infringement, then any patent licenses granted
+to that entity under this Agreement for that Contribution or the Project
+shall terminate as of the date such litigation is filed.
+
+## 4. Representation of Original Authorship
+
+You represent that each of Your Contributions is Your original creation
+(see §5 below for submissions on behalf of others) and that You are legally
+entitled to grant the above license. You represent that Your Contribution
+submissions include complete details of any third-party license or other
+restriction (including, but not limited to, related patents and trademarks)
+of which You are personally aware and which are associated with any part of
+Your Contributions.
+
+If Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission
+to make Contributions on behalf of that employer, that Your employer has
+waived such rights for Your Contributions to the Project, or that Your
+employer has executed a separate Corporate CLA with Hashevolution.
+
+## 4-bis. Relicensing Grant *(decisive clause)*
+
+> You hereby grant to **Hashevolution** the right, but not the obligation,
+> to relicense Your Contributions, in whole or in part, under any other
+> license terms of its choosing, including but not limited to other
+> open-source licenses (e.g., AGPL-3.0, Apache-2.0, BUSL-1.1) or proprietary
+> commercial licenses. This grant is irrevocable for Contributions already
+> accepted. You acknowledge that this grant enables Hashevolution to evolve
+> the Project's license model in response to market and ecosystem
+> conditions without obtaining further consent from individual contributors.
+
+**Why this clause exists**: open-source projects that later need to evolve
+their license model (e.g., MongoDB from AGPL → SSPL, Elastic from Apache →
+SSPL → AGPL, Grafana from Apache → AGPL) were able to do so because every
+contributor signed an equivalent clause from the start. Without this clause,
+any future license change would require **renegotiating individual consent
+from every contributor** — practically impossible at scale.
+
+Today PROJECT JAMES is **MIT-licensed**, and Hashevolution has no immediate
+intent to change that — the conditions and procedure for any future
+transition are tracked transparently in
+[`docs/LICENSE_PLAN.md`](../LICENSE_PLAN.md). This clause is harmless under
+MIT continuation: if Hashevolution never exercises it, contributors observe
+no effect. The clause exists solely to keep the option open.
+
+## 5. Submissions Not Your Original Work
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Project separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking
+the work as "Submitted on behalf of a third-party: [named here]".
+
+## 6. No Warranty
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notice of Inaccurate Representation
+
+You agree to notify the Project of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any
+respect.
+
+## 8. Corporate Contributions
+
+Contributions submitted on behalf of an employer that retains intellectual
+property rights to Your work require a separate Corporate CLA (CCLA). The
+CCLA will be introduced at the v0.4 First Domain Pilot milestone and will
+contain the same §4-bis Relicensing Grant. Until then, employer-rights
+Contributions should be cleared through §4 (employer permission/waiver).
+
+## Signing
+
+This CLA is administered via **CLA Assistant**
+(<https://cla-assistant.io/>). When you open your first pull request to
+`hashevolution/james-rag-evol`, the bot will request a single-click
+signature against this document. One signature covers all your future
+contributions to the Project unless the Project's license model materially
+changes (see §4-bis).
+
+## Diff log
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-19 | Hashevolution | Initial v1.0 publication. Apache ICLA v2.2 baseline + §4-bis Relicensing Grant. |

--- a/docs/legal/non-cla-contributions.md
+++ b/docs/legal/non-cla-contributions.md
@@ -1,0 +1,100 @@
+# Contributing without signing the CLA
+
+> Track B-8 from `docs/handovers/session-2026-05-09-license-infrastructure.md`
+>
+> If you've landed here from a "CLA required" check failure, the bot is
+> doing what it's designed to do — every merged contribution to PROJECT
+> JAMES requires a signed [Individual CLA](CLA.md). We can't merge work
+> without one. **But we still want your input**, and there are several
+> equally useful paths that don't require signing.
+
+## Why the CLA exists
+
+The CLA isn't a copyright transfer — you keep ownership of your code.
+What it grants is (i) a perpetual license for Hashevolution and downstream
+users to use your contribution, (ii) a patent peace clause, and
+(iii) **§4-bis Relicensing Grant** — the clause that lets the project
+evolve its license model in future without renegotiating with every past
+contributor. That last one is the decisive piece. Without it, a project
+of any longevity becomes legally frozen.
+
+If those terms aren't acceptable to you or your employer, these paths
+remain fully open.
+
+## Paths that do not require a signed CLA
+
+### 1. Bug reports
+
+Open an issue in
+[GitHub Issues](https://github.com/Hashevolution/James-RAG-Evol/issues)
+with reproduction steps, environment info, and the unexpected behavior.
+A high-quality bug report is often more valuable than a code patch —
+it lets the maintainer (or a CLA-signed contributor) fix the root cause
+correctly.
+
+### 2. Design discussion
+
+Open a thread in
+[GitHub Discussions](https://github.com/Hashevolution/James-RAG-Evol/discussions).
+Architectural ideas, alternative implementations, ecosystem comparisons,
+performance observations — all welcome, no CLA needed.
+
+### 3. Documentation suggestions in issue form
+
+Spotted a typo, an outdated example, or a missing explanation? Open an
+issue with the exact location and the suggested correction. A maintainer
+will apply it on your behalf. Doc patches in PR form still need a CLA
+because the docs are part of the licensed work.
+
+### 4. Reviewing pull requests
+
+Comment on any open PR. Constructive code review, security observations,
+or pointing out edge cases doesn't require a CLA — only your own code
+contributions do.
+
+### 5. Forks and derivative work
+
+Fork the repo and publish your own modified version under MIT — that's
+explicitly what MIT permits. You stay in control of your fork; nothing
+about your fork is required to come back here. If your fork later grows
+into something this project should learn from, you can either (a)
+contact the maintainer to propose a merge (you'd sign the CLA at that
+point) or (b) keep maintaining your fork independently.
+
+### 6. Sharing a patchset off-tree
+
+If your employer's IP policy lets you publish patches but not sign third-
+party CLAs, you can publish your patches as a gist, a separate repo, or
+an attached file to an issue. A CLA-signed contributor may then apply
+the patch upstream with attribution.
+
+### 7. Sponsorship / financial contribution
+
+If you'd like to support the project without contributing code, the
+maintainer profile lists sponsorship channels.
+
+## What we cannot do
+
+We cannot merge a pull request that contains code (or docs, or
+configuration) without a signed CLA. The CLA Assistant bot enforces
+this automatically — it isn't a judgment about the contribution's
+quality.
+
+We also can't accept partial CLAs (e.g., signing §1-3 but striking
+§4-bis). The Relicensing Grant is structurally non-negotiable; without
+it the project's license cannot legally evolve and the entire CLA loses
+its forward-looking purpose. If §4-bis is the blocker, paths 1–6 above
+are the right alternatives.
+
+## Re-evaluating later
+
+The CLA decision isn't permanent. If your circumstances change (different
+employer, different project, different role), the same single-click
+signing flow remains available. One signature, all future contributions
+covered.
+
+## Questions
+
+Ask in
+[GitHub Discussions](https://github.com/Hashevolution/James-RAG-Evol/discussions)
+or open an issue. There's no penalty for asking before signing.


### PR DESCRIPTION
## Summary

Lands the **four code-side deliverables** from Track B (CLA gate for
external PRs) of `docs/handovers/session-2026-05-09-license-infrastructure.md`.

External contributors are needed for v0.3 done-when #4 ("CLA Assistant
blocks any unsigned external PR at the workflow gate") and for Ali-
style protocol-aligned contributions that may arrive any day after the
Track 1 Provider contract landed (#324 / #325 / #326). The CLA needs
to be there *before* the first external PR, not after.

The remaining four Track B items are **operator GUI actions** and
remain in the handover for the user to execute (see §"Operator
follow-up" below).

## What this PR ships

### `docs/legal/CLA.md` — Individual CLA v1.0 (B-2)

Apache ICLA v2.2 baseline (§1-6) with the decisive **§4-bis Relicensing
Grant** added. Without §4-bis, a project of any longevity becomes
legally frozen against future license-model evolution; the clause is
the same one MongoDB / Elastic / Grafana relied on for their license
transitions. Today the project is MIT and Hashevolution has no intent
to change that (procedure tracked in `docs/LICENSE_PLAN.md`), so the
clause is **harmless under MIT continuation** — it just keeps the
option open.

### `.github/workflows/cla.yml` — CLA Assistant Action (B-5)

`contributor-assistant/github-action@v2.6.1`. Triggers on
`pull_request_target` + `issue_comment` with the exact human trigger
phrase. Signatures land in a **separate private repo**
(`Hashevolution/james-rag-evol-cla`) so the public source repo carries
no PII (contributor emails, GitHub IDs). The PAT (`secrets.CLA_BOT_PAT`)
is the secret the operator wires up in the GUI step; without it the
workflow fails loudly at run time with a clear "missing PAT" error,
**not silently bypassing the gate**. `dependabot` + `github-actions`
bots are allowlisted (not legal persons, can't sign).

### `CONTRIBUTING.md` §License (B-7)

Replaces the previous one-line MIT statement with a §License & CLA
section that (a) names the CLA, (b) explains the one-click sign flow,
(c) explains *why §4-bis exists*, (d) points contributors who cannot
sign at `docs/legal/non-cla-contributions.md`.

### `docs/legal/non-cla-contributions.md` — refusal-path doc (B-8)

Seven concrete contribution paths that don't require a CLA signature:
bug reports, design discussion, doc-issue suggestions, PR review,
forking, off-tree patchsets, sponsorship. Also explains why **partial
CLAs** (signing §1-3 but striking §4-bis) aren't accepted — the
Relicensing Grant is structurally non-negotiable.

## What this PR does NOT do

- **B-3** signature repo creation (`Hashevolution/james-rag-evol-cla`,
  private)
- **B-4** CLA Assistant install + Gist config + Activate
- **B-5 GUI portion** `CLA_BOT_PAT` generation + repo secret registration
- **B-6** first external PR dry-run

These are **operator GUI actions** and remain tracked in
`docs/handovers/session-2026-05-09-license-infrastructure.md` §3 with
step-by-step instructions.

**Critical**: until B-3 / B-4 / B-5 GUI are complete, the `cla.yml`
workflow won't actually run against PRs. The workflow file is
dormant; merging this PR doesn't activate the gate on its own.

## Verification

- **Ruff**: `All checks passed!`
- **YAML**: `cla.yml` parses; one `CLAAssistant` job with one step.
- **Full repo sweep**: 2124 passed, 0 failed (no behavior change —
  docs + workflow only).

## Operator follow-up

After this PR merges, the four GUI steps documented in the handover
are needed (in order):

1. Create private repo `Hashevolution/james-rag-evol-cla` (B-3).
2. Install the CLA Assistant GitHub App + register the Gist with
   `docs/legal/CLA.md`'s content (B-4).
3. Generate the `CLA_BOT_PAT` and add it as a repo secret named
   `CLA_BOT_PAT` (B-5 GUI portion).
4. Open a throwaway PR from a test account to confirm the bot
   posts the signature request (B-6 dry-run).

Detailed step-by-step instructions are in
`docs/handovers/session-2026-05-09-license-infrastructure.md` §3.

Closes part of Track B in v0.3 done-when #4 (the workflow gate exists;
the gate becomes active only after the operator GUI steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)