### PR TITLE
chore(tests): skip 3 server-import tests when CI=true (HF model timeout)

### DIFF
--- a/tests/test_character_prompt_cleanup.py
+++ b/tests/test_character_prompt_cleanup.py
@@ -191,6 +191,15 @@ class PersonaEndpointTests(unittest.TestCase):
     """프론트가 (drop-in) 빈 style/custom 으로 POST 해도 서버는 OK,
     그리고 GET 도 그대로 동작."""
 
+    @unittest.skipIf(
+        os.environ.get("CI") == "true",
+        "skipped in CI — `from server_llmwiki import app` pulls the "
+        "vector store + HuggingFace model into memory, which routinely "
+        "exceeds the 30s pytest-timeout on cache-miss runners. Local "
+        "runs cover this test; CI workflow already excludes other "
+        "server-import tests via --ignore=. See "
+        "docs/handovers/v0.3.0-platform-track.md `CI pytest 3 fail` note.",
+    )
     def test_persona_endpoint_still_registered(self):
         try:
             from server_llmwiki import app

--- a/tests/test_character_traits_correlations.py
+++ b/tests/test_character_traits_correlations.py
@@ -295,6 +295,12 @@ class CorrelationEndpointTests(unittest.TestCase):
     registered on the FastAPI app (sanity check — full HTTP test would
     require spinning up the server)."""
 
+    @unittest.skipIf(
+        os.environ.get("CI") == "true",
+        "skipped in CI — `from server_llmwiki import app` pulls the "
+        "vector store + HuggingFace model into memory and exceeds the "
+        "30s pytest-timeout on cache-miss runners. Local runs cover.",
+    )
     def test_endpoint_registered(self):
         try:
             from server_llmwiki import app

--- a/tests/test_domain_level_circular.py
+++ b/tests/test_domain_level_circular.py
@@ -61,6 +61,12 @@ class LevelCapRemovalTests(unittest.TestCase):
         self.assertIn('"tier_pct"', body,
             "must expose tier_pct so donut can render progress within tier")
 
+    @unittest.skipIf(
+        os.environ.get("CI") == "true",
+        "skipped in CI — KnowledgeTracker() ctor lazy-loads the "
+        "vector store + HuggingFace model and exceeds the 30s "
+        "pytest-timeout on cache-miss runners. Local runs cover.",
+    )
     def test_high_score_yields_high_level(self):
         # Smoke — accumulating score past the old cap should produce
         # level > 10. Use the public API.


### PR DESCRIPTION
## Summary

#339's pytest workflow surfaced 3 timeout failures on PR #341's run:

- `test_character_prompt_cleanup::PersonaEndpointTests::test_persona_endpoint_still_registered`
- `test_character_traits_correlations::CorrelationEndpointTests::test_endpoint_registered`
- `test_domain_level_circular::LevelCapRemovalTests::test_high_score_yields_high_level`

**Root cause is shared**: each test triggers an import that lazily
pulls the vector store + the HuggingFace
`paraphrase-multilingual-MiniLM-L12-v2` model into the process. On a
cache-miss CI runner that exceeds the 30s `pytest-timeout`. PR #341's
local sweep passed **2124 / 2124** — the failures are CI-environment
only.

Two of the three already had `try/except` around
`from server_llmwiki import app` with `skipTest` as the fallback —
but `skipTest` never fires because the import doesn't *raise*, it
just blocks past the timeout. The third
(`test_high_score_yields_high_level`) hits the same chain through
`KnowledgeTracker()`, which also lazy-loads the vector store on first
instantiation.

## Fix

Add `@unittest.skipIf(os.environ.get("CI") == "true", reason)` to each
of the three tests.

- **Local runs (`pytest tests/`)** continue to exercise them as before.
- The `CI=true` env var set by GitHub Actions (and every other
  mainstream CI provider) triggers the skip.

## Why not the alternatives

**File-level `--ignore` in `test.yml`** — the three classes contain
unrelated tests that PASS in CI today (source-grep tests in
`LevelCapRemovalTests`, `EngineIntegrationTests` in
`test_character_prompt_cleanup`, the trait correlation logic tests in
`test_character_traits_correlations`). Skipping individual tests is
the minimal precise correction.

**Raise `--timeout`** — the 30s timeout is correct; no real test
should take 30s. The broken thing is HuggingFace cache absence on
cold CI runners. A long-term fix would be a model cache or mock —
out of scope here.

## Verification

- **Local sweep** (CI env unset): **2124 passed, 0 failed** (unchanged).
- **`CI=true` selective run** on the three affected classes:
  3 skipped, 3 passed (the *other* tests in the same classes).
- **Ruff**: `All checks passed!`

Per the "3 HuggingFace network test 격리 필요" note in
`docs/handovers/v0.3.0-platform-track.md` (added after PR #341 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)