### PR TITLE
feat(plugins): contract surface — 4 Protocol types (Track C PR-C2)

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -1,0 +1,37 @@
+"""Plugin contract layer — Track C of the v0.3 Platform Skeleton.
+
+This package will eventually contain:
+
+  - ``base.py``      — Protocol types for the 4 plugin slots
+  - ``errors.py``    — PluginLoadError / PluginVersionError
+  - ``loader.py``    — JAMES_PACKS env-driven dynamic loader (PR-C3)
+  - ``manifest.py``  — pack.yaml schema + license: field (PR-C3)
+  - ``registry.py``  — in-memory slot registry (PR-C3)
+
+PR-C2 (this PR) ships ``base.py`` + ``errors.py`` only. The loader,
+manifest parser, and registry land in PR-C3.
+
+Per ``docs/design/v0.3-plugin-api.md``.
+"""
+from __future__ import annotations
+
+from core.plugins.base import (
+    KNOWN_MODES,
+    OntologyPack,
+    PanelContext,
+    PromptPack,
+    Scorer,
+    UIPanel,
+)
+from core.plugins.errors import PluginLoadError, PluginVersionError
+
+__all__ = [
+    "OntologyPack",
+    "PromptPack",
+    "UIPanel",
+    "Scorer",
+    "PanelContext",
+    "KNOWN_MODES",
+    "PluginLoadError",
+    "PluginVersionError",
+]

--- a/core/plugins/base.py
+++ b/core/plugins/base.py
@@ -1,0 +1,204 @@
+"""Plugin contract — 4 Protocol types for pack-level extensions.
+
+Track C PR-C2 of the v0.3 Plugin API skeleton. Ships the **contract
+surface only** — no loader, no manifest parser, no registry yet. Those
+land in PR-C3.
+
+The four types match `docs/design/v0.3-plugin-api.md` §"The four
+plugin types":
+
+  - ``OntologyPack``  — entity types, relation types, hierarchies
+  - ``PromptPack``    — system prompts + few-shot examples per mode
+  - ``UIPanel``       — server-rendered admin/user widgets
+  - ``Scorer``        — custom retrieval/answer scoring overrides
+
+Each is ``@runtime_checkable`` so the loader (PR-C3) can validate a
+pack at import time via ``isinstance(obj, ProtocolType)``. The
+``pack_id`` attribute is the registry key — required on every type.
+
+A pack supplies **zero or more** of these. A pure ontology pack has
+no ``PromptPack`` / ``UIPanel`` / ``Scorer``. The loader registers
+each slot independently per manifest entry.
+
+These Protocols layer ABOVE the cognitive middleware
+(``docs/ARCHITECTURE.md`` §5.7); plugins supply *content*, not new
+reasoning primitives. The existing scorer in ``core/retrieval/``, the
+existing prompts in ``core/reasoning/modes/``, and the existing
+ontology in ``core/relations_schema.py`` stay the defaults — a pack's
+slot entry overrides only the slot it registers against.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol, Tuple, runtime_checkable
+
+
+# ─── Panel context ─────────────────────────────────────────────────
+# The PanelContext object passed into UIPanel.render(). Defined here
+# rather than as a separate import so the contract is self-contained.
+# A pack does not import from server_llmwiki or fastapi — the loader
+# constructs the context and hands it in.
+
+
+class PanelContext:
+    """Read-only snapshot of the current request that UI panels need
+    in order to render correctly without leaking the actual request
+    object into pack code.
+
+    Three fields the cognitive layer already tracks:
+
+      - ``user_role``  — the ABAC role from
+        ``core/policy_engine.PolicyEngine`` ("external", "employee",
+        "admin", …). UIPanel.render() must respect this.
+      - ``session_id`` — the chat session this render is happening
+        inside. UI panels keyed on session state (e.g. recent
+        history) read this.
+      - ``locale``     — ISO 639-1 + optional region ("ko" / "en" /
+        "ko-KR"). The existing i18n.js mirrors this; pack-side text
+        chooses the rendering string from the same key.
+
+    The context is intentionally narrow. A pack that needs more
+    server state (e.g. graph node count) goes through the existing
+    admin endpoints, not through this object.
+    """
+
+    __slots__ = ("user_role", "session_id", "locale")
+
+    def __init__(
+        self,
+        *,
+        user_role: str,
+        session_id: str = "",
+        locale: str = "en",
+    ) -> None:
+        self.user_role = user_role
+        self.session_id = session_id
+        self.locale = locale
+
+
+# ─── The four plugin types ─────────────────────────────────────────
+
+
+@runtime_checkable
+class OntologyPack(Protocol):
+    """Entity types, relation types, hierarchies. Read at startup and
+    cached for the process lifetime. Lookup cost is O(1) on dict.
+
+    Required attributes:
+
+      - ``pack_id``         — registry key, matches the pack name in
+        ``packs/<pack_id>/``
+      - ``entity_types``    — tuple of entity-type strings the pack
+        introduces or overrides (e.g. ``("contract", "clause")``).
+        Empty tuple means the pack doesn't extend entity types.
+      - ``relation_types``  — tuple of relation-type strings the pack
+        adds to the ontology. Same empty-tuple semantics.
+      - ``hierarchies``     — mapping ``parent -> children`` for any
+        hierarchical relations the pack defines. Empty dict OK.
+    """
+
+    pack_id: str
+    entity_types: Tuple[str, ...]
+    relation_types: Tuple[str, ...]
+    hierarchies: Dict[str, Tuple[str, ...]]
+
+
+@runtime_checkable
+class PromptPack(Protocol):
+    """System prompts + few-shot examples per task. Returned strings
+    are concatenated into the existing prompt builder in
+    ``core/reasoning/modes/`` — packs do not rewrite the reasoning
+    loop, they only supply the text.
+    """
+
+    pack_id: str
+
+    def system_prompt(self, mode: str) -> str:
+        """Return the system-prompt string for one of the five built-in
+        modes (``"chat"``, ``"meta"``, ``"wiki_edit"``,
+        ``"self_evolve"``, ``"coding"``).
+
+        Unknown mode MUST return the empty string ``""`` — graceful
+        fallthrough lets the existing default prompt path stay in
+        control. A pack that doesn't override a mode's prompt simply
+        returns ``""`` for that mode.
+        """
+        ...
+
+    def few_shot(self, task: str) -> List[Dict[str, Any]]:
+        """Optional few-shot examples for a named task. Empty list
+        ``[]`` means "no examples"; the existing prompt path stays
+        unchanged. Each dict typically looks like
+        ``{"role": "user", "content": "..."}`` /
+        ``{"role": "assistant", "content": "..."}``.
+        """
+        ...
+
+
+@runtime_checkable
+class UIPanel(Protocol):
+    """Server-rendered admin/user widget. The HTML returned by
+    ``render()`` is sandboxed at the response-filter layer
+    (``core/security_layer``) before reaching the client — packs
+    cannot bypass that.
+
+    Path convention: ``/panels/{pack_id}/{panel_id}``. The loader
+    (PR-C3) wires the route at startup.
+    """
+
+    pack_id: str
+    panel_id: str
+
+    def render(self, ctx: PanelContext) -> str:
+        """Return server-rendered HTML for the panel. MUST respect
+        the ``ctx.user_role`` ABAC decision — a pack that ignores the
+        role and leaks admin-only content to an external user is a
+        contract violation (the conformance suite in PR-C9 catches
+        the obvious cases).
+
+        Empty string ``""`` is a legal return value — typically used
+        when the panel decides it has nothing to show for this user
+        / locale combination.
+        """
+        ...
+
+
+@runtime_checkable
+class Scorer(Protocol):
+    """Custom retrieval / answer scoring override. Plugged into the
+    existing reranker / hybrid-search slot in
+    ``core/retrieval/``. The default scorer remains active unless a
+    pack explicitly registers a ``Scorer`` against the same slot.
+
+    Multiple packs declaring scorers against the same slot is a
+    PluginLoadError — the conflict needs operator resolution, not
+    a silent precedence rule.
+    """
+
+    pack_id: str
+
+    def score(self, query: str, candidate: Dict[str, Any]) -> float:
+        """Return a ``[0.0, 1.0]`` score for the candidate's relevance
+        to the query. Higher = more relevant. Scores outside that
+        range MUST be clamped by the implementer; the existing
+        reranker treats anything outside the range as a bug.
+        """
+        ...
+
+
+# ─── Sentinel values ───────────────────────────────────────────────
+# Closed enum used by the manifest validator (PR-C3) and named here
+# rather than as a string literal duplicated across the codebase.
+
+KNOWN_MODES: Tuple[str, ...] = (
+    "chat", "meta", "wiki_edit", "self_evolve", "coding",
+)
+
+
+__all__ = [
+    "OntologyPack",
+    "PromptPack",
+    "UIPanel",
+    "Scorer",
+    "PanelContext",
+    "KNOWN_MODES",
+]

--- a/core/plugins/errors.py
+++ b/core/plugins/errors.py
@@ -1,0 +1,50 @@
+"""Plugin loader exceptions — Cognitive Phase 3 / Track C PR-C2.
+
+Two narrow error types so the loader (PR-C3) can raise something the
+operator can grep for in startup logs without it being mistaken for a
+generic Python exception:
+
+  - ``PluginLoadError`` — the pack is missing, the manifest is
+    malformed, the import fails. Operator-fixable: missing
+    ``packs/<name>/``, typo in ``JAMES_PACKS``, broken plugin code.
+  - ``PluginVersionError`` — the manifest's ``james_api:`` SemVer
+    range does not intersect the running core's version. Operator
+    needs a newer/older pack, or a newer/older JAMES.
+
+Both inherit from ``RuntimeError`` (not ``Exception`` directly) so the
+loader can keep using bare ``except RuntimeError`` at the startup
+boundary without catching every stdlib exception.
+
+Per ``docs/design/v0.3-plugin-api.md`` §"Loader semantics".
+"""
+from __future__ import annotations
+
+
+class PluginLoadError(RuntimeError):
+    """The pack cannot be loaded — missing directory, malformed
+    ``pack.yaml``, import-time exception, missing slot class.
+
+    The message MUST name the pack so operator log-grep is one-line:
+
+        raise PluginLoadError(
+            f"pack {name!r} not found at packs/{name}/"
+        )
+    """
+
+
+class PluginVersionError(RuntimeError):
+    """The pack's declared ``james_api:`` SemVer range does not
+    intersect the running JAMES core version.
+
+    The message MUST name the pack AND the version mismatch so the
+    operator can decide whether to bump JAMES, bump the pack, or
+    pin to a specific compatible pair:
+
+        raise PluginVersionError(
+            f"pack {name!r} requires james_api {required!r}; "
+            f"running core version is {current_version}"
+        )
+    """
+
+
+__all__ = ["PluginLoadError", "PluginVersionError"]

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -1,0 +1,258 @@
+"""Tests for ``core/plugins/base.py`` — Track C PR-C2.
+
+Covers the 3-item test plan in ``docs/design/v0.3-plugin-api.md``
+§"Test plan / For PR-C2":
+
+  1. Each Protocol is ``@runtime_checkable`` and ``isinstance(obj, P)``
+     works against a class that satisfies the surface.
+  2. A minimal class implementing each Protocol satisfies it.
+  3. A class missing one required field/method fails the isinstance
+     check.
+
+Plus a small set of sanity guards: PanelContext shape, errors module
+re-exports, KNOWN_MODES coverage, ``__all__`` is intentional.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.plugins import (  # noqa: E402
+    KNOWN_MODES,
+    OntologyPack,
+    PanelContext,
+    PluginLoadError,
+    PluginVersionError,
+    PromptPack,
+    Scorer,
+    UIPanel,
+)
+
+
+# ─── Minimal compliant implementations ─────────────────────────────
+
+
+class _MiniOntology:
+    pack_id = "mini_ontology"
+    entity_types = ("contract",)
+    relation_types = ("references",)
+    hierarchies = {"contract": ("clause",)}
+
+
+class _MiniPrompts:
+    pack_id = "mini_prompts"
+
+    def system_prompt(self, mode: str) -> str:
+        return "" if mode not in KNOWN_MODES else f"prompt for {mode}"
+
+    def few_shot(self, task):
+        return []
+
+
+class _MiniPanel:
+    pack_id = "mini_panels"
+    panel_id = "stats"
+
+    def render(self, ctx) -> str:
+        return f"<div>role={ctx.user_role}</div>"
+
+
+class _MiniScorer:
+    pack_id = "mini_scorer"
+
+    def score(self, query: str, candidate: dict) -> float:
+        return 0.5
+
+
+# ─── Protocol satisfaction ─────────────────────────────────────────
+
+
+class OntologyPackProtocolTests(unittest.TestCase):
+
+    def test_minimal_impl_satisfies(self):
+        self.assertIsInstance(_MiniOntology(), OntologyPack)
+
+    def test_missing_field_fails(self):
+        class _NoRelations:
+            pack_id = "x"
+            entity_types = ()
+            # relation_types missing
+            hierarchies = {}
+        self.assertNotIsInstance(_NoRelations(), OntologyPack)
+
+    def test_missing_pack_id_fails(self):
+        class _NoId:
+            entity_types = ()
+            relation_types = ()
+            hierarchies = {}
+        self.assertNotIsInstance(_NoId(), OntologyPack)
+
+
+class PromptPackProtocolTests(unittest.TestCase):
+
+    def test_minimal_impl_satisfies(self):
+        self.assertIsInstance(_MiniPrompts(), PromptPack)
+
+    def test_unknown_mode_returns_empty(self):
+        """Contract: unknown mode → graceful empty-string fallthrough.
+        Pinned via the minimal impl above + the docstring guarantee.
+        """
+        p = _MiniPrompts()
+        self.assertEqual(p.system_prompt("not_a_mode"), "")
+        self.assertEqual(p.few_shot("anything"), [])
+
+    def test_missing_system_prompt_fails(self):
+        class _NoSys:
+            pack_id = "x"
+
+            def few_shot(self, task):
+                return []
+        self.assertNotIsInstance(_NoSys(), PromptPack)
+
+    def test_missing_few_shot_fails(self):
+        class _NoFew:
+            pack_id = "x"
+
+            def system_prompt(self, mode):
+                return ""
+        self.assertNotIsInstance(_NoFew(), PromptPack)
+
+
+class UIPanelProtocolTests(unittest.TestCase):
+
+    def test_minimal_impl_satisfies(self):
+        self.assertIsInstance(_MiniPanel(), UIPanel)
+
+    def test_missing_panel_id_fails(self):
+        class _NoPid:
+            pack_id = "x"
+
+            def render(self, ctx):
+                return ""
+        self.assertNotIsInstance(_NoPid(), UIPanel)
+
+    def test_render_can_return_empty(self):
+        """Empty string is a legal return — the panel decided it has
+        nothing to show for this user/locale.
+        """
+        class _Empty:
+            pack_id = "x"
+            panel_id = "p"
+
+            def render(self, ctx):
+                return ""
+        self.assertIsInstance(_Empty(), UIPanel)
+        self.assertEqual(
+            _Empty().render(PanelContext(user_role="external")),
+            "",
+        )
+
+
+class ScorerProtocolTests(unittest.TestCase):
+
+    def test_minimal_impl_satisfies(self):
+        self.assertIsInstance(_MiniScorer(), Scorer)
+
+    def test_missing_score_fails(self):
+        class _NoScore:
+            pack_id = "x"
+        self.assertNotIsInstance(_NoScore(), Scorer)
+
+
+# ─── PanelContext shape ───────────────────────────────────────────
+
+
+class PanelContextTests(unittest.TestCase):
+
+    def test_required_user_role(self):
+        ctx = PanelContext(user_role="admin")
+        self.assertEqual(ctx.user_role, "admin")
+        self.assertEqual(ctx.session_id, "")
+        self.assertEqual(ctx.locale, "en")
+
+    def test_optional_fields(self):
+        ctx = PanelContext(
+            user_role="external",
+            session_id="s-1",
+            locale="ko",
+        )
+        self.assertEqual(ctx.session_id, "s-1")
+        self.assertEqual(ctx.locale, "ko")
+
+    def test_slots_block_extra_attributes(self):
+        """__slots__ on PanelContext keeps the surface narrow — a
+        pack that tries to attach extra state on the context object
+        fails fast rather than leaking pack state across requests.
+        """
+        ctx = PanelContext(user_role="admin")
+        with self.assertRaises(AttributeError):
+            ctx.malicious_state = "x"   # type: ignore[attr-defined]
+
+
+# ─── KNOWN_MODES coverage ──────────────────────────────────────────
+
+
+class KnownModesTests(unittest.TestCase):
+
+    def test_includes_all_five_built_in_modes(self):
+        # The five modes that core/reasoning/modes/ ships with.
+        for mode in ("chat", "meta", "wiki_edit",
+                     "self_evolve", "coding"):
+            self.assertIn(mode, KNOWN_MODES)
+
+    def test_is_tuple_not_list(self):
+        # KNOWN_MODES is a closed enum — mutability would let a
+        # pack add modes at import time, defeating the validator.
+        self.assertIsInstance(KNOWN_MODES, tuple)
+
+
+# ─── Errors ────────────────────────────────────────────────────────
+
+
+class ErrorClassesTests(unittest.TestCase):
+
+    def test_plugin_load_error_inherits_runtime_error(self):
+        # The loader (PR-C3) catches RuntimeError at the startup
+        # boundary — pin that PluginLoadError stays inside that net.
+        self.assertTrue(issubclass(PluginLoadError, RuntimeError))
+
+    def test_plugin_version_error_inherits_runtime_error(self):
+        self.assertTrue(issubclass(PluginVersionError, RuntimeError))
+
+    def test_errors_have_messages(self):
+        # Sanity — raising with a message round-trips it.
+        try:
+            raise PluginLoadError("pack 'foo' not found")
+        except PluginLoadError as e:
+            self.assertIn("foo", str(e))
+
+
+# ─── Package-level __all__ ─────────────────────────────────────────
+
+
+class PackageExportsTests(unittest.TestCase):
+
+    def test_all_4_protocols_in_all(self):
+        import core.plugins as pkg
+        for name in ("OntologyPack", "PromptPack", "UIPanel", "Scorer"):
+            self.assertIn(name, pkg.__all__)
+
+    def test_panel_context_and_known_modes_in_all(self):
+        import core.plugins as pkg
+        self.assertIn("PanelContext", pkg.__all__)
+        self.assertIn("KNOWN_MODES", pkg.__all__)
+
+    def test_errors_in_all(self):
+        import core.plugins as pkg
+        self.assertIn("PluginLoadError", pkg.__all__)
+        self.assertIn("PluginVersionError", pkg.__all__)
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Lands the **contract layer** for the v0.3 Plugin API. Infrastructure
only — no loader, no manifest parser, no registry yet. Those land in
**PR-C3**. The split mirrors the L0/L1 pattern used by both the
backends track (#283 → #284) and the Episodic memory track (#338 →
PR-9b).

Design pre-registered in `docs/design/v0.3-plugin-api.md` (#343).

## What this PR ships

### `core/plugins/base.py` — 4 Protocol types

| Protocol | Surface |
|---|---|
| `OntologyPack` | `pack_id`, `entity_types`, `relation_types`, `hierarchies` |
| `PromptPack` | `pack_id`, `system_prompt(mode)`, `few_shot(task)` |
| `UIPanel` | `pack_id`, `panel_id`, `render(ctx)` |
| `Scorer` | `pack_id`, `score(query, candidate) -> [0.0, 1.0]` |

Plus:
- **`PanelContext`** — the read-only request snapshot UI panels see,
  with `__slots__` to block accidental pack-side state attachment.
- **`KNOWN_MODES`** sentinel — the 5 built-in cognitive modes
  (`chat`, `meta`, `wiki_edit`, `self_evolve`, `coding`) the
  PromptPack manifest validator will check against in PR-C3.

Every Protocol is `@runtime_checkable` so the loader can validate
via `isinstance(obj, ProtocolType)` at import time.

### `core/plugins/errors.py` — 2 narrow exception types

- **`PluginLoadError`** — missing pack, malformed manifest, import
  failure, slot conflict.
- **`PluginVersionError`** — `james_api:` SemVer range mismatch.

Both inherit `RuntimeError` (not `Exception`) so the loader's startup
boundary stays a tight `except RuntimeError` rather than catching
every stdlib exception.

### `core/plugins/__init__.py`

Package re-exports matching the import pattern used by
`core/memory/__init__.py` and `core/reasoning/backends/__init__.py`.

### `tests/test_plugin_base.py` — 23 tests

Covers the 3-item plan in `docs/design/v0.3-plugin-api.md` §"Test
plan / For PR-C2" plus shape guards:

- **Protocol satisfaction** — each Protocol matches the minimal
  compliant impl. (4)
- **Negative path** — class missing one required field/method
  fails `isinstance`. (6)
- **`PanelContext` shape** — required `user_role`, optional
  `session_id` / `locale`, `__slots__` blocks extra attributes. (3)
- **`KNOWN_MODES` coverage** — all 5 built-in modes, tuple not list. (2)
- **Error inheritance** preserves `RuntimeError` + message
  round-trips. (3)
- **Package `__all__`** exports all 4 Protocols + `PanelContext` +
  `KNOWN_MODES` + both error classes. (3)
- **Unknown-mode** graceful empty-string return + empty few-shot. (1)
- **`render()` can legally return `""`**. (1)

## What PR-C2 does NOT do

- **Loader** (`loader.py`) — PR-C3. `JAMES_PACKS` env, dogfood gate,
  three fatal failure modes.
- **Manifest parser** (`manifest.py`) — PR-C3. `pack.yaml` schema with
  the closed `license:` enum from `docs/LICENSE_PLAN.md` §5.2.
- **In-memory registry** (`registry.py`) — PR-C3.
- **`packs/general/`** extraction — PR-C5 (the dogfood gate PR).
- **`PLUGIN_AUTHORING.md` / `VERSIONING.md`** — PR-C7 / PR-C8.

## Verification

- New `tests/test_plugin_base.py` — **23 passed in 0.05s**.
- **Full repo sweep**: **2147 passed, 0 failed** (was 2124; +23 new).
- **Ruff**: `All checks passed!`
- Module size: `base.py` ~6 KB, `errors.py` ~1.5 KB, well under the
  20 KB CLAUDE.md rule #5 cap.

## Bench note

No bench numbers attached — this PR adds the contract surface only;
no call sites in retrieval / graph / reasoning are touched. CLAUDE.md
rule #2's bench gate targets behavior regression, and contract
Protocols with no implementations have no behavior to regress.

Per `docs/design/v0.3-plugin-api.md` §"PR sequence" (PR-C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)