### PR TITLE
docs(handover): Ali turn 7 — Track 1 closure + mid-June Gemini commit

### DIFF
--- a/docs/handovers/v0.3.x-ali-collaboration-track.md
+++ b/docs/handovers/v0.3.x-ali-collaboration-track.md
@@ -55,12 +55,56 @@ All five are real-world commitments to a real-world collaborator. Not meeting th
 
 **Done when**:
 
-- `Provider` ABC compiles, has docstrings, has unit tests against a mock implementation.
-- `OllamaProvider` and `ClaudeCodeCLIProvider` pass the same conformance test suite.
-- `docs/design/v0.3-llm-provider-contract.md` is published and linked from `CHANGELOG.md`.
-- A 1-paragraph LinkedIn DM to Ali pointing at the contract URL with "you can start your Gemini Provider impl now if you like."
+- [x] `Provider` ABC compiles, has docstrings, has unit tests against a mock implementation. **(#324 PR-A — `Backend` Protocol in `core/reasoning/backends/__init__.py`, `resolve_backend_for_stage` per-stage override, 12 synth call sites swapped.)**
+- [x] `OllamaProvider` and `ClaudeCodeCLIProvider` pass the same conformance test suite. **(#325 PR-B — `tests/test_backend_conformance.py` R1–R6 + `tests/test_no_sdk_leakage.py` for the R5 architectural rule; both reference backends pass.)**
+- [x] `docs/design/v0.3-llm-provider-contract.md` is published and linked from `CHANGELOG.md`. **(#316, published 2026-05-18, before any wiring landed.)**
+- [x] A 1-paragraph LinkedIn DM to Ali pointing at the contract URL with "you can start your Gemini Provider impl now if you like." **(Sent 2026-05-19 after #324/#325/#326 merged — see Closure section below for the exchange.)**
 
-**Files affected**: `core/plugins/base.py` (new), `core/reasoning/backends/__init__.py` (updated), `core/reasoning/backends/ollama_local.py` (refactor), `core/reasoning/backends/claude_code_cli.py` (refactor), `docs/design/v0.3-llm-provider-contract.md` (new), `CHANGELOG.md` (entry).
+**Files affected**: `core/reasoning/backends/__init__.py` (updated), `core/reasoning/backends/ollama_local.py` (refactor), `core/reasoning/backends/claude_code_cli.py` (refactor), `core/reasoning/trace_helpers.py` (lambda → backend dispatch), `tests/test_backend_conformance.py` (new), `tests/test_no_sdk_leakage.py` (new), `tests/test_plugin_loader.py` (new), `docs/design/v0.3-llm-provider-contract.md` (new). `core/plugins/base.py` (the originally-named file) was reframed under the **pack-level** Plugin API track (Track C in `v0.3.0-platform-track.md`, design `docs/design/v0.3-plugin-api.md` #343, contract surface #344) since the backend layer naturally lives under `core/reasoning/backends/` rather than `core/plugins/`. The Provider contract Ali implements against is unchanged either way — same Protocol surface, same conformance suite.
+
+---
+
+### Track 1 — closure as of 2026-05-19 + Ali turn 7
+
+**Status**: ✅ **Track 1 done, ~27 days ahead of the 2026-06-15 deadline we committed in writing.**
+
+Three merged PRs:
+
+- **#324** `feat(reasoning): synth call-site backend wiring (Track 1 PR-A)` — `resolve_backend_for_stage(stage)` per-stage override (`JAMES_BACKEND_SYNTH=…`) layered on `JAMES_REASONING_BACKEND` (PR #305). 12 synth call sites moved from direct `engine.llm.call_gemma` to `get_backend(name).complete(...)`. `trace_synth_call` signature reshaped (prompt + kwargs, no lambda) so R1 of the contract is honoured at the helper boundary.
+- **#325** `test(reasoning): conformance suite + SDK leakage guard (Track 1 PR-B)` — R1–R6 conformance suite parameterized over both reference backends (hermetic, no live ollama / claude CLI in CI) + the R5 architectural test that AST-walks the middleware roots for forbidden SDK imports.
+- **#326** `feat(reasoning): JAMES_PLUGINS loader + JAMES_LLM_TEMPERATURE env (Track 1 PR-C)` — the env-var-driven backend plugin loader (failures fatal, per the contract) + `temperature` reserved kwarg propagated end-to-end (the 3×3 experiment's swept variable).
+
+**Outgoing DM to Ali (2026-05-19, post-merge)**:
+
+> Hi Ali,
+>
+> Quick update — no action needed on your side.
+>
+> Track 1 (the Provider contract wiring we agreed on around 5/18) landed on `main` today, about a month ahead of the 2026-06-15 deadline we set. Three merged PRs: \[#324 / #325 / #326]. The contract document (`docs/design/v0.3-llm-provider-contract.md`, published earlier as #316) is unchanged — what landed is the wiring, plus tests pinning every clause. Both reference backends (`ollama_local`, `claude_code_cli`) pass the full conformance suite. A Gemini API backend that satisfies the same `Backend` Protocol should drop in with no core-side changes.
+>
+> No timeline pressure — your **mid-June response window** (after your Provia Arabic-localization sprint) still works perfectly on our end. When you do come back to Track 1, the contract is ready exactly as specified. Track 3 (the 3×3 cross-experiment swap infra) naturally follows once your backend lands; we'll start that work then, not before. Schema v1.1 (catalog_poisoning) from your Track 2c review is also locked on main (#322) — thanks again for that turn. Talk soon, Jiwon
+
+**Ali's reply (2026-05-19, same day)**:
+
+> Jiwon — received, and the velocity is appreciated. Track 1 landing a month early means the integration window is fully open by the time Arabic localization clears. Will surface on Track 1 mid-June with the Gemini backend, and `ar_ecommerce.yaml` is on track for 6/1. Talk soon.
+
+**Decoded signals**:
+
+1. **Velocity acknowledged** — month-early Track 1 lands as a credibility deposit rather than as pressure.
+2. **mid-June Gemini backend commitment confirmed** — that PR will be **our first external PR**. The CLA workflow we shipped at #340 needs the four operator GUI steps (private signature repo, CLA Assistant install + Gist, `CLA_BOT_PAT` secret, dry-run) wrapped up *before* Ali's PR opens. Calendar pressure now exists on the operator side, not the code side.
+3. **`ar_ecommerce.yaml` 6/1 deadline holds** — Track 2's calendar commitment is on track. The v1.1 validator in `tests/fixtures/injection/test_fixture_format.py` (PR #322) is already the landing pad. No further code action on our side until the fixtures arrive.
+4. **Track 3 timing locks in** — once Ali's Gemini backend PR lands (mid-June), the 3×3 swap infrastructure track activates. We can do **pre-work** during the four-week window — `scripts/swap_eval_report.py` (the comparison harness from the 3×3 eval plan #315) can land before Ali's backend ships, since it's pack-agnostic.
+
+**Outgoing ACK DM to Ali (2026-05-19, third turn)**:
+
+> Got it. CLA workflow goes live this week so the Gemini backend PR has a clean signature flow. Landing pad for `ar_ecommerce.yaml` is the v1.1 validator that shipped in #322. Talk soon.
+
+**Operator follow-ups (calendar-locked)**:
+
+- **This week (2026-05-19 to 2026-05-26)**: complete the four Track B GUI steps in `docs/handovers/session-2026-05-09-license-infrastructure.md` §3 (B-3 / B-4 / B-5 GUI / B-6 dry-run). The CLA workflow becomes operational at the end of step B-6.
+- **2026-06-01**: `ar_ecommerce.yaml` arrives from Ali. Test pipeline runs automatically — no action unless schema drift is reported.
+- **Mid-June** (windowed): Gemini backend PR opens. CLA Assistant fires the signature request automatically. Conformance suite runs against the new backend.
+- **mid-June to 2026-06-29**: Track 3 swap infrastructure (separate session work).
 
 ---
 
@@ -195,11 +239,13 @@ The matrix is committed to before results land. That is the entire point of Trac
 | Date | Milestone |
 |---|---|
 | 2026-05-18 | This handover lands |
-| **2026-06-01** | **Track 2 deadline (Ali's 1–2 week commitment for the schema)** |
-| **2026-06-15** | **Track 1 deadline (our 2–4 week commitment for the Provider contract)** |
-| 2026-06-15+ | Track 3 (swap infrastructure) can start |
-| 2026-06-15+ | Track 4 (scope-lock template) signed by both |
-| 2026-06-22+ | Cross-experiment runs (parallel: ours on JAMES, Ali's on Gemini API) |
-| 2026-06-29+ | Track 5 (writeup) starts on actual data |
+| **2026-05-19** | **Track 1 closed ~27 days ahead of schedule (#324 / #325 / #326). Ali turn 7 confirms mid-June Gemini backend + `ar_ecommerce.yaml` 6/1 hold.** |
+| 2026-05-19 to 2026-05-26 | **Operator window — Track B CLA GUI 4 steps** must complete before Ali's mid-June PR (it will be our first external PR). |
+| **2026-06-01** | **Track 2 deadline — `ar_ecommerce.yaml` from Ali (15-20 fixtures × 4 categories + ≥ 5 benign).** Validator in #322 is the landing pad; no further code action our side. |
+| **2026-06-15** | ~~Track 1 deadline (our 2–4 week commitment for the Provider contract)~~ **— met early (2026-05-19).** Stays as the calendar anchor for Ali's mid-June Gemini backend window. |
+| 2026-06-15+ | Track 3 (swap infrastructure) activates once Ali's Gemini backend lands. Pre-work (`scripts/swap_eval_report.py`) can land in our queue before then. |
+| 2026-06-15+ | Track 4 (scope-lock template) signed by both. |
+| 2026-06-22+ | Cross-experiment runs (parallel: ours on JAMES, Ali's on Gemini API). |
+| 2026-06-29+ | Track 5 (writeup) starts on actual data. |
 
-Slip risk: Track 2 (1-week calendar) is tighter than Track 1 (4-week calendar). Prioritize Track 2 if a session can only do one.
+Slip risk: Track 1 is closed early; the new tight item is the **operator-side CLA GUI window** (2026-05-19 → 2026-05-26). If those four GUI steps miss the calendar, Ali's mid-June PR opens against a half-armed CLA workflow.


### PR DESCRIPTION
## Summary

Records the post-Track-1-merge exchange with Ali Afana (2026-05-19,
three turns):

1. Our outgoing DM — Track 1 done a month ahead, no pressure on
   Ali's mid-June response window
2. Ali's reply — velocity acknowledged; mid-June Gemini backend
   confirmed; `ar_ecommerce.yaml` 6/1 holds
3. Our short ACK — CLA workflow goes live this week; v1.1 validator
   is the `ar_ecommerce.yaml` landing pad

## Changes

- **Track 1 done-when checkboxes** flipped to `[x]` with the PRs
  that satisfied each clause:
  - PR #324 (synth call-site wiring + `resolve_backend_for_stage`)
  - PR #325 (R1-R6 conformance + R5 SDK leakage guard)
  - PR #316 (Provider contract document, published before wiring)
- **Files-affected list** updated to match what actually shipped
  (path is `core/reasoning/backends/`, not `core/plugins/`). One
  sentence explains the reframing — pack-level Plugin API moved to
  its own track (Track C, design #343, contract surface #344). The
  Provider contract Ali implements against is unchanged either way.
- **New section** "Track 1 — closure as of 2026-05-19 + Ali turn 7":
  full text of all three DMs + four decoded signals (velocity
  acknowledged, first external PR mid-June, `ar_ecommerce.yaml` 6/1
  on track, Track 3 timing locks in).
- **Calendar section** refreshed:
  - 2026-05-19: Track 1 closed 27 days early
  - **2026-05-19 → 2026-05-26**: operator window for Track B CLA
    GUI (the four steps in `session-2026-05-09-license-infrastructure.md`
    §3) — critical because Ali's mid-June PR will be **our first
    external PR**
  - 2026-06-15 line de-emphasized (already met) but kept as the
    calendar anchor for Ali's window
  - Slip-risk note moved from "Track 2 tighter than Track 1" to
    "operator CLA GUI window is now the tight item"

## Verification

No code change — pure doc PR. Ruff clean (markdown-only).

## Out of scope

The four operator GUI steps (B-3 / B-4 / B-5 GUI / B-6 dry-run)
remain user-side per `docs/handovers/session-2026-05-09-license-infrastructure.md`
§3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)