### PR TITLE
fix(graph): confidence noisy-OR per design memo §3 (was clamped sum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] — v0.3.x patches
+
+### Fixed
+
+- **`compute_confidence_from_sources` now implements noisy-OR**
+  (`P = 1 - Π(1 - w_i)`) per
+  [`docs/design/v0.3-knowledge-cascade.md §3`](docs/design/v0.3-knowledge-cascade.md),
+  not clamped sum. The clamped-sum implementation saturated at
+  confidence = 1.0 from just 2 corroborating sources (default LLM
+  weights ~0.7) and broke the monotone cascade semantics the design
+  memo explicitly chose noisy-OR for. Single-source identity
+  preserved → Phase A back-fills remain byte-identical. STEP 7 bench
+  green (within tolerance band, 153.1s / 13 queries). Production wiki
+  audit: 0 multi-source relations existed at the time of the fix, so
+  no historical confidence values changed; the patch lands before the
+  bug could manifest in real corroboration workflows (e.g. quarterly
+  report cascades).
+  Includes `scripts/migrate_recompute_confidence.py` for any future
+  installation that may have accumulated multi-source relations under
+  the wrong formula. 7 new tests in `tests/test_relations_schema.py`
+  lock the design contract (single-source identity, 2-source
+  divergence from clamped sum, asymptotic-not-saturated for 5+
+  sources, strict monotonicity on add/remove, per-element weight
+  clamping).
+
+---
+
 ## [0.3.0] — Platform Skeleton (2026-05-17)
 
 After 190 merged PRs since v0.2.0 (9 days, 129 test files), JAMES exits

--- a/core/relations_schema.py
+++ b/core/relations_schema.py
@@ -43,29 +43,44 @@ VALID_SOURCE_ROLES = frozenset({
     MANUAL_SOURCE_ROLE,
 })
 
-# Confidence cap. Sum of source weights can mathematically exceed 1.0 when
-# many docs corroborate the same relation; the user-visible confidence
-# stays in [0, 1] so existing UI bars / badges keep their semantics.
+# Confidence cap. Noisy-OR is mathematically in [0, 1) for finite weights
+# in [0, 1], so the cap is informational — used to keep the public type
+# contract stable for downstream code that previously saw clamped values.
 CONFIDENCE_CAP = 1.0
 
 
 def compute_confidence_from_sources(sources: list | None) -> float:
-    """sources 배열의 weight 합 (0..1 으로 cap).
+    """Noisy-OR over per-source weights — see design memo §3.
 
-    Phase A 시점에는 호출되지 않는다 — confidence 는 frontmatter 의
-    저장된 값이 정답. Phase B 에서 ingestion 이 sources 만 쓰고
-    confidence 를 derived 로 다루기 시작할 때 호출 site 가 생긴다.
+    Formula: ``P(confirmed) = 1 - Π(1 - w_i)``
+
+    Properties (the reason this formula was chosen over `sum` / `max` /
+    `mean`):
+      - 0 sources → 0.0
+      - 1 source with weight w → w (identity preserved, so single-source
+        Phase A back-fills are byte-identical to the legacy clamped sum)
+      - many sources → asymptotic to 1.0 but never saturates exactly,
+        so a quarterly-report cascade with 5–20 corroborating docs
+        keeps signal differentiation (clamped sum loses it after 2)
+      - delete cascade strictly decreases confidence (monotonic),
+        never leaves a relation at a stale 1.0 ceiling
+
+    Weights outside [0, 1] are clamped per-element before multiplication,
+    so a malformed weight cannot move the running product past 0 or
+    below 0.
     """
     if not sources:
         return 0.0
-    total = 0.0
+    product = 1.0
     for s in sources:
         if not isinstance(s, dict):
             continue
         w = s.get("weight")
-        if isinstance(w, (int, float)):
-            total += float(w)
-    return min(total, CONFIDENCE_CAP)
+        if not isinstance(w, (int, float)):
+            continue
+        w_clamped = max(0.0, min(1.0, float(w)))
+        product *= (1.0 - w_clamped)
+    return round(1.0 - product, 4)
 
 
 def read_relation_sources(rel: dict | None) -> list:

--- a/scripts/migrate_recompute_confidence.py
+++ b/scripts/migrate_recompute_confidence.py
@@ -1,0 +1,199 @@
+"""Knowledge Cascade hotfix -- confidence noisy-OR 재계산.
+
+docs/design/v0.3-knowledge-cascade.md §3 -- Phase A → E 가 머지될 때
+``compute_confidence_from_sources`` 가 clamped sum 으로 구현되어 있던
+defect 를 noisy-OR (`P = 1 - Π(1 - w_i)`) 로 정정.
+
+이 스크립트는 기존 wiki entity 파일들을 순회하면서 **2개 이상의
+source 를 가진 relation 의 confidence 만** 다시 derive 한다. 단일
+source relation 은 두 공식이 동일값을 돌려주므로 건드리지 않는다.
+
+행동:
+  1. ``wiki/`` 전체를 ``wiki.pre-noisy-or-fix/`` 로 미러 복사 (rollback)
+  2. ``wiki/entity/prod/**/*.md`` 순회
+  3. 각 relation 의 ``sources`` 가 2개 이상이면 ``confidence`` 를
+     noisy-OR 결과로 재기록. 차이가 0 (이미 정합) 이면 mutated 안 함.
+  4. 통계 출력: scanned / multi_source_relations / confidence_updated /
+     max_delta / errors
+
+옵션:
+  --dry-run         실제 쓰지 않고 영향 범위만 보고
+  --root <path>     wiki 루트 (기본: 현재 디렉토리의 wiki/)
+  --no-snapshot     스냅샷 건너뛰기 (CI 등에서 이미 백업한 경우)
+  --force           snapshot 디렉토리가 이미 있어도 덮어쓰기
+
+권장 사용 순서 (운영자):
+  1. 서버 중단
+  2. python scripts/migrate_recompute_confidence.py --dry-run
+     → 영향 범위 + max_delta 확인
+  3. python scripts/migrate_recompute_confidence.py
+     → 실제 재계산
+  4. python scripts/bench.py --suite=step7
+     → STEP 7 graph_paths 회귀 측정 (multi-source relation 이 retrieval
+        score 에 미치는 영향)
+  5. 서버 재시작
+
+문제 발생 시:
+  rmdir /S /Q wiki && move wiki.pre-noisy-or-fix wiki
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.relations_schema import compute_confidence_from_sources
+
+DEFAULT_WIKI_ROOT = Path("wiki")
+SNAPSHOT_SUFFIX   = "pre-noisy-or-fix"
+
+
+def snapshot_wiki(wiki_root: Path, force: bool = False) -> Path:
+    snap = wiki_root.with_name(f"{wiki_root.name}.{SNAPSHOT_SUFFIX}")
+    if snap.exists():
+        if not force:
+            raise FileExistsError(
+                f"snapshot already exists: {snap}\n"
+                f"  → pass --force to overwrite, or remove it manually"
+            )
+        shutil.rmtree(snap)
+    print(f"[NOISY_OR_FIX] snapshot {wiki_root} → {snap}")
+    shutil.copytree(wiki_root, snap)
+    return snap
+
+
+def split_frontmatter(text: str) -> tuple[dict, str] | tuple[None, str]:
+    """`---`\\n...`---` 형식의 markdown frontmatter 분리."""
+    if not text.startswith("---"):
+        return None, text
+    end = text.find("\n---", 4)
+    if end < 0:
+        return None, text
+    fm_raw = text[4:end].lstrip("\n")
+    body   = text[end + 4:].lstrip("\n")
+    try:
+        fm = yaml.safe_load(fm_raw) or {}
+    except yaml.YAMLError:
+        return None, text
+    if not isinstance(fm, dict):
+        return None, text
+    return fm, body
+
+
+def join_frontmatter(fm: dict, body: str) -> str:
+    return (
+        "---\n"
+        + yaml.safe_dump(fm, allow_unicode=True, sort_keys=False).rstrip()
+        + "\n---\n\n"
+        + body
+    )
+
+
+def recompute_file(path: Path, dry_run: bool) -> dict:
+    """한 entity .md 의 multi-source relation confidence 재계산.
+
+    반환: {"multi_source": N, "updated": M, "max_delta": float}
+    """
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    if fm is None:
+        return {"multi_source": 0, "updated": 0, "max_delta": 0.0}
+
+    relations = fm.get("relations")
+    if not isinstance(relations, list):
+        return {"multi_source": 0, "updated": 0, "max_delta": 0.0}
+
+    multi_source = 0
+    updated      = 0
+    max_delta    = 0.0
+    mutated      = False
+
+    for rel in relations:
+        if not isinstance(rel, dict):
+            continue
+        sources = rel.get("sources")
+        if not isinstance(sources, list) or len(sources) < 2:
+            continue
+        multi_source += 1
+        new_conf = compute_confidence_from_sources(sources)
+        old_conf = rel.get("confidence")
+        if not isinstance(old_conf, (int, float)):
+            continue
+        delta = abs(float(old_conf) - new_conf)
+        if delta < 1e-4:
+            continue
+        max_delta = max(max_delta, delta)
+        updated += 1
+        rel["confidence"] = new_conf
+        mutated = True
+
+    if mutated and not dry_run:
+        path.write_text(join_frontmatter(fm, body), encoding="utf-8")
+
+    return {
+        "multi_source": multi_source,
+        "updated":      updated,
+        "max_delta":    max_delta,
+    }
+
+
+def migrate_wiki(wiki_root: Path, dry_run: bool) -> dict:
+    entity_root = wiki_root / "entity" / "prod"
+    if not entity_root.exists():
+        print(f"[NOISY_OR_FIX] no entity root at {entity_root} -- nothing to do")
+        return {"files_scanned": 0, "multi_source": 0,
+                "updated": 0, "max_delta": 0.0, "errors": 0}
+
+    totals = {"files_scanned": 0, "multi_source": 0,
+              "updated": 0, "max_delta": 0.0, "errors": 0}
+
+    for md in sorted(entity_root.rglob("*.md")):
+        totals["files_scanned"] += 1
+        try:
+            stats = recompute_file(md, dry_run=dry_run)
+        except Exception as e:
+            totals["errors"] += 1
+            print(f"[NOISY_OR_FIX] ERROR {md}: {e}")
+            continue
+        totals["multi_source"] += stats["multi_source"]
+        totals["updated"]      += stats["updated"]
+        totals["max_delta"]     = max(totals["max_delta"], stats["max_delta"])
+
+    return totals
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run",     action="store_true")
+    parser.add_argument("--no-snapshot", action="store_true")
+    parser.add_argument("--force",       action="store_true")
+    parser.add_argument("--root", type=Path, default=DEFAULT_WIKI_ROOT)
+    args = parser.parse_args()
+
+    if not args.root.exists():
+        print(f"[NOISY_OR_FIX] wiki root not found: {args.root}")
+        sys.exit(2)
+
+    if not args.dry_run and not args.no_snapshot:
+        snapshot_wiki(args.root, force=args.force)
+    elif args.dry_run:
+        print("[NOISY_OR_FIX] dry-run -- no snapshot, no writes")
+
+    totals = migrate_wiki(args.root, dry_run=args.dry_run)
+    print("[NOISY_OR_FIX] result:")
+    print(f"  files_scanned       = {totals['files_scanned']}")
+    print(f"  multi_source_rels   = {totals['multi_source']}")
+    print(f"  confidence_updated  = {totals['updated']}")
+    print(f"  max_delta           = {totals['max_delta']:.4f}")
+    print(f"  errors              = {totals['errors']}")
+    if args.dry_run:
+        print("[NOISY_OR_FIX] dry-run -- no files were modified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -253,7 +253,7 @@ class AppendRelationSourceTests(unittest.TestCase):
         # 첫 번째는 기존 extract source 보존
         self.assertEqual(rel["sources"][0]["role"], EXTRACT_SOURCE_ROLE)
         self.assertEqual(rel["sources"][1]["role"], MANUAL_SOURCE_ROLE)
-        # confidence 는 두 source 의 weight 합
+        # confidence 는 두 source 의 noisy-OR — 헬퍼로 검증.
         self.assertEqual(rel["confidence"],
                          compute_confidence_from_sources(rel["sources"]))
 

--- a/tests/test_relations_schema.py
+++ b/tests/test_relations_schema.py
@@ -47,48 +47,118 @@ class RoleConstantsTests(unittest.TestCase):
 
 
 class ComputeConfidenceTests(unittest.TestCase):
-    """Sum-of-weights with [0, 1] cap. Phase B reads through this."""
+    """Noisy-OR (probabilistic OR) per design memo §3.
+
+    Formula: ``P = 1 - Π(1 - w_i)``. Chosen for monotone cascade
+    semantics — adding a source strictly increases P, removing one
+    strictly decreases P, no early saturation.
+    """
 
     def test_empty_sources_returns_zero(self):
         self.assertEqual(compute_confidence_from_sources([]), 0.0)
         self.assertEqual(compute_confidence_from_sources(None), 0.0)
 
     def test_single_source_returns_weight(self):
+        # 단일 source 는 noisy-OR / clamped sum 동일.
+        # 이 identity 가 Phase A 마이그레이션의 byte-identical 게이트.
         sources = [{"weight": 0.7, "role": "extract"}]
         self.assertAlmostEqual(
             compute_confidence_from_sources(sources), 0.7,
         )
 
-    def test_multiple_sources_sum(self):
+    def test_two_sources_diverge_from_clamped_sum(self):
+        # 2-source 분기 invariant — 디자인 메모 §3 의 핵심 락인.
+        # clamped sum 이면 0.7, noisy-OR 이면 1 - (0.6 * 0.7) = 0.58.
+        # 이 값이 0.58 이 아니라면 clamped sum 으로 회귀한 것.
         sources = [
             {"weight": 0.4, "role": "extract"},
             {"weight": 0.3, "role": "extract"},
         ]
         self.assertAlmostEqual(
-            compute_confidence_from_sources(sources), 0.7,
+            compute_confidence_from_sources(sources), 0.58,
+            places=4,
+            msg="clamped sum 이 돌아왔다면 0.7 이 나옴. noisy-OR 회귀.",
         )
 
-    def test_caps_at_1_0(self):
-        # 3개 doc 가 동일 relation 을 강하게 강화 — 수학적으로 1.6 이지만
-        # UI / 정책 의미상 confidence 는 [0, 1] 안에서 표현.
+    def test_many_sources_asymptotic_not_saturated(self):
+        # 디자인 메모 §3: "many sources → asymptotic to 1, but never
+        # exceeds 1". quarterly report cascade 시 5+ 출처가 모여도
+        # confidence 가 1.0 으로 평탄화되지 않아야 함.
+        sources = [{"weight": 0.7, "role": "extract"} for _ in range(5)]
+        # 1 - 0.3**5 = 1 - 0.00243 = 0.99757
+        result = compute_confidence_from_sources(sources)
+        self.assertAlmostEqual(result, 0.9976, places=4)
+        self.assertLess(
+            result, CONFIDENCE_CAP,
+            msg="noisy-OR 은 [0, 1) — 정확히 1.0 에 도달하면 saturate 회귀.",
+        )
+
+    def test_strong_corroboration_3_sources(self):
+        # 디자인 메모 §3 의 예시: 3 doc 강한 강화. clamped sum 으로는
+        # 0.7+0.6+0.3 = 1.6 → cap 1.0. noisy-OR 로는:
+        # 1 - (0.3 * 0.4 * 0.7) = 1 - 0.084 = 0.916.
         sources = [
             {"weight": 0.7, "role": "extract"},
             {"weight": 0.6, "role": "extract"},
             {"weight": 0.3, "role": "manual"},
         ]
-        self.assertEqual(
+        self.assertAlmostEqual(
+            compute_confidence_from_sources(sources), 0.916,
+            places=3,
+        )
+        # 핵심: cap 에 도달하지 않아 신호 보존.
+        self.assertLess(
             compute_confidence_from_sources(sources), CONFIDENCE_CAP,
+        )
+
+    def test_monotone_adding_source_strictly_increases(self):
+        # 디자인 메모 §3: "adding a new source — always increases".
+        # 이 monotonicity 가 cascade 단조성의 근거.
+        before = [{"weight": 0.5, "role": "extract"}]
+        after  = [{"weight": 0.5, "role": "extract"},
+                  {"weight": 0.2, "role": "extract"}]
+        self.assertGreater(
+            compute_confidence_from_sources(after),
+            compute_confidence_from_sources(before),
+        )
+
+    def test_monotone_removing_source_strictly_decreases(self):
+        # 디자인 메모 §3: "removing a source — always decreases".
+        # clamped sum 의 saturate 동작은 이를 깬다 (이미 cap 이면
+        # source 가 빠져도 안 떨어짐).
+        before = [{"weight": 0.7, "role": "extract"},
+                  {"weight": 0.6, "role": "extract"},
+                  {"weight": 0.3, "role": "manual"}]
+        after  = [{"weight": 0.7, "role": "extract"},
+                  {"weight": 0.6, "role": "extract"}]
+        self.assertGreater(
+            compute_confidence_from_sources(before),
+            compute_confidence_from_sources(after),
+        )
+
+    def test_weight_clamped_to_unit_interval(self):
+        # 노이즈 robustness — out-of-range weight 가 product 를 음수나
+        # 1 초과로 튕기지 못 하게 per-element clamp.
+        sources = [
+            {"weight":  1.5, "role": "extract"},  # 1.0 으로 clamp
+            {"weight": -0.3, "role": "extract"},  # 0.0 으로 clamp
+        ]
+        # weight 1.0 한 개만 살아남는 효과 → 1 - 0 = 1.0 정확.
+        # weight 0.0 는 (1 - 0) = 1 곱이라 product 에 영향 없음.
+        self.assertAlmostEqual(
+            compute_confidence_from_sources(sources), 1.0,
         )
 
     def test_skips_malformed_entries(self):
         # 손편집 / 외부 plugin 이 weight 누락하거나 dict 아닌 값을 넣은
         # source 가 들어오면 무시 — 다른 잘 정의된 source 는 살린다.
         sources = [
-            {"weight": 0.5},          # OK
+            {"weight": 0.5},          # OK → contributes (1 - 0.5)
             {"role": "extract"},      # weight 누락 — 무시
             "not-a-dict",              # 자체가 무효
             {"weight": "0.3"},         # str — 무시 (Phase B/E 가 float 로 검증)
         ]
+        # 유효한 source 는 weight=0.5 한 개 → noisy-OR = 0.5.
         self.assertAlmostEqual(
             compute_confidence_from_sources(sources), 0.5,
         )


### PR DESCRIPTION
## Summary

**Defect found during patent session review.** `compute_confidence_from_sources` in `core/relations_schema.py` was implemented as clamped sum (`min(Σw, 1.0)`) but [`docs/design/v0.3-knowledge-cascade.md §3`](docs/design/v0.3-knowledge-cascade.md) explicitly specifies **noisy-OR** (`P = 1 - Π(1 - w_i)`), citing **monotone cascade semantics** as the reason for choosing it over sum/max/mean.

### Impact under clamped sum (the bug)

| Sources × weight | Clamped sum | Noisy-OR (design) |
|---|---|---|
| 1 × 0.7 | 0.70 | 0.70 (identity preserved) |
| **2 × 0.7** | **1.00 (saturated)** | 0.91 |
| 5 × 0.7 | 1.00 (saturated) | 0.998 |
| 20 × 0.7 | 1.00 (saturated) | ~1.0 (asymptotic, < 1) |

With default LLM weights ~0.7, the bug saturated confidence at **2 corroborating sources** — exactly defeating the design memo §9's anticipated N=50-source quarterly-report cascades.

### Why this matters

- **Monotonicity broken**: deleting a doc from a saturated relation didn't strictly decrease confidence (it stayed at 1.0 if other sources kept it pinned). Design memo §3 chose noisy-OR specifically because "log-sum is the only one with monotone cascade semantics."
- **Information loss**: all 5–20 source corroborations collapsed to the same confidence = 1.0, defeating the entire provenance-aware graph.
- **Patent claim mismatch**: design memo's monotone-asymptotic properties didn't match the code.

### Why this was hidden

1. **Phase A back-fill is single-source** → identity (`min(w,1) == 1-(1-w)`) → byte-identical bench → bug invisible at Phase A landing.
2. **Tests locked the wrong behavior** (`tests/test_relations_schema.py:62-81` asserted `[0.4,0.3] → 0.7` and `[0.7,0.6,0.3] → 1.0`).
3. **Closure-doc invariant only tested single-source** (`compute_confidence_from_sources([{weight:0.7}]) == 0.7`) — passes under both formulas.

## Verification

- [x] `pytest tests/test_relations_schema.py tests/test_phase_a_migration.py tests/test_phase_b_ingestion_sources.py tests/test_phase_c_cascade.py tests/test_phase_e_graph_editor.py` → **91 passed**
- [x] `pytest tests/` (full sweep, server-import excluded) → **2174 passed**
- [x] `python scripts/bench.py --suite=step7 --check` → **OK, within baseline tolerances** (153.1s / 13 queries, 0 regression)
- [x] `python scripts/migrate_recompute_confidence.py --dry-run` → **278 files, 0 multi-source relations, max_delta=0.0** → bug was dormant in production wiki (caught before any real corroboration accumulated)
- [x] 7 new tests lock the design contract (single-source identity, 2-source divergence from clamped sum, asymptotic-not-saturated for 5+ sources, strict monotonicity on add/remove, per-element weight clamping)

## Files

- `core/relations_schema.py` — formula replaced + docstring cites design memo §3
- `tests/test_relations_schema.py` — 7 contract locks (was 5 sum-asserting tests)
- `tests/test_phase_e_graph_editor.py` — stale comment "weight 합" → "noisy-OR"
- `scripts/migrate_recompute_confidence.py` — new, recomputes multi-source confidences with snapshot rollback
- `CHANGELOG.md` — `[Unreleased]` entry under v0.3.x patches

## Out of scope

- Closure-doc invariant update (`docs/handovers/v0.3.x-session-2026-05-17-closure.md §9`) — handover docs are session audit trails, not maintained contracts; the new test suite serves as the executable invariant
- Production wiki recompute apply — `--dry-run` showed 0 affected relations, so no `--apply` needed. Script preserved for future installations.
- Renaming the function to `derive_confidence_from_sources` (matching design memo) — 7 call-site rename is mechanical but out of hotfix scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)