### PR TITLE
fix(graph): cross-doc source aggregation per design memo §4 Phase B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cross-document source aggregation in `process_document_for_entities`**
+  — when an entity already exists from a previous doc, the new doc's
+  extracted triples are now merged into the existing frontmatter
+  (`sources.append` per
+  [`docs/design/v0.3-knowledge-cascade.md §4`](docs/design/v0.3-knowledge-cascade.md)
+  Phase B spec), not silently dropped. The previous `continue` branch
+  at `core/wiki_generator.py:640` invalidated the entire Knowledge
+  Cascade premise: a relation could only ever have one source, so
+  no relation ever became "multi-source" — defeating the purpose of
+  the noisy-OR confidence formula and the quarterly-report-cascade
+  scenario the design memo §9 anticipates (N=50 sources/relation).
+  New helper `_merge_relations_into_existing_entity` matches on
+  `(target_name, normalized_type)`, skips duplicate `doc_id` for
+  idempotency, recomputes confidence via noisy-OR, and writes the
+  frontmatter back. Both forward and inverse directions aggregate
+  symmetrically. 5 new tests in `tests/test_phase_b_ingestion_sources.py`
+  lock the contract (cross-doc append, inverse aggregation, noisy-OR
+  confidence after 2 sources, same-doc idempotency, distinct-target
+  new-row).
+
 - **`compute_confidence_from_sources` now implements noisy-OR**
   (`P = 1 - Π(1 - w_i)`) per
   [`docs/design/v0.3-knowledge-cascade.md §3`](docs/design/v0.3-knowledge-cascade.md),

--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -639,7 +639,25 @@ class WikiGenerator:
 
             existing_id = self._find_existing_entity_id(name, etype)
             if existing_id:
-                print(f"[ENTITY-EXTRACT] '{name}' ({etype}) already exists -> skip")
+                # Cross-doc aggregation — docs/design/v0.3-knowledge-cascade.md
+                # §4 Phase B 의 "find_or_create_relation + sources.append".
+                # 이전 구현은 `continue` 로 두 번째 doc 의 강화를 통째로
+                # 버렸다 (Knowledge Cascade 핵심 가치 무효화). 이제 기존
+                # entity 의 frontmatter 에 새 doc 의 sources 만 누적 merge.
+                new_rels = self._build_entity_relations(
+                    name, extracted.get("relations", []),
+                    doc_id=doc_entity_id, ts=ingest_ts,
+                )
+                if new_rels:
+                    stats = self._merge_relations_into_existing_entity(
+                        existing_id, new_rels, doc_entity_id, ingest_ts,
+                    )
+                    print(f"[ENTITY-EXTRACT] '{name}' ({etype}) exists "
+                          f"-> merged sources={stats['sources_appended']} "
+                          f"new_rels={stats['relations_added']}")
+                else:
+                    print(f"[ENTITY-EXTRACT] '{name}' ({etype}) exists "
+                          f"-> no new triples in this doc")
                 name_to_id[name]   = existing_id
                 name_to_type[name] = etype
                 continue
@@ -877,6 +895,166 @@ class WikiGenerator:
         if inv_info and inv_info.get("label"):
             return inv_info["label"]
         return "관련"
+
+    def _merge_relations_into_existing_entity(
+        self,
+        entity_id:     str,
+        new_relations: List[Dict],
+        doc_id:        str,
+        ts:            str,
+    ) -> Dict[str, int]:
+        """기존 entity 의 frontmatter relations 에 새 doc 의 sources 누적 merge.
+
+        docs/design/v0.3-knowledge-cascade.md §4 Phase B 의
+        "find_or_create_relation + sources.append" 명세를 구현한다.
+
+        매칭 정책:
+          - 같은 (target_name, normalized_type) 쌍이면 → 기존 relation 의
+            sources 에 append (doc_id 중복은 skip — idempotent)
+          - 없으면 → 새 relation 행으로 추가 (target_id 는 UNRESOLVED,
+            resolve_pending_relations 가 추후 해소)
+
+        확신성 (confidence) 은 noisy-OR (`compute_confidence_from_sources`)
+        로 재 derive. 단조성 보장: source 추가하면 strictly 증가.
+
+        반환:
+            {"merged_into":      0 또는 1,
+             "sources_appended": int,  # 새로 추가된 source 개수
+             "relations_added":  int}  # 새 행으로 추가된 relation 개수
+        """
+        path = self.entity_id_index.get(entity_id)
+        if not path or not Path(path).exists():
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+
+        text = Path(path).read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+        end = text.find("\n---", 4)
+        if end < 0:
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+        fm_raw = text[4:end].lstrip("\n")
+        body   = text[end + 4:].lstrip("\n")
+        try:
+            fm = yaml.safe_load(fm_raw) or {}
+        except yaml.YAMLError:
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+        if not isinstance(fm, dict):
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+
+        existing_rels = fm.get("relations") or []
+        if not isinstance(existing_rels, list):
+            existing_rels = []
+
+        # type 정규화 — 같은 의미의 label 이 다른 raw 표현으로 등장해도
+        # 매칭되도록. ontology 없으면 raw label 그대로 비교.
+        try:
+            from core.ontology import normalize_relation as _norm_rel
+        except Exception:
+            def _norm_rel(label):
+                return label
+
+        def _norm_type(rel: Dict) -> str:
+            t = rel.get("type")
+            if isinstance(t, str) and t:
+                return t
+            label = rel.get("label", "")
+            return _norm_rel(label) or label
+
+        sources_appended = 0
+        relations_added  = 0
+
+        for new_rel in new_relations:
+            if not isinstance(new_rel, dict):
+                continue
+            new_sources = new_rel.get("sources") or []
+            if not isinstance(new_sources, list) or not new_sources:
+                continue
+            new_target = new_rel.get("target")
+            if not new_target:
+                continue
+            new_type = _norm_type(new_rel)
+            if not new_type:
+                continue
+
+            match_idx = None
+            for i, er in enumerate(existing_rels):
+                if not isinstance(er, dict):
+                    continue
+                if er.get("target") != new_target:
+                    continue
+                if _norm_type(er) != new_type:
+                    continue
+                match_idx = i
+                break
+
+            if match_idx is not None:
+                er = existing_rels[match_idx]
+                existing_sources = er.get("sources") or []
+                if not isinstance(existing_sources, list):
+                    existing_sources = []
+                existing_doc_ids = {
+                    s.get("doc_id") for s in existing_sources
+                    if isinstance(s, dict) and s.get("doc_id")
+                }
+                for ns in new_sources:
+                    if not isinstance(ns, dict):
+                        continue
+                    ns_did = ns.get("doc_id")
+                    if ns_did and ns_did in existing_doc_ids:
+                        # 같은 doc 가 두 번 contribute — idempotent skip.
+                        # 실제 사용 trigger: doc 재업로드 (modify cascade
+                        # Phase D 가 별도로 처리하지만 안전망).
+                        continue
+                    existing_sources.append(ns)
+                    if ns_did:
+                        existing_doc_ids.add(ns_did)
+                    sources_appended += 1
+                er["sources"]    = existing_sources
+                er["confidence"] = compute_confidence_from_sources(
+                    existing_sources)
+            else:
+                # 기존에 없던 (target, type) — 새 행 추가. target_id 는
+                # UNRESOLVED 로 두고 resolve_pending_relations 가 다음
+                # ingest 또는 refresh 시점에 매칭. label 은 new_rel 의
+                # display label 보존.
+                added = {
+                    "target":      new_target,
+                    "target_id":   new_rel.get("target_id", "UNRESOLVED"),
+                    "target_type": new_rel.get("target_type", "concept"),
+                    "type":        new_type,
+                    "label":       new_rel.get("label", new_type),
+                    "confidence":  compute_confidence_from_sources(
+                                       new_sources),
+                    "sources":     list(new_sources),
+                }
+                existing_rels.append(added)
+                relations_added += 1
+
+        if sources_appended == 0 and relations_added == 0:
+            return {"merged_into": 0, "sources_appended": 0,
+                    "relations_added": 0}
+
+        fm["relations"]  = existing_rels
+        fm["updated_at"] = datetime.now().isoformat()
+
+        new_text = (
+            "---\n"
+            + yaml.dump(fm, allow_unicode=True, default_flow_style=False)
+            + "---\n\n"
+            + body
+        )
+        Path(path).write_text(new_text, encoding="utf-8")
+
+        return {
+            "merged_into":      1,
+            "sources_appended": sources_appended,
+            "relations_added":  relations_added,
+        }
 
     def _build_entity_relations(
         self,

--- a/tests/test_phase_b_ingestion_sources.py
+++ b/tests/test_phase_b_ingestion_sources.py
@@ -350,5 +350,203 @@ class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
             )
 
 
+# ── 4. Cross-doc source aggregation (design memo §4 Phase B) ────────
+
+class CrossDocSourceAggregationTests(unittest.TestCase):
+    """디자인 메모 §4 가 명시한 'find_or_create_relation + sources.append'
+    가 두 번째 doc 에서 실제로 동작하는지 검증.
+
+    이전 구현은 기존 entity 발견 시 entire processing 을 skip 하여
+    cross-doc 강화가 작동하지 않았다 (Knowledge Cascade 핵심 가치 무효).
+    본 테스트 클래스는 그 회귀 방지 게이트.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
+        self.wiki_dir_patcher.start()
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = self.tmp
+
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+
+    def tearDown(self):
+        self.wiki_dir_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    def _read_fm(self, name: str, etype: str) -> dict:
+        path = self.wg.entity_path / etype / f"{name.lower()}.md"
+        text = path.read_text(encoding="utf-8")
+        body = text.split("---", 2)[1]
+        return yaml.safe_load(body)
+
+    def _stub_extract(self, extracted: dict):
+        self.wg._llm_extract_document_entities = (
+            lambda *a, **kw: extracted
+        )
+
+    @staticmethod
+    def _joby_nvidia_triple(label="관련", confidence=0.7):
+        return {
+            "entities": [
+                {"name": "Joby",   "type": "org",
+                 "description": "eVTOL maker"},
+                {"name": "NVIDIA", "type": "org",
+                 "description": "GPU maker"},
+            ],
+            "relations": [
+                {"source": "Joby", "target": "NVIDIA",
+                 "label": label, "confidence": confidence},
+            ],
+        }
+
+    def test_second_doc_appends_sources_to_existing_entity(self):
+        # doc1 — Joby/NVIDIA 신규 생성
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+        joby_fm = self._read_fm("Joby", "org")
+        rels1 = [r for r in joby_fm["relations"]
+                 if r.get("target") == "NVIDIA"]
+        self.assertEqual(len(rels1), 1)
+        self.assertEqual(len(rels1[0]["sources"]), 1,
+            "first doc -> single source")
+
+        # doc2 — 같은 (Joby, NVIDIA) triple. 디자인 메모 §4 명세대로
+        # 기존 relation 의 sources 에 append 되어야 함.
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc2.md", content="d2", chunk_ids=["c2"],
+        )
+        joby_fm = self._read_fm("Joby", "org")
+        rels2 = [r for r in joby_fm["relations"]
+                 if r.get("target") == "NVIDIA"]
+        self.assertEqual(len(rels2), 1,
+            "두 번째 doc 가 새 relation 행을 추가하면 안 됨 — 기존에 append")
+        self.assertEqual(len(rels2[0]["sources"]), 2,
+            "두 doc 의 sources 가 누적되어야 (이전 버그: 1개에 머무름)")
+        # 각 source 의 doc_id 가 서로 달라야
+        doc_ids = {s["doc_id"] for s in rels2[0]["sources"]}
+        self.assertEqual(len(doc_ids), 2,
+            "두 doc 의 doc_id 가 distinct 해야")
+
+    def test_second_doc_inverse_also_aggregates(self):
+        # doc1
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+        # doc2
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc2.md", content="d2", chunk_ids=["c2"],
+        )
+
+        # NVIDIA 의 inverse relation (-> Joby) 도 2 sources 가 되어야 함.
+        # 한쪽만 누적되면 graph 의 양방향 confidence drift 발생.
+        nv_fm = self._read_fm("NVIDIA", "org")
+        inv = [r for r in nv_fm["relations"]
+               if r.get("target") == "Joby"]
+        self.assertEqual(len(inv), 1)
+        self.assertEqual(len(inv[0]["sources"]), 2,
+            "inverse direction 도 cross-doc aggregation 대상")
+        roles = {s["role"] for s in inv[0]["sources"]}
+        self.assertEqual(roles, {INVERSE_SOURCE_ROLE},
+            "inverse 의 sources 는 모두 role=inverse 여야")
+
+    def test_confidence_uses_noisy_or_after_two_sources(self):
+        """2 sources × 0.7 의 결과가 noisy-OR (≈0.91) 인지 검증.
+
+        이전 clamped sum 버그 시점이었으면 1.0 이 나옴. 본 테스트는
+        noisy-OR 핫픽스 (PR #349) 와 cross-doc 핫픽스 (본 PR) 의
+        조합이 정확히 정합한 confidence 를 derive 하는지의 게이트.
+        """
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc2.md", content="d2", chunk_ids=["c2"],
+        )
+
+        joby_fm = self._read_fm("Joby", "org")
+        rel = [r for r in joby_fm["relations"]
+               if r.get("target") == "NVIDIA"][0]
+        # noisy-OR: 1 - (1-0.7)*(1-0.7) = 1 - 0.09 = 0.91
+        self.assertAlmostEqual(rel["confidence"], 0.91, places=2)
+        self.assertLess(rel["confidence"], 1.0,
+            "clamped sum 회귀라면 1.0 이 나옴")
+
+    def test_same_doc_reupload_is_idempotent(self):
+        """동일 doc_id (= 동일 filename) 의 재처리는 source 안 늘림."""
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+        # 같은 filename 으로 한 번 더 — Phase D modify cascade 의 fallback
+        # 또는 운영자 실수 시나리오.
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+
+        joby_fm = self._read_fm("Joby", "org")
+        rel = [r for r in joby_fm["relations"]
+               if r.get("target") == "NVIDIA"][0]
+        self.assertEqual(len(rel["sources"]), 1,
+            "same doc_id 가 두 번 contribute 하면 안 됨 (idempotent)")
+
+    def test_second_doc_new_target_appends_new_relation(self):
+        """doc2 가 doc1 에 없던 (Joby, Microsoft) triple 도 가져오면
+        Joby 의 frontmatter 에 새 relation 행으로 추가되어야."""
+        self._stub_extract(self._joby_nvidia_triple(confidence=0.7))
+        self.wg.process_document_for_entities(
+            filename="doc1.md", content="d1", chunk_ids=["c1"],
+        )
+
+        # doc2: Joby + Microsoft (NVIDIA 는 등장 안 함)
+        self._stub_extract({
+            "entities": [
+                {"name": "Joby",      "type": "org", "description": ""},
+                {"name": "Microsoft", "type": "org", "description": ""},
+            ],
+            "relations": [
+                {"source": "Joby", "target": "Microsoft",
+                 "label": "관련", "confidence": 0.6},
+            ],
+        })
+        self.wg.process_document_for_entities(
+            filename="doc2.md", content="d2", chunk_ids=["c2"],
+        )
+
+        joby_fm = self._read_fm("Joby", "org")
+        targets = {r.get("target") for r in joby_fm["relations"]}
+        self.assertIn("NVIDIA",    targets, "doc1 의 NVIDIA 보존")
+        self.assertIn("Microsoft", targets, "doc2 의 새 target 추가")
+
+        ms_rel = [r for r in joby_fm["relations"]
+                  if r.get("target") == "Microsoft"][0]
+        self.assertEqual(len(ms_rel["sources"]), 1,
+            "새로 추가된 relation 은 doc2 source 만")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

**Companion hotfix to PR #349 (noisy-OR confidence).** Discovered while auditing why PR #349's `--dry-run` showed 0 multi-source relations in production wiki: the ingestion path was silently dropping every cross-doc strengthening. The noisy-OR formula could not act on multi-source state because multi-source state was never being created.

### Root cause

`core/wiki_generator.py:640-645`:
```python
existing_id = self._find_existing_entity_id(name, etype)
if existing_id:
    print(f\"... already exists -> skip\")
    name_to_id[name] = existing_id
    continue   # ← _build_entity_relations + create_entity_file 둘 다 skip
```

When doc2 extracted the same (Joby, NVIDIA) triple that doc1 had already created, the entire entity-side processing was skipped. The doc2's contribution to Joby ↔ NVIDIA was discarded entirely; only doc2's *own* doc entity got created with outgoing links.

[`docs/design/v0.3-knowledge-cascade.md §4`](docs/design/v0.3-knowledge-cascade.md) Phase B explicitly specifies:
```
For each extracted (subject, predicate, object) triple:
  rel = find_or_create_relation(subject_entity, object_entity, predicate)
  rel.sources.append({doc_id, weight, role, ts})
```
\"find_or_create\". Implementation was \"if exists, skip\" — the opposite.

### Impact (combined with PR #349)

| Scenario | Before PR #349 | Between PR #349 and this PR | After both PRs |
|---|---|---|---|
| 1 doc creates (Joby, NVIDIA) | sources=[{doc1}], conf=0.7 | same | same |
| 2nd doc adds same triple | sources=[{doc1}], conf=0.7 (no change) | **same** (#349 fixed math but data never existed) | **sources=[{doc1},{doc2}], conf=0.91** |
| 5 docs strengthening | sources=[{doc1}], conf=0.7 | same (multi-source never accumulates) | sources=[5 entries], conf=0.998 |
| Delete one doc → cascade | confidence unchanged (only doc1 contributes) | same | confidence drops proportionally per noisy-OR |

PR #349 alone was insufficient. Both PRs together restore the design memo's claimed monotone-asymptotic semantics.

## Fix

New helper `_merge_relations_into_existing_entity(entity_id, new_relations, doc_id, ts)`:

- **Match**: `(target_name, normalized_type)` via `core.ontology.normalize_relation` — stable across label variants
- **Idempotent**: skips sources with the same `doc_id` already present (re-upload / Phase D fallback safety)
- **Confidence**: re-derived via `compute_confidence_from_sources` (= noisy-OR after PR #349)
- **Symmetric**: forward (this → target) and inverse (target → this) both aggregate, because each entity's own `_build_entity_relations` call adds its perspective on the same triple

The `continue` at L640 is replaced by a call to this helper. All other ingestion behavior unchanged (doc entity creation, `resolve_pending_relations`, sidecar JSON, trust gate, vector indexing).

## Verification

- [x] `pytest tests/test_phase_b_ingestion_sources.py` → **13 passed** (5 new + 8 existing)
- [x] `pytest tests/` (full sweep, server-import excluded) → **2179 passed** (was 2174 before)
- [x] `scripts/bench.py --suite=step7 --check` → **OK, within baseline tolerances** (158.4s / 13 queries, 0 regression — wiki unchanged since the fix only takes effect at the next ingest)

5 new contract locks:

| Test | What it verifies |
|---|---|
| `test_second_doc_appends_sources_to_existing_entity` | core aggregation behavior |
| `test_second_doc_inverse_also_aggregates` | symmetric forward + inverse |
| `test_confidence_uses_noisy_or_after_two_sources` | **asserts 0.91, not 1.0** — joint PR #349 + this PR contract |
| `test_same_doc_reupload_is_idempotent` | doc_id dedup |
| `test_second_doc_new_target_appends_new_relation` | distinct target → new row |

## Files

- `core/wiki_generator.py` — new helper (~150 lines) + L640 branch replacement (~20 lines)
- `tests/test_phase_b_ingestion_sources.py` — new `CrossDocSourceAggregationTests` class (5 tests)
- `CHANGELOG.md` — `[Unreleased]` Fixed entry (sibling to the noisy-OR entry from PR #349)

## Out of scope

- **Retroactive recovery of past cross-doc evidence**: not possible without re-running LLM extraction on every uploaded doc. Existing wiki relations stay single-source; future ingestion will be correct.
- **Phase D modify cascade interaction**: the idempotent `doc_id` dedup means a re-uploaded same-filename doc adds 0 new sources via this path. Phase D's wipe+reingest flow still handles content changes correctly.
- **Label normalization changes**: uses existing `core.ontology.normalize_relation`. If that returns inconsistent values across versions, matching may degrade gracefully (creates new relation row instead of merging) — not a correctness regression.
- **Closure-doc invariant update** (`docs/handovers/v0.3.x-session-2026-05-17-closure.md §9`): handover docs are session audit trails. The new test suite is the executable invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)