### PR TITLE
docs(governance): adopt Contributor Covenant v2.1 + GOVERNANCE.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,176 @@
+# Contributor Covenant Code of Conduct
+
+> **Version**: Contributor Covenant v2.1 (adopted 2026-05-20)
+> **Project**: PROJECT JAMES (`hashevolution/james-rag-evol`)
+> **Scope**: all PROJECT JAMES community spaces (GitHub repo, Discussions,
+> issues, pull requests, related Discord / Slack if any are created, and
+> any public communication where an individual represents the project)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Project-Specific Norms
+
+In addition to the general Contributor Covenant standards, PROJECT JAMES
+contributors agree to:
+
+- **Disagree with ideas, not people.** Technical pushback on a PR is welcome
+  and expected; ad hominem framing is not.
+- **Assume good intent on first read.** Maintainers and contributors are
+  bilingual (KO ↔ EN), often working asynchronously across time zones —
+  terse phrasing rarely means hostility.
+- **Help newcomers calibrate the mother-platform constraint** (CLAUDE.md
+  rule 1: no domain-specific features until v1.0) without making them feel
+  unwelcome. The constraint is non-obvious; reviewers should explain it,
+  not just reject.
+- **Keep security-disclosure traffic out of public channels.** Use the
+  process in [`SECURITY.md`](SECURITY.md). Public CoC reports of a security
+  incident are themselves a CoC issue (they expose the disclosure surface).
+
+## Enforcement Responsibilities
+
+Community leaders (currently: the project maintainer, Hashevolution) are
+responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public
+spaces. Examples of representing our community include using an official
+e-mail address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **karu-7@hanmail.net**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of
+the reporter of any incident.
+
+### What to include in a report
+
+If you are comfortable doing so, include:
+
+- A description of the incident (links to comments / PRs / issues if public)
+- The approximate date and time
+- Whether the incident is ongoing
+- Whether you have already attempted to address it directly
+
+You do not need to include all of the above to file a report. A brief note
+is enough to start the process.
+
+### Confidentiality
+
+Reports are handled confidentially by the maintainer. The reporter's
+identity is not shared with the subject of the report without the
+reporter's explicit consent.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public
+or private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during
+this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,9 +343,18 @@ publish on your own fork, etc.).
 
 ## Code of Conduct
 
-Be respectful. Disagree with ideas, not people. Help newcomers. Assume good intent.
+PROJECT JAMES adopts the **Contributor Covenant v2.1** — see
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for the full text, including
+the project-specific norms, the reporting channel (`karu-7@hanmail.net`),
+and the enforcement ladder.
 
-This is a research project — explore, experiment, ask questions.
+In short: disagree with ideas, not people. Help newcomers — especially
+when the mother-platform constraint (no domain features until v1.0) is
+non-obvious. Assume good intent on first read. Keep security disclosures
+out of public channels (see [`SECURITY.md`](SECURITY.md)).
+
+For how decisions get made on the project (BDFL through v1.0, release
+process, conflict-resolution path), see [`GOVERNANCE.md`](GOVERNANCE.md).
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,206 @@
+# PROJECT JAMES — Governance
+
+> **Status**: v0.3.x (Platform Skeleton phase)
+> **Adopted**: 2026-05-20
+> **Companion documents**:
+> - [`CLAUDE.md`](CLAUDE.md) — session-level operating rules (always-on)
+> - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contributor workflow + CLA
+> - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — community standards
+> - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — design principles + non-goals
+> - [`docs/PLATFORM_READINESS.md`](docs/PLATFORM_READINESS.md) — 6-dimension gates
+> - [`docs/LICENSE_PLAN.md`](docs/LICENSE_PLAN.md) — license-evolution triggers
+
+This document describes how decisions get made on PROJECT JAMES. It is
+deliberately short: the project is in alpha (v0.3.x), the maintainer count
+is one, and the rules below favor clarity over ceremony. Governance scales
+with the project; this document will be revisited at each gate
+(v0.4, v1.0).
+
+---
+
+## 1. Project model
+
+PROJECT JAMES is a **single-maintainer (BDFL) project through v1.0**.
+
+- **BDFL**: Hashevolution (`@Hashevolution` on GitHub), referred to in this
+  document as "the maintainer".
+- All design, release, and license decisions terminate at the maintainer.
+- The maintainer is expected to publish the *reasoning* behind decisions
+  in writing (PR description, CHANGELOG entry, or handover doc under
+  `docs/handovers/`) so contributors can model the project's direction
+  without asking.
+
+After v1.0 the project will transition to a **multi-maintainer model with
+domain pack ownership**. The transition plan is tracked under
+`docs/PLATFORM_READINESS.md` and will land as a governance amendment PR
+before the v1.0 gate.
+
+### Why BDFL through v1.0
+
+The mother-platform thesis (CLAUDE.md §1, ARCHITECTURE.md) requires that
+the platform contract — what `core/` exports, what plugins may assume,
+what trust zones exist — stay coherent. With one decision-maker, the
+contract drifts less. Community-style governance with rotating reviewers
+will arrive when there is a contract worth protecting (v1.0), not before.
+
+---
+
+## 2. Roles
+
+| Role | Who | Responsibilities | Permissions |
+|---|---|---|---|
+| **Maintainer** | Hashevolution | Reviews and merges PRs · sets roadmap · cuts releases · owns license decisions · enforces CoC | Force-push to `main` (avoided in practice) · approve security disclosures · sign releases |
+| **Reviewer** | Maintainer (sole reviewer at v0.3.x) | Reviews PRs against bench, security, scope, and CLAUDE.md rules | Approve / request-changes on any PR |
+| **Contributor** | Anyone with a signed CLA | Opens PRs, files issues, posts in Discussions, signs CLA on first PR | Open PRs · comment · file issues |
+| **Reporter (security)** | Anyone | Files a security advisory via the process in [`SECURITY.md`](SECURITY.md) | Receives credited disclosure (if requested) on fix release |
+| **Reporter (CoC)** | Anyone | Files a CoC report to `karu-7@hanmail.net` | Reports handled confidentially per [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
+
+There are currently **no formal sub-maintainers, area owners, or release
+managers** — those roles are anticipated for the post-v1.0 transition.
+
+### Becoming a contributor
+
+1. Read [`CLAUDE.md`](CLAUDE.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+2. Open a PR. The CLA Assistant bot will request a one-click signature on
+   first contribution (see [`docs/legal/CLA.md`](docs/legal/CLA.md); for
+   non-CLA paths, see [`docs/legal/non-cla-contributions.md`](docs/legal/non-cla-contributions.md)).
+3. The maintainer reviews; substantive contributors may be invited to
+   reviewer rotation post-v1.0.
+
+---
+
+## 3. Decision-making
+
+Decisions fall into three classes, each with a defined process.
+
+### Class A — Code change (default path)
+
+1. Contributor opens a PR.
+2. Maintainer reviews against:
+   - CLAUDE.md operating rules (no domain features pre-v1.0, no
+     trust-boundary bypass, no module > 20 KB)
+   - Bench numbers for PRs touching `core/retrieval`, `core/graph`, or
+     `core/reasoning` (CLAUDE.md rule 2)
+   - Test coverage for new behavior
+   - Security implications (per `SECURITY.md`)
+3. Maintainer merges (squash by default) once gates pass. PRs are not
+   auto-merged on trust-boundary touches (auth, policy, sandbox).
+
+### Class B — Architecture / non-goal change
+
+A change that adds a new module trust zone, removes a non-goal listed in
+`docs/ARCHITECTURE.md`, or alters the plugin contract requires:
+
+1. A PR to `docs/ARCHITECTURE.md` with the `architecture` label.
+2. A 72-hour public-comment window (Discussions or the PR itself).
+3. Maintainer merge with a recorded rationale in the PR body and a
+   CHANGELOG entry.
+
+### Class C — License or governance change
+
+A change to `LICENSE`, `docs/LICENSE_PLAN.md`, `GOVERNANCE.md`, the CLA,
+or the CoC requires:
+
+1. A PR with the `governance` label.
+2. A 7-day public-comment window in Discussions, linked from the PR.
+3. Notification to past contributors (where the CLA relicensing grant
+   applies) via the project's GitHub Discussions.
+4. Maintainer merge with the rationale recorded in the PR body.
+
+The CLA's §4-bis Relicensing Grant exists specifically to make Class C
+changes tractable; see [`docs/legal/CLA.md`](docs/legal/CLA.md) for
+boundaries.
+
+---
+
+## 4. Release process
+
+PROJECT JAMES uses **semantic-versioned alpha releases** during v0.x.
+
+| Step | Owner | Artifact |
+|---|---|---|
+| Cut a release branch / tag candidate | Maintainer | `vX.Y.Z` tag on `main` |
+| Update `CHANGELOG.md` with the entry | Maintainer | A new section under `## [vX.Y.Z]` |
+| Verify bench gates (STEP 7 baseline + diagnostic + security suites) | Maintainer | `[bench] OK` line in release notes |
+| Cut GitHub Release | Maintainer | Release notes link to `docs/release_notes_vX.Y.Z.md` |
+| Update `README.md` status badge if the cycle theme changed | Maintainer | Badge + status section |
+| Archive the cycle launch tracker (if a promo cycle is closing) | Maintainer | `reports/promo-assets/archive/vX.Y.Z-launch-tracker.md` |
+
+Releases are cut from `main` only. There are no separate release branches
+during v0.x. Pre-releases (e.g., `v0.4.0-rc1`) may be tagged for community
+verification at the maintainer's discretion.
+
+---
+
+## 5. Operating rules (inheritance from CLAUDE.md)
+
+The following rules are **load-bearing for governance** and are enforced
+at PR-review time. They live in `CLAUDE.md` so every Claude Code session
+sees them; they are summarized here so external contributors find them
+without reading the session brief.
+
+1. **No new domain features** (legal, food, retail, travel, finance,
+   government, etc.) until v1.0. Mother-hardening only.
+2. **Bench numbers required** for PRs touching `core/retrieval`,
+   `core/graph`, `core/reasoning`. No numbers → no merge.
+3. **Self-evolution is opt-in only.** Any change that allows auto-deploy
+   without an `approver_username` in the audit log is a bug.
+4. **Architecture changes** (new module, new trust zone, removal of a
+   non-goal) require an `architecture`-labeled PR to
+   `docs/ARCHITECTURE.md`.
+5. **Module size gate**: no file in `core/` exceeds 20 KB. Split first.
+6. **No PolicyEngine bypass** for "quick fixes". Trust boundaries are
+   the contract.
+
+A PR that violates any of these will be marked `changes-requested` with
+a link to the relevant rule.
+
+---
+
+## 6. Conflict resolution
+
+The project is small enough that disputes are resolved by direct
+conversation, but the path of escalation is documented for predictability:
+
+1. **PR-level disagreement** — discuss in the PR. If unresolved in 72
+   hours, open a Discussion linked from the PR.
+2. **Direction-level disagreement** (the maintainer says "out of scope",
+   the contributor says "this is exactly what the platform needs") —
+   open a Discussion. The maintainer will publish a written rationale
+   within 7 days. The decision is final at v0.3.x; this is the BDFL
+   model, not consensus.
+3. **CoC violation** — follow the process in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+   Reports go to `karu-7@hanmail.net`, not to public channels.
+4. **Security disagreement** — follow the process in [`SECURITY.md`](SECURITY.md).
+
+If a contributor disagrees with a maintainer decision at a level that
+cannot be reconciled, **forking is explicitly supported under the MIT
+license**, and the maintainer will not retaliate against forks. The
+project's non-CLA contribution path (`docs/legal/non-cla-contributions.md`)
+exists in part to make this exit reversible.
+
+---
+
+## 7. Amendments
+
+This document is amended by Class C decision (see §3). Each amendment
+PR must:
+
+- Use the `governance` label.
+- Open a 7-day comment window.
+- Record the previous version's hash in the PR body so amendments are
+  auditable.
+
+The amendment history is the git log of this file.
+
+---
+
+## 한국어 요약
+
+PROJECT JAMES는 v1.0까지 단일 메인테이너(BDFL) 모델로 운영합니다. 모든
+설계·릴리스·라이선스 결정은 메인테이너(Hashevolution)에게 종결되며,
+결정의 *근거*는 PR 설명·CHANGELOG·`docs/handovers/`에 기록됩니다. v1.0
+이후 다중 메인테이너·도메인 팩 소유 모델로 전환할 예정이며, 전환 계획은
+`docs/PLATFORM_READINESS.md`에 기록됩니다. CoC 신고는
+`karu-7@hanmail.net`, 보안 신고는 `SECURITY.md`의 절차를 따릅니다.
+거버넌스·라이선스 변경은 7일 공개 코멘트 기간을 두고 진행합니다.


### PR DESCRIPTION
## Summary

Adds two new top-level documents and rewires CONTRIBUTING.md to point at them:

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, full canonical
  text + a short "Project-specific norms" section calling out the
  mother-platform constraint (CLAUDE.md rule 1) and the security-disclosure
  channel (`SECURITY.md`). Reporting goes to `karu-7@hanmail.net`
  (same maintainer channel as the SECURITY.md backup).

- **`GOVERNANCE.md`** — single-maintainer (BDFL through v1.0) model,
  five roles (Maintainer / Reviewer / Contributor / Security reporter /
  CoC reporter), three decision classes (Code / Architecture / License-or-governance)
  with explicit comment windows (72 h / 7 d) for the last two, the
  release process, and a written conflict-resolution path that
  acknowledges forking as a supported exit.

- **`CONTRIBUTING.md` §Code of Conduct** — was two inline lines; now
  links to the dedicated CoC file and to GOVERNANCE.md. No other changes
  to CONTRIBUTING.md (the License/CLA section from #340 is preserved
  verbatim).

### Why this PR (silver-tier mapping)

This completes the **governance documentation surface** for the OpenSSF
Best Practices silver tier. The four silver-tier criteria in scope for
this cycle are now resolved as follows:

| Criterion | Status | Source |
|---|---|---|
| `dco` (DCO or CLA) | ✅ Met | #340 — CLA infrastructure (Apache-style ICLA v2.2 + CLA Assistant workflow) |
| `documentation_current` | ✅ Met | #348 — 3 READMEs synced to v0.3.0 Platform Skeleton |
| `code_of_conduct` | ✅ Met | **this PR** — `CODE_OF_CONDUCT.md` |
| `governance` | ✅ Met | **this PR** — `GOVERNANCE.md` |
| `roles_responsibilities` | ✅ Met | **this PR** — `GOVERNANCE.md` §2 |

After this PR + the bestpractices.dev Met flips for the items already
satisfied on main (now 9 with #339/#340/#348), Tiered % should clear
the launch-tracker target of **≥ 115%**.

## Verification

- `git diff --stat` shows 3 files: 2 new (`CODE_OF_CONDUCT.md` 7.3 KB,
  `GOVERNANCE.md` 9.4 KB), 1 edit (`CONTRIBUTING.md` +12 −3).
- Both new files are top-level (GitHub auto-detects `CODE_OF_CONDUCT.md`
  and `GOVERNANCE.md` for the Community Standards checklist).
- Internal cross-links checked manually:
  - `CONTRIBUTING.md` → `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `SECURITY.md` ✓
  - `CODE_OF_CONDUCT.md` → `SECURITY.md` ✓
  - `GOVERNANCE.md` → `CLAUDE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
    `SECURITY.md`, `docs/ARCHITECTURE.md`, `docs/PLATFORM_READINESS.md`,
    `docs/LICENSE_PLAN.md`, `docs/legal/CLA.md`,
    `docs/legal/non-cla-contributions.md` — all paths exist on main.
- No code change, so no bench numbers required (CLAUDE.md rule 2 only
  applies to `core/retrieval`, `core/graph`, `core/reasoning`).
- No `architecture` label — this is a Class C (governance) change per
  the rules introduced *by* this PR, but since `GOVERNANCE.md` does
  not yet exist on main, the 7-day comment window does not retroactively
  apply to its own introduction. Subsequent amendments to this file
  will follow that process.

## Out of scope

- **No README / CHANGELOG churn.** PR #348 already brought all three
  READMEs current; CHANGELOG entries for governance docs will land in
  the next release-notes pass, not here.
- **No CLA / DCO changes.** PR #340 settled the legal infrastructure;
  this PR only references it.
- **No CoC enforcement actions.** This PR adopts the policy; there are
  no active reports to action.
- **No multi-maintainer transition plan.** That belongs to the v1.0
  gate work and is referenced in `GOVERNANCE.md` §1 as a forward marker,
  not implemented here.
- **No `architecture`-labeled change.** Nothing in `docs/ARCHITECTURE.md`
  or any trust-zone definition moves in this PR.

## Companion artifacts (post-merge)

After merge, the maintainer flips the following on
[bestpractices.dev project 12806](https://www.bestpractices.dev/projects/12806):

- `code_of_conduct` → Met (URL: `CODE_OF_CONDUCT.md`)
- `governance` → Met (URL: `GOVERNANCE.md`)
- `roles_responsibilities` → Met (URL: `GOVERNANCE.md#2-roles`)

Plus the previously-mergeable items now backed by #339/#340/#348
(test_continuous_integration, dco, documentation_current). The Tiered %
update lands in the next launch-tracker entry.


---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_