### PR TITLE
chore(deps): bump idna to >=3.15 — GHSA-65pc-fj4g-8rjx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,12 @@ requests>=2.31.0
 # a transitive of requests, so a fresh install with a stale wheel
 # cache cannot regress us.
 urllib3>=2.7.0
+# Dependabot alerts #11/#12 — GHSA-65pc-fj4g-8rjx / CVE-2026-45409:
+# specially-crafted inputs to idna.encode() bypass the CVE-2024-3651
+# fix. Pulled in transitively by requests; pin the floor here so a
+# fresh install with a stale wheel cache cannot regress us, matching
+# the urllib3 / python-multipart approach above.
+idna>=3.15
 
 # ── Vector DB / Embeddings / Search ────────────────────────────
 chromadb>=0.4.22

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -39,7 +39,7 @@ httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
 huggingface_hub==1.9.0
-idna==3.11
+idna==3.15
 ImageIO==2.37.3
 importlib_metadata==8.7.1
 importlib_resources==7.1.0


### PR DESCRIPTION
## Summary

Closes Dependabot alerts **#11** and **#12** — `idna < 3.15` is vulnerable to a specially-crafted input that bypasses the CVE-2024-3651 fix in `idna.encode()`.

- **CVE**: CVE-2026-45409
- **GHSA**: GHSA-65pc-fj4g-8rjx
- **Severity**: medium
- **Fixed in**: 3.15

## Changes

| File | Change |
|---|---|
| `requirements_pinned.txt` | \`idna==3.11\` → \`idna==3.15\` (was already drifting; the live env had 3.13 installed, still vulnerable) |
| `requirements.txt` | Add explicit \`idna>=3.15\` floor next to the existing \`urllib3>=2.7.0\` / \`python-multipart>=0.0.27\` floors — same pattern as Dependabot alerts #5–#10. Prevents a stale wheel cache from resolving to a pre-patch version on a fresh install. |

## Verification

- [x] Local upgrade: idna 3.13 → 3.15
- [x] \`pytest tests/\` (server-import excluded) → **2187 passed**, 0 regression
- [x] Both Dependabot alerts will auto-close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)