### PR TITLE
chore(ci): add bandit SAST workflow + clean high-severity findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,42 @@
+name: security-scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Companion to .github/workflows/lint.yml (ruff F-class) and
+# .github/workflows/test.yml (pytest). Adds bandit SAST coverage for
+# common Python vulnerabilities — SQL/shell injection, weak crypto,
+# hardcoded passwords, yaml.load() abuse, insecure tempfile, etc.
+# Together with lint + tests, satisfies OpenSSF Best Practices
+# `static_analysis_common_vulnerabilities`.
+#
+# Severity policy: HIGH-only gate. Medium/low findings surface in
+# bandit's own log but do not block the PR. The bar lifts in a
+# follow-up once the current main is clean at medium severity.
+
+jobs:
+  bandit:
+    name: bandit (high-severity enforced)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install bandit
+        run: pip install 'bandit[toml]==1.7.10'
+
+      - name: Run bandit (high severity, source dirs only)
+        run: |
+          bandit -r core llm tools utils processors memory \
+            --severity-level high \
+            --format screen

--- a/core/feedback_engine.py
+++ b/core/feedback_engine.py
@@ -222,7 +222,7 @@ class FeedbackEngine:
         """응답 방향 ID 생성."""
         import hashlib
         key = f"{mode}:{query[:40]}"
-        return hashlib.md5(key.encode()).hexdigest()[:12]
+        return hashlib.md5(key.encode(), usedforsecurity=False).hexdigest()[:12]
 
     def get_stats(self) -> Dict:
         pos = sum(1 for h in self._history

--- a/core/graph_snapshot.py
+++ b/core/graph_snapshot.py
@@ -215,7 +215,7 @@ def build_snapshot(
         {"n": len(nodes), "e": len(edges), "m": max_mtime},
         sort_keys=True,
     ).encode("utf-8")
-    snapshot_hash = hashlib.sha1(sig_src).hexdigest()[:12]
+    snapshot_hash = hashlib.sha1(sig_src, usedforsecurity=False).hexdigest()[:12]
 
     snapshot = {
         "nodes": nodes,

--- a/core/memory/loom.py
+++ b/core/memory/loom.py
@@ -61,7 +61,7 @@ def _triple_key(result: Dict) -> str:
         return f"{entity_id}::{relation}::{tail_id}"
 
     # fallback: text hash
-    return hashlib.md5(text.encode()).hexdigest()
+    return hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()
 
 
 def _conflict_base_key(result: Dict) -> str:

--- a/tools/code/sandbox.py
+++ b/tools/code/sandbox.py
@@ -270,7 +270,10 @@ def safe_execute(
 
     t_start = time.time()
     try:
-        result = subprocess.run(
+        # shell=True is the sandbox contract — validate_action() above is
+        # the security gate (allowlist of commands, path normalization,
+        # role check). Bandit B602 is suppressed here, not bypassed.
+        result = subprocess.run(  # nosec B602
             command, shell=True,
             cwd=os.path.normpath(path),
             capture_output=True, text=True, timeout=timeout,

--- a/tools/patch/patch_generator.py
+++ b/tools/patch/patch_generator.py
@@ -74,7 +74,8 @@ def generate_patch(
         }
     """
     patch_id = hashlib.md5(
-        f"{target}{request}{datetime.now().isoformat()}".encode()
+        f"{target}{request}{datetime.now().isoformat()}".encode(),
+        usedforsecurity=False,
     ).hexdigest()[:12]
 
     # 1. PROTECTED_FILES 차단 (Patch 생성 자체 거부)

--- a/tools/self/file_scanner.py
+++ b/tools/self/file_scanner.py
@@ -195,7 +195,7 @@ def _build_tree(max_depth: int = 4) -> str:
 def _compute_hash(filepath: Path) -> str:
     try:
         content = filepath.read_bytes()
-        return hashlib.md5(content).hexdigest()
+        return hashlib.md5(content, usedforsecurity=False).hexdigest()
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/security.yml` — a third CI job alongside `lint`
(ruff) and `tests` (pytest) — that runs **bandit** as SAST for common
Python vulnerabilities (SQL/shell injection, weak crypto, hardcoded
passwords, yaml.load() abuse, insecure tempfile, etc.). This satisfies
OpenSSF Best Practices `static_analysis_common_vulnerabilities`.

Same-PR cleanup of pre-existing high-severity findings so the new gate
lands green:

| Finding | Files | Disposition |
|---|---|---|
| `B324` weak MD5/SHA1 for security (×5) | `core/feedback_engine.py`, `core/graph_snapshot.py`, `core/memory/loom.py`, `tools/patch/patch_generator.py`, `tools/self/file_scanner.py` | All five are non-security uses (cache keys, direction IDs, snapshot fingerprints, file-change detection, conflict-dedup keys). Annotated with `usedforsecurity=False` (Python 3.9+). |
| `B602` subprocess `shell=True` (×1) | `tools/code/sandbox.py:276` | This is the sandbox contract itself — `validate_action()` two lines above is the security gate (allowlist of commands, path normalization, role check). Annotated `# nosec B602` with rationale in-line. |

### Severity policy

The workflow gates at **HIGH severity only**. The bar lifts in a
follow-up PR once main is clean at medium severity (current count
after this PR: 10 medium, 141 low — these surface in bandit's log
but do not block).

This mirrors the existing pattern of `lint.yml` (ruff F-class enforced —
not all classes) and `tests/` selective scope (CI-incompatible tests
excluded with a documented un-ignoring iteration plan).

## Verification

Local run of the exact workflow invocation:

```
$ bandit -r core llm tools utils processors memory \
    --severity-level high --format screen

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 23642
        Total lines skipped (#nosec): 0
        Total potential issues skipped due to specifically being
        disabled (e.g., #nosec BXXX): 1   ← sandbox B602

Run metrics:
        Total issues (by severity):
                Low: 141
                Medium: 10
                High: 0
```

CLAUDE.md rule 2 (bench numbers for `core/retrieval`, `core/graph`,
`core/reasoning`) does not apply — none of the touched files live in
those subtrees. `core/graph_snapshot.py` is at the top of `core/`, not
under a `core/graph/` directory.

## Out of scope

- **Medium / low severity cleanup.** A separate follow-up will lift
  the gate after main is medium-clean.
- **bandit config file (`.bandit` / `pyproject.toml [tool.bandit]`).**
  The CLI arguments in the workflow are explicit enough; the project
  has no `pyproject.toml` yet and adding one is a larger conversation.
- **Replacing MD5/SHA1 with SHA-256.** `usedforsecurity=False` is the
  canonical signal that these hashes are intentional non-security uses;
  swapping algorithms would invalidate existing cache keys and snapshot
  fingerprints without security benefit.
- **Sandbox redesign.** `shell=True` in `tools/code/sandbox.py` is the
  contract that `validate_action()` exists to protect; refactoring it
  is a trust-boundary change requiring its own architecture-labeled PR.

## Companion artifacts (post-merge)

After merge, the maintainer flips on
[bestpractices.dev project 12806](https://www.bestpractices.dev/projects/12806):

- `static_analysis_common_vulnerabilities` → Met
  (URL: `.github/workflows/security.yml`)

This is criterion #2 of three Tier-1 silver-tier PRs in this cycle.
PR #353 (governance) covers `code_of_conduct` / `governance` /
`roles_responsibilities`; the next PR will cover `assurance_case` and
`documentation_achievements`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_