### PR TITLE
feat(memory): working memory infrastructure (Cognitive Phase 3 PR-10a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.3.x patches
 
+### Added
+
+- **Working memory infrastructure (Cognitive Phase 3 PR-10a)** —
+  `core/memory/working.py` ships a turn-scoped scratch store sibling
+  to the episodic memory landed in PR-9. Where episodic captures the
+  **final** plan/reflect/verify decisions across turns, working memory
+  holds **intra-turn** intermediate state (reflection critique drafts,
+  per-claim verifier intermediates, planner subtask scratch) that
+  reasoning stages hand off to each other while the answer is being
+  built and that the audit_log already keeps a forensic copy of.
+  In-process dict with `threading.Lock` (no SQLite) keeps the
+  "cleared at turn end" invariant safe against operator restart
+  races. ContextVar reuse: the PR-9b `(session_id, turn_id)` binding
+  is the only one needed — `working_event()` reads it directly so
+  PR-10b call sites stay one-liners.
+  15 new tests in `tests/test_working_memory.py` lock the contract
+  (round-trip, turn isolation, session isolation, keys(), clear_turn,
+  prune_idle_turns, thread-safety, helper no-op outside tracked turn,
+  helper write under bound context, singleton stability). Wiring into
+  the cognitive stages and the `engine.query()` finally-block
+  cleanup lands in PR-10b. Design memo:
+  [`docs/design/v0.3-working-memory.md`](docs/design/v0.3-working-memory.md).
+
 ### Changed
 
 - **Verifier base scan (security_validator) is now default ON**

--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -33,6 +33,14 @@ from core.memory.episodic import (
     get_episodic_memory,
     record_event as record_episodic_event,
 )
+# Cognitive Phase 3 PR-10a — turn-scoped scratch space sibling to the
+# episodic store. No call sites yet; PR-10b wires reflect / verify /
+# planner / synth. See docs/design/v0.3-working-memory.md.
+from core.memory.working import (
+    WorkingMemory,
+    get_working_memory,
+    working_event,
+)
 
 __all__ = [
     "MemoryStore",
@@ -53,4 +61,7 @@ __all__ = [
     "EPISODIC_MAX_SUMMARY_CHARS",
     "get_episodic_memory",
     "record_episodic_event",
+    "WorkingMemory",
+    "get_working_memory",
+    "working_event",
 ]

--- a/core/memory/working.py
+++ b/core/memory/working.py
@@ -1,0 +1,272 @@
+"""Turn-scoped scratch space — Cognitive Phase 3 PR-10a.
+
+In-process working memory for cognitive stages. See
+``docs/design/v0.3-working-memory.md`` for the full scope, ARCHITECTURE
+§5.7.6 for the memory-scope hierarchy, and the §5.7.2 "Reflection state
+— working memory only" invariant.
+
+PR-10a ships the store and ``working_event()`` helper but **no call
+sites**. PR-10b wires reflect / verify / planner / synth and hooks
+``clear_turn()`` into ``engine.query()``'s finally block.
+
+Two non-negotiable properties pin this module's design:
+
+1. **Turn isolation** — every read filters by ``(session_id, turn_id)``
+   at the method boundary. There is no ``keys_all_turns()`` and no
+   way for one turn's stage to read another turn's slots, even from
+   the same session.
+2. **No on-disk persistence** — process restart wipes the store.
+   Keeps the "cleared at turn end" invariant safe against operator
+   restart races, and avoids conflating with episodic's SQLite
+   persistence contract (PR-9a/PR-9b).
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ─── Storage layout ────────────────────────────────────────────────
+# Outer key:  (session_id, turn_id)  — one bucket per turn.
+# Bucket:     {"ts": last_write_unix_ts, "data": {role: {key: value}}}
+#
+# Nested dict (rather than flat (s, t, role, key) tuple) is chosen so
+# clear_turn() is one O(1) pop on the outer dict instead of an O(N)
+# prefix scan. The prune sweep runs sequentially through buckets and
+# benefits from the same shape (last-write ts at bucket level).
+
+_Bucket = Dict[str, Any]   # {"ts": float, "data": Dict[str, Dict[str, Any]]}
+
+
+class WorkingMemory:
+    """Process-wide turn-scoped scratch store.
+
+    One instance per process; isolation is enforced at the method
+    signature (every entry requires ``session_id`` + ``turn_id``).
+    Backed by a plain dict and a single ``threading.Lock`` so the
+    FastAPI thread-pool worker that runs ``rag_engine.query()`` can
+    hand off to other threads (e.g. background trace writers) without
+    a race on the bucket.
+
+    The lock is held only across the dict mutation — not across the
+    caller's stage logic — so contention stays bounded.
+    """
+
+    def __init__(self) -> None:
+        self._buckets: Dict[Tuple[str, str], _Bucket] = {}
+        self._lock = threading.Lock()
+
+    # ─── write ──────────────────────────────────────────────────
+
+    def set(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,
+        key:        str,
+        value:      Any,
+    ) -> None:
+        """Store ``value`` under the (session, turn, role, key) tuple.
+
+        Empty session_id / turn_id are silently ignored — same
+        defensive posture as ``record_event()`` in episodic.py. A
+        background job or test that forgot to bind the ContextVar
+        stays inert rather than polluting the store with ``""`` keys.
+        """
+        if not session_id or not turn_id or not role or not key:
+            return
+        bucket_key = (session_id, turn_id)
+        with self._lock:
+            bucket = self._buckets.get(bucket_key)
+            if bucket is None:
+                bucket = {"ts": time.time(), "data": {}}
+                self._buckets[bucket_key] = bucket
+            else:
+                bucket["ts"] = time.time()
+            bucket["data"].setdefault(role, {})[key] = value
+
+    # ─── read ───────────────────────────────────────────────────
+
+    def get(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,
+        key:        str,
+        default:    Any = None,
+    ) -> Any:
+        """Return the stored value, or ``default`` on miss.
+
+        Missing session/turn/role/key all collapse to the same
+        "return default" path so the caller does not have to
+        distinguish "turn never wrote anything" from "turn wrote
+        but not this role" from "role exists but not this key".
+        """
+        if not session_id or not turn_id or not role or not key:
+            return default
+        bucket_key = (session_id, turn_id)
+        with self._lock:
+            bucket = self._buckets.get(bucket_key)
+            if bucket is None:
+                return default
+            role_slot = bucket["data"].get(role)
+            if role_slot is None:
+                return default
+            return role_slot.get(key, default)
+
+    def keys(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,
+    ) -> List[str]:
+        """List the keys this turn has written under ``role``.
+
+        Stable sort by insertion is NOT guaranteed — Python's dict
+        keeps insertion order, but a caller relying on that is
+        depending on a CPython implementation detail. Sort
+        explicitly at the call site if order matters.
+        """
+        if not session_id or not turn_id or not role:
+            return []
+        bucket_key = (session_id, turn_id)
+        with self._lock:
+            bucket = self._buckets.get(bucket_key)
+            if bucket is None:
+                return []
+            role_slot = bucket["data"].get(role)
+            if role_slot is None:
+                return []
+            return list(role_slot.keys())
+
+    # ─── lifecycle ──────────────────────────────────────────────
+
+    def clear_turn(self, session_id: str, turn_id: str) -> int:
+        """Drop every slot for ``(session_id, turn_id)``. Returns the
+        number of (role, key) pairs removed — useful for trace /
+        debug rows in PR-10b's engine.query() finally hookup.
+        """
+        if not session_id or not turn_id:
+            return 0
+        bucket_key = (session_id, turn_id)
+        with self._lock:
+            bucket = self._buckets.pop(bucket_key, None)
+        if bucket is None:
+            return 0
+        return sum(len(s) for s in bucket["data"].values())
+
+    def prune_idle_turns(self, *, max_age_seconds: int) -> int:
+        """Sweep buckets whose last write is older than the threshold.
+
+        Defensive against the rare case ``engine.query()``'s finally
+        block did not run (OS-level process kill mid-request). The
+        default age at the production callsite is 600s (10 min) —
+        long enough that a slow LLM turn keeps its scratch, short
+        enough that the dict stays small over a multi-day uptime.
+
+        Returns the number of buckets removed (not slot pairs —
+        the call is about reclaiming bucket space, not counting
+        what was discarded).
+        """
+        if max_age_seconds <= 0:
+            raise ValueError("max_age_seconds must be > 0")
+        threshold = time.time() - max_age_seconds
+        to_remove: List[Tuple[str, str]] = []
+        with self._lock:
+            for k, bucket in self._buckets.items():
+                if bucket["ts"] < threshold:
+                    to_remove.append(k)
+            for k in to_remove:
+                self._buckets.pop(k, None)
+        return len(to_remove)
+
+    # ─── introspection (debugging / tests) ──────────────────────
+
+    def bucket_count(self) -> int:
+        """Number of (session_id, turn_id) buckets currently held.
+        Test helper / debug surface — not part of the public stage
+        API. PR-10b's engine finally hook ignores this.
+        """
+        with self._lock:
+            return len(self._buckets)
+
+
+# ─── module-level singleton ─────────────────────────────────────────
+
+_SINGLETON: Optional[WorkingMemory] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_working_memory() -> WorkingMemory:
+    """Process-wide singleton. Lazily constructed so importing the
+    module does not allocate the dict until a stage actually writes.
+    """
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = WorkingMemory()
+    return _SINGLETON
+
+
+def _clear_singleton_for_tests() -> None:
+    """Test helper — drop the singleton so each test class starts
+    from an empty store. Production code never calls this.
+    """
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None
+
+
+# ─── wiring helper ──────────────────────────────────────────────────
+
+def working_event(
+    *,
+    role:  str,
+    key:   str,
+    value: Any,
+) -> bool:
+    """Thin wiring helper for cognitive stages — PR-10b call sites.
+
+    Reads ``(session_id, turn_id)`` from the
+    ``core.observability.current_session`` ContextVar set by
+    ``engine.query()`` at turn start (PR-9b infrastructure), then
+    forwards to ``WorkingMemory.set()``.
+
+    Returns ``True`` on success, ``False`` when called outside a
+    tracked turn (silent no-op — same posture as
+    ``record_event()`` in episodic.py). PR-10a has no call sites;
+    PR-10b wires reflect / verify / planner / synth to it.
+    """
+    try:
+        from core.observability import get_session_context
+        session_id, turn_id = get_session_context()
+    except Exception:
+        return False
+    if not session_id or not turn_id:
+        return False
+    try:
+        get_working_memory().set(
+            session_id=session_id,
+            turn_id=turn_id,
+            role=role,
+            key=key,
+            value=value,
+        )
+        return True
+    except Exception:
+        # Working memory is best-effort. A write failure must never
+        # crash the live answer flow — same silent-skip posture as
+        # the episodic helper.
+        return False
+
+
+__all__ = [
+    "WorkingMemory",
+    "get_working_memory",
+    "working_event",
+]

--- a/docs/design/v0.3-working-memory.md
+++ b/docs/design/v0.3-working-memory.md
@@ -1,0 +1,276 @@
+# v0.3 — Working Memory (Cognitive Phase 3 PR-10)
+
+> Status: design + PR-10a infrastructure (this PR)
+> Pinned to: `docs/ARCHITECTURE.md` §5.7.2 (Trust zone, "Reflection state"
+> row), §5.7.6 (memory scope layering)
+> Tracks: `docs/handovers/v0.3-cognitive-layer-track.md` Phase 3
+> Companion: `docs/design/v0.3-episodic-memory.md` (the sister memory tier)
+
+## Why working memory exists
+
+After PR-9b, JAMES persists **final** reasoning decisions in the
+session-scoped episodic store (`core/memory/episodic.py` — plan,
+reflect, verify, synth records survive across turns within a session).
+What is missing is the **intra-turn workspace**: a place where stages
+inside the same answer pipeline can hand off intermediate state to
+each other without polluting the episodic store with drafts the
+verifier or reflection later discards.
+
+ARCHITECTURE.md §5.7.2 directly anticipates this split:
+
+> "Reflection state — working memory only — **not persisted by default**;
+>  episodic memory captures only the **final** verified answer trace."
+
+The reflection critique that drove a `revised` answer is valuable
+*while the revised step is running* (the LLM prompt is built from it)
+but useless after the turn ends — the audit_log already keeps a
+forensic copy. Storing it in episodic conflates the "decision record"
+contract.
+
+Similarly, the verifier's per-claim fact-check intermediates and the
+planner's per-subtask scratch space are working-memory-shaped: many
+of them, dropped on turn end, never compared across turns.
+
+## Position in the scope hierarchy (§5.7.6)
+
+```
+┌────────────────────────────────────────────────────────┐
+│  system     — ontology, PolicyEngine, evolutions      │
+├────────────────────────────────────────────────────────┤
+│  workspace  — wiki, vector store, audit_log           │
+├────────────────────────────────────────────────────────┤
+│  session    — episodic events (PR-9b)                  │
+│                + working memory (PR-10) ← NEW         │
+│                    - cleared at TURN END               │
+│                    - never read across turns           │
+└────────────────────────────────────────────────────────┘
+```
+
+**Two invariants pin working memory inside this row**:
+
+1. **Turn isolation, not session isolation.** A read keyed by
+   `(session_id, turn_id_A, …)` must return empty for any other
+   turn — even a turn from the same session. This is stricter than
+   episodic's session boundary. Concretely: when engine.query()
+   binds a new turn_id, the previous turn's working slots are
+   reclaimed.
+2. **No promotion to episodic.** Working slots that the cognitive
+   middleware wants to preserve must be explicitly written to
+   episodic (via the existing PR-9b `record_event`). There is no
+   automatic copy at turn end — the stages decide what was
+   final-worthy.
+
+## Comparison to episodic (the PR-9 store)
+
+| Dimension | Working memory (PR-10) | Episodic memory (PR-9) |
+|---|---|---|
+| Lifetime | one turn | session (7-day retention) |
+| Storage | in-process dict (no SQLite) | SQLite (`james_episodic.db`) |
+| Persistence | gone on process restart | survives restart |
+| Isolation key | `(session_id, turn_id, role)` | `(session_id, ...)` |
+| Typical contents | reflection critique drafts, per-claim verifier intermediates, planner subtask scratch | final plan / reflect / verify / synth decisions |
+| Read cross-turn? | **never** | yes (PR-9b cross-turn read in `engine_memory`) |
+| Promotion to higher scope | none in v0.3 | via "save as long-term memory" (PR #264) |
+
+## API surface
+
+```python
+class WorkingMemory:
+    """Process-wide turn-scoped scratch space. One instance per
+    process; isolation happens via (session_id, turn_id) keys at
+    method boundary.
+
+    Backed by a plain dict + threading.Lock. No SQLite — working
+    memory MUST NOT survive a process restart, which is the cheapest
+    way to enforce the "cleared at turn end" invariant against any
+    accidental cross-turn read.
+    """
+
+    def __init__(self) -> None: ...
+
+    # ── write ──────────────────────────────────────────────────
+    def set(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,    # "reflect.draft" / "verify.claims" / "plan.subtasks"
+        key:        str,    # arbitrary stage-defined sub-key
+        value:      Any,    # any picklable / JSON-shaped value
+    ) -> None: ...
+
+    # ── read ───────────────────────────────────────────────────
+    def get(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,
+        key:        str,
+        default:    Any = None,
+    ) -> Any: ...
+
+    def keys(
+        self,
+        *,
+        session_id: str,
+        turn_id:    str,
+        role:       str,
+    ) -> list[str]: ...
+
+    # ── lifecycle ──────────────────────────────────────────────
+    def clear_turn(
+        self, session_id: str, turn_id: str
+    ) -> int:
+        """Drop every slot under (session_id, turn_id). Returns the
+        number of slots removed. Called from engine.query() in the
+        finally block so a crashed turn still releases its scratch.
+        """
+        ...
+
+    def prune_idle_turns(self, *, max_age_seconds: int) -> int:
+        """Sweep turns whose last write is older than the threshold.
+        Defensive against engine.query() finally not running (rare:
+        OS-level process kill mid-request). Default age in the
+        callsite: 600s (10 min) — long enough that a slow LLM turn
+        won't get its working memory yanked, short enough that the
+        dict doesn't grow unbounded over a multi-day uptime.
+        """
+        ...
+```
+
+**Module-level helper (mirrors `record_event` from episodic)**:
+
+```python
+def working_event(
+    *,
+    role:  str,
+    key:   str,
+    value: Any,
+) -> bool:
+    """Thin wiring helper for cognitive stages.
+
+    Reads (session_id, turn_id) from the
+    `core.observability.current_session` ContextVar set by
+    `engine.query()` at turn start, then forwards to
+    `WorkingMemory.set()`. Returns True on success, False when
+    called outside a tracked turn (silent no-op — same pattern as
+    `episodic.record_event`).
+    """
+```
+
+The matching read helper is intentionally not provided as a
+module-level function — reads are common enough across stages that
+the caller takes the singleton explicitly:
+
+```python
+wm = get_working_memory()
+draft = wm.get(session_id=sid, turn_id=tid,
+                role="reflect.draft", key="text")
+```
+
+This keeps the read site auditable in code search (`get_working_memory`
+greppable) and prevents tests from accidentally relying on a
+"current turn" implicit binding for assertions.
+
+## Persistence — none on disk
+
+Working memory is **in-process only**. Reasons:
+
+- **Invariant enforcement**. A SQLite-backed store would survive
+  process restart, and an operator restarting JAMES mid-session
+  would silently expose the prior turn's working slots to the next
+  request. Plain-dict storage rules this out by construction.
+- **Cost shape**. A typical turn writes 5-20 slots (critique +
+  per-claim intermediates + subtask scratch), each a few KB. The
+  10-minute prune window caps memory at "active turns × ~50 KB"
+  — well inside the cost JAMES already pays for vector + graph
+  caches.
+- **Multi-process forward compat**. If v0.4 introduces a multi-
+  process topology, working memory does not become a shared
+  resource — each process owns its own. This is the correct
+  behaviour because a turn is bound to one request handler.
+
+## ContextVar reuse — no new bindings
+
+PR-9b introduced
+`core.observability.current_session = ContextVar[tuple[str, str]]`
+holding `(session_id, turn_id)`. PR-10 reuses it directly:
+
+- `working_event(...)` reads the ContextVar via
+  `get_session_context()` (already exported from observability).
+- `engine.query()` already calls `set_session_context()` at turn
+  start, so the helper "just works" without any new wiring at the
+  engine layer.
+
+PR-10b will additionally call `WorkingMemory.clear_turn(sid, tid)`
+from the `finally:` block of `engine.query()` so a crashed turn
+still releases its slots.
+
+## What PR-10a does NOT do (the wiring lives in PR-10b)
+
+- **No call sites** in `reflect.py`, `verify.py`, `planner.py`,
+  or `pipeline_synth.py`. The infrastructure ships first so the
+  schema can be reviewed in isolation; the wiring lands in PR-10b.
+  This mirrors the L0/L1 split the backends track used (PR #283 →
+  PR #284) and the PR-9a/PR-9b split the episodic track used.
+- **No Context Optimizer.** The `core/reasoning/context.py`
+  component anticipated by ARCHITECTURE.md §5.7.1 reads working
+  memory as one of its inputs (token-budget-aware evidence drop)
+  but is its own PR (tentatively PR-12). Shipping it in PR-10
+  would conflate "scratch space" with "trimming policy".
+- **No turn-end clear wiring.** PR-10a ships the `clear_turn()`
+  method but does not call it from `engine.query()`. PR-10b adds
+  the finally-block hookup. Until then the prune sweep
+  (`prune_idle_turns`) is the only floor on memory growth — fine
+  for an infra-only PR with no callers.
+
+## Trust zone
+
+| Surface | Trust | Rationale |
+|---|---|---|
+| Read across turns | **forbidden** | Method API enforces `(session_id, turn_id)` keys at every entry. No `keys_all_turns()` exists. |
+| Cross-session read | forbidden | Same — the prefix mismatches. |
+| Promotion to episodic | manual only | Stages explicitly call `record_event(...)` with the final result. No automatic copy. |
+| Plugin write (future v0.4) | PolicyEngine `cognitive.working.write` | Out of scope until plugin API lands. v0.3 has only cognitive middleware as a writer. |
+
+PolicyEngine does not yet need a permission for PR-10a because no
+endpoint exposes working memory to the user. PR-10b's
+`engine.query()` finally hook also stays inside the trust boundary
+(server-side cleanup).
+
+## Test plan (for PR-10a)
+
+1. `set()` round-trip — `get()` returns what `set()` wrote
+2. `get(default=…)` returns the default on miss
+3. **Turn isolation** — `set(s, t1, …)` then `get(s, t2, …)` returns
+   default. Stricter than session isolation.
+4. **Session isolation** — same role/key under different
+   `session_id` are independent
+5. `keys(...)` lists only the slots for the given `(s, t, role)`
+6. `clear_turn(s, t)` removes exactly that turn's slots, returns
+   count; other turns untouched
+7. `prune_idle_turns(max_age_seconds=…)` removes slots whose last
+   write is older than the threshold; recent slots survive
+8. **Thread safety** — concurrent `set`/`get` across two threads
+   does not raise or lose writes (sanity-only — full stress is out
+   of scope for v0.3)
+9. **`working_event()` no-ops outside tracked turn** — when
+   ContextVar is `("", "")`, the helper returns `False` and no
+   slot is created
+10. **`working_event()` writes when bound** — under
+    `set_session_context()`, the helper writes and `get()` retrieves
+
+## PR sequence
+
+| PR | Scope |
+|---|---|
+| **PR-10a** | `core/memory/working.py` + tests + this design memo. Wiring 0. |
+| **PR-10b** | Wire `set()/get()` into reflect / verify / planner. Hook `clear_turn()` into engine.query finally. Cross-stage integration tests. |
+| **PR-12 (optional)** | Context Optimizer (`core/reasoning/context.py`) — token-budget evidence drop driven by working memory's plan trace. |
+
+## Diff log
+
+| Date | Author | Change | PR |
+|---|---|---|---|
+| 2026-05-20 | Jiwon | Initial design (PR-10 of Cognitive Phase 3) | (this PR — PR-10a) |

--- a/docs/handovers/v0.3-cognitive-layer-track.md
+++ b/docs/handovers/v0.3-cognitive-layer-track.md
@@ -175,7 +175,8 @@ LAYER 5  Docker isolation (1 container per agent)
 |---|---|---|
 | **PR-9a** Episodic store | `core/memory/episodic.py` — session-scoped event log + SQLite schema + 24 tests | ✓ (이미 머지됨) |
 | **PR-9b** Episodic wiring | 4 cognitive stage 의 `record_event()` + ContextVar 전파 + cross-turn 컨텍스트 주입 + `GET /admin/episodic/{session_id}` | ✓ (본 PR) |
-| **PR-10** Working memory | reasoning 중 임시 state. context optimizer 의 입력 | pending |
+| **PR-10a** Working memory infra | `core/memory/working.py` — turn-scoped scratch (in-process dict, ContextVar 재활용). wiring 0 | ✓ (본 PR) |
+| **PR-10b** Working memory wiring | reflect/verify/planner/synth call sites + engine.query finally hookup | pending |
 | **PR-11** (선택) Long-term graph evolution | entity 외 **event 노드** 추가 — 디자인 §3 graph evolution 시드 | pending |
 
 ### Phase 4 — Controlled Multi-Agent

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -1,0 +1,297 @@
+"""Cognitive Phase 3 PR-10a — turn-scoped working memory unit tests.
+
+Covers the 10-item test plan in
+``docs/design/v0.3-working-memory.md`` §"Test plan". The store is
+in-process plain-dict, so every test creates a fresh
+``WorkingMemory()`` instance to stay hermetic and parallel-safe.
+
+PR-10b adds the wiring tests that exercise the helper inside the
+cognitive stages.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.memory.working import (  # noqa: E402
+    WorkingMemory,
+    get_working_memory,
+    working_event,
+    _clear_singleton_for_tests,
+)
+from core.observability import (  # noqa: E402
+    set_session_context,
+)
+
+
+# ─── 1. round-trip + isolation ──────────────────────────────────────
+
+
+class RoundTripTests(unittest.TestCase):
+
+    def test_set_get_round_trip(self):
+        """Plan item 1 — what set() wrote, get() returns."""
+        wm = WorkingMemory()
+        wm.set(session_id="s1", turn_id="t1",
+               role="reflect.draft", key="text", value="hello")
+        self.assertEqual(
+            wm.get(session_id="s1", turn_id="t1",
+                   role="reflect.draft", key="text"),
+            "hello",
+        )
+
+    def test_get_default_on_miss(self):
+        """Plan item 2 — missing slot returns default."""
+        wm = WorkingMemory()
+        # miss at every level: turn / role / key
+        self.assertIsNone(wm.get(session_id="s1", turn_id="t1",
+                                  role="x", key="y"))
+        self.assertEqual(
+            wm.get(session_id="s1", turn_id="t1",
+                   role="x", key="y", default="fallback"),
+            "fallback",
+        )
+
+    def test_overwrite_replaces_value(self):
+        """A second set() to the same (s, t, role, key) replaces the
+        earlier value — not a list append. Stages reflect / verify
+        rely on this for "current best draft" semantics.
+        """
+        wm = WorkingMemory()
+        wm.set(session_id="s1", turn_id="t1",
+               role="r", key="k", value="v1")
+        wm.set(session_id="s1", turn_id="t1",
+               role="r", key="k", value="v2")
+        self.assertEqual(
+            wm.get(session_id="s1", turn_id="t1", role="r", key="k"),
+            "v2",
+        )
+
+
+class IsolationTests(unittest.TestCase):
+    """The strictest invariant — turn isolation. A turn must never
+    see another turn's slots, even from the same session.
+    """
+
+    def test_turn_isolation(self):
+        """Plan item 3 — same session, different turn → no leak."""
+        wm = WorkingMemory()
+        wm.set(session_id="s1", turn_id="t1",
+               role="r", key="k", value="t1_value")
+        # Read under t2 — same session, different turn
+        out = wm.get(session_id="s1", turn_id="t2",
+                     role="r", key="k", default=None)
+        self.assertIsNone(out,
+            "turn isolation is the strictest invariant — a stage in "
+            "turn t2 must NOT see turn t1's working slots")
+
+    def test_session_isolation(self):
+        """Plan item 4 — same turn_id literal under different
+        session_id are independent."""
+        wm = WorkingMemory()
+        wm.set(session_id="sA", turn_id="t1",
+               role="r", key="k", value="A_value")
+        wm.set(session_id="sB", turn_id="t1",
+               role="r", key="k", value="B_value")
+        self.assertEqual(
+            wm.get(session_id="sA", turn_id="t1", role="r", key="k"),
+            "A_value",
+        )
+        self.assertEqual(
+            wm.get(session_id="sB", turn_id="t1", role="r", key="k"),
+            "B_value",
+        )
+
+
+# ─── 2. keys() + clear_turn() + prune ───────────────────────────────
+
+
+class IntrospectionTests(unittest.TestCase):
+
+    def test_keys_lists_only_role_slots(self):
+        """Plan item 5 — keys(role) returns the keys this turn wrote
+        under that role, not other roles'."""
+        wm = WorkingMemory()
+        wm.set(session_id="s", turn_id="t",
+               role="reflect.draft", key="text", value="x")
+        wm.set(session_id="s", turn_id="t",
+               role="reflect.draft", key="latency_ms", value=42)
+        wm.set(session_id="s", turn_id="t",
+               role="verify.claims", key="c1", value="claim 1")
+        out = wm.keys(session_id="s", turn_id="t",
+                      role="reflect.draft")
+        self.assertEqual(set(out), {"text", "latency_ms"})
+
+    def test_keys_returns_empty_when_role_absent(self):
+        wm = WorkingMemory()
+        self.assertEqual(
+            wm.keys(session_id="s", turn_id="t", role="missing"),
+            [],
+        )
+
+
+class ClearTurnTests(unittest.TestCase):
+
+    def test_clear_turn_removes_only_that_turn(self):
+        """Plan item 6 — clear_turn drops exactly that turn's slots."""
+        wm = WorkingMemory()
+        # Populate two turns under the same session
+        wm.set(session_id="s", turn_id="t1",
+               role="r", key="k1", value="t1k1")
+        wm.set(session_id="s", turn_id="t1",
+               role="r", key="k2", value="t1k2")
+        wm.set(session_id="s", turn_id="t2",
+               role="r", key="k1", value="t2k1")
+
+        removed = wm.clear_turn("s", "t1")
+        self.assertEqual(removed, 2,
+            "clear_turn returns the number of (role, key) pairs removed")
+
+        # t1 gone
+        self.assertIsNone(wm.get(session_id="s", turn_id="t1",
+                                  role="r", key="k1"))
+        # t2 untouched
+        self.assertEqual(
+            wm.get(session_id="s", turn_id="t2", role="r", key="k1"),
+            "t2k1",
+        )
+
+    def test_clear_turn_missing_is_noop(self):
+        wm = WorkingMemory()
+        self.assertEqual(wm.clear_turn("never", "wrote"), 0)
+
+
+class PruneTests(unittest.TestCase):
+
+    def test_prune_removes_idle_turns_only(self):
+        """Plan item 7 — buckets whose last write is older than the
+        threshold are removed; recent buckets survive."""
+        wm = WorkingMemory()
+        # Write to two turns
+        wm.set(session_id="s", turn_id="old",
+               role="r", key="k", value="x")
+        # Manually backdate the "old" bucket's ts
+        with wm._lock:
+            wm._buckets[("s", "old")]["ts"] = time.time() - 3600
+        wm.set(session_id="s", turn_id="fresh",
+               role="r", key="k", value="y")
+
+        removed = wm.prune_idle_turns(max_age_seconds=600)
+        self.assertEqual(removed, 1)
+        # fresh survives
+        self.assertEqual(
+            wm.get(session_id="s", turn_id="fresh",
+                   role="r", key="k"),
+            "y",
+        )
+        # old is gone
+        self.assertIsNone(wm.get(session_id="s", turn_id="old",
+                                  role="r", key="k"))
+
+    def test_prune_zero_or_negative_raises(self):
+        wm = WorkingMemory()
+        with self.assertRaises(ValueError):
+            wm.prune_idle_turns(max_age_seconds=0)
+        with self.assertRaises(ValueError):
+            wm.prune_idle_turns(max_age_seconds=-5)
+
+
+# ─── 3. thread safety (sanity) ──────────────────────────────────────
+
+
+class ThreadSafetyTests(unittest.TestCase):
+    """Sanity-level concurrency check — concurrent writes from two
+    threads do not raise and do not lose data. Full stress testing
+    is out of scope for v0.3."""
+
+    def test_concurrent_writes_no_data_loss(self):
+        wm = WorkingMemory()
+        N = 200
+
+        def writer(prefix: str):
+            for i in range(N):
+                wm.set(session_id="s", turn_id="t",
+                       role=prefix, key=f"k{i}", value=i)
+
+        ta = threading.Thread(target=writer, args=("A",))
+        tb = threading.Thread(target=writer, args=("B",))
+        ta.start(); tb.start()
+        ta.join();  tb.join()
+
+        # Each role should have N keys
+        self.assertEqual(
+            len(wm.keys(session_id="s", turn_id="t", role="A")),
+            N,
+        )
+        self.assertEqual(
+            len(wm.keys(session_id="s", turn_id="t", role="B")),
+            N,
+        )
+
+
+# ─── 4. working_event() helper ──────────────────────────────────────
+
+
+class HelperGateTests(unittest.TestCase):
+    """working_event() reads (session_id, turn_id) from the
+    PR-9b ContextVar. PR-10b wires this into cognitive stages.
+    """
+
+    def setUp(self):
+        _clear_singleton_for_tests()
+        set_session_context("", "")
+
+    def tearDown(self):
+        _clear_singleton_for_tests()
+        set_session_context("", "")
+
+    def test_helper_noop_when_context_unbound(self):
+        """Plan item 9 — outside a tracked turn, the helper returns
+        False and writes nothing."""
+        ok = working_event(role="r", key="k", value="v")
+        self.assertFalse(ok)
+        # The singleton was lazily created — confirm no bucket landed
+        wm = get_working_memory()
+        self.assertEqual(wm.bucket_count(), 0)
+
+    def test_helper_writes_when_context_bound(self):
+        """Plan item 10 — under set_session_context, the helper
+        writes and the stored slot is retrievable."""
+        set_session_context("s_bound", "s_bound:1")
+        ok = working_event(role="r", key="k", value="payload")
+        self.assertTrue(ok)
+        wm = get_working_memory()
+        self.assertEqual(
+            wm.get(session_id="s_bound", turn_id="s_bound:1",
+                   role="r", key="k"),
+            "payload",
+        )
+
+
+# ─── 5. singleton ───────────────────────────────────────────────────
+
+
+class SingletonTests(unittest.TestCase):
+
+    def setUp(self):
+        _clear_singleton_for_tests()
+
+    def tearDown(self):
+        _clear_singleton_for_tests()
+
+    def test_singleton_is_stable(self):
+        a = get_working_memory()
+        b = get_working_memory()
+        self.assertIs(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **turn-scoped scratch store** sibling to the episodic memory that landed in PR-9. Where episodic captures the **final** plan/reflect/verify decisions across turns within a session, working memory holds **intra-turn** intermediate state that reasoning stages hand off to each other while one answer is being built — reflection critique drafts, per-claim verifier intermediates, planner subtask scratch.

Anticipated by ARCHITECTURE.md §5.7.2:
> "Reflection state — working memory only — **not persisted by default**; episodic memory captures only the **final** verified answer trace."

## Why a sibling, not a column in episodic

| Dimension | Working memory | Episodic memory (PR-9) |
|---|---|---|
| Lifetime | one turn (cleared at turn end) | session, 7-day retention |
| Storage | in-process dict | SQLite \`james_episodic.db\` |
| Isolation key | \`(session_id, turn_id)\` | \`(session_id, ...)\` |
| Cross-turn read? | **never** | yes (PR-9b cross-turn injection) |
| Typical contents | reflect drafts, per-claim claims, subtask scratch | final decisions only |
| Process restart | gone | survives |

Conflating them would force one of the two invariants to weaken — see [\`docs/design/v0.3-working-memory.md\`](docs/design/v0.3-working-memory.md).

## What ships in PR-10a

- \`core/memory/working.py\` — \`WorkingMemory\` class (\`set\` / \`get\` / \`keys\` / \`clear_turn\` / \`prune_idle_turns\`), module-level singleton (\`get_working_memory\`), and \`working_event()\` helper that reads \`(session_id, turn_id)\` from \`core.observability.current_session\` (PR-9b ContextVar — no new bindings).
- \`core/memory/__init__.py\` — public re-exports.
- \`docs/design/v0.3-working-memory.md\` — full design.
- \`tests/test_working_memory.py\` — 15 contract locks.

## What does NOT ship (PR-10b)

- No call sites in \`reflect.py\`, \`verify.py\`, \`planner.py\`, or \`pipeline_synth.py\`.
- No \`engine.query()\` finally-block clear_turn hook.

The infra/wiring split mirrors PR-9a (#283) → PR-9b (#354).

## Verification

- [x] \`pytest tests/test_working_memory.py\` → **15 passed**
- [x] \`pytest tests/\` (server-import excluded) → **2204 passed** (was 2189 before; +15 new)
- [x] STEP 7 bench: not re-run (infra-only, no production call sites; baseline holds from PR #357).

15 contract locks:

| Test | Verifies |
|---|---|
| round-trip / default-on-miss / overwrite | API basics |
| turn isolation | the strictest invariant (stricter than session) |
| session isolation | sibling boundary |
| keys() per role | enumeration |
| clear_turn / clear_turn missing | bucket pop |
| prune_idle_turns / prune negative raises | retention sweep |
| concurrent writes no data loss | thread-safety sanity |
| working_event no-op unbound | ContextVar gate when uninstrumented |
| working_event writes when bound | ContextVar happy path |
| singleton stability | get_working_memory returns same instance |

## Files

- \`core/memory/working.py\` (new)
- \`core/memory/__init__.py\` (+5 lines: imports + __all__)
- \`tests/test_working_memory.py\` (new)
- \`docs/design/v0.3-working-memory.md\` (new)
- \`docs/handovers/v0.3-cognitive-layer-track.md\` (PR-10 row split into PR-10a done + PR-10b pending)
- \`CHANGELOG.md\` — Added entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)