### PR TITLE
feat(reasoning): wire working memory turn-end cleanup (PR-10b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Working memory turn-end cleanup wired into `engine.query()`
+  (Cognitive Phase 3 PR-10b)** — the public `query()` is now a
+  thin try/finally wrapper that delegates to a new `_query_impl`;
+  the finally block clears the turn's working-memory scratch and
+  releases the session ContextVar on every return path, including
+  exception unwinds and the early `_blocked_result` returns from
+  `pre_check`. Before this PR, a crashed turn or a pre_check
+  rejection could leave the session ContextVar bound at the thread
+  level — the next request reusing that thread would have
+  inherited a stale `(session_id, turn_id)` until
+  `set_session_context` ran again. Working memory had no production
+  call sites yet (PR-10a infra-only), but the same cleanup invariant
+  now holds end-to-end before the wiring sites are added in a
+  future PR. 3 new integration tests in `tests/test_working_memory.py`
+  lock the contract (normal return, exception, early blocked
+  return). `tests/test_chat_mode_picker.py::test_engine_query_validates_override`
+  updated to scan both `query()` and `_query_impl` for the override
+  whitelist since the validation logic now lives in `_query_impl`.
+
 - **Working memory infrastructure (Cognitive Phase 3 PR-10a)** —
   `core/memory/working.py` ships a turn-scoped scratch store sibling
   to the episodic memory landed in PR-9. Where episodic captures the

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -102,6 +102,53 @@ class ReasoningEngine:
         selected_model: str     = "",          # [#A2 phase 2] 사용자가 picker로 고른 LLM tag — 모드 결정 후 catalog 대조
         **kwargs,
     ) -> Dict[str, Any]:
+        """Public reasoning entry point.
+
+        Wraps the implementation in a ``try/finally`` so every return
+        path — including ``_blocked_result`` and exception unwinds —
+        releases the turn's working-memory scratch (PR-10b). The
+        previous body lives in ``_query_impl``; this method is a
+        thin wrapper so the cleanup invariant is impossible to skip.
+        """
+        try:
+            return self._query_impl(
+                user_query, user_role, source_type, session_id,
+                response_style, mode_override, selected_model,
+                **kwargs,
+            )
+        finally:
+            # PR-10b — release the turn's scratch and clear the
+            # session ContextVar so the next request in this
+            # thread starts uninstrumented. Both wrapped in try
+            # so a teardown failure cannot eclipse a real exception
+            # bubbling up from the impl.
+            try:
+                from core.observability import (
+                    get_session_context,
+                    set_session_context,
+                )
+                _sid, _tid = get_session_context()
+                if _sid and _tid:
+                    try:
+                        from core.memory.working import get_working_memory
+                        get_working_memory().clear_turn(_sid, _tid)
+                    except Exception:
+                        pass
+                set_session_context("", "")
+            except Exception:
+                pass
+
+    def _query_impl(
+        self,
+        user_query:  str,
+        user_role:   str        = None,
+        source_type: Optional[str] = "prod",
+        session_id:  str        = "default",
+        response_style: str     = "",
+        mode_override:  str     = "",
+        selected_model: str     = "",
+        **kwargs,
+    ) -> Dict[str, Any]:
         """
         전체 추론 파이프라인.
 

--- a/docs/handovers/v0.3-cognitive-layer-track.md
+++ b/docs/handovers/v0.3-cognitive-layer-track.md
@@ -176,7 +176,7 @@ LAYER 5  Docker isolation (1 container per agent)
 | **PR-9a** Episodic store | `core/memory/episodic.py` — session-scoped event log + SQLite schema + 24 tests | ✓ (이미 머지됨) |
 | **PR-9b** Episodic wiring | 4 cognitive stage 의 `record_event()` + ContextVar 전파 + cross-turn 컨텍스트 주입 + `GET /admin/episodic/{session_id}` | ✓ (본 PR) |
 | **PR-10a** Working memory infra | `core/memory/working.py` — turn-scoped scratch (in-process dict, ContextVar 재활용). wiring 0 | ✓ (본 PR) |
-| **PR-10b** Working memory wiring | reflect/verify/planner/synth call sites + engine.query finally hookup | pending |
+| **PR-10b** Working memory wiring | engine.query finally hookup (이번 PR — minimal: clear_turn + ContextVar reset). 의미 있는 read 측 wiring 은 PR-12 Context Optimizer 에서 진행. write 측 stash 는 그때 동반. | ✓ (본 PR) |
 | **PR-11** (선택) Long-term graph evolution | entity 외 **event 노드** 추가 — 디자인 §3 graph evolution 시드 | pending |
 
 ### Phase 4 — Controlled Multi-Agent

--- a/tests/test_chat_mode_picker.py
+++ b/tests/test_chat_mode_picker.py
@@ -78,11 +78,24 @@ class BackendModeOverrideTests(unittest.TestCase):
 
     def test_engine_query_validates_override(self):
         # Engine must check the override is a known mode AND role-allowed.
-        # Bound to query() function — find next `def ` after.
-        idx = self.eng_src.index("def query(")
-        m = re.search(r"\n    def\s+\w+\(", self.eng_src[idx + 1:])
-        end = idx + 1 + m.start() if m else idx + 12000
-        body = self.eng_src[idx:end]
+        # PR-10b split the request lifecycle: ``query()`` is now a thin
+        # try/finally wrapper that delegates to ``_query_impl`` where
+        # the override validation actually lives. Scan whichever
+        # method's body holds the override logic.
+        for fn_name in ("_query_impl", "query"):
+            try:
+                idx = self.eng_src.index(f"def {fn_name}(")
+            except ValueError:
+                continue
+            m = re.search(r"\n    def\s+\w+\(", self.eng_src[idx + 1:])
+            end = idx + 1 + m.start() if m else idx + 12000
+            body = self.eng_src[idx:end]
+            if "VALID_OVERRIDES" in body:
+                break
+        else:
+            self.fail("no engine method body contains VALID_OVERRIDES — "
+                      "override whitelist must live in query() or "
+                      "_query_impl")
         self.assertIn("VALID_OVERRIDES", body,
                       "engine must whitelist valid override modes")
         self.assertIn("ROLE_ALLOWED", body,

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -293,5 +293,138 @@ class SingletonTests(unittest.TestCase):
         self.assertIs(a, b)
 
 
+# ─── 6. engine.query() finally-block hook (PR-10b) ──────────────────
+
+
+class EngineQueryFinallyTests(unittest.TestCase):
+    """PR-10b — verify that engine.query() releases the turn's
+    working-memory scratch and clears the session ContextVar on
+    every return path (including exception unwinds inside
+    _query_impl).
+    """
+
+    def setUp(self):
+        _clear_singleton_for_tests()
+        set_session_context("", "")
+
+    def tearDown(self):
+        _clear_singleton_for_tests()
+        set_session_context("", "")
+
+    def _wm(self):
+        return get_working_memory()
+
+    def test_query_clears_working_memory_on_normal_return(self):
+        """Happy path: a normal return through _query_impl still
+        triggers the finally clear. We stub _query_impl so the test
+        stays hermetic (no Ollama / retrieval roundtrip).
+        """
+        from core.reasoning.engine import ReasoningEngine
+        engine = ReasoningEngine.__new__(ReasoningEngine)
+
+        captured = {}
+
+        def fake_impl(user_query, user_role=None, source_type="prod",
+                      session_id="default", response_style="",
+                      mode_override="", selected_model="", **kwargs):
+            # While inside the impl, the ContextVar must be bound
+            # and a working-memory write must land in the right
+            # bucket. The wrapper sets the ContextVar BEFORE
+            # delegating — except _query_impl is what sets it in
+            # the real engine. Mimic that here.
+            from core.observability import set_session_context
+            tid = f"{session_id}:1"
+            set_session_context(session_id, tid)
+            self._wm().set(
+                session_id=session_id, turn_id=tid,
+                role="reflect.draft", key="text", value="draft v1",
+            )
+            captured["sid"] = session_id
+            captured["tid"] = tid
+            return {"answer": "ok", "blocked": False}
+
+        engine._query_impl = fake_impl
+
+        out = engine.query("hello", session_id="s_normal")
+        self.assertEqual(out["answer"], "ok")
+
+        # finally must have released the slot
+        self.assertIsNone(
+            self._wm().get(session_id=captured["sid"],
+                            turn_id=captured["tid"],
+                            role="reflect.draft", key="text"),
+            "working memory must be cleared after query() returns",
+        )
+        # ContextVar must be released so the next request starts clean
+        from core.observability import get_session_context
+        sid, tid = get_session_context()
+        self.assertEqual((sid, tid), ("", ""),
+            "session ContextVar must be cleared in finally")
+
+    def test_query_clears_working_memory_on_exception(self):
+        """Critical invariant: if _query_impl raises, the finally
+        block still releases the scratch. Otherwise a single
+        crashed turn would leak its slots until the prune sweep.
+        """
+        from core.reasoning.engine import ReasoningEngine
+        engine = ReasoningEngine.__new__(ReasoningEngine)
+
+        captured = {}
+
+        def crashing_impl(user_query, user_role=None, source_type="prod",
+                          session_id="default", response_style="",
+                          mode_override="", selected_model="", **kwargs):
+            from core.observability import set_session_context
+            tid = f"{session_id}:bang"
+            set_session_context(session_id, tid)
+            self._wm().set(
+                session_id=session_id, turn_id=tid,
+                role="verify.claims", key="c1", value="written before crash",
+            )
+            captured["sid"] = session_id
+            captured["tid"] = tid
+            raise RuntimeError("synthetic mid-turn failure")
+
+        engine._query_impl = crashing_impl
+
+        with self.assertRaises(RuntimeError):
+            engine.query("oops", session_id="s_crash")
+
+        self.assertIsNone(
+            self._wm().get(session_id=captured["sid"],
+                            turn_id=captured["tid"],
+                            role="verify.claims", key="c1"),
+            "exception must not skip the finally clear",
+        )
+        from core.observability import get_session_context
+        self.assertEqual(get_session_context(), ("", ""))
+
+    def test_query_clears_when_blocked_early(self):
+        """pre_check failures return through _blocked_result without
+        the ContextVar ever being bound. The wrapper must still
+        clear safely — set_session_context("","") is a no-op
+        when nothing was bound.
+        """
+        from core.reasoning.engine import ReasoningEngine
+        engine = ReasoningEngine.__new__(ReasoningEngine)
+
+        def early_return_impl(*args, **kwargs):
+            # No set_session_context call → ContextVar stays empty.
+            return {"answer": "blocked", "blocked": True}
+
+        engine._query_impl = early_return_impl
+        # Pre-bind to verify the wrapper actively clears even what
+        # was already there before the call.
+        set_session_context("preexisting", "preexisting:0")
+
+        out = engine.query("x", session_id="s_blocked")
+        self.assertTrue(out["blocked"])
+        from core.observability import get_session_context
+        self.assertEqual(get_session_context(), ("", ""),
+            "wrapper must clear even when impl never touched the "
+            "ContextVar — a stale pre-existing binding must not "
+            "leak into the next request")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Wraps \`engine.query()\` in \`try/finally\` so every return path — including exception unwinds and the early \`_blocked_result\` returns from \`pre_check\` — releases the turn's working-memory scratch (PR-10a) and clears the session ContextVar (PR-9b).

### Before

A crashed turn or pre_check rejection could leave the session ContextVar bound at the thread level. The next request reusing that FastAPI thread-pool worker would inherit a stale \`(session_id, turn_id)\` until \`set_session_context\` ran again at the next normal entry. The window was small, but the invariant "ContextVar is empty between requests" was leaky.

### After

\`query()\` is a 50-line wrapper that delegates to a new \`_query_impl\` (body moved verbatim, no logic changes). The finally block:

\`\`\`python
finally:
    sid, tid = get_session_context()
    if sid and tid:
        get_working_memory().clear_turn(sid, tid)
    set_session_context(\"\", \"\")
\`\`\`

Both wrapped in try so a teardown failure cannot eclipse a real exception bubbling up from the impl.

## Honest scope note

Working memory has **no production call sites yet** — PR-10a was infra-only. This PR establishes the cleanup invariant first so the wiring sites added later inherit a clean lifecycle. The meaningful read-side use of working memory (token-budget-aware evidence drop, plan-trace lookup) lives in **PR-12 Context Optimizer**; per-stage write sites (reflect critique, verify per-claim) land alongside that PR because their value is paired with a read consumer.

## Verification

- [x] \`pytest tests/test_working_memory.py\` → **18 passed** (15 unit + 3 new integration)
- [x] \`pytest tests/\` (server-import excluded) → **2207 passed** (was 2204; +3 new)
- [x] \`scripts/bench.py --suite=step7 --check\` → **OK, within baseline tolerances**

3 new EngineQueryFinallyTests:

| Test | Verifies |
|---|---|
| \`test_query_clears_working_memory_on_normal_return\` | happy path |
| \`test_query_clears_working_memory_on_exception\` | exception unwind still triggers finally |
| \`test_query_clears_when_blocked_early\` | pre_check rejection + stale pre-existing ContextVar both get cleared |

One pre-existing test updated:

- \`tests/test_chat_mode_picker.py::test_engine_query_validates_override\` — scans both \`query()\` and \`_query_impl\` for \`VALID_OVERRIDES\` since the override whitelist now lives in \`_query_impl\`.

## Files

- \`core/reasoning/engine.py\` — \`query()\` → \`_query_impl\` split + try/finally wrapper.
- \`tests/test_working_memory.py\` — \`EngineQueryFinallyTests\` class (3 tests).
- \`tests/test_chat_mode_picker.py\` — search both methods.
- \`CHANGELOG.md\` — Added entry.
- \`docs/handovers/v0.3-cognitive-layer-track.md\` — PR-10b marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)