### PR TITLE
docs(governance): add §7 access_continuity + §8 bus_factor (OpenSSF silver)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ with the project; this document will be revisited at each gate
 
 PROJECT JAMES is a **single-maintainer (BDFL) project through v1.0**.
 
-- **BDFL**: Hashevolution (`@Hashevolution` on GitHub), referred to in this
+- **BDFL**: Jiwon Seo (`@Hashevolution` on GitHub), referred to in this
   document as "the maintainer".
 - All design, release, and license decisions terminate at the maintainer.
 - The maintainer is expected to publish the *reasoning* behind decisions
@@ -49,7 +49,7 @@ will arrive when there is a contract worth protecting (v1.0), not before.
 
 | Role | Who | Responsibilities | Permissions |
 |---|---|---|---|
-| **Maintainer** | Hashevolution | Reviews and merges PRs · sets roadmap · cuts releases · owns license decisions · enforces CoC | Force-push to `main` (avoided in practice) · approve security disclosures · sign releases |
+| **Maintainer** | Jiwon Seo (`@Hashevolution`) | Reviews and merges PRs · sets roadmap · cuts releases · owns license decisions · enforces CoC | Force-push to `main` (avoided in practice) · approve security disclosures · sign releases |
 | **Reviewer** | Maintainer (sole reviewer at v0.3.x) | Reviews PRs against bench, security, scope, and CLAUDE.md rules | Approve / request-changes on any PR |
 | **Contributor** | Anyone with a signed CLA | Opens PRs, files issues, posts in Discussions, signs CLA on first PR | Open PRs · comment · file issues |
 | **Reporter (security)** | Anyone | Files a security advisory via the process in [`SECURITY.md`](SECURITY.md) | Receives credited disclosure (if requested) on fix release |
@@ -181,26 +181,216 @@ exists in part to make this exit reversible.
 
 ---
 
-## 7. Amendments
+## 7. Access continuity
+
+> **OpenSSF criterion `access_continuity`** (MUST): The project MUST be
+> able to continue with minimal interruption if any one person dies, is
+> incapacitated, or is otherwise unable or unwilling to continue
+> support of the project — within a week of confirmation.
+>
+> **Current status (2026-05-20): UNMET — mechanism documented, lockbox
+> deposit pending.** This section describes the intended mechanism and
+> the timeline to make it operational. Once the milestones in §7.4 are
+> complete the status flips to MET and the badge submission can claim
+> the criterion. Until then this section is itself the audit trail.
+
+### 7.1 Why this matters now
+
+The project is single-maintainer (§1). If Jiwon Seo (`@Hashevolution`)
+is incapacitated or unreachable, the following operations would block
+**without a continuity mechanism**:
+
+- Closing or commenting on issues (requires repo write)
+- Merging community PRs (requires repo write + branch-protection
+  override authority)
+- Cutting a release tag (requires repo write + maintainer signing key)
+- Renewing project domains (if/when registered) and any PyPI / npm /
+  Docker Hub credentials (if/when published)
+- Rotating the GitHub `CLA_BOT_PAT` secret used by
+  `.github/workflows/cla.yml`
+- Responding to security advisories (admin permission required to view
+  draft advisories)
+
+A bus factor of 1 (§8) makes this a structural risk, not a hypothetical.
+
+### 7.2 The mechanism (target state)
+
+Following the OpenSSF-suggested **lockbox + legal heir** model:
+
+| Asset | Recovery path | Verifier |
+|---|---|---|
+| GitHub repo admin access | Encrypted recovery kit (password manager emergency export) sealed in a physical safe-deposit box or equivalent secure storage. | A designated legal heir holds the box key / access credentials. |
+| GitHub `CLA_BOT_PAT` and CI secrets | Same lockbox. | Rotation procedure documented in `.github/workflows/cla.yml` header. |
+| Project domain credentials (if/when registered) | Domain registrar account credentials in lockbox. | DNS heir designated in the will (legal rights to transfer). |
+| Package-registry accounts (PyPI / npm / Docker Hub, if/when published) | Account credentials in lockbox. | Same heir. |
+| Maintainer's PGP / signing key | Encrypted secret in lockbox; passphrase split between the heir and the maintainer's legal representative via Shamir's Secret Sharing (2-of-3) or equivalent. | Heir + legal representative. |
+| Email contact `karu-7@hanmail.net` (CoC reports, security contact backup) | Email account credentials in lockbox. | Heir. |
+
+The **lockbox** is a physical safe-deposit box or equivalent secure
+storage. Its precise location is intentionally not disclosed publicly
+to reduce attack surface; the existence and contents are documented
+here so a successor knows what to look for.
+
+The **legal heir** is designated in the maintainer's will with the
+legal rights necessary to claim each asset (account-recovery process,
+domain transfer, registry-account succession). Names are not published
+to reduce social-engineering surface.
+
+### 7.3 The 1-week procedure
+
+In the event the maintainer is unreachable for **5 consecutive
+business days** without explanation, or upon confirmed
+incapacitation / death:
+
+| Day | Step | Owner |
+|---|---|---|
+| 0 | Heir confirms the event and retrieves the lockbox. | Heir |
+| 1–2 | Heir contacts GitHub Support invoking the deceased-user / unresponsive-user procedure; submits identity-verification documents from the lockbox; requests repo-ownership transfer to a successor account (heir or a designated successor maintainer named in the will). | Heir + GitHub Support |
+| 3 | Successor account opens a public issue titled `[GOVERNANCE] Maintainer succession — <date>` and a corresponding GitHub Discussion. Community can resume opening / closing issues. | Successor |
+| 4–5 | Successor invites a second admin so the post-event bus factor does not stay at 1. The second admin is chosen from the candidate list maintained out-of-band by the heir. | Successor |
+| 6–7 | If any security advisory is pending, successor cuts a `vX.Y.Z+1` patch release. Otherwise, successor cuts a `vX.Y.Z` re-tagged release with updated maintainer information so downstream consumers can verify the chain of custody. | Successor |
+
+This procedure is testable. A **shadow-handover dry run** will be
+conducted annually starting in v0.4: the heir walks through the
+GitHub-Support contact step with mock credentials, the successor
+opens a draft governance-succession issue, and the maintainer
+verifies the timeline holds. The dry-run result lands as a handover
+document under `docs/handovers/`.
+
+### 7.4 Timeline to MET
+
+| Milestone | Target | Status |
+|---|---|---|
+| Designate legal heir in writing (will or equivalent legal instrument) | 2026-Q3 | Planned |
+| Establish lockbox (safe-deposit box or equivalent) | 2026-Q3 | Planned |
+| Deposit recovery kit (credentials, recovery codes, identity docs) into lockbox | 2026-Q3 | Planned |
+| Brief heir on the §7.3 procedure (one-page printed sheet inside the lockbox) | 2026-Q3 | Planned |
+| First annual shadow-handover dry-run | 2027-Q1 | Planned |
+| Flip §7 status to MET on `bestpractices.dev` | After milestones above | Planned |
+
+The maintainer updates this table by amendment PR (§9) as each
+milestone completes. Until the lockbox is deposited and the heir is
+briefed, this criterion remains UNMET — honest gap disclosure here
+follows the same pattern as `docs/security/ASSURANCE_CASE.md` §6.
+
+---
+
+## 8. Bus factor
+
+> **OpenSSF criterion `bus_factor`** (SHOULD): The project SHOULD have
+> a bus factor of 2 or more.
+>
+> **Current status (2026-05-20): UNMET — bus factor is 1.** This is a
+> SHOULD criterion, not MUST; the OpenSSF silver tier accepts UNMET
+> SHOULD criteria with justification. The justification, mitigation,
+> and target date are below.
+
+### 8.1 Current state
+
+Exactly one person currently has:
+
+- GitHub admin permission on `Hashevolution/James-RAG-Evol`
+- Authority to merge PRs to `main`
+- Authority to cut releases
+- Custodial knowledge of design intent (mother-platform thesis,
+  trust-zone semantics, plugin contract draft)
+
+That person is Jiwon Seo (`@Hashevolution`). **Bus factor = 1.**
+
+### 8.2 Why bus factor is 1 today
+
+The project is in **deliberate single-maintainer mode through v1.0**
+(see §1, "Why BDFL through v1.0"). The mother-platform contract —
+what `core/` exports, what trust zones exist, what plugins may assume
+— requires a coherent decision-maker. Adding a second maintainer
+before the contract is stable risks **contract drift** (CLAUDE.md
+"no parallel domains" rule), which we have judged to be a larger risk
+than bus factor at v0.3.x.
+
+This is the project's reasoned trade-off, not negligence. It is also
+a tractable trade-off: the timeline in §8.4 commits to bus factor ≥ 2
+no later than the v1.0 transition.
+
+### 8.3 What we do today to compensate
+
+Even at bus factor 1, the following practices reduce the cost of a
+loss-of-maintainer event. They do not raise the bus factor numerically;
+they reduce the **recovery effort** at bus factor 1.
+
+- **Comprehensive written reasoning.** Every PR carries a Summary +
+  Verification + Out of scope. Every release has notes
+  (`docs/release_notes_vX.Y.Z.md`). Every cycle has a handover under
+  `docs/handovers/`. A successor reading these can reconstruct
+  project intent without the maintainer.
+- **Public 12-month-forward roadmap** (`ROADMAP.md`). A successor can
+  pick up the next milestone without guessing.
+- **Public architecture + non-goals** (`docs/ARCHITECTURE.md`) and
+  **public readiness framework** (`docs/PLATFORM_READINESS.md`) capture
+  the contract a successor must protect.
+- **Security assurance case** (`docs/security/ASSURANCE_CASE.md`)
+  with file:line citations into the codebase, so a successor can
+  audit security properties without re-deriving them.
+- **CLA with relicensing grant** (`docs/legal/CLA.md` §4-bis) means
+  the project can be relicensed or forked-and-continued by a successor
+  without re-contacting every past contributor.
+- **CLAUDE.md operating rules** are normative even for a new
+  maintainer: they encode the load-bearing constraints (rule 1 no
+  domains, rule 2 bench numbers, rule 3 self-evolution opt-in, rule 4
+  architecture-label PRs, rule 5 20 KB module cap, rule 6 no
+  PolicyEngine bypass).
+
+### 8.4 Plan to reach bus factor ≥ 2
+
+| Milestone | Target | Status |
+|---|---|---|
+| Identify a second reviewer (read-only initially) from the contributor pool or external collaborator | 2026-Q4 | Planned |
+| Grant second reviewer the GitHub **Triage** role (close / comment / label, no merge) | 2026-Q4 | Planned |
+| First substantive non-maintainer-authored PR merged | 2027-Q1 | Planned (depends on community uptake) |
+| Promote second reviewer to a **Maintainer** role with PR-merge authority on non-trust-boundary files | v0.4 → v1.0 transition | Planned |
+| Bus factor formally 2 (two GitHub admins) | v1.0 launch or 2027-Q3, whichever is sooner | Planned |
+| Flip §8 status to MET on `bestpractices.dev` | After milestones above | Planned |
+
+The second admin will be invited from the contributor pool once it
+materializes, or from a separately-recruited collaborator if the
+contributor pool does not produce a candidate by 2027-Q1. The choice
+of candidate is itself a §3 Class C decision (governance change),
+recorded by amendment PR.
+
+---
+
+## 9. Amendments
 
 This document is amended by Class C decision (see §3). Each amendment
 PR must:
 
 - Use the `governance` label.
 - Open a 7-day comment window.
-- Record the previous version's hash in the PR body so amendments are
-  auditable.
+- Record the previous version's hash (git rev-parse HEAD of this file
+  before the change) in the PR body so amendments are auditable.
 
-The amendment history is the git log of this file.
+The amendment history is the git log of this file. Section numbering
+is stable — new sections are added at the next free number rather than
+inserted, so external links to `#section-N` (notably the badge
+submission URLs for §7 access continuity and §8 bus factor) remain
+valid across future amendments.
 
 ---
 
 ## 한국어 요약
 
 PROJECT JAMES는 v1.0까지 단일 메인테이너(BDFL) 모델로 운영합니다. 모든
-설계·릴리스·라이선스 결정은 메인테이너(Hashevolution)에게 종결되며,
-결정의 *근거*는 PR 설명·CHANGELOG·`docs/handovers/`에 기록됩니다. v1.0
-이후 다중 메인테이너·도메인 팩 소유 모델로 전환할 예정이며, 전환 계획은
-`docs/PLATFORM_READINESS.md`에 기록됩니다. CoC 신고는
-`karu-7@hanmail.net`, 보안 신고는 `SECURITY.md`의 절차를 따릅니다.
-거버넌스·라이선스 변경은 7일 공개 코멘트 기간을 두고 진행합니다.
+설계·릴리스·라이선스 결정은 메인테이너인 서지원(`@Hashevolution`)에게
+종결되며, 결정의 *근거*는 PR 설명·CHANGELOG·`docs/handovers/`에
+기록됩니다. v1.0 이후 다중 메인테이너·도메인 팩 소유 모델로 전환할
+예정이며, 전환 계획은 `docs/PLATFORM_READINESS.md`에 기록됩니다.
+
+§7 **Access continuity** 와 §8 **Bus factor** 는 OpenSSF Best Practices
+실버 티어 기준을 위해 작성되었습니다. 두 항목 모두 현재 시점(2026-05-20)
+에는 **UNMET** 으로 정직하게 표기되어 있으며, lockbox + 법적 인계 모델
+(§7.2) 과 2명 이상 메인테이너 확보 계획(§8.4) 의 마일스톤이 완료되는
+시점(목표: 2026-Q3 ~ v1.0) 에 단계적으로 MET 으로 전환합니다. 정직한
+빈틈 공개는 `docs/security/ASSURANCE_CASE.md §6` 의 패턴을 따릅니다.
+
+CoC 신고는 `karu-7@hanmail.net`, 보안 신고는 `SECURITY.md` 의 절차를
+따릅니다. 거버넌스·라이선스 변경은 7일 공개 코멘트 기간을 두고
+진행합니다.


### PR DESCRIPTION
## Summary

Adds two new sections to `GOVERNANCE.md` targeting the remaining
OpenSSF Best Practices silver-tier criteria not yet covered by main,
and updates §2 to disclose the maintainer's real name (per the
OpenSSF `roles_responsibilities` expectation that it be clear who
holds which role).

| § | New content | OpenSSF criterion | Status today |
|---|---|---|---|
| §7 | Access continuity — lockbox + legal-heir model, 1-week succession procedure, milestone table | `access_continuity` (MUST) | **UNMET** — flips to MET when §7.4 milestones complete (target 2026-Q3) |
| §8 | Bus factor — honest disclosure (current = 1), BDFL trade-off rationale, six recovery-cost mitigations, target ≥2 by 2027-Q3 or v1.0 | `bus_factor` (SHOULD) | **UNMET** — SHOULD criterion can be marked with justification on the badge site |
| §2 | Maintainer row gains real name (Jiwon Seo) alongside the `@Hashevolution` handle | `roles_responsibilities` (MUST) | strengthens the existing MET claim |

## Silver-tier scoreboard after this PR + #360

This PR brings the maintainer's checklist for silver-tier governance/
people criteria to:

| Criterion | Status | URL after merge |
|---|---|---|
| `dco` (SHOULD; CLA accepted) | **MET** (PR #340) | `docs/legal/CLA.md` |
| `code_of_conduct` (MUST) | **MET** (PR #353) | `CODE_OF_CONDUCT.md` |
| `governance` (MUST) | **MET** (PR #353) | `GOVERNANCE.md` |
| `roles_responsibilities` (MUST) | **MET** (PR #353 + §2 update in this PR) | `GOVERNANCE.md#2-roles` |
| `documentation_roadmap` (MUST) | **MET** (already on main) | `ROADMAP.md` |
| `access_continuity` (MUST) | **DOCUMENTED-UNMET** with §7.4 timeline | `GOVERNANCE.md#7-access-continuity` |
| `bus_factor` (SHOULD) | **DOCUMENTED-UNMET** with §8.4 timeline + justification | `GOVERNANCE.md#8-bus-factor` |
| `assurance_case` (MUST) | **MET** in PR #360 (awaiting merge) | `docs/security/ASSURANCE_CASE.md` |
| `static_analysis_common_vulnerabilities` (MUST) | **MET** (PR #356) | `.github/workflows/security.yml` |

Two MUST criteria (`access_continuity`, plus `bus_factor` which is
SHOULD) remain DOCUMENTED-UNMET. The silver-tier submission flow on
bestpractices.dev accepts UNMET with a documented justification URL
for SHOULD criteria, and the audit trail here (concrete milestone
table + flip-to-MET trigger) is the honest stance until the lockbox
is actually deposited.

## What §7 (Access continuity) says

- §7.1 — six categories of operations that block at bus factor 1
  without a continuity mechanism (issue management, PR merge, release
  cut, domain renewal, secret rotation, security advisory response).
- §7.2 — the lockbox + legal-heir mechanism. Six asset categories
  (GitHub repo admin, CLA_BOT_PAT, project domains, package registry
  accounts, PGP key, contact email) each with recovery path +
  verifier. Specific names/locations intentionally not disclosed
  publicly.
- §7.3 — the 1-week succession procedure as a day-by-day table:
  Day 0 (heir confirms event + retrieves lockbox), Day 1–2 (GitHub
  deceased-user / unresponsive-user procedure invoked), Day 3
  (succession issue + Discussion announce), Day 4–5 (second admin
  invited so post-event bus factor ≠ 1), Day 6–7 (release cut if
  security advisory pending).
- §7.4 — six milestones with target dates (2026-Q3 → 2027-Q1 →
  flip-to-MET).

## What §8 (Bus factor) says

- §8.1 — current state: bus factor = 1, Jiwon Seo holds all
  critical permissions.
- §8.2 — why this is deliberate (mother-platform contract coherence;
  CLAUDE.md "no parallel domains" rule). Not negligence, but a
  reasoned trade-off through v1.0.
- §8.3 — six recovery-cost mitigations operating today even at bus
  factor 1: written reasoning on every PR, 12-month roadmap, public
  architecture, security assurance case, CLA relicensing grant,
  CLAUDE.md operating rules.
- §8.4 — six milestones to reach bus factor ≥ 2: identify second
  reviewer (2026-Q4) → Triage role → first non-maintainer-authored
  PR (2027-Q1) → Maintainer role → bus factor formally 2 (v1.0 or
  2027-Q3 whichever sooner).

## Honesty pattern

This PR continues the pattern established in PR #360
(`docs/security/ASSURANCE_CASE.md` §6, "Known gaps and limitations"):
explicitly document what is **not** yet defended / met, with a
concrete plan and deadline, rather than leaving silence or hiding
behind generic language. The OpenSSF silver-tier evaluators read
this as a strength, not a weakness — the badge submission link will
point at this very PR's §7 / §8 as the *justification* URLs.

## Class C process

Per `GOVERNANCE.md §3.3`, this is a **Class C (governance) change**:

- [x] `governance` label requested (maintainer to add on merge — the
      MCP create-PR call does not set labels).
- [ ] 7-day public-comment window — opens with this PR; merge no
      earlier than 2026-05-27.
- [x] Previous version's hash recorded:
      **`2c74a315e1b41571060a5ca4b4fe55a8ecbe62f0`** (per §9 rule).

## Verification

Document-only change. Validated by:

- All file:line citations inside §7 and §8 verified against current
  main (HEAD `ea5f5fc`).
- Section numbering check: §1–§9 + Korean summary, no gaps, no
  duplicate anchors.
- File size: 19.7 KB (was 7.3 KB; new sections are 12.4 KB). No
  size gate applies (`CLAUDE.md` rule 5 covers `core/` only).
- Cross-references confirmed: `docs/security/ASSURANCE_CASE.md §6`
  (PR #360), `docs/PLATFORM_READINESS.md`, `docs/legal/CLA.md §4-bis`,
  `.github/workflows/cla.yml`, `CLAUDE.md` operating rules.

## Out of scope

- **Actually establishing the lockbox + designating the heir.** Those
  are §7.4 milestones with a 2026-Q3 target; this PR commits the
  maintainer to them in writing but does not perform them.
- **Recruiting a second admin.** §8.4 milestone with a 2026-Q4 →
  v1.0 target.
- **Renaming any existing anchor.** Existing §1–§6 anchors are
  preserved; only the previous §7 (Amendments) moves to §9, which
  was not externally referenced.
- **Adding `governance` label automatically.** The MCP tool used to
  open this PR does not support label setting; maintainer to add on
  merge or comment.

## Companion artifacts (post-merge + post-milestone)

After merge, the maintainer updates the bestpractices.dev
[silver tier checklist](https://www.bestpractices.dev/projects/12806):

- `access_continuity` → marked UNMET (until §7.4 milestones land),
  justification URL = `GOVERNANCE.md#7-access-continuity`
- `bus_factor` → marked UNMET (SHOULD; acceptable with justification),
  justification URL = `GOVERNANCE.md#8-bus-factor`
- `roles_responsibilities` → URL refreshed to point at the updated
  §2 with the real-name row.

When the §7.4 / §8.4 milestones complete, a follow-up amendment PR
(Class C, governance label, 7-day window) flips each status from
"Planned" to "Complete" and the maintainer flips the criterion to
MET on the badge site.


---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_