### PR TITLE
chore(gitignore): cover SQLite WAL/SHM sidecar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,17 @@ ENV/
 *.db
 *.sqlite
 *.sqlite3
+# SQLite WAL/SHM/journal 사이드카 — *.db 글롭이 못 잡음
+*.db-shm
+*.db-wal
+*.db-journal
+*.sqlite-shm
+*.sqlite-wal
+*.sqlite-journal
 james_users.db
 james_audit.db
 james_sessions.db
+james_episodic.db
 chroma_db/
 /memory/
 workspace/


### PR DESCRIPTION
## Summary
- `james_episodic.db-shm` / `.db-wal` from PR-9a/9b episodic store
  were showing up untracked because the `*.db` glob does not match
  SQLite's auxiliary sidecar files.
- Add explicit `*.db-shm` / `*.db-wal` / `*.db-journal` patterns for
  both `.db` and `.sqlite`, plus add `james_episodic.db` to the
  named-DB list alongside `james_users.db` / `james_audit.db` /
  `james_sessions.db`.

## Verification
- `git status` before: 2 WAL/SHM files untracked
- `git status` after: 0 (gitignored)
- No code change, no test impact (gitignore-only)

## Out of scope
- Two stray 0-byte files (`의` / `문서`) at repo root are user
  artifacts from an earlier shell mishap; left for the user to
  remove (not deleted by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)