### PR TITLE
fix(tests): drop unused current_session import (ruff F401)

### DIFF
--- a/tests/test_episodic_wiring.py
+++ b/tests/test_episodic_wiring.py
@@ -32,10 +32,7 @@ from core.memory.episodic import (  # noqa: E402
     _clear_singleton_for_tests,
 )
 import core.memory.episodic as _episodic_mod  # noqa: E402
-from core.observability import (  # noqa: E402
-    set_session_context,
-    current_session,
-)
+from core.observability import set_session_context  # noqa: E402
 
 
 def _fresh_episodic_singleton() -> EpisodicMemory:


### PR DESCRIPTION
## Summary
- PR-9b (#354) imported `core.observability.current_session` in
  `tests/test_episodic_wiring.py:37` but never referenced it (only
  `set_session_context` is used).
- ruff F-class enforcement on main is failing as a result, blocking
  every open PR's CI (surfaced on #364's gitignore-only chore).
- Collapse the multi-name import to the one symbol actually used.

## Verification
- `ruff check .` → All checks passed!
- `pytest tests/test_episodic_wiring.py -q` → 8 passed, 0 failed

## Out of scope
- Why PR-9b CI passed at merge time (likely transient ruff
  version/config drift). Not investigated; the fix here is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)