### PR TITLE
feat(schema): event entity helpers — PR-11a-1 (zero wiring)

### DIFF
--- a/core/relations_schema.py
+++ b/core/relations_schema.py
@@ -26,6 +26,7 @@ production 의 `relation["confidence"]` 읽기 경로는 Phase A 단계에서
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 
@@ -47,6 +48,83 @@ VALID_SOURCE_ROLES = frozenset({
 # in [0, 1], so the cap is informational — used to keep the public type
 # contract stable for downstream code that previously saw clamped values.
 CONFIDENCE_CAP = 1.0
+
+
+# ── Entity-type vocabulary (PR-11 graph evolution) ────────────────────
+#
+# 문서: docs/design/v0.3-graph-evolution.md
+#
+# JAMES 그래프의 5 entity type. 처음 4 종 (person/concept/org/document)
+# 은 wiki_generator 가 LLM 추출로 emit. 5번째 `event` 는 시간 축에
+# 묶인 노드로 PR-11 의 핵심. PR-11a-1 시점에는 본 상수만 존재 —
+# production 코드 (wiki_generator.py 등) 는 여전히 4 종 literal 을
+# 사용. lift 는 PR-11a-2 / PR-11b 에서.
+#
+# 이 상수는 *graph-valid* type 의 진실 원천이다. ingest-capable 의
+# subset (현재 4 종) 과 의도적으로 다르다 — admin path 로 생성된
+# event 노드는 ingest 의 emit 과 무관하게 graph 에 존재할 수 있다.
+ENTITY_TYPES_CORE: tuple[str, ...] = (
+    "person",
+    "concept",
+    "org",
+    "document",
+    "event",
+)
+
+# Event-like entity 의 list — core 는 "event" 하나. OntologyPack 의
+# entity_types 가 시간 축을 요구하는 subtype 을 추가하면 loader
+# (PR-11e) 가 이 set 을 mutate. ingest post-processor 와 admin
+# endpoint 가 멤버십으로 occurred_at 강제 여부를 결정한다.
+#
+# set (mutable) 인 이유: loader 가 startup 시점에 추가. 코드 변경 후
+# 런타임 mutate 는 정의되지 않은 동작 (test 환경에서만 _reset_
+# helper 로 의도적으로 변경).
+EVENT_LIKE_ENTITY_TYPES: set[str] = {"event"}
+
+# occurred_at 의 quantization bucket — 디자인 §4.1.
+# 미상 / 분기·연 단위 정보도 명시적으로 표현 가능하도록 5 단계 enum.
+# 저장은 항상 full ISO 8601 (예: "2026-01-10" 또는 "2026-01-10T15:32:00Z"),
+# precision 은 consumer 에게 어디까지 신뢰할지 알려주는 메타데이터.
+VALID_OCCURRED_AT_PRECISIONS: frozenset[str] = frozenset({
+    "year",
+    "month",
+    "day",
+    "hour",
+    "minute",
+})
+
+
+def validate_occurred_at(
+    value: str,
+    precision: str = "day",
+) -> None:
+    """Validate that ``value`` is a parseable ISO 8601 datetime / date
+    string AND that ``precision`` is one of the 5 supported buckets.
+
+    Raises ``ValueError`` on either failure. The function is
+    side-effect-free; callers use it as an admission gate before
+    writing an event node.
+
+    Trailing ``Z`` (Zulu / UTC) is accepted via the standard
+    ``+00:00`` substitution. Naive datetimes (no tz) are accepted —
+    the cascade and retrieval paths treat all stored timestamps as
+    workspace-local unless an explicit offset is present.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            "occurred_at must be a non-empty ISO 8601 string"
+        )
+    if precision not in VALID_OCCURRED_AT_PRECISIONS:
+        raise ValueError(
+            f"occurred_at_precision must be one of "
+            f"{sorted(VALID_OCCURRED_AT_PRECISIONS)}, got {precision!r}"
+        )
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as e:
+        raise ValueError(
+            f"occurred_at not parseable as ISO 8601: {value!r}"
+        ) from e
 
 
 def compute_confidence_from_sources(sources: list | None) -> float:

--- a/tests/test_event_entity_schema.py
+++ b/tests/test_event_entity_schema.py
@@ -1,0 +1,126 @@
+"""PR-11a-1 — event entity schema helpers.
+
+Schema-level guarantees for the upcoming `event` entity type:
+  * the 5-element entity-type tuple lists `event` as the 5th element
+  * `EVENT_LIKE_ENTITY_TYPES` starts as just `{"event"}` (loader
+    extends; tests pin the core baseline)
+  * `validate_occurred_at` accepts canonical ISO 8601 strings and
+    rejects anything else, with a clear error per failure mode
+  * the 5 precision buckets are exactly the documented set
+
+No production wiring yet — this PR is the schema substrate.
+PR-11a-2 lifts the wiki_generator literal, PR-11b adds the ingest
+emit path, PR-11c the time-bucket filter.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.relations_schema import (  # noqa: E402
+    ENTITY_TYPES_CORE,
+    EVENT_LIKE_ENTITY_TYPES,
+    VALID_OCCURRED_AT_PRECISIONS,
+    validate_occurred_at,
+)
+
+
+class EntityTypeVocabularyTests(unittest.TestCase):
+    """The 5-element tuple is the truth source for graph-valid entity
+    types. wiki_generator.py still uses a 4-element literal at this
+    point in the rollout — that drift is intentional and removed in
+    PR-11a-2."""
+
+    def test_entity_types_core_has_five_members_event_last(self):
+        self.assertEqual(len(ENTITY_TYPES_CORE), 5)
+        self.assertEqual(ENTITY_TYPES_CORE[-1], "event")
+
+    def test_entity_types_core_preserves_legacy_four(self):
+        legacy_four = ("person", "concept", "org", "document")
+        self.assertEqual(ENTITY_TYPES_CORE[: len(legacy_four)], legacy_four)
+
+    def test_event_like_entity_types_baseline_is_just_event(self):
+        # OntologyPack loader (PR-11e) extends this set at startup.
+        # Until then the core baseline is exactly one member.
+        self.assertEqual(EVENT_LIKE_ENTITY_TYPES, {"event"})
+
+
+class OccurredAtPrecisionTests(unittest.TestCase):
+    """Five quantization buckets — year, month, day, hour, minute.
+    Day is the default (matches the design memo §4.1)."""
+
+    def test_five_known_precisions(self):
+        self.assertEqual(
+            VALID_OCCURRED_AT_PRECISIONS,
+            frozenset({"year", "month", "day", "hour", "minute"}),
+        )
+
+    def test_validate_accepts_day_precision_default(self):
+        # No raise == OK
+        validate_occurred_at("2026-01-10")
+
+    def test_validate_accepts_every_known_precision(self):
+        for p in VALID_OCCURRED_AT_PRECISIONS:
+            with self.subTest(precision=p):
+                validate_occurred_at("2026-01-10T15:32:00Z", precision=p)
+
+    def test_validate_rejects_unknown_precision(self):
+        with self.assertRaisesRegex(ValueError, "occurred_at_precision"):
+            validate_occurred_at("2026-01-10", precision="quarter")
+
+
+class OccurredAtFormatTests(unittest.TestCase):
+    """ISO 8601 string parsing. Trailing Z accepted, naive datetimes
+    accepted, anything that fromisoformat can't read is rejected."""
+
+    def test_accepts_date_only(self):
+        validate_occurred_at("2026-01-10")
+
+    def test_accepts_datetime_with_z(self):
+        validate_occurred_at("2026-01-10T15:32:00Z")
+
+    def test_accepts_datetime_with_offset(self):
+        validate_occurred_at("2026-01-10T15:32:00+09:00")
+
+    def test_accepts_naive_datetime(self):
+        validate_occurred_at("2026-01-10T15:32:00")
+
+    def test_rejects_empty(self):
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            validate_occurred_at("")
+
+    def test_rejects_non_string(self):
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            validate_occurred_at(20260110)  # type: ignore[arg-type]
+
+    def test_rejects_garbage(self):
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            validate_occurred_at("yesterday")
+
+    def test_rejects_us_format(self):
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            validate_occurred_at("01/10/2026")
+
+    def test_rejects_quarter_string(self):
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            validate_occurred_at("2026-Q1")
+
+
+class IdempotenceTests(unittest.TestCase):
+    """validate_occurred_at is side-effect-free — repeated calls on
+    the same input must not raise on the second call."""
+
+    def test_repeated_validate_no_state_drift(self):
+        for _ in range(3):
+            validate_occurred_at("2026-01-10")
+            validate_occurred_at("2026-01-10T15:32:00Z", precision="minute")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Schema substrate for the upcoming `event` entity type. **No production
wiring**: wiki_generator still uses the 4-element literal, no admin
endpoint yet, no ingest emit. This PR ships the building blocks the
follow-up PRs (PR-11a-2 → PR-11e) consume.

## Summary
- `core/relations_schema.py` — 4 new symbols (~70 lines):
  - `ENTITY_TYPES_CORE: tuple` — 5 graph-valid types, `event` last
  - `EVENT_LIKE_ENTITY_TYPES: set` — baseline `{"event"}`, mutable
    (OntologyPack loader extends at startup)
  - `VALID_OCCURRED_AT_PRECISIONS: frozenset` — 5 buckets
    (year/month/day/hour/minute)
  - `validate_occurred_at(value, precision="day")` — side-effect-free
    admission gate. Accepts canonical ISO 8601 (date-only, datetime
    with Z, with offset, naive). Rejects empty / non-string /
    malformed / non-ISO / unknown precision.
- `tests/test_event_entity_schema.py` — 17 tests + 5 subtests pinned
  to design memo §4 / §10.

## Verification
- `pytest tests/test_event_entity_schema.py -v` → 17 passed (+5 subtests)
- `pytest tests/ -k "relations_schema or cascade or knowledge_cascade"`
  → **56 passed, 0 failed** — no regression on existing sources /
  cascade / noisy-OR paths
- `ruff check core/relations_schema.py tests/test_event_entity_schema.py`
  → All checks passed
- relations_schema.py 5.4 KB (under 20 KB rule #5)

## Out of scope
- `core/wiki_generator.py:132` literal lift → PR-11a-2
- `POST /admin/graph/event` endpoint → PR-11a-2
- Cascade behavior verification for event nodes → PR-11a-2
- Ingest emit path → PR-11b

Design memo: docs/design/v0.3-graph-evolution.md
Handover: docs/handovers/v0.3-cognitive-layer-track.md §3 Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)