### PR TITLE
feat(graph): event node creation — PR-11a-2 (admin path + lift)

### DIFF
--- a/core/graph_node_editor.py
+++ b/core/graph_node_editor.py
@@ -26,13 +26,20 @@ Trust model:
 """
 from __future__ import annotations
 
+import hashlib
+import re
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 # Share the file-I/O helpers with the relation editor — both modules
 # read/write the same entity .md files via the same yaml frontmatter
 # convention. A second copy of these helpers would invite drift.
 from core.graph_editor import _load_entity_by_id, _write_entity
+from core.relations_schema import (
+    EXTRACT_SOURCE_ROLE,
+    MANUAL_SOURCE_ROLE,
+    validate_occurred_at,
+)
 
 
 # Allowlist of frontmatter fields ``update_node_attributes`` may touch.
@@ -203,9 +210,147 @@ def update_node_attributes(
     }
 
 
+# ─── Event node creation (PR-11a-2) ─────────────────────────────────
+# Events live next to person/concept/org/document under
+# `wiki/entity/<source>/event/`. Identity hash includes occurred_at +
+# precision per design memo §12 open-question 2: two events on the
+# same date with the same name resolve via the hash; events on
+# different dates with the same name get distinct entity_ids.
+
+_EVENT_ENTITY_ID_SALT = "JAMES_SECURE_V1"
+
+
+def _normalize_event_name(name: str) -> str:
+    """Filename-safe lowercase form. Mirrors `WikiGenerator._normalize_name`
+    so event files coexist cleanly with the existing 4-type filenames.
+    """
+    return re.sub(r"[^\w가-힣]", "_", name.strip().lower())
+
+
+def _generate_event_entity_id(
+    name: str,
+    occurred_at: str,
+    occurred_at_precision: str,
+) -> str:
+    """Hash key: name + occurred_at + precision. Same SALT as the 4-type
+    path keeps the overall id space behaving identically (8-hex suffix,
+    `e_event_` prefix). The added time fields make distinct dates yield
+    distinct ids when the same name recurs.
+    """
+    normalized = _normalize_event_name(name)
+    raw = (
+        f"{normalized}_event_{occurred_at}_{occurred_at_precision}"
+        f"_{_EVENT_ENTITY_ID_SALT}"
+    )
+    h = hashlib.sha256(raw.encode()).hexdigest()[:8]
+    return f"e_event_{h}"
+
+
+def create_event_node(
+    name: str,
+    occurred_at: str,
+    *,
+    wiki_generator,
+    occurred_at_precision: str = "day",
+    aliases: Optional[List[str]] = None,
+    source_doc_id: Optional[str] = None,
+    source_weight: float = 1.0,
+) -> Dict[str, Any]:
+    """Create a new `entity_type=event` file under
+    ``<entity_path>/event/<normalized>.md`` and return the audit-style
+    descriptor.
+
+    Source provenance (Knowledge Cascade `sources[]`):
+      - ``source_doc_id`` None → ``role: "manual"`` (admin click)
+      - ``source_doc_id`` str  → ``role: "extract"`` (ingest path)
+
+    Raises ``ValueError`` on:
+      - empty / non-string ``name``
+      - ``occurred_at`` not ISO 8601 parseable
+      - ``occurred_at_precision`` not in the 5 supported buckets
+      - ``source_weight`` outside ``[0, 1]``
+      - file collision after dedup (extremely rare — different
+        occurred_at with same normalized name)
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("name must be a non-empty string")
+    validate_occurred_at(occurred_at, precision=occurred_at_precision)
+    if not isinstance(source_weight, (int, float)):
+        raise ValueError("source_weight must be a number")
+    if not (0.0 <= float(source_weight) <= 1.0):
+        raise ValueError(
+            f"source_weight must be in [0, 1]; got {source_weight!r}"
+        )
+
+    entity_id = _generate_event_entity_id(
+        name, occurred_at, occurred_at_precision,
+    )
+    cleaned_name    = name.strip()[:_NAME_CAP]
+    cleaned_aliases = _normalize_aliases(aliases or [])
+    now_iso         = datetime.now().isoformat()
+    source_role     = (
+        MANUAL_SOURCE_ROLE if source_doc_id is None else EXTRACT_SOURCE_ROLE
+    )
+
+    fm: Dict[str, Any] = {
+        "entity_id":            entity_id,
+        "entity_type":          "event",
+        "name":                 cleaned_name,
+        "aliases":              cleaned_aliases,
+        "occurred_at":          occurred_at,
+        "occurred_at_precision": occurred_at_precision,
+        "sources": [{
+            "doc_id":  source_doc_id,
+            "weight":  float(source_weight),
+            "role":    source_role,
+            "ts":      now_iso,
+        }],
+        "relations":  [],
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+    body = f"\n# {cleaned_name}\n\n*Event of {occurred_at}*\n"
+
+    # Resolve target directory. wiki_generator.entity_path already
+    # accounts for prod/test split.
+    event_dir = wiki_generator.entity_path / "event"
+    event_dir.mkdir(parents=True, exist_ok=True)
+
+    # Always suffix the filename with the entity_id's 8-hex tail.
+    # Reason: the hash incorporates name + occurred_at + precision, so
+    # two events with the same name on different dates get different
+    # filenames AND a duplicate creation (same name + same date) maps
+    # to the same filename which collides at the existence check —
+    # one branch, no ambiguity.
+    normalized = _normalize_event_name(cleaned_name)
+    file_path  = event_dir / f"{normalized}_{entity_id[-8:]}.md"
+    if file_path.exists():
+        raise ValueError(
+            f"event already exists: entity_id={entity_id} "
+            f"path={file_path}"
+        )
+
+    _write_entity(file_path, fm, body)
+
+    # Refresh the index so subsequent reads see the new event.
+    # Best-effort: an index refresh failure must not invalidate the
+    # on-disk write that already succeeded.
+    try:
+        wiki_generator.refresh_entity_map()
+    except Exception:
+        pass
+
+    return {
+        "entity_id":   entity_id,
+        "path":        str(file_path),
+        "frontmatter": fm,
+    }
+
+
 __all__ = [
     "NODE_EDITABLE_FIELDS",
     "NODE_ALLOWED_ENTITY_TYPES",
     "NODE_ALLOWED_SENSITIVITY",
     "update_node_attributes",
+    "create_event_node",
 ]

--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from config import WIKI_DIR
 from core.relations_schema import (
+    ENTITY_TYPES_CORE,
     EXTRACT_SOURCE_ROLE,
     INVERSE_SOURCE_ROLE,
     compute_confidence_from_sources,
@@ -129,7 +130,13 @@ class WikiGenerator:
         self.wiki_base_path = Path(WIKI_DIR)
         self.entity_path    = self.wiki_base_path / "entity" / self.source_type
 
-        self.entity_types = ["person", "concept", "org", "document"]
+        # ENTITY_TYPES_CORE = 5 types (event 5th, PR-11). LLM extraction
+        # prompt below still emits only 3 types (person/org/concept);
+        # `document` is post-processor source-attribution; `event` is
+        # admin POST path (PR-11a-2). Directory listing / index build /
+        # search default to all 5 — empty event/ dir is a no-op until
+        # the first admin event creation.
+        self.entity_types = list(ENTITY_TYPES_CORE)
 
         for t in self.entity_types:
             (self.entity_path / t).mkdir(parents=True, exist_ok=True)
@@ -154,7 +161,8 @@ class WikiGenerator:
             "## person (0)\n\n"
             "## concept (0)\n\n"
             "## org (0)\n\n"
-            "## document (0)\n"
+            "## document (0)\n\n"
+            "## event (0)\n"
         )
 
         self.index_path.write_text(content, encoding="utf-8")

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3542,6 +3542,81 @@ async def admin_graph_node_put(request: Request,
     return {"ok": True, "result": result}
 
 
+@app.post("/admin/graph/event",
+          summary="event 노드 생성 [PR-11a-2 graph evolution]")
+async def admin_graph_event_post(request: Request,
+                                 role: str = Depends(get_role_from_request)):
+    """admin 만 호출 가능. ``JAMES_GRAPH_EDIT=1`` env opt-in.
+
+    PR-11 graph evolution 의 admin 진입점. ingest path 는 여전히
+    person/org/concept/document 4 type 만 emit; event 는 본 endpoint
+    또는 후속 PR-11d (MemoryLoom date detection) 만 생성한다.
+
+    Body JSON::
+
+        {
+          "api_key":               "...",
+          "name":                  "2026 비트코인 ETF 승인",
+          "occurred_at":           "2026-01-10",
+          "occurred_at_precision": "day",          // optional, default "day"
+          "aliases":               ["BTC ETF 승인"],  // optional
+          "source_doc_id":         "d_sec_filing", // optional → role=manual when omitted
+          "source_weight":         1.0             // optional, default 1.0
+        }
+
+    Returns::
+
+        {
+          "ok":          true,
+          "entity_id":   "e_event_a1b2c3d4",
+          "path":        "wiki/entity/prod/event/<normalized>.md",
+          "frontmatter": { ... }                   // full new-file frontmatter
+        }
+    """
+    _require_graph_edit_enabled()
+    body = await request.json()
+    _require_feature(body.get("api_key", ""), role, "admin.data")
+
+    name        = body.get("name")
+    occurred_at = body.get("occurred_at")
+    if not isinstance(name, str) or not name.strip():
+        raise HTTPException(status_code=400, detail="name required")
+    if not isinstance(occurred_at, str) or not occurred_at.strip():
+        raise HTTPException(status_code=400, detail="occurred_at required")
+
+    precision     = body.get("occurred_at_precision", "day")
+    aliases       = body.get("aliases")
+    source_doc_id = body.get("source_doc_id")
+    source_weight = body.get("source_weight", 1.0)
+
+    from core.graph_node_editor import create_event_node
+    try:
+        result = create_event_node(
+            name, occurred_at,
+            wiki_generator=rag_engine.wiki_generator,
+            occurred_at_precision=precision,
+            aliases=aliases,
+            source_doc_id=source_doc_id,
+            source_weight=source_weight,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    _write_audit(
+        role, "/admin/graph/event [POST]",
+        query=_truncate_audit_blob({
+            "name":        name,
+            "occurred_at": occurred_at,
+            "precision":   precision,
+        }),
+        answer=_truncate_audit_blob({
+            "entity_id":   result["entity_id"],
+            "path":        result["path"],
+        }),
+    )
+    return {"ok": True, **result}
+
+
 @app.delete("/admin/graph/relation",
             summary="relation 자체 제거 [Knowledge Cascade Phase E]")
 async def admin_graph_relation_delete(request: Request,

--- a/tests/test_event_admin_endpoint.py
+++ b/tests/test_event_admin_endpoint.py
@@ -1,0 +1,249 @@
+"""PR-11a-2 — event node creation helper.
+
+Tests `core.graph_node_editor.create_event_node()` at the helper layer.
+The HTTP endpoint (`POST /admin/graph/event`) is a thin plumbing
+wrapper around this function (`server_llmwiki.py:admin_graph_event_post`)
+that adds auth + audit; endpoint-level tests are covered by the
+existing admin-endpoint suite pattern when the endpoint is exercised
+in a higher-level integration test.
+
+Scope: helper-level guarantees per design memo §5.2 + §12.
+
+production wiki 무영향 — tempfile 격리.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.graph_node_editor import (  # noqa: E402
+    _generate_event_entity_id,
+    create_event_node,
+)
+from core.relations_schema import (  # noqa: E402
+    EXTRACT_SOURCE_ROLE,
+    MANUAL_SOURCE_ROLE,
+)
+
+
+# ─── stub: minimum wiki_generator surface create_event_node needs ────
+
+
+class _WgStub:
+    """Mimics WikiGenerator's entity_path + refresh_entity_map. Mirrors
+    the pattern in test_phase_e_graph_editor.py:_WgStub but with the
+    `entity_path` attribute that create_event_node writes through.
+    """
+    def __init__(self, root: Path):
+        self.entity_path = root
+        self.entity_id_index: dict = {}
+        self.refresh_called = 0
+
+    def refresh_entity_map(self):
+        self.refresh_called += 1
+
+
+def _make_root() -> Path:
+    root = Path(tempfile.mkdtemp()) / "entity"
+    for t in ("person", "concept", "org", "document", "event"):
+        (root / t).mkdir(parents=True)
+    return root
+
+
+def _read_fm(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    body = text.split("---", 2)[1]
+    return yaml.safe_load(body)
+
+
+# ─── 1. happy path ──────────────────────────────────────────────────
+
+
+class CreateEventHappyPathTests(unittest.TestCase):
+
+    def test_creates_file_with_expected_frontmatter(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        result = create_event_node(
+            "2026 비트코인 ETF 승인",
+            "2026-01-10",
+            wiki_generator=wg,
+        )
+        self.assertTrue(result["entity_id"].startswith("e_event_"))
+        self.assertTrue(Path(result["path"]).exists())
+
+        fm = _read_fm(Path(result["path"]))
+        self.assertEqual(fm["entity_type"], "event")
+        self.assertEqual(fm["occurred_at"], "2026-01-10")
+        self.assertEqual(fm["occurred_at_precision"], "day")
+        self.assertEqual(fm["name"], "2026 비트코인 ETF 승인")
+        self.assertEqual(len(fm["sources"]), 1)
+        # source_doc_id omitted → role=manual
+        self.assertEqual(fm["sources"][0]["role"], MANUAL_SOURCE_ROLE)
+
+    def test_refreshes_entity_index_after_write(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        create_event_node(
+            "Event A", "2026-01-10", wiki_generator=wg,
+        )
+        self.assertEqual(wg.refresh_called, 1)
+
+    def test_source_doc_id_makes_role_extract(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        result = create_event_node(
+            "ingested event", "2026-01-10",
+            wiki_generator=wg,
+            source_doc_id="d_sec_filing_2026_01",
+            source_weight=0.85,
+        )
+        fm = _read_fm(Path(result["path"]))
+        self.assertEqual(fm["sources"][0]["role"], EXTRACT_SOURCE_ROLE)
+        self.assertEqual(fm["sources"][0]["doc_id"], "d_sec_filing_2026_01")
+        self.assertEqual(fm["sources"][0]["weight"], 0.85)
+
+    def test_aliases_normalized_and_deduped(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        result = create_event_node(
+            "Event B", "2026-01-10",
+            wiki_generator=wg,
+            aliases=["BTC ETF", "", "BTC ETF", "Bitcoin ETF"],
+        )
+        fm = _read_fm(Path(result["path"]))
+        # Empty + dupe stripped; insertion order preserved.
+        self.assertEqual(fm["aliases"], ["BTC ETF", "Bitcoin ETF"])
+
+
+# ─── 2. validation gates ────────────────────────────────────────────
+
+
+class CreateEventValidationTests(unittest.TestCase):
+
+    def test_empty_name_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "name"):
+            create_event_node("", "2026-01-10", wiki_generator=wg)
+
+    def test_whitespace_name_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "name"):
+            create_event_node("   ", "2026-01-10", wiki_generator=wg)
+
+    def test_occurred_at_garbage_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            create_event_node("X", "yesterday", wiki_generator=wg)
+
+    def test_invalid_precision_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "precision"):
+            create_event_node(
+                "X", "2026-01-10",
+                wiki_generator=wg,
+                occurred_at_precision="quarter",
+            )
+
+    def test_source_weight_out_of_range_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "source_weight"):
+            create_event_node(
+                "X", "2026-01-10",
+                wiki_generator=wg,
+                source_weight=1.5,
+            )
+
+    def test_source_weight_non_numeric_raises(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        with self.assertRaisesRegex(ValueError, "source_weight"):
+            create_event_node(
+                "X", "2026-01-10",
+                wiki_generator=wg,
+                source_weight="high",  # type: ignore[arg-type]
+            )
+
+
+# ─── 3. identity / collision (memo §12 q2) ──────────────────────────
+
+
+class IdentityCollisionTests(unittest.TestCase):
+
+    def test_same_name_different_date_yields_different_ids(self):
+        a = _generate_event_entity_id("X", "2026-01-10", "day")
+        b = _generate_event_entity_id("X", "2026-01-11", "day")
+        self.assertNotEqual(a, b)
+
+    def test_same_name_different_precision_yields_different_ids(self):
+        a = _generate_event_entity_id("X", "2026-01-10", "day")
+        b = _generate_event_entity_id("X", "2026-01-10", "month")
+        self.assertNotEqual(a, b)
+
+    def test_same_inputs_yield_stable_id(self):
+        a = _generate_event_entity_id("X", "2026-01-10", "day")
+        b = _generate_event_entity_id("X", "2026-01-10", "day")
+        self.assertEqual(a, b)
+
+    def test_two_events_same_name_different_dates_coexist(self):
+        root = _make_root()
+        wg = _WgStub(root)
+        r1 = create_event_node(
+            "Q1 실적 발표", "2026-04-15", wiki_generator=wg,
+        )
+        r2 = create_event_node(
+            "Q1 실적 발표", "2027-04-14", wiki_generator=wg,
+        )
+        self.assertNotEqual(r1["entity_id"], r2["entity_id"])
+        self.assertNotEqual(r1["path"], r2["path"])
+        self.assertTrue(Path(r1["path"]).exists())
+        self.assertTrue(Path(r2["path"]).exists())
+
+    def test_duplicate_event_raises(self):
+        # Same name + same occurred_at + same precision twice → second
+        # call surfaces "event already exists" rather than overwriting.
+        root = _make_root()
+        wg = _WgStub(root)
+        create_event_node(
+            "Dup event", "2026-01-10", wiki_generator=wg,
+        )
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            create_event_node(
+                "Dup event", "2026-01-10", wiki_generator=wg,
+            )
+
+
+# ─── 4. wiki_generator entity_types includes event (lift) ───────────
+
+
+class WikiGeneratorLiftTests(unittest.TestCase):
+    """Sanity check: after the lift, the production class's entity_types
+    starts with the legacy 4 and ends with `event`. This is the contract
+    create_event_node relies on (event directory pre-created)."""
+
+    def test_production_entity_types_includes_event_last(self):
+        # Import the production class directly. Construction is
+        # heavyweight, so just assert the constant at the wire-up site.
+        from core.relations_schema import ENTITY_TYPES_CORE
+        # This is what wiki_generator.py:132 lifts to (post-PR-11a-2):
+        self.assertIn("event", ENTITY_TYPES_CORE)
+        self.assertEqual(ENTITY_TYPES_CORE[-1], "event")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires the PR-11a-1 schema substrate to production. (a) Lifts
wiki_generator's entity_types literal to `ENTITY_TYPES_CORE`. (b) Adds
the admin-only event creation path. **No ingest emit** — that's PR-11b.

## Summary
- `core/wiki_generator.py`
  - `self.entity_types` → `list(ENTITY_TYPES_CORE)` (5 types). The
    LLM extraction prompt remains unchanged (still emits person/
    org/concept). `wiki/entity/<source>/event/` directory is
    created on init.
  - `_create_index_template` adds a `## event (0)` category.
- `core/graph_node_editor.py`
  - `create_event_node(name, occurred_at, *, ...)` helper with
    Knowledge Cascade `sources[]` (role=manual when source_doc_id
    omitted, role=extract otherwise).
  - `_generate_event_entity_id(name, occurred_at, precision)` —
    hash incorporates date + precision (memo §12 q2). Filename
    always suffixed with the 8-hex tail to make duplicates
    unambiguous.
- `server_llmwiki.py`
  - `POST /admin/graph/event` — gated on `JAMES_GRAPH_EDIT=1` env
    + `admin.data` ABAC. Body validation surfaces 400 on missing
    name / missing occurred_at / invalid ISO 8601 / invalid
    precision / out-of-range source_weight.
- `tests/test_event_admin_endpoint.py` — 16 tests (happy path,
  validation gates, identity collision, lift sanity).

## Verification
- `pytest tests/test_event_admin_endpoint.py -v` → **16 passed**
- `pytest tests/ -k "graph or wiki_generator or cascade or
  relations_schema or phase_e or event"` → **290 passed, 0 failed**
- `ruff check core/ tests/test_event_admin_endpoint.py` → All checks passed
- AST parse-check on `server_llmwiki.py` → OK
- `core/graph_node_editor.py` 12.7 KB (within rule #5 20 KB gate)
- `core/wiki_generator.py` 46 KB — **pre-existing** violation,
  not introduced by this PR (my change adds 12 lines)

## Behavior delta from main
- New empty directory created on init: `wiki/entity/<source>/event/`
- `index.md` template includes `## event (0)` header
- `entity_id_index` scans the new dir (no-op while empty)
- LLM ingest, search defaults, cascade — **unchanged for the 4
  existing entity types**

## Out of scope
- `PUT /admin/graph/node` accepting `occurred_at` on existing event
  nodes — small follow-up
- Ingest emit path for `type=event` → PR-11b
- Time-bucket retrieval filter → PR-11c
- Frontend graph-editor UI for events → out of PR-11 scope per
  memo §9 ("A timeline UI is a separate cycle")

Design memo: `docs/design/v0.3-graph-evolution.md` §5.2 / §12
Handover: `docs/handovers/v0.3-cognitive-layer-track.md` §3 Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)