### PR TITLE
feat(graph): event time-bucket filter — PR-11c

### DIFF
--- a/core/event_time_filter.py
+++ b/core/event_time_filter.py
@@ -1,0 +1,132 @@
+"""PROJECT JAMES — Event time-bucket filter (PR-11c).
+
+문서: docs/design/v0.3-graph-evolution.md §5.3
+
+`event` 노드는 ``occurred_at`` 필드를 갖는 시간 축 entity. 본 모듈은
+entity dict 리스트에서 occurred_at 윈도우 필터를 적용하는 helper
+를 제공한다. retrieval / admin / snapshot 어느 entry 에서도 같은
+필터 함수를 호출해 결과를 일관되게 제한할 수 있다.
+
+설계 메모 §5.3 의 두 규칙:
+  - filter 가 retrieval scoring 이후 적용되는 hard cut (re-weight 가
+    아닌 cut). 호출자는 이미 score 정렬된 결과에 본 함수를 적용한다.
+  - non-event entity (occurred_at 없음) 는 ``occurred_after`` 와
+    ``occurred_before`` 가 **모두 absent** 일 때만 통과. 즉 time-scoped
+    query 는 암묵적으로 event 노드로 제한된다 — 사용자가 시간을
+    명시했으면 시간 없는 노드는 답이 아니다.
+
+본 모듈은 `core/relations_schema.py` 의 ``validate_occurred_at`` 을
+재사용해 bound 자체의 ISO 8601 파싱을 강제한다. malformed entity
+의 occurred_at 은 raise 가 아닌 silent drop — 한 entity 의 dirty
+metadata 가 전체 filter 결과를 죽이지 않도록 한다.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from core.relations_schema import validate_occurred_at
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    """Best-effort ISO 8601 parse. Returns ``None`` on failure (used in
+    the per-entity loop so a dirty entity does not raise).
+
+    Accepts trailing ``Z`` via the standard ``+00:00`` substitution.
+    Naive datetimes are accepted (no tz attached); the filter treats
+    them as workspace-local just like the storage path does.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _coerce_naive(dt: datetime) -> datetime:
+    """Strip tzinfo so naive and tz-aware datetimes can be compared
+    side-by-side. JAMES treats stored occurred_at as workspace-local
+    when no offset is present (memo §4.1).
+    """
+    if dt.tzinfo is not None:
+        return dt.replace(tzinfo=None)
+    return dt
+
+
+def entity_within_time_bucket(
+    entity: Dict[str, Any],
+    occurred_after: Optional[str],
+    occurred_before: Optional[str],
+) -> bool:
+    """Decide whether one entity passes the (after, before) window.
+
+    Rules (memo §5.3):
+      - both bounds absent → every entity passes (no filter active).
+      - either bound set:
+          * non-event entities (no `occurred_at` field) are dropped.
+          * event entities with malformed `occurred_at` are dropped
+            silently (one bad entity must not poison the result set).
+          * event entities are kept iff occurred_at lies in the
+            (after, before) closed interval.
+    """
+    if occurred_after is None and occurred_before is None:
+        return True
+
+    raw = entity.get("occurred_at")
+    if raw is None:
+        return False
+    ts = _parse_iso(raw)
+    if ts is None:
+        return False
+    ts = _coerce_naive(ts)
+
+    if occurred_after is not None:
+        lo = _parse_iso(occurred_after)
+        if lo is None:
+            # bound itself is unparseable — caller should have caught
+            # earlier via validate_occurred_at, but defend in depth.
+            return False
+        if ts < _coerce_naive(lo):
+            return False
+
+    if occurred_before is not None:
+        hi = _parse_iso(occurred_before)
+        if hi is None:
+            return False
+        if ts > _coerce_naive(hi):
+            return False
+
+    return True
+
+
+def filter_entities_by_time_bucket(
+    entities: List[Dict[str, Any]],
+    *,
+    occurred_after: Optional[str] = None,
+    occurred_before: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Filter ``entities`` to those passing the time-bucket window.
+
+    Validates the bounds eagerly via ``validate_occurred_at`` so the
+    caller gets a clear ``ValueError`` for a malformed param. Per-entity
+    parsing is best-effort (see ``entity_within_time_bucket``).
+
+    Order preserved — callers that already sorted by relevance keep
+    the same ordering in the filtered output (hard cut, not re-rank).
+    """
+    if occurred_after is not None:
+        validate_occurred_at(occurred_after)
+    if occurred_before is not None:
+        validate_occurred_at(occurred_before)
+
+    return [
+        e for e in entities
+        if entity_within_time_bucket(e, occurred_after, occurred_before)
+    ]
+
+
+__all__ = [
+    "entity_within_time_bucket",
+    "filter_entities_by_time_bucket",
+]

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3311,6 +3311,80 @@ async def admin_graph_snapshot(
     )
 
 
+@app.get("/admin/graph/events",
+         summary="event 노드 시간 윈도우 조회 [PR-11c]")
+async def admin_graph_events_get(
+    api_key:         str,
+    source_type:     str = "prod",
+    occurred_after:  Optional[str] = None,
+    occurred_before: Optional[str] = None,
+    role:            str = Depends(get_role_from_request),
+):
+    """admin 만 호출 가능. snapshot 의 event-only 슬라이스 + 선택적
+    occurred_at 윈도우 필터.
+
+    Query params:
+      - ``occurred_after`` / ``occurred_before`` 둘 다 optional, ISO 8601.
+        둘 다 없을 때는 source_type 의 모든 event 반환 (filter 비활성).
+      - 둘 중 하나라도 있으면 non-event 는 자동 제거 (memo §5.3).
+
+    Returns: ``{"ok": true, "events": [{node fields...}]}``.
+    Order: entity_id 사전순 — caller 가 별도 정렬이 필요하면 그쪽에서.
+
+    400 surfacing 시나리오:
+      - occurred_after / occurred_before 가 ISO 8601 파싱 실패
+    """
+    _require_feature(api_key, role, "admin.data")
+    from core.event_time_filter import filter_entities_by_time_bucket
+    from core.graph_snapshot import build_snapshot
+
+    src = (source_type or "prod").strip().lower()
+    if src not in ("prod", "test"):
+        src = "prod"
+
+    if src == rag_engine.wiki_generator.source_type:
+        gen = rag_engine.wiki_generator
+    else:
+        from core.wiki_generator import WikiGenerator
+        gen = WikiGenerator(source_type=src)
+
+    snap = build_snapshot(
+        wiki_generator=gen, source_type=src, include_sensitive=False,
+    )
+    # snapshot 의 node 는 `occurred_at` 을 안 싣는다 (visualizer 무관).
+    # 본 endpoint 는 entity_id_index 를 직접 재방문해 frontmatter 의
+    # occurred_at 까지 끌어와야 한다.
+    enriched = []
+    for n in snap.get("nodes", []) or []:
+        if n.get("type") != "event":
+            continue
+        eid = n.get("id")
+        path = gen.entity_id_index.get(eid)
+        if not path:
+            continue
+        try:
+            fm = gen._read_frontmatter(path) or {}
+        except Exception:
+            fm = {}
+        enriched.append({
+            **n,
+            "occurred_at":           fm.get("occurred_at"),
+            "occurred_at_precision": fm.get("occurred_at_precision", "day"),
+        })
+
+    try:
+        filtered = filter_entities_by_time_bucket(
+            enriched,
+            occurred_after=occurred_after,
+            occurred_before=occurred_before,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    filtered.sort(key=lambda n: n.get("id", ""))
+    return {"ok": True, "events": filtered}
+
+
 # ─── /admin/graph/relation — Phase E graph editor (write path) ───
 #
 # docs/design/v0.3-knowledge-cascade.md §7. admin 이 `/admin/graph`

--- a/tests/test_event_time_filter.py
+++ b/tests/test_event_time_filter.py
@@ -1,0 +1,235 @@
+"""PR-11c — event time-bucket filter.
+
+`core.event_time_filter.filter_entities_by_time_bucket` is the hard
+cut applied after retrieval scoring (memo §5.3). These tests pin the
+two key rules:
+
+  1. With no bounds set, every entity passes (no filter active).
+  2. With either bound set, only events whose occurred_at lies in
+     the window pass; non-event entities are dropped.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.event_time_filter import (  # noqa: E402
+    entity_within_time_bucket,
+    filter_entities_by_time_bucket,
+)
+
+
+# ─── fixtures ──────────────────────────────────────────────────────
+
+
+def _event(eid: str, occurred_at: str) -> dict:
+    return {
+        "id":           eid,
+        "entity_type":  "event",
+        "name":         eid,
+        "occurred_at":  occurred_at,
+    }
+
+
+def _concept(eid: str) -> dict:
+    return {
+        "id":           eid,
+        "entity_type":  "concept",
+        "name":         eid,
+    }
+
+
+# ─── 1. no-bound passthrough ────────────────────────────────────────
+
+
+class NoBoundPassthroughTests(unittest.TestCase):
+    """Memo §5.3: 'concept nodes (no occurred_at) pass the filter only
+    when both occurred_after and occurred_before are absent — a
+    time-scoped query implicitly restricts to event nodes.'"""
+
+    def test_no_bounds_keeps_every_entity(self):
+        ents = [
+            _event("e1", "2026-01-10"),
+            _concept("c1"),
+            _event("e2", "2026-02-15"),
+            _concept("c2"),
+        ]
+        out = filter_entities_by_time_bucket(ents)
+        self.assertEqual([e["id"] for e in out], ["e1", "c1", "e2", "c2"])
+
+    def test_no_bounds_preserves_order(self):
+        # Hard cut must not reorder.
+        ents = [_event(f"e{i}", "2026-01-10") for i in range(5)]
+        out = filter_entities_by_time_bucket(ents)
+        self.assertEqual([e["id"] for e in out], [e["id"] for e in ents])
+
+
+# ─── 2. after / before / both ───────────────────────────────────────
+
+
+class TimeBoundsTests(unittest.TestCase):
+
+    def test_after_only_drops_earlier_events(self):
+        ents = [
+            _event("e1", "2026-01-10"),
+            _event("e2", "2026-02-15"),
+            _event("e3", "2026-03-20"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents, occurred_after="2026-02-01",
+        )
+        self.assertEqual([e["id"] for e in out], ["e2", "e3"])
+
+    def test_before_only_drops_later_events(self):
+        ents = [
+            _event("e1", "2026-01-10"),
+            _event("e2", "2026-02-15"),
+            _event("e3", "2026-03-20"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents, occurred_before="2026-02-28",
+        )
+        self.assertEqual([e["id"] for e in out], ["e1", "e2"])
+
+    def test_both_bounds_filters_to_window(self):
+        ents = [
+            _event("e1", "2026-01-10"),
+            _event("e2", "2026-02-15"),
+            _event("e3", "2026-03-20"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents,
+            occurred_after="2026-02-01",
+            occurred_before="2026-02-28",
+        )
+        self.assertEqual([e["id"] for e in out], ["e2"])
+
+    def test_bounds_are_inclusive(self):
+        # Exact-match dates pass on both endpoints (closed interval).
+        ents = [_event("e1", "2026-02-15")]
+        out = filter_entities_by_time_bucket(
+            ents,
+            occurred_after="2026-02-15",
+            occurred_before="2026-02-15",
+        )
+        self.assertEqual([e["id"] for e in out], ["e1"])
+
+    def test_datetime_with_tz_compares_against_naive_bound(self):
+        # Memo §4.1 / module docstring: naive bound and tz-aware
+        # entity are coerced to the same naive frame.
+        ents = [
+            _event("e1", "2026-01-10T15:32:00Z"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents, occurred_after="2026-01-10",
+        )
+        self.assertEqual([e["id"] for e in out], ["e1"])
+
+
+# ─── 3. non-event handling ──────────────────────────────────────────
+
+
+class NonEventEntityTests(unittest.TestCase):
+
+    def test_concept_dropped_when_any_bound_set(self):
+        ents = [
+            _concept("c1"),
+            _event("e1", "2026-02-15"),
+        ]
+        out_after = filter_entities_by_time_bucket(
+            ents, occurred_after="2026-01-01",
+        )
+        self.assertEqual([e["id"] for e in out_after], ["e1"])
+
+        out_before = filter_entities_by_time_bucket(
+            ents, occurred_before="2026-12-31",
+        )
+        self.assertEqual([e["id"] for e in out_before], ["e1"])
+
+    def test_event_with_malformed_occurred_at_drops_silently(self):
+        # One bad entity must not raise — only drop.
+        ents = [
+            {"id": "bad", "entity_type": "event",
+             "occurred_at": "yesterday"},
+            _event("good", "2026-02-15"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents, occurred_after="2026-01-01",
+        )
+        self.assertEqual([e["id"] for e in out], ["good"])
+
+    def test_event_missing_occurred_at_drops_when_bound_set(self):
+        ents = [
+            {"id": "bare", "entity_type": "event"},
+            _event("dated", "2026-02-15"),
+        ]
+        out = filter_entities_by_time_bucket(
+            ents, occurred_after="2026-01-01",
+        )
+        self.assertEqual([e["id"] for e in out], ["dated"])
+
+
+# ─── 4. bound validation ────────────────────────────────────────────
+
+
+class BoundValidationTests(unittest.TestCase):
+    """Bounds themselves must be parseable. validate_occurred_at
+    raises a clear ValueError so a malformed query param doesn't reach
+    the per-entity loop (which would silently drop every entity)."""
+
+    def test_garbage_after_bound_raises(self):
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            filter_entities_by_time_bucket(
+                [_event("e1", "2026-01-10")],
+                occurred_after="last week",
+            )
+
+    def test_garbage_before_bound_raises(self):
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            filter_entities_by_time_bucket(
+                [_event("e1", "2026-01-10")],
+                occurred_before="2026-Q1",
+            )
+
+
+# ─── 5. unit predicate ──────────────────────────────────────────────
+
+
+class PredicateUnitTests(unittest.TestCase):
+    """entity_within_time_bucket is the single-entity primitive that
+    callers can use without going through the list-level helper (e.g.
+    when streaming a large index)."""
+
+    def test_no_bounds_returns_true(self):
+        self.assertTrue(entity_within_time_bucket(_concept("c"), None, None))
+        self.assertTrue(entity_within_time_bucket(
+            _event("e", "2026-01-10"), None, None,
+        ))
+
+    def test_event_passes_when_in_window(self):
+        self.assertTrue(entity_within_time_bucket(
+            _event("e", "2026-02-15"),
+            "2026-02-01", "2026-02-28",
+        ))
+
+    def test_event_fails_when_below_lower(self):
+        self.assertFalse(entity_within_time_bucket(
+            _event("e", "2026-01-15"),
+            "2026-02-01", None,
+        ))
+
+    def test_event_fails_when_above_upper(self):
+        self.assertFalse(entity_within_time_bucket(
+            _event("e", "2026-03-15"),
+            None, "2026-02-28",
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hard cut on the entity list by `occurred_at` window. Admin endpoint
that returns event-only nodes inside the window. Filter helper is
reusable from any retrieval path; the chat-side cognitive integration
ships separately (PR-11d).

## Summary
- `core/event_time_filter.py` (NEW, 4.2 KB)
  - `entity_within_time_bucket(entity, after, before)` — single-entity
    predicate
  - `filter_entities_by_time_bucket(entities, *, after, before)` —
    list helper. Eager bound validation; per-entity malformed
    `occurred_at` drops silently. Closed interval. Order preserved.
- `GET /admin/graph/events?occurred_after=&occurred_before=&source_type=`
  — `admin.data` ABAC. 400 on malformed bound. Enriches snapshot
  nodes with `occurred_at` / `occurred_at_precision` from frontmatter.
- `tests/test_event_time_filter.py` — 16 tests on the two memo §5.3
  rules + edge cases.

## Verification
- `pytest tests/test_event_time_filter.py -v` → **16 passed**
- `pytest tests/ -k "event or graph or wiki or snapshot or cascade"`
  → **443 passed, 0 failed**
- `ruff check ...` → All checks passed
- AST parse-check on `server_llmwiki.py` → OK
- `core/event_time_filter.py` 4.2 KB (rule #5 gate ≪ 20 KB)

## Memo §5.3 rules pinned
1. Both bounds absent → filter inactive, every entity passes.
2. Either bound set → non-event entities dropped; events kept iff
   `occurred_at` in window.

## Out of scope
- Frontend timeline UI — explicit non-goal per memo §9
- Wiring into chat-side retrieval pipeline — PR-11d (alongside
  MemoryLoom) or a follow-up PR-11c-2 if 11d slips

Design memo: `docs/design/v0.3-graph-evolution.md` §5.3 + §10 test 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)