### PR TITLE
feat(ingest): event entity emit path — PR-11b

### DIFF
--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -17,6 +17,7 @@ from core.relations_schema import (
     EXTRACT_SOURCE_ROLE,
     INVERSE_SOURCE_ROLE,
     compute_confidence_from_sources,
+    validate_occurred_at,
 )
 from core.vector_store import VectorStore
 from llm.router import RouterWrapper
@@ -298,10 +299,52 @@ class WikiGenerator:
         entity_type = entity.get("type", "concept")
         name = entity.get("name", "unknown")
 
-        normalized = self._normalize_name(name)
-        entity_id = self._generate_entity_id(name, entity_type)
+        # ── Event branch (PR-11b) ─────────────────────────────────
+        # `event` requires occurred_at. If the LLM (or any caller)
+        # emits `type: event` without a parseable occurred_at, downgrade
+        # to `concept` rather than invent a date (memo §5.1: "If you
+        # cannot determine the date from the document, emit the entity
+        # as `concept` instead — do not invent a date.").
+        event_occurred_at  = ""
+        event_precision    = "day"
+        if entity_type == "event":
+            raw_at        = entity.get("occurred_at") or ""
+            raw_precision = entity.get("occurred_at_precision") or "day"
+            try:
+                validate_occurred_at(raw_at, precision=raw_precision)
+                event_occurred_at = raw_at
+                event_precision   = raw_precision
+            except ValueError:
+                # Graceful fallback. One bad LLM emit must not refuse the
+                # whole ingest — the entity still has informational value
+                # as a concept.
+                print(
+                    f"[INGEST] event entity {name!r} missing/invalid "
+                    f"occurred_at — falling back to concept"
+                )
+                entity_type = "concept"
 
-        path = self.entity_path / entity_type / f"{normalized}.md"
+        normalized = self._normalize_name(name)
+        if entity_type == "event":
+            # Hash incorporates date + precision so same name on
+            # different dates yields distinct entity_ids (memo §12 q2).
+            # Helper sits in graph_node_editor — both ingest and admin
+            # paths must produce identical ids for the same triple.
+            from core.graph_node_editor import _generate_event_entity_id
+            entity_id = _generate_event_entity_id(
+                name, event_occurred_at, event_precision,
+            )
+            # Filename suffixed with the 8-hex tail keeps duplicate
+            # detection unambiguous AND lets same-name events on
+            # different dates coexist on disk.
+            path = (
+                self.entity_path
+                / "event"
+                / f"{normalized}_{entity_id[-8:]}.md"
+            )
+        else:
+            entity_id = self._generate_entity_id(name, entity_type)
+            path = self.entity_path / entity_type / f"{normalized}.md"
 
         # aliases — `"X (Y)"` 패턴은 outer/inner도 자동 등록 (Issue #7)
         aliases = _expand_alias_candidates(name)
@@ -387,6 +430,15 @@ class WikiGenerator:
             "name":            name,
             "normalized_name": normalized,
             "aliases":         aliases,
+            # ── Event time axis (PR-11b) — only present on events ──
+            **(
+                {
+                    "occurred_at":           event_occurred_at,
+                    "occurred_at_precision": event_precision,
+                }
+                if entity_type == "event"
+                else {}
+            ),
             # ── ABAC (진단 FAIL 수정: sensitivity/owner 저장 보장) ──
             "sensitivity":     self._default_sensitivity(entity_type),
             "owner":           "system",
@@ -442,6 +494,7 @@ class WikiGenerator:
             "org":      "internal",      # 조직정보 → 내부
             "document": "confidential",  # 문서 → 기밀
             "concept":  "public",        # 개념/지식 → 공개
+            "event":    "internal",      # 시간 축 사건 → 내부 (PR-11b)
         }
         return mapping.get(entity_type, "internal")
 
@@ -796,15 +849,20 @@ class WikiGenerator:
         # by entity-type pair + "use 관련 only when nothing else fits".
         prompt = (
             "Output ONLY raw JSON. No explanation, no markdown.\n"
-            "Format: {\"entities\": [{\"name\":\"X\",\"type\":\"person|org|concept\","
-            "\"description\":\"한줄\"}], \"relations\": [{\"source\":\"X\","
+            "Format: {\"entities\": [{\"name\":\"X\",\"type\":\"person|org|concept|event\","
+            "\"description\":\"한줄\",\"occurred_at\":\"YYYY-MM-DD or omit\"}], "
+            "\"relations\": [{\"source\":\"X\","
             "\"target\":\"Y\",\"label\":\"관련\",\"confidence\":0.7}]}\n\n"
 
-            "TYPES (3 only):\n"
+            "TYPES (4 only):\n"
             "  person  = individual (Sam Altman, 이재명)\n"
             "  org     = company/institution (Anthropic, 삼성전자, 한국은행)\n"
             "  concept = idea, method, tech, AND products/tools/services\n"
             "            (RAG, GPT-4, Claude Code, Aider, 비트코인, 갤럭시)\n"
+            "  event   = time-bound occurrence (Q1 실적 발표, ETF 승인, 이벤트).\n"
+            "            MUST include occurred_at field (ISO 8601: YYYY-MM-DD).\n"
+            "            If the date is not explicit in the document, "
+            "emit as concept instead — DO NOT invent a date.\n"
             "RULE: a product/tool is CONCEPT, the maker is ORG.\n"
             "  e.g. Anthropic=org, Claude Code=concept (Anthropic 'produces' Claude Code).\n"
             "  Same name must NEVER appear as both org and concept.\n\n"

--- a/tests/test_event_ingest_emit.py
+++ b/tests/test_event_ingest_emit.py
@@ -1,0 +1,238 @@
+"""PR-11b — event entity emit path through WikiGenerator.create_entity_file.
+
+Design memo §5.1: ingest accepts `type: event` but only when the entity
+also carries a parseable `occurred_at`. Missing/invalid date triggers a
+graceful fallback to `type: concept` rather than refusing the ingest.
+
+This file pins:
+  1. happy path — valid occurred_at lands in wiki/entity/test/event/
+     with the expected frontmatter (occurred_at, occurred_at_precision,
+     entity_id derived from name + date + precision)
+  2. graceful fallback — missing/invalid occurred_at downgrades the
+     entity_type to concept (file ends up in wiki/entity/test/concept/)
+  3. same name on different dates yields distinct ids + coexists
+  4. 4-type ingest path unchanged (regression sanity)
+
+setUp mirrors `tests/test_phase_b_ingestion_sources.py` — WIKI_DIR
+monkey-patched to tempdir, vector_store / verify_before_write / LLM
+router stubbed out so we only exercise the frontmatter writer.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml  # noqa: I001
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+class _EventIngestBase(unittest.TestCase):
+    """Common harness — tempdir WIKI_DIR + stubbed vector store / router /
+    memory-trust verifier so create_entity_file's side effects are
+    isolated to disk."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
+        self.wiki_dir_patcher.start()
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = self.tmp
+
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+
+    def tearDown(self):
+        self.wiki_dir_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    def _read_fm(self, path: Path) -> dict:
+        text = path.read_text(encoding="utf-8")
+        return yaml.safe_load(text.split("---", 2)[1])
+
+
+# ─── 1. happy path ───────────────────────────────────────────────────
+
+
+class EventIngestHappyPathTests(_EventIngestBase):
+
+    def test_event_with_occurred_at_lands_in_event_dir(self):
+        entity = {
+            "name":        "2026 비트코인 ETF 승인",
+            "type":        "event",
+            "occurred_at": "2026-01-10",
+            "attributes":  {"summary": "SEC 첫 spot ETF 승인"},
+            "relations":   [],
+        }
+        out_path = self.wg.create_entity_file(
+            entity, "etf_doc.md", ["chunk1"],
+        )
+        out = Path(out_path)
+        # File path under wiki/entity/test/event/...
+        self.assertEqual(out.parent.name, "event")
+        self.assertTrue(out.exists())
+
+        fm = self._read_fm(out)
+        self.assertEqual(fm["entity_type"], "event")
+        self.assertEqual(fm["occurred_at"], "2026-01-10")
+        self.assertEqual(fm["occurred_at_precision"], "day")
+        self.assertTrue(fm["entity_id"].startswith("e_event_"))
+
+    def test_precision_explicit_value_is_preserved(self):
+        # Memo §4.1: storage is always full ISO 8601; `precision` is a
+        # consumer-side trust hint (year/month/day/hour/minute), not a
+        # parse-strictness flag.
+        entity = {
+            "name":                  "Q1 실적 발표",
+            "type":                  "event",
+            "occurred_at":           "2026-04-01",
+            "occurred_at_precision": "month",
+            "attributes":            {},
+            "relations":             [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "ir.md", []))
+        fm = self._read_fm(out)
+        self.assertEqual(fm["occurred_at_precision"], "month")
+
+    def test_sensitivity_defaults_to_internal_for_events(self):
+        entity = {
+            "name": "Earnings call", "type": "event",
+            "occurred_at": "2026-01-15",
+            "attributes": {}, "relations": [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "x.md", []))
+        fm = self._read_fm(out)
+        self.assertEqual(fm["sensitivity"], "internal")
+
+
+# ─── 2. fallback to concept ─────────────────────────────────────────
+
+
+class EventIngestFallbackTests(_EventIngestBase):
+
+    def test_event_without_occurred_at_falls_back_to_concept(self):
+        entity = {
+            "name":       "정체 모를 사건",
+            "type":       "event",
+            "attributes": {"summary": "occurred_at 없음 → concept 으로 강등"},
+            "relations":  [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "x.md", []))
+        # Falls to wiki/entity/test/concept/
+        self.assertEqual(out.parent.name, "concept")
+        fm = self._read_fm(out)
+        self.assertEqual(fm["entity_type"], "concept")
+        # No occurred_at fields leak into the concept file.
+        self.assertNotIn("occurred_at", fm)
+        self.assertNotIn("occurred_at_precision", fm)
+        # entity_id uses the 4-type derivation (not the event hash).
+        self.assertTrue(fm["entity_id"].startswith("e_concept_"))
+
+    def test_event_with_garbage_occurred_at_falls_back_to_concept(self):
+        entity = {
+            "name":        "Some event",
+            "type":        "event",
+            "occurred_at": "yesterday",   # not ISO 8601
+            "attributes":  {},
+            "relations":   [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "x.md", []))
+        self.assertEqual(out.parent.name, "concept")
+        fm = self._read_fm(out)
+        self.assertEqual(fm["entity_type"], "concept")
+
+    def test_event_with_invalid_precision_falls_back_to_concept(self):
+        entity = {
+            "name":                  "Some event",
+            "type":                  "event",
+            "occurred_at":           "2026-01-10",
+            "occurred_at_precision": "quarter",  # not in the 5-bucket set
+            "attributes":            {},
+            "relations":             [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "x.md", []))
+        self.assertEqual(out.parent.name, "concept")
+
+
+# ─── 3. identity collision (memo §12 q2) ────────────────────────────
+
+
+class EventIngestCollisionTests(_EventIngestBase):
+
+    def test_same_name_different_dates_coexist(self):
+        e1 = {
+            "name": "Q1 실적 발표", "type": "event",
+            "occurred_at": "2026-04-15",
+            "attributes": {}, "relations": [],
+        }
+        e2 = {
+            "name": "Q1 실적 발표", "type": "event",
+            "occurred_at": "2027-04-14",
+            "attributes": {}, "relations": [],
+        }
+        p1 = Path(self.wg.create_entity_file(e1, "ir1.md", []))
+        p2 = Path(self.wg.create_entity_file(e2, "ir2.md", []))
+        self.assertNotEqual(p1, p2)
+        self.assertTrue(p1.exists() and p2.exists())
+        fm1 = self._read_fm(p1)
+        fm2 = self._read_fm(p2)
+        self.assertNotEqual(fm1["entity_id"], fm2["entity_id"])
+
+
+# ─── 4. legacy 4-type path unchanged ────────────────────────────────
+
+
+class FourTypeRegressionTests(_EventIngestBase):
+    """The 4 existing entity types must keep producing the same file
+    layout as before PR-11b. Only the wiki/entity/<src>/event/ dir
+    being created on init differs."""
+
+    def test_concept_still_lands_in_concept_dir(self):
+        entity = {
+            "name": "RAG", "type": "concept",
+            "attributes": {"summary": "retrieval-augmented generation"},
+            "relations": [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "rag.md", []))
+        self.assertEqual(out.parent.name, "concept")
+        fm = self._read_fm(out)
+        self.assertEqual(fm["entity_type"], "concept")
+        self.assertNotIn("occurred_at", fm)
+
+    def test_org_still_lands_in_org_dir(self):
+        entity = {
+            "name": "Anthropic", "type": "org",
+            "attributes": {"summary": "AI safety company"},
+            "relations": [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "anth.md", []))
+        self.assertEqual(out.parent.name, "org")
+        fm = self._read_fm(out)
+        self.assertEqual(fm["entity_type"], "org")
+        self.assertNotIn("occurred_at", fm)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
LLM extraction can now emit `type: event` and create_entity_file
handles both happy path (writes to `wiki/entity/<source>/event/`) and
graceful fallback (downgrade to `concept` if `occurred_at` is missing/
invalid). Closes the ingest gap that PR-11a-1 / PR-11a-2 left open.

## Summary
- `core/wiki_generator.py`
  - `create_entity_file` event branch: validate occurred_at via
    `validate_occurred_at`; on failure, log + downgrade to concept;
    on success, use `_generate_event_entity_id` + `<normalized>_<8hex>.md`
    file path (shared with PR-11a-2's admin POST so both paths
    produce identical ids for the same triple).
  - Frontmatter gains `occurred_at` / `occurred_at_precision` ONLY
    when entity_type is `event` (no leak on fallback).
  - `_default_sensitivity`: `event` → `internal`.
  - LLM extraction prompt now lists `event` as a 4th type with the
    strict "MUST include occurred_at — DO NOT invent a date" rule.
- `tests/test_event_ingest_emit.py` — 9 tests:
  - happy path: valid occurred_at → event/ dir, precision preserved,
    sensitivity = internal
  - fallback: missing / garbage occurred_at / invalid precision all
    downgrade to concept/
  - identity: same name different dates → distinct ids coexist
  - regression: concept + org ingest unchanged

## Verification
- `pytest tests/test_event_ingest_emit.py -v` → **9 passed**
- `pytest tests/ -k "event or graph or wiki or snapshot or cascade
  or phase_b or phase_e"` → **465 passed, 0 failed**
- `ruff check core/ tests/test_event_ingest_emit.py` → All checks passed

## Behavior delta from main
- LLM extraction prompt now permits a 4th type (`event`); model
  output is parsed by the existing post-processor.
- Event entity files appear under `wiki/entity/<source>/event/` once
  the LLM identifies a dated entity.
- Fallback path logs to stdout: `[INGEST] event entity 'X' missing/
  invalid occurred_at — falling back to concept` (helpful telemetry
  while we calibrate the new prompt against real models).

## Out of scope
- Memo §4.2 event-side relation ontology rules (INVOLVED / SUBJECT_OF /
  RESULTED_IN) — documentation conventions, not enforced
- PR-11d MemoryLoom date detection
- PR-11e plugin loader extension of EVENT_LIKE_ENTITY_TYPES

Design memo: `docs/design/v0.3-graph-evolution.md` §5.1 / §10 tests 2, 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)