### PR TITLE
UI IA: 5-area contract + API↔UI map + Phase 2 dedup + chat sidebar

### DIFF
--- a/docs/UI_API_MAPPING.md
+++ b/docs/UI_API_MAPPING.md
@@ -17,7 +17,8 @@
   `workspace.js`, `graph.js`, `graph_editor.js`, `graph_node_editor.js`
 - **1 CLI consumer** of HTTP API: `scripts/bench.py` (calls `/query/`)
 - **20 orphans** (defined backend, no frontend caller)
-- **6 duplicate / overlap pairs**
+- **5 duplicate / overlap pairs** (was 6 — `/admin/metrics` vs
+  `/admin/performance/metrics/` retracted as a false duplicate, see §5)
 - **7 area-conflict endpoints** (read and write straddle two IA areas)
 
 ---
@@ -71,8 +72,11 @@ Backend exists; no frontend caller. Grouped by disposition.
 | Endpoint | Reason | Action |
 |---|---|---|
 | `GET /admin/web-search-status` | dashboard card removed | delete or restore card |
-| `GET /admin/metrics` | overlaps `/admin/performance/metrics/` | consolidate (see §5) |
 | `GET /admin/character/correlations` | read-only stat, never surfaced | surface in Observe → Character or delete |
+
+(`/admin/metrics` was listed here in an earlier draft as a duplicate
+of `/admin/performance/metrics/`; that was an error — see §5
+correction. It serves a distinct latency-histogram purpose and stays.)
 
 ### 3.4 WIP / advanced (18 endpoints, holding)
 
@@ -97,7 +101,7 @@ implementation. Each is a duplication risk.
 
 | Endpoint | Callers | Smell |
 |---|---|---|
-| `POST /login/` | `chat.js:326`, `admin.js:326`, `graph.js:126` | 3 independent login modals — extract shared component |
+| `POST /login/` | `chat.js:326`, `admin.js:326`, `graph.js:126`, `workspace.js:99` | 4 independent login modals — extracted to `Auth.login()` (auth.js); modal markup itself still per-page (IA Phase 3) |
 | `POST /password/reset/confirm` | `chat.js:909`, `admin.js` (modal) | 2 divergent implementations |
 | `POST /llm/install/` | `chat.js:463`, `admin.js:494` | `firstRunInstall()` duplicated near-verbatim |
 | `GET /admin/llm/install-progress` | `chat.js` (poll), `admin.js:515` | parallel polling loops |
@@ -110,16 +114,24 @@ between chat and admin is a real bug source.
 
 ---
 
-## 5. Duplicate / overlap pairs (6)
+## 5. Duplicate / overlap pairs (5)
 
 | # | A | B | Recommendation |
 |---|---|---|---|
-| 1 | `GET /admin/metrics` (orphan) | `GET /admin/performance/metrics/` (used) | Deprecate A; keep B as canonical |
-| 2 | `GET /admin/memory` (whole) | `GET /admin/episodic/{session_id}` (single) | Keep both, document hierarchy (whole vs slice) |
-| 3 | `/admin/entities` (entities) | `/admin/artifacts/list` (artifacts) | Clarify concept boundary — entity = graph node, artifact = user upload? document in ARCHITECTURE |
-| 4 | `GET /admin/jobs/list` (admin, orphan) | `GET /jobs/list` (user, used) | Confirm admin-wide jobs view need; if yes, wire to Observe; if no, delete |
-| 5 | `/admin/files/tree` + `/search` (read, used) | `/admin/files` DELETE/PUT (orphan) | Read OK; writes should go through CR — confirm intent |
-| 6 | `/llm/install/` vs `/admin/llm/pull` | both download models | One is first-run, other is admin re-pull; document and stop confusing the two |
+| 1 | `GET /admin/memory` (whole) | `GET /admin/episodic/{session_id}` (single) | Keep both, document hierarchy (whole vs slice) |
+| 2 | `/admin/entities` (entities) | `/admin/artifacts/list` (artifacts) | Clarify concept boundary — entity = graph node, artifact = user upload? document in ARCHITECTURE |
+| 3 | `GET /admin/jobs/list` (admin, orphan) | `GET /jobs/list` (user, used) | Confirm admin-wide jobs view need; if yes, wire to Observe; if no, delete |
+| 4 | `/admin/files/tree` + `/search` (read, used) | `/admin/files` DELETE/PUT (orphan) | Read OK; writes should go through CR — confirm intent |
+| 5 | `/llm/install/` vs `/admin/llm/pull` | both download models | One is first-run, other is admin re-pull; document and stop confusing the two |
+
+> **Correction (post-investigation, Phase 1 cleanup, 2026-05-20)**:
+> An earlier draft listed `/admin/metrics` and `/admin/performance/metrics/`
+> as a duplicate pair. They are **not** duplicates: `/admin/metrics`
+> returns trace-derived per-stage latency histograms (p50/p90/p99 from
+> `core/trace_metrics.py`), while `/admin/performance/metrics/` returns
+> self-evaluation scores (`tools/self/performance_evaluator` +
+> `tools/self/importance_scorer`). Both are intentionally distinct and
+> live; do not deprecate either.
 
 ---
 
@@ -188,7 +200,9 @@ roughly 3 modules of ~15 calls each.
 
 ### Phase 1 — Cleanup (no IA changes yet)
 
-- [ ] Mark `/admin/metrics` as deprecated; document `/admin/performance/metrics/` as canonical
+- [x] **Not a duplicate**: `/admin/metrics` (trace latency histogram)
+      and `/admin/performance/metrics/` (self-eval scores) confirmed
+      distinct; doc corrected (this commit). No code change.
 - [ ] Decide and execute: keep or delete `/history/sessions/rename/`, `/history/long-term/`, `/feedback/stats/`
 - [ ] Each of the 18 WIP endpoints (`/code/*`, `/analyze/*`, ...) gets a roadmap line or a removal
 - [ ] `/admin/web-search-status` — restore the card or delete the endpoint

--- a/docs/UI_API_MAPPING.md
+++ b/docs/UI_API_MAPPING.md
@@ -1,0 +1,235 @@
+# JAMES — API ↔ UI Cross-Reference Map
+
+> Cross-reference of every HTTP endpoint against its UI caller(s),
+> bucketed into the 5 IA areas defined in `docs/UI_IA.md`.
+> Purpose: identify orphans, duplicates, multi-callers, and
+> area conflicts so the IA migration knows what to clean up.
+>
+> Status: investigation snapshot. v0.3.0 Platform Skeleton track.
+> Last updated: 2026-05-20.
+
+---
+
+## 1. Headline numbers
+
+- **133 HTTP endpoints** (server_llmwiki.py + routers)
+- **6 frontend JS files** call into them: `chat.js`, `admin.js`,
+  `workspace.js`, `graph.js`, `graph_editor.js`, `graph_node_editor.js`
+- **1 CLI consumer** of HTTP API: `scripts/bench.py` (calls `/query/`)
+- **20 orphans** (defined backend, no frontend caller)
+- **6 duplicate / overlap pairs**
+- **7 area-conflict endpoints** (read and write straddle two IA areas)
+
+---
+
+## 2. Area distribution
+
+| Area | Count | Representative endpoints |
+|---:|---:|---|
+| Ask | 9 | `/query/`, `/history/*`, `/feedback/*` |
+| My Work | 12 | `/api-keys/*`, `/artifacts/mine/*`, `/jobs/*` |
+| Govern | 24 | `/admin/users/*`, `/admin/patches/*`, `/admin/proposals/*`, `/admin/cr/*`, `/admin/features/*` |
+| Observe | 28 | `/admin/dashboard`, `/admin/audit/*`, `/admin/memory`, `/admin/evo-reports/*`, `/admin/performance/*`, `/admin/knowledge/*`, `/admin/entities/*`, `/admin/graph/*`, `/trace/*` |
+| Configure | 22 | `/llm/*`, `/admin/web-search-*`, `/admin/character/*`, `/admin/persona`, `/admin/settings`, `/admin/learn/topic/*`, `/hardware/` |
+| Non-UI infra | 20 | `/login/`, `/signup/`, `/password/*`, `/upload/`, `/status/`, `/healthz`, HTML routes |
+| WIP / advanced | 18 | `/code/*`, `/analyze/*`, `/screen/*`, `/export/`, admin file/wiki/graph writes |
+| **Total** | **133** | |
+
+The IA core (Ask + My Work + Govern + Observe + Configure) covers
+**95 of 133** endpoints (71%). The remaining 38 are infrastructure
+(auth, health, static) or work-in-progress (multimodal, code tools)
+not yet bound to an IA area.
+
+---
+
+## 3. Orphan endpoints (20)
+
+Backend exists; no frontend caller. Grouped by disposition.
+
+### 3.1 CLI-only (intentional)
+
+| Endpoint | Caller | Action |
+|---|---|---|
+| `POST /query/` | `scripts/bench.py:104` | Mark CLI-allowed in API docstring |
+| `POST /admin/llm/pull` | (CLI / future) | Tag `cli-only` until UI binds |
+| `DELETE /admin/llm/delete` | (CLI / future) | Tag `cli-only` until UI binds |
+| `GET /admin/patch/audit` | (CLI / future) | Surface in Observe → Audit |
+
+### 3.2 Backend ready, UI not wired yet
+
+| Endpoint | Intended area | Status |
+|---|---|---|
+| `GET /admin/llm/selections` | Configure | task→LLM mapping read; **wire into Configure → LLM** |
+| `POST /admin/llm/select` | Configure | task→LLM write; **wire into Configure → LLM** |
+| `DELETE /admin/llm/select` | Configure | task→LLM clear; **wire into Configure → LLM** |
+| `POST /history/sessions/rename/` | Ask | session-rename UX missing in chat |
+| `GET /history/long-term/` | Ask / Observe | long-term memory inspector missing |
+| `GET /feedback/stats/` | Observe | feedback aggregate not surfaced |
+
+### 3.3 Deprecated or redundant
+
+| Endpoint | Reason | Action |
+|---|---|---|
+| `GET /admin/web-search-status` | dashboard card removed | delete or restore card |
+| `GET /admin/metrics` | overlaps `/admin/performance/metrics/` | consolidate (see §5) |
+| `GET /admin/character/correlations` | read-only stat, never surfaced | surface in Observe → Character or delete |
+
+### 3.4 WIP / advanced (18 endpoints, holding)
+
+`/code/read/`, `/code/analyze/`, `/code/edit/`, `/code/surface/`,
+`/analyze/image/`, `/analyze/video/`, `/screen/analyze/`,
+`/admin/jobs/list`, `/admin/jobs/{job_id}`, `/admin/artifacts/list`,
+`/admin/artifacts/{artifact_id}`, `/admin/files` (DELETE/PUT),
+`/admin/scheduler/status`, `/admin/wiki/resolve-relations`,
+`/export/`, plus 3 admin graph writes already mediated by
+`graph_editor.js` / `graph_node_editor.js`.
+
+**Disposition**: leave as-is, but each must appear on the v0.3 →
+v0.4 roadmap with a target IA area, or be removed. No silently-living
+endpoints.
+
+---
+
+## 4. Multi-caller endpoints (refactor candidates)
+
+Two or more JS files hit the same endpoint with their own
+implementation. Each is a duplication risk.
+
+| Endpoint | Callers | Smell |
+|---|---|---|
+| `POST /login/` | `chat.js:326`, `admin.js:326`, `graph.js:126` | 3 independent login modals — extract shared component |
+| `POST /password/reset/confirm` | `chat.js:909`, `admin.js` (modal) | 2 divergent implementations |
+| `POST /llm/install/` | `chat.js:463`, `admin.js:494` | `firstRunInstall()` duplicated near-verbatim |
+| `GET /admin/llm/install-progress` | `chat.js` (poll), `admin.js:515` | parallel polling loops |
+| `POST /query/` | `chat.js:1112`, `scripts/bench.py:104` | OK — one UI, one CLI; expected |
+| `GET /artifacts/mine/list` | `chat.js:788`, `workspace.js` | shared My-Work fetch — promote to util |
+
+**Highest leverage**: collapse `firstRunInstall()` and the login modal
+into shared modules. Both are first-run-critical paths where divergence
+between chat and admin is a real bug source.
+
+---
+
+## 5. Duplicate / overlap pairs (6)
+
+| # | A | B | Recommendation |
+|---|---|---|---|
+| 1 | `GET /admin/metrics` (orphan) | `GET /admin/performance/metrics/` (used) | Deprecate A; keep B as canonical |
+| 2 | `GET /admin/memory` (whole) | `GET /admin/episodic/{session_id}` (single) | Keep both, document hierarchy (whole vs slice) |
+| 3 | `/admin/entities` (entities) | `/admin/artifacts/list` (artifacts) | Clarify concept boundary — entity = graph node, artifact = user upload? document in ARCHITECTURE |
+| 4 | `GET /admin/jobs/list` (admin, orphan) | `GET /jobs/list` (user, used) | Confirm admin-wide jobs view need; if yes, wire to Observe; if no, delete |
+| 5 | `/admin/files/tree` + `/search` (read, used) | `/admin/files` DELETE/PUT (orphan) | Read OK; writes should go through CR — confirm intent |
+| 6 | `/llm/install/` vs `/admin/llm/pull` | both download models | One is first-run, other is admin re-pull; document and stop confusing the two |
+
+---
+
+## 6. Area-conflict endpoints (7)
+
+Endpoints whose read and write halves belong in **different** IA
+areas. These are the cases UI_IA.md §3.2 flagged ("mixed-mode tabs").
+
+| Endpoint | Read goes to | Write goes to | Pattern |
+|---|---|---|---|
+| `/admin/entities` | Observe | Govern (via CR) | entity edit is CR-gated |
+| `/admin/character/` (GET vs POST) | Observe | Configure | view current persona vs change it |
+| `/admin/persona` (GET vs POST) | Observe | Configure | same |
+| `/admin/cr/` (lifecycle) | Observe (audit) | My Work (propose) + Govern (approve) | three-area workflow — needs hand-off links per UI_IA §3.3 |
+| `/admin/graph/relation` (GET vs PUT/POST/DELETE) | Observe | Govern (via CR) | graph edits CR-gated |
+| `/admin/proposals/` (GET list vs approve/reject) | Observe | Govern | propose-vs-approve split |
+| `/admin/patches` (list vs approve/reject) | Observe | Govern | propose-vs-approve split |
+
+**Rule** (proposed for IA implementation): on each page, **read
+affordances always present, write affordances guarded by area**.
+A user viewing entities in Observe sees data; they cannot edit there —
+the edit button deep-links into Govern → CR Propose.
+
+---
+
+## 7. Per-file UI caller load
+
+| File | API calls | Primary area(s) | Observation |
+|---|---:|---|---|
+| `admin.js` | 45+ | Observe + Govern + Configure | mirrors 17-tab monolith — biggest split target |
+| `chat.js` | 14 | Ask + My Work | first-run install logic duplicated with admin.js |
+| `workspace.js` | 12 | My Work + Govern (CR) | CR lifecycle straddles two areas here |
+| `graph_editor.js` | 3 | Govern | relation writes |
+| `graph.js` | 2 | Observe | snapshot + login |
+| `graph_node_editor.js` | 1 | Govern | node writes |
+
+`admin.js` (45+ calls across 3 IA areas) is the single largest
+artefact of the IA debt. The Govern / Observe / Configure split
+proposed in UI_IA.md §3.2 corresponds to splitting `admin.js` into
+roughly 3 modules of ~15 calls each.
+
+---
+
+## 8. Risk signals worth flagging now
+
+1. **Ask area is anemic in practice**: of 9 endpoints, only 3 are
+   actively called (`/query/`, `/history/`, `/feedback/`). Session
+   rename, long-term memory, feedback aggregate are all wired but
+   unused — symptom of a UI that hasn't surfaced what the backend
+   can already do.
+2. **Configure → LLM is half-wired**: `/admin/llm/installed` is
+   called, but `/admin/llm/selections`, `/admin/llm/select` (POST
+   and DELETE) are orphans. Task→LLM mapping is the headline feature
+   of Configure and it has no UI.
+3. **First-run wizard is duplicated in two files**: `firstRunInstall()`
+   exists in both `chat.js` and `admin.js`. Any change to onboarding
+   has to be made twice. This is a concrete bug-source today, not
+   a hypothetical.
+4. **Login modal in 3 files**: changing login UX requires touching
+   `chat.js`, `admin.js`, `graph.js`. Pre-IA, extract into one shared
+   component regardless of the larger split.
+
+---
+
+## 9. Action checklist (derived)
+
+### Phase 1 — Cleanup (no IA changes yet)
+
+- [ ] Mark `/admin/metrics` as deprecated; document `/admin/performance/metrics/` as canonical
+- [ ] Decide and execute: keep or delete `/history/sessions/rename/`, `/history/long-term/`, `/feedback/stats/`
+- [ ] Each of the 18 WIP endpoints (`/code/*`, `/analyze/*`, ...) gets a roadmap line or a removal
+- [ ] `/admin/web-search-status` — restore the card or delete the endpoint
+
+### Phase 2 — Deduplication (no IA changes yet)
+
+- [ ] Extract first-run install (`firstRunInstall()` + progress poll) into a shared module; call from chat **and** admin
+- [ ] Extract login modal into a shared component; remove from `chat.js`, `admin.js`, `graph.js`
+- [ ] Standardize `/password/reset/confirm` implementation across `chat.js` and `admin.js`
+
+### Phase 3 — IA migration (the big one)
+
+- [ ] Split `admin.js` along Govern / Observe / Configure boundaries
+- [ ] Wire `/admin/cr/` hand-off links per UI_IA §3.3 (My Work → Govern → Observe)
+- [ ] Implement the read/write area-split rule from §6 of this doc
+- [ ] Wire `/admin/llm/selections` + `/admin/llm/select` into Configure → LLM
+
+### Phase 4 — Naming (v0.4 candidate)
+
+- [ ] API endpoint rename to align with `<area>` prefix (optional, deferred)
+- [ ] `data-action` mass-rename per UI_IA §4.1
+
+---
+
+## 10. Reconciliation note
+
+The earlier UI inventory in chat reported **119 endpoints**. This
+deeper sweep found **133** — the delta is mostly auth/infra
+(`/login/`, `/signup/`, `/password/*`, `/healthz`, `/status/`, HTML
+routes) and a handful of admin writes that the first pass collapsed.
+Use **133** as the canonical number going forward.
+
+---
+
+## 한국어 요약
+
+JAMES의 HTTP 엔드포인트 133개를 UI 5영역과 크로스레퍼런스한 결과:
+**고아 20개, 의미상 중복 6쌍, 영역 충돌 7개**가 확인됐습니다. 가장 큰
+부채는 ① `admin.js` 한 파일에 Govern·Observe·Configure가 뒤섞여 있다는
+것, ② first-run 설치/로그인 모달이 2~3 파일에 복붙되어 있다는 것,
+③ Configure → LLM의 task→모델 매핑 API(`/admin/llm/select*`)가 백엔드에만
+존재하고 UI가 없다는 것입니다. IA 마이그레이션 전에 Phase 1(고아 정리),
+Phase 2(중복 추출)만 먼저 해도 체감 개선이 큽니다. Phase 3에서 `admin.js`
+삼분할과 `/admin/cr/` 핸드오프 링크를 구현합니다.

--- a/docs/UI_IA.md
+++ b/docs/UI_IA.md
@@ -1,0 +1,201 @@
+# JAMES — UI Information Architecture (IA) Contract
+
+> One-page IA contract for the JAMES web surface. Defines how user-facing
+> actions are grouped, named, and located. Implementation lives elsewhere;
+> this file is the **shape** the UI must converge on.
+>
+> Status: draft. v0.3.0 Platform Skeleton track.
+> Last updated: 2026-05-20.
+
+---
+
+## 1. Why this document exists
+
+The current UI surface (4 HTML pages, 119 HTTP endpoints, 17 admin tabs,
+~79 `data-action` handlers) has grown by accretion. Three concrete
+symptoms:
+
+- **`admin.html` is a 73 KB single page** holding 17 unrelated tabs
+  (`dashboard, users, policy, entities, memory, patches, uploads, files,
+  audit, proposals, evo-reports, character, knowledge, performance,
+  learning, hardware, settings`). Operators, reviewers, and observers
+  share one screen.
+- **One workflow crosses pages**: Change Request proposal lives in
+  `/workspace`, approval in `/admin`, raw audit in CLI. Users page-hop
+  to finish a single intent.
+- **Action naming is inconsistent**: `data-action` and `data-page`
+  conventions differ per page, so the same verb (e.g. "approve") has no
+  predictable form.
+
+This document fixes the **structure** (where things go, how they are
+named) without prescribing visual design.
+
+---
+
+## 2. The 5 IA areas
+
+The UI is reorganized around **user intent**, not API shape. Five areas,
+mutually exclusive, collectively exhaustive:
+
+| # | Area | Audience | Intent verb | Examples |
+|---|---|---|---|---|
+| 1 | **Ask** | end user | "I want an answer" | chat, sessions, history, feedback |
+| 2 | **My Work** | end user | "manage my own artifacts" | my files, my jobs, my CR proposals, my API keys |
+| 3 | **Govern** | reviewer / admin | "decide what changes" | CR approval, patch approval, proposal review, user approval, policy matrix |
+| 4 | **Observe** | reviewer / admin | "see what happened / is happening" | audit log, trace replay, metrics, performance history, bench |
+| 5 | **Configure** | admin | "set how the system behaves" | LLM selection, web-search, persona, character, hardware, learning rules, settings |
+
+Diagram:
+
+```
+   ┌───────────────────────────────────────────────────────────────┐
+   │                          End user                             │
+   │   ┌──────────────┐                ┌────────────────────────┐  │
+   │   │     Ask      │ ──────────────▶│        My Work         │  │
+   │   │  (chat/QA)   │   produces     │  (files, jobs, CRs)    │  │
+   │   └──────────────┘    artifacts   └───────────┬────────────┘  │
+   │                                               │ proposes      │
+   └───────────────────────────────────────────────┼───────────────┘
+                                                   ▼
+   ┌───────────────────────────────────────────────────────────────┐
+   │                       Reviewer / admin                        │
+   │   ┌────────────────┐   ┌────────────────┐   ┌──────────────┐  │
+   │   │    Govern      │   │    Observe     │   │  Configure   │  │
+   │   │ (approve/deny) │◀──│ (audit/trace)  │   │ (set policy) │  │
+   │   └────────────────┘   └────────────────┘   └──────────────┘  │
+   └───────────────────────────────────────────────────────────────┘
+```
+
+Rule of thumb: if a screen lets a user **change a thing they own**, it's
+*My Work*; if it lets them **decide on a thing the system proposes**,
+it's *Govern*; if it lets them **read history**, it's *Observe*; if it
+lets them **set defaults**, it's *Configure*.
+
+---
+
+## 3. Current → Target mapping
+
+### 3.1 Top-level pages
+
+| Today | Tomorrow | Notes |
+|---|---|---|
+| `/` (chat) | **`/ask`** (or keep `/`) | unchanged scope |
+| `/workspace` | **`/my`** | rename for clarity; same scope |
+| `/admin` (17 tabs) | **`/govern`** + **`/observe`** + **`/configure`** | split — see §3.2 |
+| `/admin/graph` | **`/observe/graph`** | graph is a read view; edits go through CR |
+
+### 3.2 admin.html 17-tab redistribution
+
+| Current admin tab | Target area | Rationale |
+|---|---|---|
+| `dashboard` | Observe (landing) | summary of audit + metrics |
+| `users` | Govern | approve/reject signups |
+| `policy` | Configure | set RBAC/ABAC matrix |
+| `entities` | Observe (read) + Govern (edit via CR) | entity edits already CR-gated |
+| `memory` | Observe | episodic + long-term snapshot |
+| `patches` | Govern | approve/reject patches |
+| `uploads` | Observe | upload history (read) |
+| `files` | Govern *(admin actions)* / mirrored to My Work for own files | admin-wide file ops vs user-owned |
+| `audit` | Observe | append-only log |
+| `proposals` | Govern | approve/reject self-evolution proposals |
+| `evo-reports` | Observe | evolution history |
+| `character` | Configure | persona/tone defaults |
+| `knowledge` | Observe | ability-growth view |
+| `performance` | Observe | real-time + history metrics |
+| `learning` | Configure | learning rules + topic seeds |
+| `hardware` | Configure | LLM hw selection (first-run wizard lives here) |
+| `settings` | Configure | global settings |
+
+Result: **17 flat tabs → 3 pages (Govern: 5 / Observe: 8 / Configure: 5)**.
+Mixed-mode tabs (`entities`, `files`) appear in two areas with **distinct
+read vs write affordances**, not duplicated screens.
+
+### 3.3 Cross-page workflows that must stop crossing pages
+
+| Workflow | Today | Target |
+|---|---|---|
+| Change Request lifecycle | propose @ `/workspace`, approve @ `/admin`, audit @ CLI | propose @ **My Work**, approve @ **Govern**, audit @ **Observe** — but each step **links** to the next; no page-hop without a hand-off link |
+| Self-evolution feedback loop | feedback @ `/`, proposals @ `/admin`, bench @ CLI | feedback @ **Ask**, proposals @ **Govern**, bench @ **Observe** (read-only mirror) |
+| Trace investigation | trace_id surfaces in `/` answer, replay only via `scripts/replay_trace.py` | every answer in **Ask** carries a deep-link into **Observe → Trace** |
+
+---
+
+## 4. Naming conventions
+
+### 4.1 `data-action` (button / link verbs)
+
+Format: `<area>:<noun>:<verb>` (kebab-case, lowercase).
+
+Examples:
+
+- `ask:session:new`
+- `ask:message:send`
+- `my:cr:propose`
+- `my:job:run`
+- `govern:cr:approve`
+- `govern:cr:reject`
+- `govern:patch:approve`
+- `observe:trace:open`
+- `configure:llm:select`
+
+Migration path: keep current `data-action` values working via an alias
+map; emit a console warning when the legacy form is used; remove
+warnings + aliases at the next minor.
+
+### 4.2 `data-page` / route slugs
+
+Format: `<area>` or `<area>/<subpage>` (lowercase, no underscores).
+
+- `/ask`, `/my`, `/govern`, `/observe`, `/configure`
+- Sub-pages: `/govern/proposals`, `/observe/audit`, `/configure/llm`
+
+### 4.3 API endpoints
+
+**Out of scope for this doc.** Existing 119 endpoints stay as-is. The
+UI layer maps area pages to current endpoints. An API rename is a
+separate v0.4 candidate.
+
+---
+
+## 5. What this doc deliberately does not decide
+
+- Visual design system (colors, components, spacing) — comes after IA
+- Framework choice (vanilla JS vs Vue vs Svelte) — orthogonal
+- API endpoint renaming — separate contract
+- Mobile / responsive strategy — out of scope for v0.3
+- i18n string reorganization — follows once `data-action` names settle
+
+---
+
+## 6. Acceptance criteria for "IA is done"
+
+This contract is satisfied when:
+
+1. Every user-facing screen lives under exactly one of {Ask, My Work,
+   Govern, Observe, Configure}.
+2. `admin.html` no longer exists as a 17-tab monolith.
+3. Every `data-action` matches `<area>:<noun>:<verb>`.
+4. The three cross-page workflows in §3.3 each have explicit hand-off
+   links between pages (no silent page-hops).
+5. A new contributor can place a new screen into the correct area from
+   reading this doc alone, without asking.
+
+---
+
+## 7. Out-of-scope confirmation (per `CLAUDE.md`)
+
+This IA is **platform-level** (mother-hardening), not a domain feature.
+No legal / food / retail / travel / finance specialization is implied
+or unlocked by this restructure. Domain forks remain post-v1.0 only.
+
+---
+
+## 한국어 요약
+
+JAMES의 UI는 4페이지·119 API·17탭이 누적되며 "중구난방"이 됐습니다. 이
+문서는 **사용자 의도** 기준으로 5영역(Ask / My Work / Govern / Observe /
+Configure)을 확정하고, 현재 `/admin` 단일 페이지의 17탭을 Govern·Observe·
+Configure 3페이지로 재분배합니다. CR 제안→승인→감사 같은 작업이 페이지를
+가로질러 흩어진 문제는 **명시적 hand-off 링크**로 해소합니다. `data-action`
+명명은 `<영역>:<명사>:<동사>` 규칙으로 통일합니다. 시각 디자인·프레임워크
+선택·API 리네이밍은 이 문서 범위 밖입니다.

--- a/docs/handovers/v0.3.0-platform-track.md
+++ b/docs/handovers/v0.3.0-platform-track.md
@@ -40,6 +40,7 @@ v0.3 의 두 번째 메인 트랙으로 **Cognitive Layer** 가 추가됨. Plugi
 | **CR-E** | self-evolution gate → Change Request 래핑 | `docs/handovers/v0.2.x-cr-track.md §5` | 🟢 **PR-8 Tool Router 통해 통합 완성 (2026-05-17)** — write tool 은 자동 CR-E wrap |
 | **Cog** Cognitive Layer | retrieval / reflection / verification / memory / multi-agent | `docs/handovers/v0.3-cognitive-layer-track.md` + ARCHITECTURE.md §5.7 | 🟢 **Phase 0+1+2 핵심 머지 (2026-05-17)** — PR-7 Planner / Phase 3 잔여 |
 | **OpUX** Operational UX | 라이브 차단 4건 + external 격리 + 노드 편집 | `docs/handovers/v0.3-operational-ux-track.md` | 🟢 **사이클 12 PR-O1~O6 closed (2026-05-17)** — PR-O6b frontend / PR-O7 deferred |
+| **UI-IA** UI Information Architecture | 5영역 IA 계약 + 133 API↔UI 매핑 + 코드 중복 제거 + admin.js 분할 | `docs/handovers/v0.3.x-ui-ia-track.md` | 🟡 **Phase 2 완료 (2026-05-21)** — 브라우저 검증 부채 + Phase 3 (`admin.js` 삼분할) 미착수. branch: `claude/explore-miro-integration-zKLEv` |
 | **v0.3.0 release** | CHANGELOG + tag + GH release | `docs/release_notes_v0.3.0.md` | 🟢 **published (2026-05-17, #281)** |
 
 세션 결산: `docs/handovers/v0.3.x-session-2026-05-17-closure.md`.

--- a/docs/handovers/v0.3.x-ui-ia-track.md
+++ b/docs/handovers/v0.3.x-ui-ia-track.md
@@ -1,0 +1,236 @@
+# v0.3.x — UI IA Track Handover
+
+> **Active handover** (2026-05-21~). 새 Claude Code 세션이 이 작업을
+> 이어받는다면 `CLAUDE.md` → `docs/UI_IA.md` → 이 문서 순으로 읽으세요.
+>
+> **Branch**: `claude/explore-miro-integration-zKLEv` — 아직 main 미머지.
+> 모든 작업물이 이 브랜치에 푸시됨.
+>
+> **Theme**: v0.3 Platform Skeleton 의 한 부속 트랙. 도메인 기능 추가
+> 없음 — 모체 정돈(IA + 코드 중복 제거)만. `CLAUDE.md` rule #1 준수.
+
+---
+
+## 0. 한 줄 요약
+
+JAMES 의 UI 표면(4 HTML 페이지 / 133 HTTP API / 17 admin 탭 / ~79
+`data-action`)이 "중구난방"이라는 사용자 진단에서 출발. 1주 작업으로
+**(a) IA 계약 확정 + (b) API↔UI 매핑 전수조사 + (c) Phase 2 코드
+중복 3건 제거 + (d) 챗 세션 패널 사이드바 이동**까지 완료. 남은 큰
+일은 **Phase 3 = `admin.js` Govern/Observe/Configure 삼분할**.
+
+---
+
+## 1. 작업 산출물 (이 브랜치 7 커밋)
+
+순서: 최신 → 오래된. 모두 `claude/explore-miro-integration-zKLEv` 브랜치
+에 푸시됨.
+
+| 커밋 | 종류 | 한 줄 |
+|---|---|---|
+| `78db8de` | feat | 챗 세션 리스트를 사이드바 `data-mode="sessions"` 로 이동, 플로팅 `#session-panel` 제거 |
+| `cad431d` | docs | UI_API_MAPPING 거짓 중복 정정 (`/admin/metrics` ↔ `/admin/performance/metrics/` 은 별개) + 로그인 콜러 3→4 정정 |
+| `b829033` | refactor | `Auth.resetPasswordConfirm()` 추출 (chat + admin) |
+| `be5609c` | refactor | `Auth.login()` 추출 (chat + admin + graph + workspace 4 콜러) |
+| `9fe9275` | refactor | `LlmInstall` 컨트롤러 추출 (`/llm/install/` + `/admin/llm/install-progress` 폴링) |
+| `539af37` | docs | `docs/UI_API_MAPPING.md` — 133 엔드포인트 ↔ UI 호출 매핑 + 고아/중복/충돌 분석 |
+| `e5dab3d` | docs | `docs/UI_IA.md` — 5영역 IA 계약 (Ask / My Work / Govern / Observe / Configure) |
+
+코드 변화 누계: 신규 모듈 3개(`auth.js`, `llm-install.js`, UI 사이드바
+세션 패널), 콜러 합계 약 **-272 줄**. 동작 보존 (정적 검증만 — 브라우저
+미검증).
+
+---
+
+## 2. 핵심 산출 문서 (반드시 먼저 읽기)
+
+| 파일 | 역할 |
+|---|---|
+| `docs/UI_IA.md` | 5영역 IA **계약**. UI 의 형태가 수렴해야 할 곳. §3.2 의 17탭 재분배표가 Phase 3 의 입력. |
+| `docs/UI_API_MAPPING.md` | 133 엔드포인트 ↔ UI 호출 **매핑 + 분석**. §3 고아 20개, §5 중복 5쌍(정정 후), §6 영역 충돌 7개, §9 액션 체크리스트. |
+
+---
+
+## 3. Phase 진행 상황
+
+`docs/UI_API_MAPPING.md §9` 의 4 Phase 기준:
+
+### Phase 1 — Cleanup (doc-only 부분만 완료)
+
+- [x] `/admin/metrics` 거짓 deprecation 회피 (`cad431d`). 두 엔드포인트는
+      별개 기능 (전자=trace 지연 histogram, 후자=자기평가 점수).
+- [ ] `/history/sessions/rename/`, `/history/long-term/`, `/feedback/stats/`
+      유지/삭제 결정 — **product call 필요**, 코드 손대지 말 것.
+- [ ] 18개 WIP 엔드포인트 (`/code/*`, `/analyze/*`, `/screen/*`,
+      `/admin/wiki/resolve-relations` 등) 로드맵 라인 작성 또는 삭제.
+- [ ] `/admin/web-search-status` — 대시보드 카드 복원 또는 엔드포인트
+      삭제 결정.
+
+### Phase 2 — Deduplication ✅ **완료**
+
+- [x] `firstRunInstall()` → `LlmInstall.start()` 공통 모듈 (`9fe9275`)
+- [x] `/login/` HTTP → `Auth.login()` (`be5609c`) — 4 콜러
+- [x] `/password/reset/confirm` → `Auth.resetPasswordConfirm()` (`b829033`)
+
+Phase 2 의 누락 부분(있다면): 로그인 **모달 마크업 자체**는 4개 HTML
+파일에 흩어진 채. 마크업 단일화는 IA Phase 3 와 묶어서 진행 권장.
+
+### Phase 3 — IA migration ❌ **미착수** (가장 큰 작업)
+
+- [ ] `admin.js` (45+ API 호출, 17 탭) 을 Govern / Observe / Configure
+      **3 모듈로 분할**. UI_IA.md §3.2 의 17→(5+8+5) 재분배 표 참조.
+- [ ] `/admin/cr/` lifecycle hand-off 링크 (My Work → Govern → Observe).
+      UI_IA.md §3.3 의 3 워크플로우 중 핵심.
+- [ ] 읽기/쓰기 영역 분리 룰 적용: 7개 영역 충돌 엔드포인트 각각
+      (`/admin/entities`, `/admin/character/`, `/admin/persona`, `/admin/cr/`,
+      `/admin/graph/relation`, `/admin/proposals/`, `/admin/patches`).
+- [ ] `Configure → LLM` 화면 배선 — `/admin/llm/selections`,
+      `/admin/llm/select` (POST/DELETE) 가 백엔드만 있고 UI 없음 (mapping
+      doc §8 의 "반쪽 구현" 항목).
+
+### Phase 4 — Naming (deferred)
+
+API 엔드포인트 `<area>` prefix 정렬, `data-action` 대량 rename. v0.4
+후보로 보류.
+
+---
+
+## 4. 진행 중 작업의 검증 부채 ⚠️
+
+**원격 컨테이너 환경 = 브라우저 미접근.** Phase 2 + 챗 사이드바 작업은
+`node --check` 정적 검증만 통과. 다음 세션에서 사용자가 띄워 다음 6개
+**골든 패스**를 확인해야 함:
+
+1. 상단 헤더 💬 클릭 → 사이드바가 `sessions` 모드로 열리고 리스트 로드
+2. 다시 💬 클릭 → `upload` 모드로 복귀 (토글 의미 보존)
+3. 리스트의 과거 세션 클릭 → 그 세션의 대화 turn 로드, 활성 하이라이트 이동
+4. 사이드바 "+ 새 대화" → 새 SID 생성, 환영 화면 + 리스트 갱신
+5. 세션 항목의 ✏️ 이름변경 / 🗑️ 삭제 정상 작동
+6. 페이지 새로고침 → 마지막 사이드바 모드 복원 (localStorage `james_sidebar_mode`)
+
+추가 회귀 점검 (Phase 2 결과):
+
+7. 4 페이지 로그인 (chat / admin / graph / workspace) 모두 정상 — admin 은
+   role check 통과, graph 는 bootstrap, workspace 는 reloadData
+8. admin first-run wizard 모델 설치 → 모달 안 진행률 + 완료 자동 닫기
+9. chat 페이지 `mode-install-btn` 모델 설치 → 버튼 % 갱신 + GB 표시
+10. 비밀번호 재설정 모달 (chat / admin 양쪽) 정상
+
+**브라우저 검증 전까지 main 머지 금지.**
+
+---
+
+## 5. 의사결정 / 규약 (이미 확정된 것)
+
+이 트랙 진행 중 내려진 결정. 다음 세션은 재논의 없이 따르세요.
+
+| # | 결정 | 의미 |
+|---|---|---|
+| D1 | IA 5영역: **Ask / My Work / Govern / Observe / Configure** | UI_IA.md §2. 모든 화면은 정확히 한 영역에 속함. |
+| D2 | `admin.html` 단일 17 탭 페이지를 **3 페이지로 분할** (Govern / Observe / Configure) | UI_IA.md §3.2. Phase 3 의 헤드라인 작업. |
+| D3 | `data-action` 명명: `<area>:<noun>:<verb>` (예: `govern:cr:approve`) | UI_IA.md §4.1. 마이그레이션은 alias map 으로 점진적. |
+| D4 | **API endpoint rename 은 v0.4 candidate** | UI_IA.md §4.3. Phase 3 시점에는 기존 119+ 엔드포인트 그대로 호출. |
+| D5 | 모달 markup 자체의 단일화는 Phase 3 작업 (로그인 모달 4개, forgot-password 2개) | Phase 2 에서 HTTP wrapper 만 추출, markup 은 페이지별로 유지. |
+| D6 | `/admin/metrics` ≠ `/admin/performance/metrics/` (정정 후) | 둘 다 라이브, deprecate 금지. UI_API_MAPPING.md §5 correction box. |
+| D7 | 챗 세션 리스트는 **사이드바 `data-mode="sessions"`** 로 이동, 플로팅 `#session-panel` 제거 | `78db8de`. `#session-list` / `#session-count-badge` ID 보존. |
+| D8 | 영역 충돌 엔드포인트의 **읽기/쓰기 분리 룰**: 읽기는 어느 영역에서나 보이게, 쓰기는 해당 영역의 액션 버튼이 deep-link 로 정확한 영역으로 보냄 | UI_API_MAPPING.md §6. 7개 엔드포인트 적용 대상. |
+
+---
+
+## 6. 미세 회귀 / 부채 (인식해두기)
+
+Phase 2 작업으로 생긴 작은 i18n 부채. 차후 수습 대상:
+
+- `Auth.login()` 의 유효성 검사 메시지는 하드코드 한국어. admin.js
+  doAdminLogin 의 원래 `t('auth.password_required')` 호출은 사라짐 — 영문
+  사용자 입장에서 "아이디와 비밀번호를 입력하세요." 가 보임. 영향 적음,
+  수습은 Auth.* 가 i18n 키를 옵션으로 받게 하거나 콜러에서 pre-validate.
+- 같은 패턴이 `Auth.resetPasswordConfirm()` 에도 — admin 의 `t('auth.reset_fill_all')` 가
+  하드코드로 대체됨.
+- graph.js 의 로그인 에러 메시지가 영문 → 한국어로 미세 변경 (`'API key required (set on chat page or paste here)'` → `'API Key를 입력하세요.'`).
+- 이상 3건 모두 Phase 3 에서 모달 마크업 통일하면서 같이 정리하면 자연스러움.
+
+---
+
+## 7. 다음 세션 추천 진입 순서
+
+우선순위 순. 사용자 명시 지시가 없으면 (a)부터.
+
+### (a) 브라우저 검증 + 미세 fix
+- §4 의 골든 패스 10개 실행
+- 회귀 발견 시 즉시 fix 커밋
+- 이후 main PR 만들 수 있는 상태로 정리
+
+### (b) Phase 1 미결정 항목 결정
+사용자 product call 필요. AskUserQuestion 으로 다음을 결정:
+- `/history/sessions/rename/`, `/history/long-term/`, `/feedback/stats/` 유지/삭제
+- 18개 WIP 엔드포인트 (`/code/*`, `/analyze/*` 등) 로드맵 vs 삭제
+- `/admin/web-search-status` 대시보드 카드 복원 vs 엔드포인트 삭제
+
+### (c) Phase 3 PoC — `admin.js` 분할
+가장 큰 일. 권장 진행 방식:
+1. `admin.js` 의 45+ API 호출을 UI_IA.md §3.2 표대로 3 그룹으로 색인
+2. 새 파일 3개: `frontend/static/govern.js`, `observe.js`, `configure.js`
+3. 각 그룹의 함수를 이동, 공유 유틸은 `admin-common.js` (또는 `auth.js` 확장)
+4. HTML 측: `admin.html` 의 17 탭을 3 페이지(`/govern`, `/observe`, `/configure`)로 분할 또는 한 페이지 안에서 영역 sub-tab 으로 재배치 (선택 결정 필요)
+5. 백엔드 라우팅 — Phase 3 에서는 **URL 안 바꾸기** (D4). 그냥 새 HTML 페이지에서 기존 API 호출.
+
+PoC 단위: Govern 분할만 먼저 (5탭: users, patches, proposals, cr, features).
+검증 후 Observe / Configure 진행.
+
+### (d) `Configure → LLM` 화면 배선
+`/admin/llm/selections` + `/admin/llm/select` POST/DELETE 가 백엔드만
+존재. UI 가 생기면 task→model 매핑이 라이브로 가능. Phase 3 의 Configure
+분할과 같이 묶어서 진행 가능.
+
+### (e) 로그인 모달 마크업 통일
+4 HTML 파일의 모달 markup (서로 다른 DOM ID, 다른 필드) 을 단일
+컴포넌트로. JS 동적 삽입 또는 Web Components 검토. 비교적 큰 작업이라
+Phase 3 와 묶어서.
+
+---
+
+## 8. 중요 파일 빠른 참조
+
+```
+docs/UI_IA.md                       — IA 5영역 계약
+docs/UI_API_MAPPING.md              — 133 API ↔ UI 매핑 분석
+docs/handovers/v0.3.x-ui-ia-track.md — 이 문서
+
+frontend/static/auth.js             — Auth.login + Auth.resetPasswordConfirm (Phase 2)
+frontend/static/llm-install.js      — LlmInstall.start (Phase 2)
+
+frontend/static/chat.js             — 챗 페이지 로직 (사이드바 sessions 모드 통합 완료)
+frontend/static/admin.js            — 73KB / 17탭 / 45+ API. Phase 3 의 분할 대상
+frontend/static/graph.js, workspace.js  — 작은 페이지
+frontend/static/i18n.js             — sidebar.mode_sessions 추가됨
+
+frontend/index.html                 — 사이드바 + 헤더. data-mode="sessions" rail 신규
+frontend/admin.html                 — 73KB. Phase 3 분할 대상
+frontend/graph.html, workspace.html — 작은 페이지
+
+server_llmwiki.py                   — 133 엔드포인트 정의. Phase 3 에서 URL 변경 금지 (D4)
+```
+
+---
+
+## 9. 절대 하지 말 것
+
+`CLAUDE.md` 상위 규칙 + 이 트랙 고유:
+
+- ❌ `/admin/metrics` 또는 `/admin/performance/metrics/` 둘 중 하나
+  deprecate (D6) — 별개 기능
+- ❌ Phase 3 진입 전에 `admin.js` 일부만 무분별하게 옮기기 (반드시
+  UI_IA.md §3.2 의 17→(5+8+5) 표를 따를 것)
+- ❌ Phase 3 에서 API 엔드포인트 URL 변경 (D4)
+- ❌ 도메인 특화 코드 추가 (CLAUDE.md rule #1)
+- ❌ 브라우저 검증 없이 main 머지
+- ❌ `#session-list` / `#session-count-badge` DOM ID 변경 (D7 호환성)
+
+---
+
+## 10. 한국어 한 줄 결론
+
+UI 정돈은 **계약 + 매핑 + 중복 제거 + 사이드바 통합**까지 끝. 다음
+세션의 진짜 일은 `admin.js` 삼분할(Phase 3) — 그 전에 브라우저로
+이번 변경 검증부터.

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -993,6 +993,7 @@
 </div>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
 <script src="/static/admin.js"></script>
 <script src="/static/a11y-modal.js" defer></script>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -993,6 +993,7 @@
 </div>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/llm-install.js"></script>
 <script src="/static/admin.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -366,6 +366,7 @@
 </div>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/auth.js"></script>
 <script src="/static/graph.js"></script>
 <script src="/static/graph_editor.js"></script>
 <script src="/static/graph_node_editor.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -290,6 +290,7 @@
 </main>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/llm-install.js"></script>
 <script src="/static/chat.js"></script>
 <script src="/static/upload.js"></script>
 <script src="/static/a11y-modal.js" defer></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,35 +54,9 @@
   </div>
 </header>
 
-<!-- [P3-4] 세션 선택 패널 -->
-<div id="session-panel"
-     style="display:none;position:fixed;top:58px;right:16px;
-            width:320px;max-height:440px;overflow-y:auto;
-            background:var(--surface);border:1px solid var(--border);
-            border-radius:10px;box-shadow:0 16px 40px rgba(0,0,0,.4);
-            z-index:1000;padding:12px">
-  <div style="display:flex;justify-content:space-between;align-items:center;
-              margin-bottom:12px">
-    <div style="font-weight:600;font-size:13px;color:var(--text)"><span data-i18n="chat.previous">이전 대화</span></div>
-    <div style="display:flex;gap:6px">
-      <button data-action="new-session"
-              style="background:var(--accent);color:var(--on-accent);border:none;
-                     border-radius:6px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500">
-        <span data-i18n="chat.new_session">+ 새 대화</span>
-      </button>
-      <button data-action="toggle-session-panel"
-              aria-label="세션 패널 닫기"
-              style="background:none;border:none;color:var(--muted);
-                     cursor:pointer;font-size:16px;padding:0 4px">✕</button>
-    </div>
-  </div>
-  <div id="session-list">
-    <div style="color:var(--muted);font-size:12px;text-align:center;padding:20px"
-         data-i18n="common.loading">
-      Loading...
-    </div>
-  </div>
-</div>
+<!-- [P3-4] 세션 패널은 사이드바 'sessions' 모드로 이동.
+     #session-list / #session-count-badge ID는 그대로 보존 — chat.js의
+     loadSessionList() / 배지 갱신 로직 그대로 작동. -->
 
 <main style="position:relative">
   <button class="sidebar-open-btn" id="sidebar-open-btn"
@@ -98,10 +72,15 @@
         📂
         <span class="sidebar-rail-tip" data-i18n="sidebar.mode_upload">파일 업로드</span>
       </div>
+      <div class="sidebar-rail-item" data-mode="sessions"
+           data-action="switch-sidebar-mode">
+        💬
+        <span class="sidebar-rail-tip" data-i18n="sidebar.mode_sessions">대화 이력</span>
+      </div>
       <div class="sidebar-rail-item" data-mode="recent"
            data-action="switch-sidebar-mode">
         🕘
-        <span class="sidebar-rail-tip" data-i18n="sidebar.mode_recent">최근 챗</span>
+        <span class="sidebar-rail-tip" data-i18n="sidebar.mode_recent">내 자료</span>
       </div>
       <div class="sidebar-rail-item" data-mode="search"
            data-action="switch-sidebar-mode">
@@ -164,6 +143,32 @@
         <button class="upload-btn" id="upload-btn" data-action="upload-files" disabled>
           <span data-i18n="upload.btn_default">업로드 및 분석</span>
         </button>
+      </div>
+
+      <!-- Mode: 대화 이력 (P3-4 → 사이드바로 이동, 2026-05-21).
+           #session-list ID 보존 — chat.js의 loadSessionList()가 그대로
+           이 div를 채움. switchSidebarMode('sessions')가 활성화 시
+           자동 로드 호출. -->
+      <div class="sidebar-panel-mode" data-mode="sessions">
+        <div style="padding:10px 12px;font-size:11px;color:var(--muted);
+                    border-bottom:1px solid var(--border-2);display:flex;
+                    justify-content:space-between;align-items:center;gap:8px">
+          <span data-i18n="chat.previous"
+                style="font-weight:600;font-size:13px;color:var(--text)">이전 대화</span>
+          <button data-action="new-session"
+                  style="background:var(--accent);color:var(--on-accent);border:none;
+                         border-radius:6px;padding:5px 12px;cursor:pointer;font-size:12px;
+                         font-weight:500;flex-shrink:0">
+            <span data-i18n="chat.new_session">+ 새 대화</span>
+          </button>
+        </div>
+        <div id="session-list"
+             style="flex:1;overflow-y:auto;padding:8px 12px">
+          <div style="color:var(--muted);font-size:12px;text-align:center;padding:20px"
+               data-i18n="common.loading">
+            Loading...
+          </div>
+        </div>
       </div>
 
       <!-- Mode: 내 자료 (W8-B: artifacts/mine 으로 채움) -->
@@ -336,6 +341,11 @@
     // W8-B: lazy-load the "내 자료" list when switching into recent.
     if (modeId === 'recent' && typeof loadMineSidebar === 'function') {
       loadMineSidebar();
+    }
+    // P3-4 → sidebar: lazy-load the "대화 이력" list when switching
+    // into sessions (was: floating panel toggle).
+    if (modeId === 'sessions' && typeof loadSessionList === 'function') {
+      loadSessionList();
     }
     // Update the panel header title from the matching rail tip so
     // i18n stays in one place.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -290,6 +290,7 @@
 </main>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
 <script src="/static/chat.js"></script>
 <script src="/static/upload.js"></script>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -1218,33 +1218,15 @@ async function submitSignup() {
 
 async function submitPasswordReset() {
   const username = document.getElementById('reset-username').value.trim();
-  const token    = document.getElementById('reset-token').value.trim();
-  const newPw    = document.getElementById('reset-new-pw').value;
-  const errEl    = document.getElementById('reset-error');
+  const token = document.getElementById('reset-token').value.trim();
+  const newPw = document.getElementById('reset-new-pw').value;
+  const errEl = document.getElementById('reset-error');
   errEl.textContent = '';
-  if (!username || !token || !newPw) {
-    errEl.textContent = t('auth.reset_fill_all');
-    return;
-  }
-  try {
-    // Bare fetch — no Bearer header (anonymous flow), no api_key
-    // query (the endpoint is public). The api() helper assumes both.
-    const r = await fetch(`${API}/password/reset/confirm`, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ username, token, new_password: newPw }),
-    });
-    if (r.ok) {
-      alert(t('auth.reset_success'));
-      closeForgotPasswordModal();
-      return;
-    }
-    let detail = `${r.status}`;
-    try { detail = (await r.json()).detail || detail; } catch (_e) {}
-    errEl.textContent = detail;
-  } catch (e) {
-    errEl.textContent = e.message;
-  }
+
+  const res = await Auth.resetPasswordConfirm({ username, token, newPassword: newPw });
+  if (!res.ok) { errEl.textContent = res.error; return; }
+  alert(t('auth.reset_success'));
+  closeForgotPasswordModal();
 }
 
 /* ── Entity (item #1: search + paging + detail modal) ── */

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -366,7 +366,7 @@ async function doAdminLogin() {
    시 안 띄움. 그러나 firstRunCheck()는 항상 호출되며 dismiss 됐어도
    ↻ 새로고침 버튼이 강제 표시 가능. */
 
-let _firstRunInstallPoll = null;
+let _firstRunInstallController = null;
 
 async function firstRunCheck() {
   // 이번 세션에서 이미 dismiss됐고 모델이 ≥1개면 wizard 안 띄움.
@@ -481,6 +481,8 @@ function _firstRunRow(r, primary) {
   </div>`;
 }
 
+// HTTP + 폴링 메커니즘은 llm-install.js의 LlmInstall.start()가 담당.
+// 여기는 firstrun 모달 UI 렌더링만.
 async function firstRunInstall(model) {
   if (!model) return;
   const progressBox = document.getElementById('firstrun-progress');
@@ -489,77 +491,42 @@ async function firstRunInstall(model) {
   if (progressBox) progressBox.style.display = 'block';
   if (progressText) progressText.textContent = `${model} 설치 시작 중...`;
 
-  try {
-    const r = await fetch(
-      `${API}/llm/install/?api_key=${encodeURIComponent(apiKey)}&model=${encodeURIComponent(model)}`,
-      {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
-      },
-    );
-    if (!r.ok) {
-      const err = await r.json().catch(() => ({}));
-      throw new Error(err.detail || `HTTP ${r.status}`);
-    }
-    // 진행률 폴링
-    if (_firstRunInstallPoll) clearInterval(_firstRunInstallPoll);
-    _firstRunInstallPoll = setInterval(() => _firstRunPollProgress(model), 2500);
-    _firstRunPollProgress(model);   // 즉시 1회
-  } catch (e) {
-    if (progressText) progressText.textContent = `❌ 설치 실패: ${e.message}`;
-  }
-}
-
-async function _firstRunPollProgress(model) {
-  try {
-    const r = await fetch(
-      `${API}/admin/llm/install-progress?api_key=${encodeURIComponent(apiKey)}&model=${encodeURIComponent(model)}`,
-      { headers: { 'Authorization': `Bearer ${token}` } },
-    );
-    if (!r.ok) {
-      if (r.status === 401) {
-        // 세션 만료 — 폴링 중단 + localStorage 정리 (chat tab role
-        // badge도 같이 업데이트되도록 SSO 일관성 유지).
-        clearInterval(_firstRunInstallPoll);
-        _firstRunInstallPoll = null;
-        try {
-          localStorage.removeItem('james_token');
-          localStorage.removeItem('james_role');
-        } catch (_) {}
+  if (_firstRunInstallController) _firstRunInstallController.stop();
+  _firstRunInstallController = LlmInstall.start(model, {
+    onProgress(p) {
+      const txt = document.getElementById('firstrun-progress-text');
+      const bar = document.getElementById('firstrun-progress-bar');
+      if (txt) {
+        const pctStr = (p.percent != null) ? `${p.percent}%` : (p.status || '진행 중');
+        txt.textContent = `⏳ ${model}: ${pctStr}`;
       }
-      return;
-    }
-    const p = await r.json();
-    const progressText = document.getElementById('firstrun-progress-text');
-    const progressBar = document.getElementById('firstrun-progress-bar');
-    if (p.error) {
-      if (progressText) progressText.textContent = `❌ ${model} 실패: ${p.error}`;
-      clearInterval(_firstRunInstallPoll);
-      _firstRunInstallPoll = null;
-      return;
-    }
-    if (p.done) {
-      if (progressText) progressText.textContent = `✅ ${model} 설치 완료! 이제 답변할 수 있습니다.`;
-      if (progressBar) progressBar.style.width = '100%';
-      clearInterval(_firstRunInstallPoll);
-      _firstRunInstallPoll = null;
+      if (bar && p.percent != null) {
+        bar.style.width = `${p.percent}%`;
+      }
+    },
+    onDone() {
+      const txt = document.getElementById('firstrun-progress-text');
+      const bar = document.getElementById('firstrun-progress-bar');
+      if (txt) txt.textContent = `✅ ${model} 설치 완료! 이제 답변할 수 있습니다.`;
+      if (bar) bar.style.width = '100%';
       // 자동 닫기 (3초 후)
       setTimeout(() => {
         const modal = document.getElementById('firstrun-wizard-modal');
         if (modal) modal.style.display = 'none';
       }, 3000);
-      return;
-    }
-    if (progressText) {
-      const pctStr = (p.percent != null) ? `${p.percent}%` : (p.status || '진행 중');
-      progressText.textContent = `⏳ ${model}: ${pctStr}`;
-    }
-    if (progressBar && p.percent != null) {
-      progressBar.style.width = `${p.percent}%`;
-    }
-  } catch (e) {
-    console.warn('[firstrun-poll]', e);
-  }
+    },
+    onError(e) {
+      const txt = document.getElementById('firstrun-progress-text');
+      if (txt) txt.textContent = `❌ ${model} 실패: ${e.message}`;
+    },
+    onUnauthorized() {
+      // 세션 만료 — chat tab role-badge도 같이 갱신되도록 SSO 일관성 유지.
+      try {
+        localStorage.removeItem('james_token');
+        localStorage.removeItem('james_role');
+      } catch (_) {}
+    },
+  });
 }
 
 function firstRunDismiss() {

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -317,46 +317,21 @@ function toggleAdminPwVisibility() {
 async function doAdminLogin() {
   const username = document.getElementById('admin-login-id')?.value.trim() || 'admin';
   const password = document.getElementById('admin-login-pw')?.value || '';
-  const errEl    = document.getElementById('admin-login-error');
+  const errEl = document.getElementById('admin-login-error');
   if (errEl) errEl.textContent = '';
 
-  if (!password) { if(errEl) errEl.textContent = t('auth.password_required'); return; }
-
-  try {
-    const r = await fetch(`${API}/login/`, {
-      method:  'POST',
-      headers: {'Content-Type': 'application/json'},
-      body:    JSON.stringify({username, password, api_key: apiKey}),
-    });
-    const d = await r.json();
-
-    if (!r.ok) {
-      if(errEl) errEl.textContent = d.detail || `Login failed (${r.status})`;
-      return;
-    }
-
-    // access_token 또는 token 필드 모두 처리
-    const tok  = d.access_token || d.token || '';
-    const role = d.role || 'external';
-
-    if (!tok)            { if(errEl) errEl.textContent = t('auth.token_failed'); return; }
-    if (role !== 'admin'){ if(errEl) errEl.textContent = `Admin role required (role: ${role})`; return; }
-
-    token = tok;
-    // [#A8-4] localStorage — chat 페이지와 공유. 다른 탭의 storage 이벤트로
-    // chat 페이지 role-badge 자동 갱신.
-    localStorage.setItem('james_token', token);
-    localStorage.setItem('james_role',  role);
-
-    const modal = document.getElementById('admin-login-modal');
-    if (modal) modal.style.display = 'none';
-    loadDashboard();
-    // [PR plan-3] 로그인 후 LLM 모델 readiness 체크. 0개면 wizard 노출.
-    setTimeout(() => { try { firstRunCheck(); } catch (_) {} }, 600);
-
-  } catch (e) {
-    if(errEl) errEl.textContent = `Server error: ${e.message}`;
+  const res = await Auth.login({ username, password, apiKey, requireRole: 'admin' });
+  if (!res.ok) {
+    if (errEl) errEl.textContent = res.error;
+    return;
   }
+  token = res.token;
+
+  const modal = document.getElementById('admin-login-modal');
+  if (modal) modal.style.display = 'none';
+  loadDashboard();
+  // [PR plan-3] 로그인 후 LLM 모델 readiness 체크. 0개면 wizard 노출.
+  setTimeout(() => { try { firstRunCheck(); } catch (_) {} }, 600);
 }
 
 /* ── [PR plan-3, 2026-05-09] First-run wizard ───────────────────

--- a/frontend/static/auth.js
+++ b/frontend/static/auth.js
@@ -1,0 +1,66 @@
+/* ── auth.js ──
+   Shared /login/ HTTP wrapper for all pages (chat, admin, graph,
+   workspace).
+
+   Login modals stay per-page — markup, DOM ids, and post-login UX
+   diverge by design (chat shows chat UI, admin loads dashboard,
+   graph runs bootstrap, workspace reloads data). What used to be
+   duplicated was the POST + token parse + role check + localStorage
+   write. That now lives here.
+
+   Usage:
+     const res = await Auth.login({
+       username, password, apiKey,
+       requireRole: 'admin',   // or null to accept any role
+     });
+     if (!res.ok) { showError(res.error); return; }
+     // res.token, res.role available; localStorage already written.
+     // Caller does its own post-login UI (close modal, reload, etc.)
+*/
+(function (global) {
+  const API = window.location.origin;
+
+  async function login(opts) {
+    opts = opts || {};
+    const username = (opts.username || '').trim();
+    const password = opts.password || '';
+    const apiKey = opts.apiKey || '';
+    const requireRole = opts.requireRole || null;
+
+    if (!username || !password) {
+      return { ok: false, error: '아이디와 비밀번호를 입력하세요.' };
+    }
+    if (!apiKey) {
+      return { ok: false, error: 'API Key를 입력하세요.' };
+    }
+
+    try {
+      const r = await fetch(`${API}/login/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password, api_key: apiKey }),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        return { ok: false, error: d.detail || `로그인 실패 (${r.status})` };
+      }
+      const token = d.access_token || d.token || '';
+      const role = d.role || 'external';
+      if (!token) {
+        return { ok: false, error: '토큰 발급 실패' };
+      }
+      if (requireRole && role !== requireRole) {
+        return { ok: false, error: `${requireRole} 권한 필요 (현재: ${role})` };
+      }
+      // SSO: chat / admin / graph / workspace 탭이 storage 이벤트로
+      // 자동 동기화되도록 동일 키 사용.
+      localStorage.setItem('james_token', token);
+      localStorage.setItem('james_role', role);
+      return { ok: true, token, role };
+    } catch (e) {
+      return { ok: false, error: `서버 오류: ${e.message || e}` };
+    }
+  }
+
+  global.Auth = { login };
+})(window);

--- a/frontend/static/auth.js
+++ b/frontend/static/auth.js
@@ -1,5 +1,5 @@
 /* ── auth.js ──
-   Shared /login/ HTTP wrapper for all pages (chat, admin, graph,
+   Shared auth HTTP wrappers for all pages (chat, admin, graph,
    workspace).
 
    Login modals stay per-page — markup, DOM ids, and post-login UX
@@ -8,6 +8,11 @@
    duplicated was the POST + token parse + role check + localStorage
    write. That now lives here.
 
+   The password-reset-confirm endpoint is anonymous (no Bearer,
+   no api_key query) and was duplicated near-verbatim between
+   chat.js and admin.js — same fetch shape, same response handling,
+   only the surrounding UX (toast vs alert) differed.
+
    Usage:
      const res = await Auth.login({
        username, password, apiKey,
@@ -15,7 +20,11 @@
      });
      if (!res.ok) { showError(res.error); return; }
      // res.token, res.role available; localStorage already written.
-     // Caller does its own post-login UI (close modal, reload, etc.)
+
+     const res = await Auth.resetPasswordConfirm({
+       username, token, newPassword,
+     });
+     if (!res.ok) { showError(res.error); return; }
 */
 (function (global) {
   const API = window.location.origin;
@@ -62,5 +71,33 @@
     }
   }
 
-  global.Auth = { login };
+  async function resetPasswordConfirm(opts) {
+    opts = opts || {};
+    const username = (opts.username || '').trim();
+    const token = (opts.token || '').trim();
+    const newPassword = opts.newPassword || '';
+
+    if (!username || !token || !newPassword) {
+      return { ok: false, error: '아이디, 토큰, 새 비밀번호를 모두 입력하세요.' };
+    }
+
+    try {
+      // Bare fetch — no Bearer header (anonymous flow), no api_key
+      // query (the endpoint is public). Token-error responses
+      // collapse to 401 by design (enumeration defense).
+      const r = await fetch(`${API}/password/reset/confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, token, new_password: newPassword }),
+      });
+      if (r.ok) return { ok: true };
+      let detail = `${r.status}`;
+      try { detail = (await r.json()).detail || detail; } catch (_e) {}
+      return { ok: false, error: detail };
+    } catch (e) {
+      return { ok: false, error: `서버 오류: ${e.message || e}` };
+    }
+  }
+
+  global.Auth = { login, resetPasswordConfirm };
 })(window);

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -2278,15 +2278,17 @@ function jamesConfirm(opts) {
   });
 }
 
-/* ── [P3-4] 세션 선택 ── */
-let _sessionPanelOpen = false;
-
-async function toggleSessionPanel() {
-  _sessionPanelOpen = !_sessionPanelOpen;
-  const panel = document.getElementById('session-panel');
-  if (!panel) return;
-  panel.style.display = _sessionPanelOpen ? 'block' : 'none';
-  if (_sessionPanelOpen) await loadSessionList();
+/* ── [P3-4 → sidebar, 2026-05-21] 세션 선택 ──
+   세션 리스트는 사이드바 'sessions' 모드로 이동. 상단 헤더 💬 버튼은
+   이전 플로팅 패널의 open/close 토글 의미를 유지: 현재 sessions 모드
+   면 닫기(=기본 'upload'로 복귀), 아니면 sessions로 전환.
+   switchSidebarMode 가 sessions 진입 시 loadSessionList 를 호출하므로
+   리스트는 자동 로드된다. 직접 rail 💬 아이콘 클릭도 동일 경로. */
+function toggleSessionPanel() {
+  if (typeof switchSidebarMode !== 'function') return;
+  const railActive = document.querySelector('.sidebar-rail-item.active');
+  const currentMode = railActive?.dataset?.mode;
+  switchSidebarMode(currentMode === 'sessions' ? 'upload' : 'sessions');
 }
 
 async function loadSessionList() {
@@ -2422,14 +2424,13 @@ async function deleteSession(sessionId, event) {
 
 async function switchSession(sessionId) {
   if (sessionId === SESSION_ID) {
-    toggleSessionPanel();
+    // already on this session — nothing to do (sidebar stays as-is)
     return;
   }
   // 세션 전환: sessionStorage 업데이트 + 히스토리 로드
   localStorage.setItem('james_session', sessionId);
   // [N-3 fix] in-memory SESSION_ID / HISTORY_KEY 동기 (newSession 과 동일).
   refreshSessionGlobals();
-  toggleSessionPanel();
 
   // 현재 메시지 초기화 후 해당 세션 히스토리 표시
   const messages = document.getElementById('messages');
@@ -2445,6 +2446,8 @@ async function switchSession(sessionId) {
 
     if (!turns.length) {
       toast('선택한 세션에 대화 기록이 없습니다', 'info');
+      // refresh sidebar list so the active highlight follows.
+      loadSessionList().catch(() => {});
       return;
     }
 
@@ -2466,6 +2469,8 @@ async function switchSession(sessionId) {
     const badge = document.getElementById('session-count-badge');
     if (badge) badge.textContent = '✓';
     toast(`세션 전환 완료 (${turns.length/2}턴)`, 'success');
+    // refresh sidebar list so the active highlight follows the new session.
+    loadSessionList().catch(() => {});
   } catch(e) {
     toast(`세션 로드 실패: ${e.message}`, 'error');
   }
@@ -2478,11 +2483,12 @@ function newSession() {
   // [N-3 fix] in-memory SESSION_ID / HISTORY_KEY 도 동기. 안 그러면
   // 다음 query 가 옛 SID 로 전송되어 backend N-3 게이트가 못 풀림.
   refreshSessionGlobals();
-  toggleSessionPanel();
 
   // 화면 초기화
   const messages = document.getElementById('messages');
   if (messages) messages.innerHTML = '';
   document.getElementById('welcome')?.style?.setProperty('display', 'flex');
   toast('새 대화를 시작합니다', 'success');
+  // refresh sidebar list so the new session appears at top.
+  loadSessionList().catch(() => {});
 }

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -664,59 +664,34 @@ async function doLogin() {
   const apiKeyInput = document.getElementById('login-api-key');
   const apiKeyEntered = (apiKeyInput?.value || '').trim();
   const apiKeyToUse = apiKeyEntered || getApiKey();
-  const errEl    = document.getElementById('login-error');
+  const errEl = document.getElementById('login-error');
   errEl.textContent = '';
 
-  if (!username || !password) {
-    errEl.textContent = '아이디와 비밀번호를 입력하세요.';
-    return;
-  }
-  if (!apiKeyToUse) {
-    errEl.textContent = 'API Key를 입력하세요. (.env의 JAMES_API_KEY)';
-    apiKeyInput?.focus();
-    return;
-  }
   // 새로 입력된 값이면 localStorage에 저장 (다음 로그인 시 pre-fill).
   if (apiKeyEntered && apiKeyEntered !== getApiKey()) {
     localStorage.setItem('james_api_key', apiKeyEntered);
   }
 
-  try {
-    const r = await fetch(`${API}/login/`, {
-      method:  'POST',
-      headers: {'Content-Type': 'application/json'},
-      body:    JSON.stringify({
-        username, password,
-        api_key: apiKeyToUse,
-      }),
-    });
-
-    const data = await r.json();
-
-    if (!r.ok) {
-      errEl.textContent = data.detail || '로그인 실패';
-      return;
-    }
-
-    // 토큰 저장 [#A8-4 SSO]
-    token    = data.access_token;
-    userRole = data.role || 'employee';
-    localStorage.setItem('james_token', token);
-    localStorage.setItem('james_role',  userRole);
-
-    closeLogin();
-    updateRoleBadge();
-    // [item #1] role 변경 시 install 버튼 가시성 즉시 갱신
-    // (admin login → 미설치 모델 선택 중이면 즉시 버튼 노출, 반대로
-    //  external/employee로 다시 로그인하면 즉시 숨김)
-    try { updateInstallButton(); } catch (_) {}
-    document.getElementById('login-pw').value = '';
-
-    toast(`✅ ${username} (${userRole}) 로그인 완료`, 'success');
-
-  } catch (e) {
-    errEl.textContent = `서버 오류: ${e.message}`;
+  const res = await Auth.login({ username, password, apiKey: apiKeyToUse });
+  if (!res.ok) {
+    errEl.textContent = res.error;
+    if (res.error.includes('API Key')) apiKeyInput?.focus();
+    return;
   }
+
+  // 토큰 저장은 Auth.login이 localStorage에 했음 — 로컬 변수만 동기화.
+  token    = res.token;
+  userRole = res.role || 'employee';
+
+  closeLogin();
+  updateRoleBadge();
+  // [item #1] role 변경 시 install 버튼 가시성 즉시 갱신
+  // (admin login → 미설치 모델 선택 중이면 즉시 버튼 노출, 반대로
+  //  external/employee로 다시 로그인하면 즉시 숨김)
+  try { updateInstallButton(); } catch (_) {}
+  document.getElementById('login-pw').value = '';
+
+  toast(`✅ ${username} (${userRole}) 로그인 완료`, 'success');
 }
 
 function logout() {

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -834,31 +834,15 @@ function closeForgotPasswordOutside(e) {
 
 async function submitPasswordReset() {
   const username = document.getElementById('reset-username').value.trim();
-  const token    = document.getElementById('reset-token').value.trim();
-  const newPw    = document.getElementById('reset-new-pw').value;
-  const errEl    = document.getElementById('reset-error');
+  const token = document.getElementById('reset-token').value.trim();
+  const newPw = document.getElementById('reset-new-pw').value;
+  const errEl = document.getElementById('reset-error');
   errEl.textContent = '';
-  if (!username || !token || !newPw) {
-    errEl.textContent = '아이디, 토큰, 새 비밀번호를 모두 입력하세요.';
-    return;
-  }
-  try {
-    const r = await fetch(`${API}/password/reset/confirm`, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ username, token, new_password: newPw }),
-    });
-    if (r.ok) {
-      toast('✅ 비밀번호가 재설정되었습니다. 새 비밀번호로 로그인하세요.', 'success');
-      closeForgotPasswordModal();
-      return;
-    }
-    let detail = `${r.status}`;
-    try { detail = (await r.json()).detail || detail; } catch (_e) {}
-    errEl.textContent = detail;
-  } catch (e) {
-    errEl.textContent = `서버 오류: ${e.message}`;
-  }
+
+  const res = await Auth.resetPasswordConfirm({ username, token, newPassword: newPw });
+  if (!res.ok) { errEl.textContent = res.error; return; }
+  toast('✅ 비밀번호가 재설정되었습니다. 새 비밀번호로 로그인하세요.', 'success');
+  closeForgotPasswordModal();
 }
 
 async function doSignup() {

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -388,62 +388,9 @@ function updateInstallButton() {
    클라는 2.5s 간격으로 GET /admin/llm/install-progress?model=... 폴링.
    설치 버튼이 "📦 X 설치" → "⏳ 23.5% (X)" → "✅ 설치됨" 으로 라이브 갱신.
    사용자가 다른 페이지로 이동해도 서버 백그라운드 thread는 계속 돌아감. */
-let _installPollTimer = null;
-
-function _stopInstallPoll() {
-  if (_installPollTimer) { clearInterval(_installPollTimer); _installPollTimer = null; }
-}
-
-async function _pollInstallProgress(model, btn) {
-  try {
-    const r = await fetch(
-      `${API}/admin/llm/install-progress?api_key=${encodeURIComponent(getApiKey())}&model=${encodeURIComponent(model)}`,
-      { headers: getAuthHeaders() },
-    );
-    if (!r.ok) {
-      // 401이면 admin 권한 잃음 — poll 중단.
-      if (r.status === 401) _stopInstallPoll();
-      return;
-    }
-    const p = await r.json();
-    if (!btn || !btn.isConnected) {
-      // 버튼이 사라졌으면 (모드 picker 재로드 등) — 최소 한 번 더 알림.
-      _stopInstallPoll();
-      return;
-    }
-    if (p.error) {
-      btn.textContent = `❌ ${model} 실패`;
-      btn.title = p.error;
-      _stopInstallPoll();
-      btn.disabled = false;
-      toast(`설치 실패: ${p.error}`, 'error');
-      return;
-    }
-    if (p.done) {
-      btn.textContent = `✅ ${model} 설치 완료`;
-      btn.style.background = 'rgba(76,175,125,.18)';
-      _stopInstallPoll();
-      btn.disabled = true;   // 완료된 모델은 다시 설치 불필요
-      toast(`✅ ${model} 설치 완료`, 'success');
-      // 모드 picker 갱신 → installed=true로 라벨 새로고침
-      setTimeout(loadModePickerOptions, 600);
-      return;
-    }
-    // 진행 중 — percent 또는 status 표시.
-    const pctStr = p.percent != null ? `${p.percent}%` : '';
-    const statusStr = p.status || '진행 중';
-    if (p.percent != null) {
-      btn.textContent = `⏳ ${pctStr} (${model})`;
-    } else {
-      btn.textContent = `⏳ ${statusStr}...`;
-    }
-    btn.title = `${model} 설치 — ${statusStr}${p.completed != null && p.total != null ?
-      ` (${(p.completed/1e9).toFixed(2)}/${(p.total/1e9).toFixed(2)} GB)` : ''}`;
-  } catch (e) {
-    // 네트워크 일시 단절 — 다음 tick에 다시 시도. 폴링 멈추진 않음.
-    console.warn('[install-poll]', e);
-  }
-}
+// HTTP + 폴링 메커니즘은 llm-install.js의 LlmInstall.start()가 담당.
+// 여기는 mode-install-btn UI 렌더링만.
+let _installController = null;
 
 async function triggerModelInstall() {
   const btn = document.getElementById('mode-install-btn');
@@ -459,24 +406,39 @@ async function triggerModelInstall() {
   if (!confirm(`Ollama에 ${model} 모델을 설치합니다.\n수 GB 다운로드 — 백그라운드로 진행됩니다.\n진행 중에도 다른 페이지 이동 가능합니다.\n계속할까요?`)) return;
   btn.textContent = '⏳ 설치 시작...';
   btn.disabled = true;
-  try {
-    const r = await fetch(`${API}/llm/install/?api_key=${encodeURIComponent(getApiKey())}&model=${encodeURIComponent(model)}`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-    });
-    if (!r.ok) {
-      const err = await r.json().catch(() => ({}));
-      throw new Error(err.detail || `HTTP ${r.status}`);
-    }
-    // 설치 시작 OK — 진행률 폴링 시작.
-    _stopInstallPoll();   // 이전 폴링 잔재 제거
-    _pollInstallProgress(model, btn);   // 즉시 1회
-    _installPollTimer = setInterval(() => _pollInstallProgress(model, btn), 2500);
-  } catch (e) {
-    toast(`설치 실패: ${e.message}`, 'error');
-    btn.disabled = false;
-    btn.textContent = `📦 ${model} 설치`;
-  }
+  if (_installController) _installController.stop();
+  _installController = LlmInstall.start(model, {
+    onProgress(p) {
+      // 버튼이 사라졌으면 (모드 picker 재로드 등) — 폴링 중단.
+      if (!btn || !btn.isConnected) { _installController.stop(); return; }
+      const statusStr = p.status || '진행 중';
+      if (p.percent != null) {
+        btn.textContent = `⏳ ${p.percent}% (${model})`;
+      } else {
+        btn.textContent = `⏳ ${statusStr}...`;
+      }
+      btn.title = `${model} 설치 — ${statusStr}${p.completed != null && p.total != null ?
+        ` (${(p.completed/1e9).toFixed(2)}/${(p.total/1e9).toFixed(2)} GB)` : ''}`;
+    },
+    onDone() {
+      if (btn && btn.isConnected) {
+        btn.textContent = `✅ ${model} 설치 완료`;
+        btn.style.background = 'rgba(76,175,125,.18)';
+        btn.disabled = true;   // 완료된 모델은 다시 설치 불필요
+      }
+      toast(`✅ ${model} 설치 완료`, 'success');
+      // 모드 picker 갱신 → installed=true로 라벨 새로고침
+      setTimeout(loadModePickerOptions, 600);
+    },
+    onError(e) {
+      if (btn && btn.isConnected) {
+        btn.textContent = `❌ ${model} 실패`;
+        btn.title = e.message;
+        btn.disabled = false;
+      }
+      toast(`설치 실패: ${e.message}`, 'error');
+    },
+  });
 }
 
 function acceptModeRecommend() {

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -121,27 +121,11 @@
     var keyVal = keyInput ? keyInput.value.trim() : '';
     setLoginError('');
     if (keyVal) { apiKey = keyVal; localStorage.setItem('james_api_key', apiKey); }
-    if (!apiKey) { setLoginError('API key required (set on chat page or paste here)'); return; }
-    try {
-      var r = await fetch(API + '/login/', {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body:    JSON.stringify({ username: id, password: pw, api_key: apiKey }),
-      });
-      var j = await r.json().catch(function () { return {}; });
-      if (!r.ok) { setLoginError(j.detail || ('Login failed (' + r.status + ')')); return; }
-      var tok  = j.access_token || j.token || '';
-      var role = j.role || 'external';
-      if (!tok)              { setLoginError('No token returned'); return; }
-      if (role !== 'admin')  { setLoginError('Admin role required (got: ' + role + ')'); return; }
-      token = tok;
-      localStorage.setItem('james_token', token);
-      localStorage.setItem('james_role',  role);
-      hideLogin();
-      bootstrap();
-    } catch (e) {
-      setLoginError(String(e));
-    }
+    var res = await Auth.login({ username: id, password: pw, apiKey: apiKey, requireRole: 'admin' });
+    if (!res.ok) { setLoginError(res.error); return; }
+    token = res.token;
+    hideLogin();
+    bootstrap();
   };
 
   // ─── Snapshot fetch ────────────────────────────────────────

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -97,6 +97,7 @@ const TRANSLATIONS = {
     'auth.auth_expired':     'Authentication expired. Please log in again.',
 
     'sidebar.mode_upload':   'File upload',
+    'sidebar.mode_sessions': 'Chat history',
     'sidebar.mode_recent':   'My files',
     'sidebar.mine_title':    'My files (recent uploads)',
     'sidebar.open_workspace': 'Workspace ↗',
@@ -684,6 +685,7 @@ const TRANSLATIONS = {
     'auth.auth_expired':     '인증이 만료됐습니다. 다시 로그인해주세요.',
 
     'sidebar.mode_upload':   '파일 업로드',
+    'sidebar.mode_sessions': '대화 이력',
     'sidebar.mode_recent':   '내 자료',
     'sidebar.mine_title':    '내 자료 (최근 업로드)',
     'sidebar.open_workspace': 'Workspace ↗',

--- a/frontend/static/llm-install.js
+++ b/frontend/static/llm-install.js
@@ -1,0 +1,95 @@
+/* ── llm-install.js ──
+   Shared first-run / model install controller.
+
+   Backend: POST /llm/install/ kicks off `ollama pull`; GET
+   /admin/llm/install-progress?model=… returns { percent, status,
+   completed, total, done, error }. Two UIs share these endpoints —
+   the chat-tab install button (chat.js) and the admin first-run
+   wizard modal (admin.js). The HTTP + polling machinery lives here;
+   each caller plugs in its own UI rendering via callbacks.
+
+   Usage:
+     const c = LlmInstall.start('gemma3:1b', {
+       onStart: (model) => …,
+       onProgress: (p) => …,           // p = { percent, status, completed, total }
+       onDone: (model) => …,
+       onError: (err) => …,
+       onUnauthorized: () => …,        // 401 from progress poll
+     });
+     c.stop();                          // cancel polling (HTTP install keeps running server-side)
+*/
+(function (global) {
+  const API = window.location.origin;
+  const POLL_MS = 2500;
+
+  function _authHeaders() {
+    const t = localStorage.getItem('james_token') || '';
+    const h = { 'Content-Type': 'application/json' };
+    if (t) h['Authorization'] = `Bearer ${t}`;
+    return h;
+  }
+
+  function _apiKey() {
+    return localStorage.getItem('james_api_key') || '';
+  }
+
+  function start(model, cb) {
+    cb = cb || {};
+    let timer = null;
+    const stop = () => {
+      if (timer) { clearInterval(timer); timer = null; }
+    };
+
+    const tick = async () => {
+      try {
+        const r = await fetch(
+          `${API}/admin/llm/install-progress?api_key=${encodeURIComponent(_apiKey())}&model=${encodeURIComponent(model)}`,
+          { headers: _authHeaders() },
+        );
+        if (!r.ok) {
+          if (r.status === 401) {
+            stop();
+            if (cb.onUnauthorized) cb.onUnauthorized();
+          }
+          return;
+        }
+        const p = await r.json();
+        if (p.error) {
+          stop();
+          if (cb.onError) cb.onError(new Error(p.error));
+          return;
+        }
+        if (p.done) {
+          stop();
+          if (cb.onDone) cb.onDone(model);
+          return;
+        }
+        if (cb.onProgress) cb.onProgress(p);
+      } catch (e) {
+        console.warn('[llm-install poll]', e);
+      }
+    };
+
+    (async () => {
+      try {
+        const r = await fetch(
+          `${API}/llm/install/?api_key=${encodeURIComponent(_apiKey())}&model=${encodeURIComponent(model)}`,
+          { method: 'POST', headers: _authHeaders() },
+        );
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({}));
+          throw new Error(err.detail || `HTTP ${r.status}`);
+        }
+        if (cb.onStart) cb.onStart(model);
+        tick();
+        timer = setInterval(tick, POLL_MS);
+      } catch (e) {
+        if (cb.onError) cb.onError(e);
+      }
+    })();
+
+    return { stop };
+  }
+
+  global.LlmInstall = { start };
+})(window);

--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -87,34 +87,17 @@ async function doLogin() {
   const apiKey   = document.getElementById('login-apikey').value.trim() || _apiKey;
   const errEl    = document.getElementById('login-error');
   errEl.textContent = '';
-  if (!username || !password) {
-    errEl.textContent = '아이디와 비밀번호를 입력하세요.';
-    return;
-  }
-  if (!apiKey) {
-    errEl.textContent = 'API Key 를 입력하세요.';
-    return;
-  }
-  try {
-    const r = await fetch(`${API}/login/`, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ username, password, api_key: apiKey }),
-    });
-    const data = await r.json();
-    if (!r.ok) {
-      errEl.textContent = data.detail || '로그인 실패';
-      return;
-    }
-    _saveStored(data.access_token || data.token, data.role || 'employee', apiKey);
-    closeLogin();
-    document.getElementById('login-pw').value = '';
-    updateRoleBadge();
-    toast(`✅ ${username} (${_role}) 로그인`, 'success');
-    reloadData();
-  } catch (e) {
-    errEl.textContent = `서버 오류: ${e.message}`;
-  }
+
+  const res = await Auth.login({ username, password, apiKey });
+  if (!res.ok) { errEl.textContent = res.error; return; }
+  // Auth.login already wrote token+role to localStorage; sync locals
+  // and save apiKey separately (Auth doesn't manage api key).
+  _saveStored(res.token, res.role, apiKey);
+  closeLogin();
+  document.getElementById('login-pw').value = '';
+  updateRoleBadge();
+  toast(`✅ ${username} (${_role}) 로그인`, 'success');
+  reloadData();
 }
 
 function doLogout() {

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -435,6 +435,7 @@
 <div class="toast" id="toast"></div>
 
 <script src="/static/i18n.js"></script>
+<script src="/static/auth.js"></script>
 <script src="/static/workspace.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary

- **Contract**: `docs/UI_IA.md` defines 5 user-intent areas (Ask / My Work / Govern / Observe / Configure) and a current-to-target mapping for the 17-tab `admin.html` monolith. Naming convention: `data-action` = `<area>:<noun>:<verb>`.
- **Investigation**: `docs/UI_API_MAPPING.md` cross-references all **133 HTTP endpoints** against the 6 frontend JS files and identifies **20 orphans / 5 duplicate pairs / 7 area-conflict endpoints**. Catches a false-duplicate that would have been a regression if "fixed" (`/admin/metrics` vs `/admin/performance/metrics/` are distinct).
- **Phase 2 deduplication** (no IA migration yet — pure code cleanup):
  - `frontend/static/llm-install.js` — shared `LlmInstall.start()` controller for `/llm/install/` + progress polling. Replaces near-duplicate `firstRunInstall()` in `chat.js` and `admin.js`.
  - `frontend/static/auth.js` — shared `Auth.login()` (4 callers: chat / admin / graph / workspace) and `Auth.resetPasswordConfirm()` (2 callers). Modal markup stays per-page; only the HTTP + token + localStorage write is shared.
- **Chat sidebar reorganization**: session list + "+ 새 대화" moved from a floating `#session-panel` into a new sidebar mode `data-mode="sessions"` (💬 icon). `#session-list` / `#session-count-badge` IDs preserved so `loadSessionList()` and the badge update path work unchanged.
- **Handover**: `docs/handovers/v0.3.x-ui-ia-track.md` captures the full state for the next session (8 decisions D1–D8, Phase 3 priorities, 10 golden paths to verify, micro-regressions to be aware of). Registered in `v0.3.0-platform-track.md` so new sessions discover it.

Scope is **platform-level only** (mother-hardening). No domain features. Consistent with v0.3 Platform Skeleton track in `CLAUDE.md`.

Net frontend change: **+95 net lines** (3 new shared modules totaling ~300 lines; callers reduced by ~272 lines).

## Test plan

⚠️ **Author worked in a remote container with no browser access** — only static checks (`node --check` on all touched JS, cross-reference grep for stale symbols). Browser verification required before merge.

Golden paths (mirrors §4 of the handover doc):

**Chat sidebar (new behavior):**
- [ ] Top-header 💬 click → sidebar opens to `sessions` mode, list loads
- [ ] 💬 click again while on sessions → switches back to `upload` (toggle)
- [ ] Click a past session in the list → loads its turns, active highlight follows
- [ ] "+ 새 대화" → new SID, welcome screen returns, list refreshes with new session at top
- [ ] ✏️ rename / 🗑️ delete on a session item still work
- [ ] Reload page after viewing sessions → mode restored from localStorage `james_sidebar_mode`

**Auth regression (4 pages):**
- [ ] Login from chat page (any role)
- [ ] Login from admin page (admin role required, loads dashboard + firstrun wizard)
- [ ] Login from graph page (admin role, runs bootstrap)
- [ ] Login from workspace page (any role, reloads data)

**LlmInstall regression (2 entry points):**
- [ ] admin first-run wizard model install → progress bar in modal, auto-close on done
- [ ] chat `mode-install-btn` model install → % updates on button + GB in title

**Password reset (2 modals):**
- [ ] chat page forgot-password → success toast
- [ ] admin page forgot-password → success alert (localised via `t()`)

If anything breaks, the safe rollback is `git revert <commit>` per logical commit — each refactor is independent.

## Out of scope

- IA Phase 3 (`admin.js` split into Govern / Observe / Configure) — handover doc §7(c) is the entry point for the next session.
- Login / forgot-password **modal markup** unification (currently lives in 4 / 2 HTML files respectively) — Phase 3 work.
- API endpoint renames per UI_IA.md §4.3 — deferred to v0.4 candidate.
- Phase 1 remaining items (`/history/sessions/rename/`, `/history/long-term/`, `/feedback/stats/`, 18 WIP endpoints, `/admin/web-search-status`) need a product call before any code change.

## Notes

- 3 minor i18n regressions documented in handover §6 (admin/graph login validation strings are now hardcoded Korean — Phase 3 modal unification will absorb them naturally).
- Branch is 8 commits behind main but no overlap in touched files; rebase deferred.

Closes nothing — this is a multi-step track, see `docs/handovers/v0.3.x-ui-ia-track.md` for status table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9zSoUBrHK94amQgRjJTiq)_