### PR TITLE
chore(promo): record velog publication URL — OpenSSF silver 6-week post

### DIFF
--- a/reports/promo-assets/hada-openssf-silver-share.md
+++ b/reports/promo-assets/hada-openssf-silver-share.md
@@ -98,14 +98,15 @@ SHOULD criterion justification) 을 얹는 방식** 으로 해당 항목을 met
 
 ## 투고 시 체크
 
-- [ ] velog 글이 먼저 발행되었고 URL이 유효한지 확인
-- [ ] 외부 링크 URL을 velog URL로 교체 (위 placeholder 자리)
-- [ ] 본문 안의 `<velog URL — 발행 후 채울 자리>` 도 교체
+- [x] velog 글이 먼저 발행되었고 URL이 유효한지 확인 (2026-05-21 발행 완료)
+- [x] 외부 링크 URL을 velog URL로 교체 (위 placeholder 자리)
+- [x] 본문 안의 `<velog URL — 발행 후 채울 자리>` 도 교체
 - [ ] 댓글 응대 가능한 시간대에 투고 (한국 시간 오전 9~10시 권장 — 점심
       전 첫 페이지 노출)
 - [ ] 투고 후 30분 내 첫 댓글 들어오면 즉시 응대 (Hada는 첫 30분
       코멘트 활성도가 점수 가중)
-- [ ] 발행 직후 `launch-tracker.md` 에 게시 ID + URL 기록
+- [x] velog 발행 직후 `launch-tracker.md` 에 게시 URL 기록 (Velog (K5) 행 추가)
+- [ ] Hada 투고 후 게시 ID + URL을 `launch-tracker.md` Velog (K5) 행 옆에 추가 기록
 
 ## 톤 가이드 (댓글 응대 시)
 

--- a/reports/promo-assets/hada-openssf-silver-share.md
+++ b/reports/promo-assets/hada-openssf-silver-share.md
@@ -9,8 +9,10 @@
 ## 외부 링크 URL (velog 발행 후 채워서 투고)
 
 ```
-<velog 글 URL — 발행 후 채울 자리>
+https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0
 ```
+
+velog 발행 일자: 2026-05-21
 
 대체 후보 (velog 글 외부 페이지가 너무 안 열리는 환경 대비):
 ```
@@ -82,7 +84,7 @@ SHOULD criterion justification) 을 얹는 방식** 으로 해당 항목을 met
 
 ## 링크
 
-- 본문 (velog): <velog URL — 발행 후 채울 자리>
+- 본문 (velog): https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0
 - GitHub: https://github.com/Hashevolution/James-RAG-Evol
 - OpenSSF 페이지 (현재 passing 뱃지, silver 진척 ~133%):
   https://www.bestpractices.dev/projects/12806

--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -90,6 +90,7 @@ Three independent curators, three independent review pipelines. One acceptance i
 
 | Channel | URL | Audience | Posted |
 |---|---|---|---|
+| **X (KO) K6 — OpenSSF silver 6-week velog companion** | https://x.com/i/status/2057409108974895194 | KR (X timeline — velog K5 cross-promotion) | 2026-05-21 |
 | **Velog (K5) — OpenSSF silver 6-week progress report** | https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0 | KR (velog.io developer audience — OpenSSF/security angle) | 2026-05-21 |
 | **GeekNews (K1)** | https://news.hada.io/topic?id=29648 | KR (Hada.io tech community) | 2026-05-19 |
 | **Velog (K4) — Korean intro cross-post** | https://naver.me/GUTw3kar | KR (Naver-shortened, full at velog.io/@hashevolution) | 2026-05-19 |

--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -90,6 +90,7 @@ Three independent curators, three independent review pipelines. One acceptance i
 
 | Channel | URL | Audience | Posted |
 |---|---|---|---|
+| **Velog (K5) — OpenSSF silver 6-week progress report** | https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0 | KR (velog.io developer audience — OpenSSF/security angle) | 2026-05-21 |
 | **GeekNews (K1)** | https://news.hada.io/topic?id=29648 | KR (Hada.io tech community) | 2026-05-19 |
 | **Velog (K4) — Korean intro cross-post** | https://naver.me/GUTw3kar | KR (Naver-shortened, full at velog.io/@hashevolution) | 2026-05-19 |
 | **X (KO) K3 Video 1 — login + main chat** | https://x.com/i/status/2056628377919128016 | KR (X timeline) | 2026-05-19 |

--- a/reports/promo-assets/launch-tracker.md
+++ b/reports/promo-assets/launch-tracker.md
@@ -90,6 +90,7 @@ Three independent curators, three independent review pipelines. One acceptance i
 
 | Channel | URL | Audience | Posted |
 |---|---|---|---|
+| **Reddit r/SideProject (E1) — JAMES intro (first Reddit post)** | https://www.reddit.com/r/SideProject/s/kJPXpdKTqp | Global EN (maker / side-project community) | 2026-05-25 |
 | **X (KO) K6 — OpenSSF silver 6-week velog companion** | https://x.com/i/status/2057409108974895194 | KR (X timeline — velog K5 cross-promotion) | 2026-05-21 |
 | **Velog (K5) — OpenSSF silver 6-week progress report** | https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0 | KR (velog.io developer audience — OpenSSF/security angle) | 2026-05-21 |
 | **GeekNews (K1)** | https://news.hada.io/topic?id=29648 | KR (Hada.io tech community) | 2026-05-19 |


### PR DESCRIPTION
## Summary

Records the velog publication of the OpenSSF silver 6-week post
(drafted in PR #369) and unblocks the Hada follow-up step.

**Published URL** (2026-05-21):
`https://velog.io/@hashevolution/%EC%86%94%EB%A1%9C-%EB%A9%94%EC%9D%B8%ED%85%8C%EC%9D%B4%EB%84%88%EA%B0%80-OpenSSF-%EC%8B%A4%EB%B2%84%EC%97%90-%EB%8F%84%EC%A0%84%ED%95%98%EB%8A%94-6%EC%A3%BC-%EC%96%B4%EC%8A%88%EC%96%B4%EB%9F%B0%EC%8A%A4-%EC%BC%80%EC%9D%B4%EC%8A%A4-%EC%9E%91%EC%84%B1%EA%B8%B0`

(Decoded slug: 솔로-메인테이너가-OpenSSF-실버에-도전하는-6주-어슈어런스-케이스-작성기)

## Changes

### `reports/promo-assets/hada-openssf-silver-share.md`

- Replaced both `<velog URL — 발행 후 채울 자리>` placeholders
  (외부 링크 URL 섹션 + 본문 링크 섹션) with the real velog URL
- Added "velog 발행 일자: 2026-05-21" annotation
- Marked 4 of the 7 publish checklist items as `[x]` (velog publish,
  외부 링크 교체, 본문 placeholder 교체, launch-tracker 기록).
  Remaining 3 items stay `[ ]` — they depend on the actual Hada
  submission which is still pending
- Split the original "발행 직후 launch-tracker 기록" item into two
  (velog publish → tracker = done; Hada submit → tracker = pending)
  so the checklist stays accurate

### `reports/promo-assets/launch-tracker.md`

- Added a new row at the top of the `## Social posts` table:
  `Velog (K5) — OpenSSF silver 6-week progress report` with the
  full velog URL, audience tag, and 2026-05-21 date
- Placed above the existing K1/K4/X(KO) entries for visibility as
  the most recent publication

## Why this is a separate small PR

Per the PR #369 description's `## Companion plan` step 4:
> **+1 day**: `chore(promo):` PR updates `launch-tracker.md` with
> real publication IDs.

This is that PR. Kept small (2 files, 6 net lines changed) so it
lands quickly and doesn't block the Hada submission step.

## Out of scope

- **Hada submission itself** — user action. The share card is now
  fully filled in and ready for copy-paste to news.hada.io.
- **Recording the Hada submission ID** — separate follow-up commit
  (the last unchecked checklist item) after the Hada post lands.
- **Cross-channel English variants** (Reddit / HN / dev.to) — per
  the agreed promo plan, decided after observing velog/Hada
  response. Separate PRs at that time.
- **Updating OpenSSF/bestpractices.dev with the velog as the
  `assurance_case` or `documentation_*` justification URL** — not
  applicable; bestpractices.dev URLs should point to GitHub
  permalinks (already submitted as per the previous URL table
  message), not to velog narrative posts.

## Verification

- `grep` sweep for remaining `<velog URL` placeholders → none in
  active content (one historical mention inside an already-checked
  checklist item, which now reads `[x] 본문 안의 <velog URL — ...>
  도 교체` — the angle brackets are inside backticks describing
  *what was replaced*, not a real placeholder)
- launch-tracker entry follows the existing Social posts table
  schema (Channel · URL · Audience · Posted columns)
- velog URL spot-checked: live page renders title "솔로 메인테이너가
  OpenSSF 실버에 도전하는 6주 — 어슈어런스 케이스 작성기" matching
  the drafted title in PR #369

## Companion plan (remaining steps from PR #369's plan)

| # | Step | Owner | Status |
|---|---|---|---|
| 1 | Publish velog post | User | ✅ Done 2026-05-21 |
| 2 | Submit to Hada with filled card | User | ⏳ Pending |
| 3 | First-30-min comment response on Hada | User | ⏳ Pending (after step 2) |
| 4 | Record velog URL in launch-tracker | This PR | ✅ Done |
| 5 | Record Hada submission ID in launch-tracker | Follow-up PR | ⏳ After step 2 |
| 6 | Decide on Reddit / HN escalation | User + this session | ⏳ +2 weeks after Hada |


---
_Generated by [Claude Code](https://claude.ai/code/session_014DqsVaKno8oBgHi46cKGUV)_