### PR TITLE
feat(graph): PUT /admin/graph/node accepts event occurred_at — PR-11 tail

### DIFF
--- a/core/graph_node_editor.py
+++ b/core/graph_node_editor.py
@@ -52,6 +52,13 @@ NODE_EDITABLE_FIELDS = frozenset({
     "aliases",       # list[str] — alternative names for matching
     "summary",       # description text shown in node-detail panel
     "sensitivity",   # "normal" | "sensitive" (mask_sensitive gate)
+    # PR-11 event time-axis fields. Admit at filter level; honored only
+    # when the target node's `entity_type == "event"` (memo §5.2). For
+    # any other target type the two fields are *silently dropped* —
+    # accidental clients posting them against a person/concept node
+    # don't see a 400.
+    "occurred_at",
+    "occurred_at_precision",
 })
 
 NODE_ALLOWED_ENTITY_TYPES = frozenset({
@@ -163,8 +170,38 @@ def update_node_attributes(
             )
         cleaned["sensitivity"] = sv
 
-    # Load + diff + write.
+    # Load entity for the event-field branch (need its current
+    # entity_type to decide whether occurred_at / precision are
+    # honored or silently dropped) AND for the diff + write below.
     path, fm, body = _load_entity_by_id(entity_id, wiki_generator)
+
+    # ── Event time-axis branch (memo §5.2) ──────────────────────
+    # occurred_at / occurred_at_precision are honored only when the
+    # *existing* node is type=event. For any other type both fields
+    # are silently dropped, so an accidental client send doesn't
+    # surface as a 400.
+    has_event_payload = (
+        "occurred_at" in filtered
+        or "occurred_at_precision" in filtered
+    )
+    if has_event_payload and fm.get("entity_type") == "event":
+        # Compose the would-be new (value, precision) pair from
+        # patch ∪ existing, then validate the pair together so a
+        # partial update (only one of the two changing) still gets
+        # full ISO 8601 + enum verification.
+        new_at = filtered.get(
+            "occurred_at", fm.get("occurred_at"),
+        )
+        new_prec = filtered.get(
+            "occurred_at_precision",
+            fm.get("occurred_at_precision", "day"),
+        )
+        validate_occurred_at(new_at, precision=new_prec)
+        if "occurred_at" in filtered:
+            cleaned["occurred_at"] = filtered["occurred_at"]
+        if "occurred_at_precision" in filtered:
+            cleaned["occurred_at_precision"] = filtered["occurred_at_precision"]
+    # else: non-event target → both fields silently dropped from cleaned.
 
     before: Dict[str, Any] = {}
     after:  Dict[str, Any] = {}

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -617,11 +617,148 @@ class UpdateNodeAttributesTests(unittest.TestCase):
     def test_editable_field_allowlist_matches_doc(self):
         # Pinned for future code reviewers: any change here must be
         # paired with a doc/handover update because external callers
-        # (admin matrix UI) gate on this list.
+        # (admin matrix UI) gate on this list. PR-11 adds the two
+        # event time-axis fields — honored only when target is event
+        # (see UpdateNodeAttributesEventFieldsTests below).
         self.assertEqual(
             sorted(NODE_EDITABLE_FIELDS),
-            ["aliases", "entity_type", "name", "sensitivity", "summary"],
+            [
+                "aliases", "entity_type", "name",
+                "occurred_at", "occurred_at_precision",
+                "sensitivity", "summary",
+            ],
         )
+
+
+# ─── PR-11 — PUT event occurred_at extension ────────────────────────
+
+
+def _single_event_entity(occurred_at: str = "2026-01-10",
+                          precision: str = "day"):
+    """Single event-entity fixture mirroring `_single_entity` but for
+    the new fifth entity type. Filename uses the `<normalized>_<8hex>`
+    suffix pattern (PR-11a-2) but tests only need the entity_id key
+    indexed in the WgStub — no actual hash dependency."""
+    root = Path(tempfile.mkdtemp()) / "entity"
+    for t in ("person", "concept", "org", "document", "event"):
+        (root / t).mkdir(parents=True)
+    eid = "e_event_aaaaaaaa"
+    p = root / "event" / "etf_승인_aaaaaaaa.md"
+    _write_entity(p, {
+        "entity_id":             eid,
+        "name":                  "ETF 승인",
+        "entity_type":           "event",
+        "aliases":               [],
+        "summary":               "SEC 첫 spot ETF 승인",
+        "sensitivity":           "internal",
+        "occurred_at":           occurred_at,
+        "occurred_at_precision": precision,
+    })
+    return root, _WgStub({eid: p}), p, eid
+
+
+class UpdateNodeAttributesEventFieldsTests(unittest.TestCase):
+    """PR-11 — PUT /admin/graph/node accepts occurred_at /
+    occurred_at_precision **when target is event** (memo §5.2).
+    Non-event targets silently drop both fields."""
+
+    def test_event_occurred_at_updates(self):
+        _, wg, p, eid = _single_event_entity()
+        result = update_node_attributes(
+            eid, {"occurred_at": "2027-04-15"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], ["occurred_at"])
+        fm = _read_fm(p)
+        self.assertEqual(fm["occurred_at"], "2027-04-15")
+        # Precision unchanged.
+        self.assertEqual(fm["occurred_at_precision"], "day")
+
+    def test_event_precision_only_updates(self):
+        _, wg, p, eid = _single_event_entity()
+        result = update_node_attributes(
+            eid, {"occurred_at_precision": "month"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], ["occurred_at_precision"])
+        fm = _read_fm(p)
+        self.assertEqual(fm["occurred_at_precision"], "month")
+        # Date unchanged.
+        self.assertEqual(fm["occurred_at"], "2026-01-10")
+
+    def test_event_both_fields_at_once(self):
+        _, wg, p, eid = _single_event_entity()
+        result = update_node_attributes(
+            eid,
+            {
+                "occurred_at":           "2027-04-15T15:32:00Z",
+                "occurred_at_precision": "minute",
+            },
+            wiki_generator=wg,
+        )
+        self.assertEqual(
+            sorted(result["changed_fields"]),
+            ["occurred_at", "occurred_at_precision"],
+        )
+        fm = _read_fm(p)
+        self.assertEqual(fm["occurred_at"], "2027-04-15T15:32:00Z")
+        self.assertEqual(fm["occurred_at_precision"], "minute")
+
+    def test_event_invalid_occurred_at_raises(self):
+        _, wg, _, eid = _single_event_entity()
+        with self.assertRaisesRegex(ValueError, "ISO 8601"):
+            update_node_attributes(
+                eid, {"occurred_at": "next quarter"},
+                wiki_generator=wg,
+            )
+
+    def test_event_invalid_precision_raises(self):
+        _, wg, _, eid = _single_event_entity()
+        with self.assertRaisesRegex(ValueError, "precision"):
+            update_node_attributes(
+                eid, {"occurred_at_precision": "quarter"},
+                wiki_generator=wg,
+            )
+
+    def test_non_event_silently_drops_occurred_at(self):
+        # Sending occurred_at to a person node alongside a valid name
+        # must (a) write the name and (b) NOT touch occurred_at.
+        _, wg, p, eid = _single_entity(entity_type="person")
+        result = update_node_attributes(
+            eid,
+            {"name": "Anthropic Inc", "occurred_at": "yesterday"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], ["name"])
+        fm = _read_fm(p)
+        self.assertNotIn("occurred_at", fm,
+            "non-event target must never gain an occurred_at field")
+
+    def test_non_event_alone_returns_no_op(self):
+        # Patch with ONLY occurred_at against non-event — silently
+        # dropped, returns no-op shape (no 400, no write).
+        _, wg, _, eid = _single_entity(entity_type="org")
+        result = update_node_attributes(
+            eid, {"occurred_at": "2027-04-15"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], [])
+        self.assertEqual(result["before"], {})
+        self.assertEqual(result["after"], {})
+
+    def test_event_partial_update_validates_against_existing(self):
+        # Precision-only update must still validate the pair
+        # (existing occurred_at + new precision) so a malformed
+        # combination surfaces — not just the changed field.
+        # Here the existing date is valid + new precision is valid,
+        # so the update succeeds (regression guard against the
+        # validator running on bad input by accident).
+        _, wg, _, eid = _single_event_entity()
+        result = update_node_attributes(
+            eid, {"occurred_at_precision": "hour"},
+            wiki_generator=wg,
+        )
+        self.assertEqual(result["changed_fields"], ["occurred_at_precision"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the deferred half of PR-11a-2: design memo §5.2 said the
existing PUT path should accept `occurred_at` / `occurred_at_precision`
updates when the target is an event node, silently dropping the
two fields for other entity types. Now wired.

## Summary
- `core/graph_node_editor.py`
  - `NODE_EDITABLE_FIELDS` gains `occurred_at` + `occurred_at_precision`.
  - `update_node_attributes` gains an "Event time-axis branch":
    composes (date, precision) from patch ∪ existing, validates
    the pair via `validate_occurred_at` (full ISO 8601 + enum
    check), copies only the changed half(s) into `cleaned`.
  - Non-event targets silently drop both fields — returns the
    audit no-op shape, not a 400.
- `tests/test_phase_e_graph_editor.py`
  - Allowlist test updated for the 2 new fields (5 → 7).
  - New `UpdateNodeAttributesEventFieldsTests` — 8 tests covering
    happy paths + validation + silent-drop semantics + partial-update
    pair validation.

## Verification
- `pytest tests/test_phase_e_graph_editor.py -v` → **41 passed**
- `pytest tests/ -k "graph or wiki or event or phase_e"`
  → **420 passed, 0 failed**
- `ruff check core/ tests/test_phase_e_graph_editor.py` → All checks passed

## Behavior delta
- Admin can now amend an event's `occurred_at` / precision from the
  PUT endpoint (was: delete + recreate workaround).
- `entity_id` stays immutable across the update; the hash-suffixed
  filename does NOT change. The `_generate_event_entity_id` hash
  going stale relative to the new date is intentional — entity_id
  is the truth source, the filename hash is a uniqueness aid.

## Out of scope
- UI affordance on the Govern → Graph editor — UI-IA Phase 3 territory
- Migration / re-id for events whose occurred_at is amended (not
  needed; entity_id immutable by design)
- PR-11d MemoryLoom date hook — still deferred

Design memo: `docs/design/v0.3-graph-evolution.md` §5.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)