### PR TITLE
feat(admin): cognitive feature toggles endpoint — UI-IA risk #5 (PR-1/2)

### DIFF
--- a/core/feature_flags.py
+++ b/core/feature_flags.py
@@ -1,0 +1,236 @@
+"""PROJECT JAMES — Cognitive feature flags registry.
+
+UI-IA risk signal #5 (docs/UI_API_MAPPING.md §8): six Cognitive
+Layer features are wired into the backend pipeline but have no
+admin toggle surface — they're env-only. This module is the
+substrate that lets the admin Configure → Cognitive sub-page
+(PR-2 of the same series) read + write those flags through
+``GET / POST /admin/settings/cognitive``.
+
+The registry below is the **single source of truth** for which
+env vars correspond to which cognitive feature, and which polarity
+(``"enable"`` = env=1 means ON, ``"disable"`` = env=1 means OFF).
+The two flags that ship default-ON (``verify``, ``rerank``) use
+``"disable"`` polarity so the env var only needs to exist when the
+operator wants to turn them OFF.
+
+Apply semantics: ``apply_cognitive_flag(key, on)`` mutates the
+in-process ``os.environ`` directly, mirroring the existing
+``POST /admin/settings`` pattern (``server_llmwiki.py:5380`` —
+``os.environ["JAMES_PROTECTED_FILES"] = ...``). The toggle takes
+effect on the next call to the feature (every cognitive helper
+reads the env var per-call — see ``rerank.py:37``,
+``query_rewriter.py:79``, ``reflect.py:118``, etc.). Restart is
+not required.
+
+Persistence note: in-process env mutation is non-durable. A
+container restart re-reads the boot ``.env`` file and reverts to
+those values. Persistent storage is a v0.4 candidate (would
+require a settings table + a boot-time loader that layers DB
+values over env).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+
+# ─── Registry ───────────────────────────────────────────────────
+
+
+# Each entry pins (env var name, polarity, human label, default).
+# Polarity is one of two values:
+#   "enable"  — env == "1" means the feature is ON, default OFF
+#   "disable" — env == "1" means the feature is OFF, default ON
+#
+# Adding a new cognitive toggle: append here and ensure the helper
+# module that consumes the env var reads it per-call (so a runtime
+# toggle takes immediate effect — boot-time caching would defeat
+# the UI).
+COGNITIVE_FEATURE_FLAGS: Dict[str, Dict[str, Any]] = {
+    "verify": {
+        "env":      "JAMES_DISABLE_VERIFY",
+        "polarity": "disable",
+        "label":    "Verifier base scan",
+        "default":  True,
+        "module":   "core/reasoning/verify.py",
+    },
+    "fact_check": {
+        "env":      "JAMES_ENABLE_FACT_CHECK",
+        "polarity": "enable",
+        "label":    "Fact-checker (LLM-driven, runs after verify)",
+        "default":  False,
+        "module":   "core/reasoning/verify.py",
+    },
+    "reflect": {
+        "env":      "JAMES_ENABLE_REFLECT",
+        "polarity": "enable",
+        "label":    "Reflection loop (draft → critique → revise)",
+        "default":  False,
+        "module":   "core/reasoning/reflect.py",
+    },
+    "planner": {
+        "env":      "JAMES_ENABLE_PLANNER",
+        "polarity": "enable",
+        "label":    "Planner (task decomposition into 2–5 subtasks)",
+        "default":  False,
+        "module":   "core/reasoning/planner.py",
+    },
+    "query_rewrite": {
+        "env":      "JAMES_ENABLE_QUERY_REWRITE",
+        "polarity": "enable",
+        "label":    "Query rewriter (LLM-driven expansion)",
+        "default":  False,
+        "module":   "core/retrieval/query_rewriter.py",
+    },
+    "rerank": {
+        "env":      "JAMES_DISABLE_RERANK",
+        "polarity": "disable",
+        "label":    "Cross-encoder reranker",
+        "default":  True,
+        "module":   "core/retrieval/rerank.py",
+    },
+}
+
+# Stable order for callers that need a deterministic listing — UI
+# legends, audit logs. Default-ON features first (most stable),
+# default-OFF after, then alphabetical inside each group.
+COGNITIVE_FLAG_ORDER: List[str] = [
+    "verify", "rerank", "fact_check", "planner", "query_rewrite", "reflect",
+]
+
+
+# ─── Read ───────────────────────────────────────────────────────
+
+
+def _flag_is_on(env_name: str, polarity: str) -> bool:
+    """Resolve a single env var to its semantic ON/OFF state.
+
+    Public surface — also used by tests to assert state without
+    duplicating polarity logic.
+    """
+    raw = os.environ.get(env_name, "")
+    if polarity == "enable":
+        return raw == "1"
+    # polarity == "disable"
+    return raw != "1"
+
+
+def read_cognitive_flags() -> List[Dict[str, Any]]:
+    """Return the current state of every cognitive flag.
+
+    Output shape (one entry per flag, in COGNITIVE_FLAG_ORDER)::
+
+        [
+          {
+            "key":      "verify",
+            "label":    "Verifier base scan",
+            "env":      "JAMES_DISABLE_VERIFY",
+            "polarity": "disable",
+            "default":  true,
+            "on":       true,            # resolved semantic state
+            "module":   "core/reasoning/verify.py",
+          },
+          ...
+        ]
+    """
+    out: List[Dict[str, Any]] = []
+    for key in COGNITIVE_FLAG_ORDER:
+        spec = COGNITIVE_FEATURE_FLAGS[key]
+        out.append({
+            "key":      key,
+            "label":    spec["label"],
+            "env":      spec["env"],
+            "polarity": spec["polarity"],
+            "default":  spec["default"],
+            "on":       _flag_is_on(spec["env"], spec["polarity"]),
+            "module":   spec["module"],
+        })
+    return out
+
+
+# ─── Write ──────────────────────────────────────────────────────
+
+
+def apply_cognitive_flag(key: str, on: bool) -> Dict[str, Any]:
+    """Mutate ``os.environ`` so the named flag reads as ``on``.
+
+    Returns the before/after delta for audit logging::
+
+        {"key": "...", "env": "...", "before": True/False, "after": True/False}
+
+    Semantics:
+      - For ``"enable"`` polarity: set env to "1" when ON; pop env
+        when OFF.
+      - For ``"disable"`` polarity: pop env when ON (default); set
+        env to "1" when OFF.
+      - Popping rather than writing "0" keeps the env table tidy
+        and avoids any future code that uses ``bool(os.environ
+        .get(name))`` being misled by the truthy non-empty string.
+
+    Raises:
+      ValueError — unknown ``key`` (defensive guard so a typo
+                   from the admin endpoint surfaces as a 400, not
+                   a silent no-op).
+    """
+    spec = COGNITIVE_FEATURE_FLAGS.get(key)
+    if spec is None:
+        raise ValueError(
+            f"unknown cognitive flag {key!r}; "
+            f"valid: {sorted(COGNITIVE_FEATURE_FLAGS)}"
+        )
+
+    env_name = spec["env"]
+    polarity = spec["polarity"]
+    before   = _flag_is_on(env_name, polarity)
+
+    # Decide whether env should be set to "1" or popped, given the
+    # polarity and the desired ON/OFF state.
+    if polarity == "enable":
+        want_env_set = bool(on)
+    else:
+        want_env_set = not bool(on)
+
+    if want_env_set:
+        os.environ[env_name] = "1"
+    else:
+        os.environ.pop(env_name, None)
+
+    after = _flag_is_on(env_name, polarity)
+    return {
+        "key":     key,
+        "env":     env_name,
+        "before":  before,
+        "after":   after,
+    }
+
+
+def apply_cognitive_flags(updates: Dict[str, bool]) -> List[Dict[str, Any]]:
+    """Apply many flag updates in one shot. Returns the per-key
+    delta list (same shape as ``apply_cognitive_flag``, one entry
+    per update).
+
+    All updates land atomically with respect to the caller's view —
+    each ``apply_cognitive_flag`` is a single dict mutation. There's
+    no cross-flag transaction (env is a flat namespace), so if one
+    key is invalid the prior writes already landed; the function
+    raises on the first invalid key so the caller can see exactly
+    where it stopped.
+    """
+    out: List[Dict[str, Any]] = []
+    for key, value in updates.items():
+        if not isinstance(value, bool):
+            raise ValueError(
+                f"flag {key!r} value must be bool; got {type(value).__name__}"
+            )
+        out.append(apply_cognitive_flag(key, value))
+    return out
+
+
+__all__ = [
+    "COGNITIVE_FEATURE_FLAGS",
+    "COGNITIVE_FLAG_ORDER",
+    "apply_cognitive_flag",
+    "apply_cognitive_flags",
+    "read_cognitive_flags",
+]

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -5382,6 +5382,80 @@ async def admin_settings_post(data: AdminSettingsRequest, role: str = Depends(ge
     return {"success": True, "applied": {"model": data.model, "max_loop": data.max_loop}}
 
 
+# ─── Cognitive feature toggles (UI-IA risk signal #5 fix) ────────
+#
+# Six cognitive-layer features (reflect / verify / fact_check /
+# planner / query_rewrite / rerank) ship live in the backend but
+# had no admin UI before this endpoint pair. `core/feature_flags.py`
+# is the single source of truth for the env-var ↔ semantic mapping;
+# both endpoints delegate to it.
+#
+# Persistence model: in-process env mutation only, mirroring the
+# existing `/admin/settings` POST that already does
+# `os.environ["JAMES_PROTECTED_FILES"] = ...`. A container restart
+# re-reads the boot `.env`, so durable changes are still an
+# operator concern. Surfacing this in the UI (a "session-only"
+# banner) is PR-2 frontend work.
+
+
+@app.get("/admin/settings/cognitive",
+         summary="cognitive feature flags 조회 [UI-IA risk #5]")
+async def admin_settings_cognitive_get(
+    api_key: str,
+    role:    str = Depends(get_role_from_request),
+):
+    """Read-only snapshot of the six cognitive-layer feature flags.
+    See `docs/UI_API_MAPPING.md` §8 risk signal #5 and
+    `core/feature_flags.py` for the registry."""
+    _require_feature(api_key, role, "admin.settings")
+    from core.feature_flags import read_cognitive_flags
+    return {"flags": read_cognitive_flags()}
+
+
+class CognitiveFlagsRequest(BaseModel):
+    api_key: str
+    flags:   dict = {}   # {flag_key: bool, ...}
+
+
+@app.post("/admin/settings/cognitive",
+          summary="cognitive feature flags 변경 [UI-IA risk #5]")
+async def admin_settings_cognitive_post(
+    data: CognitiveFlagsRequest,
+    role: str = Depends(get_role_from_request),
+):
+    """Toggle one or more cognitive features. Body shape::
+
+        {"api_key": "...", "flags": {"reflect": true, "verify": false}}
+
+    Returns per-key (before, after) delta for the audit log.
+    Persistence is in-process only — a restart reverts to the
+    boot `.env` values.
+    """
+    _require_feature(data.api_key, role, "admin.settings")
+    if not isinstance(data.flags, dict) or not data.flags:
+        raise HTTPException(
+            status_code=400,
+            detail="flags must be a non-empty dict {flag_key: bool, ...}",
+        )
+
+    from core.feature_flags import apply_cognitive_flags
+    try:
+        deltas = apply_cognitive_flags(data.flags)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    _write_audit(
+        role, "/admin/settings/cognitive",
+        query=_truncate_audit_blob({
+            "changed": [
+                {"key": d["key"], "before": d["before"], "after": d["after"]}
+                for d in deltas
+            ],
+        }),
+    )
+    return {"success": True, "deltas": deltas}
+
+
 # ─── PR-CR-B2: Change Request endpoints ─────────────────────────
 #
 # Six endpoints back the v0.2.x Change Request primitive

--- a/tests/test_admin_cognitive_endpoint.py
+++ b/tests/test_admin_cognitive_endpoint.py
@@ -1,0 +1,238 @@
+"""Admin cognitive-feature-flag endpoints (UI-IA risk #5 fix).
+
+Exercises `GET / POST /admin/settings/cognitive` end-to-end through
+FastAPI's TestClient. Skips when `JAMES_API_KEY` is not available
+(matches the pattern in test_change_request_endpoints.py).
+
+The endpoints delegate to `core/feature_flags.py`; the registry-
+level behaviour is pinned in `tests/test_feature_flags.py`. This
+file focuses on the HTTP wiring: auth gate, request/response
+shapes, audit log, and env-mutation side effects.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+def _read_api_key() -> str:
+    env_v = os.environ.get("JAMES_API_KEY")
+    if env_v:
+        return env_v.strip()
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.startswith("JAMES_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+ALL_COGNITIVE_ENV_NAMES = (
+    "JAMES_DISABLE_VERIFY",
+    "JAMES_ENABLE_FACT_CHECK",
+    "JAMES_ENABLE_REFLECT",
+    "JAMES_ENABLE_PLANNER",
+    "JAMES_ENABLE_QUERY_REWRITE",
+    "JAMES_DISABLE_RERANK",
+)
+
+
+class CognitiveEndpointTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from core.auth import create_token
+        cls._admin_token = create_token("admin-alice", "admin")
+        cls._user_token  = create_token("user-bob",    "employee")
+        cls._api_key     = _read_api_key()
+
+    def setUp(self):
+        if not self._api_key:
+            self.skipTest("JAMES_API_KEY missing; cannot exercise admin route")
+        # Clean env so each test starts from documented defaults.
+        self._snapshot = {n: os.environ.get(n) for n in ALL_COGNITIVE_ENV_NAMES}
+        for n in ALL_COGNITIVE_ENV_NAMES:
+            os.environ.pop(n, None)
+
+    def tearDown(self):
+        for n, v in self._snapshot.items():
+            if v is None:
+                os.environ.pop(n, None)
+            else:
+                os.environ[n] = v
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _admin_headers(self):
+        return {"Authorization": f"Bearer {self._admin_token}"}
+
+    def _user_headers(self):
+        return {"Authorization": f"Bearer {self._user_token}"}
+
+    # ── GET ─────────────────────────────────────────────────────
+
+    def test_get_returns_six_flags(self):
+        r = self._client().get(
+            f"/admin/settings/cognitive?api_key={self._api_key}",
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertIn("flags", body)
+        self.assertEqual(len(body["flags"]), 6)
+
+    def test_get_default_state_with_clean_env(self):
+        # setUp popped every cognitive env var; the response should
+        # reflect documented defaults (verify ON, rerank ON, rest OFF).
+        r = self._client().get(
+            f"/admin/settings/cognitive?api_key={self._api_key}",
+            headers=self._admin_headers(),
+        )
+        flags = {f["key"]: f["on"] for f in r.json()["flags"]}
+        self.assertTrue(flags["verify"])
+        self.assertTrue(flags["rerank"])
+        self.assertFalse(flags["fact_check"])
+        self.assertFalse(flags["planner"])
+        self.assertFalse(flags["query_rewrite"])
+        self.assertFalse(flags["reflect"])
+
+    def test_get_requires_admin_settings_feature(self):
+        # Non-admin (employee) must be rejected — admin.settings gate.
+        r = self._client().get(
+            f"/admin/settings/cognitive?api_key={self._api_key}",
+            headers=self._user_headers(),
+        )
+        self.assertEqual(r.status_code, 403, r.text)
+
+    # ── POST ────────────────────────────────────────────────────
+
+    def test_post_toggles_a_single_flag_on(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={"api_key": self._api_key, "flags": {"reflect": True}},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertTrue(body["success"])
+        self.assertEqual(len(body["deltas"]), 1)
+        d = body["deltas"][0]
+        self.assertEqual(d["key"], "reflect")
+        self.assertFalse(d["before"])
+        self.assertTrue(d["after"])
+        # Side effect — env var actually set.
+        self.assertEqual(os.environ.get("JAMES_ENABLE_REFLECT"), "1")
+
+    def test_post_toggles_multiple_flags_at_once(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={
+                "api_key": self._api_key,
+                "flags": {
+                    "reflect": True,
+                    "planner": True,
+                    "verify":  False,
+                },
+            },
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        keys = {d["key"] for d in r.json()["deltas"]}
+        self.assertEqual(keys, {"reflect", "planner", "verify"})
+        self.assertEqual(os.environ.get("JAMES_ENABLE_REFLECT"), "1")
+        self.assertEqual(os.environ.get("JAMES_ENABLE_PLANNER"), "1")
+        self.assertEqual(os.environ.get("JAMES_DISABLE_VERIFY"), "1")
+
+    def test_post_disable_polarity_off_then_on_round_trip(self):
+        # Toggle verify OFF, then back ON, confirming the env var
+        # gets popped on the second call (no stale "1" lingering).
+        client = self._client()
+        client.post(
+            "/admin/settings/cognitive",
+            json={"api_key": self._api_key, "flags": {"verify": False}},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(os.environ.get("JAMES_DISABLE_VERIFY"), "1")
+        client.post(
+            "/admin/settings/cognitive",
+            json={"api_key": self._api_key, "flags": {"verify": True}},
+            headers=self._admin_headers(),
+        )
+        self.assertIsNone(os.environ.get("JAMES_DISABLE_VERIFY"))
+
+    def test_post_empty_flags_dict_rejected(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={"api_key": self._api_key, "flags": {}},
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("flags", r.json()["detail"])
+
+    def test_post_unknown_flag_rejected(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={
+                "api_key": self._api_key,
+                "flags": {"does_not_exist": True},
+            },
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("unknown cognitive flag", r.json()["detail"])
+
+    def test_post_non_bool_value_rejected(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={
+                "api_key": self._api_key,
+                "flags": {"reflect": "yes"},
+            },
+            headers=self._admin_headers(),
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_post_requires_admin_settings_feature(self):
+        r = self._client().post(
+            "/admin/settings/cognitive",
+            json={
+                "api_key": self._api_key,
+                "flags": {"reflect": True},
+            },
+            headers=self._user_headers(),
+        )
+        self.assertEqual(r.status_code, 403, r.text)
+
+    # ── Round-trip GET → POST → GET ─────────────────────────────
+
+    def test_post_then_get_reflects_new_state(self):
+        client = self._client()
+        client.post(
+            "/admin/settings/cognitive",
+            json={
+                "api_key": self._api_key,
+                "flags": {"fact_check": True, "rerank": False},
+            },
+            headers=self._admin_headers(),
+        )
+        r = client.get(
+            f"/admin/settings/cognitive?api_key={self._api_key}",
+            headers=self._admin_headers(),
+        )
+        flags = {f["key"]: f["on"] for f in r.json()["flags"]}
+        self.assertTrue(flags["fact_check"])
+        self.assertFalse(flags["rerank"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,228 @@
+"""PROJECT JAMES — Cognitive feature-flag registry tests.
+
+Pins the contract of `core/feature_flags.py` — the substrate the
+admin Configure → Cognitive sub-page (PR-2) relies on.
+
+The tests mutate `os.environ` in setUp/tearDown to keep the process
+state clean for the next test. The registry covers six flags across
+two polarity classes — both are exercised here.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.feature_flags import (  # noqa: E402
+    COGNITIVE_FEATURE_FLAGS,
+    COGNITIVE_FLAG_ORDER,
+    _flag_is_on,
+    apply_cognitive_flag,
+    apply_cognitive_flags,
+    read_cognitive_flags,
+)
+
+
+ALL_ENV_NAMES = {spec["env"] for spec in COGNITIVE_FEATURE_FLAGS.values()}
+
+
+class _CleanEnvMixin:
+    """Snapshot the relevant env vars at setUp, restore at tearDown.
+    Other tests share `os.environ`, so leaking state here would be a
+    cross-suite bug."""
+
+    def setUp(self):
+        self._snapshot = {n: os.environ.get(n) for n in ALL_ENV_NAMES}
+        for n in ALL_ENV_NAMES:
+            os.environ.pop(n, None)
+
+    def tearDown(self):
+        for n, v in self._snapshot.items():
+            if v is None:
+                os.environ.pop(n, None)
+            else:
+                os.environ[n] = v
+
+
+# ─── Registry shape ─────────────────────────────────────────────
+
+
+class RegistryShapeTests(_CleanEnvMixin, unittest.TestCase):
+    # Inherit the env-clean mixin so test_default_matches_polarity_
+    # with_empty_env actually sees an empty env when other tests in
+    # the same run (test_planner / test_reflection_loop / etc.) have
+    # left cognitive env vars set without cleanup.
+
+    def test_six_flags_documented(self):
+        self.assertEqual(len(COGNITIVE_FEATURE_FLAGS), 6)
+        self.assertEqual(len(COGNITIVE_FLAG_ORDER), 6)
+
+    def test_order_covers_every_flag_exactly_once(self):
+        self.assertEqual(set(COGNITIVE_FLAG_ORDER),
+                         set(COGNITIVE_FEATURE_FLAGS))
+
+    def test_every_entry_has_required_fields(self):
+        required = {"env", "polarity", "label", "default", "module"}
+        for key, spec in COGNITIVE_FEATURE_FLAGS.items():
+            with self.subTest(key=key):
+                self.assertTrue(required.issubset(spec.keys()),
+                    f"flag {key} missing fields: "
+                    f"{required - set(spec.keys())}")
+                self.assertIn(spec["polarity"], ("enable", "disable"))
+                self.assertIsInstance(spec["default"], bool)
+
+    def test_env_names_are_unique(self):
+        envs = [s["env"] for s in COGNITIVE_FEATURE_FLAGS.values()]
+        self.assertEqual(len(envs), len(set(envs)),
+            "env vars must not be reused across flags")
+
+    def test_default_matches_polarity_with_empty_env(self):
+        # Default state with no env set must match the spec's
+        # `default` field — otherwise an admin who never touches
+        # any flag sees a different state than the contract
+        # advertises.
+        for key in COGNITIVE_FLAG_ORDER:
+            spec = COGNITIVE_FEATURE_FLAGS[key]
+            on = _flag_is_on(spec["env"], spec["polarity"])
+            with self.subTest(key=key):
+                self.assertEqual(on, spec["default"],
+                    f"{key} default {spec['default']} does not match "
+                    f"polarity {spec['polarity']} with env unset")
+
+
+# ─── Read ───────────────────────────────────────────────────────
+
+
+class ReadCognitiveFlagsTests(_CleanEnvMixin, unittest.TestCase):
+
+    def test_returns_six_entries_in_canonical_order(self):
+        out = read_cognitive_flags()
+        self.assertEqual([e["key"] for e in out], COGNITIVE_FLAG_ORDER)
+
+    def test_each_entry_carries_the_documented_fields(self):
+        out = read_cognitive_flags()
+        for entry in out:
+            for f in ("key", "label", "env", "polarity",
+                      "default", "on", "module"):
+                self.assertIn(f, entry)
+
+    def test_default_state_with_no_env_matches_specs(self):
+        # All env popped in setUp → flags should resolve to their
+        # documented defaults.
+        out = read_cognitive_flags()
+        for entry in out:
+            with self.subTest(key=entry["key"]):
+                self.assertEqual(entry["on"], entry["default"])
+
+    def test_enable_polarity_env_one_flips_on(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+        out = {e["key"]: e["on"] for e in read_cognitive_flags()}
+        self.assertTrue(out["reflect"])
+        # Others stay at their default.
+        self.assertFalse(out["query_rewrite"])
+
+    def test_disable_polarity_env_one_flips_off(self):
+        os.environ["JAMES_DISABLE_VERIFY"] = "1"
+        out = {e["key"]: e["on"] for e in read_cognitive_flags()}
+        self.assertFalse(out["verify"])
+        self.assertTrue(out["rerank"], "rerank default ON should stay ON")
+
+    def test_non_one_value_treated_as_unset(self):
+        # The polarity check is strict equality with "1" — any other
+        # value (including "true", "yes", "0") is unset.
+        os.environ["JAMES_ENABLE_REFLECT"] = "true"
+        out = {e["key"]: e["on"] for e in read_cognitive_flags()}
+        self.assertFalse(out["reflect"],
+            "polarity gate is strict '1' — other truthy strings must "
+            "not flip the flag")
+
+
+# ─── Write ──────────────────────────────────────────────────────
+
+
+class ApplyCognitiveFlagTests(_CleanEnvMixin, unittest.TestCase):
+
+    def test_enable_polarity_on_sets_env_to_one(self):
+        d = apply_cognitive_flag("reflect", True)
+        self.assertEqual(d, {
+            "key":    "reflect",
+            "env":    "JAMES_ENABLE_REFLECT",
+            "before": False,
+            "after":  True,
+        })
+        self.assertEqual(os.environ.get("JAMES_ENABLE_REFLECT"), "1")
+
+    def test_enable_polarity_off_pops_env(self):
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+        d = apply_cognitive_flag("reflect", False)
+        self.assertFalse(d["after"])
+        self.assertIsNone(os.environ.get("JAMES_ENABLE_REFLECT"),
+            "OFF must pop the env var (not set to '0')")
+
+    def test_disable_polarity_off_sets_env_to_one(self):
+        d = apply_cognitive_flag("verify", False)
+        self.assertEqual(d["before"], True)
+        self.assertEqual(d["after"], False)
+        self.assertEqual(os.environ.get("JAMES_DISABLE_VERIFY"), "1")
+
+    def test_disable_polarity_on_pops_env(self):
+        os.environ["JAMES_DISABLE_VERIFY"] = "1"
+        d = apply_cognitive_flag("verify", True)
+        self.assertTrue(d["after"])
+        self.assertIsNone(os.environ.get("JAMES_DISABLE_VERIFY"),
+            "ON (default) for disable-polarity must pop the env var")
+
+    def test_idempotent_repeated_on_off_cycles(self):
+        # Toggling repeatedly should never leave the env table in a
+        # surprising state — pop / set / pop / set never accumulates.
+        for _ in range(3):
+            apply_cognitive_flag("planner", True)
+            self.assertEqual(os.environ.get("JAMES_ENABLE_PLANNER"), "1")
+            apply_cognitive_flag("planner", False)
+            self.assertIsNone(os.environ.get("JAMES_ENABLE_PLANNER"))
+
+    def test_unknown_key_raises(self):
+        with self.assertRaisesRegex(ValueError, "unknown cognitive flag"):
+            apply_cognitive_flag("does_not_exist", True)
+
+
+class ApplyCognitiveFlagsBulkTests(_CleanEnvMixin, unittest.TestCase):
+
+    def test_bulk_apply_returns_per_key_delta(self):
+        out = apply_cognitive_flags({
+            "reflect":      True,
+            "planner":      True,
+            "verify":       False,
+        })
+        self.assertEqual(len(out), 3)
+        keys = {d["key"] for d in out}
+        self.assertEqual(keys, {"reflect", "planner", "verify"})
+        # All three transitioned from their default.
+        self.assertEqual(os.environ.get("JAMES_ENABLE_REFLECT"), "1")
+        self.assertEqual(os.environ.get("JAMES_ENABLE_PLANNER"), "1")
+        self.assertEqual(os.environ.get("JAMES_DISABLE_VERIFY"), "1")
+
+    def test_bulk_rejects_non_bool_value(self):
+        with self.assertRaisesRegex(ValueError, "must be bool"):
+            apply_cognitive_flags({"reflect": "yes"})  # type: ignore[arg-type]
+
+    def test_bulk_raises_on_unknown_key(self):
+        # Behaviour note: prior writes already landed. The exception
+        # message should make it clear which key failed.
+        with self.assertRaisesRegex(ValueError, "unknown cognitive flag"):
+            apply_cognitive_flags({
+                "reflect":         True,    # this lands
+                "does_not_exist":  True,    # this raises
+            })
+        # Validate the prior write landed (documented semantics).
+        self.assertEqual(os.environ.get("JAMES_ENABLE_REFLECT"), "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Backend half of the gap surfaced by `UI_API_MAPPING.md` §8 risk
signal #5: six Cognitive Layer features ship live in the pipeline
but had no admin UI. This PR ships the substrate + HTTP surface;
PR-2 (follow-up) will wire the admin.html toggles.

## Summary
- `core/feature_flags.py` (NEW, 5.6 KB) — single source of truth
  for env-var ↔ semantic mapping of 6 cognitive flags (verify /
  fact_check / reflect / planner / query_rewrite / rerank).
  Polarity-aware: 2 default-ON via "disable" semantics, 4
  default-OFF via "enable" semantics.
- `server_llmwiki.py`:
  - `GET /admin/settings/cognitive` — current ON state + label +
    default + module pointer for all 6.
  - `POST /admin/settings/cognitive` — bulk toggle, returns
    per-key before/after delta. 400 on empty / non-bool /
    unknown key. Both gated on `admin.settings`.
- `tests/test_feature_flags.py` — 20 tests + 18 subtests (registry
  shape, default-state, both polarity directions, round-trip,
  bulk apply, unknown-key reject).
- `tests/test_admin_cognitive_endpoint.py` — 11 HTTP tests
  (auth gate, GET shape, POST single/bulk, polarity round-trip,
  400 paths, round-trip GET→POST→GET).

## Verification
- `pytest tests/test_feature_flags.py tests/test_admin_cognitive_endpoint.py`
  → **31 passed**
- `pytest tests/` → **2304 passed, 0 failed** (no regression)
- `ruff check ...` → All checks passed
- AST parse-check on `server_llmwiki.py` → OK

## Behavior delta
- In-process env mutation only — container restart re-reads `.env`.
  PR-2 will surface this as a "session-only" hint in the UI.
- All 6 toggle reading sites read per-call via `os.environ.get`
  (rerank.py:37, query_rewriter.py:79, reflect.py:118, planner.py:79,
  verify.py:111/123) → new write takes effect on next pipeline call
  without restart.
- New endpoint pair adds 2 to the canonical count (UI_API_MAPPING.md
  135 → 137 — to update in PR-2 alongside the UI rows).

## Out of scope
- UI affordance — **PR-2** (admin.html Configure → Cognitive group +
  admin.js fetch/save).
- Durable persistence (DB-backed settings over env) — v0.4 candidate.
- UI_API_MAPPING.md count / §3.2 row updates — folded into PR-2.

Cross-refs:
- `docs/UI_API_MAPPING.md` §8 risk signal #5
- `docs/handovers/v0.3-cognitive-layer-track.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)