### PR TITLE
feat(admin-ui): Memory tab feedback-stats card — close UI-IA risk #1

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -321,6 +321,19 @@
       <div class="page-title"><span data-i18n="memory.page_title">🧠 Memory 현황</span></div>
       <div class="cards" id="memory-cards"></div>
 
+      <!-- Feedback aggregate (last risk-#1 orphan / UI_API_MAPPING §3.2).
+           Surfaces /feedback/stats/ — total positives/negatives across the
+           feedback engine's accumulated signals. Small 4-stat strip; lives
+           inside the Memory tab so the operator sees it alongside the
+           long-term + sessions inventory. -->
+      <div class="section-title">▸ <span data-i18n="memory.feedback_title">📊 사용자 피드백 집계</span></div>
+      <div class="table-wrap" style="padding: 12px 20px;">
+        <div id="feedback-stats-card"
+             style="display:flex;gap:24px;flex-wrap:wrap;font-family:var(--font-mono);font-size:13px">
+          <div style="color:var(--muted);font-size:12px" data-i18n="common.loading">Loading...</div>
+        </div>
+      </div>
+
       <div class="section-title">▸ <span data-i18n="memory.longterm_title">장기 기억 (세션 요약)</span> <span style="font-size:11px;color:var(--muted);margin-left:8px">(행 클릭 → 원본 대화 펼침)</span></div>
       <div class="table-wrap">
         <table>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -1396,11 +1396,82 @@ async function loadMemory() {
     await loadLongTerm();
     // 세션 목록
     await loadSessions();
+    // 사용자 피드백 집계 (UI_API_MAPPING §3.2 — last risk-#1 orphan).
+    // Best-effort: a failure here must not blank the surrounding
+    // Memory tab UI; render an inline error and keep going.
+    try { await loadFeedbackStats(); } catch (e) { console.warn('feedback-stats:', e); }
 
   } catch (e) {
     document.getElementById('memory-cards').innerHTML =
       `<div class="empty">${e.message}</div>`;
   }
+}
+
+/* ── /feedback/stats/ 4-stat strip (UI_API_MAPPING risk #1 last row).
+   The endpoint is admin.evolution-gated and returns
+     { total, positive, negative, tracked_directions }
+   from the running FeedbackEngine. Lives inside Memory tab so an
+   operator sees feedback signal alongside the long-term + sessions
+   inventory. */
+async function loadFeedbackStats() {
+  const root = document.getElementById('feedback-stats-card');
+  if (!root) return;
+  let data;
+  try {
+    data = await api('/feedback/stats/');
+  } catch (e) {
+    root.innerHTML = `<div style="color:var(--danger);font-size:12px">
+      ${_escHtml(String(e.message || e))}</div>`;
+    return;
+  }
+  if (data && data.error) {
+    root.innerHTML = `<div style="color:var(--danger);font-size:12px">
+      ${_escHtml(String(data.error))}</div>`;
+    return;
+  }
+  // Compute helpful derived metric: positive ratio. Defensive on
+  // zero-total to avoid NaN.
+  const total = Number(data && data.total) || 0;
+  const pos   = Number(data && data.positive) || 0;
+  const neg   = Number(data && data.negative) || 0;
+  const dirs  = Number(data && data.tracked_directions) || 0;
+  const ratio = total > 0 ? Math.round((pos / total) * 100) : null;
+  const ratioLabel = ratio === null
+    ? (t('mem.feedback_no_signal') || '(no signal yet)')
+    : `${ratio}%`;
+
+  root.innerHTML = `
+    <div>
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.4px">
+        <span data-i18n="mem.feedback_total">Total signals</span>
+      </div>
+      <div style="color:var(--text);font-size:18px;font-weight:600;margin-top:2px">${total}</div>
+    </div>
+    <div>
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.4px">
+        <span data-i18n="mem.feedback_positive">Positive</span>
+      </div>
+      <div style="color:var(--success);font-size:18px;font-weight:600;margin-top:2px">${pos}</div>
+    </div>
+    <div>
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.4px">
+        <span data-i18n="mem.feedback_negative">Negative</span>
+      </div>
+      <div style="color:var(--danger);font-size:18px;font-weight:600;margin-top:2px">${neg}</div>
+    </div>
+    <div>
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.4px">
+        <span data-i18n="mem.feedback_ratio">Positive ratio</span>
+      </div>
+      <div style="color:var(--accent);font-size:18px;font-weight:600;margin-top:2px">${_escHtml(ratioLabel)}</div>
+    </div>
+    <div>
+      <div style="color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.4px">
+        <span data-i18n="mem.feedback_tracked">Tracked directions</span>
+      </div>
+      <div style="color:var(--text);font-size:18px;font-weight:600;margin-top:2px">${dirs}</div>
+    </div>`;
+  if (typeof applyTranslations === 'function') applyTranslations();
 }
 
 async function loadLongTerm() {

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -251,6 +251,13 @@ const TRANSLATIONS = {
 
     'memory.longterm_title': 'Long-term memory (session summaries)',
     'memory.session_list':   'Session list',
+    'memory.feedback_title': '📊 User feedback aggregate',
+    'mem.feedback_total':    'Total signals',
+    'mem.feedback_positive': 'Positive',
+    'mem.feedback_negative': 'Negative',
+    'mem.feedback_ratio':    'Positive ratio',
+    'mem.feedback_tracked':  'Tracked directions',
+    'mem.feedback_no_signal': '(no signal yet)',
     'session.id':            'Session ID',
     'session.turns':         'Turns',
 
@@ -860,6 +867,13 @@ const TRANSLATIONS = {
 
     'memory.longterm_title': '장기 기억 (세션 요약)',
     'memory.session_list':   '세션 목록',
+    'memory.feedback_title': '📊 사용자 피드백 집계',
+    'mem.feedback_total':    '총 신호',
+    'mem.feedback_positive': '긍정',
+    'mem.feedback_negative': '부정',
+    'mem.feedback_ratio':    '긍정 비율',
+    'mem.feedback_tracked':  '추적 중인 방향',
+    'mem.feedback_no_signal': '(신호 없음)',
     'session.id':            '세션 ID',
     'session.turns':         '대화 수',
 

--- a/tests/test_feedback_stats_ui.py
+++ b/tests/test_feedback_stats_ui.py
@@ -1,0 +1,171 @@
+"""Admin Memory tab — feedback-stats card (UI-IA risk #1 last orphan).
+
+Static snapshot pinning for the 4-stat strip that surfaces
+`GET /feedback/stats/`. Same pattern as test_cognitive_toggle_ui.py
+and test_llm_selection_ui.py.
+
+No browser; pins the wiring contract so a refactor that strips the
+card (or renames the endpoint reference) breaks loudly here.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+ROOT = Path(__file__).resolve().parent.parent
+ADMIN_HTML = ROOT / "frontend" / "admin.html"
+ADMIN_JS   = ROOT / "frontend" / "static" / "admin.js"
+I18N_JS    = ROOT / "frontend" / "static" / "i18n.js"
+
+
+class AdminHtmlSectionTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = ADMIN_HTML.read_text(encoding="utf-8")
+
+    def test_feedback_section_title_present(self):
+        self.assertIn('data-i18n="memory.feedback_title"', self.html,
+            "Memory tab must declare the feedback-aggregate section title")
+
+    def test_feedback_card_container_id(self):
+        self.assertIn('id="feedback-stats-card"', self.html,
+            "admin.js targets `#feedback-stats-card`; renaming this id "
+            "without updating the JS would silently break the render")
+
+    def test_section_lives_inside_memory_page(self):
+        # The new card lives in page-memory, not stranded elsewhere.
+        idx_page = self.html.index('id="page-memory"')
+        idx_card = self.html.index('id="feedback-stats-card"')
+        # Close the memory page sometime after the card.
+        idx_close = self.html.index('id="page-patches"', idx_card)
+        self.assertGreater(idx_card, idx_page,
+            "feedback card must be inside #page-memory")
+        self.assertGreater(idx_close, idx_card,
+            "feedback card must close before the next page block")
+
+
+class AdminJsHandlerTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.js = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_load_function_defined(self):
+        self.assertIn("async function loadFeedbackStats", self.js,
+            "loadFeedbackStats must be defined")
+
+    def test_load_hits_feedback_stats_endpoint(self):
+        idx = self.js.index("async function loadFeedbackStats")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("/feedback/stats/", body,
+            "loadFeedbackStats must GET the documented endpoint")
+
+    def test_load_is_called_from_load_memory(self):
+        # Memory tab loader must trigger the new card so it hydrates
+        # without an extra click.
+        idx = self.js.index("async function loadMemory")
+        m = re.search(r"\nasync function\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 5000
+        body = self.js[idx:end]
+        self.assertIn("loadFeedbackStats", body,
+            "loadMemory must trigger loadFeedbackStats so the card "
+            "renders when the operator opens the Memory tab")
+
+    def test_load_handles_error_path(self):
+        # The endpoint returns {error: ...} on failure (server side
+        # try/except); the render must NOT blank the surrounding UI.
+        # We pin the defensive branch + the `_escHtml` usage on the
+        # error message.
+        idx = self.js.index("async function loadFeedbackStats")
+        body = self.js[idx:idx + 4000]
+        self.assertIn("data && data.error", body,
+            "render must detect the server's {error: ...} shape")
+        # Outer try/catch on the api() call itself.
+        self.assertIn("catch (e)", body,
+            "render must wrap api() in try/catch so a 4xx doesn't "
+            "throw uncaught into loadMemory")
+        # Both error branches must escape the message.
+        self.assertGreaterEqual(body.count("_escHtml"), 2,
+            "both error branches and the ratio label must run through "
+            "_escHtml (XSS guard)")
+
+    def test_load_failure_does_not_blank_memory_tab(self):
+        # loadMemory's caller must wrap loadFeedbackStats so a network
+        # failure on /feedback/stats/ doesn't drop the long-term + sessions
+        # rows that already rendered.
+        idx = self.js.index("async function loadMemory")
+        m = re.search(r"\nasync function\s+\w+\s*\(", self.js[idx + 1:])
+        end = idx + 1 + m.start() if m else idx + 5000
+        body = self.js[idx:end]
+        # Defensive try/catch around the feedback call specifically.
+        # Form: `try { await loadFeedbackStats(); } catch (e) { ... }`
+        feedback_idx = body.index("loadFeedbackStats")
+        prelude = body[max(0, feedback_idx - 80):feedback_idx]
+        self.assertIn("try", prelude,
+            "loadMemory must defensively wrap loadFeedbackStats in "
+            "try/catch — a failure here must not blank the surrounding UI")
+
+    def test_render_computes_positive_ratio(self):
+        idx = self.js.index("async function loadFeedbackStats")
+        body = self.js[idx:idx + 4000]
+        # The 5th stat (positive ratio) is derived client-side; the
+        # backend only ships total + positive + negative + tracked.
+        self.assertIn("pos / total", body,
+            "render must derive the positive ratio client-side")
+        # Defensive on zero-total to avoid NaN%.
+        self.assertIn("total > 0", body,
+            "render must guard against divide-by-zero on no-signal state")
+
+
+class I18nKeysTests(unittest.TestCase):
+
+    REQUIRED_KEYS = [
+        "memory.feedback_title",
+        "mem.feedback_total",
+        "mem.feedback_positive",
+        "mem.feedback_negative",
+        "mem.feedback_ratio",
+        "mem.feedback_tracked",
+        "mem.feedback_no_signal",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = I18N_JS.read_text(encoding="utf-8")
+        ko_idx = cls.text.index("  ko: {")
+        cls.en_block = cls.text[:ko_idx]
+        cls.ko_block = cls.text[ko_idx:]
+
+    def test_every_required_key_in_en(self):
+        for k in self.REQUIRED_KEYS:
+            with self.subTest(key=k):
+                self.assertIn(f"'{k}':", self.en_block,
+                    f"{k} missing in en")
+
+    def test_every_required_key_in_ko(self):
+        for k in self.REQUIRED_KEYS:
+            with self.subTest(key=k):
+                self.assertIn(f"'{k}':", self.ko_block,
+                    f"{k} missing in ko")
+
+    def test_html_referenced_keys_defined(self):
+        html = ADMIN_HTML.read_text(encoding="utf-8")
+        refs = re.findall(
+            r'data-i18n="(memory\.feedback_[a-z_]+|mem\.feedback_[a-z_]+)"',
+            html,
+        )
+        self.assertGreaterEqual(len(refs), 1,
+            "admin.html must reference at least one feedback i18n key")
+        for k in set(refs):
+            with self.subTest(key=k):
+                self.assertIn(f"'{k}':", self.en_block,
+                    f"HTML references {k} which is not defined in en")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires the last orphan from the original risk-#1 cluster
(`GET /feedback/stats/`) into a small 4-stat strip inside the
admin Memory tab. Closes risk signal #1 entirely.

## Summary
- `frontend/admin.html` — new section under `#page-memory`
  between memory cards and the long-term table:
  - `▸ 📊 사용자 피드백 집계` section title
  - `#feedback-stats-card` flex strip container
- `frontend/static/admin.js`:
  - `loadFeedbackStats()` — GETs `/feedback/stats/`, renders
    5 stats (total / positive / negative / positive-ratio /
    tracked directions). Ratio derived client-side from
    `pos/total` with zero-total guard. Defensive on the server's
    `{error: ...}` shape AND the api()-level throw.
  - `loadMemory()` calls it inside a defensive try/catch — a
    `/feedback/stats/` failure must NOT blank the surrounding
    Memory tab UI.
- `frontend/static/i18n.js` — 7 keys × 2 locales:
  `memory.feedback_title` + `mem.feedback_total / _positive /
  _negative / _ratio / _tracked / _no_signal`.
- `tests/test_feedback_stats_ui.py` — **12 tests + 15 subtests**:
  section under `#page-memory`, DOM id pin, function def,
  endpoint URL, load-on-mount, error-path defensiveness,
  divide-by-zero guard, `_escHtml` count, i18n parity en/ko.

## Verification
- `pytest tests/test_feedback_stats_ui.py -v` → **12 passed**
- `pytest tests/` → **2350 passed, 0 failed**
- `ruff check .` → All checks passed
- `node --check frontend/static/{admin,i18n}.js` → OK

## UI-IA precondition checklist
| Constraint | Status |
|---|---|
| D2 (17-tab split → Phase 3) | ✅ inside existing Memory tab |
| D3 (`<area>:<noun>:<verb>`) | n/a (read-only, no save button) |
| D4 (no API URL rename) | ✅ |
| D7 (#session-list / #session-count-badge) | ✅ untouched |

## Browser verification (since no auto e2e)
1. Log in as admin → 🧠 Memory tab → 4-stat strip renders
   (default state: total=0, pos=0, neg=0, no-signal ratio).
2. Submit a few chat queries with thumbs-up/down feedback → the
   strip's numbers update when the Memory tab is reopened.
3. With the endpoint failing (block via DevTools or simulate
   500) → strip shows an inline error in --danger color, the
   long-term + sessions tables below still render normally.

## Out of scope
- UI_API_MAPPING.md sync (orphans 9 → 8, risk signal #1 closed)
  — folded into next docs-sync PR
- Per-direction shadow-score breakdown — endpoint only ships
  aggregates; richer breakdown needs a new endpoint

Cross-refs:
- `docs/UI_API_MAPPING.md` §3.2 (last risk-#1 row) + §8 risk #1
- `core/feedback_engine.py:286` (`get_feedback_stats()` source)
- `server_llmwiki.py:2175` (endpoint definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)