### PR TITLE
docs(design): admin.js split inventory — UI-IA Phase 3 PoC step 0

### DIFF
--- a/docs/design/v0.3-admin-split-inventory.md
+++ b/docs/design/v0.3-admin-split-inventory.md
@@ -1,0 +1,382 @@
+# `admin.js` Split Inventory — UI-IA Phase 3 PoC step 0
+
+> **Status**: planning artifact (PR-A of Phase 3). No code change in
+> this commit — this is the survey that the actual splits (PRs B/C/D
+> and beyond) consume.
+>
+> **Companion docs**: `docs/UI_IA.md` §3.2 (the 17→5+8+5 target),
+> `docs/handovers/v0.3.x-ui-ia-track.md` §7 (c) (PoC recipe).
+>
+> **Risk**: this is the largest concrete UI change v0.3 has slated.
+> Step 0 (this doc) lets every later step land in small,
+> independently-revertible pieces.
+
+---
+
+## 0. Why a survey first
+
+`admin.js` is **156 KB / 3911 lines / 128 functions / 47+ API
+calls**. Splitting it blind risks:
+
+- silently dropping a `data-action` route (the click delegate at
+  line 50 is the spine);
+- breaking a load-on-mount call from `showPage` (line 546 — the
+  17-tab router);
+- breaking page-to-page state-bridging (e.g. `users → reset-token
+  modal`, `proposals → loadProposals cache`).
+
+This inventory pins every function to its IA group + its
+dependency surface, so the later cut/paste PRs can quote line
+ranges and the reviewer can audit each step independently.
+
+---
+
+## 1. Headline numbers
+
+| Metric | Value |
+|---|---|
+| `admin.js` size | 156 KB (3911 lines) |
+| `admin.html` size | 74 KB |
+| Top-level functions | 128 |
+| `data-action` switch cases | ~60 (line 50–200) |
+| Page router entries (`pages` map) | 17 (line 559–578) |
+| API endpoints called | 47+ |
+| Active i18n keys referenced | ~150 |
+
+---
+
+## 2. Page-router map (the 17 tabs)
+
+Lines 559–578 of `admin.js`. Each entry maps a page id (the
+`data-page` attribute on a nav item) to a loader function — that's
+what runs when the operator clicks the tab.
+
+| `data-page` | Loader | IA target (UI_IA.md §3.2) |
+|---|---|---|
+| `dashboard` | `loadDashboard` | **Observe** (landing) |
+| `users` | `loadUsers` | **Govern** |
+| `policy` | `loadPolicy` | **Configure** |
+| `entities` | `loadEntities` | **Observe** (read) + Govern (edit via CR) |
+| `memory` | `loadMemory` | **Observe** |
+| `patches` | `loadPatches` | **Govern** |
+| `audit` | `loadAudit` | **Observe** |
+| `uploads` | `loadUploads` | **Observe** |
+| `files` | `loadFiles` | **Govern** (admin actions) / mirrored to My Work |
+| `settings` | `loadSettings` | **Configure** |
+| `proposals` | `loadProposals` | **Govern** |
+| `evo-reports` | `loadEvoReports` | **Observe** |
+| `performance` | `loadPerformance` | **Observe** |
+| `learning` | `loadLearning` | **Configure** |
+| `character` | `loadCharacter` | **Configure** |
+| `knowledge` | `loadKnowledge` | **Observe** |
+| `hardware` | `loadHardware` | **Configure** |
+
+Resulting target split: **Govern 5 / Observe 8 / Configure 5** —
+matches UI_IA.md §3.2 exactly. (`entities` and `files` are
+mixed-read/write — see §6 of this doc for the rule.)
+
+---
+
+## 3. Function inventory per group
+
+Line ranges are start-of-function only; "end" can be inferred from
+the next function in the list. Functions called by group N but
+defined in shared utils (§4) are marked with `↗ shared`.
+
+### 3.1 Govern (5 tabs)
+
+| Group | Functions | Lines |
+|---|---|---|
+| users | `loadUsers`, `_userActionEscape`, `approveUser`, `rejectUser`, `deactivateUser`, `issueResetTokenFor`, `closeResetTokenModal`, `copyResetToken` | 718, 742, 1027, 1039, 1049, 1099, 1114, 1121 |
+| patches | `loadPatches`, `patchAction` | 1614, 1636 |
+| proposals | `loadProposals`, `escAdm`, `showProposalDetail`, `approveProposal`, `rejectProposalById`, `executeWebLearnProposal`, `generateProposals` | 2583, 2638, 2642, 2654, 2669, 2696, 2727 |
+| files (admin write side) | `loadFiles`, `_renderTree`, `searchFiles`, `onFilesRootChange` | 1881, 1928, 1970, 1873 |
+| entities (edit via CR) | `openEntityDetail`, `closeEntityDetail` | 1321, 1367 |
+
+Total **23 functions** for Govern.
+
+### 3.2 Observe (8 tabs)
+
+| Group | Functions | Lines |
+|---|---|---|
+| dashboard | `loadDashboard` | 607 |
+| audit | `loadAudit`, `audit_searchInput`, `audit_reload`, `audit_page`, `_auditEscapeHtml` | 1683, 1655, 1663, 1668, 1676 |
+| memory | `loadMemory`, `loadFeedbackStats`, `loadLongTerm`, `loadSessions`, `openSessionTurns`, `closeSessionTurns`, `summarizeAndDelete` | 1373, 1416, 1477, 1504, 1536, 1580, 1585 |
+| uploads | `loadUploads`, `_uploadsPrev`, `_uploadsNext`, `_humanSize`, `_humanMtime` | 1747, 1840, 1845, 1857, 1865 |
+| evo-reports | `loadEvoReports` | 2749 |
+| performance | `loadPerformance`, `loadPerfHistory`, `runEvaluation` | 2775, 2808, 2832 |
+| knowledge | `loadKnowledge`, `renderCapabilities`, `_domainDonut`, `renderDomains` | 3635, 3649, 3671, 3705 |
+| entities (read) | `onEntitiesSearchInput`, `entitiesPage`, `loadEntities` | 1239, 1248, 1253 |
+
+Total **27 functions** for Observe.
+
+### 3.3 Configure (5 tabs)
+
+| Group | Functions | Lines |
+|---|---|---|
+| policy | `loadPolicy`, `onPolicyToggle`, `resetPolicyFeature`, `_policyToast` | 944, 998, 1016, 931 |
+| settings | `loadSettings`, `saveSettings`, `buildProtectedCheckboxes`, `getProtectedFiles`, `onLanguageChange`, `loadLlmSelections`, `saveLlmSelections`, `loadCognitiveFlags`, `saveCognitiveFlags`, `loadWebSearchConfig`, `applyWsThresholdLabel`, `saveWebSearchConfig`, `saveIdentity`, `loadIdentity` | 2067, 2452, 2041, 2061, 2024, 2148, 2215, 2303, 2358, 2474, 2533, 2550, 2402, 2441 |
+| learning | `loadLearning`, `learnTopic`, `webLearnTopic`, `learnSingleTopic`, `learnFromErrors` | 2849, 2872, 2881, 2950, 2967 |
+| character | `loadCharacter`, `_layoutForRadar`, `renderInteractiveRadar`, `onVertexPointerDown`, `_svgPointToViewBox`, `onVertexPointerMove`, `onVertexPointerUp`, `applyTraitChangeLocally`, `animateRippleFor`, `buildCharacterSummary`, `renderCharacterSummary`, `renderConnectionsPanel`, `renderTraitSliders`, `onSliderInput`, `onSliderChangeCommit`, `syncSlidersToTraits`, `saveCharacter`, `resetCharacter` | 3038, 3024, 3060, 3195, 3223, 3231, 3245, 3262, 3303, 3331, 3396, 3415, 3516, 3568, 3576, 3581, 3592, 3610 |
+| hardware | `loadHardware`, `loadLLMRecommend`, `installLLM` | 3732, 3804, 3878 |
+
+Total **44 functions** for Configure (character alone is 18 —
+the radar UI is the largest single feature).
+
+---
+
+## 4. Shared utilities (`admin-common.js` extraction candidate)
+
+These cross every group and must move out **before** any group
+split, or each new file would re-import them and the import graph
+becomes a cycle.
+
+| Function | Lines | What it does |
+|---|---|---|
+| `api(path, method, body)` | 582 | The HTTP wrapper. Handles `apiKey` query param, Bearer header, 401 → relogin. **Every** group function eventually calls this. |
+| `toast(msg, type)` | 1602 | The notification helper. Used everywhere. |
+| `_escHtml(s)` | 1740 | The XSS-guard string escape. Used by every render-into-innerHTML path. |
+| `escapeHtml(s)` | 1315 | Older alias of `_escHtml`. **Consolidate to one name** during extraction. |
+| `_userActionEscape(name)` | 718 | Security variant — strips attributes that could be HTML-injected into a `data-username` attr. Used by Users + Patches. |
+| `_selfUsernameFromToken()` | 725 | JWT subject reader. Used by Users (self-check) + change-password modal. |
+
+### Navigation + first-run (also shared)
+
+| Function | Lines |
+|---|---|
+| `toggleLang` | 21 |
+| `_bindFrontendEvents` (click delegate spine) | 50 |
+| `_bindStableInputs` | 210 |
+| `showAdminLoginModal`, `toggleAdminPwVisibility`, `doAdminLogin` | 296, 306, 319 |
+| `firstRunCheck`, `firstRunShow`, `_firstRunRow`, `firstRunInstall`, `firstRunDismiss` | 348, 378, 437, 463, 509 |
+| `toggleAdminNav`, `toggleNavSection`, `showPage` | 520, 534, 546 |
+| `changeMyPassword`, `openForgotPasswordModal`, `closeForgotPasswordModal`, `openSignupModal`, `closeSignupModal`, `submitSignup`, `submitPasswordReset` | 1065, 1143, 1151, 1165, 1176, 1187, 1221 |
+| `_fmtKeyTs`, `_renderMyApiKeys`, `issueMyApiKey`, `closeMyApiKeyModal`, `copyMyApiKey`, `revokeMyApiKey` | 826, 835, 864, 884, 891, 910 |
+
+### My Work (per UI_IA §3.2 — admin page hosts My Work surface today)
+
+`changeMyPassword`, `_renderMyApiKeys`, `issueMyApiKey`,
+`closeMyApiKeyModal`, `copyMyApiKey`, `revokeMyApiKey`,
+`_fmtKeyTs`. These belong to **My Work** in UI_IA terms but live
+in admin.html today. The HTML page split (option A below) would
+naturally lift them into `workspace.html` or a new `/my` page;
+the sub-tab option (B) leaves them in admin.
+
+Total shared utilities: **~32 functions** (mostly small).
+
+---
+
+## 5. `data-action` route inventory
+
+The click delegate at `_bindFrontendEvents` (line 50) is the spine
+that connects HTML buttons to JS handlers. Every split must
+preserve every route or buttons silently stop working.
+
+Route groups (current 60 cases):
+
+| Group | Action examples |
+|---|---|
+| Shared / navigation | `toggle-lang`, `toggle-admin-nav`, `toggle-nav-section`, `show-page` |
+| Login / first-run | `do-admin-login`, `toggle-admin-pw-visibility`, `first-run-check`, `first-run-dismiss`, `first-run-install` |
+| Auth modals | `open-signup-modal`, `close-signup-modal`, `submit-signup`, `open-forgot-password-modal`, `close-forgot-password-modal`, `submit-password-reset` |
+| API key | `issue-my-api-key`, `copy-my-api-key`, `revoke-my-api-key`, `close-my-api-key-modal`, `copy-reset-token`, `close-reset-token-modal`, `issue-reset-token-for` |
+| User (Govern) | `approve-user`, `reject-user`, `deactivate-user` |
+| Policy (Configure) | `reset-policy-feature` |
+| Entities | `entities-page`, `open-entity-detail`, `close-entity-detail` |
+| Memory | `open-session-turns`, `close-session-turns`, `summarize-and-delete` |
+| Patches (Govern) | `patch-action` |
+| Audit (Observe) | `audit-page` |
+| Uploads (Observe) | `uploads-prev`, `uploads-next`, `load-uploads` |
+| Files (Govern) | `load-files`, `search-files` |
+| Settings (Configure) | `save-settings`, `save-llm-selections`, `save-cognitive-flags`, `save-web-search-config` |
+| Proposals (Govern) | `show-proposal-detail`, `approve-proposal`, `reject-proposal-by-id`, `execute-web-learn-proposal`, `generate-proposals` |
+| Learning (Configure) | `learn-topic`, `web-learn-topic`, `learn-single-topic`, `learn-from-errors` |
+| Character / Identity (Configure) | `save-identity`, `save-character`, `reset-character` |
+| Performance (Observe) | `run-evaluation` |
+| Hardware (Configure) | `load-hardware`, `install-llm` |
+
+Phase 3 keeps the names (D3 alias map is Phase 4 territory) — the
+split only moves the function definitions; the click delegate
+itself stays in `admin-common.js`.
+
+---
+
+## 6. The 17→5+8+5 redistribution conflicts
+
+Two tabs are **mixed-mode** per UI_IA.md §3.2:
+
+- **`entities`** — read view (Observe) + edit view (Govern via CR).
+  The read goes to Observe; the edit button deep-links into
+  Govern → CR Propose. Today both live in the same admin tab;
+  after the split, the read renders in `/observe/entities` and
+  the edit button on that page is a hyperlink to
+  `/govern/cr/new?target_type=wiki_entity&target_id=…` (not a
+  modal inside Observe).
+- **`files`** — admin-wide file ops belong to Govern; the user's
+  own files belong to My Work. The current Files tab does both —
+  the split routes admin ops to `/govern/files` and user file
+  surface stays in `/my/files` (workspace.html territory).
+
+Per UI_IA.md §6 rule:
+
+> on each page, **read affordances always present, write
+> affordances guarded by area**. A user viewing entities in
+> Observe sees data; they cannot edit there — the edit button
+> deep-links into Govern → CR Propose.
+
+---
+
+## 7. Decision needed before PR-B
+
+UI-IA handover §7 (c) step 4 explicitly leaves this open:
+
+> 4. HTML 측: `admin.html` 의 17 탭을 3 페이지(`/govern`,
+>    `/observe`, `/configure`)로 분할 또는 한 페이지 안에서 영역
+>    sub-tab 으로 재배치 (선택 결정 필요)
+
+### Option A — 3 HTML pages
+
+`admin.html` (74 KB) splits into `govern.html` + `observe.html` +
+`configure.html`. Each page links to its area JS file
+(`govern.js` / `observe.js` / `configure.js`) plus the shared
+`admin-common.js`.
+
+Pros:
+- IA's "5 areas" become physical URLs (`/govern`, `/observe`,
+  `/configure`) — matches UI_IA §3.1 target.
+- Each page is small enough to load fast; operator can bookmark
+  per-role pages.
+- Backend routing stays unchanged (D4); only the HTML serving
+  layer adds 2 new routes.
+- Login modal markup unification (risk signal #4) folds in: one
+  modal markup, included on all 3 pages.
+
+Cons:
+- Larger surgical change (4 HTML files touched: 3 new + 1 deleted).
+- Cross-area workflows (CR lifecycle, evolution feedback loop —
+  UI_IA §3.3) become explicit hyperlinks rather than tab clicks.
+- Browser back/forward across areas creates a full page reload
+  per area change.
+
+### Option B — Sub-tabs inside `admin.html`
+
+`admin.html` stays as one page; the 17 tabs reorganize into 3
+super-section headers (Govern / Observe / Configure) with
+sub-tabs underneath. JS still splits into govern.js / observe.js
+/ configure.js but they all attach to the same HTML page.
+
+Pros:
+- Single HTML file — no new routes, no full-page reloads.
+- Operator stays in one page; area switch is a header click.
+- Smaller risk surface — only `admin.html` reorganizes.
+
+Cons:
+- `admin.html` stays a 74 KB monolith (D2 not fully satisfied —
+  *spirit* satisfied via 3 visual areas; *letter* not).
+- Cross-area workflows stay inside one page (less explicit
+  hand-off than Option A).
+- Login modal still per-page (only 1 page now, but if `chat.html`
+  / `workspace.html` ever consolidate too, risk #4 isn't closed).
+
+### Recommendation
+
+**Option A** for the IA contract's letter + risk #4 closure +
+URL-as-IA-spine.
+**Option B** if minimizing visual disruption + reload count
+is the higher priority.
+
+Pick one before PR-B. This doc neither prescribes nor commits.
+
+---
+
+## 8. PR ladder (proposed, post-decision)
+
+| PR | Scope | Risk | Verification |
+|---|---|---|---|
+| **A** (this) | Inventory doc, **no code change** | none | doc-only, ruff/pytest unaffected |
+| **B** | `admin-common.js` extraction (32 shared functions out of admin.js) | low — pure cut/paste, both files load in admin.html as before | static tests: every shared function still defined exactly once, click-delegate routes unchanged |
+| **C** | `govern.js` extraction (Govern 23 functions out of admin.js) | medium — risk that an Observe/Configure function depends on a Govern one via inferred name lookup | grep admin.js for any remaining reference to the moved names |
+| **D** | `observe.js` extraction (Observe 27 functions) | medium | same |
+| **E** | `configure.js` extraction (Configure 44 functions) | medium-high — character radar is intricate | same + character page golden-path browser check |
+| **F** | (Option A only) Split `admin.html` into 3 HTML pages | high | golden-path browser verification per page; risk #4 closure (login modal markup unification) folded in |
+| **G** | Cleanup: delete `admin.js` (now empty), tighten imports, drop legacy aliases (`escapeHtml` → `_escHtml`) | low | static tests + final ruff |
+
+Each PR independently revertible. PRs C/D/E can land in any
+order if PR-B is in first (the function defs no longer depend on
+admin.js's ordering once shared utils are out).
+
+---
+
+## 9. Verification strategy per PR
+
+The static-snapshot pattern proven by the 4 risk-signal-closure
+PRs in this session (#377, #378, #380, #383) applies directly:
+
+- Every moved function: **still defined exactly once** (grep
+  across all `frontend/static/*.js`).
+- Every `data-action` route: **still routed exactly once** (grep
+  the switch statement across all JS).
+- Every `loadXxx`: **still wired in `pages` map** (single grep
+  on `pages = {`).
+- Every i18n key referenced in moved markup: **still defined in
+  both en + ko blocks** (the existing
+  `test_*_ui.py` files' `I18nKeysTests` pattern).
+- `node --check` on every JS file after the cut.
+- Existing pytest suite as regression net (2350+ tests).
+
+Browser golden paths (sampled, run by operator):
+
+1. Each tab loads its data on first click.
+2. Login modal works on every entry page.
+3. `data-action` buttons (save / approve / install / etc.) fire
+   exactly one handler.
+4. Cross-area hand-offs (proposal → approval → audit log) carry
+   the same identifier across hops.
+
+---
+
+## 10. What this PR does NOT do
+
+- Move any function. Pure inventory.
+- Touch any HTML file. Pure inventory.
+- Decide between Option A and Option B (§7). That's the user's
+  call before PR-B is written.
+- Touch `chat.js`, `graph.js`, `workspace.js`. They are out of
+  scope; only `admin.js` is split here. The login-modal markup
+  unification (risk #4) is a downstream consequence of Option A
+  + a separate PR to update the other 3 pages.
+- Address the `data-action` `<area>:<noun>:<verb>` rename — UI-IA
+  decision D3 explicitly defers that to a Phase 4 / v0.4 alias
+  map.
+
+---
+
+## 11. Cross-references
+
+- `docs/UI_IA.md` §3.2 (the 17→5+8+5 target table)
+- `docs/UI_IA.md` §3.3 (cross-page workflows)
+- `docs/UI_IA.md` §6 (acceptance criteria for "IA is done")
+- `docs/UI_API_MAPPING.md` §7 (`admin.js` 51+ calls — the same
+  function count, viewed from the API side)
+- `docs/UI_API_MAPPING.md` §8 risk #4 (login modal markup —
+  closes naturally under Option A)
+- `docs/handovers/v0.3.x-ui-ia-track.md` §3 Phase 3 (the
+  pending-since-2026-05-20 item)
+- `docs/handovers/v0.3.x-ui-ia-track.md` §7 (c) (the PoC recipe
+  this doc serves as step 0 for)
+
+---
+
+## 한국어 요약
+
+`admin.js` (156 KB, 3911줄, 128 함수, 47+ API 호출) 을 IA의 5영역
+중 3영역 (Govern 5탭 / Observe 8탭 / Configure 5탭) 으로 분할하는
+Phase 3 PoC 의 **step 0** — 인벤토리 작업.
+
+본 PR 는 코드 0줄 변경. 모든 후속 PR (B–G) 가 인용할 함수별 line
+range / IA group / 의존성 surface 를 박는다. 사용자 결정 안건 1건:
+**§7 의 Option A (HTML 3-페이지 분할) vs Option B (admin.html 안의
+sub-tab 재배치)**. 이 결정 후 PR-B (admin-common.js 추출) 부터
+실제 cut/paste 가 시작된다. 각 후속 PR 은 단계적 자체 검증이 가능
+하도록 작게 (특히 PR-E 의 character radar 는 사용자 라이브 검증
+권장).


### PR DESCRIPTION
Survey + analysis artifact for the largest UI change v0.3 has
slated: splitting `admin.js` (156 KB / 3911 lines / 128 functions /
47+ API calls) along the 5+8+5 IA boundaries from UI_IA.md §3.2.

**No code change in this PR.** Pure planning artifact that the
actual splits (PRs B–G) will quote.

## What's in it
- **§2 Page-router map**: 17 `pages` entries classified per
  UI_IA.md §3.2 → Govern 5 / Observe 8 / Configure 5.
- **§3.1–3.3 Function inventory** per IA group with line
  numbers (23 Govern / 27 Observe / 44 Configure functions).
- **§4 Shared utilities** (32 functions) for the proposed
  `admin-common.js` extraction.
- **§5 `data-action` route inventory** (60 cases).
- **§6** The mixed-mode tabs (entities, files) handled per UI_IA
  §6 rule (read present, write deep-links).
- **§7 Open decision** (handover §7c step 4):
  - **Option A** — 3 HTML pages (`/govern`, `/observe`, `/configure`)
  - **Option B** — sub-tabs inside `admin.html`
  Explicit pros/cons; this doc does **not** commit either way.
- **§8 PR ladder** (B → G): 6 follow-up PRs, each independently
  revertible.
- **§9 Verification strategy** re-uses the static-snapshot pattern
  from PRs #377/#378/#380/#383.

## Why a survey first
`admin.js` is the largest concrete UI change in v0.3. Splitting
blind risks silently dropping `data-action` routes (click-delegate
spine at line 50), breaking load-on-mount via the 17-tab page
router (line 559), or breaking cross-tab state bridges
(users → reset-token modal, proposals → loadProposals cache).
This inventory pins every function to its IA group + dependency
surface so each later cut/paste PR can quote line ranges and be
reviewed independently.

## Verification
- `ruff check .` → All checks passed
- `pytest tests/` → **2350 passed, 0 failed**
- Doc-only — no code touched
- Counts cross-verified against main (grep `^(async )?function`
  on admin.js = 128 functions ✓)

## Next step — open decision
The author of PR-B needs the **Option A vs Option B** call before
writing code. That call is the user's; this doc is the briefing
that supports it.

## Out of scope
- The actual extraction. PR-B (admin-common.js) is the natural
  next step **after** the user picks A vs B in §7.
- `chat.js` / `graph.js` / `workspace.js` — only `admin.js` is in
  scope for Phase 3.
- `data-action` `<area>:<noun>:<verb>` rename — D3 defers to v0.4
  alias map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)