### PR TITLE
fix(ingest): complete PR-11b event ingest path — 3 silent gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ wiki/entity/prod/**/*.md
 wiki/prod/
 # media (audio/video) 추출 산출물 — entity 와 동일한 사용자 데이터
 wiki/media/prod/
+# test wiki — 검증/디버깅용 임시 데이터 (production 과 동일한 schema 라
+# 누수 위험은 적지만 git 추적할 가치 없음).
+wiki/entity/test/**/*.md
 # 메타 파일은 명시적으로 추적 — 카테고리 인덱스 / 폴더 보존용 .gitkeep
 !wiki/entity/prod/**/index.md
 !wiki/entity/prod/**/.gitkeep

--- a/core/wiki_generator.py
+++ b/core/wiki_generator.py
@@ -25,7 +25,7 @@ from utils.metadata import MetadataGenerator
 
 
 _SAFE_ENTITY_NAME_RE = re.compile(r'^[A-Za-z0-9가-힣\s\-_,()&·\.]{2,80}$')
-_ALLOWED_EXTRACT_TYPES = frozenset(("person", "org", "concept"))
+_ALLOWED_EXTRACT_TYPES = frozenset(("person", "org", "concept", "event"))
 _ONTOLOGY_LABELS_KO = "공부, 연구, 가르침, 소속, 근무, 분류, 구성, 관련, 생산, 산업, 분야, 설립됨"
 
 # 괄호 패턴 — 반각/전각 모두 처리. e.g. "RAG (검색 증강 생성)" / "RAG（검색 증강 생성）"
@@ -738,9 +738,34 @@ class WikiGenerator:
                 "sensitivity": "internal",
                 "source_type": self.source_type,
             }
+            # PR-11b — carry event time-axis fields from LLM extraction
+            # to the create_entity_file event branch. Without these,
+            # the event branch's validate_occurred_at() always fails
+            # and falls back to concept (the symptom that surfaced in
+            # the 2026-05-21 live verification).
+            if etype == "event":
+                if ent.get("occurred_at"):
+                    payload["occurred_at"] = ent["occurred_at"]
+                if ent.get("occurred_at_precision"):
+                    payload["occurred_at_precision"] = ent["occurred_at_precision"]
             try:
                 self.create_entity_file(payload, filename, chunk_ids, user_role=user_role)
-                eid = self._generate_entity_id(name, etype)
+                # PR-11b — event entities use the date-aware hash
+                # (`_generate_event_entity_id`, PR-11a-2) so the
+                # entity_id we record here matches the file
+                # create_entity_file actually wrote. Falling through to
+                # the 4-type `_generate_entity_id` would produce a
+                # stale id and break cross-doc aggregation / id
+                # lookups for the same event.
+                if etype == "event" and payload.get("occurred_at"):
+                    from core.graph_node_editor import _generate_event_entity_id
+                    eid = _generate_event_entity_id(
+                        name,
+                        payload["occurred_at"],
+                        payload.get("occurred_at_precision", "day"),
+                    )
+                else:
+                    eid = self._generate_entity_id(name, etype)
                 name_to_id[name]   = eid
                 name_to_type[name] = etype
                 created_ids.append(eid)

--- a/docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md
+++ b/docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md
@@ -228,9 +228,36 @@ Option A (admin.html → 3 HTML 페이지 분할) 진입 **전** 필수:
 
 라이브 검증 중 발견된 항목을 여기에 기록 → 후속 fix PR 의 입력.
 
+### 11.1 PR-11b 완성도 결함 — RESOLVED 2026-05-21
+
 | 발견일 | PR (의도) | 증상 | severity | 후속 |
 |---|---|---|---|---|
-| | | | | |
+| 2026-05-21 | #371 (PR-11b) | LLM (gemma3:12b) 가 정확히 `type=event` + `occurred_at` emit 했지만 wiki/entity/<src>/event/ 에 entity 0건 생성. ingest path 의 3 layer 가 차례로 drop / silent fallback / id mismatch. | **high** — 사용자 가시 기능이 dead code | **fix PR** — 3 layer 모두 패치 + integration regression test 추가 |
+
+세부 근본원인 — `core/wiki_generator.py` 의 3 layer 가 PR-11b 머지 시점에
+함께 갱신되지 않음:
+
+1. **`_ALLOWED_EXTRACT_TYPES`** (line 28) — frozenset 에 `"event"` 누락
+   → `_is_safe_extracted_entity` 가 line 930 에서 silent drop
+2. **`process_document_for_entities` 의 payload build** (line 730)
+   — `ent["occurred_at"]` / `ent["occurred_at_precision"]` 안 carry
+   → `create_entity_file` 의 event branch 가 항상
+     `validate_occurred_at("")` 실패 → fallback to concept
+3. **`created_ids.append(eid)` 의 hash** (line 753)
+   — `_generate_entity_id(name, etype)` (4-type 용 hash) 사용
+   → PR-11a-2 의 `_generate_event_entity_id(name, occurred_at,
+     precision)` 와 다른 id 가 list 에 들어감
+   → file 의 actual entity_id 와 list 의 entity_id 가 mismatch
+   → 향후 cross-doc aggregation / id 조회 깨짐
+
+### 11.2 관계없는 발견 (별 트랙 / 메모)
+
+PR-11b 검증 중 부수적으로 관찰된 항목 — 본 fix PR scope 아님:
+
+| 항목 | 내용 | 트랙 |
+|---|---|---|
+| **gemma4:e4b 의 event 미인식** | 4B 모델 (자메스 default) 이 PR-11b prompt 의 4번째 type `event` 를 raw JSON 응답에 emit 안 함. raw extract dump 확인 결과 gemma4:e4b 의 응답에 `type=event` 항목 0건. **이건 모델 한계** — prompt 가 아무리 명확해도 4B 가 새 type 의 conservative bias 못 넘음. 메모 `ali_demo_model_checkpoint.md` + 핸드오버 `v0.3.x-gemma4-feedback-track.md` 의 5-stage 실패 패턴과 정합. **권고**: event ingest 가 의도된 만큼 작동하려면 `.env` 의 `JAMES_LLM_MODEL=gemma3:12b` (또는 그 이상) 영구 설정. 4B 사용 시 event entity 는 admin POST path 로만 (ingest 미작동). | gemma4-feedback-track |
+| **Trust system 의 cross-source 동작** | `source_type="test"` 로 ingest 시도해도 production wiki 의 기존 entity 와 trust conflict 발생 (memory_trust 의 consistency score 가 source_type 무관). production wiki 와 같은 이름의 entity 가 있는 doc 을 test 모드에서 ingest → trust score 0 → write reject. **본 PR-11b 와 무관한 관찰**. **잠재 영향**: source_type 격리의 정신 (production 무영향 검증) 이 trust layer 에서 깨짐. | 별 사이클 — `core/memory/memory_trust.py` 의 source_type 인지 도입 검토 |
 
 ---
 

--- a/tests/test_event_ingest_emit.py
+++ b/tests/test_event_ingest_emit.py
@@ -234,5 +234,120 @@ class FourTypeRegressionTests(_EventIngestBase):
         self.assertNotIn("occurred_at", fm)
 
 
+# ─── Integration — full process_document_for_entities path ──────────
+#
+# The 2026-05-21 live-verification round on PR-11b surfaced TWO
+# completeness gaps that the unit-level tests above didn't catch:
+#
+#   (1) `_ALLOWED_EXTRACT_TYPES` was still the 3-element frozenset
+#       (person/org/concept) — type=event got silently dropped by
+#       `_is_safe_extracted_entity` before reaching create_entity_file.
+#
+#   (2) `process_document_for_entities` built a payload dict for
+#       create_entity_file but did NOT carry occurred_at /
+#       occurred_at_precision from the LLM result; create_entity_file's
+#       event branch saw empty occurred_at and fell back to concept.
+#
+# Both gaps are post-extraction (the LLM emitted the right shape;
+# the wrapper layer dropped it). This class drives the wrapper
+# end-to-end with a mocked LLM so future refactors that re-introduce
+# either gap break here.
+
+
+class ProcessDocumentEventIntegrationTests(_EventIngestBase):
+    """End-to-end check: when the LLM returns `type: event` with
+    occurred_at, the document goes through `process_document_for_entities`
+    and lands as an event entity (not a silently-dropped or
+    concept-fallback entity)."""
+
+    def _mock_llm_extract(self, *, with_occurred_at: bool,
+                           type_value: str = "event"):
+        """Patch the WikiGenerator's LLM-extract helper to return a
+        deterministic dict shaped like the real Ollama response."""
+        from unittest.mock import patch
+        payload = {
+            "entities": [
+                {
+                    "name":        "2026 비트코인 ETF 승인",
+                    "type":        type_value,
+                    "description": "SEC 첫 spot ETF 승인",
+                    **(
+                        {"occurred_at": "2026-01-10"}
+                        if with_occurred_at
+                        else {}
+                    ),
+                },
+                {
+                    "name":        "SEC",
+                    "type":        "org",
+                    "description": "미국 증권거래위원회",
+                },
+            ],
+            "relations": [],
+        }
+        return patch.object(
+            self.wg, "_llm_extract_document_entities",
+            return_value=payload,
+        )
+
+    def test_event_with_occurred_at_lands_in_event_dir(self):
+        with self._mock_llm_extract(with_occurred_at=True):
+            ids = self.wg.process_document_for_entities(
+                filename="t.txt", content="any", chunk_ids=[],
+            )
+        # 2 entities (event + org) + 1 document → 3 created.
+        # The event one is the regression-critical row.
+        event_dir = self.wg.entity_path / "event"
+        files = list(event_dir.glob("*.md"))
+        self.assertEqual(len(files), 1,
+            "process_document_for_entities must land the LLM's "
+            "type=event entity in the event/ directory — the 2026-05-21 "
+            "live-verify finding (see commit body)")
+        fm = self._read_fm(files[0])
+        self.assertEqual(fm["entity_type"], "event")
+        self.assertEqual(fm["occurred_at"], "2026-01-10",
+            "occurred_at from the LLM payload must reach the on-disk "
+            "frontmatter — payload carry-over was the second gap")
+        self.assertEqual(fm["occurred_at_precision"], "day")
+        # And the entity_id reflects the event hash (PR-11a-2 scheme).
+        self.assertTrue(fm["entity_id"].startswith("e_event_"))
+        self.assertIn(fm["entity_id"], ids,
+            "the returned entity_ids must include the event we just wrote")
+
+    def test_event_without_occurred_at_falls_back_to_concept(self):
+        # LLM emits type=event but no occurred_at. The post-processor's
+        # graceful fallback (memo §5.1: "do not invent a date") should
+        # downgrade to concept, NOT silently drop.
+        with self._mock_llm_extract(with_occurred_at=False):
+            self.wg.process_document_for_entities(
+                filename="t.txt", content="any", chunk_ids=[],
+            )
+        event_dir   = self.wg.entity_path / "event"
+        concept_dir = self.wg.entity_path / "concept"
+        self.assertEqual(len(list(event_dir.glob("*.md"))), 0,
+            "no occurred_at → must not land in event/")
+        concept_files = list(concept_dir.glob("*.md"))
+        self.assertEqual(len(concept_files), 1,
+            "fallback row must land in concept/ (one entity)")
+        fm = self._read_fm(concept_files[0])
+        self.assertEqual(fm["entity_type"], "concept")
+        self.assertNotIn("occurred_at", fm,
+            "fallback path must not leak time-axis fields into the "
+            "downgraded concept frontmatter")
+
+    def test_allowed_extract_types_still_includes_event(self):
+        # Belt + suspenders — guard the 2026-05-21 regression at the
+        # constant level so a future refactor cannot drop `event` from
+        # the safety gate without breaking this test.
+        from core.wiki_generator import _ALLOWED_EXTRACT_TYPES
+        self.assertIn("event", _ALLOWED_EXTRACT_TYPES,
+            "_ALLOWED_EXTRACT_TYPES must include 'event' — otherwise "
+            "_is_safe_extracted_entity silently drops every LLM-emitted "
+            "event entity")
+        self.assertIn("person",  _ALLOWED_EXTRACT_TYPES)
+        self.assertIn("org",     _ALLOWED_EXTRACT_TYPES)
+        self.assertIn("concept", _ALLOWED_EXTRACT_TYPES)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Surfaced by 2026-05-21 live verification** (operator's running
server, gemma3:12b). PR #371's event ingest path was effectively
dead code: the LLM emitted `type=event` with the right `occurred_at`,
but `wiki/entity/<src>/event/` stayed empty. Three layers of
`core/wiki_generator.py` were not updated by PR #371.

## Root causes (3-layer silent drop)

1. **`_ALLOWED_EXTRACT_TYPES`** (line 28) — frozenset still
   `("person", "org", "concept")`. The 4th type `"event"` was
   missing → `_is_safe_extracted_entity` (line 930) silently
   dropped every LLM-emitted event entity.

2. **`process_document_for_entities` payload build** (line 730)
   — the payload dict did not carry `ent["occurred_at"]` /
   `ent["occurred_at_precision"]` from the LLM result. With those
   missing, the event branch ran `validate_occurred_at("")`,
   raised, and fell back to concept — for the wrong reason.

3. **`created_ids.append(eid)` hash** (line 753) — used
   `_generate_entity_id(name, etype)` (4-type hash) for events.
   PR-11a-2's `_generate_event_entity_id(name, occurred_at,
   precision)` is canonical. The list got a stale id; the file
   on disk had the correct hash; future cross-doc aggregation
   would have broken.

## Fix
- `core/wiki_generator.py` — 3 minimal patches (all conditional
  on `etype == "event"` so the 4-type path is byte-identical)
- `tests/test_event_ingest_emit.py` —
  `ProcessDocumentEventIntegrationTests` (3 tests + 1
  belt+suspenders constant pin)
- `.gitignore` — `wiki/entity/test/**/*.md` (oversight in the
  original wiki/ block)
- `docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md`
  §11 — records the finding + 2 unrelated observations
  (gemma4:e4b model limit; Trust system's source_type-blind
  consistency scoring)

## Verification
- `pytest tests/test_event_ingest_emit.py -v` → **12 passed**
  (3 new + 9 existing)
- `pytest tests/` → **2353 passed, 0 failed**
- `ruff check .` → All checks passed
- **Live (gemma3:12b)**: doc with "2026년 1월 10일 SEC ETF 승인"
  → 1 event entity at `wiki/entity/test/event/...` with the
  correct frontmatter ✅

## Behavior delta
- LLM-emitted events now land in `event/` instead of being
  silently dropped / fallback-converted.
- The returned `entity_id` matches the on-disk file's id.
- 4-type ingest path is byte-identical (conditional branches
  only fire on `etype == "event"`).
- gemma4:e4b still doesn't emit `type=event` (model limit, not
  this PR's concern — documented in §11.2).

## Out of scope
- gemma4:e4b's event-type bias (different track,
  `v0.3.x-gemma4-feedback-track.md`)
- Trust system source_type awareness (different cycle)
- Cross-doc aggregation `_find_existing_entity_id` event hash
  lookup (separate small PR when the use case appears)

Cross-refs:
- PR #371 (PR-11b — original incomplete merge)
- PR #368 (PR-11a-2 — `_generate_event_entity_id` source)
- `docs/design/v0.3-graph-evolution.md` §5.1
- `docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md` §2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)