### PR TITLE
docs(handover): session 2026-05-21 closure — §13 next-session entry guide

### DIFF
--- a/docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md
+++ b/docs/handovers/v0.3.x-session-2026-05-21-review-checklist.md
@@ -263,12 +263,94 @@ PR-11b 검증 중 부수적으로 관찰된 항목 — 본 fix PR scope 아님:
 
 ## 12. 검토 메타
 
-- 작성: 2026-05-21 session 19 PR closure 후
-- 작성자: 본 세션 (Claude Opus 4.7)
+- 작성: 2026-05-21 session, 최초 19 PR closure 후 (이후 §11.1
+  fix PR + §11.2 별 발견 추가로 23 PR 까지 확장)
+- 작성자: 2026-05-21 session (Claude Opus 4.7)
 - 다음 사이클 시작 전제: §10 모든 row ✅ + §11 의 critical severity 모두 해소
+
+---
+
+## 13. 2026-05-22 진입 가이드 (내일 세션 첫 액션)
+
+### 13.1 현재 검증 진행 상태 (세션 종료 시점 2026-05-21)
+
+| Section | 상태 |
+|---|---|
+| §1 Pre-flight | 미진행 — 다음 세션 첫 액션 |
+| §2 PR-11 series | §2.2 (ingest emit) **✅ 검증 완료** — §11.1 의 PR #387 가 결함 해소 path. §2.1 / 2.3 / 2.4 / 2.5 미진행. |
+| §3 Cognitive toggle (#378) | **미진행** — 다음 세션이 lang-toggle path 진행 예정. **본 항목 의 검증 path 5 phase 는 본 세션 마지막에 chat 으로 정리됨 — 다음 세션이 chat 기록 또는 본 §13.2 참조** |
+| §4 LLM mapping (#380) | 미진행 |
+| §5 Feedback stats (#383) | 미진행 |
+| §6 History stale (#382) | 미진행 |
+| §7 UI sync / docs | 미진행 (회귀-only, 낮은 우선순위) |
+| §9 invariant matrix | 미진행 |
+| §10 Phase 3 gate | 미진행 |
+
+### 13.2 §3 cognitive 토글 검증 — 5 phase 가이드 (2026-05-21 chat 에서 도출)
+
+코드 read 로 미리 추정: `applyTranslations()` 가 DOM 전체 sweep +
+`setLang()` 가 매번 호출 → **자동 retranslate path 정상 작동
+예상**. 그러나 Phase 3 / Phase 5 에서 회귀 가능성.
+
+#### Phase 1 — 첫 로드 (현재 lang 으로 표시 OK?)
+
+- admin → ⚙️ 설정 페이지
+- 🧠 Cognitive Features section 의 6 row label / hint / save 버튼
+  이 현재 lang 으로 정확히 표시되는지
+
+#### Phase 2 — lang toggle 즉시 전환 (가장 중요)
+
+- 우측 상단 lang toggle (KO ↔ EN)
+- cognitive section 의 모든 label 가 0.5초 안에 다른 lang 으로
+  즉시 바뀌는가?
+
+#### Phase 3 — navigation round-trip 후 일관성
+
+- settings → 다른 탭 (Memory 등) → settings 다시 진입
+- cognitive section 의 label 가 현재 lang 정확히 표시?
+
+#### Phase 4 — hardcoded ON/OFF span 의 의도성 확인
+
+- toggle 클릭 시 우측 ON/OFF span 즉시 전환
+- lang=ko 시에도 "ON"/"OFF" 영문 그대로 — **의도된 hardcode**
+  (검증 결과가 의도와 다른지만 확인)
+
+#### Phase 5 — 같은 패턴의 다른 2 section
+
+- LLM mapping section (#380) 도 lang toggle 동작
+- Memory tab 의 feedback stats card (#383) 도 동일
+
+#### 회귀 발견 시 DevTools 진단
+
+```javascript
+// Console 에서
+localStorage.getItem('james_lang')       // 현재 lang
+typeof applyTranslations                  // 함수 정의 확인
+applyTranslations()                       // 수동 호출 → 정상화 시
+                                          //   → setLang 의 timing 문제
+```
+
+소요 추정: **8분** (회귀 없을 시) / **+5분** (회귀 진단 시).
+
+### 13.3 §3 외 다른 라이브 검증 path
+
+§2.1 (admin POST /admin/graph/event) 가 가장 작은 단위 검증.
+`JAMES_GRAPH_EDIT=1` 설정 후 curl 또는 admin UI 의 graph editor
+에서 event 생성 → graph 페이지의 rose/coral 노드 확인.
+
+### 13.4 라이브 검증 발견 시 후속 path
+
+- ✅ 모두 정상 → 다음 라이브 검증 항목 진행
+- ⚠️ 회귀 발견 → §11.1 형식으로 기록 + 즉시 fix PR (본 세션의
+  PR #387 처럼 — 같은 정공법 패턴)
+- ❌ 큰 회귀 → Phase 3 진입 보류, fix 우선
+
+---
 
 ## 한국어 한 줄 결론
 
-본 세션 19 PR 의 정적 검증은 **2350 tests pass + ruff clean**. 라이브 검증은
-사용자 영역 — 본 체크리스트 §1~§9 를 순서대로 진행하면 약 30-45분 소요.
+본 세션 23 PR 의 정적 검증은 **2353 tests pass + ruff clean**.
+라이브 검증은 사용자 영역 — 본 체크리스트 §1~§9 를 순서대로
+진행하면 약 30-45분 소요. §11.1 (PR-11b 결함) 은 이미 PR #387 로
+해소 — 다음 세션은 §3 cognitive 토글 검증부터 시작 (§13.2 가이드).
 모든 row ✅ 후 Option-A Phase 3 (admin.html 3-페이지 분할) 진입 안전.


### PR DESCRIPTION
Persists the 5-phase cognitive-toggle lang-toggle verification
path (worked out at chat close) into the checklist itself, so
tomorrow's session opens the doc and the next-action is right
there — no need to re-read the chat record or re-derive.

## Summary
- **§13.1** per-section status as of 2026-05-21 close (§2.2
  done via PR #387; §3/§4/§5/§6/§7/§9/§10 not started)
- **§13.2** cognitive-toggle (#378) lang-toggle verification
  path in 5 phases + DevTools diagnostic fallback. Code-read
  prediction: Phases 1/2/5 should pass; Phases 3/4 are the
  real surface
- **§13.3** smallest-unit alternative entry (§2.1 admin POST
  event) if lang-toggle path is deferred
- **§13.4** result-class branching (clean / regression / big break)
- §12 metadata bumped (19 → 23 PR scope)
- Korean closing summary updated

## Verification
- `ruff check .` → All checks passed
- Doc-only — no code touched

## Why
Session-close artefacts now persist across 3 surfaces:
1. `memory/project_state.md` (auto-memory short-form)
2. This handover (long-form, in-repo, this PR)
3. Chat record (read-only history)

Tomorrow's session reads handover → knows exactly what to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)