### PR TITLE
feat(plugins): PR-C6 — JAMES_WORKSPACE env var (resolver only)

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -44,6 +44,10 @@ from core.plugins.registry import (
     PluginRegistry,
     get_registry,
 )
+from core.plugins.workspace import (
+    get_workspace_root,
+    workspace_path,
+)
 
 __all__ = [
     # base
@@ -70,4 +74,7 @@ __all__ = [
     "DEFAULT_PACK",
     "JAMES_CORE_VERSION",
     "load_packs_from_env",
+    # workspace
+    "get_workspace_root",
+    "workspace_path",
 ]

--- a/core/plugins/workspace.py
+++ b/core/plugins/workspace.py
@@ -1,0 +1,134 @@
+"""Workspace root resolver — ``JAMES_WORKSPACE=`` env (Track C PR-C6).
+
+Multi-instance hosting groundwork: one JAMES process per workspace,
+with the same code base serving different data roots. Read at
+startup; consulted by future path-resolution code (``wiki/`` /
+``uploads/`` / ``reports/`` / ``chroma_db/``) once the path-replacement
+follow-up PR lands.
+
+**v0.3 scope is intentionally minimal**: this module defines the env
+var, the resolver, and the failure modes. The existing path constants
+in ``config.py`` are NOT yet rewritten to consume the resolver — that
+is a separate PR (PR-C6.b) because it's a large structural edit that
+must verify each call site of ``BASE_DIR`` / ``WIKI_DIR`` /
+``UPLOAD_DIR`` / ``CHROMA_DIR`` lands cleanly.
+
+Per ``docs/design/v0.3-plugin-api.md`` §"`JAMES_WORKSPACE=` env (§C-6)
+— deferred to a separate PR":
+
+> Plugin loader can ignore the env in v0.3 — the default is "the
+> current directory", which is byte-identical to today.
+
+Env semantics
+-------------
+- ``JAMES_WORKSPACE`` unset → :data:`BASE_DIR` (current behavior).
+- ``JAMES_WORKSPACE=`` (empty) → :data:`BASE_DIR` (same as unset —
+  operator's empty value is interpreted as "use default", not as
+  "explicitly empty". This is *different* from ``JAMES_PACKS=``,
+  which treats empty as a refused-start signal: packs is what JAMES
+  *runs as*, workspace is just where it stores).
+- ``JAMES_WORKSPACE=/abs/path`` → absolute path used as-is.
+- ``JAMES_WORKSPACE=relative/path`` → joined against :data:`BASE_DIR`
+  and resolved.
+
+Failure modes (all raise :class:`PluginLoadError` at startup):
+
+- Resolved path is not a directory → operator must create it first.
+- Resolved path is unreadable / unstatable.
+
+The resolver does NOT create the directory automatically. Operator
+intent matters here — silent creation of an unintended path (typo
+in env value) is worse than a loud refusal.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from core.plugins.errors import PluginLoadError
+
+# Project root, derived from this file's location. Equivalent to
+# ``config.BASE_DIR`` but imported locally to keep ``core/plugins/``
+# free of upward coupling to the project root.
+_THIS_FILE = Path(__file__).resolve()
+BASE_DIR: Path = _THIS_FILE.parent.parent.parent
+
+
+def get_workspace_root(
+    env: Optional[dict] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """Resolve the workspace root from ``JAMES_WORKSPACE``.
+
+    Arguments:
+      env:       env-var dict; defaults to ``os.environ``. Tests pass a
+                 literal dict to drive arbitrary inputs without
+                 depending on global state.
+      base_dir:  the project root used as the relative-path anchor and
+                 the default when env is unset. Defaults to
+                 :data:`BASE_DIR`. Tests pass a temp directory.
+
+    Returns:
+      Absolute :class:`pathlib.Path` to the workspace root.
+
+    Raises:
+      :class:`PluginLoadError` — env value is set to a non-empty
+      string that doesn't resolve to an existing directory.
+    """
+    env_map = os.environ if env is None else env
+    anchor = base_dir if base_dir is not None else BASE_DIR
+
+    raw = env_map.get("JAMES_WORKSPACE")
+    if raw is None or raw.strip() == "":
+        # Unset OR explicit empty → default to BASE_DIR. This
+        # preserves byte-identical behavior with the pre-PR-C6 codepath.
+        return anchor
+
+    workspace_str = raw.strip()
+    candidate = Path(workspace_str)
+    if not candidate.is_absolute():
+        # Resolve against the project root, not the process CWD —
+        # CWD can drift (e.g., a systemd service started from /).
+        candidate = anchor / candidate
+    resolved = candidate.resolve()
+
+    if not resolved.exists():
+        raise PluginLoadError(
+            f"JAMES_WORKSPACE={workspace_str!r} resolves to "
+            f"{resolved} which does not exist. Create the directory "
+            f"before starting JAMES; the resolver does not create it "
+            f"automatically (silent creation of an unintended path "
+            f"would be worse than a loud refusal)."
+        )
+    if not resolved.is_dir():
+        raise PluginLoadError(
+            f"JAMES_WORKSPACE={workspace_str!r} resolves to "
+            f"{resolved} which exists but is not a directory."
+        )
+
+    return resolved
+
+
+def workspace_path(*parts: str, env: Optional[dict] = None) -> Path:
+    """Resolve a path under the workspace root.
+
+    Convenience wrapper for the eventual path-replacement code
+    (``wiki/`` / ``uploads/`` / ``reports/`` / ``chroma_db/``). Tests
+    pass an env dict; production code calls without arguments.
+
+    Example::
+
+        workspace_path("wiki", "entity", "prod")
+        # → <workspace_root>/wiki/entity/prod
+    """
+    root = get_workspace_root(env=env)
+    return root.joinpath(*parts)
+
+
+__all__ = [
+    "BASE_DIR",
+    "get_workspace_root",
+    "workspace_path",
+]

--- a/tests/test_plugin_workspace.py
+++ b/tests/test_plugin_workspace.py
@@ -1,0 +1,216 @@
+"""PROJECT JAMES — Workspace root resolver tests (PR-C6).
+
+Covers ``core/plugins/workspace.py``:
+  - ``JAMES_WORKSPACE`` unset / empty → BASE_DIR (byte-identical default)
+  - Absolute env value → used as-is, must exist as a directory
+  - Relative env value → resolved against BASE_DIR (not process CWD)
+  - Non-existent path → PluginLoadError (no silent creation)
+  - File-instead-of-directory → PluginLoadError
+  - ``workspace_path`` convenience wrapper
+
+A regression here re-introduces a silent path-resolution fallback the
+design memo explicitly forbids (operator must see the error).
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.plugins.errors import PluginLoadError  # noqa: E402
+from core.plugins.workspace import (  # noqa: E402
+    BASE_DIR,
+    get_workspace_root,
+    workspace_path,
+)
+
+
+class DefaultBehaviorTests(unittest.TestCase):
+    """Env unset / empty must be byte-identical to the pre-PR-C6 codepath.
+
+    This is the contract the design memo states: "the default is 'the
+    current directory', which is byte-identical to today." A regression
+    here means an operator who never set the env var sees their data
+    moved — exactly the silent failure mode this PR was designed to avoid.
+    """
+
+    def test_unset_env_returns_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            result = get_workspace_root(env={}, base_dir=anchor)
+            self.assertEqual(result, anchor)
+
+    def test_empty_env_returns_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": ""}, base_dir=anchor
+            )
+            self.assertEqual(result, anchor)
+
+    def test_whitespace_only_env_returns_base_dir(self):
+        # "   " is operator intent ambiguous. Treat it as empty (the
+        # safe default) rather than as a literal directory named "   ".
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": "   "}, base_dir=anchor
+            )
+            self.assertEqual(result, anchor)
+
+    def test_default_anchor_is_repo_root(self):
+        # Defensive: BASE_DIR resolution must land on the repo root,
+        # not somewhere inside core/plugins/. The marker we look for
+        # is config.py — present at the repo root in every JAMES checkout.
+        self.assertTrue(
+            (BASE_DIR / "config.py").is_file(),
+            f"BASE_DIR={BASE_DIR} does not contain config.py — "
+            f"resolver derivation broke",
+        )
+
+
+class AbsolutePathTests(unittest.TestCase):
+
+    def test_absolute_existing_dir_used_as_is(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp).resolve()
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": str(target)},
+            )
+            self.assertEqual(result, target)
+
+    def test_absolute_path_with_surrounding_whitespace_is_stripped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp).resolve()
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": f"  {target}  "},
+            )
+            self.assertEqual(result, target)
+
+
+class RelativePathTests(unittest.TestCase):
+    """Relative paths anchor on BASE_DIR, not on the process CWD.
+
+    A systemd service started from / is a real production scenario;
+    silently resolving relative to "/" would be a catastrophic loss
+    of operator-visible data location.
+    """
+
+    def test_relative_path_anchors_on_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            (anchor / "subdir").mkdir()
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": "subdir"},
+                base_dir=anchor,
+            )
+            self.assertEqual(result, anchor / "subdir")
+
+    def test_nested_relative_path_anchors_on_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            (anchor / "a" / "b" / "c").mkdir(parents=True)
+            result = get_workspace_root(
+                env={"JAMES_WORKSPACE": "a/b/c"},
+                base_dir=anchor,
+            )
+            self.assertEqual(result, anchor / "a" / "b" / "c")
+
+
+class FailureModeTests(unittest.TestCase):
+    """Non-existent / wrong-type paths must fail loud at startup.
+
+    Silent auto-creation is rejected here because a typo in
+    ``JAMES_WORKSPACE=`` would otherwise materialize a phantom data
+    root containing no prior JAMES state — looks like a fresh install,
+    operator panics, real data appears lost.
+    """
+
+    def test_nonexistent_absolute_path_raises(self):
+        with self.assertRaisesRegex(
+            PluginLoadError, r"does not exist"
+        ):
+            get_workspace_root(
+                env={"JAMES_WORKSPACE": "/no/such/workspace/here/xyz"},
+            )
+
+    def test_nonexistent_relative_path_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            with self.assertRaisesRegex(
+                PluginLoadError, r"does not exist"
+            ):
+                get_workspace_root(
+                    env={"JAMES_WORKSPACE": "missing-subdir"},
+                    base_dir=anchor,
+                )
+
+    def test_path_pointing_at_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            file_path = Path(tmp) / "regular-file.txt"
+            file_path.write_text("not a directory", encoding="utf-8")
+            with self.assertRaisesRegex(
+                PluginLoadError, r"is not a directory"
+            ):
+                get_workspace_root(
+                    env={"JAMES_WORKSPACE": str(file_path)},
+                )
+
+    def test_error_message_names_env_value_for_log_grep(self):
+        # Operator log-grep expects the raw env value to appear in the
+        # error message, not just the resolved path. A typo in the env
+        # var shows up exactly once in logs — that's the line to fix.
+        with self.assertRaisesRegex(
+            PluginLoadError, r"typo-dir-name"
+        ):
+            get_workspace_root(
+                env={"JAMES_WORKSPACE": "/no/such/typo-dir-name"},
+            )
+
+
+class WorkspacePathWrapperTests(unittest.TestCase):
+
+    def test_workspace_path_joins_components(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            # workspace_path() uses get_workspace_root() internally;
+            # we drive it via env to land on a known root.
+            result = workspace_path(
+                "wiki", "entity", "prod",
+                env={"JAMES_WORKSPACE": str(anchor)},
+            )
+            self.assertEqual(result, anchor / "wiki" / "entity" / "prod")
+
+    def test_workspace_path_with_no_parts_is_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            result = workspace_path(
+                env={"JAMES_WORKSPACE": str(anchor)},
+            )
+            self.assertEqual(result, anchor)
+
+
+class EnvIsolationTests(unittest.TestCase):
+    """Tests must never mutate ``os.environ`` — verify by sentinel."""
+
+    def test_passing_dict_does_not_touch_os_environ(self):
+        import os
+        sentinel_key = "JAMES_WORKSPACE_TEST_SENTINEL_XYZ"
+        self.assertNotIn(sentinel_key, os.environ)
+        with tempfile.TemporaryDirectory() as tmp:
+            anchor = Path(tmp).resolve()
+            get_workspace_root(
+                env={"JAMES_WORKSPACE": str(anchor), sentinel_key: "x"},
+                base_dir=anchor,
+            )
+        self.assertNotIn(sentinel_key, os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stage A.2 of the v0.3 audit re-entry plan (`docs/handovers/v0.3.x-audit-2026-05-23.md`). Defines the `JAMES_WORKSPACE=` env var as the namespace key for future per-tenant data isolation. Adds `get_workspace_root()` + `workspace_path()` resolver in `core/plugins/workspace.py`. The path replacement (`wiki/` / `uploads/` / `reports/` / `chroma_db/` rewriting in `config.py`) is intentionally **deferred to PR-C6.b** because it's a large structural edit across many call sites that wants its own focused PR.

Per `docs/design/v0.3-plugin-api.md` §"`JAMES_WORKSPACE=` env (§C-6) — deferred to a separate PR":
> Plugin loader can ignore the env in v0.3 — the default is "the current directory", which is byte-identical to today.

This PR fulfils that contract: byte-identical default, env-driven override, no silent fallback.

## Env semantics

| `JAMES_WORKSPACE=` value | Result |
|---|---|
| unset | `BASE_DIR` (current behavior) |
| `""` / whitespace-only | `BASE_DIR` (same as unset) |
| `/abs/path` | absolute path, used as-is |
| `relative/path` | joined against `BASE_DIR` (NOT process CWD) |

The relative-path anchor choice matters: a systemd service started from `/` would otherwise silently lose operator-visible data state.

## Failure modes (all loud, no auto-creation)

- Resolved path does not exist → `PluginLoadError` (silent creation of a typo'd path would materialize a phantom data root looking like a fresh install — worse failure than a loud refusal).
- Resolved path exists but is a file → `PluginLoadError`.

## Verification

```
python -m ruff check core/plugins/workspace.py tests/test_plugin_workspace.py core/plugins/__init__.py
# All checks passed!

python -m pytest tests/test_plugin_manifest.py tests/test_plugin_registry.py tests/test_plugin_pack_loader.py tests/test_plugin_workspace.py
# 82 passed in 0.21s  (15 new from this PR)
```

15 new tests cover:
- Default byte-identical behavior (unset / empty / whitespace-only)
- Absolute + relative path resolution
- Relative paths anchor on `BASE_DIR`, not CWD
- Failure modes (nonexistent path, file-instead-of-directory)
- `workspace_path()` joins correctly
- Env-isolation sentinel (no `os.environ` mutation)

## Out of scope

- **PR-C6.b** — rewrite `config.py` `WIKI_DIR` / `UPLOAD_DIR` / `RAW_DIR` / `CHROMA_DIR` to consume the resolver. Each call site of those constants must be audited; that's the substantive structural change.
- Auto-creation of the workspace directory (explicitly rejected — see "Failure modes" above).
- Multi-instance hosting / per-tenant isolation enforcement (a v0.4 operator concern; this PR seeds only the env-var key).

## References

- Design memo: `docs/design/v0.3-plugin-api.md` §"`JAMES_WORKSPACE=` env (§C-6)"
- Audit re-entry plan: `docs/handovers/v0.3.x-audit-2026-05-23.md` Stage A.2
- Track C: previous in series was #409 (PR-C3 loader + manifest + registry).