### PR TITLE
feat(plugins): PR-C5a — packs/general/ skeleton (no-op overlay)

### DIFF
--- a/packs/general/__init__.py
+++ b/packs/general/__init__.py
@@ -1,0 +1,27 @@
+"""``packs/general/`` — the dogfood pack.
+
+The first first-party pack and the v0.3 dogfood gate for the Plugin
+contract. Loaded by default when ``JAMES_PACKS`` is unset (per the
+loader contract in ``core/plugins/loader.py``).
+
+**Scope of PR-C5a (this commit)**: declare the pack and expose the
+two pack-level Protocol implementations (:class:`GeneralOntology` and
+:class:`GeneralPrompts`) as **no-op overlays**. The existing JAMES
+defaults in ``core/relations_schema.py`` and ``core/reasoning/modes/``
+remain authoritative; the pack neither replaces nor mirrors them in
+this PR. STEP 7 byte-identity is therefore trivially satisfied — no
+behavioral change reaches the runtime.
+
+**Out of scope (deferred to PR-C5b)**: wiring ``server_llmwiki.py``
+startup to call :func:`core.plugins.loader.load_packs_from_env`. Once
+that PR lands, this pack becomes the dogfood gate the rest of v0.3
+depends on.
+
+Per ``docs/design/v0.3-plugin-api.md`` PR sequence (PR-C5).
+"""
+from __future__ import annotations
+
+from packs.general.ontology import GeneralOntology
+from packs.general.prompts import GeneralPrompts
+
+__all__ = ["GeneralOntology", "GeneralPrompts"]

--- a/packs/general/ontology.py
+++ b/packs/general/ontology.py
@@ -1,0 +1,41 @@
+"""``GeneralOntology`` — no-op overlay for the dogfood pack.
+
+This class satisfies the :class:`core.plugins.base.OntologyPack`
+Protocol with **empty tuples / dict**. It does NOT mirror or replace
+the existing JAMES default ontology in ``core/relations_schema.py``
+— the existing schema remains authoritative at runtime.
+
+The point of shipping this class in PR-C5a is to prove the slot
+binding works end-to-end: the loader can read ``pack.yaml``, import
+this class, verify it satisfies the Protocol, and register it. STEP 7
+byte-identity follows trivially because nothing the runtime consults
+has changed.
+
+PR-C5b (separate PR, deferred) will wire ``server_llmwiki.py`` startup
+to call :func:`core.plugins.loader.load_packs_from_env`, at which
+point this class becomes live in the dogfood gate. PR-C5c (further
+deferred) is where the existing default ontology — if it ever moves
+out of ``core/relations_schema.py`` — would be expressed through this
+overlay instead of staying hardcoded.
+"""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+class GeneralOntology:
+    """Pack-level ontology declaration. Empty in v0.3.
+
+    The four attributes are checked at load time via
+    ``isinstance(obj, OntologyPack)``. Empty values declare the pack
+    contributes nothing structural — the existing ontology continues
+    to drive the system.
+    """
+
+    pack_id: str = "general"
+    entity_types: Tuple[str, ...] = ()
+    relation_types: Tuple[str, ...] = ()
+    hierarchies: Dict[str, Tuple[str, ...]] = {}
+
+
+__all__ = ["GeneralOntology"]

--- a/packs/general/pack.yaml
+++ b/packs/general/pack.yaml
@@ -1,0 +1,10 @@
+name: general
+version: 0.3.0
+james_api: ">=0.3,<0.4"
+description: "JAMES default behavior pack — dogfood gate (no-op overlay in v0.3)"
+author: "Hashevolution"
+license: "MIT"
+
+plugins:
+  ontology: ontology:GeneralOntology
+  prompts: prompts:GeneralPrompts

--- a/packs/general/prompts.py
+++ b/packs/general/prompts.py
@@ -1,0 +1,37 @@
+"""``GeneralPrompts`` — no-op overlay for the dogfood pack.
+
+Satisfies the :class:`core.plugins.base.PromptPack` Protocol with
+empty-string / empty-list return values across every mode and every
+task. The existing prompt builder in ``core/reasoning/modes/`` stays
+authoritative; this class declares that the ``general`` pack supplies
+no override.
+
+See :mod:`packs.general.ontology` for the matching reasoning behind
+the no-op pattern.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class GeneralPrompts:
+    """Pack-level prompt declaration. Returns empty in v0.3.
+
+    The Protocol contract is "empty string for unknown mode" / "empty
+    list for unknown task." Returning empty for *every* mode and task
+    is a legal pack — it simply contributes no override.
+    """
+
+    pack_id: str = "general"
+
+    def system_prompt(self, mode: str) -> str:
+        # Empty string is the graceful fall-through path — the existing
+        # default prompt builder in core/reasoning/modes/ stays in
+        # control. See docs/PLUGIN_AUTHORING.md §4.2.
+        return ""
+
+    def few_shot(self, task: str) -> List[Dict[str, Any]]:
+        return []
+
+
+__all__ = ["GeneralPrompts"]

--- a/tests/test_pack_general.py
+++ b/tests/test_pack_general.py
@@ -1,0 +1,159 @@
+"""PROJECT JAMES — packs/general/ dogfood pack tests (PR-C5a).
+
+Verifies the no-op overlay pack:
+  - Manifest parses and validates
+  - GeneralOntology satisfies the OntologyPack Protocol structurally
+  - GeneralPrompts satisfies the PromptPack Protocol structurally
+  - load_packs_from_env(env={"JAMES_PACKS": "general"}) succeeds
+    against the real packs/general/ directory
+  - Empty overlay contributes zero entities / relations / hierarchies
+    and returns empty for every prompt mode / few-shot task
+
+The pack is byte-identically neutral by design — a regression here
+that suddenly registers entity types into the runtime is a contract
+violation in v0.3 (PR-C5a explicitly defers the actual-extract work
+to PR-C5b).
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.plugins.base import (  # noqa: E402
+    KNOWN_MODES,
+    OntologyPack,
+    PromptPack,
+)
+from core.plugins.loader import load_packs_from_env  # noqa: E402
+from core.plugins.manifest import read_manifest  # noqa: E402
+from core.plugins.registry import PluginRegistry  # noqa: E402
+
+from packs.general import GeneralOntology, GeneralPrompts  # noqa: E402
+
+
+_PACK_DIR = Path(__file__).resolve().parent.parent / "packs" / "general"
+
+
+class PackOnDiskTests(unittest.TestCase):
+    """The pack is shipped in this repo; verify it exists and parses."""
+
+    def test_pack_directory_exists(self):
+        self.assertTrue(_PACK_DIR.is_dir(), f"packs/general/ missing at {_PACK_DIR}")
+
+    def test_pack_yaml_exists_and_parses(self):
+        manifest = read_manifest(_PACK_DIR / "pack.yaml", "general")
+        self.assertEqual(manifest.name, "general")
+        self.assertEqual(manifest.license, "MIT")
+        # Slot mapping is exactly what __init__.py exports.
+        self.assertEqual(manifest.plugins["ontology"], "ontology:GeneralOntology")
+        self.assertEqual(manifest.plugins["prompts"], "prompts:GeneralPrompts")
+
+
+class GeneralOntologyProtocolTests(unittest.TestCase):
+    """GeneralOntology is a no-op overlay — empty everywhere."""
+
+    def test_satisfies_protocol(self):
+        # @runtime_checkable Protocols use structural isinstance —
+        # missing or mistyped attributes fail here.
+        self.assertIsInstance(GeneralOntology(), OntologyPack)
+
+    def test_pack_id_is_general(self):
+        self.assertEqual(GeneralOntology().pack_id, "general")
+
+    def test_entity_types_is_empty_tuple(self):
+        # Tuple, not list — the Protocol declares Tuple[str, ...] and
+        # the cascade-resolution graph relies on hashable type.
+        o = GeneralOntology()
+        self.assertEqual(o.entity_types, ())
+        self.assertIsInstance(o.entity_types, tuple)
+
+    def test_relation_types_is_empty_tuple(self):
+        o = GeneralOntology()
+        self.assertEqual(o.relation_types, ())
+        self.assertIsInstance(o.relation_types, tuple)
+
+    def test_hierarchies_is_empty_dict(self):
+        o = GeneralOntology()
+        self.assertEqual(o.hierarchies, {})
+        self.assertIsInstance(o.hierarchies, dict)
+
+
+class GeneralPromptsProtocolTests(unittest.TestCase):
+    """GeneralPrompts is a no-op overlay — empty everywhere."""
+
+    def test_satisfies_protocol(self):
+        self.assertIsInstance(GeneralPrompts(), PromptPack)
+
+    def test_pack_id_is_general(self):
+        self.assertEqual(GeneralPrompts().pack_id, "general")
+
+    def test_system_prompt_returns_empty_for_every_known_mode(self):
+        # Every built-in mode falls through to the existing default
+        # prompt builder in core/reasoning/modes/. A regression that
+        # makes any mode return non-empty is a v0.3 contract violation.
+        p = GeneralPrompts()
+        for mode in KNOWN_MODES:
+            with self.subTest(mode=mode):
+                self.assertEqual(p.system_prompt(mode), "")
+
+    def test_system_prompt_returns_empty_for_unknown_mode(self):
+        # Unknown mode (future JAMES adds a mode in a minor) must also
+        # return "" — never raise on input.
+        self.assertEqual(GeneralPrompts().system_prompt("future_mode"), "")
+
+    def test_few_shot_returns_empty_list_for_arbitrary_task(self):
+        p = GeneralPrompts()
+        self.assertEqual(p.few_shot("any_task"), [])
+        self.assertEqual(p.few_shot(""), [])
+
+
+class LoaderEndToEndTests(unittest.TestCase):
+    """The real packs/general/ loads through load_packs_from_env."""
+
+    def test_loader_loads_general_with_explicit_env(self):
+        registry = PluginRegistry()
+        loaded = load_packs_from_env(
+            env={"JAMES_PACKS": "general"},
+            registry=registry,
+        )
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0].name, "general")
+
+    def test_loader_loads_general_when_env_unset(self):
+        # Unset (not empty) → defaults to DEFAULT_PACK="general".
+        registry = PluginRegistry()
+        loaded = load_packs_from_env(env={}, registry=registry)
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0].name, "general")
+
+    def test_loaded_pack_registers_into_registry(self):
+        # After load, the registry has one ontology and one prompt pack
+        # bound (both no-op, but both isinstance-checked at registration).
+        registry = PluginRegistry()
+        load_packs_from_env(
+            env={"JAMES_PACKS": "general"},
+            registry=registry,
+        )
+        # registry must expose ontology + prompts slots — exact API
+        # is exercised here so a registry refactor that loses one of
+        # them is caught.
+        self.assertEqual(len(registry.ontology_packs()), 1)
+        self.assertEqual(len(registry.prompt_packs()), 1)
+        self.assertEqual(registry.ontology_packs()[0].pack_id, "general")
+        self.assertEqual(registry.prompt_packs()[0].pack_id, "general")
+        # slot_counts diagnostic also exposes the populated state.
+        counts = registry.slot_counts()
+        self.assertEqual(counts["ontology"], 1)
+        self.assertEqual(counts["prompts"], 1)
+        self.assertEqual(counts["ui"], 0)
+        self.assertEqual(counts["scorers"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 1 of the 3-hour autonomous session. Stage A.3 of the audit re-entry plan (`docs/handovers/v0.3.x-audit-2026-05-23.md`), minimum-viable interpretation. Ships `packs/general/` as the first first-party pack — a **no-op overlay** that satisfies both `OntologyPack` and `PromptPack` Protocols with empty values across the board.

The point of PR-C5a is to prove the end-to-end loader pipeline works against a real on-disk pack: manifest parse → SemVer check → slot import → Protocol validation → registry registration. **STEP 7 byte-identity is trivially satisfied** because the existing JAMES defaults in `core/relations_schema.py` + `core/reasoning/modes/` remain authoritative. The overlay contributes nothing to the runtime.

## What ships

```
packs/general/
├── __init__.py          # exports GeneralOntology + GeneralPrompts
├── pack.yaml            # manifest: name=general, version=0.3.0, MIT
├── ontology.py          # GeneralOntology — empty tuples / dict
└── prompts.py           # GeneralPrompts — "" / [] for every input

tests/test_pack_general.py  # 15 new tests
```

The manifest declares both Protocol slots:

```yaml
plugins:
  ontology: ontology:GeneralOntology
  prompts: prompts:GeneralPrompts
```

so the loader exercises both code-paths.

## Verification

```
python -m ruff check packs/general/ tests/test_pack_general.py
# All checks passed!

python -m pytest tests/test_plugin_manifest.py tests/test_plugin_registry.py \
                 tests/test_plugin_pack_loader.py tests/test_plugin_workspace.py \
                 tests/test_pack_general.py
# 97 passed in 0.21s  (15 new from this PR)
```

The new tests cover:
- Pack directory + `pack.yaml` exists and parses
- `GeneralOntology` satisfies `OntologyPack` Protocol structurally; all four attributes have the exact declared types (Tuple, not list; dict, not list-of-tuples)
- `GeneralPrompts` satisfies `PromptPack` Protocol structurally; returns `""` for every `KNOWN_MODES` entry + unknown future modes; returns `[]` for arbitrary tasks
- `load_packs_from_env({"JAMES_PACKS": "general"})` succeeds end-to-end against the real `packs/general/` directory
- `load_packs_from_env(env={})` also loads `general` (env-unset → DEFAULT_PACK fall-through)
- After load, the registry has 1 ontology + 1 prompts entry; UI and scorers stay at 0

## Out of scope

- **PR-C5b** — wire `server_llmwiki.py` startup to call `load_packs_from_env()`. Deferred to a separate PR under operator supervision because that change makes the loader live in production and is the right place to do the STEP 7 byte-identical bench.
- **PR-C5c (hypothetical)** — actually extract the default ontology / prompts out of `core/relations_schema.py` / `core/reasoning/modes/` and express them through this pack. Only worth doing if a second pack arrives and needs the shared baseline; until then, the existing hardcoded defaults are fine.

## Why no-op is the right v0.3 shape

The design memo's "byte-identical STEP 7" requirement is the load-bearing constraint. A non-trivial extraction risks ontology / prompt drift that the bench would catch only after the work is half-merged. A no-op overlay satisfies the constraint by construction and ships the loader pipeline against a real pack today — the dogfood gate proves the pipeline, not the content.

## References

- Design memo: `docs/design/v0.3-plugin-api.md` §"PR sequence" (PR-C5)
- Audit re-entry plan: `docs/handovers/v0.3.x-audit-2026-05-23.md` Stage A.3
- Track C: previous in series was #412 (PR-C7 PLUGIN_AUTHORING.md)