### PR TITLE
chore(licenses): refresh THIRD_PARTY_LICENSES.md — idna 3.13 → 3.15

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third-Party Licenses
 
-> **Generated**: 2026-05-19 via the reproduction command below.
+> **Generated**: 2026-05-23 via the reproduction command below.
 > **Scope**: every Python package present in the active venv at the time of generation.
 > **Refresh policy**: re-generate at every minor JAMES version (v0.4, v0.5, …) and whenever a dep is added.
 
@@ -87,7 +87,7 @@ JAMES itself is **MIT** (see [`LICENSE`](LICENSE)). The deps inventoried below a
 | [httpx](https://github.com/encode/httpx) | 0.28.1 | BSD |
 | [httpx-sse](https://github.com/florimondmanca/httpx-sse) | 0.4.3 | MIT |
 | [huggingface_hub](https://github.com/huggingface/huggingface_hub) | 1.13.0 | Apache-2.0 |
-| [idna](https://github.com/kjd/idna) | 3.13 | BSD-3-Clause |
+| [idna](https://github.com/kjd/idna) | 3.15 | BSD-3-Clause |
 | [ImageIO](https://github.com/imageio/imageio) | 2.37.3 | BSD-2-Clause |
 | [importlib_metadata](https://github.com/python/importlib_metadata) | 8.7.1 | Apache-2.0 |
 | [importlib_resources](https://github.com/python/importlib_resources) | 7.1.0 | Apache-2.0 |


### PR DESCRIPTION
## Summary

Stage D.2 of the v0.3 audit re-entry plan (`docs/handovers/v0.3.x-audit-2026-05-23.md`). The audit listed `THIRD_PARTY_LICENSES.md` as a pending deliverable, but the file already exists from 2026-05-19. This is the deterministic re-run via `scripts/gen_third_party_licenses.py`.

**Substantive change**: a single row — `idna 3.13 → 3.15`. That matches the security pin in `requirements.txt` (Dependabot #11/#12, CVE-2026-45409, idna.encode() bypass).

Everything else is identical:
- Total deps: 204 (unchanged)
- Normalised license buckets: 11 (unchanged)
- No new GPL-family deps; the runtime surface is still permissive

## Verification

```
git diff THIRD_PARTY_LICENSES.md | grep -E '^[+-]' | grep -v '^[+-]{3}'
# - > **Generated**: 2026-05-19 via the reproduction command below.
# + > **Generated**: 2026-05-23 via the reproduction command below.
# - | [idna](https://github.com/kjd/idna) | 3.13 | BSD-3-Clause |
# + | [idna](https://github.com/kjd/idna) | 3.15 | BSD-3-Clause |
```

## Out of scope

- **No policy change** — `docs/LICENSE_PLAN.md` and the closed Plugin license enum stay as-is.
- **No transitive-license audit redesign** — the v1.0-marketplace trigger T-Audit (`LICENSE_PLAN.md §3`) covers that.
- **Audit handover correction** — the audit doc's claim that this file was "pending" is technically correct only for "as updated state". I'm not editing operator-written handover docs in autonomous mode.

## References

- Audit re-entry plan: `docs/handovers/v0.3.x-audit-2026-05-23.md` Stage D.2
- License plan: `docs/LICENSE_PLAN.md`
- Generator: `scripts/gen_third_party_licenses.py`