### PR TITLE
feat(plugins): PR-C9 — CI eval contract for packs/* (lightweight gate)

### DIFF
--- a/.github/workflows/packs-eval.yml
+++ b/.github/workflows/packs-eval.yml
@@ -1,0 +1,72 @@
+name: packs-eval
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packs/**'
+      - 'core/plugins/**'
+      - 'scripts/eval_pack.py'
+      - '.github/workflows/packs-eval.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packs/**'
+      - 'core/plugins/**'
+      - 'scripts/eval_pack.py'
+      - '.github/workflows/packs-eval.yml'
+
+permissions:
+  contents: read
+
+# The v0.3 Plugin contract eval gate. Runs on any PR that touches a
+# pack, the plugin loader/registry/manifest, the eval script itself,
+# or this workflow. Triggers are intentionally broad — a change in
+# core/plugins/ can break every pack, so we re-validate then too.
+#
+# v0.3 scope (what this workflow checks):
+#   - Every pack on disk has a parseable, schema-valid pack.yaml
+#   - Every declared slot import resolves + satisfies its Protocol
+#   - Every pack passes ruff
+#
+# Not yet checked (deferred until CI gains an Ollama service container):
+#   - RAGAS retrieval-quality eval against a real corpus
+#   - STEP-N regression bench
+#
+# The shape of the gate is stable now (scripts/eval_pack.py is the
+# single source of truth). When CI gets an LLM endpoint, the
+# `--with-ragas` / `--with-step` flags get wired in — no workflow
+# rewrite needed.
+
+jobs:
+  eval-all-packs:
+    name: Eval every pack on the branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install runtime + tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff
+
+      - name: Run eval_pack on every pack under packs/
+        env:
+          # Same sentinel pattern as test.yml — config.py refuses to
+          # import without these. No security significance.
+          JAMES_API_KEY: ci-test-key-not-secret-do-not-use-anywhere
+          JAMES_JWT_SECRET: ci-test-secret-32-chars-padding-padding
+        run: |
+          python scripts/eval_pack.py --all
+
+      # If a future PR adds a heavyweight RAGAS step, it goes here as
+      # a separate step that uses the same eval_pack.py with new flags.
+      # The contract surface stays one script.

--- a/scripts/eval_pack.py
+++ b/scripts/eval_pack.py
@@ -1,0 +1,296 @@
+"""Pack eval contract — Track C PR-C9.
+
+Runs the v0.3 minimum-viable eval gate against ``packs/<name>/``.
+Designed for two callers:
+
+  1. **CI** (``.github/workflows/packs-eval.yml``) — invokes this per
+     changed pack on every PR that touches ``packs/``. Exit code is
+     the gate signal: 0 = pass, non-zero = block the merge.
+
+  2. **Pack authors locally** — same exit code; use it as a
+     pre-PR self-check (``docs/PLUGIN_AUTHORING.md`` §6).
+
+What the gate checks **in v0.3**:
+
+  - ``packs/<name>/`` directory exists
+  - ``pack.yaml`` parses + every required manifest field is well-typed
+  - ``james_api:`` SemVer range contains the running JAMES core version
+  - Each declared slot import path resolves; the class instantiates;
+    the instance satisfies the Protocol via ``isinstance``
+  - The pack passes ``ruff check`` (style + obvious errors)
+
+What this gate does **NOT yet check** (deferred until CI has the
+underlying infrastructure):
+
+  - **RAGAS retrieval-quality eval** — requires an LLM endpoint
+    available to the CI runner. JAMES CI has no Ollama service today.
+    Pack authors run RAGAS locally per ``docs/PLUGIN_AUTHORING.md``
+    §6 until CI gets the Ollama service container.
+  - **STEP-N regression bench** — same constraint. The committed
+    baseline (``eval/regression/step7_baseline.json``) is the
+    authoritative number; pack authors compare locally and paste the
+    diff in the PR body per CLAUDE.md rule #2.
+
+When CI gains an LLM endpoint, this script grows ``--with-ragas``
+and ``--with-step`` flags that the workflow lights up. The contract
+shape is stable now; only the gate's bite gets sharper.
+
+Usage::
+
+    python scripts/eval_pack.py <pack_name>           # full v0.3 gate
+    python scripts/eval_pack.py <pack_name> --manifest-only
+    python scripts/eval_pack.py --all                 # every pack on disk
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    # Windows console + Korean text in pack manifests = UnicodeEncodeError
+    # unless we reset the codepage. utils/console.py is the project's
+    # single source of truth for this.
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except Exception:
+    pass
+
+from core.plugins.base import (  # noqa: E402
+    OntologyPack,
+    PromptPack,
+    Scorer,
+    UIPanel,
+)
+from core.plugins.errors import (  # noqa: E402
+    PluginLoadError,
+    PluginVersionError,
+)
+from core.plugins.loader import JAMES_CORE_VERSION  # noqa: E402
+from core.plugins.manifest import (  # noqa: E402
+    Manifest,
+    check_semver,
+    read_manifest,
+)
+
+PACKS_ROOT = ROOT / "packs"
+
+# Maps slot name -> the Protocol type the isinstance check uses.
+_PROTOCOL_MAP = {
+    "ontology": OntologyPack,
+    "prompts": PromptPack,
+    "ui": UIPanel,
+    "scorers": Scorer,
+}
+
+
+class PackEvalFailure(Exception):
+    """Operator-visible failure during eval. The message is what the
+    operator (or pack author) sees in the CI log; keep it actionable.
+    """
+
+
+def _ok(line: str) -> None:
+    print(f"  OK    {line}")
+
+
+def _fail(line: str) -> None:
+    print(f"  FAIL  {line}", file=sys.stderr)
+
+
+def _check_manifest(pack_name: str) -> Manifest:
+    pack_dir = PACKS_ROOT / pack_name
+    if not pack_dir.is_dir():
+        raise PackEvalFailure(
+            f"pack {pack_name!r} not found at {pack_dir}"
+        )
+    pack_yaml = pack_dir / "pack.yaml"
+    try:
+        manifest = read_manifest(pack_yaml, pack_name)
+    except PluginLoadError as exc:
+        raise PackEvalFailure(f"manifest parse: {exc}") from exc
+    _ok(f"manifest parses: {manifest.name} v{manifest.version} ({manifest.license})")
+
+    try:
+        check_semver(pack_name, manifest.james_api, JAMES_CORE_VERSION)
+    except PluginVersionError as exc:
+        raise PackEvalFailure(f"SemVer: {exc}") from exc
+    except PluginLoadError as exc:
+        raise PackEvalFailure(f"SemVer parse: {exc}") from exc
+    _ok(f"james_api {manifest.james_api!r} contains core {JAMES_CORE_VERSION!r}")
+
+    return manifest
+
+
+def _check_slot_imports(pack_name: str, manifest: Manifest) -> None:
+    if not manifest.plugins:
+        print(f"  WARN  pack {pack_name!r} declares zero slots (legal but unusual)")
+        return
+
+    pack_dir = PACKS_ROOT / pack_name
+    pack_dir_str = str(pack_dir)
+    sys.path.insert(0, pack_dir_str)
+    try:
+        for slot, value in manifest.plugins.items():
+            entries: List[str] = (
+                [value] if isinstance(value, str) else list(value)
+            )
+            protocol_type = _PROTOCOL_MAP.get(slot)
+            if protocol_type is None:
+                # Manifest parser already rejects unknown slots; defensive.
+                raise PackEvalFailure(
+                    f"slot {slot!r} has no Protocol mapping; "
+                    f"this is a JAMES core bug, not a pack bug"
+                )
+            for import_path in entries:
+                module_path, class_name = import_path.split(":", 1)
+                try:
+                    module = importlib.import_module(module_path)
+                except ImportError as exc:
+                    raise PackEvalFailure(
+                        f"slot={slot} cannot import {module_path!r} "
+                        f"from {pack_dir}: {exc}"
+                    ) from exc
+                if not hasattr(module, class_name):
+                    raise PackEvalFailure(
+                        f"slot={slot} module {module_path!r} has no "
+                        f"class {class_name!r}"
+                    )
+                cls = getattr(module, class_name)
+                try:
+                    instance = cls()
+                except Exception as exc:  # noqa: BLE001 — wrap with context
+                    raise PackEvalFailure(
+                        f"slot={slot} instantiating "
+                        f"{module_path}:{class_name} raised "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+                if not isinstance(instance, protocol_type):
+                    raise PackEvalFailure(
+                        f"slot={slot} {module_path}:{class_name} does "
+                        f"not satisfy {protocol_type.__name__} Protocol"
+                    )
+                _ok(
+                    f"slot={slot} {module_path}:{class_name} -> "
+                    f"{protocol_type.__name__} satisfied"
+                )
+    finally:
+        try:
+            sys.path.remove(pack_dir_str)
+        except ValueError:
+            pass
+
+
+def _check_ruff(pack_name: str) -> None:
+    pack_dir = PACKS_ROOT / pack_name
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", str(pack_dir)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        # ruff not installed — surface clearly. The CI workflow
+        # installs ruff via requirements-dev-equivalent; locally an
+        # operator might be missing it.
+        raise PackEvalFailure(
+            f"ruff not available: {exc}. Install with `pip install ruff`."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise PackEvalFailure(f"ruff timed out after 60s: {exc}") from exc
+    if result.returncode != 0:
+        # Pass ruff's own output through — the messages are already
+        # actionable (file:line:col).
+        if result.stdout:
+            sys.stderr.write(result.stdout)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        raise PackEvalFailure(
+            f"ruff check failed on packs/{pack_name}/ "
+            f"(exit {result.returncode})"
+        )
+    _ok(f"ruff check passes on packs/{pack_name}/")
+
+
+def evaluate_pack(pack_name: str, *, manifest_only: bool = False) -> Tuple[bool, str]:
+    """Run the gate on one pack. Returns (passed, summary_line).
+
+    The summary_line is suitable for the CI step summary or a local
+    one-line print.
+    """
+    print(f"[eval-pack] {pack_name}")
+    try:
+        manifest = _check_manifest(pack_name)
+        if not manifest_only:
+            _check_slot_imports(pack_name, manifest)
+            _check_ruff(pack_name)
+    except PackEvalFailure as exc:
+        _fail(str(exc))
+        return False, f"{pack_name}: FAIL — {exc}"
+    summary = f"{pack_name}: PASS (v{manifest.version}, {manifest.license})"
+    print(f"[eval-pack] {summary}")
+    return True, summary
+
+
+def _discover_packs() -> List[str]:
+    if not PACKS_ROOT.is_dir():
+        return []
+    return sorted(p.name for p in PACKS_ROOT.iterdir() if p.is_dir())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pack eval gate — v0.3 minimum-viable contract."
+    )
+    parser.add_argument(
+        "pack", nargs="?",
+        help="Pack name (directory under packs/). Required unless --all.",
+    )
+    parser.add_argument(
+        "--all", action="store_true",
+        help="Evaluate every pack under packs/ in sorted order.",
+    )
+    parser.add_argument(
+        "--manifest-only", action="store_true",
+        help="Skip slot-import and ruff checks; manifest schema only.",
+    )
+    args = parser.parse_args()
+
+    if args.all and args.pack:
+        parser.error("--all and an explicit pack name are mutually exclusive")
+    if not args.all and not args.pack:
+        parser.error("either pass a pack name or --all")
+
+    targets = _discover_packs() if args.all else [args.pack]
+    if not targets:
+        print(
+            "[eval-pack] no packs found under packs/; "
+            "v0.3 dogfood pack lives at packs/general/ (PR-C5a #413)"
+        )
+        return 1
+
+    all_pass = True
+    summaries: List[str] = []
+    for name in targets:
+        ok, line = evaluate_pack(name, manifest_only=args.manifest_only)
+        summaries.append(line)
+        all_pass = all_pass and ok
+
+    print()
+    print("-" * 60)
+    print("[eval-pack] summary:")
+    for line in summaries:
+        print(f"  {line}")
+
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eval_pack_script.py
+++ b/tests/test_eval_pack_script.py
@@ -1,0 +1,96 @@
+"""PROJECT JAMES — eval_pack.py CLI tests (PR-C9).
+
+Verifies ``scripts/eval_pack.py`` returns exit 0 on the dogfood pack
+and exit 1 on obvious failure modes. The script is the single source
+of truth for the v0.3 pack eval gate — CI invokes it; a regression
+here breaks the gate for every pack PR.
+
+The tests use ``subprocess.run`` so we exercise the script as CI
+would. argparse failure exits are also part of the contract — the
+GitHub Actions log surfaces them, so we verify message text.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = PROJECT_ROOT / "scripts" / "eval_pack.py"
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Invoke the script. Default cwd is the project root.
+
+    ``encoding="utf-8"`` is explicit because the script calls
+    ``ensure_utf8_console()`` to emit UTF-8 on Windows where the
+    default cp949 / cp1252 codec cannot represent the project's
+    Korean strings; the test reader must match.
+    """
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=str(cwd or PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=120,
+    )
+
+
+class HappyPathTests(unittest.TestCase):
+
+    def test_general_pack_passes(self):
+        result = _run("general")
+        self.assertEqual(
+            result.returncode, 0,
+            f"eval_pack.py general failed:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertIn("PASS", result.stdout)
+        self.assertIn("general v0.3.0", result.stdout)
+
+    def test_all_flag_passes(self):
+        result = _run("--all")
+        self.assertEqual(
+            result.returncode, 0,
+            f"eval_pack.py --all failed:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        # The summary block lists each pack on its own line.
+        self.assertIn("general: PASS", result.stdout)
+
+    def test_manifest_only_skips_ruff(self):
+        # --manifest-only is the lightweight check for pack authors
+        # iterating on a pack.yaml without yet having Python code.
+        result = _run("general", "--manifest-only")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("manifest parses", result.stdout)
+        # The slot-import line should NOT appear under --manifest-only.
+        self.assertNotIn("Protocol satisfied", result.stdout)
+        self.assertNotIn("ruff check passes", result.stdout)
+
+
+class FailureModeTests(unittest.TestCase):
+
+    def test_missing_pack_returns_nonzero(self):
+        result = _run("does-not-exist-pack-name-xyz")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not found", (result.stdout + result.stderr).lower())
+
+    def test_no_args_errors_out(self):
+        result = _run()
+        self.assertNotEqual(result.returncode, 0)
+        # argparse prints to stderr.
+        self.assertIn("pack", result.stderr.lower())
+
+    def test_mutually_exclusive_args_error(self):
+        # --all + an explicit pack name is operator confusion; we want
+        # a clear error message, not a silent precedence rule.
+        result = _run("general", "--all")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("mutually exclusive", result.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stage A.6 of the v0.3 audit re-entry plan. Ships the CI eval gate for `packs/*/` PRs as **one script + one workflow**:

- `scripts/eval_pack.py` — single source of truth for the gate
- `.github/workflows/packs-eval.yml` — invokes the script on changes touching `packs/`, `core/plugins/`, the script itself, or the workflow

The trigger path-set is intentionally broad — a `core/plugins/` change can break every pack, so we re-validate then too.

## What the gate checks (v0.3 scope)

| Check | What |
|---|---|
| **Manifest** | `pack.yaml` parses; every required field well-typed; `james_api:` SemVer range contains the running core version |
| **Slot imports** | Each declared slot import resolves; class instantiates; instance satisfies its Protocol via `isinstance` (OntologyPack / PromptPack / UIPanel / Scorer) |
| **Lint** | `ruff check` passes on `packs/<name>/` |

## What the gate does NOT yet check

Deferred until CI gains an Ollama service container:

- **RAGAS retrieval-quality eval** against a real corpus
- **STEP-N regression bench**

When CI gets an LLM endpoint, the script grows `--with-ragas` and `--with-step` flags. The workflow adds new steps but the contract surface stays one script — no rewrites later.

## Why one script (and not a workflow-only check)

Pack authors need to run the gate locally before opening a PR. A workflow-only check ships nothing they can invoke; a script ships both: local pre-PR verification AND the CI invocation. `docs/PLUGIN_AUTHORING.md §6` already points authors at this exact recipe (manifest parse + loader smoke + isinstance check) — PR-C9 consolidates those three commands into one canonical script.

## Verification

```
python scripts/eval_pack.py general
#   OK    manifest parses: general v0.3.0 (MIT)
#   OK    james_api '>=0.3,<0.4' contains core '0.3.0'
#   OK    slot=ontology ontology:GeneralOntology -> OntologyPack satisfied
#   OK    slot=prompts prompts:GeneralPrompts -> PromptPack satisfied
#   OK    ruff check passes on packs/general/
# [eval-pack] general: PASS (v0.3.0, MIT)

python scripts/eval_pack.py --all
# (same; iterates every pack)

python -m pytest tests/test_eval_pack_script.py
# 6 passed

python -m ruff check scripts/eval_pack.py tests/test_eval_pack_script.py
# All checks passed!

# Full plugin suite (every PR-C* test + new tests):
python -m pytest tests/test_plugin_manifest.py tests/test_plugin_registry.py \
                 tests/test_plugin_pack_loader.py tests/test_plugin_workspace.py \
                 tests/test_pack_general.py tests/test_server_plugin_startup.py \
                 tests/test_eval_pack_script.py
# 105 passed
```

The 6 new CLI tests cover:
- Happy path: `general` pack, `--all`, `--manifest-only`
- Failure modes: missing pack name, no args, `--all` + explicit pack (mutually exclusive)

Tests invoke the script via `subprocess.run(..., encoding="utf-8")` — same shape CI uses.

## CLI surface

```
python scripts/eval_pack.py <pack_name>           # full v0.3 gate
python scripts/eval_pack.py <pack_name> --manifest-only
python scripts/eval_pack.py --all                 # every pack on disk
```

Exit 0 = pass; non-zero = block.

## Out of scope

- **PR-C10** — `scripts/dogfood_check.py` + CI hook. Now unblocked.
- **RAGAS / STEP-N integration** — gated on CI Ollama service container availability.

## References

- Design memo: `docs/design/v0.3-plugin-api.md` §"PR sequence" (PR-C9)
- Audit re-entry plan: `docs/handovers/v0.3.x-audit-2026-05-23.md` Stage A.6
- Track C: previous in series was #418 (PR-C5b server startup wiring)