### PR TITLE
feat(plugins): PR-C6.b — config.py consumes JAMES_WORKSPACE resolver

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,12 +58,24 @@ if os.path.exists(_env_file):
 # ────────────────────────────────────────────────────────────────
 #  Base directories — auto-detected from this file's location
 #  → Works regardless of folder name, OS, or user
+#
+#  Track C PR-C6.b: the four data directories (RAW_DIR / WIKI_DIR /
+#  UPLOAD_DIR / CHROMA_DIR) honor JAMES_WORKSPACE via the resolver in
+#  core.plugins.workspace. With the env unset the resolver returns
+#  the project root, byte-identical to the pre-v0.3 behavior. With
+#  JAMES_WORKSPACE=/some/dir the data dirs live under that workspace
+#  while BASE_DIR (the project root, used for code/asset lookups)
+#  stays anchored to this file's location.
 # ────────────────────────────────────────────────────────────────
 BASE_DIR   = os.path.dirname(os.path.abspath(__file__))
-RAW_DIR    = os.path.join(BASE_DIR, "raw")
-WIKI_DIR   = os.path.join(BASE_DIR, "wiki")
-UPLOAD_DIR = os.path.join(BASE_DIR, "uploads")
-CHROMA_DIR = os.path.join(BASE_DIR, "chroma_db")
+
+from core.plugins.workspace import get_workspace_root  # noqa: E402
+
+_WORKSPACE = str(get_workspace_root())
+RAW_DIR    = os.path.join(_WORKSPACE, "raw")
+WIKI_DIR   = os.path.join(_WORKSPACE, "wiki")
+UPLOAD_DIR = os.path.join(_WORKSPACE, "uploads")
+CHROMA_DIR = os.path.join(_WORKSPACE, "chroma_db")
 
 # ────────────────────────────────────────────────────────────────
 #  Tesseract OCR — auto-detect by OS, override via env var

--- a/tests/test_config_workspace_integration.py
+++ b/tests/test_config_workspace_integration.py
@@ -1,0 +1,134 @@
+"""[Track C PR-C6.b] config.py honors JAMES_WORKSPACE.
+
+The four derived directory constants (RAW_DIR / WIKI_DIR / UPLOAD_DIR /
+CHROMA_DIR) must resolve under the workspace root computed by
+core.plugins.workspace.get_workspace_root(), so multi-instance hosting
+(one JAMES process per workspace) can isolate per-tenant data without
+forking the path-handling code.
+
+The unit tests for the resolver itself live in test_plugin_workspace.py.
+This file is the integration sibling: it verifies that **config.py
+actually consumes the resolver**, so a regression that silently
+re-anchors a directory to BASE_DIR would fail here.
+
+Tests spawn a fresh interpreter per case because config.py runs at
+module-import time — `importlib.reload` would replay its side effects
+(.env load, logging config) against shared module state, which is
+worse than the cost of subprocesses.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_SNIPPET = (
+    "import json, config; "
+    "print(json.dumps({"
+    "'BASE_DIR': config.BASE_DIR, "
+    "'RAW_DIR': config.RAW_DIR, "
+    "'WIKI_DIR': config.WIKI_DIR, "
+    "'UPLOAD_DIR': config.UPLOAD_DIR, "
+    "'CHROMA_DIR': config.CHROMA_DIR}))"
+)
+
+
+def _dirs_with_env(env_overrides: dict) -> dict:
+    """Spawn a fresh interpreter that imports config, return the dirs.
+
+    config.py prints a `[CONFIG] .env loaded:` line if a .env file
+    exists in cwd. We take the *last* line of stdout as the JSON
+    payload to be robust against that and against any future logging.
+    """
+    env = {**os.environ, **env_overrides, "PYTHONIOENCODING": "utf-8"}
+    out = subprocess.check_output(
+        [sys.executable, "-c", _SNIPPET],
+        cwd=str(ROOT), env=env,
+    )
+    text = out.decode("utf-8", errors="replace").strip()
+    return json.loads(text.splitlines()[-1])
+
+
+class UnsetWorkspaceTests(unittest.TestCase):
+    def test_unset_dirs_anchor_to_base_dir(self):
+        """JAMES_WORKSPACE explicitly empty → data dirs under BASE_DIR."""
+        dirs = _dirs_with_env({"JAMES_WORKSPACE": ""})
+        base = dirs["BASE_DIR"]
+        # Resolver returns BASE_DIR for empty env; data dirs anchor to it.
+        # workspace.BASE_DIR uses Path.resolve() so directly compare paths.
+        for key, sub in (
+            ("RAW_DIR", "raw"),
+            ("WIKI_DIR", "wiki"),
+            ("UPLOAD_DIR", "uploads"),
+            ("CHROMA_DIR", "chroma_db"),
+        ):
+            # Both anchor to project root — compare via realpath to absorb
+            # any symlink / case-normalization difference between
+            # os.path.abspath (config.BASE_DIR) and Path.resolve()
+            # (workspace.BASE_DIR).
+            self.assertEqual(
+                os.path.realpath(dirs[key]),
+                os.path.realpath(os.path.join(base, sub)),
+                f"{key} should sit under BASE_DIR when JAMES_WORKSPACE is empty",
+            )
+
+
+class SetWorkspaceTests(unittest.TestCase):
+    def test_env_redirects_data_dirs_to_workspace(self):
+        """JAMES_WORKSPACE=<tmp> → all four data dirs live under tmp."""
+        # Resolver refuses non-existent dirs (loud failure on operator typo);
+        # use a real temp directory.
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = str(Path(tmp).resolve())
+            dirs = _dirs_with_env({"JAMES_WORKSPACE": tmp})
+            for key, sub in (
+                ("RAW_DIR", "raw"),
+                ("WIKI_DIR", "wiki"),
+                ("UPLOAD_DIR", "uploads"),
+                ("CHROMA_DIR", "chroma_db"),
+            ):
+                self.assertEqual(
+                    os.path.realpath(dirs[key]),
+                    os.path.realpath(os.path.join(workspace, sub)),
+                    f"{key} should sit under JAMES_WORKSPACE",
+                )
+            # BASE_DIR (project root) is independent of workspace.
+            self.assertEqual(
+                os.path.realpath(dirs["BASE_DIR"]),
+                os.path.realpath(str(ROOT)),
+                "BASE_DIR (project root) should NOT track JAMES_WORKSPACE",
+            )
+
+    def test_bad_workspace_path_fails_loud(self):
+        """JAMES_WORKSPACE=<missing> → config import raises (no silent fallback)."""
+        env = {
+            **os.environ,
+            "JAMES_WORKSPACE": "definitely-not-a-dir-pr-c6b-sentinel-zzz",
+            "PYTHONIOENCODING": "utf-8",
+        }
+        proc = subprocess.run(
+            [sys.executable, "-c", _SNIPPET],
+            cwd=str(ROOT), env=env,
+            capture_output=True,
+        )
+        self.assertNotEqual(
+            proc.returncode, 0,
+            "config import must fail when JAMES_WORKSPACE points to a "
+            "non-existent path — silent fallback would mask operator typos",
+        )
+        # PluginLoadError should surface by name in the traceback so
+        # operators can grep one line.
+        self.assertIn(
+            b"PluginLoadError", proc.stderr,
+            f"expected PluginLoadError in stderr, got: {proc.stderr!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wires `config.py`'s four data directories (`RAW_DIR` / `WIKI_DIR` / `UPLOAD_DIR` / `CHROMA_DIR`) through `core.plugins.workspace.get_workspace_root()` so multi-instance hosting works without forking the path-handling code.
- `BASE_DIR` (the project root, used for code/asset lookups) is unchanged. Only data dirs follow `JAMES_WORKSPACE`.
- Closes the last Plugin contract follow-up after PR-C6 (#410) shipped the resolver as resolver-only.

## Behavior

| `JAMES_WORKSPACE` value | Data dirs anchor to | Notes |
|---|---|---|
| unset / empty / whitespace | project root | byte-identical to pre-v0.3 — `WIKI_DIR` etc. unchanged |
| `/abs/path` or `relative/path` | resolved workspace | per-tenant data isolation; `BASE_DIR` stays put |
| missing / non-directory path | — | resolver raises `PluginLoadError` at config-import time (no silent fallback) |

## Verification

- 102 tests + 9 subtests pass across `tests/test_plugin_workspace.py`, `test_plugin_pack_loader.py`, `test_plugin_registry.py`, `test_plugin_manifest.py`, `test_pack_general.py`, `test_server_plugin_startup.py`, and the new `test_config_workspace_integration.py`.
- New `tests/test_config_workspace_integration.py` covers three cases via fresh-interpreter subprocess (config.py runs at import time, so reload-in-place is worse than the subprocess cost):
  1. `JAMES_WORKSPACE=''` → data dirs under `BASE_DIR`
  2. `JAMES_WORKSPACE=<tmpdir>` → data dirs under tmpdir, `BASE_DIR` independent
  3. `JAMES_WORKSPACE=<missing>` → import fails with `PluginLoadError` in stderr
- Local smoke (no env set) confirms `BASE_DIR / WIKI_DIR / UPLOAD_DIR / CHROMA_DIR / RAW_DIR` all resolve under the project root, unchanged from `main`.
- `ruff check config.py tests/test_config_workspace_integration.py` clean.

## Plugin contract status

Plugin API now at **8/8 PRs landed (this PR + PR-C10 #420 are the open ones)**:

- [x] PR-C2 / C-3 / C-5a / C-5b / C-6 / C-7 / C-8 / C-9 — already merged
- [x] PR-C6.b — **this PR**
- [ ] PR-C10 (#420) — open, CI in progress

After both merge, `ROADMAP.md` line 254 (`5/8 PRs landed`) and the `JAMES_WORKSPACE deferred to PR-C6.b` notes in `core/plugins/workspace.py` docstring + `docs/design/v0.3-plugin-api.md §"JAMES_WORKSPACE= env"` will need a docs-refresh PR.

## Out of scope

- `tools/patch/bench_gate.py` and `core/observability.py` still use a hardcoded `reports/` prefix — those are bench/trace concerns, not data-isolation concerns, and want their own PR if rerouted.
- Documentation refresh (ROADMAP.md, design memo, workspace.py docstring) — lands separately after PR-C6.b + PR-C10 both merge so it can reflect both in one pass.

## Test plan

- [x] `python -m pytest tests/test_config_workspace_integration.py tests/test_plugin_workspace.py tests/test_pack_general.py tests/test_server_plugin_startup.py` passes locally
- [x] `python -m ruff check config.py tests/test_config_workspace_integration.py` clean
- [x] `python -c "import config; print(config.WIKI_DIR)"` returns project-root-relative path unchanged (smoke)
- [ ] CI `pytest` job passes on this PR
- [ ] CI `ruff` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)