### PR TITLE
fix(plugins): loader uses per-pack qualified sys.modules key (closes main pytest red)

### DIFF
--- a/core/plugins/loader.py
+++ b/core/plugins/loader.py
@@ -27,7 +27,7 @@ PR-C5); ``JAMES_PLUGINS`` defaults to empty (no extra backend plugins).
 """
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import os
 import sys
 from pathlib import Path
@@ -128,9 +128,24 @@ def _import_slot_class(
 ):
     """Resolve ``"module:Class"`` against the pack directory.
 
-    Adds the pack directory to ``sys.path`` *only for the duration of
-    the import* so the pack's module namespace cannot collide with
-    project-level imports. Removes the path entry on return.
+    Uses :func:`importlib.util.spec_from_file_location` with a per-pack
+    qualified key in :data:`sys.modules` so two concerns are handled
+    cleanly:
+
+    1. **Cross-pack collision.** Two packs may each ship an
+       ``ontology.py``; both must load distinctly. The qualified key
+       ``_james_pack__<pack_name>__<module_path>`` is unique per pack.
+    2. **Same-pack re-load.** Test fixtures often create a temp
+       ``packs/general/`` and re-invoke the loader; the cached module
+       must be replaced with the fresh contents, not silently re-used.
+       Each call writes a fresh module object into ``sys.modules``,
+       so the second load sees the second directory's code.
+
+    Limitation (v0.3 scope): pack modules cannot use intra-pack
+    relative imports (``from .utils import X``) or sibling absolute
+    imports — the pack directory is not added to ``sys.path``. The
+    four-Protocol contract does not require multi-file packs, and
+    every shipped pack so far is single-file per slot.
     """
     if ":" not in import_path:
         raise PluginLoadError(
@@ -138,37 +153,52 @@ def _import_slot_class(
             f"'module:Class' form; got {import_path!r}"
         )
     module_path, class_name = import_path.split(":", 1)
-    pack_dir_str = str(pack_dir)
-    sys.path.insert(0, pack_dir_str)
+
+    rel_path = Path(*module_path.split(".")).with_suffix(".py")
+    file_path = pack_dir / rel_path
+    if not file_path.is_file():
+        raise PluginLoadError(
+            f"pack {pack_name!r}: cannot import module "
+            f"{module_path!r} from {pack_dir} "
+            f"(no file at {file_path})"
+        )
+
+    qualified_name = f"_james_pack__{pack_name}__{module_path}"
+
+    spec = importlib.util.spec_from_file_location(
+        qualified_name, file_path
+    )
+    if spec is None or spec.loader is None:
+        raise PluginLoadError(
+            f"pack {pack_name!r}: cannot build import spec for "
+            f"{file_path}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[qualified_name] = module
     try:
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError as exc:
-            raise PluginLoadError(
-                f"pack {pack_name!r}: cannot import module "
-                f"{module_path!r} from {pack_dir} ({exc})"
-            ) from exc
-        if not hasattr(module, class_name):
-            raise PluginLoadError(
-                f"pack {pack_name!r}: module {module_path!r} has no "
-                f"class {class_name!r}"
-            )
-        cls = getattr(module, class_name)
-        try:
-            return cls()
-        except Exception as exc:  # noqa: BLE001 — wrap with context
-            raise PluginLoadError(
-                f"pack {pack_name!r}: instantiating "
-                f"{module_path}:{class_name} raised "
-                f"{type(exc).__name__}: {exc}"
-            ) from exc
-    finally:
-        try:
-            sys.path.remove(pack_dir_str)
-        except ValueError:
-            # Pack code might have manipulated sys.path itself.
-            # Don't crash startup over a best-effort cleanup.
-            pass
+        spec.loader.exec_module(module)
+    except Exception as exc:  # noqa: BLE001 — wrap with pack context
+        sys.modules.pop(qualified_name, None)
+        raise PluginLoadError(
+            f"pack {pack_name!r}: cannot import module "
+            f"{module_path!r} from {pack_dir} "
+            f"({type(exc).__name__}: {exc})"
+        ) from exc
+
+    if not hasattr(module, class_name):
+        raise PluginLoadError(
+            f"pack {pack_name!r}: module {module_path!r} has no "
+            f"class {class_name!r}"
+        )
+    cls = getattr(module, class_name)
+    try:
+        return cls()
+    except Exception as exc:  # noqa: BLE001 — wrap with context
+        raise PluginLoadError(
+            f"pack {pack_name!r}: instantiating "
+            f"{module_path}:{class_name} raised "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
 
 
 def _iter_slot_imports(

--- a/tests/test_plugin_pack_loader.py
+++ b/tests/test_plugin_pack_loader.py
@@ -317,6 +317,119 @@ class LoaderEnvVarSeparation(unittest.TestCase):
                 )
 
 
+class LoaderModuleIsolation(_LoaderFixture):
+    """Pin the per-pack module-namespace behavior introduced by the
+    loader's switch to ``importlib.util.spec_from_file_location``.
+
+    Before the switch, ``importlib.import_module("ontology")`` cached
+    under the short name ``"ontology"`` in ``sys.modules``, so:
+
+    1. Two packs that each shipped ``ontology.py`` saw the second one
+       silently ignored (the first one's module returned from cache).
+    2. A test that loaded the production ``packs/general/`` first and
+       then a fixture pack of the same name found the production
+       module returned in place of the fixture's.
+
+    After the switch, the key is per-pack qualified (e.g.
+    ``_james_pack__general__ontology``), so both concerns dissolve.
+    """
+
+    def test_two_packs_with_same_filename_register_distinctly(self):
+        """Two packs each shipping ``ontology.py`` with different
+        ``entity_types`` must both register, each with its own
+        contents — not the first-loaded one twice."""
+        modules_a = {
+            "ontology.py": _ONTOLOGY_MODULE.format(name="alpha"),
+        }
+        _make_pack(
+            self.tmp_dir,
+            name="alpha",
+            plugins_block="ontology: ontology:GeneralOntology\n",
+            extra_modules=modules_a,
+        )
+        # Beta's ontology.py has the SAME filename but different
+        # contents — entity_types diverges so the test can prove which
+        # one each registered slot came from.
+        beta_ontology = textwrap.dedent("""\
+            from typing import Dict, Tuple
+
+
+            class GeneralOntology:
+                pack_id = "beta"
+                entity_types: Tuple[str, ...] = ("beta_only_entity",)
+                relation_types: Tuple[str, ...] = ()
+                hierarchies: Dict[str, Tuple[str, ...]] = {}
+        """)
+        _make_pack(
+            self.tmp_dir,
+            name="beta",
+            plugins_block="ontology: ontology:GeneralOntology\n",
+            extra_modules={"ontology.py": beta_ontology},
+        )
+
+        self._load(env={"JAMES_PACKS": "alpha,beta"})
+
+        packs = self.registry.ontology_packs()
+        self.assertEqual(len(packs), 2)
+        by_id = {p.pack_id: p for p in packs}
+        self.assertEqual(set(by_id), {"alpha", "beta"})
+        # Alpha kept the fixture-default "test_entity" from _ONTOLOGY_MODULE.
+        self.assertIn("test_entity", by_id["alpha"].entity_types)
+        # Beta kept its own "beta_only_entity" — would fail if the
+        # loader's old sys.modules["ontology"] cache returned alpha's
+        # module for beta's import.
+        self.assertIn("beta_only_entity", by_id["beta"].entity_types)
+        self.assertNotIn("test_entity", by_id["beta"].entity_types)
+
+    def test_relaod_same_pack_picks_up_new_file_contents(self):
+        """Reloading the same pack name against a different pack_dir
+        (or the same pack_dir with different file content) must reflect
+        the new content, not return the first-load cached module."""
+        # First load: standard fixture ontology with "test_entity".
+        modules_v1 = {
+            "ontology.py": _ONTOLOGY_MODULE.format(name="general"),
+        }
+        _make_pack(
+            self.tmp_dir,
+            name="general",
+            plugins_block="ontology: ontology:GeneralOntology\n",
+            extra_modules=modules_v1,
+        )
+        self._load(env={"JAMES_PACKS": "general"})
+        first_pack = self.registry.ontology_packs()[0]
+        self.assertIn("test_entity", first_pack.entity_types)
+
+        # Now rewrite the pack on disk and load into a *fresh* registry
+        # (the loader is the unit under test, not registry idempotence).
+        # Second load points at the same pack_dir but the ontology.py
+        # now declares a different entity. The loader must re-exec the
+        # file, not return the cached module object from the first load.
+        replaced_ontology = textwrap.dedent("""\
+            from typing import Dict, Tuple
+
+
+            class GeneralOntology:
+                pack_id = "general"
+                entity_types: Tuple[str, ...] = ("post_reload_entity",)
+                relation_types: Tuple[str, ...] = ()
+                hierarchies: Dict[str, Tuple[str, ...]] = {}
+        """)
+        general_dir = self.tmp_dir / "packs" / "general"
+        (general_dir / "ontology.py").write_text(replaced_ontology, encoding="utf-8")
+
+        fresh_registry = PluginRegistry()
+        packs_root = self.tmp_dir / "packs"
+        with mock.patch("core.plugins.loader._PACKS_ROOT", packs_root):
+            load_packs_from_env(
+                env={"JAMES_PACKS": "general"},
+                registry=fresh_registry,
+                core_version="0.3.0",
+            )
+        second_pack = fresh_registry.ontology_packs()[0]
+        self.assertIn("post_reload_entity", second_pack.entity_types)
+        self.assertNotIn("test_entity", second_pack.entity_types)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary

Replace \`importlib.import_module(short_name)\` + \`sys.path\` insert in \`_import_slot_class\` with \`importlib.util.spec_from_file_location\` keyed by a per-pack qualified name (\`_james_pack__<pack_name>__<module_path>\`). Each load writes a fresh module into \`sys.modules\` under this key.

**Drops main's pre-existing pytest failure count from 1 → 0** once merged. Plus closes a latent runtime bug: two packs that each shipped \`ontology.py\` would have silently seen the second one ignored.

## Root cause

The old loader did:

\`\`\`python
sys.path.insert(0, str(pack_dir))
module = importlib.import_module(module_path)   # e.g. "ontology"
sys.path.remove(...)
\`\`\`

\`import_module(\"ontology\")\` caches the module under the short name \`\"ontology\"\` in \`sys.modules\`. Two consequences:

1. **Cross-pack collision (latent runtime bug)**: two packs that each ship an \`ontology.py\` → second one's contents silently ignored, the cached first-pack module returned for both.
2. **Test order dependency (main's red CI)**: when \`tests/test_server_plugin_startup.py\` ran first and registered the real \`packs/general/ontology.py\`, the pack-loader test's fixture pack (\`tmp_dir/packs/general/ontology.py\` with \`entity_types=(\"test_entity\",)\`) lost — the cached real module (with empty \`entity_types\`) was returned and \`\"test_entity\" in entity_types\` failed.

## Fix

\`\`\`python
qualified_name = f\"_james_pack__{pack_name}__{module_path}\"
spec = importlib.util.spec_from_file_location(qualified_name, file_path)
module = importlib.util.module_from_spec(spec)
sys.modules[qualified_name] = module    # always overwrite
spec.loader.exec_module(module)
\`\`\`

- Each pack gets its own \`sys.modules\` namespace key.
- Each load calls \`exec_module\` fresh — same pack reloaded against different file contents (test fixtures) sees the new contents.

## Limitation (documented in docstring)

Pack modules cannot use intra-pack relative imports (\`from .utils import X\`) or sibling absolute imports — the pack directory is no longer added to \`sys.path\`. The four-Protocol contract does not require multi-file packs; every shipped pack so far is single-file per slot.

## Verification

- \`tests/test_plugin_pack_loader.py\` — **22/22 pass**, including:
  - Previously-failing \`test_ontology_slot_loaded_and_registered\` — now green.
  - Two new regression tests in \`LoaderModuleIsolation\`:
    - \`test_two_packs_with_same_filename_register_distinctly\` — packs \`alpha\` and \`beta\` both ship \`ontology.py\` with different \`entity_types\`; both register correctly.
    - \`test_relaod_same_pack_picks_up_new_file_contents\` — re-loading \`general\` after rewriting \`ontology.py\` returns the new entity.
- **110 tests + 9 subtests pass** across plugin/workspace/pack_general/registry/manifest/server_startup/eval_pack_script/config_workspace.
- \`scripts/dogfood_check.py\` — 4/4 runtime invariants still PASS.
- \`ruff check core/plugins/loader.py tests/test_plugin_pack_loader.py\` — clean.

## Out of scope

- Multi-file pack support (intra-pack imports) — deferred. The limitation is called out in the function docstring.

## Test plan

- [x] \`pytest tests/test_plugin_pack_loader.py\` → 22/22
- [x] \`pytest tests/test_plugin_workspace.py tests/test_pack_general.py tests/test_plugin_registry.py tests/test_plugin_manifest.py tests/test_server_plugin_startup.py tests/test_eval_pack_script.py tests/test_config_workspace_integration.py\` → all green
- [x] \`python scripts/dogfood_check.py\` → 4/4 PASS
- [x] \`ruff check\` on touched files → clean
- [ ] CI \`tests\` job on this PR passes (drops main from 1 failure → 0)
- [ ] CI \`lint\` / \`packs-eval\` / \`security\` / \`cla\` jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)