### PR TITLE
refactor(audit): Stage D.1 — remove 16 JSONL writer sites (Audit Phase 4b-2)

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -23,13 +23,11 @@ import requests
 import time
 import hashlib
 import base64
-import json
 import re
 from collections import OrderedDict
 from datetime import datetime
 from config import GEMMA_MODEL, OLLAMA_API_URL
 
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
 
 # ─── 에러 응답 식별자 ────────────────────────────────────────
 
@@ -63,12 +61,6 @@ def log_system_event(step: str, detail: str, level: str = "ERROR"):
         "step":   step,
         "detail": str(detail)[:300],
     }
-    try:
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_system_event
         mirror_system_event(entry)

--- a/core/graph_engine.py
+++ b/core/graph_engine.py
@@ -17,7 +17,6 @@ PROJECT JAMES - Graph Engine (Phase 4.5)
 """
 
 import re
-import json
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -34,7 +33,6 @@ from core.ontology import (
     RELATION_TYPES,
 )
 
-SYSTEM_LOG_PATH      = "james_system_log.jsonl"
 CONFIDENCE_THRESHOLD = 0.6
 MAX_DEPTH            = 4
 DFS_SCORE_THRESHOLD  = 0.05
@@ -124,12 +122,6 @@ class GraphEngine:
             "detail": str(error)[:300],
             "role":   role,
         }
-        try:
-            with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
-        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
         try:
             from core.audit_bridge import mirror_system_event
             mirror_system_event(entry)

--- a/core/memory/loom.py
+++ b/core/memory/loom.py
@@ -18,13 +18,11 @@ PROJECT JAMES - Memory Loom-lite (Phase 5)
   Gate 5: conflict detection (동일 entity+relation + 다른 tail → 양쪽 거부)
 """
 
-import json
 import hashlib
 from collections import deque
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
-SYSTEM_LOG_PATH          = "james_system_log.jsonl"
 MAX_WRITES_PER_SESSION   = 3       # 세션당 최대 저장 횟수
 MEMORY_CONFIDENCE_TH     = 0.75    # 저장 최소 confidence
 MEMORY_DEDUP_WINDOW      = 100     # 최근 N개 내 중복 검사
@@ -34,12 +32,6 @@ CONFLICT_CONFIDENCE_DIFF = 0.3     # confidence 차이 이 이상이면 conflict
 def _log(step: str, detail: str, level: str = "INFO"):
     entry = {"time": datetime.now().isoformat(), "level": level,
              "step": f"memory_loom.{step}", "detail": detail[:300]}
-    try:
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_system_event
         mirror_system_event(entry)

--- a/core/memory/trust.py
+++ b/core/memory/trust.py
@@ -18,7 +18,6 @@ PROJECT JAMES - Memory Trust Scoring (Phase 4.5)
 """
 
 import math
-import json
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 from pathlib import Path
@@ -33,7 +32,6 @@ from core.security_layer import log_system_event
 
 TRUST_THRESHOLD = 0.5      # 이 이하 → write 거부
 RECENCY_DECAY   = 0.01     # 하루당 감쇠율 (30일 후 ≈ 0.74)
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
 
 ROLE_TRUST: Dict[str, float] = {
     "admin":    1.0,
@@ -241,12 +239,6 @@ class MemoryTrustScorer:
             "threshold": TRUST_THRESHOLD,
             "reason":    reason[:200],
         }
-        try:
-            with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
-        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
         try:
             from core.audit_bridge import mirror_system_event
             mirror_system_event(entry)

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -13,23 +13,13 @@ PROJECT JAMES - Retrieval Orchestrator (Phase 5)
   ✅ 점수 재계산 없음, 순서 변경 없음
 """
 
-import json
 import re
 from datetime import datetime
 from typing import List, Dict, Optional
 
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
-
-
 def _log(step: str, detail: str):
     entry = {"time": datetime.now().isoformat(), "level": "INFO",
              "step": f"orchestrator.{step}", "detail": detail[:200]}
-    try:
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_system_event
         mirror_system_event(entry)

--- a/core/query_expander.py
+++ b/core/query_expander.py
@@ -19,7 +19,6 @@ Predictive Architecture, LeCun)와 무관** — 모듈 이름이 학술 용어�
 
 import re
 import time
-import json
 from datetime import datetime
 from typing import Optional   # noqa: F401 — kept for downstream type hints
 
@@ -31,7 +30,6 @@ TIMEOUT_SEC      = 3.0    # 이 안에 못 끝내면 bypass
 JEPA_TOKEN_HARD_LIMIT = TOKEN_HARD_LIMIT
 JEPA_TIMEOUT_SEC      = TIMEOUT_SEC
 
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
 
 # ─── 동의어 / 확장 사전 (keyword 기반, LLM 없음) ──────────
 
@@ -66,12 +64,6 @@ _STOPWORDS = {
 def _log(step: str, detail: str, level: str = "INFO"):
     entry = {"time": datetime.now().isoformat(), "level": level,
              "step": f"query_expand.{step}", "detail": detail[:200]}
-    try:
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_system_event
         mirror_system_event(entry)

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -13,7 +13,6 @@ PROJECT JAMES - Reasoning Engine (Phase 4.5)
   graph_rag_engine.py (thin wrapper) → ReasoningEngine
 """
 
-import json
 import time
 from datetime import datetime
 from typing import Dict, Any, Optional
@@ -31,7 +30,6 @@ from core.reasoning.modes import (
     handle_coding,
 )
 
-SYSTEM_LOG_PATH   = "james_system_log.jsonl"
 TIMING_TARGET_SEC = 30.0
 MAX_LOOP          = 2        # Loop 최대 반복
 LOOP_TIMEOUT      = 30.0     # 단일 loop 단계 timeout(s)
@@ -70,12 +68,6 @@ class ReasoningEngine:
             "detail": str(error)[:300],
             "role":   role,
         }
-        try:
-            with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
-        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
         try:
             from core.audit_bridge import mirror_system_event
             mirror_system_event(entry)

--- a/core/retrieval_engine.py
+++ b/core/retrieval_engine.py
@@ -23,9 +23,6 @@ from core.vector_store import VectorStore
 from core.policy_engine import default_engine as _policy
 from utils.tokenizer import tokenize
 
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
-
-
 class RetrievalEngine:
     """
     Vector + BM25 하이브리드 검색 + Entity 추출 전담.
@@ -47,12 +44,6 @@ class RetrievalEngine:
             "step":   f"retrieval_engine.{step}",
             "detail": str(error)[:300],
         }
-        try:
-            with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
-        # Phase 2: mirror to SQLite (see core/audit_bridge.py).
         try:
             from core.audit_bridge import mirror_system_event
             mirror_system_event(entry)

--- a/core/security_layer.py
+++ b/core/security_layer.py
@@ -13,7 +13,6 @@ Phase 4 신규:
 """
 
 import re
-import json
 from datetime import datetime
 from typing import Dict, List, Set, Tuple
 
@@ -21,9 +20,6 @@ from typing import Dict, List, Set, Tuple
 
 ROLE_LEVEL = {"admin": 3, "manager": 2, "employee": 1, "external": 0}
 SENSITIVITY_LEVEL = {"public": 0, "internal": 1, "confidential": 2, "secret": 3}
-
-ATTACK_LOG_PATH = "james_attack_log.jsonl"
-SYSTEM_LOG_PATH = "james_system_log.jsonl"
 
 ATTACK_PATTERNS = [
     # 영어 패턴
@@ -136,14 +132,15 @@ INSTRUCTION_INJECTION_PATTERNS = [
 # ─── 로그 ────────────────────────────────────────────────────
 
 def log_attack(query: str, role: str, attack_type: str = "injection"):
+    """Audit-log an attempted prompt-injection / risky-coding refusal.
+
+    Phase 4 (Stage D.1, 2026-05-24) of the JSONL → SQLite audit
+    migration removed the legacy `james_attack_log.jsonl` writer;
+    the SQLite audit_log table is now the sole sink, accessible via
+    `/admin/audit/list` with `endpoint LIKE 'attack:%'`.
+    """
     entry = {"time": datetime.now().isoformat(), "role": role,
              "attack_type": attack_type, "query": query[:200]}
-    try:
-        with open(ATTACK_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite audit_log (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_attack_event
         mirror_attack_event(entry, attack_type=attack_type)
@@ -151,15 +148,15 @@ def log_attack(query: str, role: str, attack_type: str = "injection"):
         pass
 
 def log_system_event(step: str, detail: str, role: str = "unknown", level: str = "ERROR"):
-    """[LOG-1] james_system_log.jsonl 영구 기록"""
+    """[LOG-1] Audit-log a system event.
+
+    Phase 4 (Stage D.1, 2026-05-24) removed the legacy
+    `james_system_log.jsonl` writer; the SQLite audit_log table is
+    now the sole sink, accessible via `/admin/audit/list` with
+    `endpoint LIKE 'system:%'`.
+    """
     entry = {"time": datetime.now().isoformat(), "level": level,
              "step": step, "detail": str(detail)[:300], "role": role}
-    try:
-        with open(SYSTEM_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 2: mirror to SQLite audit_log (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_system_event
         mirror_system_event(entry)

--- a/tests/test_router_capability.py
+++ b/tests/test_router_capability.py
@@ -16,10 +16,8 @@ Run:
 from __future__ import annotations
 
 import io
-import json
 import os
 import sys
-import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest import mock
@@ -43,31 +41,39 @@ class _FakeTool:
 
 
 def _patch_audit_log():
-    """Redirect router audit log to a tempfile for the duration of a test.
+    """Capture entries that the router would mirror to the SQLite audit_log.
 
-    Returns (patcher, log_path). The caller is responsible for stopping
-    the patcher and reading log_path.
+    Phase 4 (Stage D.1, 2026-05-24) removed the legacy JSONL writer;
+    `core.audit_bridge.mirror_to_audit_db` is now the sole sink. The
+    test captures the entries via side_effect so assertions on event
+    shape / fields stay byte-identical to the pre-Phase-4 contract
+    (the entry dict the router builds is unchanged — only the sink
+    swapped from JSONL file to SQLite row).
+
+    Returns (patcher, captured_list). The caller stops the patcher
+    in tearDown and reads `captured_list` via `_read_log`.
     """
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, encoding="utf-8",
+    captured: list = []
+
+    def _capture(entry, *args, **kwargs):
+        captured.append(entry)
+        return True
+
+    import core.audit_bridge as bridge_mod
+    patcher = mock.patch.object(
+        bridge_mod, "mirror_to_audit_db", side_effect=_capture,
     )
-    tmp.close()
-    import tools.router as router_mod
-    patcher = mock.patch.object(router_mod, "AUDIT_LOG_PATH", tmp.name)
     patcher.start()
-    return patcher, tmp.name
+    return patcher, captured
 
 
-def _read_log(path: str) -> list:
-    if not os.path.exists(path):
-        return []
-    with open(path, "r", encoding="utf-8") as f:
-        return [json.loads(line) for line in f if line.strip()]
+def _read_log(captured: list) -> list:
+    return list(captured)
 
 
 class RouterCapabilityGateTests(unittest.TestCase):
     def setUp(self):
-        self.patcher, self.log_path = _patch_audit_log()
+        self.patcher, self.captured = _patch_audit_log()
         # Router prints emoji-laden status lines; on Windows cp949 stdout
         # this raises UnicodeEncodeError under unittest. Redirect to a
         # StringIO for the duration of each test — the audit log on disk
@@ -87,10 +93,6 @@ class RouterCapabilityGateTests(unittest.TestCase):
         reg.TOOLS.update(self._saved_tools)
         self._stdout_ctx.__exit__(None, None, None)
         self.patcher.stop()
-        try:
-            os.unlink(self.log_path)
-        except OSError:
-            pass
 
     # ─── fs.read (relaxed to employee+) ───────────────────────────
 
@@ -165,7 +167,7 @@ class RouterCapabilityGateTests(unittest.TestCase):
             {"name": "read_file", "input": {"path": "./workspace/x.py"}},
             {"user_role": "admin"},
         )
-        entries = _read_log(self.log_path)
+        entries = _read_log(self.captured)
         executed = [e for e in entries if e["event"] == "TOOL_EXECUTED"]
         self.assertTrue(executed, msg=f"no TOOL_EXECUTED in {entries}")
         e = executed[-1]
@@ -179,7 +181,7 @@ class RouterCapabilityGateTests(unittest.TestCase):
             {"name": "code_editor", "input": {"path": "./workspace/x.py"}},
             {"user_role": "employee"},
         )
-        entries = _read_log(self.log_path)
+        entries = _read_log(self.captured)
         denied = [e for e in entries if e["event"] == "CAPABILITY_DENIED"]
         self.assertTrue(denied, msg=f"no CAPABILITY_DENIED in {entries}")
         self.assertTrue(denied[0]["cap_denied"])

--- a/tools/code/code_analyzer.py
+++ b/tools/code/code_analyzer.py
@@ -12,15 +12,12 @@ Sandbox 검증 + Code Reader 통과 후 분석 수행.
   ✅ tool_used 필드로 tool 추적
 """
 
-import json
 import time
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
 from tools.code.sandbox import policy_validate_path, log_security_event
 from tools.code.code_reader import CodeReader
-
-AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 
 # 분석 타입별 프롬프트 템플릿
 ANALYSIS_TEMPLATES = {
@@ -43,12 +40,6 @@ def _log_analysis(path: str, analysis_type: str, elapsed: float, success: bool):
         "success":       success,
         "layer":         "tool",
     }
-    try:
-        with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 1: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_to_audit_db
         mirror_to_audit_db(entry)
@@ -219,9 +210,10 @@ class CodeAnalyzer:
             "surface": surface,
             "layer":   "code_analyzer",
         }
+        # Mirror to SQLite (sole sink as of Phase 4 / Stage D.1).
         try:
-            with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            from core.audit_bridge import mirror_to_audit_db
+            mirror_to_audit_db(entry)
         except Exception:
             pass
 

--- a/tools/code/code_editor.py
+++ b/tools/code/code_editor.py
@@ -14,7 +14,6 @@ PROJECT JAMES - Code Editor (Phase 5.5)
 """
 
 import os
-import json
 import shutil
 import difflib
 from datetime import datetime
@@ -23,7 +22,6 @@ from typing import Optional, Tuple
 
 from tools.code.sandbox import policy_validate_path, validate_command, log_security_event
 
-AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 BACKUP_DIR     = "./workspace/.backups"
 
 # Core Engine 파일 수정 절대 금지 목록
@@ -46,12 +44,6 @@ def _log_edit(path: str, operation: str, success: bool, detail: str = ""):
         "detail":    detail[:200],
         "layer":     "tool",
     }
-    try:
-        with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 1: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_to_audit_db
         mirror_to_audit_db(entry)

--- a/tools/code/code_reader.py
+++ b/tools/code/code_reader.py
@@ -12,14 +12,11 @@ Sandbox 검증 후에만 접근 허용.
 """
 
 import os
-import json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from tools.code.sandbox import policy_validate_path, log_security_event
-
-AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 
 SUPPORTED_EXTENSIONS = {
     ".py", ".js", ".ts", ".java", ".cpp", ".c", ".h",
@@ -41,12 +38,6 @@ def _log_read(path: str, lines: int, success: bool):
         "success": success,
         "layer":   "code_reader",
     }
-    try:
-        with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-    # Phase 1: mirror to SQLite (see core/audit_bridge.py).
     try:
         from core.audit_bridge import mirror_to_audit_db
         mirror_to_audit_db(entry)

--- a/tools/code/sandbox.py
+++ b/tools/code/sandbox.py
@@ -29,7 +29,6 @@ v2.1 (유지):
 
 import os
 import re
-import json
 import time
 import subprocess
 from datetime import datetime
@@ -39,9 +38,6 @@ from typing import Tuple
 
 ALLOWED_PATHS     = ["./workspace"]
 MAX_EXEC_TIME_SEC = 10
-AUDIT_LOG_PATH    = "james_audit_tool.jsonl"
-SYSTEM_LOG_PATH   = "james_system_log.jsonl"
-
 BLOCKED_COMMANDS = [
     "rm -rf", "curl", "wget", "sudo", "chmod",
     "chown", "dd ", "mkfs", "kill", "shutdown",
@@ -79,13 +75,8 @@ def log_security_event(
         "admin_override": admin_override,
         "layer":          "sandbox",
     }
-    for path in [AUDIT_LOG_PATH, SYSTEM_LOG_PATH]:
-        try:
-            with open(path, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
-    # Phase 1: mirror to SQLite (see core/audit_bridge.py).
+    # Mirror to SQLite (see core/audit_bridge.py). Sole sink as of
+    # Phase 4 (Stage D.1, 2026-05-24).
     try:
         from core.audit_bridge import mirror_to_audit_db
         mirror_to_audit_db(entry)

--- a/tools/router.py
+++ b/tools/router.py
@@ -24,13 +24,10 @@ PROTECTED_FILES 관리:
 """
 
 import os
-import json
 from datetime import datetime
 from typing import Dict, Optional
 
 from core.policy_engine import default_engine
-
-AUDIT_LOG_PATH = "james_audit_tool.jsonl"
 
 # ─── PROTECTED_FILES (환경변수로 관리) ───────────────────────
 
@@ -86,15 +83,9 @@ def _log_tool_event(
         "exec_time_sec":   exec_time_sec,
         "layer":           "router",
     }
-    try:
-        with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-
-    # Phase 1: mirror to SQLite audit_log so /admin/audit/list can
-    # surface tool events alongside HTTP audit rows. Best-effort —
-    # bridge never raises.
+    # Mirror to SQLite audit_log so /admin/audit/list can surface
+    # tool events alongside HTTP audit rows. Best-effort — bridge
+    # never raises. Sole sink as of Phase 4 (Stage D.1, 2026-05-24).
     try:
         from core.audit_bridge import mirror_to_audit_db
         mirror_to_audit_db(entry)


### PR DESCRIPTION
## Summary

Finalizes the JSONL → SQLite audit migration. Removes the 16 legacy JSONL writer sites identified in the 2026-05-23 audit (\`docs/handovers/v0.3.x-audit-2026-05-23.md\` §9 Stage D.1). The SQLite audit_log table (via \`core.audit_bridge\`) becomes the sole sink — it has been running alongside the JSONL writers since #344, so this PR is the "Phase 4 removal" that the bridge's docstring documents.

**Net change**: **−158 / +47 lines** across 15 files. Pure refactor — no behaviour change beyond sink swap.

## What changed

Pattern identical across every site:
- Keep the \`entry = {...}\` dict (mirror contract unchanged)
- Keep the \`mirror_*\` call
- Remove the \`try: open(JSONL_PATH).write(json.dumps(entry))\` block
- Remove the now-orphaned \`*_LOG_PATH\` constants and \`import json\`

### core (9 sites)
| File | Function | Removed |
|---|---|---|
| security_layer.py | log_attack | JSONL write + ATTACK_LOG_PATH |
| security_layer.py | log_system_event | JSONL write + SYSTEM_LOG_PATH |
| gemma_client.py | log_system_event | JSONL write + SYSTEM_LOG_PATH |
| graph_engine.py | _log | JSONL write + SYSTEM_LOG_PATH |
| query_expander.py | _log | JSONL write + SYSTEM_LOG_PATH |
| orchestrator.py | _log | JSONL write + SYSTEM_LOG_PATH |
| retrieval_engine.py | _log | JSONL write + SYSTEM_LOG_PATH |
| memory/loom.py | _log | JSONL write + SYSTEM_LOG_PATH |
| memory/trust.py | _log_rejection | JSONL write + SYSTEM_LOG_PATH |
| reasoning/engine.py | _log | JSONL write + SYSTEM_LOG_PATH |

### tools (5 sites)
| File | Function | Removed |
|---|---|---|
| router.py | _log_tool_event | JSONL write + AUDIT_LOG_PATH |
| code/sandbox.py | log_security_event | Dual-write loop (audit+system) + 2 paths |
| code/code_reader.py | _log_read | JSONL write + AUDIT_LOG_PATH |
| code/code_analyzer.py | _log_analysis | JSONL write + AUDIT_LOG_PATH |
| code/code_analyzer.py | ATTACK_SURFACE_SCAN site | JSONL write **+ added mirror call** (only previously-missing site) |
| code/code_editor.py | _log_edit | JSONL write + AUDIT_LOG_PATH |

### Test migration
- **tests/test_router_capability.py** — \`_patch_audit_log()\` now mocks \`core.audit_bridge.mirror_to_audit_db\` and captures entries via \`side_effect\` instead of redirecting JSONL writes to a tempfile. The entry dict shape is unchanged, so \`event\` / \`cap_action\` / \`cap_token_id\` assertions are byte-identical. **9/9 tests pass** with the new pattern.

## Verification

- tests/test_audit_bridge.py — **21/21 pass** (mirror contract unchanged)
- tests/test_router_capability.py — **9/9 pass** (capture-via-mock pattern)
- Full pytest (CI ignore list): **1590 passed + 824 subtests passed**. Zero regression.
- \`scripts/dogfood_check.py\` — 4/4 plugin invariants PASS
- \`ruff check\` on touched files — clean (12 unused \`import json\` removed via ruff --fix)

## Stage progress

- **D.1 (16 JSONL writer sites) — ✅ this PR**
- D.2 (THIRD_PARTY_LICENSES.md) — already closed (PR #414, 2026-05-23)
- D.3 (LICENSE_PLAN.md §8 quarterly monitoring) — already closed (PR #415)

Stage D fully complete after this PR merges.

## Unblocks Stage C.4

\`core/security_layer.py\` (23 KB) module-size split was paused on this PR. Post-merge, the file shrinks ~50 lines from the JSONL writer removal. Still over the 20 KB gate, so **Stage C.4 (security_layer.py split) is the next natural step**.

## Rollback

\`git revert\` restores the JSONL writers cleanly — entry dict shapes were unchanged across the migration, and mirror calls are independent of the JSONL writes.

## Test plan

- [x] tests/test_audit_bridge.py (21/21)
- [x] tests/test_router_capability.py (9/9)
- [x] Full pytest CI ignore list (1590 + 824 subtests)
- [x] dogfood_check (4/4)
- [x] ruff clean
- [ ] CI \`tests\` job passes
- [ ] CI \`lint\` / \`packs-eval\` / \`security\` / \`cla\` remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)