### PR TITLE
refactor(graph): Stage C.5 — split core/graph_editor.py 20KB → package, all files ≤11KB

### DIFF
--- a/core/graph_editor/__init__.py
+++ b/core/graph_editor/__init__.py
@@ -1,0 +1,118 @@
+"""``core.graph_editor`` — Knowledge Cascade Phase E (graph editor backend).
+
+``docs/design/v0.3-knowledge-cascade.md`` §7 — Phase E.
+
+``/admin/graph`` 의 admin 이 edge 별 sources 를 직접 수정할 수 있게
+하는 3 endpoint 의 코어 로직. UI 가 클릭한 edge 의 source list /
+weight / role 을 받아 양방향 entity 파일의 frontmatter relation 의
+``sources`` 배열을 갱신한다.
+
+Phase B (PR #269) 가 ingestion 시점에 ``sources`` 를 stamp 하고
+Phase C (PR #270) 가 cascade 가 manual source 를 보존하도록 만들었기
+때문에, Phase E 의 manual source write 는 자연스럽게 cascade-안전:
+admin 이 추가한 ``role=manual`` source 는 doc 파일 삭제 시에도
+유지된다.
+
+Trust model (§7):
+
+- admin 만 호출 가능 (server endpoint 에서 admin.data feature gate +
+  ``JAMES_GRAPH_EDIT=1`` env flag opt-in).
+- 모든 write 는 양쪽 (forward + inverse) entity 파일에 동시 반영.
+- audit log 에 before+after sources 배열 차이 기록.
+- 두 admin 의 동시 PUT 은 last-writer-wins. POST (append) 는 commutative.
+
+Originally a single 20 KB module; split in Stage C.5 (2026-05-24)
+into a 3-module package so every file respects CLAUDE.md rule #5
+(< 20 KB). External callers — ``server_llmwiki.py`` and the
+``test_phase_e_graph_editor`` / ``test_event_admin_endpoint`` test
+files — keep their existing import paths.
+
+Node-level attribute editor (PR-O6) lives in
+``core/graph_node_editor.py`` so this module stays focused on
+edge-level mutations. The two modules share file I/O helpers via
+direct import.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+from ._helpers import (
+    _FM_SPLIT_RE,
+    _find_relation_index,
+    _inverse_type,
+    _label_for_type,
+    _load_entity_by_id,
+    _read_entity,
+    _validate_sources,
+    _write_entity,
+)
+from ._writes import (
+    append_relation_source,
+    delete_relation,
+    replace_relation_sources,
+)
+
+
+def read_relation(
+    src_entity_id: str,
+    tgt_entity_id: str,
+    relation_type: str,
+    *,
+    wiki_generator,
+) -> Optional[Dict[str, Any]]:
+    """forward 측 entity 의 frontmatter 에서 매칭 relation dict 를 그대로
+    반환 (sources 배열 포함). 없으면 None.
+
+    UI 의 edit modal 이 edge 클릭 시 sources 를 fresh load 하기 위한
+    read path. snapshot endpoint 에 sources 를 넣지 않은 이유는 213
+    entity × N relation × N source 면 wire payload 가 폭증하기 때문 —
+    on-demand fetch 로 격리.
+    """
+    src_path, src_fm, _body = _load_entity_by_id(src_entity_id, wiki_generator)
+    _ = src_path   # unused
+    rels = src_fm.get("relations") or []
+    idx = _find_relation_index(rels, tgt_entity_id, relation_type)
+    if idx is None:
+        return None
+    rel = rels[idx]
+    # 안전한 복사본 — caller 가 변형해도 frontmatter 무영향
+    if isinstance(rel, dict):
+        return dict(rel)
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────
+# Env flag helper (디자인 §7 — JAMES_GRAPH_EDIT=1 opt-in)
+# ─────────────────────────────────────────────────────────────────
+
+def graph_edit_enabled() -> bool:
+    """``JAMES_GRAPH_EDIT=1`` 이면 그래프 에디터 endpoint 사용 가능.
+
+    디자인 §7 의 graceful degradation: 첫 release cycle 동안 admin 이
+    명시적으로 켜야 한다. 기본 off — 운영자가 의도하지 않은 mutation
+    을 실수로 invoke 할 수 없게.
+    """
+    v = os.environ.get("JAMES_GRAPH_EDIT", "").strip()
+    return v in ("1", "true", "TRUE", "yes", "on")
+
+
+__all__ = [
+    # write API
+    "replace_relation_sources",
+    "append_relation_source",
+    "delete_relation",
+    # read API
+    "read_relation",
+    # env flag
+    "graph_edit_enabled",
+    # helpers (kept exported — graph_node_editor + tests import them directly)
+    "_FM_SPLIT_RE",
+    "_read_entity",
+    "_write_entity",
+    "_load_entity_by_id",
+    "_inverse_type",
+    "_label_for_type",
+    "_find_relation_index",
+    "_validate_sources",
+]

--- a/core/graph_editor/_helpers.py
+++ b/core/graph_editor/_helpers.py
@@ -1,0 +1,183 @@
+"""Graph editor — shared helpers (file I/O + ontology + relation lookup).
+
+Frontmatter read/write, entity-by-id loader, ontology-driven
+forward/inverse type pair, relation-index search, and the
+source-list normalizer/validator. Used by every write operation in
+``_writes.py`` and by the ``read_relation`` accessor in the
+package facade.
+
+Split out of the monolithic ``core/graph_editor.py`` in Stage C.5
+(2026-05-24) so the package respects CLAUDE.md rule #5 (< 20 KB
+per file).
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from core.relations_schema import (
+    MANUAL_SOURCE_ROLE,
+    VALID_SOURCE_ROLES,
+)
+
+
+_FM_SPLIT_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+# ─────────────────────────────────────────────────────────────────
+# entity 파일 I/O (cascade.py 의 helper 와 동일 패턴이지만 dedup 안 함
+# — 두 모듈은 독립 lifecycle 이라 미세 결합 회피)
+# ─────────────────────────────────────────────────────────────────
+
+def _read_entity(path: Path) -> Optional[Tuple[Dict[str, Any], str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    m = _FM_SPLIT_RE.match(text)
+    if not m:
+        return None
+    try:
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(fm, dict):
+        return None
+    return fm, m.group(2)
+
+
+def _write_entity(path: Path, fm: Dict[str, Any], body: str) -> None:
+    text = yaml.safe_dump(
+        fm, allow_unicode=True, sort_keys=False, default_flow_style=False,
+    ).rstrip()
+    path.write_text(f"---\n{text}\n---\n{body}", encoding="utf-8")
+
+
+def _load_entity_by_id(
+    entity_id: str,
+    wiki_generator,
+) -> Tuple[Path, Dict[str, Any], str]:
+    """entity_id → (path, frontmatter, body). 없으면 ValueError."""
+    idx = getattr(wiki_generator, "entity_id_index", {}) or {}
+    path = idx.get(entity_id)
+    if not path:
+        # 인덱스 미스 — fresh rebuild 한 번 시도
+        try:
+            wiki_generator.refresh_entity_map()
+            path = wiki_generator.entity_id_index.get(entity_id)
+        except Exception:
+            path = None
+    if not path:
+        raise ValueError(f"entity_id not found: {entity_id}")
+    parsed = _read_entity(Path(path))
+    if not parsed:
+        raise ValueError(f"entity file unreadable: {path}")
+    fm, body = parsed
+    return Path(path), fm, body
+
+
+# ─────────────────────────────────────────────────────────────────
+# ontology — forward/inverse type pair 도출
+# ─────────────────────────────────────────────────────────────────
+
+def _inverse_type(forward_type: str) -> str:
+    """ontology 가 정의한 inverse type 을 반환. 미정의면 자신 (대칭).
+
+    RELATED_TO 같은 대칭 relation 은 inverse 가 자신과 같다. 비대칭
+    (BELONGS_TO ↔ HAS_MEMBER) 은 명시적 mapping. 정의 부재 시 안전한
+    fallback 으로 forward 와 같은 type 반환.
+    """
+    try:
+        from core.ontology import RELATION_TYPES, normalize_relation
+    except ImportError:
+        return forward_type
+    std = normalize_relation(forward_type)
+    info = RELATION_TYPES.get(std, {})
+    inv = info.get("inverse")
+    return inv or std
+
+
+def _label_for_type(rel_type: str) -> str:
+    try:
+        from core.ontology import RELATION_TYPES, get_relation_label
+    except ImportError:
+        return rel_type
+    info = RELATION_TYPES.get(rel_type, {})
+    if info.get("label"):
+        return info["label"]
+    return get_relation_label(rel_type) or rel_type
+
+
+# ─────────────────────────────────────────────────────────────────
+# relation 매칭 + sources 합성
+# ─────────────────────────────────────────────────────────────────
+
+def _find_relation_index(
+    relations: List[Dict[str, Any]],
+    target_id: str,
+    rel_type:  str,
+) -> Optional[int]:
+    """frontmatter 의 ``relations`` 배열에서 (target_id, type) 매칭
+    relation 의 index 반환. 같은 (target_id, type) 가 여러 개 있으면
+    첫 번째. None 이면 매칭 없음."""
+    for i, rel in enumerate(relations):
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("target_id") == target_id and rel.get("type") == rel_type:
+            return i
+    return None
+
+
+def _validate_sources(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """클라이언트가 보낸 sources 배열을 정규화 + 검증.
+
+    - dict 가 아닌 항목은 drop.
+    - weight 는 [0.0, 1.0] 으로 clamp.
+    - role 은 VALID_SOURCE_ROLES 중 하나여야 함 (외 → 예외).
+    - manual / extract 등 모든 role 허용 — 보안 결정은 endpoint 에서
+      (admin 만 호출 가능).
+    - ts 가 없으면 now() 로 채움.
+    """
+    out: List[Dict[str, Any]] = []
+    now_iso = datetime.now().isoformat()
+    for s in sources or []:
+        if not isinstance(s, dict):
+            continue
+        role = s.get("role")
+        if role not in VALID_SOURCE_ROLES:
+            raise ValueError(f"invalid source role: {role!r}")
+        try:
+            w = float(s.get("weight", 0.0))
+        except (TypeError, ValueError):
+            w = 0.0
+        w = max(0.0, min(1.0, w))
+        entry: Dict[str, Any] = {
+            "doc_id": s.get("doc_id"),
+            "weight": w,
+            "role":   role,
+            "ts":     s.get("ts") or now_iso,
+        }
+        # optional metadata for manual sources
+        if role == MANUAL_SOURCE_ROLE:
+            if s.get("author"):
+                entry["author"] = str(s["author"])[:80]
+            if s.get("note"):
+                entry["note"] = str(s["note"])[:300]
+        out.append(entry)
+    return out
+
+
+__all__ = [
+    "_FM_SPLIT_RE",
+    "_read_entity",
+    "_write_entity",
+    "_load_entity_by_id",
+    "_inverse_type",
+    "_label_for_type",
+    "_find_relation_index",
+    "_validate_sources",
+]

--- a/core/graph_editor/_writes.py
+++ b/core/graph_editor/_writes.py
@@ -1,220 +1,36 @@
-"""
-PROJECT JAMES — Knowledge Cascade Phase E (graph editor backend).
+"""Graph editor — 3 edge-mutation operations (PUT / POST / DELETE).
 
-docs/design/v0.3-knowledge-cascade.md §7 — Phase E.
+The bilaterally-synced write operations called by ``/admin/graph/relation``:
 
-`/admin/graph` 의 admin 이 edge 별 sources 를 직접 수정할 수 있게 하는
-3 endpoint 의 코어 로직. UI 가 클릭한 edge 의 source list / weight /
-role 을 받아 양방향 entity 파일의 frontmatter relation 의 ``sources``
-배열을 갱신한다.
+- ``replace_relation_sources`` — PUT semantics; entire sources array
+  swapped on both forward + inverse entities
+- ``append_relation_source`` — POST semantics; commutative single-
+  source append
+- ``delete_relation`` — DELETE; remove the relation entirely from
+  both entities
 
-Phase B (PR #269) 가 ingestion 시점에 `sources` 를 stamp 하고
-Phase C (PR #270) 가 cascade 가 manual source 를 보존하도록 만들었기
-때문에, Phase E 의 manual source write 는 자연스럽게 cascade-안전:
-admin 이 추가한 ``role=manual`` source 는 doc 파일 삭제 시에도
-유지된다.
+Each returns an audit-friendly diff dict (``before`` / ``after``
+sources arrays on each side) consumed by the audit-log writer.
 
-Trust model (§7):
-  - admin 만 호출 가능 (server endpoint 에서 admin.data feature gate
-    + ``JAMES_GRAPH_EDIT=1`` env flag opt-in).
-  - 모든 write 는 양쪽 (forward + inverse) entity 파일에 동시 반영.
-  - audit log 에 before+after sources 배열 차이 기록.
-  - 두 admin 의 동시 PUT 은 last-writer-wins. POST (append) 는 commutative.
+Split out of the monolithic ``core/graph_editor.py`` in Stage C.5
+(2026-05-24). All three are re-exported from
+``core.graph_editor`` so existing import paths keep working.
 """
 from __future__ import annotations
 
-import os
-import re
-from datetime import datetime
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
-import yaml
+from core.relations_schema import compute_confidence_from_sources
 
-from core.relations_schema import (
-    MANUAL_SOURCE_ROLE,
-    VALID_SOURCE_ROLES,
-    compute_confidence_from_sources,
+from ._helpers import (
+    _find_relation_index,
+    _inverse_type,
+    _label_for_type,
+    _load_entity_by_id,
+    _validate_sources,
+    _write_entity,
 )
 
-
-_FM_SPLIT_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
-
-
-# ─────────────────────────────────────────────────────────────────
-# entity 파일 I/O (cascade.py 의 helper 와 동일 패턴이지만 dedup 안 함
-# — 두 모듈은 독립 lifecycle 이라 미세 결합 회피)
-# ─────────────────────────────────────────────────────────────────
-
-def _read_entity(path: Path) -> Optional[Tuple[Dict[str, Any], str]]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
-    m = _FM_SPLIT_RE.match(text)
-    if not m:
-        return None
-    try:
-        fm = yaml.safe_load(m.group(1)) or {}
-    except yaml.YAMLError:
-        return None
-    if not isinstance(fm, dict):
-        return None
-    return fm, m.group(2)
-
-
-def _write_entity(path: Path, fm: Dict[str, Any], body: str) -> None:
-    text = yaml.safe_dump(
-        fm, allow_unicode=True, sort_keys=False, default_flow_style=False,
-    ).rstrip()
-    path.write_text(f"---\n{text}\n---\n{body}", encoding="utf-8")
-
-
-def _load_entity_by_id(
-    entity_id: str,
-    wiki_generator,
-) -> Tuple[Path, Dict[str, Any], str]:
-    """entity_id → (path, frontmatter, body). 없으면 ValueError."""
-    idx = getattr(wiki_generator, "entity_id_index", {}) or {}
-    path = idx.get(entity_id)
-    if not path:
-        # 인덱스 미스 — fresh rebuild 한 번 시도
-        try:
-            wiki_generator.refresh_entity_map()
-            path = wiki_generator.entity_id_index.get(entity_id)
-        except Exception:
-            path = None
-    if not path:
-        raise ValueError(f"entity_id not found: {entity_id}")
-    parsed = _read_entity(Path(path))
-    if not parsed:
-        raise ValueError(f"entity file unreadable: {path}")
-    fm, body = parsed
-    return Path(path), fm, body
-
-
-# ─────────────────────────────────────────────────────────────────
-# ontology — forward/inverse type pair 도출
-# ─────────────────────────────────────────────────────────────────
-
-def _inverse_type(forward_type: str) -> str:
-    """ontology 가 정의한 inverse type 을 반환. 미정의면 자신 (대칭).
-
-    RELATED_TO 같은 대칭 relation 은 inverse 가 자신과 같다. 비대칭
-    (BELONGS_TO ↔ HAS_MEMBER) 은 명시적 mapping. 정의 부재 시 안전한
-    fallback 으로 forward 와 같은 type 반환.
-    """
-    try:
-        from core.ontology import RELATION_TYPES, normalize_relation
-    except ImportError:
-        return forward_type
-    std = normalize_relation(forward_type)
-    info = RELATION_TYPES.get(std, {})
-    inv = info.get("inverse")
-    return inv or std
-
-
-def _label_for_type(rel_type: str) -> str:
-    try:
-        from core.ontology import RELATION_TYPES, get_relation_label
-    except ImportError:
-        return rel_type
-    info = RELATION_TYPES.get(rel_type, {})
-    if info.get("label"):
-        return info["label"]
-    return get_relation_label(rel_type) or rel_type
-
-
-# ─────────────────────────────────────────────────────────────────
-# relation 매칭 + sources 합성
-# ─────────────────────────────────────────────────────────────────
-
-def _find_relation_index(
-    relations: List[Dict[str, Any]],
-    target_id: str,
-    rel_type:  str,
-) -> Optional[int]:
-    """frontmatter 의 ``relations`` 배열에서 (target_id, type) 매칭
-    relation 의 index 반환. 같은 (target_id, type) 가 여러 개 있으면
-    첫 번째. None 이면 매칭 없음."""
-    for i, rel in enumerate(relations):
-        if not isinstance(rel, dict):
-            continue
-        if rel.get("target_id") == target_id and rel.get("type") == rel_type:
-            return i
-    return None
-
-
-def read_relation(
-    src_entity_id: str,
-    tgt_entity_id: str,
-    relation_type: str,
-    *,
-    wiki_generator,
-) -> Optional[Dict[str, Any]]:
-    """forward 측 entity 의 frontmatter 에서 매칭 relation dict 를 그대로
-    반환 (sources 배열 포함). 없으면 None.
-
-    UI 의 edit modal 이 edge 클릭 시 sources 를 fresh load 하기 위한
-    read path. snapshot endpoint 에 sources 를 넣지 않은 이유는 213
-    entity × N relation × N source 면 wire payload 가 폭증하기 때문 —
-    on-demand fetch 로 격리.
-    """
-    src_path, src_fm, _body = _load_entity_by_id(src_entity_id, wiki_generator)
-    _ = src_path   # unused
-    rels = src_fm.get("relations") or []
-    idx = _find_relation_index(rels, tgt_entity_id, relation_type)
-    if idx is None:
-        return None
-    rel = rels[idx]
-    # 안전한 복사본 — caller 가 변형해도 frontmatter 무영향
-    if isinstance(rel, dict):
-        return dict(rel)
-    return None
-
-
-def _validate_sources(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """클라이언트가 보낸 sources 배열을 정규화 + 검증.
-
-    - dict 가 아닌 항목은 drop.
-    - weight 는 [0.0, 1.0] 으로 clamp.
-    - role 은 VALID_SOURCE_ROLES 중 하나여야 함 (외 → 예외).
-    - manual / extract 등 모든 role 허용 — 보안 결정은 endpoint 에서
-      (admin 만 호출 가능).
-    - ts 가 없으면 now() 로 채움.
-    """
-    out: List[Dict[str, Any]] = []
-    now_iso = datetime.now().isoformat()
-    for s in sources or []:
-        if not isinstance(s, dict):
-            continue
-        role = s.get("role")
-        if role not in VALID_SOURCE_ROLES:
-            raise ValueError(f"invalid source role: {role!r}")
-        try:
-            w = float(s.get("weight", 0.0))
-        except (TypeError, ValueError):
-            w = 0.0
-        w = max(0.0, min(1.0, w))
-        entry: Dict[str, Any] = {
-            "doc_id": s.get("doc_id"),
-            "weight": w,
-            "role":   role,
-            "ts":     s.get("ts") or now_iso,
-        }
-        # optional metadata for manual sources
-        if role == MANUAL_SOURCE_ROLE:
-            if s.get("author"):
-                entry["author"] = str(s["author"])[:80]
-            if s.get("note"):
-                entry["note"] = str(s["note"])[:300]
-        out.append(entry)
-    return out
-
-
-# ─────────────────────────────────────────────────────────────────
-# Public API — 3 mutation operations
-# ─────────────────────────────────────────────────────────────────
 
 def replace_relation_sources(
     src_entity_id: str,
@@ -476,22 +292,8 @@ def delete_relation(
     }
 
 
-# Node-level attribute editor (PR-O6) lives in ``core/graph_node_editor.py``
-# so this module stays focused on edge-level mutations under the 20 KB
-# rule #5 gate. The two modules share the file I/O helpers above via
-# direct import.
-
-
-# ─────────────────────────────────────────────────────────────────
-# Env flag helper (디자인 §7 — JAMES_GRAPH_EDIT=1 opt-in)
-# ─────────────────────────────────────────────────────────────────
-
-def graph_edit_enabled() -> bool:
-    """``JAMES_GRAPH_EDIT=1`` 이면 그래프 에디터 endpoint 사용 가능.
-
-    디자인 §7 의 graceful degradation: 첫 release cycle 동안 admin 이
-    명시적으로 켜야 한다. 기본 off — 운영자가 의도하지 않은 mutation
-    을 실수로 invoke 할 수 없게.
-    """
-    v = os.environ.get("JAMES_GRAPH_EDIT", "").strip()
-    return v in ("1", "true", "TRUE", "yes", "on")
+__all__ = [
+    "replace_relation_sources",
+    "append_relation_source",
+    "delete_relation",
+]


### PR DESCRIPTION
## Summary

Splits the boundary-case 20.1 KB monolithic \`core/graph_editor.py\` into a 3-module package. Resolves PLATFORM_READINESS Gate v0.3 dimension A for this file (**5th of five violations** after C.1/C.2/C.3/C.4).

**Module-size violations: 5 → 0. Gate A fully cleared.**

**Pure refactor**: no signatures, return shapes, or behaviour changed.

## File sizes (post-split)

| File | Size | Role |
|---|---|---|
| \`__init__.py\` | 4.3 KB | facade + \`read_relation\` + \`graph_edit_enabled\` |
| \`_helpers.py\` | 6.8 KB | frontmatter I/O + ontology helpers + relation lookup + sources validator |
| \`_writes.py\` | 11.0 KB | 3 bilateral mutation ops (replace/append/delete) |

All three files comfortably under the 20 KB gate.

## Module layout

\`\`\`
L0 helpers (yaml + ontology lazy) → _helpers.py
L1 writes (use _helpers)         → _writes.py
L1 facade (re-exports + flag)    → __init__.py
\`\`\`

No circular deps. Lazy \`core.ontology\` import preserved verbatim.

## External surface preserved

All current import paths work byte-identical:
- \`replace_relation_sources\` / \`append_relation_source\` / \`delete_relation\` / \`read_relation\` / \`graph_edit_enabled\` — server_llmwiki.py
- \`_load_entity_by_id\` / \`_write_entity\` — core/graph_node_editor.py (private helper share)
- Full re-export — test_phase_e_graph_editor.py + test_event_admin_endpoint.py

## Verification

- tests/test_phase_e_graph_editor.py + test_event_admin_endpoint.py — **57/57 pass**
- Full pytest suite (CI ignore list): **1590 passed + 823 subtests passed**. Zero regression.
- \`scripts/dogfood_check.py\` — 4/4 plugin invariants PASS.
- \`ruff check core/graph_editor/\` — clean.

## Stage C — ALL CLEAR

- C.1 (wiki_generator.py 51 KB) — ✅ PR #427
- C.2 (cascade.py 24 KB) — ✅ PR #428
- C.3 (character_profile.py 24 KB) — ✅ PR #429
- C.4 (security_layer.py 23 KB) — ✅ PR #431
- **C.5 (graph_editor.py 20 KB) — ✅ this PR**

**All 5 module-size violations cleared. PLATFORM_READINESS Gate v0.3 dimension A satisfied.**

## v0.3 → v0.4 gate remaining

- **Stage B — CR-E** (self-evolution approval → CR shadow row). Last Done-when criterion.
- **Stage E.1** — operator live re-verification (30-50 min).

After Stage B merges, v0.3 → v0.4 gate clears (all 6 dimensions + 4 Done-when satisfied).

## Test plan

- [x] tests/test_phase_e_graph_editor.py + test_event_admin_endpoint.py (57/57)
- [x] Full pytest (1590 + 823 subtests)
- [x] \`scripts/dogfood_check.py\` (4/4)
- [x] ruff clean
- [ ] CI \`tests\` passes
- [ ] CI \`lint\` / \`packs-eval\` / \`security\` / \`cla\` remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)