### PR TITLE
feat(cr): Stage B CR-E.2 — /admin/patch/approve writes self_evo_patch shadow CR row

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -3886,6 +3886,42 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
         if not rec_ok:
             raise HTTPException(status_code=500, detail=f"approval_record_failed: {rec.get('error')}")
 
+        # Stage B / CR-E.2 (2026-05-24) — shadow Change Request row.
+        # Best-effort dual-write so /admin/audit/cr can surface the
+        # approval event with the same shape as wiki_entity / run_jobs
+        # CRs. The legacy james_patch_log.jsonl + record_outcome below
+        # remain authoritative for the deploy timeline; the CR row is
+        # additive and its apply handler is a no-op (Stage B CR-E.1
+        # in core/change_request_apply.py). Failures here NEVER block
+        # the deploy path.
+        cr_shadow_id = None
+        try:
+            import hashlib as _hashlib
+            import json as _json_cr
+            from core.change_request import (
+                TARGET_SELF_EVO_PATCH, create_cr as _cr_create,
+            )
+            _patch_canon = _json_cr.dumps(rec, sort_keys=True, ensure_ascii=False)
+            _base_hash = _hashlib.sha256(_patch_canon.encode("utf-8")).hexdigest()[:16]
+            _shadow = _cr_create(
+                target_type   = TARGET_SELF_EVO_PATCH,
+                target_id     = patch_id,
+                title         = f"patch:{patch_id}",
+                description   = f"approval_method={approval_method}",
+                proposed_diff = {
+                    "target":            rec.get("target", ""),
+                    "patch_id":          patch_id,
+                    "approver_username": approver_username,
+                    "approval_method":   approval_method,
+                },
+                base_hash = _base_hash,
+                proposer  = approver_username or "<system>",
+                role      = role,
+            )
+            cr_shadow_id = _shadow.cr_id
+        except Exception:
+            pass
+
         # Re-load with approval fields baked in so apply() sees the
         # final patch shape (forward-compat — applier may grow to
         # honor approval metadata).
@@ -3895,6 +3931,13 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
         # If apply() itself failed, no bench gate to run — record and exit.
         if not ok:
             record_outcome(patch_id, "rolled_back", detail=f"apply failed: {msg}")
+            if cr_shadow_id is not None:
+                try:
+                    from core.change_request import reject_cr as _cr_reject
+                    _cr_reject(cr_shadow_id, reviewer=approver_username,
+                               reason=f"apply_failed: {msg[:100]}")
+                except Exception:
+                    pass
             return {
                 "success":           False,
                 "message":           msg,
@@ -3919,6 +3962,26 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
             before_metrics=gate.before_metrics,
             after_metrics=gate.after_metrics,
         )
+
+        # Stage B / CR-E.2 — close the shadow CR row. Bench-gate pass
+        # → merge_cr; regression → reject_cr (legacy lifecycle already
+        # rolled back the file). Best-effort.
+        if cr_shadow_id is not None:
+            try:
+                if gate.passed:
+                    from core.change_request_apply import merge_cr as _cr_merge
+                    _cr_merge(cr_shadow_id, approver=approver_username)
+                else:
+                    from core.change_request import reject_cr as _cr_reject
+                    _cr_reject(
+                        cr_shadow_id,
+                        reviewer=approver_username,
+                        reason=f"bench_regression: {gate.outcome_label}: "
+                               f"{(gate.detail or '')[:100]}",
+                    )
+            except Exception:
+                pass
+
         return {
             "success":           gate.passed,
             "message":           msg,


### PR DESCRIPTION
## Summary

**Second of the 4-PR Stage B sequence (CR-E).** Wires shadow Change Request write into the patch-approval endpoint. Dual-write strategy: \`james_patch_log.jsonl\` stays authoritative for the deploy timeline; CR row is additive shadow with a no-op apply handler (CR-E.1 #433).

## What changed

Single endpoint — \`/admin/patch/approve\` (server_llmwiki.py:3821). **Three new try/except blocks, no existing lines modified**:

1. **After \`record_approval\`** — \`create_cr(target_type=TARGET_SELF_EVO_PATCH, ...)\`. Returns \`cr_shadow_id\`.
2. **In \`apply()\` failure branch** — \`reject_cr(cr_shadow_id, reason=\"apply_failed: ...\")\`. Mirrors legacy \`record_outcome(..., \"rolled_back\")\`.
3. **After \`record_outcome\` (bench gate)** — \`merge_cr(...)\` on \`gate.passed\`, \`reject_cr(...)\` on bench regression.

All three blocks wrapped in \`try/except Exception: pass\`. **CR write failure NEVER blocks legacy deploy path.**

## Why "new lines only"

Three of the four locked tests use \`inspect.getsource(srv)\` substring assertions to pin the endpoint contract. **All substrings remain literally findable** because new lines surround them, never edit them:

- \`test_self_evolution_gate.py:174-186\` — 5 substrings pinned
- \`test_evolution_bench_gate.py:251-268\` — 4 substrings pinned
- \`test_evolution_audit_query.py:243-264\` — 3 substrings pinned

## Shadow CR shape

| Field | Value |
|---|---|
| target_type | \"self_evo_patch\" |
| target_id | patch_id |
| title | f\"patch:{patch_id}\" |
| description | f\"approval_method={approval_method}\" |
| proposed_diff | {target, patch_id, approver_username, approval_method} |
| base_hash | sha256(json.dumps(rec, sort_keys=True))[:16] |
| proposer | approver_username (fallback \"\<system>\") |
| role | caller's resolved role |

**Terminal states**:
| Path | CR status | Reason / approver |
|---|---|---|
| gate.passed | merged | merged_by = approver_username |
| apply_failed | rejected | \"apply_failed: {msg[:100]}\" |
| bench_regression | rejected | \"bench_regression: {outcome_label}: {detail[:100]}\" |

## Verification

- **All 4 locked tests pass**:
  - test_self_evolution_gate.py
  - test_evolution_bench_gate.py
  - test_evolution_rollback.py (no new write to \`james_patch_log.jsonl\` — shadow goes to CR DB)
  - test_evolution_audit_query.py
- Combined 4 locked + CR tests: **106 passed + 6 subtests**.
- Full pytest (CI ignore list): **1600 passed + 823 subtests passed**. Zero regression.
- ruff check server_llmwiki.py — clean.

## Stage B (CR-E) progress

- CR-E.1 (target enum + dispatch) — ✅ PR #433
- **CR-E.2 (patch-approve shadow write) — ✅ this PR**
- CR-E.3 (proposal-approve/reject shadow write) — pending
- CR-E.4 (audit query unify legacy JSONL + CR-shadow) — pending

## Rollback

\`git revert <this commit>\` removes the three CR call sites cleanly. Shadow CR rows already written remain in the DB as orphan (no impact on legacy flow).

## Test plan

- [x] 4 locked tests (106 + 6 subtests)
- [x] CR shadow tests (10/10)
- [x] Full pytest (1600 + 823 subtests)
- [x] ruff clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)