### PR TITLE
feat(cr): Stage B CR-E.3 — /admin/proposals/{id}/approve|reject writes self_evo_proposal shadow CR row

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -1914,11 +1914,44 @@ async def list_proposals(
         return {"proposals": [], "error": str(e)}
 
 
+def _cr_shadow_proposal_create(proposal_id: str, approver: str, role: str,
+                               action: str) -> Optional[str]:
+    """Stage B / CR-E.3 — best-effort shadow CR row for proposal events.
+
+    Returns the cr_id on success, None on any failure. The legacy
+    /admin/proposals/{id}/approve|reject flow continues regardless —
+    the CR row is additive shadow with a no-op apply handler (CR-E.1).
+    """
+    try:
+        import hashlib as _hashlib
+        from core.change_request import (
+            TARGET_SELF_EVO_PROPOSAL, create_cr as _cr_create,
+        )
+        _base = _hashlib.sha256(
+            f"proposal:{proposal_id}:{action}".encode("utf-8")
+        ).hexdigest()[:16]
+        shadow = _cr_create(
+            target_type   = TARGET_SELF_EVO_PROPOSAL,
+            target_id     = proposal_id,
+            title         = f"proposal:{action}:{proposal_id}",
+            description   = f"endpoint=/admin/proposals/{proposal_id}/{action}",
+            proposed_diff = {"proposal_id": proposal_id, "action": action,
+                             "approver": approver},
+            base_hash = _base,
+            proposer  = approver,
+            role      = role,
+        )
+        return shadow.cr_id
+    except Exception:
+        return None
+
+
 @app.post("/admin/proposals/{proposal_id}/approve",
           summary="제안 승인 → 자동 실행 [P7-EVO]")
 async def approve_proposal(
     proposal_id: str,
     api_key:     str,
+    request:     Request,
     role:        str = Depends(get_role_from_request),
 ):
     """
@@ -1926,14 +1959,47 @@ async def approve_proposal(
     실행 결과를 응답으로 반환.
     """
     _require_feature(api_key, role, "admin.evolution")
+
+    # Stage B / CR-E.3 — shadow CR row. Best-effort dual-write so the
+    # unified audit shape covers proposal approvals alongside patch
+    # approvals + wiki/run_jobs CRs. The legacy james_evo_log.jsonl +
+    # _write_audit(...) below remain authoritative.
+    approver = _bearer_username(request) or f"<role:{role}>"
+    cr_shadow_id = _cr_shadow_proposal_create(
+        proposal_id, approver, role, action="approve",
+    )
+
     try:
         from tools.self.evo_analyzer import approve_and_execute
         report = approve_and_execute(proposal_id)
         _write_audit(role, "/admin/proposals/approve",
                      query=proposal_id,
                      answer=f"success={report.get('success')}")
+
+        # CR-E.3 close — merge on success, reject on executor failure.
+        if cr_shadow_id is not None:
+            try:
+                if report.get("success"):
+                    from core.change_request_apply import merge_cr as _cr_merge
+                    _cr_merge(cr_shadow_id, approver=approver)
+                else:
+                    from core.change_request import reject_cr as _cr_reject
+                    _cr_reject(
+                        cr_shadow_id, reviewer=approver,
+                        reason=f"executor_failed: {str(report)[:100]}",
+                    )
+            except Exception:
+                pass
+
         return report
     except Exception as e:
+        if cr_shadow_id is not None:
+            try:
+                from core.change_request import reject_cr as _cr_reject
+                _cr_reject(cr_shadow_id, reviewer=approver,
+                           reason=f"exception: {str(e)[:100]}")
+            except Exception:
+                pass
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -1942,17 +2008,48 @@ async def approve_proposal(
 async def reject_proposal_api(
     proposal_id: str,
     api_key:     str,
+    request:     Request,
     reason:      str = "",
     role:        str = Depends(get_role_from_request),
 ):
     """[4-C] 제안 거부 + 사유 장기기억 저장."""
     _require_feature(api_key, role, "admin.evolution")
+
+    # Stage B / CR-E.3 — shadow CR row for reject path. Same dual-write
+    # rationale as approve_proposal above.
+    approver = _bearer_username(request) or f"<role:{role}>"
+    cr_shadow_id = _cr_shadow_proposal_create(
+        proposal_id, approver, role, action="reject",
+    )
+
     try:
         from tools.self.evo_analyzer import reject_proposal
         ok = reject_proposal(proposal_id, reason)
         _write_audit(role, "/admin/proposals/reject", query=proposal_id)
+
+        # CR-E.3 close — reject_cr regardless of `ok` (the endpoint
+        # IS the reject action; ok=False just means the storage write
+        # failed). Reason mirrors the admin-supplied reason.
+        if cr_shadow_id is not None:
+            try:
+                from core.change_request import reject_cr as _cr_reject
+                _cr_reject(
+                    cr_shadow_id, reviewer=approver,
+                    reason=(reason or "admin_rejected")[:200]
+                           + (" (storage_failed)" if not ok else ""),
+                )
+            except Exception:
+                pass
+
         return {"success": ok, "proposal_id": proposal_id}
     except Exception as e:
+        if cr_shadow_id is not None:
+            try:
+                from core.change_request import reject_cr as _cr_reject
+                _cr_reject(cr_shadow_id, reviewer=approver,
+                           reason=f"exception: {str(e)[:100]}")
+            except Exception:
+                pass
         raise HTTPException(status_code=500, detail=str(e))
 
 


### PR DESCRIPTION
## Summary

**Third of the 4-PR Stage B sequence (CR-E).** Wires shadow Change Request writes into both proposal endpoints. Same dual-write strategy as CR-E.2: legacy \`james_evo_log.jsonl\` + \`_write_audit\` stay authoritative; CR row is additive shadow with no-op apply (CR-E.1 #433, CR-E.2 #434).

## What changed — single file (server_llmwiki.py:1900-1956)

### \`_cr_shadow_proposal_create\` — new helper (module-level)
Builds + writes a shadow CR row. Returns cr_id on success, None on failure. Shared by both endpoints to avoid duplicate scaffolding.

### \`approve_proposal\`
- Added \`request: Request\` parameter so \`_bearer_username(request)\` reads the JWT subject. No existing param removed.
- Pre-execute: \`_cr_shadow_proposal_create(..., action=\"approve\")\`.
- Post-execute: \`merge_cr\` on success, \`reject_cr\` on executor_failed / exception.

### \`reject_proposal_api\`
- Added \`request: Request\` (same rationale).
- Pre-execute: \`_cr_shadow_proposal_create(..., action=\"reject\")\`.
- Post-execute: \`reject_cr\` with admin-supplied reason (mirror).

All CR calls wrapped in \`try/except Exception: pass\`. **CR write failure NEVER blocks legacy proposal flow.**

## Approver identity

\`_bearer_username(request)\` (existing helper used by 9 other endpoints) returns JWT subject; falls back to \`f\"<role:{role}>\"\` so CR \`proposer\` is never empty.

## Terminal CR states

| Endpoint | Outcome | CR status | Reason |
|---|---|---|---|
| /approve | report.success=True | merged | merged_by = approver |
| /approve | report.success=False | rejected | \"executor_failed: {report[:100]}\" |
| /approve | uncaught exception | rejected | \"exception: {e[:100]}\" |
| /reject | ok=True | rejected | admin-supplied reason (or \"admin_rejected\") |
| /reject | ok=False | rejected | reason + \" (storage_failed)\" |
| /reject | uncaught exception | rejected | \"exception: {e[:100]}\" |

## Verification

- 4 locked tests + CR + 2 proposal-using chat tests pass: **125 passed + 6 subtests**.
- Full pytest (CI ignore list): **1600 passed + 823 subtests passed**. Zero regression.
- ruff check server_llmwiki.py — clean.

## Stage B (CR-E) progress

- CR-E.1 (target enum + dispatch) — ✅ PR #433
- CR-E.2 (patch-approve shadow write) — ✅ PR #434
- **CR-E.3 (proposal-approve/reject shadow write) — ✅ this PR**
- CR-E.4 (audit query unify) — pending

After CR-E.4 merges, the **last** v0.3 → v0.4 Done-when criterion is satisfied.

## Test plan

- [x] 4 locked tests pass (no JSONL behaviour change)
- [x] CR shadow tests (10/10)
- [x] Proposal-using chat tests pass (signature compat for \`request\` param)
- [x] Full pytest (1600 + 823 subtests)
- [x] ruff clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)