### PR TITLE
feat(cr): Stage B CR-E.4 — /admin/patch/audit unifies legacy JSONL + CR-shadow

### DIFF
--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -4096,12 +4096,13 @@ async def admin_patch_approve(request: Request, role: str = Depends(get_role_fro
 
 @app.get("/admin/patch/audit", summary="Patch 라이프사이클 감사 조회 [#68 phase 2-C]")
 async def admin_patch_audit(
-    api_key:  str,
-    since:    str = "",
-    approver: str = "",
-    outcome:  str = "",
-    limit:    int = 200,
-    role:     str = Depends(get_role_from_request),
+    api_key:        str,
+    since:          str  = "",
+    approver:       str  = "",
+    outcome:        str  = "",
+    limit:          int  = 200,
+    include_shadow: bool = True,
+    role:           str  = Depends(get_role_from_request),
 ):
     """Filtered, newest-first slice of `james_patch_log.jsonl`.
 
@@ -4111,6 +4112,10 @@ async def admin_patch_audit(
       outcome:  case-insensitive `outcome` match — `deployed` /
                 `rolled_back` / `deployed_gate_skipped`
       limit:    max entries returned (default 200, hard cap 1000)
+      include_shadow: when True (default), merges projected self-evolution
+                     CR-shadow rows (Stage B / CR-E) into the feed. Each
+                     shadow row carries ``_source='cr_shadow'``. Set False
+                     to get the byte-identical pre-CR-E view.
 
     See `tools/patch/audit_query.py` for filter semantics + rationale.
     Composes with `/admin/audit` (the broader, multi-source feed) —
@@ -4123,13 +4128,15 @@ async def admin_patch_audit(
         approver=approver or None,
         outcome=outcome or None,
         limit=limit,
+        include_shadow=include_shadow,
     )
     return {
         "filters": {
-            "since":    since,
-            "approver": approver,
-            "outcome":  outcome,
-            "limit":    limit,
+            "since":          since,
+            "approver":       approver,
+            "outcome":        outcome,
+            "limit":          limit,
+            "include_shadow": include_shadow,
         },
         "count": len(rows),
         "events": rows,

--- a/tests/test_audit_query_cr_shadow.py
+++ b/tests/test_audit_query_cr_shadow.py
@@ -1,0 +1,242 @@
+"""Stage B / CR-E.4 — unified audit query (legacy JSONL + CR-shadow).
+
+Verifies `tools.patch.audit_query.query_patch_audit` correctly merges
+projected CR-shadow rows (self_evo_patch + self_evo_proposal) with
+legacy JSONL rows when ``include_shadow=True``. The projection map
+(_CR_STATUS_TO_EVENT / _CR_STATUS_TO_OUTCOME) is pinned here so a
+schema drift on either side fails this file rather than silently
+producing a malformed audit feed.
+
+Invariants pinned:
+
+1. ``include_shadow=False`` (default) → byte-identical to the
+   pre-CR-E read path. Legacy callers see no change.
+2. ``include_shadow=True`` merges CR rows with legacy JSONL rows
+   before the sort + limit.
+3. Projected rows carry ``_source='cr_shadow'`` + ``_cr_id`` +
+   ``_target_type`` so UIs can distinguish.
+4. CR status → event mapping: open=APPROVED, merged=DEPLOYED,
+   rejected=ROLLED_BACK.
+5. CR status → outcome mapping: open=None, merged=deployed,
+   rejected=rolled_back.
+6. The since / approver / outcome filters apply uniformly to both
+   legacy rows AND CR-shadow rows.
+7. ``cr_db_path`` test seam works — the projection reads from the
+   supplied path, not the production CR DB.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import core.change_request as cr_mod
+from core.change_request import (
+    TARGET_SELF_EVO_PATCH, TARGET_SELF_EVO_PROPOSAL,
+    create_cr, reject_cr,
+)
+from core.change_request_apply import merge_cr
+from tools.patch.audit_query import (
+    _CR_STATUS_TO_EVENT,
+    _CR_STATUS_TO_OUTCOME,
+    _cr_row_to_audit_entry,
+    query_patch_audit,
+)
+
+
+def _write_log(path: Path, entries: list) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+
+class ProjectionMapTests(unittest.TestCase):
+    """Pin the CR status → JSONL event/outcome mapping."""
+
+    def test_event_map_covers_all_status_values(self):
+        self.assertEqual(_CR_STATUS_TO_EVENT["open"], "APPROVED")
+        self.assertEqual(_CR_STATUS_TO_EVENT["merged"], "DEPLOYED")
+        self.assertEqual(_CR_STATUS_TO_EVENT["rejected"], "ROLLED_BACK")
+
+    def test_outcome_map_aligns_with_legacy_jsonl(self):
+        self.assertIsNone(_CR_STATUS_TO_OUTCOME["open"])
+        self.assertEqual(_CR_STATUS_TO_OUTCOME["merged"], "deployed")
+        self.assertEqual(_CR_STATUS_TO_OUTCOME["rejected"], "rolled_back")
+
+
+class _CrShadowFixture(unittest.TestCase):
+    """Each test gets a fresh empty CR DB on a tempfile."""
+
+    def setUp(self):
+        self._tmp_cr = tempfile.NamedTemporaryFile(
+            suffix=".db", delete=False,
+        )
+        self._tmp_cr.close()
+        cr_mod.init_db(self._tmp_cr.name)
+        self._saved_default = cr_mod._DEFAULT_DB
+        cr_mod._DEFAULT_DB = self._tmp_cr.name
+
+        self._tmp_log = tempfile.NamedTemporaryFile(
+            suffix=".jsonl", delete=False, mode="w", encoding="utf-8",
+        )
+        self._tmp_log.close()
+
+    def tearDown(self):
+        cr_mod._DEFAULT_DB = self._saved_default
+        for p in (self._tmp_cr.name, self._tmp_log.name):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+class CrRowProjectionTests(_CrShadowFixture):
+    def test_open_status_projects_to_approved_event(self):
+        cr = create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-open-1",
+            title="patch:p-open-1", proposed_diff={}, base_hash="h",
+            proposer="alice", role="admin",
+            db_path=self._tmp_cr.name,
+        )
+        entry = _cr_row_to_audit_entry(cr)
+        self.assertEqual(entry["event"], "APPROVED")
+        self.assertIsNone(entry["outcome"])
+        self.assertEqual(entry["patch_id"], "p-open-1")
+        self.assertEqual(entry["approver_username"], "alice")
+        self.assertEqual(entry["_source"], "cr_shadow")
+        self.assertEqual(entry["_target_type"], TARGET_SELF_EVO_PATCH)
+        self.assertEqual(entry["approver_role"], "from_cr_shadow")
+        self.assertEqual(entry["approval_method"], "shadow_cr")
+
+    def test_merged_status_projects_to_deployed(self):
+        cr = create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-merged-1",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self._tmp_cr.name,
+        )
+        merged = merge_cr(cr.cr_id, approver="bob")
+        entry = _cr_row_to_audit_entry(merged)
+        self.assertEqual(entry["event"], "DEPLOYED")
+        self.assertEqual(entry["outcome"], "deployed")
+        self.assertEqual(entry["approver_username"], "bob")  # merged_by wins
+
+    def test_rejected_status_projects_to_rolled_back(self):
+        cr = create_cr(
+            target_type=TARGET_SELF_EVO_PROPOSAL, target_id="prop-rej-1",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self._tmp_cr.name,
+        )
+        rejected = reject_cr(cr.cr_id, reviewer="carol",
+                             reason="bench_regression: outcome=rolled_back: …")
+        entry = _cr_row_to_audit_entry(rejected)
+        self.assertEqual(entry["event"], "ROLLED_BACK")
+        self.assertEqual(entry["outcome"], "rolled_back")
+        self.assertIn("bench_regression", entry["detail"])
+        self.assertEqual(entry["_target_type"], TARGET_SELF_EVO_PROPOSAL)
+
+
+class IncludeShadowToggleTests(_CrShadowFixture):
+    def test_include_shadow_false_is_byte_identical_to_legacy(self):
+        # 2 legacy lines
+        _write_log(Path(self._tmp_log.name), [
+            {"time": "2026-05-08T09:00:00", "event": "APPROVED",
+             "patch_id": "p1", "approver_username": "alice"},
+            {"time": "2026-05-08T09:01:00", "event": "DEPLOYED",
+             "patch_id": "p1", "outcome": "deployed"},
+        ])
+        # 1 CR shadow row (must not appear)
+        create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-shadow",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self._tmp_cr.name,
+        )
+        rows = query_patch_audit(
+            log_path=self._tmp_log.name,
+            include_shadow=False,
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all("_source" not in r for r in rows))
+
+    def test_include_shadow_true_merges_cr_rows(self):
+        _write_log(Path(self._tmp_log.name), [
+            {"time": "2026-05-08T09:00:00", "event": "APPROVED",
+             "patch_id": "p1", "approver_username": "alice"},
+        ])
+        create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-shadow",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="alice", db_path=self._tmp_cr.name,
+        )
+        rows = query_patch_audit(
+            log_path=self._tmp_log.name,
+            include_shadow=True,
+            cr_db_path=self._tmp_cr.name,
+        )
+        # 1 legacy + 1 shadow
+        self.assertEqual(len(rows), 2)
+        sources = [r.get("_source") for r in rows]
+        self.assertIn("cr_shadow", sources)
+        self.assertIn(None, sources)
+
+    def test_filters_apply_uniformly_to_legacy_and_shadow(self):
+        _write_log(Path(self._tmp_log.name), [
+            {"time": "2026-05-08T09:00:00", "event": "APPROVED",
+             "patch_id": "p1", "approver_username": "alice"},
+            {"time": "2026-05-08T10:00:00", "event": "DEPLOYED",
+             "patch_id": "p1", "approver_username": "alice",
+             "outcome": "deployed"},
+        ])
+        # Two shadow rows.
+        #   - cr_a: proposer=bob, merged_by=alice → projection
+        #           approver_username=alice (merged_by wins) → caught by filter
+        #   - cr_b: proposer=bob, status=open    → projection
+        #           approver_username=bob (proposer) → excluded by filter
+        # merge_cr enforces approver != proposer (invariant #7), so the
+        # cross-user pair is the natural shape for testing the filter.
+        cr_a = create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-shadow-a",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="bob", db_path=self._tmp_cr.name,
+        )
+        merge_cr(cr_a.cr_id, approver="alice")
+        create_cr(
+            target_type=TARGET_SELF_EVO_PATCH, target_id="p-shadow-b",
+            title="t", proposed_diff={}, base_hash="h",
+            proposer="bob", db_path=self._tmp_cr.name,
+        )
+        # approver="alice" filter must catch both legacy AND the
+        # merged-by-alice shadow, while excluding bob's open shadow.
+        rows = query_patch_audit(
+            approver="alice",
+            log_path=self._tmp_log.name,
+            include_shadow=True,
+            cr_db_path=self._tmp_cr.name,
+        )
+        approver_set = {r.get("approver_username") for r in rows}
+        self.assertEqual(approver_set, {"alice"},
+                         f"approver filter should constrain both sources; got {rows}")
+        # Sanity — expect exactly 3: 2 legacy alice rows + 1 alice-merged shadow.
+        self.assertEqual(len(rows), 3, f"unexpected row count: {rows}")
+
+    def test_no_shadow_rows_in_empty_cr_db(self):
+        # Pre-CR-E feed — legacy lines only, CR DB never written to.
+        _write_log(Path(self._tmp_log.name), [
+            {"time": "2026-05-08T09:00:00", "event": "APPROVED",
+             "patch_id": "p1", "approver_username": "alice"},
+        ])
+        rows = query_patch_audit(
+            log_path=self._tmp_log.name,
+            include_shadow=True,
+            cr_db_path=self._tmp_cr.name,
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertNotIn("_source", rows[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evolution_audit_query.py
+++ b/tests/test_evolution_audit_query.py
@@ -248,8 +248,13 @@ class EndpointContractTests(unittest.TestCase):
         # gates this endpoint; both enforce admin authority for the
         # admin.evolution feature.
         idx = src.index('@app.get("/admin/patch/audit"')
-        # Window: 1500 chars after the decorator covers the handler body.
-        window = src[idx:idx + 1500]
+        # Window: 2200 chars after the decorator covers the handler body.
+        # Bumped from 1500 in Stage B / CR-E.4 (2026-05-24) — the
+        # include_shadow query param + the new docstring paragraph
+        # documenting the dual-source merge pushed the response-shape
+        # block past the old window. The shape contract (filters /
+        # count / events keys + admin gating) is unchanged.
+        window = src[idx:idx + 2200]
         self.assertTrue(
             "_require_admin(api_key, role)" in window
             or '_require_feature(api_key, role, "admin.evolution")' in window,

--- a/tools/patch/audit_query.py
+++ b/tools/patch/audit_query.py
@@ -37,6 +37,7 @@ flagged in the docstring's deferred-work block.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
@@ -45,12 +46,87 @@ DEFAULT_LIMIT = 200
 MAX_LIMIT = 1000
 
 
+# Stage B / CR-E.4 (2026-05-24) — projection map from CR status →
+# legacy JSONL event/outcome. The shadow rows produced by /admin/
+# patch/approve (CR-E.2) and /admin/proposals/{id}/approve|reject
+# (CR-E.3) carry the same audit semantics in the CR table — this
+# mapping surfaces them through the same /admin/patch/audit endpoint.
+_CR_STATUS_TO_EVENT = {
+    "open":     "APPROVED",         # in-flight; legacy writes this on record_approval
+    "merged":   "DEPLOYED",         # legacy writes this on bench-pass record_outcome
+    "rejected": "ROLLED_BACK",      # legacy writes this on apply_failed / bench_regression
+}
+_CR_STATUS_TO_OUTCOME = {
+    "open":     None,               # legacy 'APPROVED' lines also lack 'outcome'
+    "merged":   "deployed",
+    "rejected": "rolled_back",
+}
+
+
+def _cr_row_to_audit_entry(cr) -> dict:
+    """Project a ``ChangeRequest`` row into the legacy JSONL entry
+    shape. Keys mirror ``tools/patch/approval.py`` writers so the
+    same filters (since / approver / outcome) work uniformly across
+    both sources."""
+    ts_epoch = cr.merged_at if cr.merged_at is not None else cr.created_at
+    try:
+        time_iso = datetime.fromtimestamp(int(ts_epoch)).isoformat()
+    except Exception:
+        time_iso = ""
+    return {
+        "time":              time_iso,
+        "event":             _CR_STATUS_TO_EVENT.get(cr.status, "SHADOW_CR"),
+        "patch_id":          cr.target_id,
+        "approver_username": cr.merged_by or cr.proposer,
+        "approver_role":     "from_cr_shadow",
+        "approval_method":   "shadow_cr",
+        "outcome":           _CR_STATUS_TO_OUTCOME.get(cr.status),
+        "detail":            cr.reject_reason or "",
+        # CR-source markers — operator UI can colour these differently
+        # from legacy JSONL rows if it wants.
+        "_source":           "cr_shadow",
+        "_cr_id":            cr.cr_id,
+        "_target_type":      cr.target_type,
+    }
+
+
+def _load_cr_shadow_rows(db_path: Optional[str] = None) -> List[dict]:
+    """Fetch self-evo CR rows + project to legacy-JSONL shape.
+
+    Best-effort: missing CR DB / import failure / unknown target_type
+    → empty list. Never raises. The caller (query_patch_audit) merges
+    these with legacy JSONL rows before sort + limit.
+    """
+    try:
+        from core.change_request import (
+            TARGET_SELF_EVO_PATCH, TARGET_SELF_EVO_PROPOSAL,
+            list_crs,
+        )
+    except Exception:
+        return []
+    out: List[dict] = []
+    for target in (TARGET_SELF_EVO_PATCH, TARGET_SELF_EVO_PROPOSAL):
+        try:
+            crs = list_crs(target_type=target, limit=500, db_path=db_path)
+        except Exception:
+            continue
+        for cr in crs:
+            try:
+                out.append(_cr_row_to_audit_entry(cr))
+            except Exception:
+                continue
+    return out
+
+
 def query_patch_audit(
     since:    Optional[str] = None,
     approver: Optional[str] = None,
     outcome:  Optional[str] = None,
     limit:    int           = DEFAULT_LIMIT,
     log_path: Optional[str] = None,
+    *,
+    include_shadow: bool          = False,
+    cr_db_path:     Optional[str] = None,
 ) -> List[dict]:
     """Return filtered patch lifecycle entries, newest-first.
 
@@ -61,12 +137,21 @@ def query_patch_audit(
                 deployed_gate_skipped). None → no filter.
       limit:    max entries returned. Clamped to [1, MAX_LIMIT].
       log_path: override file path (test seam). Default `james_patch_log.jsonl`.
+      include_shadow: Stage B / CR-E.4 — when True, merge projected
+                     self_evo_patch / self_evo_proposal CR rows into
+                     the result. Each shadow row carries
+                     ``_source='cr_shadow'`` so UIs can distinguish.
+                     Default False keeps legacy callers byte-identical;
+                     the /admin/patch/audit endpoint sets this to True.
+      cr_db_path:    override CR DB path (test seam). Default
+                     ``core.change_request._DEFAULT_DB``.
 
     Returns:
-      A list of lifecycle dicts as parsed from the JSONL, sorted by
-      `time` descending. Each dict carries at minimum `event`, `time`,
-      `patch_id`, plus event-specific fields (approver_*, outcome,
-      before/after_metrics, detail).
+      A list of lifecycle dicts sorted by ``time`` descending. Each
+      dict carries at minimum ``event``, ``time``, ``patch_id``, plus
+      event-specific fields (approver_*, outcome, before/after_metrics,
+      detail). When ``include_shadow=True`` shadow CR rows are merged
+      in with the legacy JSONL rows before the sort.
     """
     path = Path(log_path or PATCH_LOG_PATH)
     if not path.exists():
@@ -120,6 +205,23 @@ def query_patch_audit(
         # Outer read failure → return what we have. The endpoint
         # surfaces an empty-or-partial list rather than a 500.
         pass
+
+    # Stage B / CR-E.4 — merge projected CR-shadow rows (best-effort).
+    if include_shadow:
+        for entry in _load_cr_shadow_rows(cr_db_path):
+            if since_norm:
+                t = entry.get("time") or ""
+                if t < since_norm:
+                    continue
+            if approver_norm:
+                a = (entry.get("approver_username") or "").lower()
+                if a != approver_norm:
+                    continue
+            if outcome_norm:
+                o = (entry.get("outcome") or "").lower()
+                if o != outcome_norm:
+                    continue
+            rows.append(entry)
 
     # Newest-first by `time`. Entries without a time field sink to the
     # bottom (very old / malformed).


### PR DESCRIPTION
## Summary

**Final PR of the 4-PR Stage B sequence (CR-E).** Surfaces the self_evo_patch + self_evo_proposal shadow CR rows (written by CR-E.2 #434 and CR-E.3 #435) through the existing \`/admin/patch/audit\` endpoint, projected into the same legacy JSONL entry shape so the same filter set (since / approver / outcome) works uniformly across both sources.

**After this PR merges**:
> ✅ Every self-evolution approval row HAS a paired Change Request row.

That closes the **last v0.3 → v0.4 Done-when criterion**. PLATFORM_READINESS Gate v0.3 fully satisfied.

## What changed

### \`tools/patch/audit_query.py\`
- New \`_CR_STATUS_TO_EVENT\` / \`_CR_STATUS_TO_OUTCOME\` projection maps
- New \`_cr_row_to_audit_entry(cr)\` — projects ChangeRequest → legacy JSONL dict shape (time / event / patch_id / approver_username / outcome / detail + _source / _cr_id / _target_type markers)
- New \`_load_cr_shadow_rows(db_path)\` — best-effort fetch + project for both self_evo target_types
- \`query_patch_audit\` gained \`include_shadow: bool = False\` + \`cr_db_path: Optional[str] = None\` kw-only params
- Same filter set applies uniformly to both sources before global sort

### \`server_llmwiki.py\`
- \`/admin/patch/audit\` endpoint gained \`include_shadow\` query parameter (**default True** — production wants the unified feed)
- Forwards into query_patch_audit + surfaces in \`filters\` response key

### \`tests/test_evolution_audit_query.py\`
- Source-level test window bumped 1500 → 2200 chars to accommodate the new docstring + param. Shape contract unchanged.

### \`tests/test_audit_query_cr_shadow.py\` (NEW, 9 tests)
- **ProjectionMapTests (2)** — pin CR status → event/outcome mapping
- **CrRowProjectionTests (3)** — round-trip each terminal state (open / merged / rejected)
- **IncludeShadowToggleTests (4)**:
  - \`test_include_shadow_false_is_byte_identical_to_legacy\` — default off keeps pre-CR-E feed unchanged
  - \`test_include_shadow_true_merges_cr_rows\` — both sources visible
  - \`test_filters_apply_uniformly_to_legacy_and_shadow\` — approver filter constrains both sources (uses cross-user fixture for merge_cr's approver-≠-proposer invariant)
  - \`test_no_shadow_rows_in_empty_cr_db\` — graceful empty case

## CR status → legacy JSONL projection

| CR status | event | outcome | source of approver_username |
|---|---|---|---|
| open | APPROVED | (none) | proposer |
| merged | DEPLOYED | deployed | merged_by |
| rejected | ROLLED_BACK | rolled_back | proposer (reject_reason in detail) |

## Verification

- **4 locked tests + CR-E tests + new shadow tests: 115 passed + 6 subtests**:
  - test_self_evolution_gate / test_evolution_bench_gate / test_evolution_rollback (unchanged behaviour)
  - test_evolution_audit_query (window bumped; shape preserved)
  - test_change_request_core / _self_evo (CR-E.1 stays green)
  - test_audit_query_cr_shadow (NEW, 9/9)
- **Full pytest suite (CI ignore list): 1609 passed + 823 subtests passed**. Zero regression (was 1600; this PR adds +9 tests).
- ruff check on touched files — clean.

## Stage B (CR-E) — DONE

| PR | Status |
|---|---|
| CR-E.1 (target enum + dispatch) | ✅ #433 |
| CR-E.2 (patch-approve shadow write) | ✅ #434 |
| CR-E.3 (proposal-approve/reject shadow write) | ✅ #435 |
| **CR-E.4 (audit query unify) — this PR** | ✅ |

## v0.3 → v0.4 gate — fully clear after merge

| Criterion | Status |
|---|---|
| Gate A (module size < 20 KB) | ✅ Stage C 5/5 |
| Gate B (Plugin API 8 PRs) | ✅ |
| Gate C (RAGAS + STEP-N + pack-level) | ✅ |
| Gate D (JAMES_WORKSPACE) | ✅ |
| Gate E (PolicyEngine) | ✅ |
| Gate F (Single-user reproducible) | ✅ |
| Done-when 1 (external author trial) | ⚠️ infra ready, awaits Ali mid-June |
| Done-when 2 (dogfood test) | ✅ |
| **Done-when 3 (self-evolution ↔ CR pairing)** | **✅ this PR** |
| Done-when 4 (CLA Assistant gate) | ✅ |

**v0.4 Layer 4 design review can begin.**

## Test plan

- [x] 4 locked tests + CR-E.1/2/3 tests + new CR-E.4 shadow tests pass
- [x] Full pytest (1609 + 823 subtests, +9 over CR-E.3 baseline)
- [x] ruff clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)