### PR TITLE
fix(graph): node label Korean glyphs — Malgun/Apple SD/Noto KR before Inter

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -813,7 +813,17 @@
     var canvas = document.createElement('canvas');
     canvas.width = 256; canvas.height = 64;
     var ctx = canvas.getContext('2d');
-    ctx.font = 'bold 24px Inter, "Pretendard", system-ui, sans-serif';
+    // Korean-first fallback chain — canvas glyph fallback is browser-
+    // dependent and unreliable on Chromium when the primary font lacks
+    // CJK glyphs (Inter has zero Hangul coverage). Putting native CJK
+    // faces first guarantees an "엔비디아" / "삼성전자" node label
+    // renders as Hangul on every platform JAMES targets:
+    //   - Windows KO     → Malgun Gothic (preinstalled)
+    //   - macOS          → Apple SD Gothic Neo (preinstalled)
+    //   - Linux / no CJK → Noto Sans KR (if loaded), else system-ui
+    //   - Latin nodes    → Inter still applies (covers ASCII first)
+    ctx.font = 'bold 24px "Malgun Gothic", "Apple SD Gothic Neo", ' +
+               '"Noto Sans KR", "Pretendard", Inter, system-ui, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     // Drop-shadow for readability against any background.


### PR DESCRIPTION
## Summary

Surfaced during 2026-05-24 Stage E.1 Tier 1 live verification (B-2, graph node click). Korean entity labels (예: "엔비디아", "삼성전자") rendered as blank/box/"?" on graph node sprites while Latin labels rendered fine.

**Root cause**: \`createTextSprite\` in \`frontend/static/graph.js:816\` set the canvas font as:

\`\`\`js
ctx.font = 'bold 24px Inter, "Pretendard", system-ui, sans-serif'
\`\`\`

Inter has zero Hangul coverage. Pretendard is preferred but **not preinstalled** on Windows/macOS (graph page doesn't \`@font-face\` it). Chromium's per-glyph fallback when the primary font lacks a glyph is inconsistent → tofu/blank on Korean nodes.

**Fix**: reorder to put a native CJK face first:

\`\`\`js
ctx.font = 'bold 24px "Malgun Gothic", "Apple SD Gothic Neo", ' +
           '"Noto Sans KR", "Pretendard", Inter, system-ui, sans-serif'
\`\`\`

Coverage:
- Windows KO → Malgun Gothic (preinstalled)
- macOS → Apple SD Gothic Neo (preinstalled)
- Linux + Noto pack → Noto Sans KR
- Pretendard installed → uses that
- Latin-only fallback → Inter / system-ui

## Verification

- \`ruff check .\` clean (no Python touched)
- Frontend-only single-line change
- Manual (post-merge): hard-refresh \`/graph\` → Korean nodes display Hangul

## Out of scope

- Bundling Pretendard as @font-face for the whole admin UI (separate PR if operator wants unified rendering)
- Other canvas text — grep confirmed admin.js/chat.js use DOM text (CSS-driven), not canvas, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)