### PR TITLE
fix(wiki): body `## 요약` reflects entity summary — ingest mirror + builder fallback

### DIFF
--- a/core/wiki_generator/_frontmatter.py
+++ b/core/wiki_generator/_frontmatter.py
@@ -348,6 +348,19 @@ class WikiFrontmatterMixin:
 
         confidence = min(round(0.7 + 0.3 * len(attributes), 2), 1.0)
 
+        # [B-2-A fix] canonical summary lookup. Caller passes top-level
+        # `summary` (preferred — _ingestion.py mirrors it from
+        # `attributes.summary`). Fall back through `attributes.summary`
+        # and `description` so older callers that haven't been updated
+        # still produce a non-empty `## 요약` body section. Cap at 500 to
+        # keep the YAML frontmatter line-bounded.
+        summary_text = (
+            entity.get("summary")
+            or attributes.get("summary")
+            or entity.get("description")
+            or ""
+        )[:500]
+
         frontmatter = {
             # ── 식별 정보 ──
             "entity_id":       entity_id,
@@ -355,6 +368,11 @@ class WikiFrontmatterMixin:
             "name":            name,
             "normalized_name": normalized,
             "aliases":         aliases,
+            # ── Summary (top-level, canonical) ──
+            # Top-level `summary` is the canonical field; `attributes.summary`
+            # is the legacy duplicate kept for back-compat. Resync scripts
+            # treat top-level as source of truth.
+            "summary":         summary_text,
             # ── Event time axis (PR-11b) — only present on events ──
             **(
                 {
@@ -396,8 +414,12 @@ class WikiFrontmatterMixin:
             + yaml.dump(frontmatter, allow_unicode=True, default_flow_style=False)
             + "---\n\n"
             f"## 요약\n"
-            # [U-1] summary 우선, 없으면 description
-            f"{entity.get('summary', '') or entity.get('description', '')}\n\n"
+            # [B-2-A fix] reuse the canonical `summary_text` computed
+            # above. The old logic only checked top-level `summary` /
+            # `description`, which left the body blank when the caller
+            # placed the value at `attributes.summary` (the ingest path
+            # before B-2-A always did).
+            f"{summary_text}\n\n"
             f"## 관계\n{rel_summary}\n"
         )
 

--- a/core/wiki_generator/_ingestion.py
+++ b/core/wiki_generator/_ingestion.py
@@ -111,11 +111,19 @@ class WikiIngestionMixin:
                 name, extracted.get("relations", []),
                 doc_id=doc_entity_id, ts=ingest_ts,
             )
+            # [B-2-A fix] top-level `summary` mirrors `attributes.summary`
+            # so the wiki body builder (`_frontmatter.py:create_entity_file`)
+            # can populate `## 요약`. The builder only reads top-level keys;
+            # without this mirror every newly-ingested entity's body section
+            # stays empty even though `attributes.summary` carries the LLM
+            # description.
+            _desc = (ent.get("description") or "")[:300]
             payload = {
                 "name":        name,
                 "type":        etype,
+                "summary":     _desc,
                 "attributes":  {
-                    "summary":          (ent.get("description") or "")[:300],
+                    "summary":          _desc,
                     "source_document":  filename,
                 },
                 "relations":   ent_relations,
@@ -182,11 +190,15 @@ class WikiIngestionMixin:
         ]
         kw = metadata.get("keywords", [])
         kw_str = ", ".join(str(k) for k in kw) if isinstance(kw, list) else str(kw)
+        # [B-2-A fix] mirror top-level summary for the document entity too —
+        # same reason as the entity-extract branch above.
+        _doc_summary = (metadata.get("summary") or "")[:500]
         doc_payload = {
             "name":        doc_name,
             "type":        "document",
+            "summary":     _doc_summary,
             "attributes":  {
-                "summary":   (metadata.get("summary") or "")[:500],
+                "summary":   _doc_summary,
                 "category":  metadata.get("category", "기타"),
                 "keywords":  kw_str,
             },

--- a/scripts/resync_wiki_summary_body.py
+++ b/scripts/resync_wiki_summary_body.py
@@ -1,0 +1,240 @@
+"""Resync the `## 요약` body section of every wiki entity from its
+frontmatter `summary` field.
+
+## Why this script exists
+
+Before B-2-A (PR #445), the ingest path stored the LLM description at
+`attributes.summary` but the wiki body builder
+(`core/wiki_generator/_frontmatter.py:create_entity_file`) read only
+top-level `summary` / `description`. The result: every entity .md file
+under `wiki/entity/**` was written with a blank `## 요약` section even
+when `attributes.summary` carried a real description.
+
+PR #445 fixes the *forward* path — new ingests now mirror the value to
+top-level `summary` and the body builder picks it up. This script
+patches the *backlog*: roughly 100s of entity files already on disk
+whose bodies are stale.
+
+It is intentionally a one-shot script (the same pattern as
+`cleanup_web_noise_entities.py`), not a runtime hook — touching every
+wiki file on every startup would be wasteful and would mask future
+bugs in the forward path.
+
+## What it changes
+
+For each `wiki/entity/**/*.md`:
+
+1. Parse the frontmatter (PyYAML).
+2. Resolve the canonical summary:
+   `fm.get("summary") or fm.get("attributes", {}).get("summary") or ""`
+3. Find the `## 요약\\n` ... `\\n## 관계` window in the body and rewrite
+   the content between them to the canonical summary.
+4. If frontmatter top-level `summary` is missing but
+   `attributes.summary` exists, also write top-level (canonical).
+
+Files where the body is *already* in sync are left untouched.
+
+## Usage
+
+    python scripts/resync_wiki_summary_body.py              # dry-run
+    python scripts/resync_wiki_summary_body.py --apply      # write
+    python scripts/resync_wiki_summary_body.py --apply --verbose
+
+## Safety
+
+- Dry-run by default. Prints diff-style per-file output.
+- `--apply` writes files in place. Run on a clean working tree so
+  `git diff` shows the resync delta.
+- Skips files that don't parse as wiki entities (no `entity_id` /
+  `entity_type` in frontmatter).
+- Skips files whose body already matches the canonical value (idempotent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import yaml
+
+
+WIKI_ROOT = Path(__file__).resolve().parent.parent / "wiki" / "entity"
+
+# Body window: `## 요약\n<content>\n## 관계` — capture <content>.
+# DOTALL so `.` spans newlines; non-greedy so we stop at the first `## 관계`.
+_BODY_PAT = re.compile(
+    r"(## 요약\n)(.*?)(\n## 관계)",
+    re.DOTALL,
+)
+
+
+def _split_frontmatter(raw: str) -> Tuple[dict, str, str]:
+    """Return (frontmatter dict, raw frontmatter text, body text).
+
+    Wiki files follow `---\\n<yaml>\\n---\\n\\n<body>`. If the format
+    doesn't match, returns ({}, "", raw) so the caller can skip.
+    """
+    if not raw.startswith("---\n"):
+        return {}, "", raw
+    rest = raw[4:]
+    end = rest.find("\n---\n")
+    if end < 0:
+        return {}, "", raw
+    fm_text = rest[:end]
+    body = rest[end + 5 :]
+    try:
+        fm = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        return {}, "", raw
+    if not isinstance(fm, dict):
+        return {}, "", raw
+    return fm, fm_text, body
+
+
+def _canonical_summary(fm: dict) -> str:
+    """Top-level first, then `attributes.summary`, then empty."""
+    top = fm.get("summary")
+    if isinstance(top, str) and top.strip():
+        return top.strip()
+    attrs = fm.get("attributes") or {}
+    if isinstance(attrs, dict):
+        attr_sum = attrs.get("summary")
+        if isinstance(attr_sum, str) and attr_sum.strip():
+            return attr_sum.strip()
+    return ""
+
+
+def _rewrite_body(body: str, summary: str) -> Tuple[str, bool]:
+    """Replace the `## 요약` body content with `summary`.
+
+    Returns (new_body, changed). If the body lacks the `## 요약\\n...\\n## 관계`
+    structure, returns (body, False).
+    """
+    m = _BODY_PAT.search(body)
+    if not m:
+        return body, False
+    current = m.group(2).strip()
+    if current == summary.strip():
+        return body, False
+    new = _BODY_PAT.sub(
+        # group 1 = "## 요약\n", group 3 = "\n## 관계"; rebuild with new content.
+        lambda mm: mm.group(1) + summary + (("\n" if summary else "")) + mm.group(3),
+        body,
+        count=1,
+    )
+    return new, True
+
+
+def process_file(path: Path, apply: bool, verbose: bool) -> Tuple[bool, str]:
+    """Return (changed, message).
+
+    `changed` is True if the file would be rewritten (or was, when --apply).
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return False, f"SKIP {path}: read error: {e}"
+
+    fm, _fm_text, body = _split_frontmatter(raw)
+    if not fm:
+        return False, f"SKIP {path}: no parseable frontmatter"
+    if "entity_id" not in fm or "entity_type" not in fm:
+        return False, f"SKIP {path}: not a wiki entity (no entity_id/type)"
+
+    summary = _canonical_summary(fm)
+    if not summary:
+        return False, f"SKIP {path}: no summary in frontmatter"
+
+    new_body, body_changed = _rewrite_body(body, summary)
+    fm_changed = False
+    new_fm = dict(fm)
+    if not isinstance(new_fm.get("summary"), str) or not new_fm["summary"].strip():
+        new_fm["summary"] = summary
+        fm_changed = True
+
+    if not body_changed and not fm_changed:
+        if verbose:
+            return False, f"OK   {path}: already in sync"
+        return False, ""
+
+    if apply:
+        new_fm_text = yaml.dump(
+            new_fm, allow_unicode=True, default_flow_style=False, sort_keys=True
+        )
+        out = f"---\n{new_fm_text}---\n{new_body}" if not new_body.startswith("\n") else f"---\n{new_fm_text}---{new_body}"
+        path.write_text(out, encoding="utf-8")
+        tag = "WROTE"
+    else:
+        tag = "WOULD"
+
+    parts = []
+    if body_changed:
+        parts.append("body")
+    if fm_changed:
+        parts.append("fm.summary")
+    return True, f"{tag} {path}: {'+'.join(parts)} -> {summary[:60]!r}"
+
+
+def main() -> int:
+    # Korean summaries contain characters (en-dash, fullwidth punct) that
+    # crash on Windows' default cp949 console. Force UTF-8 so dry-run
+    # output is readable regardless of locale.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually rewrite files (default: dry-run)",
+    )
+    ap.add_argument(
+        "--verbose",
+        action="store_true",
+        help="print every file (including no-op skips)",
+    )
+    ap.add_argument(
+        "--root",
+        type=Path,
+        default=WIKI_ROOT,
+        help=f"wiki entity root (default: {WIKI_ROOT})",
+    )
+    args = ap.parse_args()
+
+    if not args.root.is_dir():
+        print(f"ERROR: {args.root} is not a directory", file=sys.stderr)
+        return 2
+
+    files = sorted(args.root.rglob("*.md"))
+    if not files:
+        print(f"no .md files found under {args.root}")
+        return 0
+
+    changed = 0
+    skipped = 0
+    for f in files:
+        ch, msg = process_file(f, apply=args.apply, verbose=args.verbose)
+        if ch:
+            changed += 1
+            print(msg)
+        elif msg:
+            skipped += 1
+            print(msg)
+
+    mode = "APPLIED" if args.apply else "DRY-RUN"
+    print()
+    print(f"{mode}: {changed} file(s) {'rewritten' if args.apply else 'would change'}, "
+          f"{len(files) - changed} unchanged.")
+    if not args.apply and changed > 0:
+        print("Rerun with --apply to write changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_wiki_summary_body_sync.py
+++ b/tests/test_wiki_summary_body_sync.py
@@ -1,0 +1,142 @@
+"""B-2-A — wiki body `## 요약` section must reflect the entity summary.
+
+Surfaced 2026-05-24 Stage E.1 live verification (B-2 graph): the node
+side-panel showed an empty `## 요약` section even though the
+frontmatter `summary` field was populated. Root cause: the ingest path
+stored the LLM description at `attributes.summary`, but the wiki body
+builder only read top-level `summary` / `description`. Result: every
+newly-ingested entity had a blank body section on disk.
+
+These tests pin the contract so the regression can't reappear:
+
+1. When the caller passes `attributes.summary`, the body's `## 요약`
+   section must contain that value (back-compat for callers that
+   haven't been updated to mirror).
+2. When the caller passes top-level `summary`, the body must contain
+   it (preferred path).
+3. Top-level `summary` wins when both are set (canonical).
+4. Frontmatter top-level `summary` is *always* populated (even when
+   the caller only provided `attributes.summary`) so resync /
+   downstream readers have a single source of truth.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+
+class _WikiSummaryBodyBase(unittest.TestCase):
+    """Same setup pattern as test_event_ingest_emit — isolate WIKI_DIR,
+    bypass memory/verify and vector-store side effects so we can drive
+    create_entity_file from a clean tmp dir."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
+        self.wiki_dir_patcher.start()
+        import core.wiki_generator as wg_mod
+        self._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = self.tmp
+
+        self.verify_patcher = patch(
+            "core.memory.verify_before_write",
+            return_value=(True, "ok", 0.99),
+        )
+        self.verify_patcher.start()
+        self.vs_patcher = patch("core.vector_store.VectorStore")
+        self.vs_patcher.start()
+        self.router_patcher = patch("llm.router.RouterWrapper")
+        self.router_patcher.start()
+
+        from core.wiki_generator import WikiGenerator
+        self.wg = WikiGenerator(source_type="test")
+
+    def tearDown(self):
+        self.wiki_dir_patcher.stop()
+        self.verify_patcher.stop()
+        self.vs_patcher.stop()
+        self.router_patcher.stop()
+        import core.wiki_generator as wg_mod
+        wg_mod.WIKI_DIR = self._orig_wiki_dir
+
+    def _read(self, path: Path):
+        raw = path.read_text(encoding="utf-8")
+        parts = raw.split("---", 2)
+        fm = yaml.safe_load(parts[1]) if len(parts) >= 3 else {}
+        body = parts[2] if len(parts) >= 3 else ""
+        return fm, body
+
+
+class WikiSummaryBodyTests(_WikiSummaryBodyBase):
+
+    def test_attributes_summary_populates_body(self):
+        """Legacy caller passing `attributes.summary` only — body must
+        still get filled (the bug we just fixed)."""
+        entity = {
+            "name":        "엔비디아",
+            "type":        "org",
+            "attributes":  {"summary": "AI 칩 시장의 주요 기업"},
+            "relations":   [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "src.md", ["c1"]))
+        fm, body = self._read(out)
+        self.assertIn("## 요약\nAI 칩 시장의 주요 기업\n", body)
+        # And the canonical top-level summary is populated.
+        self.assertEqual(fm["summary"], "AI 칩 시장의 주요 기업")
+
+    def test_top_level_summary_populates_body(self):
+        """Updated caller passing top-level `summary` directly."""
+        entity = {
+            "name":        "엔비디아",
+            "type":        "org",
+            "summary":     "GPU 제조 기업",
+            "attributes":  {},
+            "relations":   [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "src.md", ["c1"]))
+        fm, body = self._read(out)
+        self.assertIn("## 요약\nGPU 제조 기업\n", body)
+        self.assertEqual(fm["summary"], "GPU 제조 기업")
+
+    def test_top_level_wins_when_both_set(self):
+        """Disagreement between top-level and attributes — top-level is
+        canonical (matches the resync script's resolution order)."""
+        entity = {
+            "name":        "엔비디아",
+            "type":        "org",
+            "summary":     "GPU 제조 기업",
+            "attributes":  {"summary": "AI 칩 시장의 주요 기업"},
+            "relations":   [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "src.md", ["c1"]))
+        fm, body = self._read(out)
+        self.assertIn("## 요약\nGPU 제조 기업\n", body)
+        self.assertNotIn("AI 칩 시장의 주요 기업", body)
+        self.assertEqual(fm["summary"], "GPU 제조 기업")
+
+    def test_no_summary_anywhere_yields_empty_body_section(self):
+        """When no summary is supplied at all, the body section is
+        present but empty — not crashing, not duplicating, just blank.
+        This matches the pre-fix shape for entities ingested without a
+        description and keeps the section header stable for the resync
+        script's regex window."""
+        entity = {
+            "name":        "이름만있음",
+            "type":        "concept",
+            "attributes":  {},
+            "relations":   [],
+        }
+        out = Path(self.wg.create_entity_file(entity, "src.md", ["c1"]))
+        _fm, body = self._read(out)
+        # Header present + content empty + ## 관계 follows immediately.
+        self.assertIn("## 요약\n\n", body)
+        self.assertIn("## 관계", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Surfaced in 2026-05-24 Stage E.1 live verification (B-2 graph): node side-panel for "엔비디아" showed an empty \`## 요약\` section even though frontmatter carried \`attributes.summary: AI 칩 시장의 주요 기업\` and later (via a separate path) top-level \`summary: GPU 제조 기업\`. Two payload-key paths had drifted apart and the body was the casualty.

**Root cause** — two-step data path mismatch:
1. **Ingest** (\`_ingestion.py:114-124\`) stored LLM description at \`payload["attributes"]["summary"]\` only — top-level \`payload["summary"]\` was never set
2. **Body builder** (\`_frontmatter.py:400\`) only read \`entity.get("summary") or entity.get("description")\` — never looked at \`entity.attributes.summary\`

→ Every newly-ingested entity got a blank \`## 요약\` body. A separate downstream path later patched top-level \`summary\` onto frontmatters but didn't re-render the body, so values diverged — exactly what live verification surfaced.

## Fix (three pieces)

1. **Ingest mirrors top-level summary** — \`_ingestion.py\` sets both \`payload["summary"]\` and \`payload["attributes"]["summary"]\` from the same source (entity + document payloads).
2. **Builder uses wider fallback + writes canonical summary** — \`_frontmatter.py\` resolves once via \`top-level → attributes.summary → description\`, reuses for both frontmatter top-level field *and* \`## 요약\` body section. Top-level \`summary\` now always present (canonical); \`attributes.summary\` kept as legacy duplicate (separate cleanup PR).
3. **One-shot resync script** — \`scripts/resync_wiki_summary_body.py\` walks \`wiki/entity/**/*.md\`, normalizes backlog. **Dry-run reports 278 stale files**. Operator-driven (CR-E pattern) — not rewritten as part of this PR.

## Verification

- \`ruff check .\` clean
- 2503 passing (4 new), 861 subtests, 0 fail
- \`tests/test_wiki_summary_body_sync.py\` pins 4-case contract:
  - \`attributes.summary\` → body populated, top-level mirrored
  - top-level \`summary\` → body populated
  - both set → top-level wins
  - neither → empty body section, no crash
- Module sizes: \`_ingestion.py\` 17 KB / \`_frontmatter.py\` 18 KB (under 20 KB gate)

## Operator follow-up (after merge)

\`\`\`
python scripts/resync_wiki_summary_body.py           # review 278-file diff
python scripts/resync_wiki_summary_body.py --apply   # write
\`\`\`

## Out of scope

Same diagnostic pass — separate PRs:
- **B**: direction arrows reversed in neighbor panel
- **D**: raw markdown chars (\`**\`) in entity IDs surfacing in labels
- **E**: cleanup of \`attributes.summary\` legacy duplicate once all readers migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)