### PR TITLE
fix(graph-editor): node summary edit syncs `## 요약` body section live

### DIFF
--- a/core/graph_node_editor.py
+++ b/core/graph_node_editor.py
@@ -226,6 +226,15 @@ def update_node_attributes(
             "changed_fields": [],
         }
 
+    # [B-2-A follow-up, PR #446] If summary changed, also rewrite the
+    # body's `## 요약` section. Pre-fix the editor patched only the
+    # frontmatter, so a Save from the graph node detail panel changed
+    # `summary:` in the yaml header but left the visible body section
+    # stale — the user reported "edit doesn't reflect immediately".
+    if "summary" in changed:
+        from core.wiki_generator import sync_summary_body
+        body, _body_changed = sync_summary_body(body, fm.get("summary") or "")
+
     # Touch updated_at so cascade / monitoring picks up the change.
     fm["updated_at"] = datetime.now().isoformat()
     _write_entity(path, fm, body)

--- a/core/wiki_generator/__init__.py
+++ b/core/wiki_generator/__init__.py
@@ -37,6 +37,7 @@ from ._aliases import (
     _expand_alias_candidates,
     _load_synonyms,
 )
+from ._body_sync import sync_summary_body  # noqa: F401 — public helper
 from ._frontmatter import WikiFrontmatterMixin
 from ._index_ops import WikiIndexOpsMixin
 from ._ingestion import WikiIngestionMixin

--- a/core/wiki_generator/_body_sync.py
+++ b/core/wiki_generator/_body_sync.py
@@ -1,0 +1,57 @@
+"""Sync the wiki body's `## 요약` section to a canonical summary string.
+
+Shared by two call sites:
+
+- ``scripts/resync_wiki_summary_body.py`` — one-shot backlog migration
+  that rewrites every stale `## 요약` block on disk to match its
+  frontmatter top-level ``summary``.
+- ``core.graph_node_editor.update_node_attributes`` — runtime UI edits.
+  Pre-PR-#446 the editor only patched the frontmatter, so a "Save"
+  from the graph node detail panel changed `summary:` in the yaml
+  header but left the visible `## 요약` body section untouched —
+  exactly the regression surfaced in 2026-05-24 Stage E.1 (B-2 graph
+  follow-up).
+
+Pulled into its own module so both call sites share one regex, one
+whitespace convention, and one idempotency contract. If the body
+window evolves later (e.g. `## 본문` instead of `## 요약`), only this
+file moves.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# `## 요약\n<content>\n## 관계` — DOTALL so `.` spans newlines, non-greedy
+# so we stop at the first `## 관계` (the only section that ever follows
+# `## 요약` in the wiki body template).
+_BODY_PAT = re.compile(r"(## 요약\n)(.*?)(\n## 관계)", re.DOTALL)
+
+
+def sync_summary_body(body: str, summary: str) -> Tuple[str, bool]:
+    """Rewrite the `## 요약` body window to contain `summary`.
+
+    Returns ``(new_body, changed)``.
+
+    - ``changed=False`` when the body already matches (idempotent), or
+      when the `## 요약 ... ## 관계` window isn't present (caller decides
+      what to do — the runtime path leaves it alone, the resync script
+      skips the file).
+    - ``summary`` may be empty — that leaves the section header but
+      with blank content, matching the new-entity shape produced by
+      ``create_entity_file`` when no summary is supplied.
+    """
+    m = _BODY_PAT.search(body)
+    if not m:
+        return body, False
+    current = m.group(2).strip()
+    if current == summary.strip():
+        return body, False
+    spacer = "\n" if summary else ""
+    new = _BODY_PAT.sub(
+        lambda mm: mm.group(1) + summary + spacer + mm.group(3),
+        body,
+        count=1,
+    )
+    return new, True

--- a/scripts/resync_wiki_summary_body.py
+++ b/scripts/resync_wiki_summary_body.py
@@ -53,22 +53,21 @@ Files where the body is *already* in sync are left untouched.
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
 from typing import Tuple
 
 import yaml
 
+# Path bootstrap: scripts/ is run as a top-level script, so `core.*`
+# imports need the repo root on sys.path. Match the convention used by
+# scripts/cleanup_web_noise_entities.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.wiki_generator import sync_summary_body  # noqa: E402
+
 
 WIKI_ROOT = Path(__file__).resolve().parent.parent / "wiki" / "entity"
-
-# Body window: `## 요약\n<content>\n## 관계` — capture <content>.
-# DOTALL so `.` spans newlines; non-greedy so we stop at the first `## 관계`.
-_BODY_PAT = re.compile(
-    r"(## 요약\n)(.*?)(\n## 관계)",
-    re.DOTALL,
-)
 
 
 def _split_frontmatter(raw: str) -> Tuple[dict, str, str]:
@@ -107,27 +106,6 @@ def _canonical_summary(fm: dict) -> str:
     return ""
 
 
-def _rewrite_body(body: str, summary: str) -> Tuple[str, bool]:
-    """Replace the `## 요약` body content with `summary`.
-
-    Returns (new_body, changed). If the body lacks the `## 요약\\n...\\n## 관계`
-    structure, returns (body, False).
-    """
-    m = _BODY_PAT.search(body)
-    if not m:
-        return body, False
-    current = m.group(2).strip()
-    if current == summary.strip():
-        return body, False
-    new = _BODY_PAT.sub(
-        # group 1 = "## 요약\n", group 3 = "\n## 관계"; rebuild with new content.
-        lambda mm: mm.group(1) + summary + (("\n" if summary else "")) + mm.group(3),
-        body,
-        count=1,
-    )
-    return new, True
-
-
 def process_file(path: Path, apply: bool, verbose: bool) -> Tuple[bool, str]:
     """Return (changed, message).
 
@@ -148,7 +126,7 @@ def process_file(path: Path, apply: bool, verbose: bool) -> Tuple[bool, str]:
     if not summary:
         return False, f"SKIP {path}: no summary in frontmatter"
 
-    new_body, body_changed = _rewrite_body(body, summary)
+    new_body, body_changed = sync_summary_body(body, summary)
     fm_changed = False
     new_fm = dict(fm)
     if not isinstance(new_fm.get("summary"), str) or not new_fm["summary"].strip():

--- a/tests/test_phase_e_graph_editor.py
+++ b/tests/test_phase_e_graph_editor.py
@@ -477,6 +477,80 @@ class UpdateNodeAttributesTests(unittest.TestCase):
         self.assertIn("updated_at", fm,
             "successful write must stamp updated_at")
 
+    def test_summary_edit_syncs_body_section(self):
+        """PR #446 (B-2-A follow-up) — editing `summary` must also
+        rewrite the body's `## 요약` section, otherwise the UI shows
+        the old text and the user reports "edit doesn't reflect".
+        Pre-fix only the frontmatter was patched. Pin the contract."""
+        _, wg, p, eid = _single_entity()
+        # Overwrite the fixture with a wiki-shaped body so the
+        # `## 요약\n...\n## 관계` sync window is present (the default
+        # _write_entity helper writes just `# body\n`).
+        from textwrap import dedent
+        with open(p, "w", encoding="utf-8") as f:
+            f.write(dedent("""\
+                ---
+                entity_id: e_org_anthropic
+                entity_type: org
+                name: Anthropic
+                aliases: []
+                summary: AI lab
+                sensitivity: normal
+                ---
+
+                ## 요약
+                AI lab
+
+                ## 관계
+                - (관계 없음)
+                """))
+
+        update_node_attributes(
+            eid,
+            {"summary": "AI safety company"},
+            wiki_generator=wg,
+        )
+        text = p.read_text(encoding="utf-8")
+        # Frontmatter updated …
+        self.assertIn("summary: AI safety company", text)
+        # …and so is the body window (the regression we're pinning).
+        self.assertIn("## 요약\nAI safety company\n", text)
+        self.assertNotIn("AI lab", text,
+            "old summary must be gone from both frontmatter and body")
+
+    def test_non_summary_edit_leaves_body_alone(self):
+        """Editing a non-summary field must NOT touch the body section
+        — otherwise unrelated name/aliases edits would churn the body
+        text on every save."""
+        _, wg, p, eid = _single_entity()
+        from textwrap import dedent
+        with open(p, "w", encoding="utf-8") as f:
+            f.write(dedent("""\
+                ---
+                entity_id: e_org_anthropic
+                entity_type: org
+                name: Anthropic
+                aliases: []
+                summary: AI lab
+                sensitivity: normal
+                ---
+
+                ## 요약
+                AI lab
+
+                ## 관계
+                - (관계 없음)
+                """))
+        update_node_attributes(
+            eid,
+            {"name": "Anthropic, PBC"},
+            wiki_generator=wg,
+        )
+        text = p.read_text(encoding="utf-8")
+        self.assertIn("## 요약\nAI lab\n", text,
+            "body summary section must be untouched when summary "
+            "wasn't part of the patch")
+
     def test_empty_patch_raises(self):
         _, wg, _, eid = _single_entity()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

Surfaced in 2026-05-24 Stage E.1 follow-up to PR #445: operator edited an entity's \`summary\` from the graph node detail panel ("GPU 제조 기업" → "GPU 제조 미국 기업"), saved, and the \`## 요약\` body section on next page-load still showed the old text. Frontmatter \`summary:\` was updated, but the rendered body block was stale.

**Root cause**: \`core/graph_node_editor.update_node_attributes\` reads \`(path, fm, body)\` from disk, applies the patch to \`fm\` only, then \`_write_entity(path, fm, body)\` — \`body\` is the *original* on-disk body, never re-rendered. PR #445 fixed the *forward* (ingest) path; this is the runtime *edit* path with the same shape of bug. PR #445's description called this out: "A separate downstream code path … later patches top-level \`summary\` … That path didn't re-render the body" — confirmed by post-merge dry-run: 277/278 backlog normalized, **1 remaining** = exactly the operator's just-saved edit.

## Fix (three pieces)

1. **\`core/wiki_generator/_body_sync.py\`** (NEW) — \`sync_summary_body(body, summary)\` shared helper. \`## 요약\n...\n## 관계\` regex + idempotency + empty-handling in one place. Re-exported from \`core.wiki_generator\`.
2. **\`core/graph_node_editor.update_node_attributes\`** — when \`summary\` is in changed-fields, rewrite body via \`sync_summary_body\`. Non-summary edits leave body alone (pinned by dedicated test, so unrelated name/alias edits don't churn body).
3. **\`scripts/resync_wiki_summary_body.py\`** — drops inline \`_rewrite_body\`, uses the shared helper. DRY; no behaviour change.

## Verification

- \`ruff check .\` clean
- 2505 passing (2 new), 861 subtests, 0 fail
- \`UpdateNodeAttributesTests\`:
  - \`test_summary_edit_syncs_body_section\` — summary edit ⇒ FM + body both new value, old gone from both
  - \`test_non_summary_edit_leaves_body_alone\` — name-only edit ⇒ body untouched
- Module sizes: \`_body_sync.py\` 2 KB, \`graph_node_editor.py\` 15 KB (under 20 KB gate)
- Live confirmed: pre-fix dry-run reports the exact operator-edited file as the single stale entry

## Operator follow-up

The 1 stale file (\`엔비디아.md\`) is normalized either by re-running:
\`\`\`
python scripts/resync_wiki_summary_body.py --apply
\`\`\`
Or by re-saving through the graph editor (now self-corrects). New edits going forward write both fields atomically.

## Out of scope

- **B**: direction-arrow regression
- **D**: raw markdown chars in entity IDs
- **E**: cleanup of legacy \`attributes.summary\` duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)