### PR TITLE
fix(web-learn): treat Gemma error sentinels as empty + recover 16 stale nodes

### DIFF
--- a/scripts/recover_gemma_empty_summary.py
+++ b/scripts/recover_gemma_empty_summary.py
@@ -1,0 +1,230 @@
+"""Recover wiki entities whose summary is a Gemma error sentinel.
+
+## Why this script exists
+
+Before PR #447's forward fix, the web-learn path in `server_llmwiki.py`
+checked only `len(knowledge.strip()) < 10` before falling back to a
+snippet-based summary. The Gemma error sentinels — `[Gemma 응답 없음]`,
+`[Gemma 오류] ...`, etc. — are 13+ characters, so they sailed past the
+gate and got persisted to `attributes.summary` on disk. The graph node
+detail panel then renders that sentinel as the entity's summary, which
+is what the operator sees on the `/graph` page.
+
+Current corpus: 15 entity files match (all
+`learn_method: web_search` documents).
+
+PR #447 fixes the *forward* path so new web-learn ingests can't
+produce this state. This script patches the *backlog*: it rewrites
+each stale node's summary in place using only the metadata that's
+already on the file (no LLM call — Gemma may still be unhealthy on
+the operator's machine).
+
+## What it changes
+
+For each `wiki/entity/**/*.md` whose `summary` or `attributes.summary`
+starts with one of the Gemma `ERROR_PREFIXES`:
+
+1. Synthesize a deterministic fallback summary from the file's own
+   metadata, in this priority order:
+   - `attributes.original_query` (the question the operator asked —
+     usually the most descriptive)
+   - `attributes.keywords`        (extracted topic tokens)
+   - `name`                       (sanitized entity name)
+2. Cap at 300 chars.
+3. Rewrite frontmatter:
+   - top-level `summary` (canonical, per PR #445)
+   - `attributes.summary` (legacy field, kept in sync)
+4. Rewrite the body's `## 요약` section via the shared helper
+   `core.wiki_generator.sync_summary_body`.
+
+## Safety
+
+- Dry-run by default. Prints diff-style per-file output.
+- `--apply` writes files in place. Run on a clean working tree so
+  `git diff` shows the recovery delta.
+- Skips files whose summary is already clean.
+- Skips files that don't parse as wiki entities.
+
+## Usage
+
+    python scripts/recover_gemma_empty_summary.py             # dry-run
+    python scripts/recover_gemma_empty_summary.py --apply     # write
+    python scripts/recover_gemma_empty_summary.py --apply --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import yaml
+
+# Path bootstrap — match scripts/resync_wiki_summary_body.py convention.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.gemma_client import ERROR_PREFIXES  # noqa: E402
+from core.wiki_generator import sync_summary_body  # noqa: E402
+
+
+WIKI_ROOT = Path(__file__).resolve().parent.parent / "wiki" / "entity"
+_SUMMARY_CAP = 300
+
+
+def _split_frontmatter(raw: str) -> Tuple[dict, str]:
+    if not raw.startswith("---\n"):
+        return {}, raw
+    rest = raw[4:]
+    end = rest.find("\n---\n")
+    if end < 0:
+        return {}, raw
+    fm_text = rest[:end]
+    body = rest[end + 5 :]
+    try:
+        fm = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        return {}, raw
+    if not isinstance(fm, dict):
+        return {}, raw
+    return fm, body
+
+
+def _is_error_sentinel(s) -> bool:
+    if not isinstance(s, str):
+        return False
+    stripped = s.strip()
+    return bool(stripped) and stripped.startswith(ERROR_PREFIXES)
+
+
+def _node_needs_recovery(fm: dict) -> bool:
+    """A node needs recovery if either the top-level `summary` or
+    `attributes.summary` is a Gemma error sentinel. We treat the two
+    independently because (per PR #445) the two fields are sometimes
+    out of sync on legacy data."""
+    if _is_error_sentinel(fm.get("summary")):
+        return True
+    attrs = fm.get("attributes") or {}
+    if isinstance(attrs, dict) and _is_error_sentinel(attrs.get("summary")):
+        return True
+    return False
+
+
+def _fallback_summary(fm: dict) -> str:
+    """Synthesize a deterministic summary from metadata that's already
+    on the file. Priority: original_query > keywords > name. Always
+    returns a non-empty string for nodes that need recovery (every
+    web-learn entity carries at least a `name`)."""
+    attrs = fm.get("attributes") or {}
+    if isinstance(attrs, dict):
+        oq = attrs.get("original_query")
+        if isinstance(oq, str) and oq.strip():
+            return oq.strip()[:_SUMMARY_CAP]
+        kw = attrs.get("keywords")
+        if isinstance(kw, str) and kw.strip():
+            return kw.strip()[:_SUMMARY_CAP]
+    name = fm.get("name")
+    if isinstance(name, str) and name.strip():
+        # Strip the `web_business_` prefix and the trailing
+        # `_<timestamp>` suffix so the synthesized summary reads as the
+        # original question, not the auto-generated entity id.
+        n = name.strip()
+        if n.startswith("web_business_"):
+            n = n[len("web_business_") :]
+        # Trim a trailing `_<digits>` if present (entity name suffix).
+        import re
+        n = re.sub(r"_\d{7,}$", "", n)
+        return n.replace("_", " ")[:_SUMMARY_CAP]
+    return "(웹 검색 자료 — 자동 요약 실패)"
+
+
+def process_file(path: Path, apply: bool, verbose: bool) -> Tuple[bool, str]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return False, f"SKIP {path}: read error: {e}"
+
+    fm, body = _split_frontmatter(raw)
+    if not fm:
+        return False, ""
+    if "entity_id" not in fm or "entity_type" not in fm:
+        return False, ""
+    if not _node_needs_recovery(fm):
+        if verbose:
+            return False, f"OK   {path}: summary clean"
+        return False, ""
+
+    fallback = _fallback_summary(fm)
+    new_fm = dict(fm)
+    new_fm["summary"] = fallback
+    # Keep attributes.summary mirrored so legacy readers see the same value.
+    attrs = dict(new_fm.get("attributes") or {})
+    attrs["summary"] = fallback
+    new_fm["attributes"] = attrs
+
+    new_body, _body_changed = sync_summary_body(body, fallback)
+
+    if apply:
+        new_fm_text = yaml.dump(
+            new_fm, allow_unicode=True, default_flow_style=False, sort_keys=True
+        )
+        out = f"---\n{new_fm_text}---\n{new_body}" if not new_body.startswith("\n") else f"---\n{new_fm_text}---{new_body}"
+        path.write_text(out, encoding="utf-8")
+        tag = "WROTE"
+    else:
+        tag = "WOULD"
+    return True, f"{tag} {path}: -> {fallback[:60]!r}"
+
+
+def main() -> int:
+    # UTF-8 stdout for Korean output on Windows cp949 consoles.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--apply", action="store_true",
+        help="actually rewrite files (default: dry-run)",
+    )
+    ap.add_argument(
+        "--verbose", action="store_true",
+        help="print every file (including no-op skips)",
+    )
+    ap.add_argument(
+        "--root", type=Path, default=WIKI_ROOT,
+        help=f"wiki entity root (default: {WIKI_ROOT})",
+    )
+    args = ap.parse_args()
+
+    if not args.root.is_dir():
+        print(f"ERROR: {args.root} is not a directory", file=sys.stderr)
+        return 2
+
+    files = sorted(args.root.rglob("*.md"))
+    if not files:
+        print(f"no .md files found under {args.root}")
+        return 0
+
+    changed = 0
+    for f in files:
+        ch, msg = process_file(f, apply=args.apply, verbose=args.verbose)
+        if ch:
+            changed += 1
+            print(msg)
+        elif msg and args.verbose:
+            print(msg)
+
+    mode = "APPLIED" if args.apply else "DRY-RUN"
+    print()
+    print(f"{mode}: {changed} file(s) {'rewritten' if args.apply else 'would change'}, "
+          f"{len(files) - changed} unchanged.")
+    if not args.apply and changed > 0:
+        print("Rerun with --apply to write changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -2218,9 +2218,21 @@ async def learn_topic_api(
                 knowledge_prompt, timeout=60, use_cache=False, max_tokens=300
             )
 
-            # ⑤ LLM 0자 → snippet 기반 fallback
-            if not knowledge or len(knowledge.strip()) < 10:
-                print("[LEARN] LLM 0자 → fallback 사용")
+            # ⑤ LLM 0자 / 오류 sentinel → snippet 기반 fallback.
+            # The old condition `len < 10` let `[Gemma 응답 없음]` (13
+            # chars) and `[Gemma 오류] ...` through. Those then got
+            # written to `attributes.summary` and the body's `## 요약`
+            # — the graph node detail panel showed the sentinel string
+            # to the operator. Treat any ERROR_PREFIXES response as
+            # equivalent to empty so the fallback kicks in.
+            from core.gemma_client import ERROR_PREFIXES
+            _knowledge_stripped = (knowledge or "").strip()
+            if (
+                not _knowledge_stripped
+                or len(_knowledge_stripped) < 10
+                or _knowledge_stripped.startswith(ERROR_PREFIXES)
+            ):
+                print(f"[LEARN] LLM empty/error ('{_knowledge_stripped[:30]}') → fallback 사용")
                 parts = []
                 for r in results[:3]:
                     title = r.get('title', '')

--- a/tests/test_recover_gemma_empty_summary.py
+++ b/tests/test_recover_gemma_empty_summary.py
@@ -1,0 +1,174 @@
+"""Pin the recovery contract for `[Gemma 응답 없음]`-sentinel summaries.
+
+Pre-PR-#447 the web-learn path checked only `len(knowledge.strip()) < 10`
+before falling back, so the 13-char `[Gemma 응답 없음]` sentinel got
+persisted to `attributes.summary` on 16 entity files. PR #447's
+forward fix gates that branch; `scripts/recover_gemma_empty_summary.py`
+patches the backlog using only metadata that's already on the file.
+
+These tests verify the recovery helpers do what the operator expects:
+detect the sentinel, synthesize a non-empty fallback, and rewrite all
+three locations (top-level summary, attributes.summary, body section).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+# Path bootstrap (test runs from repo root via pytest, but the recovery
+# script lives under scripts/ and imports `from core...`).
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.recover_gemma_empty_summary import (  # noqa: E402
+    _fallback_summary,
+    _is_error_sentinel,
+    _node_needs_recovery,
+    process_file,
+)
+
+
+class IsErrorSentinelTests(unittest.TestCase):
+    def test_gemma_no_response_is_sentinel(self):
+        self.assertTrue(_is_error_sentinel("[Gemma 응답 없음]"))
+
+    def test_gemma_error_with_detail_is_sentinel(self):
+        self.assertTrue(
+            _is_error_sentinel("[Gemma 오류] 404 Client Error: Not Found"))
+
+    def test_leading_whitespace_still_detected(self):
+        self.assertTrue(_is_error_sentinel("   [Gemma 응답 없음]"))
+
+    def test_real_summary_is_not_sentinel(self):
+        self.assertFalse(
+            _is_error_sentinel("AI 칩 시장의 주요 기업"))
+
+    def test_empty_is_not_sentinel(self):
+        self.assertFalse(_is_error_sentinel(""))
+        self.assertFalse(_is_error_sentinel("   "))
+
+    def test_non_string_is_not_sentinel(self):
+        self.assertFalse(_is_error_sentinel(None))
+        self.assertFalse(_is_error_sentinel(123))
+
+
+class NodeNeedsRecoveryTests(unittest.TestCase):
+    def test_top_level_sentinel_triggers(self):
+        self.assertTrue(_node_needs_recovery({"summary": "[Gemma 응답 없음]"}))
+
+    def test_attributes_sentinel_triggers(self):
+        self.assertTrue(_node_needs_recovery(
+            {"attributes": {"summary": "[Gemma 응답 없음]"}}))
+
+    def test_both_clean_does_not_trigger(self):
+        self.assertFalse(_node_needs_recovery({
+            "summary": "GPU 제조 기업",
+            "attributes": {"summary": "AI 칩 시장의 주요 기업"},
+        }))
+
+    def test_missing_summary_does_not_trigger(self):
+        self.assertFalse(_node_needs_recovery({"name": "엔비디아"}))
+
+
+class FallbackSummaryTests(unittest.TestCase):
+    def test_prefers_original_query(self):
+        fm = {
+            "name": "web_business_MU_주식_1234567",
+            "attributes": {
+                "original_query": "MU 주식 투자 전략",
+                "keywords": "MU 주식",
+            },
+        }
+        self.assertEqual(_fallback_summary(fm), "MU 주식 투자 전략")
+
+    def test_falls_back_to_keywords(self):
+        fm = {
+            "name": "web_business_foo_1234567",
+            "attributes": {"keywords": "테스트 주제"},
+        }
+        self.assertEqual(_fallback_summary(fm), "테스트 주제")
+
+    def test_falls_back_to_name_strips_prefix_and_suffix(self):
+        """`web_business_` prefix and `_<timestamp>` suffix shouldn't
+        leak into the recovered summary."""
+        fm = {"name": "web_business_AMD_에_대해_설명_1778634167"}
+        self.assertEqual(_fallback_summary(fm), "AMD 에 대해 설명")
+
+    def test_caps_at_300_chars(self):
+        long = "가" * 500
+        fm = {"attributes": {"original_query": long}}
+        self.assertEqual(len(_fallback_summary(fm)), 300)
+
+
+class ProcessFileTests(unittest.TestCase):
+    """End-to-end: write a stale .md → run process_file(apply=True) →
+    verify frontmatter + body are all in sync."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.path = self.tmpdir / "stale.md"
+        self.path.write_text(
+            "---\n"
+            "entity_id: e_document_test\n"
+            "entity_type: document\n"
+            "name: web_business_MU_주식_1234567\n"
+            "summary: '[Gemma 응답 없음]'\n"
+            "attributes:\n"
+            "  original_query: MU 주식 투자 전략\n"
+            "  keywords: MU 주식\n"
+            "  summary: '[Gemma 응답 없음]'\n"
+            "  learn_method: web_search\n"
+            "---\n\n"
+            "## 요약\n"
+            "[Gemma 응답 없음]\n\n"
+            "## 관계\n"
+            "- (관계 없음)\n",
+            encoding="utf-8",
+        )
+
+    def test_apply_rewrites_all_three_locations(self):
+        changed, msg = process_file(self.path, apply=True, verbose=False)
+        self.assertTrue(changed, msg)
+        text = self.path.read_text(encoding="utf-8")
+        # Body section
+        self.assertIn("## 요약\nMU 주식 투자 전략\n", text)
+        self.assertNotIn("[Gemma 응답 없음]", text,
+            "sentinel must be gone from every location")
+        # Frontmatter — both top-level and attributes mirror.
+        self.assertIn("summary: MU 주식 투자 전략", text)
+
+    def test_dry_run_does_not_write(self):
+        original = self.path.read_text(encoding="utf-8")
+        changed, _msg = process_file(self.path, apply=False, verbose=False)
+        self.assertTrue(changed,
+            "dry-run still reports a change is needed")
+        self.assertEqual(self.path.read_text(encoding="utf-8"), original,
+            "dry-run must not touch the file")
+
+    def test_clean_file_is_skipped(self):
+        clean = self.tmpdir / "clean.md"
+        clean.write_text(
+            "---\n"
+            "entity_id: e_org_test\n"
+            "entity_type: org\n"
+            "name: 엔비디아\n"
+            "summary: GPU 제조 기업\n"
+            "attributes:\n"
+            "  summary: GPU 제조 기업\n"
+            "---\n\n"
+            "## 요약\n"
+            "GPU 제조 기업\n\n"
+            "## 관계\n"
+            "- (관계 없음)\n",
+            encoding="utf-8",
+        )
+        original = clean.read_text(encoding="utf-8")
+        changed, _msg = process_file(clean, apply=True, verbose=False)
+        self.assertFalse(changed)
+        self.assertEqual(clean.read_text(encoding="utf-8"), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Surfaced 2026-05-24 Stage E.1 follow-up: operator clicked a graph node (\`web_business_MU 주식 투자 시 고려해…\`) and the side-panel's \`## 요약\` showed literally \`[Gemma 응답 없음]\`. Gemma had returned its error sentinel during web-learn ingest months ago, and the fallback gate let it through.

**Root cause**: \`server_llmwiki.py:2222\` web-learn fallback was \`len(knowledge.strip()) < 10\`. But \`[Gemma 응답 없음]\` is **13 characters** → passed the gate → stored as summary. Same for the longer \`[Gemma 오류] 404 …\` sentinel. \`core/gemma_client.py:ERROR_PREFIXES\` lists four such markers, all of which can exceed 10 chars.

Dry-run scan: **16 nodes** carry one of these sentinels. All \`learn_method: web_search\` documents; cleanup_web_noise didn't touch them because they have real outgoing relations.

## Fix (three pieces)

1. **Forward gate** (\`server_llmwiki.py\`) — reject any response that \`.startswith(ERROR_PREFIXES)\` and fall through to the snippet-based fallback.
2. **Backlog recovery** (\`scripts/recover_gemma_empty_summary.py\`, NEW) — synthesizes a deterministic fallback from metadata already on disk (\`original_query → keywords → name-with-decorators-stripped\`), rewrites all three locations atomically (top-level \`summary\` + \`attributes.summary\` + body \`## 요약\` via \`sync_summary_body\` from #446). No LLM call.
3. **Tests** — sentinel detection, fallback priority, char cap (300), end-to-end \`process_file\`, idempotency on clean files.

## Verification

- \`ruff check .\` clean
- 2522 passing (17 new), 861 subtests, 0 fail
- Live dry-run reports the exact 16 stale files; recovered text reads as the original query (e.g. operator-shown node → "MU 주식 투자 시 고려해야 할 구체적인 리스크 관리 전략")

## Operator follow-up

\`\`\`
python scripts/recover_gemma_empty_summary.py             # review 16 changes
python scripts/recover_gemma_empty_summary.py --apply     # write
\`\`\`

Or skip the script and re-save individual nodes through the graph editor (PR #446) — same end state.

## Out of scope

- **B**: direction-arrow regression
- **D**: raw \`**\` markdown chars in entity IDs (some recovered summaries still carry them — separate sanitization PR)
- **E**: cleanup of \`attributes.summary\` legacy duplicate
- Underlying Gemma failures on the \`gemma4:e4b\` cognitive-stage stack are tracked in \`reports/promo-assets/devto-gemma4-write-track.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)