### PR TITLE
fix(graph): pulse direction follows data edge + src→tgt color gradient + speed bump

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -65,7 +65,9 @@
 
   // Spacing constant — radius scales with sqrt(N).
   var SPHERE_K  = 24;
-  var PULSE_MS  = 650;
+  // [Stage E.1, 2026-05-24] pulse speed bump per UX feedback — was 650.
+  // 450 keeps the eye-trail readable while making the flow feel "live".
+  var PULSE_MS  = 450;
   var STEP_GAP  = 220;             // gap between consecutive edge pulses
 
   // [#4-1, 2026-05-09] Hub detection — top 10% by degree AND degree ≥ 5.
@@ -468,9 +470,16 @@
     var stepMs = 0;
     var loopEdges = [];
     neighbors.forEach(function (item) {
-      setTimeout(function () { spawnPulse(node, item.neighbor); }, stepMs);
+      // [Stage E.1, 2026-05-24] direction contract — the pulse must travel
+      // along the data edge's source → target axis, NOT always away from
+      // the clicked node. getNeighbors() already tags each item with
+      // direction ('out' = node→neighbor, 'in' = neighbor→node); honoring
+      // it makes the lit pulse match the arrowhead the user sees.
+      var pulseSrc = (item.direction === 'in') ? item.neighbor : node;
+      var pulseTgt = (item.direction === 'in') ? node : item.neighbor;
+      setTimeout(function () { spawnPulse(pulseSrc, pulseTgt); }, stepMs);
       stepMs += STEP_GAP / 2;   // slightly faster than path replay
-      loopEdges.push({ src: node, tgt: item.neighbor });
+      loopEdges.push({ src: pulseSrc, tgt: pulseTgt });
     });
 
     // Re-trigger force-graph render so links re-color.
@@ -1081,13 +1090,16 @@
     var scene = graph.scene();
     if (!scene) return;
 
-    // [PR camera-glow] use the soft gradient texture for a comet-like
-    // wrap-around glow instead of the hard square sprite.
-    var color = getCss('--brand-2', '#4fc3f7');
-    var tex = getGlowTexture(color);
+    // [Stage E.1, 2026-05-24] color gradient src→tgt — pulse starts in
+    // source-node tint and shifts to target-node tint over its lifetime.
+    // Texture stays a neutral white radial; material.color is what we lerp.
+    // Reads as "leaving here, arriving there" and pairs with the arrowhead.
+    var srcHex = typeColor(srcNode.type) || getCss('--brand-2', '#4fc3f7');
+    var tgtHex = typeColor(tgtNode.type) || srcHex;
+    var tex = getGlowTexture('#ffffff');   // single shared white texture
     var spriteMat = new THREE.SpriteMaterial({
       map:         tex,
-      color:       0xffffff,        // texture carries the color
+      color:       new THREE.Color(srcHex),   // mutated per-frame in pulseTick
       transparent: true,
       opacity:     0.95,
       blending:    THREE.AdditiveBlending,
@@ -1099,10 +1111,12 @@
     scene.add(sprite);
 
     pulses.push({
-      sprite:  sprite,
-      src:     srcNode,
-      tgt:     tgtNode,
-      startMs: performance.now(),
+      sprite:    sprite,
+      src:       srcNode,
+      tgt:       tgtNode,
+      startMs:   performance.now(),
+      srcColor:  new THREE.Color(srcHex),
+      tgtColor:  new THREE.Color(tgtHex),
     });
   }
 
@@ -1125,6 +1139,10 @@
         // Fade-in then fade-out around midpoint.
         var op = 1.0 - Math.abs(k - 0.5) * 1.6;
         p.sprite.material.opacity = Math.max(0, op);
+        // [Stage E.1] color lerp — src tint at k=0, tgt tint at k=1.
+        if (p.srcColor && p.tgtColor && p.sprite.material.color) {
+          p.sprite.material.color.copy(p.srcColor).lerp(p.tgtColor, k);
+        }
         live.push(p);
       }
     }


### PR DESCRIPTION
## Summary

Stage E.1 follow-up — three UX wins from live verification on 2026-05-24:

1. **Direction** — pulses now travel along the edge's data source→target axis (matches the arrowhead), not always away from the clicked node. `getNeighbors()` already tagged each neighbor with `direction` (`'in'|'out'`) since #4-1; `exploreFromNode` just wasn't honoring it. For incoming edges this flips the lit-trail direction.
2. **Color gradient** — pulse sprite starts in the source-node tint (`typeColor(srcNode.type)`) and lerps to the target-node tint over its lifetime. Texture is now a single shared white radial; `material.color` carries the per-frame lerp. Reads as *"leaving here, arriving there"*.
3. **Speed** — `PULSE_MS` 650 → 450 (≈30% faster). Eye-trail still readable but the flow feels live instead of laggy.

Frontend-only — `frontend/static/graph.js` 30 / 12. No backend, no schema, no Python touched.

## Verification

- [x] `git diff --stat` — single file, +30/-12
- [ ] **Manual (post-merge, hard-refresh `/graph`)**:
  - Click a node with **outgoing** edge (e.g. LabVIEW → NI in N=283 prod snapshot): pulse flows LabVIEW → NI, matching the arrowhead. *(Was: same direction before — regression check.)*
  - Click the **target** node (NI) of an incoming edge: pulse flows from the upstream node (LabVIEW) into NI, matching the arrowhead. **This is what was broken** — previously the pulse went the wrong way for incoming edges.
  - Pulses visually start in src-node-color and arrive in tgt-node-color (e.g. concept-violet → org-amber when a concept edge points at an org).
  - Overall flow feels noticeably faster but trail is still readable.
- [x] No `ruff` / `pytest` impact — no Python files changed.

## Out of scope

- **Edge line gradient** — option C from analysis (the static edge line itself drawn with src→tgt color gradient). Separate PR if requested; performance check needed before committing.
- **Stale-node-position handling** — if a node is dragged mid-pulse the lerp still uses the live `srcNode.x/y/z`, so the pulse "follows" the node. Intentional; no change.
- **`linkDirectionalParticles`** — force-graph's built-in directional particles remain at 0 (we own the pulse visual). Not touched.
- **Issue 2 (per-source delete/edit in relation modal)** — separate branch `feat/v0.3-relation-source-per-row` queued, will land separately.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>