### PR TITLE
fix(graph): bump pulse re-fire interval 3200ms → 2000ms

### DIFF
--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -55,7 +55,12 @@
   // pass loses the "this is the live path" signal.
   var pulseLoopTimer  = null;
   var pulseLoopEdges  = [];          // [{src: node, tgt: node}]
-  var PULSE_LOOP_MS   = 3200;        // re-fire interval — 1 cycle then breath
+  // [Stage E.1, 2026-05-24] re-fire interval bumped per UX feedback —
+  // was 3200ms (one cycle then a long breath). 2000ms keeps the
+  // "this is the live path" signal continuously visible without
+  // looking frantic. PULSE_MS is the in-flight duration (450ms), so
+  // 2000ms still leaves a ~1.5s gap between cycles.
+  var PULSE_LOOP_MS   = 2000;
 
   // [PR camera-glow, 2026-05-09] node halos — soft glowing sprite
   // around each active path node, scale + opacity pulsing on a sine


### PR DESCRIPTION
## Summary

Stage E.1 follow-up to **#450** — operator feedback after seeing the direction/gradient/speed fix in action: the lit-path pulses still appeared at ~3.2s intervals, which read as *"stopped"* between cycles even though each individual pulse was now faster.

Bumped `PULSE_LOOP_MS` from `3200` to `2000` so a cycle re-fires roughly every 2 seconds — close enough to feel continuous, far enough apart that the trail still fades before the next one starts (`PULSE_MS` is 450ms, so the gap is now ~1.5s).

## What did NOT change

- `PULSE_MS` (450ms) — in-flight duration set by #450, untouched
- `STEP_GAP` (220ms) — intra-cycle stagger between sibling neighbors, untouched
- Fade curve, sprite scale, color gradient logic — all untouched

Single constant change. Frontend-only. Independent of #450 — can land before, after, or together.

## Verification

- [x] `git diff --stat` — single file, +6 / -1
- [x] No Python touched → `ruff` / `pytest` unaffected
- [ ] **Manual (post-merge, hard-refresh `/graph`)**: click a hub node, watch the lit path. Cycles should re-fire on a steady ~2s cadence, no long "dead" gap.

## Out of scope

- **User-configurable cadence** — if 2s also feels off, the next iteration would be a small slider in the sidebar (1-4s range). Not worth the UI surface yet — let one fixed value settle first.
- **Adaptive cadence** (slow when no question is active, fast when one is) — same reasoning; ship the flat improvement first.

## Process note

Authored in the same isolated worktree (`../james-d-fix`) as #452 and #454. Branched off the post-#453-merge `origin/main` (`4fc57b6`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>