### PR TITLE
chore(docs): ROADMAP v0.3 governance truthing — THIRD_PARTY_LICENSES + quarterly monitoring

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,10 +322,13 @@ via Stage D.1 (#430).
       dry-run from a separate GitHub account). External contributors
       can sign before opening their first PR with the relicensing
       grant in place.
-- [ ] `THIRD_PARTY_LICENSES.md` (dependency inventory; license-strength
-      independent) — **pending**
-- [ ] Quarterly trigger monitoring — first measurement recorded at the
-      v0.3 release in `docs/LICENSE_PLAN.md §8` — **pending**
+- [x] `THIRD_PARTY_LICENSES.md` (dependency inventory; license-strength
+      independent) — ✅ PR #414 (2026-05-23, `idna 3.13 → 3.15`
+      security pin refresh; full pip-licenses snapshot at repo root).
+      Re-run only on dependency churn.
+- [x] Quarterly trigger monitoring — first measurement recorded at the
+      v0.3 release in `docs/LICENSE_PLAN.md §8` — ✅ PR #415 (third
+      quarterly measurement, 2026-05-23, stars 5→13, triggers 0/5).
 - [ ] Trademark + patent tracks opened (lawyer consult scheduled,
       progress logged in `docs/LICENSE_PLAN.md §6 / §7`) — operator
       track


### PR DESCRIPTION
## Summary

Both items under §Governance were already landed but the ROADMAP checkboxes were stale.

| Item | PR | Date |
|---|---|---|
| `THIRD_PARTY_LICENSES.md` (dependency inventory) | #414 | 2026-05-23 |
| Quarterly trigger monitoring (1st measurement) | #415 | 2026-05-23 |

`docs/handovers/v0.3.x-audit-2026-05-23.md §9 Stage D.2/D.3` already reflected these as ✅; this PR brings the ROADMAP into sync with the audit doc.

## Verification

- Docs-only change (ROADMAP.md only, +7/-4 lines)
- No core code touched
- `THIRD_PARTY_LICENSES.md` present at repo root (verified)
- `docs/LICENSE_PLAN.md §8` has the third quarterly measurement row (verified)
- No `core/{retrieval,graph,reasoning}` impact — CLAUDE.md rule #2 N/A
- No module size impact — rule #5 N/A

## Out of scope

- Trademark + patent tracks remain `[ ]` — operator-side (lawyer consult), no checkbox change in this PR
- Other ROADMAP stale items (e.g. Measurement framework Direction 4 ✅ already correct) — not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)