### PR TITLE
docs(readme): Zenodo DOI badge + Status v0.3.0 → v0.3.1

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -5,9 +5,10 @@
 > 기반 자기진화.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.3.0-blue.svg)](docs/release_notes_v0.3.0.md)
+[![Status](https://img.shields.io/badge/Status-v0.3.1-blue.svg)](docs/release_notes_v0.3.1.md)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20363998.svg)](https://doi.org/10.5281/zenodo.20363998)
 
 ![PROJECT JAMES — 3D 온톨로지 그래프 시각화](reports/promo-assets/screenshots/06-3d-graph.jpg)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 > behind a human approval gate.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.3.0-blue.svg)](docs/release_notes_v0.3.0.md)
+[![Status](https://img.shields.io/badge/Status-v0.3.1-blue.svg)](docs/release_notes_v0.3.1.md)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20363998.svg)](https://doi.org/10.5281/zenodo.20363998)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)
 


### PR DESCRIPTION
## Summary

GitHub release v0.3.1 published 2026-05-24 08:40 UTC with Zenodo auto-minted DOI **10.5281/zenodo.20363998**. This PR makes the citation discoverable from the repository landing page.

## Changes

- `README.md` — adds `[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20363998.svg)]` badge under OpenSSF Best Practices; Status badge now links to v0.3.1 release notes.
- `README.ko.md` — identical shape, Korean header.

## Verification

- ✅ Badge URLs validate (Zenodo shields render `10.5281/zenodo.20363998`)
- ✅ Status badge link `docs/release_notes_v0.3.1.md` exists in main as of PR #465
- ✅ Docs only — no core code touched
- ✅ No `core/{retrieval,graph,reasoning}` impact

## Why a separate PR

Kept independent from the LinkedIn drafts PR (#464) so the README badge can land in main immediately for any visitor (Robin / Ali / future external linker) while the LinkedIn drafts wait for operator publish timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)