### PR TITLE
feat(admin-ui): Delete-only button + LLM spinner for session list

### DIFF
--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -173,6 +173,8 @@ function _bindFrontendEvents() {
         break;
       case 'summarize-and-delete':
         summarizeAndDelete(t.getAttribute('data-sid')); break;
+      case 'delete-session-only':
+        deleteSessionOnly(t.getAttribute('data-sid')); break;
       case 'patch-action':
         patchAction(
           t.getAttribute('data-patch-id'),
@@ -1540,6 +1542,8 @@ async function loadSessions() {
           <td class="mono">${s.started?.slice(0,16) || '-'}</td>
           <td class="mono">${s.last?.slice(0,16) || '-'}</td>
           <td>
+            <button class="btn" style="font-size:10px;background:rgba(240,98,146,.10);border:1px solid var(--red,#f06292);color:var(--red,#f06292);margin-right:4px"
+              data-action="delete-session-only" data-sid="${escapeHtml(sid)}" data-i18n='mem.delete_only'>Delete</button>
             <button class="btn btn-approve" style="font-size:10px"
               data-action="summarize-and-delete" data-sid="${escapeHtml(sid)}" data-i18n='mem.summarize_delete'>Summarize & Delete</button>
           </td>
@@ -1603,8 +1607,22 @@ function closeSessionTurns(e) {
 }
 
 async function summarizeAndDelete(sessionId) {
+  // Confirmation gate — LLM call is 30-60s long-running on gemma4:e4b.
+  // Operators frequently mistake this for the simple delete and end up
+  // waiting through a full reflect/verify-tier round-trip + a topic
+  // round-trip. Explicit confirm sets expectation.
+  const confirmMsg = t('mem.confirm_summarize_delete')
+    || `Summarize and delete? LLM call required (~30-60s on gemma4:e4b).\nFor a no-summary delete, use the "Delete" button instead.`;
+  if (!confirm(confirmMsg)) return;
+
+  // Long-running indicator — toast stays on screen until the request
+  // completes (override default 3s auto-dismiss).
+  const spinnerToast = toastPersistent(
+    t('mem.summarizing') || '⏳ Summarizing... (LLM call, may take 30-60s)',
+    'info',
+  );
   try {
-    // 1. 요약 저장
+    // 1. 요약 저장 (LLM call — long-running)
     const r = await api(`/history/summarize/?session_id=${sessionId}`, 'POST');
     if (r.success) {
       toast(`✅ ${r.topic || sessionId.slice(0,12)} saved`, 'success');
@@ -1616,7 +1634,51 @@ async function summarizeAndDelete(sessionId) {
     await loadLongTerm();
   } catch (e) {
     alert(`Failed: ${e.message}`);
+  } finally {
+    if (spinnerToast && spinnerToast.parentNode) spinnerToast.remove();
   }
+}
+
+/* ── Delete-only path (no LLM call) — for bench / temp / low-value
+   sessions where the summary is not worth a 30-60s LLM round-trip.
+   Single DELETE /history/ call + table refresh, completes in
+   sub-second. Direction 1 (PR #461) finding applied to UX: an LLM
+   call is a long-running stage and should be opt-in, not the default. */
+async function deleteSessionOnly(sessionId) {
+  const confirmMsg = t('mem.confirm_delete_only')
+    || `Delete session "${sessionId.slice(0,12)}"? (no summary, no LLM call)`;
+  if (!confirm(confirmMsg)) return;
+
+  try {
+    await api(`/history/?session_id=${sessionId}`, 'DELETE');
+    toast(
+      t('mem.deleted_no_summary') || `🗑️ ${sessionId.slice(0,12)} deleted`,
+      'success',
+    );
+    await loadSessions();
+    // long-term unchanged for this path — no summary was written, so
+    // the long-term card doesn't need a re-fetch (saves an HTTP call).
+  } catch (e) {
+    alert(`Failed: ${e.message}`);
+  }
+}
+
+/* Persistent toast — like toast() but stays on screen until caller
+   .remove()s it. Returns the DOM element so the caller can dismiss
+   it from a try/finally. Used for long-running LLM calls where the
+   default 3s auto-dismiss would hide the indicator while the user
+   is still waiting. */
+function toastPersistent(msg, type = 'info') {
+  const t = document.createElement('div');
+  const accent = type === 'info'
+    ? 'rgba(124,106,247,.15);border:1px solid #7c6af7;color:#7c6af7'
+    : 'rgba(76,175,125,.15);border:1px solid var(--success);color:var(--success)';
+  t.style.cssText = `position:fixed;bottom:24px;right:24px;padding:10px 16px;
+    border-radius:8px;font-size:13px;z-index:100;background:${accent};
+    animation:fadeIn .25s ease`;
+  t.textContent = msg;
+  document.body.appendChild(t);
+  return t;
 }
 
 function toast(msg, type = 'success') {

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -352,6 +352,13 @@ const TRANSLATIONS = {
     'mem.feedback_ratio':    'Positive ratio',
     'mem.feedback_tracked':  'Tracked directions',
     'mem.feedback_no_signal': '(no signal yet)',
+    // Session list actions (admin Memory tab > session list)
+    'mem.delete_only':              'Delete',
+    'mem.summarize_delete':         'Summarize & Delete',
+    'mem.confirm_delete_only':      'Delete this session? (no summary, no LLM call)',
+    'mem.confirm_summarize_delete': 'Summarize and delete? LLM call required (~30-60s on gemma4:e4b). For a no-summary delete, use the "Delete" button instead.',
+    'mem.summarizing':              'Summarizing... (LLM call, may take 30-60s)',
+    'mem.deleted_no_summary':       'Session deleted (no summary saved)',
     'session.id':            'Session ID',
     'session.turns':         'Turns',
 
@@ -1130,6 +1137,13 @@ const TRANSLATIONS = {
     'mem.feedback_ratio':    '긍정 비율',
     'mem.feedback_tracked':  '추적 중인 방향',
     'mem.feedback_no_signal': '(신호 없음)',
+    // Session list actions (admin Memory tab > session list)
+    'mem.delete_only':              '삭제',
+    'mem.summarize_delete':         '요약 후 삭제',
+    'mem.confirm_delete_only':      '이 세션을 삭제할까요? (요약 없이, LLM 호출 없음)',
+    'mem.confirm_summarize_delete': '요약 후 삭제할까요? LLM 호출 필요 (gemma4:e4b에서 약 30-60초). 요약 없이 삭제하려면 "삭제" 버튼을 사용하세요.',
+    'mem.summarizing':              '요약 생성 중... (LLM 호출, 30-60초 소요)',
+    'mem.deleted_no_summary':       '세션 삭제 완료 (요약 저장 안 됨)',
     'session.id':            '세션 ID',
     'session.turns':         '대화 수',
 

--- a/tests/test_admin_history_expand.py
+++ b/tests/test_admin_history_expand.py
@@ -135,5 +135,133 @@ class JsContractTests(unittest.TestCase):
                                 f"escaped to prevent XSS in the admin UI")
 
 
+class DeleteOnlyPathTests(unittest.TestCase):
+    """PR-O8 — operator added a no-LLM delete path next to the existing
+    Summarize & Delete button. The LLM-driven path (POST /history/summarize/)
+    is a long-running (30-60s) reflect/verify-tier call on gemma4:e4b
+    (Direction 1 closure finding, PR #461). Operators frequently mistake
+    it for a simple delete and end up waiting. This sub-suite locks
+    the new buttons + handlers + i18n surface in place.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        root = Path(__file__).resolve().parent.parent / "frontend" / "static"
+        cls.js   = (root / "admin.js").read_text(encoding="utf-8")
+        cls.i18n = (root / "i18n.js").read_text(encoding="utf-8")
+
+    def test_delete_only_button_in_sessions_row(self):
+        # The delete-only button must live in the action column of the
+        # session list row, alongside (not replacing) the Summarize & Delete
+        # button. Operators get to choose which path to take.
+        idx = self.js.index("async function loadSessions")
+        body = self.js[idx:idx + 1800]
+        self.assertIn('data-action="delete-session-only"', body,
+                      "delete-only button must be wired via the click delegate")
+        self.assertIn('data-action="summarize-and-delete"', body,
+                      "summarize-and-delete button must remain — delete-only "
+                      "is additive, not a replacement")
+
+    def test_delete_only_handler_registered(self):
+        self.assertIn(
+            "case 'delete-session-only':",
+            self.js,
+            "delete-session-only action must have a switch case in the "
+            "click delegate",
+        )
+        self.assertIn(
+            "async function deleteSessionOnly(",
+            self.js,
+            "deleteSessionOnly() function must be defined",
+        )
+
+    def test_delete_only_function_does_not_call_summarize(self):
+        # Critical: the delete-only path must NOT hit /history/summarize/.
+        # If it did, the bug being fixed would silently come back.
+        idx = self.js.index("async function deleteSessionOnly(")
+        body = self.js[idx:idx + 1200]
+        self.assertNotIn("/history/summarize/", body,
+                         "deleteSessionOnly must not call the summarize "
+                         "endpoint — that was the slow path being separated")
+        self.assertIn("/history/?session_id=", body,
+                      "deleteSessionOnly must call the DELETE /history/ endpoint")
+
+    def test_delete_only_has_confirm_gate(self):
+        idx = self.js.index("async function deleteSessionOnly(")
+        body = self.js[idx:idx + 1200]
+        self.assertIn("confirm(", body,
+                      "deleteSessionOnly must gate the DELETE with a confirm() "
+                      "— accidental row clicks should not wipe data")
+
+    def test_summarize_path_has_spinner(self):
+        # The summarize path is 30-60s long-running; without a persistent
+        # indicator operators think the UI froze. PR-O8 added an
+        # explicit spinner toast that lives until the request completes.
+        idx = self.js.index("async function summarizeAndDelete(")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("toastPersistent(", body,
+                      "summarizeAndDelete must use the persistent toast "
+                      "helper for the long-running LLM call")
+        # The spinner must clean up in a finally block so a failed
+        # request doesn't leave a stale toast on screen.
+        self.assertIn("finally", body,
+                      "spinner cleanup must be in a finally block to handle "
+                      "the error path too")
+
+    def test_toast_persistent_helper_exists(self):
+        self.assertIn(
+            "function toastPersistent(",
+            self.js,
+            "toastPersistent() helper must be defined — it's the persistent "
+            "long-running counterpart of toast()",
+        )
+
+    def test_summarize_path_has_expectation_gate(self):
+        # Before the LLM call fires, surface an explicit confirm that
+        # warns about the wait. Operators frequently mistook this for
+        # a simple delete; the gate sets correct expectation.
+        idx = self.js.index("async function summarizeAndDelete(")
+        body = self.js[idx:idx + 2000]
+        self.assertIn("confirm(", body,
+                      "summarizeAndDelete must gate the LLM call with a "
+                      "confirm() that explicitly mentions the wait")
+        self.assertIn("mem.confirm_summarize_delete", body,
+                      "the confirm text must use the i18n key so KR + EN "
+                      "operators both see the wait warning")
+
+    def test_i18n_keys_present_en_and_kr(self):
+        # Six new i18n keys across two languages = 12 entries total.
+        required = (
+            "mem.delete_only",
+            "mem.summarize_delete",
+            "mem.confirm_delete_only",
+            "mem.confirm_summarize_delete",
+            "mem.summarizing",
+            "mem.deleted_no_summary",
+        )
+        for k in required:
+            # quoted key matches both 'k': value and "k": value forms
+            occurrences = self.i18n.count(f"'{k}'") + self.i18n.count(f'"{k}"')
+            self.assertGreaterEqual(
+                occurrences, 2,
+                f"i18n key {k!r} must appear in both EN and KR sections "
+                f"(found {occurrences} times)",
+            )
+
+    def test_summarize_delete_key_was_previously_undefined(self):
+        # Regression guard: the HTML template referenced
+        # data-i18n='mem.summarize_delete' but the i18n table never
+        # defined it. PR-O8 adds the definition; this test pins it.
+        self.assertGreaterEqual(
+            self.i18n.count("'mem.summarize_delete'")
+            + self.i18n.count('"mem.summarize_delete"'),
+            2,
+            "mem.summarize_delete must be defined in both EN and KR — "
+            "the HTML template referenced it before PR-O8 but the i18n "
+            "table didn't carry the key, leaving the button text "
+            "untranslated under language switch",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Real-traffic UX issue from operator 2026-05-25 — clicked **Summarize & Delete** on `bench_step7_13` to clean up a STEP 7 bench session, spent 30-60s waiting through a long-running LLM call without any progress indicator, hit a 401 race during the wait, got bounced to the login page.

The deletion did go through, but the path was mis-named and mis-paced.

## Root cause

`POST /history/summarize/` calls `gemma4:e4b` twice (summary + topic, 60s + 30s timeouts each) before the DELETE fires. On a 20-turn bench session this is the reflect/verify-tier from Direction 1's natural-stop gradient (~900-1000 tokens, ~9s LLM round-trip × 2 = 18-60s end-to-end). The button label is accurate; the **lack of progress indicator + lack of a no-LLM alternative** is the actual UX bug.

## Fix — two buttons + spinner on the slow path

### Delete (new, no LLM)

- Single `DELETE /history/?session_id=...` call.
- Sub-second completion on any session size.
- Confirm gate before deletion: *"Delete this session? (no summary, no LLM call)"*.

### Summarize & Delete (preserved + improved)

- Existing button and handler stay.
- Confirm gate names the wait explicitly: *"~30-60s on gemma4:e4b. For a no-summary delete, use the 'Delete' button instead."*.
- Persistent toast indicator until the request completes; cleaned up in `finally`.

### Helper: `toastPersistent()`

Default `toast()` auto-dismisses after 3s — wrong for a 30-60s LLM call. New helper returns the DOM element; caller `.remove()`s explicitly. Keeps default `toast()` unchanged for the rest of the app.

## i18n surface

6 new keys × 2 languages = 12 entries.

**Regression fix piggybacked**: `mem.summarize_delete` was referenced by `data-i18n='mem.summarize_delete'` on the existing button but was never defined in the i18n table. Under language switch, the button text fell back to the hardcoded English innerHTML. PR-O8 defines the key in both EN and KR.

## Direction 1 alignment

This is the user-facing application of the Direction 1 cycle closure finding (PR #461 / PR #463): an LLM call is a long-running stage on `gemma4:e4b` — natural-stop length scales with task weight, summarize-a-20-turn-session lands in the reflect/verify tier (~900 tokens, 9s LLM round-trip × 2 = 18-60s end-to-end).

The fix isn't to make the call faster (cap is a ceiling, not the floor, per Direction 1) — it's to make the wait **opt-in, label it clearly, and offer a no-LLM alternative** for the common bench-cleanup case.

## Verification

- ✅ **18 tests pass** — `tests/test_admin_history_expand.py` (9 existing `HtmlContractTests` + `JsContractTests`, 9 new `DeleteOnlyPathTests`)
  - delete-only button wired in the action column
  - delete-only handler registered in the click delegate
  - `deleteSessionOnly()` does NOT call `/history/summarize/`
  - `deleteSessionOnly()` has a `confirm()` gate
  - `summarizeAndDelete()` uses `toastPersistent` + `finally` cleanup
  - `summarizeAndDelete()` has the explicit-wait confirm
  - `toastPersistent()` helper is defined
  - 6 i18n keys defined in both EN and KR sections
  - Regression guard for `mem.summarize_delete` being undefined before this PR
- ✅ ruff N/A — pure JS/HTML/i18n change
- ✅ No `core/{retrieval,graph,reasoning}` touched (CLAUDE.md rule #2 N/A)
- ✅ No module size impact

## Out of scope

- Background async for the summarize path (would require a job queue; separate cycle if operator wants the truly-async experience).
- Picking a smaller LLM model for the summary (Direction 4's 3-axis framework says the model-scale efficiency axis matters here too; deferred until summary quality is measured at 1b/3b/7b).
- Surfacing the same "Delete only" path in the chat sidebar sessions mode (`branch claude/explore-miro-integration-zKLEv`); admin UI is the most operationally important surface for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
