### PR TITLE
feat(reasoning): D5.A — Router skeleton + JAMES_AUTO_ROUTER flag

### DIFF
--- a/core/reasoning/router.py
+++ b/core/reasoning/router.py
@@ -1,0 +1,129 @@
+"""Auto-routing — per-call backend selection based on task weight.
+
+Direction 5 of the v0.3.x measurement framework follow-up
+(`docs/handovers/v0.3.x-direction5-auto-routing-track.md`).
+
+D5 sits **above** the Provider Contract (`core/llm_router.py` /
+`core/reasoning/backends/`). It does not change the contract surface;
+it decides *which* registered backend gets the call, leaving the
+backend invocation path untouched. Pre-D5 behavior:
+`JAMES_LLM_MODEL` env wins for every call. With D5 enabled
+(`JAMES_AUTO_ROUTER=1`), the router consults a per-call task-weight
+signal and selects the appropriate backend.
+
+This module is **D5.A — skeleton only**. Phase plan:
+  • D5.A (this PR) — module + flag default OFF + stub policy
+    returning the legacy backend regardless of `enabled` state.
+  • D5.B — backend registry capability tags.
+  • D5.C — actual routing policy + STEP 7 bench in PR body.
+  • D5.D — wiki entity `aliases:` + entity_extract resolve
+    (cross-lingual RAG option 3, bundled per design memo §Cross-lingual).
+  • D5.E — closure result doc + memory sync.
+
+Default-off invariant: with `JAMES_AUTO_ROUTER` unset/0, behavior is
+byte-identical to pre-D5 main. Mirrors the
+`JAMES_ADAPTIVE_BUDGET` pattern from D1
+(`core/retrieval/query_rewriter.py:_adaptive_budget_enabled`).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final, Literal, Optional
+
+ReasoningStage = Literal[
+    "query_rewriter",
+    "planner",
+    "reflect",
+    "verify",
+    "synth",
+]
+
+# Canonical default when neither JAMES_LLM_MODEL nor the router is
+# configured. Matches the rest of the codebase's implicit fallback
+# (see `core/model_resolver.py`).
+_DEFAULT_BACKEND_ID: Final[str] = "gemma4:e4b"
+
+_FLAG_ON_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+
+def _auto_router_enabled() -> bool:
+    """Env-flag gate for D5.
+
+    Default OFF — `JAMES_AUTO_ROUTER=1` (or `true` / `yes` / `on`)
+    activates the routing. Until then, `Router()` returns the legacy
+    backend on every call → byte-identical to pre-D5 main.
+
+    Mirrors `core.retrieval.query_rewriter._adaptive_budget_enabled`.
+    """
+    return os.getenv("JAMES_AUTO_ROUTER", "0").strip().lower() in _FLAG_ON_VALUES
+
+
+def _legacy_backend_id() -> str:
+    """Return whatever the rest of the codebase resolves to today.
+
+    Pre-D5, every reasoning call effectively hits `JAMES_LLM_MODEL`
+    (or the codebase default when unset). Returning the same value
+    here is the contract for `enabled=False` and the D5.A stub
+    `enabled=True` branch.
+    """
+    return os.getenv("JAMES_LLM_MODEL", _DEFAULT_BACKEND_ID) or _DEFAULT_BACKEND_ID
+
+
+class Router:
+    """Per-call backend selector.
+
+    Stateless except for the `enabled` flag captured at construction
+    time. Safe to call concurrently.
+
+    D5.A stub: `select_backend` always returns the legacy backend
+    regardless of `enabled`. The flag-on branch becomes meaningful at
+    D5.C when policy + budget signal land. This preserves the
+    default-off invariant during the D5.A/B/C build-up — opting in
+    via `JAMES_AUTO_ROUTER=1` is safe at every intermediate PR
+    because behavior is unchanged until D5.C ships the policy.
+    """
+
+    __slots__ = ("enabled",)
+
+    def __init__(self, *, enabled: Optional[bool] = None) -> None:
+        """Create a router instance.
+
+        Args:
+            enabled: explicit override. `None` (default) consults the
+                env flag. Tests pass an explicit bool.
+        """
+        self.enabled = _auto_router_enabled() if enabled is None else bool(enabled)
+
+    def select_backend(
+        self,
+        stage: ReasoningStage,
+        prompt: str,
+        *,
+        context: str = "",
+        budget_signal: Optional[int] = None,
+    ) -> str:
+        """Return the backend ID to invoke for this call.
+
+        Args:
+            stage: reasoning-stage identifier (matches D1's
+                `ReasoningStage`).
+            prompt: the prompt string the stage is about to send.
+            context: optional retrieval context. Reserved for D5.C
+                policy + D5.D cross-lingual alias resolution.
+            budget_signal: optional cap from `TaskBudget.assess(...)`.
+                D5.C will use this as the primary routing input
+                (substitution-tier → small backend, heavy-tier →
+                large backend).
+
+        Returns:
+            Backend ID string (e.g. `"gemma4:e4b"`). Currently always
+            the legacy backend; D5.C replaces the flag-on branch with
+            real policy.
+        """
+        # D5.A: flag-off and flag-on both return legacy. The branch
+        # exists so D5.C can drop policy in without touching call sites.
+        if not self.enabled:
+            return _legacy_backend_id()
+        # D5.C will replace this line with policy(stage, prompt, context, budget_signal)
+        return _legacy_backend_id()

--- a/tests/test_router_skeleton.py
+++ b/tests/test_router_skeleton.py
@@ -1,0 +1,112 @@
+"""D5.A skeleton contract tests.
+
+Pins the default-off invariant + the stub policy for the auto-router.
+D5.C will extend these with policy assertions; D5.A only locks the
+shape so subsequent PRs land without surprise behavior shifts.
+
+See `docs/handovers/v0.3.x-direction5-auto-routing-track.md` for the
+full phase plan.
+"""
+
+import os
+
+import pytest
+
+from core.reasoning.router import (
+    _DEFAULT_BACKEND_ID,
+    Router,
+    _auto_router_enabled,
+    _legacy_backend_id,
+)
+
+
+# ─── flag detection ─────────────────────────────────────────────────
+
+
+def test_flag_default_off(monkeypatch):
+    monkeypatch.delenv("JAMES_AUTO_ROUTER", raising=False)
+    assert _auto_router_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes"])
+def test_flag_on_recognized(monkeypatch, value):
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", value)
+    assert _auto_router_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "blah", "2"])
+def test_flag_off_or_invalid_treated_as_off(monkeypatch, value):
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", value)
+    assert _auto_router_enabled() is False
+
+
+# ─── legacy backend resolution ─────────────────────────────────────
+
+
+def test_legacy_backend_uses_env_when_set(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "gemma3:12b")
+    assert _legacy_backend_id() == "gemma3:12b"
+
+
+def test_legacy_backend_falls_back_when_unset(monkeypatch):
+    monkeypatch.delenv("JAMES_LLM_MODEL", raising=False)
+    assert _legacy_backend_id() == _DEFAULT_BACKEND_ID
+
+
+def test_legacy_backend_falls_back_when_empty(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "")
+    assert _legacy_backend_id() == _DEFAULT_BACKEND_ID
+
+
+# ─── Router contract ───────────────────────────────────────────────
+
+
+def test_router_flag_off_returns_legacy(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "gemma4:e4b")
+    r = Router(enabled=False)
+    assert r.enabled is False
+    assert r.select_backend("query_rewriter", "팔란티어가 뭐야") == "gemma4:e4b"
+
+
+def test_router_flag_on_stub_also_returns_legacy(monkeypatch):
+    """D5.A stub — flag-on currently returns legacy. D5.C replaces this."""
+    monkeypatch.setenv("JAMES_LLM_MODEL", "gemma4:e4b")
+    r = Router(enabled=True)
+    assert r.enabled is True
+    assert r.select_backend("query_rewriter", "팔란티어가 뭐야") == "gemma4:e4b"
+
+
+def test_router_default_construction_consults_env(monkeypatch):
+    monkeypatch.delenv("JAMES_AUTO_ROUTER", raising=False)
+    r_off = Router()
+    assert r_off.enabled is False
+
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", "1")
+    r_on = Router()
+    assert r_on.enabled is True
+
+
+def test_router_explicit_enabled_overrides_env(monkeypatch):
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", "1")
+    r = Router(enabled=False)
+    assert r.enabled is False
+
+
+def test_router_accepts_all_stages():
+    """Contract pin: every D1 ReasoningStage value is a valid call."""
+    r = Router(enabled=False)
+    for stage in ("query_rewriter", "planner", "reflect", "verify", "synth"):
+        out = r.select_backend(stage, "test")
+        assert isinstance(out, str) and out
+
+
+def test_router_accepts_optional_kwargs():
+    """Contract pin: context + budget_signal are accepted (D5.C will use)."""
+    r = Router(enabled=False)
+    out = r.select_backend(
+        "verify",
+        "test prompt",
+        context="some retrieved context",
+        budget_signal=1200,
+    )
+    assert isinstance(out, str) and out

--- a/tests/test_router_skeleton.py
+++ b/tests/test_router_skeleton.py
@@ -8,8 +8,6 @@ See `docs/handovers/v0.3.x-direction5-auto-routing-track.md` for the
 full phase plan.
 """
 
-import os
-
 import pytest
 
 from core.reasoning.router import (


### PR DESCRIPTION
## Summary

D5.A — first code surface for the **Direction 5 (Auto-routing on
Provider Contract)** cycle (design memo: PR #474).

`core/reasoning/router.py` ships as a flag-gated skeleton. The
flag (`JAMES_AUTO_ROUTER`) is default **OFF**, mirroring the D1
`JAMES_ADAPTIVE_BUDGET` pattern (`core/retrieval/query_rewriter.py:_adaptive_budget_enabled`).
Pre-D5 behavior is byte-identical because the D5.A stub policy
returns `os.getenv("JAMES_LLM_MODEL")` regardless of flag state.

The flag-on branch exists *now* so D5.C (stage wiring + STEP 7
bench) drops policy in one line (`return policy(...)`) without
touching call sites or contract tests.

## What lands

| File | Change |
|---|---|
| `core/reasoning/router.py` | NEW — 124 lines / ~5 KB. `Router(*, enabled=None)` + `select_backend(stage, prompt, *, context="", budget_signal=None) → str` + helpers (`_auto_router_enabled`, `_legacy_backend_id`, constants). |
| `tests/test_router_skeleton.py` | NEW — 23 contract tests across 3 groups (flag detection / legacy backend resolution / Router contract). |

## Verification

- ✅ **23/23 contract tests pass**
- ✅ ruff clean
- ✅ Module size: ~5 KB (CLAUDE.md rule #5 ≤20 KB safe)
- ✅ No call-site wiring — pre-existing reasoning stages unchanged
- ✅ Flag-OFF default invariant preserved (no `JAMES_LLM_MODEL` semantics change)
- ✅ `_legacy_backend_id()` falls back to `_DEFAULT_BACKEND_ID = "gemma4:e4b"` when env is unset/empty (matches existing codebase implicit default)

## Bench (CLAUDE.md rule #2)

`core/reasoning/router.py` is under `core/reasoning`, so rule
applies. D5.A is a **new module with no call-site wiring** — pre-D5
behavior is byte-identical because the legacy `JAMES_LLM_MODEL`
path is the only one in use. No STEP 7 delta measurable, no
measurement expected.

Bench numbers land at **D5.C** when the 4 cognitive stages + synth
start consulting the router. Smoke check confirms
`Router(enabled=False).select_backend(...)` returns the same string
`os.getenv("JAMES_LLM_MODEL")` returns.

## Architecture label (CLAUDE.md rule #4)

New module under `core/reasoning/` → `architecture` label applied.
Intent documented in the design memo (PR #474 →
`docs/handovers/v0.3.x-direction5-auto-routing-track.md` §Scope /
§Phase plan). `docs/ARCHITECTURE.md` amendment lands with D5.C
when the contract becomes externally observable.

## Out of scope (D5 phase plan)

- **D5.B** — backend registry capability tags (so D5.C has named tiers)
- **D5.C** — stage wiring + STEP 7 bench + audit row `reason:route`
- **D5.D** — wiki entity `aliases:` + entity_extract resolve (cross-lingual RAG option 3 follow-up to PR #472)
- **D5.E** — closure result doc + memory sync + ROADMAP D5 `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)