### PR TITLE
feat(reasoning): D5.B — backend capability tags (tier/provider)

### DIFF
--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -26,7 +26,42 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Dict, Protocol, runtime_checkable
+from typing import Dict, Final, List, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class BackendCapability:
+    """Routing-time metadata about a backend. D5.B (2026-05-25) addition.
+
+    ``tier``: model-size class —
+      • ``"small"``   ≤ 4B params (e.g. gemma4:e4b, llama 3.2:1b)
+      • ``"medium"``  12-27B (e.g. gemma3:12b, gemma4:26b sovereign)
+      • ``"large"``   70B+ or frontier cloud (e.g. Claude, GPT-4)
+
+    ``provider``: deployment surface —
+      • ``"local"``      same machine as JAMES
+      • ``"sovereign"``  operator-controlled remote (e.g. Hetzner Ollama)
+      • ``"cloud"``      third-party API (no operator control of weights)
+
+    Used by D5 Router (``core/reasoning/router.py``) at flag-on
+    selection time. Backends pre-dating D5.B do not declare a
+    ``capability`` attribute → ``get_backend_capability(name)`` returns
+    ``UNKNOWN_CAPABILITY`` for them, and D5 Router treats unknown-tier
+    backends as "fallback only, never preferred".
+
+    Free-form strings rather than enums so external plugin backends
+    can declare niche tiers (e.g. ``tier="tiny"`` for a 1B-class
+    backend) without modifying core. D5 Router policy validates
+    against known tier values; novel tiers degrade to UNKNOWN.
+    """
+    tier: str
+    provider: str
+
+
+UNKNOWN_CAPABILITY: Final[BackendCapability] = BackendCapability(
+    tier="unknown",
+    provider="unknown",
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +140,48 @@ def list_backends() -> Dict[str, Backend]:
     code goes through get_backend.
     """
     return dict(_REGISTRY)
+
+
+def get_backend_capability(name: str) -> BackendCapability:
+    """Return the declared capability of a backend, or
+    ``UNKNOWN_CAPABILITY`` if the backend pre-dates D5.B or hasn't
+    declared one.
+
+    D5.B (2026-05-25) addition. Used by D5 Router
+    (``core/reasoning/router.py``) when the auto-router flag is on.
+    Unknown-capability backends are treated as "fallback only, never
+    preferred" by D5.C policy — so an external plugin backend that
+    doesn't opt into capability declaration is still safe to keep
+    registered; it just won't be picked over a declared backend with
+    a matching tier.
+
+    Raises ``KeyError`` if ``name`` is not registered (mirrors
+    ``get_backend`` — loud failure on typos beats silent fallback).
+    """
+    backend = get_backend(name)
+    cap = getattr(backend, "capability", None)
+    if isinstance(cap, BackendCapability):
+        return cap
+    return UNKNOWN_CAPABILITY
+
+
+def list_backends_by_tier(tier: str) -> List[str]:
+    """Return backend names whose declared ``tier`` matches.
+
+    Empty list if no backends are declared at this tier — D5 Router
+    treats that as "no preferred backend, fall back to global default
+    via ``get_default_backend_id()``".
+
+    D5.B (2026-05-25) addition. Pairs with ``get_backend_capability``
+    for D5.C routing policy. Backends without a declared capability
+    are skipped (never match any tier — they are UNKNOWN, not "all").
+    """
+    out: List[str] = []
+    for name, backend in _REGISTRY.items():
+        cap = getattr(backend, "capability", None)
+        if isinstance(cap, BackendCapability) and cap.tier == tier:
+            out.append(name)
+    return out
 
 
 def _clear_for_tests() -> None:

--- a/core/reasoning/backends/claude_code_cli.py
+++ b/core/reasoning/backends/claude_code_cli.py
@@ -27,7 +27,7 @@ import subprocess
 import time
 from typing import List, Optional
 
-from core.reasoning.backends import CompletionResult
+from core.reasoning.backends import BackendCapability, CompletionResult
 
 
 _MAX_OUTPUT_BYTES = 1 * 1024 * 1024   # 1 MiB
@@ -66,6 +66,14 @@ class ClaudeCodeCliBackend:
     """
 
     backend_id = "claude_code_cli"
+
+    # D5.B capability declaration. Claude (Anthropic frontier) is
+    # "large" tier — used by D5.C policy for heavy-synthesis routing
+    # (the arm where the cost asymmetry favors the better model).
+    # ``provider="cloud"`` because the CLI hits Anthropic's API surface
+    # — operators have no control over weights, only over whether the
+    # backend is registered (opt-in via JAMES_ENABLE_CLAUDE_BACKEND=1).
+    capability = BackendCapability(tier="large", provider="cloud")
 
     def __init__(self, cli_path: Optional[str] = None) -> None:
         # Constructor-time path resolution is a snapshot; auto-registered

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import time
 from typing import Optional
 
-from core.reasoning.backends import CompletionResult
+from core.reasoning.backends import BackendCapability, CompletionResult
 
 
 class OllamaLocalBackend:
@@ -22,6 +22,15 @@ class OllamaLocalBackend:
     """
 
     backend_id = "ollama_local"
+
+    # D5.B capability declaration. Default Ollama model on a stock
+    # install is ``gemma4:e4b`` (4B class) → "small" tier. ``provider``
+    # is "local" because RouterWrapper hits ``localhost:11434`` by
+    # default. Operators pointing JAMES at a remote Ollama (e.g.
+    # Hetzner sovereign) effectively re-tier this backend; v1 records
+    # the default deployment and D5.C policy degrades gracefully when
+    # the actual ``JAMES_LLM_MODEL`` exceeds the tier expectation.
+    capability = BackendCapability(tier="small", provider="local")
 
     def __init__(self) -> None:
         self._router = None   # constructed on first .complete()

--- a/tests/test_backend_capability.py
+++ b/tests/test_backend_capability.py
@@ -1,0 +1,159 @@
+"""D5.B backend capability registry contract tests.
+
+Locks the BackendCapability dataclass + helper API shape so D5.C
+routing policy can rely on them. Also pins the two built-in
+backends' declared capabilities so a refactor that drops a
+declaration is caught here, not in production routing.
+"""
+
+import pytest
+
+from core.reasoning.backends import (
+    UNKNOWN_CAPABILITY,
+    BackendCapability,
+    _clear_for_tests,
+    get_backend_capability,
+    list_backends_by_tier,
+    register_backend,
+)
+
+
+# ─── BackendCapability dataclass shape ─────────────────────────────
+
+
+def test_capability_dataclass_is_frozen():
+    cap = BackendCapability(tier="small", provider="local")
+    with pytest.raises((AttributeError, Exception)):
+        cap.tier = "large"  # frozen dataclass refuses mutation
+
+
+def test_capability_fields():
+    cap = BackendCapability(tier="medium", provider="sovereign")
+    assert cap.tier == "medium"
+    assert cap.provider == "sovereign"
+
+
+def test_unknown_capability_is_unknown():
+    assert UNKNOWN_CAPABILITY.tier == "unknown"
+    assert UNKNOWN_CAPABILITY.provider == "unknown"
+
+
+def test_capability_equality_by_value():
+    a = BackendCapability(tier="small", provider="local")
+    b = BackendCapability(tier="small", provider="local")
+    assert a == b
+    assert a != BackendCapability(tier="large", provider="local")
+
+
+# ─── Built-in backend declarations ─────────────────────────────────
+
+
+def test_ollama_local_declares_small_local():
+    # Importing the module auto-registers the backend per
+    # core/reasoning/backends/__init__.py autoregistration block.
+    import core.reasoning.backends  # noqa: F401 — trigger autoregistration
+
+    cap = get_backend_capability("ollama_local")
+    assert cap.tier == "small"
+    assert cap.provider == "local"
+
+
+# claude_code_cli is opt-in via JAMES_ENABLE_CLAUDE_BACKEND=1.
+# We assert the class-level attribute directly (no registration needed).
+def test_claude_code_cli_class_declares_large_cloud():
+    from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
+
+    assert ClaudeCodeCliBackend.capability.tier == "large"
+    assert ClaudeCodeCliBackend.capability.provider == "cloud"
+
+
+# ─── get_backend_capability behavior ───────────────────────────────
+
+
+class _StubDeclared:
+    backend_id = "stub_declared"
+    capability = BackendCapability(tier="medium", provider="sovereign")
+
+    def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+        from core.reasoning.backends import CompletionResult
+        return CompletionResult(text="ok", backend_id=self.backend_id)
+
+
+class _StubNoCapability:
+    backend_id = "stub_legacy"
+
+    def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+        from core.reasoning.backends import CompletionResult
+        return CompletionResult(text="ok", backend_id=self.backend_id)
+
+
+@pytest.fixture
+def isolated_registry():
+    """Snapshot/restore the registry around tests that mutate it."""
+    import core.reasoning.backends as backends_mod
+    snapshot = dict(backends_mod._REGISTRY)
+    yield
+    backends_mod._REGISTRY.clear()
+    backends_mod._REGISTRY.update(snapshot)
+
+
+def test_get_capability_returns_declared(isolated_registry):
+    register_backend("stub_declared", _StubDeclared())
+    assert get_backend_capability("stub_declared") == BackendCapability(
+        tier="medium", provider="sovereign"
+    )
+
+
+def test_get_capability_returns_unknown_for_undeclared(isolated_registry):
+    register_backend("stub_legacy", _StubNoCapability())
+    assert get_backend_capability("stub_legacy") is UNKNOWN_CAPABILITY
+
+
+def test_get_capability_returns_unknown_for_wrong_type(isolated_registry):
+    class StubWrongType:
+        backend_id = "stub_wrong"
+        capability = "small"  # str, not BackendCapability
+
+        def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+            from core.reasoning.backends import CompletionResult
+            return CompletionResult(text="ok", backend_id=self.backend_id)
+
+    register_backend("stub_wrong", StubWrongType())
+    assert get_backend_capability("stub_wrong") is UNKNOWN_CAPABILITY
+
+
+def test_get_capability_raises_keyerror_for_unregistered(isolated_registry):
+    _clear_for_tests()
+    with pytest.raises(KeyError):
+        get_backend_capability("does_not_exist")
+
+
+# ─── list_backends_by_tier behavior ───────────────────────────────
+
+
+def test_list_by_tier_includes_declared(isolated_registry):
+    _clear_for_tests()
+    register_backend("a", _StubDeclared())  # tier=medium
+    assert "a" in list_backends_by_tier("medium")
+
+
+def test_list_by_tier_skips_undeclared(isolated_registry):
+    _clear_for_tests()
+    register_backend("legacy", _StubNoCapability())
+    # legacy has no capability — it should not match any tier (not even "unknown")
+    assert list_backends_by_tier("small") == []
+    assert list_backends_by_tier("medium") == []
+    assert list_backends_by_tier("large") == []
+    assert list_backends_by_tier("unknown") == []
+
+
+def test_list_by_tier_empty_for_unmatched_tier(isolated_registry):
+    _clear_for_tests()
+    register_backend("a", _StubDeclared())  # tier=medium
+    assert list_backends_by_tier("small") == []
+
+
+def test_list_by_tier_with_builtin_ollama():
+    """Sanity — the auto-registered ollama_local lands under 'small'."""
+    import core.reasoning.backends  # noqa: F401
+    assert "ollama_local" in list_backends_by_tier("small")


### PR DESCRIPTION
## Summary

Second phase of **Direction 5 (Auto-routing on Provider Contract)** —
metadata layer D5.C will consume to pick a backend by task weight.
Pure refactor: no behavior change, no call site consults
`capability` yet.

Design memo: PR #474 → `docs/handovers/v0.3.x-direction5-auto-routing-track.md` §D5.B.

## Changes

| File | Change |
|---|---|
| `core/reasoning/backends/__init__.py` | `BackendCapability(tier, provider)` frozen dataclass + `UNKNOWN_CAPABILITY` sentinel + `get_backend_capability(name)` + `list_backends_by_tier(tier)` |
| `core/reasoning/backends/ollama_local.py` | `capability = BackendCapability(tier="small", provider="local")` |
| `core/reasoning/backends/claude_code_cli.py` | `capability = BackendCapability(tier="large", provider="cloud")` |
| `tests/test_backend_capability.py` | NEW — 14 contract tests |

## Tier / provider vocabulary

`tier` (model-size class): `small` (≤4B) / `medium` (12-27B) / `large` (70B+ or frontier cloud)
`provider` (deployment): `local` / `sovereign` / `cloud`

Free-form strings (not enums) so plugin backends can declare niche tiers without modifying core. D5.C policy validates known values; novel tiers degrade to UNKNOWN.

## Backward compat

- Backends without `capability` → `get_backend_capability` returns `UNKNOWN_CAPABILITY` (not an error)
- D5.C policy treats unknown-tier as "fallback only, never preferred" → pre-D5.B plugin backends keep working
- `list_backends_by_tier` skips undeclared backends (explicit declaration required to participate in routing)

## Verification

- ✅ **37 D5.A/B contract tests pass** (14 D5.B + 23 D5.A regression)
- ✅ **158 backend/router/provider tests pass** (no regression on `test_router_capability`, `test_backend_conformance`, L0/L1 provider-contract tests)
- ✅ ruff clean
- ✅ Module size: `__init__.py` ~10 KB (rule #5 ≤20 KB safe)

## Bench (CLAUDE.md rule #2)

`core/reasoning/backends/__init__.py` is under `core/reasoning`, rule applies. D5.B is pure metadata — no call site consults `capability` yet. Pre-D5 behavior byte-identical: `resolve_backend_for_stage` / `get_default_backend_id` unchanged, 5 cognitive stages still route through legacy path until D5.C. Bench numbers land at **D5.C** when policy becomes observable.

## Architecture label (CLAUDE.md rule #4)

`Backend` protocol-adjacent surface gains an optional `capability` attribute → `architecture` label applied. `docs/ARCHITECTURE.md` amendment lands with D5.C when the contract becomes externally observable.

## Out of scope (D5 phase plan)

- **D5.C** — stage wiring + policy + STEP 7 bench + audit `reason:route`
- **D5.D** — wiki entity `aliases:` + entity_extract resolve (cross-lingual option 3)
- **D5.E** — closure result doc + memory sync + ROADMAP D5 `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)