### PR TITLE
feat(reasoning): D5.C.2.a — router helpers + query_rewriter stage wiring

### DIFF
--- a/core/reasoning/router.py
+++ b/core/reasoning/router.py
@@ -213,3 +213,101 @@ class Router:
         if not self.enabled:
             return _legacy_backend_id()
         return _route_policy(stage, prompt, context, budget_signal)
+
+
+# ─── D5.C.2 — high-level helpers for stage call sites ─────────────
+
+
+def _budget_to_tier_label(signal: Optional[int]) -> str:
+    """Map a TaskBudget cap to a short tier label for audit / debug."""
+    if signal is None:
+        return "none"
+    if signal == CAP_SUBSTITUTION:
+        return "substitution"
+    if signal == CAP_LIGHT:
+        return "light"
+    if signal == CAP_HEAVY:
+        return "heavy"
+    return f"unknown:{signal}"
+
+
+def resolve_backend(
+    stage: str,
+    prompt: str,
+    *,
+    context: str = "",
+    budget_signal: Optional[int] = None,
+    fallback_backend_id: Optional[str] = None,
+) -> str:
+    """High-level helper for stage call sites.
+
+    Replaces ``get_backend(self._backend_id)`` at the 5 cognitive
+    call sites (D5.C.2 wiring). Behavior:
+
+      • ``JAMES_AUTO_ROUTER`` flag OFF → returns ``fallback_backend_id``
+        (the stage's pre-D5 ``self._backend_id``) or ``_legacy_backend_id()``
+        if ``None``. Byte-identical to pre-D5 main.
+      • Flag ON → consults ``Router(...).select_backend(stage, prompt, ...)``
+        which dispatches to ``_route_policy`` (the D5.C.1 decision tree).
+
+    Stage call sites pass ``budget_signal`` only when the D1 adaptive
+    budget flag is also on (signal is meaningless under D1 flag-off
+    because the cap is fixed at ``DEFAULT_MAX_TOKENS=4096`` and
+    would unconditionally trigger the CAP_HEAVY branch). Without a
+    meaningful signal, the router's policy falls back to legacy.
+    """
+    r = Router()
+    if not r.enabled:
+        return fallback_backend_id or _legacy_backend_id()
+    return r.select_backend(
+        stage,  # type: ignore[arg-type]
+        prompt,
+        context=context,
+        budget_signal=budget_signal,
+    )
+
+
+def emit_route_event(
+    stage: str,
+    prompt: str,
+    selected_backend: str,
+    *,
+    budget_signal: Optional[int] = None,
+    reason: str = "policy",
+) -> None:
+    """Emit a ``reason:route`` row to ``audit_log``.
+
+    Stage call sites call this immediately after ``resolve_backend``
+    so every routing decision is auditable. Never raises — audit
+    failure must not block the production call path (mirrors the
+    pattern in ``core.audit_bridge.mirror_to_audit_db``).
+
+    The row schema (mapped onto the existing 11-column ``audit_log``
+    table):
+      • ``endpoint``  = ``"reason:route"``
+      • ``query``     = stage name (call-site identifier)
+      • ``answer``    = ``"backend={id} tier={label} reason={why}"``
+                        + a short prompt hash for cross-referencing
+                        with the originating /query/ row
+    """
+    try:
+        import hashlib
+        from core.audit_bridge import mirror_to_audit_db
+
+        prompt_hash = (
+            hashlib.sha256(prompt.encode("utf-8", errors="ignore")).hexdigest()[:8]
+            if prompt
+            else ""
+        )
+        tier_label = _budget_to_tier_label(budget_signal)
+        mirror_to_audit_db({
+            "endpoint": "reason:route",
+            "role": "system",
+            "query": stage,
+            "answer": (
+                f"backend={selected_backend} tier={tier_label} "
+                f"reason={reason} prompt={prompt_hash}"
+            ),
+        })
+    except Exception:
+        pass

--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -269,12 +269,6 @@ class QueryRewriter:
         if not force and not _enabled():
             return (query, 0, False)
 
-        try:
-            from core.reasoning.backends import get_backend
-            backend = get_backend(self._backend_id)
-        except Exception:
-            return (query, 0, False)
-
         prompt_tmpl = REWRITE_PROMPT_KO if _is_korean(query) else REWRITE_PROMPT_EN
         prompt = prompt_tmpl.format(query=query)
 
@@ -285,11 +279,49 @@ class QueryRewriter:
         # Default-off invariant: paths 1 and 3 produce the pre-D1.B cap.
         if self._max_tokens is not None:
             cap = self._max_tokens
+            _budget_for_router = None
         elif _adaptive_budget_enabled():
             cap = self._budget.assess("query_rewriter", query)
             _trace_budget(stage="query_rewriter", cap=cap, query=query)
+            # D5.C.2 — only when D1 dynamic budget is active do we feed
+            # a meaningful signal to the router. Under D1 flag-off the
+            # cap is fixed at DEFAULT_MAX_TOKENS=4096 which would
+            # unconditionally trigger the CAP_HEAVY routing branch —
+            # the wrong signal. Pass `None` and let the router fall
+            # back to legacy.
+            _budget_for_router = cap
         else:
             cap = DEFAULT_MAX_TOKENS
+            _budget_for_router = None
+
+        # D5.C.2 — flag-gated backend resolution. With JAMES_AUTO_ROUTER off
+        # `resolve_backend` returns `self._backend_id` (byte-identical to
+        # pre-D5). With flag on it consults the D5.C.1 policy (`_route_policy`).
+        try:
+            from core.reasoning.backends import get_backend
+            from core.reasoning.router import emit_route_event, resolve_backend
+
+            backend_id = resolve_backend(
+                "query_rewriter",
+                prompt,
+                budget_signal=_budget_for_router,
+                fallback_backend_id=self._backend_id,
+            )
+            backend = get_backend(backend_id)
+        except Exception:
+            return (query, 0, False)
+
+        # Audit row is emitted regardless of flag state — the routing
+        # decision (even when it is "fall back to legacy because flag
+        # off") is useful for diagnostics. Never raises (helper
+        # swallows audit failures).
+        emit_route_event(
+            "query_rewriter",
+            prompt,
+            backend_id,
+            budget_signal=_budget_for_router,
+            reason="auto" if _budget_for_router is not None else "fallback",
+        )
 
         t0 = time.time()
         try:

--- a/tests/test_query_rewriter_router_wiring.py
+++ b/tests/test_query_rewriter_router_wiring.py
@@ -1,0 +1,283 @@
+"""D5.C.2.a — QueryRewriter router wiring contract tests.
+
+Verifies the flag-gated wiring added in `core/retrieval/query_rewriter.py`:
+
+  • `JAMES_AUTO_ROUTER` flag OFF → backend = `self._backend_id`
+    (byte-identical to pre-D5)
+  • Flag ON + D1 flag OFF      → backend = `self._backend_id` (router
+    sees `budget_signal=None` → policy fallback to legacy → fallback)
+  • Flag ON + D1 flag ON       → backend resolved via router policy
+  • `emit_route_event` invoked on every successful resolution
+
+Pairs with `test_query_rewriter.py` (D1 + L0/L1 backend regression)
+and `test_router_policy.py` (D5.C.1 policy decision tree).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+
+ensure_utf8_console()
+
+
+def _completion(text="", error=""):
+    res = MagicMock()
+    res.text = text
+    res.error = error
+    return res
+
+
+class _EnvSnapshot(unittest.TestCase):
+    """Save & restore the env flags this test class manipulates."""
+
+    _FLAGS = (
+        "JAMES_ENABLE_QUERY_REWRITE",
+        "JAMES_ADAPTIVE_BUDGET",
+        "JAMES_AUTO_ROUTER",
+        "JAMES_LLM_MODEL",
+    )
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self._FLAGS}
+        # Default test env: rewriter enabled (so wiring actually fires),
+        # D1 + D5 flags both off (caller flips per test).
+        os.environ["JAMES_ENABLE_QUERY_REWRITE"] = "1"
+        os.environ.pop("JAMES_ADAPTIVE_BUDGET", None)
+        os.environ.pop("JAMES_AUTO_ROUTER", None)
+        os.environ["JAMES_LLM_MODEL"] = "fixture_legacy"
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class FlagOffPreservesFallbackTests(_EnvSnapshot):
+    """D5.C.2.a invariant: flag-off → backend = self._backend_id."""
+
+    def test_d5_off_uses_self_backend_id(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+
+        with patch(
+            "core.reasoning.backends.get_backend", return_value=fake
+        ) as get_b:
+            rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+
+        # The lookup must have used self._backend_id ("ollama_local"),
+        # not the policy default. The wiring resolved the backend before
+        # calling get_backend.
+        get_b.assert_called_with("ollama_local")
+
+    def test_d5_off_with_d1_on_still_uses_self_backend_id(self):
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        with patch(
+            "core.reasoning.backends.get_backend", return_value=fake
+        ) as get_b:
+            rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+        # D5 flag still off → router not consulted → fallback wins.
+        get_b.assert_called_with("ollama_local")
+
+
+class FlagOnD1OffRoutesToLegacyTests(_EnvSnapshot):
+    """D5 flag ON but D1 flag OFF → budget_signal=None → router policy
+    falls through to its own legacy backend (`JAMES_LLM_MODEL` env).
+    The stage's `self._backend_id` is intentionally overridden because
+    D5 ON means "let the router decide" — stage-level preferences are
+    a D5-OFF concept."""
+
+    def test_d5_on_d1_off_uses_router_legacy_not_self_backend_id(self):
+        os.environ["JAMES_AUTO_ROUTER"] = "1"
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        with patch(
+            "core.reasoning.backends.get_backend", return_value=fake
+        ) as get_b:
+            rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+        # D5 flag ON → router policy decides. With budget_signal=None
+        # the policy rule 4 (legacy) fires → router returns
+        # `_legacy_backend_id()` = JAMES_LLM_MODEL = "fixture_legacy".
+        # `self._backend_id` ("ollama_local") is intentionally ignored
+        # — D5 ON means router is the authority, not the stage.
+        get_b.assert_called_with("fixture_legacy")
+
+
+class FlagOnD1OnRoutesViaPolicyTests(_EnvSnapshot):
+    """D5 + D1 flags both ON → router consults policy with a real
+    budget signal. Short Korean query like "팔란티어가 뭐야" routes
+    through D1 → CAP_LIGHT → router policy → legacy fallback (no
+    'small' tier override registered in test env beyond the builtin
+    ollama_local)."""
+
+    def test_router_consulted_when_both_flags_on(self):
+        os.environ["JAMES_AUTO_ROUTER"] = "1"
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        # CAP_LIGHT routes to legacy (no escalation for light tier)
+        with patch(
+            "core.reasoning.backends.get_backend", return_value=fake
+        ) as get_b:
+            with patch(
+                "core.reasoning.router.emit_route_event"
+            ) as emit:
+                rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+        # Audit row emitted exactly once per call
+        emit.assert_called_once()
+        # The chosen backend = the resolved policy output; since only
+        # the builtin small tier (ollama_local) is registered AND the
+        # signal is CAP_LIGHT, the policy returns legacy fallback.
+        get_b.assert_called()
+
+
+class AuditEventEmittedTests(_EnvSnapshot):
+    """emit_route_event is called on every successful backend resolve,
+    regardless of flag state. The reason label distinguishes flag-on
+    ('auto') from flag-off ('fallback')."""
+
+    def test_emit_called_on_flag_off(self):
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            with patch(
+                "core.reasoning.router.emit_route_event"
+            ) as emit:
+                rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+        emit.assert_called_once()
+        # reason label is 'fallback' under D1 flag off (no meaningful signal)
+        kwargs = emit.call_args.kwargs
+        assert kwargs.get("reason") == "fallback"
+
+    def test_emit_called_with_auto_reason_when_d1_on(self):
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        from core.retrieval.query_rewriter import QueryRewriter
+
+        rw = QueryRewriter(backend_id="ollama_local")
+        fake = MagicMock()
+        fake.complete.return_value = _completion(
+            text='{"rewritten": "ok"}'
+        )
+        with patch("core.reasoning.backends.get_backend", return_value=fake):
+            with patch(
+                "core.reasoning.router.emit_route_event"
+            ) as emit:
+                rw.rewrite("이것은 충분히 긴 질의입니다", force=True)
+        emit.assert_called_once()
+        kwargs = emit.call_args.kwargs
+        # D1 active → budget_signal is meaningful → reason is 'auto'
+        assert kwargs.get("reason") == "auto"
+
+
+class RouterHelpersDirectTests(unittest.TestCase):
+    """Unit tests for the D5.C.2 helpers themselves
+    (`resolve_backend`, `emit_route_event`, `_budget_to_tier_label`)
+    without going through query_rewriter."""
+
+    def setUp(self):
+        self._saved_router = os.environ.get("JAMES_AUTO_ROUTER")
+        self._saved_model = os.environ.get("JAMES_LLM_MODEL")
+        os.environ.pop("JAMES_AUTO_ROUTER", None)
+        os.environ["JAMES_LLM_MODEL"] = "fixture_legacy"
+
+    def tearDown(self):
+        if self._saved_router is None:
+            os.environ.pop("JAMES_AUTO_ROUTER", None)
+        else:
+            os.environ["JAMES_AUTO_ROUTER"] = self._saved_router
+        if self._saved_model is None:
+            os.environ.pop("JAMES_LLM_MODEL", None)
+        else:
+            os.environ["JAMES_LLM_MODEL"] = self._saved_model
+
+    def test_resolve_flag_off_returns_fallback(self):
+        from core.reasoning.router import resolve_backend
+
+        out = resolve_backend(
+            "query_rewriter",
+            "any prompt",
+            fallback_backend_id="my_explicit_backend",
+        )
+        assert out == "my_explicit_backend"
+
+    def test_resolve_flag_off_no_fallback_returns_legacy(self):
+        from core.reasoning.router import resolve_backend
+
+        out = resolve_backend("query_rewriter", "any prompt")
+        assert out == "fixture_legacy"
+
+    def test_resolve_flag_on_consults_router(self):
+        os.environ["JAMES_AUTO_ROUTER"] = "1"
+        from core.reasoning.router import resolve_backend
+
+        # verify stage always escalates per D5.C.1 policy; but with
+        # only `small` tier registered (ollama_local builtin), the
+        # policy falls back to legacy.
+        out = resolve_backend(
+            "verify",
+            "any prompt",
+            fallback_backend_id="should_be_ignored_when_flag_on",
+        )
+        # Either legacy ("fixture_legacy") or the builtin small backend
+        # ID ("ollama_local") is acceptable depending on what else is
+        # registered. The key assertion is "not the fallback_backend_id
+        # passed by the caller" — router took over.
+        assert out != "should_be_ignored_when_flag_on"
+
+    def test_budget_to_tier_label(self):
+        from core.reasoning.budget import CAP_HEAVY, CAP_LIGHT, CAP_SUBSTITUTION
+        from core.reasoning.router import _budget_to_tier_label
+
+        assert _budget_to_tier_label(None) == "none"
+        assert _budget_to_tier_label(CAP_SUBSTITUTION) == "substitution"
+        assert _budget_to_tier_label(CAP_LIGHT) == "light"
+        assert _budget_to_tier_label(CAP_HEAVY) == "heavy"
+        assert _budget_to_tier_label(999) == "unknown:999"
+
+    def test_emit_route_event_never_raises(self):
+        from core.reasoning.router import emit_route_event
+
+        # Even if audit_bridge is unavailable / DB locked / etc., this
+        # must not raise — production call path can't be blocked by
+        # audit failure.
+        with patch(
+            "core.audit_bridge.mirror_to_audit_db",
+            side_effect=RuntimeError("simulated audit failure"),
+        ):
+            # Should not raise:
+            emit_route_event("verify", "any prompt", "ollama_local")


### PR DESCRIPTION
## Summary

First stage-wiring PR for **D5 (Auto-routing on Provider Contract)** —
adds `resolve_backend` / `emit_route_event` / `_budget_to_tier_label`
helpers to `core/reasoning/router.py`, wires query_rewriter through
them. Remaining 4 stages (planner, reflect, verify, synth) land in
D5.C.2.b/c/d/e — same wiring pattern, repeated.

Flag default OFF: `JAMES_AUTO_ROUTER` unset → `self._backend_id` used (byte-identical to pre-D5). 215 backend/router/provider/rewriter tests pass unchanged.

Design memo: PR #474 → `docs/handovers/v0.3.x-direction5-auto-routing-track.md` §D5.C.

## D5 ON authority model (locked here)

When `JAMES_AUTO_ROUTER=1` the router is the authority — stage-level `self._backend_id` is intentionally overridden. The stage's backend_id is a D5-OFF concept; D5 ON means "let the router decide". Operator wanting per-stage override should either keep D5 OFF or wait for the D5-aware per-stage override mechanism (v0.4 follow-up, out of scope here).

## D1 / D5 flag matrix (locked here)

| D1 | D5 | budget_signal | Backend resolved |
|---|---|---|---|
| OFF | OFF | N/A | `self._backend_id` (e.g. "ollama_local") |
| ON | OFF | N/A | `self._backend_id` |
| OFF | ON | `None` (cap is fixed 4096, meaningless) | router policy → legacy (`JAMES_LLM_MODEL`) |
| ON | ON | dynamic from `TaskBudget.assess(...)` | router policy by tier |

## What lands

| File | Change |
|---|---|
| `core/reasoning/router.py` | +`resolve_backend(...)` +`emit_route_event(...)` +`_budget_to_tier_label(...)` |
| `core/retrieval/query_rewriter.py` | `get_backend(self._backend_id)` → `get_backend(resolve_backend(...))`. cap computed first → fed to router only when D1 flag also on. Audit emission every successful resolve. |
| `tests/test_query_rewriter_router_wiring.py` | NEW — 11 contract tests (flag-off invariance, D5-on authority over D1-off, D5-on D1-on policy path, audit emission + reason label, direct helper tests) |

## Audit row schema (`reason:route`)

Per successful resolve, one row to `audit_log`:
- `endpoint` = `"reason:route"`
- `query` = stage name
- `answer` = `"backend={id} tier={label} reason={why} prompt={hash8}"`

`reason` values: `auto` (both flags on) / `fallback` (D5 on, D1 off) / `policy` (helper default). Never raises — audit failures swallowed.

## Verification

- ✅ **92 D5 + query_rewriter tests pass** (11 D5.C.2.a + 50 D5.A/B/C.1 regression + 31 query_rewriter regression)
- ✅ **215 backend/router/provider/rewriter tests pass** (no regression on L0/L1 backend, per-stage provider-contract, rewriter unit tests)
- ✅ ruff clean
- ✅ Module size: `router.py` 9 KB → ~12 KB (rule #5 ≤20 KB safe)
- ✅ Default-OFF invariance preserved at call-site (2 dedicated tests pin this)

## Bench (CLAUDE.md rule #2) — **server-live measurement requested**

`core/retrieval/query_rewriter.py` + `core/reasoning/router.py` both under bench-required paths. Wires 1 of 5 stages; flag default OFF → production call path byte-identical. 215 regression tests confirm no test-level shift.

**Operator-side STEP 7 sweep requested before merge** — D1 7-tier ground truth from `reports/promo-assets/v3prime-direction1-cognitive-stages-result.md`, run under:

1. baseline: `JAMES_AUTO_ROUTER` unset (default) → confirm latency match
2. flag-on, ollama_local only → expected identical (small-tier-only fleet → policy always falls back to legacy with `reason=fallback` audit rows)
3. (optional) flag-on + `JAMES_ENABLE_CLAUDE_BACKEND=1` → `verify` escalates → latency ↑, grounded=true rate ↑

Paste numbers into this PR body before merge. **Acceptance: no grounded=true rate regression at any tier.**

If operator can't run live bench right now, alternative is to land D5.C.2.a on test-level invariance + tag full STEP 7 to D5.E closure. Either path reviewable.

## Architecture label (CLAUDE.md rule #4)

3 new helpers + query_rewriter backend resolution contract changes from "static lookup" to "flag-gated dynamic resolution". PR carries `architecture` label. `docs/ARCHITECTURE.md` amendment lands with D5.C.2.e once full 5-stage wiring complete.

## Out of scope (D5 phase plan)

- **D5.C.2.b** planner — same pattern
- **D5.C.2.c** reflect — same pattern
- **D5.C.2.d** verify — same pattern, but D5.C.1 policy escalates this stage to `large` tier
- **D5.C.2.e** synth — `trace_helpers.py` site, slightly different shape (runtime resolution)
- **D5.D** wiki entity `aliases:` + entity_extract resolve (cross-lingual option 3)
- **D5.E** closure result doc + memory sync + ROADMAP D5 `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)