### PR TITLE
feat(reasoning): D5.C.2.b — planner stage wiring

### DIFF
--- a/core/reasoning/planner.py
+++ b/core/reasoning/planner.py
@@ -211,16 +211,39 @@ class Planner:
         if not force and not _enabled():
             return identity
 
+        is_ko = _is_korean(query)
+        tmpl = PLAN_PROMPT_KO if is_ko else PLAN_PROMPT_EN
+        prompt = tmpl.format(query=query)
+
+        # D5.C.2.b — flag-gated backend resolution. Planner is not
+        # D1-wired (uses fixed `self._max_tokens`), so `budget_signal`
+        # is always `None` here. Under D5 flag-off the helper returns
+        # `self._backend_id` (byte-identical to pre-D5). Under D5
+        # flag-on the router policy fires with budget=None → rule 4
+        # → legacy backend (planner is not grounding-critical, so it
+        # does not trigger the verify-stage escalation either).
         try:
             from core.reasoning.backends import get_backend
-            backend = get_backend(self._backend_id)
+            from core.reasoning.router import emit_route_event, resolve_backend
+
+            backend_id = resolve_backend(
+                "planner",
+                prompt,
+                budget_signal=None,
+                fallback_backend_id=self._backend_id,
+            )
+            backend = get_backend(backend_id)
         except Exception:
             self._emit_skip(query, user_role, "backend_lookup_failed")
             return identity
 
-        is_ko = _is_korean(query)
-        tmpl = PLAN_PROMPT_KO if is_ko else PLAN_PROMPT_EN
-        prompt = tmpl.format(query=query)
+        emit_route_event(
+            "planner",
+            prompt,
+            backend_id,
+            budget_signal=None,
+            reason="fallback",
+        )
 
         t0 = time.time()
         try:


### PR DESCRIPTION
## Summary

Second stage-wiring PR for **D5 (Auto-routing on Provider Contract)**. Wires `core/reasoning/planner.py` through the D5.C.2.a helpers — same pattern as query_rewriter, minus the D1 cap signal (planner is not D1-wired, so `budget_signal=None` always).

## Flag matrix (planner, no D1 wiring)

| D5 flag | Backend resolved |
|---|---|
| OFF | `self._backend_id` (byte-identical to pre-D5) |
| ON | router policy with `budget_signal=None` → rule 4 → legacy backend (`JAMES_LLM_MODEL`). Planner is not grounding-critical so verify-stage escalation does not fire either. |

Until planner gains a D1 budget signal (out of scope for D5), the ON path always falls back to legacy. Wiring is still useful: audit row records the routing decision + surface in place for the D2-absorbed metric (D5.E).

## What lands

| File | Change |
|---|---|
| `core/reasoning/planner.py` | `get_backend(self._backend_id)` → `get_backend(resolve_backend("planner", prompt, budget_signal=None, fallback_backend_id=self._backend_id))` + `emit_route_event(...)` audit row. Prompt computation moved before backend resolution so it's available as router input (purely a reorder, no behavior change). |

## Verification

- ✅ **215 backend/router/provider/rewriter tests pass** (full D5-surface regression)
- ✅ ruff clean
- ✅ Module size: `planner.py` +22 lines, unchanged headline size (well under 20 KB)

### Known pre-existing test failure (NOT caused by this PR)

`tests/test_planner.py::OptInGateTests::test_disabled_default_returns_trivial_plan` fails on operator's local machine because operator's `.env` sets `JAMES_ENABLE_PLANNER=1` (from 2026-05-25 A5 cognitive-layer verification). The flag leaks into the test process at `config.py` import time, defeating the test's `setUp` `pop`. **Reproduces on `main` HEAD without this PR** (`git stash && pytest <test>` shows the same failure). CI does not have `.env` so this test passes on CI. Not in scope for D5.C.2.b — separate fix would harden the test's env isolation.

## Bench (CLAUDE.md rule #2) — server-live deferred to D5.E

Per operator decision (PR #478 discussion, option b): D5.C.2.a–e stage wiring lands on test-level invariance; full STEP 7 sweep runs **once** at D5.E closure across all 5 wired stages. Each intermediate PR is byte-identical at the production call path because flag default is OFF.

`emit_route_event` adds one `audit_log` row per resolve call — only runtime side effect, wrapped in try/except so audit failures never block the production path.

## Architecture label (CLAUDE.md rule #4)

Same routing-contract change as D5.C.2.a, repeated for planner. `architecture` label applied. `docs/ARCHITECTURE.md` amendment lands with D5.C.2.e once full 5-stage wiring complete.

## Out of scope (D5 phase plan)

- **D5.C.2.c** reflect — same pattern
- **D5.C.2.d** verify — same pattern, grounding-critical (D5.C.1 escalates to `large` tier)
- **D5.C.2.e** synth — `trace_helpers.py` site
- **D5.D** wiki entity `aliases:` + entity_extract resolve
- **D5.E** closure + integrated STEP 7 sweep numbers (operator-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)