### PR TITLE
feat(reasoning): D5.C.2.c — reflect stage wiring + test query narrow

### DIFF
--- a/core/reasoning/reflect.py
+++ b/core/reasoning/reflect.py
@@ -189,15 +189,41 @@ class ReflectionLoop:
         if not force and not _enabled():
             return draft
 
-        try:
-            from core.reasoning.backends import get_backend
-            backend = get_backend(self._backend_id)
-        except Exception:
-            return draft
-
         is_ko = _is_korean(query) or _is_korean(draft)
         crit_tmpl = CRITIQUE_PROMPT_KO if is_ko else CRITIQUE_PROMPT_EN
         rev_tmpl = REVISE_PROMPT_KO if is_ko else REVISE_PROMPT_EN
+
+        # D5.C.2.c — flag-gated backend resolution. Reflect is not
+        # D1-wired (uses fixed critique/revise caps), so
+        # `budget_signal=None` here. Flag-off → `self._backend_id`
+        # (byte-identical). Flag-on → router policy with budget=None
+        # → rule 4 → legacy. Reflect is not grounding-critical
+        # (only `verify` is) so the escalation does not fire. Single
+        # backend serves both critique + revise calls below.
+        try:
+            from core.reasoning.backends import get_backend
+            from core.reasoning.router import emit_route_event, resolve_backend
+
+            # Critique prompt template is enough for routing — the
+            # actual prompts (critique then revise) hit the same backend.
+            router_prompt = crit_tmpl
+            backend_id = resolve_backend(
+                "reflect",
+                router_prompt,
+                budget_signal=None,
+                fallback_backend_id=self._backend_id,
+            )
+            backend = get_backend(backend_id)
+        except Exception:
+            return draft
+
+        emit_route_event(
+            "reflect",
+            router_prompt,
+            backend_id,
+            budget_signal=None,
+            reason="fallback",
+        )
 
         # ── critique pass ────────────────────────────────────
         critique_prompt = crit_tmpl.format(query=query, draft=draft)

--- a/tests/test_reflection_loop.py
+++ b/tests/test_reflection_loop.py
@@ -304,7 +304,11 @@ class TraceEmissionTests(unittest.TestCase):
         try:
             return conn.execute(
                 "SELECT * FROM audit_log "
-                "WHERE endpoint LIKE 'reason:%' ORDER BY id ASC"
+                # Narrowed from 'reason:%' to 'reason:reflect' so the
+                # D5.C.2.c-added 'reason:route' row (one per resolve
+                # call) doesn't inflate the count. Reflect emission
+                # itself is what these tests are pinning.
+                "WHERE endpoint = 'reason:reflect' ORDER BY id ASC"
             ).fetchall()
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

Third stage-wiring PR for **D5 (Auto-routing on Provider Contract)**. Wires `core/reasoning/reflect.py` — single backend resolve serves both critique + revise. Same pattern as query_rewriter / planner.

## What lands

| File | Change |
|---|---|
| `core/reasoning/reflect.py` | `get_backend(self._backend_id)` → router-aware resolution + `emit_route_event(...)`. Single resolve covers both critique and revise calls (same backend chosen for both). |
| `tests/test_reflection_loop.py` | `_rows()` helper SQL filter narrowed from `endpoint LIKE 'reason:%'` to `endpoint = 'reason:reflect'`. The D5.C.2-added `reason:route` row otherwise inflates the count (3 vs expected 2); narrowing preserves the test's intent (pin reflect emission, not all reason:* rows). |

## Flag matrix (reflect, no D1 wiring)

| D5 flag | Backend resolved |
|---|---|
| OFF | `self._backend_id` (byte-identical) |
| ON | router policy with `budget_signal=None` → rule 4 → legacy (reflect is not grounding-critical) |

## Verification

- ✅ **247 reflect/router/backend/rewriter/provider/planner tests pass**
- ✅ ruff clean
- ✅ Module size: `reflect.py` +25 lines, well under 20 KB

### Known pre-existing failure (NOT this PR)

`tests/test_reflection_loop.py::OptInGateTests::test_disabled_default_returns_draft_no_backend_call` fails on operator's local machine due to `.env JAMES_ENABLE_REFLECT=1` leak (A5 cognitive-layer verification). Reproduces on main without this PR, passes on CI (no `.env`).

## Bench — deferred to D5.E (operator decision: option b)

Production call path byte-identical (flag default OFF). One `audit_log` row per reflect call when wiring resolves a backend (try/except-wrapped, never blocks production).

## Architecture label

Same contract change as D5.C.2.a/b. `architecture` label applied. `docs/ARCHITECTURE.md` amendment at D5.C.2.e.

## Out of scope (D5 phase plan)

- **D5.C.2.d** verify — grounding-critical, where small-tier-only fleet actually escalates
- **D5.C.2.e** synth — `trace_helpers.py`
- **D5.D** wiki entity aliases (cross-lingual option 3)
- **D5.E** closure + integrated STEP 7 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)