### PR TITLE
feat(reasoning): D5.C.2.d — verify stage wiring (grounding-critical, large tier)

### DIFF
--- a/core/reasoning/verify.py
+++ b/core/reasoning/verify.py
@@ -350,18 +350,41 @@ class Verifier:
         path returns ``(True, [])`` — fact-check is a "nice to have",
         not a gate.
         """
-        try:
-            from core.reasoning.backends import get_backend
-            backend = get_backend(self._backend_id)
-        except Exception:
-            return (True, [])
-
         is_ko = _is_korean(query) or _is_korean(answer)
         tmpl = FACT_CHECK_PROMPT_KO if is_ko else FACT_CHECK_PROMPT_EN
         prompt = tmpl.format(
             query=query[:300],
             answer=answer[:2000],
             context=context[:2000],
+        )
+
+        # D5.C.2.d — flag-gated backend resolution. Verify is the
+        # grounding-critical stage: D5.C.1 policy rule 1 escalates it
+        # to `large` tier (preferred), then `medium`, then legacy.
+        # This is the stage where a small-tier-only fleet sees
+        # routing actually take effect — even with budget_signal=None
+        # the verify-stage escalation fires when a larger backend is
+        # registered (e.g. JAMES_ENABLE_CLAUDE_BACKEND=1).
+        try:
+            from core.reasoning.backends import get_backend
+            from core.reasoning.router import emit_route_event, resolve_backend
+
+            backend_id = resolve_backend(
+                "verify",
+                prompt,
+                budget_signal=None,
+                fallback_backend_id=self._backend_id,
+            )
+            backend = get_backend(backend_id)
+        except Exception:
+            return (True, [])
+
+        emit_route_event(
+            "verify",
+            prompt,
+            backend_id,
+            budget_signal=None,
+            reason="grounding-critical",
         )
 
         t0 = time.time()


### PR DESCRIPTION
## Summary

Fourth stage-wiring PR for **D5 (Auto-routing on Provider Contract)**. Wires `core/reasoning/verify.py` — **grounding-critical** stage. D5.C.1 policy rule 1 escalates this stage to `large` tier (preferred) → `medium` → legacy. Where small-tier-only fleet actually sees routing take effect on opting into a frontier backend.

## Flag matrix (verify, no D1 wiring)

| D5 flag | Backends registered | Backend resolved |
|---|---|---|
| OFF | any | `self._backend_id` (byte-identical) |
| ON | only `ollama_local` (small) | router policy → escalation fails → legacy |
| ON | + `claude_code_cli` (large) | **`claude_code_cli`** (verify wins on `large`) |
| ON | + sovereign 26b (medium) | medium tier |

## What lands

| File | Change |
|---|---|
| `core/reasoning/verify.py` | `Verifier._fact_check`: `get_backend(self._backend_id)` → router-aware resolve + `emit_route_event(..., reason="grounding-critical")`. Prompt template moved before resolve. |

`grounding-critical` reason label in audit row distinguishes this stage's escalation from the routine `fallback` label of query_rewriter / planner / reflect.

## Verification

- ✅ **32 verify tests pass**
- ✅ ruff clean
- ✅ Module size: `verify.py` +25 lines, well under 20 KB

## Bench — deferred to D5.E (operator option b)

Production call path byte-identical (flag default OFF). **Verify is the stage where flag-on routing produces the most visible signal** — if operator enables `JAMES_ENABLE_CLAUDE_BACKEND=1` between baseline and treatment runs, verify latency + grounded=true rate both shift. Other stages only escalate when D1 budget = substitution / heavy.

## Architecture label

Same contract change pattern. `architecture` label applied. `docs/ARCHITECTURE.md` amendment lands with D5.C.2.e.

## Out of scope (D5 phase plan)

- **D5.C.2.e** synth — `trace_helpers.py` (last wiring stage, closes the surface)
- **D5.D** wiki entity `aliases:` + entity_extract resolve
- **D5.E** closure + integrated STEP 7 sweep + ROADMAP D5 `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)