### PR TITLE
feat(reasoning): D5.C.2.e — synth/trace_helpers stage wiring (closes 5-stage surface)

### DIFF
--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -135,8 +135,30 @@ def trace_synth_call(
     # Backend resolution: R1 says we don't raise on the user path, so a
     # registry-level failure (no backends registered, unknown stage) is
     # converted to an error row + empty return rather than an exception.
+    #
+    # D5.C.2.e — flag-gated D5 routing on top of the existing L1
+    # `resolve_backend_for_stage` resolution. Under D5 flag OFF the
+    # D5 helper returns the L1-resolved backend ID (byte-identical to
+    # pre-D5 main). Under D5 flag ON the router policy decides, with
+    # the L1 resolution as the `fallback_backend_id`. The audit
+    # `reason:route` row lands per call (see emit_route_event).
+    #
+    # trace_helpers serves multiple stages — synth, verify, reflect,
+    # plan, rewrite, etc. The 4 cognitive stage classes
+    # (QueryRewriter / Planner / ReflectionLoop / Verifier) route
+    # through their own wiring (D5.C.2.a–d); trace_helpers's wiring
+    # here covers the synth path and any other stage that goes
+    # through `trace_synth_call` rather than the per-class call site.
     try:
-        backend_id = resolve_backend_for_stage(stage)
+        from core.reasoning.router import emit_route_event, resolve_backend
+
+        legacy_backend_id = resolve_backend_for_stage(stage)
+        backend_id = resolve_backend(
+            stage,
+            prompt,
+            budget_signal=None,
+            fallback_backend_id=legacy_backend_id,
+        )
         backend = get_backend(backend_id)
     except Exception as e:
         emit_trace_step(
@@ -154,6 +176,17 @@ def trace_synth_call(
             extras=emit_extras,
         )
         return ""
+
+    # D5.C.2.e — audit row for the resolved backend. Emitted between
+    # resolution and call so the routing decision is logged even if
+    # the subsequent backend.complete fails.
+    emit_route_event(
+        stage,
+        prompt,
+        backend_id,
+        budget_signal=None,
+        reason="fallback",
+    )
 
     result: CompletionResult = backend.complete(
         prompt,

--- a/tests/test_reasoning_trace_helpers.py
+++ b/tests/test_reasoning_trace_helpers.py
@@ -80,7 +80,14 @@ def _rows(db_path: str):
     conn.row_factory = sqlite3.Row
     try:
         return conn.execute(
-            "SELECT * FROM audit_log ORDER BY id ASC"
+            # Exclude D5.C.2-added 'reason:route' rows so the
+            # trace_helpers tests continue to count synth/etc. rows
+            # the way they did pre-D5. The 'reason:route' row is one
+            # per `resolve_backend` call (separate concern: routing
+            # audit, not synth call audit).
+            "SELECT * FROM audit_log "
+            "WHERE endpoint != 'reason:route' "
+            "ORDER BY id ASC"
         ).fetchall()
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

**Final stage-wiring PR** for D5. Wires `trace_helpers.trace_synth_call` — the unified L1 entry point (PR #305) — through the D5.C.2.a helpers. This closes the 5-stage surface: every production LLM call path now consults the D5 router (gated by flag default OFF).

## Wiring shape

| State | Behavior |
|---|---|
| D5 flag OFF | `resolve_backend_for_stage(stage)` → L1 backend (byte-identical to pre-D5) |
| D5 flag ON | L1 resolution → `fallback_backend_id`; `resolve_backend(stage, prompt, fallback=L1_id)` → router-policy backend |

`trace_helpers` covers synth + anything flowing through the unified entry point. The 4 cognitive stage classes (D5.C.2.a–d) route through their own per-class wiring.

## What lands

| File | Change |
|---|---|
| `core/reasoning/trace_helpers.py` | `trace_synth_call`: L1 `resolve_backend_for_stage` becomes the `fallback_backend_id` for D5 `resolve_backend(...)`. `emit_route_event(...)` audit row between resolution and `backend.complete` (logged even if call fails). |
| `tests/test_reasoning_trace_helpers.py` | `_rows()` SQL filter excludes `reason:route` rows — route audit is per-resolve, separate from synth-call audit these tests pin. Without exclusion `rows[0]` becomes the route row → test breaks. |

## D5 wiring surface — now complete

| Stage | PR | Audit reason | Grounding-critical? |
|---|---|---|---|
| query_rewriter | #478 | `auto` (D1 on) / `fallback` | no |
| planner | #479 | `fallback` | no |
| reflect | #480 | `fallback` | no |
| verify | #481 | `grounding-critical` | **yes** (large tier escalation) |
| **synth / trace_helpers** | **this PR** | `fallback` | depends on stage arg |

## Verification

- ✅ **12 trace_helpers tests pass**
- ✅ **362 trace/synth/backend/router/rewriter/provider/planner/reflect/verify tests pass**
- ✅ ruff clean

## Bench (CLAUDE.md rule #2) — operator STEP 7 sweep at D5.E

Operator option b: integrated sweep at D5.E across all 5 wired stages. Byte-identical at production call path (flag default OFF).

With this wiring complete, D5.E measurement is now meaningful: `JAMES_AUTO_ROUTER=1` produces visible routing decisions on every stage, all observable in `audit_log` via `reason:route` rows.

## Architecture label

`trace_helpers` is the last surface to gain D5 routing. `architecture` label applied. `docs/ARCHITECTURE.md` amendment lands with **D5.E closure** alongside integrated bench numbers.

## Out of scope (D5 phase plan)

- **D5.D** wiki entity `aliases:` + entity_extract resolve (cross-lingual option 3)
- **D5.E** closure + integrated STEP 7 sweep + ROADMAP D5 `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)