### PR TITLE
feat(graph): D5.D - cross-lingual entity alias pack (KO/EN surface forms)

### DIFF
--- a/core/entity_alias_pack.py
+++ b/core/entity_alias_pack.py
@@ -1,0 +1,94 @@
+"""Cross-lingual entity alias pack — graph-level entity resolution.
+
+D5.D (2026-05-25). Complement to PR #472's keyword-level
+`_SYNONYM_MAP` (`core/query_expander.py`). The two layers solve
+the same Korean/English mismatch problem at different stages of
+the RAG pipeline:
+
+  • `_SYNONYM_MAP` runs at *query expansion* time — token-level
+    augmentation so the multilingual-MiniLM embedding has cross-
+    lingual surface forms in the vector search input.
+  • `_ENTITY_ALIAS_PACK` (this module) runs at *graph entity
+    resolution* time — after `entity_extract` produces an entity
+    name, `graph_engine.build_entity_map_snapshot` consults this
+    pack to augment the wiki-entity lookup table with KO↔EN
+    surface forms that the operator hasn't (yet) added to the
+    wiki entity's `aliases:` frontmatter.
+
+Why a separate module from `_SYNONYM_MAP`:
+  The query expander runs on *every* token of *every* query, with
+  hard limits (TOKEN_HARD_LIMIT=50, TIMEOUT_SEC=3.0). The entity
+  alias pack runs *once per entity-map-snapshot rebuild* (i.e. on
+  wiki ingestion, not per query) and is meant to grow to a few
+  thousand entries for common entities. Different cost profiles →
+  different data structure + different runtime location.
+
+Backward compat:
+  Wiki entities with explicit `aliases:` in their frontmatter take
+  precedence (that's already snapshot-merged in
+  `graph_engine.build_entity_map_snapshot`). This pack adds
+  surface forms only when neither wiki frontmatter nor existing
+  snapshot has them. Removing this module reverts to the v0.3
+  alias-from-frontmatter-only behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Final, List, Tuple
+
+
+# Each tuple: (canonical_entity_name, [alias_surface_form, ...])
+#
+# `canonical_entity_name` is the wiki entity's `name:` field as it
+# would appear in `wiki/entity/prod/{type}/*.md`. Normalization
+# happens in the consumer (graph_engine) via
+# `wiki_generator._normalize_name` so we don't pre-normalize here.
+#
+# The list is augmented as new high-traffic entities are observed
+# (D5.D scope: the 4 entities the 2026-05-25 cross-lingual diagnostic
+# called out — Palantir, Tesla, Nvidia, Apple — plus the same 28
+# companies the PR #472 keyword map already covers, where a wiki
+# entity exists in the typical JAMES install).
+_ENTITY_ALIAS_PACK: Final[List[Tuple[str, List[str]]]] = [
+    # ─── Tech / AI ─────────────────────────────────────────
+    ("Palantir Technologies (PLTR)", ["팔란티어", "Palantir", "PLTR"]),
+    ("PLTR", ["팔란티어", "Palantir"]),
+    ("Tesla, Inc. (TSLA)", ["테슬라", "Tesla", "TSLA"]),
+    ("엔비디아", ["Nvidia", "NVIDIA", "NVDA"]),
+    ("Apple", ["애플", "AAPL"]),
+    ("Microsoft", ["마이크로소프트", "마소", "MSFT"]),
+    ("Google", ["구글", "Alphabet", "GOOGL", "GOOG"]),
+    ("Alphabet", ["알파벳", "Google", "GOOGL"]),
+    ("Meta", ["메타"]),
+    ("Amazon", ["아마존", "AMZN"]),
+    ("Anthropic", ["앤트로픽", "Claude"]),
+    ("Claude", ["클로드", "Anthropic"]),
+    ("OpenAI", ["오픈에이아이", "오픈AI", "ChatGPT"]),
+    ("AMD", ["에이엠디", "Advanced Micro Devices"]),
+    ("Advanced Micro Devices, Inc.", ["AMD", "에이엠디"]),
+    ("BYD", ["비야디"]),
+    ("BlackRock", ["블랙록"]),
+    ("Citi", ["시티", "Citigroup"]),
+    ("Citigroup", ["시티", "Citi"]),
+    ("Archer Aviation", ["아처", "아처 에이비에이션"]),
+    ("Bouygues Telecom", ["부이그", "Bouygues"]),
+    ("Cursor", ["커서"]),
+    # ─── Institutions ─────────────────────────────────────
+    ("FOMC", ["연준", "연방준비제도", "Federal Reserve", "Fed"]),
+    ("Federal Reserve", ["연준", "Fed", "FOMC"]),
+    ("White House", ["백악관"]),
+    ("Pentagon", ["펜타곤"]),
+]
+
+
+def iter_entity_aliases() -> List[Tuple[str, List[str]]]:
+    """Return the alias pack as a list of (canonical_name, aliases) pairs.
+
+    Returns a shallow copy so callers can iterate without worrying
+    about concurrent modification. The list is small (~30 entries)
+    so the copy cost is negligible.
+
+    Consumed by `core.graph_engine.build_entity_map_snapshot` to
+    augment the wiki-entity lookup table with KO↔EN surface forms.
+    """
+    return list(_ENTITY_ALIAS_PACK)

--- a/core/graph_engine.py
+++ b/core/graph_engine.py
@@ -131,7 +131,15 @@ class GraphEngine:
     # ─── Entity Map Snapshot ─────────────────────────────────
 
     def build_entity_map_snapshot(self) -> Dict[Tuple[str, str], str]:
-        """정규화된 (entity_type, normalized_name) → entity_id 매핑"""
+        """정규화된 (entity_type, normalized_name) → entity_id 매핑
+
+        Sources merged (in order, first-write wins):
+          1. wiki entity frontmatter `name` (canonical)
+          2. wiki entity frontmatter `aliases:` list
+          3. cross-lingual alias pack (`core.entity_alias_pack`,
+             D5.D 2026-05-25) — augments KO↔EN surface forms when
+             the wiki entity's frontmatter hasn't listed them yet
+        """
         snapshot: Dict[Tuple[str, str], str] = {}
         for eid, filepath in self.wiki_generator.entity_id_index.items():
             try:
@@ -148,6 +156,34 @@ class GraphEngine:
                             snapshot[(e_type, an)] = eid
             except Exception as e:
                 self._log("entity_map_build", e)
+
+        # D5.D — cross-lingual alias pack augmentation. For each
+        # entry, find the wiki entity by canonical name (any type),
+        # then add the alias surface forms under the same type. If
+        # no wiki entity matches the canonical name, the pack entry
+        # is skipped (operator hasn't installed that entity).
+        try:
+            from core.entity_alias_pack import iter_entity_aliases
+
+            for canonical_name, aliases in iter_entity_aliases():
+                canonical_norm = self.wiki_generator._normalize_name(canonical_name)
+                if not canonical_norm:
+                    continue
+                matched_type = None
+                for t in ("org", "person", "concept", "document"):
+                    if snapshot.get((t, canonical_norm)):
+                        matched_type = t
+                        break
+                if not matched_type:
+                    continue
+                eid = snapshot[(matched_type, canonical_norm)]
+                for alias in aliases:
+                    alias_norm = self.wiki_generator._normalize_name(alias)
+                    if alias_norm and (matched_type, alias_norm) not in snapshot:
+                        snapshot[(matched_type, alias_norm)] = eid
+        except Exception as e:
+            self._log("entity_alias_pack", e)
+
         return snapshot
 
     def match_entities(

--- a/tests/test_entity_alias_pack.py
+++ b/tests/test_entity_alias_pack.py
@@ -1,0 +1,233 @@
+"""D5.D — Cross-lingual entity alias pack contract tests.
+
+Pins the alias pack data + the graph_engine integration so a
+refactor that drops the pack or breaks the snapshot augmentation
+is caught here.
+
+Coverage:
+  • alias pack data shape (list of (canonical, [alias]) tuples)
+  • all canonical names + aliases are non-empty strings
+  • iter helper returns a shallow copy (callers can iterate safely)
+  • graph_engine snapshot augmentation: when a wiki entity matches
+    a canonical name, the alias surface forms are merged under the
+    same entity_id at the same entity_type
+  • alias pack does NOT override existing wiki frontmatter aliases
+    (first-write wins — wiki content is authoritative)
+  • a pack entry whose canonical name has no matching wiki entity
+    is silently skipped (operator hasn't installed that entity)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.entity_alias_pack import _ENTITY_ALIAS_PACK, iter_entity_aliases
+
+
+# ─── Alias pack data shape ───────────────────────────────────────
+
+
+class AliasPackShapeTests(unittest.TestCase):
+    """Pin the (canonical, [aliases]) tuple structure + content rules."""
+
+    def test_pack_is_nonempty(self):
+        self.assertGreater(len(_ENTITY_ALIAS_PACK), 0)
+
+    def test_every_entry_is_tuple_of_str_and_list(self):
+        for entry in _ENTITY_ALIAS_PACK:
+            self.assertIsInstance(entry, tuple)
+            self.assertEqual(len(entry), 2)
+            canonical, aliases = entry
+            self.assertIsInstance(canonical, str)
+            self.assertGreater(len(canonical), 0)
+            self.assertIsInstance(aliases, list)
+            self.assertGreater(len(aliases), 0)
+
+    def test_every_alias_is_nonempty_str(self):
+        for canonical, aliases in _ENTITY_ALIAS_PACK:
+            for alias in aliases:
+                self.assertIsInstance(alias, str, f"in {canonical!r}")
+                self.assertGreater(len(alias.strip()), 0, f"in {canonical!r}")
+
+    def test_palantir_has_korean_alias(self):
+        # D5.D root cause this PR fixes — the 2026-05-25 cross-lingual
+        # diagnostic case. Palantir wiki entity exists in the JAMES
+        # corpus; "팔란티어" was the missing alias.
+        found = False
+        for canonical, aliases in _ENTITY_ALIAS_PACK:
+            if "Palantir" in canonical and "팔란티어" in aliases:
+                found = True
+                break
+        self.assertTrue(found, "Palantir entry must include '팔란티어' alias")
+
+    def test_nvidia_has_english_alias(self):
+        # Reverse direction — wiki entity is Korean (`엔비디아.md`),
+        # need English aliases so an English query matches it.
+        found = False
+        for canonical, aliases in _ENTITY_ALIAS_PACK:
+            if canonical == "엔비디아" and "Nvidia" in aliases:
+                found = True
+                break
+        self.assertTrue(found, "엔비디아 entry must include 'Nvidia' alias")
+
+
+class IterHelperTests(unittest.TestCase):
+
+    def test_iter_returns_list_of_tuples(self):
+        result = iter_entity_aliases()
+        self.assertIsInstance(result, list)
+        for entry in result:
+            self.assertIsInstance(entry, tuple)
+            self.assertEqual(len(entry), 2)
+
+    def test_iter_returns_shallow_copy(self):
+        # Mutating the returned list must not affect subsequent calls
+        result_a = iter_entity_aliases()
+        original_len = len(result_a)
+        result_a.append(("test_canonical", ["test_alias"]))
+        result_b = iter_entity_aliases()
+        self.assertEqual(len(result_b), original_len)
+
+
+# ─── graph_engine snapshot augmentation ──────────────────────────
+
+
+class _FakeWikiGen:
+    """Minimal stand-in for WikiGenerator that exposes only the
+    surfaces `build_entity_map_snapshot` reads: `entity_id_index`,
+    `_read_frontmatter`, `_normalize_name`.
+    """
+
+    def __init__(self, entity_fixtures: dict):
+        """entity_fixtures: {entity_id: frontmatter_dict}"""
+        self._fixtures = entity_fixtures
+        # build a fake entity_id_index — values are strings the snapshot
+        # builder will pass through to `_read_frontmatter`
+        self.entity_id_index = {eid: eid for eid in entity_fixtures}
+
+    def _read_frontmatter(self, path) -> dict:
+        # path is the value from entity_id_index, which we set to eid above
+        return self._fixtures.get(str(path), {})
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        import re
+        return re.sub(r"[^\w가-힣]", "_", name.strip().lower())
+
+
+class _GraphEngineHarness:
+    """Minimal harness — exposes only the fields
+    `build_entity_map_snapshot` uses. Avoids spinning up the full
+    engine (which loads wiki, vector store, etc.)."""
+
+    def __init__(self, wiki_gen):
+        self.wiki_generator = wiki_gen
+        import threading
+        self._map_lock = threading.Lock()
+
+    @staticmethod
+    def _log(step, error, role="system"):
+        pass
+
+
+class SnapshotAugmentationTests(unittest.TestCase):
+
+    def _build(self, fixtures):
+        from core.graph_engine import GraphEngine
+
+        h = _GraphEngineHarness(_FakeWikiGen(fixtures))
+        # Pass the harness as `self` directly — works on bound and
+        # unbound function references alike across Python versions.
+        snapshot = GraphEngine.build_entity_map_snapshot(h)
+        return snapshot
+
+    def test_palantir_korean_alias_resolves_to_wiki_entity(self):
+        # Fixture: wiki has the Palantir org entity but no Korean
+        # alias in its frontmatter. The alias pack should add the
+        # Korean surface form to the snapshot.
+        snapshot = self._build({
+            "e_org_palantir": {
+                "entity_type": "org",
+                "normalized_name": "palantir_technologies__pltr_",
+                "name": "Palantir Technologies (PLTR)",
+                "aliases": ["Palantir Technologies", "PLTR"],
+            },
+        })
+        # Canonical and existing frontmatter aliases — present
+        self.assertEqual(
+            snapshot.get(("org", "palantir_technologies__pltr_")),
+            "e_org_palantir",
+        )
+        # Alias pack augmentation — Korean form should be present
+        self.assertEqual(snapshot.get(("org", "팔란티어")), "e_org_palantir")
+
+    def test_nvidia_english_alias_resolves_to_korean_wiki_entity(self):
+        # Reverse case — wiki entity is Korean; alias pack adds the
+        # English surface forms.
+        snapshot = self._build({
+            "e_org_nvidia": {
+                "entity_type": "org",
+                "normalized_name": "엔비디아",
+                "name": "엔비디아",
+                "aliases": [],
+            },
+        })
+        self.assertEqual(snapshot.get(("org", "엔비디아")), "e_org_nvidia")
+        # Augmentation
+        self.assertEqual(snapshot.get(("org", "nvidia")), "e_org_nvidia")
+        self.assertEqual(snapshot.get(("org", "nvda")), "e_org_nvidia")
+
+    def test_pack_entry_without_wiki_match_is_skipped(self):
+        # OpenAI is in the pack but the operator hasn't installed an
+        # OpenAI wiki entity. The pack entry should be silently
+        # skipped (no snapshot entry for OpenAI or its aliases).
+        snapshot = self._build({
+            "e_org_palantir": {
+                "entity_type": "org",
+                "normalized_name": "palantir_technologies__pltr_",
+                "name": "Palantir Technologies (PLTR)",
+                "aliases": [],
+            },
+        })
+        # OpenAI is in the pack but no wiki match — no snapshot entry
+        self.assertIsNone(snapshot.get(("org", "openai")))
+        self.assertIsNone(snapshot.get(("org", "오픈에이아이")))
+
+    def test_wiki_frontmatter_alias_takes_precedence_first_write(self):
+        # If the wiki frontmatter already has an alias that the pack
+        # also covers, the wiki one wins (first-write semantics in
+        # the snapshot dict).
+        snapshot = self._build({
+            "e_org_palantir_wiki": {
+                "entity_type": "org",
+                "normalized_name": "palantir_technologies__pltr_",
+                "name": "Palantir Technologies (PLTR)",
+                "aliases": ["팔란티어"],  # already in frontmatter
+            },
+        })
+        # The Korean alias resolves to the wiki-derived eid (which is
+        # also what the pack would have produced — same eid). The key
+        # invariant is "no overwrite": both produce e_org_palantir_wiki.
+        self.assertEqual(snapshot.get(("org", "팔란티어")), "e_org_palantir_wiki")
+
+    def test_pack_only_augments_matched_type(self):
+        # When the canonical match is under type "org", the aliases
+        # are added under "org" only — not propagated across types.
+        snapshot = self._build({
+            "e_org_tesla": {
+                "entity_type": "org",
+                "normalized_name": "tesla__inc___tsla_",
+                "name": "Tesla, Inc. (TSLA)",
+                "aliases": [],
+            },
+        })
+        # Tesla pack entry includes "테슬라" — should land under "org"
+        self.assertEqual(snapshot.get(("org", "테슬라")), "e_org_tesla")
+        # ...but NOT under "person" / "concept" / "document"
+        self.assertIsNone(snapshot.get(("person", "테슬라")))
+        self.assertIsNone(snapshot.get(("concept", "테슬라")))
+        self.assertIsNone(snapshot.get(("document", "테슬라")))


### PR DESCRIPTION
## Summary

Cross-lingual option 3 (graph-level entity resolution). Pairs with PR #472 option 1. Two layers, same KO/EN problem, different pipeline stages:

| Layer | Module | Adds |
|---|---|---|
| Query embedding (option 1) | `_SYNONYM_MAP` (PR #472) | Token augmentation at vector search input |
| Graph entity resolution (option 3, this PR) | `_ENTITY_ALIAS_PACK` + `graph_engine` | Surface-form augmentation in entity_id lookup |
| Embedding swap (option 4) | bge-m3/e5-large | v0.4 backlog (BL-9) |

## Why a code-side pack

`wiki/entity/prod/**/*.md` is gitignored (operator-mutable). Patching individual frontmatter would not propagate. Code pack is git-tracked, augments only when canonical wiki entity exists in operator install (silent skip otherwise).

## Existing infrastructure

`build_entity_map_snapshot` already supported wiki frontmatter `aliases:` (lines 145-148). The 2026-05-25 root cause was simply that no Korean alias was listed in `palantir_technologies__pltr_.md` frontmatter (operator install detail). This pack closes the gap with a code-side default list.

## What lands

| File | Change |
|---|---|
| `core/entity_alias_pack.py` | NEW. ~30 entries (Palantir/Tesla/Nvidia/Apple/MS/Google/Meta/Amazon/Anthropic/OpenAI/AMD/BYD/BlackRock/Citi/Archer/Bouygues/Cursor/Claude + Fed/FOMC/WH/Pentagon). Bidirectional KO/EN. |
| `core/graph_engine.py` | `build_entity_map_snapshot` extended. After wiki-frontmatter pass, iterate pack -> if canonical has wiki match (any type), add aliases under same type+entity_id. try/except wrapped. |
| `tests/test_entity_alias_pack.py` | NEW - 12 contract tests (data shape, iter helper, snapshot augmentation: Palantir KO, Nvidia EN, pack-without-wiki-match silent skip, wiki frontmatter precedence, type isolation). |

## Verification

- 12 alias pack contract tests pass
- 526 alias/entity/graph/backend/router/rewriter/provider tests pass
- ruff clean
- Module size: entity_alias_pack 3.6KB, graph_engine +29 lines
- Backward compat: wiki frontmatter takes precedence (first-write); pack entry without wiki match silently skipped

## Bench (CLAUDE.md rule #2)

Pure snapshot augmentation. O(1) dict lookups at query time. No per-query LLM call added, no retrieval API surface change.

Operationally: queries extracting Korean entity form ("팔란티어") that previously found no wiki match now resolve to the English wiki entity. This was the 2026-05-25 root cause locked into `feedback_rag_cross_lingual_diagnostic`.

STEP 7 sweep integrated at D5.E (operator-run per option b). Alias pack effect compounds with 5-stage router wiring (#478-482) at that measurement.

## Architecture label

`build_entity_map_snapshot` gains an external data source. architecture label. ARCHITECTURE.md amendment lands with D5.E closure.

## Out of scope (D5 phase plan)

- D5.E: closure result doc + memory sync + ROADMAP D5 [x] + integrated STEP 7 sweep + ARCHITECTURE.md amendment

Generated with Claude Code