### PR TITLE
feat(reasoning): D6 - retry_doubled wiring closure (D1 design/wiring gap)

### DIFF
--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -70,12 +70,21 @@ class CompletionResult:
     path — they return ``error="..."`` and let the caller decide. This
     matches RouterWrapper's existing "_LLM_ERROR_PREFIXES" pattern in
     core/reasoning/engine.py.
+
+    ``done_reason`` (D6 2026-05-25): optional truncation signal. When
+    the backend can determine the model stopped because it hit the
+    cap (vs naturally finished), it sets ``done_reason="length"``.
+    Unknown / not-truncated → empty string. Callers (`budget.complete_with_retry`)
+    branch on this to decide whether to retry with a doubled cap.
+    Backends that don't track this attribute leave it empty — the
+    caller treats absence as "no truncation signal observed".
     """
     text: str
     backend_id: str
     model: str = ""
     latency_ms: int = 0
     error: str = ""
+    done_reason: str = ""
 
 
 @runtime_checkable

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -90,12 +90,40 @@ class OllamaLocalBackend:
                          "LLM 응답 생성 중 오류")
         is_err = bool(text) and any(text.startswith(p) for p in _ERR_PREFIXES)
 
+        # D6 (2026-05-25) — done_reason heuristic. RouterWrapper does
+        # not yet expose Ollama's native `done_reason`, so we infer
+        # truncation from two signals:
+        #   1. response length is suspiciously close to the cap
+        #      (≥ 90% of `max_tokens × 4` characters — a token≈4-char
+        #      English approximation; Korean is denser so this is
+        #      conservative — bias is towards false-negatives, i.e.
+        #      missing a real truncation rather than flagging a clean
+        #      stop as truncation)
+        #   2. the response does NOT end with a sentence terminator
+        #      (`. ? ! 다 요 음 } ]` or whitespace) — a model that
+        #      stopped naturally usually ends a sentence; a model
+        #      that ran out of tokens usually doesn't
+        # Both signals must fire to set `done_reason="length"`.
+        # `complete_with_retry` (`core.reasoning.budget`) acts on it
+        # by re-issuing with `retry_doubled(max_tokens)`.
+        done_reason = ""
+        if text and not is_err:
+            char_budget_approx = max(max_tokens, 1) * 4
+            length_suspicious = len(text) >= char_budget_approx * 0.9
+            stripped = text.rstrip()
+            sentence_end = stripped.endswith((
+                ".", "?", "!", "다", "요", "음", "}", "]", "\"", "'", ")"
+            ))
+            if length_suspicious and not sentence_end:
+                done_reason = "length"
+
         return CompletionResult(
             text=text or "",
             backend_id=self.backend_id,
             model=model or "",
             latency_ms=int((time.time() - t0) * 1000),
             error=("backend reported error string" if is_err else ""),
+            done_reason=done_reason,
         )
 
 

--- a/core/reasoning/budget.py
+++ b/core/reasoning/budget.py
@@ -185,11 +185,62 @@ def retry_doubled(prev_cap: int, max_cap: int = CAP_HEAVY) -> int:
     return min(prev_cap * 2, max_cap)
 
 
+def complete_with_retry(
+    backend,
+    prompt: str,
+    *,
+    cap: int,
+    max_cap: int = CAP_HEAVY,
+    timeout: float = 60.0,
+    **opts,
+):
+    """Call `backend.complete(prompt, max_tokens=cap, …)` and retry once
+    with `retry_doubled(cap, max_cap)` if the response is truncated.
+
+    D6 (2026-05-25) — closes the design ↔ wiring gap where the
+    `retry_doubled` helper existed but no call site invoked it.
+
+    Retry trigger: `result.done_reason == "length"`. Backends that
+    don't track `done_reason` (legacy / future plugin backends)
+    leave it empty → no retry — pre-D6 behavior is preserved.
+
+    Single retry only — bounded by `max_cap` (default `CAP_HEAVY`).
+    A misclassified light task that was already at `CAP_HEAVY` won't
+    spiral; `retry_doubled` saturates at the ceiling.
+
+    `cap` and `max_cap` are integers in the same token unit
+    `backend.complete` accepts via `max_tokens`. `**opts` is
+    forwarded as-is on both the first and the retry call.
+
+    Returns the `CompletionResult` of the **retry** when one was
+    issued, otherwise the first call's result.
+    """
+    result = backend.complete(
+        prompt,
+        max_tokens=cap,
+        timeout=timeout,
+        **opts,
+    )
+    if not getattr(result, "done_reason", "") == "length":
+        return result
+    retried_cap = retry_doubled(cap, max_cap=max_cap)
+    if retried_cap <= cap:
+        # Already at the ceiling — retry would change nothing.
+        return result
+    return backend.complete(
+        prompt,
+        max_tokens=retried_cap,
+        timeout=timeout,
+        **opts,
+    )
+
+
 __all__ = [
     "CAP_SUBSTITUTION",
     "CAP_LIGHT",
     "CAP_HEAVY",
     "ReasoningStage",
     "TaskBudget",
+    "complete_with_retry",
     "retry_doubled",
 ]

--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -323,11 +323,18 @@ class QueryRewriter:
             reason="auto" if _budget_for_router is not None else "fallback",
         )
 
+        # D6 (2026-05-25) — D1 `retry_doubled` wiring closure. If the
+        # response is truncated at `cap` (done_reason="length"), the
+        # helper retries once with `retry_doubled(cap)` up to
+        # CAP_HEAVY. Backends that don't expose `done_reason` leave
+        # it empty → no retry — pre-D6 behavior preserved.
         t0 = time.time()
         try:
-            result = backend.complete(
+            from core.reasoning.budget import complete_with_retry
+            result = complete_with_retry(
+                backend,
                 prompt,
-                max_tokens=cap,
+                cap=cap,
                 timeout=self._timeout,
             )
         except Exception:

--- a/tests/test_adaptive_budget.py
+++ b/tests/test_adaptive_budget.py
@@ -246,6 +246,7 @@ def test_module_exports():
         "CAP_HEAVY",
         "ReasoningStage",
         "TaskBudget",
+        "complete_with_retry",   # D6 (2026-05-25) — retry_doubled wiring closure
         "retry_doubled",
     }
     assert set(m.__all__) == expected

--- a/tests/test_complete_with_retry.py
+++ b/tests/test_complete_with_retry.py
@@ -1,0 +1,213 @@
+"""D6 — `complete_with_retry` + `OllamaLocalBackend.done_reason` heuristic.
+
+Closes the D1 design-intent ↔ wiring gap (retry_doubled was defined
+and contract-tested but never called from any production call site).
+
+Coverage:
+  • `complete_with_retry` retries when `done_reason == "length"`
+  • Single retry only (no spiral)
+  • Cap saturated at `max_cap` (default CAP_HEAVY) — no extra call
+  • Backends without `done_reason` attribute → pre-D6 behavior (no retry)
+  • Backends with `done_reason == ""` → no retry
+  • `**opts` forwarded on both first call and retry
+  • `OllamaLocalBackend.done_reason` heuristic — length-suspicious +
+    no-sentence-end → "length"; clean stop → ""
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from core.reasoning.backends import CompletionResult
+from core.reasoning.budget import (
+    CAP_HEAVY,
+    CAP_LIGHT,
+    CAP_SUBSTITUTION,
+    complete_with_retry,
+    retry_doubled,
+)
+
+
+# ─── complete_with_retry — happy paths ────────────────────────────
+
+
+def test_no_retry_when_done_reason_empty():
+    """Default — backend returns clean response, no done_reason. No retry."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="ok", backend_id="stub", done_reason=""
+    )
+    out = complete_with_retry(backend, "any", cap=CAP_LIGHT)
+    assert out.text == "ok"
+    backend.complete.assert_called_once()
+
+
+def test_no_retry_when_done_reason_stop():
+    """Other terminal reasons (e.g. ollama 'stop') do not trigger retry."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="ok", backend_id="stub", done_reason="stop"
+    )
+    out = complete_with_retry(backend, "any", cap=CAP_LIGHT)
+    assert out.text == "ok"
+    backend.complete.assert_called_once()
+
+
+def test_retry_fires_on_done_reason_length():
+    """The D6 happy path — truncation detected → one retry with doubled cap."""
+    backend = MagicMock()
+    backend.complete.side_effect = [
+        CompletionResult(text="trunc...", backend_id="stub", done_reason="length"),
+        CompletionResult(text="full answer", backend_id="stub", done_reason=""),
+    ]
+    out = complete_with_retry(backend, "any", cap=CAP_LIGHT)
+    assert out.text == "full answer"
+    assert backend.complete.call_count == 2
+    # Second call must use doubled cap
+    first_cap = backend.complete.call_args_list[0].kwargs["max_tokens"]
+    second_cap = backend.complete.call_args_list[1].kwargs["max_tokens"]
+    assert first_cap == CAP_LIGHT
+    assert second_cap == retry_doubled(CAP_LIGHT, max_cap=CAP_HEAVY)
+
+
+def test_retry_only_once_even_if_still_truncated():
+    """A misclassified light task that's still truncated at the retry cap
+    should NOT spiral — return the second result and stop."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="still trunc...", backend_id="stub", done_reason="length"
+    )
+    complete_with_retry(backend, "any", cap=CAP_LIGHT)
+    # The function returns the *retry* result when one was issued —
+    # in this case the second (still-truncated) response, not a third.
+    assert backend.complete.call_count == 2
+
+
+def test_retry_capped_at_max_cap():
+    """Already at CAP_HEAVY → no retry (cap can't grow)."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="trunc at heavy", backend_id="stub", done_reason="length"
+    )
+    out = complete_with_retry(backend, "any", cap=CAP_HEAVY)
+    assert backend.complete.call_count == 1
+    assert out.text == "trunc at heavy"
+
+
+def test_retry_with_custom_max_cap():
+    """Caller can lower the ceiling; retry honors it."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="trunc", backend_id="stub", done_reason="length"
+    )
+    complete_with_retry(backend, "any", cap=400, max_cap=600)
+    # 400 * 2 = 800, but max_cap=600 → retry to 600
+    assert backend.complete.call_count == 2
+    assert backend.complete.call_args_list[1].kwargs["max_tokens"] == 600
+
+
+# ─── backward compat — backends without `done_reason` ────────────
+
+
+def test_backend_without_done_reason_attr_no_retry():
+    """A pre-D6 backend / plugin backend that doesn't set `done_reason`
+    should never trigger retry. Pre-D6 behavior preserved."""
+    class _LegacyResult:
+        """Mimic a CompletionResult without the done_reason field."""
+        text = "ok"
+        backend_id = "legacy"
+        error = ""
+        # No `done_reason` attribute at all
+
+    backend = MagicMock()
+    backend.complete.return_value = _LegacyResult()
+    complete_with_retry(backend, "any", cap=CAP_LIGHT)
+    backend.complete.assert_called_once()
+
+
+# ─── kwargs forwarded ──────────────────────────────────────────────
+
+
+def test_opts_forwarded_on_both_calls():
+    """`**opts` (e.g. `system`, `temperature`, `use_cache`) must be
+    forwarded as-is on both the first call and the retry."""
+    backend = MagicMock()
+    backend.complete.side_effect = [
+        CompletionResult(text="trunc", backend_id="stub", done_reason="length"),
+        CompletionResult(text="full", backend_id="stub", done_reason=""),
+    ]
+    complete_with_retry(
+        backend, "any", cap=CAP_SUBSTITUTION,
+        timeout=30.0, system="sys prompt", temperature=0.5,
+    )
+    for call in backend.complete.call_args_list:
+        assert call.kwargs["timeout"] == 30.0
+        assert call.kwargs["system"] == "sys prompt"
+        assert call.kwargs["temperature"] == 0.5
+
+
+# ─── OllamaLocalBackend.done_reason heuristic ─────────────────────
+
+
+class _FakeRouter:
+    """Stand-in for RouterWrapper. The test sets `_response_text` to
+    control what `call_gemma` returns."""
+
+    def __init__(self, response_text):
+        self._response_text = response_text
+
+    def call_gemma(self, prompt, **kwargs):
+        return self._response_text
+
+
+def _run_ollama(text, max_tokens):
+    """Construct an OllamaLocalBackend that returns `text` and call
+    `.complete(...)` with the given `max_tokens`. Returns the
+    CompletionResult."""
+    from core.reasoning.backends.ollama_local import OllamaLocalBackend
+
+    b = OllamaLocalBackend()
+    b._router = _FakeRouter(text)  # bypass lazy init
+    return b.complete("any prompt", max_tokens=max_tokens)
+
+
+def test_ollama_done_reason_empty_on_clean_stop():
+    # Short response ending with a sentence terminator → no truncation
+    out = _run_ollama("Hello. This is fine.", max_tokens=1000)
+    assert out.done_reason == ""
+
+
+def test_ollama_done_reason_length_on_long_no_sentence_end():
+    # Long response (≥ 90% of cap×4 chars) ending with no terminator
+    # → truncation suspected. cap=100 tokens → 400 chars budget →
+    # 360+ chars without terminator triggers.
+    truncated = "x" * 380  # 380 chars, no sentence end
+    out = _run_ollama(truncated, max_tokens=100)
+    assert out.done_reason == "length"
+
+
+def test_ollama_done_reason_empty_when_long_but_sentence_ends():
+    # Long response BUT ends with terminator — natural stop
+    long_clean = ("Lorem ipsum dolor sit amet, consectetur. " * 9).rstrip()
+    out = _run_ollama(long_clean, max_tokens=100)
+    # Ends with "." → clean stop
+    assert out.done_reason == ""
+
+
+def test_ollama_done_reason_empty_when_short_no_sentence_end():
+    # Short response without terminator — but not length-suspicious
+    out = _run_ollama("short", max_tokens=1000)
+    assert out.done_reason == ""
+
+
+def test_ollama_done_reason_handles_korean_terminator():
+    # Korean common terminators '다', '요', '음' must register as clean stop
+    out = _run_ollama("팔란티어는 데이터 분석 회사입니다", max_tokens=10)
+    # Ends with "다" → clean stop
+    assert out.done_reason == ""
+
+
+def test_ollama_done_reason_handles_json_terminator():
+    # JSON-style outputs ending with `}` or `]` are clean stops
+    out = _run_ollama('{"grounded": true}', max_tokens=10)
+    assert out.done_reason == ""


### PR DESCRIPTION
## Summary

Closes the D1 design vs wiring gap surfaced by the 2026-05-25 user diagnostic *"does D1 7-tier cover everything / what about exceptions?"*. The `retry_doubled()` helper had been defined + 40-test contract-locked in `core/reasoning/budget.py` since v0.3.1 but **no call site invoked it** — silent truncation at CAP_LIGHT (1200) on D1 flag-ON.

This PR ships `complete_with_retry()` + wires `query_rewriter` through it. The other 3 cognitive stages (planner / reflect / verify) stay on the legacy path — they currently use `self._max_tokens = 4096` which is already at the CAP_HEAVY ceiling, so retry would be a no-op there.

## What lands

| File | Change |
|---|---|
| `core/reasoning/backends/__init__.py` | `CompletionResult` gains optional `done_reason: str = ""` field. Backward compat: pre-D6 backends without the attribute are tolerated by the helper (returns first result, no retry). |
| `core/reasoning/backends/ollama_local.py` | `done_reason` heuristic. RouterWrapper doesn't yet expose Ollama's native `done_reason`, so we infer truncation from two signals: response length ≥ 90% of `max_tokens × 4` chars AND no sentence terminator. Conservative — biased to false negatives. Native `done_reason` is future PR (RouterWrapper extension). |
| `core/reasoning/budget.py` | NEW `complete_with_retry(backend, prompt, *, cap, max_cap=CAP_HEAVY, timeout, **opts)` helper. Single retry on `done_reason="length"`, bounded by `max_cap`, opts forwarded both calls. Added to `__all__`. |
| `core/retrieval/query_rewriter.py` | `backend.complete(...)` → `complete_with_retry(backend, ..., cap=cap)` — the only call site that currently benefits (D1 wired stage with dynamic cap signal under `JAMES_ADAPTIVE_BUDGET=1`). |
| `tests/test_complete_with_retry.py` | NEW — 14 contract tests (no retry on empty/stop, retry fires on length, single retry only, cap saturated at max_cap, custom max_cap, backend-without-done_reason-attr no retry, opts forwarded, 6 ollama_local heuristic cases). |
| `tests/test_adaptive_budget.py` | `test_module_exports` updated to include `complete_with_retry` in expected `__all__`. |

## D1 safety net status (post-D6)

| # | Net | Before | After |
|---|---|---|---|
| 1 | `retry_doubled` fallback | Definition-only, no wiring | **Wired via `complete_with_retry` on query_rewriter** |
| 2 | Falsification cycle | Unchanged | Unchanged |
| 3 | flag-off default | Unchanged | Unchanged |
| 4 | Heuristic asymmetry | Half-effective (no retry) | Backed by actual retry on the one stage where cap < CAP_HEAVY |

The 8th+ untested task type that overruns CAP_LIGHT (1200) on query_rewriter now retries at 2400 (next tier up to CAP_HEAVY). Silent truncation closed for that stage.

## Verification

- 14 new D6 tests pass
- **522 backend/router/budget/rewriter/graph/reflect/verify/alias regression tests pass**
- ruff clean

## Bench (CLAUDE.md rule #2)

`core/reasoning/budget.py` + `core/retrieval/query_rewriter.py` are under bench-required paths. D6 wiring is opt-in via `JAMES_ADAPTIVE_BUDGET` (D1 flag, default OFF). Pre-D6 behavior preserved at production call path — no operator on the existing fleet sees latency or grounded-rate change from this PR.

When D1 flag is ON, the only observable change: on calls where the model would have silently truncated at CAP_LIGHT=1200 (with no sentence-end terminator), one extra LLM call now retries at 2400 tokens. Cost = 1 extra call for false-negative-classified heavy tasks. Benefit = no silent quality regression on that subset.

Operator-run STEP 7 sweep (v0.3.2 result doc) remains the integrated measurement path. This PR adds a retry behavior that would manifest only on truncation-prone prompts not in the original 7-tier set.

## Out of scope (future)

- **Native Ollama `done_reason`** via RouterWrapper extension — the heuristic is a placeholder; native signal would be more accurate. Separate PR.
- **Wire planner / reflect / verify** through `complete_with_retry` — cap already at CAP_HEAVY there, retry is no-op. When those stages gain D1 budget signal in a future cycle, wiring follows the query_rewriter pattern.
- **`audit_log` emit on retry events** — useful for monitoring new fail cases. Follow-up.
- **D2 task-weight metric in measured form** — v0.4 cycle, when heuristic plateaus on production bench.

Generated with Claude Code