### PR TITLE
feat(reasoning): D6 follow-up - audit reason:retry emit on truncation retry

### DIFF
--- a/core/reasoning/budget.py
+++ b/core/reasoning/budget.py
@@ -192,6 +192,7 @@ def complete_with_retry(
     cap: int,
     max_cap: int = CAP_HEAVY,
     timeout: float = 60.0,
+    stage: str = "",
     **opts,
 ):
     """Call `backend.complete(prompt, max_tokens=cap, …)` and retry once
@@ -212,6 +213,12 @@ def complete_with_retry(
     `backend.complete` accepts via `max_tokens`. `**opts` is
     forwarded as-is on both the first and the retry call.
 
+    `stage` — optional caller identifier used for the audit row
+    emitted when a retry actually fires (`reason:retry` endpoint).
+    Empty string falls back to the backend_id read off the
+    `CompletionResult`. The audit emit is try/except-wrapped — an
+    audit failure never blocks the production call path.
+
     Returns the `CompletionResult` of the **retry** when one was
     issued, otherwise the first call's result.
     """
@@ -227,6 +234,37 @@ def complete_with_retry(
     if retried_cap <= cap:
         # Already at the ceiling — retry would change nothing.
         return result
+
+    # D6 audit emit — record the retry decision so operators can
+    # monitor truncation hits + tune heuristics in v3/v4 falsification
+    # cycles. Schema: endpoint="reason:retry", query=stage or
+    # backend_id, answer="cap_before=X cap_after=Y backend=Z
+    # prompt={hash8}".
+    try:
+        import hashlib
+        from core.audit_bridge import mirror_to_audit_db
+
+        backend_id = getattr(result, "backend_id", "") or "unknown"
+        prompt_hash = (
+            hashlib.sha256(prompt.encode("utf-8", errors="ignore")).hexdigest()[:8]
+            if prompt
+            else ""
+        )
+        # NOTE: `audit_bridge._resolve_query` reads `target` / `path` /
+        # `tool_used` keys, not `query`. So we put the stage in `target`
+        # to actually land in the SQL `query` column.
+        mirror_to_audit_db({
+            "endpoint": "reason:retry",
+            "role": "system",
+            "target": stage or backend_id,
+            "cap_before": cap,
+            "cap_after": retried_cap,
+            "backend": backend_id,
+            "prompt_hash": prompt_hash,
+        })
+    except Exception:
+        pass
+
     return backend.complete(
         prompt,
         max_tokens=retried_cap,

--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -336,6 +336,7 @@ class QueryRewriter:
                 prompt,
                 cap=cap,
                 timeout=self._timeout,
+                stage="query_rewriter",
             )
         except Exception:
             return (query, int((time.time() - t0) * 1000), True)

--- a/tests/test_complete_with_retry.py
+++ b/tests/test_complete_with_retry.py
@@ -16,7 +16,9 @@ Coverage:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import sqlite3
+import tempfile
+from unittest.mock import MagicMock, patch
 
 from core.reasoning.backends import CompletionResult
 from core.reasoning.budget import (
@@ -211,3 +213,135 @@ def test_ollama_done_reason_handles_json_terminator():
     # JSON-style outputs ending with `}` or `]` are clean stops
     out = _run_ollama('{"grounded": true}', max_tokens=10)
     assert out.done_reason == ""
+
+
+# ─── audit emit on retry (D6 follow-up: monitoring channel) ──────
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_audit_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _read_retry_rows(db_path: str):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM audit_log WHERE endpoint='reason:retry' "
+            "ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def test_audit_row_emitted_when_retry_fires():
+    """The retry path must drop a `reason:retry` row recording
+    cap_before/cap_after/backend so operators can monitor truncation
+    hits (D6 follow-up: monitoring channel).
+
+    `audit_bridge._resolve_answer` JSON-encodes non-reserved entry
+    keys into the `answer` column, so the asserts decode the JSON.
+    """
+    import json
+    backend = MagicMock()
+    backend.complete.side_effect = [
+        CompletionResult(text="trunc", backend_id="ollama_local", done_reason="length"),
+        CompletionResult(text="full", backend_id="ollama_local", done_reason=""),
+    ]
+    db = _fresh_audit_db()
+    with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+        complete_with_retry(
+            backend, "팔란티어가 뭐야",
+            cap=CAP_LIGHT, stage="query_rewriter",
+        )
+    rows = _read_retry_rows(db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["endpoint"] == "reason:retry"
+    assert row["query"] == "query_rewriter"
+    payload = json.loads(row["answer"])
+    assert payload["cap_before"] == 1200
+    assert payload["cap_after"] == 2400
+    assert payload["backend"] == "ollama_local"
+    assert payload["prompt_hash"]   # non-empty 8-char hash
+
+
+def test_audit_row_NOT_emitted_when_no_retry():
+    """Clean stop response → no `reason:retry` row."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="ok", backend_id="stub", done_reason=""
+    )
+    db = _fresh_audit_db()
+    with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+        complete_with_retry(backend, "any", cap=CAP_LIGHT, stage="query_rewriter")
+    rows = _read_retry_rows(db)
+    assert rows == []
+
+
+def test_audit_row_NOT_emitted_when_retry_capped():
+    """Already at CAP_HEAVY → no retry, no audit row."""
+    backend = MagicMock()
+    backend.complete.return_value = CompletionResult(
+        text="trunc at heavy", backend_id="stub", done_reason="length"
+    )
+    db = _fresh_audit_db()
+    with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+        complete_with_retry(backend, "any", cap=CAP_HEAVY, stage="query_rewriter")
+    rows = _read_retry_rows(db)
+    assert rows == []
+
+
+def test_audit_row_uses_backend_id_when_stage_empty():
+    """Caller may omit `stage` — audit row falls back to backend_id."""
+    backend = MagicMock()
+    backend.complete.side_effect = [
+        CompletionResult(text="trunc", backend_id="ollama_local", done_reason="length"),
+        CompletionResult(text="full", backend_id="ollama_local", done_reason=""),
+    ]
+    db = _fresh_audit_db()
+    with patch("core.audit_bridge._DEFAULT_AUDIT_DB", db):
+        complete_with_retry(backend, "any", cap=CAP_SUBSTITUTION)
+    rows = _read_retry_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["query"] == "ollama_local"
+
+
+def test_audit_emit_failure_does_not_block_retry():
+    """audit_bridge raising must not break the retry call path."""
+    backend = MagicMock()
+    backend.complete.side_effect = [
+        CompletionResult(text="trunc", backend_id="stub", done_reason="length"),
+        CompletionResult(text="full", backend_id="stub", done_reason=""),
+    ]
+    with patch(
+        "core.audit_bridge.mirror_to_audit_db",
+        side_effect=RuntimeError("simulated audit failure"),
+    ):
+        result = complete_with_retry(backend, "any", cap=CAP_LIGHT, stage="x")
+    # The retry still happened and the second result is returned
+    assert result.text == "full"
+    assert backend.complete.call_count == 2


### PR DESCRIPTION
## Summary

Follow-up to D6 (PR #486) — adds a monitoring channel for the retry path. When `complete_with_retry` actually fires a retry (`done_reason="length"` detected + `retried_cap > cap`), a `reason:retry` row lands in `audit_log` so operators can:

- Track truncation hits per stage (new fail-case discovery channel)
- Tune the D1.B heuristic (v3 if a pattern emerges in production)
- Monitor false-positive heuristic rate (the Ollama length+terminator heuristic could mark non-truncated responses as `length`; if retry emit count >> actual truncation count, the heuristic itself needs tuning — visible in audit_log over time)

## What lands

| File | Change |
|---|---|
| `core/reasoning/budget.py:complete_with_retry` | NEW `stage: str = ""` kwarg + audit emit between truncation detection and retry call. Uses `target` key (not `query`) per `audit_bridge._resolve_query` schema. `cap_before` / `cap_after` / `backend` / `prompt_hash` go into the answer column as JSON (auto-serialized by `audit_bridge._resolve_answer`). |
| `core/retrieval/query_rewriter.py` | passes `stage="query_rewriter"` to `complete_with_retry` so the audit row carries the call-site identifier. |
| `tests/test_complete_with_retry.py` | 5 new audit-emit tests (row emitted on retry / NOT on clean stop / NOT when cap saturated / falls back to backend_id when stage empty / retry survives audit failure). |

## Audit row schema (`reason:retry`)

| column | value |
|---|---|
| endpoint | `"reason:retry"` |
| query | stage (or backend_id when stage="") |
| answer | JSON `{"cap_before": <int>, "cap_after": <int>, "backend": "<id>", "prompt_hash": "<8 hex>"}` |
| user_role | `"system"` |

Pairs with the existing `reason:route` audit row (D5.C.2.a, PR #478) — the two endpoints together give operators a complete picture of every routing decision plus every truncation retry.

## Verification

- ✅ 19 retry tests pass (14 D6 base + 5 new audit)
- ✅ **541 backend/router/budget/rewriter/graph/reflect/verify/alias/retry regression tests pass**
- ✅ ruff clean

## Backward compat

- `audit_log` INSERT failure already try/except-wrapped — audit failures never block production
- `stage` kwarg is optional with default `""` — existing callers still work (audit row falls back to `backend_id`)

## Bench (CLAUDE.md rule #2)

`core/reasoning/budget.py` is under bench-required paths. This PR adds ONE `INSERT INTO audit_log` per actual retry firing. In the production fleet today (D1 flag default OFF) there are zero retries → zero new audit rows. With D1 flag ON, the extra cost is a single sqlite3 INSERT on the truncation subset only. Sub-millisecond local I/O on `james_audit.db`.

Operationally: strict superset of pre-follow-up behavior — no production call path is slowed, operators gain the monitoring channel.

## Out of scope (next follow-ups)

- **Native Ollama `done_reason` exposure** (RouterWrapper.call_gemma extension — more accurate signal than the length+terminator heuristic). Separate PR.
- **README DOI badge v0.3.1 → v0.3.2** (Zenodo webhook needs to finish minting first — operator confirms DOI).

Generated with Claude Code