### PR TITLE
feat(reasoning): D6 follow-up - native Ollama done_reason exposure (4-layer)

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -81,6 +81,19 @@ class GemmaClient:
         self._cache_errors = 0   # 에러 응답 캐시 거부 횟수
         self._total_calls  = 0
 
+        # D6 follow-up (2026-05-25) — native Ollama `done_reason`
+        # stashed by the most recent uncached `call_gemma` invocation.
+        # Read by `OllamaClient.generate_meta` so the
+        # `ollama_local` backend can replace the length+terminator
+        # heuristic with Ollama's native signal.
+        #
+        # Empty string when:
+        #   - call_gemma hit a cached response (no fresh ollama call)
+        #   - the upstream response did not include `done_reason`
+        #     (Ollama < 0.1.30)
+        #   - the call errored before reaching the response
+        self._last_done_reason: str = ""
+
     # ─── 캐시 메서드 ─────────────────────────────────────────
 
     def _generate_cache_key(self, content: str) -> str:
@@ -200,6 +213,11 @@ class GemmaClient:
         self._total_calls += 1
         cache_key = self._generate_cache_key(prompt)
 
+        # D6 follow-up — reset stale done_reason from prior call so
+        # a cache hit / early-return path doesn't leak the previous
+        # call's signal upward through `OllamaClient.generate_meta`.
+        self._last_done_reason = ""
+
         # 긴 프롬프트 캐시 금지
         if len(prompt) > 2000:
             use_cache = False
@@ -212,6 +230,9 @@ class GemmaClient:
                 print(f"🔥 GEMMA CACHE HIT (hits={self._cache_hits})")
                 age = time.time() - self.cache_timestamps.get(cache_key, 0)
                 print(f"[DEBUG] cache age={age:.1f}s / TTL={self.cache_ttl}s")
+                # _last_done_reason stays "" — caller treats absence
+                # as "no truncation signal observed" (heuristic fallback
+                # applies if caller uses ollama_local heuristic).
                 return cached
             else:
                 self._cache_misses += 1
@@ -260,7 +281,13 @@ class GemmaClient:
                     timeout=timeout,
                 )
                 resp.raise_for_status()
-                output = resp.json().get("response", "").strip()
+                resp_json = resp.json()
+                output = resp_json.get("response", "").strip()
+                # D6 follow-up — stash native done_reason for
+                # OllamaClient.generate_meta to forward upward.
+                # Ollama 0.1.30+ returns "stop" / "length" / "load";
+                # older versions omit the field → "" left in place.
+                self._last_done_reason = resp_json.get("done_reason", "") or ""
                 elapsed_llm = time.time() - t_call
                 print(f"[GEMMA] 응답 수신 ({elapsed_llm:.1f}s) | {len(output)}자")
 

--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -183,6 +183,17 @@ class GemmaClient:
             print로 로깅돼 운영자가 보임. 하나도 설치 안 된 경우 명확한
             "ollama pull X" 안내 메시지로 RuntimeError 발생.
         """
+        # D6 follow-up (2026-05-25) — reset stale done_reason from
+        # prior call before *anything else* (including model resolve
+        # that may raise RuntimeError when no models are installed).
+        # If reset happened after resolve, a failed resolve would
+        # leave the previous truncation signal stashed and leak
+        # upward through OllamaClient.generate_meta on the next
+        # successful call. Reset-at-entry guarantees the invariant
+        # "stash is empty unless the most recent uncached
+        # resp.json() populated it."
+        self._last_done_reason = ""
+
         if model:
             # Caller specified a tag — verify it's installed before
             # hitting Ollama. If not installed, the resolver falls
@@ -212,11 +223,6 @@ class GemmaClient:
                 print(f"[MODEL_RESOLVE] {resolved.warning}")
         self._total_calls += 1
         cache_key = self._generate_cache_key(prompt)
-
-        # D6 follow-up — reset stale done_reason from prior call so
-        # a cache hit / early-return path doesn't leak the previous
-        # call's signal upward through `OllamaClient.generate_meta`.
-        self._last_done_reason = ""
 
         # 긴 프롬프트 캐시 금지
         if len(prompt) > 2000:

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -60,20 +60,54 @@ class OllamaLocalBackend:
         # prepends; we don't double-prepend here.
         composed = f"{system}\n\n{prompt}" if system else prompt
 
+        # D6 follow-up (2026-05-25) — prefer the native Ollama
+        # `done_reason` exposed via `RouterWrapper.call_gemma_meta`.
+        # Falls back to the legacy `call_gemma` + length+terminator
+        # heuristic when:
+        #   - RouterWrapper has no `call_gemma_meta` (older deploys
+        #     or non-Ollama backends)
+        #   - the native signal is empty (Ollama < 0.1.30, or
+        #     GemmaClient hit a cache → no fresh ollama response)
+        # The fallback preserves the D6 base PR #486 behavior so
+        # `complete_with_retry` (`core.reasoning.budget`) still
+        # observes a "length" signal on truncation-suspicious text.
         t0 = time.time()
+        native_done_reason = ""
+        router = self._llm()
+        # Native path is attempted only when the router actually has
+        # `call_gemma_meta` AND returns a dict. MagicMock auto-creates
+        # missing attributes (so `hasattr` alone isn't a usable signal
+        # — test mocks would always look like they support the new
+        # method). Requiring a dict return value gracefully rejects
+        # auto-mocked attributes + future provider implementations
+        # that haven't migrated to the dict shape.
         try:
-            text = self._llm().call_gemma(
-                composed,
-                timeout=timeout,
-                use_cache=use_cache,
-                max_tokens=max_tokens,
-                model=model or None,
-                # [Track 1 PR-C, 2026-05-19] Reserved kwarg per the
-                # Provider contract §R4. None → call_gemma falls back
-                # to config.LLM_TEMPERATURE (default 0.2). Required
-                # for the Gemma 4 3×3 experiment which sweeps this.
-                temperature=temperature,
-            )
+            text = None
+            meta_fn = getattr(router, "call_gemma_meta", None)
+            if callable(meta_fn):
+                try:
+                    meta = meta_fn(
+                        composed,
+                        timeout=timeout,
+                        use_cache=use_cache,
+                        max_tokens=max_tokens,
+                        model=model or None,
+                        temperature=temperature,
+                    )
+                except Exception:
+                    meta = None
+                if isinstance(meta, dict):
+                    text = meta.get("text", "") or ""
+                    native_done_reason = meta.get("done_reason", "") or ""
+            if text is None:
+                text = router.call_gemma(
+                    composed,
+                    timeout=timeout,
+                    use_cache=use_cache,
+                    max_tokens=max_tokens,
+                    model=model or None,
+                    temperature=temperature,
+                )
         except Exception as e:
             return CompletionResult(
                 text="",
@@ -90,24 +124,21 @@ class OllamaLocalBackend:
                          "LLM 응답 생성 중 오류")
         is_err = bool(text) and any(text.startswith(p) for p in _ERR_PREFIXES)
 
-        # D6 (2026-05-25) — done_reason heuristic. RouterWrapper does
-        # not yet expose Ollama's native `done_reason`, so we infer
-        # truncation from two signals:
-        #   1. response length is suspiciously close to the cap
-        #      (≥ 90% of `max_tokens × 4` characters — a token≈4-char
-        #      English approximation; Korean is denser so this is
-        #      conservative — bias is towards false-negatives, i.e.
-        #      missing a real truncation rather than flagging a clean
-        #      stop as truncation)
-        #   2. the response does NOT end with a sentence terminator
-        #      (`. ? ! 다 요 음 } ]` or whitespace) — a model that
-        #      stopped naturally usually ends a sentence; a model
-        #      that ran out of tokens usually doesn't
-        # Both signals must fire to set `done_reason="length"`.
-        # `complete_with_retry` (`core.reasoning.budget`) acts on it
-        # by re-issuing with `retry_doubled(max_tokens)`.
+        # done_reason resolution: native first, heuristic fallback.
+        # Native values follow Ollama's vocabulary ("stop" / "length" /
+        # "load" / "" if unavailable). Heuristic only fires when:
+        #   - native is empty (signal missing)
+        #   - text is non-error
+        # so a "stop" from native does NOT get overridden by the
+        # heuristic — the precise native signal wins.
         done_reason = ""
-        if text and not is_err:
+        if native_done_reason:
+            done_reason = native_done_reason
+        elif text and not is_err:
+            # Legacy heuristic (PR #486, D6 base) — two-signal:
+            #   1. length ≥ 90% × cap × 4 chars (token ≈ 4-char approx)
+            #   2. no sentence terminator at end
+            # Both must fire to mark as "length".
             char_budget_approx = max(max_tokens, 1) * 4
             length_suspicious = len(text) >= char_budget_approx * 0.9
             stripped = text.rstrip()

--- a/llm/base.py
+++ b/llm/base.py
@@ -17,6 +17,34 @@ class BaseLLM(ABC):
     def generate(self, messages: List[Dict], **kwargs) -> str:
         raise NotImplementedError
 
+    def generate_meta(self, messages: List[Dict], **kwargs) -> Dict:
+        """Return generated text + provider metadata as a dict.
+
+        D6 follow-up (2026-05-25). Lets call sites read a native
+        truncation signal (``done_reason``) when the provider exposes
+        one, replacing the heuristic in
+        ``core.reasoning.backends.ollama_local`` with a precise signal.
+
+        Contract: returns at minimum::
+
+            {"text": str, "done_reason": str}
+
+        ``done_reason`` values follow Ollama's vocabulary:
+          - ``"stop"``    — model produced a stop token / EOS
+          - ``"length"``  — ``num_predict`` cap was hit (truncation)
+          - ``"load"``    — model still loading (rare)
+          - ``""``        — provider doesn't expose the signal
+
+        Default implementation falls back to ``.generate(...)`` so
+        pre-D6 plugin providers keep working unchanged. Provider-
+        specific overrides (Ollama, Claude API, etc.) plug in
+        their native signal.
+        """
+        return {
+            "text": self.generate(messages, **kwargs),
+            "done_reason": "",
+        }
+
     def is_available(self) -> bool:
         """provider 연결 가능 여부 확인."""
         return False

--- a/llm/providers/ollama_client.py
+++ b/llm/providers/ollama_client.py
@@ -12,6 +12,22 @@ from typing import List, Dict
 class OllamaClient(BaseLLM):
     name = "ollama"
 
+    def __init__(self):
+        # D6 follow-up (2026-05-25) — hold a single GemmaClient
+        # instance so `generate_meta` can read `_last_done_reason`
+        # after `generate(...)` returns. Pre-D6 the client was
+        # constructed inline per call; the inline construction is
+        # preserved as a fallback path inside `generate(...)` so
+        # legacy call sites that don't use `generate_meta` keep
+        # the same memory profile.
+        self._gemma_client = None
+
+    def _client(self):
+        from core.gemma_client import GemmaClient
+        if self._gemma_client is None:
+            self._gemma_client = GemmaClient()
+        return self._gemma_client
+
     def generate(self, messages: List[Dict], **kwargs) -> str:
         """messages → 단일 prompt 변환 후 GemmaClient 호출.
 
@@ -19,16 +35,43 @@ class OllamaClient(BaseLLM):
         (call_router가 이 generate를 호출하므로 호출자의 옵션이 손실 없이 전달).
         ``model`` 인자가 있으면 GemmaClient가 그 model로 ollama API 호출 (#15).
         """
-        from core.gemma_client import GemmaClient
         prompt     = "\n".join(m.get("content","") for m in messages if m.get("content"))
         timeout    = kwargs.get("timeout",    120)
         use_cache  = kwargs.get("use_cache",  True)
         max_tokens = kwargs.get("max_tokens", 0)
         model      = kwargs.get("model")
-        return GemmaClient().call_gemma(
+        return self._client().call_gemma(
             prompt, timeout=timeout, use_cache=use_cache, max_tokens=max_tokens,
             model=model,
         )
+
+    def generate_meta(self, messages: List[Dict], **kwargs) -> Dict:
+        """D6 follow-up — return text + native Ollama `done_reason`.
+
+        Calls `generate(...)` then reads the cached GemmaClient's
+        `_last_done_reason` attribute (populated inside
+        `GemmaClient.call_gemma` from the raw Ollama response).
+
+        Returns:
+            {"text": str, "done_reason": str}
+
+            `done_reason` is whatever Ollama returned ("stop" /
+            "length" / "load" / ""). Empty when:
+              - GemmaClient hit a cache (no fresh Ollama call)
+              - Ollama version < 0.1.30 (field not in response)
+              - call errored before reaching `response.json()`
+
+        The `ollama_local` backend (`core.reasoning.backends.ollama_local`)
+        consumes this to replace its length-+-terminator heuristic
+        with the precise native signal — falling back to the
+        heuristic only when `done_reason` is empty.
+        """
+        text = self.generate(messages, **kwargs)
+        client = self._client()
+        return {
+            "text": text,
+            "done_reason": getattr(client, "_last_done_reason", "") or "",
+        }
 
     def is_available(self) -> bool:
         try:

--- a/llm/router.py
+++ b/llm/router.py
@@ -180,6 +180,46 @@ def call_router(
     return llm.generate(messages, **kwargs)
 
 
+def call_router_meta(
+    prompt:    str,
+    task_type: Optional[str] = None,
+    **kwargs,
+) -> dict:
+    """D6 follow-up (2026-05-25) — text + native `done_reason`.
+
+    Mirror of `call_router` that invokes the provider's
+    `generate_meta(...)` so the caller receives the native
+    truncation signal alongside the text. Same task_type → model
+    routing logic; same Hard fallback to direct GemmaClient when
+    no provider is available (the fallback wraps the legacy
+    `call_gemma` in the BaseLLM-style dict for shape consistency).
+    """
+    # Operator override per-task (admin endpoint에서 set)
+    if task_type and "model" not in kwargs:
+        try:
+            from llm.selection import get_model_for_task
+            chosen = get_model_for_task(task_type)
+            if chosen:
+                kwargs["model"] = chosen
+        except Exception:
+            pass
+
+    llm = route(prompt, task_type=task_type)
+    if llm is None:
+        # Hard fallback path — no provider routing available.
+        # Use GemmaClient directly and read its
+        # `_last_done_reason` stash for the native signal.
+        from core.gemma_client import GemmaClient
+        client = GemmaClient()
+        text = client.call_gemma(prompt, **kwargs)
+        return {
+            "text": text,
+            "done_reason": getattr(client, "_last_done_reason", "") or "",
+        }
+    messages = [{"role": "user", "content": prompt}]
+    return llm.generate_meta(messages, **kwargs)
+
+
 class RouterWrapper:
     """GemmaClient.call_gemma 호환 인스턴스 wrapper (Issue #13 Phase 2).
 
@@ -201,6 +241,21 @@ class RouterWrapper:
     def call_gemma(self, prompt: str, **kwargs) -> str:
         task = kwargs.pop("task_type", self.default_task)
         return call_router(prompt, task_type=task, **kwargs)
+
+    def call_gemma_meta(self, prompt: str, **kwargs) -> dict:
+        """D6 follow-up (2026-05-25) — text + native `done_reason`.
+
+        Delegates to `call_router_meta` which selects the same
+        provider as `call_router` would but invokes the provider's
+        `generate_meta(...)` rather than `generate(...)`. Returns at
+        minimum `{"text": str, "done_reason": str}`.
+
+        Used by `core.reasoning.backends.ollama_local.complete` to
+        replace the length-+-terminator heuristic with the native
+        Ollama truncation signal when available.
+        """
+        task = kwargs.pop("task_type", self.default_task)
+        return call_router_meta(prompt, task_type=task, **kwargs)
 
     def call_gemma_vision(self, prompt: str, image_path: str, **kwargs) -> str:
         from core.gemma_client import GemmaClient

--- a/tests/test_native_done_reason.py
+++ b/tests/test_native_done_reason.py
@@ -1,0 +1,234 @@
+"""D6 follow-up — native Ollama `done_reason` exposure tests.
+
+Coverage:
+  • `BaseLLM.generate_meta` default returns `{"text": ..., "done_reason": ""}`
+  • `OllamaClient.generate_meta` reads `GemmaClient._last_done_reason`
+  • `RouterWrapper.call_gemma_meta` dispatches to `call_router_meta`
+  • `call_router_meta` invokes provider's `generate_meta`
+  • `ollama_local` backend prefers native signal, falls back to heuristic
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+# ─── BaseLLM.generate_meta default ───────────────────────────────
+
+
+def test_basellm_default_generate_meta_returns_dict():
+    """Provider that doesn't override `generate_meta` gets a graceful
+    default that wraps `generate(...)` in the dict shape."""
+    from llm.base import BaseLLM
+
+    class _StubProvider(BaseLLM):
+        name = "stub"
+
+        def generate(self, messages, **kwargs):
+            return "stub-text"
+
+    p = _StubProvider()
+    out = p.generate_meta([{"role": "user", "content": "hi"}])
+    assert out == {"text": "stub-text", "done_reason": ""}
+
+
+# ─── OllamaClient.generate_meta ─────────────────────────────────
+
+
+def test_ollama_client_generate_meta_reads_done_reason():
+    """OllamaClient holds a single GemmaClient instance so it can
+    read `_last_done_reason` after `generate(...)` returns."""
+    from llm.providers.ollama_client import OllamaClient
+
+    c = OllamaClient()
+    fake_gemma = MagicMock()
+    fake_gemma.call_gemma.return_value = "ok"
+    fake_gemma._last_done_reason = "length"
+    c._gemma_client = fake_gemma
+
+    out = c.generate_meta(
+        [{"role": "user", "content": "hi"}],
+        max_tokens=100, timeout=5, use_cache=False,
+    )
+    assert out == {"text": "ok", "done_reason": "length"}
+
+
+def test_ollama_client_generate_meta_empty_when_no_done_reason():
+    """If GemmaClient doesn't set _last_done_reason (cache hit / old
+    Ollama / error), the returned done_reason is empty string."""
+    from llm.providers.ollama_client import OllamaClient
+
+    c = OllamaClient()
+    fake_gemma = MagicMock()
+    fake_gemma.call_gemma.return_value = "ok"
+    fake_gemma._last_done_reason = ""
+    c._gemma_client = fake_gemma
+
+    out = c.generate_meta(
+        [{"role": "user", "content": "hi"}],
+        max_tokens=100, timeout=5, use_cache=False,
+    )
+    assert out["text"] == "ok"
+    assert out["done_reason"] == ""
+
+
+# ─── RouterWrapper.call_gemma_meta ──────────────────────────────
+
+
+def test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta():
+    """call_gemma_meta is just a thin shim over call_router_meta."""
+    from llm.router import RouterWrapper
+
+    rw = RouterWrapper("general")
+    with patch("llm.router.call_router_meta") as mock_router_meta:
+        mock_router_meta.return_value = {"text": "ok", "done_reason": "stop"}
+        out = rw.call_gemma_meta("hi", task_type="general", timeout=30)
+        mock_router_meta.assert_called_once_with(
+            "hi", task_type="general", timeout=30,
+        )
+        assert out == {"text": "ok", "done_reason": "stop"}
+
+
+def test_call_router_meta_uses_provider_generate_meta():
+    """When a provider is routed, call_router_meta invokes
+    provider.generate_meta and forwards the result dict."""
+    from llm.router import call_router_meta
+
+    fake_llm = MagicMock()
+    fake_llm.generate_meta.return_value = {"text": "ok", "done_reason": "stop"}
+    with patch("llm.router.route", return_value=fake_llm):
+        out = call_router_meta("hi")
+    assert out == {"text": "ok", "done_reason": "stop"}
+    fake_llm.generate_meta.assert_called_once()
+
+
+def test_call_router_meta_falls_back_to_gemma_client_when_no_route():
+    """If no provider matches, call_router_meta falls back to direct
+    GemmaClient.call_gemma + reads _last_done_reason."""
+    from llm.router import call_router_meta
+
+    fake_gemma = MagicMock()
+    fake_gemma.call_gemma.return_value = "ok"
+    fake_gemma._last_done_reason = "length"
+    with patch("llm.router.route", return_value=None):
+        with patch("core.gemma_client.GemmaClient", return_value=fake_gemma):
+            out = call_router_meta("hi")
+    assert out == {"text": "ok", "done_reason": "length"}
+
+
+# ─── ollama_local backend prefers native, falls back to heuristic ─
+
+
+def _run_backend_with_router(router):
+    """Build an OllamaLocalBackend with the supplied router stand-in
+    + call `.complete(...)` with cap=100. Returns the
+    CompletionResult."""
+    from core.reasoning.backends.ollama_local import OllamaLocalBackend
+
+    b = OllamaLocalBackend()
+    b._router = router
+    return b.complete("any prompt", max_tokens=100)
+
+
+def test_backend_prefers_native_done_reason_when_router_returns_dict():
+    """RouterWrapper with `call_gemma_meta` returning a dict → backend
+    consumes the native done_reason (no heuristic computation)."""
+    router = MagicMock()
+    router.call_gemma_meta.return_value = {
+        "text": "anything",   # native says "stop" wins regardless of length
+        "done_reason": "stop",
+    }
+    out = _run_backend_with_router(router)
+    assert out.text == "anything"
+    assert out.done_reason == "stop"
+
+
+def test_backend_uses_native_length_signal():
+    """Native `done_reason="length"` precision case — bypass heuristic."""
+    router = MagicMock()
+    router.call_gemma_meta.return_value = {
+        "text": "Hello world.",   # ends with sentence terminator —
+                                   # heuristic would say "stop"
+        "done_reason": "length",   # but native says length wins
+    }
+    out = _run_backend_with_router(router)
+    assert out.done_reason == "length"
+
+
+def test_backend_falls_back_to_heuristic_when_native_empty():
+    """Native returns `done_reason=""` (cache hit / old Ollama) →
+    backend applies the legacy length+terminator heuristic."""
+    router = MagicMock()
+    # Long response with no sentence terminator at end → heuristic "length"
+    truncated = "x" * 380
+    router.call_gemma_meta.return_value = {
+        "text": truncated,
+        "done_reason": "",
+    }
+    out = _run_backend_with_router(router)
+    assert out.done_reason == "length"  # heuristic fired
+
+
+def test_backend_falls_back_to_call_gemma_when_meta_not_dict():
+    """Older RouterWrapper without call_gemma_meta — backend falls
+    through to `call_gemma` + heuristic. We simulate this with a
+    router stand-in whose call_gemma_meta returns a non-dict."""
+    router = MagicMock()
+    router.call_gemma_meta.return_value = "not a dict"   # bad return type
+    router.call_gemma.return_value = "Hello world."      # legacy path
+    out = _run_backend_with_router(router)
+    # call_gemma was used, heuristic decides done_reason
+    assert out.text == "Hello world."
+    assert out.done_reason == ""   # sentence terminator → clean stop
+    router.call_gemma.assert_called_once()
+
+
+def test_backend_falls_back_to_call_gemma_when_meta_attr_missing():
+    """RouterWrapper without `call_gemma_meta` attribute at all → use
+    `call_gemma` only. Tests legacy MagicMock pattern with `spec`."""
+    from llm.router import RouterWrapper
+
+    # spec=RouterWrapper without our new method on a stripped class
+    class _LegacyRouter:
+        def call_gemma(self, prompt, **kwargs):
+            return "legacy response"
+
+    router = _LegacyRouter()
+    out = _run_backend_with_router(router)
+    assert out.text == "legacy response"
+    # spec doesn't have call_gemma_meta → backend uses legacy path
+    # done_reason is "" because text is short and clean
+    assert out.done_reason == ""
+
+    # Verify the class doesn't have call_gemma_meta (regression guard)
+    assert not hasattr(_LegacyRouter, "call_gemma_meta")
+    # Verify the current RouterWrapper *does* expose it
+    assert hasattr(RouterWrapper, "call_gemma_meta")
+
+
+# ─── GemmaClient _last_done_reason stash ─────────────────────────
+
+
+def test_gemma_client_resets_done_reason_on_each_call():
+    """A new call must clear the previous call's stashed
+    done_reason so an unrelated cache hit doesn't leak the prior
+    truncation signal upward."""
+    from core.gemma_client import GemmaClient
+
+    c = GemmaClient()
+    c._last_done_reason = "length"   # simulate prior call's stash
+
+    # Call the reset path directly (we don't actually hit Ollama in
+    # this unit test — the side effect we're checking is the
+    # `self._last_done_reason = ""` line at the top of call_gemma).
+    # Easiest: patch requests.post to short-circuit before hitting
+    # ollama, but the reset happens before the post call, so we can
+    # check the attribute after a deliberately-failing call.
+    with patch("requests.post", side_effect=RuntimeError("fail-fast")):
+        try:
+            c.call_gemma("test prompt", use_cache=False)
+        except Exception:
+            pass
+    # After the failed call, the reset (line at top of call_gemma)
+    # already ran → empty stash
+    assert c._last_done_reason == ""


### PR DESCRIPTION
## Summary

Replaces the length+terminator heuristic in `ollama_local` backend with Ollama's **native** `done_reason` signal. Heuristic stays as fallback when native is unavailable (cache hit / Ollama < 0.1.30 / call error).

Third follow-up to D6 (PR #486 wiring + PR #487 audit emit). Closes the heuristic-precision gap noted in PR #486's out-of-scope section.

## Architecture (4-layer additive change)

```
ollama_local.complete
  -> RouterWrapper.call_gemma_meta            (NEW)
     -> call_router_meta                      (NEW)
        -> OllamaClient.generate_meta         (NEW)
           -> OllamaClient.generate           (existing)
              -> GemmaClient.call_gemma       (existing)
                 -> resp.json() done_reason
                 -> stash in _last_done_reason  (NEW instance attr)
           -> read _last_done_reason          (NEW)
```

Each layer's pre-follow-up surface preserved unchanged: `generate` / `call_gemma` / `call_router` still return `str`. The `_meta` variants are additive.

## What lands

| File | Change |
|---|---|
| `core/gemma_client.py` | `_last_done_reason` instance attr. `call_gemma` resets at top + populates from `resp.json()`. Cache hit keeps empty. |
| `llm/base.py` | `BaseLLM.generate_meta` default wraps `generate()` into `{text, done_reason=\"\"}`. |
| `llm/providers/ollama_client.py` | OllamaClient holds single GemmaClient. `generate_meta` returns native signal. |
| `llm/router.py` | `call_router_meta` + `RouterWrapper.call_gemma_meta` (additive). |
| `core/reasoning/backends/ollama_local.py` | `complete()` tries native first, falls back to legacy on absent/non-dict/exception. |
| `tests/test_native_done_reason.py` | NEW 12 contract tests. |

## Done_reason resolution order

1. native non-empty (Ollama 0.1.30+ `stop`/`length`/`load`) -> use it
2. native empty (cache hit / old Ollama) -> heuristic fallback
3. non-dict return / raise -> legacy `call_gemma` + heuristic
4. no `call_gemma_meta` attr -> legacy `call_gemma` + heuristic

## Verification

- 12 new D6 follow-up native tests pass
- **587 regression tests pass** (zero existing broken)
- ruff clean on all 6 touched files

## Bench (CLAUDE.md rule #2)

`core/gemma_client.py` + `core/reasoning/backends/ollama_local.py` + `llm/router.py` + `llm/providers/ollama_client.py` all under bench paths.

- Pre-follow-up: `call_gemma(...)` -> str
- Post-PR: same + 1 dict.get + 1 attr read. Sub-microsecond. No extra LLM call.
- Improvement: precision of truncation signal, not throughput. `complete_with_retry` (PR #486) now triggers on Ollama-native `length` hits, false positives drop.

flag-OFF default unchanged.

## Backward compat

- Providers without `generate_meta` override -> BaseLLM default works
- `call_gemma` / `call_router` signatures unchanged
- `ollama_local` falls back to legacy when router lacks `call_gemma_meta`
- `_last_done_reason` is private

## Out of scope

- Native `done_reason` for other providers (Claude, DeepSeek) — separate PR if needed
- README DOI badge v0.3.1 -> v0.3.2 — operator action after Zenodo finishes minting

Generated with Claude Code