### PR TITLE
chore(readme): DOI badge v0.3.1 -> v0.3.2 + Status badge bump

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -5,10 +5,10 @@
 > 기반 자기진화.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.3.1-blue.svg)](docs/release_notes_v0.3.1.md)
+[![Status](https://img.shields.io/badge/Status-v0.3.2-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.3.2)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20363998.svg)](https://doi.org/10.5281/zenodo.20363998)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20372649.svg)](https://doi.org/10.5281/zenodo.20372649)
 
 ![PROJECT JAMES — 3D 온톨로지 그래프 시각화](reports/promo-assets/screenshots/06-3d-graph.jpg)
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 > behind a human approval gate.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.3.1-blue.svg)](docs/release_notes_v0.3.1.md)
+[![Status](https://img.shields.io/badge/Status-v0.3.2-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.3.2)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20363998.svg)](https://doi.org/10.5281/zenodo.20363998)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20372649.svg)](https://doi.org/10.5281/zenodo.20372649)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)
 


### PR DESCRIPTION
## Summary

Zenodo confirmed v0.3.2 record minted at **`10.5281/zenodo.20372649`** (concept DOI `10.5281/zenodo.20363997`). PR #466 pattern repeated.

## Changes

| Line | Before | After |
|---|---|---|
| README.md L8 / README.ko.md L8 | Status v0.3.1 -> `docs/release_notes_v0.3.1.md` | Status v0.3.2 -> GitHub release page |
| README.md L11 / README.ko.md L11 | DOI `10.5281/zenodo.20363998` | DOI `10.5281/zenodo.20372649` |

Status link swapped to GitHub release URL because `docs/release_notes_v0.3.2.md` does not exist yet (GitHub release body holds the equivalent content). Optional follow-up: create `docs/release_notes_v0.3.2.md` for docs-file consistency with v0.3.0 / v0.3.1.

## Verification

- Docs only (2 files, 2 lines each)
- Zenodo API confirmed: `title="PROJECT JAMES — Local-First Graph-RAG with Auto-Routing on Provider Contract (v0.3.2)"`, `version=v0.3.2`, `publication_date=2026-05-25`, `creators=[Seo, Jiwon]`
- GitHub release page live since 2026-05-25T04:24:18Z via PR #485 sequence
- No `core/{retrieval,graph,reasoning}` change — rule #2 N/A
- No module size impact — rule #5 N/A

## Citation chain (post-PR)

- v0.3.1 → `10.5281/zenodo.20363998` (concept DOI `20363997`)
- v0.3.2 → `10.5281/zenodo.20372649` (concept DOI `20363997`) [`isNewVersionOf` v0.3.1 per `.zenodo.json`]

The concept DOI (`20363997`) resolves to the latest version — useful for "always-latest" citations. The version DOI pinned in the badge is the citable archival snapshot.

Generated with Claude Code