### PR TITLE
chore(release): v0.3.3 prep - .zenodo.json + CHANGELOG (D6 retry cycle closure)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
-  "title": "PROJECT JAMES — Local-First Graph-RAG with Auto-Routing on Provider Contract (v0.3.2)",
-  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.3.2 lands Direction 5 (Auto-routing on Provider Contract) cycle closure — a 10-PR sequence (#474–#484) merged in a single 2026-05-25 session. The release adds a per-call backend-selection layer sitting above the existing Provider Contract: every production LLM call path (5 cognitive stages: query_rewriter / planner / reflect / verify / synth via trace_helpers) now consults a router that picks backend by task weight and stage type. A 4-rule decision tree maps the Direction 1 budget signal to a 3-tier capability taxonomy (small / medium / large × local / sovereign / cloud); the `verify` stage is grounding-critical and always escalates to the strongest registered backend. The whole layer is opt-in (`JAMES_AUTO_ROUTER=1`) with byte-identical pre-v0.3.2 behavior when the flag is unset, so existing operators see no runtime change. Cross-lingual entity resolution gained a graph-level alias pack (`core/entity_alias_pack.py`) covering ~30 high-traffic KO↔EN entities — paired with the keyword-level `_SYNONYM_MAP` (v0.3.1 follow-up PR #472) the two layers close the 2026-05-25 'Palantir resolves to unrelated PDF' diagnostic root cause. The release builds on v0.3.1 (Direction 1) and v0.3.0 (V3' Protocol v1 methodology spec) as the JAMES-side stack for the three-author joint-piece trajectory.",
+  "title": "PROJECT JAMES — Local-First Graph-RAG with D1 Retry Wiring Closure (v0.3.3)",
+  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.3.3 lands the D6 retry-wiring follow-up cycle that closed a design ↔ wiring gap surfaced by the 2026-05-25 user diagnostic question ('does D1 7-tier cover all cases / what about exceptions?'). Three-PR sequence (#486 + #487 + #488) plus two operator-trail PRs (#489 launch-tracker rows + #490 README DOI badge bump to v0.3.2). The retry_doubled helper that existed since v0.3.1 (D1 closure) but was never invoked from any call site is now wired through complete_with_retry; truncation triggers a single retry up to CAP_HEAVY, an audit_log reason:retry row records every retry decision, and native Ollama done_reason replaces the length+terminator heuristic when the provider exposes it (heuristic preserved as fallback for cache hits / Ollama < 0.1.30 / non-Ollama providers). D1 safety-net 4겹 all backed: retry wiring ✅ + falsification cycle ✅ + flag-off default ✅ + heuristic asymmetry ✅. The release builds on v0.3.2 (D5 Auto-routing) and v0.3.1 (D1 Adaptive Budgeting) as the JAMES-side stack closure for the v0.3.x cycle before v0.4 entry.",
   "upload_type": "software",
   "creators": [
     {
@@ -26,6 +26,9 @@
     "reasoning-middleware",
     "llm-evaluation",
     "v3-prime-protocol",
+    "retry-fallback",
+    "truncation-detection",
+    "audit-trail",
     "korean-nlp"
   ],
   "license": "MIT",
@@ -38,27 +41,27 @@
       "resource_type": "software"
     },
     {
-      "identifier": "10.5281/zenodo.20363998",
+      "identifier": "10.5281/zenodo.20372649",
       "relation": "isNewVersionOf",
       "resource_type": "software"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/474",
+      "identifier": "10.5281/zenodo.20363998",
+      "relation": "isDerivedFrom",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/486",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/482",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/487",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/483",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/484",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/488",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
@@ -68,5 +71,5 @@
       "resource_type": "software"
     }
   ],
-  "notes": "Direction 5 (Auto-routing) closure builds on v0.3.1 (Direction 1 — Adaptive Budgeting). The router consumes Direction 1's TaskBudget signal as input; the alias pack (D5.D) pairs with v0.3.1 follow-up PR #472 (`_SYNONYM_MAP` keyword expansion). Result document at `reports/promo-assets/v3prime-direction5-router-result.md`; architecture amendment at `docs/ARCHITECTURE.md` §5.7.8. Three-author joint-piece collaboration with Robin Converse (Triava Labs, 26b MoE cross-stack) and Ali Afana (Provia, mid-June managed-Gemini cross-stack) remains the next-cycle trajectory."
+  "notes": "v0.3.3 closes the v0.3.x stabilization arc (D1 Adaptive Budgeting v0.3.1 + D4 substitution bypass + D5 Auto-routing v0.3.2 + D6 retry wiring v0.3.3 + D6(J) methodology spec v0.3.0). The retry path is the operational counterpart to D1's measurement findings — it acts on done_reason=length signals from Ollama (native, 0.1.30+) or the conservative length+terminator heuristic (fallback). Result documents under reports/promo-assets/ + the v0.3.2 closure result doc + the V3' Protocol v1 spec at docs/research/ all stay citable as separately-versioned artifacts. Three-author joint-piece collaboration with Robin Converse (Triava Labs, 26b MoE cross-stack) and Ali Afana (Provia, mid-June managed-Gemini cross-stack) remains the next-cycle research trajectory; the JAMES-side product stack is now stable for v0.4 entry (Layer 4 Lifecycle Semantics)."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.3] — 2026-05-25 — D6 retry-wiring follow-up cycle closure (D1 design/wiring gap closed)
+
+**Theme**: close the design ↔ wiring gap surfaced by the 2026-05-25 user diagnostic question (*"does D1 7-tier cover all cases / what about exceptions?"*). The `retry_doubled` helper that existed since v0.3.1 (D1 closure) but was never invoked from any production call site is now wired through `complete_with_retry`. Truncation triggers single retry up to `CAP_HEAVY`. `audit_log reason:retry` row records every retry decision. Native Ollama `done_reason` replaces the heuristic when the provider exposes it (heuristic preserved as fallback for cache hits / Ollama < 0.1.30 / non-Ollama providers).
+
+Three-PR sequence (#486 + #487 + #488) plus two operator-trail PRs (#489 launch-tracker rows + #490 README DOI badge bump to v0.3.2).
+
+### Added — `complete_with_retry` helper (PR #486)
+
+- `core/reasoning/budget.py:complete_with_retry(backend, prompt, *, cap, max_cap=CAP_HEAVY, timeout, stage="", **opts)` — single retry on `done_reason="length"`, bounded by `max_cap`. `opts` forwarded both calls. Added to `__all__`.
+- `core/reasoning/backends/__init__.py` — `CompletionResult.done_reason: str = ""` field. Backward compat: backends without the attribute are tolerated (helper falls back to no-retry).
+- `core/reasoning/backends/ollama_local.py` — length-+-terminator heuristic. Two signals must fire to mark `"length"`: response length ≥ 90% × `max_tokens` × 4 chars AND no sentence terminator (`.`, `?`, `!`, `다`, `요`, `음`, `}`, `]`, `"`, `'`, `)`). Conservative — biased to false negatives.
+- `core/retrieval/query_rewriter.py` — `backend.complete(...)` → `complete_with_retry(...)` at the only call site where retry can actually fire (D1 wired stage with dynamic cap signal under `JAMES_ADAPTIVE_BUDGET=1`).
+- 14 contract tests in `tests/test_complete_with_retry.py` covering retry trigger / no-retry conditions / cap saturation / custom max_cap / backend-without-`done_reason` / opts forwarding / ollama heuristic edge cases.
+
+### Added — `audit_log reason:retry` emission (PR #487)
+
+- `complete_with_retry` drops one `reason:retry` row to `audit_log` every time a retry actually fires.
+- Schema: `endpoint="reason:retry"`, `target=stage` (or `backend_id` when stage empty), answer column auto-serialized JSON `{"cap_before": <int>, "cap_after": <int>, "backend": "<id>", "prompt_hash": "<8 hex>"}`.
+- Operator monitoring channel: `SELECT endpoint='reason:retry' FROM audit_log` shows retry rate / stage distribution / backend distribution for new fail-case discovery + heuristic false-positive rate tracking.
+- Audit emission is try/except-wrapped — never blocks production.
+- 5 new tests pinning the emit / no-emit conditions + reason label correctness + audit-failure-survives-retry.
+
+### Added — native Ollama `done_reason` exposure (PR #488, 4-layer additive)
+
+- `core/gemma_client.py` — `GemmaClient._last_done_reason` instance attribute populated from `resp.json().get("done_reason", "")`. Reset at the top of `call_gemma` so a cache hit / early-return path doesn't leak the prior call's signal.
+- `llm/base.py` — `BaseLLM.generate_meta(messages, **kwargs) → dict` default implementation wraps `generate(...)` into `{"text": str, "done_reason": ""}`. Providers that don't override get graceful fallback.
+- `llm/providers/ollama_client.py` — OllamaClient holds a single GemmaClient instance (`_gemma_client` lazy-initialized via `_client()`). `generate_meta` returns `{"text": ..., "done_reason": client._last_done_reason}`.
+- `llm/router.py` — `call_router_meta(prompt, task_type=None, **kwargs) → dict` mirrors `call_router`. `RouterWrapper.call_gemma_meta` is a thin shim. Hard fallback path reads `GemmaClient._last_done_reason` after the direct `call_gemma` call.
+- `core/reasoning/backends/ollama_local.py` — `complete()` tries `router.call_gemma_meta` first (callable + dict-return check); on absent / non-dict / exception, falls through to legacy `call_gemma` + heuristic.
+- 12 new tests in `tests/test_native_done_reason.py` covering BaseLLM default + OllamaClient stash read + RouterWrapper shim + `call_router_meta` + ollama_local preference order + heuristic fallback + GemmaClient reset.
+
+### Added — operator trail (PRs #489 + #490)
+
+- `reports/promo-assets/launch-tracker.md` — 3 new audit-trail rows (D5 cycle CLOSED catalog + v0.3.2 GitHub release published + D6 retry-wiring follow-up cycle).
+- `README.md` / `README.ko.md` — Status badge v0.3.1 → v0.3.2 + DOI badge `10.5281/zenodo.20363998` → `10.5281/zenodo.20372649`.
+
+### D1 safety net status — all backed
+
+| # | Net | Pre-D6 | Post-D6 |
+|---|---|---|---|
+| 1 | `retry_doubled` fallback | Definition-only, no wiring | **Wired via `complete_with_retry` (query_rewriter) + audit `reason:retry` + native Ollama `done_reason` precision** |
+| 2 | Falsification cycle | Measurement-driven heuristic evolution | + `audit_log reason:retry` row pile-up is now the monitoring channel for new fail-case discovery |
+| 3 | flag-off default | Pre-D6 byte-identical | Pre-D6 byte-identical (`JAMES_AUTO_ROUTER` / `JAMES_ADAPTIVE_BUDGET` both default OFF) |
+| 4 | Heuristic asymmetry | Half-effective (escalate but no retry) | Fully backed — escalate path retries on truncation, native signal where available |
+
+### Verified
+
+- Final state: **587 backend/router/budget/rewriter/graph/reflect/verify/alias/retry/gemma/done regression tests pass**.
+- 31 new D6 contract tests across 2 files (`test_complete_with_retry.py` 19 + `test_native_done_reason.py` 12).
+- ruff clean on all touched files.
+- Module sizes all under the 20 KB gate.
+
+### Out of scope for v0.3.3
+
+- **Native `done_reason` for other providers** (Claude / DeepSeek) — 3-condition gated (operator opts into `JAMES_ENABLE_CLAUDE_BACKEND=1` + `JAMES_AUTO_ROUTER=1` + observed `reason:retry` rows with that backend > 0). Memory: `feedback_d1_d5_retry_doubled_wiring_gap.md`.
+- **planner / reflect / verify wiring through `complete_with_retry`** — these stages currently use a fixed `self._max_tokens = 4096` which is already at the `CAP_HEAVY` ceiling, so retry would be no-op. Wiring lands together with the D1 budget signal expansion (v0.4 follow-up).
+- **D2 task-weight metric in measured form** — absorbed into D5 as the policy's heuristic classifier; revisit as a measured metric if the heuristic plateaus on production bench.
+- **Cost-based scoring v2** / **per-pack policy** / **per-stage explicit override under D5 ON** / **embedding swap (BL-9 bge-m3 / multilingual-e5-large)** — v0.4 follow-ups.
+- **D3 / D6(I)** — cross-family generalization + joint paper consolidation remain queued for the mid-June Robin / Ali Gemini collaboration window.
+
+### Acknowledgements
+
+- The 2026-05-25 user diagnostic question (*"7단계 사다리로 나누는 것이 전부 커버가 되나? 예외가 발생할 가능성이 제로는 아닐 것 같은데"*) directly motivated this cycle. The honest engineering response — admit the gap, ship the wiring, add the monitoring channel, swap the heuristic for native signal when available — followed in three small PRs over the same session.
+- D1 (`core/reasoning/budget.py`, v0.3.1) defined the `retry_doubled` helper that v0.3.3 finally activates. The 7-tier natural-stop gradient remains the measurement baseline.
+- D5 (Auto-routing, v0.3.2) shares the `audit_log` infrastructure: `reason:route` (D5.C.2.a, PR #478) + `reason:retry` (this cycle, PR #487) together give operators a complete picture of every routing decision plus every truncation retry.
+
+---
+
 ## [0.3.2] — 2026-05-25 — Direction 5 (Auto-routing on Provider Contract) cycle closure
 
 **Theme**: ship a per-call backend-selection layer above the Provider Contract. Every production LLM call path now consults a router that picks backend by task weight + stage type. Default OFF; opt-in via `JAMES_AUTO_ROUTER=1`. Byte-identical to pre-v0.3.2 at the production call path when the flag is unset. 10-PR sequence (#474–#484) merged in a single 2026-05-25 session.


### PR DESCRIPTION
## Summary

v0.3.3 release prep — captures the D6 retry-wiring follow-up cycle (#486 + #487 + #488 + #489 + #490) as a Zenodo archival artifact. Pattern mirrors PR #485 (v0.3.2 prep).

## What lands

| File | Change |
|---|---|
| `.zenodo.json` | title / description / keywords updated for v0.3.3 (retry-wiring closure theme). Relations: `isNewVersionOf` -> `10.5281/zenodo.20372649` (v0.3.2), `isDerivedFrom` -> `10.5281/zenodo.20363998` (v0.3.1); `isDocumentedBy` -> PR #486 / #487 / #488. New keywords: `retry-fallback`, `truncation-detection`, `audit-trail`. |
| `CHANGELOG.md` | `[0.3.3]` entry above `[0.3.2]`. Theme + 3-PR sequence + operator trail PRs + Added sections (helper / audit emission / native 4-layer / operator trail) + D1 safety net status table (pre-D6 vs post-D6) + Verified (587 regression + 31 new D6 contract) + Out of scope + Acknowledgements (user diagnostic question that motivated the cycle). |

## Verification

- Docs only
- All cited PRs (#486-490) verified merged on origin/main
- No `core/{retrieval,graph,reasoning}` change — rule #2 N/A
- No module size impact — rule #5 N/A
- Pattern mirrors v0.3.2 prep PR #485

## Post-merge operator action

1. `git tag v0.3.3` (current main HEAD post-merge)
2. `git push origin v0.3.3`
3. `gh release create v0.3.3` with the equivalent release body (or paste in GitHub UI)
4. Zenodo webhook auto-mints new DOI — check `https://zenodo.org/api/records?q=Hashevolution` after ~1 min
5. Follow-up micro-PR: README badge bump to v0.3.3 DOI once Zenodo confirms the mint.

Generated with Claude Code