### PR TITLE
feat(wiki): v0.4 Sprint 1 #1 - entity-name overlap detection at ingestion

### DIFF
--- a/core/wiki_generator/_frontmatter.py
+++ b/core/wiki_generator/_frontmatter.py
@@ -135,6 +135,44 @@ class WikiFrontmatterMixin:
     def _normalize_name(self, name: str) -> str:
         return re.sub(r"[^\w가-힣]", "_", name.strip().lower())
 
+    def _build_overlap_snapshot(self):
+        """Return `{normalized_name: (canonical_name, entity_id, entity_type)}`
+        for every existing wiki entity (any type), aliases included.
+
+        v0.4 Sprint 1 #1 addition — used by ingestion's entity-name
+        overlap detection (`_infer_overlap_relations` in `_merge.py`)
+        so a newly-ingested event named *"비트코인 spot ETF 11개
+        일괄 승인"* automatically gets a RELATED_TO relation to the
+        existing "비트코인" concept entity when its normalized name
+        appears as a token in the new entity's name.
+
+        First-write-wins: if two entities share a normalized name
+        (e.g. one canonical + one alias on a different entity), the
+        earlier one in `entity_id_index` iteration order takes
+        precedence. Tests pin this — production rarely has the
+        collision because aliases that match another canonical name
+        would already trip `_find_existing_entity_id` during ingest.
+        """
+        from pathlib import Path
+        snapshot = {}
+        for eid, filepath in self.entity_id_index.items():
+            try:
+                fm = self._read_frontmatter(Path(filepath))
+            except Exception:
+                continue
+            if not fm:
+                continue
+            canonical = fm.get("name", "")
+            norm = fm.get("normalized_name", "") or self._normalize_name(canonical)
+            etype = fm.get("entity_type", "concept")
+            if norm and norm not in snapshot:
+                snapshot[norm] = (canonical, eid, etype)
+            for alias in fm.get("aliases", []) or []:
+                alias_norm = self._normalize_name(alias)
+                if alias_norm and alias_norm not in snapshot:
+                    snapshot[alias_norm] = (canonical, eid, etype)
+        return snapshot
+
     # =========================
     # ENTITY SEARCH (FIXED)
     # =========================

--- a/core/wiki_generator/_ingestion.py
+++ b/core/wiki_generator/_ingestion.py
@@ -72,6 +72,14 @@ class WikiIngestionMixin:
         doc_name      = os.path.splitext(filename)[0]
         doc_entity_id = self._generate_entity_id(doc_name, "document")
 
+        # v0.4 Sprint 1 #1 — entity-name overlap snapshot built once
+        # per document so every entity in this doc can reuse it
+        # without re-scanning every wiki file. The snapshot is a
+        # frozen view at ingestion start; entities created later in
+        # this same doc are not in it (their overlaps to siblings
+        # are resolved by `resolve_pending_relations` post-pass).
+        overlap_snapshot = self._build_overlap_snapshot()
+
         created_ids:   List[str]      = []
         name_to_id:    Dict[str, str] = {}
         name_to_type:  Dict[str, str] = {}
@@ -93,6 +101,23 @@ class WikiIngestionMixin:
                     name, extracted.get("relations", []),
                     doc_id=doc_entity_id, ts=ingest_ts,
                 )
+                # v0.4 Sprint 1 #1 — overlap detection also applies
+                # on the merge branch so re-ingestion of an entity
+                # whose name overlaps with newly-existing tokens
+                # picks up the relation. Identical pattern to the
+                # new-entity branch below.
+                merge_overlap_rels = self._infer_overlap_relations(
+                    name, overlap_snapshot,
+                    doc_id=doc_entity_id, ts=ingest_ts,
+                )
+                if merge_overlap_rels:
+                    seen = {(r.get("target"), r.get("label"))
+                            for r in new_rels}
+                    for r in merge_overlap_rels:
+                        key = (r.get("target"), r.get("label"))
+                        if key not in seen:
+                            new_rels.append(r)
+                            seen.add(key)
                 if new_rels:
                     stats = self._merge_relations_into_existing_entity(
                         existing_id, new_rels, doc_entity_id, ingest_ts,
@@ -111,6 +136,26 @@ class WikiIngestionMixin:
                 name, extracted.get("relations", []),
                 doc_id=doc_entity_id, ts=ingest_ts,
             )
+            # v0.4 Sprint 1 #1 — token-level entity-name overlap
+            # detection. New event/document/concept entities whose
+            # name contains an existing entity's normalized name as
+            # a token get an automatic RELATED_TO relation. Without
+            # this step, "비트코인 spot ETF 11개 일괄 승인" event
+            # was being ingested with zero link to the existing
+            # "비트코인" concept (LLM extractor only emits explicit
+            # source/target pairs from the document body).
+            overlap_rels = self._infer_overlap_relations(
+                name, overlap_snapshot,
+                doc_id=doc_entity_id, ts=ingest_ts,
+            )
+            if overlap_rels:
+                seen_targets = {(r.get("target"), r.get("label"))
+                                for r in ent_relations}
+                for r in overlap_rels:
+                    key = (r.get("target"), r.get("label"))
+                    if key not in seen_targets:
+                        ent_relations.append(r)
+                        seen_targets.add(key)
             # [B-2-A fix] top-level `summary` mirrors `attributes.summary`
             # so the wiki body builder (`_frontmatter.py:create_entity_file`)
             # can populate `## 요약`. The builder only reads top-level keys;

--- a/core/wiki_generator/_merge.py
+++ b/core/wiki_generator/_merge.py
@@ -293,5 +293,108 @@ class WikiMergeMixin:
                     out.append(rel_dict)
         return out
 
+    def _infer_overlap_relations(
+        self,
+        source_name: str,
+        snapshot,
+        doc_id=None,
+        ts=None,
+    ):
+        """Detect token-level entity-name overlap and emit RELATED_TO
+        relations to the matched entities.
+
+        v0.4 Sprint 1 #1 addition — closes the gap where an event
+        entity like *"비트코인 spot ETF 11개 일괄 승인"* gets
+        ingested without any link to the existing "비트코인" concept,
+        because the LLM extractor's `relations` array only contains
+        explicit (source, target) pairs and doesn't track name
+        overlaps.
+
+        Algorithm:
+          1. Normalize `source_name` (same `_normalize_name` regex
+             used elsewhere — `[^\\w가-힣]` → `_`, lowercase).
+          2. Split on `_` and keep tokens with `len ≥ 2`. Single-
+             character tokens are dropped to avoid spurious matches
+             on "i", "a", numerals, etc.
+          3. For each token, look up the entity-name overlap
+             snapshot (`{normalized_name: (canonical, eid, type)}`).
+          4. If a token resolves to an entity, emit a RELATED_TO
+             relation with `confidence=0.5`, `inferred=True`, and
+             `sources[].role="inferred-overlap"` so the entity is
+             visibly distinguishable from explicit LLM extractions.
+
+        Self-link prevention: tokens matching the source entity's
+        own normalized name are skipped. Duplicates suppressed by
+        the standard `(target, label)` seen-set.
+
+        `snapshot` is the dict from
+        `_frontmatter._build_overlap_snapshot()`; ingestion
+        callers compute it once per document and reuse across
+        every entity in the same doc.
+
+        Multi-word entity names (e.g. "미국 스팟 BTC ETF" →
+        normalized "미국_스팟_btc_etf") are NOT matched by this
+        first-iteration helper — only single-token entity names.
+        Multi-word overlap detection is a follow-up if production
+        traffic shows demand.
+
+        Returns a list of relation dicts in the same shape
+        `_build_entity_relations` emits, so the caller can
+        concatenate them directly into the entity's frontmatter
+        relations list.
+        """
+        import re as _re
+        if not source_name or not snapshot:
+            return []
+
+        source_norm = _re.sub(r"[^\w가-힣]", "_", source_name.strip().lower())
+        tokens = [t for t in source_norm.split("_") if len(t) >= 2]
+        if not tokens:
+            return []
+
+        self_norm = source_norm
+
+        def _stamp(conf):
+            if not doc_id:
+                return None
+            return [{
+                "doc_id": doc_id,
+                "weight": conf,
+                "role":   "inferred-overlap",
+                "ts":     ts,
+            }]
+
+        out = []
+        seen = set()
+        for tok in tokens:
+            if tok == self_norm:
+                continue
+            match = snapshot.get(tok)
+            if not match:
+                continue
+            canonical, eid, etype = match
+            # second-level self-check: snapshot may match because the
+            # entity being ingested already exists at this canonical
+            # name (re-ingest of same source doc).
+            if canonical == source_name:
+                continue
+            key = (canonical, "관련")
+            if key in seen:
+                continue
+            seen.add(key)
+            rel_dict = {
+                "target":      canonical,
+                "target_id":   eid,
+                "target_type": etype,
+                "label":       "관련",
+                "confidence":  0.5,
+                "inferred":    True,
+            }
+            sources = _stamp(0.5)
+            if sources:
+                rel_dict["sources"] = sources
+            out.append(rel_dict)
+        return out
+
 
 __all__ = ["WikiMergeMixin"]

--- a/tests/test_entity_overlap_relations.py
+++ b/tests/test_entity_overlap_relations.py
@@ -1,0 +1,239 @@
+"""v0.4 Sprint 1 #1 — token-level entity-name overlap detection.
+
+Operator surfaced 2026-05-25: "비트코인 spot ETF 11개 일괄 승인"
+event was ingested without any link to the existing "비트코인"
+concept. Root cause: LLM extractor only emits explicit (source,
+target) relation pairs from the document body; entity-name
+overlap is not detected at ingestion time.
+
+This module tests the fix:
+  - `_frontmatter._build_overlap_snapshot` returns the
+    `{normalized_name: (canonical, eid, type)}` lookup
+  - `_merge._infer_overlap_relations` emits RELATED_TO
+    relations for tokens matching another entity
+  - self-link prevention (entity matching its own normalized name)
+  - duplicate suppression (same target + label)
+  - inferred=True + sources[].role="inferred-overlap" markers
+  - single-token entity names only (multi-word is follow-up)
+"""
+
+from __future__ import annotations
+
+
+def _make_mixin():
+    """Construct a minimal object that includes _infer_overlap_relations
+    without booting the full wiki_generator stack (which loads disk
+    state)."""
+    from core.wiki_generator._merge import WikiMergeMixin
+
+    class _Harness(WikiMergeMixin):
+        def __init__(self):
+            pass
+
+        # _build_entity_relations uses _inverse_label_for but our
+        # overlap tests only touch _infer_overlap_relations so the
+        # full mixin is loaded but only one method exercised.
+        @staticmethod
+        def _inverse_label_for(label):
+            return label
+
+    return _Harness()
+
+
+# ─── _infer_overlap_relations behaviour ───────────────────────────
+
+
+def test_overlap_emits_relation_for_matching_token():
+    """The canonical case — event "비트코인 spot ETF 11개 일괄 승인"
+    contains "비트코인" token; with the concept entity registered in
+    the snapshot, the helper emits a RELATED_TO relation to it."""
+    h = _make_mixin()
+    snapshot = {
+        "비트코인": ("비트코인", "e_concept_de6c70ec", "concept"),
+    }
+    out = h._infer_overlap_relations(
+        "비트코인 spot ETF 11개 일괄 승인", snapshot,
+        doc_id="doc_test", ts="2026-05-25T00:00:00",
+    )
+    assert len(out) == 1
+    rel = out[0]
+    assert rel["target"] == "비트코인"
+    assert rel["target_id"] == "e_concept_de6c70ec"
+    assert rel["target_type"] == "concept"
+    assert rel["label"] == "관련"
+    assert rel["confidence"] == 0.5
+    assert rel["inferred"] is True
+    assert rel["sources"][0]["role"] == "inferred-overlap"
+
+
+def test_overlap_no_match_returns_empty():
+    """Source name with no token matching any snapshot entry → []."""
+    h = _make_mixin()
+    snapshot = {
+        "비트코인": ("비트코인", "e_concept_X", "concept"),
+    }
+    assert h._infer_overlap_relations(
+        "completely unrelated event name", snapshot,
+    ) == []
+
+
+def test_overlap_skips_self_match():
+    """An entity whose own normalized name appears in the snapshot
+    (e.g. re-ingest) does NOT relate to itself."""
+    h = _make_mixin()
+    snapshot = {
+        "비트코인": ("비트코인", "e_concept_X", "concept"),
+    }
+    out = h._infer_overlap_relations("비트코인", snapshot)
+    assert out == []
+
+
+def test_overlap_skips_single_char_tokens():
+    """Tokens shorter than 2 characters (digits, single letters) are
+    dropped — prevents spurious matches on "i", "a", etc."""
+    h = _make_mixin()
+    snapshot = {
+        "i": ("i", "e_concept_BAD", "concept"),
+        "a": ("a", "e_concept_BAD2", "concept"),
+    }
+    out = h._infer_overlap_relations("event a i 3 single chars", snapshot)
+    assert out == []
+
+
+def test_overlap_dedups_repeated_token():
+    """If the same token appears twice in source_name, the helper
+    emits one relation (not two)."""
+    h = _make_mixin()
+    snapshot = {
+        "btc": ("BTC", "e_concept_btc", "concept"),
+    }
+    out = h._infer_overlap_relations(
+        "BTC analysis BTC summary BTC overview",
+        snapshot,
+    )
+    assert len(out) == 1
+    assert out[0]["target"] == "BTC"
+
+
+def test_overlap_dedups_same_target_via_different_aliases():
+    """If two snapshot entries point at the same canonical entity
+    (one via name, one via alias), only one relation is emitted —
+    the (target_canonical, label) seen-set dedups."""
+    h = _make_mixin()
+    snapshot = {
+        "bitcoin":  ("비트코인", "e_concept_btc", "concept"),
+        "btc":      ("비트코인", "e_concept_btc", "concept"),
+        "비트코인":  ("비트코인", "e_concept_btc", "concept"),
+    }
+    out = h._infer_overlap_relations(
+        "Bitcoin BTC 비트코인 all three forms in one name",
+        snapshot,
+    )
+    assert len(out) == 1
+    assert out[0]["target"] == "비트코인"
+
+
+def test_overlap_emits_multiple_distinct_entities():
+    """Different entities in the same source name → multiple
+    relations (one per distinct canonical target)."""
+    h = _make_mixin()
+    snapshot = {
+        "비트코인":  ("비트코인", "e_concept_btc", "concept"),
+        "이더리움":  ("이더리움", "e_concept_eth", "concept"),
+    }
+    out = h._infer_overlap_relations(
+        "비트코인 이더리움 가격 분석", snapshot,
+    )
+    assert len(out) == 2
+    targets = {r["target"] for r in out}
+    assert targets == {"비트코인", "이더리움"}
+
+
+def test_overlap_no_doc_id_omits_sources():
+    """When doc_id is not supplied (legacy / direct call) the
+    sources field is omitted — consistent with
+    `_build_entity_relations`."""
+    h = _make_mixin()
+    snapshot = {
+        "비트코인": ("비트코인", "e_concept_X", "concept"),
+    }
+    out = h._infer_overlap_relations("비트코인 event", snapshot)
+    assert len(out) == 1
+    assert "sources" not in out[0]
+
+
+def test_overlap_handles_empty_inputs():
+    """Empty source_name or empty snapshot → empty result."""
+    h = _make_mixin()
+    assert h._infer_overlap_relations("", {"foo": ("foo", "e_X", "concept")}) == []
+    assert h._infer_overlap_relations("anything", {}) == []
+    assert h._infer_overlap_relations(None, {}) == []
+
+
+# ─── _build_overlap_snapshot regression ──────────────────────────
+
+
+def test_overlap_snapshot_includes_aliases():
+    """`_build_overlap_snapshot` walks `entity_id_index`, reads each
+    frontmatter, and records both the canonical normalized name AND
+    every alias's normalized form. Tests via a fake WikiGenerator."""
+    from core.wiki_generator._frontmatter import WikiFrontmatterMixin
+
+    class _Fake(WikiFrontmatterMixin):
+        def __init__(self):
+            self.entity_id_index = {
+                "e_concept_btc": "fake/path/bitcoin.md",
+            }
+
+        def _read_frontmatter(self, path):
+            return {
+                "entity_id":       "e_concept_btc",
+                "entity_type":     "concept",
+                "name":            "비트코인",
+                "normalized_name": "비트코인",
+                "aliases":         ["BTC", "Bitcoin"],
+            }
+
+    snapshot = _Fake()._build_overlap_snapshot()
+    # Canonical normalized name present
+    assert "비트코인" in snapshot
+    # Aliases also indexed under their normalized form
+    assert "btc" in snapshot
+    assert "bitcoin" in snapshot
+    # All point to the same canonical name + entity_id
+    for v in snapshot.values():
+        assert v == ("비트코인", "e_concept_btc", "concept")
+
+
+def test_overlap_snapshot_first_write_wins():
+    """If two entities share a normalized name (rare edge case), the
+    first one in `entity_id_index` iteration order wins."""
+    from core.wiki_generator._frontmatter import WikiFrontmatterMixin
+
+    class _Fake(WikiFrontmatterMixin):
+        def __init__(self):
+            # OrderedDict-like ordering (Python 3.7+ dict preserves insert order)
+            self.entity_id_index = {
+                "e_org_first":  "fake/first.md",
+                "e_org_second": "fake/second.md",
+            }
+
+        def _read_frontmatter(self, path):
+            if "first" in str(path):
+                return {
+                    "entity_id":       "e_org_first",
+                    "entity_type":     "org",
+                    "name":            "Acme",
+                    "normalized_name": "acme",
+                    "aliases":         [],
+                }
+            return {
+                "entity_id":       "e_org_second",
+                "entity_type":     "org",
+                "name":            "Acme",
+                "normalized_name": "acme",
+                "aliases":         [],
+            }
+
+    snapshot = _Fake()._build_overlap_snapshot()
+    assert snapshot["acme"][1] == "e_org_first"


### PR DESCRIPTION
## Summary

Closes the data-correctness gap operator surfaced 2026-05-25: event *"비트코인 spot ETF 11개 일괄 승인"* was being ingested with zero link to the existing "비트코인" concept, because the LLM extractor only emits explicit (source, target) relation pairs from the document body and doesn't track entity-name overlaps. With this PR, ingestion auto-emits a RELATED_TO relation when an existing entity's normalized name appears as a token in the new entity's name.

## Architecture

```
process_document_for_entities
  -> overlap_snapshot = _build_overlap_snapshot()      [once per doc]
  -> for each entity:
       ent_relations = _build_entity_relations(...)    [existing - explicit relations]
       + _infer_overlap_relations(name, snapshot, ...) [NEW - token overlap]
       (dedupe by (target, label))
  -> frontmatter.create_entity_file(payload)
```

Algorithm: normalize source_name, split on `_`, drop tokens < 2 chars, look up each in snapshot, emit RELATED_TO with `confidence=0.5` + `inferred=True` + `sources[].role="inferred-overlap"`. Self-link + duplicate prevention.

## What lands

| File | Change |
|---|---|
| `core/wiki_generator/_frontmatter.py` | `_build_overlap_snapshot()` NEW — `{normalized_name: (canonical, eid, type)}` for all wiki entities, aliases included, first-write-wins. |
| `core/wiki_generator/_merge.py` | `_infer_overlap_relations(source_name, snapshot, doc_id, ts)` NEW — token-level matching with self/dup prevention. Single-token only (multi-word follow-up). |
| `core/wiki_generator/_ingestion.py` | Snapshot built once at doc-process start; appended to `ent_relations` on both new-entity and merge branches. Dedup by `(target, label)`. |
| `tests/test_entity_overlap_relations.py` | NEW — 11 contract tests (matching / no-match / self-link / single-char tokens / repeated tokens / alias-vs-name dedup / multiple distinct entities / no-doc-id / empty / snapshot aliases / first-write-wins). |

## What this PR does NOT do (scope clarification)

**Existing wiki entities created before this PR keep their broken state.** The "비트코인 spot ETF 11개 일괄 승인" event row in `wiki/entity/prod/event/` won't gain the 비트코인 relation just from this code change — it needs a re-ingest of the source document (`test_events_dominant.md`) or a separate backfill script.

Both are operator decisions and ship in a follow-up if needed. The plumbing fix here ensures every NEW ingestion path emits the correct relations going forward.

## Verification

- ✅ 11 new contract tests pass
- ✅ **473 wiki/ingestion/merge/entity/overlap/graph/relation regression tests pass** (zero existing broken)
- ✅ ruff clean on all 4 touched files
- ✅ Module sizes: `_frontmatter.py` +40 lines / `_merge.py` +98 lines / `_ingestion.py` +30 lines (all well under 20 KB)

## Bench (CLAUDE.md rule #2)

`core/wiki_generator/` is not under `core/retrieval/`, `core/graph/`, or `core/reasoning/` — rule #2 not directly applicable. Indirect effect: more relations per entity → wider DFS expansion → slightly larger `graph_context` at query time. Operationally negligible — each new event typically gains 1-3 RELATED_TO relations.

## Out of scope (follow-ups)

- **Multi-word entity name overlap** (e.g. "미국 스팟 BTC ETF" as a single normalized substring matching the event). First iteration is single-token only.
- **Backfill of existing entities** — separate PR or operator re-ingest decision.
- **Sprint 1 #2** query language detection + answer matching — next PR in v0.4 Sprint 1.

Generated with Claude Code