### PR TITLE
feat(chat-ui): v0.4 Sprint 2 #5a — sidebar hover auto-expand

### DIFF
--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -234,6 +234,19 @@ main { display: flex; flex: 1; overflow: hidden; }
 }
 .sidebar.collapsed { width: 0; border-right: none; }
 
+/* v0.4 Sprint 2 #5 — hover auto-expand when collapsed.
+   Mouse over the open-btn rail strip (or the sidebar itself once it
+   peeks back into view) temporarily expands the sidebar without
+   requiring a click. JS-driven state (`.sidebar.collapsed` toggled
+   from `toggleSidebar`) is preserved — moving the mouse away
+   re-collapses. Explicit toggle-sidebar click still persists the open
+   state across hover-leave, so power users get both affordances. */
+.sidebar-open-btn:hover ~ .sidebar.collapsed,
+.sidebar.collapsed:hover {
+  width: 340px;
+  border-right: 1px solid var(--border-2);
+}
+
 .sidebar-rail {
   width: 56px;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

CSS-only fix — hovering the open-btn rail strip (or the sidebar peek once it re-enters view) expands the chat sidebar without requiring a click.

- New sibling-selector rule on `.sidebar-open-btn:hover ~ .sidebar.collapsed` plus a self `:hover` on `.sidebar.collapsed` keep the expanded state stable while the mouse is anywhere inside the sidebar region.
- JS state (`sidebar.classList.contains('collapsed')`) unchanged — this is purely a visual peek.
- Click on `data-action="toggle-sidebar"` still persists the open state across hover-leave, so the click-toggle UX is preserved untouched.

## Verification

CSS-only delta, no Python or JS logic touched. Manual verify on dev server:

1. Click toggle to collapse the sidebar → hover the open-btn → sidebar slides in.
2. Move mouse out → collapses back.
3. Click toggle to open → stays open regardless of hover (existing behavior preserved).

## Why phase A

The original Sprint 2 #5 task bundled "hover auto-expand" with "per-page toggle consistency" (chat vs admin). Hover-expand is a self-contained chat-only fix with a clean CSS-only delta; the consistency piece needs a wider design decision (admin sidebar currently has no collapsed state on desktop, only a mobile fold). It splits into a separate follow-up PR — likely bundled with Sprint 2 #4 (sticky top nav) where the nav scaffold is the natural cross-page seam.

## Out of scope (Sprint 2 #5b follow-up)

- admin sidebar collapsed-state parity (currently desktop-always-open)
- workspace / graph page sidebar surfaces (none yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)