### PR TITLE
feat(ui): v0.4 Sprint 2 #4 — sticky top navigation on scrolling pages

### DIFF
--- a/frontend/static/admin.css
+++ b/frontend/static/admin.css
@@ -32,6 +32,14 @@
     padding: 12px 24px;
     border-bottom: 1px solid var(--border-2);
     background: var(--surface);
+    /* v0.4 Sprint 2 #4 — sticky on long scrolling pages so the
+       brand + language toggle + chat-link stay reachable. body
+       uses min-height:100dvh + flex column (so the page DOES
+       scroll for long admin tables), unlike chat/graph which
+       are overflow:hidden viewport apps. */
+    position: sticky;
+    top: 0;
+    z-index: 50;
   }
   .logo {
     font-size: 14px; font-weight: 600;

--- a/frontend/static/workspace.css
+++ b/frontend/static/workspace.css
@@ -29,6 +29,13 @@
     padding: 12px 24px;
     border-bottom: 1px solid var(--border-2);
     background: var(--surface);
+    /* v0.4 Sprint 2 #4 — sticky on long scrolling pages so the
+       brand + language toggle + chat-link stay reachable while
+       data/jobs tables scroll. Matches admin.css; chat/graph
+       intentionally skipped (overflow:hidden viewport apps). */
+    position: sticky;
+    top: 0;
+    z-index: 50;
   }
   .logo { font-size: 14px; font-weight: 600; }
   .logo span.tagline {

--- a/tests/test_header_sticky_parity.py
+++ b/tests/test_header_sticky_parity.py
@@ -1,0 +1,111 @@
+"""v0.4 Sprint 2 #4 — sticky top navigation bar contract.
+
+JAMES has four page surfaces, each with its own ``<header>`` element
++ CSS file. The Sprint 2 #4 spec asked for the header to "persist
+across scroll on every page". The right answer differs per page:
+
+  • chat (chat.css) + graph (graph.css)
+      body is overflow:hidden + flex column; the page itself never
+      scrolls — only inner panels do. ``flex-shrink: 0`` is what
+      pins the header at the top; ``position: sticky`` would be a
+      no-op (and would conflict with the no-scroll layout).
+
+  • admin (admin.css) + workspace (workspace.css)
+      body is min-height:100dvh + flex column; the document DOES
+      scroll when content overflows (long admin tables, workspace
+      data lists). For those, ``position: sticky; top: 0`` is the
+      right primitive — the header stays in view as the user
+      scrolls long content.
+
+This test pins the per-page policy so a refactor that homogenises
+the headers (e.g. adding ``position: sticky`` to chat.css) doesn't
+silently break the no-scroll layout, and dropping sticky from
+admin/workspace doesn't silently restore the disappearing-header
+bug Sprint 2 #4 fixed.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+REPO = Path(__file__).resolve().parent.parent
+STATIC = REPO / "frontend" / "static"
+
+
+def _header_block(css_source: str) -> str:
+    """Return the first ``header { … }`` rule body. Looks for the
+    bare ``header`` selector (not ``.header`` or ``#header``) to
+    avoid catching utility classes."""
+    m = re.search(r"(?:^|\s)header\s*\{([^}]+)\}", css_source, re.MULTILINE)
+    if not m:
+        return ""
+    return m.group(1)
+
+
+class HeaderStickyParityTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.styles = {
+            name: (STATIC / f"{name}.css").read_text(encoding="utf-8")
+            for name in ("admin", "workspace", "chat", "graph")
+        }
+
+    def test_admin_header_is_sticky(self):
+        block = _header_block(self.styles["admin"])
+        self.assertIn("position:", block,
+            "admin.css header block should declare position. "
+            "Sprint 2 #4 added position: sticky here.")
+        self.assertTrue(
+            re.search(r"position:\s*sticky", block),
+            "admin.css header must be position: sticky (long admin "
+            "tables scroll the document; the header must stay).")
+        self.assertTrue(
+            re.search(r"top:\s*0", block),
+            "Sticky needs top:0 to anchor the header to the viewport.")
+
+    def test_workspace_header_is_sticky(self):
+        block = _header_block(self.styles["workspace"])
+        self.assertTrue(
+            re.search(r"position:\s*sticky", block),
+            "workspace.css header must be position: sticky to match "
+            "admin behaviour — same body layout (min-height + scroll).")
+        self.assertTrue(
+            re.search(r"top:\s*0", block),
+            "Sticky needs top:0 to anchor the header to the viewport.")
+
+    def test_chat_header_is_not_sticky(self):
+        """chat.css is intentionally a no-sticky viewport app — body
+        is overflow:hidden and the header is pinned via flex-shrink.
+        Adding position:sticky here would be redundant at best and
+        could interact badly with the inner-flex layout."""
+        block = _header_block(self.styles["chat"])
+        self.assertNotIn("position: sticky", block,
+            "chat.css header should NOT be position:sticky — the "
+            "page is overflow:hidden so the document never scrolls "
+            "(only inner panels do). flex-shrink: 0 already pins "
+            "the header at the top.")
+        self.assertTrue(
+            re.search(r"flex-shrink:\s*0", block),
+            "chat.css header relies on flex-shrink: 0 instead.")
+
+    def test_graph_header_is_not_sticky(self):
+        block = _header_block(self.styles["graph"])
+        self.assertNotIn("position: sticky", block,
+            "graph.css header should NOT be position:sticky — same "
+            "rationale as chat.css (overflow:hidden viewport app).")
+        self.assertTrue(
+            re.search(r"flex-shrink:\s*0", block),
+            "graph.css header relies on flex-shrink: 0 instead.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Sprint 2 #4 spec asked for the header to "persist across scroll on every page". The right primitive differs per page surface:

- **chat** (`chat.css`) + **graph** (`graph.css`): body is `overflow:hidden` + flex column, so the page itself never scrolls — only inner panels do. `flex-shrink: 0` already pins the header at the top.
- **admin** (`admin.css`) + **workspace** (`workspace.css`): body is `min-height:100dvh` + flex column, so the document DOES scroll when content overflows (long admin tables, workspace data lists). For these, `position:sticky; top:0` is the right primitive.

### Changes
- `admin.css` → header gets `position:sticky` + `top:0` + `z-index:50`
- `workspace.css` → same trio
- `chat.css` / `graph.css` → unchanged (already correct by their own rationale)

## Verification

```
$ pytest tests/test_header_sticky_parity.py \
         tests/test_llm_active_endpoint.py \
         tests/test_i18n_char_keys_parity.py
14 passed.
```

`tests/test_header_sticky_parity.py` (new, 4 tests):
- admin.css header is sticky + top:0
- workspace.css header is sticky + top:0
- chat.css header is **NOT** sticky (and DOES have `flex-shrink:0`)
- graph.css header is **NOT** sticky (same)

The two negative assertions are deliberate — pinning per-page policy means a future refactor that "fixes the inconsistency" by adding sticky to chat/graph fails CI, prompting the author to re-read the rationale rather than silently breaking the layout.

No `core/{retrieval,graph,reasoning}` touch — bench numbers not required per CLAUDE.md rule #2.

## Out of scope (Sprint 2 follow-ups)

- **#5b**: per-page sidebar toggle consistency (admin sidebar desktop-always-open vs chat sidebar collapsed-with-rail). The sticky nav scaffold is now in place, so a unified collapsed pattern can layer on top if the operator asks.
- **#3c**: `docs/ARCHITECTURE.md` authority-chain polish.
- `admin.html` 3-page split (Option-A Phase 3) — separate architectural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)