### PR TITLE
feat(observability): v0.4 Sprint 3 BL-1 — emit_trace_step stdout mirror

### DIFF
--- a/core/reasoning/trace_schema.py
+++ b/core/reasoning/trace_schema.py
@@ -27,6 +27,7 @@ the contract those two PRs both honor.
 from __future__ import annotations
 
 import hashlib
+import os
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, Optional, FrozenSet
 
@@ -152,7 +153,52 @@ def emit_trace_step(
                 continue
             entry[k] = v
 
-    return mirror_to_audit_db(entry, db_path=db_path)
+    ok = mirror_to_audit_db(entry, db_path=db_path)
+    # v0.4 Sprint 3 BL-1 — stdout mirror so the operator sees the
+    # reasoning chain in stdout alongside the synth path. Before this,
+    # planner / reflect / verify only wrote to audit_log DB (memory:
+    # feedback_stdout_vs_audit_log_trace_split) — debugging a run
+    # required querying the DB. Follows the observability.emit_step
+    # convention: JAMES_TRACE_STDOUT=1 default ON, "0"/"false"/"no"
+    # silences the mirror. Best-effort — a cp949 console crash never
+    # blocks the reasoning path.
+    _stdout_mirror_trace_step(step, extras)
+    return ok
+
+
+def _stdout_mirror_trace_step(
+    step: TraceStep,
+    extras: Optional[Dict[str, Any]],
+) -> None:
+    """Write a single-line `[reason:<stage>] …` row to stdout.
+
+    Matches the format of observability.emit_step's mirror so the
+    operator can grep / tail a single console stream for the whole
+    chain. JAMES_TRACE_STDOUT default ON to match the operator-setup
+    convention from PR #283 (Phase 1 observability).
+    """
+    if os.getenv("JAMES_TRACE_STDOUT", "1").strip().lower() in (
+        "0", "false", "no", "",
+    ):
+        return
+    try:
+        trace_hint = ""
+        if extras:
+            tid = extras.get("trace_id") or ""
+            if isinstance(tid, str) and tid:
+                trace_hint = f" [trace {tid[:8]}]"
+        latency = f"{step.latency_ms}ms" if step.latency_ms else "?ms"
+        err = f" err={step.error[:60]}" if step.error else ""
+        print(
+            f"[reason:{step.stage}] {step.applied_rule} · "
+            f"{step.backend_id or '?'} · {latency}{trace_hint}{err}",
+            flush=True,
+        )
+    except Exception:
+        # cp949 / closed-stdout / sentinel-string crashes must never
+        # block the reasoning path. Operator sees the gap (no print)
+        # rather than a wedged request.
+        pass
 
 
 def trace_step_to_dict(step: TraceStep) -> Dict[str, Any]:

--- a/tests/test_emit_trace_step_stdout_mirror.py
+++ b/tests/test_emit_trace_step_stdout_mirror.py
@@ -1,0 +1,193 @@
+"""v0.4 Sprint 3 BL-1 — emit_trace_step stdout mirror contract.
+
+Before BL-1, the cognitive layer's planner / reflect / verify
+stages wrote rows to the audit_log table only — there was no
+stdout signal, so an operator debugging a live run had to query
+the SQLite DB to see what each stage did. The synth path mirrored
+some events via observability.emit_step but the four reasoning
+stages went silent.
+
+BL-1 added a stdout mirror inside emit_trace_step itself so every
+caller (synth + reflect + verify + planner + retrieve + ...) gets
+the same single-line `[reason:<stage>] …` console signal under the
+JAMES_TRACE_STDOUT convention (default ON; "0"/"false"/"no" off).
+
+This test pins three guarantees:
+
+  1. With JAMES_TRACE_STDOUT unset (default), emit_trace_step
+     prints a `[reason:<stage>]` line to stdout.
+  2. With JAMES_TRACE_STDOUT=0 / false / no, no print happens.
+  3. The audit_log DB mirror is unaffected — stdout is additive,
+     not a replacement.
+
+Pinning prevents a refactor that silences the mirror (or makes it
+opt-in only) from regressing the operator debugging surface.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.reasoning.trace_schema import (  # noqa: E402
+    TraceStep,
+    emit_trace_step,
+)
+
+
+class TraceStepStdoutMirrorTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._orig_env = os.environ.get("JAMES_TRACE_STDOUT")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._orig_env is None:
+            os.environ.pop("JAMES_TRACE_STDOUT", None)
+        else:
+            os.environ["JAMES_TRACE_STDOUT"] = cls._orig_env
+
+    def _emit_capture(self, step: TraceStep, extras=None) -> str:
+        """Run emit_trace_step with the audit-log mirror stubbed out
+        (returns True without touching SQLite) and capture stdout.
+
+        The audit_bridge.mirror_to_audit_db patch keeps the test
+        hermetic — no SQLite write, no DB schema dependency."""
+        buf = io.StringIO()
+        with patch("core.audit_bridge.mirror_to_audit_db", return_value=True), \
+             redirect_stdout(buf):
+            ok = emit_trace_step(step, extras=extras)
+        return buf.getvalue(), ok
+
+    def test_default_on_prints_stage_marker(self):
+        """JAMES_TRACE_STDOUT unset → mirror prints (default ON)."""
+        os.environ.pop("JAMES_TRACE_STDOUT", None)
+        step = TraceStep(
+            stage="reflect",
+            backend_id="ollama_local",
+            parent_step_id="",
+            inputs_hash="abcdef0123456789",
+            output_summary="Critique returned 3 issues.",
+            applied_rule="reflect.loop",
+            latency_ms=420,
+        )
+        out, ok = self._emit_capture(step)
+        self.assertTrue(ok, "audit mirror return should propagate")
+        self.assertIn("[reason:reflect]", out,
+            "Default ON behaviour: stdout must carry the stage marker. "
+            "JAMES_TRACE_STDOUT semantics match observability.emit_step.")
+        self.assertIn("reflect.loop", out, "applied_rule should appear")
+        self.assertIn("ollama_local", out, "backend_id should appear")
+        self.assertIn("420ms", out, "latency_ms should appear")
+
+    def test_off_with_zero_silences(self):
+        os.environ["JAMES_TRACE_STDOUT"] = "0"
+        step = TraceStep(
+            stage="verify",
+            backend_id="ollama_local",
+            parent_step_id="",
+            inputs_hash="0000000000000000",
+            output_summary="",
+            applied_rule="verify.fact_check",
+            latency_ms=100,
+        )
+        out, _ok = self._emit_capture(step)
+        self.assertEqual(out, "",
+            "JAMES_TRACE_STDOUT=0 must silence the mirror — operator's "
+            "preferred CI / log-pipeline setup relies on this.")
+
+    def test_off_with_false_and_no_silences(self):
+        """Both 'false' and 'no' should silence — matches the
+        observability.emit_step convention. Empty string also off."""
+        for val in ("false", "FALSE", "no", "NO", ""):
+            with self.subTest(val=val):
+                os.environ["JAMES_TRACE_STDOUT"] = val
+                step = TraceStep(
+                    stage="plan",
+                    backend_id="ollama_local",
+                    parent_step_id="",
+                    inputs_hash="1111111111111111",
+                    output_summary="",
+                    applied_rule="plan.decompose",
+                    latency_ms=50,
+                )
+                out, _ok = self._emit_capture(step)
+                self.assertEqual(out, "",
+                    f"JAMES_TRACE_STDOUT={val!r} must silence mirror")
+
+    def test_error_field_surfaced(self):
+        """When a stage records an error, the mirror should make it
+        visible in the same line — saves an operator from grepping
+        the audit_log to see why a stage failed."""
+        os.environ["JAMES_TRACE_STDOUT"] = "1"
+        step = TraceStep(
+            stage="verify",
+            backend_id="ollama_local",
+            parent_step_id="",
+            inputs_hash="2222222222222222",
+            output_summary="",
+            applied_rule="verify.fact_check",
+            latency_ms=999,
+            error="backend reported error string",
+        )
+        out, _ok = self._emit_capture(step)
+        self.assertIn("[reason:verify]", out)
+        self.assertIn("err=backend reported error string", out,
+            "Error text should appear inline (truncated to 60 chars).")
+
+    def test_trace_id_in_extras_surfaces(self):
+        """The synth path passes the Axis-3 trace_id via extras;
+        the mirror should include the short prefix so the operator
+        can correlate stdout lines back to a single request."""
+        os.environ["JAMES_TRACE_STDOUT"] = "1"
+        step = TraceStep(
+            stage="synth",
+            backend_id="ollama_local",
+            parent_step_id="",
+            inputs_hash="3333333333333333",
+            output_summary="",
+            applied_rule="reasoning.synth.rag",
+            latency_ms=1200,
+        )
+        out, _ok = self._emit_capture(step, extras={
+            "trace_id": "deadbeefcafebabe0011223344556677",
+        })
+        self.assertIn("[trace deadbeef]", out,
+            "Short trace_id prefix (8 chars) should appear so the "
+            "operator can grep one request across multiple stages.")
+
+    def test_audit_mirror_runs_regardless_of_stdout_setting(self):
+        """stdout silence must NOT skip the audit DB mirror — the two
+        observability layers are independent. Pinning here so a
+        future short-circuit ("skip emit if stdout off") doesn't
+        accidentally drop the DB row too."""
+        os.environ["JAMES_TRACE_STDOUT"] = "0"
+        step = TraceStep(
+            stage="retrieve",
+            backend_id="vector_store",
+            parent_step_id="",
+            inputs_hash="4444444444444444",
+            output_summary="",
+            applied_rule="retrieve.dense",
+            latency_ms=10,
+        )
+        with patch("core.audit_bridge.mirror_to_audit_db",
+                   return_value=True) as mock_mirror:
+            ok = emit_trace_step(step)
+        self.assertTrue(ok)
+        self.assertEqual(mock_mirror.call_count, 1,
+            "audit_log mirror must run once regardless of stdout setting")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The cognitive layer's planner / reflect / verify stages wrote rows to the audit_log table only — no stdout signal. Operators debugging a live run had to query SQLite to see which stage failed or how long each one took. Memory anchor: `feedback_stdout_vs_audit_log_trace_split`.

Fix: a single-line `[reason:<stage>] applied_rule · backend_id · latency [trace abc12345] [err=…]` stdout mirror lives inside `emit_trace_step` itself, so every caller (synth + planner + reflect + verify + retrieve + rerank + tool) gets the same console signal without changing call sites.

Convention matches `observability.emit_step` (PR #283): `JAMES_TRACE_STDOUT` default ON; `"0"` / `"false"` / `"no"` / empty silences. Best-effort — cp949 console crashes or closed stdout never block the reasoning path (wrapped in try/except; audit DB mirror still fires).

## Verification

```
$ pytest tests/test_emit_trace_step_stdout_mirror.py
6 passed, 5 subtests passed
$ pytest tests/test_observability.py tests/test_reasoning_trace_helpers.py tests/test_reasoning_backends.py
57 passed
```

`tests/test_emit_trace_step_stdout_mirror.py` (new, 6 tests):
- default ON prints `[reason:<stage>]` marker with applied_rule / backend / latency
- `JAMES_TRACE_STDOUT=0` silences
- `false` / `FALSE` / `no` / `NO` / empty all silence (matches observability convention)
- error field surfaces inline (truncated to 60 chars)
- trace_id extras surface as 8-char prefix for cross-stage correlation
- audit DB mirror still fires when stdout off (independence of the two layers)

## CLAUDE.md rule compliance

- **Rule #2** (`core/reasoning` bench): touch is observability-only. No change to call sites or LLM latency. STEP 7 sweep should report identical numbers; operator-run if any concern.
- **Rule #5** (20 KB cap): `core/reasoning/trace_schema.py` grows 6.7 KB → ~8.5 KB — well under cap.

## Out of scope (Sprint 3 follow-ups)

- **BL-2**: `attributes.summary` legacy field cleanup
- **D1 stage expansion**: wire planner/reflect/verify through `complete_with_retry` (depends on D1 budget signal first — currently `self._max_tokens = 4096` cap-ceiling makes retry a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)