### PR TITLE
feat(reasoning): v0.4 Sprint 3 #7a — planner D1 + retry wiring

### DIFF
--- a/core/reasoning/budget.py
+++ b/core/reasoning/budget.py
@@ -55,6 +55,7 @@ of the same surface.
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Final, Literal
 
@@ -114,6 +115,23 @@ _HEAVY_REGEX: Final[re.Pattern[str]] = re.compile(
     "|".join(re.escape(m) for m in _HEAVY_MARKERS),
     re.IGNORECASE,
 )
+
+
+def adaptive_budget_enabled() -> bool:
+    """Single source of truth for the D1 opt-in flag.
+
+    Default OFF — operators opting into the experiment set
+    ``JAMES_ADAPTIVE_BUDGET=1`` (or ``true`` / ``yes`` / ``on``).
+    Read at every call site so an env change takes effect without
+    a server restart. Mirrors the convention from
+    ``query_rewriter._adaptive_budget_enabled`` which was the first
+    site to wire D1 — extracted here so planner / reflect / verify
+    can route through one flag-check function as the v0.4 Sprint 3
+    D1 expansion lands them on the same opt-in switch.
+    """
+    return os.getenv("JAMES_ADAPTIVE_BUDGET", "0").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
 
 
 class TaskBudget:
@@ -279,6 +297,7 @@ __all__ = [
     "CAP_HEAVY",
     "ReasoningStage",
     "TaskBudget",
+    "adaptive_budget_enabled",
     "complete_with_retry",
     "retry_doubled",
 ]

--- a/core/reasoning/planner.py
+++ b/core/reasoning/planner.py
@@ -28,6 +28,11 @@ import time
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
+from core.reasoning.budget import (
+    TaskBudget,
+    adaptive_budget_enabled,
+    complete_with_retry,
+)
 from core.reasoning.trace_schema import (
     TraceStep,
     compute_inputs_hash,
@@ -185,11 +190,33 @@ class Planner:
         backend_id: str = DEFAULT_BACKEND_ID,
         *,
         timeout: float = DEFAULT_TIMEOUT_S,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: Optional[int] = None,
+        budget: Optional[TaskBudget] = None,
     ) -> None:
+        """Construct a Planner.
+
+        ``max_tokens`` behaviour (D1 Adaptive Budgeting wiring, v0.4
+        Sprint 3 #7a — mirrors query_rewriter):
+
+          • int (e.g. ``DEFAULT_MAX_TOKENS=4096``) — fixed cap; bypasses
+            TaskBudget and forces every call to this cap. The experiment
+            driver uses this for the **baseline** condition.
+          • ``None`` (default) — runtime decision:
+              - ``JAMES_ADAPTIVE_BUDGET=1`` → route through
+                ``TaskBudget.assess("planner", prompt)`` (**treatment**).
+              - flag off → fall back to ``DEFAULT_MAX_TOKENS=4096`` —
+                byte-identical to pre-D1 behaviour.
+
+        ``budget`` is the injectable TaskBudget instance. Default is a
+        fresh stateless instance.
+
+        Default-off invariant: a fresh ``Planner()`` with no env opt-in
+        must hit the same cap as before this PR. See PR-#7a tests.
+        """
         self._backend_id = backend_id
         self._timeout = timeout
         self._max_tokens = max_tokens
+        self._budget = budget if budget is not None else TaskBudget()
 
     def plan(
         self,
@@ -218,13 +245,32 @@ class Planner:
         tmpl = PLAN_PROMPT_KO if is_ko else PLAN_PROMPT_EN
         prompt = tmpl.format(query=query)
 
-        # D5.C.2.b — flag-gated backend resolution. Planner is not
-        # D1-wired (uses fixed `self._max_tokens`), so `budget_signal`
-        # is always `None` here. Under D5 flag-off the helper returns
-        # `self._backend_id` (byte-identical to pre-D5). Under D5
-        # flag-on the router policy fires with budget=None → rule 4
-        # → legacy backend (planner is not grounding-critical, so it
-        # does not trigger the verify-stage escalation either).
+        # v0.4 Sprint 3 #7a — D1 cap resolution (mirrors query_rewriter):
+        #   1. explicit int (constructor arg) → fixed cap (baseline)
+        #   2. None + JAMES_ADAPTIVE_BUDGET=1 → TaskBudget.assess (treatment)
+        #   3. None + flag off → DEFAULT_MAX_TOKENS=4096 (byte-identical)
+        # Default-off invariant: paths 1 and 3 give the pre-D1 cap so an
+        # operator who didn't opt in sees no behaviour change.
+        if self._max_tokens is not None:
+            cap = self._max_tokens
+            _budget_for_router = None
+        elif adaptive_budget_enabled():
+            # Assess against the user's *query* — not the wrapped
+            # PLAN_PROMPT_* template, which carries heavy markers like
+            # "Decompose" / "분해" as part of the instruction and would
+            # otherwise force every planning call to CAP_HEAVY. Matches
+            # query_rewriter's pattern (query, not prompt).
+            cap = self._budget.assess("planner", query)
+            _budget_for_router = cap
+        else:
+            cap = DEFAULT_MAX_TOKENS
+            _budget_for_router = None
+
+        # D5.C.2.b — flag-gated backend resolution. With D1 now active
+        # for planner (when both flags ON), `budget_signal` carries the
+        # adaptive cap so router rule 1 (CAP_SUBSTITUTION → small tier)
+        # / rule 4 (CAP_HEAVY → fallback) fire correctly. Under D1 flag
+        # off `_budget_for_router` is None → unchanged from pre-#7a.
         try:
             from core.reasoning.backends import get_backend
             from core.reasoning.router import emit_route_event, resolve_backend
@@ -232,7 +278,7 @@ class Planner:
             backend_id = resolve_backend(
                 "planner",
                 prompt,
-                budget_signal=None,
+                budget_signal=_budget_for_router,
                 fallback_backend_id=self._backend_id,
             )
             backend = get_backend(backend_id)
@@ -244,16 +290,24 @@ class Planner:
             "planner",
             prompt,
             backend_id,
-            budget_signal=None,
-            reason="fallback",
+            budget_signal=_budget_for_router,
+            reason="auto" if _budget_for_router is not None else "fallback",
         )
 
+        # D6 retry wiring (v0.4 Sprint 3 #7a) — when the planner cap
+        # is below CAP_HEAVY (D1 active + light task) and the model
+        # truncates at the cap, retry once with the doubled cap.
+        # complete_with_retry is a no-op when cap == CAP_HEAVY (which
+        # is the flag-off default), preserving pre-#7a behaviour for
+        # operators who haven't opted into D1.
         t0 = time.time()
         try:
-            result = backend.complete(
+            result = complete_with_retry(
+                backend,
                 prompt,
-                max_tokens=self._max_tokens,
+                cap=cap,
                 timeout=self._timeout,
+                stage="planner",
             )
         except Exception as e:
             err = f"{type(e).__name__}: {str(e)[:200]}"

--- a/tests/test_planner_d1_wiring.py
+++ b/tests/test_planner_d1_wiring.py
@@ -1,0 +1,232 @@
+"""v0.4 Sprint 3 #7a — Planner D1 adaptive-budget + retry wiring.
+
+Mirrors the existing query_rewriter D1+D6 wiring (PR #486 / D6 cycle,
+PR #461 / D1.B) on the Planner stage. Before this PR, the Planner held
+``self._max_tokens = 4096`` so:
+
+  - it never participated in D1 adaptive budgeting — every planning
+    call paid CAP_HEAVY (4096) even on trivial queries.
+  - it never participated in D6 retry — ``complete_with_retry`` is a
+    no-op when cap == CAP_HEAVY (already at the ceiling), so wiring
+    it through would have changed nothing.
+
+This PR makes both wirings *available* — gated behind
+``JAMES_ADAPTIVE_BUDGET=1`` like query_rewriter, so flag-off behaviour
+is byte-identical to pre-#7a.
+
+Contract pinned here
+  1. Flag OFF + default constructor → cap is DEFAULT_MAX_TOKENS=4096
+     (byte-identical to pre-#7a). No D1 / D6 surface change.
+  2. Flag OFF + explicit `max_tokens=N` → cap is N (baseline / unit
+     test path). No D1 / D6 surface change.
+  3. Flag ON + default constructor → cap is TaskBudget.assess(
+     "planner", prompt). Light prompt → CAP_LIGHT=1200; heavy
+     marker → CAP_HEAVY=4096.
+  4. Flag ON + truncated response (done_reason="length") → retry
+     once with doubled cap (complete_with_retry path).
+  5. The D5 router gets the adaptive cap as `budget_signal` when D1
+     is active, and `None` when off — preserves the "no fake signal
+     under flag-off" invariant.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.reasoning.budget import (  # noqa: E402
+    CAP_HEAVY,
+    CAP_LIGHT,
+    CAP_SUBSTITUTION,
+    TaskBudget,
+)
+
+
+class _PlannerCallCapture:
+    """Records every backend.complete call so the test can assert the
+    cap and decide what to return (first call vs retry)."""
+
+    def __init__(self, *, plan_json='{"subtasks": ["a", "b"], "rationale": "ok"}',
+                 done_reasons=None):
+        self.calls = []
+        self.plan_json = plan_json
+        # done_reasons is a list of strings to return for successive
+        # calls. Default: all "stop" → no retry.
+        self.done_reasons = list(done_reasons or [])
+
+    def complete(self, prompt, *, max_tokens, timeout, **opts):
+        idx = len(self.calls)
+        self.calls.append({
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "timeout": timeout,
+            "opts": opts,
+        })
+        dr = (
+            self.done_reasons[idx]
+            if idx < len(self.done_reasons)
+            else "stop"
+        )
+        return SimpleNamespace(
+            text=self.plan_json,
+            error="",
+            done_reason=dr,
+            latency_ms=10,
+            backend_id="ollama_local",
+        )
+
+
+class PlannerD1WiringTests(unittest.TestCase):
+
+    QUERY = "비트코인 ETF 가격 분석 방법을 단계별로 설명해줘"  # heavy marker "단계"
+
+    def setUp(self):
+        self._orig_budget = os.environ.get("JAMES_ADAPTIVE_BUDGET")
+        self._orig_planner = os.environ.get("JAMES_ENABLE_PLANNER")
+        # Planner has its own opt-in (JAMES_ENABLE_PLANNER) separate
+        # from D1 — enable it for the duration of the test class.
+        os.environ["JAMES_ENABLE_PLANNER"] = "1"
+
+    def tearDown(self):
+        for key, val in (
+            ("JAMES_ADAPTIVE_BUDGET", self._orig_budget),
+            ("JAMES_ENABLE_PLANNER", self._orig_planner),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def _run_planner(self, capture, **planner_kwargs):
+        from core.reasoning.planner import Planner
+        planner = Planner(**planner_kwargs)
+        with patch("core.reasoning.backends.get_backend", return_value=capture), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True):
+            return planner.plan(self.QUERY, force=True)
+
+    def test_flag_off_default_cap_unchanged(self):
+        """Path #3 in the docstring — flag off, default ctor → 4096."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "0"
+        cap = _PlannerCallCapture()
+        self._run_planner(cap)
+        self.assertEqual(len(cap.calls), 1,
+            "Default-off path should call backend.complete exactly once")
+        self.assertEqual(cap.calls[0]["max_tokens"], 4096,
+            "JAMES_ADAPTIVE_BUDGET=0 with default ctor must keep the "
+            "pre-#7a cap of 4096 — byte-identical invariant.")
+
+    def test_flag_off_explicit_max_tokens_honoured(self):
+        """Path #2 — explicit int bypasses TaskBudget entirely."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"  # flag on, but explicit cap wins
+        cap = _PlannerCallCapture()
+        self._run_planner(cap, max_tokens=600)
+        self.assertEqual(cap.calls[0]["max_tokens"], 600,
+            "Explicit max_tokens must override the adaptive heuristic "
+            "(matches query_rewriter D1.B contract).")
+
+    def test_flag_on_heavy_query_caps_at_heavy(self):
+        """Path #3 with heavy marker — assess returns CAP_HEAVY."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _PlannerCallCapture()
+        self._run_planner(cap)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_HEAVY,
+            "단계 in the query is a heavy-synthesis marker; "
+            "TaskBudget.assess should return CAP_HEAVY (4096).")
+
+    def test_flag_on_light_query_caps_at_light(self):
+        """Light prompt → CAP_LIGHT (no heavy marker present)."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _PlannerCallCapture()
+        from core.reasoning.planner import Planner
+        light_q = "What is Palantir's primary business model"
+        planner = Planner()
+        with patch("core.reasoning.backends.get_backend", return_value=cap), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True):
+            planner.plan(light_q, force=True)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "Light query with no heavy markers → CAP_LIGHT=1200")
+
+    def test_flag_on_retry_fires_on_length_truncation(self):
+        """Path #4 — done_reason='length' triggers complete_with_retry's
+        single retry at doubled cap (1200 → 2400 here).
+
+        Uses a query without heavy markers so the assess returns
+        CAP_LIGHT; heavy markers would push to CAP_HEAVY (the ceiling)
+        where retry would be a no-op."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _PlannerCallCapture(
+            done_reasons=["length", "stop"],
+        )
+        from core.reasoning.planner import Planner
+        # No heavy markers ("compare" / "decompose" / "step" / "단계"
+        # / "분석" etc.) — picks CAP_LIGHT path.
+        light_q = "What is the primary business model"
+        planner = Planner()
+        with patch("core.reasoning.backends.get_backend", return_value=cap), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True), \
+             patch("core.audit_bridge.mirror_to_audit_db", return_value=True):
+            planner.plan(light_q, force=True)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "Light query → CAP_LIGHT=1200 on first call")
+        self.assertEqual(len(cap.calls), 2,
+            "Length truncation should trigger exactly one retry "
+            "(complete_with_retry contract).")
+        self.assertEqual(cap.calls[1]["max_tokens"], 2 * CAP_LIGHT,
+            "Retry should double the cap (1200 → 2400).")
+
+
+class AdaptiveBudgetEnabledHelperTests(unittest.TestCase):
+    """budget.adaptive_budget_enabled() — pinned as the single source
+    of truth for the D1 opt-in flag. The 5 reasoning stages (existing:
+    query_rewriter, synth; v0.4 Sprint 3: planner, reflect, verify)
+    must all read the same env semantics."""
+
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_ADAPTIVE_BUDGET")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_ADAPTIVE_BUDGET", None)
+        else:
+            os.environ["JAMES_ADAPTIVE_BUDGET"] = self._orig
+
+    def test_default_off(self):
+        os.environ.pop("JAMES_ADAPTIVE_BUDGET", None)
+        from core.reasoning.budget import adaptive_budget_enabled
+        self.assertFalse(adaptive_budget_enabled(),
+            "Default-off invariant — no env var → flag off")
+
+    def test_truthy_values_enable(self):
+        from core.reasoning.budget import adaptive_budget_enabled
+        for val in ("1", "true", "TRUE", "yes", "YES", "on", "ON"):
+            with self.subTest(val=val):
+                os.environ["JAMES_ADAPTIVE_BUDGET"] = val
+                self.assertTrue(adaptive_budget_enabled())
+
+    def test_falsy_values_silence(self):
+        from core.reasoning.budget import adaptive_budget_enabled
+        for val in ("0", "false", "no", "off", "", "garbage"):
+            with self.subTest(val=val):
+                os.environ["JAMES_ADAPTIVE_BUDGET"] = val
+                self.assertFalse(adaptive_budget_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Background

Memory `feedback_d1_d5_retry_doubled_wiring_gap` noted that `planner` / `reflect` / `verify` held `self._max_tokens = 4096` (the cap-ceiling), so:
- they never participated in D1 adaptive budgeting — every call paid CAP_HEAVY regardless of task weight
- `complete_with_retry` was a no-op when wired (already at the ceiling)

`query_rewriter` and `synth` shipped the D1+D6 pattern (PR #461 / #486 cycles). Sprint 3 #7a brings **planner** onto the same surface; #7b / #7c will do reflect / verify next.

## What changes

- `core/reasoning/budget.py` → extract `adaptive_budget_enabled()` as the **single source of truth** for the `JAMES_ADAPTIVE_BUDGET` flag. planner / reflect / verify all import this one.
- `core/reasoning/planner.py`:
  - `Planner.__init__` accepts `max_tokens: Optional[int]` (was `int`) + new `budget: Optional[TaskBudget]` param. Same three-way semantics as query_rewriter.
  - cap is resolved per call: explicit int wins, else `adaptive_budget_enabled()` + `TaskBudget.assess("planner", query)`, else `DEFAULT_MAX_TOKENS=4096`.
  - **assess is called against the user query, not the wrapped `PLAN_PROMPT_*` template.** The template carries heavy markers ("Decompose" / "분해") as part of the instruction; passing the full prompt would force every planner call to CAP_HEAVY. Mirrors query_rewriter's pattern.
  - `backend.complete` → `complete_with_retry(...)`. On `done_reason="length"` the helper retries once at doubled cap up to CAP_HEAVY.
  - router `budget_signal` carries the adaptive cap when D1 is active (and `None` when off).

## Default-OFF invariant

Without `JAMES_ADAPTIVE_BUDGET=1`, a fresh `Planner()` with no `max_tokens` argument hits `cap=4096` — byte-identical to pre-#7a. Operators who haven't opted in see zero behavioural change.

## Verification

```
$ pytest tests/test_planner_d1_wiring.py tests/test_planner.py \
         tests/test_query_rewriter_router_wiring.py \
         tests/test_router_policy.py tests/test_router_skeleton.py \
         tests/test_emit_trace_step_stdout_mirror.py
84 passed.
```

`tests/test_planner_d1_wiring.py` (new, 8 tests):
- flag OFF + default ctor → cap is 4096
- flag OFF + explicit max_tokens → honoured
- flag ON + heavy query → CAP_HEAVY
- flag ON + light query → CAP_LIGHT
- flag ON + length truncation → retry at doubled cap
- `adaptive_budget_enabled` helper: default off / truthy-values on / falsy-values off

## CLAUDE.md rule compliance

- **Rule #2** (`core/reasoning` bench): touch is wiring-only with default-OFF byte-identical invariant. STEP 7 sweep at flag-OFF should report identical ranking numbers; flag-ON measurement is the operator-run experiment.
- **Rule #5** (20 KB cap): `planner.py` 13.8 KB → ~15 KB; `budget.py` ~7.0 KB → ~7.6 KB. Both under cap.

## Out of scope

- **#7b**: `reflect.py` D1 + retry wiring (critique + revise sub-stages)
- **#7c**: `verify.py` D1 + retry wiring (generator + critic + fact-check)
- `query_rewriter` local `_adaptive_budget_enabled()` → migrate to `budget.adaptive_budget_enabled()` (refactor follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)