### PR TITLE
feat(reasoning): v0.4 Sprint 3 #7b — reflect D1 + retry wiring

### DIFF
--- a/core/reasoning/reflect.py
+++ b/core/reasoning/reflect.py
@@ -36,6 +36,11 @@ import threading
 import time
 from typing import Optional
 
+from core.reasoning.budget import (
+    TaskBudget,
+    adaptive_budget_enabled,
+    complete_with_retry,
+)
 from core.reasoning.trace_schema import (
     TraceStep,
     compute_inputs_hash,
@@ -148,14 +153,32 @@ class ReflectionLoop:
         *,
         critique_timeout: float = DEFAULT_CRITIQUE_TIMEOUT_S,
         revise_timeout: float = DEFAULT_REVISE_TIMEOUT_S,
-        critique_max_tokens: int = DEFAULT_CRITIQUE_MAX_TOKENS,
-        revise_max_tokens: int = DEFAULT_REVISE_MAX_TOKENS,
+        critique_max_tokens: Optional[int] = None,
+        revise_max_tokens: Optional[int] = None,
+        budget: Optional[TaskBudget] = None,
     ) -> None:
+        """Construct a ReflectionLoop.
+
+        ``critique_max_tokens`` / ``revise_max_tokens`` behaviour
+        (D1 wiring, v0.4 Sprint 3 #7b — mirrors planner / query_rewriter):
+
+          • int — fixed cap (per-stage baseline).
+          • ``None`` (default) — runtime decision:
+              - ``JAMES_ADAPTIVE_BUDGET=1`` → both stages share
+                ``TaskBudget.assess("reflect", query)``.
+              - flag off → fall back to ``DEFAULT_CRITIQUE_MAX_TOKENS=4096``
+                / ``DEFAULT_REVISE_MAX_TOKENS=1024`` — byte-identical
+                to pre-#7b behaviour.
+
+        Default-off invariant: ``ReflectionLoop()`` with no kwargs and
+        no env opt-in must hit the same caps as before this PR.
+        """
         self._backend_id = backend_id
         self._critique_timeout = critique_timeout
         self._revise_timeout = revise_timeout
         self._critique_max_tokens = critique_max_tokens
         self._revise_max_tokens = revise_max_tokens
+        self._budget = budget if budget is not None else TaskBudget()
 
     def reflect(
         self,
@@ -189,13 +212,44 @@ class ReflectionLoop:
         crit_tmpl = CRITIQUE_PROMPT_KO if is_ko else CRITIQUE_PROMPT_EN
         rev_tmpl = REVISE_PROMPT_KO if is_ko else REVISE_PROMPT_EN
 
-        # D5.C.2.c — flag-gated backend resolution. Reflect is not
-        # D1-wired (uses fixed critique/revise caps), so
-        # `budget_signal=None` here. Flag-off → `self._backend_id`
-        # (byte-identical). Flag-on → router policy with budget=None
-        # → rule 4 → legacy. Reflect is not grounding-critical
-        # (only `verify` is) so the escalation does not fire. Single
-        # backend serves both critique + revise calls below.
+        # v0.4 Sprint 3 #7b — D1 cap resolution per sub-stage. Both
+        # critique and revise share `assess("reflect", query)` when
+        # D1 is active so a heavy task escalates both stages at once
+        # (and a light task gives both the same lower cap). assess
+        # is fed the user query — not the wrapped CRITIQUE_PROMPT_*
+        # / REVISE_PROMPT_* templates which carry heavy markers
+        # ("분석" / "review" etc.) as part of the instruction and
+        # would otherwise force every reflection call to CAP_HEAVY.
+        adaptive_on = adaptive_budget_enabled()
+        if adaptive_on and (
+            self._critique_max_tokens is None or self._revise_max_tokens is None
+        ):
+            _adaptive_cap = self._budget.assess("reflect", query)
+        else:
+            _adaptive_cap = None
+
+        if self._critique_max_tokens is not None:
+            crit_cap = self._critique_max_tokens
+        elif adaptive_on:
+            crit_cap = _adaptive_cap
+        else:
+            crit_cap = DEFAULT_CRITIQUE_MAX_TOKENS
+
+        if self._revise_max_tokens is not None:
+            rev_cap = self._revise_max_tokens
+        elif adaptive_on:
+            rev_cap = _adaptive_cap
+        else:
+            rev_cap = DEFAULT_REVISE_MAX_TOKENS
+
+        _budget_for_router = _adaptive_cap if adaptive_on else None
+
+        # D5.C.2.c — flag-gated backend resolution. With D1 active for
+        # reflect (when both flags ON) `budget_signal` carries the
+        # adaptive cap so router rules 1 / 4 fire on the correct
+        # signal. Under D1 flag-off `_budget_for_router` is None →
+        # unchanged from pre-#7b. Single backend serves both critique
+        # + revise calls below.
         try:
             from core.reasoning.backends import get_backend
             from core.reasoning.router import emit_route_event, resolve_backend
@@ -206,7 +260,7 @@ class ReflectionLoop:
             backend_id = resolve_backend(
                 "reflect",
                 router_prompt,
-                budget_signal=None,
+                budget_signal=_budget_for_router,
                 fallback_backend_id=self._backend_id,
             )
             backend = get_backend(backend_id)
@@ -217,8 +271,8 @@ class ReflectionLoop:
             "reflect",
             router_prompt,
             backend_id,
-            budget_signal=None,
-            reason="fallback",
+            budget_signal=_budget_for_router,
+            reason="auto" if _budget_for_router is not None else "fallback",
         )
 
         # ── critique pass ────────────────────────────────────
@@ -227,7 +281,7 @@ class ReflectionLoop:
             backend,
             critique_prompt,
             timeout=self._critique_timeout,
-            max_tokens=self._critique_max_tokens,
+            max_tokens=crit_cap,
             applied_rule="reasoning.reflect.critique",
             user_role=user_role,
         )
@@ -244,7 +298,7 @@ class ReflectionLoop:
             backend,
             revise_prompt,
             timeout=self._revise_timeout,
-            max_tokens=self._revise_max_tokens,
+            max_tokens=rev_cap,
             applied_rule="reasoning.reflect.revised",
             user_role=user_role,
         )
@@ -276,10 +330,20 @@ class ReflectionLoop:
         ``error`` set + ``blocked=1``) so the replay tool sees the
         attempt.
         """
+        # v0.4 Sprint 3 #7b — D6 retry wiring. When `max_tokens` is below
+        # CAP_HEAVY (D1 active + light task) and the model truncates at
+        # the cap, retry once with the doubled cap. No-op at the ceiling
+        # — pre-#7b behaviour preserved under flag-off.
+        # `stage="reflect"` is the audit-row tag complete_with_retry
+        # emits via `reason:retry` (D6 PR #487).
         t0 = time.time()
         try:
-            result = backend.complete(
-                prompt, max_tokens=max_tokens, timeout=timeout
+            result = complete_with_retry(
+                backend,
+                prompt,
+                cap=max_tokens,
+                timeout=timeout,
+                stage="reflect",
             )
         except Exception as e:
             latency_ms = int((time.time() - t0) * 1000)

--- a/tests/test_reflect_d1_wiring.py
+++ b/tests/test_reflect_d1_wiring.py
@@ -1,0 +1,194 @@
+"""v0.4 Sprint 3 #7b — Reflect D1 adaptive-budget + retry wiring.
+
+Same shape as test_planner_d1_wiring (#7a) on the ReflectionLoop
+stage. Pre-#7b reflect held fixed critique=4096 / revise=1024 caps
+so D1 and D6 both went unused. This PR opens both wirings behind
+``JAMES_ADAPTIVE_BUDGET=1`` (D1 opt-in flag, shared single source
+of truth via budget.adaptive_budget_enabled).
+
+Contract pinned here
+  1. Flag OFF + default ctor → caps are 4096 / 1024 (byte-identical
+     to pre-#7b). Two separate defaults preserved.
+  2. Flag OFF + explicit critique_max_tokens / revise_max_tokens
+     → those values are honoured (baseline / unit-test path).
+  3. Flag ON + default ctor → both sub-stages share
+     TaskBudget.assess("reflect", query). Heavy marker → CAP_HEAVY;
+     light → CAP_LIGHT.
+  4. Flag ON + length truncation on a light query → retry once at
+     doubled cap via complete_with_retry.
+  5. Flag ON + explicit revise_max_tokens, default critique → only
+     critique routes through assess; revise stays at the explicit
+     int. The two caps are independent.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.reasoning.budget import CAP_HEAVY, CAP_LIGHT  # noqa: E402
+
+
+class _ReflectCallCapture:
+    """Records every backend.complete call. ReflectionLoop hits the
+    backend twice per pass — once for critique, once for revise.
+    The critique result must avoid the 'NO_ISSUES' shortcut so the
+    revise pass actually runs."""
+
+    def __init__(self, *, done_reasons=None):
+        self.calls = []
+        # Default both stages return non-NO_ISSUES text → revise fires.
+        # done_reasons drives complete_with_retry retry decisions.
+        self.done_reasons = list(done_reasons or [])
+
+    def complete(self, prompt, *, max_tokens, timeout, **opts):
+        idx = len(self.calls)
+        self.calls.append({
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "timeout": timeout,
+        })
+        dr = (
+            self.done_reasons[idx]
+            if idx < len(self.done_reasons)
+            else "stop"
+        )
+        # Distinguish critique vs revise via prompt content. critique
+        # template includes "review" / "검토"; revise includes "Revise"
+        # / "개정".
+        if "Critically review" in prompt or "비판적으로 검토" in prompt:
+            text = "Issue: missing detail on point X."
+        else:
+            text = "Revised answer that fixes point X."
+        return SimpleNamespace(
+            text=text,
+            error="",
+            done_reason=dr,
+            latency_ms=10,
+            backend_id="ollama_local",
+        )
+
+
+class ReflectD1WiringTests(unittest.TestCase):
+
+    QUERY = "What is Palantir's primary business model"   # light
+    DRAFT = ("Palantir provides software for data integration. " * 5)
+
+    def setUp(self):
+        self._orig_budget = os.environ.get("JAMES_ADAPTIVE_BUDGET")
+        self._orig_reflect = os.environ.get("JAMES_ENABLE_REFLECT")
+        os.environ["JAMES_ENABLE_REFLECT"] = "1"
+
+    def tearDown(self):
+        for key, val in (
+            ("JAMES_ADAPTIVE_BUDGET", self._orig_budget),
+            ("JAMES_ENABLE_REFLECT", self._orig_reflect),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def _run(self, capture, **kw):
+        from core.reasoning.reflect import ReflectionLoop
+        loop = ReflectionLoop(**kw)
+        with patch("core.reasoning.backends.get_backend", return_value=capture), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True), \
+             patch("core.audit_bridge.mirror_to_audit_db", return_value=True):
+            return loop.reflect(self.QUERY, self.DRAFT, force=True)
+
+    def test_flag_off_default_caps_unchanged(self):
+        """Path #1 — flag OFF + default ctor → 4096 (critique) +
+        1024 (revise). Two separate defaults preserved."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "0"
+        cap = _ReflectCallCapture()
+        self._run(cap)
+        self.assertEqual(len(cap.calls), 2,
+            "Reflect should hit backend twice (critique + revise) "
+            "when critique returns a non-NO_ISSUES response.")
+        self.assertEqual(cap.calls[0]["max_tokens"], 4096,
+            "Default-off critique cap must stay at 4096.")
+        self.assertEqual(cap.calls[1]["max_tokens"], 1024,
+            "Default-off revise cap must stay at 1024.")
+
+    def test_flag_off_explicit_caps_honoured(self):
+        """Path #2 — explicit ints win regardless of flag state."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"  # flag on, but ints win
+        cap = _ReflectCallCapture()
+        self._run(cap, critique_max_tokens=600, revise_max_tokens=400)
+        self.assertEqual(cap.calls[0]["max_tokens"], 600)
+        self.assertEqual(cap.calls[1]["max_tokens"], 400)
+
+    def test_flag_on_light_query_shares_cap_across_stages(self):
+        """Path #3 — flag ON + default ctor + light query → both
+        sub-stages get CAP_LIGHT from a single assess() call."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _ReflectCallCapture()
+        self._run(cap)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "Light query → CAP_LIGHT on critique")
+        self.assertEqual(cap.calls[1]["max_tokens"], CAP_LIGHT,
+            "Light query → same CAP_LIGHT on revise (shared assess)")
+
+    def test_flag_on_heavy_query_uses_heavy(self):
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _ReflectCallCapture()
+        from core.reasoning.reflect import ReflectionLoop
+        heavy_q = "Compare these two products step by step"  # heavy markers
+        loop = ReflectionLoop()
+        with patch("core.reasoning.backends.get_backend", return_value=cap), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True), \
+             patch("core.audit_bridge.mirror_to_audit_db", return_value=True):
+            loop.reflect(heavy_q, self.DRAFT, force=True)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_HEAVY,
+            "Heavy marker in query → CAP_HEAVY on critique")
+        self.assertEqual(cap.calls[1]["max_tokens"], CAP_HEAVY,
+            "Heavy marker in query → CAP_HEAVY on revise too")
+
+    def test_flag_on_retry_fires_on_length(self):
+        """Path #4 — light query + critique truncates → retry once
+        at doubled cap (1200 → 2400). Revise still runs after retry."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        # call[0] = critique cap=1200, truncated → retry
+        # call[1] = critique retry cap=2400, stop
+        # call[2] = revise cap=1200, stop
+        cap = _ReflectCallCapture(done_reasons=["length", "stop", "stop"])
+        self._run(cap)
+        self.assertEqual(len(cap.calls), 3,
+            "Critique truncation should trigger one retry + still "
+            "run revise after.")
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "First critique call at CAP_LIGHT=1200.")
+        self.assertEqual(cap.calls[1]["max_tokens"], 2 * CAP_LIGHT,
+            "Critique retry at doubled cap=2400.")
+        self.assertEqual(cap.calls[2]["max_tokens"], CAP_LIGHT,
+            "Revise runs after critique retry at CAP_LIGHT.")
+
+    def test_flag_on_explicit_revise_independent_of_critique(self):
+        """Path #5 — independent caps: explicit revise stays fixed,
+        critique routes through assess."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _ReflectCallCapture()
+        self._run(cap, revise_max_tokens=512)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "Critique routes through assess (None + flag-on).")
+        self.assertEqual(cap.calls[1]["max_tokens"], 512,
+            "Explicit revise_max_tokens wins over assess.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Sibling of #7a (planner). `ReflectionLoop`'s critique + revise sub-stages held fixed caps (4096 + 1024) so neither D1 adaptive budgeting nor D6 retry could fire. This PR opens both wirings behind the shared `JAMES_ADAPTIVE_BUDGET` flag — planner / reflect now follow the same 3-way cap-resolution pattern that `query_rewriter` shipped in PR #461.

## What changes

- `ReflectionLoop.__init__` accepts `critique_max_tokens` / `revise_max_tokens` as `Optional[int]` (was `int`) + new `budget` param.
- **Per-call cap resolution**: when either field is `None` and `adaptive_budget_enabled()` returns `True`, a single `TaskBudget.assess("reflect", query)` result is **shared across both sub-stages**. Heavy marker → both at CAP_HEAVY; light → both at CAP_LIGHT.
- `assess` is fed the **user query**, not the wrapped CRITIQUE/REVISE_PROMPT templates which carry heavy markers ("분석" / "review") as instruction text. Same pattern as planner #7a.
- `_call` switches `backend.complete` → `complete_with_retry` with `stage="reflect"`. On `done_reason="length"` the helper retries once at doubled cap up to CAP_HEAVY.
- Router `budget_signal` carries the adaptive cap when D1 is active (and `None` when off).

## Default-OFF invariant

Without `JAMES_ADAPTIVE_BUDGET=1`, `ReflectionLoop()` with no critique/revise kwargs hits `cap=4096 (critique) + 1024 (revise)` — byte-identical to pre-#7b.

**Caps are independent**: explicit `critique_max_tokens` with default `revise` (None) under flag-on routes only the unspecified field through assess. Pinned in `test_flag_on_explicit_revise_independent_of_critique`.

## Verification

```
$ pytest tests/test_reflect_d1_wiring.py tests/test_reflection_loop.py
24 passed.
```

`tests/test_reflect_d1_wiring.py` (new, 6 tests):
- flag OFF + default ctor → 4096 / 1024
- explicit ints (regardless of flag) → honoured
- flag ON + light query → CAP_LIGHT on both sub-stages
- flag ON + heavy query → CAP_HEAVY on both sub-stages
- flag ON + critique length truncation → retry at doubled cap; revise still runs after
- flag ON + explicit revise + default critique → independent

## CLAUDE.md rule compliance

- **Rule #2** (`core/reasoning` bench): wiring-only with default-OFF byte-identical invariant.
- **Rule #5** (20 KB cap): `reflect.py` 14.4 KB → ~15.7 KB. Under cap.

## Out of scope

- **#7c**: `verify.py` D1 + retry wiring (generator + critic + fact-check, 3 sub-stages)
- `query_rewriter` local `_adaptive_budget_enabled()` → migrate to `budget.adaptive_budget_enabled()` (refactor follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)