### PR TITLE
feat(reasoning): v0.4 Sprint 3 #7c — verify D1 + retry wiring

### DIFF
--- a/core/reasoning/verify.py
+++ b/core/reasoning/verify.py
@@ -1,48 +1,28 @@
 """Verification engine — Cognitive Layer Phase 2 PR-6.
 
-ARCHITECTURE.md §5.7.1: "Verification Engine — generator → critic →
-fact_checker → security_validator → final_synthesizer". The
-generator (synth.py) and critic (reflect.py) already shipped in
-PR-5; this PR adds the **fact_checker** + **security_validator**
-passes that JAMES advertises as its security-aware reasoning
-differentiator (2026-05-14 user briefing).
+ARCHITECTURE.md §5.7.1 verifier stage. Two sub-passes:
 
-Two layers run in sequence:
-
-  1. **Security scan** — heuristic, fast (~5 ms). Reuses the existing
+  1. Security scan — heuristic, fast (~5 ms). Reuses
      INSTRUCTION_INJECTION_PATTERNS + SENSITIVE_PATTERNS from
-     core/security_layer.py so a single source of truth governs both
-     ingest-time blocking and post-synth verification. Flags injection
-     echo (a low-trust source's instruction leaked into the answer),
-     sensitive data leak (API key / password / 주민번호), and (with
-     role context) privilege over-share signals.
-  2. **Fact check** — optional, LLM-based (separate env gate
-     ``JAMES_ENABLE_FACT_CHECK=1``). Asks the backend whether each
-     claim in the answer is supported by the retrieved context;
-     parses a small JSON response. Skips silently on backend failure.
+     core/security_layer.py (single source of truth for ingest +
+     post-synth). Flags injection echo, sensitive-data leak (API key
+     / password / 주민번호), role-context privilege over-share.
+  2. Fact check — optional, LLM-based (JAMES_ENABLE_FACT_CHECK=1).
+     Asks the backend whether each claim is supported by context;
+     parses a small JSON response. Silent skip on failure.
 
-Recommendation:
+Recommendations: ``block`` (injection echo → safe refusal),
+``annotate`` (≥ 2 unsupported claims → verification note appended),
+``accept`` (default).
 
-  * ``"block"``    — security scan found injection echo (the highest
-                     severity signal). Answer is replaced with a safe
-                     refusal message; the caller still gets a string.
-  * ``"annotate"`` — fact-check found ≥ 2 unsupported claims. The
-                     original answer is preserved but appended with a
-                     short verification note.
-  * ``"accept"``   — everything passed (or only soft signals fired).
+Opt-in: JAMES_ENABLE_VERIFY=1. Fact-check doubly gated
+(JAMES_ENABLE_VERIFY + JAMES_ENABLE_FACT_CHECK) so the cheap
+heuristic can run without the LLM call.
 
-Posture: opt-in via JAMES_ENABLE_VERIFY=1. Fact-check is **doubly**
-gated (JAMES_ENABLE_VERIFY + JAMES_ENABLE_FACT_CHECK) so an operator
-can run cheap heuristic verification without the extra LLM call.
-
-CR-E integration (sustainability note): future work. When the
-verifier produces a write-recommending verdict (e.g., "answer reveals
-something that should update wiki entity X"), that write will route
-through ``core/change_request.py`` per CLAUDE.md rule #3. PR-6 itself
-doesn't produce any write-recommending verdicts — its verdicts only
-modify the answer string returned to the caller. The CR-E hook lands
-with Phase 2 PR-7/PR-8 when planner + tool router introduce
-verifier-triggered writes.
+CR-E hook: PR-6 verdicts don't write — they modify the answer
+string. Future planner / tool router will introduce
+verifier-triggered writes via core/change_request.py (CLAUDE.md
+rule #3) in Phase 2 PR-7 / PR-8.
 """
 from __future__ import annotations
 
@@ -54,6 +34,11 @@ import time
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from core.reasoning.budget import (
+    TaskBudget,
+    adaptive_budget_enabled,
+    complete_with_retry,
+)
 from core.reasoning.trace_schema import (
     TraceStep,
     compute_inputs_hash,
@@ -268,11 +253,16 @@ class Verifier:
         backend_id: str = DEFAULT_BACKEND_ID,
         *,
         fact_check_timeout: float = DEFAULT_FACT_CHECK_TIMEOUT_S,
-        fact_check_max_tokens: int = DEFAULT_FACT_CHECK_MAX_TOKENS,
+        fact_check_max_tokens: Optional[int] = None,
+        budget: Optional[TaskBudget] = None,
     ) -> None:
+        # D1 wiring (v0.4 Sprint 3 #7c, mirrors planner / reflect):
+        # fact_check_max_tokens None → JAMES_ADAPTIVE_BUDGET decides.
+        # Flag off → DEFAULT_FACT_CHECK_MAX_TOKENS (pre-#7c shape).
         self._backend_id = backend_id
         self._fact_check_timeout = fact_check_timeout
         self._fact_check_max_tokens = fact_check_max_tokens
+        self._budget = budget if budget is not None else TaskBudget()
 
     def verify(
         self,
@@ -355,13 +345,23 @@ class Verifier:
             context=context[:2000],
         )
 
+        # v0.4 Sprint 3 #7c — D1 cap resolution. assess on the query
+        # (not the FACT_CHECK_PROMPT template — that carries heavy
+        # markers in the instruction text).
+        if self._fact_check_max_tokens is not None:
+            cap = self._fact_check_max_tokens
+            _budget_for_router = None
+        elif adaptive_budget_enabled():
+            cap = self._budget.assess("verify", query)
+            _budget_for_router = cap
+        else:
+            cap = DEFAULT_FACT_CHECK_MAX_TOKENS
+            _budget_for_router = None
+
         # D5.C.2.d — flag-gated backend resolution. Verify is the
-        # grounding-critical stage: D5.C.1 policy rule 1 escalates it
-        # to `large` tier (preferred), then `medium`, then legacy.
-        # This is the stage where a small-tier-only fleet sees
-        # routing actually take effect — even with budget_signal=None
-        # the verify-stage escalation fires when a larger backend is
-        # registered (e.g. JAMES_ENABLE_CLAUDE_BACKEND=1).
+        # grounding-critical stage: D5.C.1 policy rule 1 escalates to
+        # large tier when registered. With D1 active (#7c) the
+        # budget_signal layers on rules 1 / 4.
         try:
             from core.reasoning.backends import get_backend
             from core.reasoning.router import emit_route_event, resolve_backend
@@ -369,7 +369,7 @@ class Verifier:
             backend_id = resolve_backend(
                 "verify",
                 prompt,
-                budget_signal=None,
+                budget_signal=_budget_for_router,
                 fallback_backend_id=self._backend_id,
             )
             backend = get_backend(backend_id)
@@ -380,16 +380,20 @@ class Verifier:
             "verify",
             prompt,
             backend_id,
-            budget_signal=None,
+            budget_signal=_budget_for_router,
             reason="grounding-critical",
         )
 
+        # D6 retry wiring — length truncation → retry once at doubled
+        # cap up to CAP_HEAVY. Flag-off no-op (cap already at 4096).
         t0 = time.time()
         try:
-            result = backend.complete(
+            result = complete_with_retry(
+                backend,
                 prompt,
-                max_tokens=self._fact_check_max_tokens,
+                cap=cap,
                 timeout=self._fact_check_timeout,
+                stage="verify",
             )
         except Exception as e:
             latency_ms = int((time.time() - t0) * 1000)

--- a/tests/test_verify_d1_wiring.py
+++ b/tests/test_verify_d1_wiring.py
@@ -1,0 +1,172 @@
+"""v0.4 Sprint 3 #7c — Verify D1 adaptive-budget + retry wiring.
+
+Closes the cognitive-stages D1 expansion that #7a (planner) and #7b
+(reflect) started. Verify is the grounding-critical stage —
+D5.C.1 policy rule 1 already escalates it to the large tier when a
+larger backend is registered (PR #481). This PR adds the D1 layer
+on top: when ``JAMES_ADAPTIVE_BUDGET=1`` the fact_check call routes
+through ``TaskBudget.assess("verify", query)`` and through
+``complete_with_retry`` so a light task hits CAP_LIGHT with a
+length-truncation retry path, instead of paying CAP_HEAVY upfront.
+
+The grounding-critical D5 routing decision and the D1 cap decision
+compose — both fire independently and feed the same router policy
++ retry helper that the other four stages now share.
+
+Contract pinned here
+  1. Flag OFF + default ctor → cap is 4096 (byte-identical).
+  2. Flag OFF + explicit ``fact_check_max_tokens=N`` → cap is N.
+  3. Flag ON + default ctor + light query → CAP_LIGHT.
+  4. Flag ON + heavy query → CAP_HEAVY.
+  5. Flag ON + length truncation → retry once at doubled cap.
+  6. Fact-check disabled (JAMES_ENABLE_FACT_CHECK off) → no backend
+     call at all — D1 surface stays cold (the cheaper heuristic
+     path stays cheap).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+from core.reasoning.budget import CAP_HEAVY, CAP_LIGHT  # noqa: E402
+
+
+class _VerifyCallCapture:
+    """Records every backend.complete call. Returns a fact-check
+    response shaped as JSON so the parser is happy. done_reasons
+    drives the complete_with_retry retry decision."""
+
+    JSON_OK = '{"unsupported": []}'
+
+    def __init__(self, *, done_reasons=None):
+        self.calls = []
+        self.done_reasons = list(done_reasons or [])
+
+    def complete(self, prompt, *, max_tokens, timeout, **opts):
+        idx = len(self.calls)
+        self.calls.append({
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "timeout": timeout,
+        })
+        dr = (
+            self.done_reasons[idx]
+            if idx < len(self.done_reasons)
+            else "stop"
+        )
+        return SimpleNamespace(
+            text=self.JSON_OK,
+            error="",
+            done_reason=dr,
+            latency_ms=10,
+            backend_id="ollama_local",
+        )
+
+
+class VerifyD1WiringTests(unittest.TestCase):
+
+    QUERY = "What is Palantir's primary business model"   # light query
+    ANSWER = "Palantir provides data integration software. " * 5
+    CONTEXT = "Palantir Technologies operates an AI / data platform. " * 8
+
+    def setUp(self):
+        self._orig_budget = os.environ.get("JAMES_ADAPTIVE_BUDGET")
+        self._orig_verify = os.environ.get("JAMES_ENABLE_VERIFY")
+        self._orig_fc = os.environ.get("JAMES_ENABLE_FACT_CHECK")
+        os.environ["JAMES_ENABLE_VERIFY"] = "1"
+        os.environ["JAMES_ENABLE_FACT_CHECK"] = "1"
+
+    def tearDown(self):
+        for key, val in (
+            ("JAMES_ADAPTIVE_BUDGET", self._orig_budget),
+            ("JAMES_ENABLE_VERIFY", self._orig_verify),
+            ("JAMES_ENABLE_FACT_CHECK", self._orig_fc),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def _run(self, capture, *, query=None, **ctor_kw):
+        from core.reasoning.verify import Verifier
+        verifier = Verifier(**ctor_kw)
+        q = query if query is not None else self.QUERY
+        with patch("core.reasoning.backends.get_backend", return_value=capture), \
+             patch("core.reasoning.router.resolve_backend",
+                   side_effect=lambda *_a, **kw: kw.get("fallback_backend_id", "ollama_local")), \
+             patch("core.reasoning.router.emit_route_event", return_value=None), \
+             patch("core.reasoning.trace_schema.emit_trace_step", return_value=True), \
+             patch("core.audit_bridge.mirror_to_audit_db", return_value=True):
+            return verifier.verify(q, self.ANSWER, self.CONTEXT, force=True)
+
+    def test_flag_off_default_cap_unchanged(self):
+        """Path #1 — flag off + default → 4096."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "0"
+        cap = _VerifyCallCapture()
+        self._run(cap)
+        self.assertEqual(len(cap.calls), 1,
+            "Verify should hit backend once (fact_check) when "
+            "JAMES_ENABLE_FACT_CHECK=1 and context is present.")
+        self.assertEqual(cap.calls[0]["max_tokens"], 4096,
+            "Default-off cap must stay at 4096 (byte-identical).")
+
+    def test_flag_off_explicit_cap_honoured(self):
+        """Path #2 — explicit int wins regardless of flag."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _VerifyCallCapture()
+        self._run(cap, fact_check_max_tokens=800)
+        self.assertEqual(cap.calls[0]["max_tokens"], 800)
+
+    def test_flag_on_light_query_uses_light(self):
+        """Path #3 — flag on + light query → CAP_LIGHT."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _VerifyCallCapture()
+        self._run(cap)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT,
+            "Light query (no heavy markers) → CAP_LIGHT=1200")
+
+    def test_flag_on_heavy_query_uses_heavy(self):
+        """Path #4 — heavy marker in query → CAP_HEAVY."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _VerifyCallCapture()
+        # "단계" is in _HEAVY_MARKERS.
+        heavy_q = "이 답변을 단계별로 검증해줘"
+        self._run(cap, query=heavy_q)
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_HEAVY)
+
+    def test_flag_on_retry_fires_on_length(self):
+        """Path #5 — first call truncates → retry once at doubled cap."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        cap = _VerifyCallCapture(done_reasons=["length", "stop"])
+        self._run(cap)
+        self.assertEqual(len(cap.calls), 2,
+            "Length truncation should trigger exactly one retry.")
+        self.assertEqual(cap.calls[0]["max_tokens"], CAP_LIGHT)
+        self.assertEqual(cap.calls[1]["max_tokens"], 2 * CAP_LIGHT,
+            "Retry should double the cap (1200 → 2400).")
+
+    def test_fact_check_disabled_skips_backend(self):
+        """Path #6 — without JAMES_ENABLE_FACT_CHECK no backend call
+        happens. D1 surface stays cold; the cheaper heuristic path
+        stays cheap."""
+        os.environ["JAMES_ADAPTIVE_BUDGET"] = "1"
+        os.environ.pop("JAMES_ENABLE_FACT_CHECK", None)
+        cap = _VerifyCallCapture()
+        self._run(cap)
+        self.assertEqual(len(cap.calls), 0,
+            "JAMES_ENABLE_FACT_CHECK off → no backend call. The "
+            "security-scan heuristic still runs; D1 wiring is "
+            "irrelevant on this path.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the cognitive-stages D1 expansion that #7a (planner) and #7b (reflect) started. Verify is the **grounding-critical** stage — D5.C.1 policy rule 1 already escalates it to the large tier when a larger backend is registered. This PR layers D1 on top: when `JAMES_ADAPTIVE_BUDGET=1` the fact_check call routes through `TaskBudget.assess("verify", query)` and `complete_with_retry`, so a light task hits CAP_LIGHT with a length-truncation retry path instead of paying CAP_HEAVY upfront.

The grounding-critical D5 routing decision and the D1 cap decision **compose** — both fire independently and feed the same router policy + retry helper that the other four reasoning stages now share. After #7c, **all 5 reasoning stages** (query_rewriter / synth / planner / reflect / verify) are on the same D1+D6 surface.

## What changes

- `Verifier.__init__` accepts `fact_check_max_tokens: Optional[int]` (was `int`) + new `budget: Optional[TaskBudget]` param.
- `_fact_check` resolves cap per call: explicit int wins, else `adaptive_budget_enabled()` + `TaskBudget.assess("verify", query)`, else `DEFAULT_FACT_CHECK_MAX_TOKENS=4096`.
- assess fed the **user query** (not the wrapped `FACT_CHECK_PROMPT_*` template — same pattern as planner / reflect).
- `backend.complete` → `complete_with_retry` with `stage="verify"`.

## Default-OFF invariant

Without `JAMES_ADAPTIVE_BUDGET=1`, `Verifier()` with no `fact_check_max_tokens` argument hits `cap=4096` — byte-identical to pre-#7c.

## Verification

```
$ pytest tests/test_verify_d1_wiring.py
6 passed.
```

6 new tests pin:
- flag OFF + default → 4096
- flag OFF + explicit → honoured
- flag ON + light → CAP_LIGHT
- flag ON + heavy → CAP_HEAVY
- flag ON + length truncation → retry at doubled cap
- `JAMES_ENABLE_FACT_CHECK` off → no backend call (D1 cold)

## Pre-existing failure noted

`tests/test_verifier.py::FactCheckTests::test_two_unsupported_claims_triggers_annotate` fails on main (verified via `git stash` — failure persists with unchanged code). Root cause is PR #495 (Sprint 1 #2 unified language detection): the test's `ANSWER_KO` has more English-alpha chars than Korean chars, so the dominant-script heuristic now classifies it as English while the test expects Korean formatting. Unrelated to this PR — addressed in a small follow-up.

## CLAUDE.md rule compliance

- **Rule #2** (`core/reasoning` bench): wiring-only with default-OFF byte-identical invariant.
- **Rule #5** (20 KB cap): `verify.py` 18.9 KB → 19.2 KB. Under cap.
  - During development this PR briefly exceeded the cap (21.4 KB). Docstrings trimmed in the same commit to stay under. `verify.py` is approaching the split threshold; future additions should extract `_verify_security` / `_verify_fact_check` modules first.

## Sprint 3 Task #7 closed

Planner (#7a) + Reflect (#7b) + Verify (#7c) all D1+D6 wired. The 5-stage D1 surface is now uniform.

## Out of scope

- `test_verifier.py` KO/EN format pre-existing failure (small follow-up PR)
- `query_rewriter` local `_adaptive_budget_enabled()` → migrate to `budget.adaptive_budget_enabled()` (refactor follow-up)
- `verify.py` module split (19.2 KB after this PR; future additions must split first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)