### PR TITLE
test(verifier): v0.4 Sprint 3 follow-up — rebalance ANSWER_KO under dominant-script i18n

### DIFF
--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -72,9 +72,22 @@ def _completion(text="", error=""):
 
 
 # Long-enough answer so the < 30-char gate doesn't trip.
+#
+# v0.4 Sprint 3 follow-up — rebalanced to be Korean-dominant by
+# character count. PR #495 (Sprint 1 #2) replaced the per-stage
+# `_is_korean(≥ 20%)` heuristic with `core.i18n.is_korean()`
+# (dominant-script comparison). The old fixture mixed enough
+# English alphabet ("Retrieval-Augmented Generation" / "LLM") that
+# the new heuristic classified it as English, flipping the
+# verifier's `_format` to the EN branch and breaking
+# `test_two_unsupported_claims_triggers_annotate`'s "검증:"
+# assertion. The shape stays "long-enough Korean answer about a
+# retrieval system" — the only change is dropping the inlined
+# English phrase that tipped the script ratio.
 ANSWER_KO = (
-    "RAG는 Retrieval-Augmented Generation 의 약자로, 외부 지식을 "
-    "검색해 LLM 응답에 결합하는 기법입니다."
+    "RAG(검색-증강 생성)는 외부 지식 자료를 빠르게 찾아서 언어 "
+    "모델 답변에 결합하는 방식입니다. 환각을 줄이고 출처를 "
+    "보존하는 효과가 있습니다."
 )
 ANSWER_EN = (
     "RAG stands for Retrieval-Augmented Generation, a technique that "


### PR DESCRIPTION
## Summary

Pre-existing failure surfaced during the v0.4 Sprint 3 #7c verifier D1 wiring PR (#505): `tests/test_verifier.py::FactCheckTests::test_two_unsupported_claims_triggers_annotate` asserted `"검증:"` appeared in the verifier's annotate output, but the fixture `ANSWER_KO` had ~24 Hangul characters and ~34 English alphabetic characters — **English dominant**.

The mismatch wasn't visible until PR #495 (Sprint 1 #2 unified language detection) replaced the per-stage 20%-Korean-threshold heuristic with `core.i18n.is_korean`'s **dominant-script comparison**. Under the new rule the fixture classified as English, the verifier's `_format` took the EN branch, and the assertion broke. The failure persisted on main HEAD `988fdf2` with no code change — the i18n contract had drifted under a long-stable test fixture.

## Fix

Keep the fixture's shape ("long-enough Korean answer about a retrieval system") but drop the inlined English phrase ("Retrieval-Augmented Generation" / "LLM") that tipped the script ratio. New `ANSWER_KO` is ~50 Hangul chars + 3 ASCII chars (`RAG`), comfortably Korean-dominant.

## Verification

```
$ pytest tests/test_verifier.py
22 passed.
```

No production-code change — test fixture only. Other tests that do round-trip equality (`result.final_answer == ANSWER_KO`) continue to pass: they compare the same string in / out, so the fixture rewrite is transparent.

CLAUDE.md rule compliance: `tests/` touch only.

## Out of scope (remaining Sprint 3 follow-ups)

- `query_rewriter` local `_adaptive_budget_enabled()` → migrate to `budget.adaptive_budget_enabled()` (refactor)
- `verify.py` module split (19.2 KB, approaching 20 KB cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)