### PR TITLE
refactor(retrieval): v0.4 Sprint 3 follow-up — migrate query_rewriter to budget.adaptive_budget_enabled

### DIFF
--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -42,7 +42,7 @@ from typing import Optional, Tuple
 # so a stock install (env unset) gets "ollama_local" — byte-identical
 # to v0.3.0 behavior. Operators flipping the env restart the server.
 from core.reasoning.backends import get_default_backend_id as _get_default_backend
-from core.reasoning.budget import TaskBudget
+from core.reasoning.budget import TaskBudget, adaptive_budget_enabled
 
 DEFAULT_BACKEND_ID = _get_default_backend()
 DEFAULT_TIMEOUT_S = 10.0
@@ -55,22 +55,13 @@ DEFAULT_TIMEOUT_S = 10.0
 DEFAULT_MAX_TOKENS = 4096
 
 
-def _adaptive_budget_enabled() -> bool:
-    """Env-flag gate for D1.B wiring.
-
-    Default OFF — `JAMES_ADAPTIVE_BUDGET=1` (or `true` / `yes` / `on`)
-    activates the TaskBudget routing. Until then, `QueryRewriter()`
-    behaves byte-identically to pre-D1.B (`max_tokens=DEFAULT_MAX_TOKENS`).
-
-    The experiment driver toggles this per-condition to measure baseline
-    (legacy 4096) vs treatment (dynamic) on the same fixture.
-    """
-    return os.getenv("JAMES_ADAPTIVE_BUDGET", "0").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+# v0.4 Sprint 3 follow-up — local `_adaptive_budget_enabled` migrated to
+# `core.reasoning.budget.adaptive_budget_enabled` so the 5 reasoning
+# stages (query_rewriter / synth / planner / reflect / verify) all read
+# from one source of truth. The alias below preserves any external
+# imports of the underscored name (none observed in the repo, but the
+# helper has shipped since PR #461 so 3rd-party code could reference it).
+_adaptive_budget_enabled = adaptive_budget_enabled
 
 
 def _classify_budget_reason(cap: int) -> str:
@@ -278,7 +269,7 @@ class QueryRewriter:
         if self._max_tokens is not None:
             cap = self._max_tokens
             _budget_for_router = None
-        elif _adaptive_budget_enabled():
+        elif adaptive_budget_enabled():
             cap = self._budget.assess("query_rewriter", query)
             _trace_budget(stage="query_rewriter", cap=cap, query=query)
             # D5.C.2 — only when D1 dynamic budget is active do we feed


### PR DESCRIPTION
## Summary

When Sprint 3 #7a (planner) extracted `adaptive_budget_enabled()` into `core/reasoning/budget.py` as the **single source of truth** for the D1 opt-in flag, `query_rewriter` kept its local `_adaptive_budget_enabled()` copy. The two implementations were byte-identical (same env name, same truthy-value list), but maintaining two copies invites drift — if a future PR changes the flag semantics, one site would update and the other wouldn't.

## Changes

- Import `adaptive_budget_enabled` from `core.reasoning.budget`.
- Replace the local `_adaptive_budget_enabled()` definition with a module-level alias `_adaptive_budget_enabled = adaptive_budget_enabled` so any external code still importing the underscored name keeps working (none observed in the repo, but the helper has shipped since PR #461).
- Replace the call site at `query_rewriter.rewrite()` to use the canonical name.

After this PR, **all 5 reasoning stages** (query_rewriter / synth / planner / reflect / verify) read the D1 flag through one function.

## Verification

```
$ pytest tests/test_query_rewriter_router_wiring.py \
         tests/test_planner_d1_wiring.py \
         tests/test_reflect_d1_wiring.py \
         tests/test_verify_d1_wiring.py
31 passed.
```

## CLAUDE.md rule compliance

- **Rule #2** (`core/retrieval` bench): logic-equivalent refactor — no behavioural change. STEP 7 sweep unaffected.
- **Rule #5** (20 KB cap): `query_rewriter.py` 18.7 KB → ~18.4 KB. Under cap.

## Out of scope (remaining Sprint 3 follow-up)

- `verify.py` module split (19.2 KB, approaching 20 KB cap; extract `_verify_security` / `_verify_fact_check` when next addition is needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)