### PR TITLE
feat(retrieval): v0.4 Sprint 4 BL-9 prep — embedding model abstraction (per-model paths)

### DIFF
--- a/config.py
+++ b/config.py
@@ -183,6 +183,46 @@ except ValueError:
 # ────────────────────────────────────────────────────────────────
 CHROMA_COLLECTION = "james_prototype"
 
+
+# ────────────────────────────────────────────────────────────────
+#  Embedding model — v0.4 Sprint 4 BL-9 prep
+# ────────────────────────────────────────────────────────────────
+#  Default stays at paraphrase-multilingual-MiniLM-L12-v2 so any
+#  operator pulling alpha.2 sees zero behaviour change. Setting
+#  JAMES_EMBEDDING_MODEL flips the default for the next ingestion +
+#  swaps `chroma_db` to a per-model directory + downloads the new
+#  model on first run.
+#
+#  Candidates the Sprint 4 swap PR will measure:
+#    BAAI/bge-m3                       — 24 layers, 1024 dim
+#    intfloat/multilingual-e5-large    — 24 layers, 1024 dim
+#
+#  The MiniLM default is a 384-dim 12-layer model. Switching to a
+#  1024-dim model means the existing chroma collection is unusable
+#  (cosine search requires matching dimensions), so the resolver in
+#  core/vector_store.py picks a per-model chroma directory
+#  (`chroma_db_<short>` instead of plain `chroma_db`). The default
+#  path remains `chroma_db` when the env is unset or matches the
+#  legacy MiniLM tag — backward-compat invariant.
+EMBEDDING_MODEL = os.environ.get(
+    "JAMES_EMBEDDING_MODEL",
+    "paraphrase-multilingual-MiniLM-L12-v2",
+)
+
+
+def _embedding_short_name(model_id: str) -> str:
+    """Filesystem-safe short slug for a HF embedding model id.
+
+    Used to derive `models/<short>` (cached weights) and
+    `chroma_db_<short>` (per-model vector DB) without conflicting
+    with the legacy `models/miniLM` + `chroma_db` paths the v0.3.x
+    cycle has been writing to.
+    """
+    return (model_id.split("/")[-1]
+                    .replace("-", "_")
+                    .replace(".", "_")
+                    .lower())
+
 # ────────────────────────────────────────────────────────────────
 #  API Key — required for production, falls back for dev
 # ────────────────────────────────────────────────────────────────

--- a/core/vector_store.py
+++ b/core/vector_store.py
@@ -12,25 +12,65 @@ import chromadb
 from sentence_transformers import SentenceTransformer
 import uuid
 import os
-from config import CHROMA_DIR, CHROMA_COLLECTION, BASE_DIR
+from config import (
+    BASE_DIR,
+    CHROMA_COLLECTION,
+    CHROMA_DIR,
+    EMBEDDING_MODEL,
+    _embedding_short_name,
+)
 
 # ✅ 싱글톤 모델 캐싱 (초기화 10초 → 최초 1회만)
 _MODEL_CACHE: dict = {}
 
-# 로컬 모델 경로 (없으면 HuggingFace에서 자동 다운로드)
-# BASE_DIR 기준 자동 감지 — 폴더 이동/이름 변경에 안전
-LOCAL_MODEL_PATH = os.environ.get(
-    "JAMES_MODEL_PATH",
-    os.path.join(BASE_DIR, "models", "miniLM")
-)
-FALLBACK_MODEL   = "paraphrase-multilingual-MiniLM-L12-v2"
+# v0.4 Sprint 4 BL-9 prep — derive local-cache path + chroma directory
+# from the configured embedding model. The legacy MiniLM tag stays
+# mapped to the preexisting `models/miniLM` + `chroma_db` paths so any
+# operator who hasn't set `JAMES_EMBEDDING_MODEL` sees zero file-layout
+# change. New models get isolated `models/<short>` + `chroma_db_<short>`
+# directories.
+_LEGACY_MINILM_TAG = "paraphrase-multilingual-MiniLM-L12-v2"
+
+if EMBEDDING_MODEL == _LEGACY_MINILM_TAG:
+    _DEFAULT_MODEL_DIR = os.path.join(BASE_DIR, "models", "miniLM")
+else:
+    _DEFAULT_MODEL_DIR = os.path.join(
+        BASE_DIR, "models", _embedding_short_name(EMBEDDING_MODEL),
+    )
+
+LOCAL_MODEL_PATH = os.environ.get("JAMES_MODEL_PATH", _DEFAULT_MODEL_DIR)
+FALLBACK_MODEL   = EMBEDDING_MODEL
+
+
+def _chroma_dir_for_model(base_chroma_dir: str) -> str:
+    """Per-model chroma directory resolver.
+
+    Returns ``base_chroma_dir`` unchanged when the legacy MiniLM tag
+    is configured (so existing operators keep reading from the
+    preexisting `chroma_db/`). For any other embedding model, returns
+    ``f"{base}_{short}"`` so a swap doesn't clobber the legacy
+    embeddings (cosine search requires matching dimensions; mixing
+    384-dim MiniLM and 1024-dim bge-m3 in one collection would
+    silently corrupt results).
+    """
+    if EMBEDDING_MODEL == _LEGACY_MINILM_TAG:
+        return base_chroma_dir
+    suffix = _embedding_short_name(EMBEDDING_MODEL)
+    return f"{base_chroma_dir}_{suffix}"
 
 
 class VectorStore:
     def __init__(self, base_dir=None):
-        self.db_path = os.path.join(base_dir, "chroma_db") if base_dir else CHROMA_DIR
+        # v0.4 Sprint 4 BL-9 prep — db_path resolution routes through
+        # `_chroma_dir_for_model`. Legacy MiniLM tag → unchanged
+        # `chroma_db/` (or `<base_dir>/chroma_db`). New models →
+        # per-model `chroma_db_<short>/`.
+        legacy_base = os.path.join(base_dir, "chroma_db") if base_dir else CHROMA_DIR
+        self.db_path = _chroma_dir_for_model(legacy_base)
         os.makedirs(self.db_path, exist_ok=True)
         print(f"[VECTOR_STORE] ChromaDB 경로: {self.db_path}")
+        if EMBEDDING_MODEL != _LEGACY_MINILM_TAG:
+            print(f"[VECTOR_STORE] 임베딩 모델: {EMBEDDING_MODEL} (per-model chroma dir)")
 
         self.client = chromadb.PersistentClient(path=self.db_path)
         self.collection = self.client.get_or_create_collection(

--- a/tests/test_embedding_model_abstraction.py
+++ b/tests/test_embedding_model_abstraction.py
@@ -1,0 +1,189 @@
+"""v0.4 Sprint 4 BL-9 prep — embedding model abstraction contract.
+
+Pins the **default-off byte-identical invariant** + the swap path
+for the upcoming MiniLM → bge-m3 / multilingual-e5-large swap.
+The actual swap + measurement lands in a follow-up PR; this prep
+shipping the abstraction means the swap PR can flip a single env
+var without touching call sites.
+
+Three guarantees pinned here:
+
+  1. With ``JAMES_EMBEDDING_MODEL`` unset, every file path the
+     vector store touches matches pre-#BL-9-prep: ``models/miniLM``
+     for the local cache, ``chroma_db`` for the persistent DB. An
+     operator who has never set the env variable sees zero filesystem
+     change after this PR lands.
+
+  2. With ``JAMES_EMBEDDING_MODEL`` set to a non-legacy tag (e.g.
+     ``BAAI/bge-m3``), both paths split: ``models/<short>`` for the
+     cache, ``chroma_db_<short>`` for the persistent DB. The legacy
+     ``chroma_db/`` keeps its MiniLM embeddings intact and can be
+     reloaded by clearing the env — so the prep is fully reversible.
+
+  3. ``_embedding_short_name`` produces filesystem-safe slugs for
+     every HuggingFace-style model id we plan to measure
+     (BAAI/bge-m3, intfloat/multilingual-e5-large, plus the legacy
+     paraphrase tag). The slug is stable across processes.
+
+The test patches the env BEFORE re-importing ``core.vector_store``
+because the module reads ``EMBEDDING_MODEL`` from ``config`` at
+import time. Module-level re-import is the only way to exercise
+the "env set when the module first loads" code path.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+_LEGACY_TAG = "paraphrase-multilingual-MiniLM-L12-v2"
+
+
+def _reload_with_env(env_value):
+    """Set/clear JAMES_EMBEDDING_MODEL and reload config + vector_store.
+
+    Returns the freshly-reloaded ``core.vector_store`` module so the
+    test can read its module-level constants (LOCAL_MODEL_PATH,
+    FALLBACK_MODEL, _chroma_dir_for_model). The test driver should
+    restore the original env in tearDown."""
+    if env_value is None:
+        os.environ.pop("JAMES_EMBEDDING_MODEL", None)
+    else:
+        os.environ["JAMES_EMBEDDING_MODEL"] = env_value
+    import config
+    importlib.reload(config)
+    # vector_store imports from config at module load, so re-import too.
+    if "core.vector_store" in sys.modules:
+        importlib.reload(sys.modules["core.vector_store"])
+    import core.vector_store as vs
+    return vs, config
+
+
+class EmbeddingShortNameTests(unittest.TestCase):
+    """The slug helper is the foundation of both path resolutions —
+    pin it on the exact ids the Sprint 4 swap PR will measure."""
+
+    def test_minilm_tag_slug(self):
+        from config import _embedding_short_name
+        # Note: the swap-PR resolver short-circuits the legacy tag to
+        # `models/miniLM` so the slug below is mostly relevant for
+        # *other* tags. Still pin it to catch a regex regression.
+        slug = _embedding_short_name(_LEGACY_TAG)
+        self.assertEqual(slug, "paraphrase_multilingual_minilm_l12_v2",
+            "MiniLM slug must be filesystem-safe lowercase with - → _")
+
+    def test_bge_m3_slug(self):
+        from config import _embedding_short_name
+        self.assertEqual(_embedding_short_name("BAAI/bge-m3"), "bge_m3",
+            "HF org prefix stripped + dashes underscored")
+
+    def test_multilingual_e5_large_slug(self):
+        from config import _embedding_short_name
+        self.assertEqual(
+            _embedding_short_name("intfloat/multilingual-e5-large"),
+            "multilingual_e5_large",
+        )
+
+
+class DefaultOffBackwardCompatTests(unittest.TestCase):
+    """Without the env var, paths must match pre-BL-9-prep."""
+
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_EMBEDDING_MODEL")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_EMBEDDING_MODEL", None)
+        else:
+            os.environ["JAMES_EMBEDDING_MODEL"] = self._orig
+        # Reset import state so other test files re-import a fresh module.
+        if "core.vector_store" in sys.modules:
+            importlib.reload(sys.modules["core.vector_store"])
+        import config
+        importlib.reload(config)
+
+    def test_unset_env_resolves_legacy_minilm_paths(self):
+        vs, cfg = _reload_with_env(None)
+        # Default model id matches the legacy tag.
+        self.assertEqual(cfg.EMBEDDING_MODEL, _LEGACY_TAG)
+        # Local cache path ends in ".../models/miniLM" (the directory
+        # the v0.3.x cycle has been writing to).
+        self.assertTrue(
+            vs.LOCAL_MODEL_PATH.replace("\\", "/").endswith("models/miniLM"),
+            f"Default LOCAL_MODEL_PATH ({vs.LOCAL_MODEL_PATH!r}) "
+            "must keep the legacy 'models/miniLM' suffix so existing "
+            "operators don't trigger a HuggingFace re-download.",
+        )
+
+    def test_unset_env_chroma_dir_unchanged(self):
+        vs, cfg = _reload_with_env(None)
+        # Simulate a VectorStore constructor with base_dir provided.
+        legacy = "C:/some/base/chroma_db"
+        resolved = vs._chroma_dir_for_model(legacy)
+        self.assertEqual(resolved, legacy,
+            "Default-off invariant: chroma_dir resolver returns the "
+            "input path unchanged when the legacy MiniLM tag is "
+            "configured — operator's existing chroma_db/ stays "
+            "authoritative.")
+
+
+class SwapPathTests(unittest.TestCase):
+    """With the env var set to a non-legacy tag, paths must split."""
+
+    def setUp(self):
+        self._orig = os.environ.get("JAMES_EMBEDDING_MODEL")
+
+    def tearDown(self):
+        if self._orig is None:
+            os.environ.pop("JAMES_EMBEDDING_MODEL", None)
+        else:
+            os.environ["JAMES_EMBEDDING_MODEL"] = self._orig
+        if "core.vector_store" in sys.modules:
+            importlib.reload(sys.modules["core.vector_store"])
+        import config
+        importlib.reload(config)
+
+    def test_bge_m3_uses_per_model_paths(self):
+        vs, cfg = _reload_with_env("BAAI/bge-m3")
+        self.assertEqual(cfg.EMBEDDING_MODEL, "BAAI/bge-m3")
+        self.assertTrue(
+            vs.LOCAL_MODEL_PATH.replace("\\", "/").endswith("models/bge_m3"),
+            f"BAAI/bge-m3 → LOCAL_MODEL_PATH should end in "
+            f"'models/bge_m3'; got {vs.LOCAL_MODEL_PATH!r}.",
+        )
+
+    def test_bge_m3_chroma_dir_is_per_model(self):
+        vs, cfg = _reload_with_env("BAAI/bge-m3")
+        legacy = "C:/some/base/chroma_db"
+        resolved = vs._chroma_dir_for_model(legacy)
+        self.assertEqual(resolved, "C:/some/base/chroma_db_bge_m3",
+            "BAAI/bge-m3 must use a sibling chroma_db_bge_m3/ "
+            "directory so the legacy MiniLM 384-dim embeddings in "
+            "chroma_db/ aren't clobbered.")
+
+    def test_e5_large_chroma_dir_isolation(self):
+        vs, cfg = _reload_with_env("intfloat/multilingual-e5-large")
+        legacy = "/tmp/chroma_db"
+        self.assertEqual(
+            vs._chroma_dir_for_model(legacy),
+            "/tmp/chroma_db_multilingual_e5_large",
+        )
+
+    def test_fallback_model_follows_env(self):
+        vs, cfg = _reload_with_env("BAAI/bge-m3")
+        self.assertEqual(vs.FALLBACK_MODEL, "BAAI/bge-m3",
+            "FALLBACK_MODEL is what _load_model passes to "
+            "SentenceTransformer when the local cache miss. It must "
+            "follow the env so the right model downloads.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Prep PR for the upcoming MiniLM → bge-m3 / multilingual-e5-large swap. The swap PR will flip a single env var; this PR ships the abstraction underneath so call sites don't change.

## Background

v0.3.x uses `paraphrase-multilingual-MiniLM-L12-v2` (12 layers, 384 dim). Cross-lingual retrieval diagnostic (`feedback_rag_cross_lingual_diagnostic`, BL-9) identified a 24-layer 1024-dim multilingual model (`bge-m3` or `multilingual-e5-large`) should lift grounded=true rate on Korean queries with English entity names. The swap requires re-embedding every chroma chunk (cosine search requires matching dimensions).

## What changes

- **`config.py`** → new `EMBEDDING_MODEL` constant (defaults to legacy MiniLM tag when `JAMES_EMBEDDING_MODEL` is unset) + helper `_embedding_short_name(model_id)` for filesystem-safe slugs.
- **`core/vector_store.py`**:
  - `LOCAL_MODEL_PATH` defaults to `models/miniLM` for the legacy tag (backward-compat with the v0.3.x cache directory) and `models/<short>` otherwise.
  - `FALLBACK_MODEL` follows `EMBEDDING_MODEL` so the right model downloads on cache miss.
  - New helper `_chroma_dir_for_model(base)` returns `base` unchanged for legacy tag, `f"{base}_{short}"` otherwise. `VectorStore.__init__` routes through it.
- **`tests/test_embedding_model_abstraction.py`** (new, 9 tests).

## Default-OFF invariant

An operator with no `JAMES_EMBEDDING_MODEL` set sees the **same file paths** the v0.3.x cycle has been writing to — no HuggingFace re-download, no chroma re-embed. **Reversible**: clearing the env restores the legacy paths.

## Verification

```
$ pytest tests/test_embedding_model_abstraction.py \
         tests/test_event_ingest_emit.py \
         tests/test_phase_b_ingestion_sources.py \
         tests/test_phase_c_cascade.py \
         tests/test_phase_d_modify_cascade.py \
         tests/test_attributes_summary_cleanup.py
71 passed.
```

## CLAUDE.md rule compliance

- **Rule #2** (`core/{retrieval,graph,reasoning}` bench): `vector_store.py` sits under `core/` but outside the three bench-required prefixes. Default-off invariant means STEP 7 numbers are unchanged for operators who don't set the env. **Flag-on measurement is the swap PR's job** (re-embed + STEP 7 + tier rationale in `reports/promo-assets/v0.4-embedding-swap-result.md`).
- **Rule #5** (20 KB cap): `vector_store.py` 9.1 KB → 10.2 KB; `config.py` 16.4 KB → 16.8 KB. Both under cap.

## Out of scope (Sprint 4 swap PR follow-up)

- Default flip `JAMES_EMBEDDING_MODEL` → `bge-m3` or `e5-large`
- Re-embed migration runner (existing chroma_db → new collection)
- STEP 7 measurement + tier rationale + result doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)