### PR TITLE
feat(reasoning): evidence-scope extractor + flag (LEO L.A)

### DIFF
--- a/core/reasoning/evidence_scope.py
+++ b/core/reasoning/evidence_scope.py
@@ -1,0 +1,280 @@
+"""Evidence-Scope extractor (LEO proposal — L.A skeleton).
+
+LEO (Younghu) 가 design memo
+(`docs/handovers/v0.4-leo-evidence-scope-routing-track.md`, PR #512) 에서
+제안한 *measured input-side* routing axis 의 추출기. 추론 루프가 이미
+산출한 `loop_state` (`docs`, `graph_context`, `graph_paths`) 만 읽어
+`evidence_scope ∈ [0, 1]` 스칼라 + 4-component breakdown 을 만든다.
+
+LLM 호출 0개. 추가 검색 0개. I/O 0개. 외부 의존 0개. 순수 함수.
+
+Phase plan (mirrors D5 lettering):
+  • L.0  design memo (PR #512) — landed
+  • L.A  **this PR** — extractor + JAMES_SCOPE_ROUTING flag + tests.
+         flag default OFF. flag ON/OFF 모두 byte-identical to pre-L.A
+         main *because no call site invokes this module yet* — L.C
+         배선 전까지 module 은 constructible but 무의미.
+  • L.B  D5 `router.select_backend(..., evidence_scope=...)` 인자 추가
+  • L.C  `core/reasoning/pipeline.py` Loop 1 종료 직후 측정 + 합성
+         backend 재선택 + `reason:route` audit payload 확장
+  • L.D  closure — result doc + ROADMAP entry + memory sync
+
+Default-off invariant: ``JAMES_SCOPE_ROUTING`` unset/0 → behavior
+identical to pre-L.A main. Mirrors D1's ``JAMES_ADAPTIVE_BUDGET``
+(`core.reasoning.budget.adaptive_budget_enabled`) and D5's
+``JAMES_AUTO_ROUTER`` (`core.reasoning.router._auto_router_enabled`)
+patterns — opt-in routing, never silent escalation.
+
+Mode-gate (LEO open Q #3): `engine._query_impl` dispatches `chat` /
+`meta` / `wiki_edit` / `self_evolve` / `coding` modes to `handle_*`
+helpers *before* `run_retrieval_pipeline` runs, so evidence_scope only
+ever sees the `retrieval` mode call path. No mode gate needed at the
+extractor — empty inputs naturally yield scope=0.0 as a safety net.
+
+Vocab anchor — Robin Converse's 2026-05-24 LinkedIn endorsement of
+*"parameter count buys reasoning routing precision, not just capacity"*
+named the line; D1 budget realized it on the task-weight axis; this
+module realizes it on the evidence-scope axis. LEO's contribution is
+the *measured* signal complementing the *predicted* one — see the
+design memo §"Relationship to D5 (not a fork)" for the framing.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Dict, Final, Optional, Sequence
+
+# ─── Flag ──────────────────────────────────────────────────────────
+
+_FLAG_ON_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+
+def scope_routing_enabled() -> bool:
+    """Env-flag gate. Default OFF.
+
+    `JAMES_SCOPE_ROUTING=1` (or `true` / `yes` / `on`) activates the
+    scope-based routing path *once L.C lands the call-site wiring*.
+    Until then, this flag has no behavioral effect — the extractor is
+    constructible but no production call site invokes it.
+
+    Mirrors `core.reasoning.router._auto_router_enabled` and
+    `core.reasoning.budget.adaptive_budget_enabled`.
+    """
+    return os.getenv("JAMES_SCOPE_ROUTING", "0").strip().lower() in _FLAG_ON_VALUES
+
+
+# ─── Constants (mirrored from elsewhere in the codebase) ───────────
+#
+# Both are intentionally duplicated rather than imported to keep this
+# module dependency-free at the call sites that L.C will add. A
+# consolidation refactor (single source of truth) is out of scope for
+# L.A and would touch `pipeline.py` + `graph_engine.py` simultaneously.
+
+# ChromaDB relevance gate — mirrors `pipeline.py:RELEVANCE_GATE` (local
+# constant inside `run_retrieval_pipeline`). Docs scoring below this
+# are treated as "ChromaDB returned them but they aren't real evidence".
+_RELEVANCE_THRESHOLD: Final[float] = 0.45
+
+# Graph DFS depth ceiling — mirrors `core/graph_engine.py:MAX_DEPTH`.
+# Used to normalize observed depth into [0, 1].
+_GRAPH_MAX_DEPTH: Final[int] = 4
+
+# Heuristic "wide" reference points for normalizing unbounded counts
+# into [0, 1]. Tuned against STEP 7 priors; L.D bench may revisit.
+_GRAPH_FANOUT_REFERENCE: Final[float] = 12.0
+_GRAPH_PATHS_REFERENCE: Final[float] = 8.0
+
+# Component weights (heuristic v1). All four kept as module constants
+# so L.D STEP 7 tuning or Direction 2 regression output can swap them
+# in one place without changing the API.
+#
+# Rationale (per design memo §"What 'evidence scope' is made of"):
+#   _W_EFFECTIVE_K   0.35 — "how many books did we open" is the most
+#                            direct measurement of evidence breadth
+#   _W_GRAPH_REACH   0.25 — multi-hop traversal = synthesis difficulty
+#   _W_DOC_SPREAD    0.20 — distinct sources = composition burden
+#   _W_SCORE_ENTROPY 0.20 — flat distribution = no single chunk answers
+_W_EFFECTIVE_K: Final[float] = 0.35
+_W_GRAPH_REACH: Final[float] = 0.25
+_W_DOC_SPREAD: Final[float] = 0.20
+_W_SCORE_ENTROPY: Final[float] = 0.20
+
+
+# ─── Public dataclass ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ScopeBreakdown:
+    """Audit-friendly decomposition of `evidence_scope`.
+
+    All five fields are in [0, 1]. `scope` is the weighted combination
+    of the four components, clamped to [0, 1] to defend against future
+    weight changes that don't sum to exactly 1.
+    """
+
+    effective_k: float
+    score_entropy: float
+    graph_reach: float
+    doc_spread: float
+    scope: float
+
+    def as_audit_payload(self) -> Dict[str, float]:
+        """Compact dict for the L.C `reason:route` audit row.
+
+        Schema (5 keys, all rounded to 4 decimals):
+          evidence_scope, effective_k, score_entropy, graph_reach,
+          doc_spread.
+        """
+        return {
+            "evidence_scope": round(self.scope, 4),
+            "effective_k": round(self.effective_k, 4),
+            "score_entropy": round(self.score_entropy, 4),
+            "graph_reach": round(self.graph_reach, 4),
+            "doc_spread": round(self.doc_spread, 4),
+        }
+
+
+# ─── Component extractors (private; tested via compute_scope) ──────
+
+
+def _effective_k(docs: Sequence[Dict], top_k: int) -> float:
+    """Docs with score ≥ relevance threshold, normalized to [0, 1].
+
+    0 docs over threshold → 0.0 (narrow / no real evidence).
+    `top_k` docs over threshold → 1.0 (wide).
+    """
+    if not docs or top_k <= 0:
+        return 0.0
+    above = sum(
+        1 for d in docs if float(d.get("score", 0.0)) >= _RELEVANCE_THRESHOLD
+    )
+    return min(1.0, above / float(top_k))
+
+
+def _score_entropy(docs: Sequence[Dict]) -> float:
+    """Normalized Shannon entropy of doc score distribution.
+
+    Single sharp peak (one doc dominates) → 0.0 (narrow — one chunk has
+    the answer). Flat distribution (many similar scores) → ~1.0 (wide —
+    evidence is scattered across documents).
+
+    Empty / single doc → 0.0 (no distribution to measure).
+    """
+    scores = [max(0.0, float(d.get("score", 0.0))) for d in docs]
+    positive = [s for s in scores if s > 0]
+    if len(positive) < 2:
+        return 0.0
+    total = sum(positive)
+    probs = [s / total for s in positive]
+    h = -sum(p * math.log(p) for p in probs)
+    h_max = math.log(len(positive))
+    return h / h_max if h_max > 0 else 0.0
+
+
+def _graph_reach(
+    graph_context: Sequence[Dict],
+    graph_paths: Sequence,
+) -> float:
+    """Depth × fan-out × paths, averaged into [0, 1].
+
+    No graph activity → 0.0. Deep DFS (up to MAX_DEPTH=4) with many
+    expanded entities and many reasoning paths → ~1.0.
+    """
+    if not graph_context:
+        return 0.0
+    max_depth = max(
+        (int(g.get("_dfs_depth", 0)) for g in graph_context),
+        default=0,
+    )
+    depth_norm = min(1.0, max_depth / float(_GRAPH_MAX_DEPTH))
+    fanout_norm = min(1.0, len(graph_context) / _GRAPH_FANOUT_REFERENCE)
+    paths_norm = min(1.0, len(graph_paths) / _GRAPH_PATHS_REFERENCE)
+    return (depth_norm + fanout_norm + paths_norm) / 3.0
+
+
+def _doc_spread(docs: Sequence[Dict]) -> float:
+    """Distinct source documents / total docs, in [0, 1].
+
+    All docs from one source → low (cohesive evidence).
+    Each doc from a different source → 1.0 (scattered evidence,
+    higher composition burden).
+    """
+    if not docs:
+        return 0.0
+    sources = set()
+    for d in docs:
+        s = d.get("source") or d.get("name") or d.get("path") or ""
+        if s:
+            sources.add(s)
+    return min(1.0, len(sources) / float(len(docs)))
+
+
+# ─── Public extractor ──────────────────────────────────────────────
+
+
+def compute_scope(
+    docs: Sequence[Dict],
+    graph_context: Sequence[Dict],
+    graph_paths: Sequence,
+    *,
+    top_k: int = 8,
+) -> ScopeBreakdown:
+    """Compute `evidence_scope` from retrieval + graph outputs.
+
+    Args:
+        docs: post-rerank doc list. In `core/reasoning/pipeline.py`
+            this is `loop_state["docs"]`. Each dict carries at least
+            `score` and a source identifier (`source` / `name` / `path`).
+        graph_context: DFS-expanded entity dicts. In pipeline.py this
+            is `loop_state["graph_context"]`. Each carries `_dfs_depth`.
+        graph_paths: reasoning path strings. In pipeline.py this is
+            `loop_state["graph_paths"]`.
+        top_k: nominal retrieval top_k for `_effective_k` normalization.
+            Defaults to 8, matching the orchestrator default.
+
+    Returns:
+        `ScopeBreakdown` with 4 component values + the combined scope,
+        all in [0, 1].
+
+    Properties:
+        - Pure: same inputs → same output, every call. No I/O, no LLM.
+        - Empty-safe: any combination of empty inputs returns a
+          breakdown with all zeros. This is the natural mode-gate for
+          `chat`/`self_evolve` paths that bypass retrieval (LEO open
+          Q #3 — no explicit gate needed at the extractor).
+        - Bounded: `scope` is clamped to [0, 1] even if weights change.
+
+    Routing intent (L.C):
+        Inserted between Loop 1 (graph expand) finish and the
+        `generate_answer` call in `pipeline.py`. The router consumes
+        `breakdown.scope` to decide the synth backend:
+        narrow scope → small / fast backend, wide scope → large
+        backend better at multi-document composition.
+    """
+    ek = _effective_k(docs, top_k=top_k)
+    se = _score_entropy(docs)
+    gr = _graph_reach(graph_context, graph_paths)
+    ds = _doc_spread(docs)
+    raw = (
+        _W_EFFECTIVE_K * ek
+        + _W_SCORE_ENTROPY * se
+        + _W_GRAPH_REACH * gr
+        + _W_DOC_SPREAD * ds
+    )
+    scope = max(0.0, min(1.0, raw))
+    return ScopeBreakdown(
+        effective_k=ek,
+        score_entropy=se,
+        graph_reach=gr,
+        doc_spread=ds,
+        scope=scope,
+    )
+
+
+__all__ = [
+    "ScopeBreakdown",
+    "compute_scope",
+    "scope_routing_enabled",
+]

--- a/core/reasoning/evidence_scope.py
+++ b/core/reasoning/evidence_scope.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass
-from typing import Dict, Final, Optional, Sequence
+from typing import Dict, Final, Sequence
 
 # ─── Flag ──────────────────────────────────────────────────────────
 

--- a/tests/test_adaptive_budget.py
+++ b/tests/test_adaptive_budget.py
@@ -246,6 +246,7 @@ def test_module_exports():
         "CAP_HEAVY",
         "ReasoningStage",
         "TaskBudget",
+        "adaptive_budget_enabled",   # PR #507 — single source of truth across 5 stages
         "complete_with_retry",   # D6 (2026-05-25) — retry_doubled wiring closure
         "retry_doubled",
     }

--- a/tests/test_evidence_scope.py
+++ b/tests/test_evidence_scope.py
@@ -1,0 +1,199 @@
+"""L.A contract tests for `core/reasoning/evidence_scope.py`.
+
+Pins the extractor's 4-component decomposition + the
+`JAMES_SCOPE_ROUTING` flag's default-off invariant. L.C will extend
+the test suite with engine-loop wiring tests; L.A only locks the
+shape so subsequent PRs land without surprise behavior shifts.
+
+See `docs/handovers/v0.4-leo-evidence-scope-routing-track.md` for the
+full L.0 → L.D phase plan.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.reasoning.evidence_scope import (
+    ScopeBreakdown,
+    compute_scope,
+    scope_routing_enabled,
+)
+
+
+# ─── Empty / safety-net behavior ──────────────────────────────────
+
+
+def test_empty_inputs_zero_scope():
+    """LEO open Q #3 mode-gate safety net.
+
+    `chat` / `self_evolve` paths bypass retrieval entirely, so if the
+    extractor is ever invoked with empty inputs (e.g. by accident at
+    L.C wiring time), the scope must be 0.0 — routing falls back to
+    the legacy / small backend rather than escalating.
+    """
+    breakdown = compute_scope(docs=[], graph_context=[], graph_paths=[])
+    assert breakdown.scope == 0.0
+    assert breakdown.effective_k == 0.0
+    assert breakdown.score_entropy == 0.0
+    assert breakdown.graph_reach == 0.0
+    assert breakdown.doc_spread == 0.0
+
+
+# ─── Narrow / wide signature pins ─────────────────────────────────
+
+
+def test_narrow_single_doc_low_scope():
+    """One high-score doc, no graph activity — verbatim retrieval shape.
+
+    Mirrors the V3'.e substitution arm (single chunk has the answer).
+    Expected scope is small: low effective_k (1/8), zero entropy
+    (single doc), zero graph reach, low spread (1 source / 1 doc = 1
+    in the formula but other components dominate downward).
+    """
+    docs = [{"score": 0.9, "source": "single_doc.md"}]
+    breakdown = compute_scope(docs=docs, graph_context=[], graph_paths=[])
+    assert breakdown.scope <= 0.25, f"narrow scope expected ≤ 0.25, got {breakdown.scope}"
+    assert breakdown.effective_k == pytest.approx(1 / 8)
+    assert breakdown.score_entropy == 0.0
+    assert breakdown.graph_reach == 0.0
+
+
+def test_wide_multidoc_graph_high_scope():
+    """8 docs above threshold + deep graph traversal — synthesis-heavy shape.
+
+    Mirrors a multi-document multi-hop query that needs a larger
+    backend. Expected scope is large (all 4 components fire).
+    """
+    docs = [
+        {"score": 0.6 + i * 0.01, "source": f"doc_{i}.md"} for i in range(8)
+    ]
+    graph_context = [
+        {"_dfs_depth": d, "name": f"e{d}_{i}"}
+        for d in range(1, 5)
+        for i in range(3)
+    ]
+    graph_paths = [f"path_{i}" for i in range(8)]
+    breakdown = compute_scope(
+        docs=docs,
+        graph_context=graph_context,
+        graph_paths=graph_paths,
+    )
+    assert breakdown.scope >= 0.7, f"wide scope expected ≥ 0.7, got {breakdown.scope}"
+    assert breakdown.effective_k == 1.0
+    assert breakdown.graph_reach == 1.0
+    assert breakdown.doc_spread == 1.0
+
+
+# ─── Individual component shape pins ──────────────────────────────
+
+
+def test_score_entropy_peak_vs_flat():
+    """Single-peak distribution lower than flat distribution."""
+    peak_docs = [{"score": 0.9, "source": "a.md"}] + [
+        {"score": 0.01, "source": f"b{i}.md"} for i in range(4)
+    ]
+    flat_docs = [{"score": 0.5, "source": f"c{i}.md"} for i in range(5)]
+
+    peak_breakdown = compute_scope(
+        docs=peak_docs, graph_context=[], graph_paths=[]
+    )
+    flat_breakdown = compute_scope(
+        docs=flat_docs, graph_context=[], graph_paths=[]
+    )
+
+    assert peak_breakdown.score_entropy < flat_breakdown.score_entropy
+    assert flat_breakdown.score_entropy == pytest.approx(1.0, abs=1e-9)
+
+
+def test_doc_spread_same_source_vs_distinct():
+    """All docs from one source → spread small; distinct sources → 1.0."""
+    same = [{"score": 0.5, "source": "shared.md"} for _ in range(5)]
+    distinct = [
+        {"score": 0.5, "source": f"unique_{i}.md"} for i in range(5)
+    ]
+
+    same_breakdown = compute_scope(
+        docs=same, graph_context=[], graph_paths=[]
+    )
+    distinct_breakdown = compute_scope(
+        docs=distinct, graph_context=[], graph_paths=[]
+    )
+
+    assert same_breakdown.doc_spread == pytest.approx(1 / 5)
+    assert distinct_breakdown.doc_spread == pytest.approx(1.0)
+
+
+# ─── Flag parsing ─────────────────────────────────────────────────
+
+
+def test_flag_default_off(monkeypatch):
+    monkeypatch.delenv("JAMES_SCOPE_ROUTING", raising=False)
+    assert scope_routing_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes", "  on  "])
+def test_flag_on_recognized(monkeypatch, value):
+    monkeypatch.setenv("JAMES_SCOPE_ROUTING", value)
+    assert scope_routing_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "blah", "2"])
+def test_flag_off_or_invalid_treated_as_off(monkeypatch, value):
+    monkeypatch.setenv("JAMES_SCOPE_ROUTING", value)
+    assert scope_routing_enabled() is False
+
+
+# ─── Audit payload shape ──────────────────────────────────────────
+
+
+def test_scope_breakdown_audit_payload_shape():
+    """L.C `reason:route` row schema pin — 5 keys, all rounded to 4."""
+    docs = [{"score": 0.7, "source": "a.md"}, {"score": 0.5, "source": "b.md"}]
+    breakdown = compute_scope(docs=docs, graph_context=[], graph_paths=[])
+    payload = breakdown.as_audit_payload()
+
+    assert set(payload.keys()) == {
+        "evidence_scope",
+        "effective_k",
+        "score_entropy",
+        "graph_reach",
+        "doc_spread",
+    }
+    for k, v in payload.items():
+        assert isinstance(v, float), f"{k} must be float, got {type(v)}"
+        # round(_, 4) guarantee — no value should have more than 4 decimals
+        assert v == round(v, 4), f"{k}={v} not rounded to 4 decimals"
+
+
+# ─── Determinism pin ──────────────────────────────────────────────
+
+
+def test_compute_scope_pure_deterministic():
+    """Same inputs → identical output across repeated calls."""
+    docs = [{"score": 0.65, "source": "a.md"}, {"score": 0.55, "source": "b.md"}]
+    graph_context = [{"_dfs_depth": 2, "name": "x"}]
+    graph_paths = ["a→b"]
+
+    first = compute_scope(
+        docs=docs, graph_context=graph_context, graph_paths=graph_paths
+    )
+    for _ in range(100):
+        again = compute_scope(
+            docs=docs, graph_context=graph_context, graph_paths=graph_paths
+        )
+        assert again == first
+
+
+# ─── ScopeBreakdown is a frozen dataclass ─────────────────────────
+
+
+def test_scope_breakdown_is_frozen():
+    """Defends against accidental mutation in downstream call sites."""
+    breakdown = ScopeBreakdown(
+        effective_k=0.5,
+        score_entropy=0.5,
+        graph_reach=0.5,
+        doc_spread=0.5,
+        scope=0.5,
+    )
+    with pytest.raises((AttributeError, Exception)):
+        breakdown.scope = 0.9  # type: ignore[misc]

--- a/tests/test_planner_d1_wiring.py
+++ b/tests/test_planner_d1_wiring.py
@@ -45,8 +45,6 @@ ensure_utf8_console()
 from core.reasoning.budget import (  # noqa: E402
     CAP_HEAVY,
     CAP_LIGHT,
-    CAP_SUBSTITUTION,
-    TaskBudget,
 )
 
 


### PR DESCRIPTION
## Summary

LEO Evidence-Scope Routing Track L.A — extractor + opt-in flag.

- `core/reasoning/evidence_scope.py` — `compute_scope(docs, graph_context, graph_paths) -> ScopeBreakdown`. Pure function, 0 LLM calls, 0 retrieval calls.
- `JAMES_SCOPE_ROUTING` env flag, default OFF (mirrors `JAMES_AUTO_ROUTER` / `JAMES_ADAPTIVE_BUDGET` patterns).
- 23 contract tests pinning the 4-component decomposition + flag + audit payload shape.

Origin: design memo by LEO (Younghu), landed at PR #512. This PR is the first code step of the L.0 → L.A → L.B → L.C → L.D phase plan.

## Verification

- 23/23 L.A tests pass.
- No production call site imports `evidence_scope` (verified by repo-wide grep). Flag OFF/ON byte-identical to pre-L.A main during the L.A → L.C build-up window.
- STEP 7 sanity: N/A by construction — extractor not yet invoked by any call site, code path unchanged. Full STEP 7 3-arm bench lands at L.C when the call site wires in.
- Neighbor router/budget tests: 84/85 pass. The 1 failure (`test_adaptive_budget.py::test_module_exports`) is pre-existing — PR #507 added `adaptive_budget_enabled` to `budget.__all__` but didn't update this test. Out of scope for L.A; flagging for follow-up.

## LEO Open Questions — answers

1. **Weights heuristic vs Direction 2 learning**: L.A ships heuristic v1 as module constants (`_W_EFFECTIVE_K=0.35`, `_W_GRAPH_REACH=0.25`, `_W_DOC_SPREAD=0.20`, `_W_SCORE_ENTROPY=0.20`). Direction 2 land can swap the 4 constants in one place without API change. Final tuning at L.D against STEP 7.
2. **Intent routing vs synth re-selection priority**: measurement wins over prediction. Hierarchy (enforced at L.B / L.C): explicit client model > synth re-selection (flag ON) > intent routing > legacy.
3. **chat / self_evolve mode gate**: auto-resolved. `engine._query_impl` dispatches non-retrieval modes to `handle_*` helpers *before* `run_retrieval_pipeline` runs, so `evidence_scope` only ever sees the retrieval path. Empty-input case (`compute_scope([], [], [])`) returns scope=0.0 as a defensive safety net.
4. **7-tier prediction vs measurement disagreement**: L.A returns a scalar only, makes no routing decision. L.B router policy will implement "measurement can promote/demote one tier, not two" rule. Data validation at L.D.

## Operational promise — cross-stack runs

Robin (V3'.e schema-adopted runs) and Ali (Track 3 swap_eval) cross-stack comparisons MUST run with `JAMES_SCOPE_ROUTING=0` for apples-to-apples purity. `scripts/swap_eval.py` (Track 3 pre-work) will pin this in code with an explicit `os.environ[...] = "0"`. Joint piece inclusion of evidence-scope deferred to L.D closure + at least one Ali swap_eval result.

## Out of scope (deferred)

- L.B — D5 `router.select_backend(..., evidence_scope=...)` signature extension
- L.C — `pipeline.py` Loop 1 → `generate_answer` wiring + `reason:route` audit payload extension + STEP 7 3-arm bench (narrow / wide / halt-prone)
- L.D — result doc + ROADMAP entry + memory sync
- Constant consolidation (`RELEVANCE_GATE` in pipeline.py + `MAX_DEPTH` in graph_engine.py) — keeping mirror with comment for now

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic infra
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A by construction (no call site invokes the module). Full STEP 7 at L.C.
- rule #3 (self-evolution opt-in): N/A — not touched
- rule #4 (architecture change): `architecture` label applied — new module + planned engine.py branch at L.C
- rule #5 (module ≤ 20 KB): `evidence_scope.py` 11 KB ✅