### PR TITLE
feat(reasoning): router evidence_scope arg + policy v1 (LEO L.B)

### DIFF
--- a/core/reasoning/router.py
+++ b/core/reasoning/router.py
@@ -56,6 +56,19 @@ _DEFAULT_BACKEND_ID: Final[str] = "gemma4:e4b"
 
 _FLAG_ON_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
 
+# LEO L.B — evidence-scope routing thresholds.
+# narrow: scope ≤ 0.30 → small backend (single-doc / verbatim
+#   retrieval shape — V3'.e substitution arm signature).
+# wide:   scope ≥ 0.70 → large/medium backend (multi-doc + graph
+#   fan-out — multi-hop synthesis burden, "shortening the path" applies).
+# mid-band (0.30 < scope < 0.70) → fall through to budget-based rule,
+#   so D1 task-weight signal still owns the gray zone.
+# Module constants so L.D STEP 7 tuning (or Direction 2 regression)
+# can swap them in one place without API change. Mirrors the
+# `_W_*` weight constants in `core.reasoning.evidence_scope`.
+_SCOPE_NARROW_THRESHOLD: Final[float] = 0.30
+_SCOPE_WIDE_THRESHOLD: Final[float] = 0.70
+
 
 def _auto_router_enabled() -> bool:
     """Env-flag gate for D5.
@@ -95,33 +108,66 @@ def _route_policy(
     prompt: str,
     context: str,
     budget_signal: Optional[int],
+    *,
+    evidence_scope: Optional[float] = None,
 ) -> str:
-    """D5.C.1 routing policy v1.
+    """Routing policy — D5.C.1 + LEO L.B.
 
     Decision tree (first match wins):
 
       1. `stage` ∈ ``_GROUNDING_CRITICAL_STAGES`` (currently just
          ``verify``) → prefer ``large`` tier; fall back to
          ``medium`` if no large registered; legacy otherwise.
-      2. ``budget_signal == CAP_SUBSTITUTION`` (200, verbatim
+         Grounding-critical stage wins over every other signal,
+         including measured evidence scope — a thorough verifier
+         is the whole point of `verify`.
+      2. **LEO L.B — measured evidence scope override**
+         (``evidence_scope`` not None):
+           • scope ≤ ``_SCOPE_NARROW_THRESHOLD`` (0.30) → ``small``
+             tier; legacy otherwise. Narrow retrieval = single
+             doc / verbatim arm = small model is sufficient and
+             cheaper. Matches Robin's 2026-05-23 substitution
+             bit-for-bit finding.
+           • scope ≥ ``_SCOPE_WIDE_THRESHOLD`` (0.70) → ``large`` /
+             ``medium`` tier; legacy otherwise. Wide retrieval =
+             multi-doc + graph fan-out = synthesis burden, where
+             Ali's "shortening the path" cost asymmetry applies.
+           • mid-band (0.30 < scope < 0.70) → fall through to the
+             budget rules below. Mid-scope is ambiguous; defer to
+             D1's task-weight prediction in the gray zone.
+         This is the LEO design memo §"Relationship to D5 (not a
+         fork)" axis being plugged into the existing tree.
+      3. ``budget_signal == CAP_SUBSTITUTION`` (200, verbatim
          retrieval) → prefer ``small`` tier; legacy otherwise.
          Substitution doesn't benefit from a larger model — Robin
          2026-05-23 finding: substitution-mode bypasses sampling
          entirely, so a small model gives bit-for-bit identical
          output cheaper.
-      3. ``budget_signal == CAP_HEAVY`` (4096, multi-step / 4-stage
+      4. ``budget_signal == CAP_HEAVY`` (4096, multi-step / 4-stage
          cognitive) → prefer ``large`` tier; fall back to ``medium``;
          legacy otherwise. Heavy synthesis is where the
-         cost-asymmetry argument actually favors a stronger model
-         (Ali's "shortening the path" framing — 26b finds the answer
-         in 49 tokens vs e4b's 450).
-      4. Otherwise (``CAP_LIGHT`` 1200, ``None``, or unknown
+         cost-asymmetry argument actually favors a stronger model.
+      5. Otherwise (``CAP_LIGHT`` 1200, ``None``, or unknown
          signal) → legacy backend. Light synthesis on small model
          is the v0.3.x default; routing only escalates when one of
          the rules above fires.
 
     `prompt` and `context` are reserved for D5.C.2 (prompt-surface
     signals) and D5.D (cross-lingual alias resolution).
+
+    LEO open Q #2 answer (intent routing vs synth re-selection):
+    measurement wins over prediction — rule 2 sits before rules 3/4
+    so a clear scope signal overrides the D1 budget guess. Rule 1
+    (verify) still wins over both because grounding is a stage-
+    level invariant, not a routing preference.
+
+    LEO open Q #4 answer (7-tier prediction vs evidence_scope
+    disagreement): the mid-band fall-through implements "measurement
+    can promote/demote one tier" — narrow scope (≤0.30) forces
+    small even if budget would say light/legacy; wide scope (≥0.70)
+    forces large even if budget would say substitution. The gray
+    zone leaves the budget rule untouched, so the override is a
+    bounded correction, not a wholesale replacement.
 
     The "prefer tier X, fall back to legacy" pattern means an
     operator who registers only ``ollama_local`` (the default)
@@ -133,6 +179,21 @@ def _route_policy(
         if chosen:
             return chosen
         return _legacy_backend_id()
+
+    # LEO L.B — measured evidence_scope override (rule 2).
+    # Mid-band falls through to budget rules below.
+    if evidence_scope is not None:
+        if evidence_scope <= _SCOPE_NARROW_THRESHOLD:
+            chosen = _first_in_tier("small")
+            if chosen:
+                return chosen
+            return _legacy_backend_id()
+        if evidence_scope >= _SCOPE_WIDE_THRESHOLD:
+            chosen = _first_in_tier("large") or _first_in_tier("medium")
+            if chosen:
+                return chosen
+            return _legacy_backend_id()
+        # mid-band → fall through to budget rule
 
     if budget_signal == CAP_SUBSTITUTION:
         chosen = _first_in_tier("small")
@@ -185,6 +246,7 @@ class Router:
         *,
         context: str = "",
         budget_signal: Optional[int] = None,
+        evidence_scope: Optional[float] = None,
     ) -> str:
         """Return the backend ID to invoke for this call.
 
@@ -195,24 +257,34 @@ class Router:
             context: optional retrieval context. Reserved for D5.C
                 policy + D5.D cross-lingual alias resolution.
             budget_signal: optional cap from `TaskBudget.assess(...)`.
-                D5.C will use this as the primary routing input
-                (substitution-tier → small backend, heavy-tier →
-                large backend).
+                Substitution-tier → small backend, heavy-tier → large
+                backend (D5.C.1 policy).
+            evidence_scope: optional ``ScopeBreakdown.scope`` value
+                from `core.reasoning.evidence_scope.compute_scope`
+                (LEO L.B). When passed (flag ON + L.C engine wiring),
+                a narrow scope (≤0.30) forces the small tier; a wide
+                scope (≥0.70) forces the large tier; the mid-band
+                falls through to the budget rule. `None` (the default
+                at L.B before L.C wires the engine) leaves D5.C.1
+                behaviour bit-for-bit unchanged.
 
         Returns:
-            Backend ID string (e.g. `"gemma4:e4b"`). Currently always
-            the legacy backend; D5.C replaces the flag-on branch with
-            real policy.
+            Backend ID string (e.g. `"gemma4:e4b"`). When flag OFF,
+            always the legacy backend. When flag ON, dispatches to
+            `_route_policy` (verify > scope-override > budget rules
+            > legacy).
         """
-        # D5.C.1: flag-off → legacy backend (byte-identical to pre-D5).
-        # flag-on → policy decides (see `_route_policy` for the
-        # decision tree). Wiring at the 5 stage call sites lands in
-        # D5.C.2 / D5.C.3; until then, `Router` is constructible but
-        # not yet consulted by `core/retrieval/*` or
-        # `core/reasoning/*` call sites.
+        # Flag-off → legacy backend (byte-identical to pre-D5).
+        # Flag-on → policy decides. Wiring at the 5 stage call sites
+        # for `budget_signal` landed at D5.C.2; the L.C engine wiring
+        # for `evidence_scope` is the next phase (this PR only adds
+        # the kwarg surface + policy rule).
         if not self.enabled:
             return _legacy_backend_id()
-        return _route_policy(stage, prompt, context, budget_signal)
+        return _route_policy(
+            stage, prompt, context, budget_signal,
+            evidence_scope=evidence_scope,
+        )
 
 
 # ─── D5.C.2 — high-level helpers for stage call sites ─────────────
@@ -237,6 +309,7 @@ def resolve_backend(
     *,
     context: str = "",
     budget_signal: Optional[int] = None,
+    evidence_scope: Optional[float] = None,
     fallback_backend_id: Optional[str] = None,
 ) -> str:
     """High-level helper for stage call sites.
@@ -248,13 +321,20 @@ def resolve_backend(
         (the stage's pre-D5 ``self._backend_id``) or ``_legacy_backend_id()``
         if ``None``. Byte-identical to pre-D5 main.
       • Flag ON → consults ``Router(...).select_backend(stage, prompt, ...)``
-        which dispatches to ``_route_policy`` (the D5.C.1 decision tree).
+        which dispatches to ``_route_policy``.
 
     Stage call sites pass ``budget_signal`` only when the D1 adaptive
     budget flag is also on (signal is meaningless under D1 flag-off
     because the cap is fixed at ``DEFAULT_MAX_TOKENS=4096`` and
     would unconditionally trigger the CAP_HEAVY branch). Without a
     meaningful signal, the router's policy falls back to legacy.
+
+    ``evidence_scope`` is the measured signal from
+    `core.reasoning.evidence_scope.compute_scope` (LEO L.B). The L.C
+    engine wiring will be the only caller passing this value; until
+    then the kwarg defaults to ``None`` and the L.B policy rule
+    (rule 2 in `_route_policy`) is dead code at the production call
+    path — flag OFF/ON byte-identical to pre-L.B main.
     """
     r = Router()
     if not r.enabled:
@@ -264,6 +344,7 @@ def resolve_backend(
         prompt,
         context=context,
         budget_signal=budget_signal,
+        evidence_scope=evidence_scope,
     )
 
 

--- a/tests/test_router_evidence_scope.py
+++ b/tests/test_router_evidence_scope.py
@@ -1,0 +1,300 @@
+"""LEO L.B contract tests — evidence_scope routing axis.
+
+Locks the new `evidence_scope` kwarg on `Router.select_backend`,
+`resolve_backend`, and `_route_policy`, plus the L.B policy v1
+narrow/wide override rule:
+
+  - scope <= 0.30 → prefer small tier (else legacy)
+  - scope >= 0.70 → prefer large / medium tier (else legacy)
+  - 0.30 < scope < 0.70 → fall through to D5.C.1 budget rule
+  - scope is None → D5.C.1 byte-identical (regression pin)
+  - verify stage still wins over scope (grounding-critical invariant)
+  - flag OFF → scope ignored entirely (returns legacy / fallback)
+
+Companion to:
+  - `test_router_skeleton.py` (D5.A flag + contract)
+  - `test_router_capability.py` (D5.B tier registry)
+  - `test_router_policy.py` (D5.C.1 verify/budget tree)
+  - `test_evidence_scope.py` (L.A extractor, scalar producer)
+
+L.B itself does not wire any production call site to pass
+`evidence_scope` — that is L.C (engine.py Loop 1 → generate_answer
+insertion). Until L.C lands, `evidence_scope` defaults to `None`
+across the production call chain → behavior byte-identical to
+post-L.A main.
+
+See `docs/handovers/v0.4-leo-evidence-scope-routing-track.md` for
+the full L.0 → L.D phase plan.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.reasoning.backends import (
+    BackendCapability,
+    CompletionResult,
+    _clear_for_tests,
+    register_backend,
+)
+from core.reasoning.budget import CAP_HEAVY, CAP_LIGHT, CAP_SUBSTITUTION
+from core.reasoning.router import (
+    Router,
+    _SCOPE_NARROW_THRESHOLD,
+    _SCOPE_WIDE_THRESHOLD,
+    _route_policy,
+    resolve_backend,
+)
+
+
+# ─── Stub backends (mirrors test_router_policy.py) ────────────────
+
+
+class _StubSmall:
+    backend_id = "stub_small"
+    capability = BackendCapability(tier="small", provider="local")
+
+    def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+        return CompletionResult(text="ok", backend_id=self.backend_id)
+
+
+class _StubMedium:
+    backend_id = "stub_medium"
+    capability = BackendCapability(tier="medium", provider="sovereign")
+
+    def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+        return CompletionResult(text="ok", backend_id=self.backend_id)
+
+
+class _StubLarge:
+    backend_id = "stub_large"
+    capability = BackendCapability(tier="large", provider="cloud")
+
+    def complete(self, prompt, *, system="", max_tokens=1024, timeout=60.0, **opts):
+        return CompletionResult(text="ok", backend_id=self.backend_id)
+
+
+@pytest.fixture
+def all_tiers_registered(monkeypatch):
+    """Register small/medium/large stubs. Restore the registry after."""
+    monkeypatch.setenv("JAMES_LLM_MODEL", "legacy_model")
+    import core.reasoning.backends as backends_mod
+    snapshot = dict(backends_mod._REGISTRY)
+    _clear_for_tests()
+    register_backend("stub_small", _StubSmall())
+    register_backend("stub_medium", _StubMedium())
+    register_backend("stub_large", _StubLarge())
+    yield
+    backends_mod._REGISTRY.clear()
+    backends_mod._REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def only_small_registered(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "legacy_model")
+    import core.reasoning.backends as backends_mod
+    snapshot = dict(backends_mod._REGISTRY)
+    _clear_for_tests()
+    register_backend("stub_small", _StubSmall())
+    yield
+    backends_mod._REGISTRY.clear()
+    backends_mod._REGISTRY.update(snapshot)
+
+
+# ─── Threshold constant pin ───────────────────────────────────────
+
+
+def test_threshold_constants_are_ordered():
+    """Defends future tuning — narrow must be strictly < wide."""
+    assert 0.0 <= _SCOPE_NARROW_THRESHOLD < _SCOPE_WIDE_THRESHOLD <= 1.0
+
+
+# ─── Narrow scope (≤ 0.30) → small ────────────────────────────────
+
+
+def test_narrow_scope_overrides_light_budget(all_tiers_registered):
+    """Narrow scope forces small even when budget would say legacy.
+
+    LEO open Q #4 answer in action — measurement promotes the
+    decision one tier (LIGHT/None → small) when the signal is clear.
+    """
+    assert _route_policy(
+        "synth", "any prompt", "", CAP_LIGHT, evidence_scope=0.10,
+    ) == "stub_small"
+
+
+def test_narrow_scope_at_threshold_exactly(all_tiers_registered):
+    """Boundary value — scope == 0.30 still counts as narrow."""
+    assert _route_policy(
+        "synth", "any prompt", "", None,
+        evidence_scope=_SCOPE_NARROW_THRESHOLD,
+    ) == "stub_small"
+
+
+def test_narrow_scope_falls_back_to_legacy_when_no_small(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "legacy_model")
+    import core.reasoning.backends as backends_mod
+    snapshot = dict(backends_mod._REGISTRY)
+    _clear_for_tests()
+    register_backend("stub_large", _StubLarge())
+    try:
+        assert _route_policy(
+            "synth", "any prompt", "", CAP_LIGHT, evidence_scope=0.10,
+        ) == "legacy_model"
+    finally:
+        backends_mod._REGISTRY.clear()
+        backends_mod._REGISTRY.update(snapshot)
+
+
+# ─── Wide scope (≥ 0.70) → large/medium ───────────────────────────
+
+
+def test_wide_scope_overrides_light_budget(all_tiers_registered):
+    """Wide scope forces large/medium even when budget would say legacy."""
+    assert _route_policy(
+        "synth", "any prompt", "", CAP_LIGHT, evidence_scope=0.90,
+    ) == "stub_large"
+
+
+def test_wide_scope_at_threshold_exactly(all_tiers_registered):
+    """Boundary value — scope == 0.70 still counts as wide."""
+    assert _route_policy(
+        "synth", "any prompt", "", None,
+        evidence_scope=_SCOPE_WIDE_THRESHOLD,
+    ) == "stub_large"
+
+
+def test_wide_scope_falls_back_to_medium_when_no_large(monkeypatch):
+    monkeypatch.setenv("JAMES_LLM_MODEL", "legacy_model")
+    import core.reasoning.backends as backends_mod
+    snapshot = dict(backends_mod._REGISTRY)
+    _clear_for_tests()
+    register_backend("stub_small", _StubSmall())
+    register_backend("stub_medium", _StubMedium())
+    try:
+        assert _route_policy(
+            "synth", "any prompt", "", CAP_LIGHT, evidence_scope=0.90,
+        ) == "stub_medium"
+    finally:
+        backends_mod._REGISTRY.clear()
+        backends_mod._REGISTRY.update(snapshot)
+
+
+# ─── Mid-band (0.30 < scope < 0.70) → fall through to budget ─────
+
+
+def test_mid_scope_falls_through_to_budget_substitution(all_tiers_registered):
+    """Mid scope leaves D5.C.1 substitution rule in charge."""
+    assert _route_policy(
+        "synth", "그대로 출력", "", CAP_SUBSTITUTION, evidence_scope=0.50,
+    ) == "stub_small"
+
+
+def test_mid_scope_falls_through_to_budget_heavy(all_tiers_registered):
+    """Mid scope leaves D5.C.1 heavy rule in charge."""
+    assert _route_policy(
+        "synth", "multi-step 분석", "", CAP_HEAVY, evidence_scope=0.50,
+    ) == "stub_large"
+
+
+def test_mid_scope_falls_through_to_budget_light(all_tiers_registered):
+    """Mid scope + light budget → legacy (D5.C.1 rule 4 unchanged)."""
+    assert _route_policy(
+        "synth", "short", "", CAP_LIGHT, evidence_scope=0.50,
+    ) == "legacy_model"
+
+
+# ─── scope=None → D5.C.1 unchanged (regression pin) ──────────────
+
+
+def test_scope_none_is_byte_identical_to_d5_c1(all_tiers_registered):
+    """When evidence_scope is None, every D5.C.1 outcome is preserved."""
+    # Rule 1: verify
+    assert _route_policy("verify", "p", "", None, evidence_scope=None) == "stub_large"
+    # Rule 2: substitution
+    assert _route_policy(
+        "synth", "p", "", CAP_SUBSTITUTION, evidence_scope=None,
+    ) == "stub_small"
+    # Rule 3: heavy
+    assert _route_policy(
+        "synth", "p", "", CAP_HEAVY, evidence_scope=None,
+    ) == "stub_large"
+    # Rule 4: light / unknown
+    assert _route_policy(
+        "synth", "p", "", CAP_LIGHT, evidence_scope=None,
+    ) == "legacy_model"
+
+
+# ─── verify stage wins over scope (rule 1 priority) ──────────────
+
+
+def test_verify_wins_over_narrow_scope(all_tiers_registered):
+    """Grounding-critical stage overrides even a clear narrow scope."""
+    assert _route_policy(
+        "verify", "p", "", None, evidence_scope=0.05,
+    ) == "stub_large"
+
+
+def test_verify_wins_over_wide_scope(all_tiers_registered):
+    """Grounding-critical stage and wide scope happen to agree, but the
+    selection comes from rule 1 not rule 2."""
+    assert _route_policy(
+        "verify", "p", "", None, evidence_scope=0.99,
+    ) == "stub_large"
+
+
+# ─── Router.select_backend kwarg acceptance ──────────────────────
+
+
+def test_select_backend_accepts_evidence_scope_kwarg():
+    """L.B signature pin — kwarg accepted even when flag OFF."""
+    r = Router(enabled=False)
+    out = r.select_backend(
+        "synth", "prompt", context="ctx",
+        budget_signal=CAP_LIGHT, evidence_scope=0.5,
+    )
+    assert isinstance(out, str) and out
+
+
+def test_select_backend_flag_off_ignores_scope(monkeypatch):
+    """Flag OFF returns legacy regardless of scope (byte-identical)."""
+    monkeypatch.setenv("JAMES_LLM_MODEL", "gemma4:e4b")
+    r = Router(enabled=False)
+    for scope in (0.0, 0.1, 0.5, 0.9, 1.0):
+        assert r.select_backend(
+            "synth", "p", evidence_scope=scope,
+        ) == "gemma4:e4b"
+
+
+def test_select_backend_flag_on_uses_scope(all_tiers_registered):
+    """Flag ON + scope passed → policy applies."""
+    r = Router(enabled=True)
+    assert r.select_backend(
+        "synth", "p", evidence_scope=0.10,
+    ) == "stub_small"
+    assert r.select_backend(
+        "synth", "p", evidence_scope=0.90,
+    ) == "stub_large"
+
+
+# ─── resolve_backend kwarg acceptance ────────────────────────────
+
+
+def test_resolve_backend_accepts_evidence_scope_kwarg(monkeypatch):
+    """High-level helper exposes the same surface."""
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", "0")
+    monkeypatch.setenv("JAMES_LLM_MODEL", "fallback")
+    out = resolve_backend(
+        "synth", "p", evidence_scope=0.5, fallback_backend_id="legacy",
+    )
+    # Flag OFF — fallback wins, scope is ignored
+    assert out == "legacy"
+
+
+def test_resolve_backend_flag_on_propagates_scope(
+    monkeypatch, all_tiers_registered,
+):
+    monkeypatch.setenv("JAMES_AUTO_ROUTER", "1")
+    out = resolve_backend(
+        "synth", "p", evidence_scope=0.90, fallback_backend_id="ignored",
+    )
+    assert out == "stub_large"


### PR DESCRIPTION
## Summary

LEO Evidence-Scope Routing Track L.B — extends D5's `_route_policy` decision tree with the measured-input axis from L.A (PR #513).

- New kwarg-only `evidence_scope: Optional[float] = None` on:
  - `core.reasoning.router._route_policy`
  - `core.reasoning.router.Router.select_backend`
  - `core.reasoning.router.resolve_backend`
- Policy v1 rule inserted between rule 1 (verify) and rule 3 (CAP_SUBSTITUTION):
  - `scope <= 0.30` → prefer small tier (else legacy)
  - `scope >= 0.70` → prefer large / medium tier (else legacy)
  - mid-band → fall through to existing D5.C.1 budget rules
  - `scope is None` → D5.C.1 byte-identical (regression preserved)
  - verify stage still wins (rule 1 grounding-critical invariant)
- Thresholds (`_SCOPE_NARROW_THRESHOLD=0.30`, `_SCOPE_WIDE_THRESHOLD=0.70`) as module constants so L.D STEP 7 tuning or Direction 2 regression can swap them in one place without API change.

## Verification

- 137/137 tests pass across `test_evidence_scope.py` (L.A), `test_router_evidence_scope.py` (L.B), `test_router_policy.py` (D5.C.1), `test_router_skeleton.py` (D5.A), `test_router_capability.py` (D5.B), `test_query_rewriter_router_wiring.py`, `test_adaptive_budget.py`.
- L.B production-call-site invariant verified: no file under `core/` outside `router.py` itself passes `evidence_scope=` to `select_backend` or `resolve_backend`. The kwarg defaults to `None` everywhere in the production chain → flag OFF/ON byte-identical to post-L.A main.
- STEP 7 sanity: N/A by construction — production callers do not yet pass `evidence_scope`, so the new policy rule is dead code at the production call path. Full STEP 7 3-arm bench (narrow / wide / halt-prone) lands at L.C when the engine wiring inserts the call.

## LEO open question answers locked into code

- **Q2 (intent vs synth re-selection priority)** — measurement wins over prediction. Rule 2 (evidence_scope override) sits before rules 3/4 (budget). Rule 1 (verify) still wins over both — grounding is a stage invariant, not a routing preference.
- **Q4 (7-tier prediction vs measurement disagreement)** — bounded one-tier promotion/demotion only. Extreme bands (≤0.30, ≥0.70) override budget; mid-band leaves the budget rule untouched. Not a wholesale replacement.

## Out of scope (deferred)

- L.C — `core/reasoning/pipeline.py` Loop 1 finish → `generate_answer` insertion. Compute `ScopeBreakdown` from `loop_state`, pass `evidence_scope=breakdown.scope` to `resolve_backend`, extend `reason:route` audit row payload to include the breakdown.
- L.D — result doc (`reports/promo-assets/v3prime-leo-evidence-scope-result.md`), ROADMAP entry, memory sync, threshold tuning against STEP 7.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic infra
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A by construction. Full STEP 7 at L.C.
- rule #3 (self-evolution opt-in): N/A — not touched
- rule #4 (architecture change): `architecture` label applied — router policy surface extension + planned engine.py call site at L.C
- rule #5 (module ≤ 20 KB): `router.py` 16.5 KB ✅ (up from 12 KB pre-L.B, room remaining)

L.A → L.B done. L.C next.