### PR TITLE
fix(tests): conftest pre-imports heavy modules to break CI timeout chain

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Test-suite session setup — pre-import slow modules once.
+
+## Why this file exists
+
+Several legacy test fixtures use ``unittest.mock.patch(...)`` against
+attributes inside heavy modules such as ``core.vector_store.VectorStore``
+or ``llm.router.RouterWrapper``. ``patch(...)`` resolves its dotted
+target by importing the parent module if it isn't already in
+``sys.modules``. ``core.vector_store`` pulls in
+``sentence_transformers`` + ``torch`` + ``transformers`` at module load
+(~5s cold). So the FIRST ``patch("core.vector_store.VectorStore")`` in
+any given pytest process pays that 5s cost during ``setUp``.
+
+On CI runners with no Python bytecode cache and a ``--timeout=30`` per
+test, the first test in any class that uses this fixture is one slow
+runner away from timing out mid-``setUp``. When that happens,
+``tearDown`` never runs, the ``patch("llm.router.RouterWrapper")``
+already started in the same ``setUp`` is **leaked**, and downstream
+tests in the same pytest process import a ``MagicMock`` instead of the
+real ``RouterWrapper`` — visible as e.g.
+``test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta``
+failing with *"Expected 'call_router_meta' to be called once. Called 0
+times."*
+
+## The fix
+
+Pre-import the heavy modules at session start (module-level code in
+this file runs when pytest collects ``tests/conftest.py``, before any
+test). After that, every ``patch("core.vector_store.VectorStore")`` is
+a fast attribute lookup against an already-cached module, and per-test
+``setUp`` stays well under the 30s budget.
+
+Six test files were observed using this fixture pattern (2026-05-26):
+  - tests/test_entity_name_markdown_strip.py  (was the canary failure)
+  - tests/test_wiki_summary_body_sync.py
+  - tests/test_attributes_summary_cleanup.py
+  - tests/test_event_ingest_emit.py
+  - tests/test_phase_b_ingestion_sources.py
+  - tests/test_phase_d_modify_cascade.py
+
+All six benefit from this warm-up; no test source changes required.
+
+Cost: ~5s of session-start overhead instead of ~5s of per-test
+``setUp`` overhead on cold runners. The session pays the import once;
+no test pays it.
+
+## What this does NOT do
+
+This is not a global patch / mock — it just imports. Module identity
+is preserved, so existing ``patch(...)`` calls keep working unchanged.
+If a future test relies on a fresh import of one of these modules, it
+should use ``importlib.reload(...)`` explicitly rather than dropping
+the entry from ``sys.modules``.
+"""
+from __future__ import annotations
+
+# Targets selected by surveying tests/ for `patch("...")` strings whose
+# resolution forces a heavy first-import. Order is irrelevant — each
+# import is independent. Failures here would block test collection
+# entirely, which is intentional: a broken import here means tests
+# couldn't run anyway, so fail loudly rather than silently slow.
+import core.memory  # noqa: F401 — pre-import to warm sys.modules
+import core.vector_store  # noqa: F401 — pulls torch / transformers (~5s cold)
+import core.wiki_generator  # noqa: F401 — pre-import to warm sys.modules
+import llm.router  # noqa: F401 — pre-import to warm sys.modules


### PR DESCRIPTION
## Summary

Fix the long-standing CI flake where `test_entity_name_markdown_strip::test_all_markdown_falls_back_to_unknown` randomly times out and drags `test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta` down with it.

Single new file: `tests/conftest.py` pre-imports `core.memory`, `core.vector_store`, `core.wiki_generator`, `llm.router` at session start.

## Root cause (deterministic — reproduced locally, not flaky)

1. `_MarkdownStripBase.setUp` calls `patch("core.vector_store.VectorStore")`.
2. `unittest.mock.patch` resolves dotted targets by importing the parent module if it isn't in `sys.modules`. `core.vector_store` pulls in `sentence_transformers` + `torch` + `transformers` at module load — **~5s cold import** (measured: 5.06s Windows local; longer on CI cold runners).
3. `test_all_markdown_falls_back_to_unknown` is the **first test alphabetically** in the class → it always pays the cold-import cost during setUp.
4. CI runs with `--timeout=30`. On a slow runner, 5s import + 1.3s `WikiGenerator()` init + general slowdown crosses the 30s threshold → pytest-timeout interrupts mid-setUp.
5. Interrupt fires inside setUp → **`tearDown` never runs**. The `patch("llm.router.RouterWrapper")` started earlier in the same setUp is **leaked**.
6. Subsequent tests in the same pytest process see `from llm.router import RouterWrapper` returning a `MagicMock`.
7. `test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta` then fails with `Expected 'call_router_meta' to be called once. Called 0 times.` — `RouterWrapper("general")` returns a `MagicMock` whose `call_gemma_meta` is also a `MagicMock`, never reaching the real shim that would invoke `call_router_meta`.

The two failures look unrelated but are coupled by the timeout-induced patch leak.

## Fix

`tests/conftest.py` is module-level code that pytest evaluates at session start, before any test. Pre-importing the four modules whose `patch(...)` targets force a heavy first-import means subsequent `patch("...")` calls are fast attribute lookups against an already-cached module.

Cost shift: **~5s session-start overhead (paid once)** instead of ~5s per-test setUp overhead on cold runners (paid 5+ times per affected TestCase class).

## Six test files benefit transparently (no source changes needed)

- `tests/test_entity_name_markdown_strip.py` (canary failure)
- `tests/test_wiki_summary_body_sync.py`
- `tests/test_attributes_summary_cleanup.py`
- `tests/test_event_ingest_emit.py`
- `tests/test_phase_b_ingestion_sources.py`
- `tests/test_phase_d_modify_cascade.py`

## Verification

Local repro of the failure mode:

| Run | Before | After |
|---|---|---|
| `pytest tests/test_entity_name_markdown_strip.py` (cold first-test setUp) | ~6.7s | <1s |
| `pytest tests/test_entity_name_markdown_strip.py tests/test_native_done_reason.py` (the failing combo) | 6.7s first setUp + N/A | **17 passed in 3.55s** |
| Broad sanity (CI-mirroring exclusions, `pytest tests/ ...`) | unchanged | **2548 passed, 869 subtests passed** |

## Why not …

- **Convert `setUp` → `setUpClass` in the 6 files.** Touches 6 files; each test still needs an isolated `WIKI_DIR` (tmp dir) so the `config.WIKI_DIR` patch stays per-test anyway. Smaller blast radius with one conftest.
- **Increase pytest-timeout to 60s.** Hides the symptom. Future heavier tests would push the threshold up again.
- **Mock at `sys.modules` boundary.** Would break tests that legitimately want a real `VectorStore` instance via `patch`. Conftest preserves module identity; existing `patch(...)` calls keep working bit-for-bit.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — test infrastructure
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A — no production code touched
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): N/A — conftest pre-import is convention, not new architecture
- rule #5 (module ≤ 20 KB): `tests/conftest.py` ~2.5 KB ✅