### PR TITLE
feat(reasoning): engine scope wiring + audit payload (LEO L.C)

### DIFF
--- a/core/reasoning/evidence_scope.py
+++ b/core/reasoning/evidence_scope.py
@@ -43,8 +43,10 @@ from __future__ import annotations
 
 import math
 import os
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Dict, Final, Sequence
+from typing import Dict, Final, Iterator, Optional, Sequence
 
 # ─── Flag ──────────────────────────────────────────────────────────
 
@@ -273,8 +275,64 @@ def compute_scope(
     )
 
 
+# ─── L.C — ContextVar plumbing ─────────────────────────────────────
+
+
+_current_scope: ContextVar[Optional[ScopeBreakdown]] = ContextVar(
+    "evidence_scope_current", default=None
+)
+
+
+def get_current_scope() -> Optional[ScopeBreakdown]:
+    """Read the ScopeBreakdown bound to the current context, if any.
+
+    Returns None when no `scope_context(...)` is active OR when the
+    binding inside the active scope_context was None (e.g. flag OFF).
+    `trace_helpers.trace_synth_call` reads this to enable scope-based
+    backend routing without threading kwargs through every synth-path
+    signature.
+
+    Async-safe and thread-safe — `ContextVar` semantics. Each async
+    task / thread sees its own bound value.
+    """
+    return _current_scope.get()
+
+
+@contextmanager
+def scope_context(
+    breakdown: Optional[ScopeBreakdown],
+) -> Iterator[None]:
+    """Bind a ScopeBreakdown to the current async/threading context.
+
+    Used by `core/reasoning/pipeline.py` to expose the post-Loop-1
+    scope measurement to any synth-layer LLM call inside the `with`
+    block (synth, reflect, verify all flow through trace_helpers).
+
+    Usage::
+
+        breakdown = compute_scope(docs, graph_ctx, graph_paths) \\
+            if scope_routing_enabled() else None
+        with scope_context(breakdown):
+            answer = generate_answer(...)
+
+    Best-effort guarantees:
+      - `None` is a valid binding — explicitly signals "no scope this
+        turn" rather than leaking a stale prior turn's scope.
+      - Cleanup runs even on exception (try/finally on ContextVar
+        token reset), so a synth-path raise won't leak the binding
+        into the next request handled by the same worker.
+    """
+    token = _current_scope.set(breakdown)
+    try:
+        yield
+    finally:
+        _current_scope.reset(token)
+
+
 __all__ = [
     "ScopeBreakdown",
     "compute_scope",
+    "get_current_scope",
+    "scope_context",
     "scope_routing_enabled",
 ]

--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -242,18 +242,67 @@ def run_retrieval_pipeline(
         )
         safe_context = sources_header + safe_context
 
+    # ── LEO L.C — evidence-scope measurement + scope-context bind ───
+    # When JAMES_SCOPE_ROUTING is ON, compute the post-Loop-1 scope
+    # from loop_state (docs / graph_context / graph_paths populated by
+    # Loops 0 and 1 above) and bind it via `scope_context(...)` so any
+    # synth-layer LLM call inside the `with` block can read it via
+    # `evidence_scope.get_current_scope()` and pick a scope-appropriate
+    # backend (LEO L.B router policy v1).
+    #
+    # Flag-OFF invariant: `scope_routing_enabled()` returns False →
+    # `_scope_breakdown` stays None → `scope_context(None)` is a no-op
+    # binding → trace_helpers reads None → resolve_backend gets
+    # `evidence_scope=None` → router falls back to D5 budget policy →
+    # byte-identical to post-L.B main.
+    #
+    # `chat` / `meta` / `wiki_edit` / `self_evolve` / `coding` modes
+    # never reach this point (mode dispatch in engine._query_impl
+    # routes them to `handle_*` helpers before run_retrieval_pipeline),
+    # so the LEO open Q #3 mode gate is naturally satisfied with no
+    # extra branch here.
+    from core.reasoning.evidence_scope import (
+        compute_scope,
+        scope_context,
+        scope_routing_enabled,
+    )
+    _scope_breakdown = None
+    if scope_routing_enabled():
+        try:
+            _scope_breakdown = compute_scope(
+                docs=loop_state["docs"],
+                graph_context=loop_state["graph_context"],
+                graph_paths=loop_state["graph_paths"],
+            )
+            print(
+                f"[SCOPE] evidence_scope={_scope_breakdown.scope:.3f} "
+                f"(k={_scope_breakdown.effective_k:.2f} "
+                f"H={_scope_breakdown.score_entropy:.2f} "
+                f"g={_scope_breakdown.graph_reach:.2f} "
+                f"s={_scope_breakdown.doc_spread:.2f})"
+            )
+        except Exception as e:
+            engine._log("scope_compute", e, user_role)
+
     # ── LLM 답변 생성 (delegated to pipeline_synth) ──────
     # generate_answer handles the three-way branch (web fallback /
     # canonical RAG / no-info retry) and emits the three L1 trace
     # rows on the call_gemma sites. Returns an AnswerBlock with the
     # text + web search results + the optional save-proposal id.
-    _synth = generate_answer(
-        engine, safe_query, safe_context, system_prompt, user_role,
-        unified_score,
-        response_style=response_style,
-        selected_model=selected_model,
-        force_web_search=force_web_search,
-    )
+    #
+    # The `with scope_context(...)` wrapper covers generate_answer +
+    # the reflect / verify passes that run inside it, so all five
+    # synth-path trace_synth_call invocations (rag, web_summary,
+    # web_fallback, retry_no_info, plus reflect/verify call sites
+    # that go through trace_helpers) see the same scope.
+    with scope_context(_scope_breakdown):
+        _synth = generate_answer(
+            engine, safe_query, safe_context, system_prompt, user_role,
+            unified_score,
+            response_style=response_style,
+            selected_model=selected_model,
+            force_web_search=force_web_search,
+        )
     answer = _synth.answer
     web_results = _synth.web_results
     pending_save_proposal_id = _synth.pending_save_proposal_id

--- a/core/reasoning/router.py
+++ b/core/reasoning/router.py
@@ -355,6 +355,7 @@ def emit_route_event(
     *,
     budget_signal: Optional[int] = None,
     reason: str = "policy",
+    evidence_scope: Optional[object] = None,
 ) -> None:
     """Emit a ``reason:route`` row to ``audit_log``.
 
@@ -370,6 +371,15 @@ def emit_route_event(
       • ``answer``    = ``"backend={id} tier={label} reason={why}"``
                         + a short prompt hash for cross-referencing
                         with the originating /query/ row
+                        + optional ``evidence_scope`` + 4 components
+                        (LEO L.C) when the scope was the routing input
+
+    ``evidence_scope`` accepts a
+    ``core.reasoning.evidence_scope.ScopeBreakdown`` (preferred — full
+    payload lands in the audit row) or a bare float (just the scalar
+    is emitted). ``None`` means "no scope this call" and the audit
+    string omits the scope fields entirely → flag-OFF callers stay
+    byte-identical to pre-L.C.
     """
     try:
         import hashlib
@@ -381,6 +391,21 @@ def emit_route_event(
             else ""
         )
         tier_label = _budget_to_tier_label(budget_signal)
+        scope_fragment = ""
+        if evidence_scope is not None:
+            payload_fn = getattr(evidence_scope, "as_audit_payload", None)
+            if callable(payload_fn):
+                payload = payload_fn()
+                scope_fragment = " " + " ".join(
+                    f"{k}={v}" for k, v in payload.items()
+                )
+            else:
+                try:
+                    scope_fragment = (
+                        f" evidence_scope={float(evidence_scope):.4f}"
+                    )
+                except (TypeError, ValueError):
+                    scope_fragment = ""
         mirror_to_audit_db({
             "endpoint": "reason:route",
             "role": "system",
@@ -388,6 +413,7 @@ def emit_route_event(
             "answer": (
                 f"backend={selected_backend} tier={tier_label} "
                 f"reason={reason} prompt={prompt_hash}"
+                f"{scope_fragment}"
             ),
         })
     except Exception:

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -150,13 +150,34 @@ def trace_synth_call(
     # here covers the synth path and any other stage that goes
     # through `trace_synth_call` rather than the per-class call site.
     try:
+        from core.reasoning.evidence_scope import (
+            get_current_scope,
+            scope_routing_enabled,
+        )
         from core.reasoning.router import emit_route_event, resolve_backend
+
+        # LEO L.C — flag-gated scope-based backend routing on top of
+        # the existing D5 budget-based routing. With JAMES_SCOPE_ROUTING
+        # OFF (default), `scope_breakdown` stays None → resolve_backend
+        # receives `evidence_scope=None` → router policy is byte-
+        # identical to post-L.B main. With the flag ON, pipeline.py
+        # binds the post-Loop-1 ScopeBreakdown via `scope_context(...)`
+        # and the router's L.B rule (narrow→small / wide→large) fires.
+        scope_breakdown = (
+            get_current_scope() if scope_routing_enabled() else None
+        )
+        scope_val = (
+            float(scope_breakdown.scope)
+            if scope_breakdown is not None
+            else None
+        )
 
         legacy_backend_id = resolve_backend_for_stage(stage)
         backend_id = resolve_backend(
             stage,
             prompt,
             budget_signal=None,
+            evidence_scope=scope_val,
             fallback_backend_id=legacy_backend_id,
         )
         backend = get_backend(backend_id)
@@ -177,15 +198,19 @@ def trace_synth_call(
         )
         return ""
 
-    # D5.C.2.e — audit row for the resolved backend. Emitted between
-    # resolution and call so the routing decision is logged even if
-    # the subsequent backend.complete fails.
+    # D5.C.2.e + LEO L.C — audit row for the resolved backend. Emitted
+    # between resolution and call so the routing decision is logged
+    # even if the subsequent backend.complete fails. The scope payload
+    # rides along when present so the operator can correlate
+    # `evidence_scope=X.XXXX effective_k=… score_entropy=… …` in the
+    # reason:route row with the originating /query/ row via prompt hash.
     emit_route_event(
         stage,
         prompt,
         backend_id,
         budget_signal=None,
-        reason="fallback",
+        reason="scope" if scope_breakdown is not None else "fallback",
+        evidence_scope=scope_breakdown,
     )
 
     result: CompletionResult = backend.complete(

--- a/tests/test_evidence_scope_wiring.py
+++ b/tests/test_evidence_scope_wiring.py
@@ -1,0 +1,241 @@
+"""LEO L.C contract tests — pipeline scope wiring + audit payload.
+
+Pins:
+  - `scope_context(...)` / `get_current_scope()` ContextVar contract
+    (set / get / nested / cleanup on exception)
+  - `router.emit_route_event(..., evidence_scope=...)` formats audit
+    payload correctly for ScopeBreakdown, bare float, and None
+  - `trace_helpers.trace_synth_call` reads the bound scope and passes
+    it to `resolve_backend` only when the flag is ON
+  - Flag-OFF byte-identical invariant: with the env var unset, the
+    bound scope is ignored entirely → existing audit row shape
+    preserved exactly.
+
+Companion to:
+  - `test_evidence_scope.py` (L.A extractor)
+  - `test_router_evidence_scope.py` (L.B router policy)
+
+See `docs/handovers/v0.4-leo-evidence-scope-routing-track.md` for the
+phase plan.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.reasoning.evidence_scope import (
+    ScopeBreakdown,
+    compute_scope,
+    get_current_scope,
+    scope_context,
+    scope_routing_enabled,
+)
+
+
+def _make_breakdown(scope: float = 0.5) -> ScopeBreakdown:
+    """Build a deterministic ScopeBreakdown for wiring tests."""
+    return ScopeBreakdown(
+        effective_k=scope,
+        score_entropy=scope,
+        graph_reach=scope,
+        doc_spread=scope,
+        scope=scope,
+    )
+
+
+# ─── ContextVar plumbing ──────────────────────────────────────────
+
+
+def test_get_current_scope_returns_none_when_unbound():
+    """No active scope_context → get_current_scope is None."""
+    # No `with` block — read directly
+    assert get_current_scope() is None
+
+
+def test_scope_context_binds_and_releases():
+    """Bind a breakdown inside `with`, observe via get_current_scope,
+    confirm cleanup after the block exits."""
+    breakdown = _make_breakdown(0.7)
+    assert get_current_scope() is None
+    with scope_context(breakdown):
+        assert get_current_scope() is breakdown
+    assert get_current_scope() is None
+
+
+def test_scope_context_explicit_none_binding():
+    """`scope_context(None)` is a valid explicit binding — signals
+    'no scope this turn' rather than leaking a prior turn's value."""
+    with scope_context(_make_breakdown(0.9)):
+        assert get_current_scope() is not None
+        # Inner block re-binds to None
+        with scope_context(None):
+            assert get_current_scope() is None
+        # Outer binding restored after inner block exits
+        assert get_current_scope() is not None
+
+
+def test_scope_context_cleanup_on_exception():
+    """Token reset must run even when the with-block body raises."""
+    breakdown = _make_breakdown(0.4)
+    with pytest.raises(RuntimeError, match="synth boom"):
+        with scope_context(breakdown):
+            assert get_current_scope() is breakdown
+            raise RuntimeError("synth boom")
+    # Exception propagated, but the binding was cleared.
+    assert get_current_scope() is None
+
+
+def test_scope_context_nested_restores_outer():
+    """Nested with-blocks restore the outer binding correctly."""
+    outer = _make_breakdown(0.2)
+    inner = _make_breakdown(0.8)
+    with scope_context(outer):
+        assert get_current_scope() is outer
+        with scope_context(inner):
+            assert get_current_scope() is inner
+        assert get_current_scope() is outer
+    assert get_current_scope() is None
+
+
+# ─── emit_route_event audit payload ───────────────────────────────
+
+
+def _capture_emit_payload(monkeypatch):
+    """Returns a list captured by patching `mirror_to_audit_db`."""
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        "core.audit_bridge.mirror_to_audit_db",
+        lambda payload: captured.append(payload),
+    )
+    return captured
+
+
+def test_emit_route_event_no_scope_fragment_when_none(monkeypatch):
+    """`evidence_scope=None` → audit answer omits scope fields entirely
+    (byte-identical to pre-L.C). This protects the flag-OFF invariant
+    at the audit-row level."""
+    captured = _capture_emit_payload(monkeypatch)
+    from core.reasoning.router import emit_route_event
+    emit_route_event(
+        "synth", "test prompt", "gemma4:e4b",
+        budget_signal=None, reason="fallback", evidence_scope=None,
+    )
+    assert len(captured) == 1
+    answer = captured[0]["answer"]
+    # No scope fields
+    assert "evidence_scope=" not in answer
+    assert "effective_k=" not in answer
+    # Pre-L.C shape preserved
+    assert answer.startswith("backend=gemma4:e4b tier=none reason=fallback")
+
+
+def test_emit_route_event_with_breakdown_emits_all_5_fields(monkeypatch):
+    """ScopeBreakdown payload → all 5 audit fields land verbatim."""
+    captured = _capture_emit_payload(monkeypatch)
+    from core.reasoning.router import emit_route_event
+    breakdown = _make_breakdown(0.6)
+    emit_route_event(
+        "synth", "test prompt", "stub_large",
+        budget_signal=None, reason="scope", evidence_scope=breakdown,
+    )
+    assert len(captured) == 1
+    answer = captured[0]["answer"]
+    for key in (
+        "evidence_scope=", "effective_k=", "score_entropy=",
+        "graph_reach=", "doc_spread=",
+    ):
+        assert key in answer, f"missing {key} in audit answer: {answer!r}"
+    assert "reason=scope" in answer
+
+
+def test_emit_route_event_with_bare_float_emits_scalar_only(monkeypatch):
+    """Bare float `evidence_scope=0.75` → just the scalar lands in audit
+    (no 4-component breakdown)."""
+    captured = _capture_emit_payload(monkeypatch)
+    from core.reasoning.router import emit_route_event
+    emit_route_event(
+        "synth", "test", "gemma4:e4b",
+        budget_signal=None, reason="scope", evidence_scope=0.75,
+    )
+    answer = captured[0]["answer"]
+    assert "evidence_scope=0.7500" in answer
+    # No component decomposition for bare-float path
+    assert "effective_k=" not in answer
+    assert "score_entropy=" not in answer
+
+
+def test_emit_route_event_with_invalid_scope_silently_skips_fragment(
+    monkeypatch,
+):
+    """A type that's neither ScopeBreakdown nor float-coercible →
+    scope fragment is omitted, the row still lands (never raises)."""
+    captured = _capture_emit_payload(monkeypatch)
+    from core.reasoning.router import emit_route_event
+    emit_route_event(
+        "synth", "test", "gemma4:e4b",
+        budget_signal=None, reason="scope", evidence_scope={"bad": "shape"},
+    )
+    assert len(captured) == 1
+    answer = captured[0]["answer"]
+    assert "evidence_scope=" not in answer
+
+
+# ─── trace_synth_call integration ─────────────────────────────────
+
+
+def test_flag_off_ignores_bound_scope(monkeypatch):
+    """With JAMES_SCOPE_ROUTING unset, even an active scope_context is
+    ignored — `trace_synth_call` passes `evidence_scope=None` to the
+    router and emits no scope fragment in the audit row."""
+    monkeypatch.delenv("JAMES_SCOPE_ROUTING", raising=False)
+    # scope_context binding is non-None
+    breakdown = _make_breakdown(0.9)
+    assert scope_routing_enabled() is False
+    with scope_context(breakdown):
+        # The trace_helpers wiring uses scope_routing_enabled() as the
+        # gate — confirm that flag OFF means get_current_scope is
+        # NEVER consulted to make a routing decision (the bound value
+        # exists, but the flag check short-circuits).
+        from core.reasoning.evidence_scope import (
+            get_current_scope as _get,
+            scope_routing_enabled as _enabled,
+        )
+        scope = _get() if _enabled() else None
+        assert scope is None
+        # Sanity: the bound value is still there, just gated out
+        assert _get() is breakdown
+
+
+def test_flag_on_propagates_bound_scope(monkeypatch):
+    """With JAMES_SCOPE_ROUTING=1, the scope read at the synth gate
+    matches the bound breakdown."""
+    monkeypatch.setenv("JAMES_SCOPE_ROUTING", "1")
+    breakdown = _make_breakdown(0.85)
+    assert scope_routing_enabled() is True
+    with scope_context(breakdown):
+        from core.reasoning.evidence_scope import (
+            get_current_scope as _get,
+            scope_routing_enabled as _enabled,
+        )
+        scope = _get() if _enabled() else None
+        assert scope is breakdown
+        assert scope.scope == pytest.approx(0.85)
+
+
+# ─── compute_scope + scope_context wiring (the pipeline path) ─────
+
+
+def test_compute_then_bind_round_trips_under_flag_on(monkeypatch):
+    """Mimics what pipeline.py does after Loop 1: compute scope from
+    loop_state-shaped inputs, bind, observe value at synth time."""
+    monkeypatch.setenv("JAMES_SCOPE_ROUTING", "1")
+    docs = [
+        {"score": 0.7 + i * 0.02, "source": f"d{i}.md"} for i in range(8)
+    ]
+    graph_ctx = [{"_dfs_depth": 3, "name": f"e{i}"} for i in range(6)]
+    graph_paths = ["a->b", "b->c", "c->d"]
+
+    breakdown = compute_scope(docs, graph_ctx, graph_paths)
+    with scope_context(breakdown):
+        observed = get_current_scope()
+        assert observed is breakdown
+        assert 0.4 < observed.scope < 1.0


### PR DESCRIPTION
## Summary

Wires LEO L.A extractor (PR #513) + L.B router policy (PR #514) into the production synth path. Flag OFF (`JAMES_SCOPE_ROUTING` unset) → byte-identical to post-L.B main. Flag ON → measured evidence scope drives synth-stage backend selection.

## Changes

| File | Δ | Purpose |
|---|---|---|
| `core/reasoning/evidence_scope.py` | +60 | `scope_context(...)` ContextVar + `get_current_scope()` reader |
| `core/reasoning/pipeline.py` | +63 | Compute scope after Loop 1, wrap `generate_answer(...)` in `with scope_context(...)` |
| `core/reasoning/trace_helpers.py` | +33 | `trace_synth_call` reads bound scope, passes `evidence_scope=` to `resolve_backend` + `emit_route_event` |
| `core/reasoning/router.py` | +26 | `emit_route_event` accepts ScopeBreakdown / float / None payload in audit row |
| `tests/test_evidence_scope_wiring.py` | new (12) | ContextVar + audit payload + flag gating contract pins |

## Verification

- **155/155** L.A + L.B + L.C + previously-flaky router-adjacent tests pass.
- **2560/2560** under the CI-mirroring exclusion set — no regression vs post-L.B main (was 2548; +12 from L.C tests).
- **Flag-OFF byte-identical invariant** pinned at three levels:
  - `test_flag_off_ignores_bound_scope` — the gate (`get_current_scope() if scope_routing_enabled() else None`) returns None even with a bound breakdown
  - `test_emit_route_event_no_scope_fragment_when_none` — audit `answer` string preserves the pre-L.C shape exactly
  - `pipeline.py` `_scope_breakdown` stays None when flag OFF, `scope_context(None)` is a no-op binding

## Architectural choice: ContextVar over signature threading

Threading `evidence_scope=` through `generate_answer` → 5 internal call sites → `trace_synth_call` would have churned every synth signature. ContextVar bound in `pipeline.py` and read inside `trace_synth_call`:

- Async/thread-safe via `contextvars.ContextVar`
- Cleanup guaranteed on exception (token reset in `finally`)
- No signature changes outside the seam
- Mirrors how `trace_id` already propagates in this codebase (`core.observability.get_trace_id()`)

## LEO open question #3 (mode gate) — naturally satisfied

`engine._query_impl` dispatches `chat` / `meta` / `wiki_edit` / `self_evolve` / `coding` modes to `handle_*` helpers **before** `run_retrieval_pipeline` runs. The scope wrapper only sits inside the retrieval pipeline → those modes never see a scope binding, no explicit gate needed.

## Audit payload format

With flag ON and a scope bound, the `reason:route` audit row's `answer` field carries:

```
backend=stub_large tier=none reason=scope prompt=<8-hex> \
  evidence_scope=0.7234 effective_k=0.8750 score_entropy=0.6312 \
  graph_reach=0.6667 doc_spread=1.0000
```

With flag OFF or no scope bound, the `reason=scope` and 5 scope fields are entirely omitted — pre-L.C shape preserved.

## Out of scope (deferred)

- **L.D closure**: `reports/promo-assets/v3prime-leo-evidence-scope-result.md` + ROADMAP entry + memory sync (L.A entry memo → SUPERSEDED, closure memo).
- **STEP 7 3-arm bench** (narrow / wide / halt-prone): **operator action** with live JAMES server. Flag-OFF baseline run mandatory first to confirm byte-identical invariant on the live corpus, then flag-ON arms to measure halt-rate reduction + quality preservation.
- **Reflect / verify scope-aware routing**: those stages have their own per-class `resolve_backend_for_stage(...)` call sites independent of `trace_helpers`. Wiring scope into them is L.E if data justifies it.
- **`pipeline.py` module split**: now at 19.0 KB / 20 KB gate. Future synth additions should split into `pipeline_scope.py` first.

## Operational reminder (cross-stack runs)

Robin (V3'.e schema-adopted) and Ali (Track 3 swap_eval) cross-stack comparisons MUST run with `JAMES_SCOPE_ROUTING=0` for apples-to-apples purity. `scripts/swap_eval.py` (Track 3 pre-work) will pin this in code.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic infra
- rule #2 (bench on core/{retrieval,graph,reasoning}): STEP 7 3-arm bench deferred to operator action (live LLM required); flag-OFF unit tests pin invariance
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): `architecture` label — pipeline.py routing-point + new ContextVar API surface
- rule #5 (module ≤ 20 KB): all under cap; `pipeline.py` 19 KB / 20 KB — flagged for follow-up split

L.A → L.B → L.C done. L.D (closure docs + result doc + memory sync) is the final phase; can land after operator runs STEP 7 to populate the result doc.