### PR TITLE
chore(reasoning): split pipeline.py post-loop context into pipeline_context.py

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -31,6 +31,10 @@ import time
 from typing import Any, Dict
 
 from core.reasoning.engine import MAX_LOOP, LOOP_TIMEOUT, TIMING_TARGET_SEC
+from core.reasoning.pipeline_context import (
+    apply_post_check_and_sources_header,
+    build_unified_context,
+)
 from core.reasoning.pipeline_loops import (
     run_loop_0_retrieve, run_loop_1_expand, run_loop_2_verify,
 )
@@ -160,87 +164,21 @@ def run_retrieval_pipeline(
 
         engine._elapsed(t_loop, f"LOOP-{loop_idx}")
 
-    # ── 최종 컨텍스트 결합 ───────────────────────────────
-    t_ctx = time.time()
-    try:
-        # ── unified_score v3 ────────────────────────────────
-        # 원칙: "내부 자료를 실제로 활용했나?"
-        #
-        # [핵심 개선]
-        # ChromaDB는 항상 결과를 반환하므로 docs 수만으로 판단 불가.
-        # avg_vec_score 임계값(0.45) 이상이어야 "실제 관련 자료"로 인정.
-        #
-        # 가중치:
-        #   doc_score   (55%) — 관련 자료 수 (gate 통과 시)
-        #   vec_quality (20%) — 유사도 품질   (gate 통과 시)
-        #   graph_score (25%) — 그래프 경로   (단독으론 최대 25%)
-
-        docs      = loop_state["docs"]
-        graph_ctx = loop_state["graph_context"]
-        graph_pth = loop_state["graph_paths"]
-        avg_vec   = loop_state["avg_vec_score"]
-
-        RELEVANCE_GATE = 0.45  # 이 미만 = ChromaDB가 억지로 찾은 무관한 자료
-
-        if avg_vec >= RELEVANCE_GATE and len(docs) > 0:
-            # 게이트 통과 → 실제 관련 자료 있음
-            doc_score   = min(1.0, len(docs) / 3.0)
-            vec_quality = min(1.0, (avg_vec - RELEVANCE_GATE) / 0.25)  # 0.45~0.70 → 0~1
-        else:
-            # 게이트 미통과 → 관련 자료 없음 (docs 수 무시)
-            doc_score   = 0.0
-            vec_quality = 0.0
-
-        graph_score = min(1.0, len(graph_pth) / 2.0)
-
-        unified_score = (
-            0.55 * doc_score    # 관련 자료 있는지 (핵심)
-            + 0.20 * vec_quality  # 유사도 품질
-            + 0.25 * graph_score  # 그래프 추론 (단독으론 25%까지만)
-        )
-
-        graph_ctx_str = engine.graph.build_graph_context_str(
-            graph_ctx,
-            graph_pth,
-            unified_score=unified_score,
-        )
-        final_context = loop_state["doc_context"] + graph_ctx_str
-        print(f"[CONTEXT] unified={unified_score:.3f} len={len(final_context)}"
-              f" (gate={'pass' if avg_vec >= RELEVANCE_GATE else 'fail'}"
-              f" vec={avg_vec:.3f} doc={doc_score:.2f} graph={graph_score:.2f})")
-    except Exception as e:
-        engine._log("context_build", e, user_role)
-        final_context = loop_state["doc_context"]
-    engine._elapsed(t_ctx, "context_build")
-
-    # ── Post-check ───────────────────────────────────────
-    try:
-        sec_post = engine.security.post_check(final_context, user_role)
-        safe_context = sec_post["context"] if sec_post["allowed"] else ""
-    except Exception as e:
-        engine._log("post_check", e, user_role)
-        safe_context = final_context
-
-    # item #5-A: 답변에 "관련 파일은 X.md, Y.md입니다" 형태로
-    # source 파일을 먼저 명시하기 위해 context 앞에 [관련 자료]
-    # 섹션을 prepend. 모델이 이 헤더를 보고 답변 첫 줄에 인용하도록
-    # rule_text가 지시한다 (response_style.py 참조).
-    source_names = []
-    seen_sources = set()
-    for d in (loop_state.get("docs") or [])[:5]:
-        s = d.get("source") or d.get("name") or d.get("path") or ""
-        if s and s not in seen_sources:
-            # 너무 긴 경로는 잘라서 표시
-            s_disp = s.split("/")[-1].split("\\")[-1]
-            source_names.append(s_disp[:60])
-            seen_sources.add(s)
-    if safe_context.strip() and source_names:
-        sources_header = (
-            "[관련 자료 목록]\n"
-            + "\n".join(f"- {s}" for s in source_names)
-            + "\n\n[자료 내용]\n"
-        )
-        safe_context = sources_header + safe_context
+    # ── 최종 컨텍스트 결합 + Post-check + sources header ──
+    # Extracted to pipeline_context.py (chore/v0.4-pipeline-split).
+    # `build_unified_context` returns (final_context, unified_score)
+    # after running the unified_score v3 + graph context build;
+    # `apply_post_check_and_sources_header` runs the security post_check
+    # and prepends the [관련 자료 목록] header for citation hinting.
+    # Both helpers preserve the v0.3.0+L.C behaviour byte-identical —
+    # this split is module-size hygiene (CLAUDE.md rule #5), not a
+    # semantic change.
+    final_context, unified_score = build_unified_context(
+        engine, loop_state, user_role,
+    )
+    safe_context = apply_post_check_and_sources_header(
+        engine, loop_state, final_context, user_role,
+    )
 
     # ── LEO L.C — evidence-scope measurement + scope-context bind ───
     # When JAMES_SCOPE_ROUTING is ON, compute the post-Loop-1 scope

--- a/core/reasoning/pipeline_context.py
+++ b/core/reasoning/pipeline_context.py
@@ -1,0 +1,166 @@
+"""Post-loop context build + post-check extracted from pipeline.py.
+
+CLAUDE.md rule #5 module-size gate: ``pipeline.py`` hit 19 KB / 20 KB
+after the LEO L.C scope-wiring addition. Any further synth-layer
+addition (Sprint 5 Layer 4 invariants, scope payload extensions, etc.)
+would breach. This module hosts the post-loop context combine + the
+post-check + sources-header block so the outer orchestrator stays
+under cap.
+
+Two pure-helper functions, behaviour byte-identical to the in-place
+blocks (this is a pure refactor; the existing test suite is the
+contract).
+
+  * ``build_unified_context`` — unified_score v3 calculation +
+    graph context string assembly + final_context concat. Reads
+    ``loop_state`` populated by Loops 0/1/2; returns the assembled
+    context string and the unified score for downstream use.
+  * ``apply_post_check_and_sources_header`` — engine.security.post_check
+    + the [관련 자료 목록] prepend. Reads ``loop_state["docs"]`` for
+    source names; returns the post-check'd / header-prefixed context.
+
+Both functions take the engine + user_role to support the existing
+``engine._log(...)`` error path and ``engine.security.post_check(...)``
+call site. ``engine.graph.build_graph_context_str`` is the inner
+graph rendering used unchanged.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Tuple
+
+# Relevance gate threshold — mirrors the local constant pre-extraction
+# and the ``_RELEVANCE_THRESHOLD`` in ``core.reasoning.evidence_scope``
+# (kept synchronized; a single-source consolidation refactor would
+# touch this file + evidence_scope.py + the graph_engine.py MAX_DEPTH
+# consolidation candidate simultaneously, out of scope here).
+_RELEVANCE_GATE: float = 0.45
+
+
+def build_unified_context(
+    engine,
+    loop_state: Dict[str, Any],
+    user_role: str,
+) -> Tuple[str, float]:
+    """unified_score v3 + graph context build + final_context assembly.
+
+    Reads from ``loop_state``:
+      - ``docs``           — top-k reranked retrieval docs
+      - ``graph_context``  — DFS-expanded entity dicts
+      - ``graph_paths``    — reasoning path strings
+      - ``avg_vec_score``  — average vector similarity across docs
+      - ``doc_context``    — text block built by build_doc_context
+
+    Returns:
+        ``(final_context, unified_score)`` — the concatenated text
+        block ready for the post_check stage + the unified score in
+        ``[0, 1]`` for the downstream "low_relevance" branch decision.
+
+    Failure mode: any exception is logged via ``engine._log`` and the
+    function returns ``(loop_state["doc_context"], 0.0)`` — same
+    fallback the in-place block used.
+
+    unified_score v3 rationale (preserved from the inline comment):
+      - ChromaDB always returns results, so doc count alone is
+        insufficient. avg_vec_score must clear ``_RELEVANCE_GATE``
+        (0.45) for "real evidence" classification.
+      - weights: doc_score 55% + vec_quality 20% + graph_score 25%
+        (graph alone caps at 25% so a graph-only answer can't pretend
+        it had retrieval evidence).
+    """
+    t_ctx = time.time()
+    try:
+        docs = loop_state["docs"]
+        graph_ctx = loop_state["graph_context"]
+        graph_pth = loop_state["graph_paths"]
+        avg_vec = loop_state["avg_vec_score"]
+
+        if avg_vec >= _RELEVANCE_GATE and len(docs) > 0:
+            # gate passed → real evidence present
+            doc_score = min(1.0, len(docs) / 3.0)
+            vec_quality = min(1.0, (avg_vec - _RELEVANCE_GATE) / 0.25)
+        else:
+            # gate failed → no real evidence (doc count ignored)
+            doc_score = 0.0
+            vec_quality = 0.0
+
+        graph_score = min(1.0, len(graph_pth) / 2.0)
+
+        unified_score = (
+            0.55 * doc_score
+            + 0.20 * vec_quality
+            + 0.25 * graph_score
+        )
+
+        graph_ctx_str = engine.graph.build_graph_context_str(
+            graph_ctx,
+            graph_pth,
+            unified_score=unified_score,
+        )
+        final_context = loop_state["doc_context"] + graph_ctx_str
+        gate_label = "pass" if avg_vec >= _RELEVANCE_GATE else "fail"
+        print(
+            f"[CONTEXT] unified={unified_score:.3f} "
+            f"len={len(final_context)} (gate={gate_label} "
+            f"vec={avg_vec:.3f} doc={doc_score:.2f} "
+            f"graph={graph_score:.2f})"
+        )
+    except Exception as e:
+        engine._log("context_build", e, user_role)
+        final_context = loop_state["doc_context"]
+        unified_score = 0.0
+    engine._elapsed(t_ctx, "context_build")
+    return final_context, unified_score
+
+
+def apply_post_check_and_sources_header(
+    engine,
+    loop_state: Dict[str, Any],
+    final_context: str,
+    user_role: str,
+) -> str:
+    """Security post_check + [관련 자료 목록] sources-header prepend.
+
+    Returns the ``safe_context`` string ready for synth. When
+    post_check denies, returns an empty context (matches the in-place
+    block's behaviour exactly). When the context is empty or no source
+    names are available, the [관련 자료 목록] header is omitted.
+
+    item #5-A rationale (preserved verbatim from the inline comment):
+    the LLM should cite source files in its first line; rule_text
+    in response_style.py instructs it to read this [관련 자료] header
+    and reproduce filenames in the answer.
+
+    Source names are truncated to the basename of the path (split on
+    ``/`` and ``\\``) and capped at 60 chars to keep the header
+    compact. Top 5 docs only.
+    """
+    try:
+        sec_post = engine.security.post_check(final_context, user_role)
+        safe_context = sec_post["context"] if sec_post["allowed"] else ""
+    except Exception as e:
+        engine._log("post_check", e, user_role)
+        safe_context = final_context
+
+    source_names = []
+    seen_sources = set()
+    for d in (loop_state.get("docs") or [])[:5]:
+        s = d.get("source") or d.get("name") or d.get("path") or ""
+        if s and s not in seen_sources:
+            s_disp = s.split("/")[-1].split("\\")[-1]
+            source_names.append(s_disp[:60])
+            seen_sources.add(s)
+    if safe_context.strip() and source_names:
+        sources_header = (
+            "[관련 자료 목록]\n"
+            + "\n".join(f"- {s}" for s in source_names)
+            + "\n\n[자료 내용]\n"
+        )
+        safe_context = sources_header + safe_context
+    return safe_context
+
+
+__all__ = [
+    "build_unified_context",
+    "apply_post_check_and_sources_header",
+]

--- a/tests/_pipeline_src.py
+++ b/tests/_pipeline_src.py
@@ -3,8 +3,9 @@
 After the chore splits:
 
   * ``pipeline.py`` extracted Loop 0/1/2 step bodies to
-    ``pipeline_loops.py`` and the LLM answer-generation block to
-    ``pipeline_synth.py``.
+    ``pipeline_loops.py``, the LLM answer-generation block to
+    ``pipeline_synth.py``, and the post-loop context combine +
+    sources-header block to ``pipeline_context.py``.
   * ``engine.py`` extracted the memory-context assembly to
     ``engine_memory.py`` and the canonical RAG synth to
     ``engine_synth.py``.
@@ -32,14 +33,21 @@ import inspect
 
 
 def pipeline_source() -> str:
-    """Concatenated source of the three modules that together implement
+    """Concatenated source of the four modules that together implement
     ``run_retrieval_pipeline``. Use instead of
     ``inspect.getsource(pipeline)`` when the symbol you're grepping for
-    may live in any of the three.
+    may live in any of them.
     """
-    from core.reasoning import pipeline, pipeline_loops, pipeline_synth
+    from core.reasoning import (
+        pipeline,
+        pipeline_context,
+        pipeline_loops,
+        pipeline_synth,
+    )
     return (
         inspect.getsource(pipeline)
+        + "\n"
+        + inspect.getsource(pipeline_context)
         + "\n"
         + inspect.getsource(pipeline_loops)
         + "\n"


### PR DESCRIPTION
## Summary

Module-size hygiene — CLAUDE.md rule #5 (20 KB gate). After the LEO L.C scope-wiring addition (PR #516), `pipeline.py` hit 18.9 KB. The next synth-layer addition (Sprint 5 Layer 4 invariants, scope payload extensions, etc.) would breach 20 KB.

This split is **preemptive — pure refactor, byte-identical behaviour**. The existing 2560-test suite is the contract.

## What moves

New `core/reasoning/pipeline_context.py` (~6.5 KB) hosts two self-contained helpers extracted from `run_retrieval_pipeline`:

- **`build_unified_context(engine, loop_state, user_role) → (final_context, unified_score)`** — unified_score v3 calculation (RELEVANCE_GATE=0.45 + 55/20/25 doc/vec/graph weights) + graph context string assembly + final_context concat. Same error-fallback path as the in-place block (returns `(loop_state["doc_context"], 0.0)` on exception).
- **`apply_post_check_and_sources_header(engine, loop_state, final_context, user_role) → safe_context`** — Security `post_check` + [관련 자료 목록] prepend (top-5 docs, filename-only, deduplicated). Same gating: header omitted when context is empty or source list is empty.

The `RELEVANCE_GATE` constant is now module-level `_RELEVANCE_GATE` (mirrors the value in `core.reasoning.evidence_scope._RELEVANCE_THRESHOLD` — single-source consolidation candidate noted, out of scope for this PR).

## Sizes (CLAUDE.md rule #5, 20 KB gate)

| File | Before | After |
|---|---|---|
| `core/reasoning/pipeline.py` | 19.0 KB | **16.0 KB** |
| `core/reasoning/pipeline_context.py` | — | **6.5 KB** |

3 KB headroom returned to `pipeline.py` covers Sprint 5 Layer 4 wiring + any L.C/L.D follow-ups without splitting again.

## Helper update (`tests/_pipeline_src.py`)

`pipeline_source()` already concatenates split companions (`pipeline_loops.py`, `pipeline_synth.py`) for structural tests like `test_source_files_first.py` that grep the combined source. Updated to include the new `pipeline_context.py` companion — fixes the 4 `PipelineSourcePrependTests` failures that the split would otherwise trigger.

## Verification

- Smoke import + `run_retrieval_pipeline` signature unchanged.
- `test_source_files_first.py`: **12 / 12 pass** after helper update.
- Router + L.A/L.B/L.C + previously-flaky test set: **155 / 155 pass**.
- Broad CI-mirroring sanity: **2560 pass, 870 subtests pass** — zero regression vs post-L.D-bench-wrapper main.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic refactor
- rule #2 (bench on core/{retrieval,graph,reasoning}): refactor only, no behaviour change. Existing STEP 7 baseline applies unchanged.
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): N/A — module-size split, no boundary change
- rule #5 (module ≤ 20 KB): **the whole point** ✅