### PR TITLE
chore(release): v0.4.0-alpha.3 prep — LEO routing track + Sprint 4 prep + CI/module hygiene

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,13 +1,20 @@
 {
-  "title": "PROJECT JAMES — v0.4.0-alpha.2 (UI consistency bundle + cognitive plumbing + 5-stage D1 surface)",
-  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.0-alpha.2 is the first alpha tag of the v0.4 cycle, bundling two sprints of stabilisation work between the v0.3.x stack closure (v0.3.3, D6 retry wiring) and the v0.4.0 final Layer 4 main theme (Lifecycle Semantics, planned Sprint 5).\n\nSprint 2 — UI consistency bundle (5 PRs):\n- #496 admin character profile page i18n consistency — 38 new char.* keys + onLangChange dynamic re-render + CORE/VALUES/STYLE data-i18n. Closes the long-standing bug where the character summary card body + connections panel kept rendering Korean strings in EN mode.\n- #497 chat sidebar hover auto-expand — CSS-only sibling+self :hover rule. Click-toggle UX preserved untouched.\n- #498 always-visible chat model indicator chip — new /llm/active endpoint (api_key only, not admin-gated) + chip in chat header. data-source attribute drives edge colour for non-default resolution.\n- #499 chat-side model picker popover — chip click opens popover listing installed models; selection writes to selectedModel (per-session override) + localStorage. Authority chain unchanged (per-call > env > preference > any).\n- #500 sticky top navigation on scrolling pages — admin / workspace get position:sticky on the header; chat / graph keep their overflow:hidden viewport pattern (negative-assertion tests pin the per-page policy).\n\nSprint 3 — Plumbing closure (5 PRs + 2 follow-ups):\n- #501 BL-1 emit_trace_step stdout mirror — all reasoning stages now emit single-line `[reason:<stage>]` rows under JAMES_TRACE_STDOUT. Closes feedback_stdout_vs_audit_log_trace_split: planner / reflect / verify used to write to audit_log DB only.\n- #502 BL-2 attributes.summary legacy field cleanup — new wiki writes stop emitting the top-level duplicate; read fallback kept for legacy disk files.\n- #503 / #504 / #505 D1 stage expansion (#7a planner / #7b reflect / #7c verify) — all five reasoning stages (query_rewriter / synth / planner / reflect / verify) now wire D1 adaptive-budget + D6 retry through the same TaskBudget.assess + complete_with_retry pattern. Default-off byte-identical invariant preserved. Closes feedback_d1_d5_retry_doubled_wiring_gap's note that the cognitive stages held cap-ceiling defaults so D1 + D6 were no-ops.\n- #506 follow-up — test_verifier.py ANSWER_KO fixture rebalanced under PR #495 (Sprint 1 #2) dominant-script i18n contract.\n- #507 follow-up — query_rewriter local _adaptive_budget_enabled migrated to budget.adaptive_budget_enabled (single source of truth across all 5 stages).\n\nThe alpha release stays opt-in across both D1 and D5 (JAMES_ADAPTIVE_BUDGET / JAMES_AUTO_ROUTER both default OFF). Production fleets pulling alpha.2 see zero behaviour change relative to v0.3.3.",
-  "version": "v0.4.0-alpha.2",
+  "title": "PROJECT JAMES — v0.4.0-alpha.3 (LEO Evidence-Scope routing track L.0→L.D + Sprint 4 embedding prep + CI / module hygiene)",
+  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.0-alpha.3 is the second alpha tag of the v0.4 cycle, bundling the full LEO Evidence-Scope Routing track (4 phases from design memo through engine wiring + operator bench wrapper) plus Sprint 4 embedding-abstraction prep, CI infrastructure stabilisation, and module-size hygiene. Sits between v0.4.0-alpha.2 (Sprint 2 UI consistency + Sprint 3 5-stage D1 surface, prepped 2026-05-25 but not released — superseded by this tag) and the v0.4.0 final Layer 4 main theme (Lifecycle Semantics, planned Sprint 5).\n\nLEO Evidence-Scope Routing Track (5 PRs, 4 phases) — measured input-side routing axis complementing the predicted output-side D5 budget axis:\n- #512 (external author 222315AIS — LEO / Younghu) L.0 design memo (docs/handovers/v0.4-leo-evidence-scope-routing-track.md) + README walk-back. Track originated by Jiwon's Gemma 4 generation-halt diagnostic question; Leo proposed measuring data scope (input-side) instead of predicting token count (output-side). First external contribution to the repo.\n- #513 L.A — core/reasoning/evidence_scope.py extractor + JAMES_SCOPE_ROUTING flag (default OFF). ScopeBreakdown dataclass + compute_scope() pure function reading loop_state retrieval/graph output. 4 components: effective_k (0.35) + graph_reach (0.25) + doc_spread (0.20) + score_entropy (0.20). 23 contract tests pin the API + invariants.\n- #514 L.B — Router.select_backend + resolve_backend + _route_policy gain kwarg-only evidence_scope. Policy v1 thresholds: narrow (scope ≤ 0.30) → small backend, wide (scope ≥ 0.70) → large/medium, mid-band falls through to D5 budget rule. verify stage still wins (rule 1 priority). 23 contract tests.\n- #516 L.C — ContextVar wiring (scope_context + get_current_scope) bound in pipeline.py post-Loop-1, read in trace_helpers.trace_synth_call gate. emit_route_event audit payload extended with evidence_scope + 4 components. Zero signature churn through generate_answer → trace_synth_call chain (ContextVar pattern mirrors observability.get_trace_id). 12 contract tests pin ContextVar + audit payload + flag-OFF byte-identical at three layers.\n- #517 L.D operator bench wrapper — scripts/bench_lc_scope_arms.py runs scripts/bench.py twice (flag-OFF + flag-ON) against a live JAMES server, queries audit_log for reason:route scope payload during the flag-ON window, and writes aggregated per-query delta + scope distribution to reports/research-runs/lc-scope-bench-<timestamp>.json. Deferred to operator's live-server execution window.\n\nSprint 4 prep (1 PR):\n- #509 BL-9 embedding abstraction — JAMES_EMBEDDING_MODEL env + _embedding_short_name slug helper + per-model models/<short> cache path + per-model chroma_db_<short> directory. Default-off byte-identical: legacy MiniLM tag maps to models/miniLM + chroma_db. Actual default flip + re-embed migration is the Sprint 4 swap PR.\n\nCI infrastructure (1 PR):\n- #515 conftest pre-import — tests/conftest.py warms sys.modules for core.vector_store + core.memory + core.wiki_generator + llm.router at session start. Eliminates the recurring CI flake where patch('core.vector_store.VectorStore') triggered a 5s sentence_transformers+torch cold-import cascade inside setUp, crossed the per-test 30s pytest-timeout, killed setUp mid-execution, and leaked patch('llm.router.RouterWrapper') into the next process. Six legacy test fixtures benefit transparently with no test source changes.\n\nDocs (1 PR):\n- #510 ARCHITECTURE §5.7.9 — LLM model authority chain (per-call > env > preference > any installed > none) + D5 (per-backend) vs model_resolver (per-tag) two-axis disambiguation.\n\nModule-size hygiene (1 PR):\n- #518 pipeline.py split — extract post-loop context combine + post-check + [관련 자료 목록] sources-header to core/reasoning/pipeline_context.py. Pure refactor, byte-identical. pipeline.py 19.0 KB → 16.0 KB, returns 3 KB headroom for Sprint 5 Layer 4 wiring. tests/_pipeline_src.py:pipeline_source() helper updated to include the new split companion.\n\nAll new behaviour stays opt-in: JAMES_SCOPE_ROUTING (LEO L.C, default OFF) + JAMES_EMBEDDING_MODEL (Sprint 4 prep, default MiniLM) + existing JAMES_ADAPTIVE_BUDGET / JAMES_AUTO_ROUTER (default OFF). Production fleets pulling alpha.3 see zero behaviour change relative to v0.3.3.\n\nOperator action queue for L.D closure: run scripts/bench_lc_scope_arms.py against a live server, paste the resulting aggregate JSON into reports/promo-assets/v3prime-leo-evidence-scope-result.md, tick the ROADMAP D-LEO entry. Cross-stack comparison runs (Robin V3'.e schema-adopted, Ali Track 3 swap_eval) must pin all opt-in routing flags OFF for apples-to-apples purity.",
+  "version": "v0.4.0-alpha.3",
   "upload_type": "software",
   "creators": [
     {
       "name": "Seo, Jiwon",
       "orcid": "0009-0002-0007-7860",
       "affiliation": "Hashevolution"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "LEO (Younghu)",
+      "type": "Researcher",
+      "affiliation": "ais.edu.hk"
     }
   ],
   "keywords": [
@@ -19,6 +26,9 @@
     "gemma",
     "ollama",
     "auto-routing",
+    "evidence-scope-routing",
+    "measured-input-routing",
+    "context-var-pattern",
     "provider-contract",
     "backend-capability",
     "cross-lingual-rag",
@@ -30,9 +40,9 @@
     "retry-fallback",
     "truncation-detection",
     "audit-trail",
+    "embedding-abstraction",
     "korean-nlp",
-    "ui-i18n",
-    "observability-stdout-mirror"
+    "module-size-hygiene"
   ],
   "license": "MIT",
   "access_right": "open",
@@ -54,25 +64,30 @@
       "resource_type": "software"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/496",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/512",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/500",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/513",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/503",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/514",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/505",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/516",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/517",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     }
   ],
-  "notes": "v0.4.0-alpha.2 is the alpha milestone of the v0.4 cycle — first deliverable between v0.3.x closure and v0.4.0 final (Layer 4 main theme, Sprint 5). The release ships UI consistency improvements (Sprint 2) and the 5-stage D1 surface uniformity (Sprint 3) without any production-behaviour change at the default flag setting. v0.4.0 final will add T1 Lifecycle states + T2 Event-driven transitions + T7 Cross-workspace federation primitives as the architectural shift planned for that tag (see ROADMAP.md §v0.4.0). When mint completes, the explicit isNewVersionOf chain back to v0.3.3 will land in the next deposit; v0.3.3's specific DOI is operator-supplied at GitHub release publish time. Three-author joint-piece collaboration with Robin Converse (Triava Labs) and Ali Afana (Provia) remains the next-cycle research trajectory; the JAMES-side product stack continues stabilising for v0.4.0 final."
+  "notes": "v0.4.0-alpha.3 is the second alpha milestone of the v0.4 cycle. The previously-prepped v0.4.0-alpha.2 (PR #508 metadata only, 2026-05-25, Sprint 2 UI consistency + Sprint 3 5-stage D1 surface) was never released to GitHub; this alpha.3 tag supersedes it and inherits its scope, then adds the LEO Evidence-Scope Routing track (L.0 design through L.D operator bench wrapper, 5 PRs), Sprint 4 BL-9 embedding abstraction prep, CI infrastructure stabilisation (conftest pre-import), and pipeline.py module-size hygiene. v0.4.0 final will add T1 Lifecycle states + T2 Event-driven transitions + T7 Cross-workspace federation primitives as the architectural shift planned for that tag (see ROADMAP.md §v0.4.0). The LEO contribution (#512 design memo by external author 222315AIS) is JAMES's first external PR and the first to carry a contributor entry in this deposit's metadata. When mint completes, the explicit isNewVersionOf chain back to v0.3.3 (10.5281/zenodo.20XXXXXX, operator-supplied at publish time) will land in the next deposit; the chain back to v0.3.2 / v0.3.1 (specific DOIs 10.5281/zenodo.20372649 / 10.5281/zenodo.20363998) stays explicit in related_identifiers as isDerivedFrom. Three-author joint-piece collaboration with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the next-cycle research trajectory; the JAMES-side product stack continues stabilising for v0.4.0 final."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.0-alpha.2] — 2026-05-25 — v0.4 alpha bundle (Sprint 2 UI consistency + Sprint 3 plumbing & 5-stage D1 surface)
+## [0.4.0-alpha.3] — 2026-05-26 — LEO Evidence-Scope routing track (L.0→L.D) + Sprint 4 embedding prep + CI / module hygiene
+
+**Theme**: second alpha tag of the v0.4 cycle. Bundles the full LEO Evidence-Scope Routing track (4 phases, 5 PRs) — a measured input-side routing axis complementing the predicted output-side D5 budget axis — plus Sprint 4 BL-9 embedding-abstraction prep, CI infrastructure stabilisation (conftest pre-import that eliminates a recurring CI flake), and pipeline.py module-size hygiene. Supersedes the never-released v0.4.0-alpha.2 prep (PR #508, see [0.4.0-alpha.2] below for the historical entry). **Default-off invariant preserved** across all opt-in flags (`JAMES_SCOPE_ROUTING` / `JAMES_EMBEDDING_MODEL` / `JAMES_ADAPTIVE_BUDGET` / `JAMES_AUTO_ROUTER`): production fleets pulling alpha.3 see zero behaviour change relative to v0.3.3.
+
+### LEO Evidence-Scope Routing Track (5 PRs, 4 phases — measured input-side axis)
+
+Track originated by Jiwon's Gemma 4 generation-halt diagnostic question; Leo (Younghu, external contributor, GitHub `222315AIS`) proposed measuring data scope (input-side, post-retrieval) instead of predicting token count (output-side, pre-retrieval). Five PRs across the L.0 → L.D phase plan from `docs/handovers/v0.4-leo-evidence-scope-routing-track.md`.
+
+- **#512 L.0 design memo (external — first external PR to the repo)** — `docs/handovers/v0.4-leo-evidence-scope-routing-track.md` + README walk-back trimming the future-binding "and that's how we intend to keep it" phrase. JAMES-side merge resolved + path renamed `docs/James_leo_evidencescoperoutingtrack` → `docs/handovers/v0.4-leo-evidence-scope-routing-track.md` to match the handovers/ convention. CLA workflow (shipped in #340) fired cleanly on this contribution.
+- **#513 L.A extractor + flag** — `core/reasoning/evidence_scope.py` (~13 KB). `ScopeBreakdown` frozen dataclass + `compute_scope(docs, graph_context, graph_paths) → ScopeBreakdown` pure function reading `loop_state` retrieval / graph output. 4 components weighted: `effective_k` (0.35) + `graph_reach` (0.25) + `doc_spread` (0.20) + `score_entropy` (0.20). `JAMES_SCOPE_ROUTING` env flag (default OFF). 23 contract tests in `tests/test_evidence_scope.py` pin the API + empty-input safety net + flag parsing + audit payload schema + determinism + frozen-dataclass guard. Module-level weight constants so Direction 2 regression can swap them in one place. Drive-by F401 cleanup: `Optional` unused in evidence_scope.py + `CAP_SUBSTITUTION` / `TaskBudget` unused in `test_planner_d1_wiring.py` (PR #507 leftover) + `test_adaptive_budget::test_module_exports` `__all__` updated to include PR #507's `adaptive_budget_enabled` entry.
+- **#514 L.B router signature + policy v1** — `Router.select_backend` + `resolve_backend` + `_route_policy` gain kwarg-only `evidence_scope`. Policy v1 thresholds: `_SCOPE_NARROW_THRESHOLD=0.30` / `_SCOPE_WIDE_THRESHOLD=0.70` (module constants, L.D tuning candidates). Decision rule order: verify-stage (rule 1, grounding-critical) > scope-override (rule 2, narrow → small / wide → large) > budget rules (3, 4, CAP_SUBSTITUTION / CAP_HEAVY) > legacy. mid-band (0.30 < scope < 0.70) falls through to budget — implements LEO open Q #4 "measurement can promote/demote one tier, not two" as a bounded correction rather than wholesale replacement. 23 contract tests in `tests/test_router_evidence_scope.py` (threshold ordering + narrow/wide overrides + fallback chain + mid-band fall-through + scope=None D5.C.1 regression + verify-wins-over-scope priority).
+- **#515 CI flake permanent fix — conftest pre-import (root-cause repair surfaced during L.B)** — `tests/conftest.py` warms `sys.modules` for `core.vector_store` + `core.memory` + `core.wiki_generator` + `llm.router` at session start. Root cause: `patch("core.vector_store.VectorStore")` in legacy `_MarkdownStripBase.setUp` triggered a ~5s `sentence_transformers`+`torch` cold-import cascade inside setUp, crossed the per-test 30s pytest-timeout on slow CI runners, killed setUp mid-execution → `tearDown` never ran → `patch("llm.router.RouterWrapper")` started earlier in the same setUp **leaked**, surfacing downstream as `test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta` failing with `Expected 'call_router_meta' to be called once. Called 0 times.`. Six legacy test fixtures benefit transparently with no test source changes. CI pytest stabilised: 4m34s (intermittent fail) → 3m1s (consistent green).
+- **#516 L.C engine wiring + audit payload (ContextVar pattern)** — new `scope_context(...)` context manager + `get_current_scope()` reader in `evidence_scope.py`. `pipeline.py` computes scope after Loop 1 (graph_context + graph_paths populated) and wraps `generate_answer(...)` in `with scope_context(...)` so all five synth-path `trace_synth_call` invocations (rag / web_summary / web_fallback / retry_no_info, plus reflect / verify routed through trace_helpers) see the same scope. `trace_helpers.trace_synth_call` reads `get_current_scope()` (gated on `scope_routing_enabled()`) and passes `evidence_scope=breakdown.scope` to `resolve_backend`. `router.emit_route_event` audit payload extended: with a `ScopeBreakdown` it emits all 5 fields (`evidence_scope` + 4 components); with a bare float, the scalar only; with `None`, omits the scope fragment → flag-OFF audit-row shape preserved bit-for-bit. 12 contract tests in `tests/test_evidence_scope_wiring.py` pin ContextVar set / get / nested / cleanup-on-exception + audit payload shape for ScopeBreakdown vs float vs None vs invalid + flag-OFF byte-identical at three layers. Mode-gate (LEO open Q #3) auto-resolved: `engine._query_impl` dispatches `chat` / `meta` / `wiki_edit` / `self_evolve` / `coding` modes to `handle_*` helpers **before** `run_retrieval_pipeline` runs, so the scope context only ever wraps the retrieval pipeline.
+- **#517 L.D operator bench wrapper** — `scripts/bench_lc_scope_arms.py`. Operator-runnable. Runs `scripts/bench.py --suite=step7` twice (flag-OFF baseline + flag-ON arm) against a live JAMES server, queries `audit_log` for `reason:route` rows from the flag-ON window, aggregates per-query elapsed delta + scope distribution (narrow / mid / wide bin counts) + backend selection counts into `reports/research-runs/lc-scope-bench-<timestamp>.json`. Acceptance criteria reported but not enforced (that is the L.D result doc's job). Deferred to operator's live-server execution window — L.D closure consumes the resulting aggregate JSON.
+
+### Sprint 4 prep (1 PR — Sprint 4 swap PR deferred to operator compute window)
+
+- **#509 BL-9 embedding model abstraction** — `JAMES_EMBEDDING_MODEL` env + `_embedding_short_name` slug helper + per-model `models/<short>` cache path + per-model `chroma_db_<short>` directory. Default-off byte-identical: legacy MiniLM tag maps to `models/miniLM` + `chroma_db`. Actual default flip (likely `bge-m3` or `multilingual-e5-large`) + re-embed migration runner is the Sprint 4 swap PR — operator compute window required.
+
+### Documentation (1 PR)
+
+- **#510 ARCHITECTURE §5.7.9 LLM model authority chain** — per-call > env > preference > any installed > none. D5 (per-backend) ↔ model_resolver (per-tag) two-axis disambiguation. `architecture` label PR (CLAUDE.md rule #4 compliance for the model-resolution surface documentation).
+
+### Module-size hygiene (1 PR)
+
+- **#518 pipeline.py post-loop context split** — extract `build_unified_context` (unified_score v3 + graph context assembly) + `apply_post_check_and_sources_header` (post_check + [관련 자료 목록] prepend) from `pipeline.py` to new `core/reasoning/pipeline_context.py`. Pure refactor, byte-identical behaviour. `pipeline.py` 19.0 KB → 16.0 KB, returns 3 KB headroom for Sprint 5 Layer 4 wiring without breaching the 20 KB CLAUDE.md rule #5 cap. `tests/_pipeline_src.py:pipeline_source()` helper updated to include the new split companion (preserves the structural-grep test pattern used by `test_source_files_first.py` and similar).
+
+### Default-off invariant verified (every new opt-in)
+
+| Flag | Default | Verification |
+|---|---|---|
+| `JAMES_SCOPE_ROUTING` (LEO L.C, new) | OFF | `test_flag_off_ignores_bound_scope` + `test_emit_route_event_no_scope_fragment_when_none` + pipeline.py `scope_context(None)` no-op path |
+| `JAMES_EMBEDDING_MODEL` (Sprint 4 prep, new) | unset → MiniLM tag (= legacy `models/miniLM` + `chroma_db`) | retrieval-engine tests pin per-model path resolution; default flip is the Sprint 4 swap PR, not this alpha |
+| `JAMES_ADAPTIVE_BUDGET` (D1, pre-existing) | OFF | unchanged |
+| `JAMES_AUTO_ROUTER` (D5, pre-existing) | OFF | unchanged |
+
+### Cross-stack collaboration boundary
+
+Robin (V3'.e schema-adopted research runs) and Ali (Track 3 swap_eval) cross-stack comparisons MUST pin all opt-in routing flags OFF for apples-to-apples purity. Documented in memory `feedback_cross_stack_run_flag_off` and in the L.D bench-wrapper docstring. Joint piece (mid-June trigger) inclusion of evidence-scope deferred to L.D closure + at least one Ali Track 3 swap_eval result.
+
+### Verified
+
+- 9 PRs land green on `pytest` for the changed surface + broader regression. CI pytest run-time stable at 3m1s after #515 (was 4m34s with intermittent failures pre-fix).
+- New tests added across the bundle: `test_evidence_scope.py` (23), `test_router_evidence_scope.py` (23), `test_evidence_scope_wiring.py` (12). Cumulative new tests for the LEO track: 58.
+- No `core/` file exceeds 20 KB after the bundle. `pipeline.py` post-#518 split at 16.0 KB; `router.py` 17.7 KB; `evidence_scope.py` 13 KB; `trace_helpers.py` 10.7 KB. `verify.py` remains at 19.2 KB pending the next verify addition.
+- ruff / hooks clean on every PR (including drive-by F401 cleanups bundled with #513).
+
+### Operator action
+
+GitHub release publish (`gh release create v0.4.0-alpha.3 --target main --title "v0.4.0-alpha.3 — LEO Evidence-Scope routing (L.0→L.D) + Sprint 4 prep + CI hygiene" --notes-file <changelog excerpt>`) triggers Zenodo automatic mint. The minted DOI for v0.3.3 (operator-supplied at this publish time) will be added as `isNewVersionOf` in the next deposit; the chain back to v0.3.2 / v0.3.1 (specific DOIs `10.5281/zenodo.20372649` / `10.5281/zenodo.20363998`) stays explicit in `related_identifiers` as `isDerivedFrom`. L.D closure operator path (separate from release publish): run `python scripts/bench_lc_scope_arms.py` against a live JAMES server, paste the aggregate JSON into `reports/promo-assets/v3prime-leo-evidence-scope-result.md`, tick the ROADMAP entry.
+
+### Out of scope for v0.4.0-alpha.3 (Sprint 4 swap + Sprint 5 follow-up)
+
+- **Sprint 4 swap PR** — default flip `JAMES_EMBEDDING_MODEL` → `bge-m3` (or `multilingual-e5-large`) + re-embed migration runner. Requires operator compute window for the full chroma re-embed pass.
+- **Sprint 5 Layer 4 main theme** — T1 Lifecycle states + T2 Event-driven transitions + T7 Cross-workspace federation primitives. The architectural shift planned for v0.4.0 final.
+- **LEO L.D closure docs** — `reports/promo-assets/v3prime-leo-evidence-scope-result.md` + ROADMAP entry + memory sync. Waits on operator STEP 7 live run (#517 wrapper is the input).
+- **Constant consolidation** — `RELEVANCE_GATE` (now in `pipeline_context.py`) + `MAX_DEPTH` (in `graph_engine.py`) + `_RELEVANCE_THRESHOLD` / `_GRAPH_MAX_DEPTH` (in `evidence_scope.py`) are intentionally mirrored with comments; a single-source consolidation PR would touch all three modules atomically.
+- `verify.py` module split (19.2 KB, approaching 20 KB cap; extract `_verify_security` / `_verify_fact_check` on next addition).
+
+---
+
+## [0.4.0-alpha.2] — 2026-05-25 — v0.4 alpha bundle (Sprint 2 UI consistency + Sprint 3 plumbing & 5-stage D1 surface) — **PREPPED, NOT RELEASED — superseded by [0.4.0-alpha.3]**
+
+> **Note**: this entry documents the v0.4.0-alpha.2 release prep (PR #508 — `.zenodo.json` + CHANGELOG + README badge) that landed on `main` 2026-05-25. No GitHub release was published before nine additional PRs (LEO L.0→L.D + Sprint 4 prep + CI fix + module hygiene) merged on 2026-05-26. The alpha.2 scope is now part of [0.4.0-alpha.3]'s ancestry; the historical entry below is preserved so the alpha.2 prep work (Sprint 2 + Sprint 3) is still attributable to the right window.
 
 **Theme**: first alpha tag of the v0.4 cycle — the deliverable between v0.3.x closure (v0.3.3, D6 retry wiring) and the v0.4.0 final Layer 4 main theme (Lifecycle Semantics, Sprint 5). Two sprints of stabilisation work bundled into one citable archive. **Default-off invariant preserved** across all D1 / D5 flags: production fleets pulling alpha.2 see zero behaviour change relative to v0.3.3.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,7 +5,7 @@
 > 기반 자기진화.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.0--alpha.2-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0-alpha.2)
+[![Status](https://img.shields.io/badge/Status-v0.4.0--alpha.3-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0-alpha.3)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20372649.svg)](https://doi.org/10.5281/zenodo.20372649)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > behind a human approval gate.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.0--alpha.2-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0-alpha.2)
+[![Status](https://img.shields.io/badge/Status-v0.4.0--alpha.3-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0-alpha.3)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20372649.svg)](https://doi.org/10.5281/zenodo.20372649)


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.4.0-alpha.3**. Supersedes the never-released **v0.4.0-alpha.2 prep** (PR #508 metadata only, 2026-05-25). alpha.3 inherits alpha.2's scope (Sprint 2 UI + Sprint 3 5-stage D1 surface) and adds the nine PRs merged 2026-05-25 → 2026-05-26 since alpha.2 prep landed.

**Metadata only — no code changes.** After this merges, operator runs `gh release create v0.4.0-alpha.3` which triggers Zenodo automatic mint.

## What's new in alpha.3 (the nine PRs added since alpha.2 prep)

### LEO Evidence-Scope Routing track (5 PRs, 4 phases)

| PR | Phase | What |
|---|---|---|
| #512 | L.0 | Design memo (external author 222315AIS — LEO / Younghu, first external PR) + README walk-back |
| #513 | L.A | `core/reasoning/evidence_scope.py` extractor + `JAMES_SCOPE_ROUTING` flag (default OFF). 23 contract tests. |
| #514 | L.B | Router signature extension + policy v1 (narrow 0.30 / wide 0.70 thresholds, mid-band fall-through). 23 contract tests. |
| #516 | L.C | ContextVar wiring + audit payload extension. 12 contract tests. Mode-gate auto-resolved. |
| #517 | L.D | Operator bench wrapper `scripts/bench_lc_scope_arms.py` (3-arm STEP 7). Deferred to operator's live-server execution. |

### Sprint 4 prep + CI + Docs + Hygiene (4 PRs)

| PR | Scope |
|---|---|
| #509 | BL-9 embedding model abstraction (default-off; Sprint 4 swap PR deferred to operator compute window) |
| #510 | ARCHITECTURE §5.7.9 — LLM model authority chain disambiguation |
| #515 | conftest pre-import — root-cause fix for the recurring CI flake (heavy patch leak via setUp timeout) |
| #518 | pipeline.py split 19.0 → 16.0 KB (returns 3 KB headroom before Sprint 5 wiring) |

## Files changed

| File | Δ |
|---|---|
| `.zenodo.json` | version + title + description + new `contributors` entry for LEO (Younghu) + new keywords + swapped `related_identifiers` to the LEO track PRs |
| `CHANGELOG.md` | New `[0.4.0-alpha.3]` entry above alpha.2; alpha.2 entry header annotated as "PREPPED, NOT RELEASED — superseded by [0.4.0-alpha.3]" with one-paragraph supersede explanation so alpha.2's Sprint 2+3 attribution stays in its 2026-05-25 window |
| `README.md` / `README.ko.md` | Status badge v0.4.0-alpha.2 → v0.4.0-alpha.3 (link target updated to the future release URL) |

## Default-off invariant pinned

| Flag | Default | Verification |
|---|---|---|
| `JAMES_SCOPE_ROUTING` (LEO L.C, new) | OFF | `test_flag_off_ignores_bound_scope` + `test_emit_route_event_no_scope_fragment_when_none` + pipeline.py `scope_context(None)` no-op |
| `JAMES_EMBEDDING_MODEL` (Sprint 4 prep, new) | unset → MiniLM | per-model path resolution tests |
| `JAMES_ADAPTIVE_BUDGET` (pre-existing) | OFF | unchanged |
| `JAMES_AUTO_ROUTER` (pre-existing) | OFF | unchanged |

Production fleets pulling alpha.3 see zero behaviour change relative to v0.3.3.

## Operator action (post-merge)

```bash
gh release create v0.4.0-alpha.3 --target main \
    --title "v0.4.0-alpha.3 — LEO Evidence-Scope routing (L.0→L.D) + Sprint 4 prep + CI hygiene" \
    --notes-file <CHANGELOG excerpt of the alpha.3 section>
```

Zenodo automatic mint follows from the release publish. Post-mint follow-up commit (separate PR): `.zenodo.json` `isNewVersionOf` chain back to v0.3.3 (operator-supplied DOI) + README DOI badge bump.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — release metadata only
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A — no production code touched
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): N/A — metadata only
- rule #5 (module ≤ 20 KB): N/A — metadata only