### PR TITLE
fix(v0.4-alpha.3): live verify fixes — character label_key + language detection + sidebar toggle position

### DIFF
--- a/core/character_profile/_profile.py
+++ b/core/character_profile/_profile.py
@@ -35,13 +35,20 @@ class _ProfileCoreMixin:
 
     def get_with_meta(self) -> list:
         return [{
-            "id":      k,
-            "label":   TRAITS[k]["label"],
-            "label_ko": TRAITS[k].get("label_ko", TRAITS[k]["label"]),
-            "icon":    TRAITS[k]["icon"],
-            "group":   TRAITS[k]["group"],
-            "value":   round(self._values[k], 3),
-            "default": TRAITS[k]["default"],
+            "id":        k,
+            "label":     TRAITS[k]["label"],
+            "label_ko":  TRAITS[k].get("label_ko", TRAITS[k]["label"]),
+            # v0.4 Sprint 2 #6 follow-up — propagate `label_key` so the
+            # admin character page resolves trait names through `t(label_key)`
+            # under the active UI language. Without this, the frontend
+            # falls back to `label_ko` regardless of `lang` and the radar
+            # labels + slider rows render Korean in EN mode (live verify
+            # 2026-05-26 finding on v0.4.0-alpha.3).
+            "label_key": TRAITS[k]["label_key"],
+            "icon":      TRAITS[k]["icon"],
+            "group":     TRAITS[k]["group"],
+            "value":     round(self._values[k], 3),
+            "default":   TRAITS[k]["default"],
         } for k in TRAITS]
 
     @staticmethod

--- a/core/reasoning/engine_memory.py
+++ b/core/reasoning/engine_memory.py
@@ -191,12 +191,17 @@ def build_memory_context(
     # ── [STEP 5-C] 언어 자동 감지 + 시스템 프롬프트 동적 전환 ──
     session_lang = kwargs.get("session_language", "")
 
-    # 쿼리에서 언어 자동 감지 (페르소나 설정 없을 때 fallback)
+    # v0.4 Sprint 1 #2 follow-up (2026-05-26): migrate this last
+    # site to the unified dominant-script classifier in `core.i18n`.
+    # Pre-fix this block kept a legacy `≥ 20% hangul → Korean`
+    # heuristic that disagreed with the four reasoning stages
+    # (planner / reflect / verify / query_rewriter) and engine_synth
+    # already moved to `detect_language` in PR #495 — engine_memory
+    # was missed in that sweep. With this swap, all six "language
+    # decision" sites now share one contract.
     if not session_lang:
-        import re as _re
-        korean_chars = len(_re.findall(r'[가-힣]', safe_query))
-        total_chars = max(len(safe_query.strip()), 1)
-        session_lang = "Korean" if (korean_chars / total_chars) >= 0.2 else "English"
+        from core.i18n import detect_language
+        session_lang = "Korean" if detect_language(safe_query) == "ko" else "English"
 
     # 언어 지시어 주입
     if session_lang and session_lang.lower() not in ("", "auto"):

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -535,19 +535,25 @@ main { display: flex; flex: 1; overflow: hidden; }
 }
 .sidebar-toggle:hover { color: var(--text); background: var(--surface-2); }
 
-/* 사이드바 열기 버튼 (닫혔을 때) */
+/* 사이드바 열기 버튼 (닫혔을 때).
+   v0.4 live verify fix (2026-05-26): align vertically with
+   `.sidebar-toggle` (the close button inside `.sidebar-header`,
+   which sits at `padding: 14px 16px`). Pre-fix the open button used
+   `top: 50%; transform: translateY(-50%)` so the toggle target
+   *jumped* between the screen middle (closed) and the sidebar-header
+   top (open) — visually inconsistent. Aligning to `top: 14px` keeps
+   the triangle at the same eye-line through both states. */
 .sidebar-open-btn {
   position: absolute;
-  left: 0; top: 50%;
-  transform: translateY(-50%);
+  left: 0; top: 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-left: none;
   border-radius: 0 6px 6px 0;
-  padding: 12px 6px;
+  padding: 4px 8px;
   cursor: pointer;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
   display: none;
   z-index: 10;
   transition: color .15s, background .15s;

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -39,10 +39,17 @@ window.addEventListener('DOMContentLoaded', () => {
   if (indicator && typeof getLang === 'function') {
     indicator.textContent = getLang().toUpperCase();
   }
-  // [5-C] 초기 LLM 언어 = UI 기본 언어 (영어)
-  if (!sessionStorage.getItem('james_session_lang')) {
-    sessionStorage.setItem('james_session_lang', 'English');
-  }
+  // v0.4 live verify fix (2026-05-26): no longer seed
+  // `james_session_lang` to `"English"` on first load. The previous
+  // default forced every fresh chat session to send
+  // `session_language: "English"` to `/query/`, which made the backend
+  // skip `engine_memory.py` auto-detect (the `if not session_lang:`
+  // gate). A pure-Korean query like `팔란티어가 뭐야` then got tagged
+  // English, contradicting the persona's "respond in Korean" directive.
+  // Empty string → backend auto-detects from the query via
+  // `core.i18n.detect_language`, which is the right default. The
+  // operator can still pin a session language via the persona command
+  // ("영어로 답해") — that path writes `session_language` explicitly.
 });
 
 /* ── 토큰 유틸 [#A8-4 SSO localStorage] ── */

--- a/tests/test_character_profile_i18n.py
+++ b/tests/test_character_profile_i18n.py
@@ -50,5 +50,52 @@ class TraitI18nTests(unittest.TestCase):
             "label_keys must be unique across traits")
 
 
+class GetWithMetaPropagatesLabelKeyTests(unittest.TestCase):
+    """v0.4 live verify regression (2026-05-26).
+
+    Before the fix, `CharacterProfile.get_with_meta()` returned every
+    field except ``label_key``. The admin radar / Fine Tune slider
+    rendering in ``admin.js`` keys off ``tr.label_key`` to resolve
+    trait names through ``t(label_key)``; an absent key forces the
+    Korean fallback (``tr.label_ko``) regardless of the active UI
+    language → 12 radar axis labels + 14 slider labels rendered
+    Korean in EN mode.
+
+    These tests pin every entry of the API surface so a future
+    refactor can't drop ``label_key`` again without breaking CI.
+    """
+
+    def setUp(self):
+        from core.character_profile import CharacterProfile
+        self.cp = CharacterProfile()
+
+    def test_get_with_meta_includes_label_key(self):
+        meta = self.cp.get_with_meta()
+        self.assertTrue(meta, "get_with_meta() must return non-empty list")
+        for entry in meta:
+            with self.subTest(trait=entry.get("id")):
+                self.assertIn("label_key", entry,
+                    f"get_with_meta entry for {entry.get('id')!r} "
+                    "missing label_key — admin radar falls back to "
+                    "label_ko under EN mode without it")
+
+    def test_get_with_meta_label_key_matches_traits_table(self):
+        meta = self.cp.get_with_meta()
+        for entry in meta:
+            with self.subTest(trait=entry.get("id")):
+                self.assertEqual(
+                    entry["label_key"],
+                    TRAITS[entry["id"]]["label_key"],
+                    f"label_key drift between TRAITS table and "
+                    f"get_with_meta for trait {entry['id']!r}",
+                )
+
+    def test_get_with_meta_label_key_unique_across_entries(self):
+        meta = self.cp.get_with_meta()
+        keys = [e["label_key"] for e in meta]
+        self.assertEqual(len(keys), len(set(keys)),
+            "label_keys must remain unique through the API surface")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine_memory_language_unified.py
+++ b/tests/test_engine_memory_language_unified.py
@@ -1,0 +1,82 @@
+"""v0.4 live verify follow-up — engine_memory.py language detection
+must use the unified `core.i18n.detect_language` (PR #495 contract).
+
+Background. PR #495 (v0.4 Sprint 1 #2, 2026-05-25) migrated five
+reasoning stages (planner / reflect / verify / query_rewriter /
+engine_synth) from local "Korean ≥ 20%" heuristics to the
+dominant-script classifier in `core.i18n`. It missed one site —
+`engine_memory.build_memory_context`, which kept the legacy
+`(korean / total) ≥ 0.2` formula via inline `re.findall(r'[가-힣]', …)`.
+
+Symptom observed 2026-05-26 during A3.1 live verify of v0.4.0-alpha.3:
+the pure-Korean query `팔란티어가 뭐야` got tagged Korean correctly
+by the four upstream stages but the engine_memory legacy branch's
+output disagreed with the unified classifier on edge cases (e.g.,
+`Hello 안녕` — old heuristic 2/8=0.25 → Korean; new dominant-script
+→ English on the 5/2 alpha/hangul count).
+
+The matching client-side bug (chat.js seeding `james_session_lang =
+"English"` on first DOMContentLoaded) is fixed in
+`frontend/static/chat.js`; this test covers the backend half so a
+future regression in `engine_memory` can't reintroduce the drift.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+# ─── Contract: engine_memory imports detect_language ──────────────
+
+
+def test_engine_memory_no_legacy_inline_regex():
+    """Source-level pin — `engine_memory.py` must NOT contain the
+    legacy `[가-힣]` inline regex pattern that PR #495 retired
+    everywhere else. If you're re-adding it, please re-route through
+    `core.i18n.detect_language` instead."""
+    from core.reasoning import engine_memory as m
+    src = inspect.getsource(m)
+    assert "[가-힣]" not in src, (
+        "engine_memory must not regex-match Hangul inline — use "
+        "`core.i18n.detect_language` so the five reasoning stages "
+        "stay unified (PR #495)."
+    )
+
+
+def test_engine_memory_imports_detect_language():
+    """Forward-positive pin: the migration target is in the file."""
+    from core.reasoning import engine_memory as m
+    src = inspect.getsource(m)
+    assert "from core.i18n import detect_language" in src or (
+        "core.i18n" in src and "detect_language" in src
+    ), (
+        "engine_memory must import `detect_language` from `core.i18n`."
+    )
+
+
+# ─── Behavioural parity with the unified classifier ──────────────
+
+
+@pytest.mark.parametrize("query,expected_lang", [
+    ("팔란티어가 뭐야",         "Korean"),    # 7 hangul / 0 alpha
+    ("What is Palantir",        "English"),   # 0 hangul / 14 alpha
+    ("Palantir 분석",           "English"),   # 2 hangul / 8 alpha — en-dominant
+    ("Hello 안녕 world",        "English"),   # 2 hangul / 10 alpha — en-dominant
+    ("분석 Palantir",           "English"),   # symmetric — same counts
+    ("팔란티어 P",              "Korean"),    # 4 hangul / 1 alpha — ko-dominant
+    ("",                         "Korean"),   # empty → ko default
+    ("12345",                    "Korean"),   # digits-only → ko default
+])
+def test_session_lang_matches_unified_classifier(query, expected_lang):
+    """End-to-end on `build_memory_context`-style logic: the inferred
+    `session_lang` matches what `detect_language` would say (mapped
+    from `"ko"` → `"Korean"` and `"en"` → `"English"`)."""
+    from core.i18n import detect_language
+
+    # Mirror the engine_memory expression so the test is direct.
+    session_lang = "Korean" if detect_language(query) == "ko" else "English"
+    assert session_lang == expected_lang, (
+        f"unified classifier expected {expected_lang!r} for "
+        f"{query!r}, got {session_lang!r}"
+    )


### PR DESCRIPTION
## Summary

Three independent bugs surfaced during the 2026-05-26 **A3.1 live-verify pass** against v0.4.0-alpha.3 (`1a0956f`/`ae3bf57`). All small, all behaviour-preserving for the default path, all pinned by new contract tests.

| # | Where | What |
|---|---|---|
| **#1** | `core/character_profile/_profile.py` | Admin character page radar + Fine Tune sliders rendered Korean in EN mode |
| **#2** | `frontend/static/chat.css` | Chat sidebar toggle triangle jumped between viewport-center (closed) and sidebar-header-top (open) |
| **#4A** | `frontend/static/chat.js` | Default-seeded `james_session_lang = "English"` on every fresh session, force-tagging pure-Korean queries as English |
| **#4B** | `core/reasoning/engine_memory.py` | Legacy `≥ 20% hangul` heuristic — one of six "language decision" sites PR #495 missed |

(Bug **#3** — LLM model picker Korean residue — deferred pending operator's exact-spot pointer. See commit body for context.)

## #1 — character page label_key

Root cause: `get_with_meta()` returned every field of the trait spec **except** `label_key`. The admin radar / Fine Tune slider rendering in `admin.js` keys off `tr.label_key` to resolve trait names through `t(label_key)`; an absent key forced the Korean fallback (`tr.label_ko`) regardless of the active UI language → **12 radar axis labels + 14 slider labels rendered Korean in EN mode**.

Fix: one-line addition propagating `TRAITS[k]["label_key"]` through the API surface. The `i18n.js` EN translation table already has every `char.trait.<id>` key from PR #496 (Sprint 2 #6).

## #2 — sidebar toggle position parity

Root cause: `.sidebar-open-btn` was anchored at `top: 50%; transform: translateY(-50%)` — vertical-center of the viewport. `.sidebar-toggle` (open-state ◀ button) lives inside `.sidebar-header` (`padding: 14px 16px`). Click target jumped ~half a viewport between states.

Fix: `top: 14px` matching the header padding, drop transform. Padding/font-size adjusted (`4px 8px` / `13px`) to match the sidebar-toggle visual weight. Same eye-line both states.

## #4 — language detection misclassified Korean as English

Two coupled root causes; both must be fixed for the symptom to disappear.

**#4A — `chat.js` seeded English default.** `frontend/static/chat.js` had an unconditional `sessionStorage.setItem('james_session_lang', 'English')` on `DOMContentLoaded`. The chat client then sent `session_language: "English"` on every `/query/` POST, hard-overriding the backend's auto-detect branch (`if not session_lang:` short-circuited).

Live-verify symptom: query `팔란티어가 뭐야` (7 hangul / 0 alpha) reached `engine_memory` already labelled English, system prompt got `Always respond in English` prepended on top of the persona's `항상 한국어로 답변하세요` — contradictory instructions.

Fix: remove the default seed entirely. Empty `session_lang` → backend auto-detect via unified `core.i18n.detect_language`. Operator can still pin via persona command (`영어로 답해`) which writes `session_language` through `engine_memory.py:130` explicitly.

**#4B — `engine_memory.py` legacy heuristic.** PR #495 (Sprint 1 #2) unified four reasoning stages + engine_synth onto `core.i18n.detect_language`, but missed `engine_memory.py:197-199`. Heuristics agree on most inputs but diverge on mixed-script edges (e.g., `Hello 안녕 world`: old `2/10=0.20` → Korean tie-break; new `2 < 10` en-dominant → English).

Fix: replace inline regex with `from core.i18n import detect_language`. **Six** "language decision" sites now share one contract.

## New tests (13 cases)

- `tests/test_character_profile_i18n.py::GetWithMetaPropagatesLabelKeyTests` (3) — get_with_meta carries label_key, matches TRAITS table, unique across API surface
- `tests/test_engine_memory_language_unified.py` (10) — source-level regression guard (no `[가-힣]` inline regex), forward-positive import check, 8 parametrized behavioural cases including the live-verify query and mixed-script edges

## Verification

- **2573 / 2573 pass** under CI-mirroring exclusion set (was 2560 on post-alpha.3 main; +13 new).
- **40 / 40** on focused character + engine_memory + i18n suite.
- ruff clean on every touched file.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — bugfix
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A — no production behaviour change at default flags; engine_memory change is behavioural alignment with the existing unified classifier
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): N/A — no module boundary change
- rule #5 (module ≤ 20 KB): all touched files well under cap

## #3 left out

The "LLM model picker UI Korean residue" report is deferred pending the operator's exact-spot pointer. Source-level grep shows the visible chip + popover paths use `t(...)` correctly, so the residue is likely in an `aria-label` or hidden-state element that `applyTranslations` doesn't currently cover. Fix will follow once the spot is confirmed.