### PR TITLE
feat(lifecycle): v0.4 Sprint 5 PR-0 — schema validators + clock helper

### DIFF
--- a/core/lifecycle/__init__.py
+++ b/core/lifecycle/__init__.py
@@ -1,0 +1,25 @@
+"""``core.lifecycle`` — v0.4 Layer 4 Lifecycle Semantics.
+
+This package hosts the EVENT/TEMPORAL track of the v0.4 architectural
+shift (`docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md`,
+strategic memo `docs/design/v0.4-lifecycle-semantics-roadmap.md`).
+
+Sprint 5 first-bundle scope (v0.4.0):
+
+- ``clock``                 — single ``now()`` helper (locked via
+                              entry memo §12.2; monkey-patchable for
+                              tests, used by every T1+T7 call site
+                              that needs "current time").
+- ``expiration_cascade``    — T1 batch (lands at PR-T1.B).
+- ``supersede_chain``       — T7 EVENT operations (lands at PR-T7.A).
+- ``contradiction_arbiter`` — T2 A/B classifier (lands at PR-T2.A).
+
+This PR (PR-0, validator prep) ships only the package skeleton + the
+``clock`` helper. Subsequent PR-T1.A/B + PR-T7.A/B + PR-T2.A/B/C land
+the rest.
+"""
+from __future__ import annotations
+
+from core.lifecycle import clock, schema
+
+__all__ = ["clock", "schema"]

--- a/core/lifecycle/clock.py
+++ b/core/lifecycle/clock.py
@@ -1,0 +1,64 @@
+"""Single source of truth for "current time" across the v0.4 Layer 4
+EVENT/TEMPORAL track.
+
+Locked at Sprint 5 entry memo §12.2 (2026-05-26). The choice is the
+**hybrid** option:
+
+- Production paths call ``clock.now()`` for the current-time signal.
+  ``compute_confidence_from_sources`` / expiration cascade /
+  ``supersede_edge`` / contradiction arbiter all route through this
+  single helper.
+- Tests monkey-patch ``clock.now`` to freeze time deterministically::
+
+      monkeypatch.setattr("core.lifecycle.clock.now",
+                          lambda: datetime(2026, 6, 1, 12, 0, 0,
+                                           tzinfo=timezone.utc))
+
+- The forensic replay primitive (``reconstruct_view_at(head,
+  predicate, t)``, lands at PR-T7.A) is the **only** path that
+  bypasses ``clock.now()`` — it accepts an explicit ``t`` parameter
+  for historical reconstruction.
+
+Why a separate module instead of just calling ``datetime.utcnow()``:
+
+- One monkey-patch point flips the entire EVENT/TEMPORAL clock for
+  the test suite. Without this indirection every call site would
+  need its own freezer fixture.
+- The replay primitive's explicit-``t`` path becomes visually
+  distinct from the "current" path — code review can immediately
+  tell which calls run "now" vs "as of t".
+- Future swaps (e.g., monotonic-clock for ordering, NTP-corrected
+  wall-clock for cross-machine replay) are one-file changes.
+
+Time zone policy: ``now()`` returns a **UTC-aware** ``datetime``
+(``tzinfo=timezone.utc``). All v0.4 audit rows + validity windows +
+supersede timestamps land in UTC. Display-side time-zone conversion
+is the UI's responsibility.
+
+The module is dependency-free (stdlib only) so it imports fast and
+can be reached from any test fixture without dragging in heavy
+modules.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def now() -> datetime:
+    """Return the current wall-clock time as a UTC-aware ``datetime``.
+
+    This is the single function v0.4 Layer 4 calls when it needs
+    "current time" — see module docstring for the design rationale.
+
+    Tests freeze this via::
+
+        monkeypatch.setattr("core.lifecycle.clock.now", lambda: <fixed>)
+
+    Production callers never pass arguments; the function signature
+    is intentionally argument-free so the monkey-patch lambda above
+    is signature-compatible.
+    """
+    return datetime.now(timezone.utc)
+
+
+__all__ = ["now"]

--- a/core/lifecycle/schema.py
+++ b/core/lifecycle/schema.py
@@ -1,0 +1,304 @@
+"""v0.4 Sprint 5 — T1 + T7 schema extension validators + defaults.
+
+Sprint 5 first-bundle PR-0 (validator prep, 2026-05-26). Lands the
+field vocabulary + validation + safe-default helpers before the
+migration script (PR-T1.A) or the supersede operations (PR-T7.A)
+reference them.
+
+Pure-validation surface — no clock dependency, no I/O, no
+behavioural change for v0.3-shaped data. Existing callers that
+import these symbols through ``core.relations_schema`` (the v0.3
+canonical location) continue to work; the symbols re-export from
+that module unchanged.
+
+Field vocabulary locked at the entry memo §3 + strategic memo §3.3 +
+§4.2 + §9.5.2:
+
+- **Source-level (T1)**: ``valid_from`` / ``valid_until``
+  (ISO 8601 strings or None).
+- **Edge-level (T1+T7)**: ``validity`` (``{from, to}`` dict),
+  ``status`` (``{active, superseded_by, superseded_at}`` dict),
+  ``mutation_type`` (``"active" | "invalidated" | "superseded" |
+  "expired"`` enum).
+
+The validator + defaults split:
+
+- ``validate_source_v04_fields(source)`` — raises ``ValueError`` on
+  malformed v0.4 fields. Acceptable shapes documented in the
+  function docstring.
+- ``apply_v04_source_defaults(source)`` — returns a copy of ``source``
+  with v0.4 fields filled at v0.3-equivalent safe defaults. Idempotent.
+- ``validate_edge_v04_fields(edge)`` — same contract for edges.
+- ``apply_v04_edge_defaults(edge)`` — same contract for edges.
+
+Migration script (PR-T1.A) composes ``apply_v04_*_defaults`` over the
+loaded frontmatter to migrate idempotently. Subsequent T7 / T2 PRs
+compose ``validate_*_v04_fields`` at write-time to catch malformed
+mutations before they hit the wiki.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Final
+
+
+# ─── Mutation type enum ───────────────────────────────────────────
+#
+# Per the entry memo §12.3 lock, absence in audit-log rows is
+# interpreted as ``"active"`` (matches pre-bundle semantics where no
+# mutation-type concept existed). Validator accepts the value list
+# below; ``apply_v04_edge_defaults`` fills ``"active"`` when missing.
+T1_MUTATION_ACTIVE:      Final[str] = "active"
+T1_MUTATION_INVALIDATED: Final[str] = "invalidated"   # CASCADE (Layer 3)
+T1_MUTATION_SUPERSEDED:  Final[str] = "superseded"    # EVENT (T7)
+T1_MUTATION_EXPIRED:     Final[str] = "expired"       # EVENT (T1)
+
+VALID_MUTATION_TYPES: Final[frozenset[str]] = frozenset({
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_MUTATION_EXPIRED,
+})
+
+
+# ─── Field name constants ────────────────────────────────────────
+#
+# Callers + tests reference the schema vocabulary by symbol rather
+# than string-literal duplication.
+T1_SOURCE_FIELD_VALID_FROM:  Final[str] = "valid_from"
+T1_SOURCE_FIELD_VALID_UNTIL: Final[str] = "valid_until"
+
+T7_EDGE_FIELD_VALIDITY:      Final[str] = "validity"
+T7_EDGE_FIELD_STATUS:        Final[str] = "status"
+T7_EDGE_FIELD_MUTATION_TYPE: Final[str] = "mutation_type"
+
+
+def _parse_optional_iso(value: Any) -> datetime | None:
+    """Return parsed ``datetime`` for an ISO-8601 string, ``None`` for
+    ``None``, raise ``ValueError`` on anything else (malformed string,
+    wrong type).
+
+    Trailing ``Z`` is accepted via the ``+00:00`` substitution,
+    matching ``core.relations_schema.validate_occurred_at`` so the
+    two timestamp paths share one parser contract.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"expected ISO 8601 string or None, got {type(value).__name__}"
+        )
+    if not value:
+        raise ValueError(
+            "ISO 8601 string must be non-empty (use None instead)"
+        )
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as e:
+        raise ValueError(f"not parseable as ISO 8601: {value!r}") from e
+
+
+def validate_source_v04_fields(source: dict) -> None:
+    """Raise ``ValueError`` if a source dict carries malformed T1 fields.
+
+    Acceptable shapes:
+      - missing both ``valid_from`` and ``valid_until``  → v0.3 default
+      - either or both fields present as ``None``        → indefinite
+      - either or both fields present as ISO 8601 string → bounded
+
+    Order constraint: when both are present, ``valid_from`` must be
+    strictly earlier than ``valid_until`` (zero-length / inverted
+    windows rejected so the cascade can't get stuck on a source
+    that's neither active nor expired).
+    """
+    if not isinstance(source, dict):
+        raise ValueError(
+            f"source must be a dict, got {type(source).__name__}"
+        )
+    vf = _parse_optional_iso(source.get(T1_SOURCE_FIELD_VALID_FROM))
+    vu = _parse_optional_iso(source.get(T1_SOURCE_FIELD_VALID_UNTIL))
+    if vf is not None and vu is not None and not (vf < vu):
+        raise ValueError(
+            f"valid_from must be strictly earlier than valid_until — "
+            f"got valid_from={source.get(T1_SOURCE_FIELD_VALID_FROM)!r} "
+            f"valid_until={source.get(T1_SOURCE_FIELD_VALID_UNTIL)!r}"
+        )
+
+
+def validate_edge_v04_fields(edge: dict) -> None:
+    """Raise ``ValueError`` if an edge (relation) dict carries malformed
+    T1+T7 fields.
+
+    Acceptable shapes:
+      - all three new fields missing → v0.3 default (treated as
+        active / no validity window / mutation_type="active")
+      - ``validity`` dict with ``from`` / ``to`` (both ISO-8601 strings
+        or None). Same strict-earlier constraint as
+        ``validate_source_v04_fields`` when both bounds are set.
+      - ``status`` dict with ``active`` (bool), ``superseded_by``
+        (str ID or None), ``superseded_at`` (ISO 8601 or None).
+      - ``mutation_type`` ∈ ``VALID_MUTATION_TYPES``.
+
+    Cross-field consistency (T7 invariant pinned at write-time):
+    ``status.active == False`` implies one of three:
+      1. ``mutation_type == "superseded"`` with non-empty
+         ``status.superseded_by`` AND ``status.superseded_at`` set
+      2. ``mutation_type == "invalidated"`` (CASCADE path; no
+         supersede link required)
+      3. ``mutation_type == "expired"`` (T1 path; no supersede link
+         required)
+
+    The cross-field check fires only when both ``status`` and
+    ``mutation_type`` are explicitly set — partial v0.4 shapes
+    (e.g., ``status`` set, ``mutation_type`` missing) get
+    default-applied at ``apply_v04_edge_defaults`` time.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+
+    # ─── T1+T7 validity window ───────────────────────────────────
+    validity = edge.get(T7_EDGE_FIELD_VALIDITY)
+    if validity is not None:
+        if not isinstance(validity, dict):
+            raise ValueError(
+                f"edge.validity must be a dict, got "
+                f"{type(validity).__name__}"
+            )
+        vf = _parse_optional_iso(validity.get("from"))
+        vu = _parse_optional_iso(validity.get("to"))
+        if vf is not None and vu is not None and not (vf < vu):
+            raise ValueError(
+                f"edge.validity.from must be strictly earlier than "
+                f"validity.to — got from={validity.get('from')!r} "
+                f"to={validity.get('to')!r}"
+            )
+
+    # ─── T7 status ───────────────────────────────────────────────
+    status = edge.get(T7_EDGE_FIELD_STATUS)
+    if status is not None:
+        if not isinstance(status, dict):
+            raise ValueError(
+                f"edge.status must be a dict, got "
+                f"{type(status).__name__}"
+            )
+        active = status.get("active", True)
+        if not isinstance(active, bool):
+            raise ValueError(
+                f"edge.status.active must be bool, got "
+                f"{type(active).__name__}"
+            )
+        sb = status.get("superseded_by")
+        if sb is not None and not isinstance(sb, str):
+            raise ValueError(
+                f"edge.status.superseded_by must be str ID or None, "
+                f"got {type(sb).__name__}"
+            )
+        _parse_optional_iso(status.get("superseded_at"))
+
+    # ─── T1+T7 mutation_type ─────────────────────────────────────
+    mt = edge.get(T7_EDGE_FIELD_MUTATION_TYPE)
+    if mt is not None and mt not in VALID_MUTATION_TYPES:
+        raise ValueError(
+            f"edge.mutation_type must be one of "
+            f"{sorted(VALID_MUTATION_TYPES)}, got {mt!r}"
+        )
+
+    # ─── Cross-field consistency (T7 invariant) ──────────────────
+    if isinstance(status, dict) and mt is not None:
+        active = status.get("active", True)
+        sb = status.get("superseded_by")
+        sa = status.get("superseded_at")
+        if active is False and mt == T1_MUTATION_SUPERSEDED:
+            if not sb or sa is None:
+                raise ValueError(
+                    "status.active=False with mutation_type='superseded' "
+                    "requires non-empty superseded_by AND superseded_at"
+                )
+        if active is True and mt in (
+            T1_MUTATION_INVALIDATED,
+            T1_MUTATION_SUPERSEDED,
+            T1_MUTATION_EXPIRED,
+        ):
+            raise ValueError(
+                f"status.active=True is incompatible with "
+                f"mutation_type={mt!r} — only 'active' is consistent "
+                f"with status.active=True"
+            )
+
+
+def apply_v04_source_defaults(source: dict) -> dict:
+    """Return a copy of ``source`` with v0.4 T1 fields filled at safe
+    defaults (``None`` = indefinite validity).
+
+    v0.3-equivalent semantics: the defaults map directly onto the
+    "no temporal constraint" reading existing callers already assume.
+
+    Idempotent — applying twice yields the same dict. The migration
+    script (PR-T1.A) relies on this to make ``--apply`` re-runnable.
+
+    Returns a new dict; does NOT mutate the caller's argument so the
+    function is safe to use inside list comprehensions over loaded
+    frontmatter.
+    """
+    if not isinstance(source, dict):
+        raise ValueError(
+            f"source must be a dict, got {type(source).__name__}"
+        )
+    out = dict(source)
+    out.setdefault(T1_SOURCE_FIELD_VALID_FROM, None)
+    out.setdefault(T1_SOURCE_FIELD_VALID_UNTIL, None)
+    return out
+
+
+def apply_v04_edge_defaults(edge: dict) -> dict:
+    """Return a copy of ``edge`` with v0.4 T1+T7 fields filled at safe
+    defaults.
+
+    Defaults (match v0.3 semantics for backward compat):
+      - ``validity``: ``{"from": None, "to": None}``  (indefinite)
+      - ``status``:   ``{"active": True, "superseded_by": None,
+                          "superseded_at": None}``
+      - ``mutation_type``: ``"active"``
+
+    Idempotent — running on an already-migrated edge yields the same
+    dict. The migration script (PR-T1.A) relies on this.
+
+    Returns a new dict; does NOT mutate the caller's argument.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    out = dict(edge)
+    out.setdefault(T7_EDGE_FIELD_VALIDITY, {"from": None, "to": None})
+    out.setdefault(T7_EDGE_FIELD_STATUS, {
+        "active": True,
+        "superseded_by": None,
+        "superseded_at": None,
+    })
+    out.setdefault(T7_EDGE_FIELD_MUTATION_TYPE, T1_MUTATION_ACTIVE)
+    return out
+
+
+__all__ = [
+    # mutation type enum
+    "T1_MUTATION_ACTIVE",
+    "T1_MUTATION_INVALIDATED",
+    "T1_MUTATION_SUPERSEDED",
+    "T1_MUTATION_EXPIRED",
+    "VALID_MUTATION_TYPES",
+    # field name constants
+    "T1_SOURCE_FIELD_VALID_FROM",
+    "T1_SOURCE_FIELD_VALID_UNTIL",
+    "T7_EDGE_FIELD_VALIDITY",
+    "T7_EDGE_FIELD_STATUS",
+    "T7_EDGE_FIELD_MUTATION_TYPE",
+    # validators
+    "validate_source_v04_fields",
+    "validate_edge_v04_fields",
+    # defaults
+    "apply_v04_source_defaults",
+    "apply_v04_edge_defaults",
+]

--- a/core/relations_schema.py
+++ b/core/relations_schema.py
@@ -22,6 +22,20 @@ production 의 `relation["confidence"]` 읽기 경로는 Phase A 단계에서
   * manual   — admin 이 그래프 에디터로 수동 입력 (Phase E)
   * legacy   — Phase A 마이그레이션 시점에 출처 추적 없이 back-fill
                된 사전-마이그레이션 잔류 (cascade 가 건드리지 않음)
+
+v0.4 Sprint 5 first-bundle (2026-05-26+, PR 0 validator prep):
+  Extends the schema with T1 (Temporal Validity) + T7 (Supersede
+  Chain) fields. Existing v0.3 callers see no behaviour change —
+  every new field has a v0.3-equivalent safe default. See
+  ``docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md``
+  §2 for scope + §12.2 for the clock decision.
+
+  - **Source-level (T1)**: ``valid_from`` / ``valid_until``
+    (ISO 8601 strings or None).
+  - **Edge-level (T1+T7)**: ``validity`` (``{from, to}`` dict),
+    ``status`` (``{active, superseded_by, superseded_at}`` dict),
+    ``mutation_type`` (``"active" | "invalidated" | "superseded" |
+    "expired"`` enum).
 """
 
 from __future__ import annotations
@@ -189,6 +203,29 @@ def read_relation_sources(rel: dict | None) -> list:
             "ts":     None,
         }]
     return []
+
+
+# v0.4 Sprint 5 — T1 + T7 schema extension lives in
+# ``core.lifecycle.schema`` so the v0.3 surface here stays small enough
+# to take future Phase-A follow-ups without breaching the 20 KB cap.
+# Re-export for back-compat — existing callers can still
+# ``from core.relations_schema import VALID_MUTATION_TYPES`` etc.
+from core.lifecycle.schema import (  # noqa: F401
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_SOURCE_FIELD_VALID_FROM,
+    T1_SOURCE_FIELD_VALID_UNTIL,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+    VALID_MUTATION_TYPES,
+    apply_v04_edge_defaults,
+    apply_v04_source_defaults,
+    validate_edge_v04_fields,
+    validate_source_v04_fields,
+)
 
 
 def build_legacy_source(

--- a/tests/test_lifecycle_clock.py
+++ b/tests/test_lifecycle_clock.py
@@ -1,0 +1,100 @@
+"""v0.4 Sprint 5 PR-0 — ``core.lifecycle.clock`` contract tests.
+
+Pins the single ``now()`` helper that every T1+T7 path consults for
+"current time". The contract is small but load-bearing:
+
+1. ``now()`` returns a **UTC-aware** ``datetime`` so audit rows and
+   validity windows have an unambiguous time-zone reading.
+2. ``monkeypatch.setattr("core.lifecycle.clock.now", lambda: <fixed>)``
+   actually replaces the function (the helper is module-level, not
+   class-level, so the patch works without ``autospec`` complexity).
+3. The "explicit ``t``" path of the replay primitive
+   (``reconstruct_view_at(t=<past>)``, lands at PR-T7.A) is not the
+   subject of these tests — it bypasses ``clock.now`` by design.
+
+Entry memo lock reference: §12.2 (hybrid choice — production calls
+``clock.now()``, replay endpoint accepts explicit ``t``).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+from core.lifecycle import clock
+
+
+def test_now_returns_datetime():
+    """Contract: ``now()`` returns a ``datetime`` instance."""
+    assert isinstance(clock.now(), datetime)
+
+
+def test_now_is_utc_aware():
+    """Contract: returned datetime carries a non-None tzinfo and the
+    tzinfo represents UTC. v0.4 audit rows assume UTC-aware throughout."""
+    result = clock.now()
+    assert result.tzinfo is not None, (
+        "clock.now() must return a timezone-aware datetime — audit "
+        "rows + validity windows would be ambiguous otherwise"
+    )
+    # utcoffset of UTC is timedelta(0). Equivalent to tzinfo == timezone.utc
+    # but more permissive (e.g., pytz UTC also passes).
+    assert result.utcoffset().total_seconds() == 0, (
+        "clock.now() tzinfo must represent UTC (offset 0); got "
+        f"{result.utcoffset()}"
+    )
+
+
+def test_now_advances_across_calls():
+    """Sanity — two successive calls give monotonically non-decreasing
+    timestamps. Catches a pathological monkey-patch leaking across
+    tests (e.g., a test forgot to undo a freezer)."""
+    a = clock.now()
+    b = clock.now()
+    assert b >= a, (
+        f"clock.now() must be monotonically non-decreasing within a "
+        f"single process — got a={a.isoformat()} b={b.isoformat()}"
+    )
+
+
+def test_clock_is_monkey_patchable(monkeypatch):
+    """The locked design choice (§12.2) requires that test code can
+    freeze time via ``monkeypatch.setattr``. This test guarantees the
+    contract — every T1+T7 test that needs deterministic time will
+    rely on this patch site."""
+    fixed = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.lifecycle.clock.now", lambda: fixed)
+    assert clock.now() == fixed
+    # Repeatable
+    for _ in range(10):
+        assert clock.now() == fixed
+
+
+def test_clock_patch_does_not_leak_outside_test(monkeypatch):
+    """Defensive — monkeypatch is correctly scoped to one test. Without
+    this, a freezer set in test A would persist into test B as silent
+    state contamination. pytest's monkeypatch fixture auto-undoes at
+    teardown; this test simply confirms the contract holds for our
+    setup (we patch a module-level callable, not a class attribute,
+    which is the simpler case)."""
+    fixed = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.lifecycle.clock.now", lambda: fixed)
+    assert clock.now() == fixed
+    # Teardown will undo — verified by the other tests in this file
+    # observing a live clock value.
+
+
+def test_module_surface():
+    """``core.lifecycle.clock`` exposes only ``now`` — keeps the API
+    surface single-purpose so future swaps (NTP-corrected clock,
+    monotonic ordering) land at one symbol."""
+    assert clock.__all__ == ["now"]
+    assert hasattr(clock, "now")
+
+
+def test_lifecycle_package_reexport():
+    """``core.lifecycle`` package surfaces ``clock`` for direct import
+    — keeps the call-site ``from core.lifecycle import clock`` pattern
+    cheap (no separate explicit import of the submodule)."""
+    import core.lifecycle as lifecycle_pkg
+    assert lifecycle_pkg.clock is clock
+    assert "clock" in lifecycle_pkg.__all__

--- a/tests/test_lifecycle_schema.py
+++ b/tests/test_lifecycle_schema.py
@@ -1,0 +1,470 @@
+"""v0.4 Sprint 5 PR-0 — ``core.lifecycle.schema`` contract tests.
+
+Pins the v0.4 T1+T7 schema extension (validators + safe-default
+helpers) that the migration script (PR-T1.A), supersede operations
+(PR-T7.A), and contradiction arbiter (PR-T2.A) will all reference.
+
+Contract layers covered here:
+
+1. **Field vocabulary constants** — symbol names and enum members
+   match the locked design (entry memo §3).
+2. **Source validator** (``validate_source_v04_fields``) — accepts
+   v0.3 shapes (no new fields) + all valid v0.4 shapes; rejects
+   malformed v0.4 fields with explicit ``ValueError``.
+3. **Edge validator** (``validate_edge_v04_fields``) — same contract
+   for edges plus the cross-field consistency rule (T7 invariant
+   pinned at write-time).
+4. **Defaults helpers** (``apply_v04_*_defaults``) — idempotent,
+   non-mutating, default to v0.3-equivalent semantics.
+5. **Re-export** — ``core.relations_schema`` still surfaces every new
+   symbol so v0.3 callers see no breakage.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.lifecycle.schema import (
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_SOURCE_FIELD_VALID_FROM,
+    T1_SOURCE_FIELD_VALID_UNTIL,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+    VALID_MUTATION_TYPES,
+    apply_v04_edge_defaults,
+    apply_v04_source_defaults,
+    validate_edge_v04_fields,
+    validate_source_v04_fields,
+)
+
+
+# ─── Field vocabulary ─────────────────────────────────────────────
+
+
+def test_mutation_type_enum_values():
+    """The four enum members locked at the entry memo §12.3 are
+    present + distinct."""
+    assert T1_MUTATION_ACTIVE == "active"
+    assert T1_MUTATION_INVALIDATED == "invalidated"
+    assert T1_MUTATION_SUPERSEDED == "superseded"
+    assert T1_MUTATION_EXPIRED == "expired"
+    assert VALID_MUTATION_TYPES == frozenset({
+        "active", "invalidated", "superseded", "expired",
+    })
+
+
+def test_field_name_constants():
+    """Field name constants match the locked schema vocabulary so
+    callers and tests reference them by symbol, not string-literal."""
+    assert T1_SOURCE_FIELD_VALID_FROM == "valid_from"
+    assert T1_SOURCE_FIELD_VALID_UNTIL == "valid_until"
+    assert T7_EDGE_FIELD_VALIDITY == "validity"
+    assert T7_EDGE_FIELD_STATUS == "status"
+    assert T7_EDGE_FIELD_MUTATION_TYPE == "mutation_type"
+
+
+# ─── Source validator — v0.3 shapes accepted ─────────────────────
+
+
+def test_v03_source_passes_validator():
+    """A pre-v0.4 source dict (no new fields) is accepted unchanged —
+    pins the backward-compat invariant."""
+    src = {"doc_id": "report_Q1.pdf", "weight": 0.7, "role": "extract"}
+    validate_source_v04_fields(src)   # must not raise
+
+
+def test_v03_source_with_extra_unknown_fields_passes():
+    """Unknown extra fields don't trip the validator — it only checks
+    the v0.4 fields it knows about. Forward-compat with future T3/T4
+    additions."""
+    src = {
+        "doc_id": "report_Q1.pdf",
+        "weight": 0.7,
+        "role": "extract",
+        "future_field_T3_aging": "exp_decay",
+    }
+    validate_source_v04_fields(src)
+
+
+# ─── Source validator — v0.4 valid shapes ────────────────────────
+
+
+@pytest.mark.parametrize("vf,vu", [
+    (None, None),                                # both None → indefinite
+    ("2026-04-01", None),                        # bounded from only
+    (None, "2027-04-01"),                        # bounded until only
+    ("2026-04-01", "2027-04-01"),                # both bounded
+    ("2026-04-01T00:00:00Z", "2026-04-02T00:00:00Z"),  # ISO 8601 datetime + Z
+    ("2026-04-01T12:34:56+09:00",
+     "2026-04-02T12:34:56+09:00"),               # offset-aware
+])
+def test_source_v04_valid_shapes(vf, vu):
+    """Every locked-as-valid v0.4 source shape passes."""
+    src = {
+        "doc_id": "x",
+        "weight": 0.5,
+        "role": "extract",
+        T1_SOURCE_FIELD_VALID_FROM: vf,
+        T1_SOURCE_FIELD_VALID_UNTIL: vu,
+    }
+    validate_source_v04_fields(src)
+
+
+# ─── Source validator — malformed shapes rejected ────────────────
+
+
+def test_source_not_dict_rejected():
+    with pytest.raises(ValueError, match="source must be a dict"):
+        validate_source_v04_fields("not a dict")  # type: ignore[arg-type]
+
+
+def test_source_bad_valid_from_string():
+    src = {T1_SOURCE_FIELD_VALID_FROM: "not-a-date"}
+    with pytest.raises(ValueError, match="not parseable as ISO 8601"):
+        validate_source_v04_fields(src)
+
+
+def test_source_bad_valid_until_type():
+    src = {T1_SOURCE_FIELD_VALID_UNTIL: 12345}
+    with pytest.raises(ValueError, match="expected ISO 8601 string"):
+        validate_source_v04_fields(src)
+
+
+def test_source_empty_string_valid_from_rejected():
+    src = {T1_SOURCE_FIELD_VALID_FROM: ""}
+    with pytest.raises(ValueError, match="must be non-empty"):
+        validate_source_v04_fields(src)
+
+
+def test_source_inverted_window_rejected():
+    """``valid_from`` must be strictly earlier than ``valid_until``."""
+    src = {
+        T1_SOURCE_FIELD_VALID_FROM: "2027-04-01",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2026-04-01",
+    }
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_source_v04_fields(src)
+
+
+def test_source_zero_window_rejected():
+    """Same instant on both ends is rejected — zero-length windows
+    leave the source neither active nor expired."""
+    src = {
+        T1_SOURCE_FIELD_VALID_FROM: "2026-04-01T00:00:00",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2026-04-01T00:00:00",
+    }
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_source_v04_fields(src)
+
+
+# ─── Edge validator — v0.3 shapes accepted ───────────────────────
+
+
+def test_v03_edge_passes_validator():
+    """A pre-v0.4 edge dict (no new fields) is accepted unchanged."""
+    edge = {
+        "head": "Joby",
+        "predicate": "CEO",
+        "tail": "Alice",
+        "confidence": 0.85,
+    }
+    validate_edge_v04_fields(edge)
+
+
+# ─── Edge validator — v0.4 valid shapes ──────────────────────────
+
+
+def test_edge_v04_full_active_shape():
+    """Full v0.4 shape, status active, mutation_type=active."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "Bob",
+        T7_EDGE_FIELD_VALIDITY: {"from": "2026-03-15", "to": None},
+        T7_EDGE_FIELD_STATUS: {
+            "active": True,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_ACTIVE,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_superseded_shape():
+    """A correctly-shaped superseded edge — active=False + non-empty
+    supersede link + superseded_at."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "Alice",
+        T7_EDGE_FIELD_VALIDITY: {"from": "2024-01-01", "to": "2026-03-15"},
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": "edge_bob_ceo_2026",
+            "superseded_at": "2026-03-15",
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_invalidated_shape():
+    """An invalidated edge — active=False + no supersede link."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "WrongAlice",
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_INVALIDATED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_expired_shape():
+    """An expired edge — active=False + no supersede link."""
+    edge = {
+        "head": "report_Q1", "predicate": "MENTIONS", "tail": "Alice",
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_EXPIRED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+# ─── Edge validator — malformed shapes rejected ──────────────────
+
+
+def test_edge_not_dict_rejected():
+    with pytest.raises(ValueError, match="edge must be a dict"):
+        validate_edge_v04_fields([])  # type: ignore[arg-type]
+
+
+def test_edge_validity_not_dict_rejected():
+    edge = {T7_EDGE_FIELD_VALIDITY: "2026-04-01"}
+    with pytest.raises(ValueError, match="validity must be a dict"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_validity_inverted_window_rejected():
+    edge = {T7_EDGE_FIELD_VALIDITY: {"from": "2027-01-01", "to": "2026-01-01"}}
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_status_active_not_bool_rejected():
+    edge = {T7_EDGE_FIELD_STATUS: {"active": "yes"}}
+    with pytest.raises(ValueError, match="status.active must be bool"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_superseded_by_wrong_type_rejected():
+    edge = {T7_EDGE_FIELD_STATUS: {"active": True, "superseded_by": 42}}
+    with pytest.raises(ValueError, match="superseded_by must be str"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_mutation_type_invalid_rejected():
+    edge = {T7_EDGE_FIELD_MUTATION_TYPE: "deleted"}
+    with pytest.raises(ValueError, match="mutation_type must be one of"):
+        validate_edge_v04_fields(edge)
+
+
+# ─── Edge cross-field consistency (T7 invariants) ────────────────
+
+
+def test_edge_superseded_requires_supersede_link():
+    """``status.active=False`` with ``mutation_type="superseded"``
+    requires non-empty ``superseded_by`` AND ``superseded_at``."""
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    with pytest.raises(
+        ValueError,
+        match="requires non-empty superseded_by AND superseded_at",
+    ):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_superseded_missing_superseded_at_rejected():
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": "edge_new_id",
+            "superseded_at": None,   # missing
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    with pytest.raises(ValueError, match="requires non-empty"):
+        validate_edge_v04_fields(edge)
+
+
+@pytest.mark.parametrize("mt", [
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_MUTATION_EXPIRED,
+])
+def test_edge_active_true_incompatible_with_non_active_mutation(mt):
+    """``status.active=True`` is only consistent with
+    ``mutation_type="active"`` — any inactive mutation type with
+    active=True is a contradiction."""
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": True,
+            "superseded_by": "x" if mt == T1_MUTATION_SUPERSEDED else None,
+            "superseded_at": "2026-01-01" if mt == T1_MUTATION_SUPERSEDED else None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: mt,
+    }
+    with pytest.raises(ValueError, match="incompatible with"):
+        validate_edge_v04_fields(edge)
+
+
+# ─── Source defaults helper ──────────────────────────────────────
+
+
+def test_source_defaults_fills_missing_fields():
+    src = {"doc_id": "x", "weight": 0.5, "role": "extract"}
+    out = apply_v04_source_defaults(src)
+    assert out[T1_SOURCE_FIELD_VALID_FROM] is None
+    assert out[T1_SOURCE_FIELD_VALID_UNTIL] is None
+    assert out["doc_id"] == "x"   # v0.3 fields preserved
+    assert out["weight"] == 0.5
+    assert out["role"] == "extract"
+
+
+def test_source_defaults_does_not_mutate_input():
+    """Caller's dict stays untouched — guarantees safe use inside list
+    comprehensions over loaded frontmatter."""
+    src = {"doc_id": "x"}
+    apply_v04_source_defaults(src)
+    assert T1_SOURCE_FIELD_VALID_FROM not in src
+    assert T1_SOURCE_FIELD_VALID_UNTIL not in src
+
+
+def test_source_defaults_idempotent():
+    """Applying twice yields the same dict — migration script (PR-T1.A)
+    can re-run ``--apply`` safely."""
+    src = {"doc_id": "x", "weight": 0.5}
+    once = apply_v04_source_defaults(src)
+    twice = apply_v04_source_defaults(once)
+    assert once == twice
+
+
+def test_source_defaults_preserves_existing_v04_values():
+    """If the caller already has v0.4 fields set, the defaults helper
+    keeps them — only fills genuinely missing fields."""
+    src = {
+        "doc_id": "x",
+        T1_SOURCE_FIELD_VALID_FROM: "2026-04-01",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2027-04-01",
+    }
+    out = apply_v04_source_defaults(src)
+    assert out[T1_SOURCE_FIELD_VALID_FROM] == "2026-04-01"
+    assert out[T1_SOURCE_FIELD_VALID_UNTIL] == "2027-04-01"
+
+
+def test_source_defaults_rejects_non_dict():
+    with pytest.raises(ValueError, match="source must be a dict"):
+        apply_v04_source_defaults("not a dict")  # type: ignore[arg-type]
+
+
+# ─── Edge defaults helper ────────────────────────────────────────
+
+
+def test_edge_defaults_fills_missing_fields():
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    out = apply_v04_edge_defaults(edge)
+    assert out[T7_EDGE_FIELD_VALIDITY] == {"from": None, "to": None}
+    assert out[T7_EDGE_FIELD_STATUS] == {
+        "active": True, "superseded_by": None, "superseded_at": None,
+    }
+    assert out[T7_EDGE_FIELD_MUTATION_TYPE] == T1_MUTATION_ACTIVE
+    # v0.3 fields preserved
+    assert out["head"] == "A"
+    assert out["predicate"] == "P"
+    assert out["tail"] == "B"
+
+
+def test_edge_defaults_does_not_mutate_input():
+    edge = {"head": "A"}
+    apply_v04_edge_defaults(edge)
+    assert T7_EDGE_FIELD_VALIDITY not in edge
+    assert T7_EDGE_FIELD_STATUS not in edge
+    assert T7_EDGE_FIELD_MUTATION_TYPE not in edge
+
+
+def test_edge_defaults_idempotent():
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    once = apply_v04_edge_defaults(edge)
+    twice = apply_v04_edge_defaults(once)
+    assert once == twice
+
+
+def test_edge_defaults_after_apply_validates_clean():
+    """A defaults-filled edge MUST pass the v0.4 validator. This pins
+    that the defaults match the validator's accepted-shape contract."""
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    out = apply_v04_edge_defaults(edge)
+    validate_edge_v04_fields(out)   # must not raise
+
+
+def test_edge_defaults_rejects_non_dict():
+    with pytest.raises(ValueError, match="edge must be a dict"):
+        apply_v04_edge_defaults(None)  # type: ignore[arg-type]
+
+
+# ─── Backward-compat re-export through core.relations_schema ─────
+
+
+def test_relations_schema_reexports_v04_symbols():
+    """The new symbols are accessible via the v0.3 canonical
+    ``core.relations_schema`` namespace so existing call sites that
+    grep the schema vocabulary find everything in one place."""
+    from core import relations_schema as rs
+
+    # Constants
+    assert rs.T1_MUTATION_ACTIVE == "active"
+    assert rs.T1_MUTATION_INVALIDATED == "invalidated"
+    assert rs.T1_MUTATION_SUPERSEDED == "superseded"
+    assert rs.T1_MUTATION_EXPIRED == "expired"
+    assert rs.VALID_MUTATION_TYPES == VALID_MUTATION_TYPES
+
+    # Field name constants
+    assert rs.T1_SOURCE_FIELD_VALID_FROM == "valid_from"
+    assert rs.T7_EDGE_FIELD_VALIDITY == "validity"
+
+    # Functions
+    assert rs.validate_source_v04_fields is validate_source_v04_fields
+    assert rs.validate_edge_v04_fields is validate_edge_v04_fields
+    assert rs.apply_v04_source_defaults is apply_v04_source_defaults
+    assert rs.apply_v04_edge_defaults is apply_v04_edge_defaults
+
+
+def test_relations_schema_v03_surface_unchanged():
+    """v0.3 symbols still present + work — regression pin."""
+    from core.relations_schema import (
+        VALID_SOURCE_ROLES,
+        LEGACY_SOURCE_ROLE,
+        compute_confidence_from_sources,
+        read_relation_sources,
+        validate_occurred_at,
+    )
+    assert "legacy" in VALID_SOURCE_ROLES
+    assert LEGACY_SOURCE_ROLE == "legacy"
+    assert compute_confidence_from_sources([]) == 0.0
+    assert compute_confidence_from_sources(
+        [{"weight": 0.5}]
+    ) == 0.5
+    assert read_relation_sources({}) == []
+    # validate_occurred_at signature unchanged
+    validate_occurred_at("2026-01-01", precision="day")


### PR DESCRIPTION
## Summary

**First code PR of Sprint 5**. Pure-validation surface + foundational clock helper. v0.3-equivalent safe defaults throughout → existing callers see zero behaviour change. Lands before PR-T1.A (migration script) and PR-T7.A (supersede operations) so both downstream PRs reference an already-extended schema.

Locked at Sprint 5 entry memo (PR #523) §12. Specifically:
- §12.1 LOCKED: separate prep-PR before PR-T1.A → **this PR is that prep-PR**
- §12.2 LOCKED: hybrid clock — `clock.now()` for production + explicit `t` at replay endpoint → **lands here**
- §12.3 LOCKED: mutation_type unconditional emit + absent = "active" → vocabulary lands here, emit site at PR-T2.x
- §12.4 LOCKED: on-demand cadence → no scheduler code in this PR

## New package: `core/lifecycle/`

| File | Size | Purpose |
|---|---|---|
| `__init__.py` | ~1 KB | Re-exports `clock` + `schema` submodules |
| `clock.py` | ~2.4 KB | Single `now()` helper, UTC-aware, monkey-patchable |
| `schema.py` | ~12.3 KB | v0.4 T1 + T7 vocabulary + validators + defaults |

## Modified: `core/relations_schema.py`

Re-exports the new v0.4 symbols from `core.lifecycle.schema` so existing call sites grepping the v0.3 canonical namespace (`from core.relations_schema import …`) keep finding everything. **v0.3 surface unchanged**.

Pre-extension this file was 9.2 KB. Adding the v0.4 vocabulary inline would have pushed it to 19.4 KB — half a KB shy of the 20 KB CLAUDE.md rule #5 cap. Splitting to `core/lifecycle/schema.py` puts the additions in their proper namespace AND keeps both files at safe sizes (**10.0 KB / 12.3 KB**) with comfortable headroom for v0.4.1+ extensions (T3/T6 fields land in the same schema module).

## Field vocabulary locked

- `T1_MUTATION_{ACTIVE, INVALIDATED, SUPERSEDED, EXPIRED}` + `VALID_MUTATION_TYPES` frozenset
- Field-name constants: `T1_SOURCE_FIELD_VALID_FROM/UNTIL`, `T7_EDGE_FIELD_VALIDITY/STATUS/MUTATION_TYPE`

## Validators (raise `ValueError` on malformed shapes)

| Function | Accepts |
|---|---|
| `validate_source_v04_fields(source)` | v0.3 shapes + 6 valid v0.4 T1 shapes; rejects non-dict, bad ISO 8601, inverted/zero-length window |
| `validate_edge_v04_fields(edge)` | v0.3 shapes + 4 valid v0.4 T1+T7 shapes (active / superseded / invalidated / expired); rejects 6 malformed-shape variants + 4 cross-field-consistency violations |

### T7 cross-field consistency (write-time invariant)

- `status.active=False` with `mutation_type="superseded"` requires non-empty `superseded_by` AND `superseded_at`
- `status.active=True` is only consistent with `mutation_type="active"` (any other mutation type with active=True is a contradiction)

## Defaults helpers (idempotent, non-mutating)

| Function | Output |
|---|---|
| `apply_v04_source_defaults(source)` | source + `{valid_from: None, valid_until: None}` if missing |
| `apply_v04_edge_defaults(edge)` | edge + `validity {from:None, to:None}`, `status {active:True, …}`, `mutation_type:"active"` |

Migration script (PR-T1.A) composes `apply_v04_*_defaults` over loaded frontmatter to migrate idempotently. Round-trip property pinned: `validate_edge_v04_fields(apply_v04_edge_defaults(edge))` never raises.

## New tests (51 cases)

| File | Cases | Coverage |
|---|---|---|
| `tests/test_lifecycle_clock.py` | 7 | UTC-aware contract, monotonically non-decreasing, monkey-patchable, monkey-patch teardown, module surface single-purpose, package re-export |
| `tests/test_lifecycle_schema.py` | 44 | Backward-compat (v0.3 source + edge), 6 parametrized v0.4-valid source shapes, 4 v0.4-valid edge shapes, 12 malformed rejections, 5 T7 cross-field consistency (incl. 3 parametrized "active=True incompatible" cases), 8 defaults-helper invariants, backward-compat re-export pin, v0.3 surface unchanged pin |

## Verification

- **51 / 51** new tests pass.
- **2624 / 2624** under CI-mirroring exclusion set (was 2573 on post-PR #521 main; +51 new).
- ruff clean on every touched file.

## What this PR does NOT do

- No migration script — lands at PR-T1.A.
- No expiration cascade — lands at PR-T1.B.
- No supersede operations — lands at PR-T7.A.
- No contradiction arbiter — lands at PR-T2.A.
- No wiring into engine / pipeline / graph_engine — pure-validation surface only. Every existing production code path stays behaviourally byte-identical at v0.3-default field shapes.

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic Layer 4 infra
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A — no runtime code path modified; schema vocabulary expands but every existing call site stays at v0.3 defaults
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): `architecture` label — new `core/lifecycle/` package surface
- rule #5 (module ≤ 20 KB): ✅ all under cap (10.0 / 12.3 / 2.4 / 1.0 KB)

## CI note

GitHub Actions partial outage was active when this PR opens (2026-05-26 ~11:00 UTC, ~3h ongoing). CI will run automatically once GitHub recovers. Local validation: pytest 2624 pass, ruff clean.