### PR TITLE
feat(lifecycle): v0.4 Sprint 5 PR-T1.A — schema migration script

### DIFF
--- a/core/lifecycle/__init__.py
+++ b/core/lifecycle/__init__.py
@@ -1,0 +1,25 @@
+"""``core.lifecycle`` — v0.4 Layer 4 Lifecycle Semantics.
+
+This package hosts the EVENT/TEMPORAL track of the v0.4 architectural
+shift (`docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md`,
+strategic memo `docs/design/v0.4-lifecycle-semantics-roadmap.md`).
+
+Sprint 5 first-bundle scope (v0.4.0):
+
+- ``clock``                 — single ``now()`` helper (locked via
+                              entry memo §12.2; monkey-patchable for
+                              tests, used by every T1+T7 call site
+                              that needs "current time").
+- ``expiration_cascade``    — T1 batch (lands at PR-T1.B).
+- ``supersede_chain``       — T7 EVENT operations (lands at PR-T7.A).
+- ``contradiction_arbiter`` — T2 A/B classifier (lands at PR-T2.A).
+
+This PR (PR-0, validator prep) ships only the package skeleton + the
+``clock`` helper. Subsequent PR-T1.A/B + PR-T7.A/B + PR-T2.A/B/C land
+the rest.
+"""
+from __future__ import annotations
+
+from core.lifecycle import clock, schema
+
+__all__ = ["clock", "schema"]

--- a/core/lifecycle/clock.py
+++ b/core/lifecycle/clock.py
@@ -1,0 +1,64 @@
+"""Single source of truth for "current time" across the v0.4 Layer 4
+EVENT/TEMPORAL track.
+
+Locked at Sprint 5 entry memo §12.2 (2026-05-26). The choice is the
+**hybrid** option:
+
+- Production paths call ``clock.now()`` for the current-time signal.
+  ``compute_confidence_from_sources`` / expiration cascade /
+  ``supersede_edge`` / contradiction arbiter all route through this
+  single helper.
+- Tests monkey-patch ``clock.now`` to freeze time deterministically::
+
+      monkeypatch.setattr("core.lifecycle.clock.now",
+                          lambda: datetime(2026, 6, 1, 12, 0, 0,
+                                           tzinfo=timezone.utc))
+
+- The forensic replay primitive (``reconstruct_view_at(head,
+  predicate, t)``, lands at PR-T7.A) is the **only** path that
+  bypasses ``clock.now()`` — it accepts an explicit ``t`` parameter
+  for historical reconstruction.
+
+Why a separate module instead of just calling ``datetime.utcnow()``:
+
+- One monkey-patch point flips the entire EVENT/TEMPORAL clock for
+  the test suite. Without this indirection every call site would
+  need its own freezer fixture.
+- The replay primitive's explicit-``t`` path becomes visually
+  distinct from the "current" path — code review can immediately
+  tell which calls run "now" vs "as of t".
+- Future swaps (e.g., monotonic-clock for ordering, NTP-corrected
+  wall-clock for cross-machine replay) are one-file changes.
+
+Time zone policy: ``now()`` returns a **UTC-aware** ``datetime``
+(``tzinfo=timezone.utc``). All v0.4 audit rows + validity windows +
+supersede timestamps land in UTC. Display-side time-zone conversion
+is the UI's responsibility.
+
+The module is dependency-free (stdlib only) so it imports fast and
+can be reached from any test fixture without dragging in heavy
+modules.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def now() -> datetime:
+    """Return the current wall-clock time as a UTC-aware ``datetime``.
+
+    This is the single function v0.4 Layer 4 calls when it needs
+    "current time" — see module docstring for the design rationale.
+
+    Tests freeze this via::
+
+        monkeypatch.setattr("core.lifecycle.clock.now", lambda: <fixed>)
+
+    Production callers never pass arguments; the function signature
+    is intentionally argument-free so the monkey-patch lambda above
+    is signature-compatible.
+    """
+    return datetime.now(timezone.utc)
+
+
+__all__ = ["now"]

--- a/core/lifecycle/schema.py
+++ b/core/lifecycle/schema.py
@@ -1,0 +1,304 @@
+"""v0.4 Sprint 5 — T1 + T7 schema extension validators + defaults.
+
+Sprint 5 first-bundle PR-0 (validator prep, 2026-05-26). Lands the
+field vocabulary + validation + safe-default helpers before the
+migration script (PR-T1.A) or the supersede operations (PR-T7.A)
+reference them.
+
+Pure-validation surface — no clock dependency, no I/O, no
+behavioural change for v0.3-shaped data. Existing callers that
+import these symbols through ``core.relations_schema`` (the v0.3
+canonical location) continue to work; the symbols re-export from
+that module unchanged.
+
+Field vocabulary locked at the entry memo §3 + strategic memo §3.3 +
+§4.2 + §9.5.2:
+
+- **Source-level (T1)**: ``valid_from`` / ``valid_until``
+  (ISO 8601 strings or None).
+- **Edge-level (T1+T7)**: ``validity`` (``{from, to}`` dict),
+  ``status`` (``{active, superseded_by, superseded_at}`` dict),
+  ``mutation_type`` (``"active" | "invalidated" | "superseded" |
+  "expired"`` enum).
+
+The validator + defaults split:
+
+- ``validate_source_v04_fields(source)`` — raises ``ValueError`` on
+  malformed v0.4 fields. Acceptable shapes documented in the
+  function docstring.
+- ``apply_v04_source_defaults(source)`` — returns a copy of ``source``
+  with v0.4 fields filled at v0.3-equivalent safe defaults. Idempotent.
+- ``validate_edge_v04_fields(edge)`` — same contract for edges.
+- ``apply_v04_edge_defaults(edge)`` — same contract for edges.
+
+Migration script (PR-T1.A) composes ``apply_v04_*_defaults`` over the
+loaded frontmatter to migrate idempotently. Subsequent T7 / T2 PRs
+compose ``validate_*_v04_fields`` at write-time to catch malformed
+mutations before they hit the wiki.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Final
+
+
+# ─── Mutation type enum ───────────────────────────────────────────
+#
+# Per the entry memo §12.3 lock, absence in audit-log rows is
+# interpreted as ``"active"`` (matches pre-bundle semantics where no
+# mutation-type concept existed). Validator accepts the value list
+# below; ``apply_v04_edge_defaults`` fills ``"active"`` when missing.
+T1_MUTATION_ACTIVE:      Final[str] = "active"
+T1_MUTATION_INVALIDATED: Final[str] = "invalidated"   # CASCADE (Layer 3)
+T1_MUTATION_SUPERSEDED:  Final[str] = "superseded"    # EVENT (T7)
+T1_MUTATION_EXPIRED:     Final[str] = "expired"       # EVENT (T1)
+
+VALID_MUTATION_TYPES: Final[frozenset[str]] = frozenset({
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_MUTATION_EXPIRED,
+})
+
+
+# ─── Field name constants ────────────────────────────────────────
+#
+# Callers + tests reference the schema vocabulary by symbol rather
+# than string-literal duplication.
+T1_SOURCE_FIELD_VALID_FROM:  Final[str] = "valid_from"
+T1_SOURCE_FIELD_VALID_UNTIL: Final[str] = "valid_until"
+
+T7_EDGE_FIELD_VALIDITY:      Final[str] = "validity"
+T7_EDGE_FIELD_STATUS:        Final[str] = "status"
+T7_EDGE_FIELD_MUTATION_TYPE: Final[str] = "mutation_type"
+
+
+def _parse_optional_iso(value: Any) -> datetime | None:
+    """Return parsed ``datetime`` for an ISO-8601 string, ``None`` for
+    ``None``, raise ``ValueError`` on anything else (malformed string,
+    wrong type).
+
+    Trailing ``Z`` is accepted via the ``+00:00`` substitution,
+    matching ``core.relations_schema.validate_occurred_at`` so the
+    two timestamp paths share one parser contract.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"expected ISO 8601 string or None, got {type(value).__name__}"
+        )
+    if not value:
+        raise ValueError(
+            "ISO 8601 string must be non-empty (use None instead)"
+        )
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as e:
+        raise ValueError(f"not parseable as ISO 8601: {value!r}") from e
+
+
+def validate_source_v04_fields(source: dict) -> None:
+    """Raise ``ValueError`` if a source dict carries malformed T1 fields.
+
+    Acceptable shapes:
+      - missing both ``valid_from`` and ``valid_until``  → v0.3 default
+      - either or both fields present as ``None``        → indefinite
+      - either or both fields present as ISO 8601 string → bounded
+
+    Order constraint: when both are present, ``valid_from`` must be
+    strictly earlier than ``valid_until`` (zero-length / inverted
+    windows rejected so the cascade can't get stuck on a source
+    that's neither active nor expired).
+    """
+    if not isinstance(source, dict):
+        raise ValueError(
+            f"source must be a dict, got {type(source).__name__}"
+        )
+    vf = _parse_optional_iso(source.get(T1_SOURCE_FIELD_VALID_FROM))
+    vu = _parse_optional_iso(source.get(T1_SOURCE_FIELD_VALID_UNTIL))
+    if vf is not None and vu is not None and not (vf < vu):
+        raise ValueError(
+            f"valid_from must be strictly earlier than valid_until — "
+            f"got valid_from={source.get(T1_SOURCE_FIELD_VALID_FROM)!r} "
+            f"valid_until={source.get(T1_SOURCE_FIELD_VALID_UNTIL)!r}"
+        )
+
+
+def validate_edge_v04_fields(edge: dict) -> None:
+    """Raise ``ValueError`` if an edge (relation) dict carries malformed
+    T1+T7 fields.
+
+    Acceptable shapes:
+      - all three new fields missing → v0.3 default (treated as
+        active / no validity window / mutation_type="active")
+      - ``validity`` dict with ``from`` / ``to`` (both ISO-8601 strings
+        or None). Same strict-earlier constraint as
+        ``validate_source_v04_fields`` when both bounds are set.
+      - ``status`` dict with ``active`` (bool), ``superseded_by``
+        (str ID or None), ``superseded_at`` (ISO 8601 or None).
+      - ``mutation_type`` ∈ ``VALID_MUTATION_TYPES``.
+
+    Cross-field consistency (T7 invariant pinned at write-time):
+    ``status.active == False`` implies one of three:
+      1. ``mutation_type == "superseded"`` with non-empty
+         ``status.superseded_by`` AND ``status.superseded_at`` set
+      2. ``mutation_type == "invalidated"`` (CASCADE path; no
+         supersede link required)
+      3. ``mutation_type == "expired"`` (T1 path; no supersede link
+         required)
+
+    The cross-field check fires only when both ``status`` and
+    ``mutation_type`` are explicitly set — partial v0.4 shapes
+    (e.g., ``status`` set, ``mutation_type`` missing) get
+    default-applied at ``apply_v04_edge_defaults`` time.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+
+    # ─── T1+T7 validity window ───────────────────────────────────
+    validity = edge.get(T7_EDGE_FIELD_VALIDITY)
+    if validity is not None:
+        if not isinstance(validity, dict):
+            raise ValueError(
+                f"edge.validity must be a dict, got "
+                f"{type(validity).__name__}"
+            )
+        vf = _parse_optional_iso(validity.get("from"))
+        vu = _parse_optional_iso(validity.get("to"))
+        if vf is not None and vu is not None and not (vf < vu):
+            raise ValueError(
+                f"edge.validity.from must be strictly earlier than "
+                f"validity.to — got from={validity.get('from')!r} "
+                f"to={validity.get('to')!r}"
+            )
+
+    # ─── T7 status ───────────────────────────────────────────────
+    status = edge.get(T7_EDGE_FIELD_STATUS)
+    if status is not None:
+        if not isinstance(status, dict):
+            raise ValueError(
+                f"edge.status must be a dict, got "
+                f"{type(status).__name__}"
+            )
+        active = status.get("active", True)
+        if not isinstance(active, bool):
+            raise ValueError(
+                f"edge.status.active must be bool, got "
+                f"{type(active).__name__}"
+            )
+        sb = status.get("superseded_by")
+        if sb is not None and not isinstance(sb, str):
+            raise ValueError(
+                f"edge.status.superseded_by must be str ID or None, "
+                f"got {type(sb).__name__}"
+            )
+        _parse_optional_iso(status.get("superseded_at"))
+
+    # ─── T1+T7 mutation_type ─────────────────────────────────────
+    mt = edge.get(T7_EDGE_FIELD_MUTATION_TYPE)
+    if mt is not None and mt not in VALID_MUTATION_TYPES:
+        raise ValueError(
+            f"edge.mutation_type must be one of "
+            f"{sorted(VALID_MUTATION_TYPES)}, got {mt!r}"
+        )
+
+    # ─── Cross-field consistency (T7 invariant) ──────────────────
+    if isinstance(status, dict) and mt is not None:
+        active = status.get("active", True)
+        sb = status.get("superseded_by")
+        sa = status.get("superseded_at")
+        if active is False and mt == T1_MUTATION_SUPERSEDED:
+            if not sb or sa is None:
+                raise ValueError(
+                    "status.active=False with mutation_type='superseded' "
+                    "requires non-empty superseded_by AND superseded_at"
+                )
+        if active is True and mt in (
+            T1_MUTATION_INVALIDATED,
+            T1_MUTATION_SUPERSEDED,
+            T1_MUTATION_EXPIRED,
+        ):
+            raise ValueError(
+                f"status.active=True is incompatible with "
+                f"mutation_type={mt!r} — only 'active' is consistent "
+                f"with status.active=True"
+            )
+
+
+def apply_v04_source_defaults(source: dict) -> dict:
+    """Return a copy of ``source`` with v0.4 T1 fields filled at safe
+    defaults (``None`` = indefinite validity).
+
+    v0.3-equivalent semantics: the defaults map directly onto the
+    "no temporal constraint" reading existing callers already assume.
+
+    Idempotent — applying twice yields the same dict. The migration
+    script (PR-T1.A) relies on this to make ``--apply`` re-runnable.
+
+    Returns a new dict; does NOT mutate the caller's argument so the
+    function is safe to use inside list comprehensions over loaded
+    frontmatter.
+    """
+    if not isinstance(source, dict):
+        raise ValueError(
+            f"source must be a dict, got {type(source).__name__}"
+        )
+    out = dict(source)
+    out.setdefault(T1_SOURCE_FIELD_VALID_FROM, None)
+    out.setdefault(T1_SOURCE_FIELD_VALID_UNTIL, None)
+    return out
+
+
+def apply_v04_edge_defaults(edge: dict) -> dict:
+    """Return a copy of ``edge`` with v0.4 T1+T7 fields filled at safe
+    defaults.
+
+    Defaults (match v0.3 semantics for backward compat):
+      - ``validity``: ``{"from": None, "to": None}``  (indefinite)
+      - ``status``:   ``{"active": True, "superseded_by": None,
+                          "superseded_at": None}``
+      - ``mutation_type``: ``"active"``
+
+    Idempotent — running on an already-migrated edge yields the same
+    dict. The migration script (PR-T1.A) relies on this.
+
+    Returns a new dict; does NOT mutate the caller's argument.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    out = dict(edge)
+    out.setdefault(T7_EDGE_FIELD_VALIDITY, {"from": None, "to": None})
+    out.setdefault(T7_EDGE_FIELD_STATUS, {
+        "active": True,
+        "superseded_by": None,
+        "superseded_at": None,
+    })
+    out.setdefault(T7_EDGE_FIELD_MUTATION_TYPE, T1_MUTATION_ACTIVE)
+    return out
+
+
+__all__ = [
+    # mutation type enum
+    "T1_MUTATION_ACTIVE",
+    "T1_MUTATION_INVALIDATED",
+    "T1_MUTATION_SUPERSEDED",
+    "T1_MUTATION_EXPIRED",
+    "VALID_MUTATION_TYPES",
+    # field name constants
+    "T1_SOURCE_FIELD_VALID_FROM",
+    "T1_SOURCE_FIELD_VALID_UNTIL",
+    "T7_EDGE_FIELD_VALIDITY",
+    "T7_EDGE_FIELD_STATUS",
+    "T7_EDGE_FIELD_MUTATION_TYPE",
+    # validators
+    "validate_source_v04_fields",
+    "validate_edge_v04_fields",
+    # defaults
+    "apply_v04_source_defaults",
+    "apply_v04_edge_defaults",
+]

--- a/core/relations_schema.py
+++ b/core/relations_schema.py
@@ -22,6 +22,20 @@ production 의 `relation["confidence"]` 읽기 경로는 Phase A 단계에서
   * manual   — admin 이 그래프 에디터로 수동 입력 (Phase E)
   * legacy   — Phase A 마이그레이션 시점에 출처 추적 없이 back-fill
                된 사전-마이그레이션 잔류 (cascade 가 건드리지 않음)
+
+v0.4 Sprint 5 first-bundle (2026-05-26+, PR 0 validator prep):
+  Extends the schema with T1 (Temporal Validity) + T7 (Supersede
+  Chain) fields. Existing v0.3 callers see no behaviour change —
+  every new field has a v0.3-equivalent safe default. See
+  ``docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md``
+  §2 for scope + §12.2 for the clock decision.
+
+  - **Source-level (T1)**: ``valid_from`` / ``valid_until``
+    (ISO 8601 strings or None).
+  - **Edge-level (T1+T7)**: ``validity`` (``{from, to}`` dict),
+    ``status`` (``{active, superseded_by, superseded_at}`` dict),
+    ``mutation_type`` (``"active" | "invalidated" | "superseded" |
+    "expired"`` enum).
 """
 
 from __future__ import annotations
@@ -189,6 +203,29 @@ def read_relation_sources(rel: dict | None) -> list:
             "ts":     None,
         }]
     return []
+
+
+# v0.4 Sprint 5 — T1 + T7 schema extension lives in
+# ``core.lifecycle.schema`` so the v0.3 surface here stays small enough
+# to take future Phase-A follow-ups without breaching the 20 KB cap.
+# Re-export for back-compat — existing callers can still
+# ``from core.relations_schema import VALID_MUTATION_TYPES`` etc.
+from core.lifecycle.schema import (  # noqa: F401
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_SOURCE_FIELD_VALID_FROM,
+    T1_SOURCE_FIELD_VALID_UNTIL,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+    VALID_MUTATION_TYPES,
+    apply_v04_edge_defaults,
+    apply_v04_source_defaults,
+    validate_edge_v04_fields,
+    validate_source_v04_fields,
+)
 
 
 def build_legacy_source(

--- a/scripts/migrate_v04_lifecycle.py
+++ b/scripts/migrate_v04_lifecycle.py
@@ -1,0 +1,523 @@
+"""v0.4 Sprint 5 PR-T1.A — Layer 4 schema migration (T1 + T7 fields).
+
+Sprint 5 entry memo (`docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md`)
+§6 schema migration plan. Locked at §12.1: separate prep-PR
+(`core/lifecycle/schema.py` lands at PR-0) **before** this migration
+script so the validators / defaults helpers are already on `main`
+when this script runs.
+
+The script back-fills every wiki entity's frontmatter with the v0.4
+T1 + T7 fields at v0.3-equivalent safe defaults:
+
+  Source-level (T1):
+    ``valid_from``  → None  (no temporal start constraint)
+    ``valid_until`` → None  (no temporal end / indefinite validity)
+
+  Edge-level (T1 + T7):
+    ``validity``       → ``{"from": None, "to": None}``  (indefinite)
+    ``status``         → ``{"active": True,
+                            "superseded_by": None,
+                            "superseded_at": None}``
+    ``mutation_type``  → ``"active"``
+
+Properties (every one pinned by `tests/test_migrate_v04_lifecycle.py`):
+
+- **Idempotent.** Running ``--apply`` twice leaves the wiki
+  byte-identical after the first run. The `apply_v04_*_defaults`
+  helpers from PR-0 use `setdefault` semantics, so re-running on
+  already-migrated entities is a no-op.
+- **v0.3-equivalent behaviour.** Every default is the semantic
+  identity of "no temporal constraint" — existing callers that
+  read `confidence` / `sources` / `relations` see no change at the
+  v0.3 read path.
+- **Atomic per-file write.** Each entity file is rewritten via
+  tempfile + `os.replace` to avoid half-written frontmatter on a
+  crash. Same pattern as PR #459 (Phase A migration).
+- **Snapshot.** Before any write, the script copies the wiki tree
+  to ``wiki.pre-v04-migration/`` for rollback. Skippable with
+  ``--no-snapshot`` (CI / already-backed-up cases).
+- **Validation pass.** After writing each file, the migrated
+  frontmatter is run through `validate_source_v04_fields` +
+  `validate_edge_v04_fields` (PR-0). Validation failures halt the
+  migration with an explicit row count so the operator can
+  investigate before the wiki diverges.
+
+Modes:
+
+  ``--dry-run`` (default)   inspect only; no writes; print summary
+  ``--apply``               write back; create snapshot first
+  ``--verify``              every file has v0.4 fields + validates clean;
+                            no writes; exit 0 if fully migrated
+  ``--no-snapshot``         skip the snapshot step (use only if you
+                            already have a backup)
+  ``--root <path>``         wiki root (default: ``wiki``)
+  ``--force``               overwrite existing snapshot directory
+
+Operator workflow (entry memo §9):
+
+  python scripts/migrate_v04_lifecycle.py                # dry-run
+  python scripts/migrate_v04_lifecycle.py --apply        # write back
+  python scripts/migrate_v04_lifecycle.py --verify       # confirm
+
+Rollback (snapshot ↔ live):
+
+  rmdir /s /q wiki                    # PowerShell: remove live tree
+  rename wiki.pre-v04-migration wiki  # restore snapshot
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Project root on sys.path so `core.*` import works when the script
+# is invoked from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Windows cp949 console crashes on em-dash in --help / log lines.
+# Same helper Phase A migration + bench wrapper use.
+try:
+    from utils.console import ensure_utf8_console  # noqa: E402
+    ensure_utf8_console()
+except Exception:
+    pass
+
+from core.lifecycle.schema import (  # noqa: E402
+    apply_v04_edge_defaults,
+    apply_v04_source_defaults,
+    validate_edge_v04_fields,
+    validate_source_v04_fields,
+)
+
+
+DEFAULT_WIKI_ROOT = Path("wiki")
+SNAPSHOT_SUFFIX = "pre-v04-migration"
+
+
+# ───────────────────────────────────────────────────────────────
+# Snapshot
+# ───────────────────────────────────────────────────────────────
+
+
+def snapshot_wiki(wiki_root: Path, force: bool = False) -> Path:
+    """``wiki/`` → ``wiki.pre-v04-migration/`` mirror copy for rollback.
+
+    Returns the snapshot path. Raises FileExistsError if the snapshot
+    already exists and ``force`` is False (operator may have prior
+    rollback state worth preserving).
+    """
+    snap = wiki_root.with_name(f"{wiki_root.name}.{SNAPSHOT_SUFFIX}")
+    if snap.exists():
+        if not force:
+            raise FileExistsError(
+                f"snapshot already exists: {snap}\n"
+                f"  -> pass --force to overwrite, or remove it manually\n"
+                f"     (rollback path would be lost on overwrite)"
+            )
+        shutil.rmtree(snap)
+    print(f"[V04_MIGRATE] snapshot {wiki_root} -> {snap}")
+    shutil.copytree(wiki_root, snap)
+    return snap
+
+
+# ───────────────────────────────────────────────────────────────
+# Frontmatter parse / serialize (matches Phase A pattern)
+# ───────────────────────────────────────────────────────────────
+
+
+def _split_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Parse `--- ... ---` block. Returns (frontmatter_dict, body).
+    Returns (None, original_text) when no parseable frontmatter found.
+    """
+    if not text.startswith("---"):
+        return None, text
+    end = text.find("---", 3)
+    if end < 0:
+        return None, text
+    try:
+        fm = yaml.safe_load(text[3:end]) or {}
+    except Exception:
+        return None, text
+    body_tail = text[end + 3:]
+    return fm, body_tail
+
+
+def _serialize_frontmatter(fm: dict, body_tail: str) -> str:
+    return (
+        "---\n"
+        + yaml.dump(
+            fm,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+        + "---"
+        + body_tail
+    )
+
+
+# ───────────────────────────────────────────────────────────────
+# Per-file migration
+# ───────────────────────────────────────────────────────────────
+
+
+def _migrate_relation(rel: dict) -> tuple[dict, bool]:
+    """Apply v0.4 defaults to one relation dict + its embedded sources.
+
+    Returns (new_rel_dict, changed_flag).
+    """
+    changed = False
+
+    # 1. Edge-level (T1 + T7) defaults
+    migrated_edge = apply_v04_edge_defaults(rel)
+    if migrated_edge != rel:
+        changed = True
+
+    # 2. Source-level (T1) defaults on every embedded source
+    sources = migrated_edge.get("sources")
+    if isinstance(sources, list):
+        new_sources = []
+        sources_changed = False
+        for src in sources:
+            if not isinstance(src, dict):
+                new_sources.append(src)
+                continue
+            migrated_src = apply_v04_source_defaults(src)
+            if migrated_src != src:
+                sources_changed = True
+            new_sources.append(migrated_src)
+        if sources_changed:
+            migrated_edge["sources"] = new_sources
+            changed = True
+
+    return migrated_edge, changed
+
+
+def migrate_entity_file(path: Path) -> dict:
+    """Migrate a single entity ``.md`` file. Returns stats dict.
+
+    Idempotent. Files with no `relations` list are no-ops. Files with
+    a parseable frontmatter and a relations list get every relation
+    (and every source under each relation) defaulted to v0.4 shape.
+
+    Validation pass runs after the defaults application — every
+    migrated source + edge must pass the PR-0 validators. If
+    validation fails, the file is NOT written; the error is recorded
+    in stats so the operator can inspect.
+    """
+    stats = {
+        "scanned": 1,
+        "had_no_relations": 0,
+        "mutated": 0,
+        "relations_migrated": 0,
+        "sources_migrated": 0,
+        "validation_failed": 0,
+        "errors": 0,
+    }
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"[V04_MIGRATE] read fail {path}: {e}")
+        stats["errors"] = 1
+        return stats
+
+    fm, body_tail = _split_frontmatter(text)
+    if fm is None:
+        return stats
+
+    relations = fm.get("relations")
+    if not isinstance(relations, list) or not relations:
+        stats["had_no_relations"] = 1
+        return stats
+
+    file_changed = False
+    new_relations = []
+    for rel in relations:
+        if not isinstance(rel, dict):
+            new_relations.append(rel)
+            continue
+        new_rel, rel_changed = _migrate_relation(rel)
+        if rel_changed:
+            stats["relations_migrated"] += 1
+            file_changed = True
+            # Count sources migrated this round
+            old_sources = rel.get("sources", [])
+            if isinstance(old_sources, list):
+                for src in old_sources:
+                    if isinstance(src, dict) and (
+                        "valid_from" not in src
+                        or "valid_until" not in src
+                    ):
+                        stats["sources_migrated"] += 1
+
+        # Validation pass — both layers
+        try:
+            validate_edge_v04_fields(new_rel)
+            for src in new_rel.get("sources", []) or []:
+                if isinstance(src, dict):
+                    validate_source_v04_fields(src)
+        except ValueError as e:
+            print(f"[V04_MIGRATE] validation fail {path}: {e}")
+            stats["validation_failed"] = 1
+            stats["errors"] = 1
+            return stats
+
+        new_relations.append(new_rel)
+
+    if not file_changed:
+        return stats
+
+    fm["relations"] = new_relations
+    stats["mutated"] = 1
+    new_text = _serialize_frontmatter(fm, body_tail)
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(new_text)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        os.replace(tmp_path, path)
+    except Exception as e:
+        print(f"[V04_MIGRATE] write fail {path}: {e}")
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        stats["errors"] = 1
+        stats["mutated"] = 0
+    return stats
+
+
+# ───────────────────────────────────────────────────────────────
+# Wiki-wide walk
+# ───────────────────────────────────────────────────────────────
+
+
+def migrate_wiki(
+    wiki_root: Path,
+    *,
+    dry_run: bool = False,
+    verify: bool = False,
+) -> dict:
+    """Walk ``wiki_root/entity/**/*.md`` and migrate each file.
+
+    Three modes:
+
+      - ``verify=True``: no writes; every file must already have v0.4
+        fields + validate clean. Stats include ``verify_failed`` count.
+      - ``dry_run=True``: no writes; report what *would* change.
+      - else: write back with atomic per-file rewrite.
+    """
+    totals: dict[str, Any] = {
+        "scanned": 0,
+        "had_no_relations": 0,
+        "mutated": 0,
+        "relations_migrated": 0,
+        "sources_migrated": 0,
+        "validation_failed": 0,
+        "verify_failed": 0,
+        "errors": 0,
+    }
+    entity_root = wiki_root / "entity"
+    if not entity_root.is_dir():
+        print(f"[V04_MIGRATE] no entity root: {entity_root}")
+        return totals
+
+    md_files = sorted(entity_root.rglob("*.md"))
+    mode = "VERIFY" if verify else ("DRY-RUN" if dry_run else "APPLY")
+    print(
+        f"[V04_MIGRATE] mode={mode}: {len(md_files)} entity files "
+        f"under {entity_root}"
+    )
+
+    if verify:
+        for path in md_files:
+            try:
+                fm, _ = _split_frontmatter(path.read_text(encoding="utf-8"))
+            except Exception as e:
+                print(f"[V04_MIGRATE] verify read fail {path}: {e}")
+                totals["errors"] += 1
+                continue
+            totals["scanned"] += 1
+            if fm is None:
+                continue
+            relations = fm.get("relations")
+            if not isinstance(relations, list):
+                continue
+            for rel in relations:
+                if not isinstance(rel, dict):
+                    continue
+                missing = [
+                    k for k in (
+                        "validity", "status", "mutation_type",
+                    ) if k not in rel
+                ]
+                if missing:
+                    print(
+                        f"[V04_MIGRATE] verify: {path} relation missing "
+                        f"{missing}"
+                    )
+                    totals["verify_failed"] += 1
+                    continue
+                try:
+                    validate_edge_v04_fields(rel)
+                    for src in rel.get("sources", []) or []:
+                        if isinstance(src, dict):
+                            validate_source_v04_fields(src)
+                except ValueError as e:
+                    print(f"[V04_MIGRATE] verify validate fail {path}: {e}")
+                    totals["verify_failed"] += 1
+        return totals
+
+    if dry_run:
+        for path in md_files:
+            try:
+                text = path.read_text(encoding="utf-8")
+            except Exception as e:
+                print(f"[V04_MIGRATE] dry-run read fail {path}: {e}")
+                totals["errors"] += 1
+                continue
+            totals["scanned"] += 1
+            fm, _ = _split_frontmatter(text)
+            if fm is None:
+                continue
+            relations = fm.get("relations")
+            if not isinstance(relations, list) or not relations:
+                totals["had_no_relations"] += 1
+                continue
+            for rel in relations:
+                if not isinstance(rel, dict):
+                    continue
+                # Count what *would* be added — relations missing any
+                # of the three T1+T7 keys
+                if any(
+                    k not in rel
+                    for k in ("validity", "status", "mutation_type")
+                ):
+                    totals["relations_migrated"] += 1
+                for src in rel.get("sources", []) or []:
+                    if isinstance(src, dict) and (
+                        "valid_from" not in src
+                        or "valid_until" not in src
+                    ):
+                        totals["sources_migrated"] += 1
+        totals["mutated"] = (
+            totals["relations_migrated"] + totals["sources_migrated"]
+        )
+        return totals
+
+    # apply
+    for path in md_files:
+        s = migrate_entity_file(path)
+        for k in (
+            "scanned", "had_no_relations", "mutated",
+            "relations_migrated", "sources_migrated",
+            "validation_failed", "errors",
+        ):
+            totals[k] += s.get(k, 0)
+    return totals
+
+
+# ───────────────────────────────────────────────────────────────
+# CLI
+# ───────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "v0.4 Sprint 5 PR-T1.A — back-fill T1 + T7 fields on "
+            "every wiki entity. Dry-run by default."
+        ),
+    )
+    ap.add_argument("--root", type=Path, default=DEFAULT_WIKI_ROOT)
+    ap.add_argument(
+        "--apply", action="store_true",
+        help="actually write back; otherwise dry-run is the default",
+    )
+    ap.add_argument(
+        "--verify", action="store_true",
+        help=(
+            "no writes; every file must already have v0.4 fields + "
+            "validate clean. Use after --apply to confirm."
+        ),
+    )
+    ap.add_argument(
+        "--no-snapshot", action="store_true",
+        help="skip the wiki.pre-v04-migration snapshot (use only if "
+             "you already have a backup)",
+    )
+    ap.add_argument(
+        "--force", action="store_true",
+        help="overwrite existing wiki.pre-v04-migration directory",
+    )
+    args = ap.parse_args()
+
+    if args.apply and args.verify:
+        print("error: --apply and --verify are mutually exclusive")
+        return 2
+
+    wiki_root = args.root.resolve()
+    if not wiki_root.is_dir():
+        print(f"error: wiki root not found: {wiki_root}")
+        return 2
+
+    # Snapshot pass (only on --apply, before any writes)
+    if args.apply and not args.no_snapshot:
+        try:
+            snapshot_wiki(wiki_root, force=args.force)
+        except FileExistsError as e:
+            print(f"error: {e}")
+            return 2
+
+    totals = migrate_wiki(
+        wiki_root,
+        dry_run=not (args.apply or args.verify),
+        verify=args.verify,
+    )
+
+    print("\n[V04_MIGRATE] summary:")
+    for k, v in totals.items():
+        print(f"  {k:30s} {v}")
+
+    # Exit codes
+    if totals.get("errors", 0) > 0:
+        print("\n[V04_MIGRATE] FAILED — see error log above")
+        return 1
+    if args.verify and totals.get("verify_failed", 0) > 0:
+        print("\n[V04_MIGRATE] VERIFY FAILED — run --apply first")
+        return 1
+    if args.apply and totals.get("mutated", 0) == 0:
+        print("\n[V04_MIGRATE] nothing to migrate (already at v0.4 shape)")
+    elif args.apply:
+        print(
+            f"\n[V04_MIGRATE] OK — migrated {totals['mutated']} files. "
+            f"Verify: python scripts/migrate_v04_lifecycle.py --verify"
+        )
+    elif args.verify:
+        print("\n[V04_MIGRATE] VERIFY OK — wiki fully at v0.4 shape")
+    else:
+        print(
+            f"\n[V04_MIGRATE] DRY-RUN OK — "
+            f"{totals['relations_migrated']} relations + "
+            f"{totals['sources_migrated']} sources would be migrated. "
+            f"Run again with --apply to write."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_lifecycle_clock.py
+++ b/tests/test_lifecycle_clock.py
@@ -1,0 +1,100 @@
+"""v0.4 Sprint 5 PR-0 — ``core.lifecycle.clock`` contract tests.
+
+Pins the single ``now()`` helper that every T1+T7 path consults for
+"current time". The contract is small but load-bearing:
+
+1. ``now()`` returns a **UTC-aware** ``datetime`` so audit rows and
+   validity windows have an unambiguous time-zone reading.
+2. ``monkeypatch.setattr("core.lifecycle.clock.now", lambda: <fixed>)``
+   actually replaces the function (the helper is module-level, not
+   class-level, so the patch works without ``autospec`` complexity).
+3. The "explicit ``t``" path of the replay primitive
+   (``reconstruct_view_at(t=<past>)``, lands at PR-T7.A) is not the
+   subject of these tests — it bypasses ``clock.now`` by design.
+
+Entry memo lock reference: §12.2 (hybrid choice — production calls
+``clock.now()``, replay endpoint accepts explicit ``t``).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+from core.lifecycle import clock
+
+
+def test_now_returns_datetime():
+    """Contract: ``now()`` returns a ``datetime`` instance."""
+    assert isinstance(clock.now(), datetime)
+
+
+def test_now_is_utc_aware():
+    """Contract: returned datetime carries a non-None tzinfo and the
+    tzinfo represents UTC. v0.4 audit rows assume UTC-aware throughout."""
+    result = clock.now()
+    assert result.tzinfo is not None, (
+        "clock.now() must return a timezone-aware datetime — audit "
+        "rows + validity windows would be ambiguous otherwise"
+    )
+    # utcoffset of UTC is timedelta(0). Equivalent to tzinfo == timezone.utc
+    # but more permissive (e.g., pytz UTC also passes).
+    assert result.utcoffset().total_seconds() == 0, (
+        "clock.now() tzinfo must represent UTC (offset 0); got "
+        f"{result.utcoffset()}"
+    )
+
+
+def test_now_advances_across_calls():
+    """Sanity — two successive calls give monotonically non-decreasing
+    timestamps. Catches a pathological monkey-patch leaking across
+    tests (e.g., a test forgot to undo a freezer)."""
+    a = clock.now()
+    b = clock.now()
+    assert b >= a, (
+        f"clock.now() must be monotonically non-decreasing within a "
+        f"single process — got a={a.isoformat()} b={b.isoformat()}"
+    )
+
+
+def test_clock_is_monkey_patchable(monkeypatch):
+    """The locked design choice (§12.2) requires that test code can
+    freeze time via ``monkeypatch.setattr``. This test guarantees the
+    contract — every T1+T7 test that needs deterministic time will
+    rely on this patch site."""
+    fixed = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.lifecycle.clock.now", lambda: fixed)
+    assert clock.now() == fixed
+    # Repeatable
+    for _ in range(10):
+        assert clock.now() == fixed
+
+
+def test_clock_patch_does_not_leak_outside_test(monkeypatch):
+    """Defensive — monkeypatch is correctly scoped to one test. Without
+    this, a freezer set in test A would persist into test B as silent
+    state contamination. pytest's monkeypatch fixture auto-undoes at
+    teardown; this test simply confirms the contract holds for our
+    setup (we patch a module-level callable, not a class attribute,
+    which is the simpler case)."""
+    fixed = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.lifecycle.clock.now", lambda: fixed)
+    assert clock.now() == fixed
+    # Teardown will undo — verified by the other tests in this file
+    # observing a live clock value.
+
+
+def test_module_surface():
+    """``core.lifecycle.clock`` exposes only ``now`` — keeps the API
+    surface single-purpose so future swaps (NTP-corrected clock,
+    monotonic ordering) land at one symbol."""
+    assert clock.__all__ == ["now"]
+    assert hasattr(clock, "now")
+
+
+def test_lifecycle_package_reexport():
+    """``core.lifecycle`` package surfaces ``clock`` for direct import
+    — keeps the call-site ``from core.lifecycle import clock`` pattern
+    cheap (no separate explicit import of the submodule)."""
+    import core.lifecycle as lifecycle_pkg
+    assert lifecycle_pkg.clock is clock
+    assert "clock" in lifecycle_pkg.__all__

--- a/tests/test_lifecycle_schema.py
+++ b/tests/test_lifecycle_schema.py
@@ -1,0 +1,470 @@
+"""v0.4 Sprint 5 PR-0 — ``core.lifecycle.schema`` contract tests.
+
+Pins the v0.4 T1+T7 schema extension (validators + safe-default
+helpers) that the migration script (PR-T1.A), supersede operations
+(PR-T7.A), and contradiction arbiter (PR-T2.A) will all reference.
+
+Contract layers covered here:
+
+1. **Field vocabulary constants** — symbol names and enum members
+   match the locked design (entry memo §3).
+2. **Source validator** (``validate_source_v04_fields``) — accepts
+   v0.3 shapes (no new fields) + all valid v0.4 shapes; rejects
+   malformed v0.4 fields with explicit ``ValueError``.
+3. **Edge validator** (``validate_edge_v04_fields``) — same contract
+   for edges plus the cross-field consistency rule (T7 invariant
+   pinned at write-time).
+4. **Defaults helpers** (``apply_v04_*_defaults``) — idempotent,
+   non-mutating, default to v0.3-equivalent semantics.
+5. **Re-export** — ``core.relations_schema`` still surfaces every new
+   symbol so v0.3 callers see no breakage.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.lifecycle.schema import (
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_SOURCE_FIELD_VALID_FROM,
+    T1_SOURCE_FIELD_VALID_UNTIL,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+    VALID_MUTATION_TYPES,
+    apply_v04_edge_defaults,
+    apply_v04_source_defaults,
+    validate_edge_v04_fields,
+    validate_source_v04_fields,
+)
+
+
+# ─── Field vocabulary ─────────────────────────────────────────────
+
+
+def test_mutation_type_enum_values():
+    """The four enum members locked at the entry memo §12.3 are
+    present + distinct."""
+    assert T1_MUTATION_ACTIVE == "active"
+    assert T1_MUTATION_INVALIDATED == "invalidated"
+    assert T1_MUTATION_SUPERSEDED == "superseded"
+    assert T1_MUTATION_EXPIRED == "expired"
+    assert VALID_MUTATION_TYPES == frozenset({
+        "active", "invalidated", "superseded", "expired",
+    })
+
+
+def test_field_name_constants():
+    """Field name constants match the locked schema vocabulary so
+    callers and tests reference them by symbol, not string-literal."""
+    assert T1_SOURCE_FIELD_VALID_FROM == "valid_from"
+    assert T1_SOURCE_FIELD_VALID_UNTIL == "valid_until"
+    assert T7_EDGE_FIELD_VALIDITY == "validity"
+    assert T7_EDGE_FIELD_STATUS == "status"
+    assert T7_EDGE_FIELD_MUTATION_TYPE == "mutation_type"
+
+
+# ─── Source validator — v0.3 shapes accepted ─────────────────────
+
+
+def test_v03_source_passes_validator():
+    """A pre-v0.4 source dict (no new fields) is accepted unchanged —
+    pins the backward-compat invariant."""
+    src = {"doc_id": "report_Q1.pdf", "weight": 0.7, "role": "extract"}
+    validate_source_v04_fields(src)   # must not raise
+
+
+def test_v03_source_with_extra_unknown_fields_passes():
+    """Unknown extra fields don't trip the validator — it only checks
+    the v0.4 fields it knows about. Forward-compat with future T3/T4
+    additions."""
+    src = {
+        "doc_id": "report_Q1.pdf",
+        "weight": 0.7,
+        "role": "extract",
+        "future_field_T3_aging": "exp_decay",
+    }
+    validate_source_v04_fields(src)
+
+
+# ─── Source validator — v0.4 valid shapes ────────────────────────
+
+
+@pytest.mark.parametrize("vf,vu", [
+    (None, None),                                # both None → indefinite
+    ("2026-04-01", None),                        # bounded from only
+    (None, "2027-04-01"),                        # bounded until only
+    ("2026-04-01", "2027-04-01"),                # both bounded
+    ("2026-04-01T00:00:00Z", "2026-04-02T00:00:00Z"),  # ISO 8601 datetime + Z
+    ("2026-04-01T12:34:56+09:00",
+     "2026-04-02T12:34:56+09:00"),               # offset-aware
+])
+def test_source_v04_valid_shapes(vf, vu):
+    """Every locked-as-valid v0.4 source shape passes."""
+    src = {
+        "doc_id": "x",
+        "weight": 0.5,
+        "role": "extract",
+        T1_SOURCE_FIELD_VALID_FROM: vf,
+        T1_SOURCE_FIELD_VALID_UNTIL: vu,
+    }
+    validate_source_v04_fields(src)
+
+
+# ─── Source validator — malformed shapes rejected ────────────────
+
+
+def test_source_not_dict_rejected():
+    with pytest.raises(ValueError, match="source must be a dict"):
+        validate_source_v04_fields("not a dict")  # type: ignore[arg-type]
+
+
+def test_source_bad_valid_from_string():
+    src = {T1_SOURCE_FIELD_VALID_FROM: "not-a-date"}
+    with pytest.raises(ValueError, match="not parseable as ISO 8601"):
+        validate_source_v04_fields(src)
+
+
+def test_source_bad_valid_until_type():
+    src = {T1_SOURCE_FIELD_VALID_UNTIL: 12345}
+    with pytest.raises(ValueError, match="expected ISO 8601 string"):
+        validate_source_v04_fields(src)
+
+
+def test_source_empty_string_valid_from_rejected():
+    src = {T1_SOURCE_FIELD_VALID_FROM: ""}
+    with pytest.raises(ValueError, match="must be non-empty"):
+        validate_source_v04_fields(src)
+
+
+def test_source_inverted_window_rejected():
+    """``valid_from`` must be strictly earlier than ``valid_until``."""
+    src = {
+        T1_SOURCE_FIELD_VALID_FROM: "2027-04-01",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2026-04-01",
+    }
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_source_v04_fields(src)
+
+
+def test_source_zero_window_rejected():
+    """Same instant on both ends is rejected — zero-length windows
+    leave the source neither active nor expired."""
+    src = {
+        T1_SOURCE_FIELD_VALID_FROM: "2026-04-01T00:00:00",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2026-04-01T00:00:00",
+    }
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_source_v04_fields(src)
+
+
+# ─── Edge validator — v0.3 shapes accepted ───────────────────────
+
+
+def test_v03_edge_passes_validator():
+    """A pre-v0.4 edge dict (no new fields) is accepted unchanged."""
+    edge = {
+        "head": "Joby",
+        "predicate": "CEO",
+        "tail": "Alice",
+        "confidence": 0.85,
+    }
+    validate_edge_v04_fields(edge)
+
+
+# ─── Edge validator — v0.4 valid shapes ──────────────────────────
+
+
+def test_edge_v04_full_active_shape():
+    """Full v0.4 shape, status active, mutation_type=active."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "Bob",
+        T7_EDGE_FIELD_VALIDITY: {"from": "2026-03-15", "to": None},
+        T7_EDGE_FIELD_STATUS: {
+            "active": True,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_ACTIVE,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_superseded_shape():
+    """A correctly-shaped superseded edge — active=False + non-empty
+    supersede link + superseded_at."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "Alice",
+        T7_EDGE_FIELD_VALIDITY: {"from": "2024-01-01", "to": "2026-03-15"},
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": "edge_bob_ceo_2026",
+            "superseded_at": "2026-03-15",
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_invalidated_shape():
+    """An invalidated edge — active=False + no supersede link."""
+    edge = {
+        "head": "Joby", "predicate": "CEO", "tail": "WrongAlice",
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_INVALIDATED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+def test_edge_v04_expired_shape():
+    """An expired edge — active=False + no supersede link."""
+    edge = {
+        "head": "report_Q1", "predicate": "MENTIONS", "tail": "Alice",
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_EXPIRED,
+    }
+    validate_edge_v04_fields(edge)
+
+
+# ─── Edge validator — malformed shapes rejected ──────────────────
+
+
+def test_edge_not_dict_rejected():
+    with pytest.raises(ValueError, match="edge must be a dict"):
+        validate_edge_v04_fields([])  # type: ignore[arg-type]
+
+
+def test_edge_validity_not_dict_rejected():
+    edge = {T7_EDGE_FIELD_VALIDITY: "2026-04-01"}
+    with pytest.raises(ValueError, match="validity must be a dict"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_validity_inverted_window_rejected():
+    edge = {T7_EDGE_FIELD_VALIDITY: {"from": "2027-01-01", "to": "2026-01-01"}}
+    with pytest.raises(ValueError, match="strictly earlier"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_status_active_not_bool_rejected():
+    edge = {T7_EDGE_FIELD_STATUS: {"active": "yes"}}
+    with pytest.raises(ValueError, match="status.active must be bool"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_superseded_by_wrong_type_rejected():
+    edge = {T7_EDGE_FIELD_STATUS: {"active": True, "superseded_by": 42}}
+    with pytest.raises(ValueError, match="superseded_by must be str"):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_mutation_type_invalid_rejected():
+    edge = {T7_EDGE_FIELD_MUTATION_TYPE: "deleted"}
+    with pytest.raises(ValueError, match="mutation_type must be one of"):
+        validate_edge_v04_fields(edge)
+
+
+# ─── Edge cross-field consistency (T7 invariants) ────────────────
+
+
+def test_edge_superseded_requires_supersede_link():
+    """``status.active=False`` with ``mutation_type="superseded"``
+    requires non-empty ``superseded_by`` AND ``superseded_at``."""
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    with pytest.raises(
+        ValueError,
+        match="requires non-empty superseded_by AND superseded_at",
+    ):
+        validate_edge_v04_fields(edge)
+
+
+def test_edge_superseded_missing_superseded_at_rejected():
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": False,
+            "superseded_by": "edge_new_id",
+            "superseded_at": None,   # missing
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: T1_MUTATION_SUPERSEDED,
+    }
+    with pytest.raises(ValueError, match="requires non-empty"):
+        validate_edge_v04_fields(edge)
+
+
+@pytest.mark.parametrize("mt", [
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T1_MUTATION_EXPIRED,
+])
+def test_edge_active_true_incompatible_with_non_active_mutation(mt):
+    """``status.active=True`` is only consistent with
+    ``mutation_type="active"`` — any inactive mutation type with
+    active=True is a contradiction."""
+    edge = {
+        T7_EDGE_FIELD_STATUS: {
+            "active": True,
+            "superseded_by": "x" if mt == T1_MUTATION_SUPERSEDED else None,
+            "superseded_at": "2026-01-01" if mt == T1_MUTATION_SUPERSEDED else None,
+        },
+        T7_EDGE_FIELD_MUTATION_TYPE: mt,
+    }
+    with pytest.raises(ValueError, match="incompatible with"):
+        validate_edge_v04_fields(edge)
+
+
+# ─── Source defaults helper ──────────────────────────────────────
+
+
+def test_source_defaults_fills_missing_fields():
+    src = {"doc_id": "x", "weight": 0.5, "role": "extract"}
+    out = apply_v04_source_defaults(src)
+    assert out[T1_SOURCE_FIELD_VALID_FROM] is None
+    assert out[T1_SOURCE_FIELD_VALID_UNTIL] is None
+    assert out["doc_id"] == "x"   # v0.3 fields preserved
+    assert out["weight"] == 0.5
+    assert out["role"] == "extract"
+
+
+def test_source_defaults_does_not_mutate_input():
+    """Caller's dict stays untouched — guarantees safe use inside list
+    comprehensions over loaded frontmatter."""
+    src = {"doc_id": "x"}
+    apply_v04_source_defaults(src)
+    assert T1_SOURCE_FIELD_VALID_FROM not in src
+    assert T1_SOURCE_FIELD_VALID_UNTIL not in src
+
+
+def test_source_defaults_idempotent():
+    """Applying twice yields the same dict — migration script (PR-T1.A)
+    can re-run ``--apply`` safely."""
+    src = {"doc_id": "x", "weight": 0.5}
+    once = apply_v04_source_defaults(src)
+    twice = apply_v04_source_defaults(once)
+    assert once == twice
+
+
+def test_source_defaults_preserves_existing_v04_values():
+    """If the caller already has v0.4 fields set, the defaults helper
+    keeps them — only fills genuinely missing fields."""
+    src = {
+        "doc_id": "x",
+        T1_SOURCE_FIELD_VALID_FROM: "2026-04-01",
+        T1_SOURCE_FIELD_VALID_UNTIL: "2027-04-01",
+    }
+    out = apply_v04_source_defaults(src)
+    assert out[T1_SOURCE_FIELD_VALID_FROM] == "2026-04-01"
+    assert out[T1_SOURCE_FIELD_VALID_UNTIL] == "2027-04-01"
+
+
+def test_source_defaults_rejects_non_dict():
+    with pytest.raises(ValueError, match="source must be a dict"):
+        apply_v04_source_defaults("not a dict")  # type: ignore[arg-type]
+
+
+# ─── Edge defaults helper ────────────────────────────────────────
+
+
+def test_edge_defaults_fills_missing_fields():
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    out = apply_v04_edge_defaults(edge)
+    assert out[T7_EDGE_FIELD_VALIDITY] == {"from": None, "to": None}
+    assert out[T7_EDGE_FIELD_STATUS] == {
+        "active": True, "superseded_by": None, "superseded_at": None,
+    }
+    assert out[T7_EDGE_FIELD_MUTATION_TYPE] == T1_MUTATION_ACTIVE
+    # v0.3 fields preserved
+    assert out["head"] == "A"
+    assert out["predicate"] == "P"
+    assert out["tail"] == "B"
+
+
+def test_edge_defaults_does_not_mutate_input():
+    edge = {"head": "A"}
+    apply_v04_edge_defaults(edge)
+    assert T7_EDGE_FIELD_VALIDITY not in edge
+    assert T7_EDGE_FIELD_STATUS not in edge
+    assert T7_EDGE_FIELD_MUTATION_TYPE not in edge
+
+
+def test_edge_defaults_idempotent():
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    once = apply_v04_edge_defaults(edge)
+    twice = apply_v04_edge_defaults(once)
+    assert once == twice
+
+
+def test_edge_defaults_after_apply_validates_clean():
+    """A defaults-filled edge MUST pass the v0.4 validator. This pins
+    that the defaults match the validator's accepted-shape contract."""
+    edge = {"head": "A", "predicate": "P", "tail": "B"}
+    out = apply_v04_edge_defaults(edge)
+    validate_edge_v04_fields(out)   # must not raise
+
+
+def test_edge_defaults_rejects_non_dict():
+    with pytest.raises(ValueError, match="edge must be a dict"):
+        apply_v04_edge_defaults(None)  # type: ignore[arg-type]
+
+
+# ─── Backward-compat re-export through core.relations_schema ─────
+
+
+def test_relations_schema_reexports_v04_symbols():
+    """The new symbols are accessible via the v0.3 canonical
+    ``core.relations_schema`` namespace so existing call sites that
+    grep the schema vocabulary find everything in one place."""
+    from core import relations_schema as rs
+
+    # Constants
+    assert rs.T1_MUTATION_ACTIVE == "active"
+    assert rs.T1_MUTATION_INVALIDATED == "invalidated"
+    assert rs.T1_MUTATION_SUPERSEDED == "superseded"
+    assert rs.T1_MUTATION_EXPIRED == "expired"
+    assert rs.VALID_MUTATION_TYPES == VALID_MUTATION_TYPES
+
+    # Field name constants
+    assert rs.T1_SOURCE_FIELD_VALID_FROM == "valid_from"
+    assert rs.T7_EDGE_FIELD_VALIDITY == "validity"
+
+    # Functions
+    assert rs.validate_source_v04_fields is validate_source_v04_fields
+    assert rs.validate_edge_v04_fields is validate_edge_v04_fields
+    assert rs.apply_v04_source_defaults is apply_v04_source_defaults
+    assert rs.apply_v04_edge_defaults is apply_v04_edge_defaults
+
+
+def test_relations_schema_v03_surface_unchanged():
+    """v0.3 symbols still present + work — regression pin."""
+    from core.relations_schema import (
+        VALID_SOURCE_ROLES,
+        LEGACY_SOURCE_ROLE,
+        compute_confidence_from_sources,
+        read_relation_sources,
+        validate_occurred_at,
+    )
+    assert "legacy" in VALID_SOURCE_ROLES
+    assert LEGACY_SOURCE_ROLE == "legacy"
+    assert compute_confidence_from_sources([]) == 0.0
+    assert compute_confidence_from_sources(
+        [{"weight": 0.5}]
+    ) == 0.5
+    assert read_relation_sources({}) == []
+    # validate_occurred_at signature unchanged
+    validate_occurred_at("2026-01-01", precision="day")

--- a/tests/test_migrate_v04_lifecycle.py
+++ b/tests/test_migrate_v04_lifecycle.py
@@ -1,0 +1,414 @@
+"""v0.4 Sprint 5 PR-T1.A — migration script contract tests.
+
+Pins the properties of ``scripts/migrate_v04_lifecycle.py``:
+
+1. **Idempotent** — running ``--apply`` twice leaves the wiki
+   byte-identical after the first run (the second run is a no-op).
+2. **v0.3-compatible defaults** — every back-filled field uses the
+   safe defaults locked at PR-0; nothing else in the entity
+   frontmatter is mutated.
+3. **Validation pass** — migrated files validate clean against
+   `validate_source_v04_fields` + `validate_edge_v04_fields`.
+4. **Dry-run is read-only** — ``--dry-run`` (default) leaves the
+   wiki untouched even when it reports thousands of would-be
+   mutations.
+5. **Verify mode** — reports `verify_failed > 0` when fields are
+   missing; reports clean after apply.
+6. **Snapshot path** — ``--apply`` creates ``wiki.pre-v04-migration/``
+   for rollback; ``--no-snapshot`` skips it.
+7. **No-relations files** — entities without a `relations` list pass
+   through untouched (matches `had_no_relations` bucket).
+8. **Atomic write** — a write-failure path leaves the original file
+   intact (tested via monkey-patched os.replace).
+
+Tests run against a self-contained tmp_path wiki fixture; the
+production wiki under `wiki/` is never touched.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Make `scripts/` importable for direct function calls
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+
+# ─── tmp_path wiki fixtures ───────────────────────────────────────
+
+
+def _entity_v03(name: str) -> dict:
+    """A canonical v0.3-shape entity frontmatter — sources are the
+    Phase A v0.3 surface (doc_id + role + weight + ts), and edges
+    carry confidence + sources but none of the v0.4 T1/T7 fields."""
+    return {
+        "entity_id": f"e_concept_{name}",
+        "entity_type": "concept",
+        "name": name,
+        "normalized_name": name,
+        "sensitivity": "public",
+        "source_type": "prod",
+        "version": 1,
+        "trusted": True,
+        "verified": False,
+        "owner": "system",
+        "aliases": [name],
+        "attributes": {"summary": f"{name} summary"},
+        "summary": f"{name} summary",
+        "embedding_refs": [],
+        "sources": [f"{name}.pdf"],
+        "created_at": "2026-05-01T00:00:00",
+        "updated_at": "2026-05-01T00:00:00",
+        "relations": [
+            {
+                "label": "관련",
+                "target": "OtherThing",
+                "target_id": "e_concept_other",
+                "target_type": "concept",
+                "inferred": True,
+                "confidence": 0.7,
+                "sources": [
+                    {
+                        "doc_id": None,
+                        "role": "legacy",
+                        "ts": "2026-05-07T07:42:31.951205",
+                        "weight": 0.7,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _write_entity(wiki_root: Path, kind: str, name: str, fm: dict) -> Path:
+    """Write a synthetic entity under wiki_root/entity/<kind>/<name>.md."""
+    d = wiki_root / "entity" / kind
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{name}.md"
+    body = "---\n" + yaml.safe_dump(
+        fm, allow_unicode=True, default_flow_style=False, sort_keys=True,
+    ) + "---\n## body\n"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def fresh_wiki(tmp_path):
+    """Build a tmp wiki with one v0.3-shape entity. Returns (wiki_root,
+    entity_path)."""
+    wiki_root = tmp_path / "wiki"
+    fm = _entity_v03("ACI")
+    entity_path = _write_entity(wiki_root, "concept", "ACI", fm)
+    return wiki_root, entity_path
+
+
+# ─── migrate_wiki API tests ──────────────────────────────────────
+
+
+def test_dry_run_is_read_only(fresh_wiki):
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root, entity_path = fresh_wiki
+    before = entity_path.read_text(encoding="utf-8")
+
+    totals = migrate_wiki(wiki_root, dry_run=True)
+
+    after = entity_path.read_text(encoding="utf-8")
+    assert before == after, "dry-run must not modify any file"
+    # Dry-run reports the would-be mutations
+    assert totals["scanned"] == 1
+    assert totals["relations_migrated"] == 1
+    assert totals["sources_migrated"] == 1
+
+
+def test_apply_migrates_v03_entity(fresh_wiki):
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root, entity_path = fresh_wiki
+
+    totals = migrate_wiki(wiki_root, dry_run=False, verify=False)
+
+    assert totals["scanned"] == 1
+    assert totals["mutated"] == 1
+    assert totals["relations_migrated"] == 1
+    assert totals["sources_migrated"] == 1
+    assert totals["validation_failed"] == 0
+    assert totals["errors"] == 0
+
+    # Parse the migrated frontmatter
+    text = entity_path.read_text(encoding="utf-8")
+    fm = yaml.safe_load(text.split("---", 2)[1])
+    rel = fm["relations"][0]
+    assert rel["validity"] == {"from": None, "to": None}
+    assert rel["status"] == {
+        "active": True, "superseded_by": None, "superseded_at": None,
+    }
+    assert rel["mutation_type"] == "active"
+    src = rel["sources"][0]
+    assert src["valid_from"] is None
+    assert src["valid_until"] is None
+    # v0.3 fields preserved
+    assert src["doc_id"] is None
+    assert src["role"] == "legacy"
+    assert src["weight"] == 0.7
+
+
+def test_apply_is_idempotent(fresh_wiki):
+    """Second --apply on already-migrated wiki is a no-op."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root, entity_path = fresh_wiki
+
+    migrate_wiki(wiki_root, dry_run=False)
+    first_pass = entity_path.read_text(encoding="utf-8")
+
+    totals2 = migrate_wiki(wiki_root, dry_run=False)
+    second_pass = entity_path.read_text(encoding="utf-8")
+
+    assert first_pass == second_pass, "second --apply must be a no-op"
+    assert totals2["mutated"] == 0, (
+        "second --apply must report 0 mutations"
+    )
+    assert totals2["relations_migrated"] == 0
+    assert totals2["sources_migrated"] == 0
+
+
+def test_verify_fails_on_v03_entity(fresh_wiki):
+    """Verify mode reports failure for unmigrated v0.3 entities."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root, _ = fresh_wiki
+
+    totals = migrate_wiki(wiki_root, verify=True)
+    assert totals["verify_failed"] >= 1, (
+        "verify must flag v0.3 entities as missing v0.4 fields"
+    )
+
+
+def test_verify_passes_after_apply(fresh_wiki):
+    """After --apply, verify reports zero failures."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root, _ = fresh_wiki
+
+    migrate_wiki(wiki_root, dry_run=False)
+    totals = migrate_wiki(wiki_root, verify=True)
+    assert totals["verify_failed"] == 0
+    assert totals["errors"] == 0
+
+
+def test_apply_does_not_touch_no_relations_file(tmp_path):
+    """Entity with no relations array passes through untouched."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root = tmp_path / "wiki"
+    fm = _entity_v03("Empty")
+    fm["relations"] = []  # empty list
+    path = _write_entity(wiki_root, "concept", "Empty", fm)
+    before = path.read_text(encoding="utf-8")
+
+    totals = migrate_wiki(wiki_root, dry_run=False)
+
+    after = path.read_text(encoding="utf-8")
+    assert before == after, (
+        "empty-relations file must not be rewritten"
+    )
+    assert totals["had_no_relations"] == 1
+    assert totals["mutated"] == 0
+
+
+def test_apply_handles_multiple_relations(tmp_path):
+    """Migrate every relation independently when an entity has many."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root = tmp_path / "wiki"
+    fm = _entity_v03("MultiRel")
+    fm["relations"] = [
+        {
+            "label": "관련", "target": f"T{i}",
+            "target_id": f"e_concept_t{i}", "target_type": "concept",
+            "confidence": 0.5 + i * 0.1,
+            "sources": [
+                {"doc_id": None, "role": "legacy",
+                 "ts": "2026-05-07T07:42:31", "weight": 0.5 + i * 0.1},
+            ],
+        }
+        for i in range(5)
+    ]
+    _write_entity(wiki_root, "concept", "MultiRel", fm)
+
+    totals = migrate_wiki(wiki_root, dry_run=False)
+    assert totals["relations_migrated"] == 5
+    assert totals["sources_migrated"] == 5
+    assert totals["mutated"] == 1   # one file rewritten
+
+
+def test_apply_preserves_v04_fields_on_already_migrated(tmp_path):
+    """When a relation already has v0.4 fields (some user set them
+    explicitly), the migration must NOT overwrite them with defaults.
+    This is the setdefault() invariant from PR-0."""
+    from migrate_v04_lifecycle import migrate_wiki
+    wiki_root = tmp_path / "wiki"
+    fm = _entity_v03("PreSet")
+    # Pre-set v0.4 fields on the one relation
+    fm["relations"][0]["validity"] = {
+        "from": "2026-04-01", "to": "2027-04-01",
+    }
+    fm["relations"][0]["status"] = {
+        "active": True, "superseded_by": None, "superseded_at": None,
+    }
+    fm["relations"][0]["mutation_type"] = "active"
+    fm["relations"][0]["sources"][0]["valid_from"] = "2026-04-01"
+    fm["relations"][0]["sources"][0]["valid_until"] = "2027-04-01"
+    path = _write_entity(wiki_root, "concept", "PreSet", fm)
+
+    migrate_wiki(wiki_root, dry_run=False)
+    after_fm = yaml.safe_load(
+        path.read_text(encoding="utf-8").split("---", 2)[1]
+    )
+    rel = after_fm["relations"][0]
+    assert rel["validity"] == {"from": "2026-04-01", "to": "2027-04-01"}
+    src = rel["sources"][0]
+    assert src["valid_from"] == "2026-04-01"
+    assert src["valid_until"] == "2027-04-01"
+
+
+# ─── CLI / subprocess smoke ──────────────────────────────────────
+
+
+def _run_cli(wiki_root: Path, *flags: str) -> subprocess.CompletedProcess:
+    """Run the migration script as an external process — covers the
+    full CLI path (argparse + main() + exit codes)."""
+    script = Path(__file__).resolve().parent.parent / "scripts" / "migrate_v04_lifecycle.py"
+    cmd = [sys.executable, str(script), "--root", str(wiki_root)] + list(flags)
+    return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
+
+
+def test_cli_dry_run_default(fresh_wiki):
+    """No flag → dry-run, exit 0, no writes."""
+    wiki_root, entity_path = fresh_wiki
+    before = entity_path.read_text(encoding="utf-8")
+    result = _run_cli(wiki_root)
+    assert result.returncode == 0, (
+        f"dry-run should exit 0, got {result.returncode}: {result.stderr}"
+    )
+    assert "DRY-RUN" in result.stdout
+    assert entity_path.read_text(encoding="utf-8") == before
+
+
+def test_cli_apply_then_verify(tmp_path, fresh_wiki):
+    """--apply migrates; subsequent --verify exits 0."""
+    wiki_root, entity_path = fresh_wiki
+
+    # --apply with --no-snapshot for test simplicity
+    r1 = _run_cli(wiki_root, "--apply", "--no-snapshot")
+    assert r1.returncode == 0, f"apply failed: {r1.stderr}"
+    assert "APPLY" in r1.stdout
+
+    # --verify
+    r2 = _run_cli(wiki_root, "--verify")
+    assert r2.returncode == 0, f"verify failed: {r2.stderr}"
+    assert "VERIFY OK" in r2.stdout
+
+
+def test_cli_apply_creates_snapshot(tmp_path, fresh_wiki):
+    """--apply (without --no-snapshot) creates ``wiki.pre-v04-migration/``."""
+    wiki_root, _ = fresh_wiki
+    snap = wiki_root.with_name(f"{wiki_root.name}.pre-v04-migration")
+    assert not snap.exists()
+
+    result = _run_cli(wiki_root, "--apply")
+    assert result.returncode == 0, f"apply failed: {result.stderr}"
+    assert snap.exists(), (
+        "snapshot directory must exist after --apply without --no-snapshot"
+    )
+
+
+def test_cli_apply_refuses_to_overwrite_snapshot(tmp_path, fresh_wiki):
+    """Second --apply without --force fails when snapshot already exists."""
+    wiki_root, _ = fresh_wiki
+    snap = wiki_root.with_name(f"{wiki_root.name}.pre-v04-migration")
+
+    # First apply: creates snapshot
+    r1 = _run_cli(wiki_root, "--apply")
+    assert r1.returncode == 0
+    assert snap.exists()
+
+    # Second apply without --force should refuse
+    r2 = _run_cli(wiki_root, "--apply")
+    assert r2.returncode != 0, (
+        "second --apply without --force must refuse to overwrite snapshot"
+    )
+
+
+def test_cli_apply_with_force_overwrites_snapshot(tmp_path, fresh_wiki):
+    """--apply --force overwrites existing snapshot."""
+    wiki_root, _ = fresh_wiki
+
+    r1 = _run_cli(wiki_root, "--apply")
+    assert r1.returncode == 0
+
+    r2 = _run_cli(wiki_root, "--apply", "--force")
+    assert r2.returncode == 0, f"--force apply failed: {r2.stderr}"
+
+
+def test_cli_apply_and_verify_mutually_exclusive(fresh_wiki):
+    """--apply + --verify is rejected."""
+    wiki_root, _ = fresh_wiki
+    result = _run_cli(wiki_root, "--apply", "--verify")
+    assert result.returncode != 0, (
+        "--apply and --verify together must be rejected"
+    )
+
+
+def test_cli_missing_wiki_root_exit_2(tmp_path):
+    """Nonexistent --root exits 2."""
+    fake_root = tmp_path / "does_not_exist"
+    result = _run_cli(fake_root)
+    assert result.returncode == 2
+
+
+# ─── Per-file unit tests ─────────────────────────────────────────
+
+
+def test_migrate_entity_file_returns_stats(fresh_wiki):
+    from migrate_v04_lifecycle import migrate_entity_file
+    _, entity_path = fresh_wiki
+    stats = migrate_entity_file(entity_path)
+    assert stats["scanned"] == 1
+    assert stats["mutated"] == 1
+    assert stats["relations_migrated"] == 1
+    assert stats["sources_migrated"] == 1
+    assert stats["errors"] == 0
+
+
+def test_migrate_entity_file_atomic_on_write_failure(
+    fresh_wiki, monkeypatch,
+):
+    """When os.replace fails, the original file must be intact."""
+    from migrate_v04_lifecycle import migrate_entity_file
+    _, entity_path = fresh_wiki
+    before = entity_path.read_text(encoding="utf-8")
+
+    def _boom(*a, **kw):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr("migrate_v04_lifecycle.os.replace", _boom)
+    stats = migrate_entity_file(entity_path)
+    assert stats["errors"] == 1
+    assert stats["mutated"] == 0
+    # File is the original, not half-written
+    assert entity_path.read_text(encoding="utf-8") == before
+
+
+def test_snapshot_function(tmp_path, fresh_wiki):
+    """snapshot_wiki copies the entire tree, returns the snapshot path."""
+    from migrate_v04_lifecycle import snapshot_wiki, SNAPSHOT_SUFFIX
+    wiki_root, _ = fresh_wiki
+    snap = snapshot_wiki(wiki_root)
+    assert snap.exists()
+    assert snap.name == f"{wiki_root.name}.{SNAPSHOT_SUFFIX}"
+    # Files in snap match originals byte-for-byte
+    for orig in (wiki_root.rglob("*.md")):
+        rel = orig.relative_to(wiki_root)
+        snap_file = snap / rel
+        assert snap_file.exists()
+        assert snap_file.read_bytes() == orig.read_bytes()
+    shutil.rmtree(snap)


### PR DESCRIPTION
## Summary

**Second code PR of Sprint 5**. Back-fills every wiki entity frontmatter with the v0.4 T1 + T7 fields at v0.3-equivalent safe defaults using the validators + defaults helpers shipped at PR-0 (#524).

⚠️ **Dependency**: PR-0 (#524) must merge first. This branch was cut from PR-0's branch so the `from core.lifecycle.schema import …` calls resolve locally. When PR-0 lands on main, this PR's diff cleans to only the new migration script + tests.

Sprint 5 entry memo §4 PR-T1.A scope + §6 schema migration plan + §9 operator runbook.

## What lands

| File | Size | Purpose |
|---|---|---|
| `scripts/migrate_v04_lifecycle.py` | ~14 KB | Operator-runnable migration script (4 modes) |
| `tests/test_migrate_v04_lifecycle.py` | (18 cases) | Idempotency + validation + CLI + atomic write contracts |

## Modes

```
python scripts/migrate_v04_lifecycle.py          # dry-run (default)
python scripts/migrate_v04_lifecycle.py --apply  # write back + snapshot
python scripts/migrate_v04_lifecycle.py --verify # confirm fully migrated
```

Optional flags: `--no-snapshot` (skip snapshot), `--root <path>` (override wiki root), `--force` (overwrite existing snapshot).

## Properties pinned by tests

- **Idempotent** — second `--apply` on already-migrated wiki is a no-op (zero mutations, byte-identical files).
- **v0.3-compatible defaults** — every back-filled field uses PR-0's safe defaults; nothing else in entity frontmatter is mutated.
- **Validation pass** — migrated files validate clean against `validate_source_v04_fields` + `validate_edge_v04_fields`.
- **Dry-run is read-only** — never writes; reports would-be mutation counts only.
- **Verify mode** — reports `verify_failed > 0` on unmigrated v0.3 entities; reports clean after `--apply`.
- **Atomic write** — monkey-patched `os.replace` failure leaves original file byte-identical.
- **No-relations files** — entities without relations list pass through untouched (counted in `had_no_relations`).
- **Already-migrated v0.4 fields preserved** — user-set values survive `setdefault` semantics.

## Production wiki dry-run

```
python scripts/migrate_v04_lifecycle.py

[V04_MIGRATE] mode=DRY-RUN: 313 entity files under .../wiki/entity

[V04_MIGRATE] summary:
  scanned                        313
  had_no_relations               12
  mutated                        1762
  relations_migrated             879
  sources_migrated               883
  validation_failed              0
  verify_failed                  0
  errors                         0
```

**Zero errors. Zero validation failures.** Operator's current wiki state migrates cleanly.

## Verification

- **18 / 18** PR-T1.A tests pass.
- **2642 / 2642** under CI-mirroring exclusion set (was 2624 on post-PR-0 main + branch; +18 new).
- ruff clean on both touched files.

## Operator runbook (after this PR merges, post PR-0)

```
# Step 1 — inspect (no writes)
python scripts/migrate_v04_lifecycle.py

# Step 2 — apply (writes back, creates snapshot)
python scripts/migrate_v04_lifecycle.py --apply

# Step 3 — verify
python scripts/migrate_v04_lifecycle.py --verify

# Rollback (PowerShell)
rmdir /s /q wiki
rename wiki.pre-v04-migration wiki
```

## CLAUDE.md rule check

- rule #1 (no domain features): N/A — generic Layer 4 migration
- rule #2 (bench on core/{retrieval,graph,reasoning}): N/A — the script writes to `wiki/entity/` only; no core/ runtime path behaviour change. Existing v0.3 callers see byte-identical output because every default is the semantic identity of "no temporal constraint".
- rule #3 (self-evolution opt-in): N/A
- rule #4 (architecture change): `architecture` label — Sprint 5 Layer 4 first-bundle continuation
- rule #5 (module ≤ 20 KB): script ~14 KB, well under cap

## CI note

GitHub Actions partial outage was active when this PR opens (2026-05-26 ongoing). CI will run automatically once GitHub recovers. Local validation: pytest 2642 pass, ruff clean.