### PR TITLE
feat(v0.4): BL-9 prep — embedding swap runner + bge-m3 acceptance gate

### DIFF
--- a/reports/promo-assets/v3prime-leo-evidence-scope-result.md
+++ b/reports/promo-assets/v3prime-leo-evidence-scope-result.md
@@ -561,6 +561,136 @@ verification, the L.B policy v1 has complete bench coverage.
   14% narrow ratio doesn't match production expectations — formula
   fix and threshold tuning are orthogonal knobs.
 
+## BL-9 prep — embedding swap runner + acceptance gate (2026-05-27)
+
+Branch: `feat/v0.4-bl9-embedding-swap-prep`. F7 (PR #533) confirmed
+the systemic fix is a multilingual embedding swap from
+`paraphrase-multilingual-MiniLM-L12-v2` (384-dim) to a 1024-dim
+model. BL-9 prep adds the **migration runner** + acceptance gate +
+operator workflow so the swap is a one-command operation when the
+operator has the compute window.
+
+### What landed
+
+- `scripts/migrate_embedding.py` (~270 lines) — re-encodes every
+  chunk in the legacy MiniLM chroma collection into a new per-model
+  collection at `chroma_db_<short>/`. Reads source via raw chromadb
+  (no `VectorStore` singleton pollution); writes target via a fresh
+  `SentenceTransformer` loaded from the target model id (local-first
+  with HF fallback, same pattern as `core/vector_store.py`). Refuses
+  to no-op-migrate (target == legacy → exits with explanation).
+  Batched encoder (default batch_size=32) to keep peak memory
+  predictable on workstations without GPU. `--dry-run` flag counts
+  + reports paths without touching disk.
+- `tests/test_migrate_embedding_runner.py` (3 tests) — pins
+  `_target_chroma_dir` (rejects legacy tag, computes `bge_m3` /
+  `multilingual_e5_large` slugs, future-proof against new candidates
+  like `Qwen3-Embedding-8B`).
+
+Dry-run output on the current data state:
+
+```
+=== BL-9 chroma re-embedding ===
+  source model:  paraphrase-multilingual-MiniLM-L12-v2 (legacy MiniLM)
+  target model:  BAAI/bge-m3
+  source dir:    .../chroma_db
+  target dir:    .../chroma_db_bge_m3
+  collection:    james_prototype
+
+[migrate] source chunks: 358
+[migrate] --dry-run set; no target write performed
+```
+
+### Model selection — `BAAI/bge-m3` recommended over `intfloat/multilingual-e5-large`
+
+Both candidates are 1024-dim multilingual. Recommendation comes
+from JAMES's actual use case (KO+EN mixed wiki, frequent
+proper-noun-mediated queries — F7 diagnostic):
+
+| dimension | bge-m3 | multilingual-e5-large |
+|---|---|---|
+| Release | 2024 (newer) | 2023 |
+| Korean perf (MTEB-style) | stronger | strong |
+| Multi-functional output | dense + sparse + multi-vector | dense only |
+| Train data diversity | mC4 + cross-lingual pairs + BGE-M3-Korean | mC4 + filtered web |
+| Download | ~2.27 GB | ~2.24 GB |
+| Encode latency (CPU, 1024-dim) | comparable | comparable |
+| License | MIT | MIT |
+
+`bge-m3`'s multi-functional output is the tiebreaker — the dense
+embedding alone matches e5-large on cross-lingual proper-noun
+retrieval per the BAAI benchmark, and the sparse + multi-vector
+heads are available for future rerank fusion if BL-9 isn't enough.
+
+Operator can swap to e5-large by passing
+`--target intfloat/multilingual-e5-large` instead — the runner is
+model-agnostic and the per-model chroma path keeps the old
+collection intact for rollback.
+
+### BL-9 acceptance gate
+
+Pre-swap baselines (locked):
+- **F7 chroma probe** — MCP PDF NOT in top-20 on `ko_q15_exact`,
+  `en_translation`, `name_only` variations. Rank 1 only on the
+  `concept_side` variation (English document title).
+- **step7 v4 q15 path_recall = 0.0** (Idea 1 PR #530).
+- Mean step7 path_recall = 0.80 (4/5 at 1.0).
+
+Post-swap acceptance:
+- F7 probe — MCP PDF in top-10 on `name_only` (single most-stringent
+  cross-lingual proper-noun test). `ko_q15_exact` and `en_translation`
+  expected to also reach top-20.
+- step7 v4 q15 path_recall ≥ 0.5 (1 of 2 expected nodes hit).
+- Mean step7 path_recall ≥ 0.85 (no regression on q1–q4, q15
+  contributes ≥ 0.5 instead of 0.0).
+- step7 latency band — operator-decision threshold: per-query
+  bench latency may rise 20-50% (1024-dim encode > 384-dim) but
+  total wall time should stay under 30-min/arm so the wrapper's
+  `--timeout=2400` survives.
+
+### Operator workflow
+
+```powershell
+# 1. Run the migration (~5-10 min for 358 chunks on CPU after HF download)
+python scripts/migrate_embedding.py --target BAAI/bge-m3
+
+# 2. Set env + restart JAMES server
+$env:JAMES_EMBEDDING_MODEL = "BAAI/bge-m3"
+# (stop current server, then start fresh — VectorStore reads at import)
+
+# 3. F7 probe acceptance gate
+python scripts/research/q15_chroma_probe.py
+# → Expected: MCP PDF in top-10 on `name_only` variation
+
+# 4. step7 v4 acceptance bench
+python scripts/bench_lc_scope_arms.py
+# → Expected: q15 path_recall ≥ 0.5, mean path_recall ≥ 0.85
+```
+
+Rollback is a one-env-var flip:
+
+```powershell
+$env:JAMES_EMBEDDING_MODEL = $null   # unset
+# Restart server → reads legacy MiniLM → chroma_db/ path.
+# The new chroma_db_bge_m3/ stays on disk; re-promote is one env var.
+```
+
+The migration runner only writes to `chroma_db_<short>/` — the
+legacy `chroma_db/` directory is never mutated, so rollback is safe
+even mid-flight (kill the migration; legacy state unchanged).
+
+### What this PR does NOT do
+
+- **No model download** — operator runs the migration on their own
+  compute window because the first run pulls ~2 GB from HuggingFace.
+- **No default flip** — `config.EMBEDDING_MODEL` still defaults to
+  the legacy MiniLM tag. The swap is opt-in via env so an operator
+  pulling main after this PR sees byte-identical behaviour.
+- **No live acceptance numbers** — those land in the follow-up
+  result-doc commit after the operator runs the workflow above. The
+  acceptance criteria in §"BL-9 acceptance gate" are the gates the
+  follow-up must pass.
+
 ## F7 follow-up — chroma top-k probe confirms embedding root cause (2026-05-27)
 
 Branch: `feat/v0.4-f7-chroma-topk-probe`. Built

--- a/scripts/migrate_embedding.py
+++ b/scripts/migrate_embedding.py
@@ -1,0 +1,284 @@
+"""BL-9 (Sprint 4, 2026-05-27) — chroma re-embedding runner.
+
+Re-encodes every chunk in the legacy MiniLM chroma collection into a
+new per-model collection using the target embedding model. Required
+when the operator promotes ``JAMES_EMBEDDING_MODEL`` from the legacy
+``paraphrase-multilingual-MiniLM-L12-v2`` to a 1024-dim multilingual
+model (e.g. ``BAAI/bge-m3`` or ``intfloat/multilingual-e5-large``).
+Cosine search requires matching dimensions, so a new collection at
+``chroma_db_<short>/`` is created rather than mutating the legacy
+``chroma_db/`` — that legacy directory stays intact so a rollback is
+``unset JAMES_EMBEDDING_MODEL`` away.
+
+This script reads source chunks via raw chromadb (so the source can
+keep its 384-dim embeddings) and writes target chunks via a
+fresh ``SentenceTransformer`` loaded directly from the target model
+id (no ``VectorStore`` singleton pollution between source and target
+encoders).
+
+Why F7 motivates BL-9 — short version
+-------------------------------------
+F7 (PR #533) confirmed the current MiniLM model can't bridge
+``"David Soria Parra가 누구야?"`` → ``08_MCP_(Model_Context_Protocol).pdf``
+even though the PDF embeds cleanly under its English title. Swapping
+to a 1024-dim cross-lingual model is the systemic fix. See
+``reports/promo-assets/v3prime-leo-evidence-scope-result.md``
+§"F7 follow-up" for the smoking-gun probe.
+
+Usage
+-----
+    # Dry-run — count chunks + report planned target path; no write
+    python scripts/migrate_embedding.py --target BAAI/bge-m3 --dry-run
+
+    # Real run — re-embed + write to new chroma_db_<short>/
+    python scripts/migrate_embedding.py --target BAAI/bge-m3
+
+    # First real run will download the target model (~2 GB for bge-m3)
+    # to models/<short>/ via SentenceTransformer's HF fallback.
+
+After the migration completes:
+    1. Set JAMES_EMBEDDING_MODEL=<target> in .env or shell env
+    2. Restart the JAMES server (the VectorStore module reads
+       EMBEDDING_MODEL at import time)
+    3. Run the BL-9 acceptance gate:
+         python scripts/research/q15_chroma_probe.py
+       Expected post-swap: target PDF ranks ≤ 10 on the ``name_only``
+       variation (pre-swap was NOT in top-20).
+       Then run the operator wrapper:
+         python scripts/bench_lc_scope_arms.py
+       Expected post-swap: step7 v4 q15 path_recall ≥ 0.5 (pre-swap
+       was 0.0). Mean path recall expected to rise from 0.80 baseline.
+
+Rollback
+--------
+    unset JAMES_EMBEDDING_MODEL    # PowerShell: $env:JAMES_EMBEDDING_MODEL=$null
+    # Server restart → reads legacy MiniLM tag → chroma_db/ path.
+    # The new chroma_db_<short>/ stays on disk and survives the
+    # toggle so a re-promote is a one-env-var flip away.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except Exception:
+    pass
+
+
+# Source = the legacy MiniLM collection. Resolved at config-load time
+# so this script can run independently of the runtime VectorStore
+# singleton (which would be locked to one model per process).
+from config import (  # noqa: E402
+    BASE_DIR,
+    CHROMA_COLLECTION,
+    CHROMA_DIR,
+    _embedding_short_name,
+)
+
+
+_LEGACY_MINILM_TAG = "paraphrase-multilingual-MiniLM-L12-v2"
+
+
+def _target_chroma_dir(target_model: str) -> str:
+    """Mirror of ``core.vector_store._chroma_dir_for_model`` — returns
+    where the new collection will live. Kept independent of that
+    function so the migration script doesn't depend on `EMBEDDING_MODEL`
+    being already-set to the target (the operator flips env after the
+    migration completes)."""
+    if target_model == _LEGACY_MINILM_TAG:
+        # No-op migration. The runner refuses to clobber its own source.
+        raise ValueError(
+            "target model matches the legacy MiniLM tag — "
+            "no migration needed. Operator must pass a different "
+            "JAMES_EMBEDDING_MODEL target."
+        )
+    suffix = _embedding_short_name(target_model)
+    return f"{CHROMA_DIR}_{suffix}"
+
+
+def _load_source_chunks():
+    """Yield (id, document, metadata) triples from the legacy chroma
+    collection. Uses raw chromadb client so we read the source as-is
+    without invoking the runtime VectorStore (which would lazy-load
+    the legacy SentenceTransformer model, wasting time + memory)."""
+    import chromadb
+    print(f"[migrate] source chroma dir: {CHROMA_DIR}")
+    client = chromadb.PersistentClient(path=CHROMA_DIR)
+    collection = client.get_or_create_collection(
+        name=CHROMA_COLLECTION,
+        metadata={"hnsw:space": "cosine"},
+    )
+    count = collection.count()
+    print(f"[migrate] source chunks: {count}")
+    if count == 0:
+        return
+    page = collection.get(include=["documents", "metadatas"])
+    ids = page.get("ids") or []
+    docs = page.get("documents") or []
+    metas = page.get("metadatas") or [{}] * len(ids)
+    for i, doc, meta in zip(ids, docs, metas):
+        yield i, doc, (meta or {})
+
+
+def _ensure_target_model_cached(target_model: str):
+    """Load the target SentenceTransformer, with local-first / HF
+    fallback. Saves to ``models/<short>/`` on first download so
+    subsequent JAMES server startups skip the HF roundtrip."""
+    from sentence_transformers import SentenceTransformer
+
+    short = _embedding_short_name(target_model)
+    local_dir = os.path.join(BASE_DIR, "models", short)
+
+    if os.path.exists(local_dir):
+        try:
+            model = SentenceTransformer(local_dir, local_files_only=True)
+            print(f"[migrate] target model loaded from local cache: {local_dir}")
+            return model
+        except Exception as e:
+            print(f"[migrate] local target load failed ({e}); falling back to HF")
+
+    print(f"[migrate] downloading target model from HuggingFace: {target_model}")
+    print("[migrate]   (this may take several minutes + several GB on first run)")
+    model = SentenceTransformer(target_model)
+    os.makedirs(local_dir, exist_ok=True)
+    model.save(local_dir)
+    print(f"[migrate] cached locally: {local_dir}")
+    return model
+
+
+def _encode_in_batches(model, texts: List[str], batch_size: int):
+    """Batched encode — small batches keep peak memory predictable
+    on operator workstations that may not have a GPU."""
+    for start in range(0, len(texts), batch_size):
+        end = min(start + batch_size, len(texts))
+        chunk = texts[start:end]
+        embs = model.encode(chunk, normalize_embeddings=True).tolist()
+        yield start, end, embs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="BL-9 chroma re-embedding runner.",
+    )
+    ap.add_argument(
+        "--target", required=True,
+        help="HuggingFace model id (e.g. 'BAAI/bge-m3' or "
+             "'intfloat/multilingual-e5-large')",
+    )
+    ap.add_argument(
+        "--batch-size", type=int, default=32,
+        help="encode batch size (default 32 — bge-m3 ~1024-dim fits "
+             "on 16 GB workstations at this size)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help="count chunks + report planned target path; no write",
+    )
+    args = ap.parse_args()
+
+    try:
+        target_dir = _target_chroma_dir(args.target)
+    except ValueError as e:
+        print(f"[migrate] {e}")
+        return 1
+
+    print("=== BL-9 chroma re-embedding ===")
+    print(f"  source model:  {_LEGACY_MINILM_TAG} (legacy MiniLM)")
+    print(f"  target model:  {args.target}")
+    print(f"  source dir:    {CHROMA_DIR}")
+    print(f"  target dir:    {target_dir}")
+    print(f"  collection:    {CHROMA_COLLECTION}")
+    print()
+
+    # Read source chunks first — fast operation, useful in dry-run.
+    chunks = list(_load_source_chunks())
+    if not chunks:
+        print("[migrate] source collection is empty — nothing to migrate")
+        return 0
+
+    print(f"[migrate] loaded {len(chunks)} source chunks")
+    if args.dry_run:
+        print("[migrate] --dry-run set; no target write performed")
+        return 0
+
+    if os.path.exists(target_dir):
+        existing_files = os.listdir(target_dir)
+        if existing_files:
+            print(
+                f"[migrate] WARNING: target dir already exists with "
+                f"{len(existing_files)} entries: {target_dir}"
+            )
+            print(
+                "[migrate]   Re-running on top will duplicate chunks "
+                "(chromadb ids are UUIDs from the source — same per "
+                "run so chromadb will reject duplicate id inserts)."
+            )
+            print(
+                f"[migrate]   To re-migrate from scratch: stop the JAMES "
+                f"server first (it holds a file handle on the target "
+                f"dir), then `rm -r {target_dir}` and re-run."
+            )
+
+    # Lazy-import the encoder only after dry-run path so dry-run is fast.
+    model = _ensure_target_model_cached(args.target)
+
+    import chromadb
+    print(f"[migrate] opening target collection at {target_dir}")
+    os.makedirs(target_dir, exist_ok=True)
+    target_client = chromadb.PersistentClient(path=target_dir)
+    target_collection = target_client.get_or_create_collection(
+        name=CHROMA_COLLECTION,
+        metadata={"hnsw:space": "cosine"},
+    )
+
+    ids = [c[0] for c in chunks]
+    docs = [c[1] for c in chunks]
+    metas = [c[2] for c in chunks]
+
+    t0 = time.time()
+    total_done = 0
+    for start, end, embs in _encode_in_batches(model, docs, args.batch_size):
+        target_collection.add(
+            ids=ids[start:end],
+            documents=docs[start:end],
+            embeddings=embs,
+            metadatas=metas[start:end],
+        )
+        total_done += end - start
+        elapsed = time.time() - t0
+        rate = total_done / elapsed if elapsed > 0 else 0
+        print(
+            f"[migrate] {total_done}/{len(chunks)} chunks "
+            f"({elapsed:.1f}s elapsed, {rate:.1f} chunks/s)"
+        )
+
+    final_count = target_collection.count()
+    print()
+    print("=== Migration complete ===")
+    print(f"  source chunks:  {len(chunks)}")
+    print(f"  target chunks:  {final_count}")
+    print(f"  total elapsed:  {time.time() - t0:.1f}s")
+    print()
+    print("Next steps:")
+    print(f"  1. Set JAMES_EMBEDDING_MODEL={args.target} in .env or shell env")
+    print( "  2. Restart the JAMES server")
+    print( "  3. Run BL-9 acceptance: python scripts/research/q15_chroma_probe.py")
+    print( "     Expected: MCP PDF reaches top-10 on the `name_only` variation")
+    print( "  4. Run bench wrapper for step7 v4 q15 path_recall check:")
+    print( "     python scripts/bench_lc_scope_arms.py")
+    print( "     Expected: q15 path_recall ≥ 0.5 (pre-swap was 0.0)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_migrate_embedding_runner.py
+++ b/tests/test_migrate_embedding_runner.py
@@ -1,0 +1,50 @@
+"""BL-9 (2026-05-27) — contract tests for `scripts/migrate_embedding.py`.
+
+Pins the helpers the runner depends on, without needing the
+heavyweight HF model download or a populated chroma collection.
+The end-to-end migration is verified by the operator's BL-9
+acceptance gate run (post-swap q15 chroma probe + step7 v4).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from scripts.migrate_embedding import (  # noqa: E402
+    _LEGACY_MINILM_TAG,
+    _target_chroma_dir,
+)
+
+
+def test_target_chroma_dir_rejects_legacy_tag():
+    """A no-op migration (target == legacy) would silently clobber the
+    source. The runner refuses up front."""
+    with pytest.raises(ValueError, match="legacy MiniLM"):
+        _target_chroma_dir(_LEGACY_MINILM_TAG)
+
+
+def test_target_chroma_dir_uses_short_slug_suffix():
+    """Per-model chroma dir = `<CHROMA_DIR>_<short>` — the slug
+    is filesystem-safe (lower / underscores) so the path holds on
+    Windows + Linux alike. Pins the suffix shape for bge-m3 and
+    multilingual-e5-large since those are the announced BL-9
+    candidates."""
+    from config import CHROMA_DIR
+    bge = _target_chroma_dir("BAAI/bge-m3")
+    e5  = _target_chroma_dir("intfloat/multilingual-e5-large")
+    assert bge == f"{CHROMA_DIR}_bge_m3"
+    assert e5  == f"{CHROMA_DIR}_multilingual_e5_large"
+
+
+def test_target_chroma_dir_handles_unknown_provider():
+    """Any HF-style id should produce a safe slug, not crash. Pins
+    that future-candidate models (e.g. `Qwen/Qwen3-Embedding-8B`) can
+    be passed without code changes here."""
+    out = _target_chroma_dir("Qwen/Qwen3-Embedding-8B")
+    assert out.endswith("_qwen3_embedding_8b")
+    assert "/" not in out.rsplit("/", 1)[-1]  # no slashes in the basename


### PR DESCRIPTION
## Summary

L.D F7 (PR #533) confirmed the systemic fix for cross-lingual proper-noun retrieval is a multilingual embedding swap from `paraphrase-multilingual-MiniLM-L12-v2` (384-dim) to a 1024-dim model. BL-9 abstraction landed in PR #509 (per-model `models/<short>` + `chroma_db_<short>` resolution); this PR adds the missing **migration runner + acceptance gate + operator workflow** so the swap is a one-command operation when the operator has the compute window.

## What landed

- `scripts/migrate_embedding.py` (~270 lines) — re-encodes the legacy MiniLM chroma collection into a new per-model collection at `chroma_db_<short>/`. Reads source via raw chromadb (no `VectorStore` singleton pollution); writes target via a fresh `SentenceTransformer` with local-first / HF fallback (mirrors `core/vector_store.py`). `--dry-run` flag for path preview.
- `tests/test_migrate_embedding_runner.py` (3 tests) — pin `_target_chroma_dir` rejects legacy tag, computes correct slugs, future-proof for new candidates.
- `reports/promo-assets/v3prime-leo-evidence-scope-result.md` — new "BL-9 prep" section with model selection rationale + acceptance gate spec + operator workflow + rollback path.

## Verification

Dry-run on current data state:

```
=== BL-9 chroma re-embedding ===
  source model:  paraphrase-multilingual-MiniLM-L12-v2 (legacy MiniLM)
  target model:  BAAI/bge-m3
  source dir:    .../chroma_db
  target dir:    .../chroma_db_bge_m3
  collection:    james_prototype

[migrate] source chunks: 358
[migrate] --dry-run set; no target write performed
```

12 tests pass (3 new + 9 from `test_embedding_model_abstraction.py`).

## Model recommendation — `BAAI/bge-m3` over `intfloat/multilingual-e5-large`

Both are 1024-dim MIT-licensed multilingual. bge-m3 wins for JAMES's use case (KO+EN mixed wiki + proper-noun-mediated queries — F7 diagnostic):

| dimension | bge-m3 | multilingual-e5-large |
|---|---|---|
| Release | 2024 (newer) | 2023 |
| Korean perf (MTEB) | stronger | strong |
| Output | dense + sparse + multi-vector | dense only |
| Download | ~2.27 GB | ~2.24 GB |

`bge-m3`'s multi-functional output is the tiebreaker — sparse + multi-vector heads remain available for future rerank fusion if BL-9 alone isn't enough.

Operator can swap to e5-large by passing `--target intfloat/multilingual-e5-large` — the runner is model-agnostic.

## BL-9 acceptance gate (pre-swap baselines locked, post-swap targets defined)

Pre-swap (current state):
- F7 chroma probe — MCP PDF NOT in top-20 on `ko_q15_exact`, `en_translation`, `name_only`. Rank 1 only on `concept_side` (English document title).
- step7 v4 q15 path_recall = 0.0 (Idea 1 PR #530).
- Mean step7 path_recall = 0.80 (4/5 at 1.0).

Post-swap targets:
- F7 probe — MCP PDF in **top-10 on `name_only`** (most-stringent cross-lingual test).
- step7 v4 q15 path_recall **≥ 0.5** (1/2 expected nodes).
- Mean step7 path_recall **≥ 0.85** (q15 contributes ≥ 0.5 instead of 0.0).

## Operator workflow

```powershell
# 1. Migration (~5-10 min for 358 chunks on CPU after HF download)
python scripts/migrate_embedding.py --target BAAI/bge-m3

# 2. Set env + restart server
$env:JAMES_EMBEDDING_MODEL = "BAAI/bge-m3"

# 3. F7 probe acceptance
python scripts/research/q15_chroma_probe.py

# 4. step7 v4 acceptance bench
python scripts/bench_lc_scope_arms.py
```

Rollback is a one-env-var flip — legacy `chroma_db/` is never mutated.

## Bench numbers (CLAUDE.md rule #2)

This PR doesn't touch `core/{retrieval,graph,reasoning}` — adds a one-shot offline migration runner + tests. The swap itself produces bench numbers in the follow-up commit (operator runs the workflow above).

## Out of scope

- **Model download / migration execution** — operator-side compute window.
- **Default flip in config.py** — stays opt-in via env until acceptance gates pass.
- **Live acceptance numbers** — follow-up commit after the operator runs the workflow.
- **F3** — halt-prone large-tier measurement (still requires `JAMES_ENABLE_CLAUDE_BACKEND=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)