### PR TITLE
feat(v0.4): F3 prep — bench wrapper --enable-claude flag + capture-rate gate

### DIFF
--- a/reports/promo-assets/v3prime-leo-evidence-scope-result.md
+++ b/reports/promo-assets/v3prime-leo-evidence-scope-result.md
@@ -561,6 +561,112 @@ verification, the L.B policy v1 has complete bench coverage.
   14% narrow ratio doesn't match production expectations — formula
   fix and threshold tuning are orthogonal knobs.
 
+## F3 prep — large-tier wide routing + halt-prone measurement gate (2026-05-27)
+
+Branch: `feat/v0.4-f3-halt-prone-large-tier`. F1/F4/F5 acceptance
+runs all show `backend_counts = {ollama_local: 54-69}` because no
+large/medium-tier backend was registered — the L.B wide-tier rule
+(rule 2, `evidence_scope ≥ 0.70`) fires but falls back to legacy
+because `_first_in_tier("large")` returns empty. F1 reported
+5–7 wide-band decisions per run = 32–63% of synth calls.
+
+F3 prep wires the **operator opt-in** to register the
+`claude_code_cli` large-tier backend at server-spawn time, so the
+wide-tier rule actually reaches a real route target. The backend
+itself landed in D5.B (#476) and the registration helper landed in
+the always-auto-registered backend index — F3 just adds the
+wrapper-side env propagation + an acceptance signal in the
+wrapper's per-run summary.
+
+### What landed
+
+- `scripts/bench_lc_scope_arms.py` gains `--enable-claude` CLI
+  flag. When set, the wrapper injects `JAMES_ENABLE_CLAUDE_BACKEND=1`
+  into the per-arm server env so the registry includes
+  `claude_code_cli` (tier=`large`, provider=`cloud`). Default off —
+  L.D F1/F4/F5 acceptance runs remain byte-identical to their
+  small-tier-only configuration.
+- Per-run summary gains an "F3 large-tier capture rate" block when
+  `--enable-claude` is on. Reports wide-band decisions, count that
+  reached `claude_code_cli`, and the capture ratio (target: ≥ 90%).
+- `tests/test_bench_wrapper_enable_claude.py` (4 tests) pin the
+  flag-toggle ↔ env-propagation invariant + back-compat (default
+  off does NOT inject the env).
+
+### Pre-conditions (operator-side)
+
+- `claude` CLI installed + on PATH (or `JAMES_CLAUDE_CLI_PATH` env)
+- Authenticated — either `ANTHROPIC_API_KEY` env OR
+  `~/.claude` config dir with valid session
+- Same retrieval-mode + JWT bearer infrastructure F1 already added
+
+### F3 acceptance gate
+
+Pre-fix baseline (current L.D F1/F4/F5 runs):
+- backend_counts: `ollama_local: 54+` (single-tier monolith)
+- F1 wide_count: 7 / 11 (Idea 1 acceptance run)
+- F4 wide_count: 5 / 14
+- F5 wide_count: 7 / 14
+
+Post-fix targets (operator runs `--enable-claude`):
+- backend_counts now includes `claude_code_cli` for wide-band
+  decisions
+- **F3 capture ratio: `claude_code_cli` count ≥ 90% of wide_count**
+  (some loss expected for non-grounding wide queries that race a
+  budget rule fallback)
+- No regression on small-tier queries (narrow + mid bands continue
+  to land on `ollama_local`)
+- Per-query elapsed delta — large-tier queries may take longer
+  (cloud roundtrip vs local Ollama); wrapper's 2400s subprocess
+  timeout already absorbed this for the 16-query × 2-arm run
+
+### Operator workflow
+
+```powershell
+# 1. Verify claude CLI is on PATH + authenticated
+claude --version
+$env:ANTHROPIC_API_KEY = "..."   # or rely on ~/.claude config
+
+# 2. Run wrapper with the new flag — both arms spawn server with
+#    JAMES_ENABLE_CLAUDE_BACKEND=1 + JAMES_AUTO_ROUTER=1 (forced)
+python scripts/bench_lc_scope_arms.py --enable-claude
+
+# 3. Inspect the new "F3 large-tier capture rate" summary block
+#    + per-row reason:route audit (audit_log SELECT ...
+#    WHERE answer LIKE '%backend=claude_code_cli%')
+```
+
+### Halt-prone (`done_reason=length`) follow-up
+
+The L.D handover §"STEP 7 bench plan" lists "halt-prone arm" as
+the 4th measurement axis — done_reason=length rate reduction when
+wide-scope routes to large tier. F3 prep does NOT measure that
+axis directly; the `claude_code_cli` backend's
+`CompletionResult.done_reason` is empty (the CLI doesn't surface
+a truncation signal). Two follow-ups split out:
+
+- **F3a** — instrument the backend wrapper to detect output
+  truncation heuristically (e.g. `len(output) ≥ max_tokens` or
+  `len(output) == _MAX_OUTPUT_BYTES`) and emit
+  `done_reason="length"` so the existing audit infra picks it up.
+- **F3b** — operator-run baseline of done_reason=length rate on
+  small-tier ollama_local vs large-tier claude_code_cli for the
+  same prompts. Surface in wrapper summary.
+
+Carried as separate cycles — F3 prep ships the registration plumbing
++ capture-rate gate; halt-prone instrumentation is independent
+infra work.
+
+### What this PR does NOT do
+
+- **No model download / API spend** — `--enable-claude` is operator
+  opt-in; PR default off.
+- **No production change** — `core/reasoning/backends/__init__.py`
+  already gated the `claude_code_cli` registration on
+  `JAMES_ENABLE_CLAUDE_BACKEND` since D5.B; PR uses that gate.
+- **No live acceptance numbers** — follow-up commit lands them
+  after the operator runs the workflow.
+
 ## BL-9 prep — embedding swap runner + acceptance gate (2026-05-27)
 
 Branch: `feat/v0.4-bl9-embedding-swap-prep`. F7 (PR #533) confirmed

--- a/scripts/bench_lc_scope_arms.py
+++ b/scripts/bench_lc_scope_arms.py
@@ -153,6 +153,15 @@ SERVER_HEALTHZ = SERVER_BASE_URL.rstrip("/") + "/healthz"
 SERVER_BOOT_TIMEOUT_SEC = int(os.environ.get("JAMES_SERVER_BOOT_TIMEOUT", "120"))
 
 
+# F3 (2026-05-27) — module-level toggle set from --enable-claude CLI
+# flag in main(). When True, _run_arm injects JAMES_ENABLE_CLAUDE_BACKEND=1
+# into the per-arm server env so the large-tier ``claude_code_cli``
+# backend registers + becomes a valid route target for the L.B wide-tier
+# rule. Default False keeps the small-tier-only fleet behavior the L.D
+# F1/F4/F5 acceptance runs documented.
+_ENABLE_CLAUDE_LARGE_TIER: bool = False
+
+
 def _port_in_use(host: str, port: int) -> bool:
     import socket
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -290,11 +299,19 @@ def _run_arm(arm_name: str, scope_routing: str) -> Optional[Path]:
     server_env = os.environ.copy()
     server_env["JAMES_SCOPE_ROUTING"] = scope_routing
     server_env["JAMES_AUTO_ROUTER"] = "1"
+    # F3 (2026-05-27) — optional large-tier registration. When set, the
+    # backend registry includes claude_code_cli (tier="large"), making
+    # the L.B "wide→large" rule reach a real backend instead of falling
+    # back to ollama_local. Operator must have `claude` CLI installed +
+    # authenticated (ANTHROPIC_API_KEY or ~/.claude config).
+    if _ENABLE_CLAUDE_LARGE_TIER:
+        server_env["JAMES_ENABLE_CLAUDE_BACKEND"] = "1"
 
+    extra = " JAMES_ENABLE_CLAUDE_BACKEND=1" if _ENABLE_CLAUDE_LARGE_TIER else ""
     print(
         f"\n=== ARM: {arm_name} "
         f"(JAMES_SCOPE_ROUTING={scope_routing}, "
-        f"JAMES_AUTO_ROUTER=1) ==="
+        f"JAMES_AUTO_ROUTER=1{extra}) ==="
     )
     server = _spawn_server(server_env)
     if server is None:
@@ -483,7 +500,24 @@ def main() -> int:
         "--off-path", type=Path, default=None,
         help="Reuse a prior bench.py output JSON for the flag-OFF arm.",
     )
+    ap.add_argument(
+        "--enable-claude", action="store_true",
+        help=(
+            "F3 (2026-05-27) — register the claude_code_cli large-tier "
+            "backend on both arms so the L.B wide-tier rule has a real "
+            "route target. Requires `claude` CLI installed + "
+            "ANTHROPIC_API_KEY (or ~/.claude config). Pre-fix (default): "
+            "wide-tier decisions fall back to ollama_local. With this "
+            "flag: wide-tier decisions route to claude_code_cli; the "
+            "F3 acceptance gate is backend_counts['claude_code_cli'] > 0."
+        ),
+    )
     args = ap.parse_args()
+
+    # F3 — propagate the CLI flag into the module-level toggle that
+    # `_run_arm` reads to derive per-server env.
+    global _ENABLE_CLAUDE_LARGE_TIER
+    _ENABLE_CLAUDE_LARGE_TIER = bool(args.enable_claude)
 
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -568,6 +602,24 @@ def main() -> int:
         print("\n=== Backend selection counts (flag-ON) ===")
         for b, c in sorted(agg["backend_counts"].items()):
             print(f"  {b}: {c}")
+        # F3 acceptance signal — when --enable-claude was set, large-tier
+        # decisions should reach claude_code_cli instead of falling back
+        # to ollama_local. Wide-tier decisions are the ones that matter
+        # for the "JAMES wiki naturally wide-skewed" finding (F1).
+        if _ENABLE_CLAUDE_LARGE_TIER:
+            wide = (agg.get("scope_summary") or {}).get("wide_count", 0)
+            large = agg["backend_counts"].get("claude_code_cli", 0)
+            print(
+                f"\n=== F3 large-tier capture rate ===\n"
+                f"  wide-band routing decisions: {wide}\n"
+                f"  reached claude_code_cli:    {large}\n"
+                f"  capture ratio:              "
+                f"{(large / wide * 100):.1f}% (target: >= 90%)"
+                if wide > 0 else
+                "\n=== F3 large-tier capture rate ===\n"
+                "  wide-band routing decisions: 0 (no wide-tier signal "
+                "this run — F3 acceptance inconclusive)"
+            )
 
     print("\n=== Per-query elapsed delta ===")
     for d in agg["deltas"]:

--- a/tests/test_bench_wrapper_enable_claude.py
+++ b/tests/test_bench_wrapper_enable_claude.py
@@ -1,0 +1,93 @@
+"""F3 (2026-05-27) — contract tests for bench_lc_scope_arms `--enable-claude`.
+
+Pins the flag plumbing without spawning a server. The end-to-end
+acceptance (claude_code_cli backend actually routes wide-tier
+decisions) is the operator-run acceptance gate documented in the
+result doc — runs against a live `claude` CLI + ANTHROPIC_API_KEY.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def test_module_toggle_default_off():
+    """Default (`--enable-claude` not passed) keeps the legacy
+    small-tier-only fleet behaviour. Backward-compat with the L.D
+    F1/F4/F5 acceptance runs."""
+    import importlib
+    import scripts.bench_lc_scope_arms as wrap
+    importlib.reload(wrap)
+    assert wrap._ENABLE_CLAUDE_LARGE_TIER is False
+
+
+def test_flag_plumbs_to_module_toggle(monkeypatch):
+    """Simulate CLI invocation by setting sys.argv around `main()`
+    parser setup. We can't run `main()` end-to-end (it spawns a
+    server) so we patch _run_arm to no-op and verify the module
+    toggle flips when --enable-claude is in argv."""
+    import scripts.bench_lc_scope_arms as wrap
+
+    monkeypatch.setattr(
+        wrap, "_run_arm",
+        lambda *_a, **_kw: None,  # short-circuit — main returns 1 on None
+    )
+    monkeypatch.setattr(sys, "argv", ["bench_lc_scope_arms.py", "--enable-claude"])
+    wrap._ENABLE_CLAUDE_LARGE_TIER = False
+    try:
+        rc = wrap.main()
+    except SystemExit as e:
+        rc = e.code
+    assert wrap._ENABLE_CLAUDE_LARGE_TIER is True, (
+        "--enable-claude must propagate to the module-level toggle so "
+        "_run_arm sees it before spawning the server"
+    )
+    assert rc in (None, 0, 1)
+
+
+def test_flag_injects_env_into_server_spawn(monkeypatch):
+    """When the toggle is on, _run_arm must add JAMES_ENABLE_CLAUDE_BACKEND=1
+    to the env dict before spawning the server. We capture the env
+    by patching _spawn_server."""
+    import scripts.bench_lc_scope_arms as wrap
+
+    captured_env = {}
+
+    def fake_spawn(env):
+        captured_env.update(env)
+        return None  # short-circuit the rest of _run_arm
+
+    monkeypatch.setattr(wrap, "_spawn_server", fake_spawn)
+    wrap._ENABLE_CLAUDE_LARGE_TIER = True
+    try:
+        wrap._run_arm("test-arm", "1")
+    finally:
+        wrap._ENABLE_CLAUDE_LARGE_TIER = False
+    assert captured_env.get("JAMES_ENABLE_CLAUDE_BACKEND") == "1"
+    assert captured_env.get("JAMES_AUTO_ROUTER") == "1"
+    assert captured_env.get("JAMES_SCOPE_ROUTING") == "1"
+
+
+def test_flag_off_does_not_inject_claude_env(monkeypatch):
+    """Default toggle = off → server_env must NOT contain
+    JAMES_ENABLE_CLAUDE_BACKEND. Pins back-compat invariant."""
+    import scripts.bench_lc_scope_arms as wrap
+
+    captured_env = {}
+
+    def fake_spawn(env):
+        captured_env.update(env)
+        return None
+
+    monkeypatch.setattr(wrap, "_spawn_server", fake_spawn)
+    # Make sure no inherited env leaks in
+    monkeypatch.delenv("JAMES_ENABLE_CLAUDE_BACKEND", raising=False)
+    wrap._ENABLE_CLAUDE_LARGE_TIER = False
+    wrap._run_arm("test-arm", "0")
+    assert "JAMES_ENABLE_CLAUDE_BACKEND" not in captured_env, (
+        "default toggle must not register the claude backend — "
+        "back-compat with L.D F1/F4/F5 small-tier-only fleet runs"
+    )


### PR DESCRIPTION
## Summary

L.D F3 followup. F1/F4/F5 acceptance runs all show `backend_counts = {ollama_local: 54-69}` because no large-tier backend was registered — the L.B wide-tier rule fires but falls back to legacy because `_first_in_tier("large")` is empty. F1 reported 5-7 wide-band decisions per run = 32-63% of synth calls left on the table.

F3 prep wires the **operator opt-in** to register the `claude_code_cli` large-tier backend at server-spawn time, so the wide-tier rule actually reaches a real route target.

## What landed

- `scripts/bench_lc_scope_arms.py` gains `--enable-claude` CLI flag. When set, the wrapper injects `JAMES_ENABLE_CLAUDE_BACKEND=1` into the per-arm server env. Default off — back-compat with L.D F1/F4/F5 acceptance runs.
- Per-run summary gains an "F3 large-tier capture rate" block when the flag is on — reports wide-band count, `claude_code_cli` reach count, capture ratio (target ≥ 90%).
- `tests/test_bench_wrapper_enable_claude.py` (4 tests) pin flag plumbing + back-compat (default off does NOT inject the env).
- `reports/promo-assets/v3prime-leo-evidence-scope-result.md` — new "F3 prep" section with baseline + targets + operator workflow + F3a/F3b carve-out.

## Verification

22 tests pass (4 new + 5 mode-flag + 13 path-metrics):

```
tests/test_bench_wrapper_enable_claude.py  4 passed
tests/test_bench_mode_flag.py              5 passed
tests/test_bench_path_metrics.py          13 passed
```

CLI surface confirmed:

```
--enable-claude      F3 (2026-05-27) — register the claude_code_cli large-
                     tier backend on both arms so the L.B wide-tier rule has
                     a real route target. ...
```

## F3 acceptance gate

Pre-fix baseline (current L.D F1/F4/F5 runs):
- backend_counts: `ollama_local: 54+` (single-tier monolith)
- wide_count: 5-7 per run (32-63% of synth calls)

Post-fix targets (operator runs `--enable-claude`):
- backend_counts now includes `claude_code_cli` for wide-band decisions
- **F3 capture ratio: `claude_code_cli` count ≥ 90% of wide_count**
- No regression on narrow + mid bands (continue to land on `ollama_local`)

## Operator workflow

```powershell
# 1. Verify claude CLI + auth
claude --version
$env:ANTHROPIC_API_KEY = "..."   # or ~/.claude config

# 2. Run wrapper with the new flag
python scripts/bench_lc_scope_arms.py --enable-claude

# 3. Inspect the new "F3 large-tier capture rate" summary block
```

## Halt-prone (`done_reason=length`) carry-out

The L.D handover §"STEP 7 bench plan" listed "halt-prone arm" as the 4th measurement axis. F3 prep does NOT measure that axis directly — `ClaudeCodeCliBackend.complete` returns `done_reason=""` (the CLI doesn't surface a truncation signal). Two follow-ups split out:

- **F3a** — instrument backend wrapper to detect output truncation heuristically and emit `done_reason="length"`
- **F3b** — operator-run done_reason=length comparison small-tier vs large-tier

Carried as separate cycles — F3 prep ships the registration plumbing + capture-rate gate.

## Bench numbers (CLAUDE.md rule #2)

No `core/{retrieval,graph,reasoning}` change in this PR. Live acceptance numbers come in the follow-up commit after the operator runs the workflow.

## Out of scope

- F3a / F3b (above)
- BL-9 migration acceptance run (operator step 2: `$env:JAMES_EMBEDDING_MODEL = "BAAI/bge-m3"` + server restart, separate from F3)
- Sprint 5 PR-T1.B (blocked on #524/#525)

🤖 Generated with [Claude Code](https://claude.com/claude-code)