### PR TITLE
docs(leo): BL-9 acceptance — bge-m3 swap active, q15 root moves to query expansion (F9 spawn)

### DIFF
--- a/reports/promo-assets/v3prime-leo-evidence-scope-result.md
+++ b/reports/promo-assets/v3prime-leo-evidence-scope-result.md
@@ -561,6 +561,109 @@ verification, the L.B policy v1 has complete bench coverage.
   14% narrow ratio doesn't match production expectations — formula
   fix and threshold tuning are orthogonal knobs.
 
+## BL-9 acceptance run — partial success, root cause moved (2026-05-27 PM)
+
+Branch: `feat/v0.4-bl9-acceptance-partial-f9-spawn`. Operator ran
+`scripts/migrate_embedding.py --target BAAI/bge-m3` (358 chunks
+re-embedded into `chroma_db_bge_m3/`) + persisted
+`JAMES_EMBEDDING_MODEL=BAAI/bge-m3` to `.env`. F7 chroma probe
+re-run with bge-m3 active.
+
+`reports/research-runs/q15-chroma-probe-20260527_182105.json`
+
+### Swap active confirmation — scores prove bge-m3 is the live model
+
+| variation | MiniLM (F7 baseline) | bge-m3 (this run) | Δ |
+|---|---|---|---|
+| concept_side rank-1 score | 0.8462 | **0.7576** | different ⇒ swap active |
+| en_translation top-1 score | 0.6041 | 0.6084 | different |
+| name_only top-1 score | 0.6662 | 0.5936 | different |
+
+`[VECTOR_STORE] ChromaDB 경로: …chroma_db_bge_m3` +
+`[VECTOR_STORE] 임베딩 모델: BAAI/bge-m3` confirm the runtime path.
+
+### Acceptance gate result — **FAIL on q15 `name_only`**
+
+| variation | MCP PDF rank under bge-m3 |
+|---|---|
+| ko_q15_exact | **NOT in top-20** |
+| en_translation | **NOT in top-20** |
+| name_only ← acceptance gate | **NOT in top-20** ❌ |
+| concept_side | rank 1, score 0.7576 ✅ |
+
+bge-m3 → MiniLM swap did NOT fix q15 cross-lingual proper-noun
+retrieval. Pre-swap baseline (F7) and post-swap (this run) both
+show the MCP PDF outside top-20 for any person-name query.
+
+### Root cause reattribution — query expansion, not embedding
+
+The post-swap diagnostic ran 5 query variations directly against
+the bge-m3 collection:
+
+| query | MCP PDF rank | semantic |
+|---|---|---|
+| `"David Soria Parra"` (name only) | **None** | bare-name miss |
+| `"MCP 설계자 David Soria Parra"` | **rank 1** | concept anchor + name → hit |
+| `"MCP designer Anthropic Justin Spahr-Summers"` | **rank 1** | concept anchor (en) → hit |
+| `"Anthropic MCP 공개"` (concept only) | **rank 1** | concept alone → hit |
+| `"David Soria Parra Justin Spahr-Summers JSON-RPC"` | **None** | over-specific → miss |
+
+**Root** — the MCP PDF chunk that names "David Soria Parra와
+Justin Spahr-Summers" is ~80 characters out of ~2 KB of MCP /
+JSON-RPC / Anthropic protocol description. The chunk vector is
+dominated by the dense concept tokens, so the bare-name query
+vector is too far from the chunk centroid. ANY 1024-dim multilingual
+embedding model has this property — switching to e5-large would
+hit the same wall (both are pooling-based dense encoders).
+
+The fix is **query expansion** — JAMES already has
+`core.retrieval.query_rewriter`; the question is whether it
+rewrites "David Soria Parra가 누구야?" into a concept-anchored
+form. If it does, q15 should hit. If it doesn't, that's the F9
+fix point.
+
+### BL-9 verdict — swap stays, downstream still broken
+
+- ✅ bge-m3 is now the production embedding (operator persisted
+  via `.env`)
+- ✅ 358 chunks re-embedded successfully
+- ⚠️ q15 `name_only` acceptance gate fails — root is upstream,
+  not the embedding model
+- ⏭️ **F9 spawned** (next §) — query rewriter audit on q15
+
+The swap is NOT a regression for the queries that did work — q2
+"Anthropic은 어떤 회사인가?" → still hits, q4 "BlackRock과 비트코인
+ETF" → still hits (operator's pre-swap OFF arm bench showed these
+still recall 1.0; full step7 v4 acceptance run pending operator
+ON-arm completion).
+
+Rollback path stays one env-var flip:
+
+```powershell
+# Comment out JAMES_EMBEDDING_MODEL=BAAI/bge-m3 in .env
+# Restart server → reads legacy MiniLM → chroma_db/ path.
+```
+
+## F9 (NEW, 2026-05-27) — query rewriter audit on q15
+
+BL-9 acceptance proved the chroma-side embedding can match q15 IF
+the query carries a concept anchor ("MCP" / "Anthropic"). The
+unknown variable: what does `core.retrieval.query_rewriter` actually
+output when fed "David Soria Parra가 누구야?"?
+
+Acceptance gate for F9:
+- Audit script (similar to F2 `intent_classifier_audit.py`) that
+  feeds q15 + the broken queries through `query_rewriter.rewrite`
+  + reports the rewritten text + flags whether a concept anchor
+  ("MCP" / "Anthropic" / domain noun) was added.
+- If rewriter added concept anchor → some OTHER layer is dropping
+  it before chroma. Trace through retrieve.py path.
+- If rewriter passed the bare-name through → tune the rewriter
+  prompt to add domain context (cheap fix candidate: add
+  "이 사람의 활동 도메인을 포함시켜라" to the rewriter's prompt).
+
+Out of scope for this PR — F9 carried as a separate cycle.
+
 ## F3 prep — large-tier wide routing + halt-prone measurement gate (2026-05-27)
 
 Branch: `feat/v0.4-f3-halt-prone-large-tier`. F1/F4/F5 acceptance

--- a/reports/research-runs/q15-chroma-probe-20260527_173106.json
+++ b/reports/research-runs/q15-chroma-probe-20260527_173106.json
@@ -1,0 +1,550 @@
+{
+  "generated_at": "2026-05-27T17:31:06.863587",
+  "variations": [
+    {
+      "label": "ko_q15_exact",
+      "query": "David Soria Parra가 누구야?",
+      "top_k": 20,
+      "elapsed": 0.035,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6148,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.6061,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5768,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5725,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 5,
+          "score": 0.5717,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 6,
+          "score": 0.5699,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 7,
+          "score": 0.5682,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 8,
+          "score": 0.5603,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 9,
+          "score": 0.5601,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 10,
+          "score": 0.5587,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 11,
+          "score": 0.5583,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 12,
+          "score": 0.5582,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 13,
+          "score": 0.5566,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 14,
+          "score": 0.555,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 15,
+          "score": 0.5548,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        },
+        {
+          "rank": 16,
+          "score": 0.5523,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 17,
+          "score": 0.5522,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 18,
+          "score": 0.5505,
+          "source": "web_business_**경쟁사 대비 AMD 기술적 우위 _1778634469.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [달빛향기 DalHyang](https://likedalhyang.tistory.com/ \"달빛"
+        },
+        {
+          "rank": 19,
+          "score": 0.55,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 20,
+          "score": 0.5495,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "en_translation",
+      "query": "Who is David Soria Parra?",
+      "top_k": 20,
+      "elapsed": 0.013,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6041,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5773,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5733,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 4,
+          "score": 0.5692,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 5,
+          "score": 0.5612,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 6,
+          "score": 0.5606,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 7,
+          "score": 0.5573,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 8,
+          "score": 0.5548,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 9,
+          "score": 0.5547,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 10,
+          "score": 0.5466,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 11,
+          "score": 0.5464,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 12,
+          "score": 0.5463,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "기준: 2026년 5월 Musk Ecosystem | 연혁 요약 - 1 -  Part 1. xAI xAI는 2023년 3월 9일 일론 머스크가 "
+        },
+        {
+          "rank": 13,
+          "score": 0.5462,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 14,
+          "score": 0.5453,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "기법  압축(Compaction) — 대화가 길어지면 이전 turn들을 요약본으로 대체. Claude Code는 자동 압축 트리거를  둔다.  "
+        },
+        {
+          "rank": 15,
+          "score": 0.5452,
+          "source": "web_business_로봇공학 시장 주요 경쟁사 및 비교 _1778717473.md",
+          "text_preview": "orts/robotics-technology-market/6366"
+        },
+        {
+          "rank": 16,
+          "score": 0.5449,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 17,
+          "score": 0.544,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 18,
+          "score": 0.5437,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 19,
+          "score": 0.5422,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 20,
+          "score": 0.5414,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "name_only",
+      "query": "David Soria Parra",
+      "top_k": 20,
+      "elapsed": 0.013,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6662,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 2,
+          "score": 0.6076,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 3,
+          "score": 0.5999,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5873,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 5,
+          "score": 0.5798,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "on-stock-rises/"
+        },
+        {
+          "rank": 6,
+          "score": 0.573,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 7,
+          "score": 0.5706,
+          "source": "Palantir_2024Q3_실적.pdf",
+          "text_preview": "# 파일: Palantir_2024Q3_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 8,
+          "score": 0.569,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 9,
+          "score": 0.5688,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 10,
+          "score": 0.5679,
+          "source": "Palantir_2025Q1_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q1_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 11,
+          "score": 0.5676,
+          "source": "Palantir_2025Q2_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q2_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 12,
+          "score": 0.5661,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 13,
+          "score": 0.5658,
+          "source": "type_certificate_tc__획득하기_위한_세.md",
+          "text_preview": "110.121.pdf"
+        },
+        {
+          "rank": 14,
+          "score": 0.5657,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q4_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 15,
+          "score": 0.5655,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 16,
+          "score": 0.5648,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 17,
+          "score": 0.5645,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 18,
+          "score": 0.5637,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 19,
+          "score": 0.5631,
+          "source": "web_coding_**기술적 원리 심화:** 통합 칩 _1778634839.md",
+          "text_preview": "ttps://www.techflowpost.com/ko-KR/column/4059"
+        },
+        {
+          "rank": 20,
+          "score": 0.5629,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "concept_side",
+      "query": "MCP Model Context Protocol",
+      "top_k": 20,
+      "elapsed": 0.012,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": 1,
+      "target_score": 0.8462,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.8462,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "# 파일: 08_MCP_(Model_Context_Protocol).pdf  PART 08 / 10  MCP (Model Context Prot"
+        },
+        {
+          "rank": 2,
+          "score": 0.7807,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "·확인 단계 필수  참고문헌 (References)  1. Anthropic (2024). Introducing the Model Context"
+        },
+        {
+          "rank": 3,
+          "score": 0.6925,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "넘어선다.  4. 보안 위협과 방어  MCP의  빠른  채택은  보안  우려를  키웠다. MCP  Safety  Audit  (Radosevic"
+        },
+        {
+          "rank": 4,
+          "score": 0.6793,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "채택,  이후  Google  DeepMind·Microsoft·GitHub가  합류. 2025년  12월  Anthropic은  Linux  "
+        },
+        {
+          "rank": 5,
+          "score": 0.6722,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "계, (3) 권한 최소화(read-only  우선), (4) 정기적 도구 정의 변경 감사. James의 자메스 시스템처럼 \"rag_search만"
+        },
+        {
+          "rank": 6,
+          "score": 0.6516,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "# 파일: 03_Tool_Use___Function_Calling.pdf  PART 03 / 10  Tool Use / Function Call"
+        },
+        {
+          "rank": 7,
+          "score": 0.6362,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "Language Models. ICLR.  2. Yang, J. et al. (2024). SWE-agent: Agent-Computer Int"
+        },
+        {
+          "rank": 8,
+          "score": 0.6342,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "ontinue, Cline 등 주요 코딩 에이전트는 모두 함수 호출을 핵심 골격으로 한다. 파일  읽기/쓰기, bash 실행, 웹 검색 등이 모"
+        },
+        {
+          "rank": 9,
+          "score": 0.6333,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "# 파일: 02_컨텍스트_엔지니어링.pdf  PART 02 / 10  컨텍스트 엔지니어링  Context Engineering & Window "
+        },
+        {
+          "rank": 10,
+          "score": 0.6317,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "HTTP(원격). 후자가 SaaS 벤더의 공개 MCP 서버  배포를 가능하게 했다.  3. 2025-11-25 스펙과 채택 규모  2025년 1"
+        },
+        {
+          "rank": 11,
+          "score": 0.6302,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "사전 적재가 아닌 도구 기반 JIT 조회를 우선  참고문헌 (References)  1. Anthropic Engineering (2025). "
+        },
+        {
+          "rank": 12,
+          "score": 0.6271,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "# 파일: 06_STRC모델_ETF10배매입.txt  =================================================="
+        },
+        {
+          "rank": 13,
+          "score": 0.6257,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "rboard  (Patil  et  al.,  ICML  2025)는  사실상  표준이다. 2,000여  개의  question-function"
+        },
+        {
+          "rank": 14,
+          "score": 0.6246,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "모델조차  저장소  단위  코드  생성에서  Pass@1  40%를 넘지 못함을 보고한다. 검색 정확도가 곧 생성 품질로 직결되지 않는 점, 다"
+        },
+        {
+          "rank": 15,
+          "score": 0.6241,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "사결정 · 멀티 턴 일관성에서 여전히 낮은 정확도  참고문헌 (References)  1. Patil, S. G. et al. (2025). T"
+        },
+        {
+          "rank": 16,
+          "score": 0.6212,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "제안한 패러다임으로, LLM의 파라미터 지식 한계를 외부 지식 베이스  조회로  보완한다. 코드  영역에서  RAG이  특히  중요한  이유는 "
+        },
+        {
+          "rank": 17,
+          "score": 0.6189,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "사이클  Thought → Action → Observation → Thought ... (ReAct, ICLR 2023)  핵심 개념  ACI"
+        },
+        {
+          "rank": 18,
+          "score": 0.6173,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "# 파일: 01_RAG_(검색_증강_생성).pdf  PART 01 / 10  RAG (검색 증강 생성)  Retrieval-Augmented G"
+        },
+        {
+          "rank": 19,
+          "score": 0.6163,
+          "source": "09_코딩_특화_프롬프트_엔지니어링.pdf",
+          "text_preview": "# 파일: 09_코딩_특화_프롬프트_엔지니어링.pdf  PART 09 / 10  코딩 특화 프롬프트 엔지니어링  Prompt Engineerin"
+        },
+        {
+          "rank": 20,
+          "score": 0.614,
+          "source": "web_coding_GRAPH 추론 다양한 알고리즘과 원_1779094615.md",
+          "text_preview": "그래프 알고리즘은 서로 연결된 개체 간의 관계를 분석하는 데 사용되며, 트리 자료구조는 그래프의 한 종류입니다. DFS/BFS, 최단 경로 알고"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "variations_count": 4,
+    "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+    "top_k": 20,
+    "variations_hit": 1,
+    "best_rank": 1,
+    "ranks_by_label": {
+      "ko_q15_exact": null,
+      "en_translation": null,
+      "name_only": null,
+      "concept_side": 1
+    }
+  }
+}

--- a/reports/research-runs/q15-chroma-probe-20260527_173126.json
+++ b/reports/research-runs/q15-chroma-probe-20260527_173126.json
@@ -1,0 +1,550 @@
+{
+  "generated_at": "2026-05-27T17:31:26.659889",
+  "variations": [
+    {
+      "label": "ko_q15_exact",
+      "query": "David Soria Parra가 누구야?",
+      "top_k": 20,
+      "elapsed": 0.035,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6148,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.6061,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5768,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5725,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 5,
+          "score": 0.5717,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 6,
+          "score": 0.5699,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 7,
+          "score": 0.5682,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 8,
+          "score": 0.5603,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 9,
+          "score": 0.5601,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 10,
+          "score": 0.5587,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 11,
+          "score": 0.5583,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 12,
+          "score": 0.5582,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 13,
+          "score": 0.5566,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 14,
+          "score": 0.555,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 15,
+          "score": 0.5548,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        },
+        {
+          "rank": 16,
+          "score": 0.5523,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 17,
+          "score": 0.5522,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 18,
+          "score": 0.5505,
+          "source": "web_business_**경쟁사 대비 AMD 기술적 우위 _1778634469.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [달빛향기 DalHyang](https://likedalhyang.tistory.com/ \"달빛"
+        },
+        {
+          "rank": 19,
+          "score": 0.55,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 20,
+          "score": 0.5495,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "en_translation",
+      "query": "Who is David Soria Parra?",
+      "top_k": 20,
+      "elapsed": 0.013,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6041,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5773,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5733,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 4,
+          "score": 0.5692,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 5,
+          "score": 0.5612,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 6,
+          "score": 0.5606,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 7,
+          "score": 0.5573,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 8,
+          "score": 0.5548,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 9,
+          "score": 0.5547,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 10,
+          "score": 0.5466,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 11,
+          "score": 0.5464,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 12,
+          "score": 0.5463,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "기준: 2026년 5월 Musk Ecosystem | 연혁 요약 - 1 -  Part 1. xAI xAI는 2023년 3월 9일 일론 머스크가 "
+        },
+        {
+          "rank": 13,
+          "score": 0.5462,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 14,
+          "score": 0.5453,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "기법  압축(Compaction) — 대화가 길어지면 이전 turn들을 요약본으로 대체. Claude Code는 자동 압축 트리거를  둔다.  "
+        },
+        {
+          "rank": 15,
+          "score": 0.5452,
+          "source": "web_business_로봇공학 시장 주요 경쟁사 및 비교 _1778717473.md",
+          "text_preview": "orts/robotics-technology-market/6366"
+        },
+        {
+          "rank": 16,
+          "score": 0.5449,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 17,
+          "score": 0.544,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 18,
+          "score": 0.5437,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 19,
+          "score": 0.5422,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 20,
+          "score": 0.5414,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "name_only",
+      "query": "David Soria Parra",
+      "top_k": 20,
+      "elapsed": 0.011,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6662,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 2,
+          "score": 0.6076,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 3,
+          "score": 0.5999,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5873,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 5,
+          "score": 0.5798,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "on-stock-rises/"
+        },
+        {
+          "rank": 6,
+          "score": 0.573,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 7,
+          "score": 0.5706,
+          "source": "Palantir_2024Q3_실적.pdf",
+          "text_preview": "# 파일: Palantir_2024Q3_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 8,
+          "score": 0.569,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 9,
+          "score": 0.5688,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 10,
+          "score": 0.5679,
+          "source": "Palantir_2025Q1_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q1_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 11,
+          "score": 0.5676,
+          "source": "Palantir_2025Q2_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q2_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 12,
+          "score": 0.5661,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 13,
+          "score": 0.5658,
+          "source": "type_certificate_tc__획득하기_위한_세.md",
+          "text_preview": "110.121.pdf"
+        },
+        {
+          "rank": 14,
+          "score": 0.5657,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q4_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 15,
+          "score": 0.5655,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 16,
+          "score": 0.5648,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 17,
+          "score": 0.5645,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 18,
+          "score": 0.5637,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 19,
+          "score": 0.5631,
+          "source": "web_coding_**기술적 원리 심화:** 통합 칩 _1778634839.md",
+          "text_preview": "ttps://www.techflowpost.com/ko-KR/column/4059"
+        },
+        {
+          "rank": 20,
+          "score": 0.5629,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "concept_side",
+      "query": "MCP Model Context Protocol",
+      "top_k": 20,
+      "elapsed": 0.011,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": 1,
+      "target_score": 0.8462,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.8462,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "# 파일: 08_MCP_(Model_Context_Protocol).pdf  PART 08 / 10  MCP (Model Context Prot"
+        },
+        {
+          "rank": 2,
+          "score": 0.7807,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "·확인 단계 필수  참고문헌 (References)  1. Anthropic (2024). Introducing the Model Context"
+        },
+        {
+          "rank": 3,
+          "score": 0.6925,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "넘어선다.  4. 보안 위협과 방어  MCP의  빠른  채택은  보안  우려를  키웠다. MCP  Safety  Audit  (Radosevic"
+        },
+        {
+          "rank": 4,
+          "score": 0.6793,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "채택,  이후  Google  DeepMind·Microsoft·GitHub가  합류. 2025년  12월  Anthropic은  Linux  "
+        },
+        {
+          "rank": 5,
+          "score": 0.6722,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "계, (3) 권한 최소화(read-only  우선), (4) 정기적 도구 정의 변경 감사. James의 자메스 시스템처럼 \"rag_search만"
+        },
+        {
+          "rank": 6,
+          "score": 0.6516,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "# 파일: 03_Tool_Use___Function_Calling.pdf  PART 03 / 10  Tool Use / Function Call"
+        },
+        {
+          "rank": 7,
+          "score": 0.6362,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "Language Models. ICLR.  2. Yang, J. et al. (2024). SWE-agent: Agent-Computer Int"
+        },
+        {
+          "rank": 8,
+          "score": 0.6342,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "ontinue, Cline 등 주요 코딩 에이전트는 모두 함수 호출을 핵심 골격으로 한다. 파일  읽기/쓰기, bash 실행, 웹 검색 등이 모"
+        },
+        {
+          "rank": 9,
+          "score": 0.6333,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "# 파일: 02_컨텍스트_엔지니어링.pdf  PART 02 / 10  컨텍스트 엔지니어링  Context Engineering & Window "
+        },
+        {
+          "rank": 10,
+          "score": 0.6317,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "HTTP(원격). 후자가 SaaS 벤더의 공개 MCP 서버  배포를 가능하게 했다.  3. 2025-11-25 스펙과 채택 규모  2025년 1"
+        },
+        {
+          "rank": 11,
+          "score": 0.6302,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "사전 적재가 아닌 도구 기반 JIT 조회를 우선  참고문헌 (References)  1. Anthropic Engineering (2025). "
+        },
+        {
+          "rank": 12,
+          "score": 0.6271,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "# 파일: 06_STRC모델_ETF10배매입.txt  =================================================="
+        },
+        {
+          "rank": 13,
+          "score": 0.6257,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "rboard  (Patil  et  al.,  ICML  2025)는  사실상  표준이다. 2,000여  개의  question-function"
+        },
+        {
+          "rank": 14,
+          "score": 0.6246,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "모델조차  저장소  단위  코드  생성에서  Pass@1  40%를 넘지 못함을 보고한다. 검색 정확도가 곧 생성 품질로 직결되지 않는 점, 다"
+        },
+        {
+          "rank": 15,
+          "score": 0.6241,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "사결정 · 멀티 턴 일관성에서 여전히 낮은 정확도  참고문헌 (References)  1. Patil, S. G. et al. (2025). T"
+        },
+        {
+          "rank": 16,
+          "score": 0.6212,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "제안한 패러다임으로, LLM의 파라미터 지식 한계를 외부 지식 베이스  조회로  보완한다. 코드  영역에서  RAG이  특히  중요한  이유는 "
+        },
+        {
+          "rank": 17,
+          "score": 0.6189,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "사이클  Thought → Action → Observation → Thought ... (ReAct, ICLR 2023)  핵심 개념  ACI"
+        },
+        {
+          "rank": 18,
+          "score": 0.6173,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "# 파일: 01_RAG_(검색_증강_생성).pdf  PART 01 / 10  RAG (검색 증강 생성)  Retrieval-Augmented G"
+        },
+        {
+          "rank": 19,
+          "score": 0.6163,
+          "source": "09_코딩_특화_프롬프트_엔지니어링.pdf",
+          "text_preview": "# 파일: 09_코딩_특화_프롬프트_엔지니어링.pdf  PART 09 / 10  코딩 특화 프롬프트 엔지니어링  Prompt Engineerin"
+        },
+        {
+          "rank": 20,
+          "score": 0.614,
+          "source": "web_coding_GRAPH 추론 다양한 알고리즘과 원_1779094615.md",
+          "text_preview": "그래프 알고리즘은 서로 연결된 개체 간의 관계를 분석하는 데 사용되며, 트리 자료구조는 그래프의 한 종류입니다. DFS/BFS, 최단 경로 알고"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "variations_count": 4,
+    "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+    "top_k": 20,
+    "variations_hit": 1,
+    "best_rank": 1,
+    "ranks_by_label": {
+      "ko_q15_exact": null,
+      "en_translation": null,
+      "name_only": null,
+      "concept_side": 1
+    }
+  }
+}

--- a/reports/research-runs/q15-chroma-probe-20260527_173530.json
+++ b/reports/research-runs/q15-chroma-probe-20260527_173530.json
@@ -1,0 +1,550 @@
+{
+  "generated_at": "2026-05-27T17:35:30.063068",
+  "variations": [
+    {
+      "label": "ko_q15_exact",
+      "query": "David Soria Parra가 누구야?",
+      "top_k": 20,
+      "elapsed": 0.195,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6092,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5933,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 3,
+          "score": 0.591,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 4,
+          "score": 0.5907,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 5,
+          "score": 0.5896,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [Log In](/accounts/login/?next=%2Fp%2FDUSMLzQj8rU&sourc"
+        },
+        {
+          "rank": 6,
+          "score": 0.5878,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": ")  대외활동/GDG on Campus (GDSC)  ## 엔비디아(NVIDIA) 기업 소개 & AI 황제 ‘젠슨 황’의 탄생 이야기 - 마음 "
+        },
+        {
+          "rank": 7,
+          "score": 0.5868,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 8,
+          "score": 0.5868,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 9,
+          "score": 0.5859,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 10,
+          "score": 0.5859,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| 연혁 요약 - 3 -  4. 투자·M&A·재무 이벤트 4.1 주요 자본 이벤트 | 연도      | 분류   |                "
+        },
+        {
+          "rank": 11,
+          "score": 0.5851,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 12,
+          "score": 0.5851,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 13,
+          "score": 0.585,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 14,
+          "score": 0.5837,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        },
+        {
+          "rank": 15,
+          "score": 0.5834,
+          "source": "PLTR_01_Q1_2026_실적분석.pdf",
+          "text_preview": "85%  성장은  Palantir  상장(2020)  이후  최고  YoY  증가율. CEO  Alex  Karp는  \"NVIDIA·Micron"
+        },
+        {
+          "rank": 16,
+          "score": 0.5832,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 17,
+          "score": 0.5823,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 18,
+          "score": 0.5819,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "기준: 2026년 5월 Musk Ecosystem | 연혁 요약 - 1 -  Part 1. xAI xAI는 2023년 3월 9일 일론 머스크가 "
+        },
+        {
+          "rank": 19,
+          "score": 0.5811,
+          "source": "PLTR_02_AIP_국방계약_분석.pdf",
+          "text_preview": "# 파일: PLTR_02_AIP_국방계약_분석.pdf  PALANTIR 분석 02 / 03  AIP 플랫폼과 국방 계약 심층 분석  Maven "
+        },
+        {
+          "rank": 20,
+          "score": 0.5804,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "en_translation",
+      "query": "Who is David Soria Parra?",
+      "top_k": 20,
+      "elapsed": 0.081,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6084,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5908,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 3,
+          "score": 0.5884,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 4,
+          "score": 0.5878,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 5,
+          "score": 0.5857,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [Log In](/accounts/login/?next=%2Fp%2FDUSMLzQj8rU&sourc"
+        },
+        {
+          "rank": 6,
+          "score": 0.5845,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 7,
+          "score": 0.5833,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 8,
+          "score": 0.5831,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 9,
+          "score": 0.5829,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| 연혁 요약 - 3 -  4. 투자·M&A·재무 이벤트 4.1 주요 자본 이벤트 | 연도      | 분류   |                "
+        },
+        {
+          "rank": 10,
+          "score": 0.5823,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": ")  대외활동/GDG on Campus (GDSC)  ## 엔비디아(NVIDIA) 기업 소개 & AI 황제 ‘젠슨 황’의 탄생 이야기 - 마음 "
+        },
+        {
+          "rank": 11,
+          "score": 0.5821,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 12,
+          "score": 0.5817,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 13,
+          "score": 0.5811,
+          "source": "PLTR_01_Q1_2026_실적분석.pdf",
+          "text_preview": "85%  성장은  Palantir  상장(2020)  이후  최고  YoY  증가율. CEO  Alex  Karp는  \"NVIDIA·Micron"
+        },
+        {
+          "rank": 14,
+          "score": 0.581,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 15,
+          "score": 0.5793,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        },
+        {
+          "rank": 16,
+          "score": 0.5792,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 17,
+          "score": 0.5784,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 18,
+          "score": 0.5779,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 19,
+          "score": 0.5776,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "편집 요청  이용중인 IP는 문제가 자주 발생하거나 공공 IP 대역이므로 로그인이 필요합니다.   (이 메세지는 같은 인터넷 공급업체를 사용하는"
+        },
+        {
+          "rank": 20,
+          "score": 0.577,
+          "source": "PLTR_02_AIP_국방계약_분석.pdf",
+          "text_preview": "tion  Epic  Fury)  중  24시간  내  1,000개  표적  처리  보고. Palantir의  실전  AI  능력  검증.  3"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "name_only",
+      "query": "David Soria Parra",
+      "top_k": 20,
+      "elapsed": 0.092,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.5936,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 2,
+          "score": 0.5924,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 3,
+          "score": 0.5912,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 4,
+          "score": 0.5874,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 5,
+          "score": 0.5863,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 6,
+          "score": 0.5857,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 7,
+          "score": 0.5845,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 8,
+          "score": 0.583,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 9,
+          "score": 0.5821,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 10,
+          "score": 0.5813,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "프로젝트 선정(2026년 3월): 뉴욕/뉴저지, 텍사스, 플로리다, 노스캐롤라이나, 유타. 지리적  다각화가 첫 상업 서비스 지역 후보군.  2"
+        },
+        {
+          "rank": 11,
+          "score": 0.5811,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 12,
+          "score": 0.581,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 13,
+          "score": 0.5805,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "투자      |        | | 2018~2019  | Funding  | Series J·K $1.2B+ — Starlink 본격 투자 "
+        },
+        {
+          "rank": 14,
+          "score": 0.5802,
+          "source": "web_business_AMD  대해 설명_1778634167.md",
+          "text_preview": "B0%98%EB%8F%84%EC%B2%B4-%EC%8B%9C%EB%8C%80%EC%9D%98-%ED%95%B5%EC%8B%AC-%ED%94%8C"
+        },
+        {
+          "rank": 15,
+          "score": 0.58,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 16,
+          "score": 0.5798,
+          "source": "JOBY_03_실적전망_투자리스크분석.pdf",
+          "text_preview": "클로징), 2차 트랜치 협의 중  OEM 잠재 매출  $10억 이상 예약 주문 공시  3. 두 가지 시나리오  시나리오 A (강세): 2026년"
+        },
+        {
+          "rank": 17,
+          "score": 0.5797,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 18,
+          "score": 0.5795,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "on-stock-rises/"
+        },
+        {
+          "rank": 19,
+          "score": 0.5793,
+          "source": "TSLA_02_Robotaxi_FSD_분석.pdf",
+          "text_preview": "# 파일: TSLA_02_Robotaxi_FSD_분석.pdf  TESLA 분석 02 / 03  Robotaxi·FSD 상용화 심층 분석  Cyb"
+        },
+        {
+          "rank": 20,
+          "score": 0.5789,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "concept_side",
+      "query": "MCP Model Context Protocol",
+      "top_k": 20,
+      "elapsed": 0.081,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": 1,
+      "target_score": 0.7576,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.7576,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "# 파일: 08_MCP_(Model_Context_Protocol).pdf  PART 08 / 10  MCP (Model Context Prot"
+        },
+        {
+          "rank": 2,
+          "score": 0.7516,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "·확인 단계 필수  참고문헌 (References)  1. Anthropic (2024). Introducing the Model Context"
+        },
+        {
+          "rank": 3,
+          "score": 0.6865,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "HTTP(원격). 후자가 SaaS 벤더의 공개 MCP 서버  배포를 가능하게 했다.  3. 2025-11-25 스펙과 채택 규모  2025년 1"
+        },
+        {
+          "rank": 4,
+          "score": 0.6791,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "채택,  이후  Google  DeepMind·Microsoft·GitHub가  합류. 2025년  12월  Anthropic은  Linux  "
+        },
+        {
+          "rank": 5,
+          "score": 0.6757,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "넘어선다.  4. 보안 위협과 방어  MCP의  빠른  채택은  보안  우려를  키웠다. MCP  Safety  Audit  (Radosevic"
+        },
+        {
+          "rank": 6,
+          "score": 0.6633,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "# 파일: 02_컨텍스트_엔지니어링.pdf  PART 02 / 10  컨텍스트 엔지니어링  Context Engineering & Window "
+        },
+        {
+          "rank": 7,
+          "score": 0.6413,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "사결정 · 멀티 턴 일관성에서 여전히 낮은 정확도  참고문헌 (References)  1. Patil, S. G. et al. (2025). T"
+        },
+        {
+          "rank": 8,
+          "score": 0.6397,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "순한 윈도우 확장만으로 문제가 해결되지 않는다는 점이 학계·실무에서 공통 진단이다.  2. 컨텍스트 부패 (Context Rot)  긴 컨텍스트"
+        },
+        {
+          "rank": 9,
+          "score": 0.6392,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "사전 적재가 아닌 도구 기반 JIT 조회를 우선  참고문헌 (References)  1. Anthropic Engineering (2025). "
+        },
+        {
+          "rank": 10,
+          "score": 0.6353,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "핵심 기술이다.  2. 호출 패턴 분류  Single Call — 한 함수에 한 번 호출. 가장 단순.  Parallel  Call  —  한 "
+        },
+        {
+          "rank": 11,
+          "score": 0.6351,
+          "source": "test_events_dominant.md",
+          "text_preview": "# 파일: test_events_dominant.md"
+        },
+        {
+          "rank": 12,
+          "score": 0.6347,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "기법  압축(Compaction) — 대화가 길어지면 이전 turn들을 요약본으로 대체. Claude Code는 자동 압축 트리거를  둔다.  "
+        },
+        {
+          "rank": 13,
+          "score": 0.6335,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "모델조차  저장소  단위  코드  생성에서  Pass@1  40%를 넘지 못함을 보고한다. 검색 정확도가 곧 생성 품질로 직결되지 않는 점, 다"
+        },
+        {
+          "rank": 14,
+          "score": 0.6325,
+          "source": "엔비디아_대한_설명.md",
+          "text_preview": "er: system relations: [] sensitivity: public source_type: prod sources: - web_엔비"
+        },
+        {
+          "rank": 15,
+          "score": 0.6318,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "ontinue, Cline 등 주요 코딩 에이전트는 모두 함수 호출을 핵심 골격으로 한다. 파일  읽기/쓰기, bash 실행, 웹 검색 등이 모"
+        },
+        {
+          "rank": 16,
+          "score": 0.6313,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "델이 필요할 때 view 도구로 로드한다.  Claude Code의 핵심 메커니즘.  4. 평가와 한계  AI 코딩 도구 핵심 기술 시리즈 · "
+        },
+        {
+          "rank": 17,
+          "score": 0.6296,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "# 파일: 04_Agent_Loop와_ReAct_패턴.pdf  PART 04 / 10  Agent Loop와 ReAct 패턴  Agent Loo"
+        },
+        {
+          "rank": 18,
+          "score": 0.6291,
+          "source": "자메스_코드구조.md",
+          "text_preview": "### core\\reasoning\\evidence_scope.py > Evidence-Scope extractor (LEO proposal — "
+        },
+        {
+          "rank": 19,
+          "score": 0.6275,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 20,
+          "score": 0.627,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "Language Models. ICLR.  2. Yang, J. et al. (2024). SWE-agent: Agent-Computer Int"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "variations_count": 4,
+    "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+    "top_k": 20,
+    "variations_hit": 1,
+    "best_rank": 1,
+    "ranks_by_label": {
+      "ko_q15_exact": null,
+      "en_translation": null,
+      "name_only": null,
+      "concept_side": 1
+    }
+  }
+}

--- a/reports/research-runs/q15-chroma-probe-20260527_181303.json
+++ b/reports/research-runs/q15-chroma-probe-20260527_181303.json
@@ -1,0 +1,550 @@
+{
+  "generated_at": "2026-05-27T18:13:03.925347",
+  "variations": [
+    {
+      "label": "ko_q15_exact",
+      "query": "David Soria Parra가 누구야?",
+      "top_k": 20,
+      "elapsed": 0.035,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6148,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.6061,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5768,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5725,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 5,
+          "score": 0.5717,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 6,
+          "score": 0.5699,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 7,
+          "score": 0.5682,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 8,
+          "score": 0.5603,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 9,
+          "score": 0.5601,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 10,
+          "score": 0.5587,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 11,
+          "score": 0.5583,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 12,
+          "score": 0.5582,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 13,
+          "score": 0.5566,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 14,
+          "score": 0.555,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 15,
+          "score": 0.5548,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        },
+        {
+          "rank": 16,
+          "score": 0.5523,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 17,
+          "score": 0.5522,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 18,
+          "score": 0.5505,
+          "source": "web_business_**경쟁사 대비 AMD 기술적 우위 _1778634469.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [달빛향기 DalHyang](https://likedalhyang.tistory.com/ \"달빛"
+        },
+        {
+          "rank": 19,
+          "score": 0.55,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 20,
+          "score": 0.5495,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "en_translation",
+      "query": "Who is David Soria Parra?",
+      "top_k": 20,
+      "elapsed": 0.012,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6041,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5773,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 3,
+          "score": 0.5733,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 4,
+          "score": 0.5692,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "# 파일: 02_SpaceX_연혁.pdf  Space Exploration Technologies 재사용 로켓에서 화성 식민지 인프라로 설립 2"
+        },
+        {
+          "rank": 5,
+          "score": 0.5612,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 6,
+          "score": 0.5606,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 7,
+          "score": 0.5573,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 8,
+          "score": 0.5548,
+          "source": "web_business_블랙록 대해 설명_1779080304.md",
+          "text_preview": "images/media-bin/web/global/wordmark/blackrock-logo-nav.svg)  # 국가의 성장과 함께하는 여정:"
+        },
+        {
+          "rank": 9,
+          "score": 0.5547,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 10,
+          "score": 0.5466,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 11,
+          "score": 0.5464,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "------------------------------ | --- | Tesla, Inc. |  연혁 요약 - 2 -  3."
+        },
+        {
+          "rank": 12,
+          "score": 0.5463,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "기준: 2026년 5월 Musk Ecosystem | 연혁 요약 - 1 -  Part 1. xAI xAI는 2023년 3월 9일 일론 머스크가 "
+        },
+        {
+          "rank": 13,
+          "score": 0.5462,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 14,
+          "score": 0.5453,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "기법  압축(Compaction) — 대화가 길어지면 이전 turn들을 요약본으로 대체. Claude Code는 자동 압축 트리거를  둔다.  "
+        },
+        {
+          "rank": 15,
+          "score": 0.5452,
+          "source": "web_business_로봇공학 시장 주요 경쟁사 및 비교 _1778717473.md",
+          "text_preview": "orts/robotics-technology-market/6366"
+        },
+        {
+          "rank": 16,
+          "score": 0.5449,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": ".com/article/Global-Biz/2026/01/2026013106345445493bc914ac71_1"
+        },
+        {
+          "rank": 17,
+          "score": 0.544,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        },
+        {
+          "rank": 18,
+          "score": 0.5437,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 19,
+          "score": 0.5422,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 20,
+          "score": 0.5414,
+          "source": "web_security_양자 보안 아키텍처 설계_1779080950.md",
+          "text_preview": "(/content/dam/fortinet/images/general/fortinet-logo.svg) ![](data:image/png;base"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "name_only",
+      "query": "David Soria Parra",
+      "top_k": 20,
+      "elapsed": 0.012,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6662,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 2,
+          "score": 0.6076,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 3,
+          "score": 0.5999,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 4,
+          "score": 0.5873,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 5,
+          "score": 0.5798,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "on-stock-rises/"
+        },
+        {
+          "rank": 6,
+          "score": 0.573,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "내용]   · 4월 30일 FOMC, 기준금리 3.50%~3.75% 동결 (3회 연속). · 반대 4표는 1992년 이래 최다 — 정책 분열 신"
+        },
+        {
+          "rank": 7,
+          "score": 0.5706,
+          "source": "Palantir_2024Q3_실적.pdf",
+          "text_preview": "# 파일: Palantir_2024Q3_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 8,
+          "score": 0.569,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| | ------- | --- | --------------------------------------------- | --- | Tesla,"
+        },
+        {
+          "rank": 9,
+          "score": 0.5688,
+          "source": "08_13F공시시즌_기관매집공개.txt",
+          "text_preview": "ub-advisory     아닌 직접 전략 배분이라는 점에서 더 강한 시그널.  [출처] CoinDesk, FinanceFeeds, Yello"
+        },
+        {
+          "rank": 10,
+          "score": 0.5679,
+          "source": "Palantir_2025Q1_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q1_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 11,
+          "score": 0.5676,
+          "source": "Palantir_2025Q2_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q2_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 12,
+          "score": 0.5661,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 13,
+          "score": 0.5658,
+          "source": "type_certificate_tc__획득하기_위한_세.md",
+          "text_preview": "110.121.pdf"
+        },
+        {
+          "rank": 14,
+          "score": 0.5657,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "# 파일: Palantir_2025Q4_실적.pdf  PALANTIR TECHNOLOGIES (NASDAQ: PLTR) — 분기 실적 보고 Pa"
+        },
+        {
+          "rank": 15,
+          "score": 0.5655,
+          "source": "web_science_Wi-Fi와 블루투스 결합한 하브리드_1778721167.md",
+          "text_preview": "- https://m.blog.naver.com/rohdeschwarzkorea/223609887960 - https://www.techflow"
+        },
+        {
+          "rank": 16,
+          "score": 0.5648,
+          "source": "web_science_블루투스 위치 기능 등 상품 용하 방_1778720074.md",
+          "text_preview": "inf.pstatic.net/MjAyMjA4MjRfMjgy/MDAxNjYxMzE0NDEyMDQ4.PAf9n836VjbXM8uvl_PMMb94my"
+        },
+        {
+          "rank": 17,
+          "score": 0.5645,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 18,
+          "score": 0.5637,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "# 파일: 03_Musk_관련기업_연혁.pdf  Musk Ecosystem xAI · Neuralink · The Boring Company x"
+        },
+        {
+          "rank": 19,
+          "score": 0.5631,
+          "source": "web_coding_**기술적 원리 심화:** 통합 칩 _1778634839.md",
+          "text_preview": "ttps://www.techflowpost.com/ko-KR/column/4059"
+        },
+        {
+          "rank": 20,
+          "score": 0.5629,
+          "source": "07_FOMC동결_Warsh후임임박.txt",
+          "text_preview": "# 파일: 07_FOMC동결_Warsh후임임박.txt  ================================================="
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "concept_side",
+      "query": "MCP Model Context Protocol",
+      "top_k": 20,
+      "elapsed": 0.011,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": 1,
+      "target_score": 0.8462,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.8462,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "# 파일: 08_MCP_(Model_Context_Protocol).pdf  PART 08 / 10  MCP (Model Context Prot"
+        },
+        {
+          "rank": 2,
+          "score": 0.7807,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "·확인 단계 필수  참고문헌 (References)  1. Anthropic (2024). Introducing the Model Context"
+        },
+        {
+          "rank": 3,
+          "score": 0.6925,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "넘어선다.  4. 보안 위협과 방어  MCP의  빠른  채택은  보안  우려를  키웠다. MCP  Safety  Audit  (Radosevic"
+        },
+        {
+          "rank": 4,
+          "score": 0.6793,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "채택,  이후  Google  DeepMind·Microsoft·GitHub가  합류. 2025년  12월  Anthropic은  Linux  "
+        },
+        {
+          "rank": 5,
+          "score": 0.6722,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "계, (3) 권한 최소화(read-only  우선), (4) 정기적 도구 정의 변경 감사. James의 자메스 시스템처럼 \"rag_search만"
+        },
+        {
+          "rank": 6,
+          "score": 0.6516,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "# 파일: 03_Tool_Use___Function_Calling.pdf  PART 03 / 10  Tool Use / Function Call"
+        },
+        {
+          "rank": 7,
+          "score": 0.6362,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "Language Models. ICLR.  2. Yang, J. et al. (2024). SWE-agent: Agent-Computer Int"
+        },
+        {
+          "rank": 8,
+          "score": 0.6342,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "ontinue, Cline 등 주요 코딩 에이전트는 모두 함수 호출을 핵심 골격으로 한다. 파일  읽기/쓰기, bash 실행, 웹 검색 등이 모"
+        },
+        {
+          "rank": 9,
+          "score": 0.6333,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "# 파일: 02_컨텍스트_엔지니어링.pdf  PART 02 / 10  컨텍스트 엔지니어링  Context Engineering & Window "
+        },
+        {
+          "rank": 10,
+          "score": 0.6317,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "HTTP(원격). 후자가 SaaS 벤더의 공개 MCP 서버  배포를 가능하게 했다.  3. 2025-11-25 스펙과 채택 규모  2025년 1"
+        },
+        {
+          "rank": 11,
+          "score": 0.6302,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "사전 적재가 아닌 도구 기반 JIT 조회를 우선  참고문헌 (References)  1. Anthropic Engineering (2025). "
+        },
+        {
+          "rank": 12,
+          "score": 0.6271,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "# 파일: 06_STRC모델_ETF10배매입.txt  =================================================="
+        },
+        {
+          "rank": 13,
+          "score": 0.6257,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "rboard  (Patil  et  al.,  ICML  2025)는  사실상  표준이다. 2,000여  개의  question-function"
+        },
+        {
+          "rank": 14,
+          "score": 0.6246,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "모델조차  저장소  단위  코드  생성에서  Pass@1  40%를 넘지 못함을 보고한다. 검색 정확도가 곧 생성 품질로 직결되지 않는 점, 다"
+        },
+        {
+          "rank": 15,
+          "score": 0.6241,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "사결정 · 멀티 턴 일관성에서 여전히 낮은 정확도  참고문헌 (References)  1. Patil, S. G. et al. (2025). T"
+        },
+        {
+          "rank": 16,
+          "score": 0.6212,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "제안한 패러다임으로, LLM의 파라미터 지식 한계를 외부 지식 베이스  조회로  보완한다. 코드  영역에서  RAG이  특히  중요한  이유는 "
+        },
+        {
+          "rank": 17,
+          "score": 0.6189,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "사이클  Thought → Action → Observation → Thought ... (ReAct, ICLR 2023)  핵심 개념  ACI"
+        },
+        {
+          "rank": 18,
+          "score": 0.6173,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "# 파일: 01_RAG_(검색_증강_생성).pdf  PART 01 / 10  RAG (검색 증강 생성)  Retrieval-Augmented G"
+        },
+        {
+          "rank": 19,
+          "score": 0.6163,
+          "source": "09_코딩_특화_프롬프트_엔지니어링.pdf",
+          "text_preview": "# 파일: 09_코딩_특화_프롬프트_엔지니어링.pdf  PART 09 / 10  코딩 특화 프롬프트 엔지니어링  Prompt Engineerin"
+        },
+        {
+          "rank": 20,
+          "score": 0.614,
+          "source": "web_coding_GRAPH 추론 다양한 알고리즘과 원_1779094615.md",
+          "text_preview": "그래프 알고리즘은 서로 연결된 개체 간의 관계를 분석하는 데 사용되며, 트리 자료구조는 그래프의 한 종류입니다. DFS/BFS, 최단 경로 알고"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "variations_count": 4,
+    "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+    "top_k": 20,
+    "variations_hit": 1,
+    "best_rank": 1,
+    "ranks_by_label": {
+      "ko_q15_exact": null,
+      "en_translation": null,
+      "name_only": null,
+      "concept_side": 1
+    }
+  }
+}

--- a/reports/research-runs/q15-chroma-probe-20260527_182105.json
+++ b/reports/research-runs/q15-chroma-probe-20260527_182105.json
@@ -1,0 +1,550 @@
+{
+  "generated_at": "2026-05-27T18:21:05.227406",
+  "variations": [
+    {
+      "label": "ko_q15_exact",
+      "query": "David Soria Parra가 누구야?",
+      "top_k": 20,
+      "elapsed": 0.231,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6092,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5933,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 3,
+          "score": 0.591,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 4,
+          "score": 0.5907,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 5,
+          "score": 0.5896,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [Log In](/accounts/login/?next=%2Fp%2FDUSMLzQj8rU&sourc"
+        },
+        {
+          "rank": 6,
+          "score": 0.5892,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "STRC가 par 유지 = Strategy의 자금 조달 엔진 가동 = BTC 추가 매입. · STRC가 par 이탈 = 자금 조달 일시 중단 ="
+        },
+        {
+          "rank": 7,
+          "score": 0.5878,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": ")  대외활동/GDG on Campus (GDSC)  ## 엔비디아(NVIDIA) 기업 소개 & AI 황제 ‘젠슨 황’의 탄생 이야기 - 마음 "
+        },
+        {
+          "rank": 8,
+          "score": 0.5868,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 9,
+          "score": 0.5868,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 10,
+          "score": 0.5859,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 11,
+          "score": 0.5859,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| 연혁 요약 - 3 -  4. 투자·M&A·재무 이벤트 4.1 주요 자본 이벤트 | 연도      | 분류   |                "
+        },
+        {
+          "rank": 12,
+          "score": 0.5851,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 13,
+          "score": 0.5851,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 14,
+          "score": 0.585,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 15,
+          "score": 0.5837,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        },
+        {
+          "rank": 16,
+          "score": 0.5834,
+          "source": "PLTR_01_Q1_2026_실적분석.pdf",
+          "text_preview": "85%  성장은  Palantir  상장(2020)  이후  최고  YoY  증가율. CEO  Alex  Karp는  \"NVIDIA·Micron"
+        },
+        {
+          "rank": 17,
+          "score": 0.5832,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 18,
+          "score": 0.5823,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 19,
+          "score": 0.5819,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "기준: 2026년 5월 Musk Ecosystem | 연혁 요약 - 1 -  Part 1. xAI xAI는 2023년 3월 9일 일론 머스크가 "
+        },
+        {
+          "rank": 20,
+          "score": 0.5811,
+          "source": "PLTR_02_AIP_국방계약_분석.pdf",
+          "text_preview": "# 파일: PLTR_02_AIP_국방계약_분석.pdf  PALANTIR 분석 02 / 03  AIP 플랫폼과 국방 계약 심층 분석  Maven "
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "en_translation",
+      "query": "Who is David Soria Parra?",
+      "top_k": 20,
+      "elapsed": 0.086,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.6084,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "/wikipedia-tagline-en-25.svg)  ## Contents  # Dario Amodei  | Dario Amodei | | |"
+        },
+        {
+          "rank": 2,
+          "score": 0.5908,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 3,
+          "score": 0.5884,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 4,
+          "score": 0.5878,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 5,
+          "score": 0.5873,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "STRC가 par 유지 = Strategy의 자금 조달 엔진 가동 = BTC 추가 매입. · STRC가 par 이탈 = 자금 조달 일시 중단 ="
+        },
+        {
+          "rank": 6,
+          "score": 0.5857,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [Log In](/accounts/login/?next=%2Fp%2FDUSMLzQj8rU&sourc"
+        },
+        {
+          "rank": 7,
+          "score": 0.5845,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 8,
+          "score": 0.5833,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 9,
+          "score": 0.5831,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 10,
+          "score": 0.5829,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "| 연혁 요약 - 3 -  4. 투자·M&A·재무 이벤트 4.1 주요 자본 이벤트 | 연도      | 분류   |                "
+        },
+        {
+          "rank": 11,
+          "score": 0.5823,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": ")  대외활동/GDG on Campus (GDSC)  ## 엔비디아(NVIDIA) 기업 소개 & AI 황제 ‘젠슨 황’의 탄생 이야기 - 마음 "
+        },
+        {
+          "rank": 12,
+          "score": 0.5821,
+          "source": "Palantir_2025Q4_실적.pdf",
+          "text_preview": "75 |     |       |        | —   |       | —   | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 13,
+          "score": 0.5817,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 14,
+          "score": 0.5811,
+          "source": "PLTR_01_Q1_2026_실적분석.pdf",
+          "text_preview": "85%  성장은  Palantir  상장(2020)  이후  최고  YoY  증가율. CEO  Alex  Karp는  \"NVIDIA·Micron"
+        },
+        {
+          "rank": 15,
+          "score": 0.581,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 16,
+          "score": 0.5793,
+          "source": "VANCE_02_2028_대선전략_분석.pdf",
+          "text_preview": "# 파일: VANCE_02_2028_대선전략_분석.pdf  VANCE 뉴스 02 / 02  2028 대선 포지셔닝과 정치적 도전  GOP 지지율"
+        },
+        {
+          "rank": 17,
+          "score": 0.5792,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 18,
+          "score": 0.5784,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 19,
+          "score": 0.5779,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "# 파일: 01_Tesla_연혁.pdf  TESLA, Inc. 전기차에서 AI·로봇 기업으로 설립 2003년 7월 1일 (Martin Eberh"
+        },
+        {
+          "rank": 20,
+          "score": 0.5776,
+          "source": "web_business_캐빈워시 누구?_1779524333.md",
+          "text_preview": "편집 요청  이용중인 IP는 문제가 자주 발생하거나 공공 IP 대역이므로 로그인이 필요합니다.   (이 메세지는 같은 인터넷 공급업체를 사용하는"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "name_only",
+      "query": "David Soria Parra",
+      "top_k": 20,
+      "elapsed": 0.09,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": null,
+      "target_score": null,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.5936,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "e' 실시간 뇌신호 데모         |        | | 2021    | 데모  | 원숭이 'Pager' Pong 게임 마인드컨트롤 영상"
+        },
+        {
+          "rank": 2,
+          "score": 0.5924,
+          "source": "엔비디아_대해_묻고_있데_.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 3,
+          "score": 0.5912,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "|     | 5."
+        },
+        {
+          "rank": 4,
+          "score": 0.5874,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "에어택시  네트워크 론칭은 2026년 예정.  사우디아라비아 에어택시 서비스 계획도 발표. 미국·UAE·일본·영국·한국·사우디 → 6개국 시장 "
+        },
+        {
+          "rank": 5,
+          "score": 0.5863,
+          "source": "web_science_Anthropic  본사 어디고 CE_1779083987.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 [최근 변경](/RecentChanges)[최근 토론](/RecentDiscuss)  [특수 기능]"
+        },
+        {
+          "rank": 6,
+          "score": 0.5857,
+          "source": "web_science_us army  GPS 활용한 기술 _1778721531.md",
+          "text_preview": "tem"
+        },
+        {
+          "rank": 7,
+          "score": 0.5857,
+          "source": "06_STRC모델_ETF10배매입.txt",
+          "text_preview": "STRC가 par 유지 = Strategy의 자금 조달 엔진 가동 = BTC 추가 매입. · STRC가 par 이탈 = 자금 조달 일시 중단 ="
+        },
+        {
+          "rank": 8,
+          "score": 0.5845,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "[Gemma 응답 없음]  ### 주요 내용 # [Premium Contents](/)  ## [미국주식 연구센터](/globalstocks/g"
+        },
+        {
+          "rank": 9,
+          "score": 0.583,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "S-1 SEC 제출 — 역대 최대 IPO 후보 (Saudi Aramco 비교) |        | | 2026       | 구조변경     |"
+        },
+        {
+          "rank": 10,
+          "score": 0.5821,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "– 차세대 자율비행의 신호탄**  2025년 10월 28일(미국 시간) 조비 에비에이션(Joby Aviation)은 미국 산타크루즈 본사에서 엔"
+        },
+        {
+          "rank": 11,
+          "score": 0.5813,
+          "source": "JOBY_02_NYC_시범비행_상용화전략.pdf",
+          "text_preview": "프로젝트 선정(2026년 3월): 뉴욕/뉴저지, 텍사스, 플로리다, 노스캐롤라이나, 유타. 지리적  다각화가 첫 상업 서비스 지역 후보군.  2"
+        },
+        {
+          "rank": 12,
+          "score": 0.5811,
+          "source": "Palantir_2024Q4_실적.pdf",
+          "text_preview": "00B |       |     | 1.77조원 |     | +30% |     | 5. 경영진 코멘트 (Alex Karp, CEO) CEO "
+        },
+        {
+          "rank": 13,
+          "score": 0.581,
+          "source": "엔비디아와_조비와_관계.md",
+          "text_preview": "--- aliases: - 엔비디아와 조비와 관계 attributes:   learn_method: web_search   learned_at:"
+        },
+        {
+          "rank": 14,
+          "score": 0.5805,
+          "source": "02_SpaceX_연혁.pdf",
+          "text_preview": "투자      |        | | 2018~2019  | Funding  | Series J·K $1.2B+ — Starlink 본격 투자 "
+        },
+        {
+          "rank": 15,
+          "score": 0.5802,
+          "source": "web_business_AMD  대해 설명_1778634167.md",
+          "text_preview": "B0%98%EB%8F%84%EC%B2%B4-%EC%8B%9C%EB%8C%80%EC%9D%98-%ED%95%B5%EC%8B%AC-%ED%94%8C"
+        },
+        {
+          "rank": 16,
+          "score": 0.58,
+          "source": "01_Tesla_연혁.pdf",
+          "text_preview": "rd 승인 (12단계 마일스톤)               |        | | 2019 | 글로벌    | 상하이 Gigafactory 완공 "
+        },
+        {
+          "rank": 17,
+          "score": 0.5798,
+          "source": "JOBY_03_실적전망_투자리스크분석.pdf",
+          "text_preview": "클로징), 2차 트랜치 협의 중  OEM 잠재 매출  $10억 이상 예약 주문 공시  3. 두 가지 시나리오  시나리오 A (강세): 2026년"
+        },
+        {
+          "rank": 18,
+          "score": 0.5797,
+          "source": "03_Musk_관련기업_연혁.pdf",
+          "text_preview": "착 회사다. 사용자가 자율주행 Tesla 차량에 탑승해 지하 Loop을 이동하는 방식이다. 2021년 라스베이거스 컨벤션 센터(LVCC) Loo"
+        },
+        {
+          "rank": 19,
+          "score": 0.5795,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "on-stock-rises/"
+        },
+        {
+          "rank": 20,
+          "score": 0.5793,
+          "source": "TSLA_02_Robotaxi_FSD_분석.pdf",
+          "text_preview": "# 파일: TSLA_02_Robotaxi_FSD_분석.pdf  TESLA 분석 02 / 03  Robotaxi·FSD 상용화 심층 분석  Cyb"
+        }
+      ],
+      "error": null
+    },
+    {
+      "label": "concept_side",
+      "query": "MCP Model Context Protocol",
+      "top_k": 20,
+      "elapsed": 0.102,
+      "results_count": 20,
+      "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+      "target_rank": 1,
+      "target_score": 0.7576,
+      "top_preview": [
+        {
+          "rank": 1,
+          "score": 0.7576,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "# 파일: 08_MCP_(Model_Context_Protocol).pdf  PART 08 / 10  MCP (Model Context Prot"
+        },
+        {
+          "rank": 2,
+          "score": 0.7516,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "·확인 단계 필수  참고문헌 (References)  1. Anthropic (2024). Introducing the Model Context"
+        },
+        {
+          "rank": 3,
+          "score": 0.6865,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "HTTP(원격). 후자가 SaaS 벤더의 공개 MCP 서버  배포를 가능하게 했다.  3. 2025-11-25 스펙과 채택 규모  2025년 1"
+        },
+        {
+          "rank": 4,
+          "score": 0.6791,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "채택,  이후  Google  DeepMind·Microsoft·GitHub가  합류. 2025년  12월  Anthropic은  Linux  "
+        },
+        {
+          "rank": 5,
+          "score": 0.6757,
+          "source": "08_MCP_(Model_Context_Protocol).pdf",
+          "text_preview": "넘어선다.  4. 보안 위협과 방어  MCP의  빠른  채택은  보안  우려를  키웠다. MCP  Safety  Audit  (Radosevic"
+        },
+        {
+          "rank": 6,
+          "score": 0.6633,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "# 파일: 02_컨텍스트_엔지니어링.pdf  PART 02 / 10  컨텍스트 엔지니어링  Context Engineering & Window "
+        },
+        {
+          "rank": 7,
+          "score": 0.6413,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "사결정 · 멀티 턴 일관성에서 여전히 낮은 정확도  참고문헌 (References)  1. Patil, S. G. et al. (2025). T"
+        },
+        {
+          "rank": 8,
+          "score": 0.6397,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "순한 윈도우 확장만으로 문제가 해결되지 않는다는 점이 학계·실무에서 공통 진단이다.  2. 컨텍스트 부패 (Context Rot)  긴 컨텍스트"
+        },
+        {
+          "rank": 9,
+          "score": 0.6392,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "사전 적재가 아닌 도구 기반 JIT 조회를 우선  참고문헌 (References)  1. Anthropic Engineering (2025). "
+        },
+        {
+          "rank": 10,
+          "score": 0.6353,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "핵심 기술이다.  2. 호출 패턴 분류  Single Call — 한 함수에 한 번 호출. 가장 단순.  Parallel  Call  —  한 "
+        },
+        {
+          "rank": 11,
+          "score": 0.6351,
+          "source": "test_events_dominant.md",
+          "text_preview": "# 파일: test_events_dominant.md"
+        },
+        {
+          "rank": 12,
+          "score": 0.6347,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "기법  압축(Compaction) — 대화가 길어지면 이전 turn들을 요약본으로 대체. Claude Code는 자동 압축 트리거를  둔다.  "
+        },
+        {
+          "rank": 13,
+          "score": 0.6335,
+          "source": "01_RAG_(검색_증강_생성).pdf",
+          "text_preview": "모델조차  저장소  단위  코드  생성에서  Pass@1  40%를 넘지 못함을 보고한다. 검색 정확도가 곧 생성 품질로 직결되지 않는 점, 다"
+        },
+        {
+          "rank": 14,
+          "score": 0.6325,
+          "source": "엔비디아_대한_설명.md",
+          "text_preview": "er: system relations: [] sensitivity: public source_type: prod sources: - web_엔비"
+        },
+        {
+          "rank": 15,
+          "score": 0.6318,
+          "source": "03_Tool_Use___Function_Calling.pdf",
+          "text_preview": "ontinue, Cline 등 주요 코딩 에이전트는 모두 함수 호출을 핵심 골격으로 한다. 파일  읽기/쓰기, bash 실행, 웹 검색 등이 모"
+        },
+        {
+          "rank": 16,
+          "score": 0.6313,
+          "source": "02_컨텍스트_엔지니어링.pdf",
+          "text_preview": "델이 필요할 때 view 도구로 로드한다.  Claude Code의 핵심 메커니즘.  4. 평가와 한계  AI 코딩 도구 핵심 기술 시리즈 · "
+        },
+        {
+          "rank": 17,
+          "score": 0.6296,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "# 파일: 04_Agent_Loop와_ReAct_패턴.pdf  PART 04 / 10  Agent Loop와 ReAct 패턴  Agent Loo"
+        },
+        {
+          "rank": 18,
+          "score": 0.6291,
+          "source": "자메스_코드구조.md",
+          "text_preview": "### core\\reasoning\\evidence_scope.py > Evidence-Scope extractor (LEO proposal — "
+        },
+        {
+          "rank": 19,
+          "score": 0.6275,
+          "source": "엔비디아와_조비와_관계_조사해봐.md",
+          "text_preview": "251110035226.png)  단박제보  | 제목 | 작성자 | 날짜 | 결과 | | --- | --- | --- | --- | | 증권 |"
+        },
+        {
+          "rank": 20,
+          "score": 0.627,
+          "source": "04_Agent_Loop와_ReAct_패턴.pdf",
+          "text_preview": "Language Models. ICLR.  2. Yang, J. et al. (2024). SWE-agent: Agent-Computer Int"
+        }
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "variations_count": 4,
+    "target_pdf": "08_MCP_(Model_Context_Protocol).pdf",
+    "top_k": 20,
+    "variations_hit": 1,
+    "best_rank": 1,
+    "ranks_by_label": {
+      "ko_q15_exact": null,
+      "en_translation": null,
+      "name_only": null,
+      "concept_side": 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Operator ran the BL-9 prep workflow (PR #534): migration runner re-embedded 358 chunks into `chroma_db_bge_m3/`, `.env` persisted `JAMES_EMBEDDING_MODEL=BAAI/bge-m3`. F7 chroma probe re-run + post-swap diagnostic with 5 query variations.

**Verdict: swap is active, q15 acceptance gate STILL fails, F7's embedding-root attribution was half-right.** The fix moves up one layer to query expansion. F9 spawned.

## What landed

- `reports/promo-assets/v3prime-leo-evidence-scope-result.md` — new "BL-9 acceptance run" section with swap-active confirmation, acceptance gate result, root cause reattribution, and F9 (query rewriter audit) spawn pointer.
- `reports/research-runs/q15-chroma-probe-20260527_*.json` × 5 — full probe audit trail: 3 pre-toggle confirmations + 1 post-toggle-but-wrong-session + 1 final post-toggle with bge-m3 confirmed active.

## Swap active confirmation

Scores differ (deterministic encoder ⇒ identical scores would mean same model):

| variation | MiniLM (F7 baseline) | bge-m3 (this run) |
|---|---|---|
| concept_side rank-1 score | 0.8462 | **0.7576** |
| en_translation top-1 score | 0.6041 | 0.6084 |
| name_only top-1 score | 0.6662 | 0.5936 |

`[VECTOR_STORE] ChromaDB 경로: …chroma_db_bge_m3` + `[VECTOR_STORE] 임베딩 모델: BAAI/bge-m3` confirm.

## Acceptance gate result — FAIL on q15 `name_only`

| variation | MCP PDF rank (bge-m3) |
|---|---|
| ko_q15_exact | **NOT in top-20** |
| en_translation | **NOT in top-20** |
| name_only ← acceptance gate | **NOT in top-20** ❌ |
| concept_side | rank 1, score 0.7576 ✅ |

## Root cause reattribution (5-variation probe)

| query | MCP PDF rank |
|---|---|
| `"David Soria Parra"` | **None** |
| `"MCP 설계자 David Soria Parra"` | **rank 1** ✅ |
| `"MCP designer Anthropic Justin Spahr-Summers"` | **rank 1** ✅ |
| `"Anthropic MCP 공개"` (concept only) | **rank 1** ✅ |
| `"David Soria Parra Justin Spahr-Summers JSON-RPC"` | **None** |

bge-m3 (and any 1024-dim multilingual pooling embedding) needs a concept anchor to match. The MCP PDF chunk contains "David Soria Parra와 Justin Spahr-Summers" in ~80 of ~2KB; the chunk vector is dominated by MCP/JSON-RPC/Anthropic concept tokens, so a bare-name query vector is too far from the chunk centroid. e5-large would hit the same wall.

## BL-9 stays — swap is keeping

No regression on queries that already worked (q2/q4 etc.). Rollback is one `.env` line away. The fix for q15 moves to query expansion (F9), not back to MiniLM.

## F9 (NEW) — query rewriter audit on q15

JAMES has `core.retrieval.query_rewriter`. Open question: does it rewrite "David Soria Parra가 누구야?" with a concept anchor? F9 = audit script (same pattern as F2 `intent_classifier_audit.py`) → reports rewritten text + concept-anchor presence per step7 query.

Carried as a separate cycle.

## Updated diagnosis chain (q15 zero-recall — 8 cycles compressed)

| cycle | hypothesis | verdict |
|---|---|---|
| F2 #531 | classifier misroutes | ❌ ruled out |
| F1 #527 | policy gate blocks | ✅ but JWT mitigated; q15 still misses |
| F6 #532 | extraction stochasticity | ❌ 5/5 byte-identical |
| F7 #533 | chroma embedding (MiniLM weakness) | ⚠️ partial — root deeper |
| **BL-9 acceptance (this PR)** | bge-m3 fixes it | ❌ swap active, q15 still misses |
| **post-swap 5-variation probe** | chunk-vs-query concept mismatch | ✅ **ROOT pinned** |
| **F9** (next) | query rewriter adds concept anchor? | ⏭️ to measure |

## Bench numbers (CLAUDE.md rule #2)

No `core/{retrieval,graph,reasoning}` change. Documentation + research-run JSON. Numbers in result-doc + probe JSONs.

## Out of scope

- F9 — query rewriter audit (next cycle)
- step7 v4 full bench re-run under bge-m3 (operator's ON arm in progress at PR open; follow-up commit lands the numbers)
- Chunking strategy revision (Sprint 6 candidate — would let chunks be entity-name-dense in a separate pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)