### PR TITLE
feat(v0.4): Sprint 5 PR-T1.B — expiration cascade + runner (T1 EVENT)

### DIFF
--- a/core/lifecycle/expiration_cascade.py
+++ b/core/lifecycle/expiration_cascade.py
@@ -1,0 +1,435 @@
+"""v0.4 Sprint 5 PR-T1.B — T1 expiration batch.
+
+Walks every wiki entity's frontmatter and marks edges as
+``mutation_type="expired"`` when **all** of their active sources
+have reached ``valid_until``. Sources themselves are not mutated —
+expiration is a *derived* property from ``valid_until`` ≤
+``current_time`` rather than a stored flag, so a rollback /
+re-import path stays trivial.
+
+What this module is NOT
+-----------------------
+
+- **Not a delete.** Deletion is the CASCADE concern (Layer 3
+  ``cascade_remove``). Per entry memo §3 invariant ``T7 EVENT vs
+  CASCADE``, expiration is an EVENT — preserves history, only
+  flips status so the consumer can filter.
+- **Not a confidence recompute.** Downstream
+  ``compute_confidence_from_sources`` extension (entry memo §348)
+  will accept a ``current_time`` parameter so the v0.3 read path
+  stays byte-identical. This module's only mutation surface is
+  ``edge.status`` + ``edge.mutation_type``.
+- **Not a supersede operation.** Supersede chains are PR-T7.A.
+  This module never touches ``status.superseded_by`` —
+  ``mutation_type="expired"`` is exclusive with
+  ``"superseded"``.
+
+What this module IS
+-------------------
+
+Two pure functions + one wiki-walker:
+
+- ``is_source_expired(source, current_time)`` — derived predicate.
+  ``True`` iff ``source["valid_until"]`` is a parseable ISO 8601
+  timestamp ≤ ``current_time``. ``None`` (indefinite validity) is
+  never expired. Malformed values return ``False`` defensively
+  rather than raising — the migration script (PR-T1.A) already
+  ran validators at write-time, so a malformed window here means
+  externally-edited frontmatter that the cascade should not crash
+  on.
+- ``is_edge_immune(edge)`` — opt-out hook. ``edge["manual_immune"]``
+  truthy ⇒ cascade skips this edge. Operator sets this on edges
+  whose expiration should be a manual decision (e.g., curated
+  reference relations). The flag is **edge-level only** — there
+  is no source-level immunity (sources are immutable evidence;
+  immunity is an operator policy on the relation that uses them).
+- ``expiration_cascade(entity_root, current_time, dry_run=True)``
+  — wiki walker. Loads each ``.md`` entity, iterates relations,
+  checks each relation's sources, and when **every** non-already-
+  expired source is expired (or there are no sources at all), marks
+  the edge's ``mutation_type="expired"``, ``status.active=False``.
+  Edges that are already inactive (superseded / invalidated /
+  expired) are left untouched — idempotent.
+
+Idempotency
+-----------
+
+Running the cascade twice on the same wiki + same ``current_time``
+is a no-op the second time: every targeted edge already has
+``status.active=False`` + ``mutation_type="expired"`` and the
+"already inactive" guard skips it.
+
+Atomic per-file write — same tempfile + ``os.replace`` pattern as
+PR-T1.A migration script. Half-written frontmatter on crash is
+not possible.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.lifecycle.schema import (
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_SOURCE_FIELD_VALID_UNTIL,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    apply_v04_edge_defaults,
+    validate_edge_v04_fields,
+)
+
+
+# ─── Frontmatter split / serialize (shared shape with PR-T1.A) ────
+#
+# PR-T1.A migration script has its own ``_split_frontmatter`` /
+# ``_serialize_frontmatter`` helpers. We duplicate the minimal
+# surface here rather than depend on the migration script module so
+# the cascade can live behind a tiny import cost (no operator
+# entry-point coupling). If a third caller needs the same helpers,
+# extract to ``core.lifecycle._frontmatter_io``.
+
+
+_FRONTMATTER_FENCE = "---"
+
+
+def _split_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Return (frontmatter_dict_or_None, body_tail_including_fence)."""
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
+        return None, text
+    end_idx = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == _FRONTMATTER_FENCE:
+            end_idx = i
+            break
+    if end_idx is None:
+        return None, text
+    fm_text = "".join(lines[1:end_idx])
+    body_tail = "".join(lines[end_idx:])
+    try:
+        fm = yaml.safe_load(fm_text)
+        if not isinstance(fm, dict):
+            return None, text
+        return fm, body_tail
+    except yaml.YAMLError:
+        return None, text
+
+
+def _serialize_frontmatter(fm: dict, body_tail: str) -> str:
+    """Same YAML defaults as PR-T1.A — preserve key order, allow
+    unicode (Korean entity names), no flow style."""
+    fm_text = yaml.safe_dump(
+        fm,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    if not fm_text.endswith("\n"):
+        fm_text += "\n"
+    return f"{_FRONTMATTER_FENCE}\n{fm_text}{body_tail}"
+
+
+# ─── Pure predicates ───────────────────────────────────────────────
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Best-effort ISO 8601 parse. Returns ``None`` for malformed /
+    non-string / ``None`` input — the cascade treats unparseable
+    timestamps as "indefinite" rather than raising, so externally
+    edited frontmatter can't halt the batch."""
+    if value is None or not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    # ensure timezone-aware UTC for comparison against current_time
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def is_source_expired(source: dict, current_time: datetime) -> bool:
+    """Derived predicate — source is expired iff its ``valid_until``
+    is set and ≤ ``current_time``.
+
+    Properties:
+      - ``valid_until is None``    → never expired (indefinite)
+      - ``valid_until > now``      → not yet expired
+      - ``valid_until == now``     → expired (boundary inclusive —
+                                     matches the "≤" in the entry
+                                     memo §4 spec)
+      - ``valid_until < now``      → expired
+      - malformed ``valid_until``  → treated as ``None`` (defensive)
+
+    ``current_time`` must be timezone-aware. Tests freeze the clock
+    via ``monkeypatch.setattr("core.lifecycle.clock.now", ...)``.
+    """
+    if not isinstance(source, dict):
+        return False
+    vu = _parse_iso(source.get(T1_SOURCE_FIELD_VALID_UNTIL))
+    if vu is None:
+        return False
+    return vu <= current_time
+
+
+def is_edge_immune(edge: dict) -> bool:
+    """Opt-out hook — ``edge["manual_immune"]`` truthy ⇒ cascade
+    skips this edge.
+
+    The flag is **edge-level only**. Sources are immutable evidence;
+    operator immunity is a policy on the relation that uses them,
+    not on the underlying evidence. Curated reference relations
+    (e.g., legal references that should never auto-expire even when
+    their source PDF gets a sunset date) set this.
+
+    The flag is not part of the PR-0 schema validators by design —
+    it's an operator escape hatch, not part of the canonical
+    lifecycle vocabulary. Setting it does not invalidate the edge
+    under ``validate_edge_v04_fields``.
+    """
+    if not isinstance(edge, dict):
+        return False
+    return bool(edge.get("manual_immune"))
+
+
+def _is_edge_already_inactive(edge: dict) -> bool:
+    """Idempotency guard — skip edges whose previous lifecycle state
+    already says inactive. Covers all three EVENT types from the
+    mutation_type enum: invalidated (CASCADE), superseded (T7),
+    expired (this module's own previous run).
+    """
+    mt = edge.get(T7_EDGE_FIELD_MUTATION_TYPE)
+    if mt and mt != T1_MUTATION_ACTIVE:
+        return True
+    status = edge.get(T7_EDGE_FIELD_STATUS)
+    if isinstance(status, dict) and status.get("active") is False:
+        return True
+    return False
+
+
+def _maybe_expire_edge(edge: dict, current_time: datetime) -> tuple[dict, bool]:
+    """Decide expiration for one edge.
+
+    Returns (mutated_edge, did_mutate). ``did_mutate=False`` covers:
+      - edge already inactive (idempotency guard)
+      - edge immune (operator opt-out)
+      - edge has no sources → vacuously "all sources expired" but the
+        entry memo's intent is "evidence-driven expiration"; no
+        sources means we don't know, so leave alone
+      - at least one source still active (not all expired)
+
+    When the edge does expire, the mutation is minimal:
+    ``status.active=False`` + ``mutation_type="expired"``. The
+    ``superseded_by`` / ``superseded_at`` fields are deliberately
+    left untouched — expiration is exclusive with supersede.
+    """
+    if _is_edge_already_inactive(edge):
+        return edge, False
+    if is_edge_immune(edge):
+        return edge, False
+    sources = edge.get("sources")
+    if not isinstance(sources, list) or not sources:
+        return edge, False
+
+    # All non-malformed sources must be expired for the cascade to fire.
+    saw_at_least_one_valid_source = False
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        saw_at_least_one_valid_source = True
+        if not is_source_expired(src, current_time):
+            return edge, False
+    if not saw_at_least_one_valid_source:
+        return edge, False
+
+    # Apply defaults first so we are operating on a fully-shaped edge,
+    # then flip the two fields. apply_v04_edge_defaults is idempotent.
+    new_edge = apply_v04_edge_defaults(edge)
+    status = dict(new_edge.get(T7_EDGE_FIELD_STATUS) or {})
+    status["active"] = False
+    new_edge[T7_EDGE_FIELD_STATUS] = status
+    new_edge[T7_EDGE_FIELD_MUTATION_TYPE] = T1_MUTATION_EXPIRED
+    return new_edge, True
+
+
+# ─── Wiki walker ───────────────────────────────────────────────────
+
+
+def _process_entity_file(
+    path: Path,
+    current_time: datetime,
+    dry_run: bool,
+) -> dict:
+    """Apply the cascade to one entity file. Returns stats dict.
+
+    On ``dry_run=True``, no writes — the stats still report what
+    would have been mutated so the operator can preview.
+    """
+    stats = {
+        "scanned":           1,
+        "had_no_relations":  0,
+        "edges_expired":     0,
+        "files_mutated":     0,
+        "validation_failed": 0,
+        "errors":            0,
+    }
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"[EXPIRE] read fail {path}: {e}")
+        stats["errors"] = 1
+        return stats
+
+    fm, body_tail = _split_frontmatter(text)
+    if fm is None:
+        return stats
+
+    relations = fm.get("relations")
+    if not isinstance(relations, list) or not relations:
+        stats["had_no_relations"] = 1
+        return stats
+
+    new_relations = []
+    file_changed = False
+    for rel in relations:
+        if not isinstance(rel, dict):
+            new_relations.append(rel)
+            continue
+        new_rel, did_mutate = _maybe_expire_edge(rel, current_time)
+        if did_mutate:
+            stats["edges_expired"] += 1
+            file_changed = True
+            # Validate the mutated edge before accepting — defends
+            # against a future schema change that the cascade hasn't
+            # learned about yet.
+            try:
+                validate_edge_v04_fields(new_rel)
+            except ValueError as e:
+                print(f"[EXPIRE] validation fail {path}: {e}")
+                stats["validation_failed"] = 1
+                stats["errors"] = 1
+                # Reject the mutation rather than write a malformed edge.
+                new_rel = rel
+                stats["edges_expired"] -= 1
+                file_changed = (
+                    stats["edges_expired"] > 0
+                    or len([r for r in new_relations if r is not rel]) > 0
+                )
+        new_relations.append(new_rel)
+
+    if not file_changed:
+        return stats
+
+    fm["relations"] = new_relations
+    stats["files_mutated"] = 1
+    if dry_run:
+        return stats
+
+    # Atomic per-file write (same pattern as PR-T1.A migration).
+    new_text = _serialize_frontmatter(fm, body_tail)
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(new_text)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        os.replace(tmp_path, path)
+    except Exception as e:
+        print(f"[EXPIRE] write fail {path}: {e}")
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        stats["errors"] = 1
+        stats["files_mutated"] = 0
+    return stats
+
+
+def expiration_cascade(
+    entity_root: Path | str,
+    current_time: datetime | None = None,
+    *,
+    dry_run: bool = True,
+) -> dict:
+    """Walk every entity ``.md`` under ``entity_root`` and apply the
+    T1 expiration cascade.
+
+    Args:
+        entity_root: wiki root (e.g. ``wiki``). Walks recursively;
+            only files matching ``*.md`` are considered.
+        current_time: timezone-aware UTC ``datetime``. ``None`` (the
+            default) calls ``core.lifecycle.clock.now()`` — the
+            production code path. Tests freeze time by passing an
+            explicit value.
+        dry_run: when ``True`` (default), no writes. Stats still
+            count "would have mutated" so the operator can preview.
+
+    Returns:
+        Aggregate stats dict — ``scanned`` (files seen),
+        ``had_no_relations`` (skipped, no work to do),
+        ``edges_expired`` (per-file sum), ``files_mutated``,
+        ``validation_failed`` (mutations rejected by the post-write
+        validator), ``errors`` (read / write / parse failures).
+
+    The wiki-tree filter is intentionally loose: any ``.md`` file
+    under ``entity_root`` is candidate. Production wiki layout
+    keeps entities under ``entity/prod/<type>/`` + ``entity/test/...``
+    but this function does not encode that layout — the test fixture
+    can flatten the tree without breaking anything.
+    """
+    if current_time is None:
+        from core.lifecycle.clock import now
+        current_time = now()
+
+    root = Path(entity_root)
+    if not root.exists():
+        raise FileNotFoundError(f"entity root not found: {root}")
+
+    agg = {
+        "scanned":           0,
+        "had_no_relations":  0,
+        "edges_expired":     0,
+        "files_mutated":     0,
+        "validation_failed": 0,
+        "errors":            0,
+    }
+    for entity_file in sorted(root.rglob("*.md")):
+        # Skip snapshot dirs created by PR-T1.A migration. The
+        # snapshot path is ``<wiki>.pre-v04-migration/...``; any
+        # part containing that suffix is a snapshot we should not
+        # double-process. Substring match (not equality) because
+        # the parent name is the entire ``wiki.pre-v04-migration``
+        # token.
+        if any("pre-v04-migration" in p for p in entity_file.parts):
+            continue
+        s = _process_entity_file(entity_file, current_time, dry_run)
+        for k in agg:
+            agg[k] += s.get(k, 0)
+    return agg
+
+
+__all__ = [
+    "is_source_expired",
+    "is_edge_immune",
+    "expiration_cascade",
+]
+
+
+if __name__ == "__main__":
+    # Quick smoke test — operator typically uses
+    # scripts/run_expiration_cascade.py instead.
+    sys.exit(0)

--- a/scripts/run_expiration_cascade.py
+++ b/scripts/run_expiration_cascade.py
@@ -1,0 +1,131 @@
+"""v0.4 Sprint 5 PR-T1.B — operator runner for the T1 expiration cascade.
+
+Walks the wiki, flips ``mutation_type="expired"`` + ``status.active=False``
+on every edge whose **all** active sources have reached
+``valid_until``. **Does not delete** — CASCADE is a separate path
+(Layer 3 ``cascade_remove``). Manual immunity (``edge.manual_immune``)
+respected.
+
+Modes
+-----
+
+    python scripts/run_expiration_cascade.py                # dry-run
+    python scripts/run_expiration_cascade.py --apply        # write
+    python scripts/run_expiration_cascade.py --root other_wiki
+
+Idempotent — re-running after an apply is a no-op (every affected
+edge already has ``status.active=False`` + the cascade's
+"already-inactive" guard skips it).
+
+Rollback
+--------
+
+The cascade is reversible per-edge: clear ``status.active`` back to
+``True`` + reset ``mutation_type`` to ``"active"`` in the affected
+entity file. There is no batch rollback flag — by design, expiration
+is a forward-only operational hook (an edge "un-expiring" would
+imply its source was wrong, which is a manual investigation, not a
+script).
+
+For a full rollback after ``--apply`` (e.g., the wrong wiki was
+targeted), use ``git checkout HEAD -- wiki/`` to restore the
+pre-cascade state. PR-T1.A migration writes a ``wiki.pre-v04-migration/``
+snapshot; PR-T1.B intentionally does not snapshot again because
+its mutation surface is small (two fields per edge) and a git diff
+shows the operator exactly what changed.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Project root on sys.path so `core.*` import works.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+try:
+    from utils.console import ensure_utf8_console  # noqa: E402
+    ensure_utf8_console()
+except Exception:
+    pass
+
+from core.lifecycle.clock import now as clock_now  # noqa: E402
+from core.lifecycle.expiration_cascade import expiration_cascade  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="v0.4 Sprint 5 PR-T1.B — T1 expiration cascade.",
+    )
+    ap.add_argument(
+        "--root",
+        default="wiki",
+        help="wiki root directory (default: wiki)",
+    )
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Actually write the cascaded mutations to disk. Without "
+            "this flag the script is dry-run — stats reported, "
+            "nothing written."
+        ),
+    )
+    ap.add_argument(
+        "--time",
+        default=None,
+        help=(
+            "ISO 8601 timestamp to use as current_time (test/replay "
+            "use). Default: core.lifecycle.clock.now() (UTC). "
+            "Example: --time 2026-12-31T23:59:59+00:00"
+        ),
+    )
+    args = ap.parse_args()
+
+    if args.time is not None:
+        try:
+            current_time = datetime.fromisoformat(
+                args.time.replace("Z", "+00:00")
+            )
+        except ValueError as e:
+            print(f"[EXPIRE] --time not parseable: {e}")
+            return 2
+    else:
+        current_time = clock_now()
+
+    root = Path(args.root)
+    if not root.exists():
+        print(f"[EXPIRE] wiki root not found: {root}")
+        return 2
+
+    mode_tag = "APPLY" if args.apply else "DRY-RUN"
+    print(f"=== expiration cascade ({mode_tag}) ===")
+    print(f"  wiki root:    {root.resolve()}")
+    print(f"  current_time: {current_time.isoformat()}")
+    print()
+
+    stats = expiration_cascade(
+        root,
+        current_time=current_time,
+        dry_run=not args.apply,
+    )
+
+    print("=== Stats ===")
+    for k, v in stats.items():
+        print(f"  {k:<22s}: {v}")
+
+    if stats.get("errors"):
+        return 1
+    if not args.apply and stats.get("files_mutated", 0) > 0:
+        print()
+        print(
+            f"[EXPIRE] dry-run found {stats['files_mutated']} files "
+            f"to mutate ({stats['edges_expired']} edges). "
+            f"Re-run with --apply to write."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_expiration_cascade.py
+++ b/tests/test_expiration_cascade.py
@@ -1,0 +1,364 @@
+"""v0.4 Sprint 5 PR-T1.B — contract tests for the T1 expiration cascade.
+
+Four invariants required by the entry memo §"PR-T1.B Done when":
+
+  1. test_source_expires_at_valid_until — derived predicate is
+     correct at the boundary (≤ inclusive)
+  2. test_relation_dropped_when_all_active_sources_expire — cascade
+     marks the edge when every source has expired
+  3. test_valid_until_null_means_indefinite — None valid_until ⇒
+     never expired
+  4. test_temporal_cascade_preserves_manual_immunity — operator's
+     edge.manual_immune opt-out is respected
+
+Plus a small ring of helpers (idempotency, atomic write, validator
+guard) so the cascade can be safely re-run / re-deployed.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.lifecycle.expiration_cascade import (  # noqa: E402
+    expiration_cascade,
+    is_edge_immune,
+    is_source_expired,
+)
+from core.lifecycle.schema import (  # noqa: E402
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+)
+
+
+# Reference "now" for these tests — a fixed UTC point. All
+# valid_until values in fixtures are anchored relative to this.
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _src(valid_until=None, valid_from=None, **extras) -> dict:
+    """Build a minimal v0.4 source dict for fixture composition."""
+    out = {"doc_id": "doc_x", "role": "primary", "ts": "2026-05-01T00:00:00+00:00", "weight": 0.9, **extras}
+    out["valid_from"] = valid_from
+    out["valid_until"] = valid_until
+    return out
+
+
+def _edge(sources, **extras) -> dict:
+    """Build a minimal v0.4 edge dict with the four T1+T7 fields
+    pre-defaulted so the cascade's idempotency guard does not skip."""
+    return {
+        "confidence":    0.9,
+        "label":         "관련",
+        "target":        "Target",
+        "target_id":     "e_concept_x",
+        "type":          "RELATED_TO",
+        "sources":       sources,
+        "validity":      {"from": None, "to": None},
+        "status":        {"active": True, "superseded_by": None, "superseded_at": None},
+        "mutation_type": T1_MUTATION_ACTIVE,
+        **extras,
+    }
+
+
+def _write_entity(path: Path, relations: list) -> None:
+    """Write a minimal entity .md with the given relations list."""
+    fm = {
+        "entity_id":   "e_test_abc",
+        "entity_type": "concept",
+        "name":        "TestEntity",
+        "relations":   relations,
+    }
+    text = (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True, default_flow_style=False)
+        + "---\n"
+        + "## body\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_entity_relations(path: Path) -> list:
+    text = path.read_text(encoding="utf-8")
+    # crude split — sufficient for the test fixtures (no nested ---)
+    parts = text.split("---\n", 2)
+    fm = yaml.safe_load(parts[1])
+    return fm["relations"]
+
+
+# ─── #1 — derived predicate boundary ──────────────────────────────
+
+
+def test_source_expires_at_valid_until():
+    """Boundary inclusive — ``valid_until == current_time`` ⇒ expired."""
+    earlier = (NOW - timedelta(days=1)).isoformat()
+    exactly = NOW.isoformat()
+    later   = (NOW + timedelta(days=1)).isoformat()
+
+    assert is_source_expired(_src(valid_until=earlier), NOW) is True
+    assert is_source_expired(_src(valid_until=exactly), NOW) is True
+    assert is_source_expired(_src(valid_until=later),   NOW) is False
+
+
+# ─── #2 — cascade marks edge when all sources expired ─────────────
+
+
+def test_relation_dropped_when_all_active_sources_expire(tmp_path):
+    """Wiki walker: one entity, one relation, two sources both
+    expired → edge gets mutation_type=expired, status.active=False.
+    File is rewritten."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[
+            _src(valid_until=expired, doc_id="doc_a"),
+            _src(valid_until=expired, doc_id="doc_b"),
+        ],
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["files_mutated"] == 1
+    assert stats["edges_expired"] == 1
+    assert stats["errors"] == 0
+
+    rels = _read_entity_relations(entity_path)
+    assert len(rels) == 1
+    new_edge = rels[0]
+    assert new_edge["status"]["active"] is False
+    assert new_edge["mutation_type"] == T1_MUTATION_EXPIRED
+
+
+def test_relation_NOT_dropped_when_one_source_still_active(tmp_path):
+    """Companion to #2 — one expired + one still active ⇒ edge stays
+    active. Pins the "all sources" half of the rule."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    future = (NOW + timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[
+            _src(valid_until=expired, doc_id="doc_a"),
+            _src(valid_until=future,  doc_id="doc_b"),
+        ],
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["files_mutated"] == 0
+    assert stats["edges_expired"] == 0
+
+    rels = _read_entity_relations(entity_path)
+    assert rels[0]["status"]["active"] is True
+    assert rels[0]["mutation_type"] == T1_MUTATION_ACTIVE
+
+
+# ─── #3 — None valid_until = indefinite ───────────────────────────
+
+
+def test_valid_until_null_means_indefinite():
+    """``None`` valid_until ⇒ never expired, even when current_time
+    is far in the future."""
+    assert is_source_expired(_src(valid_until=None), NOW) is False
+    future = datetime(3000, 1, 1, tzinfo=timezone.utc)
+    assert is_source_expired(_src(valid_until=None), future) is False
+
+
+def test_indefinite_source_blocks_edge_expiration(tmp_path):
+    """One expired + one indefinite ⇒ edge stays active (the
+    indefinite source is "still alive" by definition)."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[
+            _src(valid_until=expired, doc_id="doc_a"),
+            _src(valid_until=None,    doc_id="doc_b"),
+        ],
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["edges_expired"] == 0
+
+
+# ─── #4 — manual immunity opt-out ─────────────────────────────────
+
+
+def test_temporal_cascade_preserves_manual_immunity(tmp_path):
+    """Edge with ``manual_immune: True`` is never expired by the
+    cascade, even when all its sources are expired."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[
+            _src(valid_until=expired, doc_id="doc_a"),
+            _src(valid_until=expired, doc_id="doc_b"),
+        ],
+        manual_immune=True,
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["edges_expired"] == 0
+    assert stats["files_mutated"] == 0
+
+    rels = _read_entity_relations(entity_path)
+    assert rels[0]["status"]["active"] is True
+    assert rels[0]["mutation_type"] == T1_MUTATION_ACTIVE
+    assert rels[0]["manual_immune"] is True
+
+    # Direct predicate check too
+    assert is_edge_immune(edge) is True
+    assert is_edge_immune({"manual_immune": False}) is False
+    assert is_edge_immune({}) is False
+
+
+# ─── Idempotency + dry-run + already-inactive guard ───────────────
+
+
+def test_dry_run_does_not_write(tmp_path):
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(sources=[_src(valid_until=expired)])
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+    before = entity_path.read_text(encoding="utf-8")
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=True)
+    assert stats["edges_expired"] == 1
+    assert stats["files_mutated"] == 1   # would-have count
+
+    after = entity_path.read_text(encoding="utf-8")
+    assert before == after, "dry_run=True must not modify disk"
+
+
+def test_idempotent_second_apply_is_noop(tmp_path):
+    """Run apply twice — second run sees the edge already inactive
+    and skips it (mutation_type=expired and status.active=False)."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(sources=[_src(valid_until=expired)])
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    first = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert first["edges_expired"] == 1
+
+    second = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert second["edges_expired"] == 0
+    assert second["files_mutated"] == 0
+
+
+def test_already_superseded_edge_not_touched(tmp_path):
+    """Edge with mutation_type=superseded (T7 EVENT) must not be
+    re-flipped to expired even if all its sources are expired —
+    expiration is exclusive with supersede."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[_src(valid_until=expired)],
+        status={"active": False, "superseded_by": "e_x", "superseded_at": "2026-05-15T00:00:00+00:00"},
+        mutation_type=T1_MUTATION_SUPERSEDED,
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["edges_expired"] == 0
+
+    rels = _read_entity_relations(entity_path)
+    assert rels[0]["mutation_type"] == T1_MUTATION_SUPERSEDED
+    assert rels[0]["status"]["superseded_by"] == "e_x"
+
+
+def test_already_invalidated_edge_not_touched(tmp_path):
+    """Same guard for CASCADE-invalidated edges — preserves history."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(
+        sources=[_src(valid_until=expired)],
+        status={"active": False, "superseded_by": None, "superseded_at": None},
+        mutation_type=T1_MUTATION_INVALIDATED,
+    )
+    entity_path = tmp_path / "entity_a.md"
+    _write_entity(entity_path, [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["edges_expired"] == 0
+
+
+def test_clock_now_called_when_current_time_omitted(monkeypatch, tmp_path):
+    """When current_time=None, expiration_cascade calls
+    core.lifecycle.clock.now(). Monkeypatch verifies the wiring."""
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(sources=[_src(valid_until=expired)])
+    _write_entity(tmp_path / "entity_a.md", [edge])
+
+    frozen = datetime(2027, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.lifecycle.clock.now", lambda: frozen)
+    stats = expiration_cascade(tmp_path, dry_run=False)
+    assert stats["edges_expired"] == 1
+
+
+# ─── Edge cases ────────────────────────────────────────────────────
+
+
+def test_edge_with_no_sources_not_expired(tmp_path):
+    """Edge with empty sources list — vacuously "all expired" but
+    the intent is evidence-driven; no evidence ⇒ no expiration."""
+    edge = _edge(sources=[])
+    _write_entity(tmp_path / "entity_a.md", [edge])
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["edges_expired"] == 0
+
+
+def test_malformed_valid_until_treated_as_indefinite():
+    """Defensive — unparseable ISO string returns False from
+    is_source_expired (so the batch doesn't halt)."""
+    assert is_source_expired(_src(valid_until="not-a-date"), NOW) is False
+    assert is_source_expired(_src(valid_until=12345), NOW) is False
+    assert is_source_expired({}, NOW) is False
+    assert is_source_expired("not a dict", NOW) is False
+
+
+def test_entity_with_no_relations_skipped(tmp_path):
+    """Entity files without a relations list count under
+    had_no_relations and contribute zero work."""
+    fm = {"entity_id": "e_x", "name": "X", "entity_type": "concept"}
+    text = (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True, default_flow_style=False)
+        + "---\n"
+    )
+    (tmp_path / "lone.md").write_text(text, encoding="utf-8")
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["scanned"] == 1
+    assert stats["had_no_relations"] == 1
+    assert stats["edges_expired"] == 0
+
+
+def test_snapshot_dir_skipped(tmp_path):
+    """``wiki.pre-v04-migration`` snapshot dir (created by PR-T1.A)
+    must not be re-scanned — would double-apply / wreck the
+    rollback path."""
+    snap = tmp_path / "wiki.pre-v04-migration" / "entity"
+    snap.mkdir(parents=True)
+    expired = (NOW - timedelta(days=10)).isoformat()
+    edge = _edge(sources=[_src(valid_until=expired)])
+    _write_entity(snap / "ghost.md", [edge])
+
+    stats = expiration_cascade(tmp_path, current_time=NOW, dry_run=False)
+    assert stats["scanned"] == 0
+    assert stats["edges_expired"] == 0
+
+
+# ─── Missing root sanity ──────────────────────────────────────────
+
+
+def test_missing_root_raises():
+    with pytest.raises(FileNotFoundError):
+        expiration_cascade("/nonexistent/wiki/path", current_time=NOW)


### PR DESCRIPTION
## Summary

T1 expiration batch — Sprint 5 7-PR 시퀀스 첫 PR. Marks `mutation_type=expired` + `status.active=False` on every edge whose **all** sources have reached `valid_until`. **Does not delete** — CASCADE / supersede are separate paths.

Designed per `docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md` §"PR-T1.B Expiration batch + status: expired mark".

## What landed

- **`core/lifecycle/expiration_cascade.py`** (~15.5 KB) — two pure predicates + wiki walker:
  - `is_source_expired(source, current_time)` — derived predicate (boundary inclusive)
  - `is_edge_immune(edge)` — operator opt-out (`edge.manual_immune`)
  - `expiration_cascade(entity_root, current_time, dry_run=True)` — walker. Atomic per-file write (tempfile + os.replace, mirrors PR-T1.A pattern). Skips snapshot dirs.
- **`scripts/run_expiration_cascade.py`** — operator runner. `--apply` default off. `--root` / `--time` overrides. Reports stats.
- **`tests/test_expiration_cascade.py`** (16 tests, all green).

## Verification

```
85 lifecycle tests pass (PR-0 51 + PR-T1.A clock 8 + migrate 10 + PR-T1.B 16):
  tests/test_lifecycle_schema.py
  tests/test_lifecycle_clock.py
  tests/test_migrate_v04_lifecycle.py
  tests/test_expiration_cascade.py
```

The 4 entry memo invariants (§"Done when"):

| invariant | test |
|---|---|
| source expires at `valid_until` (≤ inclusive) | `test_source_expires_at_valid_until` |
| relation dropped when all active sources expire | `test_relation_dropped_when_all_active_sources_expire` |
| `valid_until` null = indefinite | `test_valid_until_null_means_indefinite` |
| temporal cascade preserves manual immunity | `test_temporal_cascade_preserves_manual_immunity` |

Plus 12 companion guards (idempotency, dry-run, mutation-type exclusivity with supersede/invalidated, clock-now wiring, malformed inputs, empty-sources vacuity, snapshot-dir skip, missing-root sanity).

Dry-run smoke against live wiki:

```
=== expiration cascade (DRY-RUN) ===
  wiki root:    /…/wiki
  current_time: 2026-05-27T10:29:27+00:00

=== Stats ===
  scanned               : 316
  had_no_relations      : 14
  edges_expired         : 0     ← expected, no source has valid_until set yet
  files_mutated         : 0
  validation_failed     : 0
  errors                : 0
```

## What this PR does NOT do (entry memo invariants preserved)

- **Does NOT delete** — CASCADE / `cascade_remove` is Layer 3, separate. This PR's mutation surface is only `edge.status.active=False` + `edge.mutation_type="expired"`.
- **Does NOT recompute confidence** — entry memo §348 schedules `compute_confidence_from_sources` extension to accept `current_time` param; separate PR.
- **Does NOT touch supersede_chain** — expiration is exclusive with supersede per the `mutation_type` enum. T7 supersede operations are PR-T7.A.

## Bench numbers (CLAUDE.md rule #2)

STEP 7 unchanged at this commit because no live wiki entity has `valid_until` set yet (pre-operator-migration state — PR-T1.A migration runner has not been applied to a wiki with explicit expiration windows). Operator validation post-bench-with-expired-source: per entry memo §"Bench" — grounded=true rate stays within ±5% (expired source dropping out should not collapse confidence; other active sources hold the edge).

## Operator workflow

```powershell
# Dry-run preview
python scripts/run_expiration_cascade.py

# Apply
python scripts/run_expiration_cascade.py --apply

# Replay at a specific time
python scripts/run_expiration_cascade.py --time 2027-01-01T00:00:00+00:00

# Custom wiki root
python scripts/run_expiration_cascade.py --root other_wiki --apply
```

Idempotent — re-running after `--apply` is a no-op (every affected edge already has `status.active=False` + the cascade's already-inactive guard skips it).

Rollback per-edge: clear `status.active` back to `True` + reset `mutation_type` to `"active"` in the affected entity file. Full rollback after wrong-target `--apply`: `git checkout HEAD -- wiki/`.

## Out of scope

- **PR-T7.A** (supersede_chain operations) — next in the 7-PR sequence
- **PR-T7.B** (release-gating invariants suite)
- **compute_confidence_from_sources(..., current_time)** extension (entry memo §348)
- **Sprint 5 closure + v0.4.0 release publish** — PR-T7.C

🤖 Generated with [Claude Code](https://claude.com/claude-code)