### PR TITLE
feat(v0.4): Sprint 5 PR-T7.A — supersede chain ops (T7 EVENT primitive)

### DIFF
--- a/core/lifecycle/supersede_chain.py
+++ b/core/lifecycle/supersede_chain.py
@@ -1,0 +1,342 @@
+"""v0.4 Sprint 5 PR-T7.A — T7 supersede chain operations.
+
+Three pure functions for the supersede primitive:
+
+  - ``supersede_edge(old_edge, new_fact, supersede_ts)`` — builds a
+    new edge from ``new_fact``, marks the old edge with
+    ``status.superseded_by = new_edge.id`` +
+    ``status.superseded_at = supersede_ts`` +
+    ``status.active = False`` + ``mutation_type = "superseded"``.
+    **Does NOT call cascade_remove** — preservation is the whole
+    point of T7 (versus Layer 3's destructive CASCADE).
+  - ``walk_supersede_chain(edge)`` — follows ``status.superseded_by``
+    pointers across the chain. Returns the ordered list with the
+    starting edge first and the active head last. Detects cycles
+    and raises (cycles are an insertion bug, never representable
+    in valid state).
+  - ``reconstruct_view_at(head, predicate, t)`` — replay primitive.
+    Given the chain head + a node-lookup ``predicate`` (caller
+    supplies the id-to-edge map), walks backward through the chain
+    and returns the edge whose ``validity`` window contained ``t``.
+    Skips edges marked ``mutation_type == "invalidated"`` (CASCADE
+    deletions are semantically gone for replay; supersede chain
+    members remain visible).
+
+What this module is NOT
+-----------------------
+
+- **Not engine-wired.** The production caller (``contradiction_arbiter``
+  B-path routing) lands at PR-T2.B / PR-T2.C. Until then, these
+  functions are pure-data utilities ready to plug in.
+- **Not a graph traversal.** The chain is a linear linked list
+  through ``status.superseded_by``. Multi-edge knowledge mutations
+  (one fact replacing several) compose via repeated
+  ``supersede_edge`` calls at the caller's discretion — no
+  fan-in/fan-out semantics here.
+- **Not a fact storage layer.** ``new_fact`` is the caller's
+  pre-shaped dict (typically the same shape the
+  ``contradiction_arbiter`` already produces from a contradicting
+  observation). This module composes ``apply_v04_edge_defaults`` on
+  top so the new edge has the v0.4 T1+T7 vocabulary populated.
+
+Why a pure module
+-----------------
+
+Tests can build chains in-memory without touching disk. Production
+callers (PR-T2.C wiring) load entity frontmatter, materialize the
+edges as dicts, call ``supersede_edge`` to produce the (new_edge,
+mutated_old_edge) pair, and write both back. The orthogonality
+keeps the wiki I/O surface out of the chain logic + lets the
+contradiction arbiter use the same primitives in a memory-only
+arbiter test.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from core.lifecycle.schema import (
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+    apply_v04_edge_defaults,
+    validate_edge_v04_fields,
+)
+
+
+# Maximum chain length the walker tolerates before declaring cycle.
+# Real chains in production should be tiny (a fact mutates rarely).
+# A large value provides safety against accidental cycles caused by
+# external mutation while still surfacing pathological loops loudly.
+_MAX_CHAIN_LENGTH: int = 1024
+
+
+def _edge_id(edge: dict) -> Optional[str]:
+    """Edges in v0.3 wiki schema don't have a canonical ``id`` field —
+    they're identified by ``(source_entity_id, target_id, type)``
+    composite. PR-T7.A introduces a synthetic ``id`` field on every
+    superseded-or-newer edge so the chain can link by reference.
+
+    The id is stored under ``edge["id"]`` (lowercase, top-level) and
+    only assigned when a chain operation needs to refer to this edge.
+    Legacy edges that have never been superseded simply lack the
+    field — that's fine because nothing points at them.
+    """
+    return edge.get("id") if isinstance(edge, dict) else None
+
+
+def _ensure_edge_id(edge: dict) -> str:
+    """Return the edge's id, assigning a fresh one if missing.
+
+    Uses ``e_edge_<10-hex>`` shape consistent with the entity-id
+    convention in ``core.graph_engine`` (``e_<type>_<10-hex>``).
+    """
+    eid = edge.get("id")
+    if eid:
+        return str(eid)
+    new = f"e_edge_{uuid.uuid4().hex[:10]}"
+    edge["id"] = new
+    return new
+
+
+# ─── supersede_edge ────────────────────────────────────────────────
+
+
+def supersede_edge(
+    old_edge: dict,
+    new_fact: dict,
+    supersede_ts: datetime,
+) -> tuple[dict, dict]:
+    """Create the new edge from ``new_fact`` + mark ``old_edge`` as
+    superseded by it.
+
+    Args:
+        old_edge: the existing edge being replaced. Must be a v0.4-
+            shaped dict (run ``apply_v04_edge_defaults`` first if you
+            loaded a raw v0.3 edge). Will be **mutated in place** —
+            the caller's reference is updated so the wiki-write path
+            picks up the new ``status`` + ``mutation_type``.
+        new_fact: the replacing edge body. Same shape as ``old_edge``
+            (relation dict from frontmatter). The new edge gets a
+            fresh synthetic id + v0.4 defaults applied + validity
+            window's ``from`` set to ``supersede_ts`` so the chain's
+            temporal ordering is intact for replay.
+        supersede_ts: UTC-aware ``datetime`` of the supersede event.
+            Written into ``old_edge.status.superseded_at`` AND used
+            as the new edge's ``validity.from``.
+
+    Returns:
+        ``(new_edge, old_edge)`` — both mutated. ``new_edge`` is a
+        fresh dict (built from ``new_fact``), ``old_edge`` is the
+        same object passed in.
+
+    Raises:
+        ValueError if either dict fails ``validate_edge_v04_fields``
+        after mutation — defends against the caller passing partial
+        v0.4 shapes that would produce an inconsistent chain.
+
+    What this function does NOT do:
+        - **No I/O.** Caller writes both edges back to the wiki.
+        - **No cascade_remove.** Old edge's sources stay; only its
+          ``status`` flips.
+        - **No re-link of downstream chains.** If ``old_edge`` was
+          itself already a chain link, the supersede is normal —
+          its ``superseded_by`` simply gets overwritten with the
+          new edge's id (the chain extends forward).
+    """
+    if not isinstance(old_edge, dict):
+        raise ValueError(f"old_edge must be a dict, got {type(old_edge).__name__}")
+    if not isinstance(new_fact, dict):
+        raise ValueError(f"new_fact must be a dict, got {type(new_fact).__name__}")
+    if not isinstance(supersede_ts, datetime):
+        raise ValueError(
+            f"supersede_ts must be datetime, got {type(supersede_ts).__name__}"
+        )
+
+    # Build the new edge. apply_v04_edge_defaults is idempotent so the
+    # caller may pass either a raw v0.3 dict or a partially-v0.4 dict.
+    new_edge: Dict[str, Any] = apply_v04_edge_defaults(new_fact)
+    # Always assign a fresh id — the new edge is a distinct entity in
+    # the chain even when its body matches an existing edge.
+    new_id = f"e_edge_{uuid.uuid4().hex[:10]}"
+    new_edge["id"] = new_id
+    # Validity window's lower bound = the supersede moment (the new
+    # fact was "true from this time forward"). Caller can override
+    # later if they have a different valid_from semantic, but the
+    # default keeps replay correct.
+    validity = dict(new_edge.get(T7_EDGE_FIELD_VALIDITY) or {})
+    validity["from"] = supersede_ts.isoformat()
+    new_edge[T7_EDGE_FIELD_VALIDITY] = validity
+
+    # Old edge mutations: must be a fully-defaulted v0.4 edge first
+    # so the status / mutation_type writes don't lose other fields.
+    defaulted_old = apply_v04_edge_defaults(old_edge)
+    # Replace the old_edge dict in place by copying the defaulted
+    # fields back. (We can't return a new dict for old_edge because
+    # the caller likely holds a list reference to it from the wiki
+    # frontmatter loader; mutating in place preserves that pointer.)
+    for k, v in defaulted_old.items():
+        old_edge[k] = v
+
+    status = dict(old_edge.get(T7_EDGE_FIELD_STATUS) or {})
+    status["active"] = False
+    status["superseded_by"] = new_id
+    status["superseded_at"] = supersede_ts.isoformat()
+    old_edge[T7_EDGE_FIELD_STATUS] = status
+    old_edge[T7_EDGE_FIELD_MUTATION_TYPE] = T1_MUTATION_SUPERSEDED
+
+    # Validate both — surface a partial-shape caller bug immediately.
+    validate_edge_v04_fields(new_edge)
+    validate_edge_v04_fields(old_edge)
+
+    return new_edge, old_edge
+
+
+# ─── walk_supersede_chain ──────────────────────────────────────────
+
+
+def walk_supersede_chain(
+    edge: dict,
+    lookup: Callable[[str], Optional[dict]],
+) -> List[dict]:
+    """Walk forward through the supersede chain starting at ``edge``.
+
+    Args:
+        edge: a chain link (typically a superseded edge — the head of
+            the chain returns just ``[edge]``).
+        lookup: caller-supplied id-to-edge function. The chain is a
+            linked list across the wiki, not held in one place, so
+            the walker delegates the materialization to the caller
+            (typically an in-memory dict the wiki-loader populated).
+
+    Returns:
+        Ordered list ``[edge, next, next_next, …, active_head]``.
+        For an edge that has never been superseded, returns ``[edge]``.
+
+    Raises:
+        ValueError if a cycle is detected (an already-visited id
+        appears again) or the chain exceeds ``_MAX_CHAIN_LENGTH``.
+        Either case is a writer-side bug (``supersede_edge`` should
+        prevent it; lookup-side corruption is the only path to a
+        cycle here).
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(f"edge must be a dict, got {type(edge).__name__}")
+
+    chain: List[dict] = [edge]
+    seen: set[str] = set()
+    eid = _edge_id(edge)
+    if eid:
+        seen.add(eid)
+
+    current = edge
+    for _ in range(_MAX_CHAIN_LENGTH):
+        status = current.get(T7_EDGE_FIELD_STATUS) or {}
+        next_id = status.get("superseded_by")
+        if not next_id:
+            return chain
+        if next_id in seen:
+            raise ValueError(
+                f"supersede chain cycle detected at id={next_id!r}"
+            )
+        next_edge = lookup(next_id)
+        if next_edge is None:
+            # Dangling pointer — the chain points past the wiki's
+            # known edges. Treat as end-of-chain rather than crash;
+            # caller's wiki snapshot may simply lack the next link.
+            return chain
+        chain.append(next_edge)
+        seen.add(next_id)
+        current = next_edge
+
+    raise ValueError(
+        f"supersede chain exceeded max length {_MAX_CHAIN_LENGTH} — "
+        f"likely cycle or pathological mutation"
+    )
+
+
+# ─── reconstruct_view_at ───────────────────────────────────────────
+
+
+def reconstruct_view_at(
+    head: dict,
+    lookup: Callable[[str], Optional[dict]],
+    t: datetime,
+) -> Optional[dict]:
+    """Replay primitive — return the edge whose ``validity`` window
+    contained ``t``.
+
+    Args:
+        head: any link in the chain. The function walks forward
+            via ``walk_supersede_chain`` to materialize the whole
+            chain, then searches backward for the matching edge.
+        lookup: same id-to-edge resolver passed to
+            ``walk_supersede_chain``.
+        t: UTC-aware ``datetime``.
+
+    Returns:
+        The first chain edge (in chain order) whose
+        ``validity.from <= t < validity.to`` (where ``None`` on
+        either bound means "open"), **excluding** edges with
+        ``mutation_type == "invalidated"`` (CASCADE deletes are
+        gone for replay even when historically present).
+
+        Returns ``None`` if no chain edge matches.
+
+    Why backward search: when the chain has multiple links, the
+    earlier ones cover earlier intervals (by ``supersede_edge``
+    contract: new edge's ``validity.from`` = supersede_ts). The
+    most-recent edge whose interval contains ``t`` is the correct
+    answer; iterating forward + returning the last match achieves
+    that.
+    """
+    chain = walk_supersede_chain(head, lookup)
+    match: Optional[dict] = None
+    for link in chain:
+        mt = link.get(T7_EDGE_FIELD_MUTATION_TYPE)
+        if mt == T1_MUTATION_INVALIDATED:
+            continue
+        validity = link.get(T7_EDGE_FIELD_VALIDITY) or {}
+        if _validity_contains(validity, t):
+            match = link
+    return match
+
+
+def _validity_contains(validity: dict, t: datetime) -> bool:
+    """``validity.from <= t < validity.to`` with ``None``-as-open
+    semantics on both bounds. Matches the schema's "indefinite"
+    convention.
+    """
+    from_str = validity.get("from")
+    to_str = validity.get("to")
+    if from_str is not None:
+        try:
+            vf = datetime.fromisoformat(str(from_str).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if t < vf:
+            return False
+    if to_str is not None:
+        try:
+            vt = datetime.fromisoformat(str(to_str).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if t >= vt:
+            return False
+    return True
+
+
+__all__ = [
+    "supersede_edge",
+    "walk_supersede_chain",
+    "reconstruct_view_at",
+    # Module-private constant exposed for the test that verifies the
+    # length cap is enforced before walk_supersede_chain spins forever.
+    "_MAX_CHAIN_LENGTH",
+    # Convenience for callers that need to mint an id without going
+    # through supersede_edge (e.g., seeding a fresh chain head).
+    "_ensure_edge_id",
+]

--- a/tests/test_t7_supersede_chain.py
+++ b/tests/test_t7_supersede_chain.py
@@ -1,0 +1,386 @@
+"""v0.4 Sprint 5 PR-T7.A — contract tests for the supersede chain.
+
+Three invariants required by the entry memo §"PR-T7.A":
+
+  1. test_supersede_preserves_old_sources — no CASCADE side effect
+     (sources stay on the old edge after supersede)
+  2. test_supersede_chain_walks_to_active — walker follows the
+     chain through all superseded links to the active head
+  3. test_supersede_chain_acyclic — walker raises on a cycle
+     instead of looping forever
+
+Plus a small ring of reconstruct_view_at + cross-mutation-type
+exclusivity + max-chain-length guard tests.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.lifecycle.schema import (  # noqa: E402
+    T1_MUTATION_ACTIVE,
+    T1_MUTATION_EXPIRED,
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+)
+from core.lifecycle.supersede_chain import (  # noqa: E402
+    _ensure_edge_id,
+    reconstruct_view_at,
+    supersede_edge,
+    walk_supersede_chain,
+)
+
+
+# Reference "now" — all supersede timestamps anchor here.
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _src(doc_id: str = "doc_x", weight: float = 0.9) -> dict:
+    """Minimal v0.4 source dict."""
+    return {
+        "doc_id":      doc_id,
+        "role":        "primary",
+        "ts":          "2026-05-01T00:00:00+00:00",
+        "weight":      weight,
+        "valid_from":  None,
+        "valid_until": None,
+    }
+
+
+def _edge(
+    *,
+    target: str = "Target",
+    sources: list | None = None,
+    mutation_type: str = T1_MUTATION_ACTIVE,
+    status: dict | None = None,
+    validity: dict | None = None,
+    edge_id: str | None = None,
+) -> dict:
+    """Build a minimal v0.4-shaped edge dict."""
+    out = {
+        "confidence":    0.9,
+        "label":         "관련",
+        "target":        target,
+        "target_id":     "e_concept_x",
+        "type":          "RELATED_TO",
+        "sources":       sources or [_src()],
+        "validity":      validity or {"from": None, "to": None},
+        "status":        status or {
+            "active":          mutation_type == T1_MUTATION_ACTIVE,
+            "superseded_by":   None,
+            "superseded_at":   None,
+        },
+        "mutation_type": mutation_type,
+    }
+    if edge_id:
+        out["id"] = edge_id
+    return out
+
+
+def _make_lookup(edges_by_id: dict[str, dict]):
+    """Build the id→edge resolver the walker expects."""
+    return lambda eid: edges_by_id.get(eid)
+
+
+# ─── #1 — sources preserved on supersede ──────────────────────────
+
+
+def test_supersede_preserves_old_sources():
+    """Old edge keeps its sources after supersede. The whole point
+    of T7 (vs Layer 3 CASCADE which removes sources) is preservation
+    for replay."""
+    old_sources = [_src("doc_a"), _src("doc_b")]
+    old = _edge(sources=old_sources, target="OldTarget")
+    new_fact = _edge(sources=[_src("doc_new")], target="NewTarget")
+
+    new_edge, mutated_old = supersede_edge(old, new_fact, NOW)
+
+    assert mutated_old["sources"] == old_sources, (
+        "supersede must NOT touch sources on the old edge — that's "
+        "CASCADE's job"
+    )
+    # Old edge mutation surface is exactly two fields + the chain link
+    assert mutated_old["status"]["active"] is False
+    assert mutated_old["status"]["superseded_by"] == new_edge["id"]
+    assert mutated_old["status"]["superseded_at"] == NOW.isoformat()
+    assert mutated_old["mutation_type"] == T1_MUTATION_SUPERSEDED
+
+
+def test_supersede_returns_old_dict_by_reference():
+    """Caller likely holds a list reference (frontmatter relations
+    list) — old_edge must be mutated in place, not replaced."""
+    old = _edge(target="OldTarget")
+    list_holding_old = [old]
+    new_fact = _edge(target="NewTarget")
+
+    _, mutated_old = supersede_edge(old, new_fact, NOW)
+
+    assert mutated_old is old, (
+        "supersede must mutate old_edge in place so the caller's "
+        "list reference picks up the change"
+    )
+    assert list_holding_old[0] is old
+    assert list_holding_old[0]["mutation_type"] == T1_MUTATION_SUPERSEDED
+
+
+def test_new_edge_gets_fresh_id_and_validity_from():
+    """new_edge gets a synthetic id + validity.from=supersede_ts so
+    the chain ordering is well-defined for replay."""
+    old = _edge(target="OldTarget")
+    new_fact = _edge(target="NewTarget")
+
+    new_edge, _ = supersede_edge(old, new_fact, NOW)
+
+    assert new_edge["id"].startswith("e_edge_")
+    assert len(new_edge["id"]) >= len("e_edge_") + 8
+    assert new_edge["validity"]["from"] == NOW.isoformat()
+
+
+# ─── #2 — walker follows chain ────────────────────────────────────
+
+
+def test_supersede_chain_walks_to_active():
+    """Build a 3-link chain (head → mid → active), walk from each
+    link, verify walker returns the correct ordered slice."""
+    active = _edge(target="V3", edge_id="e_edge_v3")
+    mid    = _edge(target="V2", edge_id="e_edge_v2")
+    head   = _edge(target="V1", edge_id="e_edge_v1")
+
+    # Wire chain: head → mid → active
+    head["status"]["superseded_by"] = "e_edge_v2"
+    head["status"]["superseded_at"] = NOW.isoformat()
+    head["status"]["active"] = False
+    head["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+    mid["status"]["superseded_by"] = "e_edge_v3"
+    mid["status"]["superseded_at"] = (NOW + timedelta(days=1)).isoformat()
+    mid["status"]["active"] = False
+    mid["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+    lookup = _make_lookup({
+        "e_edge_v1": head,
+        "e_edge_v2": mid,
+        "e_edge_v3": active,
+    })
+
+    # From head — walks the whole chain
+    chain_from_head = walk_supersede_chain(head, lookup)
+    assert [e["target"] for e in chain_from_head] == ["V1", "V2", "V3"]
+
+    # From mid — walks forward only
+    chain_from_mid = walk_supersede_chain(mid, lookup)
+    assert [e["target"] for e in chain_from_mid] == ["V2", "V3"]
+
+    # From the active head — single-element list
+    chain_from_active = walk_supersede_chain(active, lookup)
+    assert chain_from_active == [active]
+
+
+def test_supersede_chain_handles_unsuperseded_edge():
+    """Single-edge chain (no supersede) returns just the edge."""
+    only = _edge(target="Only", edge_id="e_edge_only")
+    lookup = _make_lookup({"e_edge_only": only})
+    chain = walk_supersede_chain(only, lookup)
+    assert chain == [only]
+
+
+def test_supersede_chain_handles_dangling_pointer():
+    """superseded_by points at an id the lookup can't resolve →
+    walker returns what it has so far (caller's wiki snapshot may
+    legitimately lack the next link if the next entity hasn't been
+    loaded yet)."""
+    head = _edge(target="V1", edge_id="e_edge_v1")
+    head["status"]["superseded_by"] = "e_edge_v_missing"
+    head["status"]["superseded_at"] = NOW.isoformat()
+    head["status"]["active"] = False
+    head["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+    lookup = _make_lookup({"e_edge_v1": head})  # missing target
+    chain = walk_supersede_chain(head, lookup)
+    assert chain == [head]
+
+
+# ─── #3 — cycle detection ─────────────────────────────────────────
+
+
+def test_supersede_chain_acyclic():
+    """A cyclic chain (v1→v2→v1) must raise on walk. Cycles are an
+    insertion bug that supersede_edge prevents, but the walker
+    defends against externally-mutated chains too."""
+    v1 = _edge(target="V1", edge_id="e_edge_v1")
+    v2 = _edge(target="V2", edge_id="e_edge_v2")
+    v1["status"]["superseded_by"] = "e_edge_v2"
+    v1["status"]["superseded_at"] = NOW.isoformat()
+    v1["status"]["active"] = False
+    v1["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+    v2["status"]["superseded_by"] = "e_edge_v1"   # cycle!
+    v2["status"]["superseded_at"] = NOW.isoformat()
+    v2["status"]["active"] = False
+    v2["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+    lookup = _make_lookup({"e_edge_v1": v1, "e_edge_v2": v2})
+
+    with pytest.raises(ValueError, match="cycle"):
+        walk_supersede_chain(v1, lookup)
+
+
+def test_supersede_chain_max_length_cap():
+    """Pathological linear chain longer than _MAX_CHAIN_LENGTH
+    raises rather than spinning forever. We don't actually build
+    1025 edges; we monkey-patch the cap on the module to a small
+    number and verify the limit fires."""
+    import core.lifecycle.supersede_chain as mod
+    original = mod._MAX_CHAIN_LENGTH
+    mod._MAX_CHAIN_LENGTH = 2
+    try:
+        v1 = _edge(target="V1", edge_id="e_edge_v1")
+        v2 = _edge(target="V2", edge_id="e_edge_v2")
+        v3 = _edge(target="V3", edge_id="e_edge_v3")
+        v4 = _edge(target="V4", edge_id="e_edge_v4")
+        for prev, nxt in [(v1, "e_edge_v2"), (v2, "e_edge_v3"), (v3, "e_edge_v4")]:
+            prev["status"]["superseded_by"] = nxt
+            prev["status"]["superseded_at"] = NOW.isoformat()
+            prev["status"]["active"] = False
+            prev["mutation_type"] = T1_MUTATION_SUPERSEDED
+
+        lookup = _make_lookup({
+            "e_edge_v1": v1, "e_edge_v2": v2,
+            "e_edge_v3": v3, "e_edge_v4": v4,
+        })
+        with pytest.raises(ValueError, match="exceeded max length"):
+            walk_supersede_chain(v1, lookup)
+    finally:
+        mod._MAX_CHAIN_LENGTH = original
+
+
+# ─── reconstruct_view_at — replay primitive ───────────────────────
+
+
+def test_reconstruct_view_at_returns_active_for_current_time():
+    """3-link chain — replay at the current time picks the active head."""
+    t0 = NOW - timedelta(days=10)
+    t1 = NOW - timedelta(days=5)
+    t2 = NOW
+    head = _edge(
+        target="V1", edge_id="e_edge_v1",
+        validity={"from": t0.isoformat(), "to": t1.isoformat()},
+        mutation_type=T1_MUTATION_SUPERSEDED,
+        status={"active": False, "superseded_by": "e_edge_v2",
+                "superseded_at": t1.isoformat()},
+    )
+    mid  = _edge(
+        target="V2", edge_id="e_edge_v2",
+        validity={"from": t1.isoformat(), "to": t2.isoformat()},
+        mutation_type=T1_MUTATION_SUPERSEDED,
+        status={"active": False, "superseded_by": "e_edge_v3",
+                "superseded_at": t2.isoformat()},
+    )
+    active = _edge(
+        target="V3", edge_id="e_edge_v3",
+        validity={"from": t2.isoformat(), "to": None},
+    )
+    lookup = _make_lookup({
+        "e_edge_v1": head, "e_edge_v2": mid, "e_edge_v3": active,
+    })
+
+    # At t > t2 → active head
+    got = reconstruct_view_at(head, lookup, NOW + timedelta(days=1))
+    assert got is active
+
+    # At t between t1 and t2 → mid
+    got = reconstruct_view_at(head, lookup, NOW - timedelta(days=3))
+    assert got is mid
+
+    # At t between t0 and t1 → head
+    got = reconstruct_view_at(head, lookup, NOW - timedelta(days=7))
+    assert got is head
+
+
+def test_reconstruct_view_at_skips_invalidated():
+    """An edge with mutation_type=invalidated is gone for replay —
+    CASCADE deletions are not visible in reconstructed history.
+    Supersede chain members are visible."""
+    t0 = NOW - timedelta(days=10)
+    t1 = NOW
+    invalidated = _edge(
+        target="V1", edge_id="e_edge_v1",
+        validity={"from": t0.isoformat(), "to": None},
+        mutation_type=T1_MUTATION_INVALIDATED,
+        status={"active": False, "superseded_by": None,
+                "superseded_at": None},
+    )
+    # Standalone edge — no chain — but reconstruct_view_at should
+    # walk it (single-link chain) and find no match because the
+    # only link is invalidated.
+    lookup = _make_lookup({"e_edge_v1": invalidated})
+    got = reconstruct_view_at(invalidated, lookup, t1)
+    assert got is None
+
+
+def test_reconstruct_view_at_returns_none_when_no_window_matches():
+    """All chain links' validity windows are in the past — query at
+    an even-earlier time returns None."""
+    t_past = NOW - timedelta(days=100)
+    only = _edge(
+        target="Only", edge_id="e_edge_only",
+        validity={"from": NOW.isoformat(), "to": None},
+    )
+    lookup = _make_lookup({"e_edge_only": only})
+    got = reconstruct_view_at(only, lookup, t_past)
+    assert got is None
+
+
+# ─── Cross-mutation-type guards ──────────────────────────────────
+
+
+def test_supersede_overwrites_expired_status():
+    """An edge already marked expired (T1 EVENT) can still be
+    superseded — supersede wins because supersede records WHY it's
+    inactive (the chain link), expiration just records WHEN.
+
+    This matches the entry memo §3 invariant: EVENT operations are
+    composable, only CASCADE is destructive."""
+    expired = _edge(target="V1", edge_id="e_edge_v1",
+                    mutation_type=T1_MUTATION_EXPIRED,
+                    status={"active": False, "superseded_by": None,
+                            "superseded_at": None})
+    new_fact = _edge(target="V2")
+
+    new_edge, mutated_old = supersede_edge(expired, new_fact, NOW)
+
+    assert mutated_old["mutation_type"] == T1_MUTATION_SUPERSEDED
+    assert mutated_old["status"]["superseded_by"] == new_edge["id"]
+
+
+def test_supersede_rejects_invalid_inputs():
+    """Type guards on the three args."""
+    with pytest.raises(ValueError, match="old_edge"):
+        supersede_edge("not a dict", _edge(), NOW)
+    with pytest.raises(ValueError, match="new_fact"):
+        supersede_edge(_edge(), "not a dict", NOW)
+    with pytest.raises(ValueError, match="supersede_ts"):
+        supersede_edge(_edge(), _edge(), "not a datetime")
+
+
+# ─── _ensure_edge_id helper ──────────────────────────────────────
+
+
+def test_ensure_edge_id_assigns_when_missing():
+    edge = {}
+    eid = _ensure_edge_id(edge)
+    assert eid.startswith("e_edge_")
+    assert edge["id"] == eid
+
+
+def test_ensure_edge_id_preserves_existing():
+    edge = {"id": "e_edge_existing"}
+    eid = _ensure_edge_id(edge)
+    assert eid == "e_edge_existing"
+    assert edge["id"] == "e_edge_existing"


### PR DESCRIPTION
## Summary

T7 supersede chain primitive — Sprint 5 7-PR 시퀀스 두 번째 PR. Pure-function layer with no engine wiring yet (PR-T2.B/C wires it into the contradiction arbiter production path).

Designed per `docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md` §"PR-T7.A Supersede chain operations".

## What landed

`core/lifecycle/supersede_chain.py` (~13.8 KB) — 3 pure functions:

| function | purpose |
|---|---|
| `supersede_edge(old_edge, new_fact, supersede_ts)` | Build new_edge + mark old as superseded. DOES NOT call cascade_remove. Returns (new, mutated_old). |
| `walk_supersede_chain(edge, lookup)` | Linked-list walk via `status.superseded_by`. Cycle-safe (raises) + max-length-capped (1024) + dangling-pointer-tolerant. |
| `reconstruct_view_at(head, lookup, t)` | Replay primitive. Returns chain edge whose validity window contains `t`. Skips `mutation_type=invalidated`. |

Pure-data layer — no I/O. Caller materializes edges as dicts (typically wiki frontmatter loader), passes id→edge `lookup`, gets back mutated dicts to write back.

## Verification

`tests/test_t7_supersede_chain.py` — **15 tests pass**. Total lifecycle suite **75 tests pass** when run together:

```
tests/test_lifecycle_schema.py       (PR-0)
tests/test_lifecycle_clock.py        (PR-0)
tests/test_migrate_v04_lifecycle.py  (PR-T1.A)
tests/test_expiration_cascade.py     (PR-T1.B, 16)
tests/test_t7_supersede_chain.py     (PR-T7.A, 15) ← this PR
```

The 3 entry memo invariants:

| invariant | test |
|---|---|
| `test_supersede_preserves_old_sources` | no CASCADE side effect — sources stay on old edge |
| `test_supersede_chain_walks_to_active` | walker follows chain through all superseded links |
| `test_supersede_chain_acyclic` | walker raises on cycle instead of looping |

Plus 12 companion guards (in-place mutation by reference, fresh-id + validity.from assignment, single-link / dangling-pointer handling, max-length cap, replay correctness, CASCADE-invisible-in-replay, mutation-type composability, type guards, helper assignment).

## What this PR does NOT do

- **No engine wiring** — production call site lands at PR-T2.B/C.
- **No cascade_remove invocation** — preservation is the whole T7 point (vs Layer 3 CASCADE which deletes).
- **No multi-edge fan-in/fan-out** — chain is linear linked list. One fact replacing several edges = repeated `supersede_edge` calls at the caller's discretion.

## Bench numbers (CLAUDE.md rule #2)

N/A — entry memo §"Bench" defers to PR-T2.C where the production caller lands. PR-T7.A is the pure-function layer.

## Out of scope

- **PR-T7.B** (next) — release-gating invariant test suite (`test_supersede_does_not_trigger_cascade`, `test_cascade_preserves_supersede_chain`, `test_historical_replay_via_chain`)
- **PR-T2.A** — contradiction arbiter A/B classifier
- **PR-T2.B/C** — production wiring of supersede_chain into the contradiction arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)