### PR TITLE
feat(v0.4): Sprint 5 PR-T2.B — A-path contradiction routing wire

### DIFF
--- a/core/lifecycle/contradiction_router.py
+++ b/core/lifecycle/contradiction_router.py
@@ -1,0 +1,222 @@
+"""v0.4 Sprint 5 PR-T2.B — A-path contradiction routing wire.
+
+Wires the deterministic ``classify_contradiction`` decision into
+the production CASCADE / EVENT dispatch.
+
+This PR delivers ONLY the **A-path** (cascade routing). The B-path
+(supersede chain wiring) lands at PR-T2.C — calling B here raises
+``NotImplementedError`` so a premature integration crashes loudly
+rather than silently no-op'ing.
+
+Surface
+-------
+
+  ``route_a_invalidate(bad_doc_id, entity_root, *, audit_emit=None)``
+      Run the existing ``cascade_remove_doc_from_sources`` for the
+      wrong source + emit a ``mutation_type=invalidated`` audit
+      row. Returns the cascade counts dict + the audit payload.
+
+  ``dispatch_contradiction(old_edge, new_fact, *, now, entity_root,
+                           bad_doc_id_for_a=None, audit_emit=None)``
+      End-to-end: calls ``classify_contradiction`` → dispatches.
+      A → ``route_a_invalidate`` (requires ``bad_doc_id_for_a``).
+      B → raises ``NotImplementedError`` (PR-T2.C).
+      ignore → returns ``{"action": "ignore"}``.
+
+Design notes
+------------
+
+- **A path narrowness.** The routing wire does NOT add new CASCADE
+  logic — it calls the existing ``cascade_remove_doc_from_sources``
+  unchanged. The PR's surface is two functions + an audit
+  side-effect.
+- **Bad-source identification stays at the caller.** The router
+  takes ``bad_doc_id_for_a`` explicitly rather than guessing which
+  source on ``old_edge`` is the wrong one. The caller (the
+  ingestion path that detected the contradiction) knows which doc
+  was just rejected — passing that doc_id through is one line.
+- **mutation_type audit invariant.** The audit row carries
+  ``mutation_type="invalidated"`` so the T7 replay primitive
+  (``reconstruct_view_at``) filters correctly — CASCADE
+  invalidations are gone for replay; the audit row is the only
+  trace.
+- **Default audit emitter.** When ``audit_emit`` is ``None``, falls
+  back to ``core.audit_bridge.mirror_to_audit_db`` (the same
+  mirror the reason:* events use). Tests pass an in-memory
+  capture function to assert the payload shape without touching
+  the SQLite DB.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from core.lifecycle.contradiction_arbiter import (
+    classify_contradiction,
+)
+from core.lifecycle.schema import T1_MUTATION_INVALIDATED
+
+
+AuditEmit = Callable[[Dict[str, Any]], None]
+
+
+def _default_audit_emit(payload: Dict[str, Any]) -> None:
+    """Mirror to the audit_log SQLite via core.audit_bridge. Never
+    raises — audit failure must not block the cascade write path
+    (same pattern as ``trace_synth_call``)."""
+    try:
+        from core.audit_bridge import mirror_to_audit_db
+        mirror_to_audit_db(payload)
+    except Exception:
+        pass
+
+
+def route_a_invalidate(
+    bad_doc_id: str,
+    entity_root: Path | str,
+    *,
+    audit_emit: Optional[AuditEmit] = None,
+) -> Dict[str, Any]:
+    """A-path: cascade-remove the wrong source + emit audit row.
+
+    Args:
+        bad_doc_id: the doc_id of the source identified as wrong
+            (by the caller's contradiction-detection logic).
+            ``cascade_remove_doc_from_sources`` removes this from
+            every edge that references it; manual sources and
+            non-matching doc_ids are preserved unchanged (per the
+            existing CASCADE contract — see
+            ``core/cascade/_delete.py:cascade_remove_doc_from_sources``
+            docstring).
+        entity_root: wiki entity root (typically ``wiki/entity``
+            or the wiki snapshot the cascade should target).
+        audit_emit: optional callback for the audit row. Defaults
+            to ``core.audit_bridge.mirror_to_audit_db``.
+
+    Returns:
+        ``{"action": "invalidate", "bad_doc_id": …, "counts": …,
+           "audit_payload": …}``
+
+        ``counts`` is the dict returned by
+        ``cascade_remove_doc_from_sources``:
+        ``entities_scanned`` / ``entities_touched`` /
+        ``relations_recomputed`` / ``relations_dropped``.
+
+        ``audit_payload`` is the dict that was emitted — useful
+        for callers that want to chain audit writes (e.g., write a
+        compound row for a multi-step ingestion).
+
+    Raises:
+        ValueError if ``bad_doc_id`` is empty or
+        ``entity_root`` doesn't exist.
+    """
+    if not bad_doc_id or not isinstance(bad_doc_id, str):
+        raise ValueError(f"bad_doc_id must be a non-empty str, got {bad_doc_id!r}")
+    root = Path(entity_root)
+    if not root.exists():
+        raise ValueError(f"entity_root does not exist: {root}")
+
+    # Lazy-import the cascade to avoid pulling Phase-C dependencies
+    # at module import time. The router stays import-light.
+    from core.cascade import cascade_remove_doc_from_sources
+
+    counts = cascade_remove_doc_from_sources(bad_doc_id, root)
+
+    audit_payload: Dict[str, Any] = {
+        "endpoint":      "lifecycle:invalidate",
+        "role":          "system",
+        "mutation_type": T1_MUTATION_INVALIDATED,
+        "bad_doc_id":    bad_doc_id,
+        "entities_scanned":     counts.get("entities_scanned", 0),
+        "entities_touched":     counts.get("entities_touched", 0),
+        "relations_recomputed": counts.get("relations_recomputed", 0),
+        "relations_dropped":    counts.get("relations_dropped", 0),
+    }
+    emitter = audit_emit or _default_audit_emit
+    emitter(audit_payload)
+
+    return {
+        "action":         "invalidate",
+        "bad_doc_id":     bad_doc_id,
+        "counts":         counts,
+        "audit_payload":  audit_payload,
+    }
+
+
+def dispatch_contradiction(
+    old_edge: dict,
+    new_fact: dict,
+    *,
+    now: datetime,
+    entity_root: Optional[Path | str] = None,
+    bad_doc_id_for_a: Optional[str] = None,
+    audit_emit: Optional[AuditEmit] = None,
+) -> Dict[str, Any]:
+    """Full A/B dispatch in one call. Calls
+    ``classify_contradiction`` + routes.
+
+    Args:
+        old_edge: existing v0.4-shaped edge.
+        new_fact: the contradicting observation (edge or source
+            shape — same dual-shape the classifier accepts).
+        now: UTC-aware ``datetime``.
+        entity_root: required for A-path (cascade target). Optional
+            for B / ignore.
+        bad_doc_id_for_a: required when ``classify_contradiction``
+            returns ``A_invalidate``. Caller's contradiction-detection
+            logic supplies this.
+        audit_emit: optional audit callback (A-path only — B-path
+            audit lands at PR-T2.C).
+
+    Returns:
+        For A_invalidate: see ``route_a_invalidate`` return.
+        For ignore: ``{"action": "ignore", "label": "ignore"}``.
+
+    Raises:
+        ValueError if A_invalidate is selected but required args
+        (``entity_root`` / ``bad_doc_id_for_a``) are missing.
+        NotImplementedError if classifier returns B_supersede —
+        wiring lands at PR-T2.C. Until then the caller must not
+        invoke dispatch on cases that would route to B (or accept
+        the loud failure as a guard against premature integration).
+    """
+    label = classify_contradiction(old_edge, new_fact, now=now)
+
+    if label == "ignore":
+        return {"action": "ignore", "label": "ignore"}
+
+    if label == "A_invalidate":
+        if entity_root is None:
+            raise ValueError(
+                "A_invalidate dispatch requires entity_root (cascade target)"
+            )
+        if not bad_doc_id_for_a:
+            raise ValueError(
+                "A_invalidate dispatch requires bad_doc_id_for_a — caller's "
+                "contradiction-detection logic identifies which source on "
+                "old_edge is the wrong one"
+            )
+        return route_a_invalidate(
+            bad_doc_id_for_a, entity_root, audit_emit=audit_emit,
+        )
+
+    if label == "B_supersede":
+        raise NotImplementedError(
+            "B_supersede dispatch lands at PR-T2.C — until then, callers "
+            "must filter out B-path contradictions before invoking "
+            "dispatch_contradiction. (See PR-T7.A supersede_edge for the "
+            "primitive the T2.C wire will call.)"
+        )
+
+    # Defensive — classifier returned a label we don't know about.
+    # Reachable only if classify_contradiction is extended without a
+    # matching dispatch arm here.
+    raise RuntimeError(f"unknown contradiction label: {label!r}")
+
+
+__all__ = [
+    "AuditEmit",
+    "route_a_invalidate",
+    "dispatch_contradiction",
+]

--- a/tests/test_t2_contradiction_router.py
+++ b/tests/test_t2_contradiction_router.py
@@ -1,0 +1,283 @@
+"""v0.4 Sprint 5 PR-T2.B — contract tests for the A-path router.
+
+Pins both required entry-memo invariants:
+
+  test_t2_a_class_routes_to_cascade
+    classify_contradiction → A_invalidate dispatches through
+    route_a_invalidate → cascade_remove_doc_from_sources
+
+  test_correction_invalidates_wrong_source_only
+    cascade removes only the bad doc's source from edges that
+    reference it; other sources on the same edge stay.
+
+Plus guards on the dispatcher's argument validation, B-path
+NotImplementedError, ignore-no-op, and audit row shape.
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.lifecycle.contradiction_router import (  # noqa: E402
+    dispatch_contradiction,
+    route_a_invalidate,
+)
+from core.lifecycle.schema import T1_MUTATION_INVALIDATED  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "lifecycle"
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load_fixture(tmp_path: Path) -> Path:
+    target = tmp_path / "lifecycle"
+    shutil.copytree(FIXTURE, target)
+    return target
+
+
+def _read_fm(path: Path) -> dict | None:
+    text = path.read_text(encoding="utf-8")
+    parts = text.split("---\n", 2)
+    if len(parts) < 2:
+        return None
+    try:
+        return yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+
+
+def _edge_world_changed_to_supersede() -> tuple[dict, dict]:
+    """Build an edge + new_fact pair that classifies to B_supersede."""
+    old = {
+        "sources":       [{"doc_id": "doc_a", "weight": 0.7, "ts": "2026-04-01T00:00:00+00:00"}],
+        "validity":      {"from": "2026-04-01T00:00:00+00:00", "to": "2026-05-01T00:00:00+00:00"},
+        "status":        {"active": True, "superseded_by": None, "superseded_at": None},
+        "mutation_type": "active",
+    }
+    new_fact = {
+        "valid_from": "2026-07-01T00:00:00+00:00",
+        "timestamp":  "2026-07-01T00:00:00+00:00",
+        "weight":     0.7,
+    }
+    return old, new_fact
+
+
+def _edge_corrected_invalidate(bad_doc_id: str) -> tuple[dict, dict]:
+    """Build an edge + new_fact pair that classifies to A_invalidate."""
+    old = {
+        "sources": [
+            {"doc_id": bad_doc_id, "weight": 0.7, "ts": "2026-04-01T00:00:00+00:00"},
+        ],
+        "validity":      {"from": "2026-04-01T00:00:00+00:00",
+                          "to":   "2026-05-31T00:00:00+00:00"},
+        "status":        {"active": True, "superseded_by": None, "superseded_at": None},
+        "mutation_type": "active",
+    }
+    new_fact = {
+        "valid_from": "2026-04-01T00:00:00+00:00",
+        "timestamp":  "2026-03-01T00:00:00+00:00",   # before old.vf
+        "weight":     0.95,
+    }
+    return old, new_fact
+
+
+def _edge_duplicate_ignore() -> tuple[dict, dict]:
+    """Pair that classifies to ignore."""
+    old = {
+        "sources":       [{"doc_id": "doc_a", "weight": 0.7, "ts": "2026-04-01T00:00:00+00:00"}],
+        "validity":      {"from": "2026-04-01T00:00:00+00:00",
+                          "to":   "2026-08-01T00:00:00+00:00"},
+        "status":        {"active": True, "superseded_by": None, "superseded_at": None},
+        "mutation_type": "active",
+    }
+    new_fact = {
+        "valid_from": "2026-05-15T00:00:00+00:00",
+        "timestamp":  "2026-05-15T00:00:00+00:00",
+        "weight":     0.7,
+    }
+    return old, new_fact
+
+
+# ─── Invariant 1 — A-path routes to cascade ───────────────────────
+
+
+def test_t2_a_class_routes_to_cascade(tmp_path):
+    """A_invalidate → cascade_remove_doc_from_sources runs against the
+    fixture wiki + audit row emitted with mutation_type=invalidated."""
+    wiki_root = _load_fixture(tmp_path)
+    old, new_fact = _edge_corrected_invalidate("doc_cascade_target")
+
+    captured: list[dict] = []
+    result = dispatch_contradiction(
+        old, new_fact,
+        now=NOW,
+        entity_root=wiki_root,
+        bad_doc_id_for_a="doc_cascade_target",
+        audit_emit=captured.append,
+    )
+
+    # A-path dispatched
+    assert result["action"] == "invalidate"
+
+    # Cascade ran — entity_b's lone-source relation was dropped
+    assert result["counts"]["relations_dropped"] >= 1
+
+    # Audit row emitted with the contract shape
+    assert len(captured) == 1
+    audit = captured[0]
+    assert audit["endpoint"] == "lifecycle:invalidate"
+    assert audit["mutation_type"] == T1_MUTATION_INVALIDATED
+    assert audit["bad_doc_id"] == "doc_cascade_target"
+    assert audit["entities_scanned"] >= 1
+    assert audit["relations_dropped"] >= 1
+
+
+# ─── Invariant 2 — wrong source only ─────────────────────────────
+
+
+def test_correction_invalidates_wrong_source_only(tmp_path):
+    """Cascade removes only the bad doc — entity_a's relations (which
+    don't reference doc_cascade_target) stay intact post-cascade.
+    Pins the 'other sources preserved' half of the entry memo
+    invariant."""
+    wiki_root = _load_fixture(tmp_path)
+    pre_a = _read_fm(wiki_root / "entity_a.md")
+    pre_v1 = next(r for r in pre_a["relations"] if r["id"] == "e_edge_a_v1")
+    pre_v2 = next(r for r in pre_a["relations"] if r["id"] == "e_edge_a_v2")
+
+    route_a_invalidate(
+        "doc_cascade_target", wiki_root, audit_emit=lambda _: None,
+    )
+
+    # entity_a's chain pointers + sources are untouched
+    post_a = _read_fm(wiki_root / "entity_a.md")
+    post_v1 = next(r for r in post_a["relations"] if r["id"] == "e_edge_a_v1")
+    post_v2 = next(r for r in post_a["relations"] if r["id"] == "e_edge_a_v2")
+    assert post_v1["sources"] == pre_v1["sources"]
+    assert post_v2["sources"] == pre_v2["sources"]
+    assert post_v1["status"]["superseded_by"] == "e_edge_a_v2"
+
+
+# ─── route_a_invalidate argument validation ──────────────────────
+
+
+def test_route_a_invalidate_rejects_empty_doc_id(tmp_path):
+    with pytest.raises(ValueError, match="bad_doc_id"):
+        route_a_invalidate("", tmp_path)
+
+
+def test_route_a_invalidate_rejects_missing_root():
+    with pytest.raises(ValueError, match="entity_root"):
+        route_a_invalidate("doc_x", "/nonexistent/path")
+
+
+def test_route_a_invalidate_uses_default_audit_when_no_callback(tmp_path):
+    """audit_emit=None routes through core.audit_bridge — should not
+    raise (the bridge wraps writes defensively even when SQLite is
+    missing/locked)."""
+    wiki_root = _load_fixture(tmp_path)
+    # Don't crash; cascade should still run.
+    result = route_a_invalidate("doc_cascade_target", wiki_root)
+    assert result["action"] == "invalidate"
+
+
+# ─── dispatch_contradiction routing ──────────────────────────────
+
+
+def test_dispatch_calls_classify(tmp_path):
+    """ignore label returns no-op dict + does NOT call cascade."""
+    old, new_fact = _edge_duplicate_ignore()
+    result = dispatch_contradiction(old, new_fact, now=NOW)
+    assert result == {"action": "ignore", "label": "ignore"}
+
+
+def test_dispatch_routes_a_to_cascade(tmp_path):
+    """A_invalidate dispatched → cascade ran (entity_b drop)."""
+    wiki_root = _load_fixture(tmp_path)
+    old, new_fact = _edge_corrected_invalidate("doc_cascade_target")
+
+    captured: list[dict] = []
+    result = dispatch_contradiction(
+        old, new_fact, now=NOW,
+        entity_root=wiki_root,
+        bad_doc_id_for_a="doc_cascade_target",
+        audit_emit=captured.append,
+    )
+    assert result["action"] == "invalidate"
+    assert captured[0]["mutation_type"] == T1_MUTATION_INVALIDATED
+
+
+def test_dispatch_a_requires_entity_root():
+    old, new_fact = _edge_corrected_invalidate("doc_x")
+    with pytest.raises(ValueError, match="entity_root"):
+        dispatch_contradiction(old, new_fact, now=NOW,
+                                bad_doc_id_for_a="doc_x")
+
+
+def test_dispatch_a_requires_bad_doc_id(tmp_path):
+    old, new_fact = _edge_corrected_invalidate("doc_x")
+    with pytest.raises(ValueError, match="bad_doc_id_for_a"):
+        dispatch_contradiction(old, new_fact, now=NOW,
+                                entity_root=tmp_path)
+
+
+def test_dispatch_raises_on_b_until_t2c():
+    """B_supersede dispatch must raise NotImplementedError so a
+    premature integration crashes loudly rather than silently
+    no-op'ing. The wiring lands at PR-T2.C."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    with pytest.raises(NotImplementedError, match="PR-T2.C"):
+        dispatch_contradiction(old, new_fact, now=NOW)
+
+
+def test_dispatch_unknown_label_raises_runtime_error(monkeypatch):
+    """Defensive — if classify_contradiction is extended with a new
+    label that the dispatcher doesn't know about, raise loudly."""
+    import core.lifecycle.contradiction_router as mod
+    monkeypatch.setattr(
+        mod, "classify_contradiction",
+        lambda *_a, **_kw: "X_unknown_label",
+    )
+    with pytest.raises(RuntimeError, match="unknown contradiction label"):
+        dispatch_contradiction({}, {}, now=NOW)
+
+
+# ─── Audit row contract ──────────────────────────────────────────
+
+
+def test_audit_payload_carries_mutation_type_invalidated(tmp_path):
+    """The replay primitive (reconstruct_view_at) skips edges with
+    mutation_type=invalidated. The audit row carries the same label
+    so a query of audit_log can correlate the cascade event to the
+    filtered-out edge."""
+    wiki_root = _load_fixture(tmp_path)
+    captured: list[dict] = []
+    route_a_invalidate(
+        "doc_cascade_target", wiki_root, audit_emit=captured.append,
+    )
+    assert captured[0]["mutation_type"] == T1_MUTATION_INVALIDATED
+
+
+def test_audit_payload_carries_cascade_counts(tmp_path):
+    """Counts dict from cascade_remove_doc_from_sources is included
+    in the audit row — operator can correlate audit timing to
+    cascade scope without separate query."""
+    wiki_root = _load_fixture(tmp_path)
+    captured: list[dict] = []
+    route_a_invalidate(
+        "doc_cascade_target", wiki_root, audit_emit=captured.append,
+    )
+    audit = captured[0]
+    for k in (
+        "entities_scanned", "entities_touched",
+        "relations_recomputed", "relations_dropped",
+    ):
+        assert k in audit, f"audit payload missing key: {k}"
+        assert isinstance(audit[k], int)


### PR DESCRIPTION
## Summary

T2 A-path routing wire — Sprint 5 7-PR 시퀀스 다섯 번째 PR. Wires `classify_contradiction == A_invalidate` → existing `cascade_remove_doc_from_sources` + emits `mutation_type=invalidated` audit row.

**A-path only**. B-path (supersede chain wiring) lands at PR-T2.C — calling B here raises `NotImplementedError` so a premature integration crashes loudly rather than silently no-op'ing.

## What landed

`core/lifecycle/contradiction_router.py` (~8.5 KB) — 2 functions:

```python
route_a_invalidate(bad_doc_id, entity_root, *, audit_emit=None)
    # Runs cascade_remove_doc_from_sources + emits audit row.
    # Returns counts + audit_payload.

dispatch_contradiction(old_edge, new_fact, *, now, entity_root,
                       bad_doc_id_for_a, audit_emit=None)
    # Full A/B dispatch:
    #   ignore        → no-op
    #   A_invalidate  → route_a_invalidate
    #   B_supersede   → NotImplementedError (PR-T2.C)
```

## Verification

**13 tests pass**. Full lifecycle suite **117 tests pass** when run together (PR-0 + T1.A + T1.B + T7.A + T7.B + T2.A + this PR).

Two required entry-memo invariants:

| invariant | test |
|---|---|
| A dispatches to cascade | `test_t2_a_class_routes_to_cascade` (real fixture, real cascade) |
| wrong source only | `test_correction_invalidates_wrong_source_only` (entity_a chain links untouched) |

Plus argument validation guards (empty doc_id, missing root, missing entity_root for A, missing bad_doc_id for A), dispatch routing (ignore → no-op, A → cascade, B → NotImplementedError, unknown label → RuntimeError), audit row contract (carries mutation_type + cascade counts).

## What this PR does NOT do

- **No new CASCADE logic** — reuses `cascade_remove_doc_from_sources` unchanged.
- **No B-path wiring** — that lands at PR-T2.C with the supersede chain integration.
- **No ingestion-path caller** — the dispatcher exposes the surface; the caller (future memory_loom or ingestion conflict detector) supplies `bad_doc_id_for_a` based on its own logic.

## Bench numbers (CLAUDE.md rule #2)

STEP 7 with synthetic correction scenario deferred to PR-T2.C where the full A+B wiring lands. PR-T2.B is the A-half; verifying grounded=true rate on a corrected entity requires both arms exercised in the same bench.

## Out of scope

- **PR-T2.C** (next) — B-path EVENT routing (wire `B_supersede` to `supersede_edge` from PR-T7.A) + final ingestion wiring + STEP 7 bench
- **PR-T7.C** — Sprint 5 closure + **v0.4.0 release publish**

🤖 Generated with [Claude Code](https://claude.com/claude-code)