### PR TITLE
feat(v0.4): Sprint 5 PR-T2.C — B-path supersede wiring + final A/B dispatch

### DIFF
--- a/core/lifecycle/contradiction_router.py
+++ b/core/lifecycle/contradiction_router.py
@@ -1,12 +1,10 @@
-"""v0.4 Sprint 5 PR-T2.B — A-path contradiction routing wire.
+"""v0.4 Sprint 5 PR-T2.B/T2.C — full A/B contradiction routing wire.
 
 Wires the deterministic ``classify_contradiction`` decision into
-the production CASCADE / EVENT dispatch.
-
-This PR delivers ONLY the **A-path** (cascade routing). The B-path
-(supersede chain wiring) lands at PR-T2.C — calling B here raises
-``NotImplementedError`` so a premature integration crashes loudly
-rather than silently no-op'ing.
+the production CASCADE / EVENT dispatch. PR-T2.B landed the A-path
+(cascade routing); PR-T2.C completes the surface with the B-path
+(supersede chain wiring) so ``dispatch_contradiction`` is now the
+single entry point for all three labels.
 
 Surface
 -------
@@ -16,11 +14,18 @@ Surface
       wrong source + emit a ``mutation_type=invalidated`` audit
       row. Returns the cascade counts dict + the audit payload.
 
+  ``route_b_supersede(old_edge, new_fact, supersede_ts,
+                      *, audit_emit=None)``
+      Call ``supersede_edge`` from PR-T7.A. Old edge marked
+      ``status.superseded_by = new_edge.id`` + ``mutation_type =
+      "superseded"``. Audit row carries both ids so the T7 replay
+      primitive (``reconstruct_view_at``) sees the chain.
+
   ``dispatch_contradiction(old_edge, new_fact, *, now, entity_root,
                            bad_doc_id_for_a=None, audit_emit=None)``
       End-to-end: calls ``classify_contradiction`` → dispatches.
       A → ``route_a_invalidate`` (requires ``bad_doc_id_for_a``).
-      B → raises ``NotImplementedError`` (PR-T2.C).
+      B → ``route_b_supersede`` (uses ``now`` as supersede_ts).
       ignore → returns ``{"action": "ignore"}``.
 
 Design notes
@@ -55,7 +60,11 @@ from typing import Any, Callable, Dict, Optional
 from core.lifecycle.contradiction_arbiter import (
     classify_contradiction,
 )
-from core.lifecycle.schema import T1_MUTATION_INVALIDATED
+from core.lifecycle.schema import (
+    T1_MUTATION_INVALIDATED,
+    T1_MUTATION_SUPERSEDED,
+)
+from core.lifecycle.supersede_chain import supersede_edge
 
 
 AuditEmit = Callable[[Dict[str, Any]], None]
@@ -144,6 +153,71 @@ def route_a_invalidate(
     }
 
 
+def route_b_supersede(
+    old_edge: dict,
+    new_fact: dict,
+    supersede_ts: datetime,
+    *,
+    audit_emit: Optional[AuditEmit] = None,
+) -> Dict[str, Any]:
+    """B-path: call PR-T7.A ``supersede_edge`` + emit audit row.
+
+    Args:
+        old_edge: the existing edge being superseded. **Mutated in
+            place** (PR-T7.A contract — the caller's frontmatter
+            list reference picks up the change).
+        new_fact: the new fact replacing the old edge. Same shape
+            as a v0.4 edge (relation dict from frontmatter).
+        supersede_ts: UTC-aware ``datetime`` of the supersede event.
+            Used for both ``old_edge.status.superseded_at`` and
+            ``new_edge.validity.from`` (PR-T7.A contract).
+        audit_emit: optional callback for the audit row. Defaults
+            to ``core.audit_bridge.mirror_to_audit_db``.
+
+    Returns:
+        ``{"action": "supersede", "new_edge": …, "old_edge": …,
+           "audit_payload": …}``
+
+        ``new_edge`` and ``old_edge`` are the dicts returned by
+        ``supersede_edge``. The caller writes both back to the wiki
+        (the router does NOT touch disk — same contract as
+        PR-T7.A's pure-function layer).
+
+        ``audit_payload`` carries ``mutation_type="superseded"`` +
+        ``superseded_by=<new_edge.id>`` so the T7 replay primitive
+        sees the chain when querying audit history. The PR-T7.B
+        invariant ``test_supersede_does_not_trigger_cascade``
+        verifies this path does not invoke CASCADE.
+
+    What this function does NOT do:
+        - **No I/O.** Caller writes ``new_edge`` + ``mutated_old``
+          back to the wiki (same as PR-T7.A direct callers).
+        - **No cascade_remove.** Supersede preserves the old
+          edge's sources; CASCADE is exclusive (T7 EVENT
+          invariant).
+    """
+    new_edge, mutated_old = supersede_edge(old_edge, new_fact, supersede_ts)
+
+    audit_payload: Dict[str, Any] = {
+        "endpoint":         "lifecycle:supersede",
+        "role":             "system",
+        "mutation_type":    T1_MUTATION_SUPERSEDED,
+        "old_edge_id":      mutated_old.get("id"),
+        "new_edge_id":      new_edge.get("id"),
+        "superseded_at":    supersede_ts.isoformat(),
+        "superseded_by":    new_edge.get("id"),
+    }
+    emitter = audit_emit or _default_audit_emit
+    emitter(audit_payload)
+
+    return {
+        "action":         "supersede",
+        "new_edge":       new_edge,
+        "old_edge":       mutated_old,
+        "audit_payload":  audit_payload,
+    }
+
+
 def dispatch_contradiction(
     old_edge: dict,
     new_fact: dict,
@@ -171,15 +245,15 @@ def dispatch_contradiction(
 
     Returns:
         For A_invalidate: see ``route_a_invalidate`` return.
+        For B_supersede: see ``route_b_supersede`` return. Uses
+            ``now`` as ``supersede_ts`` — the caller doesn't have
+            to track two timestamps when the contradiction is
+            being detected at the same moment it's being applied.
         For ignore: ``{"action": "ignore", "label": "ignore"}``.
 
     Raises:
         ValueError if A_invalidate is selected but required args
         (``entity_root`` / ``bad_doc_id_for_a``) are missing.
-        NotImplementedError if classifier returns B_supersede —
-        wiring lands at PR-T2.C. Until then the caller must not
-        invoke dispatch on cases that would route to B (or accept
-        the loud failure as a guard against premature integration).
     """
     label = classify_contradiction(old_edge, new_fact, now=now)
 
@@ -202,11 +276,8 @@ def dispatch_contradiction(
         )
 
     if label == "B_supersede":
-        raise NotImplementedError(
-            "B_supersede dispatch lands at PR-T2.C — until then, callers "
-            "must filter out B-path contradictions before invoking "
-            "dispatch_contradiction. (See PR-T7.A supersede_edge for the "
-            "primitive the T2.C wire will call.)"
+        return route_b_supersede(
+            old_edge, new_fact, now, audit_emit=audit_emit,
         )
 
     # Defensive — classifier returned a label we don't know about.
@@ -218,5 +289,6 @@ def dispatch_contradiction(
 __all__ = [
     "AuditEmit",
     "route_a_invalidate",
+    "route_b_supersede",
     "dispatch_contradiction",
 ]

--- a/tests/test_t2_contradiction_router.py
+++ b/tests/test_t2_contradiction_router.py
@@ -29,6 +29,10 @@ sys.path.insert(0, str(ROOT))
 from core.lifecycle.contradiction_router import (  # noqa: E402
     dispatch_contradiction,
     route_a_invalidate,
+    route_b_supersede,
+)
+from core.lifecycle.supersede_chain import (  # noqa: E402
+    reconstruct_view_at,
 )
 from core.lifecycle.schema import T1_MUTATION_INVALIDATED  # noqa: E402
 
@@ -228,13 +232,23 @@ def test_dispatch_a_requires_bad_doc_id(tmp_path):
                                 entity_root=tmp_path)
 
 
-def test_dispatch_raises_on_b_until_t2c():
-    """B_supersede dispatch must raise NotImplementedError so a
-    premature integration crashes loudly rather than silently
-    no-op'ing. The wiring lands at PR-T2.C."""
+def test_dispatch_routes_b_to_supersede():
+    """B_supersede dispatch (PR-T2.C wiring) calls supersede_edge +
+    emits the new+old ids in the audit row. Replaces the prior
+    NotImplementedError pin from PR-T2.B."""
     old, new_fact = _edge_world_changed_to_supersede()
-    with pytest.raises(NotImplementedError, match="PR-T2.C"):
-        dispatch_contradiction(old, new_fact, now=NOW)
+    captured: list[dict] = []
+    result = dispatch_contradiction(
+        old, new_fact, now=NOW, audit_emit=captured.append,
+    )
+    assert result["action"] == "supersede"
+    assert result["new_edge"]["id"].startswith("e_edge_")
+    assert result["old_edge"] is old   # mutated in place
+    assert old["mutation_type"] == "superseded"
+    assert old["status"]["superseded_by"] == result["new_edge"]["id"]
+    # Audit row carries both ids per PR-T2.C contract
+    assert captured[0]["mutation_type"] == "superseded"
+    assert captured[0]["new_edge_id"] == result["new_edge"]["id"]
 
 
 def test_dispatch_unknown_label_raises_runtime_error(monkeypatch):
@@ -281,3 +295,103 @@ def test_audit_payload_carries_cascade_counts(tmp_path):
     ):
         assert k in audit, f"audit payload missing key: {k}"
         assert isinstance(audit[k], int)
+
+
+# ─── PR-T2.C B-path tests ─────────────────────────────────────────
+
+
+def test_t2_b_class_routes_to_supersede():
+    """B_supersede dispatch invokes supersede_edge — the entry memo
+    invariant `test_t2_b_class_routes_to_supersede` from §3."""
+    old, new_fact = _edge_world_changed_to_supersede()
+
+    captured: list[dict] = []
+    result = route_b_supersede(
+        old, new_fact, NOW, audit_emit=captured.append,
+    )
+
+    assert result["action"] == "supersede"
+    new_edge = result["new_edge"]
+    mutated_old = result["old_edge"]
+    # PR-T7.A contract: new_edge gets a fresh synthetic id
+    assert new_edge["id"].startswith("e_edge_")
+    # old mutated in place — caller's reference picks up the change
+    assert mutated_old is old
+    # The two T7 invariants on old_edge
+    assert mutated_old["status"]["active"] is False
+    assert mutated_old["status"]["superseded_by"] == new_edge["id"]
+    assert mutated_old["mutation_type"] == "superseded"
+
+
+def test_supersede_audit_payload_carries_old_and_new_ids():
+    """Entry memo invariant — audit row must include both edge ids
+    so the T7 replay primitive can correlate the chain when
+    querying audit history."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    old["id"] = "e_edge_pre_existing_old"   # exercise the "old has an id" path
+
+    captured: list[dict] = []
+    route_b_supersede(old, new_fact, NOW, audit_emit=captured.append)
+
+    audit = captured[0]
+    assert audit["endpoint"] == "lifecycle:supersede"
+    assert audit["mutation_type"] == "superseded"
+    assert audit["old_edge_id"] == "e_edge_pre_existing_old"
+    assert audit["new_edge_id"].startswith("e_edge_")
+    assert audit["superseded_by"] == audit["new_edge_id"]
+    assert audit["superseded_at"] == NOW.isoformat()
+
+
+def test_supersede_dispatch_uses_now_as_supersede_ts():
+    """dispatch_contradiction passes now as supersede_ts → the new
+    edge's validity.from matches now.isoformat()."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    result = dispatch_contradiction(old, new_fact, now=NOW)
+    assert result["new_edge"]["validity"]["from"] == NOW.isoformat()
+
+
+def test_supersede_preserves_old_edge_sources():
+    """PR-T2.C invariant cross-check — supersede path does not touch
+    old edge's sources (CASCADE invariant from PR-T7.B preserved
+    through the router layer)."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    old_sources_before = list(old["sources"])
+    route_b_supersede(old, new_fact, NOW, audit_emit=lambda _: None)
+    assert old["sources"] == old_sources_before, (
+        "supersede must NOT touch old edge's sources (CASCADE-free "
+        "invariant); only status + mutation_type"
+    )
+
+
+def test_supersede_chain_replayable_after_dispatch():
+    """End-to-end: dispatch a B_supersede contradiction, then
+    reconstruct_view_at to confirm the new edge is reachable from
+    the old via the chain. Pins that the router-emitted chain is
+    walkable by the T7 replay primitive."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    old["id"] = "e_edge_v1"
+
+    result = dispatch_contradiction(old, new_fact, now=NOW)
+    new_edge = result["new_edge"]
+
+    # Build an in-memory id→edge lookup (caller would normally
+    # populate this from wiki frontmatter).
+    edges = {"e_edge_v1": old, new_edge["id"]: new_edge}
+    lookup = edges.get
+
+    # Replay at a time after the supersede → returns the new edge
+    later = datetime(2026, 12, 31, tzinfo=timezone.utc)
+    view = reconstruct_view_at(old, lookup, later)
+    assert view is not None
+    assert view["id"] == new_edge["id"]
+
+
+def test_dispatch_b_emits_audit_through_callback():
+    """audit_emit callback is invoked exactly once on the B path."""
+    old, new_fact = _edge_world_changed_to_supersede()
+    captured: list[dict] = []
+    dispatch_contradiction(
+        old, new_fact, now=NOW, audit_emit=captured.append,
+    )
+    assert len(captured) == 1
+    assert captured[0]["endpoint"] == "lifecycle:supersede"


### PR DESCRIPTION
## Summary

T2 B-path EVENT routing wire — Sprint 5 7-PR 시퀀스 여섯 번째 PR (implementation 마지막, only T7.C closure docs PR after this). Completes the contradiction dispatch surface by wiring `classify_contradiction == B_supersede` → PR-T7.A `supersede_edge`.

## What landed

`core/lifecycle/contradiction_router.py` extends:

```python
route_b_supersede(old_edge, new_fact, supersede_ts, *, audit_emit=None)
    # Calls supersede_edge from PR-T7.A.
    # Audit row: mutation_type=superseded + old_edge_id +
    # new_edge_id + superseded_by + superseded_at.
```

`dispatch_contradiction` B-branch:
- **Previously**: `raise NotImplementedError("PR-T2.C")`
- **Now**: calls `route_b_supersede(old_edge, new_fact, now, ...)` — caller doesn't track two timestamps when detection + apply happen at the same moment.

## Verification

**19 tests pass** for the router (PR-T2.B + this PR's additions). Full lifecycle suite **123 tests pass**:

```
test_lifecycle_clock + test_lifecycle_schema  (PR-0)
test_migrate_v04_lifecycle                    (PR-T1.A)
test_expiration_cascade                       (PR-T1.B, 16)
test_t7_supersede_chain                       (PR-T7.A, 15)
test_t7_release_gating_invariants             (PR-T7.B, 5)
test_t2_contradiction_arbiter                 (PR-T2.A, 17)
test_t2_contradiction_router                  (PR-T2.B+C, 19)
```

Two entry-memo invariants pinned:

| invariant | test |
|---|---|
| B dispatches to supersede | `test_t2_b_class_routes_to_supersede` |
| audit carries old + new ids | `test_supersede_audit_payload_carries_old_and_new_ids` |

Plus end-to-end replay: `test_supersede_chain_replayable_after_dispatch` — dispatch a B contradiction, then `reconstruct_view_at` confirms the new edge is reachable from the old via the chain.

## What this PR does NOT do

- **No new CASCADE / supersede logic** — reuses PR-T7.A `supersede_edge` and PR-T2.B's audit emission pattern.
- **No ingestion-path caller** — the dispatcher exposes the surface; the production caller (memory_loom / ingestion conflict detector) supplies `old_edge` + `new_fact` + `bad_doc_id_for_a` (A path only) at its own dispatch point.

## Bench numbers (CLAUDE.md rule #2)

The entry memo §"PR-T2.C Bench" calls for a canonical supersede scenario (CEO change) verifying historical query returns Alice via `reconstruct_view_at` + current query returns Bob + grounded=true rate unchanged.

That bench requires an end-to-end ingestion caller to actually exercise the dispatcher — the 6-PR Sprint 5 surface adds the primitive functions + the routing wire, but doesn't yet include the call site that detects "new fact arrived → look up old edge → invoke dispatch". The caller is the next sprint / operator integration; until then, `test_supersede_chain_replayable_after_dispatch` carries the "chain is correctly built + walkable" guarantee at the function-composition level. End-to-end STEP 7 bench deferred to the ingestion-wire PR.

## Out of scope

- **PR-T7.C** (next, final) — Sprint 5 closure docs PR + **v0.4.0 release publish**
- **Ingestion-path caller** — the call site that invokes `dispatch_contradiction` from a real ingestion event. Likely lands in a sprint-6 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)