### PR TITLE
test(research): F9.1 — query_rewriter concept-anchor audit (no production change)

### DIFF
--- a/scripts/research/query_rewriter_audit.py
+++ b/scripts/research/query_rewriter_audit.py
@@ -1,0 +1,447 @@
+"""F9 (LEO L.D follow-up, 2026-05-27) — query_rewriter concept-anchor audit.
+
+Measures whether the production ``core.retrieval.query_rewriter.QueryRewriter``
+adds **concept anchors** when rewriting bare proper-noun queries.
+
+Background — the q15 8-cycle diagnosis chain
+--------------------------------------------
+
+BL-9 (#534 + #536) confirmed bge-m3 embedding swap is active but the
+q15 acceptance gate ("David Soria Parra가 누구야?" → MCP PDF in top-10)
+still fails. Direct chroma probe (post-swap, 5 variations):
+
+    "David Soria Parra"                    → not in top-20
+    "David Soria Parra가 누구야?"           → not in top-20
+    "MCP 설계자 David Soria Parra"          → rank 1, score 0.81
+    "Anthropic MCP 공개"                    → rank 1, score 0.78
+    "MCP designer Anthropic Justin..."      → rank 1, score 0.76
+
+→ The MCP PDF chunk contains "David Soria Parra와 Justin Spahr-Summers"
+in ~80 chars of ~2 KB; the chunk vector is dominated by concept tokens
+(MCP / Model Context Protocol / Anthropic / JSON-RPC). ANY 1024-dim
+multilingual pooling embedding has the same weakness — concept anchor
+in the **query** is the missing piece, not embedding model capacity.
+
+JAMES already has a ``QueryRewriter`` at pipeline STEP 0.5b (gated by
+``JAMES_ENABLE_QUERY_REWRITE=1``). The rewriter's Korean prompt asks
+the LLM to "strengthen keywords with 1-2 synonyms" — but says NOTHING
+about concept anchors. This audit measures whether the prompt's
+synonym-only instruction is enough to cover the proper-noun case, or
+whether the prompt (or a separate step) needs an explicit
+concept-anchor expansion instruction.
+
+What this audit does NOT do
+---------------------------
+
+- **No production change.** The rewriter prompt + wiring stays
+  byte-identical. This script reads.
+- **No corpus-aware fix.** We measure the prompt's behaviour on a
+  fixed fixture; we do NOT add corpus-aware anchor generation here.
+  That fix lands at F9.2 once this audit pins what the prompt
+  currently produces.
+- **No ablation of the embedding model.** BL-9 already covered that
+  (the swap is active; q15 still fails). This audit's variable is
+  **the rewriter prompt**, not the encoder.
+
+Fixture buckets
+---------------
+
+Four buckets exercise the four shapes the production query stream
+mixes. Each row carries an ``expected_anchors`` list — the set of
+corpus tokens that, if any one appears in the rewritten text, would
+bridge the query vector to the matching chunk vectors per the BL-9
+post-swap probe.
+
+  1. **bare_proper_noun** — q15-shape. The diagnosis cluster. Should
+     get concept anchors added; currently does not (hypothesis).
+  2. **name_with_concept** — control: anchor already in original.
+     Rewriter should preserve, not strip.
+  3. **pure_concept** — control: no person name involved. Rewriter
+     should leave the concept-side query stable (the bge-m3 swap
+     already handles these).
+  4. **multi_hop_control** — q2-shape ("팔란티어의 CEO 누구"). Person
+     name PLUS company concept implicit in the query. Should already
+     work without anchor expansion; included to detect regression
+     when F9.2 introduces an expansion step.
+
+Anchor-presence heuristic
+-------------------------
+
+Case-insensitive substring match: an anchor counts as "added" if any
+member of ``expected_anchors`` appears in the rewritten text but did
+NOT appear in the original. We deliberately use a strict "not present
+in original" guard so the ``name_with_concept`` bucket scores
+correctly — its anchors already exist in the original, so the rewriter
+"preserving" them must NOT count as "adding".
+
+Each run produces ``reports/research-runs/query-rewriter-audit-
+<stamp>.json`` with per-query rows + per-bucket aggregates.
+
+Pre-requisites
+--------------
+- Ollama service reachable.
+- ``JAMES_LLM_MODEL`` set to the tag you want audited (the audit
+  records this so reruns are diffable).
+
+Usage
+-----
+    python scripts/research/query_rewriter_audit.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from utils.console import ensure_utf8_console
+    ensure_utf8_console()
+except Exception:
+    pass
+
+
+REPORTS_DIR = ROOT / "reports" / "research-runs"
+
+
+# ─── Fixture ─────────────────────────────────────────────────────────
+#
+# Tied to the current corpus (MCP PDF + Palantir wiki + finance docs).
+# When the corpus shifts substantially, refresh this fixture so the
+# anchor sets continue to reflect the actual concept tokens the
+# matching chunk vectors carry. The fixture stays inline (rather than
+# a JSON file) because this audit's value is measurement-correctness
+# of the heuristic over a known-good ground truth — splitting fixture
+# from check would make drift silent.
+#
+# Anchors are case-insensitive substrings. We list the minimal
+# bridging tokens, not exhaustive context — the heuristic is "at
+# least one anchor present", so a smaller curated set is more
+# diagnostic than a broad keyword list.
+
+_FIXTURE: List[Dict] = [
+    # ─── bucket 1: bare_proper_noun (the q15 cluster) ──────────────
+    {
+        "id":               "bpn-1",
+        "bucket":           "bare_proper_noun",
+        "text":             "David Soria Parra가 누구야?",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "step7 v4 q15 exact form — the primary diagnosis case",
+    },
+    {
+        "id":               "bpn-2",
+        "bucket":           "bare_proper_noun",
+        "text":             "David Soria Parra",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "name-only — strictest variant",
+    },
+    {
+        "id":               "bpn-3",
+        "bucket":           "bare_proper_noun",
+        "text":             "Justin Spahr-Summers는 누구야?",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "co-author of MCP — same chunk, same anchor set",
+    },
+
+    # ─── bucket 2: name_with_concept (already-working baseline) ────
+    {
+        "id":               "nwc-1",
+        "bucket":           "name_with_concept",
+        "text":             "MCP 설계자 David Soria Parra",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "BL-9 post-swap rank 1 reference — anchor already in original",
+    },
+    {
+        "id":               "nwc-2",
+        "bucket":           "name_with_concept",
+        "text":             "Anthropic의 David Soria Parra",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "company-side anchor — same effect",
+    },
+
+    # ─── bucket 3: pure_concept (no person — control) ──────────────
+    {
+        "id":               "pc-1",
+        "bucket":           "pure_concept",
+        "text":             "MCP가 뭐야?",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "no name involved — concept-only baseline",
+    },
+    {
+        "id":               "pc-2",
+        "bucket":           "pure_concept",
+        "text":             "Model Context Protocol 설명",
+        "expected_anchors": ["MCP", "Model Context Protocol", "Anthropic"],
+        "notes":            "EN concept — bge-m3 should handle directly",
+    },
+
+    # ─── bucket 4: multi_hop_control (q2-shape — already works) ────
+    {
+        "id":               "mhc-1",
+        "bucket":           "multi_hop_control",
+        "text":             "팔란티어의 CEO는 누구야?",
+        "expected_anchors": ["Palantir", "Karp", "Alex Karp", "CEO"],
+        "notes":            "step7 q2 — company + role embedded, name to be retrieved",
+    },
+    {
+        "id":               "mhc-2",
+        "bucket":           "multi_hop_control",
+        "text":             "Anthropic의 창립자는 누구야?",
+        "expected_anchors": ["Anthropic", "Amodei", "founder"],
+        "notes":            "company-name carries concept anchor by itself",
+    },
+]
+
+
+# ─── Anchor heuristic ────────────────────────────────────────────────
+
+
+def _anchors_in_text(text: str, anchors: List[str]) -> List[str]:
+    """Return anchors that appear (case-insensitive substring) in text.
+
+    Substring rather than word-boundary because Korean/English mixed
+    text has no whitespace between Hangul and Latin tokens
+    ("MCP설계자" is one token visually, "MCP" is the anchor). A
+    word-boundary regex would miss those.
+    """
+    if not text:
+        return []
+    low = text.lower()
+    found = []
+    for a in anchors:
+        if a and a.lower() in low:
+            found.append(a)
+    return found
+
+
+def _classify_anchor_outcome(
+    original: str,
+    rewritten: str,
+    anchors: List[str],
+) -> Dict:
+    """Per-row anchor outcome classification.
+
+    Three states for an anchor:
+      - **already_present**: in original AND in rewritten (preserved)
+      - **added**: in rewritten but NOT in original (the F9 win
+        signal)
+      - **dropped**: in original but NOT in rewritten (regression
+        signal — rewriter stripped a working anchor)
+      - **absent**: in neither (no-op)
+
+    Returns dict with anchor lists per state + ``added_count`` aggregate
+    used by the summary for "% of queries that got at least one anchor
+    added".
+    """
+    in_original  = set(_anchors_in_text(original,  anchors))
+    in_rewritten = set(_anchors_in_text(rewritten, anchors))
+    return {
+        "anchors_already_present": sorted(in_original  & in_rewritten),
+        "anchors_added":           sorted(in_rewritten - in_original),
+        "anchors_dropped":         sorted(in_original  - in_rewritten),
+        "anchors_absent":          sorted(set(anchors) - in_original - in_rewritten),
+        "added_count":             len(in_rewritten - in_original),
+        "dropped_count":           len(in_original  - in_rewritten),
+    }
+
+
+# ─── Per-row audit ───────────────────────────────────────────────────
+
+
+def _audit_one(row: Dict) -> Dict:
+    """Run one query through ``QueryRewriter.rewrite(force=True)``."""
+    from core.retrieval.query_rewriter import QueryRewriter
+
+    rewriter = QueryRewriter()
+    t0 = time.time()
+    try:
+        rewritten, latency_ms, attempted = rewriter.rewrite(row["text"], force=True)
+        err: Optional[str] = None
+    except Exception as e:
+        rewritten, latency_ms, attempted = row["text"], 0, False
+        err = f"{type(e).__name__}: {str(e)[:200]}"
+    elapsed_s = time.time() - t0
+
+    outcome = _classify_anchor_outcome(
+        row["text"], rewritten, row["expected_anchors"],
+    )
+    changed = rewritten != row["text"]
+
+    out: Dict = {
+        "id":                       row["id"],
+        "bucket":                   row["bucket"],
+        "text":                     row["text"],
+        "expected_anchors":         row["expected_anchors"],
+        "rewritten":                rewritten,
+        "changed":                  changed,
+        "attempted":                attempted,
+        "latency_ms":               latency_ms,
+        "elapsed_s":                round(elapsed_s, 2),
+        "anchors_already_present":  outcome["anchors_already_present"],
+        "anchors_added":            outcome["anchors_added"],
+        "anchors_dropped":          outcome["anchors_dropped"],
+        "anchors_absent":           outcome["anchors_absent"],
+    }
+    if err:
+        out["error"] = err
+    return out
+
+
+def _print_row(r: Dict) -> None:
+    if r.get("error"):
+        tag = "X "
+    elif r["anchors_added"]:
+        tag = "+ "
+    elif r["anchors_dropped"]:
+        tag = "- "
+    elif r["anchors_already_present"]:
+        tag = "= "
+    else:
+        tag = "_ "
+    added = ",".join(r["anchors_added"]) or "-"
+    text_short = (r["text"][:48] + "...") if len(r["text"]) > 48 else r["text"]
+    rew_short  = (r["rewritten"][:48] + "...") if len(r["rewritten"]) > 48 else r["rewritten"]
+    print(
+        f"  {tag} {r['id']:<6s} {r['bucket']:<19s} added={added:<28s} "
+        f"({r['latency_ms']:>5d}ms) {text_short!r} → {rew_short!r}"
+    )
+
+
+def _bucket_summary(rows: List[Dict]) -> Dict[str, Dict]:
+    """Per-bucket aggregates: anchor-add rate + drop rate + attempted rate."""
+    by_bucket: Dict[str, List[Dict]] = {}
+    for r in rows:
+        by_bucket.setdefault(r["bucket"], []).append(r)
+    out: Dict[str, Dict] = {}
+    for bucket, items in by_bucket.items():
+        n = len(items)
+        with_added   = sum(1 for r in items if r["anchors_added"])
+        with_dropped = sum(1 for r in items if r["anchors_dropped"])
+        attempted    = sum(1 for r in items if r["attempted"])
+        changed      = sum(1 for r in items if r["changed"])
+        latencies    = [r["latency_ms"] for r in items if r["attempted"]]
+        out[bucket] = {
+            "n":               n,
+            "attempted":       attempted,
+            "changed":         changed,
+            "anchor_added":    with_added,
+            "anchor_dropped":  with_dropped,
+            "anchor_added_rate":   round(with_added / n, 3) if n else 0.0,
+            "anchor_dropped_rate": round(with_dropped / n, 3) if n else 0.0,
+            "latency_ms_mean":     round(sum(latencies) / len(latencies), 1) if latencies else 0.0,
+        }
+    return out
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "F9 query_rewriter concept-anchor audit. Runs the fixture "
+            "through QueryRewriter (force=True) and reports per-bucket "
+            "anchor-add rate."
+        ),
+    )
+    ap.add_argument(
+        "--bucket", default=None,
+        help="run only one bucket (bare_proper_noun / name_with_concept / pure_concept / multi_hop_control)",
+    )
+    args = ap.parse_args()
+
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    fixture = _FIXTURE
+    if args.bucket:
+        fixture = [r for r in fixture if r["bucket"] == args.bucket]
+        if not fixture:
+            print(f"[audit] no rows match bucket={args.bucket!r}")
+            return 1
+
+    model_tag = os.environ.get("JAMES_LLM_MODEL", "<unset — backend default>")
+    embedding_tag = os.environ.get("JAMES_EMBEDDING_MODEL", "<unset — legacy MiniLM>")
+    print(
+        f"=== query_rewriter audit — model={model_tag}, "
+        f"embedding={embedding_tag}, rows={len(fixture)} ==="
+    )
+
+    rows: List[Dict] = []
+    for r in fixture:
+        out = _audit_one(r)
+        rows.append(out)
+        _print_row(out)
+
+    # ─── summary ────────────────────────────────────────────────────
+    bucket_summary = _bucket_summary(rows)
+
+    overall_n           = len(rows)
+    overall_attempted   = sum(1 for r in rows if r["attempted"])
+    overall_added       = sum(1 for r in rows if r["anchors_added"])
+    overall_dropped     = sum(1 for r in rows if r["anchors_dropped"])
+    overall_changed     = sum(1 for r in rows if r["changed"])
+    method_counts = Counter(
+        ("error" if r.get("error") else ("attempted" if r["attempted"] else "skipped"))
+        for r in rows
+    )
+
+    summary = {
+        "rows":                overall_n,
+        "attempted":           overall_attempted,
+        "changed":             overall_changed,
+        "anchor_added":        overall_added,
+        "anchor_dropped":      overall_dropped,
+        "anchor_added_rate":   round(overall_added / overall_n, 3) if overall_n else 0.0,
+        "anchor_dropped_rate": round(overall_dropped / overall_n, 3) if overall_n else 0.0,
+        "outcome_distribution": dict(method_counts),
+        "by_bucket":           bucket_summary,
+    }
+
+    print()
+    print("=== Summary ===")
+    print(f"  rows:                {overall_n}")
+    print(f"  attempted:           {overall_attempted}")
+    print(f"  changed:             {overall_changed}")
+    print(f"  anchor_added:        {overall_added} ({summary['anchor_added_rate']*100:.1f}%)")
+    print(f"  anchor_dropped:      {overall_dropped} ({summary['anchor_dropped_rate']*100:.1f}%)")
+    print(f"  outcome:             {summary['outcome_distribution']}")
+    print()
+    print("  By bucket:")
+    for bucket, s in bucket_summary.items():
+        print(
+            f"    {bucket:<19s} n={s['n']} attempted={s['attempted']} "
+            f"added={s['anchor_added']}/{s['n']} ({s['anchor_added_rate']*100:.0f}%) "
+            f"dropped={s['anchor_dropped']}/{s['n']} ({s['anchor_dropped_rate']*100:.0f}%) "
+            f"latency_mean={s['latency_ms_mean']:.0f}ms"
+        )
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = REPORTS_DIR / f"query-rewriter-audit-{stamp}.json"
+    out_path.write_text(
+        json.dumps(
+            {
+                "generated_at":   datetime.now().isoformat(),
+                "model_tag":      model_tag,
+                "embedding_tag":  embedding_tag,
+                "results":        rows,
+                "summary":        summary,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"\nsaved: {out_path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_query_rewriter_audit.py
+++ b/tests/test_query_rewriter_audit.py
@@ -1,0 +1,308 @@
+"""F9.1 — unit tests for scripts/research/query_rewriter_audit.py.
+
+The audit script itself does not modify production; these tests cover
+the heuristic logic (anchor classification + bucket aggregation +
+report-card output shape) so the audit's verdict stays trustworthy
+across reruns.
+
+What the audit script does (recap)
+----------------------------------
+
+1. Runs a curated fixture of queries through ``QueryRewriter.rewrite(
+   force=True)``.
+2. For each row, classifies anchor outcome into one of four states:
+   ``already_present`` / ``added`` / ``dropped`` / ``absent``.
+3. Aggregates per-bucket (anchor_added_rate, anchor_dropped_rate,
+   latency_ms_mean).
+4. Writes a per-run report card to
+   ``reports/research-runs/query-rewriter-audit-<stamp>.json``.
+
+What these tests cover
+----------------------
+
+- The substring matcher (``_anchors_in_text``) is case-insensitive and
+  handles the KO/EN mixed-token edge case (no whitespace between
+  Hangul and Latin) the F9 fixture explicitly designs around.
+- ``_classify_anchor_outcome`` produces the four expected anchor lists
+  + the ``added_count`` / ``dropped_count`` aggregates the bucket
+  summary depends on.
+- The fixture itself is shaped correctly: each row has the required
+  keys + a bucket from the documented set + a non-empty anchor list.
+  Catches drift if someone tweaks the fixture without keeping the
+  audit script's invariants.
+- ``_bucket_summary`` aggregates correctly across mixed-state rows
+  (one bucket has both an "added" row and a "dropped" row).
+
+These tests do NOT cover the LLM-backed ``_audit_one`` (which is what
+the operator runs against a live Ollama). The unit test for the
+rewriter LLM dispatch already lives in ``tests/test_query_rewriter.py``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def _load_audit_module():
+    """Import the audit script as a module without installing it."""
+    spec = importlib.util.spec_from_file_location(
+        "query_rewriter_audit",
+        ROOT / "scripts" / "research" / "query_rewriter_audit.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+audit_mod = _load_audit_module()
+
+
+class AnchorMatcherTests(unittest.TestCase):
+    """Case-insensitive substring matcher with mixed-script handling."""
+
+    def test_exact_match_returns_anchor(self):
+        got = audit_mod._anchors_in_text("MCP 설계자", ["MCP"])
+        self.assertEqual(got, ["MCP"])
+
+    def test_case_insensitive(self):
+        got = audit_mod._anchors_in_text("mcp protocol", ["MCP"])
+        self.assertEqual(got, ["MCP"])
+
+    def test_mixed_script_no_whitespace_token(self):
+        # F9 fixture edge case: "MCP설계자" has no whitespace between
+        # Latin (MCP) and Hangul (설계자). Substring matcher must still
+        # find the anchor.
+        got = audit_mod._anchors_in_text("MCP설계자에 대해 설명", ["MCP"])
+        self.assertEqual(got, ["MCP"])
+
+    def test_returns_all_anchors_present(self):
+        got = audit_mod._anchors_in_text(
+            "Anthropic의 MCP 설계자",
+            ["MCP", "Anthropic", "OpenAI"],
+        )
+        self.assertEqual(sorted(got), sorted(["MCP", "Anthropic"]))
+
+    def test_no_anchors_present(self):
+        got = audit_mod._anchors_in_text("팔란티어 CEO", ["MCP", "Anthropic"])
+        self.assertEqual(got, [])
+
+    def test_empty_text_returns_empty(self):
+        self.assertEqual(audit_mod._anchors_in_text("", ["MCP"]), [])
+        self.assertEqual(audit_mod._anchors_in_text(None, ["MCP"]), [])
+
+    def test_empty_anchor_skipped(self):
+        # Defensive — empty string anchor matches everything if we let
+        # it through, which would make the heuristic useless.
+        got = audit_mod._anchors_in_text("any text", ["", "MCP"])
+        self.assertEqual(got, [])
+
+    def test_whitespace_within_multi_word_anchor(self):
+        got = audit_mod._anchors_in_text(
+            "Model Context Protocol 설명",
+            ["Model Context Protocol"],
+        )
+        self.assertEqual(got, ["Model Context Protocol"])
+
+
+class AnchorOutcomeClassifierTests(unittest.TestCase):
+    """The four states (already_present / added / dropped / absent)."""
+
+    ANCHORS = ["MCP", "Model Context Protocol", "Anthropic"]
+
+    def test_added_when_in_rewritten_not_original(self):
+        out = audit_mod._classify_anchor_outcome(
+            original="David Soria Parra가 누구야?",
+            rewritten="David Soria Parra (MCP, Anthropic 관련) 누구야?",
+            anchors=self.ANCHORS,
+        )
+        self.assertEqual(sorted(out["anchors_added"]), sorted(["MCP", "Anthropic"]))
+        self.assertEqual(out["anchors_dropped"], [])
+        self.assertEqual(out["anchors_already_present"], [])
+        self.assertEqual(out["anchors_absent"], ["Model Context Protocol"])
+        self.assertEqual(out["added_count"], 2)
+        self.assertEqual(out["dropped_count"], 0)
+
+    def test_already_present_when_in_both(self):
+        out = audit_mod._classify_anchor_outcome(
+            original="MCP 설계자 David Soria Parra",
+            rewritten="MCP 설계자 (Model Context Protocol) David Soria Parra",
+            anchors=self.ANCHORS,
+        )
+        # "MCP" was already present; rewriter preserved it →
+        # already_present, NOT added. Strict guard the bucket
+        # summary depends on.
+        self.assertIn("MCP", out["anchors_already_present"])
+        self.assertNotIn("MCP", out["anchors_added"])
+        # "Model Context Protocol" was net-new in the rewrite → added
+        self.assertIn("Model Context Protocol", out["anchors_added"])
+
+    def test_dropped_when_in_original_not_rewritten(self):
+        out = audit_mod._classify_anchor_outcome(
+            original="MCP 설계자 David Soria Parra",
+            rewritten="David Soria Parra가 누구야?",   # rewriter stripped MCP
+            anchors=self.ANCHORS,
+        )
+        self.assertEqual(out["anchors_dropped"], ["MCP"])
+        self.assertEqual(out["dropped_count"], 1)
+        self.assertEqual(out["anchors_added"], [])
+
+    def test_absent_when_in_neither(self):
+        out = audit_mod._classify_anchor_outcome(
+            original="팔란티어 CEO 누구야?",
+            rewritten="Palantir CEO는?",
+            anchors=self.ANCHORS,
+        )
+        self.assertEqual(sorted(out["anchors_absent"]), sorted(self.ANCHORS))
+        self.assertEqual(out["anchors_added"], [])
+        self.assertEqual(out["anchors_dropped"], [])
+        self.assertEqual(out["anchors_already_present"], [])
+
+    def test_identity_rewrite_no_added_no_dropped(self):
+        # When rewriter returns the original unchanged (env off / parse
+        # fail / too short), anchors are preserved trivially — but the
+        # "added" count must stay zero.
+        out = audit_mod._classify_anchor_outcome(
+            original="MCP 설계자",
+            rewritten="MCP 설계자",
+            anchors=self.ANCHORS,
+        )
+        self.assertEqual(out["anchors_added"], [])
+        self.assertEqual(out["anchors_dropped"], [])
+        self.assertIn("MCP", out["anchors_already_present"])
+
+
+class FixtureShapeTests(unittest.TestCase):
+    """The fixture catalogs four buckets; each row must satisfy the
+    audit script's per-row invariants."""
+
+    REQUIRED_KEYS = {"id", "bucket", "text", "expected_anchors", "notes"}
+    KNOWN_BUCKETS = {
+        "bare_proper_noun",
+        "name_with_concept",
+        "pure_concept",
+        "multi_hop_control",
+    }
+
+    def test_every_row_has_required_keys(self):
+        for r in audit_mod._FIXTURE:
+            self.assertEqual(self.REQUIRED_KEYS - r.keys(), set(),
+                             f"row {r.get('id', '?')} missing keys")
+
+    def test_every_row_has_known_bucket(self):
+        for r in audit_mod._FIXTURE:
+            self.assertIn(r["bucket"], self.KNOWN_BUCKETS,
+                          f"row {r['id']} bucket={r['bucket']!r} unknown")
+
+    def test_every_row_has_non_empty_anchor_list(self):
+        for r in audit_mod._FIXTURE:
+            self.assertTrue(
+                r["expected_anchors"],
+                f"row {r['id']} has empty expected_anchors — heuristic would always say 'absent'",
+            )
+
+    def test_every_row_has_unique_id(self):
+        ids = [r["id"] for r in audit_mod._FIXTURE]
+        self.assertEqual(len(ids), len(set(ids)),
+                         f"duplicate ids: {[i for i in ids if ids.count(i) > 1]}")
+
+    def test_all_four_buckets_represented(self):
+        present = {r["bucket"] for r in audit_mod._FIXTURE}
+        self.assertEqual(present, self.KNOWN_BUCKETS,
+                         "the audit's by-bucket summary needs every bucket populated")
+
+    def test_bare_proper_noun_rows_carry_concept_anchors(self):
+        # The diagnosis bucket — these rows by construction must list
+        # concept anchors (not other names) since "name in rewrite"
+        # would be trivial and not the F9 signal we want.
+        for r in audit_mod._FIXTURE:
+            if r["bucket"] != "bare_proper_noun":
+                continue
+            # At least one anchor must not be a substring of the
+            # original — otherwise the row can't possibly score "added".
+            original_low = r["text"].lower()
+            net_new_anchors = [
+                a for a in r["expected_anchors"]
+                if a.lower() not in original_low
+            ]
+            self.assertTrue(
+                net_new_anchors,
+                f"row {r['id']} bare_proper_noun: every anchor already in original — anchor_added impossible",
+            )
+
+
+class BucketSummaryTests(unittest.TestCase):
+    """``_bucket_summary`` aggregates per-bucket; mixed states must
+    flow into the right counters."""
+
+    def _row(self, *, bucket, added=None, dropped=None, attempted=True,
+             changed=True, latency_ms=100):
+        added = added or []
+        dropped = dropped or []
+        return {
+            "id":              f"r-{bucket}",
+            "bucket":          bucket,
+            "anchors_added":   added,
+            "anchors_dropped": dropped,
+            "attempted":       attempted,
+            "changed":         changed,
+            "latency_ms":      latency_ms,
+        }
+
+    def test_single_bucket_added(self):
+        rows = [self._row(bucket="X", added=["MCP"], latency_ms=200)]
+        s = audit_mod._bucket_summary(rows)
+        self.assertEqual(s["X"]["n"], 1)
+        self.assertEqual(s["X"]["anchor_added"], 1)
+        self.assertEqual(s["X"]["anchor_dropped"], 0)
+        self.assertEqual(s["X"]["anchor_added_rate"], 1.0)
+        self.assertEqual(s["X"]["latency_ms_mean"], 200.0)
+
+    def test_mixed_bucket_added_and_dropped(self):
+        # One bucket with three rows: 1 added, 1 dropped, 1 no-op
+        rows = [
+            self._row(bucket="X", added=["MCP"]),
+            self._row(bucket="X", dropped=["Anthropic"]),
+            self._row(bucket="X"),
+        ]
+        s = audit_mod._bucket_summary(rows)
+        self.assertEqual(s["X"]["n"], 3)
+        self.assertEqual(s["X"]["anchor_added"], 1)
+        self.assertEqual(s["X"]["anchor_dropped"], 1)
+        self.assertAlmostEqual(s["X"]["anchor_added_rate"], 0.333, places=3)
+        self.assertAlmostEqual(s["X"]["anchor_dropped_rate"], 0.333, places=3)
+
+    def test_multi_bucket_isolation(self):
+        rows = [
+            self._row(bucket="X", added=["MCP"], latency_ms=100),
+            self._row(bucket="Y", added=[], latency_ms=200),
+        ]
+        s = audit_mod._bucket_summary(rows)
+        self.assertEqual(s["X"]["anchor_added_rate"], 1.0)
+        self.assertEqual(s["Y"]["anchor_added_rate"], 0.0)
+        self.assertEqual(s["X"]["latency_ms_mean"], 100.0)
+        self.assertEqual(s["Y"]["latency_ms_mean"], 200.0)
+
+    def test_skipped_rows_excluded_from_latency(self):
+        # A row with attempted=False (env-off or too-short) should NOT
+        # contribute to the latency mean — including it would skew the
+        # operator's read of "what does the rewriter actually cost when
+        # it runs".
+        rows = [
+            self._row(bucket="X", attempted=True,  latency_ms=300),
+            self._row(bucket="X", attempted=False, latency_ms=0),
+        ]
+        s = audit_mod._bucket_summary(rows)
+        self.assertEqual(s["X"]["latency_ms_mean"], 300.0)
+        self.assertEqual(s["X"]["attempted"], 1)
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(audit_mod._bucket_summary([]), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

LEO L.D follow-up. The q15 8-cycle diagnosis chain (F2 → F1 → F6 → F7 → BL-9 prep → BL-9 acceptance) reattributed the zero-recall root from embedding-model capacity (F7's MiniLM weakness hypothesis) to **query expansion**: bge-m3 swap is active, but bare proper-noun queries (\`\"David Soria Parra가 누구야?\"\`) still miss the MCP PDF because the chunk vector is dominated by concept tokens (MCP / Anthropic / Model Context Protocol). Concept anchor in the **query** is the missing piece, not encoder capacity.

JAMES already has a \`QueryRewriter\` at pipeline STEP 0.5b (gated by \`JAMES_ENABLE_QUERY_REWRITE=1\`). Its Korean prompt instructs the LLM to *\"strengthen keywords with 1-2 synonyms\"* but says **nothing** about concept anchors. This audit measures whether the prompt's synonym-only instruction is enough to cover the q15 case before F9.2 adds an expansion mechanism.

**No production code is touched.** This is an audit script + heuristic + 24 unit tests. Live run is operator action; live verdict drives F9.2's choice between prompt-tune vs separate-step.

## Files

- \`scripts/research/query_rewriter_audit.py\` (~340 lines):
  - 4-bucket fixture (9 queries):
    - **bare_proper_noun** — q15 cluster (\`\"David Soria Parra가 누구야?\"\`, name-only, Justin Spahr-Summers)
    - **name_with_concept** — anchor already in original (\`\"MCP 설계자 David Soria Parra\"\`)
    - **pure_concept** — no person name involved (\`\"MCP가 뭐야?\"\`, \`\"Model Context Protocol 설명\"\`)
    - **multi_hop_control** — name+company concept in query (\`\"팔란티어의 CEO 누구?\"\`, \`\"Anthropic 창립자\"\`)
  - Each row carries \`expected_anchors\` — corpus tokens that bridge the query vector to the matching chunk vectors per the BL-9 post-swap probe
  - 4-state anchor classifier per row:
    - **already_present**: in original AND rewritten (preserved)
    - **added**: in rewritten but NOT original (the F9 win signal)
    - **dropped**: in original but NOT rewritten (regression signal)
    - **absent**: in neither (no-op)
  - Per-bucket summary: \`anchor_added_rate\` / \`anchor_dropped_rate\` / \`latency_ms_mean\` (skipped rows excluded from latency)
  - Writes \`reports/research-runs/query-rewriter-audit-<stamp>.json\` for diff against future reruns (F2 pattern)
- \`tests/test_query_rewriter_audit.py\` (24 tests):
  - 8 anchor-matcher tests including the mixed-script KO/EN no-whitespace edge case (\`\"MCP설계자\"\`)
  - 5 outcome-classifier tests pinning the 4 states + the strict *\"added means NOT in original\"* guard
  - 6 fixture-shape tests (required keys, known bucket, non-empty anchors, unique id, all 4 buckets covered, \`bare_proper_noun\` rows verified to carry at least one anchor NOT in original — otherwise the row can never score \"added\")
  - 5 bucket-summary aggregator tests (mixed states, multi-bucket isolation, skipped-row latency exclusion)

## Verification

- \`pytest tests/test_query_rewriter_audit.py -v\` → **24 passed, 0.05s**
- \`ruff check scripts/research/query_rewriter_audit.py tests/test_query_rewriter_audit.py\` → clean
- No production rewriter code modified; live run is operator action:
  \`\`\`powershell
  python scripts/research/query_rewriter_audit.py
  \`\`\`

## Out of scope (F9.2)

- The actual prompt / pipeline fix lands at F9.2 based on this audit's verdict:
  - If \`bare_proper_noun\` bucket \`anchor_added_rate\` ≥ 50% on the current prompt → no fix needed; F9 closes here as a regression canary
  - If 0–10% (the hypothesis) → tune the Korean prompt to explicitly request concept anchors for proper-noun queries, OR add a separate corpus-aware anchor lookup step before rewrite
- Acceptance gate for F9.2: step7 v4 q15 \`path_recall\` ≥ 0.5 with bge-m3 swap active (the BL-9 deferred gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)