### PR TITLE
feat(retrieval): F9.3 — entity anchor pipeline wiring + JAMES_ENABLE_ENTITY_ANCHOR flag

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -53,6 +53,18 @@ def run_retrieval_pipeline(
     force_web_search: bool = False,   # [#A8-6] 사용자가 chip 클릭 시 True
     selected_model: str = "",         # [#A2 phase 2] catalog-validated user pick
 ) -> Dict[str, Any]:
+    # ── STEP 0.5a: entity anchor expansion (F9.3) ───────
+    # Opt-in via JAMES_ENABLE_ENTITY_ANCHOR=1 (default OFF). Helper
+    # at core/reasoning/pipeline_query_expansion.py — extracted to
+    # keep this file under the 20 KB CLAUDE.md rule #5 cap, mirroring
+    # PR #518's pipeline_context.py split pattern.
+    from core.reasoning.pipeline_query_expansion import (
+        apply_entity_anchor_expansion,
+    )
+    query_for_rewriter, _, _ = apply_entity_anchor_expansion(
+        engine, safe_query, user_role,
+    )
+
     # ── STEP 0.5b: query rewrite (Phase 1 PR-2) ─────────
     # Cognitive Layer §5.7.1 Query Rewriter. Replaces the historical
     # no-op kept here since v0.1 (the slot was reserved for this).
@@ -61,8 +73,13 @@ def run_retrieval_pipeline(
     # enabled, the rewriter goes through the Backend registry (L0)
     # using the local Ollama path; failures fall back to the original
     # query so the pipeline always proceeds.
+    #
+    # When F9.3 is also enabled (JAMES_ENABLE_ENTITY_ANCHOR=1) the
+    # rewriter sees `query_for_rewriter` = the anchor-augmented form
+    # produced by STEP 0.5a above. Otherwise `query_for_rewriter`
+    # equals `safe_query` byte-for-byte (the F9.3-flag-OFF path).
     t_qexp = time.time()
-    expanded_query = safe_query
+    expanded_query = query_for_rewriter
     rewrite_latency_ms = 0
     rewrite_attempted = False
     try:
@@ -74,7 +91,7 @@ def run_retrieval_pipeline(
         # 가 비어 있으면 "env 도달 안 함" / "rewriter 가 silent fail"
         # / "LLM 이 의미적으로 동일한 문자열 반환" 을 구분할 수 없었다.
         expanded_query, rewrite_latency_ms, rewrite_attempted = (
-            get_query_rewriter().rewrite(safe_query)
+            get_query_rewriter().rewrite(query_for_rewriter)
         )
     except Exception as e:
         engine._log("query_rewrite", e, user_role)
@@ -98,9 +115,16 @@ def run_retrieval_pipeline(
                 TraceStep, compute_inputs_hash, truncate_summary,
                 emit_trace_step,
             )
-            _changed = expanded_query != safe_query
+            # F9.3 — compare against query_for_rewriter (= safe_query
+            # when entity anchor was a no-op, = anchor-augmented form
+            # when F9.3 fired). This keeps "changed" meaning "did the
+            # LLM rewriter contribute anything" rather than blurring
+            # in the anchor expansion's contribution. The anchor trace
+            # row (emitted above when entity_anchor_hit) already
+            # surfaces the safe_query → query_for_rewriter delta.
+            _changed = expanded_query != query_for_rewriter
             _rewrite_extras: Dict[str, Any] = {
-                "original_query": safe_query[:200],
+                "original_query": query_for_rewriter[:200],
                 "rewritten_query": expanded_query[:200],
                 "changed": _changed,
             }
@@ -112,8 +136,8 @@ def run_retrieval_pipeline(
             except Exception:
                 pass
             _summary = (
-                f"{safe_query} → {expanded_query}" if _changed
-                else f"no change: {safe_query}"
+                f"{query_for_rewriter} → {expanded_query}" if _changed
+                else f"no change: {query_for_rewriter}"
             )
             emit_trace_step(
                 TraceStep(

--- a/core/reasoning/pipeline_query_expansion.py
+++ b/core/reasoning/pipeline_query_expansion.py
@@ -1,0 +1,150 @@
+"""F9.3 — pipeline STEP 0.5a entity anchor expansion helper.
+
+Extracted from ``pipeline.py`` to keep that module under the 20 KB
+CLAUDE.md rule #5 cap (PR-T7.C left ~3 KB headroom; F9.3 wiring +
+trace emission ate into it). Mirrors the PR #518 split pattern
+(``pipeline_context.build_unified_context`` /
+``apply_post_check_and_sources_header``).
+
+What this helper does
+---------------------
+
+1. Read the ``JAMES_ENABLE_ENTITY_ANCHOR`` env flag.
+2. If set, run the query through ``EntityAnchorExpander`` and capture
+   ``(expanded, anchors, hit)``.
+3. Emit a trace step (``applied_rule="reasoning.retrieve.entity_anchor_expand"``)
+   when the expander returned a hit so the operator can see anchor
+   contribution distinctly from the LLM rewriter's downstream trace.
+4. Return ``(query_for_rewriter, anchors_added, hit)`` — the caller
+   (``pipeline.py``) feeds ``query_for_rewriter`` into STEP 0.5b's
+   ``QueryRewriter.rewrite()``.
+
+Flag-OFF invariant
+------------------
+
+When ``JAMES_ENABLE_ENTITY_ANCHOR`` is unset / not "1":
+  - ``query_for_rewriter == safe_query`` byte-identical
+  - ``anchors_added == []``
+  - ``hit == False``
+  - no audit trace row emitted
+
+→ pipeline.py's downstream behaviour is byte-identical to pre-F9.3 main.
+
+Failure isolation
+-----------------
+
+Every exception path is logged via ``engine._log`` and falls back to
+the unchanged ``safe_query`` — F9.3 must not block retrieval if the
+expander or its index build fails. Mirrors the rewriter's pre-existing
+fallback discipline.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Tuple
+
+
+def apply_entity_anchor_expansion(
+    engine,
+    safe_query: str,
+    user_role: str,
+) -> Tuple[str, List[str], bool]:
+    """Run STEP 0.5a entity-anchor pre-expansion. See module docstring.
+
+    Returns ``(query_for_rewriter, anchors_added, hit)``.
+    """
+    query_for_rewriter = safe_query
+    anchors_added: List[str] = []
+    hit = False
+    latency_ms = 0
+    try:
+        from core.retrieval.entity_anchor_expander import (
+            entity_anchor_enabled, get_entity_anchor_expander,
+        )
+        if entity_anchor_enabled():
+            t_anchor = time.time()
+            try:
+                expanded_text, anchors_added, hit = (
+                    get_entity_anchor_expander().expand(safe_query)
+                )
+                if hit:
+                    query_for_rewriter = expanded_text
+            except Exception as e:
+                engine._log("entity_anchor_expand", e, user_role)
+            latency_ms = int((time.time() - t_anchor) * 1000)
+            engine._elapsed(t_anchor, "STEP0.5a entity_anchor")
+    except Exception as e:
+        # Module-import failure (extremely defensive — should never
+        # fire because the import is in tree at this point).
+        engine._log("entity_anchor_module_import", e, user_role)
+
+    if hit:
+        _emit_anchor_trace_step(
+            engine=engine,
+            safe_query=safe_query,
+            query_for_rewriter=query_for_rewriter,
+            anchors_added=anchors_added,
+            latency_ms=latency_ms,
+            user_role=user_role,
+        )
+
+    return (query_for_rewriter, anchors_added, hit)
+
+
+def _emit_anchor_trace_step(
+    *,
+    engine,
+    safe_query: str,
+    query_for_rewriter: str,
+    anchors_added: List[str],
+    latency_ms: int,
+    user_role: str,
+) -> None:
+    """Emit a ``retrieve``-stage trace row attributing the anchor add
+    to the entity-anchor expander (distinct from the LLM rewriter's
+    own trace row downstream).
+
+    ``stage="retrieve"`` + ``backend_id="graph_local"`` lets the
+    operator grep the audit_log for ``applied_rule="reasoning.
+    retrieve.entity_anchor_expand"`` to count anchor-expanded queries
+    in production. Mirrors the rewriter's existing trace shape so
+    the diagnostic surface stays consistent.
+    """
+    try:
+        from core.reasoning.trace_schema import (
+            TraceStep, compute_inputs_hash, truncate_summary,
+            emit_trace_step,
+        )
+        extras: Dict[str, Any] = {
+            "original_query": safe_query[:200],
+            "expanded_query": query_for_rewriter[:200],
+            "anchors_added":  anchors_added,
+            "anchor_count":   len(anchors_added),
+        }
+        try:
+            from core.observability import get_trace_id
+            tid = get_trace_id()
+            if tid:
+                extras["trace_id"] = tid
+        except Exception:
+            pass
+        emit_trace_step(
+            TraceStep(
+                stage="retrieve",
+                backend_id="graph_local",
+                parent_step_id="",
+                inputs_hash=compute_inputs_hash(safe_query),
+                output_summary=truncate_summary(
+                    f"{safe_query} → {query_for_rewriter}"
+                ),
+                applied_rule="reasoning.retrieve.entity_anchor_expand",
+                latency_ms=latency_ms,
+            ),
+            user_role=user_role,
+            extras=extras,
+        )
+    except Exception as e:
+        engine._log("entity_anchor_trace", e, user_role)
+
+
+__all__ = ["apply_entity_anchor_expansion"]

--- a/core/retrieval/entity_anchor_expander.py
+++ b/core/retrieval/entity_anchor_expander.py
@@ -62,6 +62,7 @@ What this module is NOT
 """
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -79,6 +80,24 @@ DEFAULT_TOP_N = 3
 # chosen threshold (covers short tickers like "BL", "TI" while still
 # excluding single-char noise).
 MIN_SURFACE_LENGTH = 2
+
+# Default-OFF env flag — F9.3 wiring at pipeline.py STEP 0.5a checks
+# this before invoking the expander. Mirrors the rewriter's
+# JAMES_ENABLE_QUERY_REWRITE / D1's JAMES_ADAPTIVE_BUDGET / LEO L.C's
+# JAMES_SCOPE_ROUTING / D5's JAMES_AUTO_ROUTER opt-in patterns
+# (CLAUDE.md rule #1 — production fleets pulling F9.3 see byte-
+# identical retrieval behaviour relative to F9.2 unless they opt in).
+ENV_FLAG = "JAMES_ENABLE_ENTITY_ANCHOR"
+
+
+def entity_anchor_enabled() -> bool:
+    """Return True when ``JAMES_ENABLE_ENTITY_ANCHOR=1`` is set.
+
+    Read at every call site (not cached) so operators can toggle it
+    in a long-running process by re-exporting the env var. Same
+    discipline as ``query_rewriter._enabled``.
+    """
+    return os.environ.get(ENV_FLAG) == "1"
 
 
 class EntityAnchorExpander:
@@ -327,6 +346,8 @@ def _clear_singleton_for_tests() -> None:
 __all__ = [
     "DEFAULT_TOP_N",
     "MIN_SURFACE_LENGTH",
+    "ENV_FLAG",
     "EntityAnchorExpander",
+    "entity_anchor_enabled",
     "get_entity_anchor_expander",
 ]

--- a/reports/research-runs/query-rewriter-audit-entityanchor-20260527_214942.json
+++ b/reports/research-runs/query-rewriter-audit-entityanchor-20260527_214942.json
@@ -1,0 +1,365 @@
+{
+  "generated_at": "2026-05-27T21:49:42.915972",
+  "arm": "with_entity_anchor",
+  "model_tag": "<unset — backend default>",
+  "embedding_tag": "<unset — legacy MiniLM>",
+  "results": [
+    {
+      "id": "bpn-1",
+      "bucket": "bare_proper_noun",
+      "text": "David Soria Parra가 누구야?",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "David Soria Parra가 누구야? (관련: MCP, 08_MCP_(Model_Context_Protocol))",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 12079,
+      "elapsed_s": 12.09,
+      "anchors_already_present": [],
+      "anchors_added": [
+        "MCP"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic",
+        "Model Context Protocol"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "David Soria Parra가 누구야? (관련: MCP, 08_MCP_(Model_Context_Protocol))",
+        "entity_anchors_added": [
+          "MCP",
+          "08_MCP_(Model_Context_Protocol)"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 3319
+      }
+    },
+    {
+      "id": "bpn-2",
+      "bucket": "bare_proper_noun",
+      "text": "David Soria Parra",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "David Soria Parra's association with MCP (Model Context Protocol) and 08_MCP",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 5028,
+      "elapsed_s": 5.04,
+      "anchors_already_present": [],
+      "anchors_added": [
+        "MCP",
+        "Model Context Protocol"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "David Soria Parra (관련: MCP, 08_MCP_(Model_Context_Protocol))",
+        "entity_anchors_added": [
+          "MCP",
+          "08_MCP_(Model_Context_Protocol)"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 2
+      }
+    },
+    {
+      "id": "bpn-3",
+      "bucket": "bare_proper_noun",
+      "text": "Justin Spahr-Summers는 누구야?",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "Justin Spahr-Summers의 MCP(Model Context Protocol) 관련 정보, 역할, 및 프로필",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 6667,
+      "elapsed_s": 6.68,
+      "anchors_already_present": [],
+      "anchors_added": [
+        "MCP",
+        "Model Context Protocol"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "Justin Spahr-Summers는 누구야? (관련: MCP, 08_MCP_(Model_Context_Protocol))",
+        "entity_anchors_added": [
+          "MCP",
+          "08_MCP_(Model_Context_Protocol)"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 2
+      }
+    },
+    {
+      "id": "nwc-1",
+      "bucket": "name_with_concept",
+      "text": "MCP 설계자 David Soria Parra",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "David Soria Parra, MCP 설계자 (Model Context Protocol designer), 관련 (related) 08_MCP (Model Context Protocol), OpenAI, 및 Justin Spahr-Summers",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 4357,
+      "elapsed_s": 4.37,
+      "anchors_already_present": [
+        "MCP"
+      ],
+      "anchors_added": [
+        "Model Context Protocol"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "MCP 설계자 David Soria Parra (관련: 08_MCP_(Model_Context_Protocol), OpenAI, Justin Spahr-Summers)",
+        "entity_anchors_added": [
+          "08_MCP_(Model_Context_Protocol)",
+          "OpenAI",
+          "Justin Spahr-Summers"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 4
+      }
+    },
+    {
+      "id": "nwc-2",
+      "bucket": "name_with_concept",
+      "text": "Anthropic의 David Soria Parra",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "Anthropic의 David Soria Parra와 Model Context Protocol (MCP), Context Engineering (프롬프트 엔지니어링) 관련 연구 및 기술",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 6511,
+      "elapsed_s": 6.53,
+      "anchors_already_present": [
+        "Anthropic"
+      ],
+      "anchors_added": [
+        "MCP",
+        "Model Context Protocol"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [],
+      "entity_anchor": {
+        "pre_expanded": "Anthropic의 David Soria Parra (관련: MCP, 08_MCP_(Model_Context_Protocol), Context Engineering)",
+        "entity_anchors_added": [
+          "MCP",
+          "08_MCP_(Model_Context_Protocol)",
+          "Context Engineering"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 5
+      }
+    },
+    {
+      "id": "pc-1",
+      "bucket": "pure_concept",
+      "text": "MCP가 뭐야?",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "Model Context Protocol (MCP)의 정의, 기능, 그리고 OpenAI 및 David Soria Parra와의 관련성",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 6462,
+      "elapsed_s": 6.48,
+      "anchors_already_present": [
+        "MCP"
+      ],
+      "anchors_added": [
+        "Model Context Protocol"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "MCP가 뭐야? (관련: 08_MCP_(Model_Context_Protocol), OpenAI, David Soria Parra)",
+        "entity_anchors_added": [
+          "08_MCP_(Model_Context_Protocol)",
+          "OpenAI",
+          "David Soria Parra"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 3
+      }
+    },
+    {
+      "id": "pc-2",
+      "bucket": "pure_concept",
+      "text": "Model Context Protocol 설명",
+      "expected_anchors": [
+        "MCP",
+        "Model Context Protocol",
+        "Anthropic"
+      ],
+      "rewritten": "Model Context Protocol (모델 컨텍스트 프로토콜) 정의 및 개요",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 5007,
+      "elapsed_s": 5.03,
+      "anchors_already_present": [
+        "Model Context Protocol"
+      ],
+      "anchors_added": [],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Anthropic",
+        "MCP"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "Model Context Protocol 설명",
+        "entity_anchors_added": [],
+        "entity_anchor_hit": false,
+        "entity_anchor_latency_ms": 0
+      }
+    },
+    {
+      "id": "mhc-1",
+      "bucket": "multi_hop_control",
+      "text": "팔란티어의 CEO는 누구야?",
+      "expected_anchors": [
+        "Palantir",
+        "Karp",
+        "Alex Karp",
+        "CEO"
+      ],
+      "rewritten": "팔란티어(Palantir)의 최고경영자(CEO)는 누구이며, Alex Karp의 직책과 관련 정보는 무엇인가?",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 6411,
+      "elapsed_s": 6.43,
+      "anchors_already_present": [
+        "CEO"
+      ],
+      "anchors_added": [
+        "Alex Karp",
+        "Karp",
+        "Palantir"
+      ],
+      "anchors_dropped": [],
+      "anchors_absent": [],
+      "entity_anchor": {
+        "pre_expanded": "팔란티어의 CEO는 누구야? (관련: Alex Karp, 국방부, PLTR_01_Q1_2026_실적분석)",
+        "entity_anchors_added": [
+          "Alex Karp",
+          "국방부",
+          "PLTR_01_Q1_2026_실적분석"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 2
+      }
+    },
+    {
+      "id": "mhc-2",
+      "bucket": "multi_hop_control",
+      "text": "Anthropic의 창립자는 누구야?",
+      "expected_anchors": [
+        "Anthropic",
+        "Amodei",
+        "founder"
+      ],
+      "rewritten": "Anthropic의 창립자(창업자, 설립자)는 누구이며, Context Engineering(컨텍스트 엔지니어링) 및 Model Context Protocol(MCP) 분야에 대한 정보는 무엇인가?",
+      "changed": true,
+      "attempted": true,
+      "latency_ms": 7984,
+      "elapsed_s": 7.99,
+      "anchors_already_present": [
+        "Anthropic"
+      ],
+      "anchors_added": [],
+      "anchors_dropped": [],
+      "anchors_absent": [
+        "Amodei",
+        "founder"
+      ],
+      "entity_anchor": {
+        "pre_expanded": "Anthropic의 창립자는 누구야? (관련: Context Engineering, 02_컨텍스트_엔지니어링, 08_MCP_(Model_Context_Protocol))",
+        "entity_anchors_added": [
+          "Context Engineering",
+          "02_컨텍스트_엔지니어링",
+          "08_MCP_(Model_Context_Protocol)"
+        ],
+        "entity_anchor_hit": true,
+        "entity_anchor_latency_ms": 2
+      }
+    }
+  ],
+  "summary": {
+    "rows": 9,
+    "attempted": 9,
+    "changed": 9,
+    "anchor_added": 7,
+    "anchor_dropped": 0,
+    "anchor_added_rate": 0.778,
+    "anchor_dropped_rate": 0.0,
+    "outcome_distribution": {
+      "attempted": 9
+    },
+    "by_bucket": {
+      "bare_proper_noun": {
+        "n": 3,
+        "attempted": 3,
+        "changed": 3,
+        "anchor_added": 3,
+        "anchor_dropped": 0,
+        "anchor_added_rate": 1.0,
+        "anchor_dropped_rate": 0.0,
+        "latency_ms_mean": 7924.7
+      },
+      "name_with_concept": {
+        "n": 2,
+        "attempted": 2,
+        "changed": 2,
+        "anchor_added": 2,
+        "anchor_dropped": 0,
+        "anchor_added_rate": 1.0,
+        "anchor_dropped_rate": 0.0,
+        "latency_ms_mean": 5434.0
+      },
+      "pure_concept": {
+        "n": 2,
+        "attempted": 2,
+        "changed": 2,
+        "anchor_added": 1,
+        "anchor_dropped": 0,
+        "anchor_added_rate": 0.5,
+        "anchor_dropped_rate": 0.0,
+        "latency_ms_mean": 5734.5
+      },
+      "multi_hop_control": {
+        "n": 2,
+        "attempted": 2,
+        "changed": 2,
+        "anchor_added": 1,
+        "anchor_dropped": 0,
+        "anchor_added_rate": 0.5,
+        "anchor_dropped_rate": 0.0,
+        "latency_ms_mean": 7197.5
+      }
+    }
+  }
+}

--- a/tests/_pipeline_src.py
+++ b/tests/_pipeline_src.py
@@ -4,8 +4,10 @@ After the chore splits:
 
   * ``pipeline.py`` extracted Loop 0/1/2 step bodies to
     ``pipeline_loops.py``, the LLM answer-generation block to
-    ``pipeline_synth.py``, and the post-loop context combine +
-    sources-header block to ``pipeline_context.py``.
+    ``pipeline_synth.py``, the post-loop context combine +
+    sources-header block to ``pipeline_context.py``, and the
+    F9.3 entity-anchor STEP 0.5a block to
+    ``pipeline_query_expansion.py``.
   * ``engine.py`` extracted the memory-context assembly to
     ``engine_memory.py`` and the canonical RAG synth to
     ``engine_synth.py``.
@@ -42,6 +44,7 @@ def pipeline_source() -> str:
         pipeline,
         pipeline_context,
         pipeline_loops,
+        pipeline_query_expansion,
         pipeline_synth,
     )
     return (
@@ -50,6 +53,8 @@ def pipeline_source() -> str:
         + inspect.getsource(pipeline_context)
         + "\n"
         + inspect.getsource(pipeline_loops)
+        + "\n"
+        + inspect.getsource(pipeline_query_expansion)
         + "\n"
         + inspect.getsource(pipeline_synth)
     )

--- a/tests/test_entity_anchor_pipeline_wiring.py
+++ b/tests/test_entity_anchor_pipeline_wiring.py
@@ -1,0 +1,359 @@
+"""F9.3 — pipeline STEP 0.5a entity anchor wiring contract tests.
+
+Pins the flag-gated wiring between ``apply_entity_anchor_expansion``
+(``core/reasoning/pipeline_query_expansion.py``) and the
+``EntityAnchorExpander`` module that lands at F9.2:
+
+  * ``JAMES_ENABLE_ENTITY_ANCHOR`` flag OFF → expander NEVER called,
+    returned ``query_for_rewriter`` is byte-identical to the input
+    ``safe_query``, no trace step emitted
+  * Flag ON + expander hit → query_for_rewriter carries the
+    anchor-augmented form, trace step emitted with the right
+    ``applied_rule`` + ``anchors_added`` in extras
+  * Flag ON + expander miss → query_for_rewriter falls back to
+    safe_query unchanged, no trace step emitted (hit=False signals
+    no useful work to record)
+  * Flag ON + expander raises → fallback to safe_query, error logged
+    via ``engine._log``, pipeline does not abort
+
+Companion to:
+  * ``test_entity_anchor_expander.py`` — the F9.2 module-level
+    contract tests
+  * ``test_query_rewriter_audit.py`` — the F9.1/F9.2 audit script
+    A/B harness tests
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.reasoning.pipeline_query_expansion import (  # noqa: E402
+    apply_entity_anchor_expansion,
+)
+from core.retrieval.entity_anchor_expander import (  # noqa: E402
+    ENV_FLAG,
+    entity_anchor_enabled,
+)
+
+
+# ─── Env flag isolation ──────────────────────────────────────────────
+
+
+class EntityAnchorFlagTests(unittest.TestCase):
+    """``entity_anchor_enabled()`` env flag in isolation."""
+
+    def setUp(self):
+        self._saved = os.environ.get(ENV_FLAG)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(ENV_FLAG, None)
+        else:
+            os.environ[ENV_FLAG] = self._saved
+
+    def test_unset_returns_false(self):
+        os.environ.pop(ENV_FLAG, None)
+        self.assertFalse(entity_anchor_enabled())
+
+    def test_explicit_1_returns_true(self):
+        os.environ[ENV_FLAG] = "1"
+        self.assertTrue(entity_anchor_enabled())
+
+    def test_truthy_string_other_than_1_returns_false(self):
+        """Strict ``== "1"`` check matches the rewriter's pattern —
+        ``true`` / ``on`` / ``yes`` do NOT enable the flag. Pins the
+        contract so operators don't accidentally enable F9.3 with
+        the wrong env value."""
+        for val in ("0", "true", "yes", "on", "True", " 1 ", ""):
+            os.environ[ENV_FLAG] = val
+            self.assertFalse(
+                entity_anchor_enabled(),
+                f"value {val!r} should NOT enable the flag",
+            )
+
+    def test_env_flag_constant_matches_documented_name(self):
+        """If this changes operators will mysteriously see no
+        effect when they set the documented env var. Pinning the
+        constant guards the documentation contract."""
+        self.assertEqual(ENV_FLAG, "JAMES_ENABLE_ENTITY_ANCHOR")
+
+
+# ─── apply_entity_anchor_expansion wiring ────────────────────────────
+
+
+def _make_engine() -> MagicMock:
+    """Minimal mock engine — only the methods the helper calls."""
+    engine = MagicMock()
+    engine._log    = MagicMock()
+    engine._elapsed = MagicMock()
+    return engine
+
+
+class WiringFlagOffTests(unittest.TestCase):
+    """Flag-OFF byte-identical invariant — the core regression guard."""
+
+    def setUp(self):
+        self._saved = os.environ.pop(ENV_FLAG, None)
+
+    def tearDown(self):
+        if self._saved is not None:
+            os.environ[ENV_FLAG] = self._saved
+
+    def test_flag_off_returns_safe_query_unchanged(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get:
+            result = apply_entity_anchor_expansion(
+                engine, "David Soria Parra가 누구야?", "user",
+            )
+        # Expander never called
+        mock_get.assert_not_called()
+        # Returned tuple = (query unchanged, [], False)
+        self.assertEqual(result[0], "David Soria Parra가 누구야?")
+        self.assertEqual(result[1], [])
+        self.assertFalse(result[2])
+
+    def test_flag_off_does_not_emit_trace(self):
+        engine = _make_engine()
+        with patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ) as mock_emit:
+            apply_entity_anchor_expansion(
+                engine, "팔란티어의 CEO?", "user",
+            )
+        mock_emit.assert_not_called()
+
+    def test_flag_off_no_elapsed_recorded(self):
+        """``engine._elapsed`` is the timing breadcrumb the operator
+        greps for in stdout. Under flag OFF the entire STEP 0.5a
+        block is skipped — no timing row should fire."""
+        engine = _make_engine()
+        apply_entity_anchor_expansion(
+            engine, "팔란티어의 CEO?", "user",
+        )
+        # Only fires inside the `if entity_anchor_enabled():` branch
+        engine._elapsed.assert_not_called()
+
+
+class WiringFlagOnHitTests(unittest.TestCase):
+    """Flag-ON path — entity matched, anchor injected, trace emitted."""
+
+    def setUp(self):
+        self._saved = os.environ.get(ENV_FLAG)
+        os.environ[ENV_FLAG] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(ENV_FLAG, None)
+        else:
+            os.environ[ENV_FLAG] = self._saved
+
+    def test_hit_replaces_query_with_expanded(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ):
+            mock_get.return_value.expand.return_value = (
+                "David Soria Parra가 누구야? (관련: MCP)",
+                ["MCP"],
+                True,
+            )
+            result = apply_entity_anchor_expansion(
+                engine, "David Soria Parra가 누구야?", "user",
+            )
+
+        # The expander was called with the original safe_query
+        mock_get.return_value.expand.assert_called_once_with(
+            "David Soria Parra가 누구야?",
+        )
+        # Returned tuple carries the expanded form
+        self.assertIn("(관련: MCP)", result[0])
+        self.assertEqual(result[1], ["MCP"])
+        self.assertTrue(result[2])
+
+    def test_hit_emits_trace_with_correct_applied_rule(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ) as mock_emit:
+            mock_get.return_value.expand.return_value = (
+                "팔란티어의 CEO? (관련: Alex Karp)",
+                ["Alex Karp"],
+                True,
+            )
+            apply_entity_anchor_expansion(
+                engine, "팔란티어의 CEO?", "user",
+            )
+
+        mock_emit.assert_called_once()
+        # First positional arg is the TraceStep dataclass — verify
+        # its applied_rule is the F9.3 identifier so audit_log grep
+        # works for the operator.
+        trace_step = mock_emit.call_args[0][0]
+        self.assertEqual(
+            trace_step.applied_rule,
+            "reasoning.retrieve.entity_anchor_expand",
+        )
+        # Stage is the existing "retrieve" stage (no schema change
+        # required — F9.3 reuses the rewriter's stage convention).
+        self.assertEqual(trace_step.stage, "retrieve")
+        self.assertEqual(trace_step.backend_id, "graph_local")
+
+    def test_hit_trace_extras_carry_anchor_list(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ) as mock_emit:
+            mock_get.return_value.expand.return_value = (
+                "팔란티어? (관련: Alex Karp, Peter Thiel)",
+                ["Alex Karp", "Peter Thiel"],
+                True,
+            )
+            apply_entity_anchor_expansion(
+                engine, "팔란티어?", "user",
+            )
+
+        extras = mock_emit.call_args[1]["extras"]
+        self.assertEqual(extras["anchors_added"], ["Alex Karp", "Peter Thiel"])
+        self.assertEqual(extras["anchor_count"], 2)
+        self.assertEqual(extras["original_query"], "팔란티어?")
+        self.assertIn("(관련:", extras["expanded_query"])
+
+
+class WiringFlagOnMissTests(unittest.TestCase):
+    """Flag-ON but no entity matched — fall through to safe_query."""
+
+    def setUp(self):
+        self._saved = os.environ.get(ENV_FLAG)
+        os.environ[ENV_FLAG] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(ENV_FLAG, None)
+        else:
+            os.environ[ENV_FLAG] = self._saved
+
+    def test_no_hit_returns_safe_query_unchanged(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ):
+            mock_get.return_value.expand.return_value = (
+                "Foobar Baz는?", [], False,
+            )
+            result = apply_entity_anchor_expansion(
+                engine, "Foobar Baz는?", "user",
+            )
+
+        self.assertEqual(result[0], "Foobar Baz는?")
+        self.assertEqual(result[1], [])
+        self.assertFalse(result[2])
+
+    def test_no_hit_does_not_emit_trace(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ) as mock_emit:
+            mock_get.return_value.expand.return_value = (
+                "Foobar?", [], False,
+            )
+            apply_entity_anchor_expansion(engine, "Foobar?", "user")
+
+        # No hit → no useful work to record → no trace row
+        mock_emit.assert_not_called()
+
+
+class WiringFlagOnErrorTests(unittest.TestCase):
+    """Flag-ON but expander raises — fall back to safe_query, log it."""
+
+    def setUp(self):
+        self._saved = os.environ.get(ENV_FLAG)
+        os.environ[ENV_FLAG] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(ENV_FLAG, None)
+        else:
+            os.environ[ENV_FLAG] = self._saved
+
+    def test_expander_exception_falls_back_to_safe_query(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get:
+            mock_get.return_value.expand.side_effect = RuntimeError("xyz")
+            result = apply_entity_anchor_expansion(
+                engine, "David Soria Parra가 누구야?", "user",
+            )
+
+        # safe_query returned unchanged
+        self.assertEqual(result[0], "David Soria Parra가 누구야?")
+        self.assertEqual(result[1], [])
+        self.assertFalse(result[2])
+        # error went through engine._log under the "entity_anchor_expand" tag
+        engine._log.assert_called_once()
+        self.assertEqual(engine._log.call_args[0][0], "entity_anchor_expand")
+
+    def test_expander_exception_does_not_emit_trace(self):
+        engine = _make_engine()
+        with patch(
+            "core.retrieval.entity_anchor_expander.get_entity_anchor_expander"
+        ) as mock_get, patch(
+            "core.reasoning.trace_schema.emit_trace_step"
+        ) as mock_emit:
+            mock_get.return_value.expand.side_effect = RuntimeError("xyz")
+            apply_entity_anchor_expansion(engine, "anything", "user")
+
+        mock_emit.assert_not_called()
+
+
+# ─── pipeline.py source contract ─────────────────────────────────────
+
+
+class PipelineSourceContractTests(unittest.TestCase):
+    """Structural smoke — pipeline.py invokes the helper at STEP 0.5a.
+
+    Mirrors the existing structural-grep pattern (see
+    ``tests/_pipeline_src.pipeline_source``). Catches regressions
+    like someone deleting the helper call by accident.
+    """
+
+    def test_pipeline_imports_helper(self):
+        from tests._pipeline_src import pipeline_source
+        src = pipeline_source()
+        self.assertIn(
+            "from core.reasoning.pipeline_query_expansion import",
+            src,
+        )
+        self.assertIn("apply_entity_anchor_expansion", src)
+
+    def test_pipeline_step_0_5a_marker_present(self):
+        """A grep-friendly marker that the F9.3 STEP 0.5a block
+        exists. The exact comment string is the operator's grep
+        target — pinning it here forces a deliberate update if it
+        ever changes."""
+        from tests._pipeline_src import pipeline_source
+        src = pipeline_source()
+        self.assertIn("STEP 0.5a", src)
+        self.assertIn("entity anchor expansion", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

LEO L.D follow-up. **F9.2 (PR #546) operator acceptance run on 2026-05-27 21:49 UTC**:

| Bucket | F9.1 baseline | F9.2 arm | Δ |
|---|---|---|---|
| **bare_proper_noun (q15 cluster)** | 0/3 (0%) | **3/3 (100%)** | +100pt ⭐ |
| name_with_concept | 0/2 (0%) | 2/2 (100%) | +100pt |
| pure_concept | 0/2 (0%) | 1/2 (50%) | +50pt |
| multi_hop_control | 1/2 (50%) | 1/2 (50%) | unchanged |
| **Overall** | **1/9 (11.1%)** | **7/9 (77.8%)** | +66.7pt |

Gate target was 67%; **ships at 100% on the q15 cluster**. Zero dropped anchors across all 9 fixture queries (additive only, zero regression risk).

This PR wires the F9.2 `EntityAnchorExpander` into the production pipeline at **STEP 0.5a** (BEFORE the LLM rewriter) behind `JAMES_ENABLE_ENTITY_ANCHOR=1` opt-in (**default OFF** per CLAUDE.md rule #1).

## Files

### `core/retrieval/entity_anchor_expander.py` — env flag helper

- New `ENV_FLAG = \"JAMES_ENABLE_ENTITY_ANCHOR\"` constant + new `entity_anchor_enabled() -> bool` helper that reads the env at every call (not cached) so operators can toggle in a long-running process.
- Strict `== \"1\"` check matches the rewriter's pattern — `true` / `on` / `yes` do NOT enable the flag (this is the pinned contract).

### `core/reasoning/pipeline_query_expansion.py` — STEP 0.5a helper (new, ~5 KB)

Extracted to keep `pipeline.py` under the 20 KB CLAUDE.md rule #5 cap. Mirrors PR #518's `pipeline_context.py` split.

- `apply_entity_anchor_expansion(engine, safe_query, user_role) → (query_for_rewriter, anchors_added, hit)`:
  1. Read `JAMES_ENABLE_ENTITY_ANCHOR`; OFF → byte-identical no-op (returns safe_query unchanged, no trace emitted)
  2. Run `EntityAnchorExpander.expand(safe_query)` with failure isolation: expander raising falls back to safe_query + `engine._log(\"entity_anchor_expand\", ...)`
  3. On hit, emit a trace step with `applied_rule=\"reasoning.retrieve.entity_anchor_expand\"` + `stage=\"retrieve\"` + `backend_id=\"graph_local\"`. Extras carry `anchors_added` + `anchor_count` + `original_query` + `expanded_query` + optional `trace_id`.

### `core/reasoning/pipeline.py` — STEP 0.5a call site

- New STEP 0.5a block (8 lines) invokes the helper just before STEP 0.5b query rewrite.
- STEP 0.5b trace `_changed` comparison shifted from `safe_query` to `query_for_rewriter` so \"did the rewriter contribute\" stays meaningful when the anchor changed the input (the F9.3 audit row already attributes the safe → expanded delta).
- File size: 16.0 KB → **17.4 KB** (well under the 20 KB cap).

### `tests/test_entity_anchor_pipeline_wiring.py` (16 tests, new)

- **4 env flag** isolation tests: unset → False, \"1\" → True, strict inequality for \"true\"/\"on\"/\"yes\"/empty/whitespace, env constant name pinned (catches doc-vs-code drift).
- **3 flag-OFF** wiring tests: expander never called, query_for_rewriter byte-identical to safe_query, no trace emitted, no `_elapsed` recorded.
- **3 flag-ON + hit** tests: expander called with safe_query, return carries expanded form, trace emitted with correct applied_rule + stage=\"retrieve\" + backend_id=\"graph_local\", extras carry the anchor list + count.
- **2 flag-ON + miss** tests: query falls through unchanged, no trace.
- **2 flag-ON + error** tests: expander raising falls back to safe_query, `engine._log(\"entity_anchor_expand\", ...)` called, no trace emitted.
- **2 pipeline.py structural** tests: `pipeline_source()` contains the helper import + the STEP 0.5a marker comment (operator's grep target — pinning forces deliberate update if the marker moves).

### `tests/_pipeline_src.py` — include new split companion

`pipeline_source()` now also concatenates `pipeline_query_expansion.py` so existing structural-grep tests see the F9.3 wiring.

## Verification

- `pytest tests/test_entity_anchor_pipeline_wiring.py tests/test_entity_anchor_expander.py -v` → **47 passed, 0.11s**
- `ruff check core/reasoning/pipeline.py core/reasoning/pipeline_query_expansion.py core/retrieval/entity_anchor_expander.py tests/test_entity_anchor_pipeline_wiring.py tests/_pipeline_src.py` → clean
- File sizes (CLAUDE.md rule #5):
  - `pipeline.py`: **17.4 KB** (well under 20 KB cap)
  - `pipeline_query_expansion.py`: **5.0 KB** (new)
  - `entity_anchor_expander.py`: **14.5 KB** (under 20 KB cap)
- F9.2 acceptance JSON (operator run 2026-05-27 21:49 UTC, included as audit-trail): `reports/research-runs/query-rewriter-audit-entityanchor-20260527_214942.json` — bare_proper_noun anchor_added_rate = **3/3 (100%)**.

## Default-off invariant

- `JAMES_ENABLE_ENTITY_ANCHOR` unset → STEP 0.5a is a 1-call no-op (the env check returns False before touching the expander). Returned `query_for_rewriter == safe_query` byte-identical.
- `WiringFlagOffTests` (3 tests) pins this — they verify `get_entity_anchor_expander` is **NEVER** called when the flag is unset, no trace step is emitted, no `_elapsed` timing row recorded.
- Production fleets pulling F9.3 see byte-identical retrieval behaviour relative to F9.2 unless they opt in.

## Operator activation path

After this PR merges, operators who want the q15 fix in production add to `.env`:

\`\`\`
JAMES_ENABLE_ENTITY_ANCHOR=1
\`\`\`

The flag activates immediately on next server start. step7 v4 q15 `path_recall` acceptance gate verification + ROADMAP D-F9 tick land in the F9.4 follow-up doc PR.

## Out of scope (F9.4 + later)

- **step7 v4 q15 `path_recall` ≥ 0.5 acceptance bench** (the BL-9 deferred gate) — operator run with flag ON + bge-m3 swap active
- **Anchor noise tuning**: F9.2 audit showed `target_type=document` entries (e.g. `08_MCP_(Model_Context_Protocol)` document filename, `PLTR_01_Q1_2026_실적분석`) sometimes get added as anchors. Filtering or down-weighting document-type relations is a follow-up tuning PR
- **Default flip** — F9.3 ships opt-in. Promoting to default-ON requires the F9.4 acceptance bench + at least one full step7 v4 sweep showing no regression on the other buckets
- **ROADMAP D-F9 row + handover memo updates** land in F9.4 doc PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)