### PR TITLE
docs(positioning): adopt "Replayable RAG" category framing in README + ARCHITECTURE

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,8 +1,9 @@
 # PROJECT JAMES
 
-> **로컬 우선, 감사 가능한 지식 추론 시스템**
-> — 명시적 추론 경로 + 출처 인식 지식 그래프 + 인간 승인 게이트
-> 기반 자기진화.
+> **Replayable RAG** — 모든 claim 에 출처, 모든 추론 단계에 audit
+> row, 임의 시점 T 의 시스템 상태를 바이트-동일하게 재생 가능한
+> 로컬 우선 지식 추론 시스템. 자기진화는 인간 승인 게이트 뒤에서
+> 동작.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-v0.4.0-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0)
@@ -17,12 +18,20 @@
 
 ---
 
-## 프로젝트 상태: v0.3.0 — Platform Skeleton
+## 프로젝트 상태: v0.4.0 — Layer 4 Lifecycle Semantics (first bundle)
 
-**2026-05-17 정식 릴리스** (v0.2.0 이후 9일간 190 PR, 1800+ tests).
-v0.2 → v0.3 게이트 통과 — 6축 Foundation Hardening
-(아키텍처 / 평가 / 관찰성 / 보안 / 통제 진화 / 실데이터 검증) 모두
-완료. 두 번째 사용자 게이트는 2026-05-13 마감.
+**2026-05-27 릴리스**. v0.4.0 은 Layer 4 first bundle —
+**T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction
+Arbitration** — 을 Sprint 5 의 8 PR 시퀀스로 출시. CASCADE 와
+EVENT 의 분리 invariant 가 `tests/test_t7_release_gating_invariants
+.py` (실제 wiki 픽스처 대상, 목 아님) 으로 **end-to-end 증명**.
+supersede chain 프리미티브 (`reconstruct_view_at`) 가 무관한
+CASCADE 삭제 이벤트 후에도 "시점 T 에 무엇이 참이었나" 를
+결정론적으로 답변.
+
+이전: v0.3.0 (2026-05-17) Foundation Hardening 마감 — 6 축
+(아키텍처 / 평가 / 관찰성 / 보안 / 통제 진화 / 실데이터 검증)
+모두 통과; 두 번째 사용자 게이트 2026-05-13 마감.
 
 - **프로덕션 준비 안 됨** — 운영 성숙도 (HTTPS / SSO / 멀티테넌시 /
   백업 CLI) 는 v1.0 산출물. [SECURITY.md](SECURITY.md) 참조
@@ -50,29 +59,56 @@ JAMES 는 **하나의 버티컬**을 만드는 것이 아닙니다. 법률·식�
 
 ---
 
-## 무엇이 다른가
+## 무엇이 다른가 — Replayable RAG
 
-JAMES 는 함께 찾기 드문 아이디어를 결합합니다:
+대부분의 RAG 시스템은 *"답이 뭐야?"* 한 가지 질문에 답합니다.
+JAMES 는 두 가지를 더 답합니다:
 
-1. **출처 인식 Graph-RAG** — 12 typed relation 이 임베딩 이상의
+- **시점 T 에 시스템이 무엇을 알고 있었나?** — T7 supersede chain
+  이 fact 의 과거 상태를 보존하고, `reconstruct_view_at(t)` 가
+  무관한 CASCADE 삭제 이벤트 후에도 임의 과거 시점에 활성이었던
+  edge 를 반환합니다.
+- **왜 그렇게 답했나?** — 모든 추론 단계 (query rewrite, retrieval,
+  rerank, planner, reflect, verify, synth) 가 append-only audit row
+  를 남깁니다. `scripts/replay_trace.py <trace_id>` 가 전체 시퀀스
+  를 바이트-동일하게 재구성합니다.
+
+이 둘의 결합이 JAMES 를 **Replayable RAG** 카테고리에 위치시킵니다.
+Agentic RAG (*"AI 가 무엇을 할 수 있나"* 에 최적화) 와 다르고,
+Mem0 형 메모리 layer (LLM judge 로 belief 갱신) 와 다릅니다.
+JAMES 는 LLM-free 결정론적 4-rule decision tree
+(`core/lifecycle/contradiction_arbiter.py:classify_contradiction`)
+로 belief 를 갱신하고, 과거 fact 를 overwrite 하는 대신 보존해
+replay 가능하게 만듭니다.
+
+### 어떻게 만들어졌나
+
+1. **결정론적 메모리 lifecycle** (v0.4.0) — T1 Temporal Validity +
+   T7 Supersede Chain + T2 Contradiction Arbitration. CASCADE
+   (destructive, Layer 3) 와 EVENT (history-preserving, Layer 4)
+   는 코드 path 가 분리 보장 —
+   `tests/test_t7_release_gating_invariants.py` 가 실제 wiki
+   픽스처로 release-gate.
+2. **출처 인식 Graph-RAG** — 12 typed relation 이 임베딩 이상의
    의미를 부여하고, 모든 relation 에 `sources: [{doc_id, weight,
    role, ts}]` 가 부착되어 문서 삭제/수정 시 영향받은 파생 지식만
-   외과적으로 갱신 (Knowledge Cascade A→E, v0.3.0)
-2. **Cognitive Layer** — cross-encoder reranker (디폴트 ON),
+   외과적으로 갱신 (Knowledge Cascade A→E, v0.3.0).
+3. **Cognitive Layer** — cross-encoder reranker (디폴트 ON),
    LLM query rewriter, reflection loop (draft → critique → revise),
    verification engine (security + fact check), tool router.
    하나의 `trace_id` 로 8 단계 추론 시퀀스를
-   `scripts/replay_trace.py` 로 재구성 가능
-3. **PolicyEngine — sprinkle 아닌 layer** — 역할/민감도 결정의
+   `scripts/replay_trace.py` 로 재구성 가능.
+4. **PolicyEngine — sprinkle 아닌 layer** — 역할/민감도 결정의
    단일 진입점이 retrieval / graph / output / tools 모두에 연결.
-   제거하면 6+ 모듈이 깨짐 (v0.2 Axis 4)
-4. **Change Request 프리미티브** — 모든 쓰기 (위키 편집, 워크스페이스
+   제거하면 6+ 모듈이 깨짐 (v0.2 Axis 4).
+5. **Change Request 프리미티브** — 모든 쓰기 (위키 편집, 워크스페이스
    잡, 자가-진화 패치) 가 propose → review → admin 승인 →
    atomic apply → audit 행으로 라우팅. silent write 없음.
-5. **인간 게이트 뒤 자가-진화** — 피드백 → 후보 → bench eval →
+6. **인간 게이트 뒤 자가-진화** — 피드백 → 후보 → bench eval →
    인간 승인 → 배포 → 회귀 시 auto-rollback. 배포된 모든 패치는
-   `approver_username` 감사 행을 보유 (v0.2 Axis 5)
-6. **100% 로컬** — Ollama 로 노트북에서 실행 가능
+   `approver_username` 감사 행을 보유 (v0.2 Axis 5).
+7. **100% 로컬** — Ollama 로 노트북에서 실행 가능. 기본 설정에서
+   클라우드 LLM 의존성 없음.
 
 > 모든 기능은 STEP 7 13-query baseline + RAGAS 메트릭으로 회귀
 > 테스트. `core/{retrieval,graph,reasoning}` 을 건드리는 PR 은

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # PROJECT JAMES
 
-> **Local-first, auditable knowledge reasoning system** with explicit
-> reasoning paths, a sources-aware knowledge graph, and self-evolution
-> behind a human approval gate.
+> **Replayable RAG** — a local-first knowledge reasoning system where
+> every claim is sourced, every reasoning step is audited, and the
+> system's state at any point in time can be replayed
+> byte-identically. Built behind a human approval gate for
+> self-evolution.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-v0.4.0-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0)
@@ -16,13 +18,22 @@
 
 ---
 
-## Project Status: v0.3.0 — Platform Skeleton
+## Project Status: v0.4.0 — Layer 4 Lifecycle Semantics (first bundle)
 
-Released **2026-05-17** after 190 PRs since v0.2.0 (1800+ tests).
-The v0.2 → v0.3 gate is clear: all six Foundation Hardening axes
-(architecture, eval, observability, security, controlled evolution,
-real-data validation) passed; second-user validation closed
-2026-05-13.
+Released **2026-05-27**. v0.4.0 ships the Layer 4 first bundle —
+**T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction
+Arbitration** — across an 8-PR Sprint 5 sequence. The CASCADE vs
+EVENT separation invariant is now **provable end-to-end** via
+`tests/test_t7_release_gating_invariants.py`, run against the
+actual wiki fixture (not mocks). The supersede chain primitive
+(`reconstruct_view_at`) lets the system answer "what was true at
+time T?" deterministically, even after destructive CASCADE
+operations on unrelated facts.
+
+Pre-v0.4: v0.3.0 (2026-05-17) closed Foundation Hardening — all
+six axes (architecture / eval / observability / security /
+controlled evolution / real-data validation) green; second-user
+validation closed 2026-05-13.
 
 - **NOT production-ready** — operational maturity (HTTPS / SSO /
   multi-tenancy / backup CLI) is a v1.0 deliverable; see
@@ -52,31 +63,59 @@ branching forms (Domain Pack / Distribution / Vertical Product).
 
 ---
 
-## What's Different
+## What's Different — Replayable RAG
 
-JAMES combines ideas that are rarely found together:
+Most RAG systems answer one question: *"what's the answer?"*
+JAMES answers two extra:
 
-1. **Sources-aware Graph-RAG** — 12 typed relations carry semantic
+- **What did the system know at time T?** — T7 supersede chains
+  preserve historical fact states; `reconstruct_view_at(t)` returns
+  the edge that was active at any past timestamp, even after
+  unrelated CASCADE delete events.
+- **Why did the system say that?** — every reasoning step (query
+  rewrite, retrieval, rerank, planner, reflect, verify, synth)
+  writes an append-only audit row. `scripts/replay_trace.py
+  <trace_id>` reconstructs the full sequence byte-identically.
+
+The two combined make JAMES a **Replayable RAG** system — a
+category distinct from Agentic RAG (which optimises for *what an
+AI can do*) and from Mem0-style memory layers (which use an LLM
+judge to update beliefs). JAMES updates beliefs via a
+deterministic 4-rule decision tree (`core/lifecycle/
+contradiction_arbiter.py:classify_contradiction`) that is
+LLM-free by design, and preserves both the old and the new fact
+for replay rather than overwriting.
+
+### How that's built
+
+1. **Deterministic memory lifecycle** (v0.4.0) — T1 Temporal
+   Validity + T7 Supersede Chain + T2 Contradiction Arbitration.
+   CASCADE (destructive, Layer 3) and EVENT (history-preserving,
+   Layer 4) are guaranteed-separate paths — release-gated by
+   `tests/test_t7_release_gating_invariants.py` against the real
+   wiki fixture.
+2. **Sources-aware Graph-RAG** — 12 typed relations carry semantic
    meaning beyond embeddings, and every relation carries
    `sources: [{doc_id, weight, role, ts}]` so deleting or modifying
    a document surgically updates only the affected derived knowledge
-   (Knowledge Cascade A→E, v0.3.0)
-2. **Cognitive Layer** — cross-encoder reranker (default ON), LLM
+   (Knowledge Cascade A→E, v0.3.0).
+3. **Cognitive Layer** — cross-encoder reranker (default ON), LLM
    query rewriter, reflection loop (draft → critique → revise),
    verification engine (security + fact check), and tool router.
    One `trace_id` reconstructs the full 8-stage reasoning sequence
-   via `scripts/replay_trace.py`
-3. **PolicyEngine as a layer, not a sprinkle** — single point of
+   via `scripts/replay_trace.py`.
+4. **PolicyEngine as a layer, not a sprinkle** — single point of
    role / sensitivity decisions wired into retrieval, graph, output,
-   and tools; removing it breaks 6+ modules (v0.2 Axis 4)
-4. **Change Request primitive** — every write (wiki edits, workspace
+   and tools; removing it breaks 6+ modules (v0.2 Axis 4).
+5. **Change Request primitive** — every write (wiki edits, workspace
    jobs, self-evolution patches) routes through propose → review →
    admin approval → atomic apply → audit row. No silent writes.
-5. **Self-evolution behind a human gate** — feedback → candidate →
+6. **Self-evolution behind a human gate** — feedback → candidate →
    bench eval → human approval → deploy → auto-rollback on
    regression. Every deployed patch has an `approver_username`
    audit row (v0.2 Axis 5).
-6. **100% local** — runs on a laptop with Ollama
+7. **100% local** — runs on a laptop with Ollama; no cloud LLM
+   dependency by default.
 
 > Each feature is regression-tested against the STEP 7 13-query
 > baseline + RAGAS metrics. PRs touching `core/{retrieval,graph,reasoning}`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,16 +4,38 @@
 > what it deliberately is not, and the trust boundaries that govern
 > all design decisions.
 >
-> Status: living document. Last updated: v0.3.0 (Platform Skeleton, 2026-05-20).
+> Status: living document. Last updated: v0.4.0 (Layer 4 Lifecycle Semantics first bundle, 2026-05-27).
 
 ---
 
 ## 1. Mission
 
-A **local-first, auditable knowledge reasoning system** that answers
-questions over a private knowledge base with:
+JAMES is a **Replayable RAG** system: a local-first knowledge
+reasoning system where every claim is sourced, every reasoning
+step is audited, and the system's state at any point in time
+can be replayed byte-identically.
 
-- explicit reasoning paths (sources + graph trace)
+The Replayable category is distinct from:
+
+- **Agentic RAG** — which optimises for *what an AI can do*
+  (tool use, planning, multi-step action). Replayable RAG asks
+  the orthogonal question: *what did the system know at time T,
+  and why did it answer that way?*
+- **Mem0-style memory layers** — which use an LLM judge to
+  update beliefs. Replayable RAG uses a deterministic 4-rule
+  decision tree (see §5.6 Change Request flow + the v0.4 T2
+  Contradiction Arbitration module
+  `core/lifecycle/contradiction_arbiter.py`) and **preserves**
+  the old fact alongside the new one (T7 Supersede Chain), so
+  the historical state is replayable instead of overwritten.
+
+Mission, expanded:
+
+- explicit reasoning paths (sources + graph trace, audit-log
+  replay via `scripts/replay_trace.py <trace_id>`)
+- temporal-faithful memory (`reconstruct_view_at(t)` returns
+  the edge that was active at any past timestamp, even after
+  unrelated CASCADE delete events)
 - role-based access at every stage
 - human-supervised improvement loop
 


### PR DESCRIPTION
## Summary

Names the category JAMES has been building toward but had no shared label for: **Replayable RAG**. Captures the v0.4.0 main-theme delivery (T7 supersede chain + audit-log replay = the system can answer *\"what did I know at time T?\"* and *\"why did I answer that way?\"* — both deterministically reproducible) into a single positioning line that travels.

**No code changed. Pure docs PR.**

## Why this PR

Two findings from a 2026-05-27 framing review pinned this:

1. **\"Governed RAG\"** — the obvious candidate — is already used as a product category by Infiligence (https://www.infiligence.com/post/governed-rag-secure-policy-driven-ai-retrieval-for-enterprises).
2. A web check across Replayable / Forensic / Defensible / Sovereign / Ledger RAG variants showed only \"Replayable\" is simultaneously:
   - **(a)** not claimed as a product/vendor category,
   - **(b)** directly tied to load-bearing JAMES architecture (T7 + audit_log),
   - **(c)** URL-safe + memorable + distinct from the geopolitical shadow of \"Sovereign AI\".

Decision context lives at `memory/feedback_jameses_positioning_replayable_rag.md` (operator's auto-memory, not in this repo).

## Files

### `README.md` + `README.ko.md` — parallel updates

- **Tagline (line 3–5)**: rewrites from *\"Local-first, auditable knowledge reasoning system\"* to *\"Replayable RAG — a local-first knowledge reasoning system where every claim is sourced, every reasoning step is audited, and the system's state at any point in time can be replayed byte-identically.\"* Status badge unchanged (already v0.4.0 per PR-T7.C).
- **Project Status section**: bumps the visible heading from v0.3.0 → v0.4.0 (the badge was bumped in PR-T7.C #544 but the status text was missed). Adds a one-paragraph summary of the Layer 4 first-bundle delivery + the `test_t7_release_gating_invariants.py` end-to-end provability claim. v0.3.0 history folded into a one-line *\"Pre-v0.4\"* reference.
- **\"What's Different\" section**: restructured into two parts:
  - **Lead paragraph** — names the Replayable RAG category, the two extra questions it answers, and the explicit Agentic-RAG / Mem0 contrast lines. Calls out `core/lifecycle/contradiction_arbiter.py:classify_contradiction` as the deterministic 4-rule decision tree that is the Mem0 differentiator.
  - **\"How that's built\"** — 7 bullets. New bullet **#1** is the v0.4.0 Deterministic memory lifecycle (T1 + T7 + T2 + CASCADE/EVENT separation). Existing 6 bullets (Sources-aware Graph-RAG / Cognitive Layer / PolicyEngine / Change Request / Self-evolution gate / 100% local) preserved in their existing order. No bullet deleted, no architectural claim added beyond what's already shipped in the v0.4.0 release.

### `docs/ARCHITECTURE.md` — Mission section

- **§1 Mission**: rewrites the opening paragraph to lead with the Replayable RAG category definition + the two-contrast structure (vs Agentic RAG / vs Mem0). Existing mission bullets preserved but reordered so *\"explicit reasoning paths\"* and *\"temporal-faithful memory\"* appear first (the Replayable RAG-specific guarantees). Adds explicit `reconstruct_view_at(t)` + `scripts/replay_trace.py <trace_id>` pointers so the abstract \"replayable\" claim has concrete code-to-grep handles.
- **Header status line**: bumps from *\"v0.3.0 (Platform Skeleton, 2026-05-20)\"* to *\"v0.4.0 (Layer 4 Lifecycle Semantics first bundle, 2026-05-27)\"*.

## Verification

- No code changed. Pure docs PR.
- Repo identifier unchanged (`Hashevolution/James-RAG-Evol`) — rename intentionally deferred past v0.4.0 DOI mint completion and the mid-June joint piece milestone.
- Six existing \"What's Different\" bullets all preserved verbatim (only a new #1 added, others renumbered). Architecture claim surface unchanged — every claim already had a code anchor before this commit; this commit gives them a single category name to cluster under.
- Catchphrase candidates (e.g. *\"Replayable RAG — AI that can be cross-examined, at any point in time\"*) documented in the operator's auto-memory for future promo / joint-piece use; not yet wired into the README.

## Out of scope

- **Repo rename** (`James-RAG-Evol` → `replayable-rag-james` candidate). Deferred — DOI mint cycle still active, Robin/Ali/LEO joint collaboration references the current URL. Right moment is post-mid-June joint piece + explicit collaborator notification.
- **`docs/positioning/replayable-rag-vs-agentic-rag.md`** standalone memo. Defer until Robin/Ali sign-off on the framing so a joint piece doesn't have to walk back a unilateral category claim (Build-don't-broadcast pattern).
- **`docs/PLATFORM_READINESS.md`** category-row update. Touch in a follow-up if the 6-dimension framework gets restructured around the Replayable category; not required for the framing to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)