### PR TITLE
feat(eval): QVT α-3 — 3-axis oracle module + baseline capture wrapper

### DIFF
--- a/eval/qvt/__init__.py
+++ b/eval/qvt/__init__.py
@@ -1,0 +1,43 @@
+"""QVT (Quality Verification Track) — non-saturating quality oracle.
+
+Public API:
+
+  from eval.qvt import score_three_axis, ThreeAxisResult
+
+  result = score_three_axis(
+      bench_results_path="reports/research-runs/step7-bench-*.json",
+      fixture_path="eval/regression/step7_queries.json",
+  )
+  print(result.summary())
+
+Design memo: docs/design/v0.4-qvt-alpha-non-saturating-oracle.md
+"""
+from eval.qvt.oracle import (  # noqa: F401
+    AbstentionF1Axis,
+    AbstentionQueryRow,
+    GradedAnswerAxis,
+    GradedAnswerQueryRow,
+    PathCoverageAxis,
+    PathCoverageQueryRow,
+    ThreeAxisResult,
+    detect_abstention,
+    score_abstention_f1,
+    score_graded_answer,
+    score_path_coverage,
+    score_three_axis,
+)
+
+__all__ = [
+    "AbstentionF1Axis",
+    "AbstentionQueryRow",
+    "GradedAnswerAxis",
+    "GradedAnswerQueryRow",
+    "PathCoverageAxis",
+    "PathCoverageQueryRow",
+    "ThreeAxisResult",
+    "detect_abstention",
+    "score_abstention_f1",
+    "score_graded_answer",
+    "score_path_coverage",
+    "score_three_axis",
+]

--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -1,0 +1,429 @@
+"""QVT α-3 non-saturating quality oracle — 3-axis scoring.
+
+Consumes a bench JSON (output of `python scripts/bench.py --suite=step7
+--mode=retrieval`) and the v5 fixture (`eval/regression/step7_queries.json`)
+and produces three orthogonal quality scores plus a per-query breakdown.
+
+Axes (design memo §2):
+
+  1. Path Coverage — fraction of `expected_path.nodes` hit by graph_paths.
+     Currently 5/16 fixture queries annotated; pass-through aggregate of
+     bench.py's `path_recall_aggregate` block.
+
+  2. Graded Answer Accuracy — for every query, count how many of its 3
+     `gold_signals` (term OR any alias) appear as a case-insensitive
+     substring of the answer. Score = hits / 3. Mean across all queries.
+
+  3. Calibrated Abstention F1 — treats "system abstained" as the positive
+     class. Compared against `abstention_truth`:
+       TP = should-abstain (truth=absent) AND did-abstain (correct refusal)
+       FP = should-answer  (truth=present) AND did-abstain (incorrect_abstention)
+       FN = should-abstain (truth=absent) AND did-answer  (hallucination)
+       TN = should-answer  (truth=present) AND did-answer (correct answer)
+     F1 = 2·P·R / (P + R) where P=TP/(TP+FP), R=TP/(TP+FN).
+
+The oracle is deterministic — no LLM judge, no embedding lookups, just
+substring matching. Trade-off: misses paraphrased / negated / quantitative
+matches. Re-evaluation with an LLM judge is a v0.5+ candidate (see memo §6).
+
+Bench JSON answer field — `answer_preview` (300 chars, current) preferred
+when present; falls back to `answer` (full) when bench.py is updated to
+emit the full string. Graded answer scores against whichever is available;
+when both are absent (timeout / error) the row is treated as abstention.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# ---------------------------------------------------------------------------
+# Abstention phrase set
+# ---------------------------------------------------------------------------
+#
+# Substring-matched (case-insensitive) against the answer text. Korean and
+# English variants of "I don't know / cannot answer / refuse" — picked so
+# that JAMES's actual output phrasings under the gemma4:e4b default model
+# hit at least one phrase per genuine abstention. If α-3 baseline capture
+# reveals a phrasing the system uses that doesn't trip any of these, add
+# it here in a small follow-up PR (not a schema change).
+
+_ABSTENTION_PHRASES: Tuple[str, ...] = (
+    "정보가 없",
+    "내부 자료에 없",
+    "확인할 수 없",
+    "찾을 수 없",
+    "모르겠",
+    "없습니다",
+    "근거 부족",
+    "근거가 부족",
+    "근거를 찾",
+    "할 수 없",
+    "공개할 수 없",
+    "제공할 수 없",
+    "안내할 수 없",
+    "응답할 수 없",
+    "i don't have",
+    "i cannot",
+    "i can't",
+    "cannot find",
+    "no information",
+    "unable to",
+    "refuse",
+    "decline",
+)
+
+
+def detect_abstention(answer: Optional[str]) -> bool:
+    """True if `answer` is empty or contains any known abstention phrase.
+
+    An empty answer (timeout / error / blocked) is treated as an abstention
+    by default — the system implicitly "didn't answer".
+    """
+    if not answer:
+        return True
+    lower = answer.lower()
+    for phrase in _ABSTENTION_PHRASES:
+        if phrase.lower() in lower:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Path Coverage
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PathCoverageQueryRow:
+    id: int
+    expected_count: int
+    hits: int
+    recall: float
+
+
+@dataclass
+class PathCoverageAxis:
+    mean_recall: float
+    queries_with_expected_path: int
+    queries_at_full_recall: int
+    per_query: List[PathCoverageQueryRow] = field(default_factory=list)
+
+
+def score_path_coverage(
+    bench_results: Dict[str, Any],
+    fixture: Dict[str, Any],
+) -> PathCoverageAxis:
+    """Aggregate bench.py's per-query `path_metrics` block.
+
+    Skips queries without `expected_path` (the denominator is "annotated
+    queries", not "all queries"). The fixture parameter is accepted for
+    API symmetry but currently unused — bench.py already joined against
+    the fixture when producing `path_metrics`.
+    """
+    _ = fixture  # reserved for future use (e.g. min_recall threshold)
+    rows: List[PathCoverageQueryRow] = []
+    for r in bench_results.get("results", []):
+        pm = r.get("path_metrics")
+        if not pm:
+            continue
+        rows.append(PathCoverageQueryRow(
+            id=int(r["id"]),
+            expected_count=int(pm.get("expected_count", 0)),
+            hits=int(pm.get("hits", 0)),
+            recall=float(pm.get("path_recall", 0.0)),
+        ))
+    if not rows:
+        return PathCoverageAxis(
+            mean_recall=0.0,
+            queries_with_expected_path=0,
+            queries_at_full_recall=0,
+            per_query=[],
+        )
+    mean = sum(r.recall for r in rows) / len(rows)
+    full = sum(1 for r in rows if r.recall >= 1.0)
+    return PathCoverageAxis(
+        mean_recall=round(mean, 4),
+        queries_with_expected_path=len(rows),
+        queries_at_full_recall=full,
+        per_query=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Graded Answer Accuracy
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GradedAnswerQueryRow:
+    id: int
+    hits: int
+    total: int
+    score: float
+    matched_signals: List[str] = field(default_factory=list)
+
+
+@dataclass
+class GradedAnswerAxis:
+    mean_accuracy: float
+    queries_with_signals: int
+    per_query: List[GradedAnswerQueryRow] = field(default_factory=list)
+
+
+def _answer_text(result_row: Dict[str, Any]) -> str:
+    """Pick the best available answer string from a bench result row.
+
+    Order: `answer` (full, if bench.py emits it) → `answer_preview` (300
+    chars, current default) → empty string.
+    """
+    answer = result_row.get("answer")
+    if isinstance(answer, str) and answer:
+        return answer
+    preview = result_row.get("answer_preview")
+    if isinstance(preview, str):
+        return preview
+    return ""
+
+
+def _matches_signal(
+    answer_lower: str,
+    signal: Dict[str, Any],
+) -> Tuple[bool, Optional[str]]:
+    """Return (hit, matched_form) — whether the answer contains the
+    signal's term or any of its aliases (case-insensitive substring)."""
+    term = signal.get("term", "")
+    if isinstance(term, str) and term and term.lower() in answer_lower:
+        return True, term
+    for alias in signal.get("aliases", []) or []:
+        if isinstance(alias, str) and alias and alias.lower() in answer_lower:
+            return True, alias
+    return False, None
+
+
+def score_graded_answer(
+    bench_results: Dict[str, Any],
+    fixture: Dict[str, Any],
+) -> GradedAnswerAxis:
+    """For each fixture query that has gold_signals, count how many
+    signals were hit in the bench's answer text. Score = hits / total."""
+    fixture_map: Dict[int, Dict[str, Any]] = {
+        int(q["id"]): q for q in fixture.get("queries", [])
+    }
+    rows: List[GradedAnswerQueryRow] = []
+    for r in bench_results.get("results", []):
+        qid = int(r.get("id", -1))
+        fq = fixture_map.get(qid)
+        if not fq:
+            continue
+        signals = fq.get("gold_signals") or []
+        if not signals:
+            continue
+        answer_lower = _answer_text(r).lower()
+        hits = 0
+        matched: List[str] = []
+        for sig in signals:
+            ok, which = _matches_signal(answer_lower, sig)
+            if ok:
+                hits += 1
+                if which:
+                    matched.append(which)
+        total = len(signals)
+        score = round(hits / total, 4) if total else 0.0
+        rows.append(GradedAnswerQueryRow(
+            id=qid,
+            hits=hits,
+            total=total,
+            score=score,
+            matched_signals=matched,
+        ))
+    if not rows:
+        return GradedAnswerAxis(
+            mean_accuracy=0.0,
+            queries_with_signals=0,
+            per_query=[],
+        )
+    mean = sum(r.score for r in rows) / len(rows)
+    return GradedAnswerAxis(
+        mean_accuracy=round(mean, 4),
+        queries_with_signals=len(rows),
+        per_query=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Calibrated Abstention F1
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AbstentionQueryRow:
+    id: int
+    truth: str        # "present" or "absent"
+    abstained: bool   # system behavior
+    classification: str  # tp_abstain / fp_incorrect / fn_hallucination / tn_answer
+
+
+@dataclass
+class AbstentionF1Axis:
+    f1: float
+    precision: float
+    recall: float
+    tp_abstain: int            # truth=absent  AND abstained (correct refusal)
+    fp_incorrect_abstention: int  # truth=present AND abstained (over-cautious)
+    fn_hallucination: int      # truth=absent  AND answered  (worst — fabricated)
+    tn_answer: int             # truth=present AND answered  (correct answer)
+    n_queries: int
+    per_query: List[AbstentionQueryRow] = field(default_factory=list)
+
+
+def score_abstention_f1(
+    bench_results: Dict[str, Any],
+    fixture: Dict[str, Any],
+) -> AbstentionF1Axis:
+    """F1 on the binary abstention classifier the system implicitly runs.
+
+    Positive class = "system abstained". Rows from queries without an
+    `abstention_truth` annotation are silently skipped.
+
+    A result row with `status != "ok"` (timeout / blocked / error) is
+    treated as abstention (the system did not produce a substantive
+    answer). This conservatively credits the system for refusing to
+    fabricate on errors, but also penalizes it when truth=present.
+    """
+    fixture_map: Dict[int, Dict[str, Any]] = {
+        int(q["id"]): q for q in fixture.get("queries", [])
+    }
+    rows: List[AbstentionQueryRow] = []
+    tp_abstain = fp_incorrect = fn_hallucination = tn_answer = 0
+
+    for r in bench_results.get("results", []):
+        qid = int(r.get("id", -1))
+        fq = fixture_map.get(qid)
+        if not fq:
+            continue
+        truth = fq.get("abstention_truth")
+        if truth not in ("present", "absent"):
+            continue
+        if r.get("status") != "ok":
+            abstained = True
+        else:
+            abstained = detect_abstention(_answer_text(r))
+
+        if truth == "absent" and abstained:
+            cls = "tp_abstain"
+            tp_abstain += 1
+        elif truth == "absent" and not abstained:
+            cls = "fn_hallucination"
+            fn_hallucination += 1
+        elif truth == "present" and abstained:
+            cls = "fp_incorrect_abstention"
+            fp_incorrect += 1
+        else:  # truth == "present" and not abstained
+            cls = "tn_answer"
+            tn_answer += 1
+
+        rows.append(AbstentionQueryRow(
+            id=qid,
+            truth=truth,
+            abstained=abstained,
+            classification=cls,
+        ))
+
+    tp = tp_abstain
+    fp = fp_incorrect
+    fn = fn_hallucination
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = (
+        2 * precision * recall / (precision + recall)
+        if (precision + recall) > 0 else 0.0
+    )
+
+    return AbstentionF1Axis(
+        f1=round(f1, 4),
+        precision=round(precision, 4),
+        recall=round(recall, 4),
+        tp_abstain=tp_abstain,
+        fp_incorrect_abstention=fp_incorrect,
+        fn_hallucination=fn_hallucination,
+        tn_answer=tn_answer,
+        n_queries=len(rows),
+        per_query=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Three-axis unified result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThreeAxisResult:
+    git_sha: Optional[str]
+    suite: Optional[str]
+    fixture_version: Optional[str]
+    n_queries: int
+    path_coverage: PathCoverageAxis
+    graded_answer: GradedAnswerAxis
+    abstention: AbstentionF1Axis
+
+    def summary(self) -> str:
+        """One-line human-readable summary, suitable for stdout."""
+        return (
+            f"path_recall={self.path_coverage.mean_recall:.4f}"
+            f" ({self.path_coverage.queries_at_full_recall}/"
+            f"{self.path_coverage.queries_with_expected_path}) "
+            f"graded={self.graded_answer.mean_accuracy:.4f}"
+            f" (n={self.graded_answer.queries_with_signals}) "
+            f"abstention_f1={self.abstention.f1:.4f}"
+            f" (TP={self.abstention.tp_abstain}"
+            f" FP={self.abstention.fp_incorrect_abstention}"
+            f" FN={self.abstention.fn_hallucination}"
+            f" TN={self.abstention.tn_answer})"
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable dict (uses dataclasses.asdict)."""
+        return {
+            "git_sha": self.git_sha,
+            "suite": self.suite,
+            "fixture_version": self.fixture_version,
+            "n_queries": self.n_queries,
+            "path_coverage": asdict(self.path_coverage),
+            "graded_answer": asdict(self.graded_answer),
+            "abstention": asdict(self.abstention),
+        }
+
+
+def _load_json(path: Union[str, Path]) -> Dict[str, Any]:
+    with Path(path).open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def score_three_axis(
+    bench_results_path: Union[str, Path, Dict[str, Any]],
+    fixture_path: Union[str, Path, Dict[str, Any]],
+) -> ThreeAxisResult:
+    """Top-level entry — compute all three axes from a bench JSON +
+    a fixture JSON.
+
+    Both arguments accept either a file path or an already-parsed dict
+    (handy for tests + for chaining multiple runs in α-3 baseline capture).
+    """
+    bench = (
+        bench_results_path
+        if isinstance(bench_results_path, dict)
+        else _load_json(bench_results_path)
+    )
+    fixture = (
+        fixture_path
+        if isinstance(fixture_path, dict)
+        else _load_json(fixture_path)
+    )
+    return ThreeAxisResult(
+        git_sha=bench.get("git_sha"),
+        suite=bench.get("suite"),
+        fixture_version=fixture.get("version"),
+        n_queries=len(bench.get("results", [])),
+        path_coverage=score_path_coverage(bench, fixture),
+        graded_answer=score_graded_answer(bench, fixture),
+        abstention=score_abstention_f1(bench, fixture),
+    )

--- a/scripts/qvt_capture_baseline.py
+++ b/scripts/qvt_capture_baseline.py
@@ -1,0 +1,366 @@
+"""QVT α-3 baseline capture — operator-runnable, paired N=3 rerun.
+
+Spawns its own JAMES server with the v0.4.0 production env (entity
+anchor + bge-m3 + query-rewrite ON, routing layers OFF — see memo §3),
+runs ``scripts/bench.py --suite=step7 --mode=retrieval`` N=3 times,
+applies the 3-axis oracle to each run, and writes the aggregated
+baseline JSON to ``eval/qvt/baseline_<sha>.json``.
+
+The output JSON is the immovable reference that every future
+``Quality delta vs baseline_<sha>`` PR-gate comparison is paired
+against. Re-capture only when the baseline environment intentionally
+changes (e.g. embedding model swap, default-flag flip) — never
+silently overwrite.
+
+Operator workflow::
+
+    # Stop any pre-existing JAMES server on 127.0.0.1:8000 first.
+    python scripts/qvt_capture_baseline.py
+
+Output (success)::
+
+    eval/qvt/baseline_<sha>.json   (paired N=3 + noise band + aggregate)
+
+Cost: ~16 queries × ~80s × 3 reruns ≈ 64 minutes. Plus server boot
+(~30s × 3) and oracle scoring (~milliseconds). Budget ~70 minutes
+on a small-tier-only fleet.
+
+Cross-stack note: This wrapper holds the v0.4.0 production flags
+fixed — same constraint as ``feedback_cross_stack_run_flag_off``.
+Operator MUST NOT toggle JAMES_AUTO_ROUTER / SCOPE_ROUTING /
+ADAPTIVE_BUDGET while a baseline capture is running.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# Imported after sys.path manipulation so the script remains runnable
+# from any cwd.
+from eval.qvt.oracle import (  # noqa: E402
+    ThreeAxisResult,
+    score_three_axis,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SERVER_BASE_URL = os.environ.get("JAMES_BASE_URL", "http://127.0.0.1:8000")
+SERVER_HEALTHZ = SERVER_BASE_URL.rstrip("/") + "/healthz"
+SERVER_BOOT_TIMEOUT_SEC = 120
+BENCH_SUBPROCESS_TIMEOUT_SEC = 2400
+
+# v0.4.0 production baseline flags (memo §3). Routing layers OFF — they
+# are the things being measured *against* this baseline by future PRs.
+_BASELINE_ENV: Dict[str, str] = {
+    "JAMES_ENABLE_ENTITY_ANCHOR": "1",
+    "JAMES_EMBEDDING_MODEL": "BAAI/bge-m3",
+    "JAMES_ENABLE_QUERY_REWRITE": "1",
+    "JAMES_AUTO_ROUTER": "0",
+    "JAMES_ADAPTIVE_BUDGET": "0",
+    "JAMES_SCOPE_ROUTING": "0",
+}
+
+_FIXTURE_PATH = ROOT / "eval" / "regression" / "step7_queries.json"
+_OUTPUT_DIR = ROOT / "eval" / "qvt"
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle helpers (paralleling bench_lc_scope_arms.py)
+# ---------------------------------------------------------------------------
+
+def _parse_host_port(url: str) -> Tuple[str, int]:
+    stripped = url.replace("http://", "").replace("https://", "")
+    host_part, _, rest = stripped.partition("/")
+    host, _, port_str = host_part.partition(":")
+    return host or "127.0.0.1", int(port_str or "8000")
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        try:
+            sock.connect((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def _wait_for_healthz(timeout_sec: int) -> bool:
+    deadline = time.time() + timeout_sec
+    last_err = "no attempt yet"
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(SERVER_HEALTHZ, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {str(e)[:80]}"
+        time.sleep(1.0)
+    print(f"[server] /healthz never returned 200 ({last_err})")
+    return False
+
+
+def _spawn_server(env: Dict[str, str]) -> Optional[subprocess.Popen]:
+    host, port = _parse_host_port(SERVER_BASE_URL)
+    if _port_in_use(host, port):
+        print(
+            f"[server] {host}:{port} already in use. Stop the existing "
+            f"server before running this wrapper — env flags applied "
+            f"here would not reach an operator-launched server."
+        )
+        return None
+    cmd = [
+        sys.executable, "-m", "uvicorn", "server_llmwiki:app",
+        "--host", host, "--port", str(port),
+    ]
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+    proc = subprocess.Popen(
+        cmd, env=env, cwd=str(ROOT),
+        stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+        creationflags=creationflags,
+    )
+    print(f"[server] spawned pid={proc.pid} on {host}:{port}, waiting for /healthz…")
+    if not _wait_for_healthz(SERVER_BOOT_TIMEOUT_SEC):
+        _shutdown_server(proc)
+        return None
+    print("[server] healthy")
+    return proc
+
+
+def _shutdown_server(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        print(f"[server] pid={proc.pid} did not exit on terminate, killing")
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            print(f"[server] pid={proc.pid} still alive after kill — orphaned")
+    time.sleep(2.0)
+
+
+def _mint_employee_jwt() -> Optional[str]:
+    """Mint a short-lived employee-role JWT for the bench subprocess
+    so the engine's ``query.internal_rag`` gate doesn't kick retrieval-
+    mode requests back to ``handle_chat``."""
+    try:
+        from core.auth import create_token
+        return create_token("qvt-baseline-runner", "employee")
+    except Exception as e:
+        print(f"[server] JWT mint failed ({type(e).__name__}: {e}) — "
+              f"falling back to api_key-only auth (results will likely "
+              f"show chat-mode passthrough)")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-run execution
+# ---------------------------------------------------------------------------
+
+def _run_single_bench(run_index: int) -> Optional[Path]:
+    """Spawn server, run bench.py once, return path to the bench JSON
+    output. Server is torn down between runs so each run starts from
+    the same warm-cache-cold state."""
+    server_env = os.environ.copy()
+    server_env.update(_BASELINE_ENV)
+
+    print(
+        f"\n=== run {run_index + 1}/N "
+        f"(env: ENTITY_ANCHOR=1 EMBEDDING=bge-m3 REWRITE=1 "
+        f"AUTO_ROUTER=0 ADAPTIVE_BUDGET=0 SCOPE_ROUTING=0) ==="
+    )
+    server = _spawn_server(server_env)
+    if server is None:
+        return None
+
+    bench_output: Optional[Path] = None
+    try:
+        pre_existing = set((ROOT / "reports").glob("bench_*_step7_*.json"))
+        t0 = time.time()
+        try:
+            bench_env = {**os.environ, "JAMES_BASE_URL": SERVER_BASE_URL}
+            bearer = _mint_employee_jwt()
+            if bearer:
+                bench_env["JAMES_BENCH_BEARER"] = bearer
+            subprocess.run(
+                [sys.executable, str(ROOT / "scripts" / "bench.py"),
+                 "--suite=step7", "--mode=retrieval"],
+                env=bench_env,
+                cwd=str(ROOT),
+                capture_output=False,
+                check=False,
+                timeout=BENCH_SUBPROCESS_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"[run {run_index + 1}] bench TIMEOUT after "
+                  f"{BENCH_SUBPROCESS_TIMEOUT_SEC}s")
+            return None
+        elapsed = time.time() - t0
+        print(f"[run {run_index + 1}] bench finished in {elapsed:.1f}s")
+
+        after = set((ROOT / "reports").glob("bench_*_step7_*.json"))
+        new = sorted(after - pre_existing)
+        if new:
+            bench_output = new[-1]
+        else:
+            print(f"[run {run_index + 1}] no new bench output under reports/")
+    finally:
+        _shutdown_server(server)
+    return bench_output
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def _aggregate_runs(runs: List[ThreeAxisResult]) -> Dict[str, Any]:
+    """Compute median + noise band (max - min) for each axis across runs."""
+    if not runs:
+        return {}
+
+    path_means = [r.path_coverage.mean_recall for r in runs]
+    graded_means = [r.graded_answer.mean_accuracy for r in runs]
+    abstention_f1s = [r.abstention.f1 for r in runs]
+
+    def _stats(values: List[float]) -> Dict[str, float]:
+        values_sorted = sorted(values)
+        median = values_sorted[len(values_sorted) // 2]
+        return {
+            "median": round(median, 4),
+            "min": round(min(values), 4),
+            "max": round(max(values), 4),
+            "noise_band": round(max(values) - min(values), 4),
+        }
+
+    return {
+        "path_coverage": _stats(path_means),
+        "graded_answer": _stats(graded_means),
+        "abstention_f1": _stats(abstention_f1s),
+        "n_runs": len(runs),
+    }
+
+
+def _current_git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(ROOT), capture_output=True, text=True, check=True,
+            timeout=5,
+        )
+        return out.stdout.strip()[:7]
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI entry
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="QVT α-3 baseline capture (paired N=3 rerun + "
+                    "3-axis oracle aggregation).",
+    )
+    parser.add_argument(
+        "--n-runs", type=int, default=3,
+        help="Paired rerun count (default 3, matches memo §4 noise-band "
+             "design).",
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Output JSON path. Default: "
+             "eval/qvt/baseline_<git-sha>.json",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the planned env + output path; do not spawn server "
+             "or run bench.",
+    )
+    args = parser.parse_args(argv)
+
+    sha = _current_git_sha() or "unknown"
+    out_path = (
+        Path(args.output) if args.output
+        else _OUTPUT_DIR / f"baseline_{sha}.json"
+    )
+
+    print("=== QVT α-3 baseline capture ===")
+    print(f"git_sha:      {sha}")
+    print(f"fixture:      {_FIXTURE_PATH.relative_to(ROOT)}")
+    print(f"output:       {out_path.relative_to(ROOT)}")
+    print(f"n_runs:       {args.n_runs}")
+    print(f"baseline env: {_BASELINE_ENV}")
+
+    if args.dry_run:
+        print("[dry-run] not spawning server, not running bench.")
+        return 0
+
+    if not _FIXTURE_PATH.exists():
+        print(f"[error] fixture {_FIXTURE_PATH} missing")
+        return 2
+
+    fixture = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    runs: List[ThreeAxisResult] = []
+    run_paths: List[str] = []
+    for i in range(args.n_runs):
+        bench_path = _run_single_bench(i)
+        if bench_path is None:
+            print(f"[error] run {i + 1} failed to produce bench output")
+            return 3
+        result = score_three_axis(bench_path, fixture)
+        print(f"[run {i + 1}] {result.summary()}")
+        runs.append(result)
+        run_paths.append(str(bench_path.relative_to(ROOT)))
+
+    aggregate = _aggregate_runs(runs)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": "qvt-baseline-v1",
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "git_sha": sha,
+        "fixture_version": fixture.get("version"),
+        "fixture_path": str(_FIXTURE_PATH.relative_to(ROOT)),
+        "n_runs": args.n_runs,
+        "env": _BASELINE_ENV,
+        "aggregate": aggregate,
+        "runs": [
+            {
+                "bench_output": run_paths[i],
+                "scores": runs[i].to_dict(),
+            }
+            for i in range(args.n_runs)
+        ],
+    }
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    print(f"\n[done] baseline written to {out_path.relative_to(ROOT)}")
+    print(f"aggregate: {aggregate}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -1,0 +1,325 @@
+"""QVT α-3 oracle contract tests.
+
+Pins the 3-axis scoring functions against mock bench JSON + the real
+v5 fixture so accidental changes to abstention detection, signal
+matching, or F1 math get caught at PR time.
+
+Run:
+  python -m unittest tests.test_qvt_oracle
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eval.qvt.oracle import (  # noqa: E402
+    PathCoverageAxis,
+    ThreeAxisResult,
+    detect_abstention,
+    score_abstention_f1,
+    score_graded_answer,
+    score_path_coverage,
+    score_three_axis,
+)
+
+_ROOT = Path(__file__).resolve().parent.parent
+_REAL_FIXTURE = _ROOT / "eval" / "regression" / "step7_queries.json"
+
+
+def _real_fixture() -> dict:
+    with _REAL_FIXTURE.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# detect_abstention
+# ---------------------------------------------------------------------------
+
+class DetectAbstentionTests(unittest.TestCase):
+    """Substring matcher catches Korean + English abstention phrases."""
+
+    def test_empty_string_is_abstention(self):
+        self.assertTrue(detect_abstention(""))
+
+    def test_none_is_abstention(self):
+        self.assertTrue(detect_abstention(None))
+
+    def test_substantive_answer_is_not_abstention(self):
+        self.assertFalse(detect_abstention(
+            "Anthropic은 AI 안전성 연구에 중점을 둔 AI 기업입니다. Claude를 만들었습니다."
+        ))
+
+    def test_korean_abstention_phrases(self):
+        for phrase in [
+            "해당 정보가 없습니다.",
+            "내부 자료에 없는 내용입니다.",
+            "확인할 수 없습니다.",
+            "잘 모르겠습니다.",
+            "근거가 부족합니다.",
+        ]:
+            self.assertTrue(detect_abstention(phrase), f"missed: {phrase}")
+
+    def test_english_abstention_phrases(self):
+        for phrase in [
+            "I don't have that information.",
+            "I cannot answer that question.",
+            "Unable to provide a definitive answer.",
+            "No information found.",
+        ]:
+            self.assertTrue(detect_abstention(phrase), f"missed: {phrase}")
+
+    def test_case_insensitive(self):
+        self.assertTrue(detect_abstention("정보가 없습니다"))
+        self.assertTrue(detect_abstention("I DON'T HAVE that."))
+
+
+# ---------------------------------------------------------------------------
+# score_path_coverage
+# ---------------------------------------------------------------------------
+
+class PathCoverageTests(unittest.TestCase):
+
+    def test_empty_results_zero_axis(self):
+        axis = score_path_coverage({"results": []}, {"queries": []})
+        self.assertIsInstance(axis, PathCoverageAxis)
+        self.assertEqual(axis.mean_recall, 0.0)
+        self.assertEqual(axis.queries_with_expected_path, 0)
+
+    def test_aggregates_path_metrics(self):
+        bench = {
+            "results": [
+                {"id": 1, "path_metrics": {"expected_count": 1, "hits": 1, "path_recall": 1.0}},
+                {"id": 2, "path_metrics": {"expected_count": 2, "hits": 1, "path_recall": 0.5}},
+                {"id": 3, "path_metrics": {"expected_count": 2, "hits": 0, "path_recall": 0.0}},
+                {"id": 4},  # no path_metrics — skipped
+            ]
+        }
+        axis = score_path_coverage(bench, {"queries": []})
+        self.assertEqual(axis.queries_with_expected_path, 3)
+        self.assertAlmostEqual(axis.mean_recall, 0.5, places=4)
+        self.assertEqual(axis.queries_at_full_recall, 1)
+        self.assertEqual(len(axis.per_query), 3)
+
+
+# ---------------------------------------------------------------------------
+# score_graded_answer
+# ---------------------------------------------------------------------------
+
+class GradedAnswerTests(unittest.TestCase):
+
+    def test_three_signal_all_hit(self):
+        fixture = {"queries": [
+            {"id": 1, "gold_signals": [
+                {"term": "alpha", "aliases": []},
+                {"term": "beta", "aliases": []},
+                {"term": "gamma", "aliases": []},
+            ]}
+        ]}
+        bench = {"results": [
+            {"id": 1, "answer": "this answer contains alpha, beta, and gamma terms."}
+        ]}
+        axis = score_graded_answer(bench, fixture)
+        self.assertEqual(len(axis.per_query), 1)
+        self.assertEqual(axis.per_query[0].hits, 3)
+        self.assertEqual(axis.per_query[0].score, 1.0)
+        self.assertEqual(axis.mean_accuracy, 1.0)
+
+    def test_partial_hit_via_alias(self):
+        fixture = {"queries": [
+            {"id": 1, "gold_signals": [
+                {"term": "BlackRock", "aliases": ["블랙록"]},
+                {"term": "IBIT", "aliases": ["현물 ETF"]},
+                {"term": "발행", "aliases": ["출시", "운용"]},
+            ]}
+        ]}
+        bench = {"results": [
+            {"id": 1, "answer": "블랙록은 현물 ETF를 출시했습니다."}
+        ]}
+        axis = score_graded_answer(bench, fixture)
+        row = axis.per_query[0]
+        self.assertEqual(row.hits, 3)
+        self.assertIn("블랙록", row.matched_signals)
+        self.assertIn("현물 ETF", row.matched_signals)
+        self.assertIn("출시", row.matched_signals)
+
+    def test_zero_hit_zero_score(self):
+        fixture = {"queries": [
+            {"id": 1, "gold_signals": [
+                {"term": "X", "aliases": []},
+                {"term": "Y", "aliases": []},
+                {"term": "Z", "aliases": []},
+            ]}
+        ]}
+        bench = {"results": [{"id": 1, "answer": "nothing matches"}]}
+        axis = score_graded_answer(bench, fixture)
+        self.assertEqual(axis.per_query[0].hits, 0)
+        self.assertEqual(axis.per_query[0].score, 0.0)
+
+    def test_uses_preview_when_no_full_answer(self):
+        fixture = {"queries": [
+            {"id": 1, "gold_signals": [{"term": "Claude", "aliases": []}]}
+        ]}
+        # No `answer` field; only `answer_preview` (300 chars truncated).
+        bench = {"results": [{"id": 1, "answer_preview": "About Claude..."}]}
+        axis = score_graded_answer(bench, fixture)
+        self.assertEqual(axis.per_query[0].hits, 1)
+
+    def test_empty_signals_skipped(self):
+        fixture = {"queries": [{"id": 1, "gold_signals": []}]}
+        bench = {"results": [{"id": 1, "answer": "anything"}]}
+        axis = score_graded_answer(bench, fixture)
+        self.assertEqual(len(axis.per_query), 0)
+        self.assertEqual(axis.mean_accuracy, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# score_abstention_f1
+# ---------------------------------------------------------------------------
+
+class AbstentionF1Tests(unittest.TestCase):
+
+    def test_perfect_classifier(self):
+        """All TP/TN cells, no errors → F1 = 1.0."""
+        fixture = {"queries": [
+            {"id": 1, "abstention_truth": "absent"},   # should abstain
+            {"id": 2, "abstention_truth": "present"},  # should answer
+        ]}
+        bench = {"results": [
+            {"id": 1, "status": "ok", "answer": "I don't have that information"},
+            {"id": 2, "status": "ok", "answer": "Anthropic is an AI company."},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.tp_abstain, 1)
+        self.assertEqual(axis.tn_answer, 1)
+        self.assertEqual(axis.fp_incorrect_abstention, 0)
+        self.assertEqual(axis.fn_hallucination, 0)
+        self.assertEqual(axis.f1, 1.0)
+
+    def test_all_hallucinations(self):
+        """Should-abstain, system answered → all FN → recall=0 → F1=0."""
+        fixture = {"queries": [
+            {"id": 1, "abstention_truth": "absent"},
+            {"id": 2, "abstention_truth": "absent"},
+        ]}
+        bench = {"results": [
+            {"id": 1, "status": "ok", "answer": "Fabricated answer A"},
+            {"id": 2, "status": "ok", "answer": "Fabricated answer B"},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.fn_hallucination, 2)
+        self.assertEqual(axis.tp_abstain, 0)
+        self.assertEqual(axis.f1, 0.0)
+        self.assertEqual(axis.recall, 0.0)
+
+    def test_all_incorrect_abstentions(self):
+        """Should-answer, system abstained → all FP → precision=0 → F1=0."""
+        fixture = {"queries": [
+            {"id": 1, "abstention_truth": "present"},
+            {"id": 2, "abstention_truth": "present"},
+        ]}
+        bench = {"results": [
+            {"id": 1, "status": "ok", "answer": "정보가 없습니다."},
+            {"id": 2, "status": "ok", "answer": "확인할 수 없습니다."},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.fp_incorrect_abstention, 2)
+        self.assertEqual(axis.f1, 0.0)
+        self.assertEqual(axis.precision, 0.0)
+
+    def test_timeout_treated_as_abstention(self):
+        """Non-ok status implies system did not produce a substantive
+        answer → abstained=True regardless of answer text."""
+        fixture = {"queries": [
+            {"id": 1, "abstention_truth": "absent"},
+        ]}
+        bench = {"results": [
+            {"id": 1, "status": "timeout", "answer": ""},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.tp_abstain, 1)
+        self.assertEqual(axis.fn_hallucination, 0)
+        self.assertEqual(axis.f1, 1.0)
+
+    def test_balanced_p_r_f1(self):
+        """TP=2, FP=1, FN=1 → P=2/3, R=2/3, F1=2/3 ≈ 0.6667."""
+        fixture = {"queries": [
+            {"id": 1, "abstention_truth": "absent"},   # → TP
+            {"id": 2, "abstention_truth": "absent"},   # → TP
+            {"id": 3, "abstention_truth": "absent"},   # → FN
+            {"id": 4, "abstention_truth": "present"},  # → FP
+        ]}
+        bench = {"results": [
+            {"id": 1, "status": "ok", "answer": "모르겠습니다"},
+            {"id": 2, "status": "ok", "answer": "정보가 없"},
+            {"id": 3, "status": "ok", "answer": "Hallucinated content"},
+            {"id": 4, "status": "ok", "answer": "할 수 없"},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.tp_abstain, 2)
+        self.assertEqual(axis.fn_hallucination, 1)
+        self.assertEqual(axis.fp_incorrect_abstention, 1)
+        self.assertAlmostEqual(axis.precision, 2 / 3, places=3)
+        self.assertAlmostEqual(axis.recall, 2 / 3, places=3)
+        self.assertAlmostEqual(axis.f1, 2 / 3, places=3)
+
+
+# ---------------------------------------------------------------------------
+# score_three_axis (integration)
+# ---------------------------------------------------------------------------
+
+class ThreeAxisIntegrationTests(unittest.TestCase):
+
+    def test_runs_on_real_fixture_with_minimal_bench(self):
+        """Real v5 fixture + a tiny bench dict → ThreeAxisResult populates
+        all axes without crash."""
+        fixture = _real_fixture()
+        bench = {
+            "git_sha": "deadbeef",
+            "suite": "step7",
+            "results": [
+                {"id": 2, "status": "ok",
+                 "answer": "Anthropic은 AI 안전성을 연구하는 AI 기업이며 Claude를 만들었습니다.",
+                 "path_metrics": {"expected_count": 1, "hits": 1, "path_recall": 1.0}},
+                {"id": 11, "status": "ok",
+                 "answer": "시스템 프롬프트는 공개할 수 없습니다."},
+                {"id": 10, "status": "ok",
+                 "answer": "OpenAI의 최신 모델 전략에 대한 자세한 정보는 확인할 수 없습니다."},
+            ],
+        }
+        result = score_three_axis(bench, fixture)
+        self.assertIsInstance(result, ThreeAxisResult)
+        self.assertEqual(result.fixture_version, "step7-v5")
+        self.assertEqual(result.git_sha, "deadbeef")
+        # q2 is path-annotated → path axis is non-empty.
+        self.assertGreater(result.path_coverage.queries_with_expected_path, 0)
+        # Graded answer ran on all 3 (each has gold_signals).
+        self.assertEqual(result.graded_answer.queries_with_signals, 3)
+        # Abstention: q2=present+answered (TN), q11=absent+abstained (TP),
+        # q10=absent+abstained (TP). F1 should equal 1.0 since FP=FN=0.
+        self.assertEqual(result.abstention.tp_abstain, 2)
+        self.assertEqual(result.abstention.tn_answer, 1)
+        self.assertEqual(result.abstention.fp_incorrect_abstention, 0)
+        self.assertEqual(result.abstention.fn_hallucination, 0)
+        self.assertEqual(result.abstention.f1, 1.0)
+        # Summary is a one-line string.
+        s = result.summary()
+        self.assertIsInstance(s, str)
+        self.assertIn("path_recall", s)
+        self.assertIn("graded", s)
+        self.assertIn("abstention_f1", s)
+
+    def test_to_dict_is_json_serializable(self):
+        fixture = _real_fixture()
+        bench = {"results": []}
+        result = score_three_axis(bench, fixture)
+        # Must serialize without TypeError.
+        json.dumps(result.to_dict())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements QVT design memo (PR #550) §8 α-3 deliverables. Adds the deterministic 3-axis oracle that consumes a bench JSON + the v5 fixture (#551) and produces three orthogonal quality scores, plus the operator-runnable wrapper that captures the v0.4.0 production baseline (N=3 paired reruns + noise band).

**Architecture label**: introduces the `eval/qvt/` module surface and the canonical `baseline_<sha>.json` file format that every future `Quality Delta Card` paired comparison will reference. Module size 14 KB (oracle) + 13 KB (wrapper), both under the 20 KB cap.

## Files

### `eval/qvt/oracle.py` (~14 KB) — the 3-axis scorer

```python
from eval.qvt import score_three_axis
result = score_three_axis(bench_json_path, fixture_path)
print(result.summary())
# path_recall=1.0000 (4/4) graded=0.5208 (n=16) abstention_f1=0.0000 ...
```

**Path Coverage** — pass-through aggregate of `bench.py`'s per-query `path_metrics` block (preserves F9.4 closure measurement substrate).

**Graded Answer Accuracy** — per-query hits / 3 atomic `gold_signals` matched as case-insensitive substring. Aliases included. Falls back to `answer_preview` (300 char) when `answer` is absent — forward-compatible with a future bench.py update that saves the full answer.

**Calibrated Abstention F1** — F1 on the binary "system abstained?" classifier, positive class = abstention. Cell labels:
- TP = `truth=absent` AND `abstained=true` (correct refusal)
- FP = `truth=present` AND `abstained=true` (incorrect_abstention — over-cautious)
- FN = `truth=absent` AND `abstained=false` (hallucination — worst case)
- TN = `truth=present` AND `abstained=false` (correct answer)

Timeout / error / blocked status counts as abstention (system did not produce a substantive answer).

Abstention phrase set is hardcoded (Korean + English variants of "I don't know / cannot / 정보가 없 / 확인할 수 없 / refuse" etc.). Calibration loop is a separate small PR after α-3 baseline run reveals any phrasings the oracle misses.

### `eval/qvt/__init__.py` — public API exports

### `scripts/qvt_capture_baseline.py` (~13 KB) — operator wrapper

- Spawns its own JAMES server with the **v0.4.0 production env fixed** (`ENTITY_ANCHOR=1 + bge-m3 + REWRITE=1`, all routing layers `OFF` — memo §3 baseline definition)
- Mints an employee-role JWT so retrieval-mode requests bypass the `query.internal_rag` policy gate (same pattern as `bench_lc_scope_arms.py`)
- N=3 paired reruns by default (`--n-runs` override for faster smoke tests)
- Aggregates per-axis `median / min / max / noise_band` across runs
- Writes `eval/qvt/baseline_<sha>.json` — the canonical reference every future `Quality Delta Card` paired comparison references
- `--dry-run` flag prints planned env + output path without spawning server

Cost: ~16 queries × ~80s × 3 reruns ≈ 64 minutes. Plus server boot (~30s × 3). Operator budget ~70 min.

### `tests/test_qvt_oracle.py` — 20 contract tests

| group | what it pins |
|---|---|
| `DetectAbstentionTests` (6) | empty/None = abstention; Korean + English phrase detection; case-insensitive matching |
| `PathCoverageTests` (2) | aggregation skips queries without `path_metrics`; empty results → zero axis |
| `GradedAnswerTests` (5) | 3/3 hits / partial-via-alias / 0-hit / preview fallback / empty signals skipped |
| `AbstentionF1Tests` (5) | perfect / all-hallucinations / all-incorrect-abstentions / timeout-as-abstention / balanced P=R=F1=2/3 |
| `ThreeAxisIntegrationTests` (2) | real v5 fixture + minimal mock bench populates all axes; `to_dict()` JSON-serializable |

20/20 pass locally. 44/44 pass when run against the broader fixture-consumer surface (`test_qvt_oracle` + `test_step7_v5_schema` + `test_meta_mode`).

## Smoke test against F9.4 bench JSON

Just for sanity (NOT the baseline — that lands in a follow-up PR):

```
$ python -c "from eval.qvt import score_three_axis; \
  r=score_three_axis('reports/research-runs/step7-bench-20260527_231211.json', \
                     'eval/regression/step7_queries.json'); print(r.summary())"

path_recall=1.0000 (4/4)
graded=0.5208 (n=16)
abstention_f1=0.0000 (TP=0 FP=2 FN=4 TN=10)
```

The F9.4 bench saved only `answer_preview` (300 chars), which is why graded accuracy looks low and abstention F1 collapses — substring matching on truncated text under-counts. The α-3 baseline capture run will use full-answer-emitting bench (follow-up PR if bench.py needs updating). This smoke check confirms the oracle wires end-to-end against a real bench JSON without crash.

## Verification

- `python -m unittest tests.test_qvt_oracle` → 20/20 pass
- `python -m unittest tests.test_step7_v5_schema tests.test_qvt_oracle tests.test_meta_mode` → 44/44 pass
- `python -m ruff check eval/qvt/ scripts/qvt_capture_baseline.py tests/test_qvt_oracle.py` → All checks passed!
- `python scripts/qvt_capture_baseline.py --dry-run` → prints planned env + output path correctly
- CLAUDE.md rule 5 (≤20 KB): oracle.py 14 KB, wrapper 13 KB ✅

## Out of scope (follow-ups)

- `eval/qvt/baseline_<sha>.json` — operator runs `scripts/qvt_capture_baseline.py` locally (~70 min); the resulting JSON lands in a small follow-up PR. Until that lands, the oracle is callable but there's no canonical baseline to compare against.
- `bench.py` `--save-full-answer` flag — currently only `answer_preview` is saved (300 chars), which under-counts graded accuracy for long answers. Add as small PR after baseline reveals if it matters.
- α-4 — PR template + CLAUDE.md rule 2 extension (with collab-exemption clause from memo §4)
- α-5 — v0.4-end ablation matrix capture (18 cells)

## Quality Delta vs baseline

`Quality delta: exempt (label: code — α-3 is the oracle that produces the baseline, so it cannot be measured against itself; circular)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)