### PR TITLE
chore(qvt): α-4 — PR template + CLAUDE.md rule 2 + ARCHITECTURE.md §5.7.10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+JAMES PR template (v0.4, QVT α-4 — 2026-05-28). Match the body
+sections below; CI does not enforce the structure but reviewers and
+the v0.4 quality gate (`docs/handovers/v0.4-quality-verification-track.md`)
+expect them.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What the PR does and why. -->
+
+## Verification
+
+<!-- How the change was validated. Tests run, manual checks, smoke
+results, links to bench JSONs in reports/research-runs/. -->
+
+## Quality Delta vs baseline_<sha>
+
+<!--
+Required when this PR touches `core/retrieval/`, `core/graph/`, or
+`core/reasoning/` (CLAUDE.md rule 2). Compare against the canonical
+baseline at `eval/qvt/baseline_<sha>.json`. Three axes:
+
+| axis              | baseline | this PR | Δ | sign |
+|-------------------|----------|---------|---|------|
+| Path Recall       | 0.87     | 0.91    | +0.04 | ✅ |
+| Graded Answer     | 0.71     | 0.68    | −0.03 | ⚠️ within noise |
+| Abstention F1     | 0.83     | 0.84    | +0.01 | flat |
+
+Noise band: ±<value> (from baseline JSON `aggregate.*.noise_band`).
+Verdict: <net positive / net neutral / net negative + justification>.
+
+Exempt — add this single line and delete the table when one of the
+following labels applies, then remove this comment block:
+
+  Quality delta: exempt (label: <external-contributor | joint-collab-prep | docs | chore | ci | code>)
+
+Exemption labels (design memo §4):
+  - external-contributor — Robin / Ali / other collaborator PR
+  - joint-collab-prep    — mid-June joint piece / shared deliverable
+  - docs / chore / ci    — does not touch core/
+  - code                 — circular (PR is the oracle / baseline itself)
+-->
+
+## Out of scope
+
+<!-- Explicit defers. What this PR intentionally does NOT do. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,24 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
    "no parallel domains" rule and what it forbids.
 
 2. **Every PR touching `core/retrieval`, `core/graph`, or
-   `core/reasoning` must paste bench numbers** in the description
-   (Axis 2 of v0.2 ROADMAP). PRs without numbers will not land.
+   `core/reasoning` must paste bench numbers + a Quality Delta
+   Card** in the description (Axis 2 of v0.2 ROADMAP, extended by
+   QVT α-4 2026-05-28). PRs without numbers will not land.
+   - **Bench numbers**: STEP 7 result deltas (`scripts/bench.py
+     --suite=step7 --mode=retrieval`) — latency, graph_paths,
+     answer_len.
+   - **Quality Delta Card**: 3-axis paired comparison against
+     `eval/qvt/baseline_<sha>.json` (Path Recall / Graded Answer /
+     Abstention F1). Template lives in `.github/PULL_REQUEST_TEMPLATE.md`.
+   - **Exemption labels** (skip the Quality Delta Card with one line
+     `Quality delta: exempt (label: <name>)`): `external-contributor`
+     (Robin / Ali / other collaborator PR), `joint-collab-prep`
+     (mid-June joint piece / shared deliverable), `docs` / `chore` /
+     `ci` (not touching `core/`), `code` (circular — the PR is the
+     oracle / baseline itself). Rationale: the gate is for measuring
+     JAMES-internal marginal contribution, not a collaboration
+     friction tool. See `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md`
+     §4 for the full exemption rule.
 
 3. **Self-evolution is opt-in only**. Any change that allows
    auto-deploy without an `approver_username` in the audit log

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -703,6 +703,63 @@ before the cognitive middleware is built would invert priorities. The
 brief's "12 containers per VPS" pattern is an *operations topology*, not
 an architecture; it sits on top of JAMES, not inside it.
 
+### 5.7.10 Quality Verification Track (QVT, v0.4, 2026-05-28)
+
+The §5.7.4 bench gate measures **cost** (latency, token count, graph
+fan-out). The QVT subsystem measures **marginal quality contribution**
+of each routing / caching / rewriting layer — the question "should
+this layer be ON?" was structurally unanswerable through v0.3 because
+`grounded` and `RAGAS` were saturated (1.0 ceiling) and
+`answer_relevancy` sat in the noise band. v0.4 adds three orthogonal
+non-saturating axes:
+
+| axis | source | what it catches |
+|---|---|---|
+| **Path Coverage** | `bench.py`'s `path_metrics` block (v4 added Idea-1 path-GT to 5 fixture queries; v5 keeps all 5) | retrieval / extraction regressions on relation queries (q15 zero-recall surfaced this) |
+| **Graded Answer Accuracy** | per-query 3 atomic `gold_signals` (term + aliases) matched as case-insensitive substring against the answer | over-shortening or topic drift even when path is correct |
+| **Calibrated Abstention F1** | `abstention_truth` (`present` / `absent`) compared with whether the answer triggered an abstention phrase | hallucination on no-evidence queries; over-cautious refusal on present-evidence queries |
+
+The oracle (`eval/qvt/oracle.py`) is deterministic — no LLM judge,
+no embedding lookups, just substring + path-set matching — so it is
+audit-replay safe by construction (consistent with the Replayable
+RAG positioning in §1). The canonical baseline (`eval/qvt/baseline_<sha>.json`,
+captured via `scripts/qvt_capture_baseline.py` with N=3 paired
+reruns) freezes the v0.4.0 production environment numbers. Every
+subsequent PR that touches `core/retrieval/` / `core/graph/` /
+`core/reasoning/` pastes a 3-axis Quality Delta Card paired against
+this baseline (CLAUDE.md rule 2, extended by α-4).
+
+**Trust zone**: same as §5.7.2 (Cognitive Middleware Layer) — the
+oracle reads bench JSON + fixture, produces JSON. It does NOT
+authorize anything, does NOT mutate state, does NOT have a network
+surface. Its only invariant is that the same `(bench_json, fixture)`
+input produces byte-identical output across runs.
+
+**What this subsystem is not**:
+- Not a judge / not an evaluator with semantic understanding — the
+  matcher is deterministic substring. Paraphrased / negated /
+  quantitative-approximate matches are scored low. LLM-judge
+  augmentation is a v0.5+ candidate after the deterministic floor
+  stabilizes.
+- Not a routing decision-maker. The v0.4-end ablation matrix
+  (`eval/qvt/baseline_<sha>.json` runs across all 6 routing combos ×
+  3 model tiers = 18 cells) produces evidence; the routing policy
+  decision that consumes that evidence is a separate PR (α-5).
+- Not a domain-pack metric. Path Coverage / Graded Answer /
+  Abstention F1 are platform-wide; domain packs at v1.0+ will layer
+  their own axes (legal: citation-validity, food: allergen-safety,
+  retail: SKU-resolution) without replacing the platform floor.
+
+**Subsystem files**:
+- `eval/qvt/oracle.py` — 3-axis scorers + `score_three_axis()` entry
+- `eval/qvt/baseline_<sha>.json` — canonical reference (one per
+  intentional baseline-environment change; never silently overwrite)
+- `scripts/qvt_capture_baseline.py` — operator wrapper (N=3 paired
+  reruns + noise band)
+- `eval/regression/step7_queries.json` v5 — fixture with
+  `gold_signals` + `abstention_truth` (PR #551)
+- `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md` — full design
+
 ---
 
 ## 6. Data Lifecycle (W7-A, 2026-05-11)


### PR DESCRIPTION
## Summary

Closes the gate-side of the QVT track (α-3 oracle now has the process attached to it). Bundles the `docs/ARCHITECTURE.md` reference that α-3 deferred (per CLAUDE.md rule 4 architecture-label requirement) into this same PR — α-3 and α-4 form one architectural surface.

**Architecture label**: extends the surface introduced by #552 (`eval/qvt/` module + `baseline_<sha>.json` file format) with the operational gate that consumes it. No code change beyond docs + a single-file PR template.

## Files

### `.github/PULL_REQUEST_TEMPLATE.md` (new, ~1.7 KB)

4-section template — `Summary` / `Verification` / `Quality Delta vs baseline_<sha>` / `Out of scope`. Inline HTML comment block explains the exemption labels and the one-line syntax (`Quality delta: exempt (label: <name>)`). CI does not enforce structure (matches JAMES's manual-review convention).

Active for every new PR from the merge of this branch onward.

### `CLAUDE.md` rule 2 — extended

```
2. Every PR touching `core/retrieval`, `core/graph`, or `core/reasoning`
   must paste bench numbers + a Quality Delta Card in the description...

   - Bench numbers: STEP 7 result deltas (latency / graph_paths / answer_len)
   - Quality Delta Card: 3-axis paired comparison against
     `eval/qvt/baseline_<sha>.json` (Path Recall / Graded Answer / Abstention F1)
   - Exemption labels (skip the Quality Delta Card with one line
     `Quality delta: exempt (label: <name>)`):
       * external-contributor (Robin / Ali / other collaborator PR)
       * joint-collab-prep   (mid-June joint piece / shared deliverable)
       * docs / chore / ci   (not touching core/)
       * code                (circular — the PR is the oracle / baseline itself)
```

Rationale baked into the rule body itself: *"the gate is for measuring JAMES-internal marginal contribution, not a collaboration friction tool."* Points at design memo §4 for the full exemption rule.

### `docs/ARCHITECTURE.md` §5.7.10 (new, ~57 lines)

Defines the QVT subsystem alongside §5.7.4 (Bench gate):

- §5.7.4 measures **cost** (latency / token count / graph fan-out)
- §5.7.10 measures **marginal quality contribution** (3 non-saturating axes)

The new section covers:
- Why the gap existed at v0.3 (grounded + RAGAS saturated, answer_relevancy noise band)
- The 3 axes table: Path Coverage / Graded Answer / Abstention F1 — source + what it catches
- Trust zone: same as §5.7.2 (Cognitive Middleware Layer); deterministic; replay-safe by construction (consistent with §1 Replayable RAG positioning)
- *What this subsystem is not* — not a judge, not a routing decision-maker, not a domain-pack metric
- File pointers: oracle.py / baseline.json / capture wrapper / fixture v5 / design memo

## Verification

- `wc -c CLAUDE.md docs/ARCHITECTURE.md .github/PULL_REQUEST_TEMPLATE.md`:
  - CLAUDE.md 5.5 KB (rule-set doc, no cap)
  - ARCHITECTURE.md 53.5 KB (doc, no cap)
  - PR template 1.7 KB
- `python -m unittest tests.test_step7_v5_schema tests.test_qvt_oracle tests.test_meta_mode` — 44/44 green (regression check)
- `python -m ruff check .` — no new files in scope (markdown-only changes)
- PR template renders correctly when opening a new PR (verified by inspection of the file; GitHub auto-loads this path)

## Quality Delta vs baseline

`Quality delta: exempt (label: docs)`. No code change; no measurement-relevant surface.

## Out of scope

- `eval/qvt/baseline_<sha>.json` capture — still operator-run after this PR merges. Once captured, the template's Quality Delta Card finally has a paired denominator (until then the column says "no baseline yet — pin after α-3 baseline lands").
- α-5 — v0.4-end ablation matrix capture (18 cells). Separate cycle, late June or after.
- `.github/workflows/quality-gate.yml` auto-comparison — design memo §7 open issue η, deferred to v0.5+.
- The §5.7.7 → §5.7.10 renumber cleanup memo `project_state` mentions as a Sprint 3 deferred follow-up — out of scope here (we just added a NEW §5.7.10; renumbering existing 5.7.x is a separate cycle that also touches `docs/handovers` external references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)