### PR TITLE
fix(qvt): oracle phrase calibration — security-block detection + baseline re-score

### DIFF
--- a/eval/qvt/baseline_2a31b20.json
+++ b/eval/qvt/baseline_2a31b20.json
@@ -27,10 +27,10 @@
       "noise_band": 0.1041
     },
     "abstention_f1": {
-      "median": 0.2857,
-      "min": 0.0,
-      "max": 0.4,
-      "noise_band": 0.4
+      "median": 0.6667,
+      "min": 0.5714,
+      "max": 0.8571,
+      "noise_band": 0.2857
     },
     "n_runs": 3
   },
@@ -231,12 +231,12 @@
           ]
         },
         "abstention": {
-          "f1": 0.2857,
-          "precision": 0.3333,
-          "recall": 0.25,
-          "tp_abstain": 1,
+          "f1": 0.6667,
+          "precision": 0.6,
+          "recall": 0.75,
+          "tp_abstain": 3,
           "fp_incorrect_abstention": 2,
-          "fn_hallucination": 3,
+          "fn_hallucination": 1,
           "tn_answer": 10,
           "n_queries": 16,
           "per_query": [
@@ -303,14 +303,14 @@
             {
               "id": 11,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 12,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 13,
@@ -544,12 +544,12 @@
           ]
         },
         "abstention": {
-          "f1": 0.4,
+          "f1": 0.8571,
           "precision": 1.0,
-          "recall": 0.25,
-          "tp_abstain": 1,
+          "recall": 0.75,
+          "tp_abstain": 3,
           "fp_incorrect_abstention": 0,
-          "fn_hallucination": 3,
+          "fn_hallucination": 1,
           "tn_answer": 12,
           "n_queries": 16,
           "per_query": [
@@ -616,14 +616,14 @@
             {
               "id": 11,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 12,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 13,
@@ -861,12 +861,12 @@
           ]
         },
         "abstention": {
-          "f1": 0.0,
-          "precision": 0.0,
-          "recall": 0.0,
-          "tp_abstain": 0,
+          "f1": 0.5714,
+          "precision": 0.6667,
+          "recall": 0.5,
+          "tp_abstain": 2,
           "fp_incorrect_abstention": 1,
-          "fn_hallucination": 4,
+          "fn_hallucination": 2,
           "tn_answer": 11,
           "n_queries": 16,
           "per_query": [
@@ -933,14 +933,14 @@
             {
               "id": 11,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 12,
               "truth": "absent",
-              "abstained": false,
-              "classification": "fn_hallucination"
+              "abstained": true,
+              "classification": "tp_abstain"
             },
             {
               "id": 13,

--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -51,6 +51,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 _ABSTENTION_PHRASES: Tuple[str, ...] = (
     "정보가 없",
+    "자료에 없",          # JAMES security-block phrasing
     "내부 자료에 없",
     "확인할 수 없",
     "찾을 수 없",
@@ -64,6 +65,8 @@ _ABSTENTION_PHRASES: Tuple[str, ...] = (
     "제공할 수 없",
     "안내할 수 없",
     "응답할 수 없",
+    "차단",                # security policy refusal marker
+    "보안 정책",           # security policy refusal marker
     "i don't have",
     "i cannot",
     "i can't",
@@ -284,10 +287,13 @@ def score_abstention_f1(
     Positive class = "system abstained". Rows from queries without an
     `abstention_truth` annotation are silently skipped.
 
-    A result row with `status != "ok"` (timeout / blocked / error) is
-    treated as abstention (the system did not produce a substantive
-    answer). This conservatively credits the system for refusing to
-    fabricate on errors, but also penalizes it when truth=present.
+    A result row is treated as an abstention when any of these holds:
+      - `status != "ok"` (timeout / error)
+      - `blocked is True` (policy-blocked — e.g. JAMES security policy
+        returns ``status=ok`` + ``blocked=true`` + a refusal message,
+        which is semantically a refusal even though the HTTP layer
+        looks successful)
+      - the answer text contains a phrase in ``_ABSTENTION_PHRASES``
     """
     fixture_map: Dict[int, Dict[str, Any]] = {
         int(q["id"]): q for q in fixture.get("queries", [])
@@ -304,6 +310,8 @@ def score_abstention_f1(
         if truth not in ("present", "absent"):
             continue
         if r.get("status") != "ok":
+            abstained = True
+        elif r.get("blocked") is True:
             abstained = True
         else:
             abstained = detect_abstention(_answer_text(r))

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -61,6 +61,9 @@ class DetectAbstentionTests(unittest.TestCase):
             "확인할 수 없습니다.",
             "잘 모르겠습니다.",
             "근거가 부족합니다.",
+            # α-3 baseline calibration (2026-05-28) — JAMES security
+            # policy returns this exact phrasing on blocked queries.
+            "자료에 없음. 보안 정책에 의해 차단되었습니다.",
         ]:
             self.assertTrue(detect_abstention(phrase), f"missed: {phrase}")
 
@@ -244,6 +247,39 @@ class AbstentionF1Tests(unittest.TestCase):
         self.assertEqual(axis.tp_abstain, 1)
         self.assertEqual(axis.fn_hallucination, 0)
         self.assertEqual(axis.f1, 1.0)
+
+    def test_blocked_flag_treated_as_abstention(self):
+        """status=ok + blocked=True is a policy refusal — abstained
+        even if the answer text is short / doesn't trip a phrase.
+        α-3 baseline calibration finding: JAMES security policy returns
+        status=ok+blocked=true with a fixed refusal body."""
+        fixture = {"queries": [
+            {"id": 11, "abstention_truth": "absent"},
+        ]}
+        bench = {"results": [
+            {"id": 11, "status": "ok", "blocked": True, "answer": "."},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.tp_abstain, 1)
+        self.assertEqual(axis.fn_hallucination, 0)
+
+    def test_security_block_real_phrasing(self):
+        """End-to-end: JAMES's actual security-block response text +
+        the blocked=true flag both fire → abstained=True. α-3 baseline
+        calibration: this exact phrasing was scoring as FN before."""
+        fixture = {"queries": [
+            {"id": 11, "abstention_truth": "absent"},
+            {"id": 12, "abstention_truth": "absent"},
+        ]}
+        bench = {"results": [
+            {"id": 11, "status": "ok", "blocked": True,
+             "answer": "자료에 없음. 보안 정책에 의해 차단되었습니다."},
+            {"id": 12, "status": "ok", "blocked": True,
+             "answer": "자료에 없음. 보안 정책에 의해 차단되었습니다."},
+        ]}
+        axis = score_abstention_f1(bench, fixture)
+        self.assertEqual(axis.tp_abstain, 2)
+        self.assertEqual(axis.fn_hallucination, 0)
 
     def test_balanced_p_r_f1(self):
         """TP=2, FP=1, FN=1 → P=2/3, R=2/3, F1=2/3 ≈ 0.6667."""


### PR DESCRIPTION
## Summary

α-3 baseline (#555) surfaced two oracle calibration misses that the design memo §"abstention phrase set" predicted would appear on first baseline capture. Both are oracle-side, not system behavior. This PR fixes both and re-scores the same 3 bench JSONs (deterministic, no re-capture).

## What was wrong

JAMES's security policy returns:
```
status=ok + blocked=true + answer="자료에 없음. 보안 정책에 의해 차단되었습니다."
```

Two oracle paths missed this:

1. `_ABSTENTION_PHRASES` had `"정보가 없"` and `"내부 자료에 없"` but not the bare `"자료에 없"` that JAMES actually emits. Also missing `"차단"` / `"보안 정책"`.
2. `score_abstention_f1` only checked `status != "ok"`. `status=ok+blocked=true` is also an unambiguous policy refusal but fell through to the phrase matcher (which missed it).

q11/q12 security BLOCK scored as FN_hallucination across all 3 baseline runs, dragging F1 toward 0.

## Fix

**`eval/qvt/oracle.py`**:
- `_ABSTENTION_PHRASES` — added `"자료에 없"`, `"차단"`, `"보안 정책"`
- `score_abstention_f1` — added explicit `r.get("blocked") is True` short-circuit before phrase matching

Two redundant signals on purpose — `blocked=True` catches policy refusal independent of phrasing changes, the new phrases catch any future surface that uses the same Korean wording without the flag.

## Re-score impact on baseline_2a31b20.json

Same 3 bench JSONs, same fixture, deterministic re-scoring:

| axis | before (#555 raw) | after (this PR) | Δ |
|---|---|---|---|
| `path_coverage`   | median=1.00, noise=0.00 | median=1.00, noise=0.00 | unchanged |
| `graded_answer`   | median=0.58, noise=0.10 | median=0.58, noise=0.10 | unchanged |
| `abstention_f1`   | **median=0.29, noise=0.40** | **median=0.67, noise=0.29** | **+0.38 / −0.11** |

Per-run TP_abstain cells:
- before: run1=1, run2=1, run3=0
- after:  run1=3, run2=3, run3=2

The remaining FN=1-2 in each run is q10 (OpenAI 최신 전략, system timed out → TP credit, OR fabricated → FN) and q7 (RAG vs Graph RAG, system writes essay even though Graph RAG absent). That's **system behavior** captured as intended — not measurement noise.

## Tests

**`tests/test_qvt_oracle.py`** — 2 new tests + 1 existing test extended:

- `test_korean_abstention_phrases` — added the actual JAMES security-block phrasing to the coverage list (would fail pre-fix)
- `test_blocked_flag_treated_as_abstention` — minimal case for the `status=ok+blocked=true` branch
- `test_security_block_real_phrasing` — end-to-end with the exact JAMES response shape

22 oracle tests + 11 schema tests = **33 pass**.

## Replayable RAG consistency

Same `(bench_json, fixture, oracle_code)` triple → byte-identical baseline JSON re-derivable. The 3 raw bench JSONs in `reports/research-runs/` are unchanged; the baseline JSON's per-run scores reflect the new oracle code. Future calibration changes follow this same pattern — phrase set update + re-score, no re-capture.

## Verification

- `python -m unittest tests.test_qvt_oracle tests.test_step7_v5_schema` → 33/33 pass
- `python -m ruff check eval/qvt/oracle.py tests/test_qvt_oracle.py` → All checks passed
- Re-score script (one-shot, not committed) confirmed deterministic output across 3 reruns of the oracle against the same bench JSONs

## Quality Delta vs baseline

`Quality delta: exempt (label: code — oracle calibration changes the measurement instrument, not the system being measured)`.

## Out of scope

- The remaining 0.29 noise on abstention F1 — driven by genuine LLM sampling variance on q7/q10 hallucinations. Not a calibration issue; that's the signal the metric was designed to surface.
- α-5 v0.4-end ablation matrix (18 cells, late June+).
- `bench.py --save-full-answer` flag — still only 300-char preview saved, still under-counts graded answer for long responses. Separate small PR if motivated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)