### PR TITLE
feat(lifecycle): v0.4.1 PR-T2.D-1 — contradiction ingest detector + tests

### DIFF
--- a/core/lifecycle/contradiction_ingest_detector.py
+++ b/core/lifecycle/contradiction_ingest_detector.py
@@ -1,0 +1,220 @@
+"""v0.4.1 PR-T2.D-1 — contradiction detector for ingestion-path wiring.
+
+Identifies pairs of ``(existing_rel, new_rel)`` that should be routed
+through ``dispatch_contradiction`` (PR-T2.C, already in v0.4.0) instead
+of being silently appended by
+``_merge_relations_into_existing_entity`` in ``core/wiki_generator/_merge.py``.
+
+Trigger policy is **B** (적극 — per v0.4.1 entry memo §2 + this session's
+additional LOCK): any ``(head, predicate)`` match qualifies as a
+contradiction candidate; the deterministic classifier decides
+A_invalidate / B_supersede / ignore from there. Caller's ingestion
+code only needs to identify "which existing relations are contradiction
+candidates" — the classifier handles "how to apply".
+
+Two patterns this detector recognizes:
+
+  P1 — ``different_tail``: existing_rel has same predicate as new_rel
+       but different target. Canonical case: CEO change. Same
+       ``(head, predicate=CEO_OF)`` but target Dario vs target NewName.
+
+  P2 — ``divergent_validity``: existing_rel has same ``(target, predicate)``
+       as new_rel but the existing edge carries v0.4 lifecycle metadata
+       (``validity`` / ``status`` / ``mutation_type``) that the new
+       observation may close or contradict. E.g., new observation
+       has explicit ``valid_until`` that closes the existing edge's
+       open validity.
+
+Out of scope (T2.D-1):
+
+- Calling ``dispatch_contradiction``. T2.D-2 wires this detector's
+  output into ``_merge.py``.
+- Updating existing entities. The detector is a pure read.
+- Schema validation. ``core/relations_schema.py`` owns that.
+- The actual A/B/ignore decision. ``contradiction_arbiter.classify_contradiction``
+  owns that, called by ``dispatch_contradiction``.
+
+Pure function. No I/O, no clock side-effects.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Literal pattern labels — kept as plain str for v0.4.1 to avoid
+# importing typing.Literal across all Python versions; promote to
+# Literal["different_tail", "divergent_validity"] in a follow-up
+# if/when we drop Python 3.10 support.
+ContradictionPattern = str
+
+
+def _default_predicate_normalizer(label: str) -> str:
+    """Falls back to ``core.ontology.normalize_relation`` when
+    available, identity otherwise. Mirrors the fallback pattern in
+    ``core/wiki_generator/_merge.py`` so both sites compare predicates
+    the same way."""
+    try:
+        from core.ontology import normalize_relation as _norm  # type: ignore
+        return _norm(label) or label
+    except Exception:
+        return label
+
+
+def _extract_predicate(rel: Dict[str, Any]) -> Optional[str]:
+    """The classifier matches on ``(head, predicate, tail)``. For
+    contradiction detection we use the relation ``type`` (preferred)
+    or ``label`` (fallback) as the predicate identifier. Returns
+    ``None`` for malformed input."""
+    if not isinstance(rel, dict):
+        return None
+    t = rel.get("type")
+    if isinstance(t, str) and t:
+        return t
+    label = rel.get("label")
+    if isinstance(label, str) and label:
+        return label
+    return None
+
+
+def _extract_target(rel: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(rel, dict):
+        return None
+    target = rel.get("target")
+    if isinstance(target, str) and target:
+        return target
+    return None
+
+
+def _has_v04_lifecycle(rel: Dict[str, Any]) -> bool:
+    """True if the relation carries any v0.4 lifecycle metadata
+    (``validity`` / ``status`` / ``mutation_type``).
+
+    Pattern P2 only fires when this is True. Edges without any v0.4
+    metadata are pre-v0.4 legacy — they're too schema-poor for the
+    classifier to make a meaningful A/B/ignore call, so the
+    sources-append path stays the right default for them.
+    """
+    if not isinstance(rel, dict):
+        return False
+    if rel.get("validity"):
+        return True
+    if rel.get("status"):
+        return True
+    if rel.get("mutation_type"):
+        return True
+    return False
+
+
+def find_contradiction_candidates(
+    new_rel: Dict[str, Any],
+    existing_rels: List[Dict[str, Any]],
+    *,
+    predicate_normalizer: Callable[[str], str] = _default_predicate_normalizer,
+) -> List[Tuple[Dict[str, Any], ContradictionPattern]]:
+    """For a ``new_rel`` being ingested onto an entity, find existing
+    relations on the SAME entity that may contradict it.
+
+    Returns a list of ``(existing_rel, pattern)`` pairs ordered by
+    discovery in ``existing_rels``. Empty list = no candidate (safe
+    to merge as today).
+
+    The head entity is implicit — both ``new_rel`` and ``existing_rels``
+    are by construction relations of the SAME entity (the one
+    ``_merge.py`` is merging into).
+
+    Args:
+        new_rel: the new relation about to be added (ingestion shape:
+            at least ``target`` and ``type`` or ``label``).
+        existing_rels: the entity's existing relations (loaded from
+            its frontmatter).
+        predicate_normalizer: optional callable to normalize predicate
+            labels for comparison. Default falls back to
+            ``core.ontology.normalize_relation`` with identity fallback.
+    """
+    new_target = _extract_target(new_rel)
+    new_pred_raw = _extract_predicate(new_rel)
+    if not new_pred_raw:
+        return []
+    new_pred = predicate_normalizer(new_pred_raw)
+
+    candidates: List[Tuple[Dict[str, Any], ContradictionPattern]] = []
+    for er in existing_rels:
+        if not isinstance(er, dict):
+            continue
+        er_pred_raw = _extract_predicate(er)
+        if not er_pred_raw:
+            continue
+        er_pred = predicate_normalizer(er_pred_raw)
+        if er_pred != new_pred:
+            continue
+        er_target = _extract_target(er)
+
+        # P1: same predicate, different target.
+        if er_target and new_target and er_target != new_target:
+            candidates.append((er, "different_tail"))
+            continue
+
+        # P2: same predicate + same target. Only flag when existing
+        # has v0.4 lifecycle metadata; without it, the existing edge
+        # is too schema-poor for the classifier to make a meaningful
+        # A/B/ignore call and the sources-append path is the right
+        # default.
+        if er_target == new_target and _has_v04_lifecycle(er):
+            candidates.append((er, "divergent_validity"))
+            continue
+
+    return candidates
+
+
+def to_classifier_edge_shape(
+    rel: Dict[str, Any],
+    *,
+    ingest_doc_id: Optional[str] = None,
+    ingest_ts: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Convert an ingestion-shape relation to the classifier's
+    expected ``old_edge`` / ``new_fact`` shape.
+
+    The classifier (``contradiction_arbiter.classify_contradiction``)
+    looks for:
+
+      - ``validity.from`` / ``validity.to``
+      - ``sources[].weight``
+      - ``valid_from`` (top-level OR ``validity.from`` for new_fact)
+      - ``timestamp`` / ``ts``
+
+    Ingestion-shape relations have:
+
+      - ``target`` / ``type`` / ``label``
+      - ``sources``: ``List[{doc_id, ts, weight, role}]``
+      - ``confidence`` (optional, top-level)
+
+    The two shapes overlap on ``sources``. ``validity`` may or may
+    not exist on the ingestion-shape rel (depends on whether the
+    LLM extractor produced it). If ``sources`` is missing and
+    ``ingest_doc_id`` is provided, a single-source view is
+    synthesized so the classifier rule 2 (confidence comparison)
+    can fire on a degenerate-but-still-typed shape.
+
+    Malformed input (non-dict) returns an empty dict.
+    """
+    if not isinstance(rel, dict):
+        return {}
+    out = dict(rel)
+    if "sources" not in out and ingest_doc_id is not None:
+        weight = rel.get("confidence")
+        if not isinstance(weight, (int, float)):
+            weight = None
+        out["sources"] = [{
+            "doc_id": ingest_doc_id,
+            "ts": ingest_ts,
+            "weight": weight,
+            "role": "ingest",
+        }]
+    return out
+
+
+__all__ = [
+    "ContradictionPattern",
+    "find_contradiction_candidates",
+    "to_classifier_edge_shape",
+]

--- a/tests/test_t2d1_contradiction_detector.py
+++ b/tests/test_t2d1_contradiction_detector.py
@@ -1,0 +1,247 @@
+"""v0.4.1 PR-T2.D-1 contradiction detector contract tests.
+
+Pins the detector's behavior so T2.D-2 (the wiring PR) and any
+future caller can rely on the (existing_rel, pattern) shape.
+
+Run:
+  python -m unittest tests.test_t2d1_contradiction_detector
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.lifecycle.contradiction_ingest_detector import (  # noqa: E402
+    find_contradiction_candidates,
+    to_classifier_edge_shape,
+)
+
+
+# ---------------------------------------------------------------------------
+# find_contradiction_candidates
+# ---------------------------------------------------------------------------
+
+class FindContradictionCandidatesTests(unittest.TestCase):
+    """Pattern P1 (different_tail) + Pattern P2 (divergent_validity)
+    + the degenerate cases."""
+
+    def test_empty_existing_returns_empty(self):
+        result = find_contradiction_candidates(
+            {"target": "X", "type": "CEO_OF"},
+            [],
+        )
+        self.assertEqual(result, [])
+
+    def test_no_predicate_returns_empty(self):
+        """new_rel without predicate (no type or label) can't
+        identify a contradiction edge."""
+        result = find_contradiction_candidates(
+            {"target": "X"},
+            [{"target": "X", "type": "CEO_OF"}],
+        )
+        self.assertEqual(result, [])
+
+    def test_non_dict_new_rel_returns_empty(self):
+        result = find_contradiction_candidates(
+            "not a dict",  # type: ignore[arg-type]
+            [{"target": "X", "type": "CEO_OF"}],
+        )
+        self.assertEqual(result, [])
+
+    def test_different_predicate_no_match(self):
+        """Same target but different predicate = unrelated edges,
+        not a contradiction. Uses identity normalizer so the
+        production ontology mapping (which collapses many specific
+        labels to ``RELATED_TO``) doesn't accidentally match them."""
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{"target": "X", "type": "BASED_IN"}]
+        result = find_contradiction_candidates(
+            new, existing, predicate_normalizer=lambda x: x,
+        )
+        self.assertEqual(result, [])
+
+    def test_p1_different_tail_canonical_ceo_change(self):
+        """Canonical CEO-change scenario: same predicate, different
+        target. THIS is the case the v0.4.1 entry memo §1 calls out."""
+        new = {"target": "NewName", "type": "CEO_OF"}
+        existing = [{"target": "Dario", "type": "CEO_OF"}]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+        rel, pattern = result[0]
+        self.assertEqual(rel["target"], "Dario")
+        self.assertEqual(pattern, "different_tail")
+
+    def test_p2_same_pair_with_validity(self):
+        """Same (target, predicate) + existing has v0.4 validity →
+        divergent_validity candidate. New observation may close
+        existing edge's open window."""
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{
+            "target": "X", "type": "CEO_OF",
+            "validity": {"from": "2026-01-01", "to": None},
+        }]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+        _, pattern = result[0]
+        self.assertEqual(pattern, "divergent_validity")
+
+    def test_p2_same_pair_with_status(self):
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{
+            "target": "X", "type": "CEO_OF",
+            "status": {"active": True},
+        }]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+        _, pattern = result[0]
+        self.assertEqual(pattern, "divergent_validity")
+
+    def test_p2_same_pair_with_mutation_type(self):
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{
+            "target": "X", "type": "CEO_OF",
+            "mutation_type": "active",
+        }]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+        _, pattern = result[0]
+        self.assertEqual(pattern, "divergent_validity")
+
+    def test_p2_same_pair_no_lifecycle_skipped(self):
+        """Legacy edge without v0.4 metadata = safe to merge sources
+        as today (the conservative-within-B variant — pre-v0.4 edges
+        don't go through the classifier)."""
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{"target": "X", "type": "CEO_OF"}]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(result, [])
+
+    def test_label_used_when_type_missing(self):
+        """Ingestion-shape relations sometimes have `label` instead
+        of `type` (Korean labels from LLM extraction). The detector
+        falls back to label."""
+        new = {"target": "X", "label": "CEO_OF"}
+        existing = [{"target": "Y", "label": "CEO_OF"}]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+        _, pattern = result[0]
+        self.assertEqual(pattern, "different_tail")
+
+    def test_multiple_candidates_returned_in_order(self):
+        """The detector reports all candidates; the caller decides
+        which to dispatch first. Uses identity normalizer so the
+        production ontology mapping (which collapses many labels to
+        ``RELATED_TO``) doesn't interfere with the test setup."""
+        new = {"target": "NewName", "type": "CEO_OF"}
+        existing = [
+            {"target": "Dario", "type": "CEO_OF"},  # P1
+            {
+                "target": "NewName", "type": "CEO_OF",
+                "validity": {"from": "2026-01-01"},
+            },  # P2
+            {"target": "Z", "type": "BASED_IN"},  # unrelated predicate
+        ]
+        result = find_contradiction_candidates(
+            new, existing, predicate_normalizer=lambda x: x,
+        )
+        self.assertEqual(len(result), 2)
+        patterns = [p for _, p in result]
+        # Discovery order in existing_rels is preserved.
+        self.assertEqual(patterns, ["different_tail", "divergent_validity"])
+
+    def test_malformed_existing_rels_skipped_safely(self):
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [
+            None,  # type: ignore[list-item]
+            "not a dict",  # type: ignore[list-item]
+            {},
+            {"target": "Y", "type": "CEO_OF"},
+        ]
+        result = find_contradiction_candidates(new, existing)
+        self.assertEqual(len(result), 1)
+
+    def test_custom_normalizer_used(self):
+        """If callers pass a custom predicate_normalizer (e.g. for
+        non-default ontology mapping), it's applied to BOTH sides."""
+        def norm(label: str) -> str:
+            return "CEO" if label in ("CEO_OF", "leads") else label
+        new = {"target": "X", "type": "CEO_OF"}
+        existing = [{"target": "Y", "type": "leads"}]
+        result = find_contradiction_candidates(
+            new, existing, predicate_normalizer=norm,
+        )
+        self.assertEqual(len(result), 1)
+        _, pattern = result[0]
+        self.assertEqual(pattern, "different_tail")
+
+
+# ---------------------------------------------------------------------------
+# to_classifier_edge_shape
+# ---------------------------------------------------------------------------
+
+class ToClassifierEdgeShapeTests(unittest.TestCase):
+
+    def test_passthrough_when_sources_present(self):
+        """Existing relations already have sources from prior ingest
+        — leave them alone."""
+        rel = {
+            "target": "X", "type": "CEO_OF",
+            "sources": [{"doc_id": "d", "weight": 0.8}],
+        }
+        r = to_classifier_edge_shape(rel)
+        self.assertEqual(r["target"], "X")
+        self.assertEqual(r["sources"], [{"doc_id": "d", "weight": 0.8}])
+
+    def test_synthesizes_source_from_ingest_meta(self):
+        """New observations may arrive without `sources` populated
+        (the LLM extractor sometimes emits flat dicts). Caller
+        supplies doc_id + ts to bake a single-source view so the
+        classifier rule 2 (confidence comparison) has something to
+        chew on."""
+        rel = {"target": "X", "type": "CEO_OF", "confidence": 0.9}
+        r = to_classifier_edge_shape(
+            rel, ingest_doc_id="doc_123", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(len(r["sources"]), 1)
+        s = r["sources"][0]
+        self.assertEqual(s["doc_id"], "doc_123")
+        self.assertEqual(s["ts"], "2026-05-28T00:00:00Z")
+        self.assertEqual(s["weight"], 0.9)
+        self.assertEqual(s["role"], "ingest")
+
+    def test_synthesizes_source_with_no_confidence(self):
+        """If confidence isn't a number, weight stays None — the
+        classifier rule 2 handles None gracefully (best_source_weight
+        returns None, rule 2 skips)."""
+        rel = {"target": "X", "type": "CEO_OF"}
+        r = to_classifier_edge_shape(
+            rel, ingest_doc_id="doc_123", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(len(r["sources"]), 1)
+        self.assertIsNone(r["sources"][0]["weight"])
+
+    def test_does_not_synthesize_without_ingest_doc_id(self):
+        """Without ingest_doc_id, leave sources absent — caller
+        already knows the rel has no source attribution."""
+        rel = {"target": "X", "type": "CEO_OF"}
+        r = to_classifier_edge_shape(rel)
+        self.assertNotIn("sources", r)
+
+    def test_malformed_input_returns_empty(self):
+        self.assertEqual(to_classifier_edge_shape(None), {})  # type: ignore[arg-type]
+        self.assertEqual(to_classifier_edge_shape("nope"), {})  # type: ignore[arg-type]
+
+    def test_does_not_mutate_input(self):
+        rel = {"target": "X", "type": "CEO_OF", "confidence": 0.9}
+        before = dict(rel)
+        _ = to_classifier_edge_shape(
+            rel, ingest_doc_id="doc_123", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(rel, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First of three split PRs for v0.4.0 carry-over **PR-T2.D** per v0.4.1 entry memo (#557) + this session's additional LOCKs:

| # | PR | scope |
|---|---|---|
| **1** | **this PR** | detector module + tests (no production wiring) |
| 2 | T2.D-2 | wire detector into `core/wiki_generator/_merge.py` |
| 3 | T2.D-3 | step7 v6 q17 CEO-change fixture + acceptance bench |

**Trigger policy LOCK = B (적극)** — per v0.4.1 entry memo §2 + this session's additional LOCK. Any `(head, predicate)` match on the SAME entity qualifies as a contradiction candidate; the deterministic classifier (`contradiction_arbiter.classify_contradiction`, already shipped in v0.4.0 #541) decides A_invalidate / B_supersede / ignore from there.

## Files

### `core/lifecycle/contradiction_ingest_detector.py` (~8 KB)

Two pure functions + the `ContradictionPattern` label type:

```python
def find_contradiction_candidates(
    new_rel: Dict[str, Any],
    existing_rels: List[Dict[str, Any]],
    *,
    predicate_normalizer: Callable[[str], str] = _default_predicate_normalizer,
) -> List[Tuple[Dict[str, Any], ContradictionPattern]]:
    """Returns list of (existing_rel, pattern) — empty list = safe to merge as today."""
```

Recognizes two patterns:

- **P1 "different_tail"** — same predicate, different target. Canonical CEO-change (entry memo §1 example: Anthropic CEO Dario → NewName).
- **P2 "divergent_validity"** — same `(target, predicate)` where the existing edge carries v0.4 lifecycle metadata (`validity` / `status` / `mutation_type`). Pre-v0.4 legacy edges without lifecycle metadata stay on the sources-append path.

```python
def to_classifier_edge_shape(
    rel: Dict[str, Any],
    *,
    ingest_doc_id: Optional[str] = None,
    ingest_ts: Optional[str] = None,
) -> Dict[str, Any]:
    """Adapter — fills in a single-source view when the new fact
    arrived without sources (some LLM extractors emit flat dicts)."""
```

Pure function module — no I/O, no clock side-effects. Matches the `contradiction_arbiter` design pattern.

### `tests/test_t2d1_contradiction_detector.py` — 19 contract tests

| group | what it pins |
|---|---|
| `FindContradictionCandidatesTests` (13) | P1 / P2 / negative paths (different predicate, no v0.4 lifecycle) / multiple candidates in discovery order / malformed input / custom normalizer / label-vs-type fallback |
| `ToClassifierEdgeShapeTests` (6) | passthrough when sources present / synthesis with confidence / synthesis with no-confidence / no-synthesis without ingest_doc_id / malformed input / does-not-mutate-input |

Tests pass with identity-normalizer overrides on the cases where production ontology normalization would mask the semantic (e.g. CEO_OF and BASED_IN both collapse to RELATED_TO in `core.ontology`).

## Verification

- `python -m unittest tests.test_t2d1_contradiction_detector` → **19/19 pass**
- Regression suite (T2.D-1 + T2 router + QVT oracle + step7 v5 schema): **52/52 pass**
- `python -m ruff check core/lifecycle/contradiction_ingest_detector.py tests/test_t2d1_contradiction_detector.py` → All checks passed
- Module size **8 KB** (CLAUDE.md rule 5: ≤ 20 KB) ✓

## Quality Delta vs baseline

`Quality delta: exempt (label: code — pure helper module + tests, no production caller yet; QVT axes unaffected until T2.D-2 wires it into ingestion)`.

## Out of scope

- T2.D-2 — wire into `_merge_relations_into_existing_entity`, invoke `dispatch_contradiction`, handle the A/B/ignore return shapes
- T2.D-3 — step7 v6 q17 CEO-change fixture + end-to-end acceptance bench under entity-anchor=1 + bge-m3 env
- Re-baseline of `baseline_2a31b20.json` — T2.D doesn't touch retrieval / graph / reasoning paths; no QVT delta expected
- T6 cycle (PR-T6.A onwards) — depends on T2.D landing first

🤖 Generated with [Claude Code](https://claude.com/claude-code)