### PR TITLE
feat(lifecycle): v0.4.1 PR-T2.D-2 — flag-gated contradiction dispatch in merge

### DIFF
--- a/core/lifecycle/ingest_contradiction.py
+++ b/core/lifecycle/ingest_contradiction.py
@@ -1,0 +1,227 @@
+"""v0.4.1 PR-T2.D-2 — ingestion-path contradiction dispatch.
+
+Wires the v0.4.0 contradiction infrastructure
+(``classify_contradiction`` + ``supersede_edge``) into the
+``core/wiki_generator/_merge.py`` merge loop. Pre-merge hook: before
+new relations are sources-appended, identify contradiction candidates
+via PR-T2.D-1's detector, run the classifier, and apply the
+no-file-I/O branches in-line.
+
+## Trigger policy LOCK — B (적극)
+
+Per v0.4.1 entry memo §2 + this session's added LOCK. Any
+``(head, predicate)`` match on the same entity qualifies as a
+contradiction candidate; the classifier (already deterministic
+v0.4.0 #541) decides A_invalidate / B_supersede / ignore.
+
+## Scope split — three labels handled differently
+
+| label | how this PR handles it | rationale |
+|---|---|---|
+| ``B_supersede`` | call ``supersede_edge`` in-line → ``new_edge`` appended to ``existing_rels``, ``old_edge`` mutated in place. new_rel filtered out. | pure function, no file I/O, race-free |
+| ``ignore`` | drop ``new_rel`` from the merge output | the classifier already said "duplicate"; nothing to do |
+| ``A_invalidate`` | **deferred to T2.D-2.b** — this PR logs only. ``new_rel`` is dropped (cascade would handle the bad source). | ``route_a_invalidate`` calls ``cascade_remove_doc_from_sources`` which mutates entity files while ``_merge.py`` has the same files open in memory → write-after-read race. T2.D-2.b restructures the merge flow to handle this safely. |
+
+## Flag-gated
+
+``JAMES_T2D_INGEST_DISPATCH=1`` enables the dispatch hook. Default
+OFF preserves byte-identical legacy behavior. After T2.D-3
+acceptance (step7 v6 CEO-change bench), a separate small PR flips
+the default ON.
+
+## What this module is NOT
+
+- Not a full ``dispatch_contradiction`` re-implementation. The
+  router (``core.lifecycle.contradiction_router``) stays intact;
+  this module is the ingestion-specific pre-merge hook that uses
+  the same building blocks differently because of the in-memory
+  state ownership.
+- Not idempotent under repeated ingestion. Calling this twice on
+  the same ``(new_rels, existing_rels)`` may double-supersede
+  (creating two new edges where one is enough). The
+  ``_merge.py`` caller invokes it once per merge.
+- Not a CASCADE path. A_invalidate is logged for the audit trail
+  but no source removal happens in this PR (T2.D-2.b will).
+
+Pure function (no I/O) for the B + ignore + log paths. A_invalidate
+audit row is emitted via the optional ``audit_emit`` callback —
+caller can persist to ``audit_log`` if desired, this module does
+not import the audit bridge directly.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from core.lifecycle.contradiction_arbiter import (
+    classify_contradiction,
+)
+from core.lifecycle.contradiction_ingest_detector import (
+    find_contradiction_candidates,
+    to_classifier_edge_shape,
+)
+from core.lifecycle.supersede_chain import supersede_edge
+
+
+AuditEmit = Callable[[Dict[str, Any]], None]
+
+
+def _noop_audit(_payload: Dict[str, Any]) -> None:
+    """No-op default — callers that don't pass ``audit_emit`` just
+    get the in-memory dispatch results in the returned log without
+    any side-channel emission."""
+    return None
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    """Lenient ISO 8601 parse mirroring ``contradiction_arbiter._parse_iso``."""
+    if value is None or not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def dispatch_contradictions_for_merge(
+    new_rels: List[Dict[str, Any]],
+    existing_rels: List[Dict[str, Any]],
+    *,
+    ingest_doc_id: str,
+    ingest_ts: str,
+    audit_emit: Optional[AuditEmit] = None,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Pre-merge contradiction dispatch.
+
+    For each new_rel in ``new_rels``:
+      1. Run PR-T2.D-1's detector against ``existing_rels``.
+      2. If candidates exist, take the first one (multi-candidate
+         dispatch ordering is T2.D-2.b territory).
+      3. Convert both sides to classifier shape, call
+         ``classify_contradiction``.
+      4. Apply the label:
+         - **B_supersede** — call ``supersede_edge``, append the
+           new edge to ``existing_rels``, drop new_rel from the
+           returned list.
+         - **ignore** — drop new_rel.
+         - **A_invalidate** — log + drop new_rel (cascade deferred).
+      5. If no candidates, pass new_rel through unchanged.
+
+    ``existing_rels`` IS MUTATED IN PLACE — the caller's frontmatter
+    list reference picks up the supersede chain links (matches
+    ``supersede_edge``'s contract).
+
+    Args:
+        new_rels: relations the caller is about to merge (ingestion
+            shape: ``target`` + ``type``/``label`` + optional
+            ``sources``).
+        existing_rels: the entity's current relations (from
+            frontmatter). MUTATED for B_supersede paths.
+        ingest_doc_id: document being ingested. Used as ``new_fact``
+            timestamp / source attribution when the new rel doesn't
+            carry its own.
+        ingest_ts: ISO 8601 string of ingest moment. Used as
+            ``supersede_ts`` for B paths + ``new_fact.timestamp``
+            for the classifier.
+        audit_emit: optional callback for emitting audit rows
+            (``mutation_type=invalidated`` / ``superseded`` /
+            ``ignored``). Defaults to no-op.
+
+    Returns:
+        ``(rels_to_merge, dispatch_log)``:
+          - ``rels_to_merge``: ``new_rels`` with contradicting ones
+            filtered out. The caller's regular sources-append path
+            handles whatever remains.
+          - ``dispatch_log``: per-decision audit entries
+            (``new_rel``, ``existing_rel``, ``pattern``, ``label``,
+            ``action``). Useful for tests + future ``audit_log`` mirroring.
+    """
+    emit = audit_emit or _noop_audit
+    rels_to_merge: List[Dict[str, Any]] = []
+    dispatch_log: List[Dict[str, Any]] = []
+
+    now_dt = _parse_iso(ingest_ts) or datetime.now(timezone.utc)
+
+    for new_rel in new_rels:
+        if not isinstance(new_rel, dict):
+            continue
+        candidates = find_contradiction_candidates(new_rel, existing_rels)
+        if not candidates:
+            rels_to_merge.append(new_rel)
+            continue
+
+        # T2.D-2 scope: dispatch on first candidate only. Multi-candidate
+        # ordering (e.g. dispatch on P1 first, then P2) is T2.D-2.b.
+        existing_rel, pattern = candidates[0]
+        old_shape = to_classifier_edge_shape(existing_rel)
+        new_shape = to_classifier_edge_shape(
+            new_rel, ingest_doc_id=ingest_doc_id, ingest_ts=ingest_ts,
+        )
+        label = classify_contradiction(old_shape, new_shape, now=now_dt)
+
+        log_entry: Dict[str, Any] = {
+            "new_rel":      new_rel,
+            "existing_rel": existing_rel,
+            "pattern":      pattern,
+            "label":        label,
+        }
+
+        if label == "ignore":
+            log_entry["action"] = "drop_new_rel_ignored"
+            emit({
+                "endpoint":      "lifecycle:ingest_contradiction",
+                "role":          "system",
+                "mutation_type": "ignored",
+                "pattern":       pattern,
+            })
+
+        elif label == "B_supersede":
+            new_edge, _mutated_old = supersede_edge(
+                existing_rel, new_rel, now_dt,
+            )
+            existing_rels.append(new_edge)
+            log_entry["action"] = "supersede_applied"
+            log_entry["new_edge_id"] = new_edge.get("id")
+            log_entry["old_edge_id"] = existing_rel.get("id")
+            emit({
+                "endpoint":      "lifecycle:ingest_contradiction",
+                "role":          "system",
+                "mutation_type": "superseded",
+                "old_edge_id":   existing_rel.get("id"),
+                "new_edge_id":   new_edge.get("id"),
+                "superseded_at": now_dt.isoformat(),
+            })
+
+        elif label == "A_invalidate":
+            # T2.D-2.b territory — cascade_remove is deferred so
+            # _merge.py doesn't race with cascade on the same entity
+            # file. This PR logs the decision; the new_rel is
+            # dropped on the assumption that the deferred cascade
+            # would have invalidated the conflicting source.
+            log_entry["action"] = "a_invalidate_logged_deferred"
+            emit({
+                "endpoint":      "lifecycle:ingest_contradiction",
+                "role":          "system",
+                "mutation_type": "invalidated_deferred",
+                "pattern":       pattern,
+                "note":          "cascade_remove deferred to T2.D-2.b",
+            })
+
+        else:
+            # Defensive — classifier returned a label we don't
+            # know. Keep new_rel so we don't silently lose data.
+            log_entry["action"] = "kept_unknown_label"
+            rels_to_merge.append(new_rel)
+
+        dispatch_log.append(log_entry)
+
+    return rels_to_merge, dispatch_log
+
+
+__all__ = [
+    "AuditEmit",
+    "dispatch_contradictions_for_merge",
+]

--- a/core/wiki_generator/_merge.py
+++ b/core/wiki_generator/_merge.py
@@ -13,12 +13,16 @@ composes the mixins onto ``WikiGenerator``.
 """
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
 
+from core.lifecycle.ingest_contradiction import (
+    dispatch_contradictions_for_merge,
+)
 from core.relations_schema import (
     EXTRACT_SOURCE_ROLE,
     INVERSE_SOURCE_ROLE,
@@ -133,6 +137,33 @@ class WikiMergeMixin:
 
         sources_appended = 0
         relations_added  = 0
+
+        # T2.D-2 — opt-in contradiction dispatch pre-merge hook.
+        # JAMES_T2D_INGEST_DISPATCH=1 enables the v0.4.1 contradiction
+        # arbiter on (head, predicate) matches between new_relations
+        # and existing_rels. Default OFF preserves byte-identical
+        # legacy behavior. B_supersede + ignore paths handled in-line;
+        # A_invalidate is logged + deferred to T2.D-2.b (cascade race
+        # with the in-memory entity edit is the open problem). The
+        # dispatcher mutates existing_rels in place for B_supersede
+        # (new edge appended via supersede_edge contract) and returns
+        # a filtered new_relations list for the regular merge loop.
+        if os.environ.get("JAMES_T2D_INGEST_DISPATCH") == "1":
+            try:
+                new_relations, _dispatch_log = dispatch_contradictions_for_merge(
+                    list(new_relations),
+                    existing_rels,
+                    ingest_doc_id=doc_id,
+                    ingest_ts=ts,
+                )
+            except Exception as e:
+                # Defensive — never let the dispatch hook crash the
+                # merge. Fall back to legacy behavior; the operator
+                # sees the exception via the audit_log audit emitter
+                # configured at boot, or via stdout.
+                print(f"[t2d-ingest] dispatch hook crashed, "
+                      f"falling back to legacy merge: "
+                      f"{type(e).__name__}: {e}")
 
         for new_rel in new_relations:
             if not isinstance(new_rel, dict):

--- a/tests/test_t2d2_ingest_contradiction.py
+++ b/tests/test_t2d2_ingest_contradiction.py
@@ -1,0 +1,311 @@
+"""v0.4.1 PR-T2.D-2 contradiction dispatch contract tests.
+
+Pins the three label-paths the dispatcher handles in this PR:
+
+  - B_supersede → ``supersede_edge`` in-line, new_edge appended,
+    new_rel dropped
+  - ignore     → new_rel dropped, log entry only
+  - A_invalidate → log + drop (cascade deferred to T2.D-2.b)
+
+Plus the negative paths (no candidates → passthrough; defensive
+crash recovery in _merge.py wiring).
+
+Run:
+  python -m unittest tests.test_t2d2_ingest_contradiction
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.lifecycle.ingest_contradiction import (  # noqa: E402
+    dispatch_contradictions_for_merge,
+)
+
+
+def _v04_edge(target: str, predicate: str, *, valid_from: str = "2025-01-01T00:00:00Z",
+              valid_to: str | None = None, sources_weight: float = 0.8,
+              edge_id: str = "e_edge_existing") -> dict:
+    """Build a v0.4-shaped existing edge for the classifier."""
+    return {
+        "id":      edge_id,
+        "target":  target,
+        "type":    predicate,
+        "label":   predicate,
+        "validity": {"from": valid_from, "to": valid_to},
+        "status":   {"active": True},
+        "mutation_type": "active",
+        "sources": [
+            {"doc_id": "old_doc", "ts": valid_from,
+             "weight": sources_weight, "role": "legacy"},
+        ],
+    }
+
+
+def _new_rel(target: str, predicate: str, *,
+             confidence: float = 0.9) -> dict:
+    """Build an ingestion-shape new relation."""
+    return {
+        "target":     target,
+        "type":       predicate,
+        "label":      predicate,
+        "confidence": confidence,
+        "sources":    [
+            {"doc_id": "new_doc", "ts": "2026-05-28T00:00:00Z",
+             "weight": confidence, "role": "extract"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# B_supersede path
+# ---------------------------------------------------------------------------
+
+class BSupersedePathTests(unittest.TestCase):
+    """Rule 1: new_fact.valid_from > old_edge.validity.to (or now).
+    Classifier returns B_supersede; supersede_edge applied."""
+
+    def test_b_supersede_adds_new_edge_and_drops_new_rel(self):
+        existing = [
+            _v04_edge("Dario", "CEO_OF", valid_from="2024-01-01T00:00:00Z",
+                      valid_to="2026-01-01T00:00:00Z"),
+        ]
+        new_rel = _new_rel("NewName", "CEO_OF")
+        # valid_from on new_rel = ingest_ts; the classifier reads
+        # new_fact.valid_from OR validity.from OR timestamp/ts.
+        new_rel["valid_from"] = "2026-05-28T00:00:00Z"
+
+        rels_to_merge, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="new_doc",
+            ingest_ts="2026-05-28T00:00:00Z",
+        )
+
+        # new_rel was dropped from the merge list (supersede handled it).
+        self.assertEqual(rels_to_merge, [])
+        # existing_rels gained the new_edge AND mutated the old edge.
+        self.assertEqual(len(existing), 2)
+        # Old edge mutated in-place — status carries superseded_by.
+        old_after = existing[0]
+        new_edge = existing[1]
+        self.assertEqual(old_after["status"].get("superseded_by"),
+                         new_edge.get("id"))
+        # Log entry shape.
+        self.assertEqual(len(log), 1)
+        self.assertEqual(log[0]["label"], "B_supersede")
+        self.assertEqual(log[0]["action"], "supersede_applied")
+        self.assertEqual(log[0]["new_edge_id"], new_edge.get("id"))
+
+
+# ---------------------------------------------------------------------------
+# ignore path
+# ---------------------------------------------------------------------------
+
+class IgnorePathTests(unittest.TestCase):
+    """Rule 3: keys match, new_fact.timestamp inside old_edge.validity,
+    no confidence delta → ignore."""
+
+    def test_ignore_drops_new_rel_no_supersede(self):
+        existing = [
+            _v04_edge("X", "RELATED_TO", valid_from="2024-01-01T00:00:00Z",
+                      valid_to="2027-01-01T00:00:00Z", sources_weight=0.85),
+        ]
+        # Same target + same confidence + timestamp inside window
+        # → classifier returns "ignore".
+        new_rel = _new_rel("X", "RELATED_TO", confidence=0.85)
+        new_rel["timestamp"] = "2026-01-01T00:00:00Z"
+
+        rels_to_merge, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="dup_doc",
+            ingest_ts="2026-01-01T00:00:00Z",
+        )
+
+        # new_rel was dropped.
+        self.assertEqual(rels_to_merge, [])
+        # No new edge appended (supersede did NOT run).
+        self.assertEqual(len(existing), 1)
+        # Log entry says ignore.
+        self.assertEqual(len(log), 1)
+        self.assertEqual(log[0]["label"], "ignore")
+        self.assertEqual(log[0]["action"], "drop_new_rel_ignored")
+
+
+# ---------------------------------------------------------------------------
+# A_invalidate path — deferred (logged only)
+# ---------------------------------------------------------------------------
+
+class AInvalidateDeferredPathTests(unittest.TestCase):
+    """Rule 2: A_invalidate fires when new is higher-confidence AND
+    timestamp ≤ old_edge.validity.from. T2.D-2 only LOGS — cascade
+    deferred to T2.D-2.b (race with _merge.py write-after-read)."""
+
+    def test_a_invalidate_logged_and_new_rel_dropped(self):
+        existing = [
+            _v04_edge("X", "RELATED_TO", valid_from="2026-01-01T00:00:00Z",
+                      sources_weight=0.5),
+        ]
+        # Higher-confidence retroactive correction.
+        new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
+        new_rel["timestamp"] = "2025-06-01T00:00:00Z"
+
+        rels_to_merge, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="correction_doc",
+            ingest_ts="2025-06-01T00:00:00Z",
+        )
+
+        # new_rel was dropped on the assumption a future cascade
+        # invalidates the wrong source.
+        self.assertEqual(rels_to_merge, [])
+        # No new edge — supersede did NOT run. T2.D-2.b will
+        # call cascade after the merge completes.
+        self.assertEqual(len(existing), 1)
+        # Log carries the deferred marker.
+        self.assertEqual(len(log), 1)
+        self.assertEqual(log[0]["label"], "A_invalidate")
+        self.assertEqual(log[0]["action"], "a_invalidate_logged_deferred")
+
+
+# ---------------------------------------------------------------------------
+# No-candidate passthrough
+# ---------------------------------------------------------------------------
+
+class NoCandidatePassthroughTests(unittest.TestCase):
+
+    def test_no_match_keeps_new_rel(self):
+        """Empty existing → no candidates → passthrough.
+
+        Note: production ``core.ontology.normalize_relation`` collapses
+        many specific predicate labels (CEO_OF, BASED_IN, etc.) into
+        the umbrella ``RELATED_TO``. So tests that want "different
+        predicate, no match" need to either use predicates that
+        survive normalization OR use an empty existing list. Using
+        empty here keeps the test focused on the passthrough contract.
+        """
+        existing: list = []
+        new_rel = _new_rel("Y", "BASED_IN")
+        rels_to_merge, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(rels_to_merge, [new_rel])
+        self.assertEqual(log, [])
+
+    def test_legacy_existing_no_lifecycle_keeps_new_rel(self):
+        """Existing edge without v0.4 lifecycle metadata → detector
+        returns no candidate → passthrough."""
+        existing = [{"target": "X", "type": "RELATED_TO"}]
+        new_rel = _new_rel("X", "RELATED_TO")
+        rels_to_merge, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(rels_to_merge, [new_rel])
+        self.assertEqual(log, [])
+
+    def test_empty_input_returns_empty(self):
+        rels, log = dispatch_contradictions_for_merge(
+            [], [],
+            ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(rels, [])
+        self.assertEqual(log, [])
+
+
+# ---------------------------------------------------------------------------
+# Audit emit callback
+# ---------------------------------------------------------------------------
+
+class AuditEmitTests(unittest.TestCase):
+
+    def test_b_supersede_emits_audit_row(self):
+        existing = [
+            _v04_edge("Dario", "CEO_OF", valid_from="2024-01-01T00:00:00Z",
+                      valid_to="2026-01-01T00:00:00Z"),
+        ]
+        new_rel = _new_rel("NewName", "CEO_OF")
+        new_rel["valid_from"] = "2026-05-28T00:00:00Z"
+
+        emit = MagicMock()
+        dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="new_doc", ingest_ts="2026-05-28T00:00:00Z",
+            audit_emit=emit,
+        )
+
+        emit.assert_called_once()
+        payload = emit.call_args[0][0]
+        self.assertEqual(payload["endpoint"], "lifecycle:ingest_contradiction")
+        self.assertEqual(payload["mutation_type"], "superseded")
+        self.assertIn("old_edge_id", payload)
+        self.assertIn("new_edge_id", payload)
+
+    def test_a_invalidate_emits_deferred_marker(self):
+        existing = [
+            _v04_edge("X", "RELATED_TO", valid_from="2026-01-01T00:00:00Z",
+                      sources_weight=0.5),
+        ]
+        new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
+        new_rel["timestamp"] = "2025-06-01T00:00:00Z"
+
+        emit = MagicMock()
+        dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="correction_doc",
+            ingest_ts="2025-06-01T00:00:00Z",
+            audit_emit=emit,
+        )
+
+        emit.assert_called_once()
+        payload = emit.call_args[0][0]
+        self.assertEqual(payload["mutation_type"], "invalidated_deferred")
+        self.assertEqual(payload["note"], "cascade_remove deferred to T2.D-2.b")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class EdgeCaseTests(unittest.TestCase):
+
+    def test_malformed_new_rels_skipped(self):
+        """Empty existing → only structural shape of new_rels matters.
+        Valid dicts pass through; non-dicts are skipped."""
+        existing: list = []
+        # Mix of None, str, valid dict
+        rels, log = dispatch_contradictions_for_merge(
+            [None, "not a dict", {"target": "Y", "type": "BASED_IN"}],  # type: ignore[list-item]
+            existing,
+            ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
+        )
+        self.assertEqual(len(rels), 1)
+        self.assertEqual(rels[0]["target"], "Y")
+
+    def test_ingest_ts_parse_fallback_to_now(self):
+        """Malformed ingest_ts → falls back to datetime.now(UTC)."""
+        existing = [
+            _v04_edge("Dario", "CEO_OF", valid_from="2024-01-01T00:00:00Z",
+                      valid_to="2026-01-01T00:00:00Z"),
+        ]
+        new_rel = _new_rel("NewName", "CEO_OF")
+        new_rel["valid_from"] = "2026-05-28T00:00:00Z"
+
+        # ingest_ts is garbage → falls back to now(UTC) which is
+        # 2026-05-28T... > 2026-01-01 valid_to → B_supersede still fires
+        rels, log = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="doc", ingest_ts="not an iso date",
+        )
+        self.assertEqual(len(log), 1)
+        # B_supersede should still fire because new valid_from is
+        # strictly later than old validity.to.
+        self.assertEqual(log[0]["label"], "B_supersede")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wires the v0.4.0 contradiction infrastructure (`classify_contradiction` + `supersede_edge`) into `core/wiki_generator/_merge.py`'s `_merge_relations_into_existing_entity` loop via a new pre-merge hook. **Flag default OFF** (`JAMES_T2D_INGEST_DISPATCH=0`) → production byte-identical to today.

Second of three PRs for v0.4.0 carry-over PR-T2.D:
- ✅ T2.D-1 (#558) — detector module + tests
- **T2.D-2 (this PR)** — wiring with flag gate
- ⏳ T2.D-3 — step7 v6 q17 CEO-change fixture + acceptance bench
- ⏳ T2.D-4 — flip flag default to ON after acceptance lands

## Label handling split

| label | this PR | rationale |
|---|---|---|
| `B_supersede` | call `supersede_edge` in-line → `new_edge` appended to `existing_rels`, `old_edge` mutated in place, `new_rel` filtered out | pure function, no file I/O, race-free |
| `ignore` | drop `new_rel` from merge output | classifier said "duplicate"; nothing to do |
| `A_invalidate` | **LOG + drop `new_rel`** (cascade deferred to T2.D-2.b) | `route_a_invalidate` → `cascade_remove_doc_from_sources` mutates entity files while `_merge.py` has the same files open in memory → write-after-read race. T2.D-2.b restructures the merge flow to handle this safely. |

## Files

### `core/lifecycle/ingest_contradiction.py` (~9 KB)

```python
def dispatch_contradictions_for_merge(
    new_rels, existing_rels, *,
    ingest_doc_id, ingest_ts,
    audit_emit=None,
) -> Tuple[List[dict], List[dict]]:
    """(rels_to_merge, dispatch_log)"""
```

- Iterates `new_rels`, finds candidates via PR-T2.D-1 detector, classifies, applies B + ignore + log-only A in-line
- `existing_rels` **MUTATED in place** (`supersede_edge` contract)
- `audit_emit` callback optional — emits `mutation_type` rows for the audit trail

### `core/wiki_generator/_merge.py` (+31 LOC)

Pre-merge hook reads `JAMES_T2D_INGEST_DISPATCH` env. On exception falls back to legacy behavior (defensive try/except so the hook can't crash production merges). `new_relations` variable rebound to the dispatcher's filtered list. Existing match-loop logic downstream unchanged.

### `tests/test_t2d2_ingest_contradiction.py` — 10 contract tests

| group | what it pins |
|---|---|
| `BSupersedePathTests` (1) | B_supersede: new_edge appended + old.status.superseded_by set + new_rel dropped |
| `IgnorePathTests` (1) | ignore: new_rel dropped + no edge added |
| `AInvalidateDeferredPathTests` (1) | A_invalidate: logged with deferred marker + drop |
| `NoCandidatePassthroughTests` (3) | empty existing / no v0.4 lifecycle / empty input → passthrough |
| `AuditEmitTests` (2) | B + A audit row shapes |
| `EdgeCaseTests` (2) | malformed new_rels skipped / ingest_ts parse fallback to `datetime.now(UTC)` |

## Verification

- `pytest tests/test_t2_contradiction_router.py tests/test_t2d1_contradiction_detector.py tests/test_t2d2_ingest_contradiction.py` → **48/48 pass**
- `ruff check core/lifecycle/ingest_contradiction.py core/wiki_generator/_merge.py tests/test_t2d2_ingest_contradiction.py` → All checks passed
- Module size **9 KB** (CLAUDE.md rule 5: ≤ 20 KB) ✓
- Flag default OFF confirmed via smoke import test → `_merge.py` does NOT invoke `dispatch_contradictions_for_merge` unless `JAMES_T2D_INGEST_DISPATCH=1` is set

## Out of scope

- **T2.D-2.b** — proper A_invalidate handling without race. Likely approach: dispatcher returns a `pending_cascades` list; `_merge.py` writes the entity first, then a post-merge runner calls `cascade_remove_doc_from_sources`. OR move the dispatch hook to `_ingestion.py` (before `_merge_relations_into_existing_entity` gets called) so file ops happen before in-memory load.
- **T2.D-3** — step7 v6 q17 CEO-change fixture + end-to-end acceptance bench with `JAMES_T2D_INGEST_DISPATCH=1`
- **T2.D-4** — flip flag default to ON after acceptance lands
- Re-baseline of `baseline_2a31b20.json` — T2.D-2 default-OFF doesn't change retrieval/graph/reasoning behavior; no QVT delta expected

## Quality Delta vs baseline

`Quality delta: exempt (label: code — flag-gated default OFF, no behavior change in production; new code path is opt-in. Future PR that flips default ON will paste a Quality Delta Card paired against baseline_2a31b20.json to validate retrieval/graph/reasoning behavior under flag=1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)