### PR TITLE
fix(lifecycle): v0.4.1 PR-T2.D-2.b — A_invalidate cascade race fix via pending_cascades

### DIFF
--- a/core/lifecycle/ingest_contradiction.py
+++ b/core/lifecycle/ingest_contradiction.py
@@ -1,11 +1,18 @@
-"""v0.4.1 PR-T2.D-2 — ingestion-path contradiction dispatch.
+"""v0.4.1 PR-T2.D-2 + T2.D-2.b — ingestion-path contradiction dispatch.
 
 Wires the v0.4.0 contradiction infrastructure
 (``classify_contradiction`` + ``supersede_edge``) into the
 ``core/wiki_generator/_merge.py`` merge loop. Pre-merge hook: before
 new relations are sources-appended, identify contradiction candidates
-via PR-T2.D-1's detector, run the classifier, and apply the
-no-file-I/O branches in-line.
+via PR-T2.D-1's detector, run the classifier, and apply the resulting
+label.
+
+T2.D-2.b extends T2.D-2 with proper A_invalidate handling via the
+``PendingCascade`` deferred-execution pattern — the dispatcher
+records cascade requests but doesn't execute them; the caller
+(``_merge.py``) applies them AFTER writing back the entity it had
+loaded in memory. This sidesteps the write-after-read race that
+T2.D-2 dropped A_invalidate over.
 
 ## Trigger policy LOCK — B (적극)
 
@@ -14,13 +21,13 @@ Per v0.4.1 entry memo §2 + this session's added LOCK. Any
 contradiction candidate; the classifier (already deterministic
 v0.4.0 #541) decides A_invalidate / B_supersede / ignore.
 
-## Scope split — three labels handled differently
+## Scope — three labels handled differently
 
-| label | how this PR handles it | rationale |
+| label | how the dispatcher handles it | rationale |
 |---|---|---|
 | ``B_supersede`` | call ``supersede_edge`` in-line → ``new_edge`` appended to ``existing_rels``, ``old_edge`` mutated in place. new_rel filtered out. | pure function, no file I/O, race-free |
 | ``ignore`` | drop ``new_rel`` from the merge output | the classifier already said "duplicate"; nothing to do |
-| ``A_invalidate`` | **deferred to T2.D-2.b** — this PR logs only. ``new_rel`` is dropped (cascade would handle the bad source). | ``route_a_invalidate`` calls ``cascade_remove_doc_from_sources`` which mutates entity files while ``_merge.py`` has the same files open in memory → write-after-read race. T2.D-2.b restructures the merge flow to handle this safely. |
+| ``A_invalidate`` | record a ``PendingCascade`` for the lowest-weight non-manual source on existing_rel + **keep new_rel** so the regular merge loop appends it as a fresh edge. Caller runs the cascade post-write via ``apply_pending_cascades``. | ``cascade_remove_doc_from_sources`` mutates entity files; deferring until AFTER ``_merge.py`` writes prevents the write-after-read race. |
 
 ## Flag-gated
 
@@ -50,9 +57,12 @@ not import the audit bridge directly.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from core.cascade._delete import cascade_remove_doc_from_sources
 from core.lifecycle.contradiction_arbiter import (
     classify_contradiction,
 )
@@ -64,6 +74,19 @@ from core.lifecycle.supersede_chain import supersede_edge
 
 
 AuditEmit = Callable[[Dict[str, Any]], None]
+
+
+@dataclass
+class PendingCascade:
+    """A cascade request captured during dispatch but not yet executed.
+
+    The caller (``_merge.py``) runs ``apply_pending_cascades`` after
+    writing back the entity it had loaded in memory, so the cascade's
+    file mutations don't race with the merge's pending write.
+    """
+    bad_doc_id: str
+    pattern: str         # "different_tail" | "divergent_validity"
+    audit_payload: Dict[str, Any] = field(default_factory=dict)
 
 
 def _noop_audit(_payload: Dict[str, Any]) -> None:
@@ -131,17 +154,23 @@ def dispatch_contradictions_for_merge(
             ``ignored``). Defaults to no-op.
 
     Returns:
-        ``(rels_to_merge, dispatch_log)``:
-          - ``rels_to_merge``: ``new_rels`` with contradicting ones
-            filtered out. The caller's regular sources-append path
-            handles whatever remains.
+        ``(rels_to_merge, dispatch_log, pending_cascades)``:
+          - ``rels_to_merge``: ``new_rels`` with B_supersede/ignore
+            cases filtered out. A_invalidate cases stay so the regular
+            sources-append path adds the new rel as a fresh edge
+            (cascade runs after the write removes the wrong source).
           - ``dispatch_log``: per-decision audit entries
             (``new_rel``, ``existing_rel``, ``pattern``, ``label``,
-            ``action``). Useful for tests + future ``audit_log`` mirroring.
+            ``action``). Useful for tests + ``audit_log`` mirroring.
+          - ``pending_cascades``: deferred ``PendingCascade`` requests
+            the caller MUST execute (via ``apply_pending_cascades``)
+            after writing back its in-memory entity state — otherwise
+            A_invalidate decisions are silently dropped.
     """
     emit = audit_emit or _noop_audit
     rels_to_merge: List[Dict[str, Any]] = []
     dispatch_log: List[Dict[str, Any]] = []
+    pending_cascades: List[PendingCascade] = []
 
     now_dt = _parse_iso(ingest_ts) or datetime.now(timezone.utc)
 
@@ -196,19 +225,45 @@ def dispatch_contradictions_for_merge(
             })
 
         elif label == "A_invalidate":
-            # T2.D-2.b territory — cascade_remove is deferred so
-            # _merge.py doesn't race with cascade on the same entity
-            # file. This PR logs the decision; the new_rel is
-            # dropped on the assumption that the deferred cascade
-            # would have invalidated the conflicting source.
-            log_entry["action"] = "a_invalidate_logged_deferred"
-            emit({
-                "endpoint":      "lifecycle:ingest_contradiction",
-                "role":          "system",
-                "mutation_type": "invalidated_deferred",
-                "pattern":       pattern,
-                "note":          "cascade_remove deferred to T2.D-2.b",
-            })
+            # T2.D-2.b — collect a PendingCascade for the lowest-weight
+            # non-manual source on existing_rel + KEEP new_rel in
+            # rels_to_merge. The regular merge loop appends new_rel
+            # as a fresh edge; the caller runs the cascade
+            # post-write so it doesn't race with the in-memory
+            # entity edit.
+            bad_doc_id = _pick_cascade_target(existing_rel)
+            if bad_doc_id is None:
+                # No cascadeable source on existing_rel — keep new_rel
+                # and log as no-op. Defensive: an edge with no usable
+                # source shouldn't have made it to dispatch, but if
+                # it did we don't manufacture an invalid cascade.
+                log_entry["action"] = "a_invalidate_no_cascade_target"
+                rels_to_merge.append(new_rel)
+                emit({
+                    "endpoint":      "lifecycle:ingest_contradiction",
+                    "role":          "system",
+                    "mutation_type": "invalidated_skipped",
+                    "pattern":       pattern,
+                    "note":          "existing_rel has no cascadeable source",
+                })
+            else:
+                audit_payload = {
+                    "endpoint":      "lifecycle:ingest_contradiction",
+                    "role":          "system",
+                    "mutation_type": "invalidated",
+                    "pattern":       pattern,
+                    "bad_doc_id":    bad_doc_id,
+                    "old_edge_id":   existing_rel.get("id"),
+                }
+                pending_cascades.append(PendingCascade(
+                    bad_doc_id=bad_doc_id,
+                    pattern=pattern,
+                    audit_payload=audit_payload,
+                ))
+                rels_to_merge.append(new_rel)
+                log_entry["action"] = "a_invalidate_cascade_pending"
+                log_entry["bad_doc_id"] = bad_doc_id
+                emit(audit_payload)
 
         else:
             # Defensive — classifier returned a label we don't
@@ -218,10 +273,92 @@ def dispatch_contradictions_for_merge(
 
         dispatch_log.append(log_entry)
 
-    return rels_to_merge, dispatch_log
+    return rels_to_merge, dispatch_log, pending_cascades
+
+
+def _pick_cascade_target(existing_rel: Dict[str, Any]) -> Optional[str]:
+    """Pick the doc_id whose source should be cascaded out of the
+    existing edge. Conservative heuristic: lowest-weight non-manual
+    source. Returns ``None`` if no eligible source.
+
+    Manual sources are NEVER returned — ``cascade_remove_doc_from_sources``
+    preserves them by design (manual role = operator-curated, immune
+    from cascade), and picking one as the cascade target would be a
+    no-op that hides the actual cascade miss.
+    """
+    sources = existing_rel.get("sources") if isinstance(existing_rel, dict) else None
+    if not isinstance(sources, list) or not sources:
+        return None
+    eligible: List[Tuple[float, str]] = []
+    for s in sources:
+        if not isinstance(s, dict):
+            continue
+        doc_id = s.get("doc_id")
+        role = s.get("role")
+        if not isinstance(doc_id, str) or not doc_id:
+            continue
+        if role == "manual":
+            continue
+        weight = s.get("weight")
+        weight_f = float(weight) if isinstance(weight, (int, float)) else 0.0
+        eligible.append((weight_f, doc_id))
+    if not eligible:
+        return None
+    eligible.sort(key=lambda x: x[0])
+    return eligible[0][1]
+
+
+def apply_pending_cascades(
+    pending_cascades: List[PendingCascade],
+    entity_root: Union[Path, str],
+    *,
+    audit_emit: Optional[AuditEmit] = None,
+) -> List[Dict[str, Any]]:
+    """Execute the cascade requests captured by
+    ``dispatch_contradictions_for_merge`` against the wiki on disk.
+
+    Call AFTER the caller writes back any in-memory entity state.
+    Otherwise the cascade can race with the pending write (T2.D-2's
+    original bug).
+
+    Args:
+        pending_cascades: list from ``dispatch_contradictions_for_merge``.
+        entity_root: directory whose ``rglob("*.md")`` is the wiki's
+            entity file set (typically ``wiki/entity/prod/`` or
+            equivalent). Each cascade removes ``bad_doc_id`` from
+            every entity file under this root.
+        audit_emit: optional callback for emitting post-cascade
+            audit rows (one per cascade), enriched with the
+            ``cascade_remove`` counts dict.
+
+    Returns:
+        list of per-cascade result dicts, each ``{"bad_doc_id": …,
+        "counts": {entities_scanned, entities_touched,
+        relations_recomputed, relations_dropped}}``. Empty list
+        when no cascades were pending.
+    """
+    if not pending_cascades:
+        return []
+    emit = audit_emit or _noop_audit
+    root = Path(entity_root)
+    results: List[Dict[str, Any]] = []
+    for pc in pending_cascades:
+        counts = cascade_remove_doc_from_sources(pc.bad_doc_id, root)
+        results.append({
+            "bad_doc_id": pc.bad_doc_id,
+            "counts":     counts,
+        })
+        payload = dict(pc.audit_payload)
+        payload["cascade_counts"] = counts
+        payload.setdefault("mutation_type", "invalidated")
+        payload["mutation_type"] = "invalidated_applied"
+        emit(payload)
+    return results
 
 
 __all__ = [
     "AuditEmit",
+    "PendingCascade",
+    "apply_pending_cascades",
     "dispatch_contradictions_for_merge",
 ]

--- a/core/wiki_generator/_merge.py
+++ b/core/wiki_generator/_merge.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from core.lifecycle.ingest_contradiction import (
+    apply_pending_cascades,
     dispatch_contradictions_for_merge,
 )
 from core.relations_schema import (
@@ -138,23 +139,26 @@ class WikiMergeMixin:
         sources_appended = 0
         relations_added  = 0
 
-        # T2.D-2 — opt-in contradiction dispatch pre-merge hook.
+        # T2.D-2 + T2.D-2.b — opt-in contradiction dispatch pre-merge hook.
         # JAMES_T2D_INGEST_DISPATCH=1 enables the v0.4.1 contradiction
         # arbiter on (head, predicate) matches between new_relations
         # and existing_rels. Default OFF preserves byte-identical
         # legacy behavior. B_supersede + ignore paths handled in-line;
-        # A_invalidate is logged + deferred to T2.D-2.b (cascade race
-        # with the in-memory entity edit is the open problem). The
-        # dispatcher mutates existing_rels in place for B_supersede
-        # (new edge appended via supersede_edge contract) and returns
-        # a filtered new_relations list for the regular merge loop.
+        # A_invalidate captured as pending_cascades for post-write
+        # execution (see below). The dispatcher mutates existing_rels
+        # in place for B_supersede (new edge appended via supersede_edge
+        # contract) and returns a filtered new_relations list for the
+        # regular merge loop.
+        pending_cascades: list = []
         if os.environ.get("JAMES_T2D_INGEST_DISPATCH") == "1":
             try:
-                new_relations, _dispatch_log = dispatch_contradictions_for_merge(
-                    list(new_relations),
-                    existing_rels,
-                    ingest_doc_id=doc_id,
-                    ingest_ts=ts,
+                new_relations, _dispatch_log, pending_cascades = (
+                    dispatch_contradictions_for_merge(
+                        list(new_relations),
+                        existing_rels,
+                        ingest_doc_id=doc_id,
+                        ingest_ts=ts,
+                    )
                 )
             except Exception as e:
                 # Defensive — never let the dispatch hook crash the
@@ -164,6 +168,7 @@ class WikiMergeMixin:
                 print(f"[t2d-ingest] dispatch hook crashed, "
                       f"falling back to legacy merge: "
                       f"{type(e).__name__}: {e}")
+                pending_cascades = []
 
         for new_rel in new_relations:
             if not isinstance(new_rel, dict):
@@ -246,6 +251,20 @@ class WikiMergeMixin:
             + body
         )
         Path(path).write_text(new_text, encoding="utf-8")
+
+        # T2.D-2.b — execute pending_cascades AFTER write_text so the
+        # cascade's file mutations don't race with this entity's
+        # pending write. The cascade may further modify this entity's
+        # file (removing the bad source); that's a separate read-then-
+        # write inside cascade_remove_doc_from_sources and is safe
+        # because the merge write has already committed.
+        if pending_cascades:
+            try:
+                entity_root = self.wiki_base_path / "entity" / self.source_type
+                apply_pending_cascades(pending_cascades, entity_root)
+            except Exception as e:
+                print(f"[t2d-ingest] post-write cascade crashed; merge "
+                      f"already committed: {type(e).__name__}: {e}")
 
         return {
             "merged_into":      1,

--- a/tests/test_t2d2_ingest_contradiction.py
+++ b/tests/test_t2d2_ingest_contradiction.py
@@ -18,11 +18,14 @@ from __future__ import annotations
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.lifecycle.ingest_contradiction import (  # noqa: E402
+    PendingCascade,
+    apply_pending_cascades,
     dispatch_contradictions_for_merge,
 )
 
@@ -79,7 +82,7 @@ class BSupersedePathTests(unittest.TestCase):
         # new_fact.valid_from OR validity.from OR timestamp/ts.
         new_rel["valid_from"] = "2026-05-28T00:00:00Z"
 
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="new_doc",
             ingest_ts="2026-05-28T00:00:00Z",
@@ -119,7 +122,7 @@ class IgnorePathTests(unittest.TestCase):
         new_rel = _new_rel("X", "RELATED_TO", confidence=0.85)
         new_rel["timestamp"] = "2026-01-01T00:00:00Z"
 
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="dup_doc",
             ingest_ts="2026-01-01T00:00:00Z",
@@ -139,36 +142,48 @@ class IgnorePathTests(unittest.TestCase):
 # A_invalidate path — deferred (logged only)
 # ---------------------------------------------------------------------------
 
-class AInvalidateDeferredPathTests(unittest.TestCase):
+class AInvalidatePendingCascadeTests(unittest.TestCase):
     """Rule 2: A_invalidate fires when new is higher-confidence AND
-    timestamp ≤ old_edge.validity.from. T2.D-2 only LOGS — cascade
-    deferred to T2.D-2.b (race with _merge.py write-after-read)."""
+    timestamp ≤ old_edge.validity.from. T2.D-2.b: dispatcher captures
+    a PendingCascade + KEEPS new_rel for the regular merge loop.
+    Caller (``_merge.py``) runs ``apply_pending_cascades`` after
+    writing the entity to avoid the write-after-read race."""
 
-    def test_a_invalidate_logged_and_new_rel_dropped(self):
+    def test_a_invalidate_records_pending_cascade(self):
         existing = [
             _v04_edge("X", "RELATED_TO", valid_from="2026-01-01T00:00:00Z",
-                      sources_weight=0.5),
+                      sources_weight=0.5,
+                      edge_id="e_edge_existing"),
         ]
         # Higher-confidence retroactive correction.
         new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
         new_rel["timestamp"] = "2025-06-01T00:00:00Z"
 
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="correction_doc",
             ingest_ts="2025-06-01T00:00:00Z",
         )
 
-        # new_rel was dropped on the assumption a future cascade
-        # invalidates the wrong source.
-        self.assertEqual(rels_to_merge, [])
-        # No new edge — supersede did NOT run. T2.D-2.b will
-        # call cascade after the merge completes.
+        # new_rel is KEPT — the regular merge loop adds it as a fresh
+        # edge; the post-write cascade removes the wrong source.
+        self.assertEqual(rels_to_merge, [new_rel])
+        # No supersede edge appended.
         self.assertEqual(len(existing), 1)
-        # Log carries the deferred marker.
+        # Log carries the cascade-pending marker + bad_doc_id.
         self.assertEqual(len(log), 1)
         self.assertEqual(log[0]["label"], "A_invalidate")
-        self.assertEqual(log[0]["action"], "a_invalidate_logged_deferred")
+        self.assertEqual(log[0]["action"], "a_invalidate_cascade_pending")
+        self.assertEqual(log[0]["bad_doc_id"], "old_doc")
+        # Pending cascades list contains the cascade request.
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].bad_doc_id, "old_doc")
+        self.assertEqual(pending[0].pattern, "divergent_validity")
+        self.assertIn("audit_payload", pending[0].__dict__)
+        self.assertEqual(
+            pending[0].audit_payload["old_edge_id"],
+            "e_edge_existing",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +204,7 @@ class NoCandidatePassthroughTests(unittest.TestCase):
         """
         existing: list = []
         new_rel = _new_rel("Y", "BASED_IN")
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
         )
@@ -201,7 +216,7 @@ class NoCandidatePassthroughTests(unittest.TestCase):
         returns no candidate → passthrough."""
         existing = [{"target": "X", "type": "RELATED_TO"}]
         new_rel = _new_rel("X", "RELATED_TO")
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
         )
@@ -209,7 +224,7 @@ class NoCandidatePassthroughTests(unittest.TestCase):
         self.assertEqual(log, [])
 
     def test_empty_input_returns_empty(self):
-        rels, log = dispatch_contradictions_for_merge(
+        rels, log, _pending = dispatch_contradictions_for_merge(
             [], [],
             ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
         )
@@ -245,10 +260,16 @@ class AuditEmitTests(unittest.TestCase):
         self.assertIn("old_edge_id", payload)
         self.assertIn("new_edge_id", payload)
 
-    def test_a_invalidate_emits_deferred_marker(self):
+    def test_a_invalidate_emits_pending_cascade_audit(self):
+        """T2.D-2.b — A_invalidate emits a regular ``invalidated``
+        audit row carrying ``bad_doc_id`` + ``old_edge_id``. The
+        ``apply_pending_cascades`` post-write helper then emits a
+        second audit row (mutation_type=invalidated_applied) with
+        the cascade counts. This test covers only the dispatcher's
+        pre-cascade emit; apply_pending_cascades tests cover the rest."""
         existing = [
             _v04_edge("X", "RELATED_TO", valid_from="2026-01-01T00:00:00Z",
-                      sources_weight=0.5),
+                      sources_weight=0.5, edge_id="e_edge_a"),
         ]
         new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
         new_rel["timestamp"] = "2025-06-01T00:00:00Z"
@@ -263,8 +284,11 @@ class AuditEmitTests(unittest.TestCase):
 
         emit.assert_called_once()
         payload = emit.call_args[0][0]
-        self.assertEqual(payload["mutation_type"], "invalidated_deferred")
-        self.assertEqual(payload["note"], "cascade_remove deferred to T2.D-2.b")
+        self.assertEqual(payload["mutation_type"], "invalidated")
+        self.assertEqual(payload["bad_doc_id"], "old_doc")
+        self.assertEqual(payload["old_edge_id"], "e_edge_a")
+        self.assertEqual(payload["endpoint"],
+                         "lifecycle:ingest_contradiction")
 
 
 # ---------------------------------------------------------------------------
@@ -278,7 +302,7 @@ class EdgeCaseTests(unittest.TestCase):
         Valid dicts pass through; non-dicts are skipped."""
         existing: list = []
         # Mix of None, str, valid dict
-        rels, log = dispatch_contradictions_for_merge(
+        rels, log, _pending = dispatch_contradictions_for_merge(
             [None, "not a dict", {"target": "Y", "type": "BASED_IN"}],  # type: ignore[list-item]
             existing,
             ingest_doc_id="doc", ingest_ts="2026-05-28T00:00:00Z",
@@ -297,7 +321,7 @@ class EdgeCaseTests(unittest.TestCase):
 
         # ingest_ts is garbage → falls back to now(UTC) which is
         # 2026-05-28T... > 2026-01-01 valid_to → B_supersede still fires
-        rels, log = dispatch_contradictions_for_merge(
+        rels, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], existing,
             ingest_doc_id="doc", ingest_ts="not an iso date",
         )
@@ -305,6 +329,170 @@ class EdgeCaseTests(unittest.TestCase):
         # B_supersede should still fire because new valid_from is
         # strictly later than old validity.to.
         self.assertEqual(log[0]["label"], "B_supersede")
+
+
+# ---------------------------------------------------------------------------
+# apply_pending_cascades — T2.D-2.b post-write cascade execution
+# ---------------------------------------------------------------------------
+
+class ApplyPendingCascadesTests(unittest.TestCase):
+    """The helper that runs the cascade requests collected during
+    dispatch. Caller MUST invoke this after writing back the in-memory
+    entity state — otherwise A_invalidate cascades are silently
+    dropped (the dispatcher just records them)."""
+
+    def test_empty_list_returns_empty(self):
+        result = apply_pending_cascades([], Path("/tmp/nope"))
+        self.assertEqual(result, [])
+
+    def test_calls_cascade_remove_per_request(self):
+        """Each PendingCascade triggers one cascade_remove call.
+        Mock the underlying function to keep the test filesystem-free."""
+        cascades = [
+            PendingCascade(
+                bad_doc_id="bad_doc_1",
+                pattern="divergent_validity",
+                audit_payload={"endpoint": "lifecycle:ingest_contradiction",
+                               "mutation_type": "invalidated",
+                               "bad_doc_id": "bad_doc_1",
+                               "old_edge_id": "e_edge_a"},
+            ),
+            PendingCascade(
+                bad_doc_id="bad_doc_2",
+                pattern="different_tail",
+                audit_payload={"endpoint": "lifecycle:ingest_contradiction",
+                               "mutation_type": "invalidated",
+                               "bad_doc_id": "bad_doc_2",
+                               "old_edge_id": "e_edge_b"},
+            ),
+        ]
+        fake_counts = {
+            "entities_scanned":     5,
+            "entities_touched":     1,
+            "relations_recomputed": 1,
+            "relations_dropped":    0,
+        }
+        with patch(
+            "core.lifecycle.ingest_contradiction.cascade_remove_doc_from_sources",
+            return_value=fake_counts,
+        ) as mock_cascade:
+            results = apply_pending_cascades(cascades, Path("/fake/root"))
+        self.assertEqual(mock_cascade.call_count, 2)
+        # Per-cascade result includes bad_doc_id + counts.
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["bad_doc_id"], "bad_doc_1")
+        self.assertEqual(results[0]["counts"], fake_counts)
+        self.assertEqual(results[1]["bad_doc_id"], "bad_doc_2")
+
+    def test_audit_emit_post_cascade(self):
+        """Each cascade emission carries the audit payload from the
+        pending cascade + a ``cascade_counts`` key + mutation_type
+        promoted to ``invalidated_applied``."""
+        pending = [PendingCascade(
+            bad_doc_id="bad_doc_x",
+            pattern="divergent_validity",
+            audit_payload={"endpoint": "lifecycle:ingest_contradiction",
+                           "mutation_type": "invalidated",
+                           "bad_doc_id": "bad_doc_x",
+                           "old_edge_id": "e_edge_x"},
+        )]
+        fake_counts = {
+            "entities_scanned":     3,
+            "entities_touched":     1,
+            "relations_recomputed": 0,
+            "relations_dropped":    1,
+        }
+        emit = MagicMock()
+        with patch(
+            "core.lifecycle.ingest_contradiction.cascade_remove_doc_from_sources",
+            return_value=fake_counts,
+        ):
+            apply_pending_cascades(pending, Path("/fake/root"), audit_emit=emit)
+        emit.assert_called_once()
+        payload = emit.call_args[0][0]
+        self.assertEqual(payload["mutation_type"], "invalidated_applied")
+        self.assertEqual(payload["bad_doc_id"], "bad_doc_x")
+        self.assertEqual(payload["cascade_counts"], fake_counts)
+        self.assertEqual(payload["old_edge_id"], "e_edge_x")
+
+
+# ---------------------------------------------------------------------------
+# _pick_cascade_target — the bad_doc_id heuristic
+# ---------------------------------------------------------------------------
+
+class PickCascadeTargetTests(unittest.TestCase):
+    """Test the lowest-weight-non-manual heuristic via the dispatcher
+    (the helper is module-private; we exercise it through the public
+    A_invalidate path)."""
+
+    def test_skips_manual_sources(self):
+        """Manual-role sources are NEVER picked as the cascade target —
+        cascade_remove preserves them by design. The lowest-weight
+        NON-MANUAL source is chosen.
+
+        Existing best non-manual = strong_doc 0.9 → new_rel needs
+        confidence > 0.9 to trigger classifier rule 2 (A_invalidate).
+        Manual weight stays out of the best-source comparison because
+        the classifier reads sources[].weight uniformly; the
+        ``_pick_cascade_target`` heuristic is separate."""
+        existing = [{
+            "id": "e_edge_a",
+            "target": "X", "type": "RELATED_TO",
+            "validity": {"from": "2026-01-01T00:00:00Z", "to": None},
+            "status": {"active": True},
+            "mutation_type": "active",
+            "sources": [
+                {"doc_id": "manual_seed", "role": "manual",  "weight": 0.5},
+                {"doc_id": "weak_doc",    "role": "extract", "weight": 0.3},
+                {"doc_id": "strong_doc",  "role": "extract", "weight": 0.9},
+            ],
+        }]
+        new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
+        new_rel["timestamp"] = "2025-06-01T00:00:00Z"
+
+        _rels, log, pending = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="correction_doc",
+            ingest_ts="2025-06-01T00:00:00Z",
+        )
+        # Classifier should have routed to A_invalidate.
+        self.assertEqual(log[0]["label"], "A_invalidate")
+        # bad_doc_id should be the LOWEST-weight NON-MANUAL source.
+        self.assertEqual(log[0]["bad_doc_id"], "weak_doc")
+        self.assertEqual(pending[0].bad_doc_id, "weak_doc")
+
+    def test_no_cascadeable_source_skips(self):
+        """Existing edge has only manual sources → no cascade target →
+        action = a_invalidate_no_cascade_target, new_rel kept anyway.
+
+        Note: this test uses _v04_edge-style with manual=0.6 source
+        so the classifier still picks A_invalidate (new 0.95 > best
+        manual 0.6) — exercising the no-eligible-cascade-target path
+        of ``_pick_cascade_target``."""
+        existing = [{
+            "id": "e_edge_a",
+            "target": "X", "type": "RELATED_TO",
+            "validity": {"from": "2026-01-01T00:00:00Z", "to": None},
+            "status": {"active": True},
+            "mutation_type": "active",
+            "sources": [
+                {"doc_id": "manual_seed", "role": "manual", "weight": 0.6},
+            ],
+        }]
+        new_rel = _new_rel("X", "RELATED_TO", confidence=0.95)
+        new_rel["timestamp"] = "2025-06-01T00:00:00Z"
+
+        rels, log, pending = dispatch_contradictions_for_merge(
+            [new_rel], existing,
+            ingest_doc_id="correction_doc",
+            ingest_ts="2025-06-01T00:00:00Z",
+        )
+        # Classifier still says A_invalidate (new > best).
+        self.assertEqual(log[0]["label"], "A_invalidate")
+        # But there's no eligible cascade source → no pending.
+        self.assertEqual(rels, [new_rel])  # kept anyway
+        self.assertEqual(len(pending), 0)
+        self.assertEqual(log[0]["action"], "a_invalidate_no_cascade_target")
 
 
 if __name__ == "__main__":

--- a/tests/test_t2d3_dispatch_acceptance.py
+++ b/tests/test_t2d3_dispatch_acceptance.py
@@ -121,7 +121,7 @@ class BSupersedeAcceptanceTests(unittest.TestCase):
             valid_from="2026-06-01T00:00:00Z",
         )
 
-        rels_to_merge, log = dispatch_contradictions_for_merge(
+        rels_to_merge, log, _pending = dispatch_contradictions_for_merge(
             [new_rel], self.existing_rels,
             ingest_doc_id="press_release_2026_q2",
             ingest_ts="2026-06-01T00:00:00Z",


### PR DESCRIPTION
## Summary

Closes the **T2.D-2 deferred A_invalidate path** that the v0.4.1 entry memo flagged as carry-over. The dispatcher now captures cascade requests as `PendingCascade` records instead of silently logging them; the caller (`_merge.py`) runs `apply_pending_cascades` AFTER writing back its in-memory entity state, so the cascade's file mutations don't race with the merge's pending write.

| # | PR | scope |
|---|---|---|
| ✅ T2.D-1 | #558 | contradiction detector + tests |
| ✅ T2.D-2 | #559 | flag-gated dispatch (B + ignore + log-only A) |
| ✅ T2.D-3 | #560 | step7 v6 q17 + acceptance test |
| **T2.D-2.b** | **this PR** | A_invalidate cascade race fix |
| ⏳ T2.D-4 | — | flip `JAMES_T2D_INGEST_DISPATCH` default to ON |

## API change — 3-tuple return

```python
# Before (T2.D-2): 2-tuple
rels_to_merge, dispatch_log = dispatch_contradictions_for_merge(...)

# After (T2.D-2.b): 3-tuple
rels_to_merge, dispatch_log, pending_cascades = dispatch_contradictions_for_merge(...)
```

**Breaking** vs T2.D-2's contract. The production caller (`_merge.py`) + 9 call sites in `tests/test_t2d2_ingest_contradiction.py` + 1 call site in `tests/test_t2d3_dispatch_acceptance.py` all updated in this PR.

## A_invalidate flow

**Before** (T2.D-2): logged only, `new_rel` dropped.

**After** (T2.D-2.b):
1. Dispatcher records a `PendingCascade(bad_doc_id, pattern, audit_payload)`.
2. **`new_rel` is KEPT** in `rels_to_merge` so the regular merge loop appends it as a fresh edge.
3. After `_merge.py` calls `Path(path).write_text(...)`, it calls `apply_pending_cascades(pending_cascades, entity_root)`.
4. The cascade removes `bad_doc_id` sources from every entity file. The just-written entity may itself be touched — that's safe because the write committed first.

## The `bad_doc_id` heuristic

`_pick_cascade_target(existing_rel)` picks the **lowest-weight non-manual** source's `doc_id`. Manual sources are excluded by design (`cascade_remove_doc_from_sources` preserves them).

If existing_rel has no eligible source (only manual / no sources at all), the dispatcher logs `a_invalidate_no_cascade_target` + emits `mutation_type=invalidated_skipped` + keeps `new_rel` for the regular merge.

## Files

| file | LOC change |
|---|---|
| `core/lifecycle/ingest_contradiction.py` | +159 (15 KB total, under 20 KB cap) |
| `core/wiki_generator/_merge.py` | +22 (capture pending + post-write apply) |
| `tests/test_t2d2_ingest_contradiction.py` | +200 (renamed + extended A_invalidate tests, new ApplyPendingCascadesTests + PickCascadeTargetTests) |
| `tests/test_t2d3_dispatch_acceptance.py` | +1 (3-tuple compat) |

## Verification

- `python -m unittest tests.test_t2d2_ingest_contradiction tests.test_t2d3_dispatch_acceptance tests.test_t2d1_contradiction_detector tests.test_qvt_oracle tests.test_step7_v5_schema` → **73/73 pass**
- `python -m ruff check core/lifecycle/ingest_contradiction.py core/wiki_generator/_merge.py tests/test_t2d2_ingest_contradiction.py` → All checks passed
- Module size **15 KB** (CLAUDE.md rule 5 ≤ 20 KB) ✓
- Flag default OFF preserved → production byte-identical unless `JAMES_T2D_INGEST_DISPATCH=1`

## Audit replay invariant preserved

`apply_pending_cascades` is fully deterministic given the same input ordering. `(bench_json, fixture, oracle_code, dispatch_inputs)` → byte-identical end state. Consistent with the Replayable RAG positioning.

## Quality Delta vs baseline

`Quality delta: exempt (label: code — flag-gated default OFF; flip to default ON happens in T2.D-4 alongside a fresh baseline capture that paired-compares vs baseline_2a31b20.json)`.

## Out of scope

- **T2.D-4** — operator seeds the production Anthropic CEO_OF edge (or similar v0.4 lifecycle edge) + flips `JAMES_T2D_INGEST_DISPATCH` to default ON + captures a fresh baseline JSON.
- Multi-candidate dispatch ordering (P1 first, then P2) — current heuristic is "first candidate wins"; revisit when fixtures show this matters.
- `cascade_remove_doc_from_sources` re-reading the entity file post-merge is unavoidable; the safety guarantee is that it happens AFTER the merge write, not concurrent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)