### PR TITLE
feat(lifecycle): v0.4.1 PR-T6.A — derived_from schema + cycle validator + migration

### DIFF
--- a/core/lifecycle/schema.py
+++ b/core/lifecycle/schema.py
@@ -72,6 +72,28 @@ T7_EDGE_FIELD_VALIDITY:      Final[str] = "validity"
 T7_EDGE_FIELD_STATUS:        Final[str] = "status"
 T7_EDGE_FIELD_MUTATION_TYPE: Final[str] = "mutation_type"
 
+# ─── T6 Causality Chain (v0.4.1, 2026-05-28) ─────────────────────
+#
+# Edge-level ``derived_from`` field tracks the base facts that an
+# inferred edge depends on. When a base fact is invalidated by
+# CASCADE, derived edges automatically lose their support and become
+# invalidation candidates (T6 cascade, separate module).
+#
+# Per v0.4.1 entry memo Decision 3 LOCK: cycles are rejected at
+# schema validation time (a derivation that includes itself in its
+# transitive chain is genuine schema confusion).
+T6_EDGE_FIELD_DERIVED_FROM: Final[str] = "derived_from"
+
+T6_DERIVATION_TRANSITIVE: Final[str] = "transitive"
+T6_DERIVATION_OPERATOR:   Final[str] = "operator"
+T6_DERIVATION_INFERRED:   Final[str] = "inferred"
+
+VALID_DERIVATION_TYPES: Final[frozenset[str]] = frozenset({
+    T6_DERIVATION_TRANSITIVE,
+    T6_DERIVATION_OPERATOR,
+    T6_DERIVATION_INFERRED,
+})
+
 
 def _parse_optional_iso(value: Any) -> datetime | None:
     """Return parsed ``datetime`` for an ISO-8601 string, ``None`` for
@@ -282,6 +304,135 @@ def apply_v04_edge_defaults(edge: dict) -> dict:
     return out
 
 
+# ─── T6 derived_from validator + defaults (v0.4.1) ───────────────
+
+
+def validate_edge_t6_derived_from(
+    edge: dict,
+    *,
+    edges_by_id: dict | None = None,
+) -> None:
+    """Raise ``ValueError`` if the edge's ``derived_from`` field is
+    malformed OR (when ``edges_by_id`` is provided) introduces a
+    derivation cycle.
+
+    Acceptable shapes:
+      - ``derived_from`` missing → OK (treated as ``[]``, v0.3-equivalent)
+      - ``derived_from: []``     → OK (the migration-script default)
+      - ``derived_from: [{base_fact_id: str, derivation: str ∈
+        VALID_DERIVATION_TYPES}, …]`` → validated entry-by-entry
+
+    Decision 3 LOCK (v0.4.1 entry memo §2): when ``edges_by_id`` is
+    provided (mapping ``id`` → ``edge`` for all edges in scope), this
+    function walks each ``base_fact_id``'s transitive chain and raises
+    ``ValueError`` on cycle (the edge itself appears in its own
+    ancestor set). Pass ``edges_by_id=None`` to skip cycle detection
+    (single-edge validation without ancestor context).
+
+    Args:
+        edge: the edge dict to validate.
+        edges_by_id: optional map from edge id to edge dict, used for
+            cycle detection. When omitted, only shape is checked.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+
+    derived_from = edge.get(T6_EDGE_FIELD_DERIVED_FROM)
+    if derived_from is None:
+        return
+    if not isinstance(derived_from, list):
+        raise ValueError(
+            f"edge.derived_from must be a list, got "
+            f"{type(derived_from).__name__}"
+        )
+
+    for i, entry in enumerate(derived_from):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"edge.derived_from[{i}] must be a dict, got "
+                f"{type(entry).__name__}"
+            )
+        base_fact_id = entry.get("base_fact_id")
+        if not isinstance(base_fact_id, str) or not base_fact_id:
+            raise ValueError(
+                f"edge.derived_from[{i}].base_fact_id must be a "
+                f"non-empty str, got {base_fact_id!r}"
+            )
+        derivation = entry.get("derivation")
+        if derivation not in VALID_DERIVATION_TYPES:
+            raise ValueError(
+                f"edge.derived_from[{i}].derivation must be one of "
+                f"{sorted(VALID_DERIVATION_TYPES)}, got {derivation!r}"
+            )
+
+    # Decision 3 LOCK — cycle rejection. Walk every base_fact_id's
+    # transitive chain; if we encounter the edge's own id, raise.
+    if edges_by_id is None:
+        return
+    edge_id = edge.get("id")
+    if not isinstance(edge_id, str) or not edge_id:
+        # Without a stable id we can't recognize the cycle endpoint.
+        # Skip — calling code that wants strict cycle checking sets
+        # an id on the edge before validation.
+        return
+    _walk_for_cycle(edge_id, derived_from, edges_by_id, visited=set())
+
+
+def _walk_for_cycle(
+    target_id: str,
+    derivations: list,
+    edges_by_id: dict,
+    *,
+    visited: set,
+) -> None:
+    """Recursive helper for cycle detection. Walks transitive base
+    chains; raises ``ValueError`` if ``target_id`` reappears."""
+    for entry in derivations:
+        if not isinstance(entry, dict):
+            continue
+        base_fact_id = entry.get("base_fact_id")
+        if not isinstance(base_fact_id, str) or not base_fact_id:
+            continue
+        if base_fact_id == target_id:
+            raise ValueError(
+                f"derivation cycle: edge id={target_id!r} appears in "
+                f"its own transitive derived_from chain — Decision 3 "
+                f"LOCK rejects self-referential derivations"
+            )
+        if base_fact_id in visited:
+            continue
+        visited.add(base_fact_id)
+        base = edges_by_id.get(base_fact_id)
+        if not isinstance(base, dict):
+            continue
+        base_derivations = base.get(T6_EDGE_FIELD_DERIVED_FROM)
+        if isinstance(base_derivations, list):
+            _walk_for_cycle(
+                target_id, base_derivations, edges_by_id,
+                visited=visited,
+            )
+
+
+def apply_t6_edge_defaults(edge: dict) -> dict:
+    """Return a copy of ``edge`` with the v0.4.1 ``derived_from``
+    field set to ``[]`` when absent. Idempotent — re-running on an
+    already-migrated edge yields the same dict.
+
+    The migration script (T6.A's ``scripts/migrate_v041_lifecycle.py``)
+    calls this on every edge in every entity file, then writes back
+    only when the dict actually changed (byte-stable).
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    out = dict(edge)
+    out.setdefault(T6_EDGE_FIELD_DERIVED_FROM, [])
+    return out
+
+
 __all__ = [
     # mutation type enum
     "T1_MUTATION_ACTIVE",
@@ -295,6 +446,15 @@ __all__ = [
     "T7_EDGE_FIELD_VALIDITY",
     "T7_EDGE_FIELD_STATUS",
     "T7_EDGE_FIELD_MUTATION_TYPE",
+    "T6_EDGE_FIELD_DERIVED_FROM",
+    # T6 derivation type enum
+    "T6_DERIVATION_TRANSITIVE",
+    "T6_DERIVATION_OPERATOR",
+    "T6_DERIVATION_INFERRED",
+    "VALID_DERIVATION_TYPES",
+    # T6 validators + defaults
+    "validate_edge_t6_derived_from",
+    "apply_t6_edge_defaults",
     # validators
     "validate_source_v04_fields",
     "validate_edge_v04_fields",

--- a/scripts/migrate_v041_lifecycle.py
+++ b/scripts/migrate_v041_lifecycle.py
@@ -1,0 +1,323 @@
+"""v0.4.1 PR-T6.A — Layer 4 schema migration (T6 derived_from field).
+
+v0.4.1 entry memo §3 PR-T6.A scope. Adds ``derived_from: []`` to every
+relation in every wiki entity. The validator + defaults helpers
+land first at ``core/lifecycle/schema.py``
+(``apply_t6_edge_defaults`` + ``validate_edge_t6_derived_from``); this
+script back-fills the wiki on disk.
+
+Default field value (every newly-migrated relation):
+
+  ``derived_from: []``  (no inferred-fact dependencies — v0.3-equivalent)
+
+Properties (every one pinned by ``tests/test_migrate_v041_lifecycle.py``):
+
+- **Idempotent.** Running ``--apply`` twice leaves the wiki byte-
+  identical after the first run. ``apply_t6_edge_defaults`` uses
+  ``setdefault`` semantics, so re-running on already-migrated entities
+  is a no-op.
+- **v0.3-equivalent behavior.** The default ``[]`` says "no derivation
+  base" — existing callers that don't yet read ``derived_from`` see
+  no behavior change.
+- **Atomic per-file write.** ``tempfile.NamedTemporaryFile`` +
+  ``os.replace`` so a crash mid-write doesn't half-update a file.
+- **Snapshot first.** ``--apply`` defaults to copying the wiki to
+  ``wiki.pre-v041-migration/`` so the operator has a one-step
+  rollback path. ``--no-snapshot`` skips when the operator has
+  already taken one.
+
+Operator workflow::
+
+    # 1. Dry-run (default) — count entities that would change
+    python scripts/migrate_v041_lifecycle.py --root wiki
+
+    # 2. Apply with snapshot (creates wiki.pre-v041-migration/)
+    python scripts/migrate_v041_lifecycle.py --root wiki --apply
+
+    # 3. Verify (rerun apply path — should be byte-stable)
+    python scripts/migrate_v041_lifecycle.py --root wiki --verify
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from utils.console import ensure_utf8_console  # noqa: E402
+    ensure_utf8_console()
+except Exception:
+    pass
+
+from core.lifecycle.schema import (  # noqa: E402
+    apply_t6_edge_defaults,
+)
+
+
+DEFAULT_WIKI_ROOT = Path("wiki")
+SNAPSHOT_SUFFIX = "pre-v041-migration"
+
+
+# ───────────────────────────────────────────────────────────────
+# Snapshot
+# ───────────────────────────────────────────────────────────────
+
+
+def snapshot_wiki(wiki_root: Path, force: bool = False) -> Path:
+    """``wiki/`` → ``wiki.pre-v041-migration/`` mirror copy for rollback."""
+    snap = wiki_root.with_name(f"{wiki_root.name}.{SNAPSHOT_SUFFIX}")
+    if snap.exists():
+        if not force:
+            raise FileExistsError(
+                f"snapshot already exists: {snap}\n"
+                f"  -> pass --force to overwrite, or remove it manually\n"
+                f"     (rollback path would be lost on overwrite)"
+            )
+        shutil.rmtree(snap)
+    print(f"[V041_MIGRATE] snapshot {wiki_root} -> {snap}")
+    shutil.copytree(wiki_root, snap)
+    return snap
+
+
+# ───────────────────────────────────────────────────────────────
+# Frontmatter parse / serialize (mirrors v04 migration pattern)
+# ───────────────────────────────────────────────────────────────
+
+
+def _split_frontmatter(text: str) -> tuple[dict | None, str]:
+    if not text.startswith("---"):
+        return None, text
+    end = text.find("---", 3)
+    if end < 0:
+        return None, text
+    try:
+        fm = yaml.safe_load(text[3:end]) or {}
+    except Exception:
+        return None, text
+    body_tail = text[end + 3:]
+    return fm, body_tail
+
+
+def _serialize_frontmatter(fm: dict, body_tail: str) -> str:
+    return (
+        "---\n"
+        + yaml.dump(
+            fm,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+        + "---"
+        + body_tail
+    )
+
+
+# ───────────────────────────────────────────────────────────────
+# Per-file migration
+# ───────────────────────────────────────────────────────────────
+
+
+def _migrate_relation(rel: dict) -> Tuple[dict, bool]:
+    """Apply T6 defaults to one relation. Returns (new_rel, changed)."""
+    migrated = apply_t6_edge_defaults(rel)
+    return migrated, migrated != rel
+
+
+def migrate_entity_file(path: Path) -> dict:
+    """Migrate a single entity .md file in memory. Returns stats dict.
+
+    Stats:
+      {"changed": bool, "relations_total": int, "relations_changed": int,
+       "new_text": str | None}
+
+    Does NOT write back — the caller decides (dry-run vs apply).
+    """
+    text = path.read_text(encoding="utf-8")
+    fm, body_tail = _split_frontmatter(text)
+    if not isinstance(fm, dict):
+        return {
+            "changed": False,
+            "relations_total": 0,
+            "relations_changed": 0,
+            "new_text": None,
+        }
+    relations = fm.get("relations") or []
+    if not isinstance(relations, list):
+        return {
+            "changed": False,
+            "relations_total": 0,
+            "relations_changed": 0,
+            "new_text": None,
+        }
+
+    new_rels = []
+    changed_count = 0
+    for rel in relations:
+        if not isinstance(rel, dict):
+            new_rels.append(rel)
+            continue
+        migrated, changed = _migrate_relation(rel)
+        new_rels.append(migrated)
+        if changed:
+            changed_count += 1
+
+    if changed_count == 0:
+        return {
+            "changed": False,
+            "relations_total": len(relations),
+            "relations_changed": 0,
+            "new_text": None,
+        }
+
+    fm["relations"] = new_rels
+    new_text = _serialize_frontmatter(fm, body_tail)
+    return {
+        "changed": True,
+        "relations_total": len(relations),
+        "relations_changed": changed_count,
+        "new_text": new_text,
+    }
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    """tempfile + os.replace — crash mid-write never half-updates."""
+    dirpath = path.parent
+    fd, tmp = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(dirpath),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+# ───────────────────────────────────────────────────────────────
+# Top-level walker
+# ───────────────────────────────────────────────────────────────
+
+
+def migrate_wiki(
+    wiki_root: Path,
+    *,
+    apply: bool = False,
+    verify: bool = False,
+) -> dict:
+    """Walk ``wiki_root`` for entity .md files, apply T6 defaults.
+
+    Modes:
+      - ``apply=False``: dry-run. Counts changes; no writes.
+      - ``apply=True``: write back changed files atomically.
+      - ``verify=True``: dry-run, but assert zero changes (idempotency check
+        run after ``--apply``).
+    """
+    entity_root = wiki_root / "entity"
+    if not entity_root.exists():
+        print(f"[V041_MIGRATE] no entity dir at {entity_root}; nothing to do")
+        return {
+            "files_scanned": 0,
+            "files_changed": 0,
+            "relations_changed": 0,
+            "verify_violations": 0,
+        }
+
+    files_scanned = 0
+    files_changed = 0
+    relations_changed = 0
+    verify_violations = 0
+
+    for path in sorted(entity_root.rglob("*.md")):
+        files_scanned += 1
+        stats = migrate_entity_file(path)
+        if not stats["changed"]:
+            continue
+        files_changed += 1
+        relations_changed += stats["relations_changed"]
+        if verify:
+            verify_violations += 1
+            print(
+                f"[V041_MIGRATE][VERIFY-VIOLATION] {path} would change "
+                f"({stats['relations_changed']} relations) — re-run --apply"
+            )
+            continue
+        if apply:
+            _write_atomic(path, stats["new_text"])
+
+    return {
+        "files_scanned":     files_scanned,
+        "files_changed":     files_changed,
+        "relations_changed": relations_changed,
+        "verify_violations": verify_violations,
+    }
+
+
+# ───────────────────────────────────────────────────────────────
+# CLI entry
+# ───────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="v0.4.1 PR-T6.A — T6 derived_from migration. "
+                    "Default is --dry-run."
+    )
+    ap.add_argument("--root", type=Path, default=DEFAULT_WIKI_ROOT,
+                    help="Wiki root (default: ./wiki).")
+    ap.add_argument("--apply", action="store_true",
+                    help="Write changes back. Default = dry-run.")
+    ap.add_argument("--verify", action="store_true",
+                    help="Dry-run + assert zero pending changes "
+                         "(idempotency check after --apply).")
+    ap.add_argument("--no-snapshot", action="store_true",
+                    help="Skip snapshot creation when --apply.")
+    ap.add_argument("--force", action="store_true",
+                    help="Overwrite existing snapshot.")
+    args = ap.parse_args()
+
+    if args.apply and args.verify:
+        print("[V041_MIGRATE] --apply and --verify are mutually exclusive")
+        return 2
+
+    if not args.root.exists():
+        print(f"[V041_MIGRATE] wiki root not found: {args.root}")
+        return 2
+
+    if args.apply and not args.no_snapshot:
+        try:
+            snapshot_wiki(args.root, force=args.force)
+        except FileExistsError as e:
+            print(f"[V041_MIGRATE] {e}")
+            return 2
+
+    stats = migrate_wiki(args.root, apply=args.apply, verify=args.verify)
+
+    print("[V041_MIGRATE] === summary ===")
+    print(f"  files_scanned:     {stats['files_scanned']}")
+    print(f"  files_changed:     {stats['files_changed']}")
+    print(f"  relations_changed: {stats['relations_changed']}")
+    if args.verify:
+        print(f"  verify_violations: {stats['verify_violations']}")
+        if stats["verify_violations"] > 0:
+            return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_t6a_derived_from_schema.py
+++ b/tests/test_t6a_derived_from_schema.py
@@ -1,0 +1,315 @@
+"""v0.4.1 PR-T6.A — derived_from schema + migration contract tests.
+
+Pins the v0.4.1 §3 PR-T6.A deliverables:
+
+  - ``validate_edge_t6_derived_from`` shape checks (list of dicts,
+    ``base_fact_id: str``, ``derivation`` in
+    ``VALID_DERIVATION_TYPES``)
+  - **Decision 3 LOCK** — cycle rejection at write time when
+    ``edges_by_id`` is supplied
+  - ``apply_t6_edge_defaults`` adds ``derived_from: []`` when absent,
+    idempotent
+  - ``scripts/migrate_v041_lifecycle.py`` migrates every entity's
+    relations + is byte-stable on second run + the --verify mode
+    catches a stale state
+
+Run:
+  python -m unittest tests.test_t6a_derived_from_schema
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.lifecycle.schema import (  # noqa: E402
+    T6_EDGE_FIELD_DERIVED_FROM,
+    apply_t6_edge_defaults,
+    validate_edge_t6_derived_from,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_edge_t6_derived_from — shape checks
+# ---------------------------------------------------------------------------
+
+class ValidateShapeTests(unittest.TestCase):
+
+    def test_missing_field_is_valid(self):
+        """v0.3-equivalent — no derived_from key means no derivation
+        dependency. The validator accepts this so unmigrated edges
+        loaded from older snapshots pass."""
+        validate_edge_t6_derived_from({"id": "e1"})
+
+    def test_empty_list_is_valid(self):
+        """The migration default."""
+        validate_edge_t6_derived_from({"id": "e1", "derived_from": []})
+
+    def test_valid_entry_passes(self):
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "e_base_a", "derivation": "transitive"},
+                {"base_fact_id": "e_base_b", "derivation": "operator"},
+                {"base_fact_id": "e_base_c", "derivation": "inferred"},
+            ],
+        }
+        validate_edge_t6_derived_from(edge)
+
+    def test_non_list_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be a list"):
+            validate_edge_t6_derived_from({
+                "id": "e1", "derived_from": "not a list"
+            })
+
+    def test_entry_must_be_dict(self):
+        with self.assertRaisesRegex(ValueError, "must be a dict"):
+            validate_edge_t6_derived_from({
+                "id": "e1",
+                "derived_from": ["not a dict"],
+            })
+
+    def test_missing_base_fact_id_rejected(self):
+        with self.assertRaisesRegex(ValueError, "base_fact_id must be a"):
+            validate_edge_t6_derived_from({
+                "id": "e1",
+                "derived_from": [{"derivation": "transitive"}],
+            })
+
+    def test_empty_base_fact_id_rejected(self):
+        with self.assertRaisesRegex(ValueError, "base_fact_id must be a"):
+            validate_edge_t6_derived_from({
+                "id": "e1",
+                "derived_from": [
+                    {"base_fact_id": "", "derivation": "transitive"},
+                ],
+            })
+
+    def test_invalid_derivation_value_rejected(self):
+        with self.assertRaisesRegex(ValueError, "derivation must be one of"):
+            validate_edge_t6_derived_from({
+                "id": "e1",
+                "derived_from": [
+                    {"base_fact_id": "e_base", "derivation": "made-up"},
+                ],
+            })
+
+
+# ---------------------------------------------------------------------------
+# Decision 3 LOCK — cycle rejection
+# ---------------------------------------------------------------------------
+
+class CycleRejectionTests(unittest.TestCase):
+    """Decision 3 LOCK (entry memo §2): a derivation chain that
+    transitively includes the edge itself is rejected at write time."""
+
+    def test_self_reference_rejected(self):
+        """The smallest possible cycle — edge derives from itself."""
+        edge = {
+            "id": "e_self",
+            "derived_from": [
+                {"base_fact_id": "e_self", "derivation": "transitive"},
+            ],
+        }
+        edges_by_id = {"e_self": edge}
+        with self.assertRaisesRegex(ValueError, "derivation cycle"):
+            validate_edge_t6_derived_from(edge, edges_by_id=edges_by_id)
+
+    def test_two_hop_cycle_rejected(self):
+        """e_a → e_b → e_a is a cycle through the chain."""
+        e_a = {
+            "id": "e_a",
+            "derived_from": [
+                {"base_fact_id": "e_b", "derivation": "transitive"},
+            ],
+        }
+        e_b = {
+            "id": "e_b",
+            "derived_from": [
+                {"base_fact_id": "e_a", "derivation": "transitive"},
+            ],
+        }
+        edges_by_id = {"e_a": e_a, "e_b": e_b}
+        with self.assertRaisesRegex(ValueError, "derivation cycle"):
+            validate_edge_t6_derived_from(e_a, edges_by_id=edges_by_id)
+
+    def test_acyclic_chain_passes(self):
+        """e_a derives from e_b; e_b derives from e_c (no self loop)."""
+        e_c = {"id": "e_c"}
+        e_b = {
+            "id": "e_b",
+            "derived_from": [
+                {"base_fact_id": "e_c", "derivation": "transitive"},
+            ],
+        }
+        e_a = {
+            "id": "e_a",
+            "derived_from": [
+                {"base_fact_id": "e_b", "derivation": "transitive"},
+            ],
+        }
+        edges_by_id = {"e_a": e_a, "e_b": e_b, "e_c": e_c}
+        validate_edge_t6_derived_from(e_a, edges_by_id=edges_by_id)
+
+    def test_cycle_check_skipped_without_edges_by_id(self):
+        """Caller can skip cycle check by passing edges_by_id=None
+        (default). Single-edge validation only checks shape."""
+        edge = {
+            "id": "e_self",
+            "derived_from": [
+                {"base_fact_id": "e_self", "derivation": "transitive"},
+            ],
+        }
+        validate_edge_t6_derived_from(edge)  # no edges_by_id → no cycle check
+
+    def test_cycle_check_skipped_without_edge_id(self):
+        """Edges without an id can't be cycle-checked (no stable
+        endpoint to recognize). Shape still validates, cycle check
+        is a no-op."""
+        edge = {
+            "derived_from": [
+                {"base_fact_id": "e_some", "derivation": "transitive"},
+            ],
+        }
+        validate_edge_t6_derived_from(edge, edges_by_id={"e_some": edge})
+
+    def test_dangling_base_fact_id_silently_skipped(self):
+        """If a base_fact_id doesn't exist in edges_by_id, treat as
+        end-of-chain (lookup returns None). No cycle = no error.
+        Validates only against shape + the cycle invariant."""
+        edge = {
+            "id": "e_a",
+            "derived_from": [
+                {"base_fact_id": "e_missing", "derivation": "transitive"},
+            ],
+        }
+        edges_by_id = {"e_a": edge}  # e_missing absent
+        validate_edge_t6_derived_from(edge, edges_by_id=edges_by_id)
+
+
+# ---------------------------------------------------------------------------
+# apply_t6_edge_defaults
+# ---------------------------------------------------------------------------
+
+class ApplyDefaultsTests(unittest.TestCase):
+
+    def test_adds_empty_list_when_absent(self):
+        out = apply_t6_edge_defaults({"id": "e1"})
+        self.assertEqual(out.get(T6_EDGE_FIELD_DERIVED_FROM), [])
+
+    def test_preserves_existing_derived_from(self):
+        existing = [{"base_fact_id": "e_base", "derivation": "transitive"}]
+        out = apply_t6_edge_defaults({"id": "e1", "derived_from": existing})
+        self.assertEqual(out.get(T6_EDGE_FIELD_DERIVED_FROM), existing)
+
+    def test_idempotent(self):
+        """Re-running on an already-migrated edge yields the same dict."""
+        once = apply_t6_edge_defaults({"id": "e1"})
+        twice = apply_t6_edge_defaults(once)
+        self.assertEqual(once, twice)
+
+    def test_does_not_mutate_input(self):
+        edge = {"id": "e1"}
+        before = dict(edge)
+        _ = apply_t6_edge_defaults(edge)
+        self.assertEqual(edge, before)
+
+    def test_rejects_non_dict(self):
+        with self.assertRaisesRegex(ValueError, "must be a dict"):
+            apply_t6_edge_defaults("not a dict")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# migration script — integration via tempfile wiki
+# ---------------------------------------------------------------------------
+
+# Import inside tests so the script's top-level utils.console call
+# doesn't fire at module load on every CI run.
+
+class MigrationScriptTests(unittest.TestCase):
+    """Build a tiny wiki under tmpdir, call migrate_wiki + verify."""
+
+    def _make_entity(self, root: Path, name: str, relations: list) -> Path:
+        ent_dir = root / "entity" / "prod" / "concept"
+        ent_dir.mkdir(parents=True, exist_ok=True)
+        path = ent_dir / f"{name}.md"
+        import yaml
+        fm = {
+            "name": name,
+            "entity_type": "concept",
+            "relations": relations,
+        }
+        text = (
+            "---\n"
+            + yaml.dump(fm, allow_unicode=True, default_flow_style=False,
+                        sort_keys=True)
+            + "---\n"
+            + f"\n## Summary\n{name}\n"
+        )
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_dry_run_counts_changes(self):
+        from scripts.migrate_v041_lifecycle import migrate_wiki
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            self._make_entity(root, "EntityA", [
+                {"target": "X", "type": "RELATED_TO",
+                 "sources": [{"doc_id": "d", "role": "extract"}]},
+            ])
+            stats = migrate_wiki(root, apply=False)
+            self.assertEqual(stats["files_scanned"], 1)
+            self.assertEqual(stats["files_changed"], 1)
+            self.assertEqual(stats["relations_changed"], 1)
+            # Dry-run does NOT write the change.
+            text = (root / "entity" / "prod" / "concept" / "EntityA.md") \
+                .read_text(encoding="utf-8")
+            self.assertNotIn("derived_from", text)
+
+    def test_apply_writes_field_and_is_idempotent(self):
+        from scripts.migrate_v041_lifecycle import migrate_wiki
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            path = self._make_entity(root, "EntityB", [
+                {"target": "X", "type": "RELATED_TO",
+                 "sources": [{"doc_id": "d", "role": "extract"}]},
+            ])
+            # First apply — writes change.
+            stats1 = migrate_wiki(root, apply=True)
+            self.assertEqual(stats1["files_changed"], 1)
+            text1 = path.read_text(encoding="utf-8")
+            self.assertIn("derived_from", text1)
+            # Second apply — idempotent (no change).
+            stats2 = migrate_wiki(root, apply=True)
+            self.assertEqual(stats2["files_changed"], 0)
+            text2 = path.read_text(encoding="utf-8")
+            self.assertEqual(text1, text2)
+
+    def test_verify_after_apply_passes(self):
+        from scripts.migrate_v041_lifecycle import migrate_wiki
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            self._make_entity(root, "EntityC", [
+                {"target": "X", "type": "RELATED_TO"},
+            ])
+            migrate_wiki(root, apply=True)
+            stats = migrate_wiki(root, verify=True)
+            self.assertEqual(stats["verify_violations"], 0)
+
+    def test_verify_before_apply_flags_violations(self):
+        from scripts.migrate_v041_lifecycle import migrate_wiki
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            self._make_entity(root, "EntityD", [
+                {"target": "X", "type": "RELATED_TO"},
+            ])
+            stats = migrate_wiki(root, verify=True)
+            self.assertGreater(stats["verify_violations"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First implementation PR for the **v0.4.1 T6 Causality Chain** track per the v0.4.1 entry memo (#557) §3 PR-T6.A row. Adds the `derived_from` field to the relation schema + migration script that back-fills it on every existing wiki entity.

T6 closes the CASCADE pillar: when a base fact is invalidated, derived facts (those whose sources are other edges) auto-invalidate. **T6.A is the data-shape foundation** — subsequent PRs (T6.B/C/D/E) build the detection / cascade / integration / closure on top.

| # | PR | scope |
|---|---|---|
| **T6.A** | **this PR** | derived_from schema + validator + migration |
| ⏳ T6.B | — | `core/lifecycle/derivation.py` (extraction helper) |
| ⏳ T6.C | — | `core/lifecycle/causality.py` (`invalidate_derived_facts`) |
| ⏳ T6.D | — | integration + 4 release-gating invariants |
| ⏳ T6.E | — | v0.4.1 closure docs + release publish |

## Decision 3 LOCK applied

Per entry memo §2: **derivation cycles are rejected at schema validation time**. A relation whose `derived_from` transitive chain includes its own `id` raises `ValueError` from `validate_edge_t6_derived_from(edge, edges_by_id=...)`. Tests cover the self-reference case + a 2-hop cycle (`e_a → e_b → e_a`).

## Files

### `core/lifecycle/schema.py` (+~160 LOC, total 18.9 KB / 20 KB cap)

- Constants: `T6_EDGE_FIELD_DERIVED_FROM`, derivation type enum (`T6_DERIVATION_TRANSITIVE` / `T6_DERIVATION_OPERATOR` / `T6_DERIVATION_INFERRED`), `VALID_DERIVATION_TYPES` frozenset.
- `validate_edge_t6_derived_from(edge, *, edges_by_id=None)` — shape check + optional cycle detection when `edges_by_id` is provided.
- `apply_t6_edge_defaults(edge)` — idempotent `setdefault` of `derived_from: []`. Matches the v0.4.0 `apply_v04_edge_defaults` pattern.
- `__all__` updated.

### `scripts/migrate_v041_lifecycle.py` (~10 KB, new)

Mirrors the v0.4.0 `migrate_v04_lifecycle.py` pattern (PR-T1.A).

- Walks `wiki/entity/` for `.md` files
- For each relation, calls `apply_t6_edge_defaults`
- Writes back ONLY when changed (byte-stable on re-apply)
- `--dry-run` (default), `--apply` (with `wiki.pre-v041-migration/` snapshot), `--verify` (asserts zero pending changes after apply), `--no-snapshot`, `--force`
- Atomic per-file writes via `tempfile` + `os.replace` so a crash mid-write never half-updates

Operator workflow:
```bash
# 1. Dry-run (default) — count entities that would change
python scripts/migrate_v041_lifecycle.py --root wiki

# 2. Apply with snapshot
python scripts/migrate_v041_lifecycle.py --root wiki --apply

# 3. Verify (rerun should be byte-stable)
python scripts/migrate_v041_lifecycle.py --root wiki --verify
```

### `tests/test_t6a_derived_from_schema.py` — 23 contract tests

| group | what it pins |
|---|---|
| `ValidateShapeTests` (8) | missing/empty/valid/non-list/non-dict entry/missing base_fact_id/empty base_fact_id/invalid derivation |
| `CycleRejectionTests` (6) | self-reference / 2-hop cycle / acyclic chain passes / cycle check skipped without `edges_by_id` / cycle check skipped without edge id / dangling base_fact_id silently skipped (treated as end-of-chain) |
| `ApplyDefaultsTests` (5) | adds `[]` when absent / preserves existing / idempotent / does-not-mutate-input / rejects non-dict |
| `MigrationScriptTests` (4) | dry-run counts changes, apply writes + is byte-stable on re-apply, verify after apply passes, verify before apply flags violations |

## Verification

- `python -m unittest tests.test_t6a_derived_from_schema` → **23/23 pass**
- Full adjacent regression (T6.A + T2.D-1/2/2.b/3 + QVT + schema) → **85/85 pass**
- `ruff` clean
- Module size `core/lifecycle/schema.py` 18.9 KB (CLAUDE.md rule 5 ≤ 20 KB)
- `scripts/migrate_v041_lifecycle.py` 10 KB

## Quality Delta vs baseline

`Quality delta: exempt (label: code — schema field is additive + optional; existing callers that don't read derived_from see no behavior change. Migration script is operator-run; the wiki on disk gains derived_from: [] on every relation but no retrieval/graph/reasoning behavior shifts. Re-baseline not needed.)`.

## Out of scope

- **T6.B** — `core/lifecycle/derivation.py` (extraction helper: operator-tagged path + flag-gated LLM path)
- **T6.C** — `core/lifecycle/causality.py` (`invalidate_derived_facts(base_fact_id, *, audit_emit)`)
- **T6.D** — integration with `cascade_remove_doc_from_sources` + 4 release-gating invariants
- **T6.E** — v0.4.1 closure docs + release publish
- Operator action: `python scripts/migrate_v041_lifecycle.py --root wiki --apply` after this PR lands (back-fills every relation with `derived_from: []`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)