### PR TITLE
feat(lifecycle): v0.4.1 PR-T6.C — invalidate_derived_facts (per-derivation-type C-semantics)

### DIFF
--- a/core/lifecycle/causality.py
+++ b/core/lifecycle/causality.py
@@ -1,0 +1,288 @@
+"""v0.4.1 PR-T6.C — derivation-aware invalidation cascade.
+
+When a base fact is fully removed (sources=[]), edges whose
+``derived_from`` references that base may need to invalidate too.
+This module implements the **per-derivation-type semantics**
+(Decision 4 LOCK clarification, 2026-05-28):
+
+  - ``derivation: "transitive"`` (chain inference, e.g. A→B→C ⇒ A→C):
+    **ANY-trigger**. Loss of any single base breaks the chain →
+    invalidate the derived edge.
+
+  - ``derivation: "inferred"`` (LLM-suggested single conclusion):
+    **ANY-trigger**. The inference rests on the cited base; if that
+    base is gone, the inference is suspect → invalidate.
+
+  - ``derivation: "operator"`` (human-tagged multi-source support):
+    **ALL-trigger**. Loss of one base leaves remaining bases as
+    alternative support → keep alive. Only when ALL operator bases
+    are gone does the edge invalidate.
+
+Mixed-derivation edges (e.g. one transitive + two operator) are
+evaluated jointly:
+
+    invalidate := (any transitive/inferred base empty) OR
+                  (operator entries exist AND all of them empty)
+
+## What "invalidate" means here
+
+Soft invalidate (matches T7 supersede pattern):
+  - ``status.active = False``
+  - ``mutation_type = "invalidated"``
+  - ``sources`` preserved (the edge survives for T7 replay; CASCADE-
+    style drop is a separate concern).
+
+Audit row emitted per invalidation carries ``mutation_type =
+"invalidated_by_cascade"`` so the T7 replay primitive can reconstruct
+the derivation-cascade history from audit_log alone.
+
+## What this module is NOT
+
+- Not a transitive cascade. The function invalidates the directly-
+  derived edges; if those edges are themselves base for further
+  derivations, the caller calls ``invalidate_derived_facts`` again
+  (or passes the full ``additional_empty_bases`` set up-front).
+  Transitive auto-walk is a v0.4.2+ candidate.
+- Not a CASCADE replacement. ``cascade_remove_doc_from_sources``
+  handles source-level removal; T6.C handles derived-edge-level
+  invalidation. They compose: cascade empties a base's sources,
+  then ``invalidate_derived_facts(base_id)`` propagates downstream.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Union
+
+import yaml
+
+from core.lifecycle.schema import (
+    T1_MUTATION_INVALIDATED,
+    T6_DERIVATION_INFERRED,
+    T6_DERIVATION_OPERATOR,
+    T6_DERIVATION_TRANSITIVE,
+    T6_EDGE_FIELD_DERIVED_FROM,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+)
+
+
+AuditEmit = Callable[[Dict[str, Any]], None]
+
+
+# ANY-trigger derivation types (loss of any base → invalidate)
+_ANY_TRIGGER_DERIVATIONS: frozenset[str] = frozenset({
+    T6_DERIVATION_TRANSITIVE,
+    T6_DERIVATION_INFERRED,
+})
+
+
+def _noop_audit(_payload: Dict[str, Any]) -> None:
+    return None
+
+
+def _split_frontmatter(text: str) -> tuple[dict | None, str]:
+    if not text.startswith("---"):
+        return None, text
+    end = text.find("---", 3)
+    if end < 0:
+        return None, text
+    try:
+        fm = yaml.safe_load(text[3:end]) or {}
+    except Exception:
+        return None, text
+    body_tail = text[end + 3:]
+    return fm, body_tail
+
+
+def _serialize_frontmatter(fm: dict, body_tail: str) -> str:
+    return (
+        "---\n"
+        + yaml.dump(fm, allow_unicode=True, default_flow_style=False,
+                    sort_keys=True)
+        + "---"
+        + body_tail
+    )
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    """tempfile + os.replace — crash mid-write never half-updates."""
+    fd, tmp = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def should_invalidate_edge(
+    edge: Dict[str, Any],
+    empty_bases: Set[str],
+) -> bool:
+    """Decision 4 (C-semantics) evaluator.
+
+    Returns True iff the edge's ``derived_from`` evaluates to
+    "invalidated" given the set of currently-empty base ids:
+
+      - ANY transitive/inferred entry whose base is in ``empty_bases``
+        → invalidate
+      - operator entries exist AND ALL of them have bases in
+        ``empty_bases`` → invalidate
+      - Otherwise → preserve.
+
+    Returns False for edges with empty/missing ``derived_from``
+    (nothing to invalidate against).
+    """
+    if not isinstance(edge, dict):
+        return False
+    derived_from = edge.get(T6_EDGE_FIELD_DERIVED_FROM)
+    if not isinstance(derived_from, list) or not derived_from:
+        return False
+
+    operator_entries: List[Dict[str, Any]] = []
+    for entry in derived_from:
+        if not isinstance(entry, dict):
+            continue
+        base_id = entry.get("base_fact_id")
+        derivation = entry.get("derivation")
+        if not isinstance(base_id, str) or not base_id:
+            continue
+        if derivation in _ANY_TRIGGER_DERIVATIONS:
+            if base_id in empty_bases:
+                return True
+        elif derivation == T6_DERIVATION_OPERATOR:
+            operator_entries.append(entry)
+
+    if operator_entries:
+        all_operator_empty = all(
+            entry.get("base_fact_id") in empty_bases
+            for entry in operator_entries
+        )
+        if all_operator_empty:
+            return True
+
+    return False
+
+
+def _iter_entity_files(entity_root: Path):
+    if not entity_root.exists():
+        return
+    yield from entity_root.rglob("*.md")
+
+
+def invalidate_derived_facts(
+    base_fact_id: str,
+    entity_root: Union[Path, str],
+    *,
+    additional_empty_bases: Optional[Set[str]] = None,
+    audit_emit: Optional[AuditEmit] = None,
+) -> List[str]:
+    """Invalidate edges derived from ``base_fact_id`` (and optionally
+    other known-empty bases) per the C-semantics.
+
+    Args:
+        base_fact_id: the base fact that just became empty
+            (sources=[]). Required.
+        entity_root: directory whose ``rglob("*.md")`` is the wiki's
+            entity file set (typically ``wiki/entity/prod/``).
+        additional_empty_bases: optional extra base ids known to be
+            empty in the same operation. Useful for batch cascades:
+            the caller assembles the full empty-set up front so the
+            operator-derivation ALL-trigger fires correctly even when
+            multiple bases vanish simultaneously.
+        audit_emit: optional callback. Each invalidation emits one
+            row with ``mutation_type="invalidated_by_cascade"`` +
+            ``base_fact_id`` + ``derived_edge_id`` + ``entity_path``.
+
+    Returns:
+        list of invalidated edge ids (the edges' ``id`` fields).
+
+    Side effects:
+        - Mutates entity files on disk: sets ``status.active=False``
+          and ``mutation_type="invalidated"`` on each invalidated
+          edge. ``sources`` preserved for T7 replay.
+        - Writes atomically per file (tempfile + os.replace).
+    """
+    if not isinstance(base_fact_id, str) or not base_fact_id:
+        raise ValueError(
+            f"base_fact_id must be non-empty str, got {base_fact_id!r}"
+        )
+    root = Path(entity_root)
+    emit = audit_emit or _noop_audit
+
+    empty_bases: Set[str] = {base_fact_id}
+    if additional_empty_bases:
+        empty_bases.update(b for b in additional_empty_bases if isinstance(b, str))
+
+    invalidated_ids: List[str] = []
+
+    for path in _iter_entity_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm, body_tail = _split_frontmatter(text)
+        if not isinstance(fm, dict):
+            continue
+        relations = fm.get("relations") or []
+        if not isinstance(relations, list):
+            continue
+
+        file_changed = False
+        for rel in relations:
+            if not isinstance(rel, dict):
+                continue
+            if not should_invalidate_edge(rel, empty_bases):
+                continue
+
+            edge_id = rel.get("id")
+            # Mark soft-invalidated (T7-style: keep edge for replay).
+            status = rel.get(T7_EDGE_FIELD_STATUS)
+            if isinstance(status, dict):
+                status["active"] = False
+            else:
+                rel[T7_EDGE_FIELD_STATUS] = {
+                    "active": False,
+                    "superseded_by": None,
+                    "superseded_at": None,
+                }
+            rel[T7_EDGE_FIELD_MUTATION_TYPE] = T1_MUTATION_INVALIDATED
+            file_changed = True
+            if isinstance(edge_id, str) and edge_id:
+                invalidated_ids.append(edge_id)
+            emit({
+                "endpoint":         "lifecycle:t6_cascade",
+                "role":             "system",
+                "mutation_type":    "invalidated_by_cascade",
+                "base_fact_id":     base_fact_id,
+                "additional_empty_bases": sorted(
+                    b for b in empty_bases if b != base_fact_id
+                ),
+                "derived_edge_id":  edge_id,
+                "entity_path":      str(path.relative_to(root))
+                                    if path.is_relative_to(root)
+                                    else str(path),
+            })
+
+        if file_changed:
+            new_text = _serialize_frontmatter(fm, body_tail)
+            _write_atomic(path, new_text)
+
+    return invalidated_ids
+
+
+__all__ = [
+    "AuditEmit",
+    "invalidate_derived_facts",
+    "should_invalidate_edge",
+]

--- a/tests/test_t6c_causality_cascade.py
+++ b/tests/test_t6c_causality_cascade.py
@@ -1,0 +1,350 @@
+"""v0.4.1 PR-T6.C — derivation-aware invalidation cascade tests.
+
+Pins the per-derivation-type C-semantics (entry memo §2 Decision 4,
+clarified 2026-05-28):
+
+  - ``transitive`` / ``inferred`` → ANY-trigger
+  - ``operator`` → ALL-trigger
+  - mixed → invalidate iff (any transitive/inferred broken) OR
+    (all operator broken when at least one exists)
+
+Run:
+  python -m unittest tests.test_t6c_causality_cascade
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.lifecycle.causality import (  # noqa: E402
+    invalidate_derived_facts,
+    should_invalidate_edge,
+)
+
+
+# ---------------------------------------------------------------------------
+# should_invalidate_edge — pure function, no I/O
+# ---------------------------------------------------------------------------
+
+class ShouldInvalidateEdgeTests(unittest.TestCase):
+    """The C-semantics decision evaluator."""
+
+    def test_transitive_any_trigger(self):
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "transitive"},
+                {"base_fact_id": "b2", "derivation": "transitive"},
+            ],
+        }
+        # b1 empty → invalidate (transitive ANY-trigger)
+        self.assertTrue(should_invalidate_edge(edge, {"b1"}))
+
+    def test_inferred_any_trigger(self):
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "inferred"},
+            ],
+        }
+        self.assertTrue(should_invalidate_edge(edge, {"b1"}))
+
+    def test_operator_single_entry_all_trigger(self):
+        """One operator entry only — its base empty means 'all
+        operator entries empty' (trivially)."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "operator"},
+            ],
+        }
+        self.assertTrue(should_invalidate_edge(edge, {"b1"}))
+
+    def test_operator_multi_entry_partial_loss_preserves(self):
+        """Two operator entries, one empty, other alive → keep."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "operator"},
+                {"base_fact_id": "b2", "derivation": "operator"},
+            ],
+        }
+        self.assertFalse(should_invalidate_edge(edge, {"b1"}))
+
+    def test_operator_multi_entry_all_empty_invalidates(self):
+        """Both operator bases empty → invalidate."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "operator"},
+                {"base_fact_id": "b2", "derivation": "operator"},
+            ],
+        }
+        self.assertTrue(should_invalidate_edge(edge, {"b1", "b2"}))
+
+    def test_mixed_transitive_overrides_operator_partial(self):
+        """Mixed: 1 transitive + 2 operator. transitive empty →
+        invalidate (transitive ANY-trigger fires regardless of
+        operator-state)."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "transitive"},
+                {"base_fact_id": "b2", "derivation": "operator"},
+                {"base_fact_id": "b3", "derivation": "operator"},
+            ],
+        }
+        self.assertTrue(should_invalidate_edge(edge, {"b1"}))
+
+    def test_mixed_operator_partial_with_transitive_alive(self):
+        """Mixed: transitive alive, one operator empty → keep
+        (transitive intact, operator partial)."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "transitive"},
+                {"base_fact_id": "b2", "derivation": "operator"},
+                {"base_fact_id": "b3", "derivation": "operator"},
+            ],
+        }
+        self.assertFalse(should_invalidate_edge(edge, {"b2"}))
+
+    def test_empty_derived_from_no_invalidation(self):
+        edge = {"id": "e_derived", "derived_from": []}
+        self.assertFalse(should_invalidate_edge(edge, {"b1"}))
+
+    def test_missing_derived_from_no_invalidation(self):
+        edge = {"id": "e_derived"}
+        self.assertFalse(should_invalidate_edge(edge, {"b1"}))
+
+    def test_unknown_derivation_type_ignored(self):
+        """Schema validator would reject unknown derivation values,
+        but defensively the cascade evaluator just skips them rather
+        than firing."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "mystery"},
+            ],
+        }
+        self.assertFalse(should_invalidate_edge(edge, {"b1"}))
+
+    def test_empty_bases_set_no_invalidation(self):
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "transitive"},
+            ],
+        }
+        self.assertFalse(should_invalidate_edge(edge, set()))
+
+
+# ---------------------------------------------------------------------------
+# invalidate_derived_facts — file-walking integration
+# ---------------------------------------------------------------------------
+
+
+def _write_entity(root: Path, name: str, relations: list) -> Path:
+    """Write a minimal entity .md file with the given relations."""
+    ent_dir = root / "entity" / "prod" / "concept"
+    ent_dir.mkdir(parents=True, exist_ok=True)
+    path = ent_dir / f"{name}.md"
+    fm = {
+        "entity_id":   f"e_concept_{name.lower()}",
+        "entity_type": "concept",
+        "name":        name,
+        "relations":   relations,
+    }
+    text = (
+        "---\n"
+        + yaml.dump(fm, allow_unicode=True, default_flow_style=False,
+                    sort_keys=True)
+        + "---\n\n"
+        + f"## Summary\n{name}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _load_relations(path: Path) -> list:
+    text = path.read_text(encoding="utf-8")
+    fm_text = text.split("---", 2)[1]
+    return yaml.safe_load(fm_text).get("relations", [])
+
+
+class InvalidateDerivedFactsTests(unittest.TestCase):
+
+    def test_invalidates_directly_derived_edge(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "A", [
+                {
+                    "id":        "e_a_derived",
+                    "target":    "X",
+                    "type":      "BASED_IN",
+                    "sources":   [{"doc_id": "d1", "role": "extract",
+                                   "weight": 0.8}],
+                    "derived_from": [
+                        {"base_fact_id": "e_base_x",
+                         "derivation": "transitive"},
+                    ],
+                },
+            ])
+            entity_root = root / "entity"
+            invalidated = invalidate_derived_facts(
+                "e_base_x", entity_root,
+            )
+            self.assertEqual(invalidated, ["e_a_derived"])
+            # Edge mutated on disk.
+            rels = _load_relations(
+                root / "entity" / "prod" / "concept" / "A.md"
+            )
+            self.assertEqual(rels[0]["mutation_type"], "invalidated")
+            self.assertFalse(rels[0]["status"]["active"])
+            # Sources preserved (T7 replay friendly).
+            self.assertEqual(len(rels[0]["sources"]), 1)
+
+    def test_preserves_when_no_match(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "B", [
+                {
+                    "id":        "e_b_derived",
+                    "target":    "Y",
+                    "type":      "RELATED_TO",
+                    "derived_from": [
+                        {"base_fact_id": "e_other",
+                         "derivation": "transitive"},
+                    ],
+                },
+            ])
+            entity_root = root / "entity"
+            invalidated = invalidate_derived_facts(
+                "e_base_x", entity_root,  # different from e_other
+            )
+            self.assertEqual(invalidated, [])
+
+    def test_additional_empty_bases_enables_all_trigger(self):
+        """Operator multi-entry: invalidate only when caller passes
+        ``additional_empty_bases`` covering all entries."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "C", [
+                {
+                    "id":     "e_c_derived",
+                    "target": "Z",
+                    "type":   "RELATED_TO",
+                    "derived_from": [
+                        {"base_fact_id": "e_op1",
+                         "derivation": "operator"},
+                        {"base_fact_id": "e_op2",
+                         "derivation": "operator"},
+                    ],
+                },
+            ])
+            entity_root = root / "entity"
+
+            # Call with only e_op1 → operator partial loss → preserved
+            partial = invalidate_derived_facts("e_op1", entity_root)
+            self.assertEqual(partial, [])
+
+            # Call with both via additional_empty_bases → all-trigger fires
+            full = invalidate_derived_facts(
+                "e_op1", entity_root,
+                additional_empty_bases={"e_op2"},
+            )
+            self.assertEqual(full, ["e_c_derived"])
+
+    def test_audit_row_per_invalidation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "D", [
+                {
+                    "id":     "e_d_derived",
+                    "target": "X",
+                    "type":   "RELATED_TO",
+                    "derived_from": [
+                        {"base_fact_id": "e_base_x",
+                         "derivation": "inferred"},
+                    ],
+                },
+            ])
+            entity_root = root / "entity"
+            emit = MagicMock()
+            invalidate_derived_facts(
+                "e_base_x", entity_root, audit_emit=emit,
+            )
+            emit.assert_called_once()
+            payload = emit.call_args[0][0]
+            self.assertEqual(payload["mutation_type"],
+                             "invalidated_by_cascade")
+            self.assertEqual(payload["base_fact_id"], "e_base_x")
+            self.assertEqual(payload["derived_edge_id"], "e_d_derived")
+            self.assertIn("entity_path", payload)
+
+    def test_walks_multiple_entities(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "EA", [{
+                "id": "e_a1", "target": "X", "type": "RELATED_TO",
+                "derived_from": [{"base_fact_id": "e_base",
+                                  "derivation": "transitive"}],
+            }])
+            _write_entity(root, "EB", [{
+                "id": "e_b1", "target": "Y", "type": "RELATED_TO",
+                "derived_from": [{"base_fact_id": "e_base",
+                                  "derivation": "transitive"}],
+            }])
+            _write_entity(root, "EC", [{
+                "id": "e_c1", "target": "Z", "type": "RELATED_TO",
+                # No matching base → preserved
+                "derived_from": [{"base_fact_id": "e_other",
+                                  "derivation": "transitive"}],
+            }])
+            entity_root = root / "entity"
+            invalidated = invalidate_derived_facts("e_base", entity_root)
+            self.assertEqual(sorted(invalidated), ["e_a1", "e_b1"])
+
+    def test_rejects_empty_base_fact_id(self):
+        with self.assertRaisesRegex(ValueError, "must be non-empty"):
+            invalidate_derived_facts("", Path("/fake"))
+
+    def test_no_entity_dir_returns_empty(self):
+        """If entity_root doesn't exist, no walk → no invalidations,
+        no crash."""
+        result = invalidate_derived_facts(
+            "e_base", Path("/this/path/definitely/does/not/exist"),
+        )
+        self.assertEqual(result, [])
+
+    def test_status_dict_synthesized_when_missing(self):
+        """Edge without an existing status dict → cascade synthesizes
+        one with active=False."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "EE", [{
+                "id": "e_e1", "target": "X", "type": "RELATED_TO",
+                "derived_from": [{"base_fact_id": "e_base",
+                                  "derivation": "transitive"}],
+                # no status field
+            }])
+            entity_root = root / "entity"
+            invalidated = invalidate_derived_facts("e_base", entity_root)
+            self.assertEqual(invalidated, ["e_e1"])
+            rels = _load_relations(
+                root / "entity" / "prod" / "concept" / "EE.md"
+            )
+            self.assertIn("status", rels[0])
+            self.assertFalse(rels[0]["status"]["active"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third implementation PR for the v0.4.1 T6 Causality Chain track per the v0.4.1 entry memo (#557) §3 PR-T6.C row. Walks the wiki to find edges derived from a given (now-empty) base fact and invalidates them per the **C-semantics** (Decision 4 LOCK clarified 2026-05-28):

| derivation type | trigger |
|---|---|
| `transitive` (chain inference) | **ANY** base empty → invalidate |
| `inferred` (LLM single conclusion) | **ANY** base empty → invalidate |
| `operator` (multi-source human tag) | **ALL** bases empty → invalidate |

Mixed-derivation edges evaluated jointly:

```
invalidate := (any transitive/inferred base empty) OR
              (operator entries exist AND all empty)
```

| # | PR | scope |
|---|---|---|
| ✅ T6.A | #562 | derived_from schema + validator + migration |
| ✅ T6.B | #563 | derivation extraction (operator-tagged + LLM-inferred) |
| **T6.C** | **this PR** | invalidate_derived_facts cascade |
| ⏳ T6.D | — | integration + 4 release-gating invariants |
| ⏳ T6.E | — | v0.4.1 closure docs + release |

## What "invalidate" means

**Soft invalidate** (matches T7 supersede pattern):
- `status.active = False`
- `mutation_type = "invalidated"`
- `sources` **preserved** → edge survives for T7 replay

Audit row emitted per invalidation carries `mutation_type = "invalidated_by_cascade"` + chain pointers so the T7 replay primitive can reconstruct the derivation-cascade history from `audit_log` alone.

## Files

### `core/lifecycle/causality.py` (~10 KB)

```python
def should_invalidate_edge(edge: dict, empty_bases: set[str]) -> bool:
    """Pure decision function. No I/O; testable in isolation."""

def invalidate_derived_facts(
    base_fact_id: str,
    entity_root: Path | str,
    *,
    additional_empty_bases: set[str] | None = None,
    audit_emit: Callable | None = None,
) -> list[str]:
    """Walk entity files, invalidate matching edges atomically."""
```

Atomic per-file writes via `tempfile.mkstemp` + `os.replace` so crashes mid-write never half-update.

Non-transitive by default. Caller cascades transitively by re-calling per newly-invalidated id, OR batches via `additional_empty_bases`. Auto-walk is a v0.4.2+ candidate.

### `tests/test_t6c_causality_cascade.py` — 19 contract tests

| group | tests |
|---|---|
| `ShouldInvalidateEdgeTests` (11) | transitive any-trigger / inferred any-trigger / operator single-entry / operator multi-entry partial preserved / operator multi-entry all empty invalidates / mixed transitive overrides operator partial / mixed operator partial with transitive alive preserves / empty derived_from / missing derived_from / unknown derivation type ignored / empty empty_bases set |
| `InvalidateDerivedFactsTests` (8) | direct invalidation writes file / no-match preserves / additional_empty_bases enables operator ALL-trigger / audit row per invalidation / walks multiple entities / rejects empty base_fact_id / no entity dir returns empty / status dict synthesized when missing |

## Verification

- `python -m unittest tests.test_t6c_causality_cascade` → **19/19 pass**
- Full adjacent regression (T6.A + T6.B + T6.C + T2.D + QVT) → **93/93 pass**
- `ruff check` clean
- Module size **9.6 KB** (CLAUDE.md rule 5 ≤ 20 KB) ✓

## Entry memo §2 Decision 4 clarification

The original memo text *"strict invalidate when any base fact is fully removed"* collapsed three cases into one. The schema already encodes the distinction (`T6_DERIVATION_TRANSITIVE` / `_OPERATOR` / `_INFERRED`); this PR restores per-derivation semantics. The §2 memo update lands in T6.E closure to keep the entry-memo + invariants in lockstep.

## Quality Delta vs baseline

`Quality delta: exempt (label: code — pure helper module + tests; no production caller wired yet. T6.D integration PR will paste a Quality Delta Card paired against baseline_2a31b20.json once the release-gating invariants land.)`.

## Out of scope

- **T6.D** — integration with `cascade_remove_doc_from_sources` + 4 release-gating invariants
- **T6.E** — v0.4.1 closure docs + release publish + entry memo §2 Decision 4 clarification
- Transitive auto-walk in a single call (currently caller re-invokes / batches via `additional_empty_bases`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)