### PR TITLE
fix(lifecycle): v0.4.1 PR-T6.C.b — refine C-semantics (foundational vs corroborative)

### DIFF
--- a/core/lifecycle/causality.py
+++ b/core/lifecycle/causality.py
@@ -1,28 +1,35 @@
-"""v0.4.1 PR-T6.C — derivation-aware invalidation cascade.
+"""v0.4.1 PR-T6.C + T6.C.b — derivation-aware invalidation cascade.
 
 When a base fact is fully removed (sources=[]), edges whose
 ``derived_from`` references that base may need to invalidate too.
-This module implements the **per-derivation-type semantics**
-(Decision 4 LOCK clarification, 2026-05-28):
+This module implements the **foundational-vs-corroborative semantics**
+(Decision 4 LOCK refined 2026-05-28, T6.C.b):
 
-  - ``derivation: "transitive"`` (chain inference, e.g. A→B→C ⇒ A→C):
-    **ANY-trigger**. Loss of any single base breaks the chain →
-    invalidate the derived edge.
+  - **Hard deps** (``transitive`` / ``inferred``) — structural
+    chain links. Loss of any one breaks the derivation → invalidate.
 
-  - ``derivation: "inferred"`` (LLM-suggested single conclusion):
-    **ANY-trigger**. The inference rests on the cited base; if that
-    base is gone, the inference is suspect → invalidate.
+  - **Soft deps** (``operator``) — corroborative evidence that
+    strengthens the conclusion but doesn't single-handedly support
+    it when hard deps are present. Loss of any one (while hard deps
+    stay alive) only WEAKENS the derivation, doesn't invalidate.
 
-  - ``derivation: "operator"`` (human-tagged multi-source support):
-    **ALL-trigger**. Loss of one base leaves remaining bases as
-    alternative support → keep alive. Only when ALL operator bases
-    are gone does the edge invalidate.
+Combined rules (T6.C.b refinement):
 
-Mixed-derivation edges (e.g. one transitive + two operator) are
-evaluated jointly:
+    invalidate :=
+        (any hard dep base empty)
+      OR
+        (hard_deps == [] AND soft_deps != [] AND all soft empty)
 
-    invalidate := (any transitive/inferred base empty) OR
-                  (operator entries exist AND all of them empty)
+This corrects the original T6.C semantics where ``operator``-only
+emptiness fired even when hard deps were alive. The original case
+the refinement fixes:
+
+  derived edge has [b1 transitive, b2 operator]
+  → b2 gone (b1 alive)
+  → original T6.C: invalidate (operator-all-empty trivially fires
+    when there's only one operator entry)
+  → T6.C.b: preserve (transitive intact; operator was just
+    corroborative; loss weakens but doesn't break)
 
 ## What "invalidate" means here
 
@@ -129,19 +136,27 @@ def should_invalidate_edge(
     edge: Dict[str, Any],
     empty_bases: Set[str],
 ) -> bool:
-    """Decision 4 (C-semantics) evaluator.
+    """T6.C.b foundational-vs-corroborative evaluator.
 
     Returns True iff the edge's ``derived_from`` evaluates to
     "invalidated" given the set of currently-empty base ids:
 
-      - ANY transitive/inferred entry whose base is in ``empty_bases``
-        → invalidate
-      - operator entries exist AND ALL of them have bases in
-        ``empty_bases`` → invalidate
-      - Otherwise → preserve.
+      Rule 1 (hard dep break): ANY transitive/inferred entry whose
+        base is in ``empty_bases`` → invalidate. Structural chain
+        links — losing one breaks the derivation regardless of how
+        many corroborators remain.
 
-    Returns False for edges with empty/missing ``derived_from``
-    (nothing to invalidate against).
+      Rule 2 (lone-corroborator collapse): hard_deps == [] AND
+        operator entries exist AND ALL operator bases empty →
+        invalidate. The edge was supported only by corroborators;
+        all corroborators gone means no support at all.
+
+      Otherwise → preserve.
+
+    Crucially, when hard deps are present and alive, operator loss
+    (even total) does NOT invalidate — corroborators only WEAKEN
+    a foundationally-supported derivation. Confidence reduction is
+    T3 (Aging) territory.
     """
     if not isinstance(edge, dict):
         return False
@@ -149,6 +164,7 @@ def should_invalidate_edge(
     if not isinstance(derived_from, list) or not derived_from:
         return False
 
+    hard_entries: List[Dict[str, Any]] = []
     operator_entries: List[Dict[str, Any]] = []
     for entry in derived_from:
         if not isinstance(entry, dict):
@@ -158,12 +174,18 @@ def should_invalidate_edge(
         if not isinstance(base_id, str) or not base_id:
             continue
         if derivation in _ANY_TRIGGER_DERIVATIONS:
-            if base_id in empty_bases:
-                return True
+            hard_entries.append(entry)
         elif derivation == T6_DERIVATION_OPERATOR:
             operator_entries.append(entry)
 
-    if operator_entries:
+    # Rule 1 — any hard dep empty → invalidate (structural break).
+    for entry in hard_entries:
+        if entry.get("base_fact_id") in empty_bases:
+            return True
+
+    # Rule 2 — no hard deps, operator-only edge, all operators
+    # empty → invalidate (no support remains).
+    if not hard_entries and operator_entries:
         all_operator_empty = all(
             entry.get("base_fact_id") in empty_bases
             for entry in operator_entries

--- a/tests/test_t6c_causality_cascade.py
+++ b/tests/test_t6c_causality_cascade.py
@@ -1,12 +1,20 @@
-"""v0.4.1 PR-T6.C — derivation-aware invalidation cascade tests.
+"""v0.4.1 PR-T6.C + T6.C.b — derivation-aware invalidation cascade tests.
 
-Pins the per-derivation-type C-semantics (entry memo §2 Decision 4,
-clarified 2026-05-28):
+Pins the foundational-vs-corroborative semantics (entry memo §2
+Decision 4, refined 2026-05-28 in T6.C.b):
 
-  - ``transitive`` / ``inferred`` → ANY-trigger
-  - ``operator`` → ALL-trigger
-  - mixed → invalidate iff (any transitive/inferred broken) OR
-    (all operator broken when at least one exists)
+  - ``transitive`` / ``inferred`` = hard deps (structural chain links)
+    → ANY-trigger: loss of any one breaks the derivation.
+  - ``operator`` = soft deps (corroborative evidence)
+    → contributes only when no hard dep supports the edge; when
+       hard deps are present and alive, operator loss only WEAKENS,
+       doesn't invalidate.
+
+Combined: invalidate iff (any hard dep base empty) OR
+                          (no hard deps AND all operator bases empty)
+
+T6.C.b corrects the original T6.C edge case where one transitive
++ one operator with operator gone invalidated incorrectly.
 
 Run:
   python -m unittest tests.test_t6c_causality_cascade
@@ -145,6 +153,76 @@ class ShouldInvalidateEdgeTests(unittest.TestCase):
             ],
         }
         self.assertFalse(should_invalidate_edge(edge, set()))
+
+    def test_t6cb_corroborator_loss_with_foundation_preserves(self):
+        """T6.C.b refinement: ONE transitive (foundation) + ONE operator
+        (corroborator). The operator base goes empty; foundation alive.
+
+        Original T6.C: invalidate (operator-all-empty trivially fires
+        with one operator entry).
+        T6.C.b: preserve (foundation intact; lost corroborator only
+        weakens the derivation, doesn't break it).
+
+        Mirrors the "캘리포니아는 미국이다" + "어른 X가 봤다" example:
+        losing the corroborator (X's testimony) while the chain link
+        survives = derivation weakens but holds.
+        """
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b_foundation",
+                 "derivation": "transitive"},
+                {"base_fact_id": "b_corroborator",
+                 "derivation": "operator"},
+            ],
+        }
+        # Only the corroborator empty → preserve.
+        self.assertFalse(
+            should_invalidate_edge(edge, {"b_corroborator"})
+        )
+
+    def test_t6cb_all_corroborators_lost_with_foundation_preserves(self):
+        """T6.C.b refinement: 1 transitive + 3 operator. ALL operator
+        bases go empty; foundation alive → preserve. The foundation
+        still supports the derivation alone."""
+        edge = {
+            "id": "e_derived",
+            "derived_from": [
+                {"base_fact_id": "b_foundation",
+                 "derivation": "transitive"},
+                {"base_fact_id": "b_corr1", "derivation": "operator"},
+                {"base_fact_id": "b_corr2", "derivation": "operator"},
+                {"base_fact_id": "b_corr3", "derivation": "operator"},
+            ],
+        }
+        # All operators empty, foundation alive → preserve.
+        self.assertFalse(
+            should_invalidate_edge(
+                edge, {"b_corr1", "b_corr2", "b_corr3"},
+            ),
+        )
+        # Now the foundation is also lost → invalidate (Rule 1).
+        self.assertTrue(
+            should_invalidate_edge(
+                edge,
+                {"b_foundation", "b_corr1", "b_corr2", "b_corr3"},
+            ),
+        )
+
+    def test_t6cb_operator_only_edge_still_collapses_when_all_gone(self):
+        """Rule 2 boundary: operator-only edge (no hard deps) with
+        ALL operator bases empty → invalidate. The "lone corroborator
+        collapse" case — no foundation to fall back on."""
+        edge = {
+            "id": "e_corr_only",
+            "derived_from": [
+                {"base_fact_id": "b1", "derivation": "operator"},
+                {"base_fact_id": "b2", "derivation": "operator"},
+            ],
+        }
+        self.assertTrue(should_invalidate_edge(edge, {"b1", "b2"}))
+        # Partial loss still preserves.
+        self.assertFalse(should_invalidate_edge(edge, {"b1"}))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

T6.C (#564) shipped per-derivation-type cascade but collapsed a subtle case the user flagged in review: a derived edge with **ONE** transitive (foundation) + **ONE** operator (corroborator), when the operator base goes empty while the transitive base stays alive, was being invalidated because *"operator entries exist AND all empty → invalidate"* fired trivially with N=1 operator entry.

**User-clarified intent**: operator entries are **corroborative**, not load-bearing. When a foundational chain link (transitive/inferred) is alive, losing corroborators only **WEAKENS** the derivation, never invalidates it. Confidence reduction is T3 (Aging) territory; T6 is binary (invalidate or preserve).

## Refined C-semantics

```
invalidate :=
    (any hard dep base empty)              # Rule 1: structural break
  OR
    (hard_deps == [] AND operator entries exist
     AND all operator bases empty)         # Rule 2: lone-corroborator collapse
```

- **Hard deps** = `transitive` / `inferred` (chain links / single inference)
- **Soft deps** = `operator` (multi-source human evidence)
- Operator entries NEVER fire Rule 2 when hard deps are present and alive.

## Real-world example

derived edge *"철수가 미국에 산다"*:
- `b_california_in_usa` → `transitive` (foundation, chain link)
- `b_witness_X` → `operator` (corroborator, "X가 봤다")

| scenario | original T6.C | T6.C.b (this PR) | correct? |
|---|---|---|---|
| `b_witness_X` empty (foundation alive) | invalidate | **preserve** | ✓ corroborator loss only weakens |
| `b_california_in_usa` empty (witness alive) | invalidate | invalidate | ✓ Rule 1 fires |
| both empty | invalidate | invalidate | ✓ Rule 1 fires |
| `b_witness_X` alone supports edge, then empties | invalidate | invalidate | ✓ Rule 2 fires (no hard deps) |

## Files

### `core/lifecycle/causality.py`

- `should_invalidate_edge` rewritten with explicit `hard_deps` / `operator_entries` partitioning + the two-rule evaluation.
- Module docstring updated to spell out the refinement + real-world example.

### `tests/test_t6c_causality_cascade.py`

3 new test cases:

| test | what it pins |
|---|---|
| `test_t6cb_corroborator_loss_with_foundation_preserves` | canonical "캘리포니아 + X testimony" scenario |
| `test_t6cb_all_corroborators_lost_with_foundation_preserves` | 1 transitive + 3 operator, all operator gone → preserve; foundation also gone → invalidate |
| `test_t6cb_operator_only_edge_still_collapses_when_all_gone` | Rule 2 boundary: operator-only edge with all empty → invalidate, partial loss → preserve |

Existing 11 `ShouldInvalidateEdgeTests` + 8 `InvalidateDerivedFactsTests` all still pass — they didn't exercise the misclassified case.

## Verification

- `python -m unittest tests.test_t6c_causality_cascade` → **22/22 pass** (19 original + 3 new T6.C.b cases)
- Full adjacent regression (T6.A + T6.B + T6.C + T2.D + QVT) → **107/107 pass**
- `ruff check` clean

## Quality Delta vs baseline

`Quality delta: exempt (label: code — pure decision-function fix + tests. No production caller wired yet; semantic correction strengthens the T6.D integration about to land.)`.

## Out of scope

- **T6.D** — integration with `cascade_remove_doc_from_sources` + 4 release-gating invariants (the entry memo's `test_partial_base_loss_preserves_derived` invariant now has unambiguous semantics to gate against — T6.C.b refinement makes Decision 4's "preserve on partial loss" behavior the default for mixed-derivation edges).
- **T6.E** — v0.4.1 closure docs + entry memo §2 Decision 4 text update (both the original *"any base fact"* text + this refinement land in the closure doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)