### PR TITLE
feat(lifecycle): v0.4.1 PR-T6.D — cascade integration + 4 release-gating invariants

### DIFF
--- a/core/cascade/_delete.py
+++ b/core/cascade/_delete.py
@@ -32,7 +32,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 import shutil
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from core.relations_schema import (
     MANUAL_SOURCE_ROLE,
@@ -50,18 +50,43 @@ from ._helpers import (
 def cascade_remove_doc_from_sources(
     doc_entity_id: str,
     entity_root:   Path,
+    *,
+    audit_emit:    Optional[Callable[[Dict[str, Any]], None]] = None,
+    propagate_t6:  bool = True,
 ) -> Dict[str, int]:
     """모든 entity 의 relation sources 에서 ``doc_entity_id`` 항목을 제거.
 
     설계 §14 의 reference 구현. manual / legacy source 는 건드리지 않음.
     sources 가 모두 사라진 relation 은 relation 자체가 사라진다.
 
+    v0.4.1 PR-T6.D — when a relation is dropped (sources became empty),
+    its ``id`` is collected as a ``base_fact_id`` for the downstream
+    T6 causality cascade. After this function's primary loop completes,
+    ``invalidate_derived_facts`` (T6.C) is invoked with the full set
+    of dropped ids, walking the wiki once to find edges whose
+    ``derived_from`` references any of them. Per the T6.C.b refined
+    semantics, only edges with broken foundational (transitive/inferred)
+    bases — OR purely-corroborator edges with all bases gone —
+    invalidate; edges with surviving foundational support stay alive.
+
+    Args:
+        doc_entity_id: doc whose sources are being purged.
+        entity_root: wiki entity root for the walk.
+        audit_emit: optional callback for T6 audit rows. Each
+            T6-invalidated edge gets one row with
+            ``mutation_type="invalidated_by_cascade"``.
+        propagate_t6: opt-out switch (default True). Set False for
+            test scenarios that need the pre-T6.D byte-identical
+            behavior, or for callers that intentionally separate
+            the cascade and T6 phases.
+
     Returns:
         counts = {
-          "entities_scanned":     int,
-          "entities_touched":     int,
-          "relations_recomputed": int,
-          "relations_dropped":    int,
+          "entities_scanned":      int,
+          "entities_touched":      int,
+          "relations_recomputed":  int,
+          "relations_dropped":     int,
+          "derived_invalidated":   int,  # v0.4.1 PR-T6.D
         }
     """
     counts = {
@@ -69,7 +94,9 @@ def cascade_remove_doc_from_sources(
         "entities_touched":     0,
         "relations_recomputed": 0,
         "relations_dropped":    0,
+        "derived_invalidated":  0,
     }
+    dropped_rel_ids: List[str] = []  # T6.D — base_fact_id candidates
     for path in _iter_entity_files(entity_root):
         parsed = _read_frontmatter(path)
         if not parsed:
@@ -105,6 +132,14 @@ def cascade_remove_doc_from_sources(
             touched = True
             if not kept:
                 counts["relations_dropped"] += 1
+                # T6.D — collect the dropped relation's id as a
+                # base_fact_id candidate for the downstream causality
+                # cascade. Relations without an id can't be the target
+                # of any derived_from reference (no stable handle), so
+                # they're silently skipped from the propagation set.
+                rel_id = rel.get("id")
+                if isinstance(rel_id, str) and rel_id:
+                    dropped_rel_ids.append(rel_id)
                 continue   # relation 자체가 사라짐
             rel["sources"]    = kept
             rel["confidence"] = compute_confidence_from_sources(kept)
@@ -115,6 +150,25 @@ def cascade_remove_doc_from_sources(
             counts["entities_touched"] += 1
             fm["relations"] = new_rels
             _write_frontmatter(path, fm, body)
+
+    # v0.4.1 PR-T6.D — propagate causality cascade. Dropped relations
+    # may have been base_fact_id targets of derived edges elsewhere
+    # in the wiki. Call invalidate_derived_facts once with the full
+    # set so the walk is O(N entity files) instead of O(N × dropped).
+    # Per-derived-edge T6.C.b semantics still evaluates correctly.
+    if propagate_t6 and dropped_rel_ids:
+        # Import locally to avoid circular-import risk + keep T6
+        # optional for callers that don't pull it in.
+        from core.lifecycle.causality import invalidate_derived_facts
+        first = dropped_rel_ids[0]
+        rest = set(dropped_rel_ids[1:])
+        invalidated = invalidate_derived_facts(
+            first,
+            entity_root,
+            additional_empty_bases=rest,
+            audit_emit=audit_emit,
+        )
+        counts["derived_invalidated"] = len(invalidated)
 
     return counts
 

--- a/tests/test_t6_release_gating_invariants.py
+++ b/tests/test_t6_release_gating_invariants.py
@@ -1,0 +1,304 @@
+"""v0.4.1 PR-T6.D — release-gating invariants for the T6 Causality Chain.
+
+Four invariants the v0.4.1 entry memo §3 marked as "must hold before
+v0.4.1 release":
+
+  1. test_derived_invalidated_when_base_removed — cascade removes a
+     doc, the base relation that used to depend on that doc loses its
+     sources, the derived edge automatically transitions to
+     status.active=False + mutation_type=invalidated. End-to-end via
+     the real cascade_remove_doc_from_sources call site.
+
+  2. test_partial_base_loss_preserves_derived — T6.C.b refinement:
+     a derived edge with foundation alive + corroborator gone stays
+     active. Confidence-decay-on-corroborator-loss is T3 territory;
+     T6 binary stays binary.
+
+  3. test_causality_chain_acyclic_rejected_at_write — Decision 3
+     LOCK: a relation whose derived_from transitively points to
+     itself fails validate_edge_t6_derived_from at write time.
+
+  4. test_cascade_invalidate_emits_audit_row — every derived
+     invalidation surfaces in audit_log with mutation_type=
+     "invalidated_by_cascade" + chain pointers so the T7 replay
+     primitive can reconstruct the history.
+
+Unlike the unit tests in tests/test_t6c_causality_cascade.py, these
+invariants run end-to-end against a real wiki fixture built on
+tmpdir + actual cascade_remove_doc_from_sources(). A regression in
+the integration surfaces here on every PR thereafter.
+
+Run:
+  python -m pytest tests/test_t6_release_gating_invariants.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.cascade._delete import cascade_remove_doc_from_sources  # noqa: E402
+from core.lifecycle.schema import (  # noqa: E402
+    validate_edge_t6_derived_from,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — real entity files on tmpdir
+# ---------------------------------------------------------------------------
+
+def _write_entity(root: Path, ent_type: str, name: str,
+                  relations: list, *, etype: str = "concept") -> Path:
+    """Write a v0.4-shaped entity file."""
+    ent_dir = root / "entity" / "prod" / etype
+    ent_dir.mkdir(parents=True, exist_ok=True)
+    path = ent_dir / f"{name}.md"
+    fm = {
+        "entity_id":   f"e_{etype}_{name.lower()}",
+        "entity_type": etype,
+        "name":        name,
+        "relations":   relations,
+        "sources":     ["seed.md"],
+    }
+    text = (
+        "---\n"
+        + yaml.dump(fm, allow_unicode=True, default_flow_style=False,
+                    sort_keys=True)
+        + "---\n\n"
+        + f"## Summary\n{name}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _load_relations(path: Path) -> list:
+    text = path.read_text(encoding="utf-8")
+    fm_text = text.split("---", 2)[1]
+    return yaml.safe_load(fm_text).get("relations", [])
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — derived invalidated when base removed
+# ---------------------------------------------------------------------------
+
+class DerivedInvalidatedWhenBaseRemovedTests(unittest.TestCase):
+    """Cascade-remove a doc → base relation drops (sources empty)
+    → derived edge auto-invalidates via the T6.D propagation."""
+
+    def test_derived_invalidated_when_base_removed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            # Base entity carrying a relation whose only source is
+            # the doc we're about to remove.
+            _write_entity(root, "concept", "Base", [{
+                "id":      "e_base_rel",
+                "target":  "BaseTarget",
+                "type":    "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_A", "role": "extract", "weight": 0.9,
+                }],
+            }])
+            # Derived entity whose relation references e_base_rel as a
+            # transitive (hard) base.
+            _write_entity(root, "concept", "Derived", [{
+                "id":           "e_derived_rel",
+                "target":       "DerivedTarget",
+                "type":         "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_unrelated", "role": "extract",
+                    "weight": 0.8,
+                }],
+                "derived_from": [
+                    {"base_fact_id": "e_base_rel",
+                     "derivation": "transitive"},
+                ],
+            }])
+            entity_root = root / "entity"
+
+            counts = cascade_remove_doc_from_sources("doc_A", entity_root)
+
+            # Base relation dropped + derived invalidated.
+            self.assertEqual(counts["relations_dropped"], 1)
+            self.assertEqual(counts["derived_invalidated"], 1)
+
+            derived_rels = _load_relations(
+                root / "entity" / "prod" / "concept" / "Derived.md"
+            )
+            self.assertEqual(len(derived_rels), 1)
+            self.assertEqual(
+                derived_rels[0].get("mutation_type"), "invalidated"
+            )
+            self.assertFalse(
+                derived_rels[0].get("status", {}).get("active", True)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — partial base loss preserves derived (T6.C.b)
+# ---------------------------------------------------------------------------
+
+class PartialBaseLossPreservesDerivedTests(unittest.TestCase):
+    """T6.C.b refinement: a derived edge with a foundational
+    (transitive) base alive + a corroborative (operator) base lost
+    stays active. The cascade-removed doc only affects the
+    corroborator's base; the foundation chain is untouched."""
+
+    def test_partial_base_loss_preserves_derived(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            # Two base relations: one from a doc that will SURVIVE,
+            # one from a doc we'll remove. The derived edge references
+            # the latter as an operator (corroborator) entry + the
+            # former as a transitive (foundation).
+            _write_entity(root, "concept", "Foundation", [{
+                "id":      "e_foundation_rel",
+                "target":  "X",
+                "type":    "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_survives", "role": "extract",
+                    "weight": 0.95,
+                }],
+            }])
+            _write_entity(root, "concept", "Corroborator", [{
+                "id":      "e_corr_rel",
+                "target":  "Y",
+                "type":    "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_remove", "role": "extract",
+                    "weight": 0.6,
+                }],
+            }])
+            _write_entity(root, "concept", "Derived", [{
+                "id":           "e_derived_rel",
+                "target":       "DerivedTarget",
+                "type":         "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_unrelated", "role": "extract",
+                    "weight": 0.8,
+                }],
+                "derived_from": [
+                    {"base_fact_id": "e_foundation_rel",
+                     "derivation": "transitive"},
+                    {"base_fact_id": "e_corr_rel",
+                     "derivation": "operator"},
+                ],
+            }])
+            entity_root = root / "entity"
+
+            cascade_remove_doc_from_sources("doc_remove", entity_root)
+
+            # Foundation alive → derived preserved (T6.C.b).
+            derived_rels = _load_relations(
+                root / "entity" / "prod" / "concept" / "Derived.md"
+            )
+            self.assertEqual(len(derived_rels), 1)
+            # Derived's own mutation_type stays at v0.4 default
+            # ("active") since the cascade only touched the corroborator
+            # and T6.C.b preserves on partial loss.
+            self.assertNotEqual(
+                derived_rels[0].get("mutation_type"), "invalidated"
+            )
+            status = derived_rels[0].get("status", {})
+            # Either absent (v0.4 default) or active=True; not
+            # invalidated.
+            self.assertNotEqual(status.get("active"), False)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — causality chain acyclic rejected at write
+# ---------------------------------------------------------------------------
+
+class CausalityChainAcyclicTests(unittest.TestCase):
+    """Decision 3 LOCK — a relation whose derived_from transitively
+    points to itself raises at validate_edge_t6_derived_from time
+    (the write-side gate from T6.A)."""
+
+    def test_self_reference_rejected_at_write(self):
+        edge = {
+            "id": "e_self",
+            "derived_from": [
+                {"base_fact_id": "e_self", "derivation": "transitive"},
+            ],
+        }
+        with self.assertRaisesRegex(ValueError, "derivation cycle"):
+            validate_edge_t6_derived_from(
+                edge, edges_by_id={"e_self": edge},
+            )
+
+    def test_two_hop_cycle_rejected_at_write(self):
+        e_a = {
+            "id": "e_a",
+            "derived_from": [
+                {"base_fact_id": "e_b", "derivation": "transitive"},
+            ],
+        }
+        e_b = {
+            "id": "e_b",
+            "derived_from": [
+                {"base_fact_id": "e_a", "derivation": "transitive"},
+            ],
+        }
+        edges_by_id = {"e_a": e_a, "e_b": e_b}
+        with self.assertRaisesRegex(ValueError, "derivation cycle"):
+            validate_edge_t6_derived_from(e_a, edges_by_id=edges_by_id)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — cascade invalidation emits audit row
+# ---------------------------------------------------------------------------
+
+class CascadeInvalidateAuditTests(unittest.TestCase):
+    """Every T6 invalidation surfaces in audit_log with
+    ``mutation_type="invalidated_by_cascade"`` + chain pointers
+    so the T7 replay primitive can reconstruct the history."""
+
+    def test_cascade_invalidate_emits_audit_row(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            _write_entity(root, "concept", "Base", [{
+                "id":      "e_base_rel",
+                "target":  "X",
+                "type":    "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_A", "role": "extract", "weight": 0.9,
+                }],
+            }])
+            _write_entity(root, "concept", "Derived", [{
+                "id":           "e_derived_rel",
+                "target":       "Y",
+                "type":         "RELATED_TO",
+                "sources": [{
+                    "doc_id": "doc_unrelated", "role": "extract",
+                    "weight": 0.8,
+                }],
+                "derived_from": [
+                    {"base_fact_id": "e_base_rel",
+                     "derivation": "transitive"},
+                ],
+            }])
+            entity_root = root / "entity"
+            emit = MagicMock()
+
+            cascade_remove_doc_from_sources(
+                "doc_A", entity_root, audit_emit=emit,
+            )
+
+            emit.assert_called_once()
+            payload = emit.call_args[0][0]
+            self.assertEqual(
+                payload["mutation_type"], "invalidated_by_cascade"
+            )
+            self.assertEqual(payload["base_fact_id"], "e_base_rel")
+            self.assertEqual(payload["derived_edge_id"], "e_derived_rel")
+            self.assertIn("entity_path", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Final implementation PR for the v0.4.1 T6 Causality Chain track per the v0.4.1 entry memo (#557) §3 PR-T6.D row. Wires `invalidate_derived_facts` (T6.C / T6.C.b semantics) into the production CASCADE call site + lands the **four release-gating invariants** the entry memo §4 acceptance gates against.

| # | PR | scope |
|---|---|---|
| ✅ T6.A | #562 | derived_from schema + validator + migration |
| ✅ T6.B | #563 | derivation extraction (operator-tagged + LLM-inferred) |
| ✅ T6.C | #564 | invalidate_derived_facts cascade |
| ✅ T6.C.b | #565 | foundational vs corroborative refinement |
| **T6.D** | **this PR** | cascade integration + 4 release-gating invariants |
| ⏳ T6.E | — | v0.4.1 closure docs + release publish |

## What changed

### `core/cascade/_delete.py` — `cascade_remove_doc_from_sources` extended

New keyword-only kwargs:
- `audit_emit: Optional[Callable]` (default None) — forwarded to `invalidate_derived_facts`
- `propagate_t6: bool = True` — opt-out for tests / callers that need pre-T6.D behavior

Tracks `dropped_rel_ids` during the primary loop — every relation whose sources become empty AND carries an `id` is collected. After the primary loop, single call:

```python
invalidate_derived_facts(
    dropped_rel_ids[0],
    entity_root,
    additional_empty_bases=set(rest),
    audit_emit=audit_emit,
)
```

**Single walk over the wiki** — O(entities) not O(dropped × entities). Per-edge T6.C.b semantics (foundational vs corroborative) evaluates correctly across the batch.

Returns counts dict gains `derived_invalidated` field.

### `tests/test_t6_release_gating_invariants.py` — new (~10 KB)

Four invariants the entry memo §3 marked as "must hold before v0.4.1 release", all running **end-to-end against tmpdir wiki fixtures + the real cascade call** (no cascade mocks):

| # | invariant | what it pins |
|---|---|---|
| 1 | `test_derived_invalidated_when_base_removed` | cascade-remove doc → base relation drops → derived auto-invalidates via T6.D propagation |
| 2 | `test_partial_base_loss_preserves_derived` | T6.C.b refinement: derived with foundation alive + corroborator gone stays active |
| 3 | `test_causality_chain_acyclic_rejected_at_write` | Decision 3 LOCK: self-reference + 2-hop cycle rejected by `validate_edge_t6_derived_from` |
| 4 | `test_cascade_invalidate_emits_audit_row` | every T6 invalidation emits audit row with `mutation_type="invalidated_by_cascade"` + chain pointers (base_fact_id / derived_edge_id / entity_path) |

## Verification

- `python -m unittest tests.test_t6_release_gating_invariants` → **5/5 pass** (4 invariants + 1 extra cycle case)
- Full adjacent regression (T6.A + T6.B + T6.C + T6.C.b + T6.D + T2.D + QVT + schema) → **112/112 pass**
- `pytest tests/test_phase_c_cascade.py tests/test_phase_e_graph_editor.py tests/test_t7_release_gating_invariants.py` → **69/69 pass** (existing cascade tests unaffected)
- `ruff check` clean

## Backward compatibility

- New kwargs are keyword-only with safe defaults — positional callers don't break.
- Existing return-dict callers don't fail on the new `derived_invalidated` key.
- For wiki snapshots without any `derived_from` annotations (the default state after T6.A migration — every relation gets `derived_from: []`), `invalidate_derived_facts` walks the wiki finding zero candidates → no behavior change. **Byte-identical retrieval relative to v0.4.0** holds until operators (or v0.4.2+ LLM path) start populating `derived_from` lists.

## Quality Delta vs baseline

`Quality delta: exempt (label: code — production wiring with safe default; no behavior change on the current wiki because derived_from is empty after migration. The T6.E closure PR will paste the Quality Delta Card against baseline_2a31b20.json once the v0.4.1 release prep adds re-baseline JSON.)`.

## Out of scope — only T6.E remains

T6.E (v0.4.1 closure + release):
- `ROADMAP.md` v0.4.1 ✅
- `CHANGELOG.md` `[0.4.1]` entry
- `.zenodo.json` v0.4.1 metadata
- `README.md` Status badge bump
- `docs/release_notes_v0.4.1.md`
- Entry memo §2 Decision 4 text update (per-derivation semantics + C.b refinement)
- GitHub release + Zenodo auto-mint (operator action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)