### PR TITLE
chore(release): v0.4.1 PR-T6.E — closure docs + release prep

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
-  "title": "PROJECT JAMES — v0.4.0 (Layer 4 Lifecycle Semantics first bundle — T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction Arbitration; CASCADE/EVENT separation provable)",
-  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.0 is the v0.4 cycle's final tag, shipping the Layer 4 Lifecycle Semantics first bundle (T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction Arbitration) as a release-gated 8-PR sequence executed in a single Sprint 5 session. The CASCADE vs EVENT separation invariant the v0.4 cycle was retargeted around is now provable end-to-end via tests/test_t7_release_gating_invariants.py (5 tests run against the actual wiki fixture, not mocks). Inherits v0.4.0-alpha.3 (10.5281/zenodo.20391100): LEO Evidence-Scope Routing track + Sprint 4 embedding prep + CI / module hygiene.\n\nSprint 5 Layer 4 first bundle (8 PRs per docs/handovers/v0.4.0-sprint5-layer4-first-bundle-entry.md):\n- #524 PR-0 — schema validators + clock helper. core/lifecycle/schema.py (~9 KB) + core/lifecycle/clock.py (~2 KB) + core/relations_schema.py re-export. Field vocabulary: source-level valid_from/valid_until, edge-level validity/status/mutation_type. clock.now() is the single monkeypatch point for the entire EVENT/TEMPORAL track. 51 contract tests.\n- #525 PR-T1.A — schema migration script. scripts/migrate_v04_lifecycle.py. --dry-run default + --apply writes back via tempfile + os.replace (no half-written frontmatter). Pre-write snapshot to wiki.pre-v04-migration/. --verify mode. Idempotent at the byte level after the first apply. 18 contract tests.\n- #538 PR-T1.B — expiration cascade + runner. core/lifecycle/expiration_cascade.py (~15.5 KB) + scripts/run_expiration_cascade.py. Marks mutation_type=expired + status.active=False on every edge whose ALL non-malformed sources have reached valid_until. Does NOT delete (CASCADE concern, separated by design). Manual immunity via edge.manual_immune opt-out. 16 contract tests including the 4 entry-memo invariants.\n- #539 PR-T7.A — supersede chain ops (T7 EVENT primitive). core/lifecycle/supersede_chain.py (~13.8 KB) — 3 pure functions: supersede_edge(old, new_fact, ts) (DOES NOT call cascade_remove), walk_supersede_chain (cycle-safe, max-length-capped, dangling-pointer-tolerant), reconstruct_view_at (replay primitive, skips mutation_type=invalidated). 15 contract tests including 3 entry-memo invariants.\n- #540 PR-T7.B — release-gating invariants suite. tests/test_t7_release_gating_invariants.py (5 tests) + tests/fixtures/lifecycle/ (curated 3-entity wiki). Three release-gating invariants: test_supersede_does_not_trigger_cascade (defense-in-depth — patches both core.cascade.cascade_remove_doc_from_sources + the underlying _delete.* entry point), test_cascade_preserves_supersede_chain (real CASCADE against the fixture; chain links byte-identical post-CASCADE), test_historical_replay_via_chain (end-to-end: CASCADE → supersede_edge → reconstruct_view_at at 3 times → correct chain link). Run against the actual wiki fixture, not mocks.\n- #541 PR-T2.A — A/B contradiction classifier. core/lifecycle/contradiction_arbiter.py (~10.2 KB). Single deterministic function classify_contradiction(old_edge, new_fact, *, now) → Literal['A_invalidate','B_supersede','ignore']. 4-rule decision tree (first match wins): rule 1 B_supersede when world changed, rule 2 A_invalidate when higher-confidence retroactive correction, rule 3 ignore when duplicate inside window with no confidence delta, rule 4 B_supersede default for edge cases (safer than CASCADE). LLM-free by design — the Mem0 differentiator (Mem0 routes via LLM-judge; JAMES routes via this deterministic rule tree). 17 contract tests including 12 parametrized branch cases.\n- #542 PR-T2.B — A-path contradiction routing wire. core/lifecycle/contradiction_router.py (~8.5 KB initial). route_a_invalidate(bad_doc_id, entity_root, *, audit_emit) runs the existing cascade_remove_doc_from_sources unchanged + emits a mutation_type=invalidated audit row. dispatch_contradiction(old_edge, new_fact, ...) is the full A/B dispatcher (B-path raised NotImplementedError at this PR — wired in PR-T2.C). 13 contract tests.\n- #543 PR-T2.C — B-path supersede wiring + final A/B dispatch. Extends contradiction_router.py (~11.3 KB) with route_b_supersede(old_edge, new_fact, supersede_ts, *, audit_emit) calling supersede_edge from PR-T7.A. Audit row carries old_edge_id + new_edge_id + superseded_by + superseded_at so the T7 replay primitive sees the chain. 19 router tests total including end-to-end test_supersede_chain_replayable_after_dispatch.\n- #544 PR-T7.C — Sprint 5 closure docs + v0.4.0 release prep (this deposit). ROADMAP.md v0.4.0 marked closed with the Done-when checklist all green. .zenodo.json + CHANGELOG entry + README.md Status badge bumped to v0.4.0. docs/release_notes_v0.4.0.md.\n\nLEO L.D measurement-substrate (10 cycles, PR #526~#536) hardened the bench substrate against the alpha.3-shipped LEO Evidence-Scope routing track. F1 (retrieval-mode bench + JWT bearer) + F4 (narrow-scope fixture + L.B threshold floor finding) + F5 (k=0 floor fix in evidence_scope.py) + Idea 1 (Path Recall ground truth with expected_path.nodes) + F2 (IntentClassifier audit refuting earlier attribution) + F6 (q15 repeat-run audit refuting stochasticity) + F7 (chroma top-k probe surfacing MiniLM proper-noun weakness) + BL-9 acceptance run (partial — bge-m3 swap active, q15 fix reattributed to query-expansion layer, F9 spawned). #537 QVT handover (docs/handovers/v0.4-quality-verification-track.md) formalises the meta-frame: cost is rigorously measured (V3' protocol cross-validated through Robin's 26b matrix work) but quality is assumed; the Sprint 5 8-PR sequence is the QVT step-3 PR-gate first installment.\n\nDefault-off invariant preserved across every opt-in flag added in this cycle (JAMES_SCOPE_ROUTING / JAMES_AUTO_ROUTER / JAMES_ADAPTIVE_BUDGET / JAMES_EMBEDDING_MODEL / JAMES_ENABLE_CLAUDE_BACKEND). Production fleets pulling v0.4.0 see byte-identical retrieval behaviour relative to v0.4.0-alpha.3 unless they opt into one of the flags.\n\nVerification: Sprint 5 lifecycle suite 123+ tests all green; router + scope suite 187 tests + 77 stage-D1 wiring tests all green; bench / harness contracts 31 tests all green; 5 live wrapper acceptance runs preserved as audit trail under reports/research-runs/.\n\nWhat v0.4.0 does NOT do: no ingestion-path caller for dispatch_contradiction (carried into v0.4.1 with the canonical CEO-change STEP 7 bench); no production BL-9 embedding swap default flip (waits on F9 query-expansion fix); no T3/T4/T5/T6 (those land at v0.4.1/v0.4.2/v0.4.3).",
-  "version": "v0.4.0",
+  "title": "PROJECT JAMES — v0.4.1 (T6 Causality Chain — CASCADE extension for derived facts; per-derivation-type foundational-vs-corroborative semantics; QVT α track full closure)",
+  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.1 ships the T6 Causality Chain — the CASCADE extension that closes the pillar v0.4.0 only half-finished. When cascade_remove_doc_from_sources empties a base fact's sources, edges whose derived_from references that base now auto-invalidate via invalidate_derived_facts. Per-derivation-type foundational-vs-corroborative semantics (T6.C.b refinement): transitive / inferred are hard deps (any base empty → invalidate); operator is corroborative (only invalidates when no hard deps AND all operator bases empty). Plus the v0.4.0 carry-over dispatch_contradiction wiring (T2.D-1/2/2.b/3) lands as flag-gated default-OFF, and the QVT α track ships end-to-end (3-axis non-saturating oracle + canonical baseline_2a31b20.json + PR-gate template + ARCHITECTURE.md §5.7.10).\n\nT6 5-PR sequence:\n- #562 PR-T6.A — derived_from schema + cycle validator (Decision 3 LOCK rejects self-referential derivations at write time) + idempotent migration script (scripts/migrate_v041_lifecycle.py, --dry-run/--apply/--verify, pre-write snapshot). 23 contract tests.\n- #563 PR-T6.B — derivation extraction. core/lifecycle/derivation.py extract_derivation_chain(new_rel, *, context_edges_by_id, llm_provider, enable_llm). Operator-tagged path validates + cycle-checks. LLM-inferred path default OFF via JAMES_T6_LLM_DERIVATION; provider is caller-supplied (module never imports an LLM client). 14 tests.\n- #564 PR-T6.C — invalidate_derived_facts cascade. core/lifecycle/causality.py soft-invalidates (status.active=False + mutation_type=invalidated, sources preserved → edge survives for T7 replay). Atomic per-file writes. 19 tests.\n- #565 PR-T6.C.b — foundational-vs-corroborative refinement. User-clarified intent during review: T6.C had collapsed the 1-transitive + 1-operator case (operator gone → invalidate trivially). C.b refines: transitive / inferred are structural chain links (hard deps); operator is corroborative (soft — strengthens but doesn't single-handedly support when hard deps are alive). 3 new tests pin the case explicitly.\n- #566 PR-T6.D — cascade_remove_doc_from_sources integration + 4 release-gating invariants. Single walk over the wiki with all dropped relation ids batched via additional_empty_bases. tests/test_t6_release_gating_invariants.py runs against tmpdir wiki fixtures with the REAL cascade call (not mocks): test_derived_invalidated_when_base_removed, test_partial_base_loss_preserves_derived (T6.C.b), test_self_reference_rejected_at_write + test_two_hop_cycle_rejected_at_write (Decision 3), test_cascade_invalidate_emits_audit_row. 69 pre-T6 cascade tests still green; CASCADE/EVENT separation invariants from v0.4.0 hold unchanged.\n\nv0.4.0 carry-over T2.D (4 PRs):\n- #558 PR-T2.D-1 — contradiction ingest detector. core/lifecycle/contradiction_ingest_detector.py find_contradiction_candidates (P1 different_tail = CEO-change scenario; P2 divergent_validity). 19 tests.\n- #559 PR-T2.D-2 — flag-gated dispatch in _merge.py. JAMES_T2D_INGEST_DISPATCH=1 default OFF → production byte-identical until operator opts in. B_supersede + ignore handled in-line. 10 tests.\n- #561 PR-T2.D-2.b — A_invalidate cascade race fix via PendingCascade deferred-execution pattern. Dispatcher captures cascade requests; _merge.py calls apply_pending_cascades AFTER writing back its entity (no race). Bad-doc-id heuristic: lowest-weight non-manual source. 15 tests.\n- #560 PR-T2.D-3 — step7 v6 q17 'Anthropic의 CEO는 누구야?' (category ceo-change, abstention_truth absent today, dual-purpose gold_signals matching both abstention phrases AND the actual answer post-seed) + tests/test_t2d3_dispatch_acceptance.py end-to-end synthetic CEO-change. 6 tests.\n\nQVT α track full closure (6 PRs):\n- #550 PR-α-1 design memo — docs/design/v0.4-qvt-alpha-non-saturating-oracle.md. 3-axis non-saturating oracle (Path Coverage / Graded Answer Accuracy / Calibrated Abstention F1) + fixture schema v5 + per-PR Quality Delta Card pattern + 5 exemption labels + 18-cell ablation-matrix shape for v0.4-end.\n- #551 PR-α-2 step7 fixture v4 → v5 — gold_signals (3 atomic claims per query, deterministic substring + alias matcher) + abstention_truth (12 present / 4 absent) + min_recall on 5 path-annotated queries.\n- #552 PR-α-3 oracle module + capture wrapper — eval/qvt/oracle.py 3-axis scorer + scripts/qvt_capture_baseline.py operator wrapper (N=3 paired reruns, v0.4.0 production env fixed).\n- #553 PR-α-4 PR-gate template + CLAUDE.md rule 2 + ARCHITECTURE.md §5.7.10 — Quality Delta Card section, exemption-label one-liner, QVT subsystem named alongside §5.7.4 Bench gate.\n- #555 PR-α-3 baseline capture — eval/qvt/baseline_2a31b20.json canonical reference. N=3 paired, 64-minute operator run. 3 raw bench JSONs under reports/research-runs/ for audit replay.\n- #556 PR-α-3 oracle phrase calibration — Korean security-block phrase additions + blocked=True short-circuit. abstention_f1 lifted from 0.29 → 0.67 median (+0.38).\n\nAlso in v0.4.1:\n- #548 Replayable RAG positioning. README + ARCHITECTURE adopt 'Replayable RAG' as the JAMES category framing.\n- #549 F9 cycle full closure. q15 'David Soria Parra가 누구야?' zero-recall 8-cycle diagnostic ended with path_recall = 1.0 after JAMES_ENABLE_ENTITY_ANCHOR=1 + bge-m3 + JAMES_ENABLE_QUERY_REWRITE=1.\n- #554 v0.4.0 post-mint DOI badge bump (10.5281/zenodo.20391100 → 10.5281/zenodo.20411354).\n- #557 v0.4.1 entry memo. 4-decision LOCK (eager trigger / operator-tagged + LLM flag / strict cycle reject / C.b foundational-vs-corroborative).\n\nDefault-off invariant preserved across every opt-in flag added in this cycle (JAMES_T2D_INGEST_DISPATCH / JAMES_T6_LLM_DERIVATION). T6.D cascade integration default-on but byte-identical retrieval because migration adds derived_from: [] (empty).\n\nVerification: T6 lifecycle suite 83+ contract tests; T2.D ingest suite 50 tests; QVT α 22+ oracle tests + 11 step7 schema tests + canonical baseline_2a31b20.json; 69 pre-T6 cascade tests still green; CASCADE/EVENT separation invariants from v0.4.0 hold unchanged.\n\nWhat v0.4.1 does NOT do: no production flip of JAMES_T2D_INGEST_DISPATCH default to ON; no production population of derived_from; no T3/T4/T5 (those land at v0.4.2/v0.4.3); no v0.4-end QVT ablation matrix capture (18 cells, ~20-hour operator run, deferred to late June+).",
+  "version": "v0.4.1",
   "upload_type": "software",
   "creators": [
     {
@@ -51,7 +51,13 @@
     "mem0-differentiator",
     "deterministic-rule-tree",
     "release-gating-invariants",
-    "quality-verification-track"
+    "quality-verification-track",
+    "causality-chain",
+    "derived-fact-propagation",
+    "foundational-vs-corroborative",
+    "non-saturating-quality-oracle",
+    "pr-gate-quality-delta-card",
+    "replayable-rag"
   ],
   "license": "MIT",
   "access_right": "open",
@@ -63,8 +69,13 @@
       "resource_type": "software"
     },
     {
-      "identifier": "10.5281/zenodo.20391100",
+      "identifier": "10.5281/zenodo.20411354",
       "relation": "isNewVersionOf",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "10.5281/zenodo.20391100",
+      "relation": "isDerivedFrom",
       "resource_type": "software"
     },
     {
@@ -83,50 +94,100 @@
       "resource_type": "software"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/524",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/548",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/525",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/549",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/538",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/550",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/539",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/551",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/540",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/552",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/541",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/553",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/542",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/554",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/543",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/555",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/544",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/556",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/557",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/558",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/559",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/560",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/561",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/562",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/563",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/564",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/565",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/566",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     }
   ],
-  "notes": "v0.4.0 is the v0.4 cycle's final tag. It ships the Layer 4 Lifecycle Semantics first bundle (T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction Arbitration) as a release-gated 8-PR Sprint 5 sequence. The CASCADE vs EVENT separation invariant is now provable end-to-end via tests/test_t7_release_gating_invariants.py against the actual wiki fixture. Layer 4 follow-ons (T3 / T4 / T5 / T6 + an ingestion-path caller for dispatch_contradiction) land in v0.4.1~v0.4.3 per ROADMAP phase plan. The LEO contribution chain (alpha.3 PRs #512~#517 + this tag's bench-substrate hardening PRs #526~#536 + #537 QVT handover) remains JAMES's first external-contributor track. The isNewVersionOf chain back to v0.4.0-alpha.3 (10.5281/zenodo.20391100) makes the DOI lineage explicit; the chain back to v0.3.3 / v0.3.2 / v0.3.1 stays via the alpha.3 record. Three-author joint-piece collaboration with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the mid-June trajectory."
+  "notes": "v0.4.1 closes the CASCADE pillar v0.4.0 only half-finished. T6 Causality Chain ships as a 5-PR sequence (T6.A schema + cycle validator + migration → T6.B derivation extraction → T6.C invalidate_derived_facts cascade → T6.C.b foundational-vs-corroborative refinement → T6.D cascade integration + 4 release-gating invariants). Plus the v0.4.0 carry-over dispatch_contradiction wiring (T2.D-1/2/2.b/3) lands as flag-gated default-OFF. Plus the QVT α track ships end-to-end (3-axis non-saturating oracle + canonical baseline_2a31b20.json + PR-gate template + ARCHITECTURE §5.7.10). All decisions back-traceable to the T6.C.b user-clarified semantics during T6.C review. The isNewVersionOf chain back to v0.4.0 (10.5281/zenodo.20411354) makes the DOI lineage explicit; the chain back to v0.4.0-alpha.3 (10.5281/zenodo.20391100) and v0.3.x stays via isDerivedFrom. Three-author joint-piece collaboration with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the mid-June trajectory."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.1] — 2026-05-28 — T6 Causality Chain (CASCADE extension) — derived-fact propagation
+
+**Theme**: v0.4.1 closes the CASCADE pillar that v0.4.0 only half-finished. When `cascade_remove_doc_from_sources` empties a base fact's sources, edges whose `derived_from` references that base now auto-invalidate via `invalidate_derived_facts` — the derivation chain stays internally consistent without manual operator intervention. Per-derivation-type semantics (T6.C.b refinement): `transitive` / `inferred` are hard deps (any base empty → invalidate); `operator` is corroborative (only invalidates when no hard deps AND all operator bases empty). Plus the v0.4.0 carry-over `dispatch_contradiction` wiring (T2.D-1/2/2.b/3) lands as flag-gated default-OFF, the QVT α track ships end-to-end (oracle + canonical baseline JSON + PR-gate template), and `tests/test_t6_release_gating_invariants.py` provides 4 release-gating invariants against real wiki fixtures.
+
+**Default-off invariant preserved**. `JAMES_T2D_INGEST_DISPATCH` (T2.D wiring) + `JAMES_T6_LLM_DERIVATION` (T6.B LLM path) both default OFF. T6.D cascade integration is on by default but the wiki gains `derived_from: []` (empty) via T6.A migration so byte-identical retrieval behaviour relative to v0.4.0 holds until operators (or v0.4.2+ LLM path) start populating `derived_from`.
+
+### T6 Causality Chain — 5-PR sequence (#562 ~ #566)
+
+Per `docs/handovers/v0.4.1-t6-causality-chain-entry.md` plan:
+
+- **#562 PR-T6.A — schema + cycle validator + migration**. `core/lifecycle/schema.py` gains `T6_EDGE_FIELD_DERIVED_FROM` + `VALID_DERIVATION_TYPES` (`transitive` / `operator` / `inferred`) + `validate_edge_t6_derived_from(edge, *, edges_by_id)` (Decision 3 LOCK — cycle rejection at write time) + idempotent `apply_t6_edge_defaults`. `scripts/migrate_v041_lifecycle.py` adds `derived_from: []` to every existing relation atomically (`--dry-run` / `--apply` / `--verify` / pre-write snapshot to `wiki.pre-v041-migration/`). 23 contract tests.
+- **#563 PR-T6.B — derivation extraction (operator-tagged + flag-gated LLM)**. `core/lifecycle/derivation.py` (~10 KB). `extract_derivation_chain(new_rel, *, context_edges_by_id, llm_provider, enable_llm)` — operator-tagged path validates + cycle-checks; LLM-inferred path (default OFF via `JAMES_T6_LLM_DERIVATION`) delegates to caller-supplied `LLMDerivationProvider` callable. Module never imports an LLM client directly. 14 contract tests.
+- **#564 PR-T6.C — `invalidate_derived_facts` cascade**. `core/lifecycle/causality.py` (~10 KB). `should_invalidate_edge` (pure decision) + `invalidate_derived_facts(base_fact_id, entity_root, *, additional_empty_bases, audit_emit)`. Soft-invalidate: `status.active=False` + `mutation_type=invalidated`, `sources` preserved → edge survives for T7 replay. Atomic per-file writes. 19 contract tests.
+- **#565 PR-T6.C.b — foundational vs corroborative refinement**. T6.C had collapsed the 1-transitive + 1-operator case (operator gone → invalidate trivially); user clarified intent during review. C.b refines: `transitive` / `inferred` are structural chain links (**hard deps**); `operator` is corroborative (**soft** — strengthens but doesn't single-handedly support when hard deps are alive). Invalidation rules: any hard dep base empty → invalidate (structural break); OR no hard deps AND operator entries exist AND all operator bases empty → invalidate (lone-corroborator collapse). 22 tests (19 original + 3 new C.b).
+- **#566 PR-T6.D — cascade integration + 4 release-gating invariants**. `cascade_remove_doc_from_sources` extended (kwargs `audit_emit` + `propagate_t6=True` opt-out). After the primary loop, single call to `invalidate_derived_facts` with all dropped relation ids batched via `additional_empty_bases`. `tests/test_t6_release_gating_invariants.py` (5 tests against tmpdir wiki fixtures + real `cascade_remove_doc_from_sources`): `test_derived_invalidated_when_base_removed`, `test_partial_base_loss_preserves_derived` (T6.C.b refinement), `test_self_reference_rejected_at_write` + `test_two_hop_cycle_rejected_at_write` (Decision 3), `test_cascade_invalidate_emits_audit_row`. 69 existing cascade tests (`test_phase_c_cascade.py` + `test_phase_e_graph_editor.py` + `test_t7_release_gating_invariants.py`) all still pass — no regression.
+
+T6 lifecycle suite total: **83+ contract tests** pass.
+
+### v0.4.0 carry-over — `dispatch_contradiction` ingestion wiring (T2.D, 4 PRs, #558 ~ #561)
+
+v0.4.0 release notes called out the ingestion-path caller for `dispatch_contradiction` as a v0.4.1 deliverable. Shipped in 4 sub-PRs:
+
+- **#558 PR-T2.D-1 — contradiction ingest detector + tests**. `core/lifecycle/contradiction_ingest_detector.py` (~8 KB). `find_contradiction_candidates(new_rel, existing_rels)` returns (existing_rel, pattern) pairs — pattern P1 "different_tail" (CEO-change scenario: same predicate, different target), P2 "divergent_validity" (same target with v0.4 lifecycle metadata). `to_classifier_edge_shape` adapter for the ingestion → classifier shape bridge. 19 contract tests.
+- **#559 PR-T2.D-2 — flag-gated dispatch in merge**. `core/lifecycle/ingest_contradiction.py` (~9 KB) + `core/wiki_generator/_merge.py` pre-merge hook. `dispatch_contradictions_for_merge(new_rels, existing_rels, *, ingest_doc_id, ingest_ts, audit_emit)`. B_supersede + ignore in-line; `JAMES_T2D_INGEST_DISPATCH=1` default OFF → production byte-identical until opt-in. 10 contract tests.
+- **#561 PR-T2.D-2.b — A_invalidate cascade race fix via pending_cascades**. T2.D-2 logged-only A_invalidate (cascade would race with the in-memory `_merge.py` write-after-read). T2.D-2.b introduces `PendingCascade` dataclass + `apply_pending_cascades(pending, entity_root, *, audit_emit)`; dispatcher captures cascade requests; `_merge.py` calls the apply helper AFTER writing back its entity (no race). Bad-doc-id heuristic: lowest-weight non-manual source. Manual sources never targeted (`cascade_remove` preserves them by design). 15 tests including 3 `ApplyPendingCascadesTests` + 2 `PickCascadeTargetTests`.
+- **#560 PR-T2.D-3 — step7 v6 q17 CEO + acceptance integration**. `eval/regression/step7_queries.json` bumped to v6 with q17 *"Anthropic의 CEO는 누구야?"* (category `ceo-change`, `abstention_truth: "absent"` today, dual-purpose `gold_signals` matching both abstention phrases AND the actual answer post-seed). `tests/test_t2d3_dispatch_acceptance.py` (6 tests) — end-to-end CEO-change scenario via synthetic seed edge + dispatch + `walk_supersede_chain` returns ordered chain.
+
+### QVT α track closure (6 PRs, #550 ~ #553 + #555 + #556)
+
+QVT formalised in v0.4.0 (handover memo #537) ships its full **α-track implementation** in v0.4.1:
+
+- **#550 PR-α-1 — design memo**. `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md` (~14 KB). 3-axis non-saturating oracle (Path Coverage / Graded Answer Accuracy / Calibrated Abstention F1) + fixture schema v5 + per-PR Quality Delta Card pattern + 5 exemption labels (`external-contributor` / `joint-collab-prep` / `docs` / `chore` / `ci` / `code`) + 18-cell ablation-matrix shape for v0.4-end.
+- **#551 PR-α-2 — step7 fixture v4 → v5**. 16-query fixture extended with `gold_signals` (3 atomic claims per query, deterministic substring + alias matcher) + `abstention_truth` (12 present / 4 absent) + `min_recall: 1.0` on 5 path-annotated queries. `tests/test_step7_v5_schema.py` (11 invariant tests). `expected_path.edges` deferred (current graph schema uses generic `RELATED_TO` only).
+- **#552 PR-α-3 — oracle module + capture wrapper**. `eval/qvt/oracle.py` (~14 KB) — `detect_abstention` (Korean + English phrase matcher), `score_path_coverage`, `score_graded_answer`, `score_abstention_f1` (positive class = abstained), `score_three_axis` top-level + `ThreeAxisResult` dataclass. `scripts/qvt_capture_baseline.py` (~13 KB) — operator wrapper spawning its own server with v0.4.0 production env fixed (ENTITY_ANCHOR=1 + bge-m3 + REWRITE=1, routing layers OFF), N=3 paired reruns, atomic median / min / max / noise_band aggregation. 20 oracle contract tests + `eval/qvt/__init__.py` public API.
+- **#553 PR-α-4 — PR-gate template + CLAUDE.md rule 2 + ARCHITECTURE.md §5.7.10**. `.github/PULL_REQUEST_TEMPLATE.md` introduces the Quality Delta Card section with the exemption-label one-liner. CLAUDE.md rule 2 extended (bench + delta card with `core/`-touch trigger). `docs/ARCHITECTURE.md` §5.7.10 names the QVT subsystem alongside §5.7.4 (Bench gate): cost vs marginal quality contribution.
+- **#555 PR-α-3 baseline capture — `baseline_2a31b20.json`**. Canonical reference (~25 KB) for every future Quality Delta Card comparison. N=3 paired reruns, ~64-minute operator run. Aggregate (raw): `path_coverage` 1.00 / 0.00 noise; `graded_answer` 0.58 / 0.10 noise; `abstention_f1` 0.29 / 0.40 noise. 3 raw bench JSONs under `reports/research-runs/` for audit replay.
+- **#556 PR-α-3 oracle phrase calibration**. Baseline capture surfaced two oracle misses (Korean security-block `"자료에 없"` / `"차단"` missing + `blocked=True` flag unused). Fix: add phrases + `blocked=True` short-circuit. Re-scored baseline (same 3 bench JSONs, deterministic). `abstention_f1` lifted **0.29 → 0.67** median (+0.38); noise band tightened 0.40 → 0.29. 2 new oracle tests pin the regression.
+
+QVT α track total: **22+ oracle contract tests** + canonical `baseline_2a31b20.json`.
+
+### v0.4.1 also ships
+
+- **Replayable RAG positioning** (#548). README + ARCHITECTURE adopt "Replayable RAG" as the JAMES category framing. Two contrast lines (vs Agentic RAG / vs Mem0) + `core/lifecycle/contradiction_arbiter.py:classify_contradiction` named as the Mem0 differentiator. Repo rename deferred past mid-June joint piece milestone.
+- **F9 cycle full closure** (#549). q15 *"David Soria Parra가 누구야?"* zero-recall 8-cycle diagnostic ended with `path_recall = 1.0` after `JAMES_ENABLE_ENTITY_ANCHOR=1` + `JAMES_EMBEDDING_MODEL=BAAI/bge-m3` + `JAMES_ENABLE_QUERY_REWRITE=1`. Closure result doc + audit-trail bench JSON under `reports/research-runs/`.
+- **v0.4.0 post-mint DOI badge** (#554). README DOI shields bumped `10.5281/zenodo.20391100` → `10.5281/zenodo.20411354` (v0.4.0 Zenodo mint).
+- **v0.4.1 entry memo** (#557). `docs/handovers/v0.4.1-t6-causality-chain-entry.md` — 4-decision LOCK section (eager trigger / operator-tagged + LLM flag / strict cycle reject / **C.b foundational-vs-corroborative semantics** — Decision 4 clarified during this release vs the original memo text).
+
+### Verification
+
+- **T6 lifecycle suite**: 83+ contract tests pass.
+- **T2.D ingest suite**: 50 contract tests.
+- **QVT α**: 22+ oracle contract tests + 11 step7 v5 schema tests + canonical `baseline_2a31b20.json`.
+- **No regression**: 69 pre-T6 cascade tests still green; CASCADE/EVENT separation invariants from v0.4.0 hold unchanged.
+
+### What v0.4.1 does NOT do
+
+- No production flip of `JAMES_T2D_INGEST_DISPATCH` default to ON (operator opts in until fixtures exercise dispatch broadly).
+- No production population of `derived_from` (migration adds `[]`; operator-tagged + v0.4.2+ LLM-inferred path fill them in).
+- No T3 (Aging) / T4 (Reviewer) / T5 (Snapshot replay) — those land at v0.4.2 / v0.4.3.
+- No v0.4-end QVT ablation matrix capture (18 cells, ~20-hour operator run, deferred to late June+).
+
+---
+
 ## [0.4.0] — 2026-05-27 — Layer 4 Lifecycle Semantics (T1 + T7 + T2 first bundle) — CASCADE/EVENT separation provable
 
 **Theme**: v0.4.0 final. Ships the Layer 4 Lifecycle Semantics first bundle (T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction Arbitration) as a release-gated 8-PR sequence per the Sprint 5 entry memo. The CASCADE vs EVENT separation invariant the v0.4 cycle was retargeted around is now **provable end-to-end** via `tests/test_t7_release_gating_invariants.py` (run against the actual `tests/fixtures/lifecycle/` wiki, not mocks). Plus the L.D measurement-substrate sprint (10 cycles, PR #526~#536) that hardened the bench substrate against the LEO Evidence-Scope routing track shipped in alpha.3, and the Quality Verification Track (QVT) handover (#537) that formalises the measurement loop the L.D cycles built.

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 > 동작.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.0-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0)
+[![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20411354.svg)](https://doi.org/10.5281/zenodo.20411354)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > self-evolution.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.0-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.0)
+[![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20411354.svg)](https://doi.org/10.5281/zenodo.20411354)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -671,6 +671,72 @@ Reference architecture: `docs/architecture/memory-lifecycle-architecture.md`.
 
 ---
 
+## v0.4.1 — T6 Causality Chain (CASCADE extension, shipped 2026-05-28)
+
+**Status**: ✅ **CLOSED**. T6 Causality Chain landed as the v0.4.1 cycle's main theme (5-PR sequence T6.A → T6.B → T6.C → T6.C.b refinement → T6.D + the v0.4.0 carry-over T2.D-1/2/2.b/3 + QVT α track full closure). 21 PRs in a single multi-day session (#548 ~ #566).
+
+**Entry handover**: `docs/handovers/v0.4.1-t6-causality-chain-entry.md` — 4-LOCK decisions (eager trigger / operator-tagged + LLM flag / strict cycle reject / **C.b foundational-vs-corroborative semantics** — Decision 4 refined in T6.C.b vs the original memo text).
+
+### Done — T6 5-PR sequence + 4 release-gating invariants
+
+- **PR-T6.A** (#562) — `derived_from` schema field + `validate_edge_t6_derived_from` cycle validator (Decision 3 LOCK) + `apply_t6_edge_defaults` idempotent helper. `scripts/migrate_v041_lifecycle.py` (`--dry-run` / `--apply` / `--verify` / pre-write snapshot). 23 contract tests.
+- **PR-T6.B** (#563) — `core/lifecycle/derivation.py` `extract_derivation_chain` (operator-tagged path + `JAMES_T6_LLM_DERIVATION` flag-gated LLM-inferred path). 14 contract tests.
+- **PR-T6.C** (#564) — `core/lifecycle/causality.py` `invalidate_derived_facts(base_fact_id, entity_root, *, additional_empty_bases, audit_emit)`. Soft-invalidate (status.active=False + mutation_type=invalidated, sources preserved for T7 replay). Atomic per-file writes. 19 contract tests.
+- **PR-T6.C.b** (#565) — foundational-vs-corroborative refinement. `transitive` / `inferred` are hard deps (any base empty → invalidate); `operator` is corroborative (only invalidates when no hard deps AND all operator bases empty). 22 tests (19 original + 3 new C.b cases).
+- **PR-T6.D** (#566) — cascade integration. `cascade_remove_doc_from_sources` now calls `invalidate_derived_facts` for every relation whose sources became empty (single walk batched via `additional_empty_bases`). `tests/test_t6_release_gating_invariants.py` (5 tests): `test_derived_invalidated_when_base_removed`, `test_partial_base_loss_preserves_derived` (T6.C.b), `test_self_reference_rejected_at_write` + `test_two_hop_cycle_rejected_at_write` (Decision 3), `test_cascade_invalidate_emits_audit_row`. Run against tmpdir wiki fixtures + real `cascade_remove_doc_from_sources` — no mocks of the cascade itself.
+
+### Done — v0.4.0 carry-over `dispatch_contradiction` ingestion wiring (T2.D, 4 PRs)
+
+- **PR-T2.D-1** (#558) — `core/lifecycle/contradiction_ingest_detector.py` (P1 different_tail + P2 divergent_validity patterns). 19 tests.
+- **PR-T2.D-2** (#559) — `core/lifecycle/ingest_contradiction.py` + `_merge.py` pre-merge hook. Flag-gated by `JAMES_T2D_INGEST_DISPATCH` (default OFF). 10 tests.
+- **PR-T2.D-2.b** (#561) — A_invalidate cascade race fix via `PendingCascade` deferred-execution. 15 tests.
+- **PR-T2.D-3** (#560) — step7 v6 q17 *"Anthropic의 CEO는 누구야?"* + acceptance integration test. 6 tests.
+
+### Done — QVT α track full closure (6 PRs)
+
+- **PR-α-1** (#550) — `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md`. 3-axis non-saturating oracle + per-PR Quality Delta Card pattern + 5 exemption labels.
+- **PR-α-2** (#551) — step7 fixture v4 → v5 (`gold_signals` + `abstention_truth`).
+- **PR-α-3** (#552) — `eval/qvt/oracle.py` + `scripts/qvt_capture_baseline.py` (operator wrapper).
+- **PR-α-4** (#553) — `.github/PULL_REQUEST_TEMPLATE.md` + CLAUDE.md rule 2 extension + `docs/ARCHITECTURE.md` §5.7.10 QVT subsystem.
+- **PR-α-3 baseline capture** (#555) — `eval/qvt/baseline_2a31b20.json` (N=3 paired reruns, canonical reference).
+- **PR-α-3 oracle calibration** (#556) — Korean security-block phrase additions + `blocked=True` short-circuit. `abstention_f1` 0.29 → 0.67 median.
+
+### Done — also in v0.4.1
+
+- **Replayable RAG positioning** (#548) — README + ARCHITECTURE category framing.
+- **F9 cycle full closure** (#549) — q15 zero-recall closure result doc + audit-trail bench JSON.
+- **v0.4.0 post-mint DOI** (#554) — `10.5281/zenodo.20411354`.
+- **v0.4.1 entry memo** (#557).
+
+### Default-off invariant preserved across every opt-in
+
+| Flag | Default | Verification |
+|---|---|---|
+| `JAMES_T2D_INGEST_DISPATCH` (T2.D-2) | OFF | `_merge.py` pre-merge hook only fires when `=1` |
+| `JAMES_T6_LLM_DERIVATION` (T6.B) | OFF | `extract_derivation_chain` LLM-inferred path needs provider AND flag |
+| T6.D cascade integration | ON (default-on per cycle scope) | byte-identical retrieval because migration adds `derived_from: []`; no actual derivations yet |
+
+### Done when — ✅ All items satisfied at v0.4.1 (2026-05-28)
+
+- ✅ T6 5-PR sequence merged with all 83+ contract tests green.
+- ✅ T6.D 4 release-gating invariants run against real wiki fixtures (`tests/test_t6_release_gating_invariants.py`).
+- ✅ T2.D ingestion wiring (carry-over from v0.4.0) shipped with race-free pending_cascades pattern.
+- ✅ QVT α track complete: oracle module + canonical baseline JSON + PR-gate template + CLAUDE.md rule 2 extension + ARCHITECTURE.md §5.7.10.
+- ✅ Migration script (`scripts/migrate_v041_lifecycle.py`) is idempotent + byte-stable; `--verify` mode confirms.
+- ✅ 69 pre-T6 cascade tests still green (no regression).
+- ✅ Closure docs published: `docs/release_notes_v0.4.1.md` + CHANGELOG `[0.4.1]` + `.zenodo.json` v0.4.1.
+
+### Out of scope (deferred to v0.4.2+)
+
+- **T3 Evidence Aging** — confidence decay over time (EVENT track)
+- **T4 Reviewer Authority Hierarchy** — multi-level governance (GOVERNANCE track)
+- **T5 Replayable Audit Graph** — full event-sourced reconstruction (partial in v0.4.0 via `reconstruct_view_at`)
+- v0.4-end QVT ablation matrix capture (18 cells × N=3 reruns, ~20 hours operator-run)
+- `JAMES_T2D_INGEST_DISPATCH` default flip to ON (waits for fixture coverage)
+- Production seeding of `derived_from` (waits for operator workflow or v0.4.2+ LLM path)
+
+---
+
 ## v0.5.0 — First Domain Pilot (~6 months after v0.4)
 
 **Theme**: prove the platform contract by running ONE real domain

--- a/docs/handovers/v0.4.1-t6-causality-chain-entry.md
+++ b/docs/handovers/v0.4.1-t6-causality-chain-entry.md
@@ -125,13 +125,57 @@ appear during migration and need graceful handling.
 
 ### Decision 4 — Confidence propagation: strict invalidate vs gradual decay
 
-> **LOCKED: strict invalidate when **any** base fact is fully removed
-> (sources empty). Gradual confidence decay deferred to T3.**
+> **LOCKED (refined 2026-05-28 in T6.C.b): per-derivation-type
+> foundational-vs-corroborative semantics. Gradual confidence decay
+> stays deferred to T3.**
 
-T6 only handles the binary case: base fact has sources / base fact
-has no sources. The "base confidence dropped from 0.9 to 0.4 — should
-derived also drop?" case is T3's territory (Aging). Keeping T6 binary
-keeps it composable with T3 later.
+T6 handles the binary case: each base fact has sources or doesn't.
+The "base confidence dropped from 0.9 to 0.4 — should derived also
+drop?" case is T3's territory (Aging). Keeping T6 binary keeps it
+composable with T3 later.
+
+**The binary trigger is per-derivation-type** (refined during T6.C
+review):
+
+  - `derivation: "transitive"` (chain inference, e.g. A→B→C ⇒ A→C):
+    **hard dep**. Loss of any one base breaks the chain → invalidate
+    the derived edge.
+  - `derivation: "inferred"` (LLM-suggested single conclusion):
+    **hard dep**. The inference rests on the cited base; if that
+    base is gone, the inference is suspect → invalidate.
+  - `derivation: "operator"` (human-tagged multi-source support):
+    **soft / corroborative**. Loss of any one leaves remaining bases
+    as alternative support (and any surviving hard dep still
+    supports the structure) → keep alive.
+
+Combined invalidation rule (T6.C.b in `core/lifecycle/causality.py`):
+
+```
+invalidate :=
+    (any hard dep base empty)                            # structural break
+  OR
+    (no hard deps AND all operator bases empty)          # lone-corroborator collapse
+```
+
+The earlier memo text *"strict invalidate when any base fact is
+fully removed"* read as a single ANY-trigger across all derivation
+types. The user-clarified intent during T6.C review was the
+per-type semantics above — schema already encoded the distinction
+(`T6_DERIVATION_TRANSITIVE` / `_OPERATOR` / `_INFERRED`); the cascade
+module now respects it.
+
+**Real-world example** (Joby-USA via California):
+
+  derived edge "Joby is in USA":
+    - `b_california_in_usa` → `transitive` (foundation, chain link)
+    - `b_witness_X_testimony` → `operator` (corroborator)
+
+  Lose `b_witness_X_testimony`:
+    - foundation alive → preserve (corroborator loss only weakens,
+      doesn't break the chain).
+
+  Lose `b_california_in_usa`:
+    - foundation broken → invalidate (rule 1 fires).
 
 ---
 

--- a/docs/release_notes_v0.4.1.md
+++ b/docs/release_notes_v0.4.1.md
@@ -1,0 +1,122 @@
+# v0.4.1 — T6 Causality Chain (CASCADE extension) + QVT α track full closure
+
+**Theme**: v0.4.1 closes the CASCADE pillar that v0.4.0 only half-finished. When `cascade_remove_doc_from_sources` empties a base fact's sources, edges whose `derived_from` references that base now auto-invalidate via `invalidate_derived_facts` — the derivation chain stays internally consistent without manual operator intervention. Plus the v0.4.0 carry-over `dispatch_contradiction` ingestion wiring (T2.D-1/2/2.b/3) lands as flag-gated default-OFF, and the QVT α track ships end-to-end.
+
+## Why this is a citable release
+
+v0.4.0 shipped the **EVENT** track (T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction Arbitration) and made the CASCADE/EVENT separation provable. v0.4.1 ships the **CASCADE companion** (T6): when CASCADE removes a doc and the resulting empty base facts had derived edges depending on them, those derived edges auto-invalidate. The wiki stays internally consistent without manual operator intervention.
+
+The **T6.C.b foundational-vs-corroborative refinement** is the architectural insight that landed during T6.C user review: not all `derived_from` entries are equal. `transitive` / `inferred` are structural chain links (loss of any one breaks the derivation); `operator` is corroborative (strengthens but doesn't single-handedly support when foundation is alive). This distinction is what the existing T6.A schema constants already encoded — the cascade module now respects it.
+
+## What v0.4.1 delivers
+
+### T6 Causality Chain — 5-PR sequence
+
+Per `docs/handovers/v0.4.1-t6-causality-chain-entry.md`:
+
+| Module | Surface | LoC | Tests |
+|---|---|---|---|
+| `core/lifecycle/schema.py` (extended) | `T6_EDGE_FIELD_DERIVED_FROM` + `VALID_DERIVATION_TYPES` + `validate_edge_t6_derived_from` (Decision 3 cycle reject) + `apply_t6_edge_defaults` | +~160 LOC | 23 |
+| `scripts/migrate_v041_lifecycle.py` | `--dry-run` / `--apply` / `--verify` + pre-write snapshot | ~10 KB | — |
+| `core/lifecycle/derivation.py` | `extract_derivation_chain` (operator-tagged + flag-gated LLM) | ~10 KB | 14 |
+| `core/lifecycle/causality.py` | `should_invalidate_edge` (pure decision) + `invalidate_derived_facts` (soft invalidate, atomic per-file writes) | ~10 KB | 22 |
+| `core/cascade/_delete.py` (extended) | `cascade_remove_doc_from_sources` invokes `invalidate_derived_facts` post-loop | +~30 LOC | (release-gating) |
+| `tests/test_t6_release_gating_invariants.py` | 4 release-gating invariants vs tmpdir wiki fixtures + real cascade | — | 5 |
+
+**83+ contract tests** pass when run together. 69 pre-T6 cascade tests (`test_phase_c_cascade.py` + `test_phase_e_graph_editor.py` + `test_t7_release_gating_invariants.py`) all still pass — **no regression**.
+
+### Four release-gating invariants (T6.D)
+
+`tests/test_t6_release_gating_invariants.py` — all four must remain green:
+
+1. **`test_derived_invalidated_when_base_removed`** — cascade-remove a doc → base relation drops (sources empty) → derived edge auto-invalidates via T6.D propagation. End-to-end via the real `cascade_remove_doc_from_sources` call.
+2. **`test_partial_base_loss_preserves_derived`** — T6.C.b refinement: a derived edge with foundation (`transitive`) alive + corroborator (`operator`) gone stays active. Confidence-decay-on-corroborator-loss is T3 territory; T6 is binary.
+3. **`test_causality_chain_acyclic_rejected_at_write`** — Decision 3 LOCK: self-reference + 2-hop cycle rejected by `validate_edge_t6_derived_from`.
+4. **`test_cascade_invalidate_emits_audit_row`** — every T6 invalidation emits an audit row with `mutation_type="invalidated_by_cascade"` + chain pointers (base_fact_id, derived_edge_id, entity_path) so the T7 replay primitive can reconstruct the history.
+
+### T2.D — v0.4.0 carry-over `dispatch_contradiction` ingestion wiring (4 PRs)
+
+The v0.4.0 release notes called this out as a v0.4.1 deliverable. Shipped:
+
+| PR | scope |
+|---|---|
+| **#558 PR-T2.D-1** | `core/lifecycle/contradiction_ingest_detector.py` (~8 KB) — pattern P1 different_tail (CEO-change), P2 divergent_validity. 19 tests. |
+| **#559 PR-T2.D-2** | `core/lifecycle/ingest_contradiction.py` (~9 KB) + `_merge.py` pre-merge hook. `JAMES_T2D_INGEST_DISPATCH=1` default OFF. 10 tests. |
+| **#561 PR-T2.D-2.b** | A_invalidate cascade race fix via `PendingCascade` deferred-execution. Dispatcher captures cascade requests; `_merge.py` applies them AFTER writing back. Bad-doc-id heuristic: lowest-weight non-manual source. 15 tests. |
+| **#560 PR-T2.D-3** | step7 v6 q17 *"Anthropic의 CEO는 누구야?"* + `tests/test_t2d3_dispatch_acceptance.py` (6 tests) end-to-end synthetic CEO-change. |
+
+### QVT α track full closure (6 PRs)
+
+QVT was formalised in v0.4.0 (handover memo #537). v0.4.1 ships its full **α-track implementation**:
+
+| PR | scope |
+|---|---|
+| **#550 PR-α-1** | `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md` (~14 KB). 3-axis oracle (Path Coverage / Graded Answer / Abstention F1) + fixture schema v5 + per-PR Quality Delta Card pattern + 5 exemption labels + 18-cell ablation matrix shape. |
+| **#551 PR-α-2** | step7 fixture v4 → v5. `gold_signals` (3 atomic claims per query) + `abstention_truth` (12 present / 4 absent) + `min_recall: 1.0` on path-annotated queries. 11 invariant tests. |
+| **#552 PR-α-3** | `eval/qvt/oracle.py` (~14 KB) — 3-axis scorer. `scripts/qvt_capture_baseline.py` (~13 KB) — operator wrapper, N=3 paired reruns. 20 contract tests. |
+| **#553 PR-α-4** | `.github/PULL_REQUEST_TEMPLATE.md` + CLAUDE.md rule 2 extension + `docs/ARCHITECTURE.md` §5.7.10. |
+| **#555 PR-α-3 baseline capture** | `eval/qvt/baseline_2a31b20.json` (~25 KB) — canonical reference. N=3 paired, 64-minute operator run. |
+| **#556 PR-α-3 oracle calibration** | Korean security-block phrase additions + `blocked=True` short-circuit. `abstention_f1` **0.29 → 0.67** median (+0.38). |
+
+`baseline_2a31b20.json` is now the immovable denominator for every future Quality Delta Card comparison.
+
+### Replayable RAG positioning + other ships
+
+- **#548 Replayable RAG positioning** — README + ARCHITECTURE adopt "Replayable RAG" as the JAMES category framing. Two contrast lines (vs Agentic RAG / vs Mem0).
+- **#549 F9 cycle full closure** — q15 *"David Soria Parra가 누구야?"* zero-recall 8-cycle diagnostic ended with `path_recall = 1.0`.
+- **#554 v0.4.0 post-mint DOI badge** — README DOI shields bumped to `10.5281/zenodo.20411354`.
+- **#557 v0.4.1 entry memo** — 4-LOCK decisions (eager trigger / operator-tagged + LLM flag / strict cycle reject / **C.b foundational-vs-corroborative** — Decision 4 refined during this release).
+
+## Default-off invariant verified (every new opt-in)
+
+| Flag | Default | Verification |
+|---|---|---|
+| `JAMES_T2D_INGEST_DISPATCH` (T2.D-2) | OFF | `_merge.py` pre-merge hook only fires when `=1` |
+| `JAMES_T6_LLM_DERIVATION` (T6.B) | OFF | `extract_derivation_chain` LLM-inferred path needs both flag AND caller-supplied provider |
+| T6.D cascade integration | ON (cycle scope) | byte-identical retrieval because migration adds `derived_from: []`; no actual derivations populated yet |
+
+Production fleets pulling v0.4.1 see byte-identical retrieval behavior relative to v0.4.0 unless they opt into one of the flags OR start populating `derived_from`.
+
+## What v0.4.1 does NOT do
+
+- No production flip of `JAMES_T2D_INGEST_DISPATCH` default to ON.
+- No production population of `derived_from` (the migration adds `[]`; operator-tagged ingestion + the v0.4.2+ LLM-inferred path fill them in).
+- No T3 (Aging) / T4 (Reviewer) / T5 (Snapshot replay) — those land at v0.4.2 / v0.4.3.
+- No v0.4-end QVT ablation matrix capture (18 cells, ~20-hour operator run, deferred to late June+).
+
+## Operator action (post-merge)
+
+```powershell
+# Optional but recommended for fleets that ingest new docs:
+python scripts/migrate_v041_lifecycle.py --root wiki --apply
+
+# Verify byte-stability:
+python scripts/migrate_v041_lifecycle.py --root wiki --verify
+
+# GitHub release publish (Zenodo auto-mint follows):
+gh release create v0.4.1 --target main \
+    --title "v0.4.1 — T6 Causality Chain (CASCADE extension) + QVT α track full closure" \
+    --notes-file docs/release_notes_v0.4.1.md
+```
+
+## DOI lineage
+
+```
+v0.4.1          (this release, Zenodo auto-mint pending)
+  ↑ isNewVersionOf
+v0.4.0          10.5281/zenodo.20411354
+  ↑ isDerivedFrom
+v0.4.0-alpha.3  10.5281/zenodo.20391100
+  ↑ isDerivedFrom
+v0.3.3          10.5281/zenodo.20374227
+v0.3.2          10.5281/zenodo.20372649
+v0.3.1          10.5281/zenodo.20363998
+```
+
+## Verification
+
+- T6 lifecycle suite: 83+ contract tests pass.
+- T2.D ingest suite: 50 contract tests.
+- QVT α: 22+ oracle contract tests + 11 step7 v5 schema tests + canonical `baseline_2a31b20.json`.
+- No regression: 69 pre-T6 cascade tests still green; CASCADE/EVENT separation invariants from v0.4.0 hold unchanged.
+- All five v0.4.1-cycle release-gating invariants green (T6.D 4 + T6.A Decision 3).


### PR DESCRIPTION
## Summary

Final PR of the v0.4.1 cycle per the v0.4.1 T6 entry memo (#557) §3 PR-T6.E row. Pure docs. Marks the T6 Causality Chain + T2.D carry-over + QVT α track as closed and prepares the GitHub release + Zenodo auto-mint.

| # | PR | scope |
|---|---|---|
| ✅ T6.A | #562 | derived_from schema + validator + migration |
| ✅ T6.B | #563 | derivation extraction |
| ✅ T6.C | #564 | invalidate_derived_facts cascade |
| ✅ T6.C.b | #565 | foundational vs corroborative refinement |
| ✅ T6.D | #566 | cascade integration + 4 release-gating invariants |
| **T6.E** | **this PR** | closure docs + release prep |

## Files

### `ROADMAP.md` — new v0.4.1 section
- Between v0.4.0 and v0.5.0, **CLOSED** status
- Full 5-PR T6 sequence + 4-PR T2.D carry-over + 6-PR QVT α track + 4 "also ships" (#548/#549/#554/#557)
- Done-when checklist all green
- Default-off invariant table

### `CHANGELOG.md` — `[0.4.1] — 2026-05-28` entry above [0.4.0]
- Per-PR breakdown across T6 (5) + T2.D (4) + QVT α (6) + 4 also-ships
- Verification summary + "what v0.4.1 does NOT do"

### `.zenodo.json`
- title + description rewritten for v0.4.1
- `version` → `v0.4.1`
- `related_identifiers`: `isNewVersionOf` promoted to v0.4.0 DOI (`10.5281/zenodo.20411354`); alpha.3 DOI moved to `isDerivedFrom`; v0.3.x chain preserved. `isDocumentedBy` entries swapped to v0.4.1 PRs (#548 ~ #566)
- keywords adds `causality-chain` / `derived-fact-propagation` / `foundational-vs-corroborative` / `non-saturating-quality-oracle` / `pr-gate-quality-delta-card` / `replayable-rag`
- notes shortened to closure narrative + DOI chain explanation

### `README.md` / `README.ko.md`
- Status badge **v0.4.0 → v0.4.1**
- DOI shield stays at v0.4.0 mint until v0.4.1 Zenodo auto-mint completes — follow-up small PR bumps once the new DOI is known

### `docs/release_notes_v0.4.1.md` — new (~9 KB)
- Theme + why citable + T6 5-PR sequence + 4 release-gating invariants spelled out + T2.D table + QVT α table + Replayable RAG positioning + default-off invariant + operator action + DOI lineage

### `docs/handovers/v0.4.1-t6-causality-chain-entry.md` §2 Decision 4
- Refined LOCK text: per-derivation-type C-semantics + explicit foundational-vs-corroborative refinement (T6.C.b)
- Joby-USA via California real-world example showing foundation (transitive) vs corroborator (operator witness)
- Links to `core/lifecycle/causality.py` for production truth

## Operator action (post-merge)

```bash
gh release create v0.4.1 --target main \
    --title "v0.4.1 — T6 Causality Chain (CASCADE extension) + QVT α track full closure" \
    --notes-file docs/release_notes_v0.4.1.md
```

Zenodo auto-mint follows from the release publish. Once the new DOI is known, follow-up small PR bumps the README DOI shield + adds the v0.4.1 DOI to `.zenodo.json`'s `isNewVersionOf` chain for the NEXT release (same pattern as PR #554 did for v0.4.0).

## Verification

- All files are pure docs / JSON config; no code change
- `.zenodo.json` validates as JSON; new keys + values inspect cleanly
- ROADMAP / CHANGELOG / release notes cross-reference the same PR numbers consistently
- entry memo §2 Decision 4 text now reflects what `core/lifecycle/causality.py` (T6.C + T6.C.b) actually implements

## Quality Delta vs baseline

`Quality delta: exempt (label: docs — pure closure docs PR. No code change; no QVT axis touched. The previous T6.A~D + T2.D-1~3 PRs all carried `code` exemption flags during the cycle; the v0.4-end QVT ablation matrix capture is the next quality-axis event, deferred per ROADMAP to late June+.)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)