### PR TITLE
chore(release): v0.4.1 post-mint — README DOI badges → 10.5281/zenodo.20426719

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 [![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20411354.svg)](https://doi.org/10.5281/zenodo.20411354)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20426719.svg)](https://doi.org/10.5281/zenodo.20426719)
 
 ![PROJECT JAMES — 3D 온톨로지 그래프 시각화](reports/promo-assets/screenshots/06-3d-graph.jpg)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20411354.svg)](https://doi.org/10.5281/zenodo.20411354)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20426719.svg)](https://doi.org/10.5281/zenodo.20426719)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)
 


### PR DESCRIPTION
## Summary

Zenodo auto-mint of v0.4.1 (2026-05-28, ~2 min after `gh release create`) succeeded — DOI `10.5281/zenodo.20426719`. This PR bumps the README DOI shields from v0.4.0 (`20411354`) to v0.4.1 (`20426719`). Both `README.md` and `README.ko.md`.

DOI lineage:
```
v0.4.1               10.5281/zenodo.20426719   ← this PR
v0.4.0               10.5281/zenodo.20411354
v0.4.0-alpha.3       10.5281/zenodo.20391100
v0.3.3               10.5281/zenodo.20374227
v0.3.2               10.5281/zenodo.20372649
v0.3.1               10.5281/zenodo.20363998
```

## Verification

- Diff: 2 lines (`README.md` line 13, `README.ko.md` line 12).
- Status badges already point at v0.4.1 release page (landed in PR #567 closure prep).
- DOI URL `https://doi.org/10.5281/zenodo.20426719` resolves to the live Zenodo record.
- `.zenodo.json` `isNewVersionOf: 10.5281/zenodo.20411354` (v0.4.0) correctly describes the v0.4.1 release that was just minted — no edit needed here.

## Out of scope

- **`.zenodo.json` `isNewVersionOf` chain promotion** — currently points to v0.4.0 (`20411354`), which correctly describes the v0.4.1 release that was just minted. The next chain promotion (`isNewVersionOf → 20426719`, demoting v0.4.0 to `isDerivedFrom`) lands in the v0.4.2 release prep PR — matching the established pattern from PR #520 (alpha.3 post-mint → v0.3.3 chain) + PR #544 (v0.4.0 prep → alpha.3 chain) + PR #554 (v0.4.0 post-mint, same shape as this PR).
- CHANGELOG entry — already has `[0.4.1]` from PR #567 (T6.E closure).
- `README.ko.md` "프로젝트 상태" 본문이 아직 v0.4.0 텍스트로 남아있는 점 — DOI bump scope 바깥, 별 follow-up.

## Quality Delta vs baseline

`Quality delta: exempt (label: chore)`. README badge bump; does not touch \`core/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)