### PR TITLE
docs(readme.ko): v0.4.1 body sync — 프로젝트 상태 v0.4.0 → v0.4.1

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,16 +18,25 @@
 
 ---
 
-## 프로젝트 상태: v0.4.0 — Layer 4 Lifecycle Semantics (first bundle)
+## 프로젝트 상태: v0.4.1 — T6 Causality Chain (CASCADE extension)
 
-**2026-05-27 릴리스**. v0.4.0 은 Layer 4 first bundle —
+**2026-05-28 릴리스**. v0.4.1 은 v0.4.0 이 절반만 마친 CASCADE
+pillar 를 마감합니다. base fact 의 sources 가 모두 제거되면,
+`derived_from` 이 그 base 를 가리키는 edge 들이
+`invalidate_derived_facts` 로 자동 무효화 — 파생 체인이 운영자
+개입 없이 내부 정합성을 유지합니다. derivation-type 별 semantics
+(T6.C.b 정정): `transitive` / `inferred` 는 구조적 체인 링크
+(any base empty → invalidate); `operator` 는 보조적
+(hard deps 가 없고 모든 operator base 가 비었을 때만 invalidate).
+
+이전: **v0.4.0** (2026-05-27) 은 Layer 4 first bundle —
 **T1 Temporal Validity + T7 Supersede Chain + T2 Contradiction
 Arbitration** — 을 Sprint 5 의 8 PR 시퀀스로 출시. CASCADE 와
-EVENT 의 분리 invariant 가 `tests/test_t7_release_gating_invariants
-.py` (실제 wiki 픽스처 대상, 목 아님) 으로 **end-to-end 증명**.
-supersede chain 프리미티브 (`reconstruct_view_at`) 가 무관한
-CASCADE 삭제 이벤트 후에도 "시점 T 에 무엇이 참이었나" 를
-결정론적으로 답변.
+EVENT 의 분리 invariant 가
+`tests/test_t7_release_gating_invariants.py` (실제 wiki 픽스처
+대상, 목 아님) 으로 **end-to-end 증명**. supersede chain
+프리미티브 (`reconstruct_view_at`) 가 무관한 CASCADE 삭제 이벤트
+후에도 "시점 T 에 무엇이 참이었나" 를 결정론적으로 답변.
 
 이전: v0.3.0 (2026-05-17) Foundation Hardening 마감 — 6 축
 (아키텍처 / 평가 / 관찰성 / 보안 / 통제 진화 / 실데이터 검증)


### PR DESCRIPTION
## Summary

After #569 merged, `README.ko.md` body still read "프로젝트 상태: v0.4.0" — inconsistent with `README.md` v0.4.1 section (lines 41-65). This PR syncs the Korean README body to v0.4.1 (T6 Causality Chain) so badge state + body state agree on both READMEs. v0.4.0 demoted to "이전:" paragraph mirroring the English structure.

Scope: `README.ko.md` 라인 21-30 영역만. 영문 README.md + #567 번역 단락 구조와 매칭.

## Verification

- Diff: 1 file, +17 / -8 lines. README.ko.md only.
- v0.4.1 status header + 단락 (T6.C.b foundational-vs-corroborative semantics 정정 포함) + "이전: v0.4.0" 강등 단락 + "이전: v0.3.0" Foundation Hardening 단락 (변경 없음).
- 이전 PR (#569) 에서 한 줄 (DOI 배지) 만 손댄 좁은 scope 와 본문 sync 를 분리 — chore vs docs.

## Out of scope

- 다른 한국어 페이지 (README.beginner.ko.md 등) 추적은 별 PR.
- 영문/한국어 평가 fixture / 한국어 ARCHITECTURE 동기화는 별 cycle.

## Quality Delta vs baseline

\`Quality delta: exempt (label: docs)\`. README body translation; does not touch \`core/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)