### PR TITLE
chore(server-split): v0.4.x PR-A foundation — routes/ scaffold + audit gate + boot smoke (no endpoint moves)

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,0 +1,16 @@
+"""HTTP route modules extracted from server_llmwiki.py.
+
+Per docs/design/v0.4.x-server-split.md (Stage 0 design memo). The server-split
+roadmap is an 8-PR sequence; this package surfaces as `from routes.<domain>
+import router` per domain (auth / llm / jobs / artifacts / evolution /
+coding / admin), each registered via `app.include_router(router)` in
+server_llmwiki.py.
+
+Invariants (all PRs in the cycle must satisfy):
+  1. URL byte-identical (regression gate: scripts/audit_endpoint_paths.py)
+  2. Middleware execution order unchanged
+  3. _write_audit emit timing + fields unchanged
+  4. /static mount path unchanged
+  5. @app.on_event("startup") behaviour unchanged
+  6. pytest tests/ — collected / passed / xfail delta == 0
+"""

--- a/routes/_deps.py
+++ b/routes/_deps.py
@@ -1,0 +1,55 @@
+"""Singleton getters for FastAPI router modules.
+
+Pattern: server_llmwiki.py creates singletons at boot (rag_engine,
+file_processor, _rate_limiter) then calls set_* to register them.
+Router modules import the corresponding get_* and call inside handlers.
+
+This decouples routers from server_llmwiki.py — no circular imports —
+while keeping the boot order explicit (set_* must precede include_router).
+Per the v0.4.x server-split design memo §3.1.
+"""
+from typing import Any
+
+_rag_engine: Any = None
+_file_processor: Any = None
+_rate_limiter: Any = None
+
+
+def set_rag_engine(engine) -> None:
+    global _rag_engine
+    _rag_engine = engine
+
+
+def set_file_processor(fp) -> None:
+    global _file_processor
+    _file_processor = fp
+
+
+def set_rate_limiter(rl) -> None:
+    global _rate_limiter
+    _rate_limiter = rl
+
+
+def get_rag_engine():
+    if _rag_engine is None:
+        raise RuntimeError(
+            "rag_engine not initialized — server boot order violation. "
+            "server_llmwiki.py must call set_rag_engine() before include_router()."
+        )
+    return _rag_engine
+
+
+def get_file_processor():
+    if _file_processor is None:
+        raise RuntimeError(
+            "file_processor not initialized — server boot order violation."
+        )
+    return _file_processor
+
+
+def get_rate_limiter():
+    if _rate_limiter is None:
+        raise RuntimeError(
+            "_rate_limiter not initialized — server boot order violation."
+        )
+    return _rate_limiter

--- a/routes/_helpers.py
+++ b/routes/_helpers.py
@@ -1,0 +1,209 @@
+"""Shared auth + audit helpers extracted from server_llmwiki.py.
+
+These helpers were defined inline in server_llmwiki.py before the v0.4.x
+server-split cycle (docs/design/v0.4.x-server-split.md, Stage 0). They
+move here so routes/<domain>.py can import them without circular
+dependency back into the server module.
+
+server_llmwiki.py re-imports them for back-compat — any handler still
+inline in the server module continues to use the same names.
+
+Invariant: function signatures + behaviour byte-identical to the
+pre-split definitions. The 24 `_write_audit` emit sites elsewhere in
+the codebase must not see any timing or field shift.
+"""
+import json
+import os
+import sqlite3
+from datetime import datetime
+from typing import Optional
+
+from fastapi import Depends, Header, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from config import API_KEY, BASE_DIR
+from core.api_keys import verify_api_key as _api_key_verify
+from core.auth import (
+    ALLOWED_ROLES,
+    DEV_MODE,
+    get_role_from_token,
+    verify_token as _auth_verify_token,
+)
+from core.policy_engine import default_engine
+
+# Single source of truth for the bearer scheme. Both server_llmwiki.py
+# and routes/<domain>.py import it from here so Depends(bearer_scheme)
+# always references the same callable instance.
+bearer_scheme = HTTPBearer(auto_error=False)
+
+_AUDIT_DB = os.path.join(BASE_DIR, "james_audit.db")
+
+
+# ─── Audit ──────────────────────────────────────────────────────────
+
+def _write_audit(
+    user_role: str,
+    endpoint:  str,
+    query:     str   = "",
+    answer:    str   = "",
+    graph_paths: list = None,
+    blocked:   bool  = False,
+    security_event: str = "",
+    elapsed_sec: float = 0.0,
+    ip_address: str  = "",
+):
+    """[P4-SRV-2] 감사 로그 DB 기록 (graph_path 포함)"""
+    try:
+        conn = sqlite3.connect(_AUDIT_DB, check_same_thread=False)
+        conn.execute(
+            """INSERT INTO audit_log
+               (timestamp, user_role, endpoint, query, answer, graph_paths,
+                blocked, security_event, elapsed_sec, ip_address)
+               VALUES (?,?,?,?,?,?,?,?,?,?)""",
+            (
+                datetime.now().isoformat(),
+                user_role,
+                endpoint,
+                query[:500],
+                answer[:500],
+                json.dumps(graph_paths or [], ensure_ascii=False)[:1000],
+                int(blocked),
+                security_event[:200],
+                round(elapsed_sec, 2),
+                ip_address,
+            ),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        print(f"[AUDIT] 로그 기록 실패: {e}")
+
+
+# ─── Request introspection ──────────────────────────────────────────
+
+def get_client_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _bearer_username(request: Request) -> Optional[str]:
+    """Pull `sub` (username) out of the Bearer JWT, or None.
+
+    Used to scope per-account operations to the JWT subject rather than
+    a body field so the client cannot self-impersonate.
+    """
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    payload = _auth_verify_token(auth_header[7:].strip())
+    return (payload or {}).get("sub") if payload else None
+
+
+# ─── API key + role resolution ──────────────────────────────────────
+
+def verify_api_key(api_key: str):
+    """Accept either the system API_KEY or a per-user ``jms_...`` key.
+
+    Raises 403 if neither matches. Only validates the credential;
+    role-based authorization continues to consult
+    ``get_role_from_request`` (system key → external, user key → owner
+    role).
+    """
+    if api_key and api_key.startswith("jms_"):
+        if _api_key_verify(api_key) is not None:
+            return
+    elif api_key == API_KEY:
+        return
+    raise HTTPException(status_code=403, detail="API Key 오류")
+
+
+def resolve_api_key_principal(api_key: str) -> Optional[dict]:
+    """Non-raising counterpart to ``verify_api_key``.
+
+    Returns ``{"source", "username", "role"}`` or None. Used by
+    ``get_role_from_request`` to map a user key to the owner's role
+    without raising on miss.
+    """
+    if not api_key:
+        return None
+    if api_key.startswith("jms_"):
+        out = _api_key_verify(api_key)
+        if out is not None:
+            return {"source": "user", **out}
+        return None
+    if api_key == API_KEY:
+        # System key intentionally does NOT carry admin authority by
+        # itself — pairing it with an admin JWT is still required for
+        # admin endpoints. Role here is currently NOT consumed
+        # (get_role_from_request only honors source == "user").
+        # [default-deny fallback 2026-05-18] employee → external.
+        return {"source": "system", "username": "system", "role": "external"}
+    return None
+
+
+def get_role_from_request(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
+    x_role: Optional[str] = Header(None, alias="X-Role"),
+    x_api_key: Optional[str] = Header(None, alias="X-API-Key"),
+) -> str:
+    """JWT > user API key > X-Role (dev) > default external.
+
+    [W4 P3-2] User API keys (``jms_...``) now surface the owner's
+    role to authorization gates. The system key remains external
+    so a leaked .env value cannot self-elevate to admin.
+    """
+    if credentials and credentials.credentials:
+        role = get_role_from_token(credentials.credentials)
+        print(f"[AUTH] JWT role: {role}")
+        return role
+
+    # W4 P3-2: X-API-Key header takes precedence over ?api_key= so
+    # clients on shared proxies (where logs may capture the URL) can
+    # move the credential out of the URL line.
+    key = (x_api_key or "").strip() or request.query_params.get("api_key", "")
+    if key:
+        principal = resolve_api_key_principal(key)
+        if principal and principal["source"] == "user":
+            print(f"[AUTH] user API key: {principal['username']} (role={principal['role']})")
+            return principal["role"]
+
+    if x_role and x_role in ALLOWED_ROLES:
+        if DEV_MODE:
+            print(f"[AUTH] X-Role 헤더 사용: {x_role} (개발 모드)")
+            return x_role
+
+    # [default-deny fallback 2026-05-18] external (not employee) so the
+    # internal_rag gate fires correctly for anonymous callers — see the
+    # historical note in PR-O5 (cycle 12, #292).
+    return "external"
+
+
+# ─── Admin / feature gates ──────────────────────────────────────────
+
+def _require_admin(api_key: str, role: str):
+    """Admin API 접근 검증. api_key 검증 + role=admin 체크."""
+    verify_api_key(api_key)
+    if role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail="admin 권한 필요 — admin 계정으로 로그인하세요",
+        )
+
+
+def _require_feature(api_key: str, role: str, feature_id: str):
+    """[W4-Q2] api_key + per-feature gate (consults PolicyEngine).
+
+    For features whose default_allowed is ``{"admin"}``, behaviour is
+    identical to ``_require_admin``. New admin.* features land here
+    instead so the policy matrix is the single source of truth.
+    """
+    verify_api_key(api_key)
+    d = default_engine.can_use_feature(role, feature_id)
+    if not d.allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"권한이 부족합니다. ({feature_id})",
+        )

--- a/scripts/audit_endpoint_paths.py
+++ b/scripts/audit_endpoint_paths.py
@@ -1,0 +1,228 @@
+"""Server-split regression gate — endpoint URL byte-identical invariant.
+
+Per docs/design/v0.4.x-server-split.md §2.1 + §6.1.
+
+Compares the set of (method, path) tuples registered on the current FastAPI
+app against a baseline captured from a base branch (default: main). If the
+sets differ by even one entry, exit-code 1 and print +added / -removed.
+
+This gate runs on every server-split PR (A → H) so the URL surface stays
+byte-identical through the cycle. It does NOT care about handler internals
+— only the routing table.
+
+Usage
+-----
+  python scripts/audit_endpoint_paths.py                # diff vs origin/main
+  python scripts/audit_endpoint_paths.py main           # diff vs main
+  python scripts/audit_endpoint_paths.py <sha>          # diff vs commit
+  python scripts/audit_endpoint_paths.py --baseline-file routes.json
+  python scripts/audit_endpoint_paths.py --capture routes.json
+
+Exit codes
+----------
+  0 — endpoint sets identical
+  1 — diff present (printed)
+  2 — wrapper error (git missing, import failed, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# FastAPI auto-registers these regardless of source. Excluded from the
+# invariant comparison so refactors that don't touch app.openapi config
+# don't show false-positive churn.
+_FASTAPI_AUTO_PATHS = frozenset({
+    "/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json",
+})
+
+
+def _collect_current_endpoints() -> set[tuple[str, str]]:
+    """Import server_llmwiki and read its routing table.
+
+    Returns the set of (method, path) tuples for routes that surface a
+    real HTTP method (skips Mount / WebSocket / etc).
+    """
+    # Make sure we import from the repo, not a stale installed package.
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        import server_llmwiki  # type: ignore
+    except Exception as exc:  # pragma: no cover — surfacing import errors
+        print(f"FAIL: could not import server_llmwiki — {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    pairs: set[tuple[str, str]] = set()
+    for route in server_llmwiki.app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if not path or not methods:
+            # Mount (StaticFiles), Starlette WebSocketRoute, etc. — skip.
+            continue
+        if path in _FASTAPI_AUTO_PATHS:
+            continue
+        for m in methods:
+            # `route.methods` is the explicit method set on the route
+            # (e.g. {"GET"}). HEAD is handled by Starlette at request
+            # time without a separate route entry, so don't synthesize
+            # ("HEAD", path) here — keep it to what app.routes actually
+            # reports, which is the same shape on both sides.
+            pairs.add((m.upper(), path))
+    return pairs
+
+
+def _collect_baseline_from_git(ref: str) -> set[tuple[str, str]]:
+    """Run this script under a worktree of `ref` and read its output.
+
+    The cleanest way to compare two snapshots of the routing table is to
+    actually IMPORT each version's server_llmwiki and read app.routes. We
+    do that by:
+      1. `git worktree add` a temp dir at the requested ref
+      2. running this script there with --capture <tmp>.json
+      3. parsing the captured json
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wt_dir = Path(tmp) / "wt"
+        capture_file = Path(tmp) / "routes.json"
+        # Create worktree
+        try:
+            subprocess.run(
+                ["git", "worktree", "add", "-f", "--detach", str(wt_dir), ref],
+                cwd=REPO_ROOT, check=True, capture_output=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(f"FAIL: git worktree add {ref} — {exc.stderr.decode(errors='replace')}",
+                  file=sys.stderr)
+            sys.exit(2)
+        try:
+            # Run this very script from the worktree, --capture into shared file
+            script = wt_dir / "scripts" / "audit_endpoint_paths.py"
+            if not script.exists():
+                # Baseline ref predates this script; fall back to AST scan.
+                return _ast_scan_for_endpoints(wt_dir / "server_llmwiki.py")
+            res = subprocess.run(
+                [sys.executable, str(script), "--capture", str(capture_file)],
+                cwd=wt_dir, check=False, capture_output=True,
+            )
+            if res.returncode != 0:
+                print(f"FAIL: capture from {ref} returned {res.returncode}",
+                      file=sys.stderr)
+                print(res.stderr.decode(errors="replace"), file=sys.stderr)
+                sys.exit(2)
+            data = json.loads(capture_file.read_text(encoding="utf-8"))
+            return {tuple(pair) for pair in data["endpoints"]}
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "-f", str(wt_dir)],
+                cwd=REPO_ROOT, check=False, capture_output=True,
+            )
+
+
+def _ast_scan_for_endpoints(server_path: Path) -> set[tuple[str, str]]:
+    """Fallback: parse @app.<method>("path", ...) decorators via AST.
+
+    Used when the baseline ref predates this script (no capture available).
+    Imperfect for routes registered via include_router after split, but
+    pre-split server_llmwiki.py has every route inline as @app.* — so this
+    gives a correct baseline for cycle-start comparisons.
+    """
+    import ast
+
+    pairs: set[tuple[str, str]] = set()
+    try:
+        tree = ast.parse(server_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"FAIL: no server_llmwiki.py at {server_path}", file=sys.stderr)
+        sys.exit(2)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for deco in node.decorator_list:
+            if not isinstance(deco, ast.Call):
+                continue
+            func = deco.func
+            # Match @app.<method>(...) where method ∈ {get, post, ...}
+            if (isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "app"
+                and func.attr.lower() in {"get", "post", "put", "delete", "patch"}):
+                if not deco.args:
+                    continue
+                first = deco.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    method = func.attr.upper()
+                    path = first.value
+                    if path in _FASTAPI_AUTO_PATHS:
+                        continue
+                    pairs.add((method, path))
+    return pairs
+
+
+def _format_diff(added: Iterable[tuple[str, str]],
+                 removed: Iterable[tuple[str, str]]) -> str:
+    out = []
+    for method, path in sorted(added):
+        out.append(f"  + {method:7s} {path}")
+    for method, path in sorted(removed):
+        out.append(f"  - {method:7s} {path}")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "ref", nargs="?", default="origin/main",
+        help="git ref to compare against (default: origin/main)",
+    )
+    parser.add_argument(
+        "--baseline-file", type=Path,
+        help="read baseline from a previously captured JSON instead of git",
+    )
+    parser.add_argument(
+        "--capture", type=Path,
+        help="write current endpoint set to JSON and exit (no comparison)",
+    )
+    args = parser.parse_args()
+
+    current = _collect_current_endpoints()
+
+    if args.capture:
+        payload = {
+            "endpoints": sorted(list(p) for p in current),
+            "count": len(current),
+        }
+        args.capture.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"captured {len(current)} endpoints → {args.capture}")
+        return 0
+
+    if args.baseline_file:
+        data = json.loads(args.baseline_file.read_text(encoding="utf-8"))
+        baseline = {tuple(p) for p in data["endpoints"]}
+    else:
+        baseline = _collect_baseline_from_git(args.ref)
+
+    added = current - baseline
+    removed = baseline - current
+
+    if not added and not removed:
+        print(f"OK: {len(current)} endpoints identical to {args.ref}")
+        return 0
+
+    print(f"FAIL: +{len(added)} -{len(removed)} (current={len(current)}, "
+          f"baseline={len(baseline)})", file=sys.stderr)
+    print(_format_diff(added, removed), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -25,23 +25,21 @@ import json
 from datetime import datetime
 from collections import defaultdict
 from urllib.parse import quote
-from fastapi import FastAPI, UploadFile, File, HTTPException, Form, Header, Depends, Request
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import FastAPI, UploadFile, File, HTTPException, Form, Depends, Request
 from fastapi.responses import JSONResponse, HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import Optional
 
-from config import BASE_DIR, UPLOAD_DIR, WIKI_DIR, CHROMA_DIR, API_KEY, MAX_UPLOAD_BYTES
+from config import BASE_DIR, UPLOAD_DIR, WIKI_DIR, CHROMA_DIR, MAX_UPLOAD_BYTES
 from core.graph_rag_engine import RAGEngine
 from core.feedback_engine import FeedbackEngine
 from core.auth import (
-    authenticate, get_role_from_token, ALLOWED_ROLES, DEV_MODE,
+    authenticate, ALLOWED_ROLES,
     signup as _auth_signup, list_users as _auth_list_users,
     approve_user as _auth_approve_user,
     reject_user as _auth_reject_user,
     deactivate_user as _auth_deactivate_user,
-    verify_token as _auth_verify_token,
 )
 from core.auth_reset import (
     change_password    as _auth_change_password,
@@ -53,25 +51,23 @@ from core.api_keys import (
     issue_api_key  as _api_key_issue,
     revoke_api_key as _api_key_revoke,
     list_api_keys  as _api_key_list,
-    verify_api_key as _api_key_verify,
 )
 from core.policy_engine import default_engine
 from processors.file_processor import FileProcessor
 
 # Server-split scaffolding (v0.4.x cycle, PR-A) — auth/audit helpers
-# moved to routes/_helpers.py. Re-imported here so other handlers still
-# inline in this module use the same names. routes/<domain>.py modules
-# import from routes/_helpers directly. See docs/design/v0.4.x-server-split.md.
+# moved to routes/_helpers.py. Re-imported here so handlers still inline
+# in this module continue to use the same names. routes/<domain>.py
+# modules import from routes/_helpers directly. See
+# docs/design/v0.4.x-server-split.md.
 from routes._helpers import (
     _AUDIT_DB,
     _bearer_username,
     _require_admin,
     _require_feature,
     _write_audit,
-    bearer_scheme,
     get_client_ip,
     get_role_from_request,
-    resolve_api_key_principal,
     verify_api_key,
 )
 from routes._deps import (

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -32,7 +32,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import Optional
 
-from config import UPLOAD_DIR, WIKI_DIR, CHROMA_DIR, API_KEY, MAX_UPLOAD_BYTES
+from config import BASE_DIR, UPLOAD_DIR, WIKI_DIR, CHROMA_DIR, API_KEY, MAX_UPLOAD_BYTES
 from core.graph_rag_engine import RAGEngine
 from core.feedback_engine import FeedbackEngine
 from core.auth import (
@@ -58,11 +58,27 @@ from core.api_keys import (
 from core.policy_engine import default_engine
 from processors.file_processor import FileProcessor
 
-try:
-    from config import BASE_DIR
-    _AUDIT_DB = os.path.join(BASE_DIR, "james_audit.db")
-except ImportError:
-    _AUDIT_DB = "james_audit.db"
+# Server-split scaffolding (v0.4.x cycle, PR-A) — auth/audit helpers
+# moved to routes/_helpers.py. Re-imported here so other handlers still
+# inline in this module use the same names. routes/<domain>.py modules
+# import from routes/_helpers directly. See docs/design/v0.4.x-server-split.md.
+from routes._helpers import (
+    _AUDIT_DB,
+    _bearer_username,
+    _require_admin,
+    _require_feature,
+    _write_audit,
+    bearer_scheme,
+    get_client_ip,
+    get_role_from_request,
+    resolve_api_key_principal,
+    verify_api_key,
+)
+from routes._deps import (
+    set_file_processor,
+    set_rag_engine,
+    set_rate_limiter,
+)
 
 # ─── [P4-SRV-2] 감사 로그 DB 초기화 ─────────────────────────
 
@@ -88,43 +104,6 @@ def _init_audit_db():
     print(f"[AUDIT] DB 초기화: {_AUDIT_DB}")
 
 _init_audit_db()
-
-def _write_audit(
-    user_role: str,
-    endpoint:  str,
-    query:     str     = "",
-    answer:    str     = "",
-    graph_paths: list  = None,
-    blocked:   bool    = False,
-    security_event: str = "",
-    elapsed_sec: float = 0.0,
-    ip_address: str    = "",
-):
-    """[P4-SRV-2] 감사 로그 DB 기록 (graph_path 포함)"""
-    try:
-        conn = sqlite3.connect(_AUDIT_DB, check_same_thread=False)
-        conn.execute(
-            """INSERT INTO audit_log
-               (timestamp, user_role, endpoint, query, answer, graph_paths,
-                blocked, security_event, elapsed_sec, ip_address)
-               VALUES (?,?,?,?,?,?,?,?,?,?)""",
-            (
-                datetime.now().isoformat(),
-                user_role,
-                endpoint,
-                query[:500],
-                answer[:500],
-                json.dumps(graph_paths or [], ensure_ascii=False)[:1000],
-                int(blocked),
-                security_event[:200],
-                round(elapsed_sec, 2),
-                ip_address,
-            ),
-        )
-        conn.commit()
-        conn.close()
-    except Exception as e:
-        print(f"[AUDIT] 로그 기록 실패: {e}")
 
 # ─── [P4-SRV-1] Rate Limiter ─────────────────────────────────
 
@@ -253,7 +232,15 @@ os.makedirs(CHROMA_DIR, exist_ok=True)
 
 rag_engine     = RAGEngine(default_role="external")
 file_processor = FileProcessor()
-bearer_scheme  = HTTPBearer(auto_error=False)
+# bearer_scheme moved to routes/_helpers.py (single source of truth for
+# Depends(bearer_scheme) across server + extracted routers).
+
+# Register singletons with routes/_deps so extracted routers can fetch them
+# via get_rag_engine() / get_file_processor() / get_rate_limiter().
+# Must precede any app.include_router() call below.
+set_rag_engine(rag_engine)
+set_file_processor(file_processor)
+set_rate_limiter(_rate_limiter)
 
 
 @app.on_event("startup")
@@ -395,103 +382,10 @@ async def on_startup():
     asyncio.create_task(_index())
 
 # ─── 인증 헬퍼 ───────────────────────────────────────────────
-
-def verify_api_key(api_key: str):
-    """Accept either the system API_KEY or a per-user ``jms_...`` key.
-
-    Raises 403 if neither matches. This function only validates the
-    credential; role-based authorization continues to consult
-    ``get_role_from_request`` (so a bare system key still gets the
-    employee role, and a user key gets the owner's actual role).
-    """
-    if api_key and api_key.startswith("jms_"):
-        if _api_key_verify(api_key) is not None:
-            return
-    elif api_key == API_KEY:
-        return
-    raise HTTPException(status_code=403, detail="API Key 오류")
-
-
-def resolve_api_key_principal(api_key: str) -> Optional[dict]:
-    """Non-raising counterpart to ``verify_api_key``.
-
-    Returns ``{"source", "username", "role"}`` or None. Used by
-    ``get_role_from_request`` to map a user key to the owner's role
-    without raising on miss (the caller decides whether absence is
-    an error).
-    """
-    if not api_key:
-        return None
-    if api_key.startswith("jms_"):
-        out = _api_key_verify(api_key)
-        if out is not None:
-            return {"source": "user", **out}
-        return None
-    if api_key == API_KEY:
-        # System key intentionally does NOT carry admin authority by
-        # itself — pairing it with an admin JWT is still required for
-        # admin endpoints. The role field here is currently NOT
-        # consumed (``get_role_from_request`` only honors
-        # ``source == "user"`` and falls through for "system"), but we
-        # keep it in sync with the fallback (external) so any future
-        # caller that does honor it gets the secure default.
-        # [default-deny fallback 2026-05-18] employee → external.
-        return {"source": "system", "username": "system", "role": "external"}
-    return None
-
-
-def get_role_from_request(
-    request: Request,
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
-    x_role: Optional[str] = Header(None, alias="X-Role"),
-    x_api_key: Optional[str] = Header(None, alias="X-API-Key"),
-) -> str:
-    """JWT > user API key > X-Role (dev) > default employee.
-
-    [W4 P3-2] User API keys (``jms_...``) now surface the owner's
-    role to authorization gates. The system key remains employee
-    so a leaked .env value cannot self-elevate to admin.
-    """
-    if credentials and credentials.credentials:
-        role = get_role_from_token(credentials.credentials)
-        print(f"[AUTH] JWT role: {role}")
-        return role
-
-    # W4 P3-2: X-API-Key header takes precedence over ?api_key= so
-    # clients on shared proxies (where logs may capture the URL) can
-    # move the credential out of the URL line.
-    key = (x_api_key or "").strip() or request.query_params.get("api_key", "")
-    if key:
-        principal = resolve_api_key_principal(key)
-        if principal and principal["source"] == "user":
-            print(f"[AUTH] user API key: {principal['username']} (role={principal['role']})")
-            return principal["role"]
-
-    if x_role and x_role in ALLOWED_ROLES:
-        if DEV_MODE:
-            print(f"[AUTH] X-Role 헤더 사용: {x_role} (개발 모드)")
-            return x_role
-
-    # [default-deny fallback 2026-05-18] employee → external.
-    # Previously (single-local-user posture): "api_key 통과 = 신뢰
-    # 사용자 → employee 수준 부여" — convenient for solo operators but
-    # the implicit elevation undercut PR-O5 (cycle 12, #292) — the
-    # internal_rag gate is policy-attached to the external role, and
-    # an anonymous caller with only the system API key was silently
-    # promoted past that gate. Fallback is now external so the secure
-    # default actually fires: chat / meta still work for a bare key,
-    # retrieval / coding / admin paths require an explicit login.
-    # System operators who want the old behaviour can either (a) log
-    # in (gets their real role from JWT), (b) use a user API key in
-    # the jms_... format that maps to a specific role via
-    # ``resolve_api_key_principal``, or (c) set X-Role in DEV_MODE.
-    return "external"
-
-def get_client_ip(request: Request) -> str:
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+# verify_api_key, resolve_api_key_principal, get_role_from_request,
+# get_client_ip — moved to routes/_helpers.py (v0.4.x server-split PR-A,
+# single source of truth across server + extracted routers). Re-imported
+# at top of this module for back-compat with handlers still inline here.
 
 # ─── Pydantic 모델 ───────────────────────────────────────────
 
@@ -2737,40 +2631,8 @@ async def code_surface(
 
 
 # ── Phase 7: Admin API ──────────────────────────────────────────────────────
-
-def _require_admin(api_key: str, role: str):
-    """
-    Admin API 접근 검증.
-    api_key 검증 + role=admin 체크 (보안 유지)
-    """
-    verify_api_key(api_key)
-    if role != "admin":
-        raise HTTPException(status_code=403,
-                            detail="admin 권한 필요 — admin 계정으로 로그인하세요")
-
-
-def _require_feature(api_key: str, role: str, feature_id: str):
-    """[W4-Q2] Validate api_key + consult PolicyEngine.can_use_feature.
-
-    Same shape as _require_admin but consults the per-feature gate
-    from W4-Q1 instead of the hardcoded ``role != "admin"`` check.
-    For features whose default_allowed set is ``{"admin"}`` (every
-    admin.* feature in the Q1 catalog), behaviour is identical to
-    _require_admin — that equivalence is the safety net for Q2-a's
-    rewrite of existing endpoints.
-
-    Q2-b will add new admin.* features for the remaining endpoints
-    (settings/llm/persona/...) and replace their _require_admin
-    calls similarly.
-    """
-    verify_api_key(api_key)
-    from core.policy_engine import default_engine
-    d = default_engine.can_use_feature(role, feature_id)
-    if not d.allowed:
-        raise HTTPException(
-            status_code=403,
-            detail=f"권한이 부족합니다. ({feature_id})",
-        )
+# _require_admin, _require_feature — moved to routes/_helpers.py (v0.4.x
+# server-split PR-A). Re-imported at top.
 
 
 @app.get("/admin/dashboard", summary="관리자 대시보드 [P7]")
@@ -3020,19 +2882,7 @@ async def admin_users_deactivate(
 
 
 # ─── W4 P2-B: password change + reset-token workflow ────────────
-
-def _bearer_username(request: Request) -> Optional[str]:
-    """Pull `sub` (username) out of the Bearer JWT, or None.
-
-    The endpoints below need the caller's username to scope the
-    operation to their own account. We use the JWT subject claim
-    rather than a body field so the client cannot self-impersonate.
-    """
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return None
-    payload = _auth_verify_token(auth_header[7:].strip())
-    return (payload or {}).get("sub") if payload else None
+# _bearer_username — moved to routes/_helpers.py (v0.4.x server-split PR-A).
 
 
 class PasswordChangeRequest(BaseModel):

--- a/tests/test_server_boot_smoke.py
+++ b/tests/test_server_boot_smoke.py
@@ -1,0 +1,165 @@
+"""Server-split boot smoke — invariants 2 + 4 + 5 (docs/design/v0.4.x-server-split.md).
+
+Verifies that across every PR in the v0.4.x server-split cycle:
+  - app boots without exception (module imports)
+  - middleware stack order unchanged (rate_limit OUTER, no_cache_static INNER)
+  - /static mount path present
+  - @app.on_event("startup") hook registered
+  - core route shape (auth + ops endpoints) intact
+
+Does NOT exercise handler bodies — that is `pytest tests/` at large. This
+file is the structural-snapshot test the design memo §6.2 sketches.
+
+The audit_endpoint_paths.py script covers invariant 1 (URL byte-identical).
+This file covers the rest of the bootstrap surface.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def _import_app():
+    """Import server_llmwiki and return its FastAPI app.
+
+    Wrapped in a function so import errors surface as a test failure rather
+    than a collection-time crash that hides the line number.
+    """
+    import server_llmwiki  # noqa: F401  (side-effect import: DB init + state)
+    return server_llmwiki.app
+
+
+def _path_set(routes: Iterable) -> set[str]:
+    return {getattr(r, "path", None) for r in routes if getattr(r, "path", None)}
+
+
+def test_app_imports_cleanly():
+    """Invariant: server_llmwiki imports without raising."""
+    app = _import_app()
+    assert app is not None
+    assert app.title == "PROJECT JAMES - AI Knowledge Engine"
+
+
+def test_static_mount_present():
+    """Invariant 4: /static mount survives the split."""
+    app = _import_app()
+    # Starlette Mount objects expose .path; iterate looking for /static.
+    mounts = [r for r in app.routes if type(r).__name__ == "Mount"]
+    paths = {getattr(m, "path", None) for m in mounts}
+    assert "/static" in paths, f"/static mount missing — found {paths}"
+
+
+def test_middleware_stack_includes_rate_limit_and_no_cache():
+    """Invariant 2: middleware stack carries the two HTTP middlewares.
+
+    Starlette stores user-added middleware in `app.user_middleware` as a
+    list, but `add_middleware` does `insert(0, ...)` — so the LAST one
+    decorated lives at index 0 and becomes OUTERMOST at request time
+    (Starlette wraps `for ... in reversed(middleware)` in
+    `build_middleware_stack`).
+
+    Concretely for the server pre-split:
+      - `@app.middleware("http")` on no_cache_static (line 187) → added first
+      - `@app.middleware("http")` on rate_limit_middleware (line 606) → added second
+      - app.user_middleware = [rate_limit, no_cache_static]
+      - At request time: rate_limit runs OUTER (can 429 short-circuit),
+        no_cache_static runs INNER (adjusts response headers).
+
+    We assert rate_limit at a LOWER index than no_cache_static so the
+    short-circuit ordering survives every server-split PR.
+    """
+    app = _import_app()
+    # `user_middleware` is the order user added them — last = outermost.
+    names = []
+    for mw in app.user_middleware:
+        # Each is a Middleware(BaseHTTPMiddleware, dispatch=<fn>, ...).
+        dispatch = mw.kwargs.get("dispatch") if hasattr(mw, "kwargs") else None
+        if dispatch is None:
+            # Older Starlette layouts store the func differently — fall
+            # back to repr matching to keep this test stable across
+            # Starlette upgrades (string-match the function name).
+            dispatch = mw
+        names.append(getattr(dispatch, "__name__", repr(dispatch)))
+
+    haystack = "\n".join(names)
+    assert "no_cache_static" in haystack, (
+        f"no_cache_static missing from middleware stack:\n{haystack}"
+    )
+    assert "rate_limit_middleware" in haystack, (
+        f"rate_limit_middleware missing from middleware stack:\n{haystack}"
+    )
+    # rate_limit_middleware was decorated LAST → insert(0) → ends up at
+    # lower index than no_cache_static → outermost at request time.
+    idx_no_cache = next(
+        i for i, n in enumerate(names) if "no_cache_static" in n
+    )
+    idx_rate = next(
+        i for i, n in enumerate(names) if "rate_limit_middleware" in n
+    )
+    assert idx_rate < idx_no_cache, (
+        f"middleware order wrong — rate_limit_middleware must be at lower "
+        f"index than no_cache_static (outermost at request time, can 429 "
+        f"short-circuit). Got: {names}"
+    )
+
+
+def test_startup_event_registered():
+    """Invariant 5: @app.on_event("startup") survives the split."""
+    app = _import_app()
+    handlers = app.router.on_startup
+    # Should be non-empty; the named handler is `on_startup` from
+    # server_llmwiki.py.
+    assert handlers, "no startup event handlers registered"
+    names = [getattr(h, "__name__", repr(h)) for h in handlers]
+    assert any("on_startup" in n for n in names), (
+        f"on_startup handler missing from startup hooks: {names}"
+    )
+
+
+def test_core_auth_and_ops_routes_present():
+    """Anchor routes that every server-split PR (A → H) must keep alive.
+
+    Picks a small, deliberately stable subset — the URL byte-identical
+    invariant (scripts/audit_endpoint_paths.py) is the comprehensive
+    check; this test exists so a smoke-test failure points at the
+    likely-broken category fast.
+    """
+    app = _import_app()
+    paths = _path_set(app.routes)
+
+    anchor = {
+        # Operations endpoints — always public.
+        "/healthz",
+        "/",
+        # Auth surface.
+        "/login/",
+        "/signup/",
+        # Upload + query — high-traffic auth-gated.
+        "/upload/",
+        "/query/",
+        # API key management — present in routes/auth.py post-PR-A.1.
+        "/api-keys/list",
+        # Admin user mgmt.
+        "/admin/users",
+    }
+    missing = anchor - paths
+    assert not missing, f"anchor routes missing post-split: {sorted(missing)}"
+
+
+def test_routes_deps_singletons_registered():
+    """PR-A foundation: routes/_deps singletons populated at boot.
+
+    set_rag_engine / set_file_processor / set_rate_limiter must be called
+    before any include_router so extracted routers see real instances.
+    This test imports the server (triggering boot) then asserts the
+    routes/_deps getters return non-None.
+    """
+    _import_app()  # Triggers server boot + set_* calls.
+
+    from routes._deps import (
+        get_file_processor,
+        get_rag_engine,
+        get_rate_limiter,
+    )
+    assert get_rag_engine() is not None
+    assert get_file_processor() is not None
+    assert get_rate_limiter() is not None


### PR DESCRIPTION
## Summary

server_llmwiki.py 분할 8-PR 시퀀스의 **첫 PR**. design memo `docs/design/v0.4.x-server-split.md` (PR #571) 의 §3 + §6 foundation. **endpoint 이동 0** — routes/ scaffold + 8 helpers 추출 + URL byte-identical 회귀 게이트 + boot smoke test 만.

## Scope 재결정 (실측 후 + 사용자 confirm)

design memo PR-A 추정 ~400 lines 이동이었으나 실측 **745 lines + 8 helpers + auth/upload trust boundary**. 단일 PR risk 가 design memo §10 anti-rush 권장 수준을 넘어가 PR-A 를 foundation only 로 좁히고, 13 endpoint 이동을 PR-A.1 으로 분리. 사용자 confirm (Recommended).

## 들어간 것 (6 files, +711 / -188)

### `routes/` 패키지 신설

- **`routes/__init__.py`** — 8-PR invariants 6개 docstring
- **`routes/_deps.py`** (55 LOC) — singleton getter 패턴
  - `set_rag_engine` / `set_file_processor` / `set_rate_limiter` (server boot 가 호출)
  - `get_rag_engine` / `get_file_processor` / `get_rate_limiter` (extracted router 가 호출)
  - initialized 체크 → 명시 `RuntimeError` (boot order 강제)
- **`routes/_helpers.py`** (209 LOC) — 8 helpers 단일 source-of-truth:
  - `_write_audit` (24 호출 사이트 — emit timing/field 동일)
  - `get_client_ip` / `_bearer_username`
  - `verify_api_key` (server-local — system key OR jms_*) / `resolve_api_key_principal` / `get_role_from_request`
  - `_require_admin` / `_require_feature`
  - `bearer_scheme` (Depends() 단일 인스턴스)
  - `_AUDIT_DB` 경로
  내부 동작 byte-identical (handler signature + 동작 변경 0).

### `scripts/audit_endpoint_paths.py` (228 LOC) — 회귀 게이트

design memo §2.1 + §6.1 명시. URL byte-identical invariant 검증.
- 현재 app.routes vs git ref baseline 비교 (worktree-based capture)
- 베이스라인 ref 가 이 스크립트 이전이면 AST fallback
- FastAPI auto-routes (\`/docs\`, \`/redoc\`, \`/openapi.json\`, \`/docs/oauth2-redirect\`) 양쪽에서 제외
- 사용: \`python scripts/audit_endpoint_paths.py [ref]\` → exit 0 (identical) / 1 (diff) / 2 (wrapper error)
- **검증: \`python scripts/audit_endpoint_paths.py origin/main\` → OK: 125 endpoints identical to origin/main** ✓

### `tests/test_server_boot_smoke.py` (165 LOC) — invariants 2/4/5

design memo §6.2 명시. invariant 1 은 audit script 가 cover.

| 테스트 | invariant |
|---|---|
| `test_app_imports_cleanly` | module import 정상 |
| `test_static_mount_present` | (#4) \`/static\` mount 생존 |
| `test_middleware_stack_includes_rate_limit_and_no_cache` | (#2) middleware 순서 (rate_limit OUTER, no_cache_static INNER) — Starlette \`insert(0)\` 의미 docstring 명시 |
| `test_startup_event_registered` | (#5) \`@app.on_event("startup")\` |
| `test_core_auth_and_ops_routes_present` | anchor route 8개 |
| `test_routes_deps_singletons_registered` | set_* 동작 |

**6/6 green.**

### `server_llmwiki.py` 수정

- \`from routes._helpers import (...)\` — 8 helpers re-import (server 내부에 잔류하는 handler 들이 같은 이름으로 계속 사용)
- \`from routes._deps import set_rag_engine, set_file_processor, set_rate_limiter\` — boot 시 등록
- 8 helper 정의 제거 (단일 SOT = routes/_helpers.py)
- \`BASE_DIR\` 를 config import 에 추가 (try/except 블록 제거 부산물)
- 코멘트로 이동 사실 docstring 명시
- \`bearer_scheme = HTTPBearer(auto_error=False)\` 제거 (routes/_helpers.py 가 SOT)

## Verification (design memo §5 contract)

| invariant | 결과 |
|---|---|
| 1. URL byte-identical | ✓ \`python scripts/audit_endpoint_paths.py origin/main\` → **125 endpoints identical** |
| 2. Middleware order | ✓ \`test_middleware_stack_includes_rate_limit_and_no_cache\` pass (rate_limit OUTER 위치 명시 검증) |
| 3. \`_write_audit\` emit | ✓ 24 사이트 모두 같은 함수, 같은 sqlite3 INSERT (routes/_helpers.py SOT) |
| 4. \`/static\` mount | ✓ \`test_static_mount_present\` pass |
| 5. startup event | ✓ \`test_startup_event_registered\` pass |
| 6. pytest 회귀 | ✓ **3288 passed** + 6 new smoke tests. 1 fail (\`test_unset_env_chroma_dir_unchanged\` + \`test_unset_env_resolves_legacy_minilm_paths\`) 는 .env 에 \`JAMES_EMBEDDING_MODEL=BAAI/bge-m3\` 가 있어 config reload 가 unset 을 무효화하는 **pre-existing 테스트 격리 버그** — 본 PR 무관 (origin/main 에서도 동일 실패) |

## Out of scope (PR-A.1 으로 deferred)

- \`routes/auth.py\` 작성 (~750 LOC)
- 13 endpoint 이동 (\`/login/\`, \`/signup/\`, \`/upload/\`, \`/admin/users\` ×4, \`/password/*\`, \`/api-keys/*\`, \`/admin/users/issue-reset-token\`)
- \`app.include_router(auth_router)\` 와이어
- audit_endpoint_paths.py 가 capture 모드로 PR-A.1 의 0-diff 검증

## Quality Delta vs baseline

\`Quality delta: exempt (label: chore)\`. 라우팅 표면 byte-identical, \`core/\` 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)