### PR TITLE
chore(server-split): v0.4.x PR-C — jobs/scheduler routes → routes/jobs.py (9 endpoints + DI lazy forwarder)

### DIFF
--- a/routes/_deps.py
+++ b/routes/_deps.py
@@ -1,55 +1,56 @@
-"""Singleton getters for FastAPI router modules.
+"""Singleton accessors for FastAPI router modules.
 
-Pattern: server_llmwiki.py creates singletons at boot (rag_engine,
-file_processor, _rate_limiter) then calls set_* to register them.
-Router modules import the corresponding get_* and call inside handlers.
+Pattern (v0.4.x server-split): server_llmwiki.py creates rag_engine /
+file_processor / _rate_limiter as module-level globals at boot. Router
+modules in routes/<domain>.py call ``get_<name>()`` here, which
+lazy-forwards to ``server_llmwiki.<name>`` at call time.
 
-This decouples routers from server_llmwiki.py — no circular imports —
-while keeping the boot order explicit (set_* must precede include_router).
-Per the v0.4.x server-split design memo §3.1.
+The forwarder design (rather than a snapshot taken via set_*) preserves
+two important behaviours from before the split:
+
+  - Tests that monkeypatch ``server_llmwiki.rag_engine = stub`` to
+    inject a fake engine continue to work transparently — the next
+    handler invocation reads the patched attribute.
+  - There is exactly one source of truth for each singleton. set_*
+    snapshots would create two locations that could drift if an
+    operator-on-call swapped one and not the other.
+
+Lazy ``import server_llmwiki`` (inside the getter, not at module
+top) avoids the circular import: server_llmwiki imports routes/_helpers
+and routes/<domain>, those import routes/_deps; if routes/_deps
+imported server_llmwiki at module top, server_llmwiki would still be
+mid-import and the attribute wouldn't exist yet.
+
+set_* hooks are kept as no-ops so server_llmwiki's boot-time
+``set_rag_engine(rag_engine)`` calls (added in PR-A.0) don't need to
+be removed — they're free annotation of intent.
 """
-from typing import Any
-
-_rag_engine: Any = None
-_file_processor: Any = None
-_rate_limiter: Any = None
+from __future__ import annotations
 
 
 def set_rag_engine(engine) -> None:
-    global _rag_engine
-    _rag_engine = engine
+    """Kept for back-compat with PR-A.0 boot code. No-op — get_rag_engine
+    forwards lazily to server_llmwiki.rag_engine at call time."""
 
 
 def set_file_processor(fp) -> None:
-    global _file_processor
-    _file_processor = fp
+    """Kept for back-compat. No-op (see set_rag_engine)."""
 
 
 def set_rate_limiter(rl) -> None:
-    global _rate_limiter
-    _rate_limiter = rl
+    """Kept for back-compat. No-op (see set_rag_engine)."""
 
 
 def get_rag_engine():
-    if _rag_engine is None:
-        raise RuntimeError(
-            "rag_engine not initialized — server boot order violation. "
-            "server_llmwiki.py must call set_rag_engine() before include_router()."
-        )
-    return _rag_engine
+    import server_llmwiki
+    return server_llmwiki.rag_engine
 
 
 def get_file_processor():
-    if _file_processor is None:
-        raise RuntimeError(
-            "file_processor not initialized — server boot order violation."
-        )
-    return _file_processor
+    import server_llmwiki
+    return server_llmwiki.file_processor
 
 
 def get_rate_limiter():
-    if _rate_limiter is None:
-        raise RuntimeError(
-            "_rate_limiter not initialized — server boot order violation."
-        )
-    return _rate_limiter
+    import server_llmwiki
+    return server_llmwiki._rate_limiter

--- a/routes/jobs.py
+++ b/routes/jobs.py
@@ -1,0 +1,302 @@
+"""Workspace jobs + scheduler routes.
+
+Extracted from server_llmwiki.py per docs/design/v0.4.x-server-split.md
+PR-C. 9 endpoints + 3 Pydantic models moved verbatim — handler body
+byte-identical (only ``@app.<m>`` -> ``@router.<m>``).
+
+URL invariant: ``python scripts/audit_endpoint_paths.py origin/main``
+must report 0-diff against the pre-PR-C baseline.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from routes._helpers import (
+    _bearer_username,
+    _require_feature,
+    _write_audit,
+    get_client_ip,
+    get_role_from_request,
+)
+
+router = APIRouter()
+
+
+# ─── Pydantic models ───────────────────────────────────────────────
+
+class JobRunRequest(BaseModel):
+    job_type:   str
+    input_refs: list = []
+    options:    Optional[dict] = None
+
+class JobScheduleRequest(BaseModel):
+    job_type:      str
+    input_refs:    list = []
+    options:       Optional[dict] = None
+    schedule_cron: str   # "hourly" | "every:N" | "daily:HH:MM" | "weekly:DOW:HH:MM"
+
+class JobUnscheduleRequest(BaseModel):
+    job_id: str
+
+# ─── Endpoints ─────────────────────────────────────────────────────
+
+@router.post("/jobs/run", summary="워크스페이스 job 실행 (W8-A)")
+async def jobs_run(
+    data:    JobRunRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    """workspace.run_jobs feature gate. Owner is the JWT subject
+    (no JWT → 401 — anonymous can't run jobs). Body has no owner
+    field; the server is the source of truth."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.run_jobs").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.run_jobs)")
+    owner = _bearer_username(request)
+    if not owner:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
+    from core.workspace import register_job, execute_job, HANDLERS
+    if data.job_type not in HANDLERS:
+        raise HTTPException(status_code=400,
+                            detail=f"unknown job_type: {data.job_type}")
+    job_id = register_job(data.job_type, data.input_refs or [],
+                          owner=owner, options=data.options)
+    ip = get_client_ip(request)
+    _write_audit(role, "/jobs/run", query=f"{data.job_type}/{job_id}",
+                 security_event="job_started", ip_address=ip)
+    row = execute_job(job_id)
+    final_event = "job_done" if row["status"] == "done" else f"job_{row['status']}"
+    _write_audit(role, "/jobs/run", query=f"{data.job_type}/{job_id}",
+                 security_event=final_event, ip_address=ip)
+    return row
+
+@router.post("/jobs/schedule",
+          summary="워크스페이스 job 예약 (정기 실행, W8-D)")
+async def jobs_schedule(
+    data:    JobScheduleRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    """Insert a scheduled job. ``workspace.schedule`` feature gate
+    (admin only by default — cron-driven jobs touch shared resources
+    so the grant is intentionally narrow).
+
+    The DSL is validated up front: an unrecognised spec returns 400
+    rather than persisting a row that the scheduler would silently
+    ignore. The first ``next_run_at`` is computed from the spec; the
+    Scheduler updates it after each successful tick.
+    """
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.schedule").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.schedule)")
+    owner = _bearer_username(request)
+    if not owner:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
+    from core.workspace import register_job, HANDLERS
+    from core.scheduler import compute_next_run
+    if data.job_type not in HANDLERS:
+        raise HTTPException(status_code=400,
+                            detail=f"unknown job_type: {data.job_type}")
+
+    now = int(time.time())
+    next_at = compute_next_run(data.schedule_cron, now)
+    if next_at is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"unknown schedule spec: {data.schedule_cron!r}. "
+                    "Use 'hourly' / 'every:N' / 'daily:HH:MM' / "
+                    "'weekly:DOW:HH:MM'."),
+        )
+
+    job_id = register_job(
+        data.job_type, data.input_refs or [],
+        owner=owner, options=data.options,
+        schedule_cron=data.schedule_cron, next_run_at=next_at,
+    )
+    ip = get_client_ip(request)
+    _write_audit(role, "/jobs/schedule",
+                 query=f"{data.job_type}/{job_id}",
+                 security_event=f"scheduled cron={data.schedule_cron}",
+                 ip_address=ip)
+    return {
+        "ok":            True,
+        "job_id":        job_id,
+        "schedule_cron": data.schedule_cron,
+        "next_run_at":   next_at,
+    }
+
+@router.post("/jobs/unschedule",
+          summary="정기 실행 해제 (W8-D follow-up)")
+async def jobs_unschedule(
+    data:    JobUnscheduleRequest,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    """Converts a scheduled row back into a one-shot. Mirror of
+    /jobs/schedule's authority surface — workspace.schedule
+    (admin-only default). 404 when the job doesn't exist or is
+    already a one-shot."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.schedule").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.schedule)")
+    from core.scheduler import unschedule_job
+    ok = unschedule_job(data.job_id)
+    ip = get_client_ip(request)
+    if not ok:
+        _write_audit(role, "/jobs/unschedule", query=data.job_id,
+                     security_event="unschedule_failed (unknown or one-shot)",
+                     ip_address=ip)
+        raise HTTPException(
+            status_code=404,
+            detail="해당 job 이 없거나 이미 정기실행이 아닙니다.",
+        )
+    _write_audit(role, "/jobs/unschedule", query=data.job_id,
+                 security_event="unscheduled", ip_address=ip)
+    return {"ok": True, "job_id": data.job_id}
+
+@router.get("/admin/scheduler/status",
+         summary="스케줄러 상태 + 다음 firing 목록 (W8-D follow-up)")
+async def admin_scheduler_status(
+    api_key: str,
+    limit:   int = 20,
+    role:    str = Depends(get_role_from_request),
+):
+    """Scheduler health snapshot.
+
+    Returns the live ``default_scheduler`` state (is_running,
+    poll_interval_sec, retention_days, last_retention) plus the next
+    N scheduled rows sorted by ``next_run_at``. Operator can spot
+    "scheduler stopped" (is_running=False), "retention never ran"
+    (last_retention=0), or "this job is stuck" (next_run_at in the
+    past) at a glance.
+
+    Gated by admin.metrics (matches /admin/metrics / dashboard).
+    """
+    _require_feature(api_key, role, "admin.metrics")
+    from core.scheduler import default_scheduler, list_upcoming_scheduled
+    return {
+        "is_running":         default_scheduler.is_running(),
+        "poll_interval_sec":  default_scheduler.poll_interval_sec,
+        "retention_days":     default_scheduler.retention_days,
+        "last_retention_at":  default_scheduler._last_retention,
+        "now":                int(time.time()),
+        "upcoming":           list_upcoming_scheduled(limit=limit),
+    }
+
+@router.get("/jobs/list", summary="내 job 목록 (W8-A)")
+async def jobs_list(
+    request: Request,
+    status:  str = "",
+    limit:   int = 50,
+    offset:  int = 0,
+    role:    str = Depends(get_role_from_request),
+):
+    """Self-view — gated by workspace.view (lower bar than
+    run_jobs; reading your own queue is universally useful)."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.view").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.view)")
+    owner = _bearer_username(request)
+    if not owner:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+    from core.workspace import list_jobs, count_jobs
+    s = status.strip() or None
+    return {
+        "items":  list_jobs(owner=owner, status=s, limit=limit, offset=offset),
+        "total":  count_jobs(owner=owner, status=s),
+        "status": s or "",
+        "limit":  limit,
+        "offset": offset,
+    }
+
+@router.get("/jobs/{job_id}", summary="내 job 상세 (W8-A)")
+async def jobs_detail(
+    job_id:  str,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.view").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.view)")
+    owner = _bearer_username(request)
+    if not owner:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+    from core.workspace import get_job
+    row = get_job(job_id, requester_username=owner)
+    if row is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return row
+
+@router.get("/jobs/{job_id}/download", summary="job 결과 다운로드 (W8-A)")
+async def jobs_download(
+    job_id:  str,
+    request: Request,
+    role:    str = Depends(get_role_from_request),
+):
+    """Stream the produced file. Cross-owner access surfaces as 404
+    (the row lookup returns None for non-owners; we don't leak the
+    job_id space)."""
+    from core.policy_engine import default_engine as _pe
+    if not _pe.can_use_feature(role, "workspace.view").allowed:
+        raise HTTPException(status_code=403,
+                            detail="권한이 부족합니다. (workspace.view)")
+    owner = _bearer_username(request)
+    if not owner:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+    from core.workspace import get_job
+    row = get_job(job_id, requester_username=owner)
+    if row is None or not row.get("output_path"):
+        raise HTTPException(status_code=404, detail="job result not found")
+    try:
+        from config import BASE_DIR
+        full = os.path.join(BASE_DIR, row["output_path"])
+    except ImportError:
+        full = row["output_path"]
+    if not os.path.exists(full):
+        raise HTTPException(status_code=404, detail="output file missing on disk")
+    return FileResponse(full, filename=os.path.basename(full))
+
+@router.get("/admin/jobs/list", summary="모든 job 목록 — admin (W8-A)")
+async def admin_jobs_list(
+    api_key: str,
+    status:  str = "",
+    limit:   int = 50,
+    offset:  int = 0,
+    role:    str = Depends(get_role_from_request),
+):
+    _require_feature(api_key, role, "admin.data")
+    from core.workspace import list_jobs, count_jobs
+    s = status.strip() or None
+    return {
+        "items":  list_jobs(status=s, limit=limit, offset=offset),
+        "total":  count_jobs(status=s),
+        "status": s or "",
+        "limit":  limit,
+        "offset": offset,
+    }
+
+@router.get("/admin/jobs/{job_id}", summary="job 상세 — admin (W8-A)")
+async def admin_jobs_detail(
+    job_id:  str,
+    api_key: str,
+    role:    str = Depends(get_role_from_request),
+):
+    _require_feature(api_key, role, "admin.data")
+    from core.workspace import get_job
+    row = get_job(job_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return row

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -240,6 +240,10 @@ from routes.llm import (  # noqa: F401
 )
 app.include_router(llm_router)
 
+# v0.4.x server-split PR-C — workspace jobs + scheduler routes.
+from routes.jobs import router as jobs_router
+app.include_router(jobs_router)
+
 
 
 @app.on_event("startup")
@@ -3424,291 +3428,34 @@ async def mine_artifacts_detail(
 # sizes. /jobs/run blocks until the row reaches done/failed. Scheduler
 # (cron-driven) is W8-A2; this PR is pure on-demand execution.
 
-class JobRunRequest(BaseModel):
-    job_type:   str
-    input_refs: list = []
-    options:    Optional[dict] = None
 
 
-@app.post("/jobs/run", summary="워크스페이스 job 실행 (W8-A)")
-async def jobs_run(
-    data:    JobRunRequest,
-    request: Request,
-    role:    str = Depends(get_role_from_request),
-):
-    """workspace.run_jobs feature gate. Owner is the JWT subject
-    (no JWT → 401 — anonymous can't run jobs). Body has no owner
-    field; the server is the source of truth."""
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.run_jobs").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.run_jobs)")
-    owner = _bearer_username(request)
-    if not owner:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
-
-    from core.workspace import register_job, execute_job, HANDLERS
-    if data.job_type not in HANDLERS:
-        raise HTTPException(status_code=400,
-                            detail=f"unknown job_type: {data.job_type}")
-    job_id = register_job(data.job_type, data.input_refs or [],
-                          owner=owner, options=data.options)
-    ip = get_client_ip(request)
-    _write_audit(role, "/jobs/run", query=f"{data.job_type}/{job_id}",
-                 security_event="job_started", ip_address=ip)
-    row = execute_job(job_id)
-    final_event = "job_done" if row["status"] == "done" else f"job_{row['status']}"
-    _write_audit(role, "/jobs/run", query=f"{data.job_type}/{job_id}",
-                 security_event=final_event, ip_address=ip)
-    return row
 
 
 # ─── W8-D: schedule a recurring job ────────────────────────────
 
-class JobScheduleRequest(BaseModel):
-    job_type:      str
-    input_refs:    list = []
-    options:       Optional[dict] = None
-    schedule_cron: str   # "hourly" | "every:N" | "daily:HH:MM" | "weekly:DOW:HH:MM"
 
 
-@app.post("/jobs/schedule",
-          summary="워크스페이스 job 예약 (정기 실행, W8-D)")
-async def jobs_schedule(
-    data:    JobScheduleRequest,
-    request: Request,
-    role:    str = Depends(get_role_from_request),
-):
-    """Insert a scheduled job. ``workspace.schedule`` feature gate
-    (admin only by default — cron-driven jobs touch shared resources
-    so the grant is intentionally narrow).
-
-    The DSL is validated up front: an unrecognised spec returns 400
-    rather than persisting a row that the scheduler would silently
-    ignore. The first ``next_run_at`` is computed from the spec; the
-    Scheduler updates it after each successful tick.
-    """
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.schedule").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.schedule)")
-    owner = _bearer_username(request)
-    if not owner:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
-
-    from core.workspace import register_job, HANDLERS
-    from core.scheduler import compute_next_run
-    if data.job_type not in HANDLERS:
-        raise HTTPException(status_code=400,
-                            detail=f"unknown job_type: {data.job_type}")
-
-    now = int(time.time())
-    next_at = compute_next_run(data.schedule_cron, now)
-    if next_at is None:
-        raise HTTPException(
-            status_code=400,
-            detail=(f"unknown schedule spec: {data.schedule_cron!r}. "
-                    "Use 'hourly' / 'every:N' / 'daily:HH:MM' / "
-                    "'weekly:DOW:HH:MM'."),
-        )
-
-    job_id = register_job(
-        data.job_type, data.input_refs or [],
-        owner=owner, options=data.options,
-        schedule_cron=data.schedule_cron, next_run_at=next_at,
-    )
-    ip = get_client_ip(request)
-    _write_audit(role, "/jobs/schedule",
-                 query=f"{data.job_type}/{job_id}",
-                 security_event=f"scheduled cron={data.schedule_cron}",
-                 ip_address=ip)
-    return {
-        "ok":            True,
-        "job_id":        job_id,
-        "schedule_cron": data.schedule_cron,
-        "next_run_at":   next_at,
-    }
 
 
 # ─── W8-D follow-up: unschedule + scheduler status ─────────────
 
-class JobUnscheduleRequest(BaseModel):
-    job_id: str
 
 
-@app.post("/jobs/unschedule",
-          summary="정기 실행 해제 (W8-D follow-up)")
-async def jobs_unschedule(
-    data:    JobUnscheduleRequest,
-    request: Request,
-    role:    str = Depends(get_role_from_request),
-):
-    """Converts a scheduled row back into a one-shot. Mirror of
-    /jobs/schedule's authority surface — workspace.schedule
-    (admin-only default). 404 when the job doesn't exist or is
-    already a one-shot."""
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.schedule").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.schedule)")
-    from core.scheduler import unschedule_job
-    ok = unschedule_job(data.job_id)
-    ip = get_client_ip(request)
-    if not ok:
-        _write_audit(role, "/jobs/unschedule", query=data.job_id,
-                     security_event="unschedule_failed (unknown or one-shot)",
-                     ip_address=ip)
-        raise HTTPException(
-            status_code=404,
-            detail="해당 job 이 없거나 이미 정기실행이 아닙니다.",
-        )
-    _write_audit(role, "/jobs/unschedule", query=data.job_id,
-                 security_event="unscheduled", ip_address=ip)
-    return {"ok": True, "job_id": data.job_id}
 
 
-@app.get("/admin/scheduler/status",
-         summary="스케줄러 상태 + 다음 firing 목록 (W8-D follow-up)")
-async def admin_scheduler_status(
-    api_key: str,
-    limit:   int = 20,
-    role:    str = Depends(get_role_from_request),
-):
-    """Scheduler health snapshot.
-
-    Returns the live ``default_scheduler`` state (is_running,
-    poll_interval_sec, retention_days, last_retention) plus the next
-    N scheduled rows sorted by ``next_run_at``. Operator can spot
-    "scheduler stopped" (is_running=False), "retention never ran"
-    (last_retention=0), or "this job is stuck" (next_run_at in the
-    past) at a glance.
-
-    Gated by admin.metrics (matches /admin/metrics / dashboard).
-    """
-    _require_feature(api_key, role, "admin.metrics")
-    from core.scheduler import default_scheduler, list_upcoming_scheduled
-    return {
-        "is_running":         default_scheduler.is_running(),
-        "poll_interval_sec":  default_scheduler.poll_interval_sec,
-        "retention_days":     default_scheduler.retention_days,
-        "last_retention_at":  default_scheduler._last_retention,
-        "now":                int(time.time()),
-        "upcoming":           list_upcoming_scheduled(limit=limit),
-    }
 
 
-@app.get("/jobs/list", summary="내 job 목록 (W8-A)")
-async def jobs_list(
-    request: Request,
-    status:  str = "",
-    limit:   int = 50,
-    offset:  int = 0,
-    role:    str = Depends(get_role_from_request),
-):
-    """Self-view — gated by workspace.view (lower bar than
-    run_jobs; reading your own queue is universally useful)."""
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.view").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.view)")
-    owner = _bearer_username(request)
-    if not owner:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
-    from core.workspace import list_jobs, count_jobs
-    s = status.strip() or None
-    return {
-        "items":  list_jobs(owner=owner, status=s, limit=limit, offset=offset),
-        "total":  count_jobs(owner=owner, status=s),
-        "status": s or "",
-        "limit":  limit,
-        "offset": offset,
-    }
 
 
-@app.get("/jobs/{job_id}", summary="내 job 상세 (W8-A)")
-async def jobs_detail(
-    job_id:  str,
-    request: Request,
-    role:    str = Depends(get_role_from_request),
-):
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.view").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.view)")
-    owner = _bearer_username(request)
-    if not owner:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
-    from core.workspace import get_job
-    row = get_job(job_id, requester_username=owner)
-    if row is None:
-        raise HTTPException(status_code=404, detail="job not found")
-    return row
 
 
-@app.get("/jobs/{job_id}/download", summary="job 결과 다운로드 (W8-A)")
-async def jobs_download(
-    job_id:  str,
-    request: Request,
-    role:    str = Depends(get_role_from_request),
-):
-    """Stream the produced file. Cross-owner access surfaces as 404
-    (the row lookup returns None for non-owners; we don't leak the
-    job_id space)."""
-    from core.policy_engine import default_engine as _pe
-    if not _pe.can_use_feature(role, "workspace.view").allowed:
-        raise HTTPException(status_code=403,
-                            detail="권한이 부족합니다. (workspace.view)")
-    owner = _bearer_username(request)
-    if not owner:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
-    from core.workspace import get_job
-    row = get_job(job_id, requester_username=owner)
-    if row is None or not row.get("output_path"):
-        raise HTTPException(status_code=404, detail="job result not found")
-    try:
-        from config import BASE_DIR
-        full = os.path.join(BASE_DIR, row["output_path"])
-    except ImportError:
-        full = row["output_path"]
-    if not os.path.exists(full):
-        raise HTTPException(status_code=404, detail="output file missing on disk")
-    return FileResponse(full, filename=os.path.basename(full))
 
 
 # ── admin-side mirrors (admin.data feature, sees every owner) ──
 
-@app.get("/admin/jobs/list", summary="모든 job 목록 — admin (W8-A)")
-async def admin_jobs_list(
-    api_key: str,
-    status:  str = "",
-    limit:   int = 50,
-    offset:  int = 0,
-    role:    str = Depends(get_role_from_request),
-):
-    _require_feature(api_key, role, "admin.data")
-    from core.workspace import list_jobs, count_jobs
-    s = status.strip() or None
-    return {
-        "items":  list_jobs(status=s, limit=limit, offset=offset),
-        "total":  count_jobs(status=s),
-        "status": s or "",
-        "limit":  limit,
-        "offset": offset,
-    }
 
 
-@app.get("/admin/jobs/{job_id}", summary="job 상세 — admin (W8-A)")
-async def admin_jobs_detail(
-    job_id:  str,
-    api_key: str,
-    role:    str = Depends(get_role_from_request),
-):
-    _require_feature(api_key, role, "admin.data")
-    from core.workspace import get_job
-    row = get_job(job_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail="job not found")
-    return row
 
 
 # ─── W4-Q1: feature capability matrix ──────────────────────────

--- a/tests/_server_split_helpers.py
+++ b/tests/_server_split_helpers.py
@@ -28,8 +28,8 @@ def combined_server_source() -> str:
     import server_llmwiki  # noqa: F401  — surfaces import errors clearly
     parts: list[str] = [inspect.getsource(server_llmwiki)]
 
-    # Probe known routes/* modules. Add new ones here as PR-C..PR-H land.
-    for mod_name in ("routes.auth", "routes.llm"):
+    # Probe known routes/* modules. Add new ones here as PR-D..PR-H land.
+    for mod_name in ("routes.auth", "routes.llm", "routes.jobs"):
         try:
             mod = importlib.import_module(mod_name)
             parts.append(


### PR DESCRIPTION
> **PR-stack**: base = \`chore/v0.4.x-pr-b-llm-router-move\` (#574, LLM routes). Merge order: #572 → #573 → #574 → this PR.

## Summary

8-PR sequence 중 **네 번째 PR**. W8 workspace jobs + scheduler 분리 + DI getter 가 monkeypatch 호환되도록 lazy-forwarder 패턴 전환.

## 이동된 surface (253 lines 서버에서 제거)

### 9 endpoints
- \`/jobs/run\`, \`/jobs/schedule\`, \`/jobs/unschedule\`
- \`/jobs/list\`, \`/jobs/{job_id}\`, \`/jobs/{job_id}/download\`
- \`/admin/scheduler/status\`
- \`/admin/jobs/list\`, \`/admin/jobs/{job_id}\`

### 3 Pydantic 모델
\`JobRunRequest\`, \`JobScheduleRequest\`, \`JobUnscheduleRequest\`

## routes/_deps.py — DI lazy-forwarder 패턴 전환

기존 PR-A.0 의 snapshot-via-\`set_*\` 패턴은 monkeypatch 호환성 깨짐:
- 테스트가 \`srv.rag_engine = stub\` 으로 attribute 패치 → server module만 변경
- \`routes/_deps._rag_engine\` 은 boot 시점 snapshot 이라 stub 안 봄
- 결과: extracted router 가 stub 대신 원본 engine 사용

전환:
\`\`\`python
def get_rag_engine():
    import server_llmwiki  # lazy — 호출 시점, circular 회피
    return server_llmwiki.rag_engine
\`\`\`

- 모든 \`get_*\` 가 lazy-forwarder 로 변환
- \`set_*\` 는 no-op 유지 (PR-A.0 boot 코드 back-compat)
- 단일 SOT (server module attribute) + monkeypatch 자연 통과

검증: \`tests/test_workspace_jobs.py\` + \`tests/test_scheduler.py\` 의 \`srv.rag_engine = _StubEngine()\` 패턴 모두 그대로 작동.

## tests/_server_split_helpers.py 갱신

\`combined_server_source()\` 의 routes/* 모듈 목록에 \`routes.jobs\` 추가.

## server_llmwiki.py 변경

- 9 endpoint + 3 Pydantic 제거 (~253 lines)
- \`from routes.jobs import router as jobs_router\` + \`app.include_router(jobs_router)\` (llm_router 다음)
- ruff --fix 가 unused import 자동 정리

## Verification (design memo §5 contract)

| invariant | 결과 |
|---|---|
| **1. URL byte-identical** | ✓ \`python scripts/audit_endpoint_paths.py origin/main\` → **OK: 125 endpoints identical to origin/main** |
| **2. Middleware order** | ✓ \`test_middleware_stack_includes_rate_limit_and_no_cache\` pass |
| **3. \`_write_audit\` emit** | ✓ 24 사이트 동일 (routes/_helpers SOT) |
| **4. \`/static\` mount** | ✓ \`test_static_mount_present\` pass |
| **5. startup event** | ✓ \`test_startup_event_registered\` pass |
| **6. pytest 회귀** | ✓ **3294 passed, 0 failed** (2 .env-flakes deselected — pre-existing) |
| **ruff F-class** | ✓ All checks passed |

## 변경 통계

\`\`\`
 routes/_deps.py                |  73 +++++-----
 routes/jobs.py                 | 302 ++++++++++++++++++++++++++++++++++++++
 server_llmwiki.py              | 261 +-----------------------------
 tests/_server_split_helpers.py |   4 +-
 4 files changed, 345 insertions(+), 295 deletions(-)
\`\`\`

server_llmwiki.py: 4685 → 4439 lines (−246). 8-PR roadmap 진행률 ≈ **25%** (1455/5894).

## Out of scope (다음 PR 들로)

- **PR-D**: \`/artifacts/*\` + \`/admin/artifacts/*\` (W7-A data artifacts)
- **PR-E**: Phase 7 자기진화 + 멀티모달
- **PR-F**: \`/code/*\` (코딩 에이전트)
- **PR-G**: 잔여 \`/admin/*\`
- **PR-H**: server_llmwiki.py 최종 정리 (~500 lines target)

## Quality Delta vs baseline

\`Quality delta: exempt (label: chore)\`. URL 표면 byte-identical, \`core/\` 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)