### PR TITLE
chore(server-split): v0.4.x PR-F — coding agent routes → routes/coding.py (4 endpoints)

### DIFF
--- a/routes/coding.py
+++ b/routes/coding.py
@@ -1,0 +1,197 @@
+"""Coding agent routes (Phase 5.5).
+
+Extracted from server_llmwiki.py per docs/design/v0.4.x-server-split.md
+PR-F. 4 endpoints + 3 Pydantic models moved verbatim — handler body
+byte-identical (only ``@app.<m>`` -> ``@router.<m>``).
+
+URL invariant: ``python scripts/audit_endpoint_paths.py origin/main``
+must report 0-diff against the pre-PR-F baseline.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from routes._helpers import (
+    _AUDIT_DB,
+    _write_audit,
+    get_client_ip,
+    get_role_from_request,
+    verify_api_key,
+)
+
+router = APIRouter()
+
+# ─── Pydantic models ───
+
+class CodeReadRequest(BaseModel):
+    api_key:    str
+    path:       str
+    start_line: int = 1
+    end_line:   Optional[int] = None
+
+class CodeAnalyzeRequest(BaseModel):
+    api_key:       str
+    path:          str
+    analysis_type: str = "review"
+
+class CodeEditRequest(BaseModel):
+    api_key:     str
+    path:        str
+    content:     str
+    start_line:  Optional[int] = None
+    end_line:    Optional[int] = None
+
+class CodeResponse(BaseModel):
+    success: bool
+    result:  str
+    meta:    dict = {}
+
+# ─── Endpoints ───
+
+@router.post("/code/read/", response_model=CodeResponse, summary="코드 읽기 [P5.5]",
+          description="workspace 내 파일 읽기 전용. Sandbox 검증 필수.")
+async def code_read(
+    data: CodeReadRequest,
+    request: Request,
+    role: str = Depends(get_role_from_request),
+):
+    verify_api_key(data.api_key)
+    ip = get_client_ip(request)
+
+    # employee 이상만 허용
+    from core.security_layer import ROLE_LEVEL
+    if ROLE_LEVEL.get(role, 0) < 1:
+        raise HTTPException(status_code=403, detail="코드 읽기는 employee 이상 권한 필요")
+
+    try:
+        from tools.code.code_reader import CodeReader
+        reader = CodeReader()
+        ok, content, meta = reader.read_file(data.path, data.start_line, data.end_line)
+        _write_audit(role, "/code/read/", query=data.path, ip_address=ip)
+        return {"success": ok, "result": content, "meta": meta}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/code/analyze/", response_model=CodeResponse, summary="코드 분석 [P5.5]",
+          description="JAMES Core Engine을 통한 코드 분석. Sandbox 검증 필수.")
+async def code_analyze(
+    data: CodeAnalyzeRequest,
+    request: Request,
+    role: str = Depends(get_role_from_request),
+):
+    verify_api_key(data.api_key)
+    ip = get_client_ip(request)
+
+    from core.security_layer import ROLE_LEVEL
+    if ROLE_LEVEL.get(role, 0) < 1:
+        raise HTTPException(status_code=403, detail="코드 분석은 employee 이상 권한 필요")
+
+    try:
+        from tools.code.code_analyzer import CodeAnalyzer
+        analyzer = CodeAnalyzer(user_role=role)
+        ok, result, meta = analyzer.analyze_file(data.path, data.analysis_type)
+        _write_audit(role, "/code/analyze/", query=f"{data.path}:{data.analysis_type}",
+                     answer=result[:200], ip_address=ip)
+        return {"success": ok, "result": result, "meta": meta}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/code/edit/", response_model=CodeResponse, summary="코드 수정 [P5.5]",
+          description="Sandbox 검증 통과 후 파일 수정. admin 전용.")
+async def code_edit(
+    data: CodeEditRequest,
+    request: Request,
+    role: str = Depends(get_role_from_request),
+):
+    verify_api_key(data.api_key)
+    ip = get_client_ip(request)
+
+    # [P5.5] 코드 수정은 admin 전용 (보수적 정책)
+    if role != "admin":
+        _write_audit(role, "/code/edit/",
+                     security_event=f"edit_denied role={role}",
+                     blocked=True, ip_address=ip)
+        raise HTTPException(status_code=403, detail="코드 수정은 admin 권한 필요")
+
+    try:
+        from tools.code.code_editor import CodeEditor
+        editor = CodeEditor()
+        if data.start_line and data.end_line:
+            ok, msg, diff = editor.replace_lines(
+                data.path, data.start_line, data.end_line, data.content
+            )
+            meta = {"diff": diff[:500]}
+        else:
+            ok, msg = editor.write_file(data.path, data.content)
+            meta = {}
+
+        _write_audit(role, "/code/edit/", query=data.path,
+                     answer=msg, ip_address=ip)
+        return {"success": ok, "result": msg, "meta": meta}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/code/surface/", summary="공격 surface 수집 [P5.5]",
+         description="코딩 에이전트 사용 중 수집된 보안 이벤트 조회. admin 전용.")
+async def code_surface(
+    api_key: str,
+    role: str = Depends(get_role_from_request),
+):
+    """[Phase 4b-1] SQLite audit_log 기반 attack-surface 집계.
+
+    이전: james_audit_tool.jsonl 을 통째로 읽어 4가지 event_type
+    (SANDBOX_BLOCK / PATH_VIOLATION / ATTACK_SURFACE_SCAN /
+    PROTECTED_FILE_BLOCK) 만 필터. 파일 누적 시 O(file size).
+    이제: Phase 1 mirror 가 audit_log.security_event 에 동일 값을
+    기록하므로 ``security_event IN (...)`` 단일 쿼리로 끝남. 응답
+    스키마는 그대로 유지 (total_events / events / summary).
+    """
+    verify_api_key(api_key)
+    if role != "admin":
+        raise HTTPException(status_code=403, detail="admin 전용")
+
+    _SURFACE_EVENTS = (
+        "SANDBOX_BLOCK", "PATH_VIOLATION",
+        "ATTACK_SURFACE_SCAN", "PROTECTED_FILE_BLOCK",
+    )
+    events: list = []
+    try:
+        conn = sqlite3.connect(_AUDIT_DB, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        placeholders = ",".join("?" for _ in _SURFACE_EVENTS)
+        rows = conn.execute(
+            f"SELECT timestamp, user_role, endpoint, query, "
+            f"       security_event, blocked "
+            f"FROM audit_log "
+            f"WHERE security_event IN ({placeholders}) "
+            f"ORDER BY id ASC",
+            _SURFACE_EVENTS,
+        ).fetchall()
+        conn.close()
+        for r in rows:
+            events.append({
+                "time":    r["timestamp"],
+                "event":   r["security_event"],
+                "role":    r["user_role"],
+                "detail":  (r["query"] or "")[:300],
+                "blocked": bool(r["blocked"]),
+            })
+    except Exception:
+        # audit_log unavailable → empty surface rather than 500
+        # (matches the pre-migration behaviour of missing JSONL).
+        pass
+
+    return {
+        "total_events": len(events),
+        "events":       events[-50:],   # 최근 50개
+        "summary": {
+            "sandbox_blocks":   sum(1 for e in events if e["event"] == "SANDBOX_BLOCK"),
+            "path_violations":  sum(1 for e in events if e["event"] == "PATH_VIOLATION"),
+            "surface_scans":    sum(1 for e in events if e["event"] == "ATTACK_SURFACE_SCAN"),
+            "protected_blocks": sum(1 for e in events if e["event"] == "PROTECTED_FILE_BLOCK"),
+        }
+    }

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -252,6 +252,10 @@ app.include_router(artifacts_router)
 from routes.evolution import router as evolution_router
 app.include_router(evolution_router)
 
+# v0.4.x server-split PR-F — coding agent routes.
+from routes.coding import router as coding_router
+app.include_router(coding_router)
+
 
 
 @app.on_event("startup")
@@ -1298,176 +1302,17 @@ async def root():
 
 # ─── Phase 5.5: 코딩 에이전트 엔드포인트 ──────────────────────
 
-class CodeReadRequest(BaseModel):
-    api_key:    str
-    path:       str
-    start_line: int = 1
-    end_line:   Optional[int] = None
-
-class CodeAnalyzeRequest(BaseModel):
-    api_key:       str
-    path:          str
-    analysis_type: str = "review"
-
-class CodeEditRequest(BaseModel):
-    api_key:     str
-    path:        str
-    content:     str
-    start_line:  Optional[int] = None
-    end_line:    Optional[int] = None
-
-class CodeResponse(BaseModel):
-    success: bool
-    result:  str
-    meta:    dict = {}
 
 
-@app.post("/code/read/", response_model=CodeResponse, summary="코드 읽기 [P5.5]",
-          description="workspace 내 파일 읽기 전용. Sandbox 검증 필수.")
-async def code_read(
-    data: CodeReadRequest,
-    request: Request,
-    role: str = Depends(get_role_from_request),
-):
-    verify_api_key(data.api_key)
-    ip = get_client_ip(request)
-
-    # employee 이상만 허용
-    from core.security_layer import ROLE_LEVEL
-    if ROLE_LEVEL.get(role, 0) < 1:
-        raise HTTPException(status_code=403, detail="코드 읽기는 employee 이상 권한 필요")
-
-    try:
-        from tools.code.code_reader import CodeReader
-        reader = CodeReader()
-        ok, content, meta = reader.read_file(data.path, data.start_line, data.end_line)
-        _write_audit(role, "/code/read/", query=data.path, ip_address=ip)
-        return {"success": ok, "result": content, "meta": meta}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post("/code/analyze/", response_model=CodeResponse, summary="코드 분석 [P5.5]",
-          description="JAMES Core Engine을 통한 코드 분석. Sandbox 검증 필수.")
-async def code_analyze(
-    data: CodeAnalyzeRequest,
-    request: Request,
-    role: str = Depends(get_role_from_request),
-):
-    verify_api_key(data.api_key)
-    ip = get_client_ip(request)
-
-    from core.security_layer import ROLE_LEVEL
-    if ROLE_LEVEL.get(role, 0) < 1:
-        raise HTTPException(status_code=403, detail="코드 분석은 employee 이상 권한 필요")
-
-    try:
-        from tools.code.code_analyzer import CodeAnalyzer
-        analyzer = CodeAnalyzer(user_role=role)
-        ok, result, meta = analyzer.analyze_file(data.path, data.analysis_type)
-        _write_audit(role, "/code/analyze/", query=f"{data.path}:{data.analysis_type}",
-                     answer=result[:200], ip_address=ip)
-        return {"success": ok, "result": result, "meta": meta}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post("/code/edit/", response_model=CodeResponse, summary="코드 수정 [P5.5]",
-          description="Sandbox 검증 통과 후 파일 수정. admin 전용.")
-async def code_edit(
-    data: CodeEditRequest,
-    request: Request,
-    role: str = Depends(get_role_from_request),
-):
-    verify_api_key(data.api_key)
-    ip = get_client_ip(request)
-
-    # [P5.5] 코드 수정은 admin 전용 (보수적 정책)
-    if role != "admin":
-        _write_audit(role, "/code/edit/",
-                     security_event=f"edit_denied role={role}",
-                     blocked=True, ip_address=ip)
-        raise HTTPException(status_code=403, detail="코드 수정은 admin 권한 필요")
-
-    try:
-        from tools.code.code_editor import CodeEditor
-        editor = CodeEditor()
-        if data.start_line and data.end_line:
-            ok, msg, diff = editor.replace_lines(
-                data.path, data.start_line, data.end_line, data.content
-            )
-            meta = {"diff": diff[:500]}
-        else:
-            ok, msg = editor.write_file(data.path, data.content)
-            meta = {}
-
-        _write_audit(role, "/code/edit/", query=data.path,
-                     answer=msg, ip_address=ip)
-        return {"success": ok, "result": msg, "meta": meta}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/code/surface/", summary="공격 surface 수집 [P5.5]",
-         description="코딩 에이전트 사용 중 수집된 보안 이벤트 조회. admin 전용.")
-async def code_surface(
-    api_key: str,
-    role: str = Depends(get_role_from_request),
-):
-    """[Phase 4b-1] SQLite audit_log 기반 attack-surface 집계.
 
-    이전: james_audit_tool.jsonl 을 통째로 읽어 4가지 event_type
-    (SANDBOX_BLOCK / PATH_VIOLATION / ATTACK_SURFACE_SCAN /
-    PROTECTED_FILE_BLOCK) 만 필터. 파일 누적 시 O(file size).
-    이제: Phase 1 mirror 가 audit_log.security_event 에 동일 값을
-    기록하므로 ``security_event IN (...)`` 단일 쿼리로 끝남. 응답
-    스키마는 그대로 유지 (total_events / events / summary).
-    """
-    verify_api_key(api_key)
-    if role != "admin":
-        raise HTTPException(status_code=403, detail="admin 전용")
 
-    _SURFACE_EVENTS = (
-        "SANDBOX_BLOCK", "PATH_VIOLATION",
-        "ATTACK_SURFACE_SCAN", "PROTECTED_FILE_BLOCK",
-    )
-    events: list = []
-    try:
-        conn = sqlite3.connect(_AUDIT_DB, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        placeholders = ",".join("?" for _ in _SURFACE_EVENTS)
-        rows = conn.execute(
-            f"SELECT timestamp, user_role, endpoint, query, "
-            f"       security_event, blocked "
-            f"FROM audit_log "
-            f"WHERE security_event IN ({placeholders}) "
-            f"ORDER BY id ASC",
-            _SURFACE_EVENTS,
-        ).fetchall()
-        conn.close()
-        for r in rows:
-            events.append({
-                "time":    r["timestamp"],
-                "event":   r["security_event"],
-                "role":    r["user_role"],
-                "detail":  (r["query"] or "")[:300],
-                "blocked": bool(r["blocked"]),
-            })
-    except Exception:
-        # audit_log unavailable → empty surface rather than 500
-        # (matches the pre-migration behaviour of missing JSONL).
-        pass
 
-    return {
-        "total_events": len(events),
-        "events":       events[-50:],   # 최근 50개
-        "summary": {
-            "sandbox_blocks":   sum(1 for e in events if e["event"] == "SANDBOX_BLOCK"),
-            "path_violations":  sum(1 for e in events if e["event"] == "PATH_VIOLATION"),
-            "surface_scans":    sum(1 for e in events if e["event"] == "ATTACK_SURFACE_SCAN"),
-            "protected_blocks": sum(1 for e in events if e["event"] == "PROTECTED_FILE_BLOCK"),
-        }
-    }
 
 
 # ── Phase 7: Admin API ──────────────────────────────────────────────────────

--- a/tests/_server_split_helpers.py
+++ b/tests/_server_split_helpers.py
@@ -28,8 +28,11 @@ def combined_server_source() -> str:
     import server_llmwiki  # noqa: F401  — surfaces import errors clearly
     parts: list[str] = [inspect.getsource(server_llmwiki)]
 
-    # Probe known routes/* modules. Add new ones here as PR-F..PR-H land.
-    for mod_name in ("routes.auth", "routes.llm", "routes.jobs", "routes.artifacts", "routes.evolution"):
+    # Probe known routes/* modules. Add new ones here as PR-G..PR-H land.
+    for mod_name in (
+        "routes.auth", "routes.llm", "routes.jobs", "routes.artifacts",
+        "routes.evolution", "routes.coding",
+    ):
         try:
             mod = importlib.import_module(mod_name)
             parts.append(

--- a/tests/test_code_surface_sqlite.py
+++ b/tests/test_code_surface_sqlite.py
@@ -86,16 +86,34 @@ class CodeSurfaceSqliteTests(unittest.TestCase):
         if not self._api_key:
             self.skipTest("JAMES_API_KEY missing")
         import server_llmwiki as srv
+        import routes._helpers as _h
+        import routes.coding as _c
         self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         self._tmp.close()
         self.db = self._tmp.name
-        self._saved_db = srv._AUDIT_DB
+        # /code/surface/ handler moved to routes/coding.py in v0.4.x
+        # PR-F (server-split). It imports `_AUDIT_DB` from
+        # routes/_helpers at module-load time — so the snapshot lives
+        # in THREE places now (server_llmwiki, routes/_helpers,
+        # routes/coding). Patch all three so the handler resolves to
+        # our temp DB regardless of which binding it reads.
+        self._saved = {
+            "srv":     srv._AUDIT_DB,
+            "helpers": _h._AUDIT_DB,
+            "coding":  _c._AUDIT_DB,
+        }
         srv._AUDIT_DB = self.db
+        _h._AUDIT_DB = self.db
+        _c._AUDIT_DB = self.db
         _seed(self.db, self._fixture())
 
     def tearDown(self):
         import server_llmwiki as srv
-        srv._AUDIT_DB = self._saved_db
+        import routes._helpers as _h
+        import routes.coding as _c
+        srv._AUDIT_DB = self._saved["srv"]
+        _h._AUDIT_DB = self._saved["helpers"]
+        _c._AUDIT_DB = self._saved["coding"]
         Path(self.db).unlink(missing_ok=True)
 
     def _fixture(self) -> list[dict]:
@@ -237,11 +255,19 @@ class CodeSurfaceEmptyDbTests(unittest.TestCase):
         if not self._api_key:
             self.skipTest("JAMES_API_KEY missing")
         import server_llmwiki as srv
+        import routes._helpers as _h
+        import routes.coding as _c
         self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         self._tmp.close()
         self.db = self._tmp.name
-        self._saved_db = srv._AUDIT_DB
+        self._saved = {
+            "srv":     srv._AUDIT_DB,
+            "helpers": _h._AUDIT_DB,
+            "coding":  _c._AUDIT_DB,
+        }
         srv._AUDIT_DB = self.db
+        _h._AUDIT_DB = self.db
+        _c._AUDIT_DB = self.db
         conn = sqlite3.connect(self.db)
         conn.execute(_SCHEMA)
         conn.commit()
@@ -249,7 +275,11 @@ class CodeSurfaceEmptyDbTests(unittest.TestCase):
 
     def tearDown(self):
         import server_llmwiki as srv
-        srv._AUDIT_DB = self._saved_db
+        import routes._helpers as _h
+        import routes.coding as _c
+        srv._AUDIT_DB = self._saved["srv"]
+        _h._AUDIT_DB = self._saved["helpers"]
+        _c._AUDIT_DB = self._saved["coding"]
         Path(self.db).unlink(missing_ok=True)
 
     def test_empty_db_returns_zero_counts(self):


### PR DESCRIPTION
> **PR-stack**: base = \`chore/v0.4.x-pr-e-evolution-router-move\` (#577). 7번째 PR.

## Summary

8-PR sequence 일곱 번째. Phase 5.5 코딩 에이전트 분리.

## 이동된 surface (155 lines)

### 4 endpoints
- \`/code/read/\`, \`/code/analyze/\`, \`/code/edit/\`, \`/code/surface/\`

### 4 Pydantic
\`CodeReadRequest\`, \`CodeAnalyzeRequest\`, \`CodeEditRequest\`, \`CodeResponse\`

## tests
- \`_server_split_helpers.py\`: \`routes.coding\` 추가
- \`test_code_surface_sqlite.py\` setUp/tearDown: \`srv._AUDIT_DB\` monkeypatch 가 module-snapshot 갈아 끼우게 확장 — server + \`routes._helpers\` + \`routes.coding\` 3 곳 patch

## Verification

| invariant | 결과 |
|---|---|
| 1. URL byte-identical | ✓ **125 endpoints identical to origin/main** |
| 2-5. middleware/audit/static/startup | ✓ smoke pass |
| 6. pytest 회귀 | ✓ **3294 passed, 0 failed** |
| ruff F-class | ✓ All checks passed |

server_llmwiki.py: 3692 → 3537 lines (−155). 8-PR roadmap 진행률 ≈ **40%** (2357/5894).

## Out of scope
- **PR-G**: 잔여 \`/admin/*\` (~1500 lines 예상)
- **PR-H**: server 최종 정리

\`Quality delta: exempt (label: chore)\`. URL byte-identical, \`core/\` 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)