### PR TITLE
fix(test): stabilize flaky pytest via conftest warm-up (2 lazy modules + WikiGenerator)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,30 @@ Cost: ~5s of session-start overhead instead of ~5s of per-test
 ``setUp`` overhead on cold runners. The session pays the import once;
 no test pays it.
 
+## 2026-05-29 extension — flaky-fix follow-up
+
+The original conftest (above) pre-imported the four heavy modules but
+two tests still failed intermittently on cold CI runners:
+
+  - ``test_entity_name_markdown_strip::test_all_markdown_falls_back_to_unknown``
+    — timeout (>30s)
+  - ``test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta``
+    — cascade failure when the entity-name test's setUp times out and
+    leaks ``patch("llm.router.RouterWrapper")``
+
+Two additions to cover the remaining lazy-import paths that fire
+during ``WikiFrontmatterMixin.create_entity_file``:
+
+  - ``core.ontology`` / ``core.graph_node_editor`` — both `from … import`
+    lazily inside the create_entity_file method body, so the first test
+    that drives that path pays their first-import cost. Pre-importing
+    here lifts that out of per-test ``setUp``.
+  - A ``WikiGenerator`` warm-up instantiation forces every mixin
+    ``__init__`` (Frontmatter / Merge / Ingestion) to run once at
+    session start, priming any LRU caches or class-level lazy attrs.
+    Wrapped in try/except — instantiation side-effects (filesystem,
+    config) are recoverable; we just want the cache primed.
+
 ## What this does NOT do
 
 This is not a global patch / mock — it just imports. Module identity
@@ -63,3 +87,21 @@ import core.memory  # noqa: F401 — pre-import to warm sys.modules
 import core.vector_store  # noqa: F401 — pulls torch / transformers (~5s cold)
 import core.wiki_generator  # noqa: F401 — pre-import to warm sys.modules
 import llm.router  # noqa: F401 — pre-import to warm sys.modules
+
+# 2026-05-29 — additional pre-imports for create_entity_file lazy paths.
+import core.graph_node_editor  # noqa: F401 — lazy-imported in _frontmatter.py:310
+import core.ontology  # noqa: F401 — lazy-imported in _frontmatter.py:336
+
+# 2026-05-29 — warm-up WikiGenerator so every mixin __init__ runs once
+# at session start. Side-effects are recoverable; we only need caches
+# primed for create_entity_file's first call to stay under 30s on cold
+# CI runners.
+try:
+    from core.wiki_generator import WikiGenerator
+    WikiGenerator(source_type="test")
+except Exception:
+    # Instantiation side-effects (filesystem, network, config) are not
+    # required to succeed — the goal is just to trigger any lazy
+    # imports / one-shot setup the class performs. Tests that need a
+    # working instance build their own under isolated tmp dirs.
+    pass


### PR DESCRIPTION
## Summary

Two pytest failures observed on cold CI runners (e.g. PR #571 baseline, #576 run 2) traced to a cascade:

1. **`test_entity_name_markdown_strip::test_all_markdown_falls_back_to_unknown`** — `setUp` + `create_entity_file` path on cold runners exceeds the 30s pytest-timeout. setUp times out mid-`patch(...)` → `tearDown` never runs.
2. **`test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta`** — cascade. The leaked `patch("llm.router.RouterWrapper")` from (1) persists in the same pytest process, so the next test imports a `MagicMock` instead of the real class. Mock target points to a Mock attribute → 0 calls → `AssertionError: Expected 'call_router_meta' to be called once. Called 0 times.`

The original 2026-05-26 conftest (`tests/conftest.py`) pre-imported four heavy modules. Two more lazy-import paths inside `_frontmatter.create_entity_file` still fired on first run and pushed `setUp` toward the 30s timeout:

- `core.graph_node_editor` — lazy `from core.graph_node_editor import _generate_event_entity_id` at `_frontmatter.py:310`
- `core.ontology` — lazy `from core.ontology import …` at `_frontmatter.py:336`

Also added a session-start `WikiGenerator(source_type="test")` warm-up so all three mixin `__init__` paths + bge_m3 weight load (~6s cold) run once at pytest collection instead of inside the first test's `setUp` budget. Wrapped in `try/except` — instantiation side-effects (filesystem/config) are recoverable; only the lazy caches need priming.

## Verification

- Local conftest import cost: **6.64s** (was ~1s).
- That cost is paid once per pytest process, not inside the first test's 30s `setUp` budget.
- Local pytest run on Windows / Python 3.14 still passes (existing Windows-only `cp949` encoding fail in `_frontmatter.py:256` is unrelated and pre-existed).

## Out of scope

- Root-cause fix of the `cp949` encoding issue in `_frontmatter.py:256` print (Windows-only — doesn't affect CI).
- Refactoring `_MarkdownStripBase.setUp` to use `setUpClass` for cheaper per-test setup. If this conftest fix is insufficient, that's the next escalation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)