### PR TITLE
docs(handover): sync 2026-05-29 checkpoint to EOD main HEAD + addendum

### DIFF
--- a/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
+++ b/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
@@ -3,8 +3,13 @@
 > **Status**: open — comprehensive checkpoint covering Ali/Robin
 > collaboration state + JAMES-internal pipeline state + misalignment
 > ledger as of 2026-05-29
-> **Date**: 2026-05-29 (latest origin/main HEAD: `8ecfe51` server-split
-> PR-F)
+> **Date**: 2026-05-29 (latest origin/main HEAD: `9a989f1` — handover
+> doc landed via PR #583, server-split closed 9/9, flaky-fix conftest
+> via PR #582)
+> **Body-frozen snapshot point**: `8ecfe51` server-split PR-F. The
+> §1 → §5 narrative captures state at that point. End-of-day deltas
+> through `9a989f1` are recorded in §11 addendum so the misalignment
+> ledger doesn't drift away from the snapshot it was reasoned over.
 > **Companion documents**:
 >   - `docs/handovers/v0.3.x-ali-collaboration-track.md` — Ali turn-by-turn
 >     ledger + Track 1-5
@@ -237,10 +242,14 @@ cooling concern was Ali-shaped only.
 
 ### 🟢 Watch (monitoring only)
 
-#### M8. Server-split 8-PR roadmap closure
+#### M8. Server-split 8-PR roadmap closure ✅ RESOLVED 2026-05-29 EOD
 
-- Currently 7+ of 8 PRs landed (PR-A through PR-F + PR-A.1)
-- After closure, reclaim ~1 week for collaboration line
+- Body snapshot point: 7+ of 8 PRs landed (PR-A through PR-F + PR-A.1)
+- **End-of-day**: **9/9 closed** — PR-G (#579 admin 47-endpoints) + PR-H
+  (#580 final cleanup, `server_llmwiki.py` 6021 → 904 lines, -85%) +
+  Stage 0 design memo (#571). Details in §11 addendum.
+- ✅ Collaboration-line bandwidth notionally reclaimed; whether it
+  *actually* flows to M1-M4 is the test in the next session.
 
 #### M9. Joint Zenodo 3-author (or 4-author with Vadym) DOI
 
@@ -377,3 +386,97 @@ Robin 라인은 완전 정상 (Phase R1~R6 모두 positive endorsement). Ali
 - Solo per-stack engineering DOI (v0.3.1):
   10.5281/zenodo.20363998 (reframed as dataset+protocol on 2026-05-24
   course-correction)
+
+---
+
+## 11. End-of-day addendum (2026-05-29 PM session)
+
+The body §1-§10 is intentionally frozen at HEAD `8ecfe51` so the
+misalignment ledger and the reasoning behind it stays internally
+consistent. This addendum records what happened *after* that snapshot
+within the same calendar day, so a future session reading top-to-bottom
+sees the current main state without the body silently drifting.
+
+### 11.1 Main HEAD progression (8ecfe51 → 9a989f1)
+
+| Commit | PR | Substance |
+|---|---|---|
+| `d560997` | #571 | Stage 0 design memo (`docs/design/v0.4.x-server-split.md`) — was unmerged at 8ecfe51 snapshot; merged at start of PM session |
+| `7511c6b` | #576 | server-split PR-D — W7-A artifacts + upload-history → `routes/artifacts.py` (5 endpoints) |
+| `56a3eb2` | #577 | server-split PR-E — Phase 7 evolution + learn + patch → `routes/evolution.py` (13 endpoints) |
+| `8ecfe51` | #578 | server-split PR-F — coding agent → `routes/coding.py` (4 endpoints) *(body snapshot point)* |
+| `f8f2312` | #579 | server-split PR-G — remaining `/admin/*` → `routes/admin.py` (47 endpoints + 19 helpers) |
+| `da776c9` | #580 | server-split PR-H — final extraction (5 router modules: query/history/feedback/multimodal/ops) + `server_llmwiki.py` 904 lines |
+| `844e8c9` | #582 | pytest flaky partial fix — conftest pre-import 2 lazy modules + WikiGenerator warm-up (pass rate ~50% → ~75%) |
+| `9a989f1` | #583 | this handover doc landed |
+
+### 11.2 Server-split closure metrics (M8 fully resolved)
+
+| Measurement | Pre (`7140576`) | Post (`da776c9`) | Δ |
+|---|---|---|---|
+| `server_llmwiki.py` lines | 6021 | **904** | **-85%** |
+| `routes/*.py` total | 0 | 5893 | extracted |
+| router modules | 0 | **15** (12 endpoint routers + `__init__`/`_deps`/`_helpers`) | — |
+
+Endpoint router lines: `admin` (2142), `auth` (806), `evolution` (640),
+`llm` (520), `jobs` (302), `query` (251), `ops` (210), `artifacts`
+(193), `coding` (197), `history` (156), `multimodal` (136), `feedback`
+(59).
+
+### 11.3 Pytest flaky cluster (partial fix landed)
+
+Two CI tests intermittently fail on cold Ubuntu / Python 3.11 runners
+under `--timeout=30`, traced to a cascade:
+
+1. `test_entity_name_markdown_strip::test_all_markdown_falls_back_to_unknown` — setUp + create_entity_file path exceeds 30s; tearDown skipped → patch leak
+2. `test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta` — cascade: leaked `patch("llm.router.RouterWrapper")` makes the next test import a MagicMock → mock target points at Mock attribute → 0 calls
+
+PR #582 added `core.graph_node_editor` + `core.ontology` to conftest
+pre-imports and a session-start `WikiGenerator(source_type="test")`
+warm-up. Local cost: 6.6s once per session. Pass rate moved from
+~50% → ~75% across 4 reruns. **Not fully stabilized**; proper fix is
+a separate follow-up:
+
+- Option A (preferred): refactor `_MarkdownStripBase.setUp` → `setUpClass`
+- Option B (framework-level): introduce `pytest-rerunfailures` with a
+  reason allowlist (Timeout / AssertionError on Mock)
+
+### 11.4 What this PM session reinforces (M7 pattern)
+
+The body §5 M7 reads:
+
+> Last 7 days: nearly all main commits are JAMES-internal (server-split,
+> QVT, T6, q15). Collaboration line (Direction 3, Track 4, article,
+> joint piece) = zero progress.
+
+This PM session added **7 more main commits**, all JAMES-internal
+(server-split PRs G/H + flaky fix + doc landing). M7 is *not* a stale
+warning — it is the precise pattern this session repeated one more
+turn. The fact that M8 closed doesn't change M7; it just removes
+M8 as an excuse for the next session to defer M1-M4.
+
+### 11.5 Updated next-session guidance (supersedes §8 first step)
+
+§8 still applies in spirit; the only adjustment is that the four
+Critical items (M1-M4) are now the **only** open Critical items, since
+M8 is resolved. Specifically:
+
+- **Engineering capacity reclaimed**: the ~1 week M8 estimated is now
+  free. The question is whether the next session spends it on M1-M4
+  (collaboration) or on the new internal candidates listed below.
+- **Internal candidates queued** (deferrable per M7 if collab work is
+  picked first): v0.4.2 T3 Aging entry, α-5 ablation matrix (18 cells,
+  operator-run), pytest flaky proper fix (§11.3 Option A or B).
+- **The trap to avoid**: picking an internal candidate "because it's
+  smaller" and rolling M1-M4 to next week. That is the exact decision
+  pattern M7 names.
+
+### 11.6 Cross-document syncs needed (low-priority docs hygiene)
+
+- `MEMORY.md` `server_split_candidate.md` already updated to "9/9
+  CLOSED" status at PM session end (memory-side sync done in-session).
+- `feedback_pytest_flaky_native_done_reason_entity_markdown.md` added
+  to memory (new flaky-fix follow-up record).
+- `ROADMAP.md` v0.4.x section may want a one-line "server-split
+  CLOSED 2026-05-29" badge; defer to next session bundling with M1-M4
+  pickup so this addendum doesn't trigger a separate roadmap PR.


### PR DESCRIPTION
## Summary

The handover doc landed via PR #583 was a port-as-is of the original `45279ed` snapshot, frozen at HEAD `8ecfe51` (server-split PR-F). End-of-day work on the same calendar day (server-split PR-G/H closure, flaky-fix conftest #582, the handover doc itself #583) wasn't reflected. This PR syncs the doc to current main HEAD `9a989f1` **without rewriting the frozen body narrative** — the misalignment ledger reasoning depends on the snapshot it was reasoned over.

## Approach

- **Body §1-§10 unchanged.** That section is internally consistent against HEAD `8ecfe51`; rewriting it would risk drift between the M-ledger reasoning and the state it was reasoned about.
- **Header note** updated to name the EOD HEAD pointer (`9a989f1`) and explicitly call out the body-frozen snapshot point so future readers know where the body narrative is anchored.
- **M8 (server-split closure, Watch tier)** updated to ✅ RESOLVED — single-line status flip + pointer to §11 for details. M8 is the only ledger item whose state changed inside the same calendar day.
- **New §11 addendum** captures EOD deltas:
  - 11.1 Main HEAD progression table (8 commits, 8ecfe51 → 9a989f1)
  - 11.2 Server-split closure metrics (6021 → 904 lines, -85%; 15 router modules)
  - 11.3 Pytest flaky cluster — partial fix landed via #582, proper fix queued
  - 11.4 What this PM session reinforces about M7 — the 7 additional JAMES-internal commits are the exact pattern M7 names
  - 11.5 Updated next-session guidance superseding §8 first-step
  - 11.6 Cross-document syncs done in-session

## Verification

- 108 insertions / 5 deletions in `docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md` only
- `Quality delta: exempt (label: docs)`
- Future EOD addenda for this checkpoint follow the same pattern: append to §11 rather than rewrite the frozen ledger

## Out of scope

- ROADMAP.md "server-split CLOSED" badge — deferred per §11.6 to next session bundling with M1-M4 pickup (avoids triggering a separate roadmap PR for a one-line change)
- Pytest flaky proper fix (§11.3 Option A setUpClass refactor or Option B pytest-rerunfailures) — separate cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)