### PR TITLE
fix(bench): auto-mint admin bearer when JAMES_BENCH_BEARER unset + M4 §10 finding

### DIFF
--- a/reports/research-runs/step7-bench-variance-analysis-2026-05-29.md
+++ b/reports/research-runs/step7-bench-variance-analysis-2026-05-29.md
@@ -166,7 +166,44 @@ This follow-up is operator-run because the wall-time budget (~1h Ollama inferenc
 - v0.4-end QVT ablation matrix (18 cells × N=3) is a separate operator-run task (ROADMAP v0.4.1 OOS). Not blocked by this analysis.
 - The 158.3s figure cited in PR #399's STEP 7 bench line is from a specific measurement context (single-mode mini-bench, not the full suite). This analysis covers the full-suite baseline, which is the framework PR #399's claim sits inside, not a literal reproduction of the single number.
 
-## 9. Related
+## 10. Environment dependency finding (2026-05-29 PM follow-up)
+
+While capturing a post-T6 baseline to answer Q2, a deeper finding surfaced. The 5/27 reference and the 5/28 baseline runs were captured with `JAMES_BENCH_BEARER` set in the operator session (not committed anywhere — no record in `.env`, no mention in handover, no memo). Without the bearer, `bench.py` posts to `/query/` with `api_key=2026` only, which the server treats as `external` role. The `query.internal_rag` policy gate blocks `external`, and the request silently falls through to `handle_chat` — the script still exits 0, the JSON still records 17 rows, but every row is chat-passthrough instead of RAG-path.
+
+### Evidence
+
+| Capture | sha | bearer in env? | mode distribution | graph_paths total | total_s |
+|---|---|---|---|---|---|
+| 5/27 ref | f2c088f | yes (implied) | `""` × 15, `(none)` × 1 | 313 | 1323.1 |
+| 5/28 run1 | 2a31b20 | yes (implied) | `""` × 14, `(none)` × 2 | 271 | 1333.4 |
+| 5/28 run2 | 2a31b20 | yes (implied) | `""` × 15, `(none)` × 1 | 305 | 1247.4 |
+| 5/28 run3 | 2a31b20 | yes (implied) | `""` × 16 | 325 | 1277.9 |
+| 5/29 post-T6 | e663933 | **no** | `chat` × 14, `""` × 2, `meta` × 1 | **0** | **221.4** |
+| 5/29 reproduce | **2a31b20** | **no** | `chat` × 13, `""` × 2, `meta` × 1 | **0** | **207.9** |
+
+Same sha (`2a31b20`) producing different `graph_paths_total` (271-325 vs 0) and different `total_seconds` (~1300 vs ~210) — and the only varying factor across the two captures is the presence of `JAMES_BENCH_BEARER`. This isolates the cause to the bearer / policy-gate path, not a code regression.
+
+### Implication for §6 Decision table
+
+The §6 decisions still stand for what they actually claim:
+- **Q1 (5/28 3-run internal consistency)**: still ✅ pass. The three runs are self-consistent — bearer was equally set for all three.
+- **PR #399 cap-fix reproducibility at `2a31b20`**: still ✅ pass *within the bearer-set measurement frame*.
+
+What §10 adds is a measurement-methodology integrity finding:
+- **Any future bench measurement that wants to reproduce the 5/28 baseline's absolute numbers must have `JAMES_BENCH_BEARER` set.** Without it, the comparison is chat-passthrough vs RAG-path — a category mistake, not a regression.
+- The Q2 question (v0.4.1 lifecycle effect on baseline) can be answered by the §7 follow-up *only if the follow-up uses a bearer*. Otherwise it measures the wrong code path.
+
+### Mitigation landed in this PR
+
+`scripts/bench.py` now auto-mints an admin bearer via `core.auth.create_token("bench", "admin")` when `JAMES_BENCH_BEARER` is not provided in env, and emits a stderr warning so the operator knows where the token came from. This removes the "silent chat-passthrough" failure mode. Override stays available for operators who want a specific role (e.g. `employee` for tier-boundary tests).
+
+### Effect on Robin/Ali collaboration narrative
+
+None. Robin and Ali measurements run against their own stacks (sovereign Ollama for Robin, managed Gemini for Ali) — they do not hit the JAMES server and are unaffected by the bearer issue. The JAMES-side joint-piece main evidence is V3'.a-V3'.d, which uses `scripts/research/v3prime_*.py` calling Ollama HTTP directly (bypassing both the bench script and the JAMES server). PR #399's "STEP 7 bench no-regression" line is a *secondary* check; the main evidence stack for the joint piece is the V3' direct-measurement set, which is unaffected.
+
+This finding is internal JAMES measurement-tool integrity, not a collaboration data integrity event.
+
+## 11. Related
 
 - handover doc `docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md` §5 M4, §6 Tier 1.3, §7 risk matrix
 - launch-tracker `reports/promo-assets/launch-tracker.md` (5/28 baseline capture rows pending status update via §7 follow-up)

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -71,6 +71,56 @@ def _load_api_key() -> str:
     )
 
 
+def _resolve_bearer() -> str:
+    """Return the JWT bearer for retrieval-mode bench access.
+
+    Precedence:
+      1. ``JAMES_BENCH_BEARER`` env (operator-provided, e.g. a token
+         minted with a specific role for a targeted scenario).
+      2. Auto-mint an admin token via ``core.auth.create_token`` and
+         emit a stderr warning so the operator knows where the token
+         came from.
+
+    The fallback exists because ``/query/`` routes through
+    ``query.internal_rag``, which blocks external role and silently
+    falls through to ``handle_chat`` (``mode="chat"``,
+    ``graph_paths_count=0``). Without a bearer, bench numbers reflect
+    chat-passthrough latency, not RAG-path latency — a category
+    mistake easy to miss because the script still exits 0.
+
+    Surfaced 2026-05-29 during M4 step7 baseline reproduction: an
+    attempt to re-measure the 2026-05-28 baseline yielded ~6× faster
+    totals + ``graph_paths_total=0``, traced to ``JAMES_BENCH_BEARER``
+    being unset in the new session. Same code, same fixture, same
+    sha — only the bearer presence differed. See
+    ``feedback_bench_step7_chat_mode_passthrough`` for the original
+    2026-05-27 diagnostic, and
+    ``reports/research-runs/step7-bench-variance-analysis-2026-05-29.md``
+    §10 for the follow-up.
+    """
+    env_v = os.environ.get("JAMES_BENCH_BEARER", "").strip()
+    if env_v:
+        return env_v
+    try:
+        from core.auth import create_token
+    except Exception as e:
+        print(
+            f"[bench] WARN: could not import core.auth.create_token "
+            f"({e!r}). Proceeding without bearer — expect chat-passthrough "
+            f"numbers (mode=chat, graph_paths_count=0).",
+            file=sys.stderr,
+        )
+        return ""
+    token = create_token("bench", "admin")
+    print(
+        "[bench] JAMES_BENCH_BEARER not set — auto-minted admin token "
+        "for RAG-path measurement (subject=bench, role=admin). Set the "
+        "env var to override (e.g. role=employee for tier checks).",
+        file=sys.stderr,
+    )
+    return token
+
+
 def _git_sha() -> str:
     try:
         out = subprocess.check_output(
@@ -178,6 +228,7 @@ def _load_baseline(name: str) -> Optional[Dict]:
 def _run_one(
     api_key: str, q: Dict, endpoint: str, timeout: int,
     default_mode: Optional[str] = None,
+    bearer: str = "",
 ) -> Dict:
     """Run a single query against the live server. Returns the row dict that
     bench reports operate on.
@@ -189,6 +240,13 @@ def _run_one(
     ``"retrieval"`` for L.D evidence-scope measurement which would
     otherwise hit chat-mode passthrough). See
     ``feedback_bench_step7_chat_mode_passthrough`` for context.
+
+    ``bearer``: JWT bearer for retrieval-mode bench access. Resolved
+    once in ``main()`` via ``_resolve_bearer()`` and passed in so every
+    query reuses the same token (consistent expiry window across the
+    whole suite). External role is policy-blocked from
+    ``query.internal_rag`` and falls through to ``handle_chat``, so
+    without a bearer the bench reports chat-passthrough numbers.
     """
     t0 = time.time()
     body: Dict = {
@@ -200,13 +258,7 @@ def _run_one(
     if mode_override:
         body["mode_override"] = mode_override
     headers = {}
-    bearer = os.environ.get("JAMES_BENCH_BEARER", "").strip()
     if bearer:
-        # JWT bearer for role-elevated bench runs (e.g. retrieval mode
-        # requires employee+ since external is policy-blocked from
-        # `query.internal_rag` → falls back to handle_chat regardless
-        # of mode_override). Mint via `core.auth.create_token(name,
-        # role)` in the wrapper; never commit a real token.
         headers["Authorization"] = f"Bearer {bearer}"
     try:
         r = requests.post(
@@ -377,6 +429,7 @@ def main() -> int:
     effective_default_mode = args.mode or suite.get("default_mode")
 
     api_key = _load_api_key()
+    bearer  = _resolve_bearer()
     print(f"=== bench {args.suite} ({len(queries)} queries) ===\n")
     if effective_default_mode:
         print(f"[bench] mode_override default: {effective_default_mode!r} "
@@ -385,7 +438,9 @@ def main() -> int:
     results: List[Dict] = []
     t_total = time.time()
     for q in queries:
-        res = _run_one(api_key, q, endpoint, timeout, effective_default_mode)
+        res = _run_one(
+            api_key, q, endpoint, timeout, effective_default_mode, bearer,
+        )
         results.append(res)
         _print_row(res, len(queries))
     total = round(time.time() - t_total, 1)


### PR DESCRIPTION
## Summary

The M4 §7 follow-up (post-T6 step7 baseline capture) surfaced a measurement-methodology integrity finding: `bench.py` silently falls through to chat-passthrough when `JAMES_BENCH_BEARER` is not set in env, because the server treats `api_key=2026` alone as `external` role and the `query.internal_rag` policy gate blocks `external`. The script still exits 0, JSON still records 17 rows — only the underlying code path is wrong.

This PR fixes the silent failure mode and documents the diagnostic chain in the M4 analysis doc.

## Evidence

| Capture | sha | bearer env | mode dist | graph_paths total | total_s |
|---|---|---|---|---|---|
| 5/27 ref | f2c088f | yes (implied) | `""` × 15 | 313 | 1323 |
| 5/28 run1/2/3 | 2a31b20 | yes (implied) | `""` × 14-16 | 271-325 | 1247-1333 |
| 5/29 post-T6 | e663933 | **no** | `chat` × 14 | **0** | **221** |
| 5/29 reproduce | **2a31b20** | **no** | `chat` × 13 | **0** | **208** |

Same sha (`2a31b20`) produced different `graph_paths_total` (271-325 vs 0) and different `total_seconds` (~1300 vs ~210) between 5/28 and 5/29 captures. The only varying factor is bearer presence → isolates the cause to env / policy gate, not code regression.

## Changes

### `scripts/bench.py`

- New `_resolve_bearer()` function:
  1. Use `JAMES_BENCH_BEARER` env if set (operator opt-in for a specific role, e.g. `employee` for tier checks)
  2. Otherwise auto-mint an admin token via `core.auth.create_token("bench", "admin")` and print a stderr warning naming the source
- `_run_one()` now takes `bearer` as a parameter; `main()` resolves once and reuses across all 17 queries (consistent expiry window)
- Removed the in-`_run_one` env read

### `reports/research-runs/step7-bench-variance-analysis-2026-05-29.md`

New §10 "Environment dependency finding" covers:
- The diagnostic chain (5/27-5/28 captures had bearer; 5/29 did not; same-sha reproduce isolates cause to bearer not code)
- Implication for §6 Decision table (Q1 + PR #399 reproducibility hold *within the bearer-set frame*; Q2 follow-up requires bearer to be valid)
- The mitigation landed in this PR
- "Effect on Robin/Ali collaboration narrative: none" — Robin/Ali measurements run against their own stacks (sovereign Ollama / managed Gemini), JAMES-side joint-piece evidence is V3'.a-V3'.d via research drivers that bypass both `bench.py` and the JAMES server. PR #399's STEP 7 bench line is a *secondary* check; main joint-piece evidence is the V3' direct-measurement set

## Verification

- Unit-level: `_resolve_bearer()` with empty env returns a 180-char JWT that `verify_token` decodes to `{'sub': 'bench', 'role': 'admin'}` (admin role bypasses the policy gate)
- Integration-level: deferred to the M4 §7 follow-up 3-run capture (~1h operator wall time)
- `Quality delta: exempt (label: ci)` — bench tooling change, not core/retrieval

## Out of scope

- 3-run post-T6 baseline capture itself (operator wall time, separate cycle)
- ROADMAP / launch-tracker status updates reflecting M4 closure (deferred to the follow-up bundle to avoid fragmenting the status record)
- `pytest-rerunfailures` flaky proper fix (handover §11.3 — separate cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)