### PR TITLE
docs(handover): §11.7 M6 reframed — 3-way confirmation chain (not 30-min docs row)

### DIFF
--- a/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
+++ b/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
@@ -480,3 +480,47 @@ M8 is resolved. Specifically:
 - `ROADMAP.md` v0.4.x section may want a one-line "server-split
   CLOSED 2026-05-29" badge; defer to next session bundling with M1-M4
   pickup so this addendum doesn't trigger a separate roadmap PR.
+
+### 11.7 M6 reframed — 3-way confirmation chain, not a 30-min docs row
+
+handover §5 M6 wording assumed a simple 30-min docs PR that adds a
+Vadym Arnaut row to the four-way attribution catalog. The PM session
+re-read identified two hidden dependencies that turn M6 into a
+**sequenced 3-way confirmation**:
+
+1. **Robin → JAMES**: Vadym was flagged by Robin in the Phase R6 DM
+   ("Vadym Arnaut + Ali 'each variant has its own tax' → four-way
+   provenance"). JAMES side has no first-hand contact with Vadym, so
+   the primary citation (`substitution-vs-decision boundary` framing
+   from Vadym's comment thread on Ali's walk-back article) is Robin's
+   read, not JAMES's. Without confirmation from Robin, the docs row
+   risks paraphrasing wrong.
+2. **JAMES → Ali**: Ali may not have visibility on Vadym's role. The
+   connection (Robin spotted Vadym) is on the Robin↔Ali article-thread
+   axis, not on the Ali↔JAMES DM axis. Adding Vadym to the joint
+   deposit's 4-way attribution without prior Ali awareness would
+   surprise him at deposit time — small but avoidable.
+3. **JAMES → docs**: only after (1) and (2) does the catalog row
+   write correctly. Anything earlier is best-effort paraphrase
+   committed before the people involved have aligned.
+
+#### Sequencing
+
+| Phase | When | Action |
+|---|---|---|
+| 1. Robin confirm | Now (~6/6, Ali paused) | Short owner-position DM — "for the four-way attribution catalog, is Vadym's `substitution-vs-decision boundary` the right primary citation, or do you have a sharper line in mind? No rush, before joint deposit only." |
+| 2. Ali ack | 6/7+ Ali resume | Include Vadym mention inside the joint-deposit discussion DM (don't open a separate thread just for this — it would over-weight a small item). Ali either acks (proceed) or asks for context (return to 1 with sharper material). |
+| 3. Docs row | After (1) + (2) | `.zenodo.json` creators + `docs/handovers/v0.3.x-ali-collaboration-track.md` §Track 5 + handover four-way attribution table all updated in one bundled PR. |
+
+#### Status update
+
+- M6 priority: 🟡 Important — unchanged.
+- M6 effort: ~30 min single PR → **1-2h spread across ~2 weeks** (Robin DM short + Ali resume integration + final bundled PR).
+- M6 dependency: gates the joint deposit (M9) since 4-way attribution must lock before `.zenodo.json` creators can be finalized.
+
+#### Reusable pattern
+
+The 3-way structure (collaborator A flags 3rd party X → JAMES needs
+B's awareness before docs commit) is reusable. Captured as memory
+`feedback_m6_vadym_attribution_3way_timing.md` so future "X
+contribution flagged via Y" cases get the same sequencing.


### PR DESCRIPTION
## Summary

Reframes handover §5 M6 from a simple 30-min docs PR into a sequenced 3-way confirmation chain. The frozen body §1-§10 stays unchanged; this is an addendum-only update under §11.

## What changed in M6 understanding

Original §5 M6 read M6 as a single docs PR adding a Vadym Arnaut row to the four-way attribution catalog. PM session re-read identified two hidden dependencies:

1. **Robin → JAMES** — Robin is the source flagger (Phase R6 DM, 2026-05-24). JAMES has no first-hand Vadym contact, so the primary citation (`substitution-vs-decision boundary` from Vadym's comment thread on Ali's walk-back article) is Robin's read and needs his confirmation before docs commit.
2. **JAMES → Ali** — Ali may not have visibility on Vadym's role (connection is on the Robin↔Ali article-thread axis, not the Ali↔JAMES DM axis). Adding Vadym to joint-deposit attribution without prior Ali awareness would surprise him at deposit time.
3. **JAMES → docs** — only after (1) and (2) does the catalog row write correctly. Anything earlier is best-effort paraphrase committed before the people involved have aligned.

## Sequencing (now explicit)

| Phase | When | Action |
|---|---|---|
| 1. Robin confirm | Now (~6/6, Ali paused) | Short owner-position DM asking for the right primary citation |
| 2. Ali ack | 6/7+ Ali resume | Include Vadym mention inside joint-deposit discussion (no separate thread) |
| 3. Docs row | After (1) + (2) | Bundled PR: `.zenodo.json` creators + handover four-way table + Ali collab track §Track 5 |

## Status revisions

- M6 priority: 🟡 Important — unchanged
- M6 effort: 30 min single PR → **1-2h spread across ~2 weeks**
- M6 dependency: **gates M9** (joint deposit) since 4-way attribution must lock before `.zenodo.json` creators can be finalized

## Pattern captured for reuse

Memory file `feedback_m6_vadym_attribution_3way_timing.md` (memory side, not in this PR) — any future "X contribution flagged via Y" case gets the same Robin → JAMES → Ali → docs sequencing.

## Verification

- `Quality delta: exempt (label: docs)`
- 44-line addendum to existing §11; body §1-§10 untouched (frozen-body convention preserved)
- 1 file changed

## Out of scope

- Robin DM itself (operator-side, separate channel — drafts provided in chat)
- Ali Phase 2 inclusion (gates on 6/7+ Ali resume; not actionable this session)
- Final docs row PR (gates on Phases 1+2 confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)