### PR TITLE
docs(handover): §11.7 Phase 1 — natural-trigger piggyback only (no single-purpose DM)

### DIFF
--- a/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
+++ b/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
@@ -508,9 +508,18 @@ re-read identified two hidden dependencies that turn M6 into a
 
 | Phase | When | Action |
 |---|---|---|
-| 1. Robin confirm | Now (~6/6, Ali paused) | Short owner-position DM — "for the four-way attribution catalog, is Vadym's `substitution-vs-decision boundary` the right primary citation, or do you have a sharper line in mind? No rush, before joint deposit only." |
+| 1. Robin confirm | **Natural trigger only** (incoming Robin DM, or outgoing JAMES DM about something else worth telling Robin — Direction 3 first result, Ali-side timing update, etc.). Do NOT single-purpose-DM just to ask the Vadym question. | When a natural occasion fires, append the Vadym ask as a short tail: "Also — for the four-way attribution catalog: is Vadym's `substitution-vs-decision boundary` the right primary citation, or do you have a sharper line in mind? And his affiliation / preferred handle for the `.zenodo.json` creators field. No rush, only before joint deposit pre-publish." |
 | 2. Ali ack | 6/7+ Ali resume | Include Vadym mention inside the joint-deposit discussion DM (don't open a separate thread just for this — it would over-weight a small item). Ali either acks (proceed) or asks for context (return to 1 with sharper material). |
 | 3. Docs row | After (1) + (2) | `.zenodo.json` creators + `docs/handovers/v0.3.x-ali-collaboration-track.md` §Track 5 + handover four-way attribution table all updated in one bundled PR. |
+
+> **Why "natural trigger only" for Phase 1**: a single-purpose
+> confirmation DM costs measurement-framework owner standing more than
+> it gains (Robin is already the source flagger and will land on this
+> at the joint deposit either way). Piggybacking on a natural occasion
+> preserves communication economy + owner position. If no natural
+> trigger fires before the joint-deposit pre-publish window, the ask
+> graduates to "next outgoing DM regardless of topic" since the
+> deposit gate is fixed.
 
 #### Status update
 


### PR DESCRIPTION
## Summary

§11.7 Phase 1 (M6 Vadym confirmation step) reworded from "short single-purpose Robin DM now" → "natural-trigger piggyback only". Operator refinement: a standalone ask costs measurement-framework owner standing more than it gains, since Robin will land on Vadym at the joint deposit either way.

## What changed

### Phase 1 row in the §11.7 sequencing table

- **When**: Now → "Natural trigger only" (incoming Robin DM on any topic, or outgoing JAMES DM about something else worth telling Robin — Direction 3 first result, Ali-side timing update, etc.)
- **Action**: Standalone DM → short tail appended to whatever the natural-trigger DM is carrying. Payload also expanded to bundle the `.zenodo.json` affiliation/handle question so the tail fires once not twice.

### Why-block added below the table

Single-purpose confirmation DM reads as burden ("ask out of context") — the `feedback_collaborator_consent_default` "no action needed" tone is harder to honor in a single-purpose message. Piggybacking preserves communication economy + owner position simultaneously.

### Fallback

If no natural trigger fires before the joint-deposit pre-publish window, the ask graduates to "next outgoing DM regardless of topic" since the deposit gate is fixed.

## Memory side (not in this PR)

`feedback_m6_vadym_attribution_3way_timing.md` §"DM 톤 규칙" gains a new "Trigger rule — 단독 DM 금지, natural piggyback 만 (2026-05-29 사용자 결정)" subsection capturing the general pattern for reuse on any future "external-attribution small ask" case.

## Verification

- `Quality delta: exempt (label: docs)`
- 10 insertions / 1 deletion in one row + one why-block
- Frozen-body convention preserved: §11 addendum-only

## Out of scope

- The Robin DM itself (gated on natural trigger per the new rule)
- Memory file update (already landed in-session; not under repo git)
- Phase 2 / Phase 3 unchanged from #588 landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)