### PR TITLE
docs(handover): §11.9 M5 deferred to Ali resume — collab rendezvous timing

### DIFF
--- a/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
+++ b/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
@@ -556,3 +556,59 @@ The 3-way structure (collaborator A flags 3rd party X → JAMES needs
 B's awareness before docs commit) is reusable. Captured as memory
 `feedback_m6_vadym_attribution_3way_timing.md` so future "X
 contribution flagged via Y" cases get the same sequencing.
+
+### 11.9 M5 deferred to Ali resume — collab rendezvous timing
+
+handover §5 M5 (Track 4 pre-experiment scope-lock note) sat in
+"Important — draft before mid-June" with no Ali-dependency wording.
+Operator refinement (2026-05-29 evening): a scope-lock note is by
+construction a **two-party agreement document** (sub-author / method /
+byline). Drafting unilaterally during Ali's paused window (through
+6/6) costs Ali a review-burden first thing after resume — small but
+avoidable.
+
+Updated rule:
+
+- **M5 deferred to Ali resume (6/7+).** First draft is co-drafted (or
+  draft-then-immediate-share) rather than landed before Ali sees it.
+- Time budget unchanged: Track 3 starts mid-June, so 6/7 + ~1 week =
+  comfortable window before scope-lock must be agreed.
+- M5 priority stays 🟡 Important; only the *timing* moves.
+
+#### Same pattern applies to other Ali-dependent items
+
+Once M5 reclassifies, the remaining open M-ledger items group cleanly
+around the same 6/7 rendezvous:
+
+| M | Ali dependency | 6/7 trigger? |
+|---|---|---|
+| M5 Track 4 scope-lock note | two-party agreement | ✅ |
+| M6 Phase 2 (Ali ack of Vadym mention) | Ali awareness gate | ✅ (per §11.7) |
+| M6 Phase 3 (docs row PR) | gated on Phases 1+2 | ✅ |
+| M9 joint deposit | two-party final | ✅ |
+| M3 Direction 3 | technically solo-runnable, but framework-fit timing under user review | (separate decision) |
+
+→ 6/7 = the collaboration-line **rendezvous point**. All Ali-coupled
+work converges there. M3 stays under its own user-deferred review;
+everything else either already closed (M1, M4) or queues at 6/7.
+
+#### Why this matters for the next session
+
+- The "what's open" answer for the collaboration line is no longer
+  "M5, M6 Phase 2/3, M9 — independent items at varying urgency" but
+  "one rendezvous at 6/7+ that resolves four items in sequence".
+- Internal-line capacity through 6/6 → 6/7 is genuinely free for
+  internal candidates (T3 Aging entry, α-5, pytest flaky proper fix)
+  *or* the M3 decision review — without the M7 trap of "did we skip
+  collab work that was actually doable".
+- The M3 decision is the only collab-line item with optionality
+  during this window; everything else is calendar-gated.
+
+#### Captured rule
+
+Memory file `feedback_ali_resume_notice_june6.md` gains a new
+"Ali-pause collab-dependent work scheduling" subsection capturing
+the general rule: during a collaborator's paused window, defer
+two-party agreement documents to the resume even when solo-drafting
+is technically possible — the cost of a review-burden on resume
+exceeds the value of having a draft ready.


### PR DESCRIPTION
## Summary

§11.9 added — M5 (Track 4 pre-experiment scope-lock note) reclassified from "draft before mid-June" → "deferred to Ali resume 6/7+", along with explicit grouping of all remaining Ali-coupled M-items around the same rendezvous.

## Why

§5 M5 originally had no Ali-dependency wording, so it could read as soloable. A scope-lock note is by construction a **two-party agreement document** (sub-author / method / byline). Drafting unilaterally during Ali's paused window (through 6/6) costs Ali a review-burden first thing after resume — small but avoidable.

## What changed in M5

- Action: deferred to Ali resume (6/7+). First draft co-drafted or draft-then-immediate-share rather than landed before Ali sees it.
- Time budget: unchanged (Track 3 starts mid-June, 6/7 + ~1 week comfortable)
- Priority: still 🟡 Important — only the *timing* moves

## Same-pattern grouping

Once M5 reclassifies, the open Ali-coupled M-ledger items group cleanly:

| M | Ali dependency | 6/7 trigger? |
|---|---|---|
| M5 Track 4 scope-lock note | two-party agreement | ✅ |
| M6 Phase 2 (Ali ack of Vadym mention) | Ali awareness gate | ✅ (per §11.7) |
| M6 Phase 3 (docs row PR) | gated on Phase 2 | ✅ |
| M9 joint deposit | two-party final | ✅ |
| M3 Direction 3 | technically solo, framework-fit timing under user review | (separate decision) |

→ 6/7 = the collaboration-line **rendezvous point**. All Ali-coupled work converges there.

## Effect for next-session reading

- Collab-line answer is no longer "M5/M6/M9 — independent items at varying urgency" but "one rendezvous at 6/7 resolves four items in sequence"
- Internal-line capacity through 6/6 is genuinely free for internal candidates (T3 Aging entry, α-5, pytest flaky proper fix) *or* the M3 decision review — without M7 trap (Ali-side input is absent during the paused window, so internal-only ≠ collab avoidance)
- 6/7 후에는 즉시 collab line 으로 capacity shift 권장 — M7 trap risk 가 그 시점부터 다시 적용

## Memory side (not in this PR)

`feedback_ali_resume_notice_june6.md` gains a new "Ali-pause collab-dependent work scheduling" subsection capturing the general rule (two-party agreement docs deferred during a collaborator's paused window) as reusable scheduling guidance.

## Verification

- `Quality delta: exempt (label: docs)`
- 56-line addendum to existing §11; body §1-§10 untouched (frozen-body convention preserved)
- 1 file changed

## Out of scope

- The M5 draft itself (gated on 6/7+)
- M9 prep solo work — orthogonal (allowed solo per `feedback_build_dont_broadcast`; just not finalize)
- M3 decision review — separate user-pending item

🤖 Generated with [Claude Code](https://claude.com/claude-code)