### PR TITLE
fix(test): extend setUpClass pattern to 2 sibling files (canary follow-up)

### DIFF
--- a/tests/test_attributes_summary_cleanup.py
+++ b/tests/test_attributes_summary_cleanup.py
@@ -56,34 +56,35 @@ class _Base(unittest.TestCase):
     """Same pattern as test_wiki_summary_body_sync — isolate WIKI_DIR
     and bypass memory/verify/vector-store side effects."""
 
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
-        self.wiki_dir_patcher.start()
+    # Class-level patches + WikiGenerator (sibling of PR #592 canary).
+    # See conftest.py docstring + PR #582 / PR #592 history.
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+        cls._patchers = [
+            patch("config.WIKI_DIR", cls.tmp),
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
         import core.wiki_generator as wg_mod
-        self._orig_wiki_dir = wg_mod.WIKI_DIR
-        wg_mod.WIKI_DIR = self.tmp
-
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
+        cls._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = cls.tmp
         from core.wiki_generator import WikiGenerator
-        self.wg = WikiGenerator(source_type="test")
+        cls.wg = WikiGenerator(source_type="test")
 
-    def tearDown(self):
-        self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
         import core.wiki_generator as wg_mod
-        wg_mod.WIKI_DIR = self._orig_wiki_dir
+        wg_mod.WIKI_DIR = cls._orig_wiki_dir
 
     def _read_fm(self, path: Path):
         raw = path.read_text(encoding="utf-8")

--- a/tests/test_wiki_summary_body_sync.py
+++ b/tests/test_wiki_summary_body_sync.py
@@ -35,34 +35,35 @@ class _WikiSummaryBodyBase(unittest.TestCase):
     bypass memory/verify and vector-store side effects so we can drive
     create_entity_file from a clean tmp dir."""
 
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
-        self.wiki_dir_patcher.start()
+    # Class-level patches + WikiGenerator (sibling of PR #592 canary).
+    # See conftest.py docstring + PR #582 / PR #592 history.
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+        cls._patchers = [
+            patch("config.WIKI_DIR", cls.tmp),
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
         import core.wiki_generator as wg_mod
-        self._orig_wiki_dir = wg_mod.WIKI_DIR
-        wg_mod.WIKI_DIR = self.tmp
-
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
+        cls._orig_wiki_dir = wg_mod.WIKI_DIR
+        wg_mod.WIKI_DIR = cls.tmp
         from core.wiki_generator import WikiGenerator
-        self.wg = WikiGenerator(source_type="test")
+        cls.wg = WikiGenerator(source_type="test")
 
-    def tearDown(self):
-        self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
         import core.wiki_generator as wg_mod
-        wg_mod.WIKI_DIR = self._orig_wiki_dir
+        wg_mod.WIKI_DIR = cls._orig_wiki_dir
 
     def _read(self, path: Path):
         raw = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Sibling extension of PR #592 canary (`_MarkdownStripBase` → `setUpClass`). Per-file risk analysis revealed that 3 of the 5 candidate sibling files have **cross-test state pollution** when the WikiGenerator is shared at class level; only the 2 risk-free files land here.

## Landed (same `setUpClass` pattern as the canary)

| File | Tests | Risk class |
|---|---|---|
| `tests/test_wiki_summary_body_sync.py` | 4 | low — frontmatter assertions only |
| `tests/test_attributes_summary_cleanup.py` | 3 | low — frontmatter assertions only |

Both have a single test class on the base, exercise only frontmatter assertions (not `process_document_for_entities`), so the shared class-level WikiGenerator does not accumulate cross-test state.

## Deferred (state-pollution risk)

| File | Risk | Evidence |
|---|---|---|
| `test_event_ingest_emit.py` | 5 test classes share `_EventIngestBase`; `ProcessDocumentEventIntegrationTests` calls `process_document_for_entities` and leaves event entities in the shared tmp wiki | Verified by local rerun that fails with *"no occurred_at must not land in event/"* when an earlier test left one |
| `test_phase_b_ingestion_sources.py` | 3 separate test classes including `ProcessDocument*` and `CrossDoc*` — same cross-doc aggregation risk by design | Predicted, not tested |
| `test_phase_d_modify_cascade.py` | Different setup pattern (`tmp_root` + `uploads_dir`) — needs its own design pass | Predicted |

These 3 files need a different fix shape: keep the 4 patches class-level (heavy cost), but renew the WikiGenerator + tmp dir per-test (state isolation). Designing that pattern is a separate follow-up.

## Local verification

```
3-file combined run (canary + 2 new): 12 passed in 0.19s
2 new files alone:                    7 passed in 0.13s
```

## Cluster coverage after this PR

| File | Status |
|---|---|
| test_entity_name_markdown_strip (canary) | ✅ #592 (4/4 reruns) |
| test_wiki_summary_body_sync | ✅ this PR |
| test_attributes_summary_cleanup | ✅ this PR |
| test_event_ingest_emit | ⏭️ deferred |
| test_phase_b_ingestion_sources | ⏭️ deferred |
| test_phase_d_modify_cascade | ⏭️ deferred |

**3/6 of the cluster covered.** Cascade flake rate should already improve materially since the entity_name canary was the original cascade trigger; the two new files are also frequent flake offenders per CI logs.

## Verification plan

- Local: ✅ 12/12 pass in 0.19s
- CI initial: trust check
- CI rerun 2-3 times to confirm flake reduction (canary went 4/4, looking for similar here)

## Out of scope

- The 3 deferred files (separate follow-up with per-test wg-renew design)
- `pytest-rerunfailures` framework-level retry (handover §11.3 Option B; defer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)