### PR TITLE
docs(handover): §11.3 pytest flaky status — Option A 3/6 closed, 3 deferred

### DIFF
--- a/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
+++ b/docs/handovers/v0.4.x-session-2026-05-29-collaboration-checkpoint.md
@@ -423,7 +423,7 @@ Endpoint router lines: `admin` (2142), `auth` (806), `evolution` (640),
 (193), `coding` (197), `history` (156), `multimodal` (136), `feedback`
 (59).
 
-### 11.3 Pytest flaky cluster (partial fix landed)
+### 11.3 Pytest flaky cluster (proper fix in progress — 3/6 closed)
 
 Two CI tests intermittently fail on cold Ubuntu / Python 3.11 runners
 under `--timeout=30`, traced to a cascade:
@@ -431,15 +431,34 @@ under `--timeout=30`, traced to a cascade:
 1. `test_entity_name_markdown_strip::test_all_markdown_falls_back_to_unknown` — setUp + create_entity_file path exceeds 30s; tearDown skipped → patch leak
 2. `test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta` — cascade: leaked `patch("llm.router.RouterWrapper")` makes the next test import a MagicMock → mock target points at Mock attribute → 0 calls
 
-PR #582 added `core.graph_node_editor` + `core.ontology` to conftest
-pre-imports and a session-start `WikiGenerator(source_type="test")`
-warm-up. Local cost: 6.6s once per session. Pass rate moved from
-~50% → ~75% across 4 reruns. **Not fully stabilized**; proper fix is
-a separate follow-up:
+#### Fix progression
 
-- Option A (preferred): refactor `_MarkdownStripBase.setUp` → `setUpClass`
-- Option B (framework-level): introduce `pytest-rerunfailures` with a
-  reason allowlist (Timeout / AssertionError on Mock)
+- **PR #582 (partial)** — added `core.graph_node_editor` + `core.ontology` to conftest pre-imports and a session-start `WikiGenerator(source_type="test")` warm-up. Local cost: 6.6s once per session. Pass rate moved from ~50% → ~75% across 4 reruns.
+- **PR #592 (canary)** — Option A applied to `test_entity_name_markdown_strip.py` (`_MarkdownStripBase.setUp` → `setUpClass`). Local: 5/5 pass in 0.09s (was ~25-55s). CI: 4/4 reruns clean = root-cause fix confirmed for this file.
+- **PR #593 (2 siblings)** — same `setUpClass` pattern extended to `test_wiki_summary_body_sync.py` + `test_attributes_summary_cleanup.py`. CI: 3/3 reruns clean.
+
+#### Cluster coverage
+
+| File | Status |
+|---|---|
+| `test_entity_name_markdown_strip` | ✅ #592 (root-cause fix, 4/4 reruns) |
+| `test_wiki_summary_body_sync` | ✅ #593 |
+| `test_attributes_summary_cleanup` | ✅ #593 |
+| `test_event_ingest_emit` | ⏭️ deferred (5 test classes share `_EventIngestBase`; `ProcessDocumentEventIntegrationTests` calls `process_document_for_entities` → cross-test state pollution. Local reproduce confirmed.) |
+| `test_phase_b_ingestion_sources` | ⏭️ deferred (3 test classes incl. `ProcessDocument*` + `CrossDoc*` — same cross-doc aggregation risk by design) |
+| `test_phase_d_modify_cascade` | ⏭️ deferred (different setup pattern — `tmp_root` + `uploads_dir` — needs its own design pass) |
+
+**3/6 cluster covered.** Cascade flake rate should already drop materially since the entity_name canary was the original cascade trigger; the two PR #593 files are also frequent flake offenders per CI logs.
+
+#### Deferred — required design shape
+
+The 3 deferred files cannot use the canary's straight setUpClass move. Two require **per-test WikiGenerator + tmp dir renew** (heavy patches still class-level for cost) so that `process_document_for_entities` runs against a fresh wiki each test. The third (`phase_d_modify_cascade`) has a different setup baseline entirely and needs its own analysis.
+
+Design memo target: `feedback_pytest_flaky_native_done_reason_entity_markdown.md` extension when the next attempt fires. Effort estimate: 1-2h for design + 30 min per file = ~3h total. Not blocking; queue as a separate cycle.
+
+#### Option B (framework-level) — still on the table for the deferred 3
+
+If the per-test wg-renew design proves fragile or invasive, `pytest-rerunfailures` with a reason allowlist (Timeout / AssertionError on Mock) becomes the fallback for the remaining 3 files. Captured as the secondary path in the memory follow-up note.
 
 ### 11.4 What this PM session reinforces (M7 pattern)
 


### PR DESCRIPTION
## Summary

§11.3 (pytest flaky cluster) status updated from "partial fix landed" (PR #582 only) to "proper fix in progress — 3/6 closed". Same-PR memory file `feedback_pytest_flaky_native_done_reason_entity_markdown.md` already received the matching deferred-3 design notes in-session.

## Cluster status

| File | Status | PR |
|---|---|---|
| `test_entity_name_markdown_strip` | ✅ root-cause fix, 4/4 reruns | #592 |
| `test_wiki_summary_body_sync` | ✅ | #593 |
| `test_attributes_summary_cleanup` | ✅ | #593 |
| `test_event_ingest_emit` | ⏭️ deferred | — |
| `test_phase_b_ingestion_sources` | ⏭️ deferred | — |
| `test_phase_d_modify_cascade` | ⏭️ deferred | — |

**3/6 closed.** Cascade flake rate should drop materially since the entity_name canary was the original cascade trigger.

## Deferred 3 — required design shape

Cannot use the canary's straight setUpClass move; the test classes call `process_document_for_entities` or rely on cross-doc aggregation, which a shared class-level WikiGenerator pollutes.

Required: keep the 4 patches class-level (heavy cost), renew WikiGenerator + tmp dir per-test for state isolation. Local reproduce of the pollution path verified for `test_event_ingest_emit` ("no occurred_at must not land in event/" — earlier test left one in the shared tmp wiki).

Effort estimate: ~3h (1-2h design + 30 min per file). Separate cycle.

## Option B fallback

`pytest-rerunfailures` (`--reruns 2 --only-rerun "Timeout|AssertionError"`) stays available as a secondary path for the deferred 3 if the per-test wg-renew design proves fragile.

## Verification

- `Quality delta: exempt (label: docs)`
- 28 insertions / 9 deletions in §11.3
- Body §1-§10 untouched (frozen-body convention preserved)

## Out of scope

- The deferred 3 files (separate follow-up cycle)
- pytest-rerunfailures actual introduction (Option B path; only if Option A fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)