### PR TITLE
fix(test): deferred 3 files — per-test wg-renew + class-level patches (cluster 6/6 closed)

### DIFF
--- a/tests/test_event_ingest_emit.py
+++ b/tests/test_event_ingest_emit.py
@@ -37,7 +37,50 @@ ensure_utf8_console()
 class _EventIngestBase(unittest.TestCase):
     """Common harness — tempdir WIKI_DIR + stubbed vector store / router /
     memory-trust verifier so create_entity_file's side effects are
-    isolated to disk."""
+    isolated to disk.
+
+    Split design (sibling of PR #592/#593 canary; wg-renew variant for
+    state-pollution-sensitive subclasses):
+
+    - **3 heavy patches at class level** (`core.memory.verify_before_write`,
+      `core.vector_store.VectorStore`, `llm.router.RouterWrapper`).
+      These trigger heavyweight imports (sentence_transformers / torch /
+      router module load) — ~5-10s on cold CI. Pay once per class
+      instead of once per test.
+    - **WIKI_DIR patch + WikiGenerator instantiation per-test.**
+      Multiple test classes here (HappyPath / Fallback / Collision /
+      FourTypeRegression / ProcessDocumentEventIntegration) share this
+      base. `ProcessDocumentEventIntegrationTests` calls
+      `process_document_for_entities`, which writes entities into the
+      shared tmp wiki — without per-test renewal, a previous test's
+      event entity leaks into the next test's "no event in event/"
+      assertion (verified locally during PR #593 sibling extension
+      attempt). The per-test tmp + wg pair restores state isolation
+      at minimal cost (WikiGenerator __init__ is cheap after the
+      class-level patches have already primed the heavy imports).
+
+    See `feedback_pytest_flaky_native_done_reason_entity_markdown.md`
+    for the full design history (Option A canary → siblings → wg-renew
+    variant for deferred 3).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patchers = [
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -46,25 +89,11 @@ class _EventIngestBase(unittest.TestCase):
         import core.wiki_generator as wg_mod
         self._orig_wiki_dir = wg_mod.WIKI_DIR
         wg_mod.WIKI_DIR = self.tmp
-
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
         from core.wiki_generator import WikiGenerator
         self.wg = WikiGenerator(source_type="test")
 
     def tearDown(self):
         self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
         import core.wiki_generator as wg_mod
         wg_mod.WIKI_DIR = self._orig_wiki_dir
 

--- a/tests/test_phase_b_ingestion_sources.py
+++ b/tests/test_phase_b_ingestion_sources.py
@@ -125,38 +125,42 @@ class BuildEntityRelationsSourcesTests(unittest.TestCase):
 
 class CreateEntityFileSourcesPropagationTests(unittest.TestCase):
     """caller 가 미리 채운 sources 를 frontmatter 에 그대로 쓰고
-    confidence 를 sources 로부터 derive 한다."""
+    confidence 를 sources 로부터 derive 한다.
+
+    Split design: 3 heavy patches at class level, wiki_dir + wg
+    per-test. See feedback_pytest_flaky_native_done_reason_entity_markdown.md.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patchers = [
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
 
     def setUp(self):
-        # WikiGenerator 가 WIKI_DIR 을 통째로 import 하므로 monkey-patch.
         self.tmp = tempfile.mkdtemp()
         self.wiki_dir_patcher = patch("config.WIKI_DIR", self.tmp)
         self.wiki_dir_patcher.start()
-        # core.wiki_generator 가 module-load 시 import 한 WIKI_DIR 도 갈아끼움
         import core.wiki_generator as wg_mod
         self._orig_wiki_dir = wg_mod.WIKI_DIR
         wg_mod.WIKI_DIR = self.tmp
-
-        # vector_store / verify_before_write 의 side effect 비활성.
-        # (테스트는 frontmatter 만 검증)
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
         from core.wiki_generator import WikiGenerator
         self.wg = WikiGenerator(source_type="test")
 
     def tearDown(self):
         self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
         import core.wiki_generator as wg_mod
         wg_mod.WIKI_DIR = self._orig_wiki_dir
 
@@ -224,7 +228,30 @@ class CreateEntityFileSourcesPropagationTests(unittest.TestCase):
 
 class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
     """LLM 추출 mock 후 실제 frontmatter (entity + inverse + doc) 가
-    sources 를 갖는지 확인."""
+    sources 를 갖는지 확인.
+
+    Split design: 3 heavy patches at class level, wiki_dir + wg + LLM
+    extract mock per-test (process_document writes entities into the
+    wiki — per-test renewal isolates them).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patchers = [
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -233,17 +260,6 @@ class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
         import core.wiki_generator as wg_mod
         self._orig_wiki_dir = wg_mod.WIKI_DIR
         wg_mod.WIKI_DIR = self.tmp
-
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
         from core.wiki_generator import WikiGenerator
         self.wg = WikiGenerator(source_type="test")
 
@@ -266,9 +282,6 @@ class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
 
     def tearDown(self):
         self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
         import core.wiki_generator as wg_mod
         wg_mod.WIKI_DIR = self._orig_wiki_dir
 
@@ -359,7 +372,31 @@ class CrossDocSourceAggregationTests(unittest.TestCase):
     이전 구현은 기존 entity 발견 시 entire processing 을 skip 하여
     cross-doc 강화가 작동하지 않았다 (Knowledge Cascade 핵심 가치 무효).
     본 테스트 클래스는 그 회귀 방지 게이트.
+
+    Split design: 3 heavy patches at class level, wiki_dir + wg
+    per-test. Cross-doc aggregation tests *intentionally* call
+    process_document_for_entities multiple times within a single
+    test — that's the design they verify. The per-test wg-renew
+    isolates one test's multiple process calls from the next test's.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patchers = [
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -368,25 +405,11 @@ class CrossDocSourceAggregationTests(unittest.TestCase):
         import core.wiki_generator as wg_mod
         self._orig_wiki_dir = wg_mod.WIKI_DIR
         wg_mod.WIKI_DIR = self.tmp
-
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
-
         from core.wiki_generator import WikiGenerator
         self.wg = WikiGenerator(source_type="test")
 
     def tearDown(self):
         self.wiki_dir_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
         import core.wiki_generator as wg_mod
         wg_mod.WIKI_DIR = self._orig_wiki_dir
 

--- a/tests/test_phase_d_modify_cascade.py
+++ b/tests/test_phase_d_modify_cascade.py
@@ -169,7 +169,32 @@ def _read_fm(path: Path) -> dict:
 
 class CascadeModifyDocIntegrationTests(unittest.TestCase):
     """전체 cascade_modify_doc 호출 — 기존 doc 의 wiki 가 새 content 의
-    추출로 정확히 교체되는지 검증."""
+    추출로 정확히 교체되는지 검증.
+
+    Split design (variant of event_ingest / phase_b): 3 heavy patches
+    at class level, wiki_dir + tmp_root + entity files + extract mock
+    + vs MagicMock per-test. The richer per-test setUp (uploads dir,
+    pre-existing entity files, sidecar) requires full state isolation
+    each test, so wiki_dir patch + WikiGenerator stay per-test.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patchers = [
+            patch(
+                "core.memory.verify_before_write",
+                return_value=(True, "ok", 0.99),
+            ),
+            patch("core.vector_store.VectorStore"),
+            patch("llm.router.RouterWrapper"),
+        ]
+        for p in cls._patchers:
+            p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patchers:
+            p.stop()
 
     def setUp(self):
         self.tmp_root = Path(tempfile.mkdtemp())
@@ -182,15 +207,6 @@ class CascadeModifyDocIntegrationTests(unittest.TestCase):
         import core.wiki_generator as wg_mod
         self._orig_wiki_dir = wg_mod.WIKI_DIR
         wg_mod.WIKI_DIR = str(self.tmp_root / "wiki")
-        self.verify_patcher = patch(
-            "core.memory.verify_before_write",
-            return_value=(True, "ok", 0.99),
-        )
-        self.verify_patcher.start()
-        self.vs_patcher = patch("core.vector_store.VectorStore")
-        self.vs_patcher.start()
-        self.router_patcher = patch("llm.router.RouterWrapper")
-        self.router_patcher.start()
 
         from core.wiki_generator import WikiGenerator
         self.wg = WikiGenerator(source_type="test")
@@ -295,9 +311,6 @@ class CascadeModifyDocIntegrationTests(unittest.TestCase):
 
     def tearDown(self):
         self.wiki_patcher.stop()
-        self.verify_patcher.stop()
-        self.vs_patcher.stop()
-        self.router_patcher.stop()
         import core.wiki_generator as wg_mod
         wg_mod.WIKI_DIR = self._orig_wiki_dir
 


### PR DESCRIPTION
## Summary

Closes the pytest flaky cluster (6/6) per handover §11.3. The canary (PR #592) and 2-sibling extension (PR #593) used a straight setUpClass move; the 3 files in this PR need state isolation per test (process_document_for_entities + cross-doc aggregation), so the design splits.

## Split design

- **3 heavy patches at class level** (`core.memory.verify_before_write` / `core.vector_store.VectorStore` / `llm.router.RouterWrapper`). Heavy-import cost (sentence_transformers / torch / router module) paid once per class.
- **`WIKI_DIR` patch + WikiGenerator + tmp dir per-test.** Each test gets a fresh wiki so prior-test entities don't leak into the next test's assertions.

This is the **wg-renew variant** of the canary's pattern — captured as the documented shape for any future state-pollution-sensitive test class.

## Why per-test wg-renew was required

| File | Pollution source |
|---|---|
| `test_event_ingest_emit.py` | `ProcessDocumentEventIntegrationTests` calls `process_document_for_entities` — verified locally during PR #593 sibling attempt that earlier test's event entity leaked into the next test's "no event in event/" assertion |
| `test_phase_b_ingestion_sources.py` | `ProcessDocument*` + `CrossDoc*` classes — cross-doc aggregation is the design they verify, requires fresh wiki per test |
| `test_phase_d_modify_cascade.py` | `CascadeModifyDocIntegrationTests` writes pre-existing entity files + uploads dir + sidecar per test; full state isolation needed |

## Verification

```
tests/test_event_ingest_emit.py:          12 passed in 0.27s
tests/test_phase_b_ingestion_sources.py:  13 passed in 0.68s
tests/test_phase_d_modify_cascade.py:     13 passed in 0.36s
Combined 6-file cluster + native_done_reason cascade: 62 passed in 3.55s
```

## Cluster status (handover §11.3) after this PR

| File | PR |
|---|---|
| test_entity_name_markdown_strip | ✅ #592 |
| test_wiki_summary_body_sync | ✅ #593 |
| test_attributes_summary_cleanup | ✅ #593 |
| test_event_ingest_emit | ✅ **this PR** |
| test_phase_b_ingestion_sources | ✅ **this PR** |
| test_phase_d_modify_cascade | ✅ **this PR** |

**6/6 covered.** Option B fallback (`pytest-rerunfailures`) no longer needed for this cluster; can stay in the toolkit memory for unrelated future flaky cases.

## Verification plan

- Local: ✅ 62/62 passed
- CI initial: trust check
- CI rerun 2 times to confirm full-cluster stability (cluster closure = cascade flake should be gone for good)

## Out of scope

- handover §11.3 status update reflecting 6/6 closure (separate follow-up — single-line edit)
- memory file matching update (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)