### PR TITLE
fix(test): conftest pre-import server_llmwiki (close last cascade origin)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,19 @@ import llm.router  # noqa: F401 — pre-import to warm sys.modules
 import core.graph_node_editor  # noqa: F401 — lazy-imported in _frontmatter.py:310
 import core.ontology  # noqa: F401 — lazy-imported in _frontmatter.py:336
 
+# 2026-05-29 evening — additional cascade origin found:
+# `tests/test_admin_cognitive_endpoint.py::CognitiveEndpointTests`
+# calls ``_client()`` which does ``import server_llmwiki as srv`` +
+# ``TestClient(srv.app)``. The server module pulls in all routes/ +
+# every FastAPI startup-event dependency — local import cost ~9.4s
+# (cold) on top of the routes-package walk. On a cold CI runner that
+# brings the first call_into-cognitive-endpoint test up to or past
+# the 30s pytest-timeout budget. Pre-importing here pays the cost
+# once per session and stops the cascade that surfaced via
+# ``test_native_done_reason`` still flaking after PRs #582 / #592 /
+# #593 / #595 closed the original 6-file cluster.
+import server_llmwiki  # noqa: F401 — pulls all routes/ + heavy startup deps
+
 # 2026-05-29 — warm-up WikiGenerator so every mixin __init__ runs once
 # at session start. Side-effects are recoverable; we only need caches
 # primed for create_entity_file's first call to stay under 30s on cold


### PR DESCRIPTION
## Summary

After PR #595 closed the cluster 6/6 with the wg-renew pattern, `test_native_done_reason` still fell into the cascade on 1/4 CI reruns. Diagnosis traced the residual origin **outside the cluster**:

```
tests/test_admin_cognitive_endpoint.py::CognitiveEndpointTests._client()
  → import server_llmwiki as srv
  → TestClient(srv.app)
```

`server_llmwiki` import is ~9.4s (cold local) on its own, pulling all `routes/*` + every FastAPI startup-event dependency. On a cold CI runner that pushes the first `test_admin_cognitive_endpoint` test into or past the 30s pytest-timeout. When that times out mid-setUp, downstream tests in the same pytest process inherit the broken state — the same cascade shape that drove the original 6-file cluster.

## Fix

Add `server_llmwiki` to the conftest session-start pre-import list. Pay the 9.4s once per pytest process instead of inside the first `_client()` call.

```python
# Local cost: conftest 6.6s → 7.6s
# (most server_llmwiki deps already in the pre-import set;
#  only the routes/* walk adds new cost)
import server_llmwiki  # noqa: F401
```

## Verification

Local on Windows / Python 3.14:

```
83 passed in 3.68s
(6-file cluster + native_done_reason + external_role_isolation
 + admin_cognitive_endpoint)
```

Expected CI rerun rate: back to 100% (PR #592 / PR #593 baseline before the residual surfaced).

## Diagnosis path captured

The 4-step diagnosis is the reusable pattern for future flake hunts:

1. Grep `patch("llm.router.*")` users — 9 files, 6 are cluster (fixed), 1 is the affected test itself, 2 are conftest (no patch start) + external_role (`with` block)
2. Grep `RouterWrapper / llm.router` references in other files — 4 candidates ruled out (just imports, no patches)
3. CI fail log — `test_admin_cognitive_endpoint::test_get_default_state_with_clean_env` ran just before `test_native_done_reason::test_router_wrapper_call_gemma_meta_dispatches_to_call_router_meta`
4. Source inspection — `_client()` does `import server_llmwiki + TestClient(srv.app)` = heavy first-import not in conftest

## Verification plan

- Local: ✅ 83/83 pass
- CI initial: trust check
- CI rerun 3+ times — looking for 4/4 or 5/5 cluster-closure rate (PR #595 dropped to 3/4 = residual evidence)

## Out of scope

- handover §11.3 update reflecting "cluster + residual origin both closed" — separate small follow-up
- Memory `feedback_pytest_flaky_native_done_reason_entity_markdown` update — separate small follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)