### PR TITLE
feat(research): D3 §16.7 — reasoning cost is model-invariant, not e4b-specific

### DIFF
--- a/reports/research-runs/v3prime-cross-family-final-2026-05-29.md
+++ b/reports/research-runs/v3prime-cross-family-final-2026-05-29.md
@@ -438,7 +438,41 @@ JAMES production calls Ollama via **`/api/generate` with `think` unset**, and `g
 
 ### 16.6 Artifact
 
-- `scripts/research/v3prime_e4b_mechanism_probe.py` — self-contained, reproducible. Part A (live stream: visible vs counted tokens), Part B (stored-JSON chars/token corroboration: e4b 0.71 vs others ~4.8), Part C (`think` toggle root-cause isolation). cp949-safe.
+- `scripts/research/v3prime_e4b_mechanism_probe.py` — self-contained, reproducible. Part A (live stream: visible vs counted tokens), Part B (stored-JSON chars/token corroboration: e4b 0.71 vs others ~4.8), Part C (`think` toggle root-cause isolation), Part D (cross-model reasoning-cost comparison, §16.7). cp949-safe.
+
+### 16.7 Is the reasoning cost e4b-specific? No — it is a default-mode difference, not an efficiency defect
+
+Natural follow-up: can the "thinking cost" be measured on the *other* models too? Two findings settle it.
+
+**(A) Native `think` toggle is e4b-only.** `ollama show` confirms only `gemma4:e4b` declares the `thinking` capability; the other six list `completion` (+ `tools`/`vision`/`insert`). Passing `think:true` to a non-thinking model is rejected:
+
+```
+/api/chat think=true on qwen2.5:7b → HTTP 400 Bad Request
+```
+
+So there is no native thinking phase to toggle or measure on the other six — their reasoning happens implicitly in the forward pass and emits **no** extra output tokens (§16.1: `eval_count == visible`).
+
+**(B) Prompt-induced explicit reasoning is universal and comparable in cost.** Forcing any model to reason out loud ("Think step by step through each relevant clause before giving your final recommendation") converts the implicit reasoning into explicit output tokens, which `eval_count` then captures (cap=4096, temp=0.2, single-item e-commerce):
+
+| Model | plain `eval_count` | CoT `eval_count` | induced reasoning tokens |
+|---|---|---|---|
+| `qwen2.5:7b` | 63 | 272 | +209 |
+| `gemma3:12b` | 51 | 440 | +389 |
+| `llama3.1:8b` | 72 | 240 | +168 |
+| `gemma2:2b` | 48 | 215 | +167 |
+
+The induced reasoning cost (~170–390 tokens) lands in the **same band as e4b's native trace (~377)** — `gemma3:12b` at +389 is essentially identical. Explicit reasoning costs roughly the same on every model.
+
+**Reframing.** `gemma4:e4b` is **not** abnormally expensive at reasoning. The cap-400 floor is a **default-mode** difference, not a reasoning-efficiency defect:
+
+| | `gemma4:e4b` (thinking model) | other six (standard models) |
+|---|---|---|
+| explicit reasoning | **default-on** | opt-in (only when prompted) |
+| visibility | **hidden** (stripped from `response`) | visible (it is the requested output) |
+| counted in `num_predict` budget | yes | yes |
+| operator perception | "unexplained floor" | "I asked for it" |
+
+When the other six are *asked* to reason, they pay the same token tax and could floor at the same caps; when e4b is told `think=false`, it drops to ~45 tokens like the others. The asymmetry is entirely "reasoning on-by-default and invisible" vs "reasoning off-by-default and visible." This is the cleanest cross-family statement of the mechanism for the joint piece: the token economy of reasoning is roughly model-invariant; what differs is the **default reasoning mode and its visibility**.
 
 ## 14. Related
 

--- a/scripts/research/v3prime_e4b_mechanism_probe.py
+++ b/scripts/research/v3prime_e4b_mechanism_probe.py
@@ -217,6 +217,70 @@ def part_c_thinking_toggle() -> None:
     )
 
 
+SYNTHESIS_PROMPT_COT = (
+    "Based on the policy context below, advise whether a customer who "
+    "bought a linen shirt, washed it, and now wants to return it qualifies "
+    "for a refund. Think step by step through each relevant clause before "
+    "giving your final recommendation.\n\nContext:\n" + CONTEXT_FIXTURE
+    + "\nReasoning:"
+)
+
+
+def _gen_eval(model: str, prompt: str, cap: int = 4096) -> int:
+    body = json.dumps({
+        "model": model, "prompt": prompt, "stream": False,
+        "options": {"num_predict": cap, "temperature": 0.2},
+    }).encode("utf-8")
+    req = request.Request(OLLAMA_URL, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=180) as resp:
+        return json.loads(resp.read().decode()).get("eval_count") or 0
+
+
+def part_d_crossmodel_reasoning() -> None:
+    """Is the reasoning cost e4b-specific? Compare native think-only vs
+    prompt-induced explicit reasoning across the panel (§16.7)."""
+    print("## Part D — is the reasoning cost e4b-specific? "
+          "(native think vs prompt-induced CoT, §16.7)\n")
+    # (A) native think toggle is e4b-only — rejected elsewhere.
+    chat_url = OLLAMA_URL.replace("/api/generate", "/api/chat")
+    body = json.dumps({
+        "model": "qwen2.5:7b",
+        "messages": [{"role": "user", "content": SYNTHESIS_PROMPT}],
+        "stream": False, "think": True,
+        "options": {"num_predict": 512, "temperature": 0.2},
+    }).encode("utf-8")
+    req = request.Request(chat_url, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    try:
+        with request.urlopen(req, timeout=120):
+            verdict = "accepted (unexpected)"
+    except Exception as exc:  # HTTP 400 for non-thinking models
+        verdict = f"rejected — {str(exc)[:40]}"
+    print(f"(A) native think=true on qwen2.5:7b (no thinking capability): "
+          f"{verdict}\n")
+
+    # (B) prompt-induced CoT cost across the standard models.
+    print("(B) prompt-induced explicit reasoning (eval_count, cap=4096):\n")
+    print(f"| {'model':<14} | {'plain':>6} | {'CoT':>5} | "
+          f"{'induced reasoning':>17} |")
+    print(f"|{'-'*16}|{'-'*8}|{'-'*7}|{'-'*19}|")
+    for model in ["qwen2.5:7b", "gemma3:12b", "llama3.1:8b", "gemma2:2b"]:
+        try:
+            plain = _gen_eval(model, SYNTHESIS_PROMPT)
+            cot = _gen_eval(model, SYNTHESIS_PROMPT_COT)
+            print(f"| {model:<14} | {plain:>6} | {cot:>5} | "
+                  f"{cot - plain:>+17} |")
+        except Exception as exc:  # pragma: no cover
+            print(f"| {model:<14} | ERROR {str(exc)[:30]} |")
+    print(
+        "\nReading: induced reasoning (~170-390 tokens) matches e4b's native "
+        "trace (~377). Reasoning costs the same on every model — e4b is not "
+        "abnormally expensive. The floor is a DEFAULT-MODE difference "
+        "(reasoning on-by-default + hidden) not an efficiency defect.\n"
+    )
+
+
 def main() -> None:
     print("# V3'.e mechanism probe — gemma4:e4b cap-400 floor\n")
     print("Headline: the floor is the gemma4:e4b THINKING TRACE consuming the "
@@ -225,6 +289,7 @@ def main() -> None:
     part_a_live()
     part_b_stored()
     part_c_thinking_toggle()
+    part_d_crossmodel_reasoning()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to §16 (PR #602): **is the thinking-token cost unique to `gemma4:e4b`?** Answer: no — the token economy of reasoning is roughly model-invariant. The cap-400 floor is a **default-mode** difference, not a reasoning-efficiency defect.

### Findings (report §16.7)

**(A) Native `think` toggle is e4b-only.** `ollama show` confirms only `gemma4:e4b` declares the `thinking` capability. Passing `think:true` to a non-thinking model is rejected:
```
/api/chat think=true on qwen2.5:7b → HTTP 400 Bad Request
```

**(B) Prompt-induced explicit reasoning is universal and comparable.** A "think step by step" prompt converts implicit reasoning into output tokens:

| Model | plain eval | CoT eval | induced reasoning |
|---|---|---|---|
| qwen2.5:7b | 63 | 272 | +209 |
| gemma3:12b | 51 | 440 | +389 |
| llama3.1:8b | 72 | 240 | +168 |
| gemma2:2b | 48 | 215 | +167 |

Induced reasoning (~170–390 tokens) matches e4b's native trace (~377); `gemma3:12b` at +389 is essentially identical.

### Reframing
| | `gemma4:e4b` | other six |
|---|---|---|
| explicit reasoning | default-on | opt-in (when prompted) |
| visibility | hidden (stripped from `response`) | visible (the requested output) |
| counted in `num_predict` | yes | yes |

When the other six are asked to reason, they pay the same tax and could floor at the same caps; when e4b is told `think=false`, it drops to ~45 tokens. The asymmetry is entirely "reasoning on-by-default + invisible" vs "off-by-default + visible."

## Verification

- `python scripts/research/v3prime_e4b_mechanism_probe.py` — new Part D (native think rejection + prompt-induced CoT comparison). Reproduced: induced +151..+389 across re-runs, same conclusion.
- Report: `reports/research-runs/v3prime-cross-family-final-2026-05-29.md` §16.7.

## Out of scope

No `core/` change. JAMES operational mitigation remains the separately-flagged §16.5 follow-up.

Quality delta: exempt (label: joint-collab-prep) — research driver + report only, no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
