### PR TITLE
feat(research): D1 7-tier budget — thinking-trace decomposition (internal upgrade study)

### DIFF
--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -57,7 +57,7 @@ any ledger before this reconciliation.
 | A2 ★ | **gemma4:e4b `think=false` operational fix** (§16.5 of D3 final) | 🆕 spawned task chip (2026-05-30) | JAMES default model silently spends ~85% of `num_predict` on a hidden thinking trace; caps < ~450 risk empty output. Touches `core/` → needs Quality Delta Card. |
 | A3 ★ | **think-mode quality boundary experiment** | 🆕 deferred (next session) | Measure which cognitive stages need thinking ON vs where `think=false` is free. Feeds A2's per-stage policy. |
 | A4 | **pytest flaky structural root fix** | 🟡 current fix is stabilization | `test_native_done_reason` + `test_entity_name_markdown_strip` order/timeout pollution. Cluster stabilized (#582/#592/#595/#596) but not root-fixed. |
-| A5 ★ | **D1 stage expansion** — wire planner/reflect/verify through `complete_with_retry` | 🟡 intentional no-op today | They hold `_max_tokens = 4096`; needs a budget signal first. **Directly related to A2/A3** — 4096 is held precisely to clear the e4b thinking-trace floor. |
+| A5 ★ | **D1 stage expansion** — wire planner/reflect/verify through `complete_with_retry` | 🟡 mechanism now known (2026-05-30) | The cap=4096 hold is now **explained**: planner/reflect/verify budgets are 82–98% thinking trace on e4b (verify 1164 tok → 23 visible). See `reports/research-runs/d1-7tier-thinking-decomposition-internal-2026-05-30.md`. D4 should route on the think-OFF/visible budget. Still gated on A3 (quality impact of think=false per stage). |
 | A6 | **admin.html → 3-page split** (UI-IA Phase 3) | 🟡 open across two cycles | Inventory done (PR #385); split deferred. Operator decision. |
 | A7 | **BL-8 wiki aliases** (proper-noun cross-lingual) | 🟡 deferred | Not a blocker — q15 routed through F9/query-expansion instead. |
 

--- a/reports/research-runs/d1-7tier-thinking-decomposition-internal-2026-05-30.md
+++ b/reports/research-runs/d1-7tier-thinking-decomposition-internal-2026-05-30.md
@@ -1,0 +1,132 @@
+# D1 7-tier budget — thinking-trace decomposition (INTERNAL upgrade study)
+
+**Date**: 2026-05-30
+**Framing**: 🔧 **JAMES-internal upgrade study — NOT a joint-piece artifact.**
+**Trigger**: D3 §16 mechanism (gemma4:e4b cap-floor = thinking trace) applied to the D1 7-tier budget gradient.
+**Driver**: `scripts/research/v3prime_e4b_7tier_thinking_split.py` (+ existing D1/D3 JSONs).
+
+> **Why this is internal, not collaboration.** D1's "7-tier monotonic
+> natural-stop gradient (62→1681 tokens, 27×)" is JAMES's own measurement
+> axis, on JAMES's own default model. This study asks an *operational* question
+> about JAMES routing — it does not touch the Robin 26b-scale anchor or the Ali
+> managed-Gemini axis, and it does **not restate the public 27× figure**. The
+> number stands; this study *recontextualises its interpretation internally*.
+> Any external framing revision folds into the joint piece at the rendezvous,
+> not a unilateral post. See D3 report §17.5 + memory `d3_e4b_floor_mechanism_thinking_trace`.
+
+## 1. Question
+
+D1's per-stage budget signal (`core/reasoning/budget.py`) routes off the 7-tier
+gradient, and D5/LEO consume the same per-call budget. After §16 showed ~85% of
+gemma4:e4b's *synthesis* budget is a hidden thinking trace, the operational
+question is:
+
+> For each of the 7 tiers D1 routes on, how much of `gemma4:e4b`'s per-tier
+> budget is the thinking trace vs visible output — i.e. is D1 routing on task
+> **workload** or on **reasoning-mode cost**?
+
+## 2. Method
+
+Stream `gemma4:e4b` on each of the 7 tier prompts (cap=4096, T=0.2), counting
+visible `response` tokens against `eval_count` (the gap = hidden thinking trace,
+language-independent — important since the cognitive tiers are Korean and a
+chars/token heuristic does not transfer). Then re-run each tier with
+`think=false` to show the reclaimable budget. Cross-family context comes from
+the existing D1/D3 cap=4096 natural-budget JSONs (no new cross-family runs).
+
+The 7 tiers (D1 ordering): substitution / light-synth / heavy-synth (English
+e-commerce) + query_rewrite / planner / reflect / verify (Korean cognitive,
+prompts pinned from `core/reasoning/*`).
+
+## 3. gemma4:e4b per-tier decomposition
+
+| Tier | visible tok | eval_count (think ON) | hidden | hidden % | eval (think OFF) | reclaim |
+|---|---|---|---|---|---|---|
+| 1. substitution | 61 | 62 | 1 | 2% | 62 | 0% |
+| 2. light_synth | 59 | 433 | 374 | **86%** | 60 | 86% |
+| 3. heavy_synth | 107 | 596 | 489 | **82%** | 100 | 83% |
+| 4. query_rewrite | 38 | 534 | 496 | **93%** | 28 | 95% |
+| 5. planner | 92 | 685 | 593 | **87%** | 95 | 86% |
+| 6. reflect | 580 | 1492 | 912 | 61% | 463 | 69% |
+| 7. verify | 23 | 1164 | 1141 | **98%** | 24 | 98% |
+
+Gradient spans: think-ON `eval_count` **62→1492 (24×)** ← *this is the column the public D1 "27×" measures*; think-OFF (workload-only) 24→463 (19×); visible-output-only 23→580 (25×).
+
+## 4. Cross-family context (existing JSONs, natural median eval_count, cap=4096, T=0.2)
+
+The other six panel models have **no thinking capability** (§16.7), so their
+`eval_count` == visible output.
+
+| tier | gemma2 | qwen2.5 | qwen2.5-coder | llama3.1 | gemma3 | deepseek-v2 |
+|---|---|---|---|---|---|---|
+| substitution | 63 | 59 | 59 | 58 | 62 | 4 |
+| light_synth | 57 | 72 | 95 | 89 | 73 | 89 |
+| planner | 99 | 99 | 99 | 95 | 60 | 375 |
+| reflect | 336 | 191 | 4 | 464 | 643 | 787 |
+| verify | 18 | 86 | 19 | 90 | 24 | 17 |
+
+(query_rewrite and heavy_synth cross-family not in existing JSONs; not load-bearing for the internal question.)
+
+## 5. Findings
+
+**F1 — On `gemma4:e4b`, 5 of 7 tiers are 82–98% thinking trace.** substitution
+(2%) is the think-free baseline; reflect (61%) is mixed; light_synth /
+heavy_synth / query_rewrite / planner / verify are 82–98% thinking. `think=false`
+reclaims 83–98% of those tiers' budget (verify 1164→24, query_rewrite 534→28,
+planner 685→95) with the visible answer unchanged.
+
+**F2 — The D1 budget *magnitude* is, on e4b, substantially a thinking-trace
+gradient, not a workload gradient.** What D1 routes on for verify is a
+1164-token budget whose *visible output is 23 tokens*. The 24× "span ratio"
+looks similar with think ON vs OFF, but that is coincidental (different tiers
+sit at the extremes); the per-tier **magnitudes** collapse 5–48× when reasoning
+is disabled.
+
+**F3 — `reflect` is the exception: real cross-model workload.** reflect has 580
+*visible* tokens on e4b (not just thinking), and the cross-family grid confirms
+other non-thinking models are also verbose on reflect (gemma3 643, deepseek 787,
+llama3.1 464). So the reflect tier carries genuine task-workload signal; the
+others are e4b-reasoning-inflated.
+
+**Net**: the 7-tier gradient is a **mix** — `reflect` (and the substitution
+baseline) are real workload; the remaining five tiers' magnitudes on e4b are
+dominated by the thinking trace.
+
+## 6. Operational implications (A5 / D4 / D5)
+
+1. **A5 (planner/reflect/verify hold cap=4096) is now explained.** They are sized
+   to clear the thinking trace (verify needs 1164, reflect 1492, planner 685),
+   not the visible output (23 / 580 / 92). With `think=false`, verify/planner
+   need ~24/95 tokens — caps could drop 7–48× on those stages.
+2. **D1/D5 budget routing caveat.** The per-call budget signal these consume is,
+   on e4b, mostly reasoning-mode cost. Routing decisions keyed to it are keyed to
+   "is reasoning on" more than "is the task heavy". D4 (task-weight metric) should
+   measure the **think-OFF / visible** budget if it wants a workload signal.
+3. **Reclaim is gated on quality (A3).** `think=false` reclaims 83–98% on five
+   tiers, but whether disabling reasoning *degrades* those stages is unmeasured
+   on hard inputs — that is exactly the deferred A3 think-mode quality-boundary
+   experiment. reflect keeps 463 visible tokens think-OFF (output survives);
+   verify's visible output is tiny either way (23–24) so its 1141 thinking tokens
+   may or may not change the verdict. **Do not flip `think=false` in production
+   until A3 measures per-stage quality impact.**
+
+## 7. Collaboration handling
+
+- The public D1 "27×" figure is **not restated or corrected here**. The
+  measurement stands; the interpretation gains a thinking-trace caveat that is
+  internal-only until the joint piece.
+- This study stays in JAMES's D1 slot. It does not pre-empt or alter the Robin /
+  Ali cross-family narrative. Share/recontextualisation folds into the joint
+  piece at the 6/6+ rendezvous (same discipline as D3 §17.5).
+
+## 8. Artifact
+
+- `scripts/research/v3prime_e4b_7tier_thinking_split.py` — streams e4b on all 7
+  tiers (think ON visible/hidden split + think OFF reclaim), reuses the pinned
+  `core/reasoning/*` prompt constants. cp949-safe.
+
+## 9. Backlog linkage
+
+Advances **A5** (D1 stage expansion — now has the mechanism) and informs **D4**
+(task-weight metric should use think-OFF budget). Gated next step is **A3**
+(think-mode quality boundary). See `docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md`.

--- a/scripts/research/v3prime_e4b_7tier_thinking_split.py
+++ b/scripts/research/v3prime_e4b_7tier_thinking_split.py
@@ -1,0 +1,165 @@
+"""V3'.e — is D1's 7-tier budget gradient workload, or gemma4:e4b thinking?
+
+INTERNAL-UPGRADE experiment (not a joint-piece artifact). D1's headline
+"7-tier monotonic natural-stop gradient" (62 -> 1681 tokens, 27x range) was
+measured on `gemma4:e4b` ONLY. §16 showed that ~85% of e4b's *synthesis*
+token budget is a hidden thinking trace, not output. This probe asks the
+operational question that follows:
+
+    For each of the 7 tiers D1's budget signal routes on, how much of
+    gemma4:e4b's per-tier budget is the thinking trace vs visible output?
+
+Why JAMES cares (internal upgrade, not publication):
+  - D1 `core/reasoning/budget.py` routes per-stage caps off this gradient.
+  - D5 / LEO routing consume the same per-call budget signal.
+  - A5 (planner/reflect/verify hold cap=4096) is sized to clear this budget.
+  If a tier's budget is mostly thinking trace, the budget signal is routing
+  on reasoning-mode cost, not task workload — which changes how A5/D4/D5
+  should size and interpret it. think=false reclaims it where reasoning is
+  not needed.
+
+Method: stream gemma4:e4b on each of the 7 tier prompts (cap=4096, T=0.2),
+count visible `response` tokens vs `eval_count` (the gap = hidden thinking
+trace, language-independent — important since the cognitive tiers are
+Korean and chars/token heuristics do not transfer). Then re-run each tier
+with think=false to show the reclaimable budget.
+
+Collaboration note: this measures JAMES's own default model on JAMES's own
+D1 axis. It does not touch the Robin 26b-scale anchor or the Ali managed-
+Gemini axis, and it does not restate the public 27x figure — it
+*recontextualises it internally* (the number stands; the interpretation
+gains a thinking-trace caveat). Internal-land only; any external framing
+revision folds into the joint piece at the rendezvous.
+
+The 7 tiers (D1 ordering): substitution / light-synthesis / heavy-synthesis
+(English e-commerce) + query_rewrite / planner / reflect / verify (Korean
+cognitive, prompts pinned from core/reasoning/*).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from urllib import request
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parents[2]
+RESEARCH = REPO / "scripts" / "research"
+GEN_URL = "http://127.0.0.1:11434/api/generate"
+CHAT_URL = "http://127.0.0.1:11434/api/chat"
+MODEL = "gemma4:e4b"
+QUERY = "BlackRock 과 Vanguard 의 ETF 전략 차이를 비교해줘"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, RESEARCH / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def build_tiers() -> list[tuple[str, str]]:
+    ems = _load("v3prime_e_mode_split")
+    cx = _load("v3prime_e_mode_split_complex")
+    pl = _load("v3prime_planner")
+    rf = _load("v3prime_reflect")
+    vf = _load("v3prime_verify")
+    qr = _load("v3prime_query_rewriter")
+    return [
+        ("1.substitution", ems.SUBSTITUTION_PROMPT.format(context=ems.CONTEXT_FIXTURE)),
+        ("2.light_synth", ems.SYNTHESIS_PROMPT.format(context=ems.CONTEXT_FIXTURE)),
+        ("3.heavy_synth", cx.SYNTHESIS_PROMPT.format(context=cx.CONTEXT_FIXTURE)),
+        ("4.query_rewrite", qr.REWRITE_PROMPT_KO.format(query=QUERY)),
+        ("5.planner", pl.PLAN_PROMPT_KO.format(query=QUERY)),
+        ("6.reflect", rf.CRITIQUE_PROMPT_KO.format(query=QUERY, draft=rf.FIXTURE_DRAFT_KO)),
+        ("7.verify", vf.FACT_CHECK_PROMPT_KO.format(
+            query=QUERY, answer=vf.FIXTURE_ANSWER_KO, context=vf.FIXTURE_CONTEXT_KO)),
+    ]
+
+
+def stream_visible(prompt: str, cap: int = 4096) -> dict:
+    body = json.dumps({
+        "model": MODEL, "prompt": prompt, "stream": True,
+        "options": {"num_predict": cap, "temperature": 0.2},
+    }).encode("utf-8")
+    req = request.Request(GEN_URL, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    visible = 0
+    final: dict = {}
+    with request.urlopen(req, timeout=300) as resp:
+        for line in resp:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if obj.get("response"):
+                visible += 1
+            if obj.get("done"):
+                final = obj
+    ec = final.get("eval_count") or 0
+    return {"visible": visible, "eval": ec, "hidden": ec - visible,
+            "hidden_pct": (100 * (ec - visible) / ec) if ec else 0.0,
+            "done": final.get("done_reason")}
+
+
+def think_false_eval(prompt: str, cap: int = 4096) -> int:
+    body = json.dumps({
+        "model": MODEL, "prompt": prompt, "stream": False, "think": False,
+        "options": {"num_predict": cap, "temperature": 0.2},
+    }).encode("utf-8")
+    req = request.Request(GEN_URL, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=300) as resp:
+        return json.loads(resp.read().decode()).get("eval_count") or 0
+
+
+def main() -> None:
+    print("# gemma4:e4b 7-tier budget — thinking-trace decomposition (INTERNAL)\n")
+    print("Question: is D1's 7-tier budget gradient workload, or thinking trace?\n")
+    print(f"| Tier | visible tok | eval_count (think ON) | hidden | hidden % | "
+          f"eval (think OFF) | reclaim |")
+    print(f"|---|---|---|---|---|---|---|")
+    rows = []
+    for tier, prompt in build_tiers():
+        on = stream_visible(prompt)
+        off = think_false_eval(prompt)
+        reclaim = on["eval"] - off
+        rows.append((tier, on, off, reclaim))
+        print(f"| {tier} | {on['visible']} | {on['eval']} | {on['hidden']} | "
+              f"{on['hidden_pct']:.0f}% | {off} | -{reclaim} |")
+    print(
+        "\nReading:\n"
+        "- `hidden %` = share of the tier's budget that is the thinking trace "
+        "(consumed by num_predict, stripped from response).\n"
+        "- `eval (think OFF)` = budget when reasoning is disabled — the "
+        "workload-only cost.\n"
+        "- High hidden% tiers: D1's budget signal there is routing on "
+        "reasoning-mode cost, not task workload. think=false reclaims it where "
+        "the stage does not need reasoning (A5/D4/D5 implication).\n"
+    )
+    visible_grad = [r[1]["visible"] for r in rows]
+    off_grad = [r[2] for r in rows]
+    on_grad = [r[1]["eval"] for r in rows]
+    def span(g):
+        g = [x for x in g if x]
+        return f"{min(g)}->{max(g)} ({max(g)/max(min(g),1):.0f}x)" if g else "—"
+    print(f"Gradient span — think ON (eval_count): {span(on_grad)}  "
+          f"<- the public D1 '27x' figure is this column")
+    print(f"Gradient span — think OFF (workload-only): {span(off_grad)}")
+    print(f"Gradient span — visible output only:       {span(visible_grad)}")
+    print(
+        "\nIf the think-OFF / visible spans are much flatter than the think-ON "
+        "span, the 27x gradient is substantially a thinking-trace gradient on "
+        "e4b, not a pure workload gradient. Recontextualise internally; do NOT "
+        "restate the public figure unilaterally."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Applies the D3 §16 mechanism (gemma4:e4b cap-floor = thinking trace) to D1's 7-tier budget gradient. **INTERNAL upgrade study, not a joint-piece artifact** — measures JAMES's own default model on JAMES's own D1 axis; does not touch the Robin 26b / Ali Gemini axes and does not restate the public D1 "27×" figure.

### Finding (stream e4b on 7 tiers: visible vs eval_count + think=false)
- **5 of 7 tiers are 82–98% thinking trace** on e4b (verify 1164→23 visible; query_rewrite 534→28 think-OFF; planner 685→95).
- **reflect is the exception** (61% hidden, 580 visible); cross-family grid confirms other non-thinking models are also verbose on reflect (gemma3 643, deepseek 787) → reflect = real workload, the rest are e4b-reasoning-inflated.
- Net: the gradient is a **mix** — reflect + substitution are real workload; the other five tiers' magnitudes are thinking-dominated.

### Operational (A5/D4/D5)
- Explains why planner/reflect/verify hold cap=4096 (sized for the thinking trace, not output).
- D4 task-weight metric should route on the **think-OFF/visible** budget.
- Reclaim via think=false is **gated on A3** (per-stage quality impact, unmeasured) — do NOT flip in production yet.

### Collaboration
Public 27× **not restated/corrected** here; recontextualised internally only, folds into the joint piece at the rendezvous (D3 §17.5 discipline).

## Verification
`python scripts/research/v3prime_e4b_7tier_thinking_split.py` (reuses pinned core/reasoning/* prompts; cp949-safe). Cross-family context from existing D1/D3 JSONs, no new cross-family runs.

## Out of scope
A3 quality-boundary experiment (the gate for any think=false production change). No `core/` change.

Quality delta: exempt (label: docs) — research driver + internal report, no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)