### PR TITLE
feat(reasoning): A2 — gemma4:e4b per-stage think-mode policy (opt-in)

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -26,6 +26,7 @@ import base64
 import re
 from collections import OrderedDict
 from datetime import datetime
+from typing import Optional
 from config import GEMMA_MODEL, OLLAMA_API_URL
 
 
@@ -169,6 +170,7 @@ class GemmaClient:
         max_tokens: int = 0,
         model: str = None,
         temperature: float = None,
+        think: Optional[bool] = None,
     ) -> str:
         """
         Gemma 모델 호출.
@@ -222,7 +224,17 @@ class GemmaClient:
             if resolved.warning:
                 print(f"[MODEL_RESOLVE] {resolved.warning}")
         self._total_calls += 1
-        cache_key = self._generate_cache_key(prompt)
+        # A2 — think-mode is part of the request shape (§16.2: think=False
+        # produces a different (shorter, no-trace) response than the
+        # default). The cache key must vary with it, otherwise the first
+        # think=ON answer would be returned to a later think=OFF caller
+        # (silent staleness). Model also varies the response, so include
+        # both in the key salt — keeps backward compat when think=None
+        # and actual_model is the historical default.
+        from core.reasoning.think_policy import is_thinking_capable
+        emit_think = think is not None and is_thinking_capable(actual_model)
+        cache_salt = f"|model={actual_model}|think={think if emit_think else 'default'}"
+        cache_key = self._generate_cache_key(prompt + cache_salt)
 
         # 긴 프롬프트 캐시 금지
         if len(prompt) > 2000:
@@ -255,13 +267,20 @@ class GemmaClient:
         t_call   = time.time()
         for _ in range(1):   # 재시도 1회 고정 (이중 timeout 방지)
             try:
-                resp = requests.post(
-                    OLLAMA_API_URL,
-                    json={
-                        "model":  actual_model,
-                        "prompt": prompt,
-                        "stream": False,
-                        "options": {
+                # A2 — emit `think` field only when (caller specified)
+                # AND (model is thinking-capable). Non-thinking models
+                # reject `think:true` with HTTP 400 (§16.7); we omit the
+                # field entirely to keep their request body byte-identical
+                # to pre-A2. think=False on gemma4:e4b collapses eval_count
+                # from ~400 to ~45 with the same visible answer (§16.2).
+                body: dict = {
+                    "model":  actual_model,
+                    "prompt": prompt,
+                    "stream": False,
+                }
+                if emit_think:
+                    body["think"] = bool(think)
+                body["options"] = {
                             # [#A8-5 2026-05-09] num_predict 기본값 2000 → 8192.
                             # 사용자 보고: "대화 글자수가 중간에 짤리지 않고
                             # 최대한 다 나올수 있도록". 이전 2000 토큰 ≈ 한국어
@@ -282,8 +301,10 @@ class GemmaClient:
                                 else __import__("config").LLM_TEMPERATURE
                             ),
                             "num_ctx":     8192,   # [#A8-5] 4096 → 8192 (긴 답변 토큰까지 수용)
-                        },
-                    },
+                        }
+                resp = requests.post(
+                    OLLAMA_API_URL,
+                    json=body,
                     timeout=timeout,
                 )
                 resp.raise_for_status()

--- a/core/reasoning/backends/ollama_local.py
+++ b/core/reasoning/backends/ollama_local.py
@@ -51,6 +51,7 @@ class OllamaLocalBackend:
         model: Optional[str] = None,
         use_cache: bool = True,
         temperature: Optional[float] = None,
+        think: Optional[bool] = None,
         **opts,
     ) -> CompletionResult:
         # RouterWrapper.call_gemma already absorbs system_prompt via the
@@ -93,6 +94,7 @@ class OllamaLocalBackend:
                         max_tokens=max_tokens,
                         model=model or None,
                         temperature=temperature,
+                        think=think,
                     )
                 except Exception:
                     meta = None
@@ -107,6 +109,7 @@ class OllamaLocalBackend:
                     max_tokens=max_tokens,
                     model=model or None,
                     temperature=temperature,
+                    think=think,
                 )
         except Exception as e:
             return CompletionResult(

--- a/core/reasoning/engine_synth.py
+++ b/core/reasoning/engine_synth.py
@@ -151,6 +151,7 @@ def generate_rag_answer(
         # backend rather than calling RouterWrapper directly. Default
         # backend (ollama_local) is byte-identical to the v0.3.0 path;
         # JAMES_BACKEND_SYNTH retargets without touching this code.
+        from core.reasoning.think_policy import think_for_stage
         answer = trace_synth_call(
             prompt,
             applied_rule="reasoning.synth.rag",
@@ -158,6 +159,7 @@ def generate_rag_answer(
             use_cache=True,
             max_tokens=style.max_tokens,
             model=selected_model or None,
+            think=think_for_stage("synth"),
         )
         if not answer or any(answer.startswith(p) for p in LLM_ERROR_PREFIXES):
             return "답변 생성에 실패했습니다."

--- a/core/reasoning/planner.py
+++ b/core/reasoning/planner.py
@@ -302,12 +302,14 @@ class Planner:
         # operators who haven't opted into D1.
         t0 = time.time()
         try:
+            from core.reasoning.think_policy import think_for_stage
             result = complete_with_retry(
                 backend,
                 prompt,
                 cap=cap,
                 timeout=self._timeout,
                 stage="planner",
+                think=think_for_stage("planner"),
             )
         except Exception as e:
             err = f"{type(e).__name__}: {str(e)[:200]}"

--- a/core/reasoning/reflect.py
+++ b/core/reasoning/reflect.py
@@ -436,12 +436,14 @@ class ReflectionLoop:
         # emits via `reason:retry` (D6 PR #487).
         t0 = time.time()
         try:
+            from core.reasoning.think_policy import think_for_stage
             result = complete_with_retry(
                 backend,
                 prompt,
                 cap=max_tokens,
                 timeout=timeout,
                 stage="reflect",
+                think=think_for_stage("reflect"),
             )
         except Exception as e:
             latency_ms = int((time.time() - t0) * 1000)

--- a/core/reasoning/think_policy.py
+++ b/core/reasoning/think_policy.py
@@ -1,0 +1,99 @@
+"""Per-stage `think` policy for gemma4:e4b (A2, feeds from A3).
+
+§16.5 of `reports/research-runs/v3prime-cross-family-final-2026-05-29.md`
+identified that gemma4:e4b silently spends ~85% of `num_predict` on a
+hidden default-on "Thinking Process:" reasoning trace; A3 then measured
+the *quality* impact of `think=false` on hard fixtures per cognitive
+stage (`reports/research-runs/v3prime-a3-think-quality-boundary-*.md`).
+
+A3 verdict (n=5/cell, deterministic graders, hard fixtures):
+- planner        — think=OFF safe (Δquality=+0.04, reclaim ~770 tok)
+- reflect        — think=OFF safe (Δquality=0,    reclaim ~690 tok)
+- verify         — think=OFF safe (Δquality=0,    reclaim ~900 tok)
+- synthesis      — think=OFF wins (Δquality=-0.60 with thinking,
+                                   conflict-detection 100% vs 40%)
+- query_rewriter — think=OFF safe (Δquality=0,    reclaim ~580 tok)
+
+This module centralises the per-stage policy so a future revisit (LLM-
+judge v2, new stages, new thinking-capable models) edits one file. The
+policy is *opt-in*: the env flag `JAMES_GEMMA4_E4B_THINK_OFF=1` activates
+it. Default is OFF for backward compatibility — operators verify on
+their own data before flipping.
+
+Model gating: the policy only applies to thinking-capable checkpoints
+(currently the `gemma4:e4b` family — the only Ollama panel model that
+declares the `thinking` capability in §16.2). For non-thinking models the
+call site emits no `think` field, so the request body stays byte-
+identical to pre-A2 behaviour even with the flag ON.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# A3-verified safe stages (think=OFF either matches or beats think=ON
+# on hard fixtures, with budget reclaim). Keep the names in sync with
+# the `stage=` strings passed to `complete_with_retry` / `trace_synth_call`.
+_SAFE_STAGES: frozenset[str] = frozenset({
+    "planner",
+    "reflect",
+    "verify",
+    "synth",             # engine_synth.generate_rag_answer → trace_synth_call
+    "query_rewriter",    # core/retrieval/query_rewriter.py (stage tag)
+})
+
+# Thinking-capable model checkpoints. §16.2: only gemma4:e4b in the
+# v3prime cross-family panel declares the `thinking` capability via
+# `ollama show`. Non-thinking checkpoints would reject the field (or
+# ignore it); the call site uses this list to decide whether to emit
+# the field at all. New checkpoints are added explicitly — false
+# positives here cause silent HTTP 400s on non-thinking backends.
+_THINKING_CAPABLE_PREFIXES: tuple[str, ...] = (
+    "gemma4:e4b",
+)
+
+_ENV_FLAG = "JAMES_GEMMA4_E4B_THINK_OFF"
+
+
+def _flag_active() -> bool:
+    """Operator gate. Default OFF for backward compatibility."""
+    val = os.environ.get(_ENV_FLAG, "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def is_thinking_capable(model: str) -> bool:
+    """Whether ``model`` is a checkpoint that emits a hidden thinking
+    trace by default (§16.2). Used by `core/gemma_client.py` to decide
+    whether to emit the `think` field in the Ollama request body — a
+    non-thinking model would reject (HTTP 400) or ignore it.
+    """
+    if not model:
+        return False
+    return any(model.startswith(p) for p in _THINKING_CAPABLE_PREFIXES)
+
+
+def think_for_stage(stage: str) -> Optional[bool]:
+    """A3-derived per-stage think policy. Returns:
+
+    - ``False`` when the flag is ON and the stage is on the A3 safe-list
+      → caller should request the thinking trace off.
+    - ``None`` otherwise (flag OFF, or unknown stage) → caller does not
+      override; backend uses its default (think=on for gemma4:e4b).
+
+    The model gating (is_thinking_capable) is applied downstream in
+    `GemmaClient.call_gemma` so this function can be called without
+    knowing the target model — keeps the per-stage call sites uncluttered.
+    """
+    if not _flag_active():
+        return None
+    if stage in _SAFE_STAGES:
+        return False
+    return None
+
+
+__all__ = [
+    "_SAFE_STAGES",                # exposed for tests / audits
+    "_THINKING_CAPABLE_PREFIXES",  # exposed for tests / audits
+    "is_thinking_capable",
+    "think_for_stage",
+]

--- a/core/reasoning/verify.py
+++ b/core/reasoning/verify.py
@@ -388,12 +388,14 @@ class Verifier:
         # cap up to CAP_HEAVY. Flag-off no-op (cap already at 4096).
         t0 = time.time()
         try:
+            from core.reasoning.think_policy import think_for_stage
             result = complete_with_retry(
                 backend,
                 prompt,
                 cap=cap,
                 timeout=self._fact_check_timeout,
                 stage="verify",
+                think=think_for_stage("verify"),
             )
         except Exception as e:
             latency_ms = int((time.time() - t0) * 1000)

--- a/core/retrieval/query_rewriter.py
+++ b/core/retrieval/query_rewriter.py
@@ -320,12 +320,14 @@ class QueryRewriter:
         t0 = time.time()
         try:
             from core.reasoning.budget import complete_with_retry
+            from core.reasoning.think_policy import think_for_stage
             result = complete_with_retry(
                 backend,
                 prompt,
                 cap=cap,
                 timeout=self._timeout,
                 stage="query_rewriter",
+                think=think_for_stage("query_rewriter"),
             )
         except Exception:
             return (query, int((time.time() - t0) * 1000), True)

--- a/tests/test_think_policy.py
+++ b/tests/test_think_policy.py
@@ -1,0 +1,89 @@
+"""Tests for `core/reasoning/think_policy.py` (A2 — A3-feed per-stage think policy).
+
+Behaviour pinned:
+- Flag OFF (default) → every stage returns None (no override, byte-identical
+  to pre-A2 request shape).
+- Flag ON → A3 safe-list stages return False; unknown stages return None.
+- Model gate (`is_thinking_capable`) recognises gemma4:e4b only; other
+  panel models in §16.2 (qwen2.5:7b / gemma3:12b / llama3.1:8b / gemma2:2b
+  / deepseek-v2:16b) return False so the call site suppresses the `think`
+  field on their request body (avoiding the HTTP 400 in §16.7).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import unittest
+
+
+class ThinkPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Always start from a known-clean env per test.
+        self._prev = os.environ.pop("JAMES_GEMMA4_E4B_THINK_OFF", None)
+        import core.reasoning.think_policy as tp
+        self.tp = importlib.reload(tp)
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop("JAMES_GEMMA4_E4B_THINK_OFF", None)
+        else:
+            os.environ["JAMES_GEMMA4_E4B_THINK_OFF"] = self._prev
+        importlib.reload(self.tp)
+
+    # ─── Flag gating ────────────────────────────────────────────
+
+    def test_flag_off_default_returns_none_for_all_stages(self) -> None:
+        for stage in ("planner", "reflect", "verify", "synth",
+                      "query_rewriter", "unknown_stage"):
+            with self.subTest(stage=stage):
+                self.assertIsNone(self.tp.think_for_stage(stage))
+
+    def test_flag_on_returns_false_for_safe_list_stages(self) -> None:
+        os.environ["JAMES_GEMMA4_E4B_THINK_OFF"] = "1"
+        tp = importlib.reload(self.tp)
+        for stage in ("planner", "reflect", "verify", "synth",
+                      "query_rewriter"):
+            with self.subTest(stage=stage):
+                self.assertIs(tp.think_for_stage(stage), False)
+
+    def test_flag_on_returns_none_for_unknown_stage(self) -> None:
+        os.environ["JAMES_GEMMA4_E4B_THINK_OFF"] = "1"
+        tp = importlib.reload(self.tp)
+        self.assertIsNone(tp.think_for_stage("unknown"))
+        self.assertIsNone(tp.think_for_stage(""))
+
+    def test_flag_accepts_truthy_string_variants(self) -> None:
+        for raw in ("1", "true", "TRUE", "yes", "On"):
+            os.environ["JAMES_GEMMA4_E4B_THINK_OFF"] = raw
+            tp = importlib.reload(self.tp)
+            with self.subTest(raw=raw):
+                self.assertIs(tp.think_for_stage("planner"), False)
+
+    def test_flag_rejects_falsy_string_variants(self) -> None:
+        for raw in ("0", "false", "no", "off", "", "anything-else"):
+            os.environ["JAMES_GEMMA4_E4B_THINK_OFF"] = raw
+            tp = importlib.reload(self.tp)
+            with self.subTest(raw=raw):
+                self.assertIsNone(tp.think_for_stage("planner"))
+
+    # ─── Model gating ───────────────────────────────────────────
+
+    def test_thinking_capable_recognises_gemma4_e4b(self) -> None:
+        self.assertTrue(self.tp.is_thinking_capable("gemma4:e4b"))
+        # Family is matched by prefix, so future e4b variants land.
+        self.assertTrue(self.tp.is_thinking_capable("gemma4:e4b-q4"))
+
+    def test_thinking_capable_rejects_non_thinking_panel_models(self) -> None:
+        # §16.2 panel — only gemma4:e4b declares the thinking capability.
+        for tag in ("gemma3:12b", "gemma2:2b", "qwen2.5:7b",
+                    "qwen2.5-coder:7b", "llama3.1:8b", "deepseek-v2:16b"):
+            with self.subTest(tag=tag):
+                self.assertFalse(self.tp.is_thinking_capable(tag))
+
+    def test_thinking_capable_handles_empty_model(self) -> None:
+        self.assertFalse(self.tp.is_thinking_capable(""))
+        self.assertFalse(self.tp.is_thinking_capable(None))  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Operationalises A3 (#608): all 5 cognitive stages run as well or better with `think=False` on gemma4:e4b, recovering ~85% of `num_predict` budget and clearing the §16.5 empty-output trap.
- New `core/reasoning/think_policy.py` — A3-feed safe-list × env flag (`JAMES_GEMMA4_E4B_THINK_OFF`) × thinking-capable model whitelist.
- `think: Optional[bool]` kwarg threaded through `GemmaClient.call_gemma` → `OllamaLocalBackend.complete` → 5 stage call sites.
- **Default OFF** — opt-in flag, byte-identical to pre-A2 when unset.

## Quality Delta Card

Baseline: A3 measurement at #608 (gemma4:e4b cap=4096 n=5/cell, deterministic graders, 5 cognitive stages × hard fixtures).
Reasoning track: per-stage think on/off paired comparison; all 5 stages OFF safe or wins (#608 §Headline).

|             | Path Recall | Graded Answer | Abstention F1 |
|-------------|-------------|---------------|---------------|
| Δ vs base   | n/a         | n/a           | n/a           |

**Quality delta: exempt (label: `code`)** — this PR's own measurement oracle is #608's deterministic-grader 5×2 hard-fixture matrix; the α-3 step7 oracle does not exercise the per-stage think toggle. A3 hard-fixture report at `reports/research-runs/v3prime-a3-think-quality-boundary-20260530T103648.md` is the load-bearing quality evidence.

## Bench numbers (E2E on gemma4:e4b)

| | think=None (default) | think=False (flag ON) |
|---|---|---|
| cap=400 chars | 13 (empty fallback) | 195 |
| cap=400 latency | 14.3s (full cap on thinking) | **0.6s** |

think=False on gemma4:e4b at cap=400 collapses `eval_count` from ~400 to ~45 with identical visible answer + clears §16.5 empty-output trap.

Cross-model safety: gemma3:12b `think=False` call succeeds (5.2s, 197 chars) — field correctly suppressed, no HTTP 400.

## Test plan

- [x] `tests/test_think_policy.py` — 8 unit tests + 28 subtests (flag gating, safe-list, model whitelist, env-string variants)
- [x] Regression: `pytest -k "planner or reflect or verify or query_rewriter or gemma_client"` → 232 passed, 21 subtests passed
- [x] E2E smoke (gemma4:e4b cap=400): default → empty/14.3s; think=False → 195 chars/0.6s
- [x] Cross-model safety: gemma3:12b think=False → no HTTP 400, normal response

## Out of scope

- **Default flip** — separate follow-up PR gated on: (a) LLM-judge v2 agreement with A3 verdicts; (b) ~1 week user dogfood production observation; (c) Quality Delta Card on real-query baseline.
- Stages outside the A3-safe list (no caller in JAMES today; future cognitive stages must measure before joining).
- Other thinking-capable models — add to `_THINKING_CAPABLE_PREFIXES` explicitly after per-model A3-style measurement; false positives risk silent HTTP 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)