### PR TITLE
feat(research): A3 v2 — LLM-judge confirmation reframes A2 default-flip

### DIFF
--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -144,6 +144,46 @@ Next thread for the same solo window:
    on real-query baseline).
 3. **A1 (α-5 ablation)** — independent of the above; can start in parallel.
 
+### 7.2 Update 2026-05-30 PM-2 — A3 v2 LLM-judge result reframes A2 default-flip
+
+LLM-judge v2 landed (PR follow-up to #608/#609). Result on 3 surprising A3 cells:
+
+| Cell | A3 (det. grader) | judge | agreement |
+|---|---|---|---|
+| verify EASY | OFF wins (0.6/1.0) | tie (4 tie / 1 biased) | WEAKER |
+| synthesis HARD | OFF wins (0.4/1.0) | tie (5/5 position_biased) | WEAKER |
+| planner HARD | tie | tie | AGREE |
+
+Two findings reframe the A2 default-flip plan:
+
+- **synthesis HARD was 5/5 position-biased**: gemma3:12b judge picked
+  whichever answer was presented as A regardless of think mode. The
+  A3 deterministic grader's "conflict_flag 1.0 vs 0.4" likely reflects
+  keyword-matching variance, not a real quality gap between the two
+  answers. A3's strongest "OFF wins" signal does not survive a
+  paired-judge replay.
+- **No cell produced an "ON wins" judge verdict** — judge never said
+  thinking helps. The opt-in A2 plumbing remains safe to ship.
+
+**Decision** — A2 default-flip is **not** scheduled. The new gate for
+any future flip is a **real-query Quality Delta Card** (production
+query distribution, not synthetic fixtures) against the α-3 step7
+oracle, with the flag ON for ≥ 1 week of user dogfood. Synthetic
+fixtures + deterministic grader + local LLM-judge are not strong
+enough oracles to justify a global behavior change on their own.
+
+**Methodological lesson** (added to memory): a fixture that lets the
+deterministic grader read a clear signal does not guarantee that signal
+is the actual quality dimension — keyword/JSON-shape matchers can pick
+up artifacts that don't translate to "which answer is better." When
+the grader-positive direction also fails LLM-judge confirmation, the
+honest read is "no measurable difference," not "the grader was right
+and the judge missed it." This applies generally to future
+A3-style think-mode / cap / temperature studies.
+
+A1 (α-5) is unaffected — it measures layer × model on QVT 3-axis,
+which is a separate axis from think-mode.
+
 A5 (D1 stage expansion) is partially unblocked: the cap=4096 hold is now
 mechanistically explained (#606), but the per-stage cap policy update
 should wait for the A2 default-flip so D4 (task-weight) measures on the

--- a/reports/research-runs/v3prime-a3-v2-llm-judge-20260530T112325.json
+++ b/reports/research-runs/v3prime-a3-v2-llm-judge-20260530T112325.json
@@ -1,0 +1,533 @@
+{
+  "metadata": {
+    "started_utc": "2026-05-30T11:19:11.575696+00:00",
+    "driver": "v3prime_a3_v2_llm_judge.py",
+    "generator_model": "gemma4:e4b",
+    "judge_model": "gemma3:12b",
+    "cap": 4096,
+    "temperature": 0.2,
+    "n": 5,
+    "cells_selected": [
+      [
+        "verify",
+        "easy"
+      ],
+      [
+        "synthesis",
+        "hard"
+      ],
+      [
+        "planner",
+        "hard"
+      ]
+    ],
+    "closes": "A3 LLM-judge reservation gate (PR #608 §reservation)",
+    "finished_utc": "2026-05-30T11:23:25.565323+00:00"
+  },
+  "cells": [
+    {
+      "stage": "verify",
+      "fixture": "easy",
+      "a3_verdict": "OFF wins (judgment_correct 0.6 ON vs 1.0 OFF)",
+      "pairs": [
+        {
+          "idx": 1,
+          "on": {
+            "elapsed_s": 14.35,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 1009,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 0.51,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 24,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 2,
+          "on": {
+            "elapsed_s": 9.58,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 958,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 0.51,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 24,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 3,
+          "on": {
+            "elapsed_s": 11.04,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 1110,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 0.51,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 24,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 4,
+          "on": {
+            "elapsed_s": 10.61,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 1071,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 0.52,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 24,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 5,
+          "on": {
+            "elapsed_s": 12.07,
+            "response": "```json\n{\n  \"grounded\": false,\n  \"unsupported\": [\n    \"BlackRock 운용 보수는 평균 0.10~0.30% 수준이다.\"\n  ]\n}\n```",
+            "eval_count": 1210,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 0.51,
+            "response": "```json\n{\n  \"grounded\": true,\n  \"unsupported\": []\n}\n```",
+            "eval_count": 24,
+            "done_reason": "stop"
+          }
+        }
+      ],
+      "judgements": [
+        {
+          "pair_idx": 1,
+          "pos1": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음."
+          },
+          "pos2": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시하고, unsupported 주장이 없음."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "tie"
+        },
+        {
+          "pair_idx": 2,
+          "pos1": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음."
+          },
+          "pos2": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장은 없음."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "tie"
+        },
+        {
+          "pair_idx": 3,
+          "pos1": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시하고, unsupported 주장이 없음."
+          },
+          "pos2": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료를 정확히 반영하여 grounded: true, unsupported: [] 로 평가할 수 있다."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "tie"
+        },
+        {
+          "pair_idx": 4,
+          "pos1": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장은 없음."
+          },
+          "pos2": {
+            "verdict": "tie",
+            "mode": "tie",
+            "rationale": "두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "tie"
+        },
+        {
+          "pair_idx": 5,
+          "pos1": {
+            "verdict": "B_wins",
+            "mode": "OFF",
+            "rationale": "답변 B는 모든 주장이 내부 자료에 의해 뒷받침됨을 정확히 판단했고, 답변 A는 오류를 범함."
+          },
+          "pos2": {
+            "verdict": "B_wins",
+            "mode": "ON",
+            "rationale": "답변 B는 BlackRock 운용 보수 주장의 unsupported를 정확히 지적, 답변 A는 모든 주장을 grounded로 잘못 판단."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        }
+      ],
+      "tally": {
+        "agreed": 4,
+        "ON_wins": 0,
+        "OFF_wins": 0,
+        "tie": 4,
+        "position_biased": 1,
+        "judge_parse_fail": 0
+      },
+      "judge_direction": "tie"
+    },
+    {
+      "stage": "synthesis",
+      "fixture": "hard",
+      "a3_verdict": "OFF wins (conflict_flag 0.4 ON vs 1.0 OFF)",
+      "pairs": [
+        {
+          "idx": 1,
+          "on": {
+            "elapsed_s": 15.13,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\n| Feature | VOO (Vanguard) | IVV (BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Issuer** | Vanguard | BlackRock | State Street |\n| **Expense Ratio** | 0.03% (Current official rate, per Doc B). **Conflict/Note:** Document B notes that the rate is under review for an increase to 0.05% as of 2026 Q1. | 0.03% | 0.0945% |\n| **AUM** | 1.2T USD (Document A). Also noted as having the #1 AUM (Document C). | 0.5T USD | 0.5T USD |\n\n***\n\n### Summary of Findings and Conflicts\n\n**1. Expense Ratio:**\n*   **VOO:** The current official expense ratio is 0.03% (Doc A, Doc B). However, Document B explicitly flags a potential conflict/change, noting that the rate is under review for an increase to 0.05% as of 2026 Q1.\n*   **IVV & SPY:** No conflicts were found for the expense ratios provided in Document A.\n\n**2. AUM:**\n*   **VOO:** Document A states the AUM is 1.2T USD. Document C corroborates that VOO has the #1 AUM among the listed ETFs.\n*   **IVV & SPY:** Both are listed with an AUM of 0.5T USD in Document A.\n\n**3. Issuer:**\n*   The issuers were identified as Vanguard (VOO), BlackRock (IVV), and State Street (SPY) based on the context provided in the documents.",
+            "eval_count": 1117,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 5.24,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\nBased on the provided documents, here is a comparison of the three S&P 500 ETFs:\n\n| Feature | VOO (Vanguard) | IVV (iShares/BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Expense Ratio** | 0.03% (Document A) / **Conflict:** Document B notes a potential increase to 0.05% in 2026 Q1, but the current official rate is 0.03%. | 0.03% (Document A) | 0.0945% (Document A) |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Issuer** | Vanguard | BlackRock (Document A, Document C) | State Street (Document A) |\n\n---\n\n### Detailed Field Analysis & Conflict Flagging\n\n**1. Expense Ratio:**\n*   **VOO:** Document A states **0.03%**. Document B provides context, noting that while the current official rate is 0.03%, Vanguard is *reviewing* an increase to 0.05% for 2026 Q1. **(Conflict Flagged: Document B suggests a potential future change not reflected in the primary data point of Document A.)**\n*   **IVV:** Document A states **0.03%**. (No conflicting information found.)\n*   **SPY:** Document A states **0.0945%**. (No conflicting information found.)\n\n**2. AUM (Assets Under Management):**\n*   **VOO:** Document A states **1.2T USD**.\n*   **IVV:** Document A states **0.5T USD**.\n*   **SPY:** Document A states **0.5T USD**.\n*   *(Note: Document C mentions VOO has the highest AUM, which aligns with the 1.2T USD figure provided in Document A.)*\n\n**3. Issuer:**\n*   **VOO:** Vanguard (Document A).\n*   **IVV:** BlackRock (Document A and Document C).\n*   **SPY:** State Street (Document A).",
+            "eval_count": 526,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 2,
+          "on": {
+            "elapsed_s": 10.9,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\n| Feature | VOO (Vanguard) | IVV (BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Issuer** | Vanguard | BlackRock | State Street |\n| **AUM** | 1.2T USD (Document A) / AUM #1 (Document C) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Expense Ratio** | **Conflict/Update:** Document A lists 0.03%. Document B states the current official rate is 0.03%, but notes that a review for 0.05% is being considered. | 0.03% (Document A) | 0.0945% (Document A) |\n\n***\n\n### Summary of Findings and Conflicts\n\n**1. Expense Ratio (ER)**\n*   **Conflict Flag:** VOO's expense ratio is noted as having two values. Document A lists the rate as **0.03%**. Document B clarifies that while the current official rate is **0.03%**, the fund is reviewing an increase to **0.05%**.\n\n**2. AUM (Assets Under Management)**\n*   The documents provide specific figures (1.2T USD for VOO; 0.5T USD for IVV and SPY).\n*   Document C adds qualitative context: VOO is noted as having the highest AUM (#1).\n\n**3. Issuer**\n*   The issuer for each ETF is clearly identified in Document A (Vanguard, BlackRock, State Street).\n*   Document C confirms IVV is classified as BlackRock's core index ETF.",
+            "eval_count": 1114,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 5.61,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\nBased on the provided documents, here is a comparison of the three S&P 500 ETFs:\n\n| Feature | VOO (Vanguard) | IVV (iShares/BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Expense Ratio** | 0.03% (Document A); *Potential increase to 0.05% (Document B)* | 0.03% (Document A) | 0.0945% (Document A) |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Issuer** | Vanguard | BlackRock (Document A, Document C) | State Street (Document A) |\n\n---\n\n### Detailed Comparison Points:\n\n**1. Expense Ratio:**\n*   **VOO:** Document A lists it at **0.03%**. Document B notes that while the current official ratio is 0.03%, there is a review for an increase to **0.05%** in Q1 2026.\n*   **IVV:** Document A lists it at **0.03%**.\n*   **SPY:** Document A lists it at **0.0945%**.\n\n**2. AUM (Assets Under Management):**\n*   **VOO:** **1.2T USD** (Document A).\n*   **IVV:** **0.5T USD** (Document A).\n*   **SPY:** **0.5T USD** (Document A).\n\n**3. Issuer:**\n*   **VOO:** Vanguard (Document A).\n*   **IVV:** BlackRock (Document A, Document C).\n*   **SPY:** State Street (Document A).\n\n### Conflict Flagging:\n\n*   **Expense Ratio (VOO):** There is a potential conflict/update noted. Document A states the ratio is **0.03%**, but Document B indicates that the ratio is under review for an increase to **0.05%** in Q1 2026. (The current official rate is cited as 0.03% in Document B).\n*   **AUM:** No direct conflict is found, but Document C notes that VOO has the highest AUM, which aligns with the data in Document A (1.2T USD).",
+            "eval_count": 562,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 3,
+          "on": {
+            "elapsed_s": 11.3,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\n| Feature | VOO (Vanguard) | IVV (BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Issuer** | Vanguard (Implied) | BlackRock (Document C) | State Street (Implied) |\n| **AUM** | 1.2T USD (Document A). Also noted as having the highest AUM (Document C). | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Expense Ratio** | **0.03%** (Document A). **Conflict/Note:** Document B states the current official rate is 0.03%, but notes that a review for 0.05% is pending. | 0.03% (Document A) | 0.0945% (Document A) |\n\n***\n\n### Summary of Conflicts and Notes\n\n**1. VOO Expense Ratio:**\n*   **Conflict/Update:** Document B provides a critical update regarding VOO's expense ratio. While the current official rate is cited as **0.03%** (Document A), Document B notes that the expense ratio is under review for an increase to **0.05%**.\n\n**2. AUM/Ranking:**\n*   Document C notes that VOO has the highest AUM, which aligns with the specific figure provided in Document A (1.2T USD).\n\n**3. Issuer:**\n*   The issuer for IVV is explicitly stated as BlackRock in Document C. The issuers for VOO and SPY are implied by the full names/context but are not explicitly stated in the documents.",
+            "eval_count": 1149,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 5.08,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\nBased on the provided documents, here is a comparison of the three S&P 500 ETFs:\n\n| Feature | VOO (Vanguard) | IVV (iShares/BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Expense Ratio** | 0.03% (Document A) / *Potential increase to 0.05% (Document B)* | 0.03% (Document A) | 0.0945% (Document A) |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Issuer** | Vanguard | BlackRock (Document A, Document C) | State Street (Document A) |\n\n---\n\n### Detailed Field Analysis & Conflict Flagging\n\n**1. Expense Ratio:**\n*   **VOO:** Document A states **0.03%**. Document B notes that while the current official rate is 0.03%, there is a review for an increase to **0.05%** in Q1 2026.\n*   **IVV:** Document A states **0.03%**.\n*   **SPY:** Document A states **0.0945%**.\n*   **Conflict:** No direct numerical conflict exists for the *current* reported rates, but Document B introduces a potential future change for VOO.\n\n**2. AUM (Assets Under Management):**\n*   **VOO:** Document A states **1.2T USD**.\n*   **IVV:** Document A states **0.5T USD**.\n*   **SPY:** Document A states **0.5T USD**.\n*   **Conflict:** No conflicts found. (Note: Document C mentions VOO has the highest AUM, which aligns with the 1.2T figure provided in Document A).\n\n**3. Issuer:**\n*   **VOO:** Vanguard (Document A).\n*   **IVV:** BlackRock (Document A, Document C).\n*   **SPY:** State Street (Document A).\n*   **Conflict:** No conflicts found.",
+            "eval_count": 509,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 4,
+          "on": {
+            "elapsed_s": 10.63,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\n| Feature | VOO (Vanguard) | IVV (BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Issuer** | Vanguard (Implied) | BlackRock (Doc C) | State Street (Implied) |\n| **AUM** | 1.2T USD (Doc A). Also noted as having the highest AUM (Doc C). | 0.5T USD (Doc A) | 0.5T USD (Doc A) |\n| **Expense Ratio** | **Conflict/Update:** Doc A states 0.03%. Doc B states the current official rate is 0.03%, but notes that a review for 0.05% is being considered. | 0.03% (Doc A) | 0.0945% (Doc A) |\n\n***\n\n### Summary of Findings and Conflicts\n\n**Expense Ratio Conflict (VOO):**\n*   Document A lists the expense ratio as **0.03%**.\n*   Document B provides a more recent update, stating the current official rate is **0.03%**, but explicitly notes that the rate is under review for a potential increase to **0.05%**.\n\n**Other Conflicts:**\n*   No numerical conflicts were found for the AUM or the expense ratios of IVV or SPY.",
+            "eval_count": 1085,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 6.05,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\nBased on the provided documents, here is a comparison of the three S&P 500 ETFs:\n\n| Feature | VOO (Vanguard) | IVV (iShares/BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Expense Ratio** | 0.03% (Document A) / **Conflict:** Document B notes a potential increase to 0.05% but confirms the current official rate is 0.03%. | 0.03% (Document A) | 0.0945% (Document A) |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Issuer** | Vanguard | BlackRock (Document A) / BlackRock (Document C) | State Street (Document A) |\n\n---\n\n### Detailed Field Analysis and Conflict Flagging\n\n**1. Expense Ratio:**\n*   **VOO:** Document A states **0.03%**. Document B provides context, stating the *current official* rate is **0.03%**, although a review for an increase to 0.05% is underway. **(No direct conflict on the stated current rate, but a future change is noted.)**\n*   **IVV:** Document A states **0.03%**. (No conflicting information found.)\n*   **SPY:** Document A states **0.0945%**. (No conflicting information found.)\n\n**2. AUM (Assets Under Management):**\n*   **VOO:** Document A states **1.2T USD**.\n*   **IVV:** Document A states **0.5T USD**.\n*   **SPY:** Document A states **0.5T USD**.\n*   **Conflict Check:** Document C mentions VOO has the highest AUM, which aligns with the 1.2T USD figure provided in Document A. No numerical conflicts were found for AUM.\n\n**3. Issuer:**\n*   **VOO:** Vanguard (Document A).\n*   **IVV:** BlackRock (Document A & C).\n*   **SPY:** State Street (Document A).\n\n***\n\n**Summary of Conflicts/Notes:**\n\n*   **Expense Ratio (VOO):** There is no conflict regarding the *current* stated rate (0.03%), but Document B warns that this rate is under review for a potential increase to 0.05%.\n*   **AUM/Ranking:** Document C notes that VOO has the highest AUM, which is consistent with the data provided in Document A.",
+            "eval_count": 608,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 5,
+          "on": {
+            "elapsed_s": 11.25,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\n| Feature | VOO (Vanguard) | IVV (BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Issuer** | Vanguard | BlackRock | State Street |\n| **Expense Ratio** | **0.03%** (Document A) | 0.03% (Document A) | 0.0945% (Document A) |\n| | **Conflict/Update:** Document B notes that while the current official ratio is 0.03%, the fund is reviewing an increase to 0.05% as of 2026 Q1. | | |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| | **Context:** Document C notes that VOO is the ETF with the highest AUM. | | |\n\n***\n\n### Summary of Findings and Conflicts\n\n**1. Expense Ratio:**\n*   **VOO:** The primary conflict/update is noted between Document A and Document B. Document A lists the ratio as 0.03%, but Document B provides a warning that the fund is reviewing an increase to 0.05% as of 2026 Q1.\n*   **IVV & SPY:** No conflicts were found for the expense ratios.\n\n**2. AUM:**\n*   **VOO:** Document A provides the specific figure (1.2T USD), and Document C corroborates that VOO has the highest AUM among the listed ETFs.\n*   **IVV & SPY:** Both are listed with 0.5T USD in Document A.\n\n**3. Issuer:**\n*   The issuer for each ETF is clearly identified in Document A (Vanguard, BlackRock, State Street).",
+            "eval_count": 1138,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 5.68,
+            "response": "## S&P 500 ETF Comparison (VOO, IVV, SPY)\n\nBased on the provided documents, here is a comparison of the three S&P 500 ETFs:\n\n| Feature | VOO (Vanguard) | IVV (iShares/BlackRock) | SPY (State Street) |\n| :--- | :--- | :--- | :--- |\n| **Expense Ratio** | 0.03% (Document A) / 0.05% (Potential, Document B) | 0.03% (Document A) | 0.0945% (Document A) |\n| **AUM** | 1.2T USD (Document A) | 0.5T USD (Document A) | 0.5T USD (Document A) |\n| **Issuer** | Vanguard | BlackRock (Document A, Document C) | State Street (Document A) |\n\n---\n\n### Detailed Comparison Points:\n\n**1. Expense Ratio:**\n*   **VOO:** Document A states the expense ratio is **0.03%**. Document B notes that while the current official rate is 0.03%, it is under review for an increase to 0.05% in Q1 2026.\n*   **IVV:** Document A states the expense ratio is **0.03%**.\n*   **SPY:** Document A states the expense ratio is **0.0945%**.\n\n**2. AUM (Assets Under Management):**\n*   **VOO:** Document A states the AUM is **1.2T USD**.\n*   **IVV:** Document A states the AUM is **0.5T USD**.\n*   **SPY:** Document A states the AUM is **0.5T USD**.\n\n**3. Issuer:**\n*   **VOO:** Vanguard\n*   **IVV:** BlackRock (Document C confirms BlackRock association)\n*   **SPY:** State Street\n\n### Conflict Flagging:\n\n*   **Expense Ratio (VOO):** There is a potential conflict/update noted. Document A lists the expense ratio as **0.03%**, but Document B indicates that Vanguard is *reviewing* an increase to **0.05%** for Q1 2026. The current official rate cited is 0.03%.\n*   **AUM (IVV & SPY):** No conflict found. Both documents agree that the AUM for IVV and SPY is **0.5T USD** (based on Document A).",
+            "eval_count": 567,
+            "done_reason": "stop"
+          }
+        }
+      ],
+      "judgements": [
+        {
+          "pair_idx": 1,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A는 충돌을 더 명확하게 설명하고, 요약 섹션에서 충돌을 강조한다."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A는 표와 상세 분석을 통해 충돌을 더 명확하게 제시하고, 정보의 출처를 명시함."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 2,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A는 표와 요약으로 정보를 더 체계적으로 정리하여 가독성이 더 좋습니다."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A는 표와 상세 설명을 모두 제공하여 비교가 더 명료하고 포괄적입니다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 3,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A는 충돌을 더 명확하게 강조하고, 요약 섹션을 통해 가독성을 높임."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A는 표와 상세 분석을 통해 정보를 더 체계적으로 제시하고, 충돌을 명확히 설명합니다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 4,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A는 충돌을 더 명확하게 표시하고, 요약 섹션으로 정리하여 가독성이 더 좋습니다."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A는 더 자세한 분석과 표를 제공하여 비교를 더 명료하게 제시합니다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 5,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A는 표와 요약으로 정보를 더 체계적으로 정리하여 가독성이 더 좋습니다."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A는 표와 상세 설명으로 정보를 더 체계적으로 정리했고, 충돌 사항을 명확하게 표시함."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        }
+      ],
+      "tally": {
+        "agreed": 0,
+        "ON_wins": 0,
+        "OFF_wins": 0,
+        "tie": 0,
+        "position_biased": 5,
+        "judge_parse_fail": 0
+      },
+      "judge_direction": "tie"
+    },
+    {
+      "stage": "planner",
+      "fixture": "hard",
+      "a3_verdict": "tie (Δ=+0.04, sanity check)",
+      "pairs": [
+        {
+          "idx": 1,
+          "on": {
+            "elapsed_s": 13.41,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 고(高)인플레이션(5% 이상) 및 저(低)인플레이션(2% 수준) 시나리오별 자산군별 경제적 영향 분석\",\n    \"각 시나리오별로 가장 유리한 자산군(Asset Class) 결정\",\n    \"고인플레이션 시나리오에 유리한 자산군 내에서 expense ratio가 가장 낮은 ETF 3개 선정\",\n    \"저인플레이션 시나리오에 유리한 자산군 내에서 expense ratio가 가장 낮은 ETF 3개 선정\",\n    \"선정된 자산군 및 ETF를 비교 분석한 최종 보고서 작성\"\n  ],\n  \"rationale\": \"경제 시나리오 분석 -> 자산군 결정 -> 각 시나리오별 ETF 선정 -> 최종 보고서 작성의 논리적 순서를 따름\"\n}\n```",
+            "eval_count": 933,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 2.06,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 미국 인플레이션 5% 이상 유지 시나리오와 2% 안정 시나리오별 거시 경제 분석 및 예상 자산군 결정\",\n    \"각 시나리오별로 유리한 자산군을 확정하고, 해당 자산군 내에서 대표 ETF 목록 조사\",\n    \"조사된 ETF 목록 중 expense ratio가 가장 낮은 ETF 3개씩 선정\",\n    \"선정된 ETF 6개(각 시나리오별 3개)의 상세 정보(운용보수, 추적지수 등) 비교 분석 및 보고서 작성\"\n  ],\n  \"rationale\": \"질문의 핵심 요구사항(시나리오별 자산군 결정 -> ETF 선정 -> 비교 보고서 작성)을 논리적 순서로 분해했습니다.\"\n}\n```",
+            "eval_count": 193,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 2,
+          "on": {
+            "elapsed_s": 8.96,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 고인플레이션(5% 이상) 및 저인플레이션(2% 수준) 시나리오별 유리 자산군을 결정\",\n    \"각 시나리오별 유리 자산군 내에서 expense ratio가 가장 낮은 ETF 3개를 선정 및 비교\",\n    \"선정된 자산군과 ETF를 바탕으로 비교 보고서 작성\"\n  ],\n  \"rationale\": \"경제 시나리오 분석 -> 자산군 및 ETF 선정 -> 최종 보고서 작성의 순서로 진행되어야 질문의 모든 요소를 충족할 수 있다.\"\n}\n```",
+            "eval_count": 911,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 1.87,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 미국 인플레이션 5% 이상 유지 시나리오와 2% 안정 시나리오의 경제적 특징 분석\",\n    \"각 시나리오별로 유리한 자산군(Asset Class) 결정\",\n    \"결정된 각 자산군별로 운용보수(Expense Ratio)가 가장 낮은 ETF 3개 조사\",\n    \"조사된 ETF 6개(각 시나리오별 3개)를 비교 분석하는 보고서 초안 작성\"\n  ],\n  \"rationale\": \"질문의 핵심 요구사항(시나리오 분석 -> 자산군 결정 -> ETF 선정 및 비교 보고서 작성)을 순차적으로 충족하도록 분해함.\"\n}\n```",
+            "eval_count": 174,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 3,
+          "on": {
+            "elapsed_s": 8.15,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 고인플레이션(5% 이상) 및 저인플레이션(2% 수준) 시나리오별 경제 환경 분석\",\n    \"각 시나리오에 유리한 자산군을 결정하고 그 근거를 제시\",\n    \"결정된 자산군 내에서 expense ratio가 가장 낮은 ETF 3개씩 선정\",\n    \"두 시나리오별 ETF 비교 보고서를 작성하여 최종 결론 도출\"\n  ],\n  \"rationale\": \"경제 시나리오 분석 → 자산군 결정 → 구체적인 상품(ETF) 선정 → 최종 보고서 작성의 논리적 흐름을 따름\"\n}\n```",
+            "eval_count": 828,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 2.13,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 미국 인플레이션 5% 이상 유지 시나리오와 2% 안정화 시나리오별 거시경제 분석 및 예상 자산군 결정\",\n    \"각 시나리오별로 유리한 자산군을 확정하고, 해당 자산군 내에서 ETF 검색 및 필터링\",\n    \"선정된 자산군별로 Expense Ratio가 가장 낮은 ETF 3개씩 추출\",\n    \"추출된 ETF 6개(각 시나리오별 3개)의 주요 특징, 성과, 비용 구조를 비교 분석하여 보고서 초안 작성\"\n  ],\n  \"rationale\": \"질문의 핵심 요구사항(시나리오별 자산군 결정 -> ETF 선정 -> 비교 보고서 작성)을 논리적 순서에 따라 4단계로 분해했습니다.\"\n}\n```",
+            "eval_count": 200,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 4,
+          "on": {
+            "elapsed_s": 8.91,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 고인플레이션(5% 이상) 시나리오에서 유리한 자산군을 결정하라.\",\n    \"2026년 저인플레이션(2% 수준) 시나리오에서 유리한 자산군을 결정하라.\",\n    \"각 시나리오별로 결정된 자산군 내에서 expense ratio가 가장 낮은 ETF 3개를 조사하고 비교하라.\",\n    \"조사된 자산군 및 ETF 정보를 바탕으로 비교 보고서를 작성하라.\"\n  ],\n  \"rationale\": \"경제 시나리오 분석 → 자산군 결정 → 구체적인 상품(ETF) 선정 및 비교 → 최종 보고서 작성의 순서로 진행된다.\"\n}\n```",
+            "eval_count": 910,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 2.06,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 미국 인플레이션 5% 이상 유지 시나리오와 2% 안정화 시나리오별 거시 경제 분석 및 예상 자산군 결정\",\n    \"각 시나리오별로 유리한 자산군을 확정하고, 해당 자산군 내에서 ETF 검색 및 필터링\",\n    \"선정된 자산군별로 expense ratio가 가장 낮은 ETF 3개씩 추출\",\n    \"추출된 ETF 6개(각 시나리오별 3개)의 주요 특징, 성과, 그리고 비교 분석 보고서 작성\"\n  ],\n  \"rationale\": \"질문의 복잡성을 고려하여, 시나리오 분석 -> 자산군 결정 -> ETF 선정 -> 최종 보고서 작성의 순서로 논리적 흐름을 구성했습니다.\"\n}\n```",
+            "eval_count": 194,
+            "done_reason": "stop"
+          }
+        },
+        {
+          "idx": 5,
+          "on": {
+            "elapsed_s": 8.88,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 고인플레이션(5% 이상) 및 저인플레이션(2% 수준) 시나리오의 경제적 영향을 분석한다.\",\n    \"각 시나리오별로 가장 유리한 자산군을 결정한다.\",\n    \"결정된 자산군별로 expense ratio가 가장 낮은 ETF 3개를 조사하여 비교한다.\",\n    \"두 시나리오의 ETF들을 종합적으로 비교하고 최종 보고서를 작성한다.\"\n  ],\n  \"rationale\": \"질문은 시나리오 분석(1) -> 자산군 결정(2) -> 구체 상품(ETF) 선정 및 비교(3) -> 최종 보고서 작성(4)의 순서로 진행되어야 하므로, 이 4단계가 가장 논리적이고 순차적인 하위 작업 분해이다.\"\n}\n```",
+            "eval_count": 902,
+            "done_reason": "stop"
+          },
+          "off": {
+            "elapsed_s": 2.18,
+            "response": "```json\n{\n  \"subtasks\": [\n    \"2026년 미국 인플레이션 5% 이상 유지 시나리오와 2% 안정 시나리오별 거시 경제 분석 및 예상 자산군 결정\",\n    \"각 시나리오별 유리한 자산군을 기반으로, 해당 자산군 내에서 운용보수(expense ratio)가 낮은 ETF 목록 조사\",\n    \"각 시나리오별로 선정된 자산군 내에서 expense ratio가 가장 낮은 ETF 3개 선정 및 데이터 수집\",\n    \"선정된 ETF 3개에 대한 비교 분석 보고서 작성 (성능, 비용 효율성 등 포함)\"\n  ],\n  \"rationale\": \"질문의 복잡한 조건(시나리오 분기, 자산군 결정, ETF 필터링, 비교 보고서 작성)을 순차적으로 처리하기 위해 4단계로 분해함.\"\n}\n```",
+            "eval_count": 204,
+            "done_reason": "stop"
+          }
+        }
+      ],
+      "judgements": [
+        {
+          "pair_idx": 1,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "A는 시나리오별 자산군 분석을 명시하여 질문의 핵심을 더 잘 반영함."
+          },
+          "pos2": {
+            "verdict": "B_wins",
+            "mode": "ON",
+            "rationale": "B는 시나리오별 자산군 분석을 명확히 분리하여 더 세분화된 접근 방식을 취했습니다."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "ON"
+        },
+        {
+          "pair_idx": 2,
+          "pos1": {
+            "verdict": "B_wins",
+            "mode": "OFF",
+            "rationale": "B는 시나리오 분석을 명시하여 A보다 더 포괄적이고, 자산군과 ETF의 의존성도 더 자연스럽다."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "A는 시나리오 분석을 명시하여 더 포괄적이며, B는 너무 간략하다."
+          },
+          "agreement": "agreed",
+          "agreed_mode": "OFF"
+        },
+        {
+          "pair_idx": 3,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "A는 시나리오별 분석을 명시하여 질문의 핵심을 더 잘 반영하고, B보다 더 간결함."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A가 시나리오별 분석을 명시하여 더 포괄적이고, 단계별 의존성도 자연스럽습니다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 4,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "A는 간결하고 명확하며, B는 불필요한 세분화와 전문 용어 사용이 많음."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "A는 시나리오별 자산군 분석을 먼저 수행하여 B보다 더 논리적인 순서를 갖는다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        },
+        {
+          "pair_idx": 5,
+          "pos1": {
+            "verdict": "A_wins",
+            "mode": "ON",
+            "rationale": "답변 A가 더 간결하고 질문의 핵심 단계를 잘 반영함."
+          },
+          "pos2": {
+            "verdict": "A_wins",
+            "mode": "OFF",
+            "rationale": "답변 A가 인플레이션 시나리오를 명시적으로 언급하여 더 포괄적이고, 단계별 흐름이 자연스럽다."
+          },
+          "agreement": "position_biased",
+          "agreed_mode": null
+        }
+      ],
+      "tally": {
+        "agreed": 2,
+        "ON_wins": 1,
+        "OFF_wins": 1,
+        "tie": 0,
+        "position_biased": 3,
+        "judge_parse_fail": 0
+      },
+      "judge_direction": "tie"
+    }
+  ]
+}

--- a/reports/research-runs/v3prime-a3-v2-llm-judge-20260530T112325.md
+++ b/reports/research-runs/v3prime-a3-v2-llm-judge-20260530T112325.md
@@ -1,0 +1,44 @@
+# A3 v2 — LLM-judge confirmation on 3 surprising A3 cells
+
+**Date**: 2026-05-30T11:19:11.575696+00:00
+**Generator**: gemma4:e4b  **Judge**: gemma3:12b  **Cap**: 4096  **Temp**: 0.2  **n pairs/cell**: 5
+**Closes**: A3 (#608) LLM-judge reservation gate; feeds A2 (#609) default-flip follow-up decision.
+
+## Verdicts
+
+| Cell | A3 (det. grader) | judge tally (ON/OFF/tie/biased/fail) | judge direction | agreement w/ A3 |
+|---|---|---|---|---|
+| verify/easy | OFF wins (judgment_correct 0.6 ON vs 1.0 OFF) | 0/0/4/1/0 | **tie** | WEAKER (judge: tie) |
+| synthesis/hard | OFF wins (conflict_flag 0.4 ON vs 1.0 OFF) | 0/0/0/5/0 | **tie** | WEAKER (judge: tie) |
+| planner/hard | tie (Δ=+0.04, sanity check) | 1/1/0/3/0 | **tie** | AGREE |
+
+Tally column order: **ON_wins / OFF_wins / tie / position_biased / judge_parse_fail** (`n_pairs=5` so the first four sum to ≤ n_pairs).
+
+## Reading
+
+- **Agreement methodology**: each pair is judged TWICE with A/B positions swapped. A pair counts as 'agreed' only if both positions yield the same winner (or both say tie); else 'position_biased' and excluded from the tally.
+- **Cell verdict**: aggregate of agreed pairs only. A judge_direction of 'OFF wins' / 'ON wins' / 'tie' is reported by majority among agreed pairs.
+- **A2 default-flip gate**: 3 AGREE → A3 strengthened → next gate is 1-week real-query dogfood + Quality Delta Card. Any DISAGREE → stage walks back from the A2 safe-list (opt-in still ships).
+
+## Per-pair rationales (sampling)
+
+### verify/easy
+- pair 1: pos1=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음.'), pos2=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시하고, unsupported 주장이 없음.') → agreed/tie
+- pair 2: pos1=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음.'), pos2=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장은 없음.') → agreed/tie
+- pair 3: pos1=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시하고, unsupported 주장이 없음.'), pos2=tie ('두 답변 모두 내부 자료를 정확히 반영하여 grounded: true, unsupported: [] 로 평가') → agreed/tie
+- pair 4: pos1=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장은 없음.'), pos2=tie ('두 답변 모두 내부 자료에 의해 뒷받침되는 주장을 정확히 제시했고, unsupported 주장이 없음.') → agreed/tie
+- pair 5: pos1=OFF ('답변 B는 모든 주장이 내부 자료에 의해 뒷받침됨을 정확히 판단했고, 답변 A는 오류를 범함.'), pos2=ON ('답변 B는 BlackRock 운용 보수 주장의 unsupported를 정확히 지적, 답변 A는 모든 주장을 ') → position_biased/None
+
+### synthesis/hard
+- pair 1: pos1=ON ('답변 A는 충돌을 더 명확하게 설명하고, 요약 섹션에서 충돌을 강조한다.'), pos2=OFF ('답변 A는 표와 상세 분석을 통해 충돌을 더 명확하게 제시하고, 정보의 출처를 명시함.') → position_biased/None
+- pair 2: pos1=ON ('답변 A는 표와 요약으로 정보를 더 체계적으로 정리하여 가독성이 더 좋습니다.'), pos2=OFF ('답변 A는 표와 상세 설명을 모두 제공하여 비교가 더 명료하고 포괄적입니다.') → position_biased/None
+- pair 3: pos1=ON ('답변 A는 충돌을 더 명확하게 강조하고, 요약 섹션을 통해 가독성을 높임.'), pos2=OFF ('답변 A는 표와 상세 분석을 통해 정보를 더 체계적으로 제시하고, 충돌을 명확히 설명합니다.') → position_biased/None
+- pair 4: pos1=ON ('답변 A는 충돌을 더 명확하게 표시하고, 요약 섹션으로 정리하여 가독성이 더 좋습니다.'), pos2=OFF ('답변 A는 더 자세한 분석과 표를 제공하여 비교를 더 명료하게 제시합니다.') → position_biased/None
+- pair 5: pos1=ON ('답변 A는 표와 요약으로 정보를 더 체계적으로 정리하여 가독성이 더 좋습니다.'), pos2=OFF ('답변 A는 표와 상세 설명으로 정보를 더 체계적으로 정리했고, 충돌 사항을 명확하게 표시함.') → position_biased/None
+
+### planner/hard
+- pair 1: pos1=ON ('A는 시나리오별 자산군 분석을 명시하여 질문의 핵심을 더 잘 반영함.'), pos2=ON ('B는 시나리오별 자산군 분석을 명확히 분리하여 더 세분화된 접근 방식을 취했습니다.') → agreed/ON
+- pair 2: pos1=OFF ('B는 시나리오 분석을 명시하여 A보다 더 포괄적이고, 자산군과 ETF의 의존성도 더 자연스럽다.'), pos2=OFF ('A는 시나리오 분석을 명시하여 더 포괄적이며, B는 너무 간략하다.') → agreed/OFF
+- pair 3: pos1=ON ('A는 시나리오별 분석을 명시하여 질문의 핵심을 더 잘 반영하고, B보다 더 간결함.'), pos2=OFF ('답변 A가 시나리오별 분석을 명시하여 더 포괄적이고, 단계별 의존성도 자연스럽습니다.') → position_biased/None
+- pair 4: pos1=ON ('A는 간결하고 명확하며, B는 불필요한 세분화와 전문 용어 사용이 많음.'), pos2=OFF ('A는 시나리오별 자산군 분석을 먼저 수행하여 B보다 더 논리적인 순서를 갖는다.') → position_biased/None
+- pair 5: pos1=ON ('답변 A가 더 간결하고 질문의 핵심 단계를 잘 반영함.'), pos2=OFF ('답변 A가 인플레이션 시나리오를 명시적으로 언급하여 더 포괄적이고, 단계별 흐름이 자연스럽다.') → position_biased/None

--- a/scripts/research/v3prime_a3_v2_llm_judge.py
+++ b/scripts/research/v3prime_a3_v2_llm_judge.py
@@ -1,0 +1,447 @@
+"""A3 v2 — LLM-judge confirmation on the 3 surprising A3 cells.
+
+A3 (PR #608) used deterministic graders only. v2 is the reserved-trigger
+LLM-judge upgrade gated to the 3 cells most worth a second opinion:
+
+  - verify EASY    — A3 grader said think=ON judgment_correct=0.6 (3/5
+                     wrong) vs think=OFF=1.0. Biggest "overthinking
+                     hurts" signal — is it real, or did the grader
+                     mis-parse 3 perfectly fine answers?
+  - synthesis HARD — A3 grader said think=ON conflict_flag=0.4 (2/5)
+                     vs think=OFF=1.0 (5/5). Biggest "think=OFF wins"
+                     signal — is the OFF answer actually clearer about
+                     the planted VOO 0.03% vs 0.05% conflict, or did
+                     the keyword grader miss nuanced ON answers?
+  - planner HARD   — A3 grader said Δ=+0.04 (essentially tie). Middle
+                     case: sanity check that judge agrees "tie" rather
+                     than "ON micro-wins" (which would flag the grader
+                     as too coarse).
+
+Method
+------
+1. **Regenerate** the n=5 paired outputs per cell (A3 stored only
+   signals, not raw text). Same fixture, model (gemma4:e4b), cap=4096,
+   temp=0.2, n=5, with full response captured this time.
+2. **Paired judge** on gemma3:12b (local, no external API). For each
+   of the 5 pairs, judge twice with the A/B positions swapped — this
+   controls for position bias (a known LLM-judge failure mode).
+3. **Per-pair verdict**: A_wins / B_wins / tie. A pair is "agreement"
+   only when both positional runs yield the same winner OR both say
+   tie. Disagreement (position-dependent verdict) → mark "position-
+   biased" and exclude from the cell verdict.
+4. **Cell verdict**: aggregate winners across the n=5 agreed pairs.
+   Compare to A3 grader's direction.
+
+Output: JSON dump + markdown report. cp949-safe.
+
+If judge agrees with A3 on all 3 cells → A3 grader strengthened →
+A2 default-flip plan stays on schedule. If judge disagrees on any
+cell → flag it, walk back the default-flip plan for that stage,
+keep the opt-in shipping behaviour.
+
+Cost: ~30 e4b generation calls (~10s each, ~5 min) + 30 judge calls
+(~15s each on gemma3:12b, ~7-8 min) = ~12-13 min total.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib import error, request
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+REPO = Path(__file__).resolve().parents[2]
+RESEARCH = REPO / "scripts" / "research"
+REPORTS = REPO / "reports" / "research-runs"
+GEN_URL = "http://127.0.0.1:11434/api/generate"
+GEN_MODEL = "gemma4:e4b"
+JUDGE_MODEL = "gemma3:12b"
+DEFAULT_TEMP = 0.2
+DEFAULT_CAP = 4096
+DEFAULT_N = 5
+GEN_TIMEOUT = 180.0
+JUDGE_TIMEOUT = 240.0
+
+
+# Reuse the A3 driver's fixture builders so the prompts are byte-identical.
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, RESEARCH / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+a3 = _load("v3prime_a3_think_quality_boundary")
+EASY = a3.build_easy_prompts()
+HARD = a3.build_hard_prompts()
+
+
+# ────────────────────────────────────────────────────────────────────
+# Cell selection — the 3 surprising A3 cells worth a judge.
+# ────────────────────────────────────────────────────────────────────
+
+
+CELLS: list[dict] = [
+    {
+        "stage": "verify",
+        "fixture": "easy",
+        "prompt": EASY["verify"],
+        "a3_verdict": "OFF wins (judgment_correct 0.6 ON vs 1.0 OFF)",
+        # Judge criterion phrased for verify: which answer's grounded/
+        # unsupported judgment is more accurate against the provided context?
+        "criterion_ko": (
+            "각 답변은 [질문]/[답변]/[내부 자료] 묶음에 대한 검증 결과 (grounded 여부 "
+            "+ unsupported 주장 리스트) 를 JSON 으로 반환한다. 더 정확한 판단을 "
+            "한 쪽을 고르라: (a) grounded 값이 자료 지지/모순 상태와 일치하는가, "
+            "(b) unsupported 리스트가 실제 자료에 없는/모순되는 주장만 정확히 "
+            "잡았는가. 두 판단이 동등하게 정확하면 'tie'."
+        ),
+    },
+    {
+        "stage": "synthesis",
+        "fixture": "hard",
+        "prompt": HARD["synthesis"],
+        "a3_verdict": "OFF wins (conflict_flag 0.4 ON vs 1.0 OFF)",
+        "criterion_ko": (
+            "각 답변은 VOO / IVV / SPY 세 ETF 의 (expense ratio, AUM, issuer) "
+            "비교를 작성한다. 문서 안에 VOO 의 expense ratio 가 0.03% vs 0.05% "
+            "두 값으로 충돌한다 — 좋은 답변은 이 충돌을 명시적으로 지적해야 "
+            "한다. 더 나은 답변을 고르라: (a) 세 ETF 모두 다루는가, (b) "
+            "fee 충돌을 명시했는가, (c) 비교가 명료한가. 동등하면 'tie'."
+        ),
+    },
+    {
+        "stage": "planner",
+        "fixture": "hard",
+        "prompt": HARD["planner"],
+        "a3_verdict": "tie (Δ=+0.04, sanity check)",
+        "criterion_ko": (
+            "각 답변은 다단계 조건부 질문을 subtasks JSON 으로 분해한다. 더 "
+            "나은 분해를 고르라: (a) 인플레이션 시나리오 분기를 포함했는가, "
+            "(b) '자산군 결정 → ETF 추리기' 의존성 순서가 자연스러운가, "
+            "(c) subtask 가 짧고 명령형인가. 동등하면 'tie'."
+        ),
+    },
+]
+
+
+# ────────────────────────────────────────────────────────────────────
+# Ollama call (gen + judge)
+# ────────────────────────────────────────────────────────────────────
+
+
+def gen_call(prompt: str, *, think: bool, model: str = GEN_MODEL,
+             cap: int = DEFAULT_CAP, temp: float = DEFAULT_TEMP,
+             timeout: float = GEN_TIMEOUT) -> dict:
+    body = json.dumps({
+        "model": model, "prompt": prompt, "stream": False, "think": think,
+        "options": {"num_predict": cap, "temperature": temp},
+    }).encode("utf-8")
+    req = request.Request(GEN_URL, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (error.HTTPError, error.URLError) as e:
+        return {"_error": str(e), "elapsed_s": round(time.monotonic() - t0, 2)}
+    return {
+        "elapsed_s": round(time.monotonic() - t0, 2),
+        "response": payload.get("response", "") or "",
+        "eval_count": payload.get("eval_count") or 0,
+        "done_reason": payload.get("done_reason", "?"),
+    }
+
+
+JUDGE_PROMPT_KO = (
+    "당신은 답변 품질 평가 심판입니다. 같은 입력에 대한 두 답변 (A, B) 중 어느 "
+    "쪽이 평가 기준을 더 잘 만족하는지 판단하세요. **편향 방지를 위해 답변 길이 "
+    "/ 형식 / 순서에 영향받지 말고, 평가 기준에만 집중하세요.**\n\n"
+    "[입력]\n{prompt}\n\n"
+    "[답변 A]\n{a}\n\n"
+    "[답변 B]\n{b}\n\n"
+    "[평가 기준]\n{criterion}\n\n"
+    "JSON 으로만 응답:\n"
+    '{{"verdict": "A_wins" | "B_wins" | "tie", "rationale": "한 줄 이유 (50자 이내)"}}'
+)
+
+
+def judge_call(prompt: str, a: str, b: str, criterion: str, *,
+               model: str = JUDGE_MODEL, temp: float = DEFAULT_TEMP,
+               timeout: float = JUDGE_TIMEOUT) -> dict:
+    full = JUDGE_PROMPT_KO.format(prompt=prompt, a=a, b=b, criterion=criterion)
+    body = json.dumps({
+        "model": model, "prompt": full, "stream": False,
+        "options": {"num_predict": 512, "temperature": temp},
+    }).encode("utf-8")
+    req = request.Request(GEN_URL, data=body, method="POST",
+                          headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (error.HTTPError, error.URLError) as e:
+        return {"_error": str(e), "elapsed_s": round(time.monotonic() - t0, 2)}
+    raw = payload.get("response", "") or ""
+    parsed = _parse_judge(raw)
+    return {
+        "elapsed_s": round(time.monotonic() - t0, 2),
+        "raw": raw,
+        "verdict": parsed.get("verdict"),
+        "rationale": parsed.get("rationale", ""),
+        "eval_count": payload.get("eval_count") or 0,
+    }
+
+
+_JUDGE_JSON_RE = re.compile(r'\{[^{}]*"verdict"\s*:\s*"(A_wins|B_wins|tie)"', re.DOTALL)
+
+
+def _parse_judge(text: str) -> dict:
+    t = text.strip()
+    if t.startswith("```"):
+        t = re.sub(r"^```(?:json)?\s*", "", t)
+        t = re.sub(r"\s*```\s*$", "", t)
+    try:
+        blob = json.loads(t)
+        if isinstance(blob, dict) and blob.get("verdict") in ("A_wins", "B_wins", "tie"):
+            return {"verdict": blob["verdict"],
+                    "rationale": (blob.get("rationale", "") or "")[:200]}
+    except (json.JSONDecodeError, ValueError):
+        pass
+    m = _JUDGE_JSON_RE.search(text)
+    if m:
+        return {"verdict": m.group(1), "rationale": ""}
+    return {"verdict": None, "rationale": ""}
+
+
+# ────────────────────────────────────────────────────────────────────
+# Per-cell run: generate n pairs (think on/off), then judge each pair
+# in both positions (bias control).
+# ────────────────────────────────────────────────────────────────────
+
+
+def run_cell(cell: dict, *, n: int) -> dict:
+    stage = cell["stage"]
+    fixture = cell["fixture"]
+    prompt = cell["prompt"]
+    crit = cell["criterion_ko"]
+
+    print(f"\n=== {stage}/{fixture} — A3 verdict: {cell['a3_verdict']} ===")
+    print(f"Generating {n} pairs (think on/off) on {GEN_MODEL}...")
+    pairs: list[dict] = []
+    for i in range(n):
+        on = gen_call(prompt, think=True)
+        off = gen_call(prompt, think=False)
+        pairs.append({"idx": i + 1, "on": on, "off": off})
+        on_chars = len(on.get("response", ""))
+        off_chars = len(off.get("response", ""))
+        print(f"  pair {i+1}: ON eval={on.get('eval_count')} chars={on_chars} "
+              f"| OFF eval={off.get('eval_count')} chars={off_chars}")
+
+    print(f"Judging {2 * n} judgments ({JUDGE_MODEL}, both positions per pair)...")
+    judgements: list[dict] = []
+    for p in pairs:
+        on_text = p["on"].get("response", "")
+        off_text = p["off"].get("response", "")
+        # Position 1: A=ON, B=OFF
+        j1 = judge_call(prompt, on_text, off_text, crit)
+        # Position 2: A=OFF, B=ON (swap)
+        j2 = judge_call(prompt, off_text, on_text, crit)
+
+        # Translate raw verdicts back to think-mode (so A/B position is
+        # neutralised). pos1: A_wins → ON wins ; B_wins → OFF wins.
+        # pos2: A_wins → OFF wins ; B_wins → ON wins.
+        def _to_mode(verdict: str | None, swapped: bool) -> str | None:
+            if verdict == "tie":
+                return "tie"
+            if verdict == "A_wins":
+                return "OFF" if swapped else "ON"
+            if verdict == "B_wins":
+                return "ON" if swapped else "OFF"
+            return None
+
+        mode_pos1 = _to_mode(j1.get("verdict"), swapped=False)
+        mode_pos2 = _to_mode(j2.get("verdict"), swapped=True)
+
+        if mode_pos1 is None or mode_pos2 is None:
+            agreement = "judge_parse_fail"
+            agreed_mode = None
+        elif mode_pos1 == mode_pos2:
+            agreement = "agreed"
+            agreed_mode = mode_pos1
+        else:
+            agreement = "position_biased"
+            agreed_mode = None
+
+        judgements.append({
+            "pair_idx": p["idx"],
+            "pos1": {"verdict": j1.get("verdict"), "mode": mode_pos1,
+                     "rationale": j1.get("rationale")},
+            "pos2": {"verdict": j2.get("verdict"), "mode": mode_pos2,
+                     "rationale": j2.get("rationale")},
+            "agreement": agreement,
+            "agreed_mode": agreed_mode,
+        })
+        print(f"  pair {p['idx']}: pos1={mode_pos1} pos2={mode_pos2} -> "
+              f"{agreement}/{agreed_mode}")
+
+    # Cell aggregate
+    agreed = [j for j in judgements if j["agreement"] == "agreed"]
+    n_on = sum(1 for j in agreed if j["agreed_mode"] == "ON")
+    n_off = sum(1 for j in agreed if j["agreed_mode"] == "OFF")
+    n_tie = sum(1 for j in agreed if j["agreed_mode"] == "tie")
+    n_biased = sum(1 for j in judgements if j["agreement"] == "position_biased")
+    n_fail = sum(1 for j in judgements if j["agreement"] == "judge_parse_fail")
+
+    if n_off > n_on:
+        judge_direction = "OFF wins"
+    elif n_on > n_off:
+        judge_direction = "ON wins"
+    else:
+        judge_direction = "tie"
+    return {
+        "stage": stage,
+        "fixture": fixture,
+        "a3_verdict": cell["a3_verdict"],
+        "pairs": pairs,
+        "judgements": judgements,
+        "tally": {
+            "agreed": len(agreed),
+            "ON_wins": n_on,
+            "OFF_wins": n_off,
+            "tie": n_tie,
+            "position_biased": n_biased,
+            "judge_parse_fail": n_fail,
+        },
+        "judge_direction": judge_direction,
+    }
+
+
+def render_report(results: dict) -> str:
+    meta = results["metadata"]
+    out: list[str] = [
+        "# A3 v2 — LLM-judge confirmation on 3 surprising A3 cells",
+        "",
+        f"**Date**: {meta['started_utc']}",
+        f"**Generator**: {GEN_MODEL}  **Judge**: {JUDGE_MODEL}  "
+        f"**Cap**: {meta['cap']}  **Temp**: {meta['temperature']}  "
+        f"**n pairs/cell**: {meta['n']}",
+        f"**Closes**: A3 (#608) LLM-judge reservation gate; feeds A2 (#609) "
+        f"default-flip follow-up decision.",
+        "",
+        "## Verdicts",
+        "",
+        "| Cell | A3 (det. grader) | judge tally (ON/OFF/tie/biased/fail) | "
+        "judge direction | agreement w/ A3 |",
+        "|---|---|---|---|---|",
+    ]
+    for cell in results["cells"]:
+        t = cell["tally"]
+        tally_str = (f"{t['ON_wins']}/{t['OFF_wins']}/{t['tie']}/"
+                     f"{t['position_biased']}/{t['judge_parse_fail']}")
+        a3_dir = "OFF" if "OFF wins" in cell["a3_verdict"] else (
+            "tie" if "tie" in cell["a3_verdict"] else "?"
+        )
+        jd = cell["judge_direction"]
+        if a3_dir == "OFF" and jd == "OFF wins":
+            agree = "AGREE"
+        elif a3_dir == "tie" and jd == "tie":
+            agree = "AGREE"
+        elif a3_dir == "tie" and jd in ("OFF wins", "ON wins"):
+            # tie in grader but judge picks one — grader was too coarse
+            agree = f"weaker tie (judge: {jd})"
+        elif a3_dir == "OFF" and jd == "tie":
+            agree = "WEAKER (judge: tie)"
+        elif a3_dir == "OFF" and jd == "ON wins":
+            agree = "DISAGREE (judge: ON wins)"
+        else:
+            agree = f"check ({a3_dir} vs {jd})"
+        out.append(f"| {cell['stage']}/{cell['fixture']} | {cell['a3_verdict']} "
+                   f"| {tally_str} | **{jd}** | {agree} |")
+    out += [
+        "",
+        "Tally column order: **ON_wins / OFF_wins / tie / position_biased / judge_parse_fail** "
+        "(`n_pairs={n}` so the first four sum to ≤ n_pairs).".format(n=meta["n"]),
+        "",
+        "## Reading",
+        "",
+        "- **Agreement methodology**: each pair is judged TWICE with A/B "
+        "positions swapped. A pair counts as 'agreed' only if both positions "
+        "yield the same winner (or both say tie); else 'position_biased' and "
+        "excluded from the tally.",
+        "- **Cell verdict**: aggregate of agreed pairs only. A judge_direction "
+        "of 'OFF wins' / 'ON wins' / 'tie' is reported by majority among "
+        "agreed pairs.",
+        "- **A2 default-flip gate**: 3 AGREE → A3 strengthened → next gate "
+        "is 1-week real-query dogfood + Quality Delta Card. Any DISAGREE → "
+        "stage walks back from the A2 safe-list (opt-in still ships).",
+        "",
+        "## Per-pair rationales (sampling)",
+        "",
+    ]
+    for cell in results["cells"]:
+        out.append(f"### {cell['stage']}/{cell['fixture']}")
+        for j in cell["judgements"]:
+            out.append(
+                f"- pair {j['pair_idx']}: pos1={j['pos1']['mode']} "
+                f"({j['pos1']['rationale'][:60]!r}), pos2={j['pos2']['mode']} "
+                f"({j['pos2']['rationale'][:60]!r}) → {j['agreement']}"
+                f"/{j['agreed_mode']}"
+            )
+        out.append("")
+    return "\n".join(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=DEFAULT_N)
+    ap.add_argument("--cap", type=int, default=DEFAULT_CAP)
+    ap.add_argument("--temp", type=float, default=DEFAULT_TEMP)
+    args = ap.parse_args()
+
+    started = datetime.now(timezone.utc).isoformat()
+    results: dict = {
+        "metadata": {
+            "started_utc": started,
+            "driver": "v3prime_a3_v2_llm_judge.py",
+            "generator_model": GEN_MODEL,
+            "judge_model": JUDGE_MODEL,
+            "cap": args.cap,
+            "temperature": args.temp,
+            "n": args.n,
+            "cells_selected": [(c["stage"], c["fixture"]) for c in CELLS],
+            "closes": "A3 LLM-judge reservation gate (PR #608 §reservation)",
+        },
+        "cells": [],
+    }
+    print(f"A3 v2 — {len(CELLS)} cells × n={args.n} pairs × 2 judge positions "
+          f"= {len(CELLS) * args.n} gen-pair + {len(CELLS) * args.n * 2} judge calls\n")
+
+    for cell in CELLS:
+        cell_result = run_cell(cell, n=args.n)
+        results["cells"].append(cell_result)
+
+    results["metadata"]["finished_utc"] = datetime.now(timezone.utc).isoformat()
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    REPORTS.mkdir(parents=True, exist_ok=True)
+    json_path = REPORTS / f"v3prime-a3-v2-llm-judge-{ts}.json"
+    md_path = REPORTS / f"v3prime-a3-v2-llm-judge-{ts}.md"
+    json_path.write_text(json.dumps(results, ensure_ascii=False, indent=2),
+                         encoding="utf-8")
+    md = render_report(results)
+    md_path.write_text(md, encoding="utf-8")
+    print(f"\nJSON: {json_path}\nMD:   {md_path}\n")
+    print(md)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- LLM-judge upgrade reserved at #608. 3 surprising A3 cells × n=5 paired generation on gemma4:e4b + paired judge on gemma3:12b with A/B position swap.
- 15 pair-gen + 30 judge calls. Result file: \`reports/research-runs/v3prime-a3-v2-llm-judge-20260530T112325.{json,md}\`.

## Verdicts

| Cell | A3 (det. grader) | Judge | Agreement |
|---|---|---|---|
| verify EASY | OFF wins (0.6/1.0) | tie (4 tie / 1 biased) | WEAKER |
| synthesis HARD | OFF wins (0.4/1.0) | tie (5/5 position_biased) | WEAKER |
| planner HARD | tie | tie (1 ON / 1 OFF / 3 biased) | AGREE |

**No cell produced an \"ON wins\" judge verdict** — thinking does not demonstrably help on any cell. But the OFF-wins magnitude A3 reported also does not survive paired-judge replay (synthesis HARD's 5/5 position bias is the cleanest evidence: judge picked whichever answer was shown first regardless of think mode).

## Reframing A2 (#609) default-flip

The new gate for any default-flip is a **real-query Quality Delta Card** against the α-3 step7 oracle on production query distribution (not synthetic fixtures), with the flag ON for ≥ 1 week of user dogfood. Synthetic fixtures + deterministic grader + local LLM-judge together are not strong enough oracles to justify a global behavior change.

The opt-in plumbing in #609 remains safe — no \"ON wins\" signal means no regression risk. Dogfood proceeds as planned.

## Methodological lesson (added to backlog §7.2)

A fixture that lets the deterministic grader read a clear signal does NOT guarantee that signal is the actual quality dimension — keyword/JSON-shape matchers can pick up artifacts. When grader-positive direction also fails LLM-judge confirmation, the honest read is \"no measurable difference,\" not \"the grader was right and the judge missed it.\" This generalizes to future A3-style think-mode / cap / temperature studies.

## Test plan

- [x] Driver runs end-to-end (gemma4:e4b gen + gemma3:12b judge, local Ollama, cap=4096 temp=0.2 n=5)
- [x] Paired judge with A/B position swap; pair counts as \"agreed\" only when both positions yield same winner
- [x] JSON + markdown emit at \`reports/research-runs/v3prime-a3-v2-llm-judge-<ts>.{json,md}\`
- [x] Backlog reconciliation §7.2 records the reframing + methodological lesson

## Out of scope

- Re-running A3 with a stronger oracle (LLM-judge as primary grader). Deferred — would re-litigate #608 rather than advancing the matrix design.
- Repeating v2 on the remaining 2 hard cells (reflect HARD, query_rewriter HARD). Their A3 Δ was 0 so judge confirmation would not change the A2 decision.
- A1 (α-5 ablation) — orthogonal axis (layer × model on QVT 3-axis), continues independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)