### PR TITLE
feat(qvt): α-5 reset — MultiHop-RAG external benchmark + 5-axis × query-type matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,20 @@ wiki/entity/test/**/*.md
 wiki.pre-v03-migration/
 wiki.rollback-trash/
 
+# α-5 benchmark workspaces — corpus / chroma / ingested wiki / per-cell
+# JSON outputs are all re-derivable from the dataset adapter
+# (scripts/hotpot/download_multihop_rag.py) + the build_fixture script
+# + the matrix runner. Only the structural files (README, .env,
+# ATTRIBUTION) are tracked so reviewers see the layout.
+workspaces/*/raw/
+workspaces/*/uploads/
+workspaces/*/wiki/
+workspaces/*/chroma_db*/
+workspaces/*/eval/multihop_rag_raw_queries.json
+workspaces/*/eval/multihop_rag_queries.json
+workspaces/*/eval/qvt/baseline_*.json
+workspaces/*/reports/
+
 # 운영자 튜닝 가능한 런타임 설정 (web search role/threshold 등).
 # 코드 안에 안전한 기본값 존재 — 운영자별 오버라이드는 로컬에만.
 web_search_config.json

--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -53,7 +53,7 @@ any ledger before this reconciliation.
 
 | # | Item | Status | Notes |
 |---|---|---|---|
-| A1 ★ | **QVT α-5 ablation matrix** (18 cells = 6 layer-combos × 3 model tiers; `scripts/qvt_ablation_matrix.py` + report) | 🟡 prep landed + prereq plan (2026-05-30 PM-4) — driver + 18-cell design + 4-risk prereq plan + oracle negation guard; pending data work + T0 smoke | **Keystone**: gates D1/D5/LEO flag-ON decisions. Design at `docs/design/v0.4-qvt-alpha-5-ablation-matrix.md`. **Prereq plan at `docs/design/v0.4-qvt-alpha-5-prereqs-plan.md` resolves**: (§1) oracle paraphrase weakness — negation guard landed; (§2) fixture saturation — path axis at 1.0 ceiling needs fixture v6+ expansion (user data work); (§3) workload scoping — `--t0-smoke` (~2.2h) gates whether to run T1 (5.5h) or T2 (13h); (§4) null-result risk — pre-registered hypotheses per layer. Run order: data work (5.2/5.3) → re-capture α-3 baseline → `--t0-smoke` → conditional T1/T2. |
+| A1 ★ | **QVT α-5 ablation matrix** (19 cells = 18 standard + 1 sanity think=ON; `scripts/qvt_ablation_matrix.py` + report) | 🟡 reset + 5-axis prep landed (2026-05-30 PM-5, this cycle) — MultiHop-RAG external benchmark + 5-axis oracle + query-type cross-tab + sanity-think-on hook + findings log; pending operator workspace ingest + baseline + T0 smoke run | **Keystone**: gates D1/D5/LEO flag-ON decisions + per-query-type routing policy (user req #2) + cost/quality tradeoff (user req #3). Design: `docs/design/v0.4-qvt-alpha-5-ablation-matrix.md` (18-cell axes) + `docs/design/v0.4-qvt-alpha-5-prereqs-plan.md` (4 risks) + `~/.claude/plans/quiet-hugging-iverson.md` (post-#614 reset → MultiHop-RAG + 5-axis + cross-tab). Workspace: `./workspaces/hotpot_eval/` (`JAMES_WORKSPACE` env). Run order: workspace ingest (~1-4h, A2 think=OFF) → 5-axis baseline capture (~70min, `--suite multihop_rag`) → `--t0-smoke --sanity-think-on` (~3.3h, includes M_M/L1 think=ON sanity cell) → conditional T1 (M_M, ~5.5h) → conditional T2 (M_S+M_L, ~13h). step7 v7 (#614) stays as internal regression canary only. |
 | A2 ★ | **gemma4:e4b `think=false` operational fix** (§16.5 of D3 final) | ✅ LANDED #609 (2026-05-30 opt-in plumbing) | `core/reasoning/think_policy.py` + 5 stage call sites + `JAMES_GEMMA4_E4B_THINK_OFF` flag (default OFF). Default-flip is a separate follow-up gated on LLM-judge v2 + 1 week dogfood + Quality Delta Card on real-query baseline. |
 | A3 ★ | **think-mode quality boundary experiment** | ✅ LANDED #608 (2026-05-30) | All 5 cognitive stages: think=OFF safe or wins on hard fixtures (gemma4:e4b, n=5, deterministic graders). Feeds A2. Follow-up = LLM-judge v2 (2-3 ambiguous cells, gemma3:12b paired judge) — reserved trigger only. |
 | A4 | **pytest flaky structural root fix** | 🟡 current fix is stabilization | `test_native_done_reason` + `test_entity_name_markdown_strip` order/timeout pollution. Cluster stabilized (#582/#592/#595/#596) but not root-fixed. |
@@ -188,3 +188,45 @@ A5 (D1 stage expansion) is partially unblocked: the cap=4096 hold is now
 mechanistically explained (#606), but the per-stage cap policy update
 should wait for the A2 default-flip so D4 (task-weight) measures on the
 think-OFF/visible budget rather than the inflated default.
+
+### 7.3 Update 2026-05-30 PM-5 — α-5 reset to MultiHop-RAG + 5-axis (post-#614)
+
+Pre-α-5 audit of fixture v7 (#614) revealed **construct validity** and
+**oracle reach** risks that would compromise the matrix run:
+
+- v7 hard queries q18/q19/q20 were drafted by inspecting wiki entities
+  first and writing queries to match — measuring "can JAMES find the
+  entities I told it were there" rather than capability.
+- No external benchmark in the repo (`eval/RESULTS.md` defers BEIR /
+  KLUE-RC indefinitely). Α-5 routing decisions without external
+  evidence would be hard to defend in review.
+
+**Decision** — full reset of the α-5 evaluation surface:
+
+1. **External benchmark**: MultiHop-RAG (Tang & Yang 2024, EMNLP) —
+   2,556 multi-hop QA × 609 articles, CC-BY-4.0, 4 question types
+   (comparison / inference / temporal / null).
+2. **Workspace isolation**: `./workspaces/hotpot_eval/` via
+   `JAMES_WORKSPACE` (existing config.py:74 abstraction — code change 0
+   on production path).
+3. **5-axis oracle**: quality 3 (path / graded / abstention) +
+   **cost 2 (token, latency)** — user requirement #3 token / time
+   efficiency integration. Pareto-aware verdict rule (strong-adopt /
+   adopt / efficiency-adopt / tier-gated / reject / zero).
+4. **Per-question-type cross-tab**: matrix runner now emits routing
+   policy recommendations per query type — user requirement #2.
+5. **think-mode handling**: matrix primary is think=OFF (workspace
+   `.env` `JAMES_GEMMA4_E4B_THINK_OFF=1`), with a single sanity cell
+   `L1/M_M think=ON` (`--sanity-think-on`) to keep A2 default-flip
+   evidence inside the matrix.
+6. **Incidental findings log**: `reports/research-runs/
+   qvt-ablation-findings.md` running log; entries tagged
+   `mechanism-candidate` / `universal-law` get memo drafts after the
+   run (user requirement #5).
+
+v7 PR #614 stays landed as **internal regression canary** — not the
+load-bearing evidence for α-5 routing decisions.
+
+Plan: `~/.claude/plans/quiet-hugging-iverson.md` (approved 2026-05-30).
+Steps 1-6/8-10 ship as one PR; Steps 7/9-operator are user-side
+(workspace ingest + baseline + matrix run, ~3-6h total compute).

--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -418,6 +418,113 @@ def score_abstention_f1(
 
 
 # ---------------------------------------------------------------------------
+# Cost axes (Step 5 of α-5 plan — quality×cost integrated matrix)
+#
+# bench.py captures per-query ``elapsed`` (seconds) directly. ``eval_count``
+# (Ollama-side token count) is NOT exposed by the server's /query/ response
+# today, so token cost is approximated by ``answer_len`` (characters in
+# the response). ~4 chars/token English / ~2 chars/token Korean — the
+# proxy is monotonic but biased by language mix. Operators interpreting
+# Δ_token_cost across cells should focus on within-tier comparison
+# (same prompt language) rather than cross-tier absolute values.
+#
+# A future PR can wire Ollama ``eval_count`` through the server response
+# and swap this proxy for the real number; the axis interface stays
+# identical (mean + p95 + per_query rows).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CostQueryRow:
+    id: int
+    elapsed_s: float
+    answer_chars: int   # token-cost proxy until server forwards eval_count
+
+
+@dataclass
+class TokenCostAxis:
+    """Per-query answer chars (token-cost proxy). Lower is better."""
+    mean_chars: float
+    p95_chars: float
+    n_queries: int
+    per_query: List[CostQueryRow] = field(default_factory=list)
+
+
+@dataclass
+class LatencyCostAxis:
+    """Per-query wall-clock elapsed. Lower is better."""
+    mean_s: float
+    p95_s: float
+    n_queries: int
+    per_query: List[CostQueryRow] = field(default_factory=list)
+
+
+def _percentile(values: List[float], p: float) -> float:
+    """Nearest-rank percentile (good enough for n≥20 cells)."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if p <= 0:
+        return s[0]
+    if p >= 1.0:
+        return s[-1]
+    # nearest-rank: index = ceil(p * n) - 1
+    import math
+    idx = max(0, min(len(s) - 1, math.ceil(p * len(s)) - 1))
+    return s[idx]
+
+
+def _collect_cost_rows(bench_results: Dict[str, Any]) -> List[CostQueryRow]:
+    rows: List[CostQueryRow] = []
+    for r in bench_results.get("results", []):
+        # Successful + answered queries only — timeouts / errors would
+        # bias the cost axis toward "very cheap" (zero output) when in
+        # practice they are operational failures, not efficiency wins.
+        if r.get("status") != "ok":
+            continue
+        elapsed = r.get("elapsed")
+        if elapsed is None:
+            continue
+        # Prefer explicit answer_len when bench.py emitted it; fall back
+        # to answer_preview length (300-char truncated) for older runs.
+        chars = r.get("answer_len")
+        if chars is None:
+            chars = len(r.get("answer_preview", "") or "")
+        rows.append(CostQueryRow(
+            id=int(r.get("id", -1)),
+            elapsed_s=float(elapsed),
+            answer_chars=int(chars),
+        ))
+    return rows
+
+
+def score_token_cost(bench_results: Dict[str, Any]) -> TokenCostAxis:
+    rows = _collect_cost_rows(bench_results)
+    if not rows:
+        return TokenCostAxis(mean_chars=0.0, p95_chars=0.0, n_queries=0)
+    chars = [r.answer_chars for r in rows]
+    return TokenCostAxis(
+        mean_chars=round(sum(chars) / len(chars), 2),
+        p95_chars=round(_percentile([float(c) for c in chars], 0.95), 2),
+        n_queries=len(rows),
+        per_query=rows,
+    )
+
+
+def score_latency_cost(bench_results: Dict[str, Any]) -> LatencyCostAxis:
+    rows = _collect_cost_rows(bench_results)
+    if not rows:
+        return LatencyCostAxis(mean_s=0.0, p95_s=0.0, n_queries=0)
+    elapsed = [r.elapsed_s for r in rows]
+    return LatencyCostAxis(
+        mean_s=round(sum(elapsed) / len(elapsed), 3),
+        p95_s=round(_percentile(elapsed, 0.95), 3),
+        n_queries=len(rows),
+        per_query=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Three-axis unified result
 # ---------------------------------------------------------------------------
 
@@ -493,3 +600,156 @@ def score_three_axis(
         graded_answer=score_graded_answer(bench, fixture),
         abstention=score_abstention_f1(bench, fixture),
     )
+
+
+# ---------------------------------------------------------------------------
+# Five-axis result — α-5 quality×cost integrated (Step 5)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FiveAxisResult:
+    """3 quality axes (existing) + 2 cost axes (new). Used by the α-5
+    ablation matrix runner to express verdicts on the (quality, cost)
+    Pareto plane rather than quality alone.
+
+    The 3 quality axes are *delegated* to the existing `ThreeAxisResult`
+    so any caller that already understands the 3-axis schema keeps
+    working — `.three_axis` gives the unchanged object. Cost axes are
+    additive fields.
+    """
+    three_axis: ThreeAxisResult
+    token_cost: TokenCostAxis
+    latency_cost: LatencyCostAxis
+
+    # Convenience accessors — keep call sites short.
+    @property
+    def git_sha(self) -> Optional[str]:
+        return self.three_axis.git_sha
+
+    @property
+    def suite(self) -> Optional[str]:
+        return self.three_axis.suite
+
+    @property
+    def fixture_version(self) -> Optional[str]:
+        return self.three_axis.fixture_version
+
+    @property
+    def n_queries(self) -> int:
+        return self.three_axis.n_queries
+
+    @property
+    def path_coverage(self) -> PathCoverageAxis:
+        return self.three_axis.path_coverage
+
+    @property
+    def graded_answer(self) -> GradedAnswerAxis:
+        return self.three_axis.graded_answer
+
+    @property
+    def abstention(self) -> AbstentionF1Axis:
+        return self.three_axis.abstention
+
+    def summary(self) -> str:
+        return (
+            f"{self.three_axis.summary()} "
+            f"token_cost(chars)={self.token_cost.mean_chars:.1f}/"
+            f"p95={self.token_cost.p95_chars:.1f} "
+            f"latency(s)={self.latency_cost.mean_s:.2f}/"
+            f"p95={self.latency_cost.p95_s:.2f}"
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = self.three_axis.to_dict()
+        d["token_cost"] = asdict(self.token_cost)
+        d["latency_cost"] = asdict(self.latency_cost)
+        return d
+
+
+def score_five_axis(
+    bench_results_path: Union[str, Path, Dict[str, Any]],
+    fixture_path: Union[str, Path, Dict[str, Any]],
+) -> FiveAxisResult:
+    """Top-level α-5 entry — quality 3-axis (path/graded/abstention) +
+    cost 2-axis (token, latency).
+
+    Backward-compatible: callers that only need 3-axis can still use
+    ``score_three_axis``; ``FiveAxisResult.three_axis`` exposes the
+    same shape so legacy code paths keep working when migrated.
+    """
+    three = score_three_axis(bench_results_path, fixture_path)
+    # Re-load bench dict once for the cost axes (cheap — file already cached
+    # by the OS after the 3-axis pass). Accept dict to skip when caller
+    # already has it.
+    bench = (
+        bench_results_path
+        if isinstance(bench_results_path, dict)
+        else _load_json(bench_results_path)
+    )
+    return FiveAxisResult(
+        three_axis=three,
+        token_cost=score_token_cost(bench),
+        latency_cost=score_latency_cost(bench),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-question_type 5-axis breakdown (α-5 plan Step 6 cross-tab)
+# ---------------------------------------------------------------------------
+
+
+def score_five_axis_by_question_type(
+    bench_results_path: Union[str, Path, Dict[str, Any]],
+    fixture_path: Union[str, Path, Dict[str, Any]],
+) -> Dict[str, FiveAxisResult]:
+    """Return one FiveAxisResult per `question_type` present in the
+    bench output (Step 6 cross-tab).
+
+    Requires both the bench rows and the fixture queries to carry the
+    `question_type` field (MultiHop-RAG fixture does this; step7 does
+    not — returns an empty dict in that case). The function partitions
+    both the bench results and the fixture queries by question_type,
+    then runs the 5-axis scorer on each partition independently. Two
+    partitions of size 0 (no overlap) are skipped silently.
+
+    Sum-up: per-type results carry the same FiveAxisResult schema as
+    the global one, so the matrix runner can compute Δ per (type, layer,
+    tier) using the same machinery.
+    """
+    bench = (
+        bench_results_path
+        if isinstance(bench_results_path, dict)
+        else _load_json(bench_results_path)
+    )
+    fixture = (
+        fixture_path
+        if isinstance(fixture_path, dict)
+        else _load_json(fixture_path)
+    )
+    bench_rows = bench.get("results", [])
+    fixture_queries = fixture.get("queries", [])
+
+    # Collect question types observed on the bench side.
+    types_seen: set[str] = set()
+    for r in bench_rows:
+        qt = r.get("question_type")
+        if isinstance(qt, str) and qt:
+            types_seen.add(qt)
+    if not types_seen:
+        return {}
+
+    out: Dict[str, FiveAxisResult] = {}
+    for qt in sorted(types_seen):
+        sub_bench = {
+            **{k: v for k, v in bench.items() if k != "results"},
+            "results": [r for r in bench_rows if r.get("question_type") == qt],
+        }
+        sub_fixture = {
+            **{k: v for k, v in fixture.items() if k != "queries"},
+            "queries": [q for q in fixture_queries if q.get("question_type") == qt],
+        }
+        if not sub_bench["results"] or not sub_fixture["queries"]:
+            continue
+        out[qt] = score_five_axis(sub_bench, sub_fixture)
+    return out

--- a/reports/research-runs/qvt-ablation-findings.md
+++ b/reports/research-runs/qvt-ablation-findings.md
@@ -1,0 +1,91 @@
+# QVT α-5 Ablation — Incidental Findings Log
+
+> **Purpose** — Capture observations during the α-5 ablation matrix run
+> that don't fit a verdict cell but might be **mechanism candidates**
+> or **universal laws** worth re-running / writing up later.
+>
+> **Plan reference**: `~/.claude/plans/quiet-hugging-iverson.md` Step 10.
+> **User requirement #5**: "모델별 특성 / 보편적 법칙 발견 시 반드시 보고 후 추후
+> 연구될 수 있도록 메모."
+>
+> **Style** — Each entry is short (3-5 lines). Date, cell context, what
+> was observed, why it's surprising, recommended follow-up. **Do not**
+> debug here — flag the surprise, capture the data pointer, move on.
+
+---
+
+## How to add a finding
+
+1. Add a `### YYYY-MM-DD — <slug>` entry at the bottom of the
+   "Findings" section below.
+2. Fill the 5 fields (cell / observation / surprise / data pointer /
+   follow-up).
+3. If the finding crosses cells (e.g. consistent pattern across all
+   M_S cells), tag it `pattern:` instead of `cell:`.
+4. After the matrix run completes, scan this file and propose memo
+   draft entries for findings tagged `mechanism-candidate` or
+   `universal-law`. Memo lands under `memory/finding_<slug>.md` after
+   user confirmation (see Step 10 of the plan for the trigger
+   workflow).
+
+## Categories (pick the strongest)
+
+- **mechanism-candidate** — "I think X explains Y in this cell."
+  Triggers a follow-up probe (next session) to confirm or refute.
+  Example pattern: A3 thinking trace (#608 §16) — initially flagged
+  here as "gemma4:e4b spends 85% of budget on hidden tokens",
+  promoted to a mechanism via `v3prime_e4b_mechanism_probe.py`.
+- **universal-law** — "This holds across all tiers / all layers / all
+  query types." Worth a separate cross-axis confirmation run. Example:
+  D3 §16.7 "reasoning cost is model-invariant" (#603) started as a
+  cross-family observation, promoted to a paper-ready statement.
+- **anti-pattern** — Surprising in the wrong direction (a layer that
+  *hurt* quality on a tier we expected it to help). Document so we
+  don't re-recommend it.
+- **data-quality** — Suspicious result that suggests fixture / oracle
+  bias rather than a real signal (e.g., constant abstention F1 across
+  cells suggests the abstention phrase matcher is the bottleneck, not
+  the layers).
+- **operational** — Runtime / setup issue worth surfacing (e.g., ingest
+  pipeline crashed on a specific article; budget caps interacting with
+  routing).
+
+---
+
+## Findings
+
+<!-- Add entries below this line, newest at the bottom. -->
+
+(none yet — populated as cells run)
+
+---
+
+## Promoted to memory
+
+When a finding is promoted to a memory entry (Step 10 trigger), record
+the promotion here so the trail stays auditable:
+
+| Date | Finding slug | Memory file | Confirmed by |
+|---|---|---|---|
+
+(none yet)
+
+---
+
+## Carry-over from prior tracks (for context — not new findings)
+
+The following mechanism findings already landed in memory before α-5
+runs. Listed here so a reviewer scanning this log understands what
+"counts as a mechanism" in this project's history:
+
+- `d3_e4b_floor_mechanism_thinking_trace` — gemma4:e4b's hidden
+  thinking trace consumes ~85% of `num_predict` (#608 §16, PR #602).
+  Promoted from an A3 observation to a cross-family law in #603/#604.
+- `feedback_q15_chroma_embedding_root_pinned` — MiniLM struggles with
+  proper-noun-mediated retrieval (F7/F9 cycle). Promoted to BL-9
+  embedding swap.
+- `feedback_bench_step7_chat_mode_passthrough` — IntentClassifier
+  routes retrieval-mode bench queries to chat mode without the
+  bearer token. Caused a measurement-bias correction.
+
+These are the kinds of entries this log aims to seed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,6 +84,13 @@ openai-whisper>=20231117
 #   pip install ragas --only-binary=:all:
 ragas>=0.4.0
 
+# α-5 external benchmark — MultiHop-RAG (Tang & Yang 2024, EMNLP).
+# Used by scripts/hotpot/download_multihop_rag.py to pull the dataset
+# from HuggingFace into workspaces/hotpot_eval/. Read-only adapter;
+# no impact on production unless JAMES_WORKSPACE is set to the
+# benchmark workspace.
+datasets>=2.14.0
+
 # ═══════════════════════════════════════════════════════════════
 #  System Requirements (install separately, not via pip)
 # ═══════════════════════════════════════════════════════════════

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -133,10 +133,39 @@ def _git_sha() -> str:
 
 
 def _load_suite(name: str) -> Dict:
-    path = ROOT / "eval" / "regression" / f"{name}_queries.json"
-    if not path.exists():
-        raise RuntimeError(f"suite definition not found: {path}")
-    return json.loads(path.read_text(encoding="utf-8"))
+    """Locate suite fixture. Two search locations, in order:
+
+    1. ``eval/regression/{name}_queries.json`` (project-root canonical,
+       used by step7 and any future internal regression suites).
+    2. ``$JAMES_WORKSPACE/eval/{name}_queries.json`` (workspace-relative,
+       used by external benchmark suites like ``multihop_rag`` that live
+       under ``workspaces/<name>/``). The workspace abstraction
+       (config.py:74, ``core/plugins/workspace.py::get_workspace_root``)
+       isolates the benchmark corpus + fixture from production state.
+
+    Raises if neither location resolves — caller sees both attempted
+    paths so a typo or missing build step is diagnosable in one read.
+    """
+    canonical = ROOT / "eval" / "regression" / f"{name}_queries.json"
+    if canonical.exists():
+        return json.loads(canonical.read_text(encoding="utf-8"))
+
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        ws_path = Path(ws_raw).resolve() / "eval" / f"{name}_queries.json"
+        if ws_path.exists():
+            return json.loads(ws_path.read_text(encoding="utf-8"))
+        # Workspace set but file missing — surface it explicitly.
+        raise RuntimeError(
+            f"suite definition not found:\n"
+            f"  tried: {canonical}\n"
+            f"  tried: {ws_path}\n"
+            f"  hint:  build it first (e.g. scripts/hotpot/build_fixture.py)"
+        )
+    raise RuntimeError(
+        f"suite definition not found: {canonical}\n"
+        f"(set JAMES_WORKSPACE to also search a benchmark workspace's eval/)"
+    )
 
 
 def _parse_path_nodes(path_strs) -> set:
@@ -278,6 +307,11 @@ def _run_one(
 
     base = {"id": q["id"], "category": q["category"], "text": q["text"],
             "elapsed": round(elapsed, 1)}
+    # α-5 plan Step 6 — preserve fixture's `question_type` for cross-tab
+    # analysis (MultiHop-RAG inference/comparison/temporal/null_query).
+    # Quietly skipped when the suite doesn't carry the field (step7).
+    if "question_type" in q:
+        base["question_type"] = q["question_type"]
 
     if r.status_code != 200:
         base.update({
@@ -420,10 +454,30 @@ def main() -> int:
             "Precedence: per-query `mode` > --mode > suite `default_mode` > omit."
         ),
     )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help=("Resolve the suite + print plan (count, version, fixture path); "
+              "make no HTTP calls and write no bench JSON. Used by the α-5 "
+              "wiring smoke check before any compute is spent."),
+    )
     args = ap.parse_args()
 
     suite = _load_suite(args.suite)
     queries = suite.get("queries", [])
+    if args.dry_run:
+        print(f"=== bench {args.suite} dry-run ===")
+        print(f"version:       {suite.get('version', '?')}")
+        print(f"description:   {(suite.get('description') or '')[:120]}")
+        print(f"queries:       {len(queries)}")
+        # Surface question_type distribution if present (multihop_rag fixture
+        # builder emits it — useful sanity for the Step 3 → Step 4 wiring).
+        dist = suite.get("type_distribution")
+        if dist:
+            print("type_distribution:")
+            for t, n in dist.items():
+                print(f"  {t}: {n}")
+        return 0
+
     endpoint = (suite.get("endpoint") or {}).get("url", "/query/")
     timeout  = int((suite.get("endpoint") or {}).get("timeout", 120))
     effective_default_mode = args.mode or suite.get("default_mode")

--- a/scripts/hotpot/__init__.py
+++ b/scripts/hotpot/__init__.py
@@ -1,0 +1,9 @@
+"""α-5 external benchmark adapters (MultiHop-RAG, Tang & Yang 2024).
+
+This package downloads, builds, and feeds the MultiHop-RAG dataset
+into JAMES via the workspace abstraction (config.py:74,
+`core/plugins/workspace.py::get_workspace_root`). All artifacts land
+under `workspaces/hotpot_eval/`; production state is untouched.
+
+Plan: `~/.claude/plans/quiet-hugging-iverson.md`.
+"""

--- a/scripts/hotpot/build_fixture.py
+++ b/scripts/hotpot/build_fixture.py
@@ -1,0 +1,304 @@
+"""Step 3 — Build the step7-compatible fixture from MultiHop-RAG raw queries.
+
+Reads ``$JAMES_WORKSPACE/eval/multihop_rag_raw_queries.json`` (produced by
+Step 2) and emits ``$JAMES_WORKSPACE/eval/multihop_rag_queries.json`` in
+the same format JAMES's bench.py / QVT oracle already understand.
+
+Field mapping per query
+-----------------------
+  raw.query           → fixture.text
+  raw.question_type   → fixture.category + fixture.question_type
+                        ('null_query' ⇒ abstention_truth='absent')
+  raw.answer          → fixture.gold_signals[0].term
+  evidence.fact[0..1] → fixture.gold_signals[1].term, [2].term
+                        (first proper-noun-ish token from each fact)
+  evidence.title      → fixture.expected_path.nodes (capped at 4)
+  null_query          → no expected_path (no graph traversal target);
+                        gold_signals = abstention indicators
+
+Schema version: ``multihop-rag-v1``. Compatible with QVT oracle:
+  - 3 gold_signals per query (step7 v5+ invariant)
+  - expected_path.nodes + min_recall when applicable
+  - abstention_truth ∈ {'present', 'absent'}
+
+Subset modes (--subset):
+  balanced-200   50 per question_type (200 total — α-5 default)
+  balanced-100   25 per question_type (100 total — smoke / fast smoke)
+  balanced-500   125 per question_type (500 total — heavier)
+  full           all 2,556 (NOT recommended for α-5 — see plan §risks #4)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+SUBSETS: dict[str, int | None] = {
+    "balanced-100": 25,
+    "balanced-200": 50,
+    "balanced-500": 125,
+    "full": None,
+}
+
+EXPECTED_PATH_MAX_NODES = 4
+GOLD_SIGNAL_COUNT = 3
+
+# Tokens we ignore when picking a "key noun" from an evidence fact.
+_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "but", "of", "in", "on", "at", "to",
+    "for", "with", "by", "from", "as", "is", "was", "are", "were", "be",
+    "been", "being", "has", "have", "had", "do", "does", "did", "this",
+    "that", "these", "those", "it", "its", "his", "her", "their", "our",
+    "we", "they", "them", "he", "she", "you", "your", "my", "i", "me",
+    "if", "then", "than", "so", "such", "not", "no", "yes", "also",
+})
+
+# Pick "noun-ish" token = starts with capital OR digits-only OR mixed-case acronym.
+_NOUN_TOKEN_RE = re.compile(r"\b[A-Z][a-zA-Z0-9\-]{2,}\b|\b\d{4,}\b|\b[A-Z]{2,}\b")
+
+ABSTENTION_SIGNALS = (
+    "Insufficient",
+    "cannot",
+    "no information",
+)
+
+
+def _workspace() -> Path:
+    raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if not raw:
+        sys.exit(
+            "[build_fixture] JAMES_WORKSPACE is not set. Export it first:\n"
+            "  export JAMES_WORKSPACE=./workspaces/hotpot_eval"
+        )
+    ws = Path(raw).resolve()
+    if not ws.exists():
+        sys.exit(f"[build_fixture] workspace {ws} does not exist")
+    return ws
+
+
+def _pick_key_noun(fact: str, taken: set[str]) -> str:
+    """Pick the first noun-ish token in ``fact`` that is not already in
+    ``taken`` (case-insensitive) and not a stopword.
+    """
+    if not fact:
+        return ""
+    for m in _NOUN_TOKEN_RE.finditer(fact):
+        token = m.group(0)
+        if token.lower() in _STOPWORDS:
+            continue
+        if token.lower() in {t.lower() for t in taken}:
+            continue
+        return token
+    # Fallback — return the first non-stopword word.
+    for w in re.split(r"\s+", fact):
+        w = w.strip(".,;:()'\"!?")
+        if not w or w.lower() in _STOPWORDS:
+            continue
+        if w.lower() in {t.lower() for t in taken}:
+            continue
+        return w
+    return ""
+
+
+def _gold_signals_for(answer: str, evidence_list: list[dict]) -> list[dict]:
+    """Three gold_signals per query (step7 v5+ invariant).
+
+    - [0] = the gold answer text itself (literal claim).
+    - [1] = first noun-ish token from the first evidence fact.
+    - [2] = first noun-ish token from the second evidence fact (or
+            source name when only one fact exists).
+    """
+    signals: list[dict] = []
+    answer = (answer or "").strip()
+    taken: set[str] = set()
+    if answer:
+        signals.append({"term": answer, "aliases": []})
+        taken.add(answer)
+    facts = [(e.get("fact") or "") for e in (evidence_list or [])]
+    sources = [(e.get("source") or "") for e in (evidence_list or [])]
+    for i, fact in enumerate(facts):
+        if len(signals) >= GOLD_SIGNAL_COUNT:
+            break
+        n = _pick_key_noun(fact, taken)
+        if n:
+            signals.append({"term": n, "aliases": []})
+            taken.add(n)
+    # Pad with source names if we still need more.
+    for src in sources:
+        if len(signals) >= GOLD_SIGNAL_COUNT:
+            break
+        if src and src not in taken:
+            signals.append({"term": src, "aliases": []})
+            taken.add(src)
+    # Final fallback — pad with the answer's first 30 chars so the
+    # schema invariant (always 3 signals) holds even for sparse rows.
+    while len(signals) < GOLD_SIGNAL_COUNT:
+        filler = (answer[:30] + f" [pad{len(signals)}]").strip() or f"pad{len(signals)}"
+        signals.append({"term": filler, "aliases": []})
+    return signals[:GOLD_SIGNAL_COUNT]
+
+
+def _null_gold_signals() -> list[dict]:
+    """For null_query: gold = abstention phrases. Graded_answer for null
+    queries measures whether the answer contains a refusal phrase; the
+    abstention_f1 axis is the load-bearing one."""
+    return [{"term": s, "aliases": []} for s in ABSTENTION_SIGNALS]
+
+
+def _min_recall_for_evidence(n_evidence: int) -> float:
+    """Tune so a perfectly-retrieving production hits 1.0 but partial
+    retrieval registers ≥ 0.5 — keeps the axis non-saturating."""
+    if n_evidence <= 1:
+        return 1.0
+    if n_evidence == 2:
+        return 1.0
+    if n_evidence == 3:
+        return 0.67
+    return 0.75
+
+
+def convert(raw: dict, qid: int) -> dict:
+    """Convert one raw MultiHop-RAG query into a step7-format fixture row."""
+    qtype = raw.get("question_type", "unknown")
+    evidence = raw.get("evidence_list") or []
+    is_null = qtype == "null_query"
+
+    out: dict = {
+        "id": qid,
+        "category": f"hotpot-{qtype.replace('_query', '')}",
+        "question_type": qtype,    # preserve original — Step 6 cross-tab keys on this
+        "text": raw.get("query", "").strip(),
+        "abstention_truth": "absent" if is_null else "present",
+    }
+
+    if is_null:
+        out["gold_signals"] = _null_gold_signals()
+        # No expected_path — graph traversal not meaningful when corpus
+        # lacks the answer.
+    else:
+        out["gold_signals"] = _gold_signals_for(raw.get("answer", ""), evidence)
+        # expected_path.nodes from evidence titles (deduplicated, capped).
+        seen: list[str] = []
+        for e in evidence:
+            t = (e.get("title") or "").strip()
+            if t and t not in seen:
+                seen.append(t)
+            if len(seen) >= EXPECTED_PATH_MAX_NODES:
+                break
+        if seen:
+            out["expected_path"] = {
+                "nodes": seen,
+                "min_recall": _min_recall_for_evidence(len(seen)),
+            }
+    return out
+
+
+def _select_subset(raw_queries: list[dict], subset: str) -> list[dict]:
+    cap = SUBSETS[subset]
+    if cap is None:
+        return raw_queries
+    by_type: dict[str, list[dict]] = defaultdict(list)
+    for q in raw_queries:
+        by_type[q.get("question_type", "unknown")].append(q)
+    selected: list[dict] = []
+    for qtype, lst in by_type.items():
+        # Deterministic — take first `cap` per type (no shuffle so re-runs
+        # are byte-identical). Operators can re-shuffle by passing a
+        # different seed via build_fixture --seed later if desired.
+        selected.extend(lst[:cap])
+    return selected
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="MultiHop-RAG → step7 fixture")
+    ap.add_argument(
+        "--subset", choices=list(SUBSETS.keys()), default="balanced-200",
+        help=f"Subset selector (default balanced-200). Sizes: {SUBSETS}",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help="Print plan + 1 row per type; write nothing.",
+    )
+    args = ap.parse_args()
+
+    ws = _workspace()
+    raw_path = ws / "eval" / "multihop_rag_raw_queries.json"
+    out_path = ws / "eval" / "multihop_rag_queries.json"
+    if not raw_path.exists():
+        sys.exit(
+            f"[build_fixture] raw queries not found: {raw_path}\n"
+            "Run scripts/hotpot/download_multihop_rag.py first."
+        )
+
+    print(f"[build_fixture] reading {raw_path.name}…")
+    raw = json.loads(raw_path.read_text(encoding="utf-8"))
+    raw_queries = raw.get("queries", [])
+    print(f"  → {len(raw_queries)} raw queries")
+
+    selected_raw = _select_subset(raw_queries, args.subset)
+    print(f"[build_fixture] subset={args.subset!r} → {len(selected_raw)} queries selected")
+    type_dist = Counter(q.get("question_type", "?") for q in selected_raw)
+    for t, n in type_dist.most_common():
+        print(f"  {t}: {n}")
+
+    fixture_queries: list[dict] = []
+    for idx, raw_q in enumerate(selected_raw, start=1):
+        fixture_queries.append(convert(raw_q, idx))
+
+    if args.dry_run:
+        print("\n[dry-run] one row per question_type:")
+        seen_types: set[str] = set()
+        for q in fixture_queries:
+            if q["question_type"] in seen_types:
+                continue
+            seen_types.add(q["question_type"])
+            print(json.dumps(q, ensure_ascii=False, indent=2))
+            print()
+            if len(seen_types) >= 4:
+                break
+        return 0
+
+    # Build the final fixture JSON in step7's schema shape so the
+    # existing oracle / schema tests recognise it.
+    fixture_payload = {
+        "version": "multihop-rag-v1",
+        "description": (
+            "MultiHop-RAG (Tang & Yang 2024, EMNLP) — α-5 external "
+            "benchmark fixture. Each query carries 3 gold_signals + "
+            "optional expected_path + abstention_truth. question_type "
+            "is preserved as fixture field so the α-5 ablation runner "
+            "can cross-tab per type. See plan: "
+            "~/.claude/plans/quiet-hugging-iverson.md."
+        ),
+        "source_dataset": raw.get("dataset_id"),
+        "source_license": raw.get("license"),
+        "source_citation": raw.get("citation"),
+        "built_at_utc": datetime.now(timezone.utc).isoformat(),
+        "subset": args.subset,
+        "type_distribution": dict(type_dist),
+        "queries": fixture_queries,
+    }
+    out_path.write_text(
+        json.dumps(fixture_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(f"\n[build_fixture] wrote {out_path.relative_to(ws.parent.parent) if (ws.parent.parent / 'README.md').exists() else out_path}")
+    print(
+        f"\n[done] Step 3 complete ({len(fixture_queries)} queries). Next:\n"
+        f"  python scripts/bench.py --suite=multihop_rag --dry-run  # Step 4 smoke"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hotpot/download_multihop_rag.py
+++ b/scripts/hotpot/download_multihop_rag.py
@@ -1,0 +1,226 @@
+"""Step 2 — Download MultiHop-RAG (Tang & Yang 2024, EMNLP) into the
+hotpot_eval workspace.
+
+Pulls two configs from HuggingFace ``yixuantt/MultiHopRAG``:
+
+  - ``corpus``      : 609 news articles  (category, title, body, source, …)
+  - ``MultiHopRAG`` : 2,556 queries      (query, answer, evidence_list,
+                                          question_type ∈ {comparison_query,
+                                          inference_query, temporal_query,
+                                          null_query})
+
+Saves:
+  - One ``.txt`` per article under ``$JAMES_WORKSPACE/raw/`` so the
+    existing JAMES ingest pipeline can absorb them in Step 7.
+  - Queries as a single ``$JAMES_WORKSPACE/eval/multihop_rag_raw_queries.json``
+    so Step 3 (build_fixture.py) can convert them into the step7-format
+    fixture without re-downloading.
+  - ``$JAMES_WORKSPACE/ATTRIBUTION.md`` capturing the CC-BY-4.0 license
+    + citation per the dataset README.
+
+Idempotent: re-running skips files that already exist (size check). Cap
+the article file name to a short slug so Windows long-path limits don't
+bite — title can be 200+ chars in this dataset.
+
+Plan reference: `~/.claude/plans/quiet-hugging-iverson.md` Step 2.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+DATASET_ID = "yixuantt/MultiHopRAG"
+DATASET_CITATION = (
+    "Tang, Yixuan and Yang, Yi. "
+    "\"MultiHop-RAG: Benchmarking Retrieval-Augmented Generation for "
+    "Multi-Hop Queries.\" Findings of EMNLP, 2024. "
+    "https://huggingface.co/datasets/yixuantt/MultiHopRAG"
+)
+LICENSE = "CC-BY-4.0"
+
+# Slug max length so the combined filename stays comfortably under
+# Windows MAX_PATH-style limits. Original titles can be 200+ chars.
+SLUG_MAX = 80
+# Trim/normalize for filesystem safety.
+_SLUG_BAD = re.compile(r"[^a-zA-Z0-9\-\.]+")
+
+
+def _slug(text: str) -> str:
+    s = _SLUG_BAD.sub("-", (text or "untitled").strip()).strip("-")
+    return s[:SLUG_MAX] if s else "untitled"
+
+
+def _workspace() -> Path:
+    """Resolve workspace. ``JAMES_WORKSPACE`` must be set to point at
+    the hotpot_eval workspace; refuse to scribble in the project root.
+    """
+    raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if not raw:
+        sys.exit(
+            "[download_multihop_rag] JAMES_WORKSPACE is not set. Refusing "
+            "to write into the project root. Export it first, e.g.:\n"
+            "  export JAMES_WORKSPACE=./workspaces/hotpot_eval"
+        )
+    ws = Path(raw).resolve()
+    if not ws.exists():
+        sys.exit(f"[download_multihop_rag] workspace {ws} does not exist")
+    return ws
+
+
+def _write_article(out_dir: Path, idx: int, row: dict) -> Path:
+    title = row.get("title") or "untitled"
+    slug = _slug(title)
+    fname = f"multihop_{idx:04d}_{slug}.txt"
+    path = out_dir / fname
+    if path.exists() and path.stat().st_size > 0:
+        return path
+    body = row.get("body", "") or ""
+    header = (
+        f"# {title}\n\n"
+        f"Source: {row.get('source', '?')}\n"
+        f"URL: {row.get('url', '?')}\n"
+        f"Author: {row.get('author', '?')}\n"
+        f"Published: {row.get('published_at', '?')}\n"
+        f"Category: {row.get('category', '?')}\n\n"
+        f"---\n\n"
+    )
+    path.write_text(header + body, encoding="utf-8")
+    return path
+
+
+def _write_attribution(ws: Path) -> Path:
+    path = ws / "ATTRIBUTION.md"
+    if path.exists():
+        return path
+    path.write_text(
+        "# Dataset Attribution — MultiHop-RAG\n\n"
+        f"**Source**: HuggingFace `{DATASET_ID}`\n"
+        f"**License**: {LICENSE}\n"
+        f"**Citation**:\n\n"
+        f"> {DATASET_CITATION}\n\n"
+        "## Use within JAMES\n\n"
+        "The MultiHop-RAG corpus (609 news articles, predominantly\n"
+        "English-language news from 2023-09 to 2023-12) is ingested into\n"
+        "this workspace's `wiki/` via the standard JAMES pipeline\n"
+        "(`scripts/ingest_pipeline.py`). The 2,556 query set is converted\n"
+        "into step7-format fixture by `scripts/hotpot/build_fixture.py`\n"
+        "and consumed by `scripts/qvt_ablation_matrix.py` for the α-5\n"
+        "ablation matrix.\n\n"
+        "Per CC-BY-4.0, this attribution file MUST stay alongside any\n"
+        "redistributed corpus snapshot. Production wiki (project root\n"
+        "`./wiki/`) is unaffected by this benchmark workspace — see\n"
+        "`workspaces/hotpot_eval/README.md`.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Download MultiHop-RAG into hotpot_eval workspace")
+    ap.add_argument(
+        "--limit-articles", type=int, default=0,
+        help="Cap article count (0 = all 609). Useful for smoke testing.",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help="Print plan + first article preview; write nothing.",
+    )
+    args = ap.parse_args()
+
+    ws = _workspace()
+    raw_dir = ws / "raw"
+    eval_dir = ws / "eval"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    eval_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[download_multihop_rag] workspace: {ws}")
+    print(f"[download_multihop_rag] dataset:   {DATASET_ID}")
+
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        sys.exit(
+            "[download_multihop_rag] `datasets` library not installed.\n"
+            "  pip install 'datasets>=2.14.0'"
+        )
+
+    print("[download_multihop_rag] loading corpus split…")
+    corpus = load_dataset(DATASET_ID, "corpus", split="train")
+    print(f"  → {len(corpus)} articles")
+
+    print("[download_multihop_rag] loading MultiHopRAG (queries) split…")
+    queries = load_dataset(DATASET_ID, "MultiHopRAG", split="train")
+    print(f"  → {len(queries)} queries")
+
+    if args.dry_run:
+        print("\n[dry-run] first article preview:")
+        sample = corpus[0]
+        print(f"  title:  {sample.get('title', '?')[:80]}")
+        print(f"  source: {sample.get('source', '?')}")
+        print(f"  body chars: {len(sample.get('body', ''))}")
+        print("\n[dry-run] first query preview:")
+        q = queries[0]
+        print(f"  query:    {q.get('query', '')[:100]}…")
+        print(f"  answer:   {q.get('answer', '?')}")
+        print(f"  type:     {q.get('question_type', '?')}")
+        print(f"  evidence: {len(q.get('evidence_list', []))} entries")
+        return 0
+
+    # Articles — flat .txt files under raw/.
+    print(f"\n[download_multihop_rag] writing articles to {raw_dir.relative_to(ws.parent.parent if (ws.parent.parent / 'README.md').exists() else ws)}…")
+    n_articles = len(corpus) if args.limit_articles <= 0 else min(args.limit_articles, len(corpus))
+    n_written = n_skipped = 0
+    for i in range(n_articles):
+        path = _write_article(raw_dir, i, dict(corpus[i]))
+        if path.stat().st_mtime > 0 and path.stat().st_size > 0:
+            # Already-existed-or-just-wrote — coarse counter.
+            if (datetime.now(timezone.utc).timestamp() - path.stat().st_mtime) > 60:
+                n_skipped += 1
+            else:
+                n_written += 1
+        if (i + 1) % 50 == 0:
+            print(f"  [{i+1}/{n_articles}] …")
+    print(f"  → wrote/refreshed {n_written}, skipped (already present) {n_skipped}")
+
+    # Queries — single JSON for downstream Step 3 (build_fixture).
+    queries_path = eval_dir / "multihop_rag_raw_queries.json"
+    print(f"\n[download_multihop_rag] writing raw queries to {queries_path.name}…")
+    raw_queries_payload = {
+        "schema": "multihop-rag-raw-v1",
+        "downloaded_at_utc": datetime.now(timezone.utc).isoformat(),
+        "dataset_id": DATASET_ID,
+        "license": LICENSE,
+        "citation": DATASET_CITATION,
+        "n_queries": len(queries),
+        "queries": [dict(q) for q in queries],
+    }
+    queries_path.write_text(
+        json.dumps(raw_queries_payload, ensure_ascii=False, indent=2,
+                   default=str),
+        encoding="utf-8",
+    )
+    print(f"  → {len(queries)} queries saved")
+
+    # Attribution memo.
+    attr_path = _write_attribution(ws)
+    print(f"\n[download_multihop_rag] attribution: {attr_path.name}")
+
+    print(
+        "\n[done] Step 2 complete. Next:\n"
+        "  python scripts/hotpot/build_fixture.py --subset balanced-200"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -69,7 +69,11 @@ from typing import Any, Dict, List, Optional, Tuple
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
-from eval.qvt.oracle import ThreeAxisResult, score_three_axis  # noqa: E402
+from eval.qvt.oracle import (  # noqa: E402
+    FiveAxisResult,
+    score_five_axis,
+    score_five_axis_by_question_type,
+)
 
 # ---------------------------------------------------------------------------
 # Matrix definition (memo §2)
@@ -157,10 +161,42 @@ SERVER_HEALTHZ = SERVER_BASE_URL.rstrip("/") + "/healthz"
 SERVER_BOOT_TIMEOUT_SEC = 120
 BENCH_SUBPROCESS_TIMEOUT_SEC = 2400
 
-_FIXTURE_PATH = ROOT / "eval" / "regression" / "step7_queries.json"
+_DEFAULT_FIXTURE_PATH = ROOT / "eval" / "regression" / "step7_queries.json"
 _OUTPUT_DIR = ROOT / "reports" / "research-runs" / "qvt-ablation-cells"
 _REPORT_DIR = ROOT / "reports" / "promo-assets"
 _BASELINE_DIR = ROOT / "eval" / "qvt"
+
+
+def _resolve_fixture(suite: str) -> Path:
+    """Same resolution as bench.py:_load_suite — eval/regression/ first,
+    workspace's eval/ fallback. Lets `--suite=multihop_rag` find the
+    α-5 fixture without hardcoding."""
+    canonical = ROOT / "eval" / "regression" / f"{suite}_queries.json"
+    if canonical.exists():
+        return canonical
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        ws_path = Path(ws_raw).resolve() / "eval" / f"{suite}_queries.json"
+        if ws_path.exists():
+            return ws_path
+    return canonical  # caller prints "missing" diagnostic against this
+
+
+def _resolve_output_dir() -> Path:
+    """Per-cell JSON output dir — workspace-relative when set, else the
+    project's `reports/research-runs/qvt-ablation-cells/`."""
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        return (Path(ws_raw).resolve()
+                / "reports" / "research-runs" / "qvt-ablation-cells")
+    return _OUTPUT_DIR
+
+
+def _resolve_baseline_dir() -> Path:
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        return Path(ws_raw).resolve() / "eval" / "qvt"
+    return _BASELINE_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -261,22 +297,42 @@ def _mint_employee_jwt() -> Optional[str]:
 # Per-cell execution
 # ---------------------------------------------------------------------------
 
-def _cell_env(row: str, tier: str) -> Dict[str, str]:
-    """Compose the full env for one cell: OS env + fixed + row + tier."""
+def _cell_env(row: str, tier: str,
+              think_override: Optional[bool] = None) -> Dict[str, str]:
+    """Compose the full env for one cell: OS env + fixed + row + tier +
+    optional `JAMES_GEMMA4_E4B_THINK_OFF` override (Step 9 sanity cell).
+
+    `think_override` semantics:
+      None         — inherit from process env (workspace .env's setting).
+      True         — force `JAMES_GEMMA4_E4B_THINK_OFF=1` (matrix primary).
+      False        — force the variable unset (sanity cell — restores
+                     production default = thinking ON).
+    """
     env = os.environ.copy()
     env.update(_FIXED_ENV)
     env.update(_ROW_ENVS[row])
     env["JAMES_LLM_MODEL"] = _TIER_MODELS[tier]
+    if think_override is True:
+        env["JAMES_GEMMA4_E4B_THINK_OFF"] = "1"
+    elif think_override is False:
+        # Force unset — sanity cell reverts to production default.
+        env.pop("JAMES_GEMMA4_E4B_THINK_OFF", None)
     return env
 
 
-def _run_single_bench(row: str, tier: str, run_index: int) -> Optional[Path]:
-    server_env = _cell_env(row, tier)
+def _run_single_bench(row: str, tier: str, run_index: int,
+                      think_override: Optional[bool] = None) -> Optional[Path]:
+    server_env = _cell_env(row, tier, think_override=think_override)
 
     flagged = {k: v for k, v in _ROW_ENVS[row].items()}
+    think_tag = ""
+    if think_override is True:
+        think_tag = " think=OFF (primary)"
+    elif think_override is False:
+        think_tag = " think=ON (sanity)"
     print(
         f"\n=== cell {row}/{tier} run {run_index + 1}/N "
-        f"(model={_TIER_MODELS[tier]}, env={flagged}) ==="
+        f"(model={_TIER_MODELS[tier]}, env={flagged}{think_tag}) ==="
     )
     server = _spawn_server(server_env)
     if server is None:
@@ -320,14 +376,21 @@ def _run_single_bench(row: str, tier: str, run_index: int) -> Optional[Path]:
     return bench_output
 
 
-def _aggregate_runs(runs: List[ThreeAxisResult]) -> Dict[str, Any]:
-    """Same shape as qvt_capture_baseline._aggregate_runs for cell-vs-
-    baseline comparability."""
+def _aggregate_runs(runs: List[FiveAxisResult]) -> Dict[str, Any]:
+    """5-axis aggregation: 3 quality (path/graded/abstention) + 2 cost
+    (token, latency). Same per-axis stats shape (median/min/max/
+    noise_band) so the matrix render can compute Δ vs baseline uniformly.
+    """
     if not runs:
         return {}
     path_means = [r.path_coverage.mean_recall for r in runs]
     graded_means = [r.graded_answer.mean_accuracy for r in runs]
     abstention_f1s = [r.abstention.f1 for r in runs]
+    # Cost axes — lower is better. We report mean (paired with the
+    # per-query p95 captured in to_dict() for tail-watching) and same
+    # noise-band shape as quality axes.
+    token_means = [r.token_cost.mean_chars for r in runs]
+    latency_means = [r.latency_cost.mean_s for r in runs]
 
     def _stats(values: List[float]) -> Dict[str, float]:
         values_sorted = sorted(values)
@@ -343,6 +406,8 @@ def _aggregate_runs(runs: List[ThreeAxisResult]) -> Dict[str, Any]:
         "path_coverage": _stats(path_means),
         "graded_answer": _stats(graded_means),
         "abstention_f1": _stats(abstention_f1s),
+        "token_cost": _stats(token_means),
+        "latency_cost": _stats(latency_means),
         "n_runs": len(runs),
     }
 
@@ -359,36 +424,71 @@ def _current_git_sha() -> Optional[str]:
         return None
 
 
-def _cell_output_path(row: str, tier: str) -> Path:
-    return _OUTPUT_DIR / f"qvt-ablation-cell-{row}-{tier}.json"
+def _cell_output_path(row: str, tier: str,
+                      sanity_think_on: bool = False) -> Path:
+    suffix = "-thinkON" if sanity_think_on else ""
+    return _resolve_output_dir() / f"qvt-ablation-cell-{row}-{tier}{suffix}.json"
 
 
 def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
-              sha: str, resume: bool) -> Optional[Dict[str, Any]]:
+              sha: str, resume: bool,
+              sanity_think_on: bool = False) -> Optional[Dict[str, Any]]:
     """Run one cell. Writes per-cell JSON. Returns the payload (or
-    loads-and-returns when --resume hits an existing file)."""
-    out = _cell_output_path(row, tier)
+    loads-and-returns when --resume hits an existing file).
+
+    `sanity_think_on=True` (Step 9): forces gemma4:e4b's `think=ON`
+    (matrix sanity supplement — production default). Output JSON gets
+    `-thinkON` suffix so the standard L1/M_M cell and the sanity cell
+    coexist on disk.
+    """
+    out = _cell_output_path(row, tier, sanity_think_on=sanity_think_on)
     if resume and out.exists():
-        print(f"[cell {row}/{tier}] --resume: skipping, "
+        cell_tag = f"{row}/{tier}{' (sanity think=ON)' if sanity_think_on else ''}"
+        print(f"[cell {cell_tag}] --resume: skipping, "
               f"{out.relative_to(ROOT)} exists")
         return json.loads(out.read_text(encoding="utf-8"))
 
-    runs: List[ThreeAxisResult] = []
+    # Determine think override: sanity cell forces think=ON; other cells
+    # inherit (workspace .env sets JAMES_GEMMA4_E4B_THINK_OFF=1 for the
+    # primary matrix). Pass through to bench subprocess via _cell_env.
+    think_override: Optional[bool] = False if sanity_think_on else None
+    runs: List[FiveAxisResult] = []
+    # Per-run per-question_type breakdowns (α-5 plan Step 6 cross-tab).
+    # Empty for step7 fixtures that don't carry the field — those cells
+    # simply skip the per-type aggregation.
+    runs_by_type: List[Dict[str, FiveAxisResult]] = []
     run_paths: List[str] = []
+    cell_label = f"{row}/{tier}{' (sanity think=ON)' if sanity_think_on else ''}"
     for i in range(n_runs):
-        bench_path = _run_single_bench(row, tier, i)
+        bench_path = _run_single_bench(row, tier, i,
+                                       think_override=think_override)
         if bench_path is None:
-            print(f"[cell {row}/{tier}] run {i + 1} failed to produce "
+            print(f"[cell {cell_label}] run {i + 1} failed to produce "
                   f"bench output — aborting cell")
             return None
-        result = score_three_axis(bench_path, fixture)
-        print(f"[cell {row}/{tier} run {i + 1}] {result.summary()}")
+        result = score_five_axis(bench_path, fixture)
+        print(f"[cell {cell_label} run {i + 1}] {result.summary()}")
         runs.append(result)
+        runs_by_type.append(score_five_axis_by_question_type(bench_path, fixture))
         run_paths.append(str(bench_path.relative_to(ROOT)))
 
     aggregate = _aggregate_runs(runs)
+    # Per-question_type aggregation. Same shape as `aggregate` but keyed
+    # by question_type. Empty for non-cross-tab suites.
+    aggregate_by_type: Dict[str, Dict[str, Any]] = {}
+    if runs_by_type and any(runs_by_type):
+        all_types: set[str] = set()
+        for d in runs_by_type:
+            all_types.update(d.keys())
+        for qt in sorted(all_types):
+            sub_runs: List[FiveAxisResult] = [
+                d[qt] for d in runs_by_type if qt in d
+            ]
+            if sub_runs:
+                aggregate_by_type[qt] = _aggregate_runs(sub_runs)
+
     payload = {
-        "schema": "qvt-ablation-cell-v1",
+        "schema": "qvt-ablation-cell-v2",  # v2 adds aggregate_by_question_type
         "captured_at": datetime.now(timezone.utc).isoformat(),
         "git_sha": sha,
         "row": row,
@@ -397,20 +497,28 @@ def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
         "model": _TIER_MODELS[tier],
         "env": _ROW_ENVS[row],
         "fixed_env": _FIXED_ENV,
+        # Step 9 — sanity cell flag travels in the JSON so the report
+        # writer can distinguish it from the primary L1/M_M (think=OFF).
+        "sanity_think_on": bool(sanity_think_on),
         "fixture_version": fixture.get("version"),
         "n_runs": n_runs,
         "aggregate": aggregate,
+        "aggregate_by_question_type": aggregate_by_type,
         "runs": [
             {"bench_output": run_paths[i], "scores": runs[i].to_dict()}
             for i in range(n_runs)
         ],
     }
-    _OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    _resolve_output_dir().mkdir(parents=True, exist_ok=True)
     out.write_text(
         json.dumps(payload, indent=2, ensure_ascii=False, default=str),
         encoding="utf-8",
     )
-    print(f"[cell {row}/{tier}] wrote {out.relative_to(ROOT)}")
+    try:
+        rel = out.relative_to(ROOT)
+    except ValueError:
+        rel = out
+    print(f"[cell {cell_label}] wrote {rel}")
     return payload
 
 
@@ -418,11 +526,20 @@ def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
 # Report rendering (--render-report)
 # ---------------------------------------------------------------------------
 
+_QUALITY_AXES = ("path_coverage", "graded_answer", "abstention_f1")
+_COST_AXES = ("token_cost", "latency_cost")
+
+
 def _classify_delta(deltas: Dict[str, float], noise_band: Dict[str, float]) -> str:
-    """Memo §3.1 verdict rule."""
+    """3-axis quality verdict (legacy, used by step7 path).
+
+    Memo §3.1 verdict rule — positive / mixed / zero / negative / regression
+    against quality axes only. Kept for back-compat; the α-5 5-axis
+    runner uses `_classify_five_axis_delta` instead.
+    """
     positives = []
     negatives = []
-    for axis in ("path_coverage", "graded_answer", "abstention_f1"):
+    for axis in _QUALITY_AXES:
         d = deltas.get(axis, 0.0)
         band = noise_band.get(axis, 0.0)
         if d > band:
@@ -440,14 +557,63 @@ def _classify_delta(deltas: Dict[str, float], noise_band: Dict[str, float]) -> s
     return "zero"
 
 
+def _classify_five_axis_delta(deltas: Dict[str, float],
+                              noise_band: Dict[str, float]) -> str:
+    """5-axis Pareto-aware verdict (plan Step 5).
+
+    Quality side: any quality axis Δ > +noise_band ⇒ quality_positive.
+                  any quality axis Δ < -noise_band ⇒ quality_negative.
+    Cost side  : cost axis is "lower is better", so token/latency Δ
+                  < -noise_band (numerically smaller than baseline) is
+                  cost-positive, and Δ > +noise_band is cost-regression.
+
+    Combined verdicts (plan §implementation step 5):
+      - quality_positive + cost_positive  → "strong-adopt"
+      - quality_positive + cost_flat      → "adopt"
+      - quality_flat     + cost_positive  → "efficiency-adopt"
+      - quality_positive + cost_negative  → "tier-gated"
+      - quality_negative + *              → "reject"  (no cost gain redeems quality loss)
+      - else (quality_flat + cost_flat)   → "zero"
+    """
+    q_pos = q_neg = 0
+    for axis in _QUALITY_AXES:
+        d = deltas.get(axis, 0.0)
+        band = noise_band.get(axis, 0.0)
+        if d > band:
+            q_pos += 1
+        elif d < -band:
+            q_neg += 1
+    c_pos = c_neg = 0
+    for axis in _COST_AXES:
+        d = deltas.get(axis, 0.0)
+        band = noise_band.get(axis, 0.0)
+        # Cost down (Δ < -band) is good; cost up (Δ > +band) is bad.
+        if d < -band:
+            c_pos += 1
+        elif d > band:
+            c_neg += 1
+    if q_neg > 0:
+        return "reject"
+    if q_pos > 0 and c_pos > 0 and c_neg == 0:
+        return "strong-adopt"
+    if q_pos > 0 and c_pos == 0 and c_neg == 0:
+        return "adopt"
+    if q_pos > 0 and c_neg > 0:
+        return "tier-gated"
+    if q_pos == 0 and c_pos > 0 and c_neg == 0:
+        return "efficiency-adopt"
+    return "zero"
+
+
 def _read_baseline() -> Optional[Dict[str, Any]]:
-    files = sorted(_BASELINE_DIR.glob("baseline_*.json"))
+    baseline_dir = _resolve_baseline_dir()
+    files = sorted(baseline_dir.glob("baseline_*.json"))
     if not files:
-        print(f"[report] no baseline JSON under {_BASELINE_DIR.relative_to(ROOT)}")
+        print(f"[report] no baseline JSON under {baseline_dir}")
         return None
     # Most recent SHA — operator captures one baseline per release.
     latest = files[-1]
-    print(f"[report] using baseline {latest.relative_to(ROOT)}")
+    print(f"[report] using baseline {latest}")
     return json.loads(latest.read_text(encoding="utf-8"))
 
 
@@ -456,15 +622,14 @@ def _render_report(out_path: Path) -> int:
     if baseline is None:
         return 4
     base_agg = baseline.get("aggregate", {})
+    # 5-axis baseline medians + noise bands.
+    _ALL_AXES = ("path_coverage", "graded_answer", "abstention_f1",
+                 "token_cost", "latency_cost")
     base_med = {
-        "path_coverage": base_agg.get("path_coverage", {}).get("median"),
-        "graded_answer": base_agg.get("graded_answer", {}).get("median"),
-        "abstention_f1": base_agg.get("abstention_f1", {}).get("median"),
+        ax: base_agg.get(ax, {}).get("median") for ax in _ALL_AXES
     }
     base_noise = {
-        "path_coverage": base_agg.get("path_coverage", {}).get("noise_band", 0.0),
-        "graded_answer": base_agg.get("graded_answer", {}).get("noise_band", 0.0),
-        "abstention_f1": base_agg.get("abstention_f1", {}).get("noise_band", 0.0),
+        ax: base_agg.get(ax, {}).get("noise_band", 0.0) for ax in _ALL_AXES
     }
 
     cells: List[Dict[str, Any]] = []
@@ -477,70 +642,194 @@ def _render_report(out_path: Path) -> int:
 
     if not cells:
         print(f"[report] no per-cell JSONs found under "
-              f"{_OUTPUT_DIR.relative_to(ROOT)}")
+              f"{_resolve_output_dir()}")
         return 5
 
     rows: List[str] = [
-        "# QVT α-5 ablation matrix — 18-cell verdict",
+        "# QVT α-5 ablation matrix — 5-axis × 18-cell verdict",
         "",
         f"**Baseline**: `{baseline.get('git_sha', 'unknown')}` "
         f"(captured {baseline.get('captured_at', '?')}).",
         f"**Cells available**: {len(cells)}/{len(_ROW_ENVS) * len(_TIER_MODELS)}.",
         "",
         "| Row | Tier | Model | Path Δ | Graded Δ | Abst F1 Δ | "
-        "Noise band (P/G/A) | Verdict |",
-        "|---|---|---|---|---|---|---|---|",
+        "Token Δ | Latency Δ (s) | Verdict |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for c in cells:
         agg = c.get("aggregate", {})
-        med = {
-            "path_coverage": agg.get("path_coverage", {}).get("median"),
-            "graded_answer": agg.get("graded_answer", {}).get("median"),
-            "abstention_f1": agg.get("abstention_f1", {}).get("median"),
-        }
+        med = {ax: agg.get(ax, {}).get("median") for ax in _ALL_AXES}
         deltas: Dict[str, float] = {}
-        for axis in ("path_coverage", "graded_answer", "abstention_f1"):
+        for axis in _ALL_AXES:
             if med[axis] is None or base_med[axis] is None:
                 deltas[axis] = 0.0
             else:
                 deltas[axis] = round(med[axis] - base_med[axis], 4)
-        verdict = _classify_delta(deltas, base_noise)
+        verdict = _classify_five_axis_delta(deltas, base_noise)
         rows.append(
             f"| {c['row']} ({c['row_label']}) | {c['tier']} | "
             f"`{c['model']}` | {deltas['path_coverage']:+.3f} | "
             f"{deltas['graded_answer']:+.3f} | "
             f"{deltas['abstention_f1']:+.3f} | "
-            f"{base_noise['path_coverage']:.3f}/"
-            f"{base_noise['graded_answer']:.3f}/"
-            f"{base_noise['abstention_f1']:.3f} | "
+            f"{deltas['token_cost']:+.0f} | "
+            f"{deltas['latency_cost']:+.2f} | "
             f"**{verdict}** |"
         )
 
     rows += [
         "",
-        "## Verdict rule",
+        "## 5-axis Pareto-aware verdict rule (plan Step 5)",
         "",
         "Per cell, Δ vs L1/M_M baseline median per axis. Noise band =",
-        "max − min across the baseline's paired-N=3 runs. Classification:",
+        "max − min across the baseline's paired-N=3 runs.",
         "",
-        "- **positive** — all 3 axes Δ > noise band",
-        "- **mixed** — at least one Δ > band, none Δ < −band",
-        "- **zero** — all |Δ| ≤ band",
-        "- **negative** — at least one Δ < −band, none Δ > band",
-        "- **regression** — all 3 axes Δ < −band",
+        "Quality axes (higher = better): path_coverage, graded_answer, abstention_f1.",
+        "Cost axes (lower = better): token_cost (answer chars proxy), latency_cost (seconds).",
         "",
-        "## Routing policy decision (memo §3.2)",
+        "- **strong-adopt** — at least one quality Δ > +band AND at least",
+        "  one cost Δ < −band (lower = improvement), no cost regression",
+        "- **adopt** — quality+ on at least one axis, cost flat",
+        "- **efficiency-adopt** — quality flat, cost down on at least one axis",
+        "- **tier-gated** — quality+ but cost regressed (justify per tier;",
+        "  small-tier accept, large-tier reject)",
+        "- **reject** — any quality axis Δ < −band (no cost gain redeems)",
+        "- **zero** — within noise band on all five",
+        "",
+        "## Routing policy decision",
         "",
         "| Per-tier pattern | Policy |",
         "|---|---|",
-        "| `positive` on ≥ 2 tiers including M_M | enable as default (flip `.env.example`) |",
-        "| `positive` only on one tier | tier-gated (router policy keys on `JAMES_LLM_MODEL`) |",
+        "| `strong-adopt` or `adopt` on ≥ 2 tiers incl. M_M | enable as default (flip `.env.example`) |",
+        "| `efficiency-adopt` on all tiers | enable as default (free efficiency) |",
+        "| only one tier `*-adopt` | tier-gated (router keys on `JAMES_LLM_MODEL`) |",
         "| `zero` on all tiers | delete / document as inert (deprecation PR) |",
-        "| `negative` or `regression` on ≥ 1 tier | keep opt-in indefinitely |",
+        "| `reject` on ≥ 1 tier | keep opt-in indefinitely |",
+        "| `tier-gated` verdict on any cell | per-tier evaluation (small ≤ large?) |",
         "",
         "Follow-up PRs (one per layer with non-`zero` verdict) cite the",
         "specific cell here as their Quality Delta Card source.",
     ]
+
+    # ──────────────────────────────────────────────────────────
+    # Step 6 — Per-question_type cross-tab + routing policy recs.
+    # Skipped silently when no cell carries `aggregate_by_question_type`
+    # (legacy v1 cells, or step7 fixture without question_type).
+    # ──────────────────────────────────────────────────────────
+    cells_with_types = [c for c in cells if c.get("aggregate_by_question_type")]
+    if cells_with_types:
+        # Union of all question types across all cells.
+        all_qts: set[str] = set()
+        for c in cells_with_types:
+            all_qts.update(c["aggregate_by_question_type"].keys())
+        all_qts_sorted = sorted(all_qts)
+
+        rows.append("")
+        rows.append("## Cross-tab — verdict per `question_type` × `(row, tier)`")
+        rows.append("")
+        rows.append(
+            "Per question_type Δ vs the **L1/M_M baseline of the same "
+            "question_type** (intra-type comparison — keeps the "
+            "baseline subgroup size and language consistent). Verdict "
+            "uses the 5-axis Pareto rule."
+        )
+        rows.append("")
+        # Find L1/M_M cell once for baseline per type.
+        l1_mm_cell = None
+        for c in cells_with_types:
+            if c["row"] == "L1" and c["tier"] == "M_M":
+                l1_mm_cell = c
+                break
+        if l1_mm_cell is None:
+            rows.append("(no L1/M_M cell present — cross-tab uses global baseline instead)")
+            rows.append("")
+
+        def _per_type_base_med(qt: str) -> Dict[str, Optional[float]]:
+            if l1_mm_cell is not None:
+                ag = l1_mm_cell.get("aggregate_by_question_type", {}).get(qt, {})
+            else:
+                ag = base_agg  # fall back to global baseline
+            return {ax: ag.get(ax, {}).get("median") for ax in _ALL_AXES}
+
+        def _per_type_base_noise(qt: str) -> Dict[str, float]:
+            if l1_mm_cell is not None:
+                ag = l1_mm_cell.get("aggregate_by_question_type", {}).get(qt, {})
+            else:
+                ag = base_agg
+            return {ax: ag.get(ax, {}).get("noise_band", 0.0) for ax in _ALL_AXES}
+
+        # Routing policy aggregator: per question_type, collect winning
+        # (cell, verdict) so the recommended routing rule is sourced
+        # from the strongest cell per type.
+        per_type_winners: Dict[str, List[tuple]] = {qt: [] for qt in all_qts_sorted}
+
+        for qt in all_qts_sorted:
+            rows.append(f"### `{qt}`")
+            rows.append("")
+            rows.append("| Row | Tier | Model | Path Δ | Graded Δ | Abst F1 Δ | "
+                        "Token Δ | Latency Δ | Verdict |")
+            rows.append("|---|---|---|---|---|---|---|---|---|")
+            base_med_qt = _per_type_base_med(qt)
+            base_noise_qt = _per_type_base_noise(qt)
+            for c in cells_with_types:
+                ag_qt = c.get("aggregate_by_question_type", {}).get(qt)
+                if not ag_qt:
+                    continue
+                med = {ax: ag_qt.get(ax, {}).get("median") for ax in _ALL_AXES}
+                deltas_qt: Dict[str, float] = {}
+                for axis in _ALL_AXES:
+                    if med[axis] is None or base_med_qt[axis] is None:
+                        deltas_qt[axis] = 0.0
+                    else:
+                        deltas_qt[axis] = round(med[axis] - base_med_qt[axis], 4)
+                verdict_qt = _classify_five_axis_delta(deltas_qt, base_noise_qt)
+                rows.append(
+                    f"| {c['row']} | {c['tier']} | `{c['model']}` | "
+                    f"{deltas_qt['path_coverage']:+.3f} | "
+                    f"{deltas_qt['graded_answer']:+.3f} | "
+                    f"{deltas_qt['abstention_f1']:+.3f} | "
+                    f"{deltas_qt['token_cost']:+.0f} | "
+                    f"{deltas_qt['latency_cost']:+.2f} | "
+                    f"**{verdict_qt}** |"
+                )
+                if verdict_qt in ("strong-adopt", "adopt", "efficiency-adopt"):
+                    per_type_winners[qt].append(
+                        (verdict_qt, c['row'], c['tier'], c['model'])
+                    )
+            rows.append("")
+
+        # Routing policy recommendation — per question_type, pick the
+        # strongest verdict cell. Priority: strong-adopt > adopt >
+        # efficiency-adopt. Within tier preference: M_M (production
+        # default) > M_S > M_L, so a tie prefers the production-tier cell.
+        rows.append("## Routing policy recommendation (auto-generated)")
+        rows.append("")
+        rows.append(
+            "Each row maps a query type to a (model, layer-stack) recipe "
+            "derived from the strongest verdict cell on that type. "
+            "Operator: feed these into the routing layer's policy file. "
+            "Plan §6 deliverable for user requirement #2."
+        )
+        rows.append("")
+        rows.append("| Query type | Recommended (model, row) | Source verdict | Evidence cell |")
+        rows.append("|---|---|---|---|")
+
+        _VERDICT_RANK = {"strong-adopt": 3, "adopt": 2, "efficiency-adopt": 1}
+        _TIER_RANK = {"M_M": 3, "M_S": 2, "M_L": 1}  # prefer production
+        for qt in all_qts_sorted:
+            winners = per_type_winners[qt]
+            if not winners:
+                rows.append(f"| `{qt}` | n/a — no adopt verdict | — | — |")
+                continue
+            # Sort by (verdict rank desc, tier rank desc) — best first.
+            winners.sort(key=lambda w: (_VERDICT_RANK[w[0]], _TIER_RANK[w[1]]),
+                         reverse=True)
+            verdict, row_id, tier_id, model = winners[0]
+            rows.append(
+                f"| `{qt}` | `{model}` + **{row_id}** ({_ROW_LABELS[row_id]}) | "
+                f"{verdict} | {row_id}/{tier_id} |"
+            )
+        rows.append("")
+
     _REPORT_DIR.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(rows), encoding="utf-8")
     print(f"[report] wrote {out_path.relative_to(ROOT)}")
@@ -600,6 +889,20 @@ def main(argv: Optional[List[str]] = None) -> int:
              "If |graded_answer Δ| < 0.05, STOP and skip M_S/M_L — the "
              "matrix is null and 18 h of further compute would be wasted.",
     )
+    parser.add_argument(
+        "--sanity-think-on", action="store_true",
+        help="Plan Step 9 sanity cell — additionally run the L1/M_M cell "
+             "with `JAMES_GEMMA4_E4B_THINK_OFF` unset (production default "
+             "= think=ON). Output JSON gets a `-thinkON` suffix and the "
+             "5-axis Δ vs L1/M_M (primary, think=OFF) lands in the report "
+             "as the A2 default-flip evidence supplement. ~22 min extra "
+             "compute at n_runs=3.",
+    )
+    parser.add_argument(
+        "--suite", type=str, default="step7",
+        help="Suite name. Use 'multihop_rag' for the α-5 external "
+             "benchmark (workspace-resolved fixture).",
+    )
     args = parser.parse_args(argv)
 
     if args.render_report:
@@ -623,16 +926,22 @@ def main(argv: Optional[List[str]] = None) -> int:
     rows = _parse_subset(args.rows, list(_ROW_ENVS.keys()), "rows")
     tiers = _parse_subset(args.tiers, list(_TIER_MODELS.keys()), "tiers")
     sha = _current_git_sha() or "unknown"
+    fixture_path = _resolve_fixture(args.suite)
+    out_dir = _resolve_output_dir()
 
+    n_cells = len(rows) * len(tiers) + (1 if args.sanity_think_on else 0)
     print("=== QVT α-5 ablation matrix ===")
     print(f"git_sha:    {sha}")
-    print(f"fixture:    {_FIXTURE_PATH.relative_to(ROOT)}")
+    print(f"suite:      {args.suite}")
+    print(f"fixture:    {fixture_path}")
+    print(f"output:     {out_dir}")
     print(f"rows:       {rows}")
     print(f"tiers:      {tiers}  → {[_TIER_MODELS[t] for t in tiers]}")
     print(f"n_runs:     {args.n_runs}")
     print(f"resume:     {args.resume}")
-    print(f"cells:      {len(rows) * len(tiers)} "
-          f"(~{round(len(rows) * len(tiers) * 66 / 60, 1)} h compute)")
+    print(f"sanity:     {'YES (M_M/L1 think=ON extra cell)' if args.sanity_think_on else 'no'}")
+    print(f"cells:      {n_cells} "
+          f"(~{round(n_cells * 66 / 60, 1)} h compute)")
 
     if args.dry_run:
         print("\n[dry-run] cells planned:")
@@ -640,12 +949,16 @@ def main(argv: Optional[List[str]] = None) -> int:
             for tier in tiers:
                 print(f"  {row}/{tier} model={_TIER_MODELS[tier]} "
                       f"env={_ROW_ENVS[row]}")
+        if args.sanity_think_on:
+            print(f"  L1/M_M sanity (think=ON, suffix '-thinkON') "
+                  f"model={_TIER_MODELS['M_M']}")
         return 0
 
-    if not _FIXTURE_PATH.exists():
-        print(f"[error] fixture {_FIXTURE_PATH} missing")
+    if not fixture_path.exists():
+        print(f"[error] fixture {fixture_path} missing — build it first "
+              f"(e.g. scripts/hotpot/build_fixture.py for multihop_rag)")
         return 2
-    fixture = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
     n_ok = 0
     n_fail = 0
@@ -658,8 +971,25 @@ def main(argv: Optional[List[str]] = None) -> int:
             else:
                 n_ok += 1
 
+    # Step 9 sanity cell — run after the standard grid so its think=ON
+    # measurement uses the same fixture + same runner state.
+    if args.sanity_think_on:
+        if "M_M" not in tiers or "L1" not in rows:
+            print("[sanity] WARNING: --sanity-think-on requires the standard "
+                  "L1/M_M cell in the run. Skipping sanity cell because "
+                  "neither L1 nor M_M is in the subset.")
+        else:
+            sanity_payload = _run_cell(
+                "L1", "M_M", args.n_runs, fixture, sha,
+                resume=args.resume, sanity_think_on=True,
+            )
+            if sanity_payload is None:
+                n_fail += 1
+            else:
+                n_ok += 1
+
     print(f"\n[done] cells succeeded: {n_ok}, failed: {n_fail}")
-    print(f"Per-cell JSONs at {_OUTPUT_DIR.relative_to(ROOT)}.")
+    print(f"Per-cell JSONs at {out_dir}.")
 
     # T0 smoke verdict — print the prereq §3 decision in-line so the
     # operator knows whether to proceed to T1 or stop, without having
@@ -670,24 +1000,47 @@ def main(argv: Optional[List[str]] = None) -> int:
         if l1.exists() and l5.exists():
             j1 = json.loads(l1.read_text(encoding="utf-8"))
             j5 = json.loads(l5.read_text(encoding="utf-8"))
-            g1 = j1["aggregate"]["graded_answer"]["median"]
-            g5 = j5["aggregate"]["graded_answer"]["median"]
-            delta = round(g5 - g1, 4)
-            print(f"\n=== T0 smoke verdict ===")
-            print(f"L1 graded_answer median: {g1:.4f}")
-            print(f"L5 graded_answer median: {g5:.4f}")
-            print(f"Δ (full stack vs baseline): {delta:+.4f}")
-            if abs(delta) < 0.05:
+            # 5-axis deltas. Quality threshold 0.05 (unchanged) +
+            # cost thresholds: ~10% of L1 median for each cost axis.
+            def _med(j: dict, axis: str) -> float:
+                return float(j["aggregate"].get(axis, {}).get("median") or 0.0)
+            quality_axes = ("path_coverage", "graded_answer", "abstention_f1")
+            cost_axes = ("token_cost", "latency_cost")
+            quality_d = {ax: round(_med(j5, ax) - _med(j1, ax), 4) for ax in quality_axes}
+            cost_d = {ax: round(_med(j5, ax) - _med(j1, ax), 4) for ax in cost_axes}
+            print(f"\n=== T0 smoke verdict (5-axis) ===")
+            for ax, d in quality_d.items():
+                print(f"  {ax:15s} L1={_med(j1, ax):.4f} L5={_med(j5, ax):.4f} Δ={d:+.4f}")
+            for ax, d in cost_d.items():
+                print(f"  {ax:15s} L1={_med(j1, ax):.4f} L5={_med(j5, ax):.4f} Δ={d:+.4f} (down=better)")
+            # Quality signal: any quality axis Δ moves > 0.05.
+            quality_moved = any(abs(d) >= 0.05 for d in quality_d.values())
+            # Cost signal: token_cost Δ moves > 10% of L1, OR latency Δ > 10% of L1.
+            l1_token = max(_med(j1, "token_cost"), 1.0)
+            l1_lat = max(_med(j1, "latency_cost"), 0.1)
+            cost_moved = (abs(cost_d["token_cost"]) >= 0.10 * l1_token
+                          or abs(cost_d["latency_cost"]) >= 0.10 * l1_lat)
+            if not quality_moved and not cost_moved:
                 print(
                     "VERDICT: matrix likely NULL at production tier "
-                    f"(|Δ|={abs(delta):.4f} < 0.05). Do NOT run T2 "
-                    f"(M_S / M_L) — savings ~18 h. See prereq §3 + §4."
+                    "(no quality axis moves ≥ 0.05 AND no cost axis moves "
+                    "≥ 10%). Do NOT run T2 (M_S / M_L) — savings ~18 h."
+                )
+            elif quality_moved and not cost_moved:
+                print(
+                    "VERDICT: matrix has QUALITY signal at production tier. "
+                    "Proceed to T1 (`--tiers M_M`, ~5.5 h)."
+                )
+            elif cost_moved and not quality_moved:
+                print(
+                    "VERDICT: matrix has COST-only signal at production tier "
+                    "(quality flat, cost ≥ 10% Δ). Likely efficiency-adopt "
+                    "verdict — proceed to T1 to isolate which layer."
                 )
             else:
                 print(
-                    "VERDICT: matrix has SIGNAL at production tier "
-                    f"(|Δ|={abs(delta):.4f} ≥ 0.05). Proceed to T1 "
-                    f"(`--tiers M_M`, ~5.5 h) to isolate which layer."
+                    "VERDICT: matrix has both QUALITY and COST signal. "
+                    "Proceed to T1 + likely T2 for tier-gating decisions."
                 )
 
     print(f"\nRender the consolidated report with:\n"

--- a/scripts/qvt_capture_baseline.py
+++ b/scripts/qvt_capture_baseline.py
@@ -50,7 +50,10 @@ sys.path.insert(0, str(ROOT))
 # Imported after sys.path manipulation so the script remains runnable
 # from any cwd.
 from eval.qvt.oracle import (  # noqa: E402
+    FiveAxisResult,
     ThreeAxisResult,
+    score_five_axis,
+    score_five_axis_by_question_type,
     score_three_axis,
 )
 
@@ -177,15 +180,21 @@ def _mint_employee_jwt() -> Optional[str]:
 # Per-run execution
 # ---------------------------------------------------------------------------
 
-def _run_single_bench(run_index: int) -> Optional[Path]:
+def _run_single_bench(run_index: int, suite: str) -> Optional[Path]:
     """Spawn server, run bench.py once, return path to the bench JSON
     output. Server is torn down between runs so each run starts from
-    the same warm-cache-cold state."""
+    the same warm-cache-cold state.
+
+    `suite` is forwarded to bench.py as `--suite=<suite>`. Output JSONs
+    on the reports/ side use the suite name in their filename
+    (`bench_<sha>_<suite>_<ts>.json`) so the new-file diff below
+    matches whichever suite is being captured.
+    """
     server_env = os.environ.copy()
     server_env.update(_BASELINE_ENV)
 
     print(
-        f"\n=== run {run_index + 1}/N "
+        f"\n=== run {run_index + 1}/N — suite={suite} "
         f"(env: ENTITY_ANCHOR=1 EMBEDDING=bge-m3 REWRITE=1 "
         f"AUTO_ROUTER=0 ADAPTIVE_BUDGET=0 SCOPE_ROUTING=0) ==="
     )
@@ -195,7 +204,8 @@ def _run_single_bench(run_index: int) -> Optional[Path]:
 
     bench_output: Optional[Path] = None
     try:
-        pre_existing = set((ROOT / "reports").glob("bench_*_step7_*.json"))
+        glob_pattern = f"bench_*_{suite}_*.json"
+        pre_existing = set((ROOT / "reports").glob(glob_pattern))
         t0 = time.time()
         try:
             bench_env = {**os.environ, "JAMES_BASE_URL": SERVER_BASE_URL}
@@ -204,7 +214,7 @@ def _run_single_bench(run_index: int) -> Optional[Path]:
                 bench_env["JAMES_BENCH_BEARER"] = bearer
             subprocess.run(
                 [sys.executable, str(ROOT / "scripts" / "bench.py"),
-                 "--suite=step7", "--mode=retrieval"],
+                 f"--suite={suite}", "--mode=retrieval"],
                 env=bench_env,
                 cwd=str(ROOT),
                 capture_output=False,
@@ -218,7 +228,7 @@ def _run_single_bench(run_index: int) -> Optional[Path]:
         elapsed = time.time() - t0
         print(f"[run {run_index + 1}] bench finished in {elapsed:.1f}s")
 
-        after = set((ROOT / "reports").glob("bench_*_step7_*.json"))
+        after = set((ROOT / "reports").glob(glob_pattern))
         new = sorted(after - pre_existing)
         if new:
             bench_output = new[-1]
@@ -233,14 +243,32 @@ def _run_single_bench(run_index: int) -> Optional[Path]:
 # Aggregation
 # ---------------------------------------------------------------------------
 
-def _aggregate_runs(runs: List[ThreeAxisResult]) -> Dict[str, Any]:
-    """Compute median + noise band (max - min) for each axis across runs."""
+def _aggregate_runs(runs: List[FiveAxisResult]) -> Dict[str, Any]:
+    """5-axis aggregation — quality 3-axis (path/graded/abstention) +
+    cost 2-axis (token_cost, latency_cost). Per-axis stats:
+    median + min + max + noise_band (max−min).
+
+    Back-compat note: legacy callers passing a list of `ThreeAxisResult`
+    still work because `FiveAxisResult` is structurally compatible on
+    the quality-axis accessors used here.
+    """
     if not runs:
         return {}
 
     path_means = [r.path_coverage.mean_recall for r in runs]
     graded_means = [r.graded_answer.mean_accuracy for r in runs]
     abstention_f1s = [r.abstention.f1 for r in runs]
+    # Cost axes only present on FiveAxisResult; gracefully degrade for
+    # the legacy 3-axis caller in case anything still feeds those in.
+    token_means: List[float] = []
+    latency_means: List[float] = []
+    for r in runs:
+        token = getattr(r, "token_cost", None)
+        latency = getattr(r, "latency_cost", None)
+        if token is not None:
+            token_means.append(token.mean_chars)
+        if latency is not None:
+            latency_means.append(latency.mean_s)
 
     def _stats(values: List[float]) -> Dict[str, float]:
         values_sorted = sorted(values)
@@ -252,12 +280,17 @@ def _aggregate_runs(runs: List[ThreeAxisResult]) -> Dict[str, Any]:
             "noise_band": round(max(values) - min(values), 4),
         }
 
-    return {
+    out: Dict[str, Any] = {
         "path_coverage": _stats(path_means),
         "graded_answer": _stats(graded_means),
         "abstention_f1": _stats(abstention_f1s),
         "n_runs": len(runs),
     }
+    if token_means:
+        out["token_cost"] = _stats(token_means)
+    if latency_means:
+        out["latency_cost"] = _stats(latency_means)
+    return out
 
 
 def _current_git_sha() -> Optional[str]:
@@ -276,10 +309,34 @@ def _current_git_sha() -> Optional[str]:
 # CLI entry
 # ---------------------------------------------------------------------------
 
+def _resolve_fixture(suite: str) -> Path:
+    """Locate fixture: project-root `eval/regression/{suite}_queries.json`
+    if present, else `$JAMES_WORKSPACE/eval/{suite}_queries.json`. Mirrors
+    `scripts/bench.py:_load_suite` resolution so the two scripts agree."""
+    canonical = ROOT / "eval" / "regression" / f"{suite}_queries.json"
+    if canonical.exists():
+        return canonical
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        ws_path = Path(ws_raw).resolve() / "eval" / f"{suite}_queries.json"
+        if ws_path.exists():
+            return ws_path
+    return canonical  # caller prints "missing" against this expected path
+
+
+def _resolve_output_dir() -> Path:
+    """α-5 baseline lives under the active workspace's eval/qvt/ when a
+    workspace is set; otherwise under the project's `eval/qvt/`."""
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        return Path(ws_raw).resolve() / "eval" / "qvt"
+    return _OUTPUT_DIR
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="QVT α-3 baseline capture (paired N=3 rerun + "
-                    "3-axis oracle aggregation).",
+        description="QVT α-3/α-5 baseline capture (paired N=3 rerun + "
+                    "5-axis oracle aggregation).",
     )
     parser.add_argument(
         "--n-runs", type=int, default=3,
@@ -287,9 +344,15 @@ def main(argv: Optional[List[str]] = None) -> int:
              "design).",
     )
     parser.add_argument(
+        "--suite", type=str, default="step7",
+        help="Suite name. Default 'step7' (project-root canonical). "
+             "Use 'multihop_rag' to capture against the α-5 external "
+             "benchmark workspace.",
+    )
+    parser.add_argument(
         "--output", type=str, default=None,
         help="Output JSON path. Default: "
-             "eval/qvt/baseline_<git-sha>.json",
+             "<workspace>/eval/qvt/baseline_<git-sha>.json",
     )
     parser.add_argument(
         "--dry-run", action="store_true",
@@ -299,15 +362,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     sha = _current_git_sha() or "unknown"
+    fixture_path = _resolve_fixture(args.suite)
+    out_dir = _resolve_output_dir()
     out_path = (
         Path(args.output) if args.output
-        else _OUTPUT_DIR / f"baseline_{sha}.json"
+        else out_dir / f"baseline_{sha}.json"
     )
 
-    print("=== QVT α-3 baseline capture ===")
+    print("=== QVT 5-axis baseline capture ===")
     print(f"git_sha:      {sha}")
-    print(f"fixture:      {_FIXTURE_PATH.relative_to(ROOT)}")
-    print(f"output:       {out_path.relative_to(ROOT)}")
+    print(f"suite:        {args.suite}")
+    print(f"fixture:      {fixture_path}")
+    print(f"output:       {out_path}")
     print(f"n_runs:       {args.n_runs}")
     print(f"baseline env: {_BASELINE_ENV}")
 
@@ -315,20 +381,21 @@ def main(argv: Optional[List[str]] = None) -> int:
         print("[dry-run] not spawning server, not running bench.")
         return 0
 
-    if not _FIXTURE_PATH.exists():
-        print(f"[error] fixture {_FIXTURE_PATH} missing")
+    if not fixture_path.exists():
+        print(f"[error] fixture {fixture_path} missing — build it first "
+              f"(e.g. scripts/hotpot/build_fixture.py for multihop_rag)")
         return 2
 
-    fixture = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
-    runs: List[ThreeAxisResult] = []
+    runs: List[FiveAxisResult] = []
     run_paths: List[str] = []
     for i in range(args.n_runs):
-        bench_path = _run_single_bench(i)
+        bench_path = _run_single_bench(i, args.suite)
         if bench_path is None:
             print(f"[error] run {i + 1} failed to produce bench output")
             return 3
-        result = score_three_axis(bench_path, fixture)
+        result = score_five_axis(bench_path, fixture)
         print(f"[run {i + 1}] {result.summary()}")
         runs.append(result)
         run_paths.append(str(bench_path.relative_to(ROOT)))
@@ -336,15 +403,36 @@ def main(argv: Optional[List[str]] = None) -> int:
     aggregate = _aggregate_runs(runs)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Per-question_type aggregation (when the suite carries the field —
+    # multihop_rag does; step7 does not). Aggregates with the same
+    # 5-axis shape so downstream Δ computations use one helper.
+    by_type_per_run: List[Dict[str, FiveAxisResult]] = []
+    for run_path in run_paths:
+        full_bench_path = ROOT / run_path
+        by_type_per_run.append(
+            score_five_axis_by_question_type(full_bench_path, fixture)
+        )
+    aggregate_by_question_type: Dict[str, Dict[str, Any]] = {}
+    if any(by_type_per_run):
+        all_qts: set[str] = set()
+        for d in by_type_per_run:
+            all_qts.update(d.keys())
+        for qt in sorted(all_qts):
+            sub = [d[qt] for d in by_type_per_run if qt in d]
+            if sub:
+                aggregate_by_question_type[qt] = _aggregate_runs(sub)
+
     payload = {
-        "schema": "qvt-baseline-v1",
+        "schema": "qvt-baseline-v2",  # v2 adds 5-axis + per_question_type
         "captured_at": datetime.now(timezone.utc).isoformat(),
         "git_sha": sha,
+        "suite": args.suite,
         "fixture_version": fixture.get("version"),
-        "fixture_path": str(_FIXTURE_PATH.relative_to(ROOT)),
+        "fixture_path": str(fixture_path),
         "n_runs": args.n_runs,
         "env": _BASELINE_ENV,
         "aggregate": aggregate,
+        "aggregate_by_question_type": aggregate_by_question_type,
         "runs": [
             {
                 "bench_output": run_paths[i],
@@ -357,8 +445,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         json.dumps(payload, indent=2, ensure_ascii=False, default=str),
         encoding="utf-8",
     )
-    print(f"\n[done] baseline written to {out_path.relative_to(ROOT)}")
+    print(f"\n[done] baseline written to {out_path}")
     print(f"aggregate: {aggregate}")
+    if aggregate_by_question_type:
+        print(f"per-type aggregates: {list(aggregate_by_question_type.keys())}")
     return 0
 
 

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -18,13 +18,20 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from eval.qvt.oracle import (  # noqa: E402
+    FiveAxisResult,
+    LatencyCostAxis,
     PathCoverageAxis,
     ThreeAxisResult,
+    TokenCostAxis,
+    _percentile,
     detect_abstention,
     score_abstention_f1,
+    score_five_axis,
     score_graded_answer,
+    score_latency_cost,
     score_path_coverage,
     score_three_axis,
+    score_token_cost,
 )
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -424,6 +431,152 @@ class ThreeAxisIntegrationTests(unittest.TestCase):
         result = score_three_axis(bench, fixture)
         # Must serialize without TypeError.
         json.dumps(result.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Cost axes — Step 5 (5-axis extension for α-5 plan)
+# ---------------------------------------------------------------------------
+
+class PercentileHelperTests(unittest.TestCase):
+    def test_p50_odd_length(self):
+        # Nearest-rank: ceil(0.5 * 5) - 1 = 2 → element 3 (1-indexed) → 3.
+        self.assertEqual(_percentile([1, 2, 3, 4, 5], 0.5), 3)
+
+    def test_p95(self):
+        # Nearest-rank: ceil(0.95 * 10) - 1 = 9 → last element → 10.
+        self.assertEqual(_percentile(list(range(1, 11)), 0.95), 10)
+
+    def test_empty_returns_zero(self):
+        self.assertEqual(_percentile([], 0.5), 0.0)
+
+    def test_zero_percentile_returns_min(self):
+        self.assertEqual(_percentile([3.0, 1.0, 2.0], 0.0), 1.0)
+
+
+class TokenCostAxisTests(unittest.TestCase):
+    """answer_len is the token-cost proxy; failures / timeouts excluded."""
+
+    def test_mean_and_p95_on_ok_rows_only(self):
+        bench = {"results": [
+            {"id": 1, "status": "ok", "elapsed": 1.0, "answer_len": 100},
+            {"id": 2, "status": "ok", "elapsed": 2.0, "answer_len": 200},
+            {"id": 3, "status": "ok", "elapsed": 3.0, "answer_len": 300},
+            {"id": 4, "status": "timeout", "elapsed": 60.0},  # excluded
+            {"id": 5, "status": "error", "elapsed": 5.0},     # excluded
+        ]}
+        axis = score_token_cost(bench)
+        self.assertEqual(axis.n_queries, 3)
+        self.assertEqual(axis.mean_chars, 200.0)
+        # Nearest-rank p95 of {100, 200, 300} = 300.
+        self.assertEqual(axis.p95_chars, 300.0)
+
+    def test_falls_back_to_answer_preview_chars(self):
+        # Older bench JSONs may omit answer_len but always have preview.
+        bench = {"results": [
+            {"id": 1, "status": "ok", "elapsed": 1.0,
+             "answer_preview": "x" * 250},
+        ]}
+        axis = score_token_cost(bench)
+        self.assertEqual(axis.mean_chars, 250.0)
+
+    def test_empty_returns_zero_axis(self):
+        axis = score_token_cost({"results": []})
+        self.assertEqual(axis.n_queries, 0)
+        self.assertEqual(axis.mean_chars, 0.0)
+
+
+class LatencyCostAxisTests(unittest.TestCase):
+    def test_mean_and_p95_seconds(self):
+        bench = {"results": [
+            {"id": 1, "status": "ok", "elapsed": 2.0, "answer_len": 100},
+            {"id": 2, "status": "ok", "elapsed": 4.0, "answer_len": 100},
+            {"id": 3, "status": "ok", "elapsed": 6.0, "answer_len": 100},
+        ]}
+        axis = score_latency_cost(bench)
+        self.assertEqual(axis.n_queries, 3)
+        self.assertEqual(axis.mean_s, 4.0)
+        self.assertEqual(axis.p95_s, 6.0)
+
+    def test_timeout_rows_skipped(self):
+        bench = {"results": [
+            {"id": 1, "status": "ok", "elapsed": 2.0, "answer_len": 100},
+            {"id": 2, "status": "timeout", "elapsed": 120.0},
+        ]}
+        axis = score_latency_cost(bench)
+        # Timeout row would skew mean → ensure it's excluded.
+        self.assertEqual(axis.n_queries, 1)
+        self.assertEqual(axis.mean_s, 2.0)
+
+    def test_empty_returns_zero_axis(self):
+        axis = score_latency_cost({"results": []})
+        self.assertEqual(axis.n_queries, 0)
+
+
+class FiveAxisResultTests(unittest.TestCase):
+    """The 5-axis integration object — quality 3-axis + cost 2-axis."""
+
+    def _minimal_bench(self) -> dict:
+        return {
+            "git_sha": "abc1234",
+            "suite": "multihop_rag",
+            "results": [
+                {"id": 1, "status": "ok", "elapsed": 1.5, "answer_len": 120,
+                 "answer_preview": "Foo bar.", "blocked": False,
+                 "graph_paths_count": 3},
+                {"id": 2, "status": "ok", "elapsed": 3.0, "answer_len": 240,
+                 "answer_preview": "정보가 없습니다.", "blocked": False,
+                 "graph_paths_count": 0},
+            ],
+        }
+
+    def _minimal_fixture(self) -> dict:
+        return {
+            "version": "multihop-rag-test",
+            "queries": [
+                {"id": 1, "category": "test", "text": "Q1",
+                 "gold_signals": [{"term": "Foo", "aliases": []}],
+                 "abstention_truth": "present"},
+                {"id": 2, "category": "test", "text": "Q2",
+                 "gold_signals": [{"term": "Bar", "aliases": []}],
+                 "abstention_truth": "absent"},
+            ],
+        }
+
+    def test_score_five_axis_returns_correct_type(self):
+        result = score_five_axis(self._minimal_bench(), self._minimal_fixture())
+        self.assertIsInstance(result, FiveAxisResult)
+        self.assertIsInstance(result.three_axis, ThreeAxisResult)
+        self.assertIsInstance(result.token_cost, TokenCostAxis)
+        self.assertIsInstance(result.latency_cost, LatencyCostAxis)
+
+    def test_quality_axes_delegate_to_three_axis(self):
+        result = score_five_axis(self._minimal_bench(), self._minimal_fixture())
+        # Proxy properties must return the underlying axes.
+        self.assertIs(result.path_coverage, result.three_axis.path_coverage)
+        self.assertIs(result.graded_answer, result.three_axis.graded_answer)
+        self.assertIs(result.abstention, result.three_axis.abstention)
+
+    def test_to_dict_contains_all_five_axes(self):
+        result = score_five_axis(self._minimal_bench(), self._minimal_fixture())
+        d = result.to_dict()
+        for key in ("path_coverage", "graded_answer", "abstention",
+                    "token_cost", "latency_cost"):
+            self.assertIn(key, d)
+        # JSON-serializable.
+        json.dumps(d)
+
+    def test_summary_contains_cost_axes(self):
+        result = score_five_axis(self._minimal_bench(), self._minimal_fixture())
+        s = result.summary()
+        self.assertIn("token_cost", s)
+        self.assertIn("latency", s)
+
+    def test_metadata_proxies(self):
+        result = score_five_axis(self._minimal_bench(), self._minimal_fixture())
+        self.assertEqual(result.git_sha, "abc1234")
+        self.assertEqual(result.suite, "multihop_rag")
+        self.assertEqual(result.fixture_version, "multihop-rag-test")
+        self.assertEqual(result.n_queries, 2)
 
 
 if __name__ == "__main__":

--- a/workspaces/hotpot_eval/.env.example
+++ b/workspaces/hotpot_eval/.env.example
@@ -1,0 +1,21 @@
+# α-5 benchmark workspace .env template
+# Copy to `workspaces/hotpot_eval/.env`, then activate together:
+#   cp workspaces/hotpot_eval/.env.example workspaces/hotpot_eval/.env
+#   export JAMES_WORKSPACE=./workspaces/hotpot_eval
+#   source workspaces/hotpot_eval/.env
+
+# A2 (PR #609) — gemma4:e4b 의 thinking trace 비활성화.
+# 매트릭스 fair-comparison primary 결정 (plan 결정 섹션 참조):
+# - gemma3:4b / gemma3:12b 는 thinking capability 없음 (model whitelist 자동 suppressed)
+# - gemma4:e4b 만 영향 받아 num_predict ~85% 회수 → cost axis 측정 의미 유지
+# - sanity cell (M_M/L1 think=ON) 은 ablation runner 가 --sanity-think-on 으로 별도 측정
+JAMES_GEMMA4_E4B_THINK_OFF=1
+
+# BL-9 (multilingual embedding) — production 과 동일. 영문 MultiHop-RAG query 의
+# proper-noun-mediated retrieval 정확도 보장.
+JAMES_EMBEDDING_MODEL=BAAI/bge-m3
+
+# 측정 시 layer flags (ENTITY_ANCHOR / QUERY_REWRITE / AUTO_ROUTER / ADAPTIVE_BUDGET /
+# SCOPE_ROUTING) 는 qvt_ablation_matrix.py 의 per-cell env 가 덮어쓰므로 여기 안 박음.
+# 기본 baseline (L1 production) 환경은 ENTITY_ANCHOR=1 + QUERY_REWRITE=1 (다른 라우팅
+# layer 는 OFF) 으로 runner 가 설정.

--- a/workspaces/hotpot_eval/ATTRIBUTION.md
+++ b/workspaces/hotpot_eval/ATTRIBUTION.md
@@ -1,0 +1,22 @@
+# Dataset Attribution — MultiHop-RAG
+
+**Source**: HuggingFace `yixuantt/MultiHopRAG`
+**License**: CC-BY-4.0
+**Citation**:
+
+> Tang, Yixuan and Yang, Yi. "MultiHop-RAG: Benchmarking Retrieval-Augmented Generation for Multi-Hop Queries." Findings of EMNLP, 2024. https://huggingface.co/datasets/yixuantt/MultiHopRAG
+
+## Use within JAMES
+
+The MultiHop-RAG corpus (609 news articles, predominantly
+English-language news from 2023-09 to 2023-12) is ingested into
+this workspace's `wiki/` via the standard JAMES pipeline
+(`scripts/ingest_pipeline.py`). The 2,556 query set is converted
+into step7-format fixture by `scripts/hotpot/build_fixture.py`
+and consumed by `scripts/qvt_ablation_matrix.py` for the α-5
+ablation matrix.
+
+Per CC-BY-4.0, this attribution file MUST stay alongside any
+redistributed corpus snapshot. Production wiki (project root
+`./wiki/`) is unaffected by this benchmark workspace — see
+`workspaces/hotpot_eval/README.md`.

--- a/workspaces/hotpot_eval/README.md
+++ b/workspaces/hotpot_eval/README.md
@@ -1,0 +1,64 @@
+# α-5 Benchmark Workspace — MultiHop-RAG
+
+External-benchmark workspace for the α-5 ablation matrix. Completely
+isolated from the production wiki (`./wiki/`, `./chroma_db_bge_m3/`).
+
+## Activation
+
+```bash
+export JAMES_WORKSPACE=./workspaces/hotpot_eval
+source workspaces/hotpot_eval/.env
+```
+
+Then run any JAMES script. All data directories (`WIKI_DIR`,
+`CHROMA_DIR`, `RAW_DIR`, `UPLOAD_DIR`) resolve under this workspace via
+`core/plugins/workspace.py::get_workspace_root()`. The production
+workspace at the repo root is untouched.
+
+## Restore production
+
+```bash
+unset JAMES_WORKSPACE
+```
+
+That's it. Production state is byte-identical because the workspace
+abstraction (config.py:74) returns the project root when the env is
+unset.
+
+## Layout
+
+```
+workspaces/hotpot_eval/
+├── .env                          # think=OFF + bge-m3 (this workspace's defaults)
+├── README.md                     # this file
+├── ATTRIBUTION.md                # MultiHop-RAG license / attribution (Step 2)
+├── raw/                          # MultiHop-RAG corpus (609 articles after Step 2)
+├── uploads/                      # uploaded-doc staging (mirrors prod)
+├── wiki/
+│   ├── entity/
+│   │   ├── prod/                 # populated by Step 7 (ingest pipeline)
+│   │   └── test/
+│   └── media/
+├── chroma_db_bge_m3/             # populated by Step 7
+├── eval/
+│   ├── multihop_rag_queries.json # fixture (Step 3)
+│   └── qvt/
+│       └── baseline_<sha>.json   # Step 8 output
+└── reports/research-runs/
+    └── qvt-ablation-cells-hotpot/ # Step 9 per-cell JSONs
+```
+
+## Source of truth
+
+- Plan: `~/.claude/plans/quiet-hugging-iverson.md` (post-#614 reset)
+- Prior cycle: PR #608 (A3), #609 (A2), #611 (A3 v2), #612 (α-5 prep),
+  #613 (α-5 prereq), #614 (step7 v7 — now internal canary only)
+- Dataset: Tang & Yang 2024 "MultiHop-RAG" (EMNLP 2024). 2,556 multi-hop
+  QA over 609 news articles. CC-BY-4.0.
+
+## Restore
+
+Git tag `v0.4-pre-hotpot` marks the commit before this workspace was
+created. Roll back with `git reset --hard v0.4-pre-hotpot` if needed
+(but the workspace itself is removable just by `rm -rf workspaces/
+hotpot_eval/` since it lives entirely inside this directory).


### PR DESCRIPTION
## Summary

Full reset of the α-5 evaluation surface post-#614 audit. Two methodological problems prompted this:

1. **Construct validity** — v7 hard queries q18/q19/q20 were drafted by inspecting wiki entities first, then writing queries to match. Fitting-to-answer-key.
2. **No external benchmark** — `eval/RESULTS.md` defers BEIR / KLUE-RC indefinitely. Internal-only routing decisions hard to defend.

User-decided direction: **MultiHop-RAG** (Tang & Yang 2024, EMNLP, CC-BY-4.0) — 2,556 multi-hop QA × 609 articles × 4 question types — loaded into an isolated workspace via the existing `JAMES_WORKSPACE` abstraction. Five user requirements drove the design:

| # | Requirement | This PR's response |
|---|---|---|
| 1 | layer × model on/off optimization | 5-axis matrix verdict with Pareto-aware rule |
| 2 | query-type → (model, layer-stack) routing policy | per-question-type cross-tab + auto routing recs |
| 3 | token / time efficiency integrated | NEW cost axes (token_cost, latency_cost) |
| 4 | external benchmark for review credibility | MultiHop-RAG dataset + workspace + adapters |
| 5 | incidental findings → memo trigger | findings.md running log + memo draft path |

Plan: \`~/.claude/plans/quiet-hugging-iverson.md\`.

## What ships (11 steps from the plan)

| Step | Component |
|---|---|
| 1 | `workspaces/hotpot_eval/` skeleton + `.env.example` (think=OFF + bge-m3) + README + ATTRIBUTION + `git tag v0.4-pre-hotpot` |
| 2 | `scripts/hotpot/download_multihop_rag.py` — HuggingFace adapter, idempotent, dry-run |
| 3 | `scripts/hotpot/build_fixture.py` — raw queries → step7-format with question_type preserved, subset selectors balanced-100/200/500/full |
| 4 | `scripts/bench.py` — `--suite=multihop_rag` resolver + `--dry-run` + question_type forwarding |
| 5 | `eval/qvt/oracle.py` — FiveAxisResult + score_five_axis (3 quality + 2 cost). ThreeAxisResult stays for back-compat. |
| 5 (cont.) | `scripts/qvt_ablation_matrix.py` — Pareto-aware verdict rule (strong-adopt / adopt / efficiency-adopt / tier-gated / reject / zero), 5-axis report columns, T0 smoke considers both quality + cost |
| 6 | `eval/qvt/oracle.py:score_five_axis_by_question_type` + matrix runner per-cell `aggregate_by_question_type` + cross-tab report section + auto-generated routing policy recommendations |
| 8 | `scripts/qvt_capture_baseline.py` — `--suite` arg, workspace-aware paths, schema v2 5-axis + per_question_type |
| 9 | `scripts/qvt_ablation_matrix.py:--sanity-think-on` — 19th cell = M_M/L1 think=ON, suffix `-thinkON`, keeps A2 default-flip evidence inside the matrix |
| 10 | `reports/research-runs/qvt-ablation-findings.md` — running log template + taxonomy + memo trigger path |
| 11 | Backlog reconciliation A1 row + §7.3 update |

step7 v7 (PR #614) stays landed as **internal regression canary** only. α-5 routing decisions cite MultiHop-RAG cells.

## think-mode decision (matrix-side)

Primary measurement: **think=OFF** (`JAMES_GEMMA4_E4B_THINK_OFF=1` in workspace .env). 4 reasons in plan §결정 — model-fair (other tiers have no thinking capability), user req #3 alignment, A2 production mirror, A2 whitelist asymmetry-free. Sanity cell `M_M/L1 think=ON` (`--sanity-think-on`) preserves production-default evidence inside the matrix for A2 default-flip follow-up.

## Test plan

- [x] `pytest tests/test_qvt_oracle.py tests/test_step7_v5_schema.py tests/test_think_policy.py tests/test_complete_with_retry.py` → **81 passed**, no regression
- [x] New tests: 4 percentile, 3 token_cost, 3 latency_cost, 5 FiveAxisResult — all green
- [x] `download_multihop_rag.py` full download → 609 articles + 2,556 raw queries
- [x] `build_fixture.py --subset balanced-200` → 200 queries (50/type)
- [x] `bench.py --suite=multihop_rag --dry-run` → fixture resolved, type_distribution printed
- [x] `bench.py --suite=step7 --dry-run` → backward-compat preserved
- [x] `qvt_capture_baseline.py --suite multihop_rag --dry-run` → workspace fixture + output path correct
- [x] `qvt_ablation_matrix.py --t0-smoke --sanity-think-on --suite multihop_rag --dry-run` → 3 cells planned (2 standard + 1 sanity)
- [ ] Operator: workspace ingest (~1-4h, A2 think=OFF) → 5-axis baseline (~70min) → T0 smoke (~3.3h) → adaptive T1/T2

## Operator quick-reference

```bash
export JAMES_WORKSPACE=./workspaces/hotpot_eval
cp workspaces/hotpot_eval/.env.example workspaces/hotpot_eval/.env
source workspaces/hotpot_eval/.env

python scripts/hotpot/download_multihop_rag.py
python scripts/hotpot/build_fixture.py --subset balanced-200
python scripts/ingest_pipeline.py --source \$JAMES_WORKSPACE/raw/
python scripts/qvt_capture_baseline.py --suite multihop_rag
python scripts/qvt_ablation_matrix.py --t0-smoke --sanity-think-on --suite multihop_rag
```

## Out of scope

- α-5 run itself (operator-side compute, ~3-21h adaptive)
- Korean translation of MultiHop-RAG / separate Korean RAG benchmark (defer v0.5+)
- HotpotQA as second axis (single-track decision)
- Real-query Quality Delta Card cycle (A2 default-flip, separate track)
- Server-side `eval_count` forwarding (token_cost is answer_len proxy; future PR can swap without changing the axis interface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)