### PR TITLE
docs(handover): α-5 execution observations §7.4 — per-type signal + path methodology

### DIFF
--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -230,3 +230,64 @@ load-bearing evidence for α-5 routing decisions.
 Plan: `~/.claude/plans/quiet-hugging-iverson.md` (approved 2026-05-30).
 Steps 1-6/8-10 ship as one PR; Steps 7/9-operator are user-side
 (workspace ingest + baseline + matrix run, ~3-6h total compute).
+
+### 7.4 Update 2026-05-31 — α-5 execution observations (post-#616)
+
+End-to-end execution surfaced 3 issues + 1 methodological finding.
+Recording so future cycles don't re-discover them.
+
+**Fixes that landed (#616):**
+
+- `scripts/hotpot/ingest_corpus.py` — plan referenced
+  `scripts/ingest_pipeline.py` which doesn't exist. Wrapper spawns the
+  workspace-aware server + mints admin JWT + posts each .txt to
+  `/upload/`. Validated 0 failures on 183-article targeted ingest.
+- `BENCH_SUBPROCESS_TIMEOUT_SEC` 2400→14400. The 40-min ceiling fit
+  step7 (~8 min) but suffocated MultiHop-RAG balanced-100 at ~107 min.
+  Caught when first baseline timed out at run 1.
+- Baseline `baseline_f7762a3.json` aggregate captured (n_runs=1,
+  balanced-100, 107 min).
+
+**Workspace runtime observations:**
+
+- Ingest: 183 articles, 264 min (~45-180s/article — latency grew
+  monotonically with workspace size; first article 110s warmup, last
+  was 197s). Final state: 931 entities + 46MB chroma.
+- Baseline: 100 queries × ~64s = 107 min total. Heavy compared to
+  step7 (~30s) due to entity_anchor expansion on 931 entities.
+- T0 smoke estimate: 3 cells × 100 × 64s ≈ 5.3h.
+
+**Per-question-type baseline signal** (the load-bearing finding for
+user requirement #2 routing-policy evidence):
+
+| type | path | graded | abst_f1 | token | latency |
+|---|---|---|---|---|---|
+| inference | 0.000 | **0.547** | 0.000* | 669 | 62s |
+| comparison | 0.000 | 0.293 | 0.000* | 1389 | 67s |
+| temporal | 0.000 | 0.320 | 0.000* | **1717** | 69s |
+| null | 0.000 | 0.173 | **0.387** | 561 | 58s |
+
+`*` abst_f1 is undefined for `present`-truth types (no positive
+class samples) and reports as 0. The axis is only meaningful on
+null_query, where the system hallucinated 19/25 (76%) — the
+load-bearing signal the matrix routing layers must reduce.
+
+**Path-axis methodological finding** (full entry at
+`reports/research-runs/qvt-ablation-findings.md`, tag
+`multihop-rag-path-axis-dead`):
+
+MultiHop-RAG's `evidence_list[].title` measures "did the system
+cite the right source" — semantically a *document-entity* identity
+check. JAMES's graph traversal surfaces *concept/org/person*
+entities (the entities extracted FROM articles), not the document
+entity itself. graph_paths returned 18-179 nodes/query (mean 60),
+but `path_recall = 0.000` on 75/75 path-annotated queries because
+the expected nodes are article titles.
+
+Three follow-up probes recorded; cheapest is to accept the axis as
+fixture-incompatible and mark "n/a — fixture limitation" in the
+matrix report. Matrix verdicts continue on the other 4 axes
+(graded / abstention / token / latency) with the Pareto rule on a
+smaller surface.
+
+**T0 smoke** running in background; full matrix render after.


### PR DESCRIPTION
## Summary

Adds §7.4 to the backlog reconciliation documenting the end-to-end α-5 plan execution observations + per-question-type baseline signal table.

## Per-question-type baseline (load-bearing for user req #2)

| type | path | graded | abst_f1 | token | latency |
|---|---|---|---|---|---|
| inference | 0.000 | **0.547** | 0.000* | 669 | 62s |
| comparison | 0.000 | 0.293 | 0.000* | 1389 | 67s |
| temporal | 0.000 | 0.320 | 0.000* | **1717** | 69s |
| null | 0.000 | 0.173 | **0.387** | 561 | 58s |

\`*\` abst_f1 = 0 for \`present\`-truth types (no positive class samples). null_query hallucinates 19/25 (76%) — load-bearing signal for routing layers to reduce.

## Path-axis finding

MultiHop-RAG's \`evidence_list.title\` checks document-entity identity; JAMES graph traverses concept/org/person entities (extracted from articles), not the documents themselves. Path axis is fixture-incompatible for MultiHop-RAG. Matrix Pareto rule still works on the 4 active axes.

## Test plan

- [x] Doc-only change, no code touched
- [x] References #616 for the actual code fixes (ingest wrapper + bench timeout)
- [x] References \`reports/research-runs/qvt-ablation-findings.md\` for the path-axis entry

## Out of scope

- Path-axis fix (3 probe ideas in findings.md, follow-up PR)
- T0 smoke results (running in background, separate report after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)