### PR TITLE
fix(qvt): α-5 source-recall — path axis credits sources (citations) too

### DIFF
--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -95,7 +95,50 @@ def detect_abstention(answer: Optional[str]) -> bool:
 
 # ---------------------------------------------------------------------------
 # Path Coverage
+#
+# α-5 plan §findings 2026-05-31 — the path axis is now scored against
+# BOTH `graph_paths` entities (per-query `path_metrics` from bench.py)
+# AND `sources` (top-3 source documents citation field, per
+# `core/reasoning/pipeline.py:343`). MultiHop-RAG's
+# `evidence_list.title` semantic ("did the system cite the right
+# source") doesn't match graph_paths (entity-centric) but does match
+# the `sources` field (document-centric). Both signal types contribute
+# to a unified path-recall axis after slug normalisation.
 # ---------------------------------------------------------------------------
+
+# Slug normaliser — used to bring three different naming surfaces into
+# a single comparable form:
+#
+#   - fixture expected node: "The FTX trial is bigger than Sam …"
+#   - graph entity name    : "Sam Bankman-Fried"
+#   - source document file : "multihop_0009_SBF-Trial-The-latest-…txt"
+#
+# All three become lowercase ascii-alphanumeric-dash strings capped at
+# 80 chars. The `multihop_<id>_` prefix and `.txt` suffix on source
+# filenames are stripped before slugging so the comparable form is just
+# the article slug.
+import re as _re  # noqa: E402
+
+_SOURCE_PREFIX_RE = _re.compile(r"^multihop_\d+_")
+_SLUG_BAD_RE = _re.compile(r"[^a-z0-9\-]+")
+_SLUG_MAX = 80
+
+
+def _slug_for_match(s: str) -> str:
+    if not s:
+        return ""
+    s = s.strip()
+    # Drop multihop_<id>_ prefix on source filenames.
+    s = _SOURCE_PREFIX_RE.sub("", s)
+    # Drop common file extensions on source filenames.
+    if s.lower().endswith(".txt"):
+        s = s[:-4]
+    elif s.lower().endswith(".pdf"):
+        s = s[:-4]
+    s = s.lower()
+    s = _SLUG_BAD_RE.sub("-", s).strip("-")
+    return s[:_SLUG_MAX]
+
 
 @dataclass
 class PathCoverageQueryRow:
@@ -103,6 +146,8 @@ class PathCoverageQueryRow:
     expected_count: int
     hits: int
     recall: float
+    via_graph: int = 0        # how many hits came from graph_paths
+    via_sources: int = 0      # how many hits came from `sources` citations
 
 
 @dataclass
@@ -113,28 +158,122 @@ class PathCoverageAxis:
     per_query: List[PathCoverageQueryRow] = field(default_factory=list)
 
 
+def _graph_node_slugs_from_bench_row(r: Dict[str, Any]) -> set:
+    """Best-effort recovery of graph entity names from a bench row.
+
+    bench.py's per-row `path_metrics` block has aggregate counts but not
+    the raw `actual_paths` list. The unified recall axis can still match
+    via `sources` (always captured post-2026-05-31). For graph-path
+    matching, the row needs to have stored either `graph_paths` (list of
+    path strings) or a `path_metrics.actual_nodes` field. When absent,
+    graph-side returns the empty set and `sources` carries the axis.
+    """
+    nodes: set = set()
+    raw_paths = r.get("graph_paths") or []
+    if raw_paths:
+        # Strings like "<src> -[REL]→ <tgt> -[REL]→ <tgt2>". The same
+        # parsing bench.py uses pre-`_path_metrics` — but we re-derive
+        # here because the raw list isn't stored in path_metrics.
+        for ps in raw_paths:
+            if not isinstance(ps, str):
+                continue
+            parts = ps.split(" -[")
+            if parts and parts[0].strip():
+                nodes.add(_slug_for_match(parts[0].strip()))
+            for part in parts[1:]:
+                if "]→ " in part:
+                    target = part.split("]→ ", 1)[1].strip()
+                    if target:
+                        nodes.add(_slug_for_match(target))
+    return nodes
+
+
 def score_path_coverage(
     bench_results: Dict[str, Any],
     fixture: Dict[str, Any],
 ) -> PathCoverageAxis:
-    """Aggregate bench.py's per-query `path_metrics` block.
+    """Unified path-recall axis against expected nodes (titles or entity
+    names), with hits credited from BOTH graph_paths entities AND the
+    `sources` document-citation field (post-α-5 plan §findings).
 
-    Skips queries without `expected_path` (the denominator is "annotated
-    queries", not "all queries"). The fixture parameter is accepted for
-    API symmetry but currently unused — bench.py already joined against
-    the fixture when producing `path_metrics`.
+    Match semantics: slug-normalise both sides (lowercase, dash-separated,
+    `multihop_<id>_` prefix stripped from source filenames, `.txt`/`.pdf`
+    extension stripped). A hit on either side counts toward recall.
+
+    The fixture parameter is currently used to map row → expected nodes
+    when the bench row didn't store `path_metrics` (queries with
+    `expected_path` set but no `path_metrics` block — bench.py emits one
+    when graph_paths is non-empty; we keep the fixture as authority).
     """
-    _ = fixture  # reserved for future use (e.g. min_recall threshold)
+    # Map fixture queries by id for expected-nodes lookup.
+    fixture_map: Dict[int, Dict[str, Any]] = {
+        int(q["id"]): q for q in fixture.get("queries", [])
+    }
     rows: List[PathCoverageQueryRow] = []
     for r in bench_results.get("results", []):
-        pm = r.get("path_metrics")
-        if not pm:
+        qid = int(r.get("id", -1))
+        fq = fixture_map.get(qid)
+        # Legacy compatibility — when no fixture context is available
+        # but bench already stored `path_metrics`, trust those numbers.
+        # The new unified scorer requires fixture lookup for slug
+        # comparison; this branch lets historic bench JSONs (step7 v5/v6
+        # or tests with empty fixture) keep working unchanged.
+        if not fq:
+            pm = r.get("path_metrics")
+            if not pm:
+                continue
+            hits = int(pm.get("hits", 0))
+            rows.append(PathCoverageQueryRow(
+                id=qid,
+                expected_count=int(pm.get("expected_count", 0)),
+                hits=hits,
+                recall=float(pm.get("path_recall", 0.0)),
+                via_graph=hits,
+                via_sources=0,
+            ))
             continue
+        ep = fq.get("expected_path") or {}
+        expected_nodes = ep.get("nodes") or []
+        if not expected_nodes:
+            continue
+        expected_slugs = {_slug_for_match(n) for n in expected_nodes
+                          if isinstance(n, str)}
+        expected_slugs.discard("")
+        if not expected_slugs:
+            continue
+
+        # Graph-side hits: prefer row.graph_paths (added when present);
+        # fall back to bench.py's aggregate path_metrics.hits if raw
+        # paths aren't stored. The latter is graph-only and loses the
+        # source-side credit.
+        graph_slugs = _graph_node_slugs_from_bench_row(r)
+        # Source-side hits: the citation list.
+        source_slugs = {_slug_for_match(s) for s in (r.get("sources") or [])
+                        if isinstance(s, str)}
+        source_slugs.discard("")
+
+        via_graph = len(expected_slugs & graph_slugs)
+        via_sources = len(expected_slugs & source_slugs)
+        # A title can be hit via either side; dedup so recall ≤ 1.0.
+        union_hits = len(expected_slugs & (graph_slugs | source_slugs))
+
+        # When bench.py emitted no graph_paths AND no sources, fall back
+        # to whatever path_metrics.hits says so legacy bench JSONs
+        # without the new fields don't regress to all-zero.
+        if not graph_slugs and not source_slugs:
+            pm = r.get("path_metrics")
+            if pm:
+                union_hits = int(pm.get("hits", 0))
+                via_graph = union_hits  # treat all as graph-side legacy
+
+        recall = union_hits / len(expected_slugs) if expected_slugs else 0.0
         rows.append(PathCoverageQueryRow(
-            id=int(r["id"]),
-            expected_count=int(pm.get("expected_count", 0)),
-            hits=int(pm.get("hits", 0)),
-            recall=float(pm.get("path_recall", 0.0)),
+            id=qid,
+            expected_count=len(expected_slugs),
+            hits=union_hits,
+            recall=round(recall, 4),
+            via_graph=via_graph,
+            via_sources=via_sources,
         ))
     if not rows:
         return PathCoverageAxis(

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -324,6 +324,13 @@ def _run_one(
     data = r.json() or {}
     answer = (data.get("answer") or "").strip()
     actual_paths = data.get("graph_paths") or []
+    # α-5 plan §findings 2026-05-31 — `sources` is the citation field
+    # (top-3 source documents that fed the LLM, per
+    # core/reasoning/pipeline.py:343). Capturing it here so the oracle
+    # can score source-recall against the fixture's expected article
+    # titles — that's the MultiHop-RAG `evidence_list.title` semantic,
+    # which doesn't map onto the entity-only `graph_paths`.
+    actual_sources = data.get("sources") or []
     base.update({
         "status":            "ok",
         "answer_len":        len(answer),
@@ -332,9 +339,14 @@ def _run_one(
         "graph_paths_count": len(actual_paths),
         "mode":              data.get("mode", ""),
         "unified_score":     data.get("unified_score"),
+        "sources":           actual_sources,
     })
     # Idea 1 (2026-05-27) — Path Recall/Precision when the suite
     # declares `expected_path.nodes`. Queries without the field skip.
+    # The oracle (eval/qvt/oracle.py::score_path_coverage) is the
+    # authority on path scoring; `path_metrics` here stays as a
+    # graph-entity-only signal for legacy callers. Oracle considers
+    # both `path_metrics` and `sources` when computing the axis.
     expected_path = q.get("expected_path") or {}
     expected_nodes = expected_path.get("nodes") or []
     pm = _path_metrics(actual_paths, expected_nodes)

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -115,6 +115,105 @@ class PathCoverageTests(unittest.TestCase):
         self.assertEqual(axis.queries_at_full_recall, 1)
         self.assertEqual(len(axis.per_query), 3)
 
+    # α-5 §findings 2026-05-31 — source-side path scoring tests.
+
+    def test_source_match_full_recall(self):
+        """JAMES `sources` filenames slug-match all expected article titles."""
+        bench = {"results": [{
+            "id": 1, "status": "ok",
+            "sources": [
+                "multihop_0009_SBF-Trial-The-latest-updates-from-the-FTX-collapse-s-courtroom-drama.txt",
+                "multihop_0010_SBF-s-trial-starts-soon-but-how-did-he-and-FTX-get-here.txt",
+                "multihop_0175_The-FTX-trial-is-bigger-than-Sam-Bankman-Fried.txt",
+            ],
+        }]}
+        fixture = {"queries": [{
+            "id": 1, "category": "test",
+            "expected_path": {"nodes": [
+                "SBF Trial: The latest updates from the FTX collapse's courtroom drama",
+                "SBF's trial starts soon, but how did he — and FTX — get here?",
+                "The FTX trial is bigger than Sam Bankman-Fried",
+            ], "min_recall": 1.0},
+        }]}
+        axis = score_path_coverage(bench, fixture)
+        self.assertEqual(len(axis.per_query), 1)
+        self.assertEqual(axis.per_query[0].hits, 3)
+        self.assertEqual(axis.per_query[0].via_sources, 3)
+        self.assertEqual(axis.per_query[0].via_graph, 0)
+        self.assertAlmostEqual(axis.mean_recall, 1.0, places=4)
+
+    def test_source_partial_match(self):
+        """Top-3 sources contain only 2 of 3 expected articles."""
+        bench = {"results": [{
+            "id": 1, "status": "ok",
+            "sources": [
+                "multihop_0009_SBF-Trial-The-latest-updates-from-the-FTX-collapse-s-courtroom-drama.txt",
+                "multihop_0010_SBF-s-trial-starts-soon-but-how-did-he-and-FTX-get-here.txt",
+                "multihop_0999_Unrelated-article.txt",
+            ],
+        }]}
+        fixture = {"queries": [{
+            "id": 1, "category": "test",
+            "expected_path": {"nodes": [
+                "SBF Trial: The latest updates from the FTX collapse's courtroom drama",
+                "SBF's trial starts soon, but how did he — and FTX — get here?",
+                "The FTX trial is bigger than Sam Bankman-Fried",
+            ], "min_recall": 1.0},
+        }]}
+        axis = score_path_coverage(bench, fixture)
+        self.assertAlmostEqual(axis.per_query[0].recall, 2 / 3, places=4)
+
+    def test_unified_credit_from_both_sides(self):
+        """A hit from graph_paths AND a hit from sources both count, but
+        a title matched on both sides is credited once (no double count)."""
+        bench = {"results": [{
+            "id": 1, "status": "ok",
+            "graph_paths": [
+                # A path that contains 'The FTX trial …' as a node — this
+                # is a synthetic graph-entity match the way bench parses
+                # path strings.
+                "The FTX trial is bigger than Sam Bankman-Fried -[REL]→ Sam Bankman-Fried",
+            ],
+            "sources": [
+                # Source filename also covers the same article.
+                "multihop_0175_The-FTX-trial-is-bigger-than-Sam-Bankman-Fried.txt",
+                # And a second article covered by sources only.
+                "multihop_0010_SBF-s-trial-starts-soon-but-how-did-he-and-FTX-get-here.txt",
+            ],
+        }]}
+        fixture = {"queries": [{
+            "id": 1, "category": "test",
+            "expected_path": {"nodes": [
+                "The FTX trial is bigger than Sam Bankman-Fried",
+                "SBF's trial starts soon, but how did he — and FTX — get here?",
+            ], "min_recall": 1.0},
+        }]}
+        axis = score_path_coverage(bench, fixture)
+        self.assertEqual(axis.per_query[0].hits, 2)
+        # First article matched on both sides; second only via sources.
+        # via_graph counts pre-dedup hits from graph side; via_sources
+        # counts pre-dedup hits from sources side. Each hit is allowed
+        # to appear in both counters.
+        self.assertEqual(axis.per_query[0].via_graph, 1)
+        self.assertEqual(axis.per_query[0].via_sources, 2)
+        self.assertAlmostEqual(axis.per_query[0].recall, 1.0, places=4)
+
+    def test_no_sources_no_graph_no_hits(self):
+        bench = {"results": [{
+            "id": 1, "status": "ok",
+            "sources": [
+                "multihop_0999_completely-unrelated-article.txt",
+            ],
+        }]}
+        fixture = {"queries": [{
+            "id": 1, "category": "test",
+            "expected_path": {"nodes": ["The FTX trial is bigger than Sam Bankman-Fried"],
+                              "min_recall": 1.0},
+        }]}
+        axis = score_path_coverage(bench, fixture)
+        self.assertEqual(axis.per_query[0].hits, 0)
+        self.assertEqual(axis.per_query[0].recall, 0.0)
+
 
 # ---------------------------------------------------------------------------
 # score_graded_answer


### PR DESCRIPTION
## Summary

Root-cause of #616's \`path_recall=0.000\` finding: bench.py only inspected \`graph_paths\` (entity traversal), but JAMES's \`/query/\` response carries a separate \`sources\` field (top-3 cited documents, per \`core/reasoning/pipeline.py:343\`). MultiHop-RAG's \`evidence_list.title\` is a document-centric question that the existing path metric couldn't answer because it only looked at concept/org/person entity traversal.

This PR makes the path axis a unified "did the system reach the right knowledge" recall across BOTH signals.

## Verified end-to-end

- ChromaDB \`source\` metadata stores literal filenames (\`multihop_0000_200-of-the-best-deals-…txt\`); \`pipeline.py:343\` forwards them into \`response.sources\` as-is — confirmed by inspecting the live workspace's bge_m3 collection
- Slug-normalised fixture titles match workspace raw files for q1: all 3 expected articles found
- 47/47 oracle tests pass (43 existing + 4 new source-match cases)
- No regression in step7 (legacy bench rows without \`sources\` fall back to bench-precomputed \`path_metrics.hits\` via the new oracle branch)

## How matching works

The \`_slug_for_match\` normaliser unifies three naming surfaces:

| Surface | Example | Normalised |
|---|---|---|
| fixture expected node | "The FTX trial is bigger than Sam Bankman-Fried" | \`the-ftx-trial-is-bigger-than-sam-bankman-fried\` |
| graph entity name | "Sam Bankman-Fried" | \`sam-bankman-fried\` |
| source document file | "multihop_0009_SBF-Trial-The-latest-…txt" | \`sbf-trial-the-latest-updates-from-the-ftx-collapse-s-courtroom-dr\` |

Common slug → \`multihop_<id>_\` prefix stripped, \`.txt\`/\`.pdf\` stripped, lowercase, dash-separated, 80-char cap. Same on both sides → set intersection on slug.

Per-query row reports \`via_graph\` and \`via_sources\` separately — future analysis can distinguish "graph traversal hit" from "citation hit" for routing-policy interpretation.

## Test plan

- [x] \`pytest tests/test_qvt_oracle.py\` → 47 passed
- [x] Unit smoke against live fixture + workspace files
- [x] ChromaDB metadata inspection
- [ ] Re-capture baseline → should see non-zero \`path_recall\`
- [ ] Re-run α-5 T0 smoke

## Out of scope

- step7 fixture re-evaluation under new oracle (no scope change expected — wiki-canonical entity names already match)
- α-5 matrix re-run (next operator action after baseline re-capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)