### PR TITLE
docs(findings): α-5 — 4-bucket diagnostic taxonomy + dual purpose framing

### DIFF
--- a/reports/research-runs/qvt-ablation-findings.md
+++ b/reports/research-runs/qvt-ablation-findings.md
@@ -50,14 +50,44 @@
   pipeline crashed on a specific article; budget caps interacting with
   routing).
 
+## Diagnostic bucket (MANDATORY field, per user guidance 2026-05-31 PM-2)
+
+Before this finding becomes a code change, classify which solution
+bucket it belongs to. Getting the bucket wrong → wrong fix.
+
+| Bucket | Symptom | Solution shape | Examples in repo |
+|---|---|---|---|
+| **(a) Architecture** | layer's designed boundary / shape is wrong | redesign / split / merge | (none yet this cycle) |
+| **(b) LLM model** | model capability ceiling | tier change / model swap | A3 #608 — gemma4:e4b thinking trace; D3 #602/#603 — model-invariant cost |
+| **(c) Feature gap** | no layer covers this need | new layer design | D6 LLM-judge (deferred); abstention nuance beyond phrase matcher |
+| **(d) Measurement artifact** | oracle / fixture / bench misses real JAMES output | matcher fix (zero JAMES code change) | #618 source-recall; #619 abstention phrases |
+
+Diagnosis order (priority): **(d) first** — cheapest to rule out;
+**(b)** — same layer fails on multiple tiers?; **(a)** — design vs
+observed behaviour mismatch; **(c)** — only after the above are ruled
+out (otherwise you build a layer that didn't need to exist).
+
+The 4-step verification rule for ruling out (d) is documented in memory
+`feedback_oracle_phrase_artifacts.md` — apply it BEFORE proposing a
+fix in any of the other three buckets.
+
+Every entry below MUST include a `bucket:` line tagging (a)/(b)/(c)/(d).
+"unclassified — needs more sampling" is fine while waiting on data.
+
 ---
 
 ## Findings
 
 <!-- Add entries below this line, newest at the bottom. -->
 
-### 2026-05-31 — multihop-rag-path-axis-dead
+### 2026-05-31 — multihop-rag-path-axis-dead → RESOLVED (bucket-d) (#618)
 
+- **bucket**: (d) measurement artifact — bench.py was dropping
+  `response.sources`; JAMES citation design was correct all along.
+  Diagnosis: applied the 4-step rule (axis 0 → sample answers manually →
+  check `response` keys → reconcile design vs matcher) and found
+  `core/reasoning/pipeline.py:343` emits `sources: [d["source"] for d
+  in docs[:3]]` while bench only inspected `graph_paths`.
 - **pattern**: 100/100 queries with `expected_path` → `path_recall = 0.000`
 - **cell context**: baseline L1/M_M (`baseline_f7762a3.json`), workspace
   ingested 183 articles (931 entities)


### PR DESCRIPTION
## Summary

Per user guidance: α-5 measurement has two simultaneous purposes:

1. **Routing decision** (already known) — flag-ON / tier-gating per layer
2. **Reasoning capability evidence** — competitive narrative that JAMES's layer stack measurably outperforms peers (publishable, user requirement #4)

When matrix findings surface, classify the next-step into one of four buckets BEFORE proposing a code change:

| Bucket | Symptom | Solution shape | This-cycle example |
|---|---|---|---|
| **(a) Architecture** | layer designed wrong shape | redesign / split | (none yet) |
| **(b) LLM model** | model capability ceiling | tier / swap | A3 #608 thinking trace |
| **(c) Feature gap** | no layer covers | new layer | D6 LLM-judge (deferred) |
| **(d) Measurement** | oracle/fixture/bench misses real output | matcher fix (zero JAMES code change) | #618 source-recall; #619 abstention phrases |

Diagnosis order: **(d) first** (cheapest to rule out), then (b), then (a), then (c).

## Why this matters now

Both major findings this cycle ("path_recall=0" + "76% null_query hallucination") were bucket (d). Without the discipline:
- Path=0 → would have proposed new citation layer (c) — WRONG (\`sources\` field existed)
- 76% hallucination → would have proposed grounding architecture (a) — WRONG (phrase detector too narrow)

The dual-purpose framing also matters: bucket (d) artifacts must be removed BEFORE the reasoning-capability narrative is reported externally, or the publishable signal becomes noise.

## Changes

- Add **4-bucket diagnostic taxonomy** section to \`reports/research-runs/qvt-ablation-findings.md\`
- Make **bucket: tagging mandatory** on every entry going forward
- Update existing \`multihop-rag-path-axis-dead\` entry to mark \`bucket: (d) + RESOLVED (#618)\`
- Cross-reference the 4-step verification rule in memory \`feedback_oracle_phrase_artifacts.md\`

## Out of scope

- Mechanism-finding promotion to memory (separate workflow, see Step 10 of plan)
- ROADMAP update with the dual-purpose framing (defer to v0.4-end summary PR after α-5 matrix completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)