### PR TITLE
fix(qvt): α-5 render_report defensive path + §7.4 bucket retroactive tag

### DIFF
--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -279,8 +279,8 @@ appears below the original table.
 `*` abst_f1 is undefined for `present`-truth types (no positive
 class samples) and reports as 0.
 
-**Re-scored aggregate after #619 (abstention phrases) on the same
-bench JSON**:
+**Re-scored aggregate after #619 (abstention phrases, bucket: (d)
+measurement artifact) on the same bench JSON**:
 
 | Metric | Before #619 | After #619 |
 |---|---|---|
@@ -306,7 +306,7 @@ vs matcher` — is recorded in memory `feedback_oracle_phrase_artifacts`
 as a 4-step verification rule to run BEFORE interpreting matrix Δ
 values in future cycles.
 
-**Path-axis finding — RESOLVED** (#618):
+**Path-axis finding — RESOLVED** (#618, **bucket: (d) measurement artifact**):
 
 The original "graph_paths surfaces concept/org/person entities but
 expects article titles" framing was based on bench.py only reading

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -830,9 +830,17 @@ def _render_report(out_path: Path) -> int:
             )
         rows.append("")
 
-    _REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(rows), encoding="utf-8")
-    print(f"[report] wrote {out_path.relative_to(ROOT)}")
+    # Defensive — out_path may live outside ROOT when the operator passes
+    # an absolute path or runs against a JAMES_WORKSPACE that's not a
+    # subpath of the project. relative_to would raise ValueError; fall
+    # back to the absolute path so the diagnostic line still prints.
+    try:
+        rel = out_path.relative_to(ROOT)
+    except ValueError:
+        rel = out_path
+    print(f"[report] wrote {rel}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Two small follow-ups to the α-5 cycle (#618 #619 #620 #621):

### \`scripts/qvt_ablation_matrix.py::_render_report\` defensive fix

\`out_path.relative_to(ROOT)\` raises \`ValueError\` when out_path isn't a subpath of ROOT — could bite if an operator passes \`--output\` an absolute path outside the repo, or JAMES_WORKSPACE is set somewhere outside the project. Falls back to the absolute path so the diagnostic line still prints.

Also \`_REPORT_DIR.mkdir\` → \`out_path.parent.mkdir\` — same value in production today, but respects whatever the caller passed.

Caught by a mock-based 4-test sanity check (sanity output paths, 5-axis verdict edges, aggregate_runs key shape, 3-cell render). Will not trigger in the live α-5 run (workspace lives under ROOT) but prevents the next operator path surprise.

### §7.4 bucket retroactive tags

#621 landed the 4-bucket diagnostic taxonomy with mandatory tagging on findings. Backfills the §7.4 \"Path-axis finding RESOLVED\" and \"Re-scored aggregate after #619\" sections with explicit \`bucket: (d) measurement artifact\` annotations. Memory \`feedback_oracle_phrase_artifacts.md\` events 1 and 2 also tagged.

Both major α-5 findings (\"path_recall=0\" + \"76% null_query hallucination\") were bucket (d) — making that classification explicit in the public backlog ensures future cycles read the chain without re-deriving.

## Test plan

- [x] Mock-based 4-test sanity (paths, verdict, aggregate, render) — all PASS
- [x] No effect on the running baseline subprocess (qvt_capture_baseline; matrix runner not in flight)

## Out of scope

- Proper unit test file for matrix runner (separate follow-up)
- ROADMAP §v0.4-end update with bucket framework (planned after α-5 matrix completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)