### PR TITLE
fix(qvt): α-5 round-2 polish — bench session_id suite-aware + 3 narrow abstention phrases

### DIFF
--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -90,6 +90,9 @@ _ABSTENTION_PHRASES: Tuple[str, ...] = (
     "impossible to identify",
     "cannot be determined",
     "cannot be answered",
+    "cannot be confirmed",     # α-5 R cycle 2026-05-31: q58 etc
+    "cannot be identified",    # q69
+    "none of the provided",    # q51 ("Source files: None of the provided …")
     "insufficient information",
     "insufficient data",
 )

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -258,6 +258,7 @@ def _run_one(
     api_key: str, q: Dict, endpoint: str, timeout: int,
     default_mode: Optional[str] = None,
     bearer: str = "",
+    suite: str = "step7",
 ) -> Dict:
     """Run a single query against the live server. Returns the row dict that
     bench reports operate on.
@@ -281,7 +282,13 @@ def _run_one(
     body: Dict = {
         "question":   q["text"],
         "api_key":    api_key,
-        "session_id": f"bench_step7_{q['id']}",
+        # session_id was hardcoded "bench_step7_*" for years — fine for
+        # the original suite but landed in the audit log identically for
+        # multihop_rag / future suites, which made trace correlation
+        # ambiguous when both ran on the same workspace. Suffix on the
+        # actual suite so each run partition is distinguishable in
+        # `reports/trace/*.jsonl` + the `audit_log` table.
+        "session_id": f"bench_{suite}_{q['id']}",
     }
     mode_override = q.get("mode") or default_mode
     if mode_override:
@@ -506,6 +513,7 @@ def main() -> int:
     for q in queries:
         res = _run_one(
             api_key, q, endpoint, timeout, effective_default_mode, bearer,
+            suite=args.suite,
         )
         results.append(res)
         _print_row(res, len(queries))


### PR DESCRIPTION
## Summary

Two small tightening fixes from inspecting the running α-5 cycle.

### Y. \`scripts/bench.py\` session_id is now suite-aware

session_id was hardcoded \`bench_step7_<id>\` regardless of \`--suite\`. Audit-log and trace files identically named when multihop_rag (and future suites) ran on the same workspace — per-suite correlation ambiguous. Now \`bench_<suite>_<id>\`.

### R. 3 more narrow abstention phrases

Inspecting the 9 remaining FNs on baseline_f7762a3 found 7 still-abstaining responses + 1 borderline + 1 real hallucination. Adds three narrow phrases that only appear in unhedged refusal positions:

- \`cannot be confirmed\` — q58
- \`cannot be identified\` — q69
- \`none of the provided\` — q51

| Metric | After #619 | After R |
|---|---|---|
| TP_abstain | 16 | 19 |
| FP_incorrect_abstention | 10 | 10 |
| FN_hallucination | 9 | 6 |
| TN_answer | 65 | 65 |
| **abstention_f1** | **0.627** | **0.704** |

Zero new FPs. Remaining 6 FNs split between "not possible to / is not available" phrasings (carry FP risk in disclaimers) and 1 genuine hallucination ("first letter of the Asian country is I" — confident wrong answer routing layers can plausibly improve). The riskier phrases stay out; LLM-judge bucket-(c) is the proper future fix.

## Test plan

- [x] \`pytest tests/test_qvt_oracle.py\` → 47 passed
- [x] Re-scored bench JSON: F1 0.63 → 0.70

## Out of scope

- LLM-judge abstention detector (bucket-(c) feature gap, deferred)
- Refixturing q63 (borderline answer+disclaimer — judgment call)
- Refixturing q64 (real hallucination — leave for matrix routing to improve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)