### PR TITLE
docs(α-5): Pareto verdict walk-through + CLAUDE.md rule 2 fix-PR exempt + post-mortem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,22 +33,38 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 2. **Every PR touching `core/retrieval`, `core/graph`, or
    `core/reasoning` must paste bench numbers + a Quality Delta
    Card** in the description (Axis 2 of v0.2 ROADMAP, extended by
-   QVT α-4 2026-05-28). PRs without numbers will not land.
+   QVT α-4 2026-05-28, α-5 cycle 2026-05-31). PRs without
+   numbers will not land.
    - **Bench numbers**: STEP 7 result deltas (`scripts/bench.py
      --suite=step7 --mode=retrieval`) — latency, graph_paths,
      answer_len.
-   - **Quality Delta Card**: 3-axis paired comparison against
-     `eval/qvt/baseline_<sha>.json` (Path Recall / Graded Answer /
-     Abstention F1). Template lives in `.github/PULL_REQUEST_TEMPLATE.md`.
+   - **Quality Delta Card**: 3-axis (or, after α-5 lands, 5-axis)
+     paired comparison against `eval/qvt/baseline_<sha>.json`
+     (Path Recall / Graded Answer / Abstention F1 / + Token Cost /
+     Latency Cost). Template lives in
+     `.github/PULL_REQUEST_TEMPLATE.md`. The α-5 Pareto verdict
+     rule (`scripts/qvt_ablation_matrix.py::_classify_five_axis_delta`)
+     applies once the 5-axis baseline is the canonical reference.
    - **Exemption labels** (skip the Quality Delta Card with one line
      `Quality delta: exempt (label: <name>)`): `external-contributor`
      (Robin / Ali / other collaborator PR), `joint-collab-prep`
      (mid-June joint piece / shared deliverable), `docs` / `chore` /
      `ci` (not touching `core/`), `code` (circular — the PR is the
-     oracle / baseline itself). Rationale: the gate is for measuring
+     oracle / baseline itself), **`fix` (oracle/fixture/bench
+     correction PR — the very thing being corrected is what would be
+     measured against)**. Rationale: the gate is for measuring
      JAMES-internal marginal contribution, not a collaboration
-     friction tool. See `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md`
-     §4 for the full exemption rule.
+     friction tool, and not a measurement-side hygiene PR. See
+     `docs/design/v0.4-qvt-alpha-non-saturating-oracle.md` §4 for the
+     full exemption rule.
+   - **`fix` label discipline** (α-5 cycle lesson): when the PR
+     corrects a measurement-side artifact in oracle / fixture / bench
+     (e.g. bucket-(d) findings per `feedback_oracle_phrase_artifacts`),
+     state the exemption explicitly in the description. The α-5 cycle
+     saw 5 fix PRs (#618 #619 #622 #623 #625) where the Quality Delta
+     Card would either circular-reference the broken oracle or
+     measure noise. Explicit `Quality delta: exempt (label: fix)`
+     keeps the review readable without paste-noise.
 
 3. **Self-evolution is opt-in only**. Any change that allows
    auto-deploy without an `approver_username` in the audit log

--- a/docs/design/v0.4-qvt-alpha-5-ablation-matrix.md
+++ b/docs/design/v0.4-qvt-alpha-5-ablation-matrix.md
@@ -149,24 +149,102 @@ Then per-cell Δ vs L1/M_M baseline:
 }
 ```
 
-### 3.1 Verdict rule
+### 3.1 Verdict rule (5-axis Pareto, post-#615)
 
-For each cell, classify Δ against the L1/same-tier noise band:
+The original 3-axis rule (positive/mixed/zero/negative/regression) was
+replaced when cost axes were added (PR #615). The current Pareto-aware
+6-verdict rule lives at
+`scripts/qvt_ablation_matrix.py::_classify_five_axis_delta` and is
+applied during `--render-report`.
 
-- **`positive`** — all 3 axes Δ > noise_band of L1 at same tier
-- **`mixed`** — at least one axis Δ > noise_band, none Δ < −noise_band
-- **`zero`** — all 3 axes |Δ| ≤ noise_band (cell adds noise, no signal)
-- **`negative`** — at least one axis Δ < −noise_band, none Δ > noise_band
-- **`regression`** — all 3 axes Δ < −noise_band
+#### Definitions
 
-### 3.2 Routing policy decisions (the actual α-5 output)
+| Term | Means |
+|---|---|
+| **quality axes** | `path_coverage`, `graded_answer`, `abstention_f1` — higher = better |
+| **cost axes** | `token_cost`, `latency_cost` — *lower* = better |
+| **noise band** | per-axis `max − min` across the baseline's paired-N=3 runs (canonical baseline is `eval/qvt/baseline_<sha>.json`) |
+| **quality+** | at least one quality axis Δ > +noise_band |
+| **quality−** | at least one quality axis Δ < −noise_band |
+| **cost+** | at least one cost axis Δ < −noise_band (lower is better — improvement) |
+| **cost−** | at least one cost axis Δ > +noise_band (worse) |
+
+#### The 6 verdicts
+
+| # | Verdict | When | Policy implication |
+|---|---|---|---|
+| 1 | **strong-adopt** | quality+ AND cost+ AND no cost− | both axes win — best case, default on |
+| 2 | **adopt** | quality+ AND cost flat (no Δ > band on cost axes) | quality wins, cost neutral — default on |
+| 3 | **efficiency-adopt** | quality flat AND cost+ | free efficiency, no quality cost — default on |
+| 4 | **tier-gated** | quality+ AND cost− | quality wins but cost regressed — accept on small tier (cost amortized), refuse on large tier |
+| 5 | **reject** | quality− on any axis | no cost gain redeems quality loss — keep opt-in indefinitely |
+| 6 | **zero** | all axes within noise | layer is inert at production tier — ablation evidence supports deprecation |
+
+#### Worked examples (synthetic, noise = 0.05 quality / 100 token / 5s latency)
+
+**Example A — strong-adopt**:
+```
+Δ = { path: +0.08, graded: +0.02, abst: +0.01, token: -150, latency: -3 }
+quality+: yes (path moves past 0.05 band)
+cost+:    yes (token down 150 > 100 band)
+cost−:    no
+→ strong-adopt
+```
+
+**Example B — efficiency-adopt** (the routing layer didn't help quality
+but burned fewer tokens):
+```
+Δ = { path: 0.0, graded: 0.0, abst: +0.02, token: -200, latency: 0 }
+quality+: no (abst Δ inside band)
+cost+:    yes (token down 200)
+→ efficiency-adopt
+```
+
+**Example C — tier-gated** (quality boost is real but at higher cost
+— accept on small tier where it amortizes, refuse on large where the
+small model is already cheap):
+```
+Δ = { path: +0.10, graded: 0.0, abst: 0.0, token: +250, latency: +12 }
+quality+: yes
+cost−:    yes (both cost axes worse)
+→ tier-gated
+```
+
+**Example D — reject** (any quality regression is the disqualifier;
+cost gains do not redeem it):
+```
+Δ = { path: -0.08, graded: +0.03, abst: 0.0, token: -500, latency: -20 }
+quality−: yes (path regressed past band)
+→ reject
+```
+
+**Example E — zero** (the most common verdict for layers that look
+busy but don't move the needle):
+```
+Δ = { path: +0.01, graded: -0.02, abst: 0.0, token: +30, latency: +1 }
+quality+: no, quality−: no, cost+: no, cost−: no
+→ zero
+```
+
+### 3.2 Routing policy decisions per-tier pattern (the actual α-5 output)
 
 | Per-tier pattern | Policy decision |
 |---|---|
-| Layer L_x = `positive` on ≥ 2 tiers including M_M | **enable as default** — ship `=1` in `.env.example` |
-| L_x = `positive` only on one tier | **tier-gated** — router policy picks `=1` for that tier model only |
-| L_x = `zero` on all tiers | **delete or document as inert** — ablation evidence supports removal/deprecation |
-| L_x = `negative` or `regression` on ≥ 1 tier | **keep opt-in, never default** — layer ships behind `=0` indefinitely |
+| `strong-adopt` or `adopt` on ≥ 2 tiers incl. M_M | **enable as default** — ship `=1` in `.env.example` |
+| `efficiency-adopt` on all tiers | **enable as default** — free efficiency, no quality cost |
+| only one tier `*-adopt` | **tier-gated** — router policy keys on `JAMES_LLM_MODEL` |
+| `tier-gated` verdict on any cell | **per-tier evaluation** — small ≤ large? (small accepts cost overhead, large rejects) |
+| `zero` on all tiers | **delete or document as inert** — deprecation PR with `architecture` label |
+| `reject` on ≥ 1 tier | **keep opt-in indefinitely** — layer ships behind `=0` |
+
+Per-question-type cross-tab (PR #615 §6): when a layer is `tier-gated`
+on overall verdict but unanimously `*-adopt` on a single
+`question_type`, the layer becomes **type-gated** — routed only for
+queries the IntentClassifier labels with that type. The matrix renderer
+(`scripts/qvt_ablation_matrix.py::_render_report`) emits the per-type
+recommendation table automatically — copy verbatim into the cycle
+analysis (template at
+`reports/research-runs/qvt-ablation-T0-smoke-analysis-TEMPLATE.md`).
 
 This is the exact mechanism CLAUDE.md §2 (Quality Delta Card) was
 designed to feed.

--- a/reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md
+++ b/reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md
@@ -1,0 +1,249 @@
+# α-5 Diagnostic Chain — Post-Mortem (2026-05-30~31)
+
+> Narrative of how three landmark "JAMES fails" findings during the
+> α-5 cycle turned out to be measurement-side artifacts, not real
+> JAMES weaknesses. Recording the chain so future cycles inherit the
+> instinct + the rule, not the surprise.
+
+---
+
+## What we measured
+
+The α-5 ablation matrix (`docs/design/v0.4-qvt-alpha-5-ablation-matrix.md`)
+is the first JAMES evaluation against an external benchmark
+(MultiHop-RAG, Tang & Yang 2024). When the first baseline landed
+(`baseline_f7762a3.json`, 2026-05-31 06:38, 100 queries) the headline
+read:
+
+| Axis | Baseline 1 (raw) | Initial interpretation |
+|---|---|---|
+| path_coverage | **0.000** | "JAMES citation completely broken" |
+| graded_answer | 0.333 | "JAMES gets ~1/3 of facts" |
+| abstention_f1 | 0.316 | "JAMES hallucinates 76% on null queries" |
+
+All three numbers were misleading on the JAMES-side, accurate on the
+measurement-side. The cycle eventually pinned the corrected baseline
+(`baseline_3a961a3_rescored.json`, the same bench data re-scored
+through `eval/qvt/oracle.py` at main `40ae383+`):
+
+| Axis | Baseline 1 (rescored) | Correction |
+|---|---|---|
+| **path_coverage** | **0.404** | bench was dropping the `sources` field |
+| graded_answer | 0.343 | small graded uplift (different bench run) |
+| **abstention_f1** | **0.704** | phrase list missed gemma4:e4b's English refusals |
+
+---
+
+## The three corrections, in order
+
+### Correction 1 — path_coverage 0.000 → 0.404 (PR #618)
+
+**Symptom**: `path_recall = 0.000` on all 75 path-annotated queries.
+Bench captured `graph_paths` (18-179 nodes/query, mean 60), so the
+graph traversal *was* working.
+
+**Wrong first interpretation**: "JAMES surfaces concept entities but
+not document entities — fixture is fundamentally incompatible with
+JAMES's graph-RAG shape." That framing was about to become a paragraph
+in the §7.4 backlog.
+
+**User catch** (the decisive moment):
+
+> "출처 인용에 대한 것도 내가 자메스상 설계해놓은 것으로 기억하는데,
+> 만약 이게 안되있으면 문제가 될듯. 보완해야할것같아."
+
+Translation: *"I remember designing source citation on JAMES — if
+that's not working, that's a problem. Need to fix."*
+
+This is the moment the chain pivoted. JAMES, by design, returns a
+`sources` field separate from `graph_paths` in every `/query/`
+response (`core/reasoning/pipeline.py:343`: `[d.get("source",
+"unknown") for d in loop_state["docs"][:3]]`).
+
+**Root cause**: `scripts/bench.py:326` read only
+`data.get("graph_paths")`. The `sources` field was emitted by JAMES
+all along, just discarded by bench.
+
+**Fix scope**: bench captures `sources`, oracle's
+`score_path_coverage` scores against *both* `graph_paths` entities
+AND `sources` filenames after slug normalisation. `via_graph` and
+`via_sources` are tracked separately per query so future analysis can
+distinguish concept-traversal wins from citation-layer wins.
+
+**Bucket**: (d) measurement artifact. JAMES code change: 0.
+
+---
+
+### Correction 2 — abstention_f1 0.316 → 0.704 (PRs #619 + #623)
+
+**Symptom**: 19/25 null_query rows classified as
+`FN_hallucination` — system answered when truth was `absent`. Reads
+as a 76% hallucination rate.
+
+**Wrong first interpretation**: "JAMES's grounding is weak; need
+architecture change to add a refusal gate."
+
+**Diagnostic chain** (4-step rule from
+`memory/feedback_oracle_phrase_artifacts.md`):
+
+1. Read 5 sample answers from the FN bucket directly.
+2. Discover phrases like *"impossible to answer"*, *"cannot be
+   determined"*, *"None of the provided internal data relate to…"* —
+   semantically refusals, not hallucinations.
+3. Cross-check `eval/qvt/oracle.py::_ABSTENTION_PHRASES`: the list
+   was Korean-dominant ("정보가 없", "찾을 수 없"…) with a thin
+   English tail ("no information", "cannot find"). gemma4:e4b's
+   grounding-trained English refusals landed in a blind spot.
+4. Confirm: the model is *correctly abstaining* via phrasings the
+   detector doesn't recognise.
+
+**Two-stage fix**:
+
+- **#619** added 7 narrow English refusal phrases (`impossible to
+  answer`, `cannot be determined`, `insufficient information`, etc.).
+  F1: 0.316 → 0.627. FN: 19 → 9.
+- **#623** added 3 more after inspecting the remaining FNs (`none of
+  the provided`, `cannot be confirmed`, `cannot be identified`).
+  F1: 0.627 → 0.704. FN: 9 → 6.
+
+Each round kept phrases narrow on purpose — broader patterns like
+*"does not contain"* / *"is not present"* would FP-match
+disclaimers in partial-answer-plus-caveat responses ("The company is
+Amazon. However, the source material does not contain…"). The
+discipline: each phrase must appear only in unhedged refusal
+positions in the actual dataset before it joins the list.
+
+**Real hallucination rate after both rounds**: 6/25 = **24%**, not
+76%. Of the 6, 1 is a confident wrong answer (*"The first letter of
+the Asian country is I."*) — the real signal a routing layer could
+plausibly improve.
+
+**Bucket**: (d) measurement artifact (round 1) + (d) again (round 2).
+JAMES code change: 0.
+
+---
+
+### Correction 3 — matrix runner respected wrong suite (PR #625)
+
+**Symptom**: T0 smoke restart was 25 minutes into a 117-minute cell,
+and the first cell JSON had been written with path_coverage=0.017,
+abstention_f1=0.000. The cell JSON also recorded:
+
+  `bench_output: bench_3a961a3_step7_20260531_101025.json`
+
+`_step7_` is the smoking gun. The matrix was supposed to be
+measuring `multihop_rag`.
+
+**Wrong first interpretation** (averted): the operator might have
+let T0 finish 5.3 hours later, looked at the numbers, and concluded
+"JAMES routing layers do nothing" — because step7's Korean wiki
+fixture is meaningless against the hotpot_eval workspace's English
+news corpus.
+
+**Diagnosis** (the 4-step rule does NOT apply here — this is a wiring
+bug, not a measurement-coverage bug):
+
+1. Cell completes too fast → check the bench filename.
+2. Filename says `_step7_` → check `_run_single_bench`.
+3. Line 352: `"--suite=step7"` hardcoded.
+4. `--suite=multihop_rag` plumbed everywhere ELSE (fixture resolver,
+   output dir, baseline capture) but missed the per-cell bench
+   subprocess.
+
+**Bucket**: (a) architecture. The plumbing got 90% of the way through
+when --suite was first added; the per-cell subprocess call was the
+10% that was missed.
+
+**Caught by**: a planned stale-cell-JSON cleanup that the operator
+triggered as a routine hygiene check while T0 was running. Without
+that cleanup, the 5.3-hour T0 would have finished and the wrong
+verdict would have been the published result. The cleanup wasn't
+*looking* for the bug — but it forced inspection of the cell JSON
+file, which surfaced the filename. **Routine hygiene > careful
+review** as a bug-catcher.
+
+---
+
+## What stays in the head after this
+
+### 1. The four-step rule (from `feedback_oracle_phrase_artifacts.md`)
+
+When an axis reads as `0` or `saturated` or `wildly off`, **before**
+proposing any code change:
+
+1. Read 3-5 raw answer / response samples for that axis.
+2. Confirm what the oracle / fixture / bench is actually comparing
+   against vs what JAMES emits.
+3. Check the JAMES response keys (`routes/query.py::QueryResponse`)
+   + the pipeline code (`core/reasoning/pipeline.py`).
+4. Only after (d) measurement-side is ruled out, consider buckets
+   (a) architecture / (b) model / (c) feature gap.
+
+### 2. Routine hygiene catches non-obvious bugs
+
+The matrix-runner suite bug (#625) was not caught by code review,
+not by tests, not by the dry-run. It was caught by a routine cleanup
+that forced one cell JSON to be opened. **Plan deliberate hygiene
+loops into long-running cycles** — they pay back for themselves the
+moment they catch one bug like this.
+
+### 3. The user's domain knowledge is the strongest signal
+
+The pivot moment for path_coverage=0 was a single line from the
+user remembering JAMES's citation design. No automated test
+caught it; the existing UI didn't surface it. The discipline:
+when a system's owner says "wait, that doesn't match the design,"
+treat it as the highest-priority signal.
+
+### 4. Each "fix" PR after #618 / #619 / #623 / #625 is bucket-(d) or
+   bucket-(a) on the *measurement side*, not the JAMES side. None
+   of them rewrote JAMES retrieval, grounding, or routing logic.
+   The JAMES code did exactly what it was designed to do all
+   along.
+
+---
+
+## What the corrected baseline says (the load-bearing read)
+
+`baseline_3a961a3_rescored.json`, current main, balanced-100 against
+MultiHop-RAG:
+
+```
+path_coverage:  0.404  (positive — citation layer works)
+graded_answer:  0.343  (1/3 of gold facts surface in the answer)
+abstention_f1:  0.609  (true F1 after phrase recovery)
+token_cost:     1150   chars/query (mean), 2912 (p95)
+latency_cost:   64s    /query (mean), 75s (p95)
+```
+
+Per-question-type (from `aggregate_by_question_type` in the same
+file):
+
+```
+comparison:  path=0.45  graded=0.28  ★ best path
+inference:   path=0.38  graded=0.52  ★ best graded
+temporal:    path=0.39  graded=0.33  longest answers
+null:        path=n/a   graded=0.17  abst_f1=0.57 (most queries refuse)
+```
+
+This is the actual starting point for the matrix verdict — not the
+"76% hallucination + zero path" framing of the first read.
+
+---
+
+## References
+
+- PRs: #616 (initial baseline + first finding), #618 (path
+  source-recall), #619 (abstention round 1), #620 (rescore tool +
+  §7.4 correction), #621 (4-bucket taxonomy), #622 (render_report
+  defensive + bucket retroactive), #623 (abstention round 2),
+  #624 (ROADMAP §v0.4.x record), #625 (matrix runner suite bug),
+  #626 (analysis template)
+- Memory: `feedback_oracle_phrase_artifacts` — 4-step rule + 4-bucket
+  taxonomy
+- Backlog: `docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md`
+  §7.3 (cycle reset) + §7.4 (corrections)
+- Design: `docs/design/v0.4-qvt-alpha-5-ablation-matrix.md` §3.1
+  (Pareto verdict walk-through) + §3.2 (routing policy)
+- Findings log: `reports/research-runs/qvt-ablation-findings.md`
+  (mandatory bucket tag per #621)


### PR DESCRIPTION
## Summary

Three closure-side docs from the α-5 cycle while T0 smoke is in flight.

### \`docs/design/v0.4-qvt-alpha-5-ablation-matrix.md\` §3.1 walk-through

The 3-axis verdict rule was replaced by 5-axis Pareto in #615 but the design memo still showed the old version. §3.1 now matches \`_classify_five_axis_delta\` with 6 verdicts + 5 worked examples (strong-adopt / efficiency-adopt / tier-gated / reject / zero / adopt). §3.2 routing-policy table updated for per-question-type cross-tab.

### CLAUDE.md rule 2 — \`fix\` label exemption

α-5 cycle saw 5 fix PRs (#618 #619 #622 #623 #625) where Quality Delta Card would either circular-reference the broken oracle or measure noise. The exemption list grows by one label — \`fix\` — to formally permit what was happening anyway. Rule body now also names the bucket-(d) discipline.

### \`reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md\`

End-to-end narrative of three "JAMES fails" findings that all turned out to be measurement-side artifacts:

1. **path_coverage=0** → user catch pivoted to bench dropping \`sources\`. #618.
2. **76% null hallucination** → manual sample reading surfaced English refusal phrases the list missed. #619 + #623.
3. **Matrix suite hardcoded** → routine cleanup noticed cell completed-too-fast + filename mismatch. #625.

Four cycle-lessons at the bottom:
- 4-step rule (read samples → confirm comparison → check response keys → rule out (d) before (a)/(b)/(c))
- Routine hygiene catches non-obvious bugs
- User domain knowledge is the strongest signal
- Every cycle fix was bucket-(d) or bucket-(a) on the *measurement* side — none rewrote JAMES logic

## Test plan

- [x] \`pytest tests/test_qvt_oracle.py tests/test_step7_v5_schema.py tests/test_think_policy.py tests/test_complete_with_retry.py\` → 85 passed + 28 subtests
- [x] Doc-only change, no code touched

## Quality delta

exempt (label: \`docs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)