### PR TITLE
feat(qvt): qvt_promote_findings.py — auto-draft memory entries from findings.md

### DIFF
--- a/reports/research-runs/promoted-findings/README.md
+++ b/reports/research-runs/promoted-findings/README.md
@@ -1,0 +1,53 @@
+# Promoted findings — staging area
+
+Drafts created by `scripts/qvt_promote_findings.py` land here.
+
+## What is in this directory
+
+Auto-drafted memory entry candidates derived from the
+`mechanism-candidate` / `universal-law` tagged entries in
+`reports/research-runs/qvt-ablation-findings.md`. Each file mirrors
+the structure of a real memory entry (frontmatter + body) but lives
+in the repo so the promotion trail is auditable.
+
+These are **drafts**, not active memories. They become active when
+the operator:
+
+1. Reviews the draft for accuracy and framing.
+2. Edits the `description:` line and body where needed.
+3. Moves the file to the real memory directory
+   (`~/.claude/projects/<id>/memory/`).
+4. Adds a one-line entry under `MEMORY.md`.
+5. Records the promotion in the `## Promoted to memory` table of
+   `qvt-ablation-findings.md`.
+
+## Usage
+
+```bash
+python scripts/qvt_promote_findings.py             # write drafts to this dir
+python scripts/qvt_promote_findings.py --dry-run   # preview without writing
+python scripts/qvt_promote_findings.py --force     # overwrite existing drafts
+python scripts/qvt_promote_findings.py --include-anti-pattern
+# point at the real memory dir directly:
+python scripts/qvt_promote_findings.py --memory-dir ~/.claude/projects/<id>/memory
+```
+
+## Why staging (and not direct write to memory dir)
+
+The user's memory dir is outside the repo; auto-writing there mixes
+"things the user accepted" with "things a script proposed". Staging
+in-repo keeps the promotion event visible in git history. Once
+reviewed, the user copies into the real memory dir.
+
+## What does NOT get promoted
+
+- `data-quality` tagged findings — these are bench / oracle bugs and
+  belong in PR descriptions, not memory.
+- `operational` tagged findings — runtime / setup notes are not
+  durable knowledge.
+- `anti-pattern` — opt-in via `--include-anti-pattern`.
+
+If a finding carries multiple tags (e.g. `data-quality +
+mechanism-candidate`), it is promoted because of the
+mechanism-candidate tag; the data-quality character can be edited
+out during review.

--- a/reports/research-runs/promoted-findings/finding_multihop_rag_path_axis_dead.md
+++ b/reports/research-runs/promoted-findings/finding_multihop_rag_path_axis_dead.md
@@ -1,0 +1,62 @@
+---
+name: finding-multihop-rag-path-axis-dead
+description: [2026-05-31, bucket-(d)] this is not just a slug formatting issue. graph_paths
+metadata:
+  type: project
+---
+
+# Finding — multihop-rag-path-axis-dead (2026-05-31)
+
+**Bucket**: (d)  
+**Tags**: data-quality, mechanism-candidate
+
+## Source entry (verbatim from `reports/research-runs/qvt-ablation-findings.md`)
+
+- **bucket**: (d) measurement artifact — bench.py was dropping
+  `response.sources`; JAMES citation design was correct all along.
+  Diagnosis: applied the 4-step rule (axis 0 → sample answers manually →
+  check `response` keys → reconcile design vs matcher) and found
+  `core/reasoning/pipeline.py:343` emits `sources: [d["source"] for d
+  in docs[:3]]` while bench only inspected `graph_paths`.
+- **pattern**: 100/100 queries with `expected_path` → `path_recall = 0.000`
+- **cell context**: baseline L1/M_M (`baseline_f7762a3.json`), workspace
+  ingested 183 articles (931 entities)
+- **observation**: graph_paths actually returned 18-179 nodes per query
+  (mean 60) but **none of them are MultiHop-RAG evidence article titles**.
+  Sample q1 expected = `['The FTX trial is bigger than Sam Bankman-Fried',
+  'SBF's trial starts soon, but how did he — and FTX — get here?', …]`;
+  actual document entity name = `multihop_0010_SBF-s-trial-starts-soon-but-
+  how-did-he-and-FTX-get-here` (prefix + slugified, max 80 chars).
+- **surprise**: this is not just a slug formatting issue. graph_paths
+  surfaces **concept / org / person entities** (the entities *extracted
+  from* the article), not the **document entity** (the article itself).
+  MultiHop-RAG's `evidence_list[].title` measures "did the system cite the
+  right *source*" — that semantic doesn't map onto JAMES's concept-centric
+  graph traversal.
+- **data pointer**: `reports/bench_f7762a3_multihop_rag_20260531_063800.json`
+  + `workspaces/hotpot_eval/eval/qvt/baseline_f7762a3.json` aggregate
+- **follow-up tag**: `data-quality` + `mechanism-candidate`
+- **probe ideas**:
+  1. Modify `scripts/hotpot/build_fixture.py` to map each evidence title
+     to the *concept/org entities extracted from that article*
+     (post-ingest fixture rebuild). Requires loading wiki to find which
+     concepts came from `source_document=multihop_<id>_<slug>.txt`.
+  2. Modify `eval/qvt/oracle.py:score_path_coverage` to also credit
+     document-via-`doc_id` matches when bench output includes the
+     traversed document IDs.
+  3. Accept path axis as fixture-incompatible for MultiHop-RAG; rely on
+     graded + abstention + token + latency for matrix verdicts. Mark
+     path Δ as "n/a — fixture limitation" in report.
+  - Option 3 is cheapest; options 1 / 2 are methodologically cleaner.
+- **immediate impact on α-5**: matrix loses 1/5 axes for verdict
+  discrimination. With 4 remaining axes (3 quality + 2 cost; path frozen
+  at 0), Pareto verdict still works but on a smaller surface. Sanity cell
+  (think=ON vs OFF) still measurable on all 4 active axes.
+
+## Promotion provenance
+
+- Auto-drafted by `scripts/qvt_promote_findings.py` on the entry dated 2026-05-31.
+- This is a DRAFT memo. Review before adding a line under MEMORY.md.
+- If the finding was already resolved by a PR (e.g. `→ RESOLVED (#N)`),
+  consider whether the memo should be archived as feedback rather than
+  carried as an open mechanism candidate.

--- a/scripts/qvt_promote_findings.py
+++ b/scripts/qvt_promote_findings.py
@@ -1,0 +1,280 @@
+"""Promote findings tagged mechanism-candidate or universal-law into
+memory entry drafts.
+
+Reads `reports/research-runs/qvt-ablation-findings.md`, parses each
+`### YYYY-MM-DD — <slug>` entry, filters by the `follow-up tag:`
+field, and emits a draft memory file under
+`<staging>/finding_<slug>.md` for each qualifying finding.
+
+Design intent (plan Step 10, user requirement #5):
+- The script DRAFTS only. It does not modify the user's MEMORY.md
+  index. User reviews drafts and decides which to land.
+- Default staging dir: `reports/research-runs/promoted-findings/`
+  (under repo, so it lands via PR rather than touching the user's
+  home directory).
+- Optional --memory-dir <path> lets the operator point at the real
+  memory home (`~/.claude/projects/<id>/memory/`) once they've
+  reviewed the drafts.
+- Idempotent: skips drafts that already exist unless --force is given.
+
+Promotion criteria (per findings.md §Categories):
+- `mechanism-candidate` — promoted
+- `universal-law` — promoted
+- `anti-pattern` — NOT promoted by default (--include-anti-pattern
+  to override)
+- `data-quality` — NOT promoted; these are bench/oracle bugs and
+  belong in fix PR descriptions, not memory
+- `operational` — NOT promoted; runtime/setup issues, not knowledge
+
+Output format mirrors the existing memory frontmatter convention:
+
+    ---
+    name: finding-<slug>
+    description: <one-line summary from the finding>
+    metadata:
+      type: project
+    ---
+
+    <body assembled from the finding fields>
+
+The body keeps the original 5+ field structure so the user can edit
+in place rather than re-deriving from prose.
+
+Usage:
+    python scripts/qvt_promote_findings.py
+    python scripts/qvt_promote_findings.py --memory-dir ~/.claude/projects/.../memory
+    python scripts/qvt_promote_findings.py --force
+    python scripts/qvt_promote_findings.py --include-anti-pattern
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FINDINGS = ROOT / "reports" / "research-runs" / "qvt-ablation-findings.md"
+DEFAULT_STAGING = ROOT / "reports" / "research-runs" / "promoted-findings"
+
+PROMOTE_TAGS_DEFAULT = {"mechanism-candidate", "universal-law"}
+PROMOTE_TAGS_WITH_ANTI = PROMOTE_TAGS_DEFAULT | {"anti-pattern"}
+
+HEADING_RE = re.compile(r"^###\s+(\d{4}-\d{2}-\d{2})\s+—\s+(.+?)\s*$")
+FIELD_RE = re.compile(r"^\s*-\s+\*\*([a-zA-Z_-][a-zA-Z0-9 _-]*)\*\*:\s*(.*)$")
+TAG_SPLIT_RE = re.compile(r"[\s,+/]+")
+
+
+@dataclass
+class Finding:
+    date: str
+    slug: str
+    raw_body: str
+    fields: dict[str, str] = field(default_factory=dict)
+    tags: set[str] = field(default_factory=set)
+    bucket: Optional[str] = None
+
+    @property
+    def memory_name(self) -> str:
+        return f"finding-{self.slug}"
+
+    @property
+    def memory_filename(self) -> str:
+        # mirror the snake_case convention used elsewhere in memory/
+        safe = self.slug.replace("-", "_")
+        return f"finding_{safe}.md"
+
+
+def _strip_resolution_suffix(slug: str) -> str:
+    """The findings log sometimes appends " → RESOLVED ..." to the slug
+    for entries that have been closed. Strip that for the canonical
+    slug used in filenames."""
+    cut = re.split(r"\s+→\s+", slug, maxsplit=1)
+    return cut[0].strip()
+
+
+def parse_findings(text: str) -> list[Finding]:
+    """Walk the markdown; collect heading→body chunks; parse fields."""
+    # Restrict to the "## Findings" section to avoid catching
+    # the carry-over examples or other H2 sections.
+    findings_start = text.find("\n## Findings")
+    if findings_start == -1:
+        return []
+    promoted_start = text.find("\n## Promoted to memory", findings_start)
+    if promoted_start == -1:
+        section = text[findings_start:]
+    else:
+        section = text[findings_start:promoted_start]
+
+    out: list[Finding] = []
+    lines = section.splitlines()
+    i = 0
+    while i < len(lines):
+        m = HEADING_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        date, slug_raw = m.group(1), m.group(2)
+        slug = _strip_resolution_suffix(slug_raw)
+        body_lines: list[str] = []
+        i += 1
+        while i < len(lines) and not HEADING_RE.match(lines[i]) and not lines[i].startswith("## "):
+            # bound entries by H3 (next finding) or H2 (next section)
+            if lines[i].strip() == "---":
+                # findings are separated by a horizontal rule; respect it
+                break
+            body_lines.append(lines[i])
+            i += 1
+        finding = Finding(date=date, slug=slug, raw_body="\n".join(body_lines).strip())
+        _populate_fields(finding)
+        out.append(finding)
+    return out
+
+
+def _populate_fields(f: Finding) -> None:
+    """Extract `- **field**: value` pairs and the bucket / tag set."""
+    for line in f.raw_body.splitlines():
+        m = FIELD_RE.match(line)
+        if not m:
+            continue
+        key, val = m.group(1).strip().lower(), m.group(2).strip()
+        f.fields[key] = val
+        if key == "bucket":
+            # examples seen in file: "(d) measurement artifact — ..." or "(a) ..."
+            bm = re.match(r"\(([a-d])\)", val)
+            if bm:
+                f.bucket = bm.group(1)
+        elif key in ("follow-up tag", "follow up tag", "tag", "tags"):
+            for piece in TAG_SPLIT_RE.split(val):
+                piece = piece.strip().strip("`").strip("'\"").lower()
+                if piece:
+                    f.tags.add(piece)
+
+
+def _one_line_description(f: Finding) -> str:
+    """Synthesize a one-line memory description from the finding fields."""
+    surprise = f.fields.get("surprise", "")
+    observation = f.fields.get("observation", "")
+    bucket_str = f"bucket-({f.bucket})" if f.bucket else "bucket-?"
+    head = surprise or observation or f.raw_body[:140]
+    # collapse whitespace, cap at ~140 chars for the description line
+    head = re.sub(r"\s+", " ", head).strip()
+    if len(head) > 140:
+        head = head[:137].rstrip() + "..."
+    return f"[{f.date}, {bucket_str}] {head}"
+
+
+def render_draft(f: Finding) -> str:
+    description = _one_line_description(f)
+    tag_line = ", ".join(sorted(f.tags)) if f.tags else "(none)"
+    bucket_line = f.bucket or "?"
+    body_block = f.raw_body
+    return (
+        "---\n"
+        f"name: {f.memory_name}\n"
+        f"description: {description}\n"
+        "metadata:\n"
+        "  type: project\n"
+        "---\n"
+        "\n"
+        f"# Finding — {f.slug} ({f.date})\n"
+        "\n"
+        f"**Bucket**: ({bucket_line})  \n"
+        f"**Tags**: {tag_line}\n"
+        "\n"
+        "## Source entry (verbatim from `reports/research-runs/qvt-ablation-findings.md`)\n"
+        "\n"
+        f"{body_block}\n"
+        "\n"
+        "## Promotion provenance\n"
+        "\n"
+        f"- Auto-drafted by `scripts/qvt_promote_findings.py` on the entry dated {f.date}.\n"
+        "- This is a DRAFT memo. Review before adding a line under MEMORY.md.\n"
+        "- If the finding was already resolved by a PR (e.g. `→ RESOLVED (#N)`),\n"
+        "  consider whether the memo should be archived as feedback rather than\n"
+        "  carried as an open mechanism candidate.\n"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--findings", type=Path, default=DEFAULT_FINDINGS,
+                   help=f"Path to findings markdown (default: {DEFAULT_FINDINGS.relative_to(ROOT)})")
+    p.add_argument("--memory-dir", type=Path, default=DEFAULT_STAGING,
+                   help=f"Where to write drafts (default: {DEFAULT_STAGING.relative_to(ROOT)})")
+    p.add_argument("--force", action="store_true",
+                   help="Overwrite existing draft files")
+    p.add_argument("--include-anti-pattern", action="store_true",
+                   help="Also promote anti-pattern tagged findings")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would be written without touching disk")
+    args = p.parse_args()
+
+    findings_path: Path = args.findings
+    if not findings_path.exists():
+        print(f"[error] findings file not found: {findings_path}", file=sys.stderr)
+        return 2
+
+    text = findings_path.read_text(encoding="utf-8")
+    findings = parse_findings(text)
+    if not findings:
+        print(f"[info] no finding entries in {findings_path}")
+        return 0
+
+    promote_tags = PROMOTE_TAGS_WITH_ANTI if args.include_anti_pattern else PROMOTE_TAGS_DEFAULT
+
+    staging: Path = args.memory_dir
+    if not args.dry_run:
+        staging.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    skipped = 0
+    rejected = 0
+    summary: list[tuple[str, str, str]] = []  # (status, slug, reason)
+
+    for f in findings:
+        match = f.tags & promote_tags
+        if not match:
+            rejected += 1
+            summary.append(("rejected", f.slug, f"no promotion tag (tags: {sorted(f.tags) or 'none'})"))
+            continue
+
+        dest = staging / f.memory_filename
+        if dest.exists() and not args.force:
+            skipped += 1
+            summary.append(("skipped", f.slug, f"draft exists: {dest.relative_to(ROOT) if dest.is_relative_to(ROOT) else dest}"))
+            continue
+
+        draft = render_draft(f)
+        if args.dry_run:
+            written += 1
+            summary.append(("would-write", f.slug, f"-> {dest.relative_to(ROOT) if dest.is_relative_to(ROOT) else dest} ({len(draft)} bytes)"))
+        else:
+            dest.write_text(draft, encoding="utf-8")
+            written += 1
+            summary.append(("written", f.slug, f"-> {dest.relative_to(ROOT) if dest.is_relative_to(ROOT) else dest}"))
+
+    # Output summary
+    print(f"\n=== qvt_promote_findings summary ===")
+    print(f"Findings scanned: {len(findings)}")
+    print(f"Promotion tags accepted: {sorted(promote_tags)}")
+    print(f"Written: {written}  Skipped: {skipped}  Rejected: {rejected}")
+    print("")
+    for status, slug, reason in summary:
+        print(f"  [{status}] {slug} -- {reason}")
+    print("")
+    if written and not args.dry_run:
+        print("Next steps:")
+        print("  1. Review each draft under the staging dir for accuracy / framing.")
+        print("  2. Move accepted drafts into your real memory dir.")
+        print("  3. Add a one-line entry under MEMORY.md for each kept draft.")
+        print("  4. Record the promotion in the `## Promoted to memory` table of the findings log.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_qvt_promote_findings.py
+++ b/tests/test_qvt_promote_findings.py
@@ -1,0 +1,173 @@
+"""Contract tests for scripts/qvt_promote_findings.py.
+
+These exercise the parser and the promote filter on a synthetic
+findings.md to keep the script honest as the findings log format
+evolves.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "qvt_promote_findings.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("qvt_promote_findings", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["qvt_promote_findings"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+qpf = _load_module()
+
+
+SYNTHETIC = """\
+# Header
+
+Preamble text.
+
+## How to add a finding
+
+Some boilerplate.
+
+## Findings
+
+<!-- comment -->
+
+### 2026-05-31 — alpha-finding-a
+
+- **bucket**: (b) LLM model capability — small tier ceiling
+- **pattern**: 3/3 M_S cells show abstention F1 collapse
+- **observation**: M_S abstains 80% on truth=present temporal queries
+- **surprise**: gemma3:4b under-commits when temporal anchoring conflicts
+- **data pointer**: `reports/x.json`
+- **follow-up tag**: `mechanism-candidate`
+- **probe ideas**: more sampling on temporal subset
+
+### 2026-05-31 — beta-finding-b
+
+- **bucket**: (d) measurement artifact
+- **observation**: bench dropped sources
+- **follow-up tag**: `data-quality`
+- **data pointer**: `reports/y.json`
+
+### 2026-05-31 — gamma-finding-c → RESOLVED (#999)
+
+- **bucket**: (a) Architecture
+- **observation**: layer wires duplicate retrieval
+- **follow-up tag**: `universal-law` + `anti-pattern`
+
+### 2026-05-31 — delta-finding-d
+
+- **bucket**: (c) feature gap
+- **observation**: no abstention judge
+- **follow-up tag**: `operational`
+
+---
+
+## Promoted to memory
+
+| Date | Finding slug | Memory file | Confirmed by |
+|---|---|---|---|
+
+(none)
+
+## Carry-over from prior tracks
+
+- some-other-thing — should NOT be parsed as a finding.
+"""
+
+
+def test_parse_findings_count_and_slugs():
+    findings = qpf.parse_findings(SYNTHETIC)
+    slugs = [f.slug for f in findings]
+    assert slugs == [
+        "alpha-finding-a",
+        "beta-finding-b",
+        "gamma-finding-c",  # resolution suffix stripped
+        "delta-finding-d",
+    ]
+
+
+def test_parse_findings_extracts_bucket():
+    findings = qpf.parse_findings(SYNTHETIC)
+    buckets = {f.slug: f.bucket for f in findings}
+    assert buckets == {
+        "alpha-finding-a": "b",
+        "beta-finding-b": "d",
+        "gamma-finding-c": "a",
+        "delta-finding-d": "c",
+    }
+
+
+def test_parse_findings_strips_backticks_from_tags():
+    findings = qpf.parse_findings(SYNTHETIC)
+    tags = {f.slug: f.tags for f in findings}
+    assert tags["alpha-finding-a"] == {"mechanism-candidate"}
+    assert tags["beta-finding-b"] == {"data-quality"}
+    assert tags["gamma-finding-c"] == {"universal-law", "anti-pattern"}
+    assert tags["delta-finding-d"] == {"operational"}
+
+
+def test_carry_over_section_not_parsed_as_finding():
+    findings = qpf.parse_findings(SYNTHETIC)
+    assert "some-other-thing" not in [f.slug for f in findings]
+
+
+def test_filename_uses_snake_case():
+    findings = qpf.parse_findings(SYNTHETIC)
+    by_slug = {f.slug: f for f in findings}
+    assert by_slug["alpha-finding-a"].memory_filename == "finding_alpha_finding_a.md"
+
+
+def test_render_draft_contains_frontmatter_and_body():
+    findings = qpf.parse_findings(SYNTHETIC)
+    f = findings[0]  # alpha
+    out = qpf.render_draft(f)
+    assert out.startswith("---\n")
+    assert "name: finding-alpha-finding-a" in out
+    assert "type: project" in out
+    assert "## Source entry" in out
+    assert "**Bucket**: (b)" in out
+    assert "mechanism-candidate" in out
+
+
+def test_promotion_filter_default_keeps_mechanism_and_universal():
+    findings = qpf.parse_findings(SYNTHETIC)
+    promoted = [f for f in findings if f.tags & qpf.PROMOTE_TAGS_DEFAULT]
+    slugs = sorted(f.slug for f in promoted)
+    assert slugs == ["alpha-finding-a", "gamma-finding-c"]
+
+
+def test_promotion_filter_with_anti_pattern_keeps_three():
+    findings = qpf.parse_findings(SYNTHETIC)
+    promoted = [f for f in findings if f.tags & qpf.PROMOTE_TAGS_WITH_ANTI]
+    slugs = sorted(f.slug for f in promoted)
+    # alpha (mechanism), gamma (universal-law + anti-pattern)
+    # beta has only data-quality, delta has only operational → not promoted
+    assert slugs == ["alpha-finding-a", "gamma-finding-c"]
+
+
+def test_data_quality_and_operational_not_promoted_by_default():
+    findings = qpf.parse_findings(SYNTHETIC)
+    promoted_default = {f.slug for f in findings if f.tags & qpf.PROMOTE_TAGS_DEFAULT}
+    assert "beta-finding-b" not in promoted_default
+    assert "delta-finding-d" not in promoted_default
+
+
+def test_one_line_description_includes_date_and_bucket():
+    findings = qpf.parse_findings(SYNTHETIC)
+    f = findings[0]
+    desc = qpf._one_line_description(f)
+    assert desc.startswith("[2026-05-31, bucket-(b)]")
+
+
+def test_empty_findings_section_returns_empty():
+    text = "# Header\n\nNo findings section here.\n"
+    assert qpf.parse_findings(text) == []


### PR DESCRIPTION
## Summary

- `scripts/qvt_promote_findings.py` parses `reports/research-runs/qvt-ablation-findings.md`, filters entries tagged `mechanism-candidate` / `universal-law` (opt-in `--include-anti-pattern`), and emits draft memory entries to in-repo staging at `reports/research-runs/promoted-findings/`
- Plan Step 10 deliverable + user requirement #5 (mechanism findings must auto-trigger memo draft) — operationalised
- Drafts mirror the existing memory frontmatter format; the operator reviews, edits, then moves accepted drafts into the real memory dir (not auto-written there — staging keeps the promotion trail auditable in git)
- Idempotent (`--force` to overwrite), `--dry-run` for preview, `--memory-dir <path>` to target a different output

## Verification

- 11/11 contract tests pass: parser (heading detection, section bounds, resolution-suffix stripping, backtick-stripped tags), bucket extraction, promotion filter (default / with-anti-pattern / exclusions), draft rendering
- Smoke-tested against the existing `multihop-rag-path-axis-dead` finding — correctly extracted `bucket=(d)`, `tags={data-quality, mechanism-candidate}`, produced a clean 3336-byte draft
- `data-quality` and `operational` tagged findings correctly excluded by default (these belong in PR descriptions / runtime logs, not memory)

## Out of scope

- Auto-writing into the user's MEMORY.md or memory dir — explicit non-goal; user reviews drafts before they land
- Per-tag prompt templates — current rendering uses a single shape for all promotion-eligible tags; per-tag variation can land later if drafts diverge in practice

Quality delta: exempt (label: chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)