### PR TITLE
fix(observability): _trace_root() honours JAMES_WORKSPACE (D11)

### DIFF
--- a/core/observability.py
+++ b/core/observability.py
@@ -117,7 +117,12 @@ _TRACE_ROOT_OVERRIDE: Optional[Path] = None
 def _trace_root() -> Path:
     if _TRACE_ROOT_OVERRIDE is not None:
         return _TRACE_ROOT_OVERRIDE
-    # Default: <project_root>/reports/trace
+    # Workspace-aware: route per-trace JSONL into the active workspace
+    # so isolated benchmarks (e.g. `JAMES_WORKSPACE=./workspaces/hotpot_eval`)
+    # don't leak traces into the production tree.
+    ws_raw = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws_raw:
+        return Path(ws_raw).resolve() / "reports" / "trace"
     here = Path(__file__).resolve().parent.parent
     return here / "reports" / "trace"
 

--- a/tests/test_observability_trace_root_workspace.py
+++ b/tests/test_observability_trace_root_workspace.py
@@ -1,0 +1,77 @@
+"""Contract — `core.observability._trace_root()` honours JAMES_WORKSPACE.
+
+Before this fix (D11, 2026-05-31), `_trace_root()` always returned
+`<repo_root>/reports/trace`, ignoring `JAMES_WORKSPACE`. A
+benchmark workspace (`JAMES_WORKSPACE=./workspaces/hotpot_eval`)
+would still write traces into the production tree — a small but
+real isolation leak.
+
+Three guarantees pinned here:
+
+  1. With `JAMES_WORKSPACE` unset, `_trace_root()` falls back to
+     `<project_root>/reports/trace` (legacy behaviour preserved).
+  2. With `JAMES_WORKSPACE=<path>`, `_trace_root()` returns
+     `<path>/reports/trace` (resolved absolute).
+  3. The `set_trace_root()` test seam still wins over both
+     branches — a tmpdir override is unconditional.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.observability import _trace_root, set_trace_root  # noqa: E402
+
+
+class TraceRootWorkspaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        set_trace_root(None)  # reset any override leaked from prior tests
+
+    def tearDown(self) -> None:
+        set_trace_root(None)
+
+    def test_default_when_workspace_unset(self) -> None:
+        with patch.dict("os.environ", {"JAMES_WORKSPACE": ""}, clear=False):
+            root = _trace_root()
+        expected = Path(__file__).resolve().parent.parent / "reports" / "trace"
+        self.assertEqual(root, expected)
+
+    def test_default_when_workspace_unset_truly_absent(self) -> None:
+        import os
+        env = dict(os.environ)
+        env.pop("JAMES_WORKSPACE", None)
+        with patch.dict("os.environ", env, clear=True):
+            root = _trace_root()
+        expected = Path(__file__).resolve().parent.parent / "reports" / "trace"
+        self.assertEqual(root, expected)
+
+    def test_workspace_set_routes_to_workspace_subtree(self) -> None:
+        ws = Path("/tmp/test_workspace_xyz")
+        with patch.dict("os.environ", {"JAMES_WORKSPACE": str(ws)}, clear=False):
+            root = _trace_root()
+        self.assertEqual(root, ws.resolve() / "reports" / "trace")
+
+    def test_workspace_whitespace_treated_as_unset(self) -> None:
+        with patch.dict("os.environ", {"JAMES_WORKSPACE": "   "}, clear=False):
+            root = _trace_root()
+        expected = Path(__file__).resolve().parent.parent / "reports" / "trace"
+        self.assertEqual(root, expected)
+
+    def test_set_trace_root_override_wins_over_workspace(self) -> None:
+        override = Path("/tmp/test_override_abc")
+        set_trace_root(override)
+        try:
+            with patch.dict("os.environ", {"JAMES_WORKSPACE": "/tmp/some/ws"}, clear=False):
+                root = _trace_root()
+        finally:
+            set_trace_root(None)
+        self.assertEqual(root, override)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `core/observability.py:_trace_root()` previously always returned `<repo_root>/reports/trace`, ignoring `JAMES_WORKSPACE`
- Isolated benchmark workspaces (e.g. `JAMES_WORKSPACE=./workspaces/hotpot_eval`) would still write per-trace JSONL files into the production tree — small but real isolation leak observed mid-flight during the α-5 T0 smoke (recorded in `docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md` §7.6)
- Backlog row D11

## Verification

- 5/5 new contract tests pass:
  - workspace unset (empty string) → repo root
  - workspace unset (truly absent) → repo root
  - workspace set → `<workspace>/reports/trace` (resolved absolute)
  - whitespace-only env value treated as unset
  - `set_trace_root()` test override still wins over both branches (test seam preserved)
- 12 existing observability tests (`test_emit_trace_step_stdout_mirror`, `test_admin_trace_endpoint`) still green — no regression
- Bench results unaffected: bench JSONs go through `_resolve_output_dir` which already honoured the env

## Out of scope

- Migration of existing trace files from repo root into the workspace tree
- Retroactive workspace-routing for the α-5 T0 smoke run already in flight (cell 1 traces stay in repo root; cells 2/3 + sanity get the new path)

CLAUDE.md rule 2: not applicable (touches `core/observability.py`, not `core/retrieval` / `core/graph` / `core/reasoning`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)