### PR TITLE
docs(α-5): Correction 4 — matrix glob bug post-mortem + narrative + backlog §7.9

### DIFF
--- a/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
+++ b/docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md
@@ -418,5 +418,76 @@ fix needed.
 
 | # | Item | Target | Status |
 |---|---|---|---|
-| D11 ★ | `core/observability.py::_trace_root()` workspace-aware (eliminate trace leak across workspaces) | v0.4.2 | observed during α-5 T0 — `JAMES_WORKSPACE` not honoured by trace writer |
-| D12 ★ | A2 default-flip Quality Delta Card pre-template | post-α-5 closure | gate from §7.2 — real-query gate, paste-ready scaffold |
+| D11 ★ | `core/observability.py::_trace_root()` workspace-aware (eliminate trace leak across workspaces) | v0.4.2 | observed during α-5 T0 — `JAMES_WORKSPACE` not honoured by trace writer. ✅ landed PR #635 (2026-05-31). |
+| D12 ★ | A2 default-flip Quality Delta Card pre-template | post-α-5 closure | gate from §7.2 — real-query gate, paste-ready scaffold. ✅ landed PR #636 (2026-05-31). |
+
+### 7.9 Update 2026-05-31 PM — matrix runner glob bug (Correction 4)
+
+When cell 1 (L1/M_M) of the in-flight α-5 T0 smoke completed at
+12:07 KST, the cell JSON aggregate showed `path_coverage = 0.000`,
+`abstention_f1 = 0.000`, `graded_answer = 0.028` — three saturated
+quality axes. Applying the 4-step rule from
+`feedback_oracle_phrase_artifacts` as routine hygiene immediately
+flagged the cell JSON's `runs[0].bench_output` field: it pointed at
+`bench_nogit_step7_20260507_194228.json` (24 days old, step7 suite,
+12 queries). The fresh multihop_rag bench file
+`bench_87ed176_multihop_rag_20260531_120746.json` (100 queries,
+6598 s of compute, 100/100 sources captured) was sitting
+unreferenced beside it.
+
+**Root cause** (`scripts/qvt_ablation_matrix.py:380`): the post-bench
+detection glob was still hardcoded `bench_*_step7_*.json`. PR #625
+correctly threaded `--suite={suite}` to the bench subprocess CALL
+(line 355 uses `glob_pattern = f"bench_*_{suite}_*.json"` for the
+pre-existing set), but the line 380 glob for the *after* set was
+overlooked. The matrix subprocess wrote the correct multihop_rag
+bench, but the runner could not see it; `new[-1]` returned the
+lexicographically last stale step7 file.
+
+**Bucket**: (a) architecture. Sibling oversight to #625. The plumbing
+was 95% complete; this was the final 5%.
+
+**Fix**: PR #638 — one-line change replacing `"bench_*_step7_*.json"`
+with `glob_pattern` (the same variable already used for `pre_existing`).
+Companion tool `scripts/qvt_rescore_ablation_cell.py` re-aggregates
+existing cell JSONs against the actual multihop_rag bench files
+(auto-resolve by mtime proximity to the cell file), writes a
+`.before-rescore.json` side-copy for the diagnostic trail.
+
+**Strategy chosen**: do NOT kill the running matrix task. The bench
+JSONs are written correctly (the subprocess wiring is fine); only
+the cell aggregate scoring is wrong. Cells 2/3 + sanity will finish
+under the existing runner; post-hoc rescore at matrix end is
+~seconds per cell.
+
+**Real cell L1/M_M numbers** (after rescore against the actual bench
+file):
+
+| Axis              | Stale step7 (cell JSON) | Real multihop_rag |
+|-------------------|-------------------------|-------------------|
+| path_coverage     | 0.000                   | **0.419**         |
+| graded_answer     | 0.028                   | **0.327**         |
+| abstention_f1     | 0.000                   | **0.591**         |
+| token_cost        | 2212 chars              | 1224 chars        |
+| latency_cost      | 42.68 s                 | 65.99 s           |
+
+These are mid-range baseline numbers — exactly what an L1 cell
+should report. Layer-on cells need to *improve* on them, not
+collapse from 0/0/0.028.
+
+**Wrong-fix avoided** (Correction 4): had the saturated read been
+taken as truth, the entire matrix would have re-interpreted as
+"JAMES baseline is already dead; routing-layer cells can't help
+what's broken." Multi-hour debug spiral averted by ~5 minutes of
+4-step-rule application to the first cell JSON the matrix wrote.
+
+**Cumulative score**: 4 wrong-fix-averted corrections in this cycle
+(#618 / #619 / #623 / #638). Cumulative JAMES code change
+attributable to α-5 measurement debt: **0 lines**.
+
+**Discipline generalisation**: the 4-step rule was originally
+codified in `feedback_oracle_phrase_artifacts` as a bucket-(d)
+"matcher coverage" tool. Correction 4 demonstrates the same
+procedure catches bucket-(a) plumbing bugs identically. Memory
+update follow-up: broaden the rule's framing to "any measurement-
+side wiring" and add Correction 4 as the worked bucket-(a) example.

--- a/reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md
+++ b/reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md
@@ -162,6 +162,94 @@ verdict would have been the published result. The cleanup wasn't
 file, which surfaced the filename. **Routine hygiene > careful
 review** as a bug-catcher.
 
+### Correction 4 — matrix runner bench-output glob still hardcoded step7 (PR #638)
+
+**Symptom**: T0 smoke cell L1/M_M completed cleanly at 12:07; cell
+JSON written immediately after; 4-step rule applied as a routine
+check on the first cell aggregate. All three quality axes saturated:
+path_coverage = 0.0, abstention_f1 = 0.0, graded_answer = 0.0278
+(one stale row matched the generic "Based" keyword). Cost axes
+plausible-but-low (token=2212, latency=42.68 s) — a mismatch with
+the actual 65 s mean visible in the trace files.
+
+  `bench_output: bench_nogit_step7_20260507_194228.json`
+
+`bench_nogit_step7_*` is the smoking gun *again*. The cell JSON
+recorded a step7 file from **2026-05-07** (24 days before the run)
+even though the matrix subprocess was correctly invoking
+`--suite=multihop_rag` and writing
+`bench_87ed176_multihop_rag_20260531_120746.json` (the fresh
+100-query bench, 6598 s of compute).
+
+**Diagnosis** (4-step rule, applied step by step):
+
+1. axis values — three quality axes at 0/saturated; cost axes
+   "almost normal." Suspicious enough to inspect.
+2. Read the cell `runs[0].bench_output` — `bench_nogit_step7_*` from
+   May 7th, n_queries=12. The actual matrix run was a 100-query
+   multihop_rag suite. Smoking gun.
+3. Check what `_run_single_bench` does post-bench. Line 380:
+   `after = set((ROOT / "reports").glob("bench_*_step7_*.json"))`.
+   Hardcoded step7 glob. The pre-existing set on line 355 uses
+   `bench_*_{suite}_*.json` (correct), so `after - pre_existing`
+   only contained stale step7 files that happened to land between
+   line 356 and line 380 — none of which were the fresh multihop
+   bench. `new[-1]` then picked the lexicographically last,
+   `bench_nogit_*` from May 7.
+4. Reconcile design vs matcher: the matrix DOES write the right
+   bench file; the runner's score collection just CAN'T SEE IT,
+   so it picks an unrelated stale step7 file as the "newly emitted"
+   bench output and scores 12 unrelated queries as the cell result.
+
+**Bucket**: (a) architecture. Sibling oversight to #625: that PR
+fixed the subprocess CALL but didn't audit the glob used to detect
+the subprocess's OUTPUT. The plumbing was 95% the way through;
+this was the final 5%.
+
+**Wrong first interpretation** (averted, again): the cell shows
+"JAMES L1 baseline gets 0/0/0.028 on 5-axis." Without the 4-step
+rule applied to the cell JSON, the operator would have concluded
+the baseline cell already shows JAMES can't do MultiHop-RAG at all,
+and the remaining 18 cells would be re-interpreted as "tier-and-
+layer choices don't matter because the baseline is dead." A
+multi-hour debug spiral was avoided.
+
+**The real numbers** (after `scripts/qvt_rescore_ablation_cell.py`
+ran on the same cell JSON against the *actual* bench file):
+
+| Axis              | Stale step7 (0/0/0.028) | Real multihop_rag |
+|-------------------|-------------------------|-------------------|
+| path_coverage     | 0.000                   | **0.419**         |
+| graded_answer     | 0.028                   | **0.327**         |
+| abstention_f1     | 0.000                   | **0.591**         |
+| token_cost        | 2212 chars              | 1224 chars        |
+| latency_cost      | 42.68 s                 | 65.99 s           |
+
+Same matrix run, same JAMES code, same cell — completely different
+verdict. The numbers above are L1/M_M baseline; the layer-on cells
+ought to *improve* on them, not collapse from 0/0/0.028.
+
+**Caught by**: the same 4-step rule the cycle's prior memory entry
+codified, applied as part of the planned "look at the first cell
+JSON when it lands" hygiene check (i.e. the cycle's own learning
+from Correction 3). This is the second wrong-fix averted by the
+same discipline within the same cycle.
+
+**Companion tool**: `scripts/qvt_rescore_ablation_cell.py` —
+auto-resolves the correct bench file by mtime proximity to the cell
+file, rewrites `runs[*].scores` + `aggregate`, writes a side-copy
+`.before-rescore.json` for the diagnostic trail. The currently-
+running T0 matrix is NOT killed — it continues to produce correct
+bench JSONs while the cell aggregates are scored wrong, and post-
+hoc rescore at matrix end is cheap (~seconds per cell).
+
+**4-step rule is bucket-(a)-applicable too**. The original memory
+entry framed the rule as primarily a bucket-(d) "matcher coverage"
+tool. Correction 4 shows the same procedure catches bucket-(a)
+plumbing bugs identically — saturated axis → read samples → check
+the wiring layer → reconcile design vs matcher. Update the rule
+text accordingly.
+
 ---
 
 ## What stays in the head after this

--- a/reports/research-runs/alpha-5-publishable-narrative-DRAFT.md
+++ b/reports/research-runs/alpha-5-publishable-narrative-DRAFT.md
@@ -212,6 +212,69 @@ fix**.
 
 ---
 
+## Section 5.5 — The fourth case, caught mid-write
+
+[Added 2026-05-31 PM during T0 smoke completion.]
+
+The cycle made four wrong-fix-averted corrections, not three. The
+fourth landed as PR #638 when the first T0 cell JSON wrote at 12:07
+and the 4-step rule was applied to it as routine hygiene (per
+discipline 7.3 below).
+
+The cell aggregate reported `path_coverage=0.000`, `abstention_f1=0.000`,
+and `graded_answer=0.028` on a 100-query MultiHop-RAG cell. Three
+saturated quality axes on a JAMES baseline that already showed
+graded ≈ 0.33 + path ≈ 0.40 on the corrected baseline JSON. The
+saturation was too clean.
+
+Step 1: axis values triggered the rule. Step 2: read the cell JSON's
+`runs[0].bench_output` field — it pointed at
+`bench_nogit_step7_20260507_194228.json`, a 24-day-old step7 file
+from a completely different fixture. Step 3: trace the matrix runner.
+The bench subprocess was correctly running `--suite=multihop_rag` (the
+#625 fix from earlier in the cycle), writing a fresh 100-query bench
+to `bench_87ed176_multihop_rag_20260531_120746.json`. But the runner's
+post-bench detection glob (`bench_*_step7_*.json`, line 380) still
+scanned the legacy suite and never saw the fresh file. `new[-1]`
+returned the lexicographically last stale step7 file. Step 4:
+reconcile design vs matcher — the matrix is producing the right
+measurement, but the score-collection wiring sees the wrong file.
+
+Bucket-(a) architecture. Sibling oversight to #625: that PR fixed the
+subprocess CALL but didn't audit the glob used to detect the
+subprocess's OUTPUT. The plumbing was 95% the way through; this was
+the final 5%.
+
+Real numbers after `scripts/qvt_rescore_ablation_cell.py` swapped in
+the actual bench file:
+
+| Axis              | Stale step7 (0/0/0.028) | Real multihop_rag |
+|-------------------|-------------------------|-------------------|
+| path_coverage     | 0.000                   | **0.419**         |
+| graded_answer     | 0.028                   | **0.327**         |
+| abstention_f1     | 0.000                   | **0.591**         |
+
+Same cell, same matrix run, same JAMES code — completely different
+verdict. If the operator had taken the saturated read as truth, the
+entire matrix would have been re-interpreted as "JAMES baseline is
+already 0; layer-on cells can't help what's dead." A multi-hour
+debug spiral was averted by ~5 minutes of 4-step-rule application
+to the first cell JSON the matrix wrote.
+
+The wider lesson: **the 4-step rule is bucket-(a) applicable too**.
+The original `feedback_oracle_phrase_artifacts` memory framed the
+rule as primarily a bucket-(d) "matcher coverage" tool. Case 4
+shows the same procedure catches bucket-(a) plumbing bugs
+identically — saturated axis → read samples → check the wiring
+layer → reconcile design vs matcher. The rule generalises from
+"oracle phrase coverage" to "any measurement-side wiring."
+
+This is the second wrong-fix averted by the same discipline within
+the same cycle. The cycle's contribution is the rule's
+*generalisation* across both buckets, not just the per-case fixes.
+
+---
+
 ## Section 6 — The cycle as evidence
 
 [FILL: this is the section that depends on the actual α-5 matrix


### PR DESCRIPTION
## Summary

- Absorbs QQ (#638) into the cycle's 3 narrative docs as a 4th wrong-fix-averted correction
- Post-mortem doc — new \"Correction 4\" section walks through the 4-step rule applied step by step + shows the stale-vs-real numbers table (0/0/0.028 → 0.42/0.33/0.59)
- Publishable narrative — new §5.5 \"The fourth case, caught mid-write\" frames the lesson for the joint audience: discipline generalisation as the contribution
- Backlog §7.9 — records #638 + cell rescore tool + the \"don't kill the running matrix\" strategy + real L1/M_M numbers table; §7.8 marks D11/D12 landed

## Key generalisation locked

The 4-step rule was originally codified in `feedback_oracle_phrase_artifacts` as bucket-(d) \"matcher coverage\" guidance. Correction 4 demonstrates the same procedure catches bucket-(a) plumbing bugs identically — broaden the rule to \"any measurement-side wiring.\"

## Wrong-fix avoided count: 4 (cumulative)

- #618 (path_recall=0 → 0.42)
- #619+#623 (76% hallucination → 36%, then F1 → 0.70)
- #625 (matrix subprocess suite-arg)
- #638 (matrix score-collection glob)

Cumulative JAMES code change attributable to α-5 measurement debt: **0 lines**.

## Verification

- No code change. Pure narrative absorption.
- Cross-references all three docs preserved.

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)