### PR TITLE
docs(design): α-6 sector × LLM ablation matrix — successor to α-5

### DIFF
--- a/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
+++ b/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
@@ -1,0 +1,404 @@
+# Design Memo — α-6 Sector × LLM Ablation Matrix
+
+> **Status**: design. Successor to α-5 (T0 closed 2026-05-31, Branch B verdict).
+> α-5 measured 5 routing flags at 1 model tier. α-6 reshapes to:
+> (a) **sector-level** ablation (10 sectors of JAMES infrastructure),
+> (b) **multi-LLM** comparison (gemma family + claude + openai + others),
+> (c) **B+C from α-5 prior recommendation folded as α-6 Phase 0** —
+> answer the user's actual question: *"Does the JAMES reasoning stack
+> outperform plain gemma4 / vanilla RAG?"*
+>
+> **작성일**: 2026-05-31 PM (post α-5 T0 closure)
+> **Trigger**: 2026-05-31 user clarification:
+> *"기본 자메스 와 슈퍼 자메스의 차이가 정확히 뭐야"* +
+> *"권장대로하되, 자메스 인프라별로 섹터를 스펙별로 묶어서 어떤게 추가되면 좋고 나쁜지가 나오도록 하고, 나중에는 젬마4 뿐아니라 다른 llm, 모델별로도 각각 측정할수 있게"*
+
+---
+
+## 0. TL;DR
+
+α-5 toggled 5 routing flags at gemma4:e4b. The 3 cells that ran
+(L1, L5, sanity) told us routing layers are inert at the production
+tier, but they did NOT compare JAMES vs vanilla gemma4 or vanilla
+RAG — because the L0 / L1 baselines already had every other JAMES
+sector (vector / graph / citation / abstention / audit / lifecycle /
+policy) silently on.
+
+α-6 fixes both gaps:
+
+1. **Sector ablation** — decompose JAMES into 10 sectors, each
+   toggleable as a unit. Cells are sector combinations, not flag
+   combinations.
+2. **Multi-LLM extension** — measure each sector combination across
+   N model providers (local Ollama family + API-backed claude / gpt /
+   gemini). Same matrix, model is the column.
+
+The matrix is `sectors × LLMs`. Each cell answers
+*"adding sector S to LLM L moves quality by Δ at cost Δ."*
+
+---
+
+## 1. Sector taxonomy (10 sectors)
+
+| ID | Sector | Concrete code surface | Ablation difficulty |
+|---|---|---|---|
+| **S1** | Retrieval foundation (vector RAG) | `core/retrieval_engine.py`, `core/vector_store.py`, chroma + bge-m3 top-k | EASY — already a flag (`JAMES_RAG_DISABLED` or similar) |
+| **S2** | Knowledge graph layer | `core/graph_engine.py`, `core/graph_rag_engine.py`, wiki entity traversal | MEDIUM — needs new flag `JAMES_DISABLE_GRAPH` |
+| **S3** | Query preprocessing | `core/query_expander.py`, `entity_anchor`, `query_rewrite` | DONE — `JAMES_ENABLE_ENTITY_ANCHOR` / `JAMES_ENABLE_QUERY_REWRITE` |
+| **S4** | Citation / Sources layer | `core/reasoning/pipeline.py:343` `sources: [d["source"] for d in docs[:3]]` | MEDIUM — needs flag `JAMES_DISABLE_SOURCES_FIELD` |
+| **S5** | Abstention / Refusal | `core/reasoning/pipeline.py` abstention phrasings + empty-result short-circuit | MEDIUM — needs `JAMES_DISABLE_ABSTENTION` |
+| **S6** | Cognitive stages | `core/reasoning/` planner / reflect / verify (separate from synth) | MEDIUM — per-stage flags exist; need bundle flag |
+| **S7** | Routing layers (α-5 measured) | AUTO_ROUTER + ADAPTIVE_BUDGET + SCOPE_ROUTING | DONE — these are the α-5 flags |
+| **S8** | Lifecycle (T1-T7) | `core/lifecycle/` validity / derivation / supersede | LOW-VALUE for benchmark — MultiHop-RAG has no time axis. Measure later. |
+| **S9** | Policy + Trust | `core/policy_engine.py`, `core/memory/trust.py` | LOW-VALUE for benchmark — policy gates security, not answer quality. Measure later. |
+| **S10** | Audit / Observability | `core/audit_*`, `core/observability.py` | NOT MEASURABLE on quality axes — replay capability is a different axis. Carry as note, not cell. |
+
+**Measured sectors for α-6 quality matrix**: S1, S2, S3, S4, S5, S6, S7.
+**Carried as notes** (not in cells): S8, S9, S10 — they're real
+JAMES differentiators but don't move the 5-axis oracle on a
+non-temporal benchmark like MultiHop-RAG.
+
+---
+
+## 2. The α-5 → α-6 mental shift
+
+### α-5 cell schema (what we just did)
+
+```
+each cell = (routing_layer_combo, single_model)
+
+L1 baseline = {ENTITY_ANCHOR=1, QUERY_REWRITE=1,
+               AUTO_ROUTER=0, ADAPTIVE_BUDGET=0, SCOPE_ROUTING=0,
+               model="gemma4:e4b"}
+
+L5 full     = {ENTITY_ANCHOR=1, QUERY_REWRITE=1,
+               AUTO_ROUTER=1, ADAPTIVE_BUDGET=1, SCOPE_ROUTING=1,
+               model="gemma4:e4b"}
+```
+
+L1 ↔ L5 measures "adding 3 routing flags helps?" while every other
+JAMES sector stays silently on.
+
+### α-6 cell schema (proposal)
+
+```
+each cell = (sector_bitmap, LLM_provider)
+
+C_minus     = {S1=0, S2=0, S3=0, S4=0, S5=0, S6=0, S7=0, model=M}
+            = pure model, no JAMES at all (just /chat/ to the model)
+
+C_rag_basic = {S1=1, S2=0, S3=0, S4=0, S5=0, S6=0, S7=0, model=M}
+            = model + vanilla RAG (chroma top-k) only
+
+C_rag_cited = {S1=1, S2=0, S3=0, S4=1, S5=0, S6=0, S7=0, model=M}
+            = + citation/sources layer (S4)
+
+C_rag_graph = {S1=1, S2=1, S3=1, S4=1, S5=0, S6=0, S7=0, model=M}
+            = + graph + query preprocessing
+            (closest to "JAMES production stack without routing/cognitive")
+
+C_rag_full  = {S1=1, S2=1, S3=1, S4=1, S5=1, S6=1, S7=0, model=M}
+            = JAMES full stack EXCEPT routing layers
+            (this is α-5's L1!)
+
+C_rag_routed = {S1=1, S2=1, S3=1, S4=1, S5=1, S6=1, S7=1, model=M}
+            = JAMES full stack WITH routing layers
+            (this is α-5's L5!)
+```
+
+α-6 = `{C_minus, C_rag_basic, C_rag_cited, C_rag_graph, C_rag_full, C_rag_routed}` × `{M = gemma4:e4b, gemma3:4b, gemma3:12b, claude-haiku-4-5, claude-sonnet-4-6, gpt-5-mini, ...}`.
+
+α-5's L1 / L5 / sanity become exactly 2 cells of α-6
+(`C_rag_full` and `C_rag_routed` at gemma4:e4b). They carry forward.
+
+---
+
+## 3. Cell costs (compute estimate)
+
+At MultiHop-RAG balanced-100, 1 cell ≈ 110 min on local gemma4:e4b.
+Estimate per provider class:
+
+| Provider class | Per-cell cost (100 queries) | Constraints |
+|---|---|---|
+| Local Ollama (gemma3/4 family) | 90-120 min wall-clock | local compute, free |
+| Local Ollama (larger models 12b+) | 200-400 min | local compute, slow |
+| API (Anthropic claude-haiku-4-5) | 8-15 min, ~$0.10-0.30 | rate limit, $-cost |
+| API (claude-sonnet-4-6) | 8-15 min, ~$1-3 | rate limit, $-cost |
+| API (openai gpt-5-mini) | 8-15 min, ~$0.20-0.50 | rate limit, $-cost |
+| API (gemini-2.5-flash) | 8-15 min, ~$0.10-0.30 | rate limit, $-cost |
+
+**Full matrix size**: 6 cells × 6 models = 36 cells. At local-tier
+average 100 min/cell × 30 local cells + ~10 min average × 6 API
+cells = **52 hours wall-clock + ~$20-50 API cost** for the full
+matrix.
+
+**Phasing** (next section) cuts this drastically by running cells
+adaptively.
+
+---
+
+## 4. Phasing — adaptive matrix
+
+Don't run 36 cells in one go. Each phase gates the next.
+
+### Phase 0 — α-5 closure carry-over (FREE, already have data)
+
+Treat α-5's L1 + L5 cells as α-6's `C_rag_full(gemma4:e4b)` and
+`C_rag_routed(gemma4:e4b)`. No new measurement; just relabel.
+
+**Yields**: 2 cells of the matrix already filled.
+
+### Phase 1 — The core comparison the user actually wanted (4 cells)
+
+```
+C_minus(gemma4:e4b)      — pure gemma4
+C_rag_basic(gemma4:e4b)  — gemma4 + vanilla chroma RAG
+C_rag_graph(gemma4:e4b)  — + graph + preprocessing
+C_rag_full(gemma4:e4b)   — full JAMES stack (already have from α-5)
+```
+
+3 new cells × 110 min = ~5.5 hours, single tier. Answers the user's
+question: *"does each JAMES sector add value?"*
+
+Pre-req: implement flags for S1, S2, S4, S5, S6 (currently only S3
++ S7 have flags). **This is 2-3 days of engineering**.
+
+### Phase 2 — Tier-gated check (3 cells, optional)
+
+Same 4 Phase 1 sectors at M_S (gemma3:4b) — tests whether small
+models benefit MORE from JAMES sectors (the tier-gating hypothesis
+α-5 couldn't answer).
+
+If `Δ(rag_full - minus)` at M_S is larger than at M_M → JAMES
+helps small models more → tier-gated default-on.
+
+### Phase 3 — API-backed LLM comparison (6 cells)
+
+Same 4 Phase 1 sectors at one API model
+(`claude-haiku-4-5` recommended — cheapest, fast). Tells whether
+JAMES sectors help an already-strong model or are local-model
+crutches.
+
+Cost: ~1 hour wall-clock + ~$5 API.
+
+### Phase 4 — Cross-family broadening (optional)
+
+Repeat Phase 3 on gpt-5-mini, gemini-2.5-flash for cross-family
+external evidence. Cost: ~$10-15.
+
+### Phase 5 — Routing on top (defer)
+
+Add S7 (routing) cells across the same matrix. α-5 already showed
+S7 inert at gemma4:e4b; Phase 5 tests whether it's inert at
+smaller models / API models too.
+
+---
+
+## 5. Engineering preconditions
+
+### 5.1 New env flags needed (Phase 1 blocker)
+
+| Sector | Flag | Default | Effect when 0 |
+|---|---|---|---|
+| S1 | `JAMES_DISABLE_RAG_RETRIEVAL` | 0 | bypass chroma top-k, send empty context to LLM |
+| S2 | `JAMES_DISABLE_GRAPH` | 0 | skip graph traversal, `graph_paths` stays empty |
+| S4 | `JAMES_DISABLE_SOURCES_FIELD` | 0 | `response.sources` not emitted (forces path axis to score 0 via_sources) |
+| S5 | `JAMES_DISABLE_ABSTENTION` | 0 | always answer, never refuse |
+| S6 | `JAMES_DISABLE_COGNITIVE_STAGES` | 0 | planner / reflect / verify stages skipped |
+
+Implementation cost per flag: ~30-90 min including a contract test.
+5 flags = ~1 day of work.
+
+### 5.2 LLM provider abstraction (Phase 3 blocker)
+
+`core/llm_catalog.py` + `core/model_resolver.py` already exist —
+check whether they support claude / openai / gemini providers, or
+just Ollama. If just Ollama, add provider adapters
+(~1-2 days per provider including auth + cost tracking).
+
+### 5.3 Cost tracking (Phase 3 blocker)
+
+bench.py needs to capture API $-cost per query (claude/openai
+billing) for the cost axis. Replaces / augments the chars-based
+token_cost when the provider is API-backed.
+
+### 5.4 Rate limiting (Phase 3 blocker)
+
+API providers throttle. The matrix needs a per-provider
+rate-limit-aware bench runner (sleep / retry / batch) for API cells.
+
+---
+
+## 6. External baseline comparison (the "C" from α-5 prior recommendation)
+
+Independently of the in-house matrix, cross-reference against
+published baselines for the same benchmark. MultiHop-RAG paper
+(Tang & Yang, EMNLP 2024) reports baselines for various RAG
+configurations.
+
+Procedure:
+1. Read their evaluation methodology (`metrics.py` in their repo).
+2. Map their metrics → our 5-axis where mappable.
+3. Reproduce one of their published baseline configurations
+   locally (e.g., vanilla LangChain RAG with bge-m3 + a small
+   model) to confirm our test bed reproduces their numbers
+   ±noise.
+4. Pin the reproduced numbers as an external anchor in the matrix.
+
+This deliverable lands as a separate doc:
+`reports/research-runs/multihop-rag-paper-baseline-comparison.md`.
+
+Effort: 1-2 days of engineering, no compute beyond rerunning one
+existing configuration.
+
+---
+
+## 7. Naming convention
+
+Cell name format: `C_<sector-spec>_<model-tag>`
+
+- `C_minus_gemma4-e4b` — pure model
+- `C_rag-basic_gemma4-e4b` — + S1
+- `C_rag-cited_gemma4-e4b` — + S1 + S4
+- `C_rag-graph_gemma4-e4b` — + S1 + S2 + S3 + S4
+- `C_rag-full_gemma4-e4b` — JAMES no-routing (α-5 L1)
+- `C_rag-routed_gemma4-e4b` — JAMES + routing (α-5 L5)
+- `C_rag-full_claude-haiku-4-5` — JAMES no-routing on API
+- ...
+
+Cell JSON filename follows: `qvt-ablation-cell-C_<spec>_<model>.json`.
+
+---
+
+## 8. Deliverables per α-6 phase
+
+| Phase | Deliverable | Trigger |
+|---|---|---|
+| 0 | Relabel α-5 cells into α-6 namespace | free, immediate |
+| Engineering pre | 5 new env flags (S1, S2, S4, S5, S6) | engineering decision |
+| 1 | 3 new cells answering "does each JAMES sector add value at gemma4:e4b?" | Phase 0 + Engineering pre |
+| 2 | 3 cells at M_S — tier-gated check | Phase 1 verdict has signal |
+| 3 | 4 cells at claude-haiku — multi-LLM check | Phase 1 + LLM provider abstraction |
+| 4 | gpt + gemini — cross-family broadening | Phase 3 confirms approach works |
+| 5 | Routing-layer interaction with smaller models | independent, low-priority |
+
+Each phase outputs:
+- Matrix render with new column / new rows
+- Per-cell JSON in workspace
+- Cycle summary doc update
+- Findings entry per surprising Δ
+
+---
+
+## 9. Open methodology questions
+
+### 9.1 Is `C_minus` (pure LLM) reasonable to call "RAG-free"?
+
+`C_minus` sends just the user's question to the model — no context.
+For a true "RAG-free" comparison, the model gets no documents at
+all. This is the right baseline for *"does retrieval help at all?"*
+but pure LLMs on MultiHop-RAG will likely score very low on
+path/graded (no docs cited, no facts). The point is the comparison,
+not the absolute number.
+
+### 9.2 Provider-cost axis vs local-compute axis
+
+API providers don't have a meaningful "tokens" cost (they bill by
+input+output tokens which doesn't map onto our chars-based
+proxy). Cost axis for API cells becomes USD; cost axis for local
+cells stays seconds/chars. The matrix needs **two cost columns**
+when mixed.
+
+### 9.3 What if Phase 1 shows a sector hurts (negative Δ)?
+
+E.g., adding S5 (abstention) might lower graded_answer because it
+short-circuits some borderline-answerable queries. If so, the
+finding is bucket-(a) (architecture: refusal threshold too eager)
+or bucket-(b) (model-specific: abstention pattern model-dependent).
+The 4-step rule from
+`memory/feedback_oracle_phrase_artifacts.md` applies before
+proposing a fix.
+
+### 9.4 Should S8 / S9 / S10 (lifecycle / policy / audit) get measured at all?
+
+These three sectors are JAMES's load-bearing differentiators
+(Replayable RAG ⊂ S10 + S8) but don't move quality axes on a
+non-temporal benchmark. Three options:
+- (a) Skip — note as "not measurable on this benchmark"
+- (b) Build a temporal benchmark for S8 / S10 — separate research direction
+- (c) Use existing audit-replay invariants as deterministic
+  contract tests (already done in v0.4.0 test suite)
+
+Recommendation: (c) — already covered by `test_t7_release_gating_invariants.py`;
+no need to add to α-6.
+
+### 9.5 Multi-LLM identity invariance
+
+If the matrix shows JAMES helps claude AND gemma4 AND gpt
+equally, that's a strong universality claim. If only gemma4
+benefits, that's "JAMES is a small-model crutch" which is a real
+position (not bad, just specific).
+
+---
+
+## 10. Position guard (per user clarification 2026-05-31)
+
+The user explicitly flagged
+*"Replayable RAG 도 자메스의 특성 중 하나라 봐야할것같고 아예 전체를 거기에
+끼워맞추려하면 원래 목적을 잃을수도 있으니"*
+— don't reframe the platform identity around one differentiator.
+
+Applied here:
+- α-6 measures **JAMES sectors' marginal contributions**, not
+  "Replayable RAG validation."
+- Outputs frame as *"sector S adds Δ at LLM L"*, not as *"more
+  evidence for Replayable RAG."*
+- Sector S8 / S10 (lifecycle / audit — the Replayable RAG bits)
+  stay out of cells; they're acknowledged as orthogonal axes the
+  benchmark can't measure.
+- Mother-platform identity (local-first auditable knowledge
+  reasoning platform, 6-dim readiness toward v1.0) stays primary
+  in any α-6 publication.
+
+---
+
+## 11. Cycle naming + relation to α-5
+
+α-5 cycle stays closed. T0 evidence published as
+"production-tier routing-layer verdict." α-6 cycle is a separate
+ship.
+
+| Cycle | Question | Status |
+|---|---|---|
+| α-5 (closed) | "Do routing layers help at production tier?" | No (Branch B) |
+| α-6 Phase 1 | "Does each JAMES sector add value at gemma4:e4b?" | scheduled |
+| α-6 Phase 2 | "Tier-gating — do smaller models benefit more?" | gated |
+| α-6 Phase 3 | "Are JAMES sectors LLM-universal?" | gated |
+| α-6 Phase 4 | "Cross-family broadening" | optional |
+
+Each phase ends with publishable closure. The full α-6 doesn't
+need to run end-to-end before the next phase becomes meaningful.
+
+---
+
+## 12. Out of scope for this design memo
+
+- Implementation of the 5 new sector flags — separate PRs, one per flag
+- LLM provider adapter implementations — separate PRs per provider
+- API auth / billing integration — operator action
+- Specific MultiHop-RAG paper baseline reproduction — separate
+  measurement deliverable
+- Cycle-closure narrative integration — wait for Phase 1 results
+- Cost projection for the full matrix — refined per phase
+
+---
+
+## 13. References
+
+- α-5 cycle closure: ROADMAP §v0.4.x α-5 cycle "T0 verdict + post-closure"
+- α-5 publishable narrative (Branch B): `reports/research-runs/alpha-5-publishable-narrative-DRAFT.md` §6.2
+- α-5 backlog reconciliation §7.10: `docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md`
+- Matrix runner: `scripts/qvt_ablation_matrix.py`
+- 4-step rule: `memory/feedback_oracle_phrase_artifacts.md`
+- Position guard: `memory/feedback_jameses_positioning_replayable_rag.md` §"정정 2026-05-31"
+- LLM provider modules to extend: `core/llm_catalog.py`, `core/model_resolver.py`, `core/gemma_client.py`


### PR DESCRIPTION
## Summary

α-6 cycle design memo, reshaping ablation away from α-5's "5 routing flags at one model" toward what the user actually wanted:

1. **Sector-level ablation** (10 JAMES infrastructure sectors, 7 measurable on quality axes)
2. **Multi-LLM extension** (gemma family + claude + openai + gemini)
3. **Folds the unanswered α-5 question** ("does each JAMES sector add value vs vanilla gemma4 / vanilla RAG?") into Phase 1

## User clarification (2026-05-31 PM)

After α-5 T0 closure, two clarifications shaped this design:
- *"기본 자메스 와 슈퍼 자메스의 차이가 정확히 뭐야"* — α-5's L1 baseline already had every JAMES sector silently on; the comparison "JAMES vs vanilla gemma4" was never made
- *"자메스 인프라별로 섹터를 스펙별로 묶어서 어떤게 추가되면 좋고 나쁜지가 나오도록 하고, 나중에는 젬마4 뿐아니라 다른 llm, 모델별로도 각각 측정"*

## Cell schema shift

α-5: `(routing_flag_combo, single_model)` — 18 flag combos × 1 model
α-6: `(sector_bitmap, LLM_provider)` — 6 sector combos × N models

α-5's L1 + L5 cells become α-6's `C_rag-full(gemma4:e4b)` + `C_rag-routed(gemma4:e4b)` for free.

## 5-phase plan

| Phase | Cells | Wall-clock | Cost |
|---|---|---|---|
| 0 — α-5 carry-over | 2 (relabel) | 0 | $0 |
| Engineering pre | 5 new env flags | ~1 day | $0 |
| 1 — gemma4 sectors | 3 new (C_minus / C_rag-basic / C_rag-graph) | ~5.5h | $0 |
| 2 — tier-gating | 3 at gemma3:4b | ~3h | $0 |
| 3 — multi-LLM | 4 at claude-haiku | ~1h | ~$5 |
| 4 — cross-family | gpt + gemini | ~1h | ~$10-15 |
| 5 — routing × small-model | optional | TBD | TBD |

## Engineering preconditions (gating)

5 new env flags needed before Phase 1 can run:
- `JAMES_DISABLE_RAG_RETRIEVAL` (S1)
- `JAMES_DISABLE_GRAPH` (S2)
- `JAMES_DISABLE_SOURCES_FIELD` (S4)
- `JAMES_DISABLE_ABSTENTION` (S5)
- `JAMES_DISABLE_COGNITIVE_STAGES` (S6)

Each ~30-90 min including contract test → ~1 day total.

LLM provider abstraction extension needed for Phase 3+ (claude / openai / gemini adapters).

## Position guard applied

Per the 2026-05-31 user clarification about Replayable RAG being one characteristic not the whole identity:
- α-6 measures sectors as **marginal contributions** (not Replayable RAG validation)
- Sectors S8 (lifecycle) / S10 (audit) — the Replayable RAG bits — stay OUT of cells; they're orthogonal axes the benchmark can't measure
- Mother-platform identity stays primary in publication

## Verification

- No code change. Design memo only.
- Cross-references α-5 closure (#645), 4-step rule, positioning memory
- Cost/time projections per phase grounded in α-5 measurement (110 min/cell at gemma4:e4b balanced-100)

## Out of scope (deferred to separate PRs)

- 5 env flag implementations
- LLM provider adapter implementations
- API cost tracking + rate limiting
- MultiHop-RAG paper baseline reproduction (separate research-runs deliverable)
- Cycle closure narrative — wait for Phase 1 results

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)