### PR TITLE
docs(design): α-6 local-first phasing — 9 local Ollama models inventoried (CCC)

### DIFF
--- a/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
+++ b/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
@@ -30,8 +30,11 @@ policy) silently on.
    toggleable as a unit. Cells are sector combinations, not flag
    combinations.
 2. **Multi-LLM extension** — measure each sector combination across
-   N model providers (local Ollama family + API-backed claude / gpt /
-   gemini). Same matrix, model is the column.
+   multiple local Ollama models first (gemma3:1b/4b/12b/27b, gemma2:2b,
+   gemma4:e4b, qwen2.5:7b, llama3.1:8b, deepseek-v2:16b — 9 inventoried
+   locally as of 2026-05-31). API providers (claude / gpt / gemini)
+   deferred to Phase 4+ per user clarification *"일단 자메스에 깔린
+   로컬 모델들 부터 해보면될듯함"*.
 
 The matrix is `sectors × LLMs`. Each cell answers
 *"adding sector S to LLM L moves quality by Δ at cost Δ."*
@@ -172,25 +175,66 @@ models benefit MORE from JAMES sectors (the tier-gating hypothesis
 If `Δ(rag_full - minus)` at M_S is larger than at M_M → JAMES
 helps small models more → tier-gated default-on.
 
-### Phase 3 — API-backed LLM comparison (6 cells)
+### Phase 3 — Local-LLM family extension (user-clarified 2026-05-31: local first)
+
+User clarification post-design:
+*"위에서 llm 모델별이라는 것은 일단 자메스에 깔린 로컬 모델들 부터
+해보면될듯함"*
+→ Phase 3 = cross-family + cross-scale **local Ollama models** first.
+API providers deferred to Phase 4+.
+
+Inventoried locally (per `ollama list` 2026-05-31):
+
+| Model | Size | Family | Role in α-6 Phase 3 |
+|---|---|---|---|
+| `gemma3:1b` | 815 MB | Google gemma3 | extreme-small tier (below current M_S) |
+| `gemma3:4b` | 3.3 GB | Google gemma3 | M_S (already α-5 tier definition) |
+| `gemma4:e4b` | 9.6 GB | Google gemma4 | M_M production (already α-5 measured) |
+| `gemma3:12b` | 8.1 GB | Google gemma3 | M_L (already α-5 tier definition) |
+| `gemma3:27b` | 17 GB | Google gemma3 | XL tier (above current M_L) |
+| `gemma2:2b` | 1.6 GB | Google gemma2 | older-family small |
+| `qwen2.5:7b` | 4.7 GB | Alibaba qwen | cross-family small/mid |
+| `llama3.1:8b` | 4.9 GB | Meta llama | cross-family mid |
+| `deepseek-v2:16b` | 8.9 GB | DeepSeek MoE | cross-family MoE |
+
+**Phase 3 recommended sub-phasing** (run cheapest cells first):
+
+| Sub-phase | Cells | Models | Rationale | Time |
+|---|---|---|---|---|
+| 3.a | `C_rag-full + C_rag-routed` × {gemma3:1b, gemma3:4b, gemma3:12b, gemma3:27b} | gemma3 family scale ladder | tests "does the α-5 inert verdict hold across gemma3 scales?" | ~12-18 h |
+| 3.b | `C_rag-full + C_rag-routed` × {gemma2:2b, qwen2.5:7b, llama3.1:8b, deepseek-v2:16b} | cross-family at comparable size to gemma4:e4b | tests "is JAMES family-universal or gemma-specific?" | ~8-12 h |
+| 3.c | `C_minus + C_rag-basic + C_rag-graph + C_rag-full` × {best-discriminating model from 3.a/b} | full sector ablation on the model where Δ is largest | answers "which JAMES sectors transfer to other families?" | ~6-9 h |
+
+Skip:
+- `qwen2.5-coder:*` (code-specialized; off-task for multi-hop QA)
+- `llava:13b` (multimodal; no image queries in MultiHop-RAG)
+
+**Cost: zero** ($ + auth) — all local compute. Wall-clock total
+~26-40 hours across 3.a + 3.b + 3.c, runnable as background tasks
+spread over multiple days.
+
+### Phase 4 — API-backed LLM comparison (deferred until Phase 3 verdict)
 
 Same 4 Phase 1 sectors at one API model
 (`claude-haiku-4-5` recommended — cheapest, fast). Tells whether
-JAMES sectors help an already-strong model or are local-model
-crutches.
+JAMES sectors help an already-strong API model or are local-model
+crutches. Gated on Phase 3 — if Phase 3 already shows
+family-universality, Phase 4 mostly confirms; if Phase 3 shows
+gemma-specific lift, Phase 4 disambiguates "local vs API" from
+"family vs family."
 
-Cost: ~1 hour wall-clock + ~$5 API.
+Cost: ~1 hour wall-clock + ~$5 API per LLM.
 
-### Phase 4 — Cross-family broadening (optional)
+### Phase 5 — Cross-provider broadening (optional, deferred)
 
-Repeat Phase 3 on gpt-5-mini, gemini-2.5-flash for cross-family
+Repeat Phase 4 on gpt-5-mini, gemini-2.5-flash for cross-provider
 external evidence. Cost: ~$10-15.
 
-### Phase 5 — Routing on top (defer)
+### Phase 6 — Routing on top (defer)
 
 Add S7 (routing) cells across the same matrix. α-5 already showed
-S7 inert at gemma4:e4b; Phase 5 tests whether it's inert at
-smaller models / API models too.
+S7 inert at gemma4:e4b; Phase 6 tests whether it's inert at smaller
+models / cross-family models / API models too.
 
 ---
 
@@ -209,23 +253,29 @@ smaller models / API models too.
 Implementation cost per flag: ~30-90 min including a contract test.
 5 flags = ~1 day of work.
 
-### 5.2 LLM provider abstraction (Phase 3 blocker)
+### 5.2 LLM provider abstraction (Phase 4 blocker, NOT Phase 3)
 
-`core/llm_catalog.py` + `core/model_resolver.py` already exist —
-check whether they support claude / openai / gemini providers, or
-just Ollama. If just Ollama, add provider adapters
-(~1-2 days per provider including auth + cost tracking).
+`core/llm_catalog.py` + `core/model_resolver.py` already support
+Ollama (per `core/gemma_client.py`). **Phase 3 is local-only**
+(per user clarification 2026-05-31) so no provider abstraction
+extension needed for Phase 3.
 
-### 5.3 Cost tracking (Phase 3 blocker)
+For Phase 4+ API providers: check whether the existing modules
+support claude / openai / gemini, or just Ollama. If just Ollama,
+add provider adapters (~1-2 days per provider including auth +
+cost tracking). **Defer until Phase 3 verdict.**
 
-bench.py needs to capture API $-cost per query (claude/openai
-billing) for the cost axis. Replaces / augments the chars-based
-token_cost when the provider is API-backed.
+### 5.3 Cost tracking (Phase 4+ blocker, NOT Phase 3)
 
-### 5.4 Rate limiting (Phase 3 blocker)
+Local-only Phase 3 uses the existing chars-based `token_cost` axis
++ seconds-based `latency_cost` unchanged. Phase 4+ needs USD-based
+cost axis for API providers; deferred.
 
-API providers throttle. The matrix needs a per-provider
-rate-limit-aware bench runner (sleep / retry / batch) for API cells.
+### 5.4 Rate limiting (Phase 4+ blocker, NOT Phase 3)
+
+Local Ollama has no rate limit (constrained by GPU only). Phase 4+
+API providers need per-provider rate-limit-aware bench runner;
+deferred.
 
 ---
 
@@ -272,15 +322,18 @@ Cell JSON filename follows: `qvt-ablation-cell-C_<spec>_<model>.json`.
 
 ## 8. Deliverables per α-6 phase
 
-| Phase | Deliverable | Trigger |
-|---|---|---|
-| 0 | Relabel α-5 cells into α-6 namespace | free, immediate |
-| Engineering pre | 5 new env flags (S1, S2, S4, S5, S6) | engineering decision |
-| 1 | 3 new cells answering "does each JAMES sector add value at gemma4:e4b?" | Phase 0 + Engineering pre |
-| 2 | 3 cells at M_S — tier-gated check | Phase 1 verdict has signal |
-| 3 | 4 cells at claude-haiku — multi-LLM check | Phase 1 + LLM provider abstraction |
-| 4 | gpt + gemini — cross-family broadening | Phase 3 confirms approach works |
-| 5 | Routing-layer interaction with smaller models | independent, low-priority |
+| Phase | Deliverable | Trigger | $ | Time |
+|---|---|---|---|---|
+| 0 | Relabel α-5 cells into α-6 namespace | free, immediate | $0 | 0 |
+| Engineering pre | 5 new env flags (S1, S2, S4, S5, S6) | engineering decision | $0 | ~1 day |
+| 1 | 3 new cells answering "does each JAMES sector add value at gemma4:e4b?" | Phase 0 + Engineering pre | $0 | ~5.5h |
+| 2 | 3 cells at M_S (gemma3:4b) — tier-gated check | Phase 1 verdict has signal | $0 | ~3h |
+| **3a** | gemma3 scale ladder: 1b / 4b / 12b / 27b × {C_rag-full, C_rag-routed} | Phase 1 | $0 | ~12-18h |
+| **3b** | cross-family: gemma2:2b / qwen2.5:7b / llama3.1:8b / deepseek-v2:16b × {C_rag-full, C_rag-routed} | Phase 1 | $0 | ~8-12h |
+| **3c** | full sector ablation on best-discriminating model from 3a/b | 3a + 3b | $0 | ~6-9h |
+| 4 | claude-haiku — multi-LLM check, API | Phase 3 + LLM provider abstraction | ~$5 | ~1h |
+| 5 | gpt + gemini cross-family broadening | Phase 4 confirms | ~$10-15 | ~1h |
+| 6 | Routing-layer interaction with smaller / cross-family / API models | independent, low-priority | TBD | TBD |
 
 Each phase outputs:
 - Matrix render with new column / new rows


### PR DESCRIPTION
## Summary

User clarification post-α-6 design landing:
> *"위에서 llm 모델별이라는 것은 일단 자메스에 깔린 로컬 모델들 부터 해보면될듯함"*

Reshape Phase 3 to use locally-installed Ollama models first. API providers (claude / gpt / gemini) move to Phase 4+, deferred until Phase 3 verdict.

## Local model inventory (per `ollama list` 2026-05-31)

| Model | Size | Family | Role |
|---|---|---|---|
| gemma3:1b | 815 MB | gemma3 | extreme-small |
| gemma3:4b | 3.3 GB | gemma3 | M_S |
| gemma4:e4b | 9.6 GB | gemma4 | M_M production |
| gemma3:12b | 8.1 GB | gemma3 | M_L |
| gemma3:27b | 17 GB | gemma3 | XL |
| gemma2:2b | 1.6 GB | gemma2 | older small |
| qwen2.5:7b | 4.7 GB | qwen | cross-family small/mid |
| llama3.1:8b | 4.9 GB | llama | cross-family mid |
| deepseek-v2:16b | 8.9 GB | deepseek MoE | cross-family MoE |

Skip: `qwen2.5-coder:*` (code), `llava:13b` (multimodal) — off-task for multi-hop QA.

## Phase 3 sub-phasing (cheapest first, all local, $0)

- **3a** (~12-18h): gemma3 scale ladder × `{C_rag-full, C_rag-routed}` — does α-5 inert verdict hold across scale?
- **3b** (~8-12h): cross-family at comparable size — JAMES family-universal or gemma-specific?
- **3c** (~6-9h): full sector ablation on best-discriminating model from 3a/b

Total: ~26-40h wall-clock, runnable as background tasks over multiple days.

## §5 engineering preconditions reshape

§5.2-5.4 (LLM provider abstraction / cost tracking / rate limiting) re-marked as **Phase 4+ blockers, NOT Phase 3 blockers**. Phase 3 lands with zero API engineering investment.

## Verification

- No code change. Design amendment only.
- `ollama list` output captured into design memo's inventory table
- Cross-references unchanged: 4-step rule, position guard, α-5 closure

## Out of scope

- Implementing Phase 3 measurement runs (operator decision)
- API provider adapters (Phase 4+, deferred)
- Per-model performance tuning (test-bed only, defaults preserved)

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)