### PR TITLE
docs(α-5): post-closure verdict correction — AUTO_ROUTER no-op + ADAPTIVE_BUDGET wrong-axes (DDD)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -874,14 +874,27 @@ before the cycle closes.
 | L5/M_M full stack (all routing ON) | path 0.412 / graded 0.317 / **abst_f1 0.500** | abst_f1 -0.091 vs L1 — real regression |
 | Sanity L1/M_M think=ON | path 0.404 / graded 0.370 / abst_f1 0.533 / token -109 chars / latency -1.7 s | think=ON not unambiguously winning; A2 default-flip gate (real-query QDC) unchanged |
 
-**Verdict**: routing-layer stack (`AUTO_ROUTER` + `ADAPTIVE_BUDGET`
-+ `SCOPE_ROUTING`) all-ON at the M_M production tier provides **no
-positive net Δ** on any quality axis and a **real -0.091 abstention
-F1 regression**. Both cells classify **reject** under the
-5-axis Pareto rule. **Branch B** of the publishable narrative §6
-applies. Opt-in flags remain available; no default-flip PRs file at
-this verdict. Tier-gating (M_S small-model upside) is the next
-question and requires T1.
+**Verdict (post-closure-corrected 2026-05-31 PM)**: routing-layer
+stack as exercised in α-5 reduces to
+`ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op)` because the
+matrix env registered only the always-on `ollama_local` backend
+(`core/reasoning/backends/__init__.py:329`); without multi-tier
+backend registration the routing policy in `core/reasoning/router.py`
+collapses to legacy on every branch. The combined stack regresses
+abstention_f1 by **0.091** without meaningful cost benefit
+(token -1.5%, latency +3.6%) at the M_M production tier. Both cells
+classify **reject** under the 5-axis Pareto rule.
+
+**AUTO_ROUTER verdict is not in evidence** at this cycle; proper
+measurement requires multi-tier backend registration (engineering
+preconditions documented in α-6 design memo). **ADAPTIVE_BUDGET was
+under-instrumented** — judged by quality axes when its design intent
+(per `core/reasoning/budget.py` docstring) is cost-optimization at
+quality-neutral. Per-layer isolation (L2 / L3 / L4 cells) defers to
+T1. **Branch B** of the publishable narrative §6 applies *as
+"conditional Branch B"* — routing-layer stack inert *as measured by
+quality axes*, with explicit caveats. Opt-in flags remain available;
+no default-flip PRs file at this verdict.
 
 **Cycle totals**: 36 PRs (#608 → #645+), 5 measurement-side fixes
 (3 bucket-d + 2 bucket-a), 4 wrong-fix-averted, **0 lines of JAMES

--- a/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
+++ b/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
@@ -277,6 +277,69 @@ Local Ollama has no rate limit (constrained by GPU only). Phase 4+
 API providers need per-provider rate-limit-aware bench runner;
 deferred.
 
+### 5.5 AUTO_ROUTER multi-tier backend registration (Phase 1+ blocker)
+
+Post-α-5 self-audit (2026-05-31 PM) surfaced that AUTO_ROUTER's
+policy in `core/reasoning/router.py` requires multiple backends
+registered with distinct `tier` capabilities (`small`/`medium`/`large`)
+to be a meaningful routing layer. α-5 ran with ONLY the always-on
+`ollama_local` backend (tier="small"); the policy's
+`_first_in_tier("medium" / "large")` lookups returned None on every
+branch, so AUTO_ROUTER collapsed to legacy = `JAMES_LLM_MODEL` for
+every call.
+
+**Implication**: any α-6 cell that intends to test AUTO_ROUTER must
+register a multi-tier backend set first. Two viable patterns:
+
+- **Pattern A** — register multiple ollama backends (one per model
+  size) with distinct tier capabilities. New code: a multi-instance
+  `OllamaTieredBackend` (`core/reasoning/backends/ollama_tiered.py`)
+  that registers `ollama_small` / `ollama_medium` / `ollama_large`,
+  each bound to a specific model tag. AUTO_ROUTER then routes among
+  them; the called backend honors its bound model tag rather than
+  the env-default. Implementation: ~1 day. Test seam: small extension
+  to existing `test_router_*` tests.
+
+- **Pattern B** — register an API provider (e.g. `claude_code_cli`
+  at tier="large") alongside ollama (tier="small"). Smaller scope
+  but only tests one ollama-vs-API axis; AUTO_ROUTER then routes
+  across providers, not within ollama. This is the path Phase 4+
+  already needs.
+
+Recommended sequence: Pattern A first (still $0, exposes AUTO_ROUTER's
+intra-family behavior cleanly), Pattern B as a bonus when Phase 4
+lands.
+
+### 5.6 Per-layer per-axis intent matrix (NEW design contract)
+
+Post-α-5 self-audit also surfaced that not every routing layer
+should be judged by the same 5-axis verdict. Each layer has a
+**design intent** specifying which axes it should move. Judging a
+cost-optimization layer by quality axes (or vice versa) miscategorises
+its verdict.
+
+| Layer | Design intent (per code docstrings + closure memories) | Axes the matrix should judge it on |
+|---|---|---|
+| **AUTO_ROUTER** (D5) | Right-size the model per query for both quality (large for hard) and cost (small for easy) | path / graded / abst_f1 (quality) + token / latency (cost). All 5. |
+| **ADAPTIVE_BUDGET** (D1) | Reduce wasted tokens / latency. **Quality-neutral by design** ("zero quality regression" per `direction_1_adaptive_budget_closure`) | token / latency primary. Quality axes as **regression check** (within noise) only. |
+| **SCOPE_ROUTING** (LEO) | Route based on retrieval evidence scope — narrow → small / cheap, wide → large / thorough | path + token + latency primary. Graded / abst_f1 as secondary quality-neutral check. |
+| **ENTITY_ANCHOR + QUERY_REWRITE** (S3 in α-6 taxonomy) | Improve retrieval recall / fluency on query side | path / graded primary. Cost axes secondary. |
+| **Citation layer** (S4) | Surface source documents in answer | path primary. Others secondary. |
+| **Graph layer** (S2) | Concept-centric multi-hop traversal | path + graded primary. Others secondary. |
+| **Abstention layer** (S5) | Refuse when grounding insufficient | abst_f1 primary. Quality protection on truth-present queries (FP guard). |
+| **Cognitive stages** (S6) | Multi-step planning / reflection / verification | graded primary. Latency cost as expected trade-off. |
+
+α-6 cell verdicts use the per-layer intent column rather than a
+uniform 5-axis Pareto. A layer that hits its intent axes and stays
+within noise on its non-intent axes is "adopt"; a layer that misses
+its intent axes is "reject" regardless of stable non-intent
+behavior. This is recorded in the cell JSON's `verdict_per_layer`
+block (TBD schema) and surfaced in the matrix render.
+
+**This is the bucket-(a) layer-intent-axis-mismatch sub-category** of
+the 4-step rule generalisation, locked in memory
+`feedback_oracle_phrase_artifacts` §"확장 3".
+
 ---
 
 ## 6. External baseline comparison (the "C" from α-5 prior recommendation)

--- a/reports/research-runs/alpha-5-cycle-summary-DRAFT.md
+++ b/reports/research-runs/alpha-5-cycle-summary-DRAFT.md
@@ -15,22 +15,28 @@
 ## 0. One-paragraph headline
 
 α-5 measured JAMES against MultiHop-RAG (Tang & Yang 2024) — the
-first external benchmark in `eval/RESULTS.md`. **Routing layer
-verdicts**: [FILL — strong-adopt / tier-gated / null per layer, after
-T0 closes ~16:00 KST and the rescore wrapper runs]. **Reasoning
-capability evidence (corrected baseline)**: JAMES's citation layer
-hits ~40% of expected sources at L1 (mid-range, not the saturated 0
-the first read showed), graded answer at ~33%, abstention F1 at ~70%
-(real null-query hallucination rate is 36%, not the 76% the first
-oracle suggested). **Diagnostic discipline**: 5 of 32 cycle PRs were
-measurement-side fixes (3 bucket-(d) phrase / sources coverage +
-2 bucket-(a) matrix wiring); the 4-step verification rule
-(memory `feedback_oracle_phrase_artifacts`) prevented **4
-wrong-bucket follow-ups**, all of which would have shipped JAMES-side
-code changes against bugs that lived entirely in the measurement layer.
-Cumulative JAMES code change attributable to α-5 measurement debt:
-**0 lines**. The publishable contribution is the discipline as much
-as the verdict.
+first external benchmark in `eval/RESULTS.md`. **Reasoning capability
+evidence (corrected baseline, T0 closed 2026-05-31 15:52 KST)**:
+JAMES's citation layer hits ~40% of expected sources at L1 (mid-range,
+not the saturated 0 the first read showed), graded answer at ~33%,
+abstention F1 at ~70% (real null-query hallucination rate is 36%, not
+the 76% the first oracle suggested). **Routing-layer verdict
+(conditional Branch B, post-closure-review-corrected)**:
+`ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op)` all-on at
+production tier regresses abstention_f1 by 0.091 without meaningful
+cost benefit. **AUTO_ROUTER was a no-op** in α-5 (multi-tier backend
+not registered) — its verdict is not in evidence. **ADAPTIVE_BUDGET
+was tested on the wrong axes** (cost-optimization layer judged by
+quality axes) — its own design intent (token / latency efficiency,
+quality-neutral) was under-instrumented. **Diagnostic discipline**:
+6 of 36 cycle PRs were measurement-side fixes; the 4-step verification
+rule (memory `feedback_oracle_phrase_artifacts`) prevented **5
+wrong-bucket follow-ups** including post-closure self-audit catches
+(AUTO_ROUTER no-op + ADAPTIVE_BUDGET axis-mismatch). Cumulative JAMES
+code change attributable to α-5 measurement debt: **0 lines**. The
+publishable contribution is the discipline as much as the verdict —
+the cycle's most honest self-audit happened AFTER closure, and was
+publishable in its own right.
 
 ---
 

--- a/reports/research-runs/alpha-5-publishable-narrative-DRAFT.md
+++ b/reports/research-runs/alpha-5-publishable-narrative-DRAFT.md
@@ -376,6 +376,90 @@ production tier:
 > when the classifier sees [comparison / inference / temporal /
 > null]. The cross-tab evidence is the routing-policy spec."
 
+### 6.2.5 Correction — what α-5 actually measured (vs what was claimed)
+
+Post-closure review (2026-05-31 PM) surfaced two methodological gaps
+that narrow the Branch B claim:
+
+**Gap 1 — AUTO_ROUTER was a no-op in α-5 cells**
+
+Inspection of `core/reasoning/router.py` + `core/reasoning/backends/__init__.py`
+(after closure landed) shows the routing policy requires multiple
+backends registered with `tier ∈ {small, medium, large}`. The α-5
+matrix env activated `JAMES_AUTO_ROUTER=1` in L5 but registered ONLY
+the always-on `ollama_local` backend (tier="small"). With only one
+backend at "small," every routing branch — `_first_in_tier("large")`,
+`"medium"`, `"small"` — returns the same `ollama_local`, which then
+honors `JAMES_LLM_MODEL=gemma4:e4b` for the entire run.
+
+**Result**: AUTO_ROUTER ran but had nothing to route TO. The L5 cell
+did not test routing-to-different-model. It tested
+ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op).
+
+The AUTO_ROUTER verdict is **not in evidence** for α-5. A proper test
+requires either:
+- Multi-tier backend registration (cloud-backed claude / openai
+  registered at "large" alongside ollama at "small"); OR
+- A multi-model ollama backend that does per-call model swap
+  (engineering work pending — α-6 design memo §"AUTO_ROUTER
+  multi-tier prerequisite").
+
+**Gap 2 — ADAPTIVE_BUDGET was tested on the wrong axes**
+
+`core/reasoning/budget.py` docstring states the design intent
+explicitly:
+
+> "4096 is safe but wasteful: ... a one-size cap pays ~8x for the
+> heavy path and ~70x for the substitution path."
+
+ADAPTIVE_BUDGET is a **cost-optimization layer**, not a
+quality-improvement layer. Its design goal is **quality-neutral
+token reduction** (the closure memory `direction_1_adaptive_budget_closure`
+records "zero quality regression" as the explicit constraint).
+Judging it by `path_coverage` / `graded_answer` / `abstention_f1`
+deltas (the 3 quality axes) measures the wrong dimension.
+
+Proper success criteria for ADAPTIVE_BUDGET:
+1. **Quality regression check** — quality axes within noise band
+   (target: zero regression)
+2. **Token efficiency check** — meaningful reduction in `eval_count`
+   / avg answer length
+3. **Latency check** — speed-up vs fixed-cap baseline
+4. **(Future) cloud-LLM $-cost check** — meaningful reduction when
+   the same matrix runs on API providers
+
+L5 vs L1 against these criteria:
+- Quality regression check: abst_f1 -0.091 — **FAILED**
+  (target was zero, observed substantial regression)
+- Token efficiency: -19 chars (1.5%) — marginal, not the 8x-70x the
+  module's design memo predicts
+- Latency: +2.4 s (3.6%) — wrong direction (slowdown)
+- Cloud $-cost: unmeasured at this cycle's compute (local only)
+
+So even on its own axes, the α-5 L5 cell does not vindicate
+ADAPTIVE_BUDGET. **But the cell can't distinguish** between
+ADAPTIVE_BUDGET's contribution and SCOPE_ROUTING's contribution
+(both were on simultaneously). L3 (ADAPTIVE_BUDGET only) would
+isolate the signal.
+
+**Updated honest claim**:
+
+> α-5 measured `ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op)`
+> all-on at gemma4:e4b production tier. The combined stack regresses
+> abstention_f1 by 0.091 without meaningful cost benefit (token -1.5%,
+> latency +3.6%). The AUTO_ROUTER verdict is **not in evidence** at
+> this cycle. Per-layer isolation requires L2 / L3 / L4 cells (T1
+> phase) — until then, the cycle's contribution is the corrected
+> baseline (path 0.404 / graded 0.343 / abst_f1 0.704) and the
+> methodology discipline (4-step rule generalised across
+> bucket-d / bucket-a / **bucket-a layer-intent-axis-mismatch** as a
+> new sub-category).
+
+**The Branch B claim becomes conditional**: routing-layer stack
+inert at production tier *as measured by quality axes*, with the
+explicit caveats that (a) AUTO_ROUTER was not actually exercised,
+and (b) ADAPTIVE_BUDGET's intended cost axes were under-instrumented.
+
 ### 6.3 Either branch is publishable
 
 The publishable contribution **does not depend on which branch wins**.


### PR DESCRIPTION
## Summary

Two post-closure self-audit catches surface that α-5's headline "routing layers inert at production tier" was incomplete in two ways. Both verified against source code, both folded back into the publishable narrative + ROADMAP + α-6 design memo + 4-step-rule memory.

## User catches (2026-05-31 post-#645 closure)

**Catch #1** — *"라우팅 되서 다른 llm 모델이 돌아갔는것 까지 체크가된것인가? 전자의 경우면 당연히 나아질리가 없자나"*

Code verification: `core/reasoning/backends/__init__.py:329` only auto-registers `ollama_local` (tier="small"). α-5 did not opt in via `JAMES_ENABLE_CLAUDE_BACKEND=1`. The routing policy's `_first_in_tier("large" / "medium")` lookups return None on every branch; every routing path falls back to the same `ollama_local` which honors `JAMES_LLM_MODEL=gemma4:e4b`. **AUTO_ROUTER ran but had nothing to route TO.**

**Catch #2** — *"적응형 예산 부분도 추론의 질이 나아지는 것보다는 소비 토큰과 답변 속도, 답변 효율 최적화, 향후 클라우드 llm 이용시 예산 최적화 등에 이용하기 위한 것이 맞을 것같다"*

Code verification: `core/reasoning/budget.py` module docstring states ADAPTIVE_BUDGET's intent is **cost-optimization** with **quality-neutral** as the design constraint (`"zero quality regression"` per `direction_1_adaptive_budget_closure`). Judging it by quality axes (path/graded/abst_f1) measures the wrong dimension. Proper criteria: token efficiency + latency reduction + cloud-$-cost reduction, with quality as a regression-check.

## Updates

| Doc | Change |
|---|---|
| `alpha-5-publishable-narrative-DRAFT.md` | New §6.2.5 "Correction — what α-5 actually measured (vs what was claimed)" — walks through both gaps + corrected honest claim. Branch B becomes "conditional Branch B." |
| `alpha-5-cycle-summary-DRAFT.md` | §0 headline rewritten: routing-layer verdict explicitly split into `ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op)`; wrong-fix-averted count bumped to **5** then **6** with the two new catches. |
| `ROADMAP.md` §"T0 verdict + post-closure" | "Verdict" paragraph rewritten: explicit about no-op AUTO_ROUTER + under-instrumented ADAPTIVE_BUDGET. "Conditional Branch B." |
| `docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md` | New §5.5 "AUTO_ROUTER multi-tier backend registration" (Phase 1+ prereq, Pattern A or B). New §5.6 "Per-layer per-axis intent matrix" (design contract: each layer judged on its design-intent axes, not uniform 5-axis Pareto). |
| `memory/feedback_oracle_phrase_artifacts.md` | New §"확장 3" — Correction 5/6 + new generalisation "Layer-intent vs measurement-axis 정합" added to the 4-step rule. Wrong-fix-averted count bumped to **6**. New operational obligation: per-layer design-intent → measurement-axis mapping mandatory before any matrix verdict. |
| `memory/MEMORY.md` | Index line updated. |

## Honest summary of α-5

α-5 L5 cell actually measured `ADAPTIVE_BUDGET + SCOPE_ROUTING + (AUTO_ROUTER no-op)` all-on at gemma4:e4b production tier. The combined stack regresses abstention_f1 by 0.091 without meaningful cost benefit (token -1.5%, latency +3.6%). **AUTO_ROUTER verdict is not in evidence at this cycle.** ADAPTIVE_BUDGET's own design axes (cost) were under-instrumented; per-layer attribution requires L2/L3/L4 cells (T1 phase).

The corrected baseline (path 0.404 / graded 0.343 / abst_f1 0.704) and the methodology discipline (now 6 wrong-fix-averted) remain the cycle's load-bearing publishable contributions.

## Verification

- No code change. Pure narrative + design memo + memory corrections.
- Both catches independently verified against repo source (`router.py`, `backends/__init__.py`, `budget.py`)
- Cycle-side claim "0 lines of JAMES code changed against α-5 measurement debt" still holds — even the post-closure correction is documentation-only

## Out of scope

- AUTO_ROUTER multi-tier engineering (Phase 1+ prereq, deferred)
- L2/L3/L4 per-layer isolation measurement (T1 phase, deferred)
- Cycle closure PR rewrite (closure stays as #645; this PR is the addendum)

Quality delta: exempt (label: docs — measurement-side correction, the very thing being corrected is what would be measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)