### PR TITLE
docs(readme): mother-platform framing primary, Replayable RAG as one differentiator (GGG)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,9 +1,17 @@
 # PROJECT JAMES
 
-> **Replayable RAG** — 모든 claim 에 출처, 모든 추론 단계에 audit
-> row, 임의 시점 T 의 시스템 상태를 바이트-동일하게 재생 가능한
-> 로컬 우선 지식 추론 시스템. 자기진화는 인간 승인 게이트 뒤에서
-> 동작.
+> **JAMES** — 로컬 우선, 감사 가능한 지식 추론 **플랫폼**. Graph-RAG
+> 검색, 결정론적 모순 중재, append-only audit log, replayable
+> knowledge state, 인간 승인 게이트 기반 자기진화. v1.0 까지
+> **범용 mother 플랫폼** 으로 강화; 도메인 팩 (법률 · 식품 · 유통 · 여행 등)
+> 분화는 v1.0 이후 (
+> [`docs/PLATFORM_READINESS.md`](docs/PLATFORM_READINESS.md) 참조).
+>
+> **차별점 한 줄**: *Replayable RAG* — T7 supersede 체인 + audit log
+> append-only 조합으로 시점 T 의 시스템 상태를 바이트-동일하게 재구성
+> 가능 (`reconstruct_view_at`). Graph-RAG 검색, Knowledge Cascade
+> (Layer 3), Layer 4 Lifecycle (T1–T7), Plugin API, 결정론적 4-rule
+> 모순 트리 등도 모두 first-class 차별점.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # PROJECT JAMES
 
-> **Replayable RAG** — a local-first knowledge reasoning system where
-> every claim is sourced, every reasoning step is audited, and the
-> system's state at any point in time can be replayed
-> byte-identically. Built behind a human approval gate for
-> self-evolution.
+> **JAMES** — a local-first, auditable knowledge reasoning platform.
+> Graph-RAG retrieval, deterministic contradiction arbitration,
+> append-only audit log, replayable knowledge state, and a human
+> approval gate for self-evolution. Built as a general
+> **mother platform** through v1.0; domain packs (legal, food,
+> retail, …) branch off only after v1.0 (see
+> [`docs/PLATFORM_READINESS.md`](docs/PLATFORM_READINESS.md)).
+>
+> **One differentiator highlight**: *Replayable RAG* — the system's
+> state at any past point can be reconstructed byte-identically via
+> the T7 supersede chain + append-only audit log (`reconstruct_view_at`).
+> Other first-class differentiators include Graph-RAG retrieval,
+> Knowledge Cascade (Layer 3), Layer 4 Lifecycle (T1–T7), the Plugin
+> API, and the deterministic 4-rule contradiction tree.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)


### PR DESCRIPTION
## Summary

Applies positioning guard from `memory/feedback_jameses_positioning_replayable_rag.md` "정정 2026-05-31": Replayable RAG = **one** differentiator, not the whole identity.

## Before

> Replayable RAG -- a local-first knowledge reasoning system where every claim is sourced, every reasoning step is audited, and the system's state at any point in time can be replayed byte-identically.

## After

> JAMES -- a local-first, auditable knowledge reasoning **platform**. Graph-RAG retrieval, deterministic contradiction arbitration, append-only audit log, replayable knowledge state, and a human approval gate for self-evolution. Built as a general **mother platform** through v1.0; domain packs (legal, food, retail, …) branch off only after v1.0.
>
> **One differentiator highlight**: *Replayable RAG* — T7 supersede chain + append-only audit log. Other first-class differentiators include Graph-RAG, Knowledge Cascade, Layer 4 Lifecycle, Plugin API, and the deterministic 4-rule contradiction tree.

## Verification

- No code change
- Applied to both `README.md` and `README.ko.md` for parity
- `PLATFORM_READINESS.md` link added so readers can dig into the 6-dimension readiness framework

## Out of scope

- Other doc surfaces (ARCHITECTURE.md / docs/positioning/ etc.) — separate sweep if needed
- Repo rename (still held per positioning memory "rename 강도 ↑ 보류")

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)