### PR TITLE
docs(α-6): CLAUDE.md rule 2 layer-intent extension + verdict_per_layer schema (NNN+OOO)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,23 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
      Card would either circular-reference the broken oracle or
      measure noise. Explicit `Quality delta: exempt (label: fix)`
      keeps the review readable without paste-noise.
+   - **Layer-intent matrix** (α-6 cycle extension 2026-05-31): when a
+     PR touches one of the routing / cognitive layers
+     (`AUTO_ROUTER` / `ADAPTIVE_BUDGET` / `SCOPE_ROUTING` /
+     `ENTITY_ANCHOR` / `QUERY_REWRITE` / `Citation` / `Graph` /
+     `Abstention` / `Cognitive Stages`), the Quality Delta Card MUST
+     be scored against the layer's **design-intent axes** (per
+     `docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md` §5.6 +
+     memory `mechanism_layer_intent_axis_alignment`). Uniform 5-axis
+     judgment is rejected for these PRs because it mis-classifies
+     cost-optimization layers as quality regressions (α-5 post-closure
+     self-audit lesson, sub-categories 5/6 of bucket-(a)). The PR
+     description must include a short *"intent axes vs regression
+     axes"* split with the appropriate per-layer matrix entry.
+     **Layer measurement prerequisites must also be confirmed** —
+     e.g., AUTO_ROUTER PRs require multi-tier backend registration
+     evidence (otherwise the layer is no-op and the PR's number is
+     "not in evidence," not "no effect").
 
 3. **Self-evolution is opt-in only**. Any change that allows
    auto-deploy without an `approver_username` in the audit log

--- a/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
+++ b/docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md
@@ -333,12 +333,105 @@ its verdict.
 uniform 5-axis Pareto. A layer that hits its intent axes and stays
 within noise on its non-intent axes is "adopt"; a layer that misses
 its intent axes is "reject" regardless of stable non-intent
-behavior. This is recorded in the cell JSON's `verdict_per_layer`
-block (TBD schema) and surfaced in the matrix render.
+behavior.
 
 **This is the bucket-(a) layer-intent-axis-mismatch sub-category** of
 the 4-step rule generalisation, locked in memory
 `feedback_oracle_phrase_artifacts` §"확장 3".
+
+### 5.6.1 `verdict_per_layer` JSON schema (cell-level)
+
+Each α-6 cell JSON gains a `verdict_per_layer` block alongside the
+existing `aggregate` block. The new block is canonical for cells
+where one or more sector flags differ from the L1 baseline; cells
+that don't toggle any sector emit an empty `verdict_per_layer: []`
+and fall back to the legacy 5-axis Pareto verdict.
+
+```json
+{
+  "verdict_per_layer": [
+    {
+      "layer_id": "ADAPTIVE_BUDGET",
+      "flag": "JAMES_ADAPTIVE_BUDGET",
+      "flag_value": "1",
+      "design_intent": "토큰 효율 (quality-neutral)",
+      "primary_axes": ["token_cost", "latency_cost"],
+      "regression_check_axes": ["path_coverage", "graded_answer", "abstention_f1"],
+      "prerequisites_met": true,
+      "prerequisite_notes": null,
+      "per_axis_delta": {
+        "token_cost": {"delta": -19.13, "noise_band": 50.0, "verdict_contribution": "flat"},
+        "latency_cost": {"delta": +2.38, "noise_band": 5.0, "verdict_contribution": "flat"},
+        "path_coverage": {"delta": -0.007, "noise_band": 0.02, "verdict_contribution": "within-noise"},
+        "graded_answer": {"delta": -0.010, "noise_band": 0.02, "verdict_contribution": "within-noise"},
+        "abstention_f1": {"delta": -0.091, "noise_band": 0.05, "verdict_contribution": "regression"}
+      },
+      "verdict": "reject",
+      "reason": "regression on regression-check axis (abstention_f1) without compensating primary-axis improvement"
+    }
+  ]
+}
+```
+
+Field semantics:
+
+| Field | Meaning | Required |
+|---|---|---|
+| `layer_id` | canonical short name (matches the per-layer intent table) | yes |
+| `flag` | env flag controlling the layer | yes |
+| `flag_value` | value in this cell (`"0"` / `"1"`) | yes |
+| `design_intent` | one-line statement (from §5.6 table) | yes |
+| `primary_axes` | axes the layer is designed to move | yes |
+| `regression_check_axes` | axes the layer should not move past noise | yes |
+| `prerequisites_met` | bool — were the layer's measurement preconditions met? (e.g., multi-tier backend for AUTO_ROUTER) | yes |
+| `prerequisite_notes` | string or null — explains "not in evidence" if prerequisites missed | conditional |
+| `per_axis_delta` | per-axis Δ + noise_band + verdict_contribution | yes |
+| `verdict_contribution` per axis | one of `"primary-improvement"` / `"primary-flat"` / `"primary-regression"` / `"within-noise"` / `"regression"` (for regression-check axes) | yes |
+| `verdict` | one of `"strong-adopt"` / `"adopt"` / `"efficiency-adopt"` / `"tier-gated"` / `"reject"` / `"zero"` / `"not in evidence"` | yes |
+| `reason` | one-sentence justification | yes |
+
+### 5.6.2 Verdict rule (per-layer)
+
+```
+if not prerequisites_met:
+    verdict = "not in evidence"
+else if any regression_check_axes has verdict_contribution == "regression":
+    verdict = "reject"
+else if all primary_axes within noise:
+    verdict = "zero"
+else if primary_axes positive AND cost axes improved:
+    verdict = "strong-adopt"
+else if primary_axes positive AND cost axes flat:
+    verdict = "adopt"
+else if primary_axes flat AND cost axes improved:
+    verdict = "efficiency-adopt"
+else if primary_axes positive AND cost axes regressed:
+    verdict = "tier-gated"  # explain per tier in `reason`
+```
+
+The legacy `_classify_five_axis_delta` (in
+`scripts/qvt_ablation_matrix.py`) stays for α-5 cells; α-6 cells
+add the per-layer block alongside it. Matrix render aggregates the
+per-layer verdicts up; the uniform 5-axis verdict serves as the
+last-resort summary when sector flags don't apply.
+
+### 5.6.3 Application example — the α-5 L5 cell, re-judged
+
+If we apply the new schema to α-5's L5 cell (which had
+ADAPTIVE_BUDGET + SCOPE_ROUTING + AUTO_ROUTER on), the per-layer
+verdicts come out as:
+
+| Layer | prerequisites_met | primary_axes Δ | regression_check Δ | verdict |
+|---|---|---|---|---|
+| AUTO_ROUTER | **false** (single-backend) | n/a | n/a | **"not in evidence"** |
+| ADAPTIVE_BUDGET | true | token -1.5%, latency +3.6% | abst_f1 -0.091 | **"reject"** (regression on quality protection axis) |
+| SCOPE_ROUTING | true | path +0%, token -1.5%, latency +3.6% | graded -1%, abst_f1 -9% | **"reject"** (regression on abst_f1 + graded) |
+
+The honest cell-level summary: routing-stack inert OR mildly
+regressive; one layer cannot be evaluated.
+
+This matches the corrected α-5 closure narrative (§6.2.5 of
+`alpha-5-publishable-narrative-DRAFT.md`).
 
 ---
 


### PR DESCRIPTION
## Summary

Two cycle-discipline lock-ins from the α-5 post-closure self-audit:

**OOO — CLAUDE.md rule 2 extension**: PRs touching routing/cognitive layers MUST score the Quality Delta Card against per-layer design-intent axes (not uniform 5-axis Pareto). Layer measurement prerequisites must also be confirmed.

**NNN — `verdict_per_layer` JSON schema**: Cell JSON gains a `verdict_per_layer` block per toggled layer. Schema covers prerequisites_met, primary_axes, regression_check_axes, per_axis_delta, verdict, reason.

## Why

α-5 post-closure self-audit found:
- AUTO_ROUTER was no-op (multi-tier backend not registered) → "not in evidence", not "no effect"
- ADAPTIVE_BUDGET was judged on quality axes when its design intent is cost-optimization

Both errors come from **uniform 5-axis judgment** when layers have heterogeneous design intents. The fix is a per-layer matrix.

## Worked example (§5.6.3 of α-6 design)

α-5's L5 cell re-judged with the new schema:

| Layer | prerequisites_met | verdict |
|---|---|---|
| AUTO_ROUTER | **false** (single-backend) | **not in evidence** |
| ADAPTIVE_BUDGET | true | **reject** (regression on quality-protection axis) |
| SCOPE_ROUTING | true | **reject** (multiple regression) |

Matches the corrected α-5 closure narrative §6.2.5.

## Verification

- No code change (policy + schema only)
- Legacy `_classify_five_axis_delta` stays for α-5 cells; α-6 adds the per-layer block alongside
- Cross-references: α-5 publishable narrative §6.2.5, memory `mechanism_layer_intent_axis_alignment`, α-6 design §5.5/§5.6

## Out of scope

- Matrix runner implementation of `verdict_per_layer` emission — lands with α-6 Phase 1 measurement
- AUTO_ROUTER multi-tier backend code — separate sequence per α-6 §5.5

Quality delta: exempt (label: docs — policy update, the PR is the rule itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)