### PR TITLE
docs(α-5): DOI bump defer decision (SSS) + cycle PR index (TTT)

### DIFF
--- a/docs/handovers/v0.4-doi-bump-defer-2026-05-31.md
+++ b/docs/handovers/v0.4-doi-bump-defer-2026-05-31.md
@@ -1,0 +1,138 @@
+# DOI Bump — Defer Decision (SSS)
+
+> **Decision**: 추가 JAMES Zenodo DOI mint **보류**. 다음 시점 결정은
+> mid-June joint piece 협업 framing 확정 후.
+>
+> **작성일**: 2026-05-31 PM (α-5 cycle 45 PR 종료, T1 mid-flight)
+> **Trigger**: 사용자 catch — *"지금 DOI는 협업 연구하고 상관없으려나"*
+> (= "지금 DOI bump 가 협업 연구와 독립 아니지 않을까")
+
+---
+
+## 0. TL;DR
+
+이미 mint 된 두 single-author Zenodo DOI (v0.4.0 / v0.4.1) 외에
+**추가 mint 보류**. 이유: α-5 cycle 의 가장 publishable 한 contribution
+은 *방법론* (4-step rule / 4-bucket taxonomy / layer-intent matrix)
+이고, 이건 **Vehicle C** (multi-author preprint) 가 적합 — joint
+piece. Single-author Vehicle A DOI 에 방법론 claim 들어가면
+attribution 충돌 + 이전 v0.3.1 walk-back 패턴 반복.
+
+---
+
+## 1. 기존 DOI 상태 (memory `project_state` 기준 확인)
+
+| Version | DOI | Vehicle | Date |
+|---|---|---|---|
+| v0.4.0 | `10.5281/zenodo.20411354` | A (single-author release) | 2026-05-27 |
+| v0.4.1 | `10.5281/zenodo.20426719` | A (single-author release) | 2026-05-28 |
+
+α-5 cycle 자체는 **버전 bump 없음** (코드 변경 0 줄 against
+measurement debt). v0.4.2 는 T3 Evidence Aging cycle 시점 = 미정.
+
+---
+
+## 2. α-5 의 두 종류 publishable 자산
+
+| 자산 종류 | 매체 (vehicle) | 발행 주체 | 시점 |
+|---|---|---|---|
+| **JAMES 코드 작품** (T6 closure, 5-axis oracle, matrix infra) | A (single-author release DOI) | Hashevolution 단독 | v0.4.2 ship 시점 |
+| **방법론 contribution** (4-step rule, 4-bucket taxonomy, layer-intent matrix, 6 wrong-fix-averted lesson) | C (multi-author preprint) | Hashevolution + Robin + Ali (+ Vadym?) joint piece | mid-June 6/6+ rendezvous 후 |
+
+두 자산이 **같은 cycle 에서 나왔지만 발행 매체가 다름**.
+
+---
+
+## 3. 보류 이유 — Vehicle 충돌 패턴
+
+Memory `feedback_intent_vehicle_gap_collective_archival` §"vehicle-
+framing 5-축" 의 lesson:
+
+> "Vehicle A (release artifact) 안에 D type claim (discovery
+> claim) 넣으면 over-claim — walk-back 필요."
+
+v0.3.1 시점에 이미 한 번 겪음:
+- v0.3.1 Vehicle A DOI 의 description 에 "first multi-trillion-
+  parameter local-first ..." 형 claim 들어감
+- Robin/Ali 협업 직전에 그 claim 이 무겁다 catch
+- walk-back / framing 강등 / metadata 재작성 cycle
+
+α-5 의 방법론 claim ("4-step rule + 4-bucket taxonomy") 이
+Vehicle A 안에 들어가면 같은 패턴 재현 위험:
+- joint piece 가 같은 방법론으로 Vehicle C 발행 준비 중
+- single-author DOI 가 먼저 박히면 attribution 분쟁
+- 협업자가 "이미 단독 DOI 에 박았네" 인식
+
+---
+
+## 4. 트랙 분리
+
+| 트랙 | 시점 | 내용 | 시작 조건 |
+|---|---|---|---|
+| **트랙 1 — JAMES code release v0.4.2** | T3 Evidence Aging ship | 코드 artifact 만 description. α-5 도 *"infrastructure cycle"* 한 줄. 방법론 claim 0. | T3 코드 ship |
+| **트랙 2 — Joint piece preprint** | mid-June + Ali resume + 6/6 rendezvous 후 | 방법론 모두 여기. 4-step rule / 4-bucket taxonomy / α-5 의 6 wrong-fix-averted / layer-intent matrix. Co-author. | Robin DM + Ali ack |
+
+두 트랙은 **독립 시점** 으로 진행. Vehicle 혼동 없음.
+
+---
+
+## 5. 무엇이 SSS 보류 의 의미
+
+- ❌ v0.4.2 DOI mint 지금 안 함 (T3 ship 안 됨)
+- ❌ α-5 만의 supplement DOI mint 안 함 (방법론 over-claim 위험)
+- ❌ Zenodo metadata draft 미리 안 만듦 (이른 framing 고정 위험)
+
+- ✅ v0.4.0 / v0.4.1 기존 DOI 그대로 유지
+- ✅ 방법론 자산은 **joint piece 협상 시점** 결정
+- ✅ T3 ship 시 v0.4.2 DOI 검토 — description 은 코드만
+
+---
+
+## 6. 다음 결정 시점
+
+| 트리거 | 행동 | 의사결정자 |
+|---|---|---|
+| T3 Evidence Aging ship | v0.4.2 release DOI 검토 | Hashevolution 단독 (Vehicle A clean) |
+| Mid-June 6/6+ Ali resume | joint piece framing 협의 | Hashevolution + Robin + Ali |
+| Joint piece framing 확정 | joint Vehicle C DOI 작업 | 모든 co-author |
+| Joint piece publish | (가능 시) cross-link from v0.4.x release DOI description | Hashevolution |
+
+순서가 **release → joint** 이면 release DOI 가 joint 를 cross-link
+가능. **joint → release** 이면 joint DOI 가 release 를 reference.
+어느 순서든 attribution 분쟁 없음.
+
+---
+
+## 7. 자가 점검 체크리스트
+
+다음 세션에서 DOI bump 충동 생길 때 확인:
+
+- [ ] α-5 의 *코드* 변경이 v0.4.x 새 version 에 해당하는가?
+      → α-5 코드 변경 0 줄 = NO. 새 DOI 무관.
+- [ ] α-5 의 *방법론* 을 단독 DOI 에 박을 의도가 있는가?
+      → YES 면 STOP. joint piece 가 적합한 매체.
+- [ ] joint piece framing 이 확정됐는가?
+      → NO 면 추가 DOI mint 보류 지속.
+- [ ] T3 Evidence Aging 이 ship 됐는가?
+      → NO 면 v0.4.2 DOI 도 시기상조.
+
+세 NO 가 모두 YES 가 될 때까지 DOI bump 보류.
+
+---
+
+## 8. 관련 메모리 / 문서
+
+- `memory/feedback_intent_vehicle_gap_collective_archival` —
+  vehicle A/B/C/D/E 분류 + walk-back lesson + Soft/Hard 4-축 진단
+- `memory/feedback_jameses_positioning_replayable_rag` §"정정
+  2026-05-31" — Replayable RAG = 한 차원, 전체 정체성 아님 (DOI
+  description framing 직접 영향)
+- `memory/feedback_build_dont_broadcast` — 방향 진입 시 단독 의미
+  판정. α-5 방법론 = 연구 발행 = 협업 박자
+- `memory/feedback_high_stakes_endorsement_posture` — like only,
+  단독 framing 안 함
+- ROADMAP §v0.4.x α-5 cycle — α-5 closure 의 publishable 자산 정리
+- `reports/research-runs/alpha-5-publishable-narrative-DRAFT.md`
+  §6.2.5 + §10 — narrative 가 vehicle C 적합 형태
+- `reports/research-runs/multihop-rag-paper-baseline-comparison.md`
+  (PR #651) — 외부 비교 plan, joint piece 의 자연스러운 component

--- a/reports/research-runs/alpha-5-cycle-pr-index.md
+++ b/reports/research-runs/alpha-5-cycle-pr-index.md
@@ -1,0 +1,224 @@
+# α-5 Cycle PR Index (2026-05-30 → 2026-05-31)
+
+> 45 PRs across one multi-day session. This index gives a
+> by-category view of what each PR did so a future operator
+> can navigate the cycle without re-reading every PR description.
+>
+> **Cycle span**: PR #608 → PR #654 (sequentially landed)
+> **Cycle PRs in flight at write time**: none (T1 mid-flight is
+> matrix re-run, not a new PR)
+> **Cumulative JAMES code change attributable to α-5
+> measurement debt**: **0 lines**
+
+---
+
+## Quick stats
+
+| Category | Count |
+|---|---|
+| Total cycle PRs | **45** |
+| α-5 inheritor (think-mode preludes) | 4 (#608/#609/#610/#611) |
+| α-5 cycle proper (#612 onward) | 41 |
+| Measurement-side fixes (bucket-d / bucket-a) | 5 |
+| Design / methodology docs | 17 |
+| Tooling scripts | 9 |
+| Tests | 1 (4-step rule contract) |
+| Operator-facing handovers / runbooks | 5 |
+| Closure docs | 4 |
+| Post-closure self-audit | 5 (CCC / DDD / EEE / FFF / RRR + more) |
+| Cycle-side wrong-fix-averted | 6 (with 1 RRR-candidate pending T1 close) |
+
+---
+
+## A. Think-mode preludes (α-5 inheritor, #608-#611)
+
+| PR | Title | Topic |
+|---|---|---|
+| #608 | A3 — think-mode quality boundary | 5 stages × hard fixtures |
+| #609 | A2 — gemma4:e4b per-stage think-mode policy | opt-in plumbing |
+| #610 | backlog reconciliation A3 #608 + A2 #609 closure sync | handover |
+| #611 | A3 v2 — LLM-judge confirmation | 3 surprising cells |
+
+Used in α-5 as workspace `.env` `JAMES_GEMMA4_E4B_THINK_OFF=1` policy.
+
+---
+
+## B. α-5 entry (#612-#615)
+
+| PR | Title | Topic |
+|---|---|---|
+| #612 | α-5 prep — driver + design memo | operator-ready matrix |
+| #613 | α-5 prereq plan | 4-risk addressal + oracle negation + T0 smoke gate |
+| #614 | step7 v6 → v7 — path annotation | internal canary (later) |
+| #615 | α-5 reset — MultiHop-RAG external benchmark | 5-axis × question-type matrix |
+
+PR #615 is the reset point — post-#614 fixture v7 risks moved the cycle to MultiHop-RAG.
+
+---
+
+## C. α-5 execution + bucket-(d) corrections (#616-#623)
+
+| PR | Title | Bucket | Wrong-fix avoided |
+|---|---|---|---|
+| #616 | α-5 execute — ingest wrapper + bench timeout fix | exec | — |
+| #617 | handover §7.4 first per-question-type signal | docs | — |
+| #618 | source-recall — bench dropped `sources` field | **(d)** | path=0 → real 0.42 (Correction 1) |
+| #619 | abstention phrases — gemma4:e4b English refusal | **(d)** | hallucination 76% → 36% (Correction 2a) |
+| #620 | rescore tool + §7.4 hallucination rate correction | tool | — |
+| #621 | 4-bucket diagnostic taxonomy + dual purpose | docs | — |
+| #622 | render_report defensive path + bucket retroactive | fix | — |
+| #623 | abstention phrases round-2 + session_id suite-aware | **(d)** | F1 → 0.70 (Correction 2b) |
+
+The 3 bucket-(d) PRs are the cycle's first three wrong-fix-averted.
+
+---
+
+## D. α-5 cycle entry to ROADMAP + matrix runner fix (#624-#625)
+
+| PR | Title | Bucket |
+|---|---|---|
+| #624 | ROADMAP §v0.4.x α-5 cycle (in flight) | docs |
+| #625 | matrix runner subprocess suite-arg (was hardcoded step7) | **(a)** — Correction 3 |
+
+PR #625 is the cycle's 4th wrong-fix-averted (bucket-(a) sibling to #618/#619/#623 measurement-side family).
+
+---
+
+## E. T0 prep infrastructure (#626-#633)
+
+| PR | Title | Type |
+|---|---|---|
+| #626 | T0 smoke result analysis TEMPLATE | docs |
+| #627 | Pareto verdict walk-through + CLAUDE.md `fix` exempt + post-mortem | docs |
+| #628 | T0 analysis fill script | tool |
+| #629 | oracle.py → package split design (deferred) | docs |
+| #630 | α-5 cycle summary outline | docs |
+| #631 | publishable narrative draft — "Don't Build a Layer for the Bug" | docs |
+| #632 | bucket-(c) LLM-judge abstention detector design memo | docs |
+| #633 | `qvt_promote_findings.py` — auto-draft memory entries | tool |
+
+8 PRs of T0 prep infrastructure during the smoke run.
+
+---
+
+## F. Mid-cycle sync + 2 operational fixes (#634-#637)
+
+| PR | Title | Type |
+|---|---|---|
+| #634 | mid-cycle sync — ROADMAP PR table to 24 + backlog §7.5/7.6/7.7/7.8 | docs |
+| #635 | `core/observability.py::_trace_root()` workspace-aware (D11) | fix (code) |
+| #636 | A2 default-flip Quality Delta Card pre-template (D12) | docs |
+| #637 | 4-step rule contract test | test |
+
+PR #635 is the only code-side change — but it's a code hygiene fix, not a measurement-debt fix (D11 was queued before T0 started).
+
+---
+
+## G. Correction 4 (matrix glob bug) (#638-#640)
+
+| PR | Title | Bucket |
+|---|---|---|
+| #638 | matrix bench-output glob suite-aware (sibling to #625) + cell rescore tool | **(a)** — Correction 4 |
+| #639 | Correction 4 post-mortem + narrative + backlog §7.9 | docs |
+| #640 | `qvt_rescore_all_cells.py` — matrix-end audit + bulk rescore wrapper | tool |
+
+PR #638 is the 5th wrong-fix-averted (bucket-(a) wiring sibling to #625).
+
+---
+
+## H. T0 closure (#641-#645)
+
+| PR | Title | Type |
+|---|---|---|
+| #641 | matrix closure runbook (operator sequence) | docs |
+| #642 | cycle summary draft — Correction 4 absorption + 32-PR ledger | docs |
+| #643 | publishable narrative §1 + §4 — Correction 4 absorbed | docs |
+| #644 | publishable narrative §6 split — baseline + routing verdict | docs |
+| #645 | T0 CLOSURE — Branch B verdict, routing inert at production tier | docs (closure) |
+
+PR #645 is the formal T0 closure PR.
+
+---
+
+## I. Post-closure self-audit + α-6 design (#646-#648)
+
+| PR | Title | Type |
+|---|---|---|
+| #646 | α-6 sector × LLM ablation matrix — successor to α-5 | docs (design) |
+| #647 | α-6 local-first phasing — 9 local Ollama models inventoried | docs (design) |
+| #648 | α-5 post-closure verdict correction — AUTO_ROUTER no-op + ADAPTIVE_BUDGET wrong-axes | docs (correction) |
+
+PR #648 carries Correction 5 (AUTO_ROUTER no-op, **bucket-(a) wiring**) AND Correction 6 (ADAPTIVE_BUDGET wrong-axes, **bucket-(a) layer-intent-axis-mismatch** — new sub-category). Cycle's 6 wrong-fix-averted total.
+
+---
+
+## J. T1-wait window (#649-#654)
+
+| PR | Title | Type |
+|---|---|---|
+| #649 | README mother-platform framing primary (GGG) | docs |
+| #650 | α-6 engineering pre — 5 sector flag PR sequence plan (FFF) | docs (design) |
+| #651 | MultiHop-RAG paper baseline comparison plan (EEE) | docs (research) |
+| #652 | CLAUDE.md rule 2 layer-intent extension + verdict_per_layer schema (NNN+OOO) | docs (policy) |
+| #653 | `qvt_recover_cell_json.py` — manual cell JSON recovery (QQQ) | tool |
+| #654 | T1 L3 silent-failure hypothesis memo (RRR) | docs (investigation) |
+
+6 PRs during the T1 background run while the matrix re-tested L3 / L4 cells.
+
+---
+
+## K. Memory entries (user dir, not in repo)
+
+| Slug | Topic |
+|---|---|
+| `alpha_5_multihop_rag_reset` | α-5 reset rationale + 5-axis Pareto + question-type cross-tab |
+| `feedback_oracle_phrase_artifacts` | 4-step rule (확장 1+2+3) — bucket-(d) phrase coverage + bucket-(a) wiring + bucket-(a) layer-intent mismatch |
+| `mechanism_layer_intent_axis_alignment` | RAG-general mechanism for per-layer per-axis matching |
+| `feedback_jameses_positioning_replayable_rag` (correction) | Replayable RAG = one differentiator, not whole identity |
+
+4 memory entries written / updated. JJJ promoted the layer-intent mechanism to a standalone entry.
+
+---
+
+## L. Operator artifacts (matrix outputs)
+
+| Path | Content |
+|---|---|
+| `reports/promo-assets/v0.4-qvt-ablation-matrix-20260531T065209.md` | T0 matrix report (3 cells + sanity) |
+| `reports/research-runs/qvt-ablation-T0-smoke-result-20260531-1552.md` | T0 analysis (filled) |
+| `reports/research-runs/qvt-ablation-rescore-summary.md` | T0 cell-rescore audit |
+| `reports/research-runs/alpha-5-cycle-summary-DRAFT.md` | cycle summary (filled per closure) |
+| `reports/research-runs/alpha-5-publishable-narrative-DRAFT.md` | publishable narrative (5 sections filled) |
+| `reports/research-runs/alpha-5-diagnostic-chain-post-mortem.md` | post-mortem (4 corrections) |
+| `reports/research-runs/multihop-rag-paper-baseline-comparison.md` | external baseline comparison plan (EEE) |
+| `reports/research-runs/t1-l3-silent-failure-hypothesis-2026-05-31.md` | T1 silent-failure investigation memo (RRR) |
+| `workspaces/hotpot_eval/eval/qvt/baseline_3a961a3_rescored.json` | corrected α-5 baseline (path 0.404 / graded 0.343 / abst_f1 0.704) |
+
+---
+
+## M. Status of follow-up tracks
+
+| Track | Trigger | Status |
+|---|---|---|
+| α-5 T1 (L3+L4 measurement) | post-T0 | **in flight** (cell L4 active, L3 silent-failure under investigation) |
+| α-5 T2 (M_S + M_L tiers) | T1 verdict | deferred |
+| A2 default-flip | G1+G2+G3 gates | template ready (#636), gate unchanged |
+| Oracle package split | post-closure clean | design ready (#629), deferred |
+| Bucket-(c) LLM-judge | post split | design ready (#632), deferred |
+| α-6 Engineering pre (5 sector flags) | operator decision | plan ready (#650), unstarted |
+| α-6 Phase 1 (sector ablation × gemma4) | post Engineering pre | gated |
+| α-6 Phase 3 (local LLM family) | post Phase 1 | gated |
+| MultiHop-RAG paper baseline reproduction | independent | plan ready (#651), unstarted |
+| AUTO_ROUTER multi-tier engineering | α-6 Phase 5+ blocker | sketched (#646 §5.5), unstarted |
+| DOI bump | post mid-June joint piece framing | **explicitly deferred** (see `docs/handovers/v0.4-doi-bump-defer-2026-05-31.md`) |
+| Joint piece negotiation | 6/6+ Ali resume | Lane C, on hold |
+
+---
+
+## N. References
+
+- ROADMAP §v0.4.x α-5 cycle — section anchor
+- Backlog handover §7.10 — closure run log
+- 4-step rule: `memory/feedback_oracle_phrase_artifacts.md`
+- Layer-intent mechanism: `memory/mechanism_layer_intent_axis_alignment.md`
+- DOI defer decision: `docs/handovers/v0.4-doi-bump-defer-2026-05-31.md`


### PR DESCRIPTION
## Summary

Two cycle-wrap-up docs:

**SSS — DOI bump defer decision**: explicit hold until T3 ships AND mid-June joint piece framing confirmed. α-5 methodology belongs to Vehicle C (multi-author preprint); putting it in Vehicle A (single-author DOI) would recreate the v0.3.1 walk-back pattern.

**TTT — α-5 cycle PR index**: 45 PRs categorised into 12 sections (A-N) for navigation. Per-PR one-line descriptions + bucket tags + wrong-fix-averted attribution.

## Why SSS now

User catch: *"지금 DOI는 협업 연구하고 상관없으려나"* — recognises that DOI bump is NOT independent of the collaboration track. Recording the defer decision explicitly so a future session doesn't re-trigger the mint impulse.

4-question self-check baked in:
- α-5 code change for v0.4.x bump? → 0 lines, NO
- α-5 methodology in single-author DOI? → YES → STOP
- Joint piece framing confirmed? → NO until mid-June
- T3 Evidence Aging shipped? → NO

All four NOs must clear before any new DOI mint.

## Why TTT now

45 PRs in one cycle is dense. Without an index, future operator has to re-read every PR description to navigate. The index gives a category view + status of every follow-up track in one place.

## Verification

- No code change. Two organizational docs.
- Cross-references all 45 PRs by number + categorises by purpose
- DOI defer decision aligns with `feedback_intent_vehicle_gap_collective_archival` (vehicle A/C separation) + `feedback_jameses_positioning_replayable_rag` §"정정 2026-05-31"

## Out of scope

- Actual DOI mint (explicitly deferred per SSS)
- Bumping v0.4.2 version (T3 not shipped)
- Joint piece preparation (Lane C on hold until 6/6+ Ali resume)

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)