### PR TITLE
feat(α-6 S1): JAMES_DISABLE_RAG_RETRIEVAL env flag — RAG retrieval sector ablation

### DIFF
--- a/core/reasoning/pipeline_loops.py
+++ b/core/reasoning/pipeline_loops.py
@@ -46,6 +46,19 @@ def run_loop_0_retrieve(
       - ``avg_vec_score``   — average vector score over docs
     """
     print("\n[LOOP-0] retrieve (Orchestrator)")
+    # α-6 S1 sector ablation — `JAMES_DISABLE_RAG_RETRIEVAL=1` skips
+    # vector + BM25 retrieval entirely. The model receives no
+    # retrieved context (must answer from parametric knowledge or
+    # refuse). Used by α-6 cell `C_minus` (pure LLM baseline).
+    if os.environ.get("JAMES_DISABLE_RAG_RETRIEVAL") == "1":
+        loop_state["docs"] = []
+        loop_state["doc_context"] = ""
+        loop_state["avg_vec_score"] = 0.0
+        log_stage("retrieve", top_k=0, avg_vec_score=0.0,
+                  top_vector_score=0.0, top_bm25_score=None,
+                  source_type=source_type, sector_disabled=True)
+        print("  docs=0 (S1 disabled — JAMES_DISABLE_RAG_RETRIEVAL=1)")
+        return
     try:
         from core.orchestrator import retrieve as orch_retrieve
         docs = orch_retrieve(

--- a/tests/test_sector_flag_s1_rag.py
+++ b/tests/test_sector_flag_s1_rag.py
@@ -1,0 +1,84 @@
+"""Contract — `JAMES_DISABLE_RAG_RETRIEVAL` env flag (α-6 sector S1).
+
+Three invariants pinned:
+  1. Flag unset (default) → `run_loop_0_retrieve` calls
+     `engine.retrieval.hybrid_search` (via orchestrator) and
+     populates `loop_state["docs"]` with results.
+  2. Flag set to "1" → early-return: docs == [], doc_context == "",
+     avg_vec_score == 0.0; no calls to orchestrator / hybrid_search.
+  3. Flag set to "1" + an exception in the would-have-been path
+     does NOT raise (early-return never enters the try-block).
+
+This is the C_minus cell baseline — pure LLM with no retrieval.
+The model must answer from parametric knowledge or refuse.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.reasoning.pipeline_loops import run_loop_0_retrieve  # noqa: E402
+
+
+def _make_engine(raise_in_search: bool = False):
+    eng = MagicMock()
+    if raise_in_search:
+        eng.retrieval.hybrid_search.side_effect = RuntimeError("boom")
+    else:
+        eng.retrieval.hybrid_search.return_value = [
+            {"text": "doc1 text", "source": "doc1.txt", "score": 0.9},
+            {"text": "doc2 text", "source": "doc2.txt", "score": 0.7},
+        ]
+    eng.retrieval.build_doc_context.return_value = ("ctx", 0.8)
+    return eng
+
+
+class S1RagRetrievalFlagContract(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("JAMES_DISABLE_RAG_RETRIEVAL", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("JAMES_DISABLE_RAG_RETRIEVAL", None)
+
+    def test_flag_unset_calls_retrieval(self):
+        eng = _make_engine()
+        state: dict = {"expanded_query": "q"}
+        with patch("core.orchestrator.retrieve") as mock_orch:
+            mock_orch.return_value = [
+                {"text": "x", "source": "a.txt", "score": 0.5},
+            ]
+            run_loop_0_retrieve(eng, state, "q", "employee", "prod")
+            mock_orch.assert_called_once()
+        # State populated.
+        self.assertTrue(len(state["docs"]) >= 1)
+
+    def test_flag_set_short_circuits(self):
+        eng = _make_engine()
+        state: dict = {"expanded_query": "q"}
+        with patch.dict(os.environ, {"JAMES_DISABLE_RAG_RETRIEVAL": "1"}):
+            with patch("core.orchestrator.retrieve") as mock_orch:
+                run_loop_0_retrieve(eng, state, "q", "employee", "prod")
+                mock_orch.assert_not_called()
+            eng.retrieval.hybrid_search.assert_not_called()
+            eng.retrieval.build_doc_context.assert_not_called()
+        self.assertEqual(state["docs"], [])
+        self.assertEqual(state["doc_context"], "")
+        self.assertEqual(state["avg_vec_score"], 0.0)
+
+    def test_flag_set_swallows_would_have_been_exceptions(self):
+        eng = _make_engine(raise_in_search=True)
+        state: dict = {"expanded_query": "q"}
+        with patch.dict(os.environ, {"JAMES_DISABLE_RAG_RETRIEVAL": "1"}):
+            # Must not raise even though hybrid_search would have.
+            run_loop_0_retrieve(eng, state, "q", "employee", "prod")
+        eng.retrieval.hybrid_search.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third of 5 sector flag PRs (FFF #650). Adds env-flag early-return in `run_loop_0_retrieve` so the chroma/BM25 retrieval layer can be toggled off for α-6 sector ablation cells.

This is the **C_minus cell baseline** — pure LLM with no retrieved context. The model must answer from parametric knowledge or refuse. Quality axes should drop sharply (the comparison point that validates "does retrieval help at all?").

## Code change (~13 lines)

`core/reasoning/pipeline_loops.py`:
- `run_loop_0_retrieve` early-return when `JAMES_DISABLE_RAG_RETRIEVAL=1`:
  - `docs=[], doc_context="", avg_vec_score=0.0`
  - `log_stage("retrieve", sector_disabled=True, ...)`
  - return before orchestrator / hybrid_search calls

## Contract tests (3 cases)

1. Flag unset → orchestrator + hybrid_search called; docs populated
2. Flag=1 → no calls to orchestrator / hybrid_search / build_doc_context; docs==[] doc_context=="" avg_vec_score==0.0
3. Flag=1 + would-have-been exception → no raise (early-return)

## Verification

- 10/10 sector flag tests pass (S1 + S2 + S4)
- Production default byte-identical (flag unset = identical to pre-PR)

## Out of scope

- S5 Abstention / S6 Cognitive flags — PRs 4-5
- Matrix runner --sector-cells extension

Quality delta: exempt (label: code — α-6 ablation infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)