### PR TITLE
feat(α-6 S5): JAMES_DISABLE_ABSTENTION env flag — abstention-softener sector ablation

### DIFF
--- a/core/reasoning/pipeline_synth.py
+++ b/core/reasoning/pipeline_synth.py
@@ -16,6 +16,7 @@ Returns a small dataclass so the caller can keep the existing
 """
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
@@ -235,8 +236,12 @@ def generate_answer(
             answer = engine._generate_answer(safe_query, safe_context, system_prompt, response_style=response_style, selected_model=selected_model)
 
         # [P7] "자료 없음" 단독 응답(추론 없음)이면 system_prompt 포함 재시도
+        # α-6 S5 sector ablation — `JAMES_DISABLE_ABSTENTION=1` skips the
+        # retry-no-info pass so the LLM's first "자료에 없음" answer stands.
+        # The cell measures JAMES *without* the abstention softener.
         _no_data = ("자료에 없음. 관련된", "답변 생성에 실패", "LLM 응답 생성 중 오류")
-        if answer and any(answer.startswith(p) for p in _no_data):
+        _s5_disabled = os.environ.get("JAMES_DISABLE_ABSTENTION") == "1"
+        if not _s5_disabled and answer and any(answer.startswith(p) for p in _no_data):
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
             from core.response_style import resolve_style as _resolve_style
             _style_retry = _resolve_style(response_style)

--- a/tests/test_sector_flag_s5_abstention.py
+++ b/tests/test_sector_flag_s5_abstention.py
@@ -1,0 +1,78 @@
+"""Contract — `JAMES_DISABLE_ABSTENTION` env flag (α-6 sector S5).
+
+Three invariants pinned (testing the env-gate expression directly
+rather than running the full synth path which requires a live LLM):
+
+  1. Flag unset (default) → the retry-no-info pass condition
+     evaluates True for a "자료에 없음" prefix answer.
+  2. Flag set to "1" → the retry-no-info pass condition evaluates
+     False even for a "자료에 없음" prefix answer (the early
+     refusal stands; no softening retry).
+  3. Flag set to "1" with a non-refusal answer is a no-op — only
+     refusal-prefix answers were touched by the retry pass anyway.
+
+The full synth-side behavior (model call, retry prompt assembly)
+is exercised by the live integration tests; this contract test
+pins the gate logic directly.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def _gate_condition(answer: str) -> bool:
+    """Mirror the gate at core/reasoning/pipeline_synth.py:237-241."""
+    _no_data = ("자료에 없음. 관련된", "답변 생성에 실패",
+                "LLM 응답 생성 중 오류")
+    _s5_disabled = os.environ.get("JAMES_DISABLE_ABSTENTION") == "1"
+    return (not _s5_disabled and answer
+            and any(answer.startswith(p) for p in _no_data))
+
+
+class S5AbstentionFlagContract(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("JAMES_DISABLE_ABSTENTION", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("JAMES_DISABLE_ABSTENTION", None)
+
+    def test_flag_unset_retry_triggers_on_refusal_prefix(self):
+        self.assertTrue(_gate_condition(
+            "자료에 없음. 관련된 정보를 찾을 수 없습니다."))
+        self.assertTrue(_gate_condition("답변 생성에 실패했습니다."))
+
+    def test_flag_set_skips_retry_on_refusal_prefix(self):
+        with patch.dict(os.environ,
+                        {"JAMES_DISABLE_ABSTENTION": "1"}, clear=False):
+            self.assertFalse(_gate_condition(
+                "자료에 없음. 관련된 정보를 찾을 수 없습니다."))
+            self.assertFalse(_gate_condition("답변 생성에 실패했습니다."))
+
+    def test_flag_set_irrelevant_for_normal_answers(self):
+        # Both modes should evaluate False for normal substantive
+        # answers — the retry was always refusal-prefix-only.
+        normal = "The company is Amazon. Q3 revenue grew 12%."
+        self.assertFalse(_gate_condition(normal))
+        with patch.dict(os.environ,
+                        {"JAMES_DISABLE_ABSTENTION": "1"}, clear=False):
+            self.assertFalse(_gate_condition(normal))
+
+    def test_flag_toggle_back_and_forth(self):
+        prefix_ans = "자료에 없음. 관련된 자료가 없습니다."
+        self.assertTrue(_gate_condition(prefix_ans))
+        with patch.dict(os.environ,
+                        {"JAMES_DISABLE_ABSTENTION": "1"}, clear=False):
+            self.assertFalse(_gate_condition(prefix_ans))
+        # Re-check after exiting patch context.
+        self.assertTrue(_gate_condition(prefix_ans))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fourth of 5 sector flag PRs (FFF #650). Adds env-flag gate around the retry-no-info pass in `pipeline_synth` so the abstention-softener can be toggled off for α-6 sector ablation cells.

When unset (production default), JAMES detects "자료에 없음" prefix answers and retries with a softening system_prompt that often turns the refusal into a substantive answer. When set to `1`, the early refusal stands — the cell measures JAMES *without* the abstention softener.

## Code change (~4 lines)

`core/reasoning/pipeline_synth.py`:
- `import os`
- Retry-no-info gate at line ~239 now also checks `JAMES_DISABLE_ABSTENTION`

## Contract tests (4 cases)

Tests pin the gate logic directly (no live LLM required):
1. Flag unset → retry triggers on "자료에 없음" / "답변 생성에 실패" prefix
2. Flag=1 → retry skipped on those same prefix answers
3. Flag=1 is no-op for normal substantive answers (retry was prefix-only)
4. Toggle reads env at call time

## Verification

- 14/14 sector flag tests pass (S1 + S2 + S4 + S5)
- Production byte-identical when unset

## Out of scope

- S6 Cognitive Stages flag — PR 5 (final)
- Matrix runner `--sector-cells` extension

Quality delta: exempt (label: code — α-6 ablation infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)