### PR TITLE
feat(α-6 S6): JAMES_DISABLE_COGNITIVE_STAGES env flag — master kill-switch (5/5 complete)

### DIFF
--- a/core/reasoning/planner.py
+++ b/core/reasoning/planner.py
@@ -85,6 +85,10 @@ class Plan:
 
 
 def _enabled() -> bool:
+    # α-6 S6 sector ablation — `JAMES_DISABLE_COGNITIVE_STAGES=1`
+    # forces all cognitive stages OFF regardless of per-stage flags.
+    if os.environ.get("JAMES_DISABLE_COGNITIVE_STAGES") == "1":
+        return False
     return os.environ.get("JAMES_ENABLE_PLANNER") == "1"
 
 

--- a/core/reasoning/reflect.py
+++ b/core/reasoning/reflect.py
@@ -209,6 +209,10 @@ REVISE_PROMPT_EN = (
 
 
 def _enabled() -> bool:
+    # α-6 S6 sector ablation — `JAMES_DISABLE_COGNITIVE_STAGES=1`
+    # forces all cognitive stages OFF regardless of per-stage flags.
+    if os.environ.get("JAMES_DISABLE_COGNITIVE_STAGES") == "1":
+        return False
     return os.environ.get("JAMES_ENABLE_REFLECT") == "1"
 
 

--- a/core/reasoning/verify.py
+++ b/core/reasoning/verify.py
@@ -97,6 +97,10 @@ def _enabled() -> bool:
     Fact-checking (LLM-driven, +5-15s/query) remains opt-in — see
     :func:`_fact_check_enabled`.
     """
+    # α-6 S6 sector ablation — `JAMES_DISABLE_COGNITIVE_STAGES=1`
+    # forces all cognitive stages OFF regardless of per-stage flags.
+    if os.environ.get("JAMES_DISABLE_COGNITIVE_STAGES") == "1":
+        return False
     return os.environ.get("JAMES_DISABLE_VERIFY") != "1"
 
 

--- a/tests/test_sector_flag_s6_cognitive.py
+++ b/tests/test_sector_flag_s6_cognitive.py
@@ -1,0 +1,97 @@
+"""Contract — `JAMES_DISABLE_COGNITIVE_STAGES` env flag (α-6 sector S6).
+
+Master kill-switch that forces ALL cognitive stages
+(planner / reflect / verify / fact_check) to OFF regardless of their
+per-stage env flags.
+
+Four invariants pinned (one per stage):
+  1. planner `_enabled()` returns False when S6 disabled, even if
+     JAMES_ENABLE_PLANNER=1.
+  2. reflect `_enabled()` same.
+  3. verify `_enabled()` returns False when S6 disabled, even though
+     verify's per-stage default is ON (JAMES_DISABLE_VERIFY != "1").
+  4. fact_check is gated through verify._enabled() (chain pattern),
+     so it inherits the S6 master gate automatically.
+
+The S6 flag is the C_rag-graph cell's natural exclusion (no
+cognitive stages on top of the graph layer).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# Import the private gates so the test pins the actual gate
+# expression, not a re-implementation.
+from core.reasoning.planner import _enabled as planner_enabled  # noqa: E402
+from core.reasoning.reflect import _enabled as reflect_enabled  # noqa: E402
+from core.reasoning.verify import (  # noqa: E402
+    _enabled as verify_enabled,
+    _fact_check_enabled,
+)
+
+
+class S6CognitiveFlagContract(unittest.TestCase):
+    def setUp(self) -> None:
+        for env in ("JAMES_DISABLE_COGNITIVE_STAGES",
+                    "JAMES_ENABLE_PLANNER",
+                    "JAMES_ENABLE_REFLECT",
+                    "JAMES_DISABLE_VERIFY",
+                    "JAMES_ENABLE_FACT_CHECK"):
+            os.environ.pop(env, None)
+
+    def tearDown(self) -> None:
+        for env in ("JAMES_DISABLE_COGNITIVE_STAGES",
+                    "JAMES_ENABLE_PLANNER",
+                    "JAMES_ENABLE_REFLECT",
+                    "JAMES_DISABLE_VERIFY",
+                    "JAMES_ENABLE_FACT_CHECK"):
+            os.environ.pop(env, None)
+
+    def test_planner_off_when_master_disabled(self):
+        with patch.dict(os.environ,
+                        {"JAMES_ENABLE_PLANNER": "1",
+                         "JAMES_DISABLE_COGNITIVE_STAGES": "1"}):
+            self.assertFalse(planner_enabled())
+
+    def test_planner_on_when_master_unset(self):
+        with patch.dict(os.environ, {"JAMES_ENABLE_PLANNER": "1"}):
+            self.assertTrue(planner_enabled())
+
+    def test_reflect_off_when_master_disabled(self):
+        with patch.dict(os.environ,
+                        {"JAMES_ENABLE_REFLECT": "1",
+                         "JAMES_DISABLE_COGNITIVE_STAGES": "1"}):
+            self.assertFalse(reflect_enabled())
+
+    def test_reflect_on_when_master_unset(self):
+        with patch.dict(os.environ, {"JAMES_ENABLE_REFLECT": "1"}):
+            self.assertTrue(reflect_enabled())
+
+    def test_verify_off_when_master_disabled(self):
+        # verify's default is ON (DISABLE_VERIFY != "1"); master
+        # still forces it OFF.
+        with patch.dict(os.environ,
+                        {"JAMES_DISABLE_COGNITIVE_STAGES": "1"}):
+            self.assertFalse(verify_enabled())
+
+    def test_verify_on_by_default_when_master_unset(self):
+        self.assertTrue(verify_enabled())
+
+    def test_fact_check_inherits_master_gate_via_verify(self):
+        # fact_check chains through verify._enabled() so master
+        # disable cascades.
+        with patch.dict(os.environ,
+                        {"JAMES_ENABLE_FACT_CHECK": "1",
+                         "JAMES_DISABLE_COGNITIVE_STAGES": "1"}):
+            self.assertFalse(_fact_check_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**Final** of 5 sector flag PRs (FFF #650). Master kill-switch that forces ALL cognitive stages (planner / reflect / verify / fact_check) to OFF regardless of their per-stage env flags.

## Code change (~12 lines, 3 stages × 4 lines)

Each of `planner._enabled()` / `reflect._enabled()` / `verify._enabled()` gets a master-flag short-circuit at the top:

```python
if os.environ.get("JAMES_DISABLE_COGNITIVE_STAGES") == "1":
    return False
```

`fact_check` inherits via the existing `_enabled() and ...` chain in `verify.py` — no separate guard.

## Contract tests (7 cases)

- planner OFF when master disabled even with `JAMES_ENABLE_PLANNER=1`
- planner ON when master unset (with `JAMES_ENABLE_PLANNER=1`)
- reflect OFF / ON similar
- verify OFF when master disabled (overrides default-ON state)
- verify ON by default when master unset
- fact_check inherits master gate via chain

## α-6 Engineering pre — sequence complete (5/5)

| PR | Flag | Sector |
|---|---|---|
| #657 | `JAMES_DISABLE_SOURCES_FIELD` | S4 Citation |
| #658 | `JAMES_DISABLE_GRAPH` | S2 Graph |
| #659 | `JAMES_DISABLE_RAG_RETRIEVAL` | S1 RAG |
| #660 | `JAMES_DISABLE_ABSTENTION` | S5 Abstention |
| **this** | `JAMES_DISABLE_COGNITIVE_STAGES` | S6 Cognitive |

**21 sector-flag contract tests all green.** Production byte-identical when all flags unset.

## Next steps

1. Matrix runner `--sector-cells` extension to wire flags into cell env blocks
2. α-6 Phase 1 measurement runbook (~5.5h compute, 3 new cells: `C_minus` / `C_rag-basic` / `C_rag-graph` at gemma4:e4b)
3. Ollama healthcheck before launch (UUU lesson, post-mortem #656)

## Verification

- 21/21 sector flag tests pass
- Production default byte-identical when unset

Quality delta: exempt (label: code — α-6 ablation infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)