### PR TITLE
feat(α-6): matrix runner --sector-cells extension — wire 5 sector flags into cell envs

### DIFF
--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -144,6 +144,87 @@ _ROW_LABELS: Dict[str, str] = {
 }
 
 
+# α-6 sector cells (per docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md §2).
+# Each cell layers on L1 (production-default ENTITY_ANCHOR + QUERY_REWRITE)
+# but toggles the 5 sector disable-flags (PRs #657-#661) to ablate
+# infrastructure sectors. Production-byte-identical when no sector flag
+# is set; the matrix runner overlays these on top of L1's row env when
+# the operator passes --sector-cells.
+#
+# Cell taxonomy (S1 RAG / S2 Graph / S3 Preproc / S4 Cite / S5 Abst /
+# S6 Cog):
+#   C_minus      = none on  (pure LLM, no JAMES)
+#   C_rag-basic  = S1 only
+#   C_rag-cited  = S1 + S4
+#   C_rag-graph  = S1 + S2 + S3 + S4 (= "JAMES retrieval + graph + cite,
+#                                       no abstention softener, no
+#                                       cognitive stages")
+#   C_rag-full   = all on (= α-5 L1 cell — already measured)
+#   C_rag-routed = full + routing layers (= α-5 L5 cell — already measured)
+_SECTOR_CELL_ENVS: Dict[str, Dict[str, str]] = {
+    "C_minus": {
+        # Pure LLM — all 5 sector flags ON (disable everything except
+        # S3 query preprocessing, which is the row's responsibility).
+        # Also disable S3 by overriding the row env below.
+        "JAMES_DISABLE_RAG_RETRIEVAL":    "1",
+        "JAMES_DISABLE_GRAPH":            "1",
+        "JAMES_DISABLE_SOURCES_FIELD":    "1",
+        "JAMES_DISABLE_ABSTENTION":       "1",
+        "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+        # S3 also off — override row ENV's ENABLE flags
+        "JAMES_ENABLE_ENTITY_ANCHOR":     "0",
+        "JAMES_ENABLE_QUERY_REWRITE":     "0",
+    },
+    "C_rag-basic": {
+        # S1 (RAG) only — everything else off.
+        "JAMES_DISABLE_GRAPH":            "1",
+        "JAMES_DISABLE_SOURCES_FIELD":    "1",
+        "JAMES_DISABLE_ABSTENTION":       "1",
+        "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+        # S3 off — basic RAG means no entity anchor + no rewrite
+        "JAMES_ENABLE_ENTITY_ANCHOR":     "0",
+        "JAMES_ENABLE_QUERY_REWRITE":     "0",
+    },
+    "C_rag-cited": {
+        # S1 + S4 on; S2 / S3 / S5 / S6 off.
+        "JAMES_DISABLE_GRAPH":            "1",
+        "JAMES_DISABLE_ABSTENTION":       "1",
+        "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+        "JAMES_ENABLE_ENTITY_ANCHOR":     "0",
+        "JAMES_ENABLE_QUERY_REWRITE":     "0",
+    },
+    "C_rag-graph": {
+        # S1 + S2 + S3 + S4 on; S5 + S6 off.
+        # S3 stays ON (row's defaults: ENTITY_ANCHOR=1, QUERY_REWRITE=1).
+        "JAMES_DISABLE_ABSTENTION":       "1",
+        "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+    },
+    "C_rag-full": {
+        # Equivalent to α-5 L1 — all sectors on, no routing layers.
+        # No sector disable flag; row's L1 default applies.
+    },
+    "C_rag-routed": {
+        # Equivalent to α-5 L5 — all sectors on + all routing layers on.
+        # Operator should pair this with --rows L5 instead of using
+        # --sector-cells for clarity, but we list it here for the
+        # naming-convention completeness.
+        "JAMES_AUTO_ROUTER":      "1",
+        "JAMES_ADAPTIVE_BUDGET":  "1",
+        "JAMES_SCOPE_ROUTING":    "1",
+    },
+}
+
+
+_SECTOR_CELL_LABELS: Dict[str, str] = {
+    "C_minus":      "pure LLM (no JAMES)",
+    "C_rag-basic":  "+ RAG only",
+    "C_rag-cited":  "+ RAG + citation (S4)",
+    "C_rag-graph":  "+ RAG + graph + S3 preproc + citation",
+    "C_rag-full":   "JAMES full stack (= α-5 L1)",
+    "C_rag-routed": "JAMES + routing layers (= α-5 L5)",
+}
+
+
 # Model tier → Ollama tag (memo §2.2)
 _TIER_MODELS: Dict[str, str] = {
     "M_S": "gemma3:4b",
@@ -298,15 +379,23 @@ def _mint_employee_jwt() -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _cell_env(row: str, tier: str,
-              think_override: Optional[bool] = None) -> Dict[str, str]:
+              think_override: Optional[bool] = None,
+              sector_cell: Optional[str] = None) -> Dict[str, str]:
     """Compose the full env for one cell: OS env + fixed + row + tier +
-    optional `JAMES_GEMMA4_E4B_THINK_OFF` override (Step 9 sanity cell).
+    optional `JAMES_GEMMA4_E4B_THINK_OFF` override + optional α-6 sector
+    cell overlay.
 
     `think_override` semantics:
       None         — inherit from process env (workspace .env's setting).
       True         — force `JAMES_GEMMA4_E4B_THINK_OFF=1` (matrix primary).
       False        — force the variable unset (sanity cell — restores
                      production default = thinking ON).
+
+    `sector_cell` (α-6) — when set to one of `_SECTOR_CELL_ENVS` keys,
+    the cell's sector-flag dict overlays the row's flags. This lets
+    α-6 cells like `C_minus` (everything off) reuse the L1 row's
+    base env while toggling the 5 sector disable-flags
+    (JAMES_DISABLE_* per PRs #657-#661).
     """
     env = os.environ.copy()
     env.update(_FIXED_ENV)
@@ -317,32 +406,49 @@ def _cell_env(row: str, tier: str,
     elif think_override is False:
         # Force unset — sanity cell reverts to production default.
         env.pop("JAMES_GEMMA4_E4B_THINK_OFF", None)
+    if sector_cell is not None:
+        if sector_cell not in _SECTOR_CELL_ENVS:
+            raise ValueError(
+                f"unknown sector cell {sector_cell!r}; "
+                f"choose from {sorted(_SECTOR_CELL_ENVS.keys())}"
+            )
+        env.update(_SECTOR_CELL_ENVS[sector_cell])
     return env
 
 
 def _run_single_bench(row: str, tier: str, run_index: int,
                       suite: str = "step7",
-                      think_override: Optional[bool] = None) -> Optional[Path]:
+                      think_override: Optional[bool] = None,
+                      sector_cell: Optional[str] = None) -> Optional[Path]:
     """Run one bench subprocess against the configured suite.
 
     `suite` carries the matrix runner's --suite argument through; the
     pre-α-5 default was hardcoded "step7" (the legacy regression suite)
     and remained as default for back-compat.
 
+    `sector_cell` (α-6) — when set, the row's flag dict is overlaid
+    with the sector cell's `_SECTOR_CELL_ENVS[sector_cell]` so the
+    matrix can run α-6 cells (C_minus / C_rag-basic / C_rag-cited /
+    C_rag-graph etc.) on top of an L1 row.
+
     bench JSON output detection uses the same `{suite}_*.json` glob so
     multihop_rag (or any future suite) finds its own newly-written file
     rather than searching an unrelated suite's output.
     """
-    server_env = _cell_env(row, tier, think_override=think_override)
+    server_env = _cell_env(row, tier, think_override=think_override,
+                           sector_cell=sector_cell)
 
     flagged = {k: v for k, v in _ROW_ENVS[row].items()}
+    if sector_cell is not None:
+        flagged.update(_SECTOR_CELL_ENVS[sector_cell])
     think_tag = ""
     if think_override is True:
         think_tag = " think=OFF (primary)"
     elif think_override is False:
         think_tag = " think=ON (sanity)"
+    cell_id = f"{sector_cell}/{tier}" if sector_cell else f"{row}/{tier}"
     print(
-        f"\n=== cell {row}/{tier} run {run_index + 1}/N "
+        f"\n=== cell {cell_id} run {run_index + 1}/N "
         f"(model={_TIER_MODELS[tier]}, suite={suite}, "
         f"env={flagged}{think_tag}) ==="
     )
@@ -438,15 +544,19 @@ def _current_git_sha() -> Optional[str]:
 
 
 def _cell_output_path(row: str, tier: str,
-                      sanity_think_on: bool = False) -> Path:
+                      sanity_think_on: bool = False,
+                      sector_cell: Optional[str] = None) -> Path:
     suffix = "-thinkON" if sanity_think_on else ""
+    if sector_cell:
+        return _resolve_output_dir() / f"qvt-ablation-cell-{sector_cell}-{tier}{suffix}.json"
     return _resolve_output_dir() / f"qvt-ablation-cell-{row}-{tier}{suffix}.json"
 
 
 def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
               sha: str, resume: bool,
               sanity_think_on: bool = False,
-              suite: str = "step7") -> Optional[Dict[str, Any]]:
+              suite: str = "step7",
+              sector_cell: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Run one cell. Writes per-cell JSON. Returns the payload (or
     loads-and-returns when --resume hits an existing file).
 
@@ -454,10 +564,18 @@ def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
     (matrix sanity supplement — production default). Output JSON gets
     `-thinkON` suffix so the standard L1/M_M cell and the sanity cell
     coexist on disk.
+
+    `sector_cell` (α-6) — when set, the cell's row env is overlaid
+    with the sector cell's flag dict (`_SECTOR_CELL_ENVS[sector_cell]`).
+    The output filename uses the sector cell name instead of the row
+    name (e.g. `qvt-ablation-cell-C_minus-M_M.json`).
     """
-    out = _cell_output_path(row, tier, sanity_think_on=sanity_think_on)
+    out = _cell_output_path(row, tier, sanity_think_on=sanity_think_on,
+                            sector_cell=sector_cell)
     if resume and out.exists():
-        cell_tag = f"{row}/{tier}{' (sanity think=ON)' if sanity_think_on else ''}"
+        cell_tag = (f"{sector_cell}/{tier}" if sector_cell
+                    else f"{row}/{tier}")
+        cell_tag += " (sanity think=ON)" if sanity_think_on else ""
         print(f"[cell {cell_tag}] --resume: skipping, "
               f"{out.relative_to(ROOT)} exists")
         return json.loads(out.read_text(encoding="utf-8"))
@@ -472,11 +590,14 @@ def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
     # simply skip the per-type aggregation.
     runs_by_type: List[Dict[str, FiveAxisResult]] = []
     run_paths: List[str] = []
-    cell_label = f"{row}/{tier}{' (sanity think=ON)' if sanity_think_on else ''}"
+    cell_label = (f"{sector_cell}/{tier}" if sector_cell
+                  else f"{row}/{tier}")
+    cell_label += " (sanity think=ON)" if sanity_think_on else ""
     for i in range(n_runs):
         bench_path = _run_single_bench(row, tier, i,
                                        suite=suite,
-                                       think_override=think_override)
+                                       think_override=think_override,
+                                       sector_cell=sector_cell)
         if bench_path is None:
             print(f"[cell {cell_label}] run {i + 1} failed to produce "
                   f"bench output — aborting cell")
@@ -502,19 +623,32 @@ def _run_cell(row: str, tier: str, n_runs: int, fixture: Dict[str, Any],
             if sub_runs:
                 aggregate_by_type[qt] = _aggregate_runs(sub_runs)
 
+    # Compose the effective env block — row flags + sector overlay
+    # (α-6). The cell JSON records what *actually* ran, not just the
+    # row defaults.
+    effective_env: Dict[str, str] = dict(_ROW_ENVS[row])
+    if sector_cell:
+        effective_env.update(_SECTOR_CELL_ENVS[sector_cell])
+
     payload = {
-        "schema": "qvt-ablation-cell-v2",  # v2 adds aggregate_by_question_type
+        # v3 adds optional sector_cell + sector_cell_label fields. Cells
+        # without --sector-cells stay schema-v2 compatible.
+        "schema": "qvt-ablation-cell-v3" if sector_cell else "qvt-ablation-cell-v2",
         "captured_at": datetime.now(timezone.utc).isoformat(),
         "git_sha": sha,
         "row": row,
         "row_label": _ROW_LABELS[row],
         "tier": tier,
         "model": _TIER_MODELS[tier],
-        "env": _ROW_ENVS[row],
+        "env": effective_env,
         "fixed_env": _FIXED_ENV,
         # Step 9 — sanity cell flag travels in the JSON so the report
         # writer can distinguish it from the primary L1/M_M (think=OFF).
         "sanity_think_on": bool(sanity_think_on),
+        # α-6 — sector_cell metadata (None when classic row-based cell)
+        "sector_cell": sector_cell,
+        "sector_cell_label": (_SECTOR_CELL_LABELS.get(sector_cell)
+                              if sector_cell else None),
         "fixture_version": fixture.get("version"),
         "n_runs": n_runs,
         "aggregate": aggregate,
@@ -926,6 +1060,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Suite name. Use 'multihop_rag' for the α-5 external "
              "benchmark (workspace-resolved fixture).",
     )
+    parser.add_argument(
+        "--sector-cells", type=str, default=None,
+        help="α-6 sector ablation cells (comma-separated). Available: "
+             f"{','.join(sorted(_SECTOR_CELL_ENVS.keys()))}. Each cell "
+             "overlays its sector-flag dict on top of L1's row env. "
+             "Mutually exclusive with --rows.",
+    )
     args = parser.parse_args(argv)
 
     if args.render_report:
@@ -936,9 +1077,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     # T0 smoke gate (α-5 prereq §3) takes precedence over --rows/--tiers
     # so an operator can fire the gate run with one flag.
     if args.t0_smoke:
-        if args.rows or args.tiers:
+        if args.rows or args.tiers or args.sector_cells:
             print("[error] --t0-smoke implies --tiers M_M --rows L1,L5; "
-                  "remove --rows/--tiers or drop --t0-smoke")
+                  "remove --rows/--tiers/--sector-cells or drop --t0-smoke")
             return 7
         args.rows = "L1,L5"
         args.tiers = "M_M"
@@ -946,19 +1087,38 @@ def main(argv: Optional[List[str]] = None) -> int:
               "M_M × {L1, L5} (~2.2 h). Verdict rule: if |graded_answer "
               "Δ| < 0.05 → matrix null at production tier → STOP.")
 
+    # α-6 — --sector-cells is mutually exclusive with --rows. When
+    # passed, the runner iterates over (sector_cell, tier) pairs;
+    # the row used as base is always L1 (production).
+    sector_cells: List[Optional[str]] = []
+    if args.sector_cells:
+        if args.rows:
+            print("[error] --sector-cells is mutually exclusive with --rows")
+            return 7
+        sector_cells = _parse_subset(
+            args.sector_cells, list(_SECTOR_CELL_ENVS.keys()), "sector-cells")
+        # In sector mode the row is fixed to L1 (production-default
+        # ENTITY_ANCHOR + QUERY_REWRITE; sector overlay further toggles).
+        args.rows = "L1"
+
     rows = _parse_subset(args.rows, list(_ROW_ENVS.keys()), "rows")
     tiers = _parse_subset(args.tiers, list(_TIER_MODELS.keys()), "tiers")
     sha = _current_git_sha() or "unknown"
     fixture_path = _resolve_fixture(args.suite)
     out_dir = _resolve_output_dir()
 
-    n_cells = len(rows) * len(tiers) + (1 if args.sanity_think_on else 0)
+    # Cell count includes sector cells (α-6) when in sector mode.
+    n_grid_cells = (len(sector_cells) if sector_cells else len(rows)) * len(tiers)
+    n_cells = n_grid_cells + (1 if args.sanity_think_on else 0)
     print("=== QVT α-5 ablation matrix ===")
     print(f"git_sha:    {sha}")
     print(f"suite:      {args.suite}")
     print(f"fixture:    {fixture_path}")
     print(f"output:     {out_dir}")
-    print(f"rows:       {rows}")
+    if sector_cells:
+        print(f"sector_cells: {sector_cells} (base row: L1)")
+    else:
+        print(f"rows:       {rows}")
     print(f"tiers:      {tiers}  → {[_TIER_MODELS[t] for t in tiers]}")
     print(f"n_runs:     {args.n_runs}")
     print(f"resume:     {args.resume}")
@@ -968,10 +1128,16 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.dry_run:
         print("\n[dry-run] cells planned:")
-        for row in rows:
-            for tier in tiers:
-                print(f"  {row}/{tier} model={_TIER_MODELS[tier]} "
-                      f"env={_ROW_ENVS[row]}")
+        if sector_cells:
+            for sc in sector_cells:
+                for tier in tiers:
+                    print(f"  {sc}/{tier} model={_TIER_MODELS[tier]} "
+                          f"(L1 base + sector overlay)")
+        else:
+            for row in rows:
+                for tier in tiers:
+                    print(f"  {row}/{tier} model={_TIER_MODELS[tier]} "
+                          f"env={_ROW_ENVS[row]}")
         if args.sanity_think_on:
             print(f"  L1/M_M sanity (think=ON, suffix '-thinkON') "
                   f"model={_TIER_MODELS['M_M']}")
@@ -985,14 +1151,25 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     n_ok = 0
     n_fail = 0
-    for row in rows:
-        for tier in tiers:
-            payload = _run_cell(row, tier, args.n_runs, fixture, sha,
-                                resume=args.resume, suite=args.suite)
-            if payload is None:
-                n_fail += 1
-            else:
-                n_ok += 1
+    if sector_cells:
+        for sc in sector_cells:
+            for tier in tiers:
+                payload = _run_cell("L1", tier, args.n_runs, fixture, sha,
+                                    resume=args.resume, suite=args.suite,
+                                    sector_cell=sc)
+                if payload is None:
+                    n_fail += 1
+                else:
+                    n_ok += 1
+    else:
+        for row in rows:
+            for tier in tiers:
+                payload = _run_cell(row, tier, args.n_runs, fixture, sha,
+                                    resume=args.resume, suite=args.suite)
+                if payload is None:
+                    n_fail += 1
+                else:
+                    n_ok += 1
 
     # Step 9 sanity cell — run after the standard grid so its think=ON
     # measurement uses the same fixture + same runner state.

--- a/tests/test_qvt_matrix_sector_cells.py
+++ b/tests/test_qvt_matrix_sector_cells.py
@@ -1,0 +1,136 @@
+"""Contract — `scripts/qvt_ablation_matrix.py --sector-cells` extension.
+
+Pins:
+  1. `_SECTOR_CELL_ENVS` has the 6 standard α-6 cells (C_minus,
+     C_rag-basic, C_rag-cited, C_rag-graph, C_rag-full, C_rag-routed).
+  2. `_cell_env(row="L1", tier="M_M", sector_cell="C_minus")` overlays
+     the sector flag dict on top of L1's row env. All 5 sector
+     disable-flags + S3 ENABLE flags get set to disable values for
+     C_minus.
+  3. C_rag-graph keeps S3 (ENTITY_ANCHOR + QUERY_REWRITE) ON (because
+     C_rag-graph is "+ graph + preprocessing").
+  4. `_cell_output_path` produces `qvt-ablation-cell-C_minus-M_M.json`
+     when sector_cell is set, vs `qvt-ablation-cell-L1-M_M.json` when
+     row-only.
+  5. Unknown sector_cell raises ValueError.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "qvt_ablation_matrix.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "qvt_ablation_matrix", SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["qvt_ablation_matrix"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+m = _load_module()
+
+
+class SectorCellsRegistryTests(unittest.TestCase):
+    def test_six_standard_sector_cells_exist(self):
+        expected = {"C_minus", "C_rag-basic", "C_rag-cited",
+                    "C_rag-graph", "C_rag-full", "C_rag-routed"}
+        self.assertEqual(set(m._SECTOR_CELL_ENVS.keys()), expected)
+
+    def test_each_sector_cell_has_a_label(self):
+        for cell in m._SECTOR_CELL_ENVS:
+            self.assertIn(cell, m._SECTOR_CELL_LABELS)
+
+
+class CellEnvOverlayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Clean any env leaks.
+        for env in ("JAMES_DISABLE_RAG_RETRIEVAL", "JAMES_DISABLE_GRAPH",
+                    "JAMES_DISABLE_SOURCES_FIELD", "JAMES_DISABLE_ABSTENTION",
+                    "JAMES_DISABLE_COGNITIVE_STAGES",
+                    "JAMES_ENABLE_ENTITY_ANCHOR", "JAMES_ENABLE_QUERY_REWRITE"):
+            os.environ.pop(env, None)
+
+    def test_c_minus_disables_all_sectors_including_s3(self):
+        env = m._cell_env("L1", "M_M", sector_cell="C_minus")
+        # S1, S2, S4, S5, S6 disable-flags all "1"
+        for flag in ("JAMES_DISABLE_RAG_RETRIEVAL", "JAMES_DISABLE_GRAPH",
+                     "JAMES_DISABLE_SOURCES_FIELD", "JAMES_DISABLE_ABSTENTION",
+                     "JAMES_DISABLE_COGNITIVE_STAGES"):
+            self.assertEqual(env[flag], "1",
+                             f"C_minus must disable {flag}")
+        # S3 also off (ENTITY_ANCHOR + QUERY_REWRITE explicitly set to "0")
+        self.assertEqual(env["JAMES_ENABLE_ENTITY_ANCHOR"], "0")
+        self.assertEqual(env["JAMES_ENABLE_QUERY_REWRITE"], "0")
+
+    def test_c_rag_basic_disables_all_except_s1(self):
+        env = m._cell_env("L1", "M_M", sector_cell="C_rag-basic")
+        # S2, S4, S5, S6 disabled; S1 stays default (NO disable flag).
+        self.assertNotIn("JAMES_DISABLE_RAG_RETRIEVAL", env)
+        for flag in ("JAMES_DISABLE_GRAPH", "JAMES_DISABLE_SOURCES_FIELD",
+                     "JAMES_DISABLE_ABSTENTION", "JAMES_DISABLE_COGNITIVE_STAGES"):
+            self.assertEqual(env[flag], "1")
+        # S3 off
+        self.assertEqual(env["JAMES_ENABLE_ENTITY_ANCHOR"], "0")
+
+    def test_c_rag_graph_keeps_s3_on(self):
+        env = m._cell_env("L1", "M_M", sector_cell="C_rag-graph")
+        # S3 must stay ON (L1 row default = "1")
+        self.assertEqual(env["JAMES_ENABLE_ENTITY_ANCHOR"], "1")
+        self.assertEqual(env["JAMES_ENABLE_QUERY_REWRITE"], "1")
+        # S5 + S6 still disabled
+        self.assertEqual(env["JAMES_DISABLE_ABSTENTION"], "1")
+        self.assertEqual(env["JAMES_DISABLE_COGNITIVE_STAGES"], "1")
+        # S1 + S2 + S4 NOT disabled
+        self.assertNotIn("JAMES_DISABLE_RAG_RETRIEVAL", env)
+        self.assertNotIn("JAMES_DISABLE_GRAPH", env)
+        self.assertNotIn("JAMES_DISABLE_SOURCES_FIELD", env)
+
+    def test_unknown_sector_cell_raises(self):
+        with self.assertRaises(ValueError):
+            m._cell_env("L1", "M_M", sector_cell="C_does_not_exist")
+
+    def test_sector_cell_none_is_pure_row_env(self):
+        env_with = m._cell_env("L1", "M_M", sector_cell=None)
+        env_without = m._cell_env("L1", "M_M")
+        # The two must produce identical envs (modulo unrelated OS vars).
+        for key in m._ROW_ENVS["L1"]:
+            self.assertEqual(env_with[key], env_without[key])
+
+
+class CellOutputPathTests(unittest.TestCase):
+    def test_row_only_path(self):
+        with patch.object(m, "_resolve_output_dir",
+                          return_value=Path("/tmp/cells")):
+            p = m._cell_output_path("L1", "M_M")
+            self.assertTrue(p.name.endswith("qvt-ablation-cell-L1-M_M.json"))
+
+    def test_sector_cell_path(self):
+        with patch.object(m, "_resolve_output_dir",
+                          return_value=Path("/tmp/cells")):
+            p = m._cell_output_path("L1", "M_M", sector_cell="C_minus")
+            self.assertTrue(p.name.endswith(
+                "qvt-ablation-cell-C_minus-M_M.json"))
+
+    def test_sector_cell_with_sanity(self):
+        with patch.object(m, "_resolve_output_dir",
+                          return_value=Path("/tmp/cells")):
+            p = m._cell_output_path("L1", "M_M",
+                                    sanity_think_on=True,
+                                    sector_cell="C_minus")
+            self.assertTrue(p.name.endswith(
+                "qvt-ablation-cell-C_minus-M_M-thinkON.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Action 1 of next-session entry runbook (handover #662). Wires the 5 sector flags (PRs #657-#661) into the matrix runner's cell env composition so α-6 cells can be launched with one command.

## New surfaces

- `_SECTOR_CELL_ENVS` dict — 6 standard α-6 cells: `C_minus` / `C_rag-basic` / `C_rag-cited` / `C_rag-graph` / `C_rag-full` / `C_rag-routed`
- `_SECTOR_CELL_LABELS` dict — operator-readable cell descriptions
- `--sector-cells` CLI flag — comma-separated cell list, mutually exclusive with `--rows`; base row fixed to L1, sector dict overlays

## Cell taxonomy (matches α-6 design §2)

| Cell | S1 RAG | S2 Graph | S3 Preproc | S4 Cite | S5 Abst | S6 Cog |
|---|---|---|---|---|---|---|
| C_minus | OFF | OFF | OFF | OFF | OFF | OFF |
| C_rag-basic | ON | OFF | OFF | OFF | OFF | OFF |
| C_rag-cited | ON | OFF | OFF | ON | OFF | OFF |
| C_rag-graph | ON | ON | ON | ON | OFF | OFF |
| C_rag-full | ON | ON | ON | ON | ON | ON (= α-5 L1) |
| C_rag-routed | full + routing layers (= α-5 L5) | | | | | |

## Threading

Sector_cell parameter threaded through `_cell_env` / `_run_single_bench` / `_cell_output_path` / `_run_cell` and the main dispatch loop. Output JSONs use sector name in filename (`qvt-ablation-cell-C_minus-M_M.json`) and gain `sector_cell` + `sector_cell_label` metadata (schema-v3).

## Contract tests (10 cases)

- 6 standard cells registered
- C_minus disables all 5 sectors + S3 preprocessing
- C_rag-basic keeps S1 ON, disables others, S3 off
- C_rag-graph keeps S3 ON (preprocessing for graph), disables S5 + S6
- Unknown sector_cell raises ValueError
- sector_cell=None produces back-compat env (byte-identical)
- _cell_output_path uses sector name
- sanity_think_on + sector_cell composes

## Verification

- 31/31 tests pass (10 new sector-cells + 21 existing sector flag contracts)
- Dry-run smoke: `--sector-cells C_minus,C_rag-basic,C_rag-graph --dry-run` produces expected 3 cells
- Production paths (--rows / --tiers / --t0-smoke) byte-identical when sector flag not used

## Next step (handover Action 2)

```powershell
$env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
$env:PYTHONIOENCODING = "utf-8"

python scripts/qvt_ablation_matrix.py `
    --tiers M_M --suite multihop_rag --n-runs 1 `
    --sector-cells C_minus,C_rag-basic,C_rag-graph
```

3 new cells × ~110 min = ~5.5h. Answers the user's core question: "does each JAMES sector add value vs vanilla gemma4?"

## Out of scope

- Phase 1 measurement (separate operator action)
- Renderer update for sector-cell payloads (lands when first sector cell completes)
- Multi-tier backend / API providers (Phase 4+)

Quality delta: exempt (label: code — α-6 ablation infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)