### PR TITLE
docs(α-6): Phase 2 entry — tier-gated check at gemma3:4b (YYY)

### DIFF
--- a/docs/handovers/v0.4-alpha-6-phase-2-entry.md
+++ b/docs/handovers/v0.4-alpha-6-phase-2-entry.md
@@ -1,0 +1,144 @@
+# α-6 Phase 2 Entry — Tier-Gated Check (gemma3:4b)
+
+> **Status**: entry doc. Phase 2 is the natural follow-on to Phase 1
+> (in-flight task `ba3jwm9rt`) when Phase 1 verdict is **not null**.
+> Reuses the same 3 sector cells (`C_minus` / `C_rag-basic` /
+> `C_rag-graph`) at the smaller M_S tier (`gemma3:4b`) instead of
+> M_M (`gemma4:e4b`).
+>
+> **Trigger**: Phase 1 closure (analysis doc lands per template #665).
+> **Compute**: ~2-3 h on gemma3:4b (smaller model, faster
+> per-query than M_M's gemma4:e4b).
+> **Cost**: $0 (local Ollama).
+
+---
+
+## 0. The Phase 2 question
+
+*"Do smaller models (gemma3:4b) benefit MORE from JAMES sectors
+than the production-tier gemma4:e4b?"*
+
+The α-5 cycle was unable to answer this — only M_M was measured.
+The hypothesis (tier-gated routing): smaller models have weaker
+parametric knowledge, so retrieval / graph / citation should help
+them more in relative terms. If true, the routing policy becomes:
+- gemma3:4b (M_S, small) → full JAMES stack
+- gemma4:e4b (M_M, prod) → tunable per Phase 1 verdict
+- gemma3:12b (M_L, large) → maybe less stack helps (Phase 3 question)
+
+---
+
+## 1. Launch conditions (when Phase 2 makes sense)
+
+Run Phase 2 if Phase 1 shows one of these:
+
+| Phase 1 signal | Phase 2 recommended? | Why |
+|---|---|---|
+| Sectors add value at M_M (positive Δ progression) | **YES** | confirms whether small models gain even more |
+| Sectors null at M_M (all Δ within noise) | **MAYBE** | Phase 2 may surface small-model gains M_M masked |
+| Sectors regressive at M_M (negative Δ) | **NO** — bucket first | apply 4-step rule; defer Phase 2 |
+| Phase 1 has measurement artifacts (timeout cascade etc.) | **NO** | fix the measurement first |
+
+The decision matrix in the Phase 1 analysis template (#665) §6
+points to this doc when the trigger fires.
+
+---
+
+## 2. Launch command
+
+```powershell
+# Pre-flight: Ollama healthy (UUU lesson)
+Restart-Service Ollama
+ollama list  # gemma3:4b present + responsive
+
+$env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
+$env:PYTHONIOENCODING = "utf-8"
+$env:PYTHONUNBUFFERED = "1"
+
+python -u scripts/qvt_ablation_matrix.py `
+    --tiers M_S --suite multihop_rag --n-runs 1 `
+    --sector-cells C_minus,C_rag-basic,C_rag-graph
+```
+
+Same 3 cells, same suite (multihop_rag balanced-100), **tier
+switched** from `M_M` to `M_S`. Output filenames pick up the tier
+suffix:
+- `qvt-ablation-cell-C_minus-M_S.json`
+- `qvt-ablation-cell-C_rag-basic-M_S.json`
+- `qvt-ablation-cell-C_rag-graph-M_S.json`
+
+---
+
+## 3. Expected compute
+
+| Cell | Estimated time | Why |
+|---|---|---|
+| C_minus / M_S | ~15 min | smallest model + no retrieval |
+| C_rag-basic / M_S | ~25 min | + chroma retrieval |
+| C_rag-graph / M_S | ~35 min | + graph traversal + preproc |
+
+Total: **~75 min** (vs Phase 1's ~2-2.5h on M_M).
+
+gemma3:4b is ~2.5x smaller than gemma4:e4b parameters; expect
+proportionally faster per-query latency. If a cell exceeds 90 min
+on M_S, apply the 4-step rule (likely Ollama issue, not JAMES).
+
+---
+
+## 4. Reading the Phase 2 result
+
+Adopt the same Phase 1 template (#665) verbatim — change `M_M` to
+`M_S` and reuse the analysis sections. The new comparison is
+**Phase 2 sector progression vs Phase 1 sector progression**:
+
+| Reading | Tier-gated verdict |
+|---|---|
+| Phase 2 Δ steeper than Phase 1 Δ (small model gains more) | **Tier-gated routing recommended** — full JAMES for M_S, partial for M_M |
+| Phase 2 Δ similar to Phase 1 Δ | **Sectors are model-invariant** — same policy for both tiers |
+| Phase 2 Δ flatter than Phase 1 Δ (small model gains less) | **Surprise** — smaller model already capable without JAMES; investigate before generalising |
+
+The cycle's discipline applies: a "surprise" read triggers the
+4-step rule before any conclusion.
+
+---
+
+## 5. Decision tree (post-Phase 2)
+
+| Phase 2 verdict | Next step |
+|---|---|
+| Tier-gated routing recommended | File `feat(routing): tier-gated default — M_S → full stack` PR with Quality Delta Card citing both phases |
+| Sectors model-invariant | Phase 3a (gemma3 scale ladder 1b/4b/12b/27b) tests whether the invariance holds across more scales |
+| Surprise (M_S gains less) | Phase 3b (cross-family at qwen/llama/deepseek) — is the surprise gemma-specific or universal? |
+| Phase 2 hits timeout cascade (UUU pattern) | Restart Ollama + rerun once; if recurrent, escalate (likely Ollama/GPU issue) |
+
+---
+
+## 6. Out of scope for Phase 2
+
+- M_L tier (gemma3:12b) — separate phase (Phase 3a sub-step) to
+  avoid 3-tier compute commitment in one window
+- Cross-family models (qwen, llama, deepseek) — Phase 3b
+- API providers (claude/gpt/gemini) — Phase 4+
+- Routing layer × small model interaction — Phase 5/6
+
+---
+
+## 7. Operational gotchas (carry-over from cycle)
+
+- **Ollama healthcheck** before launch (UUU #656)
+- **`python -u`** for unbuffered stdout (UUU #656)
+- **4-step rule** on first cell JSON (memory `feedback_oracle_phrase_artifacts`)
+- **Per-layer intent verdict**, not uniform 5-axis (CLAUDE.md rule 2 #652)
+- **No DOI bump** during this phase (SSS #655)
+
+---
+
+## 8. References
+
+- α-6 design memo: `docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md`
+- Phase 1 analysis template: `reports/research-runs/alpha-6-phase-1-analysis-TEMPLATE.md` (#665)
+- Matrix runner sector cells: PR #663
+- Renderer sector cells: PR #664
+- Phase 2 trigger: Phase 1 closure analysis doc
+- Phase 3 (scale ladder + cross-family): α-6 design §3 sub-phases
+- UUU timeout cascade post-mortem: `reports/research-runs/t1-timeout-cascade-postmortem-2026-06-01.md`


### PR DESCRIPTION
## Summary

Entry doc for the natural Phase 1 follow-on. When Phase 1 analysis (template #665) shows non-null signal, Phase 2 reuses the same 3 sector cells at M_S (gemma3:4b) instead of M_M (gemma4:e4b).

## The Phase 2 question

*"Do smaller models benefit MORE from JAMES sectors than the production tier?"* — the tier-gated routing hypothesis α-5 could not answer because only M_M was measured.

## Launch trigger matrix (§1)

| Phase 1 signal | Phase 2 recommended? |
|---|---|
| Sectors add value at M_M | **YES** |
| Sectors null at M_M | **MAYBE** (may surface small-model gains) |
| Sectors regressive at M_M | **NO** — bucket first via 4-step rule |
| Phase 1 has measurement artifacts | **NO** — fix measurement first |

## Compute estimate

~75 min total (smaller model is proportionally faster):
- C_minus / M_S: ~15 min
- C_rag-basic / M_S: ~25 min
- C_rag-graph / M_S: ~35 min

vs Phase 1's ~2-2.5h on M_M.

## Decision tree post-Phase 2 (§5)

| Verdict | Next |
|---|---|
| Tier-gated routing | file routing default PR with both phases as evidence |
| Sectors model-invariant | Phase 3a (gemma3 scale ladder) |
| Surprise (M_S gains less) | Phase 3b (cross-family) |
| Timeout cascade | Ollama restart + rerun (UUU pattern) |

## Verification

- No code change. Entry doc only.
- Cross-references: α-6 design memo, Phase 1 template (#665), matrix runner (#663), renderer (#664), UUU post-mortem (#656)
- All operational gotchas from the cycle pinned (Ollama healthcheck, python -u, 4-step rule, per-layer intent verdict, DOI hold)

## Out of scope

- M_L tier (Phase 3a sub-step)
- Cross-family models (Phase 3b)
- API providers (Phase 4+)
- Routing × small-model interaction (Phase 5/6)

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)