### PR TITLE
feat(α-6): matrix runner — add M_XS / M_XL tiers for Phase 3a scale ladder

### DIFF
--- a/docs/handovers/v0.4-next-session-entry-2026-06-01-PM.md
+++ b/docs/handovers/v0.4-next-session-entry-2026-06-01-PM.md
@@ -19,8 +19,10 @@
   floor** (gemma3 scale ladder).
 - **Cumulative JAMES code change against α-5+α-6 measurement debt**:
   **0 lines**.
-- **Cumulative wrong-fix-averted**: **8** (7 in α-5 + 1 in α-6
-  Phase 2 rate-limit corruption).
+- **Cumulative wrong-fix-averted**: **9** (7 in α-5 + 1 in α-6
+  Phase 2 rate-limit corruption + 1 in α-6 Phase 3a matrix runner
+  tier→model silent substitution, PR #677). 9th sub-pattern variant:
+  "wrong measurement averted" rather than "wrong code fix averted".
 
 ---
 
@@ -98,20 +100,37 @@ ollama list  # gemma3:1b / 4b / 12b / 27b should respond snappy
 
 Goal: localize the S5+S6 capability floor.
 
+**Tier flag, NOT env var** — `qvt_ablation_matrix.py` overrides
+`JAMES_LLM_MODEL` from `_TIER_MODELS[tier]` in `_build_env` (line 411),
+so `$env:JAMES_LLM_MODEL = ...` was silently ignored. PR #677 added the
+M_XS / M_XL tier mappings so `--tiers M_XS / M_L / M_XL` resolves to
+gemma3:1b / 12b / 27b directly. Cell filenames also get distinct
+`-M_XS` / `-M_L` / `-M_XL` suffixes — no collision with canonical
+Phase 2 `M_S = gemma3:4b` cells.
+
 ```powershell
 $env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
 $env:PYTHONIOENCODING = "utf-8"
 $env:PYTHONUNBUFFERED = "1"
 
-# Step 1 — gemma3:1b (extreme small tier)
-$env:JAMES_LLM_MODEL = "gemma3:1b"
+# Step 1 — gemma3:1b via M_XS tier (extreme small / below-floor probe)
 python -u scripts/qvt_ablation_matrix.py `
-    --tiers M_S --suite multihop_rag --n-runs 1 `
+    --tiers M_XS --suite multihop_rag --n-runs 1 `
     --sector-cells C_minus,C_rag-full
-# ~10-15 min compute (very fast, watch for rate limit)
-```
+# ~10-15 min compute (fast on 1b; watch for rate limit)
 
-Then repeat with `gemma3:12b` and `gemma3:27b` (each ~30-90 min).
+# Step 2 — gemma3:12b via M_L tier (ladder midpoint)
+python -u scripts/qvt_ablation_matrix.py `
+    --tiers M_L --suite multihop_rag --n-runs 1 `
+    --sector-cells C_minus,C_rag-full
+# ~30-90 min compute
+
+# Step 3 — gemma3:27b via M_XL tier (saturation point probe)
+python -u scripts/qvt_ablation_matrix.py `
+    --tiers M_XL --suite multihop_rag --n-runs 1 `
+    --sector-cells C_minus,C_rag-full
+# ~30-90 min compute
+```
 
 **ETA total**: 2.5-3.5h (much less than the original 12-18h estimate
 because we only run 2 cells per scale — C_minus + C_rag-full — not
@@ -120,10 +139,18 @@ the full sector ablation).
 ### Action 2 — Phase 3a analysis (post-completion)
 
 ```powershell
-# Per scale point:
+# Per scale point — match --tier to the tier you ran the cells under:
 python scripts/alpha6_fill_phase1.py `
-    --tier M_S --phase-label "Phase 3a (gemma3:1b)" `
+    --tier M_XS --phase-label "Phase 3a (gemma3:1b)" `
     --out reports/research-runs/alpha-6-phase-3a-gemma3-1b-analysis-20260602.md
+
+python scripts/alpha6_fill_phase1.py `
+    --tier M_L --phase-label "Phase 3a (gemma3:12b)" `
+    --out reports/research-runs/alpha-6-phase-3a-gemma3-12b-analysis-20260602.md
+
+python scripts/alpha6_fill_phase1.py `
+    --tier M_XL --phase-label "Phase 3a (gemma3:27b)" `
+    --out reports/research-runs/alpha-6-phase-3a-gemma3-27b-analysis-20260602.md
 
 # Then a separate combined view doc (manual)
 # showing the recovery curve across 1b/4b/12b/e4b/27b
@@ -175,6 +202,15 @@ capability floor signal.
 5. **`fix` label exemption for measurement-side PRs** — CLAUDE.md
    rule 2 `fix` exemption. PRs correcting oracle / fixture / bench /
    matrix-runner wiring state `Quality delta: exempt (label: fix)`.
+
+6. **Matrix runner tier→model is hardcoded** (#677, 9th wrong-fix-
+   averted, before-launch variant) — `_TIER_MODELS[tier]` overwrites
+   `JAMES_LLM_MODEL` in `_build_env`. Use `--tiers <tier>` only; env
+   var override is inert. Cell filenames key on tier letter (not
+   model tag), so same-tier-different-model runs collide — backup
+   first. Caught here by latency arithmetic (1-2s expected on 1b →
+   12-26s on C_rag-full meant 4b was running). See memory
+   `feedback_matrix_runner_tier_model_override`.
 
 6. **DOI hold** — no new JAMES Zenodo DOI until T3 ships AND
    mid-June joint piece framing confirmed (per SSS #655 4-question

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -5,7 +5,9 @@ Implements the matrix specified in
 
   6 layer rows  (L0 floor / L1 baseline / L2 +AUTO_ROUTER /
                  L3 +ADAPTIVE_BUDGET / L4 +SCOPE_ROUTING / L5 full)
-  3 model tiers (M_S gemma3:4b / M_M gemma4:e4b / M_L gemma3:12b)
+  5 model tiers (M_XS gemma3:1b / M_S gemma3:4b / M_M gemma4:e4b /
+                 M_L gemma3:12b / M_XL gemma3:27b)  -- α-6 Phase 3a
+                 added M_XS / M_XL for the gemma3 scale ladder
   × paired N=3 reruns
   × 3-axis QVT oracle (path / graded / abstention)
   = 18 cells × ~66 min ≈ 20 hours operator-side compute.
@@ -233,11 +235,13 @@ _SECTOR_CELL_LABELS: Dict[str, str] = {
 }
 
 
-# Model tier → Ollama tag (memo §2.2)
+# Model tier → Ollama tag (memo §2.2; α-6 Phase 3a adds M_XS / M_XL)
 _TIER_MODELS: Dict[str, str] = {
+    "M_XS": "gemma3:1b",   # α-6 Phase 3a — extreme small (capability floor probe)
     "M_S": "gemma3:4b",
     "M_M": "gemma4:e4b",   # production default; α-3 baseline tier
     "M_L": "gemma3:12b",
+    "M_XL": "gemma3:27b",  # α-6 Phase 3a — large (saturation point probe)
 }
 
 
@@ -982,7 +986,8 @@ def _render_report(out_path: Path) -> int:
         rows.append("|---|---|---|---|")
 
         _VERDICT_RANK = {"strong-adopt": 3, "adopt": 2, "efficiency-adopt": 1}
-        _TIER_RANK = {"M_M": 3, "M_S": 2, "M_L": 1}  # prefer production
+        _TIER_RANK = {"M_M": 3, "M_S": 2, "M_L": 1,
+                      "M_XS": 0, "M_XL": 0}  # prefer production; α-6 scale-ladder tiers tied last
         for qt in all_qts_sorted:
             winners = per_type_winners[qt]
             if not winners:
@@ -1142,7 +1147,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     parser.add_argument(
         "--tiers", type=str, default=None,
-        help="Comma-separated subset of M_S/M_M/M_L (default: all).",
+        help="Comma-separated subset of M_XS/M_S/M_M/M_L/M_XL (default: all).",
     )
     parser.add_argument(
         "--resume", action="store_true",


### PR DESCRIPTION
## Summary

- Adds two missing scale-ladder tiers to `_TIER_MODELS`: **M_XS = gemma3:1b** (below-floor probe) and **M_XL = gemma3:27b** (saturation probe). M_L = gemma3:12b already mapped, reused for ladder midpoint.
- Fixes the silent-data-corruption trap surfaced when the Phase 3a handover doc launch command (`$env:JAMES_LLM_MODEL = "gemma3:1b"; ... --tiers M_S`) ran the wrong model: `_build_env` (line 411) overwrites `JAMES_LLM_MODEL` from the tier map regardless of any externally-set value, so the env override was inert.
- Updates `_TIER_RANK` (M_XS / M_XL tied last after production M_M), argparse help string, and module docstring header.

## Verification

```powershell
$env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
python scripts/qvt_ablation_matrix.py --tiers M_XS --suite multihop_rag `
    --n-runs 1 --sector-cells C_minus,C_rag-full --dry-run
```

→ ``tiers:      ['M_XS']  → ['gemma3:1b']``
→ ``C_minus/M_XS model=gemma3:1b``
→ ``C_rag-full/M_XS model=gemma3:1b``

Output filename naming (`qvt-ablation-cell-{sector_cell}-{tier}.json`) now resolves to distinct `-M_XS` / `-M_L` / `-M_XL` paths — Phase 3a never collides with the canonical Phase 2 `M_S = gemma3:4b` cells.

## How this was caught (8th wrong-fix-averted pattern, before-launch variant)

Started the handover-documented Phase 3a 1b launch in background; the matrix runner cell descriptor log showed `model=gemma3:4b` instead of `gemma3:1b`, and per-query latency rose from 1-2s (expected for 1b) to 12-26s (consistent with 4b on the C_rag-full cell). The 4-step rule arithmetic extension (#671 lesson) made the latency anomaly easy to bucket: "raw timing doesn't match the expected scale → check upstream config." Stopped the run at query 33/100 (~30 min sunk on duplicate Phase 2 data), grep'd `_TIER_MODELS`, found the override at line 411, added M_XS / M_XL.

## Out of scope

- Cross-family tiers (qwen2.5:7b / llama3.1:8b / deepseek-v2:16b) for Phase 3b — deferred until Phase 3a confirms a clean capability floor signal worth disambiguating across families.
- Updating the handover doc's launch command — will be amended in the Phase 3a closure PR with the corrected `--tiers M_XS / M_L / M_XL` form.

Quality delta: exempt (label: fix) — measurement infrastructure enabler; the per-tier cell numbers are exactly what the PR enables producing, so a Quality Delta Card here would be circular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)