### PR TITLE
docs(α-7): next session entry handover — α-7 launch ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,15 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
   QVT α track. v0.2.0 (Foundation Hardening) and v0.3.0
   (Platform Skeleton) both fully closed; v0.4.0 (Layer 4 Lifecycle:
   T1+T7+T2 first bundle) shipped 2026-05-27.
-- **Active theme**: **α-6 measurement cycle in flight (Phase 3a)** —
-  MultiHop-RAG external benchmark, 5-axis Pareto oracle, scale-ladder
-  measurement of JAMES sector contributions across gemma3 1b/4b/12b/27b
-  + gemma4 e4b. Phase 1 + Phase 2 closed (2026-06-01 AM); Phase 3a
-  scale ladder running. Closure → α-7 (graph top-K fix) → α-8 (ontology
-  typed-filter A/B). Domain pilot (v0.5) still gated.
+- **Active theme**: **α-7 — graph top-K filter** (first JAMES code
+  change against α-5+α-6 measurement debt; design memo at
+  `docs/design/v0.4-alpha-7-graph-topk.md`, sub-finding bucket-(d)
+  oracle phrase add at `reports/research-runs/alpha-7-bucket-d-oracle-phrase-gap.md`).
+  α-6 cycle closed 2026-06-01 PM (PR #678) with 5-point S4 universal-law
+  candidate, 5-mode taxonomy (cycle-specific empirical), 9 wrong-fix-
+  averted, 0 JAMES code lines changed. Sequence: α-7 → 5-tier mode
+  re-measurement → Phase 3b proper (5 families × n=3) → α-8 ontology.
+  Domain pilot (v0.5) still gated.
 - **Strategic frame**: We are still building a **mother platform**;
   v1.0 vertical domain branching remains the only authorised
   specialisation point. The 2026-06-01 strategic discussion narrowed
@@ -108,7 +111,8 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 
 | Purpose | File |
 |---|---|
-| **🟢 NEXT SESSION ENTRY (read this first)** | **`docs/handovers/v0.4-next-session-entry-2026-06-01-PM.md`** |
+| **🟢 NEXT SESSION ENTRY (read this first)** | **`docs/handovers/v0.4-next-session-entry-2026-06-02-alpha7.md`** |
+| Previous session entry (Phase 3a launch — now sealed) | `docs/handovers/v0.4-next-session-entry-2026-06-01-PM.md` |
 | Strategic vision + 6-dimension readiness | `docs/PLATFORM_READINESS.md` |
 | Architecture & non-goals | `docs/ARCHITECTURE.md` |
 | 6-axis v0.2 plan + future v0.3/v0.4/v1.0 | `ROADMAP.md` |
@@ -161,4 +165,4 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 
 자메스는 **v1.0까지 "범용 모체"로만** 강화합니다. 도메인 분화(법률·식품·유통·여행 등)는 v1.0 이후에만 시작합니다. 이 세션에서 도메인 코드를 추가하지 마세요.
 
-**현재 위치**: v0.4.1 완료 (DOI `10.5281/zenodo.20426719`) → α-6 측정 사이클 Phase 3a 진행 중 (gemma3 1b/12b/27b scale ladder). 다음 사이클 순서: α-7 (graph top-K fix) → α-8 (온톨로지 typed-filter A/B). v0.5 첫 도메인 후보 = 기업 내부지식 온톨로지 (수평 — 도메인 vertical 아님). 자세한 내용은 `docs/PLATFORM_READINESS.md` + `ROADMAP.md` + `docs/handovers/v0.4.x-backlog-reconciliation-2026-05-30.md`.
+**현재 위치**: v0.4.1 완료 (DOI `10.5281/zenodo.20426719`) → α-6 사이클 closed 2026-06-01 PM (PR #678, 5-point S4 universal candidate + 5-mode taxonomy cycle-specific empirical). 다음 사이클 순서: α-7 (graph top-K fix, design memo 있음) → α-7 5-tier mode re-measurement → Phase 3b proper (5 families × n=3 ≈ 45h) → α-8 ontology typed-filter. v0.5 첫 도메인 후보 = 기업 내부지식 ontology (수평 — vertical 아님). 다음 세션 entry: `docs/handovers/v0.4-next-session-entry-2026-06-02-alpha7.md`. 자세한 내용은 `docs/PLATFORM_READINESS.md` + `ROADMAP.md`.

--- a/docs/handovers/v0.4-next-session-entry-2026-06-02-alpha7.md
+++ b/docs/handovers/v0.4-next-session-entry-2026-06-02-alpha7.md
@@ -1,0 +1,353 @@
+# Next Session Entry — α-7 Graph Top-K Ready
+
+> **Status**: α-6 cycle closed (PR #678 merged into `main` at `9a8a018`,
+> 2026-06-01 PM). α-7 graph top-K fix is the natural next launch, per
+> P3 sequencing decision.
+> **Cycle PRs landed this session**: 11 commits squash-merged as PR #678
+> **Project total**: 79+ PRs (#608 → #678+)
+>
+> **Resume entry point**: read this file → confirm Ollama healthy →
+> execute §4 first command (α-7 implementation).
+
+---
+
+## 0. Where the project is
+
+- **Version**: v0.4.1 (latest minted DOI `10.5281/zenodo.20426719`).
+  α-6 measurement cycle is now **closed**; no version bump required
+  (measurement / methodology only).
+- **Active theme**: α-7 — **graph top-K filter implementation** (first
+  JAMES code change against α-5 + α-6 measurement debt — 8 wrong-fix-
+  averted so far, 0 lines of JAMES code changed).
+- **Cumulative JAMES code change against measurement debt**: **0
+  lines** (α-5: 0, α-6: 0). α-7 ships the first code change.
+- **Cumulative wrong-fix-averted**: **9** (7 in α-5 + 1 in α-6 Phase 2
+  rate-limit + 1 in α-6 Phase 3a matrix runner tier override).
+- **Cycle order (per P3, 2026-06-01)**: α-7 → α-7 5-tier mode
+  re-measurement → Phase 3b proper (5 families × n=3) → α-8 ontology.
+
+---
+
+## 1. Headline findings from α-6 (sealed; for orientation)
+
+⭐⭐⭐ **candidate** — S4 citation path Δ +0.41 tier-invariant 5-point
+series across 1b/4b/12b/27b/e4b (27× model size, 2 families). Within
+±0.012; pure-LLM abst_f1 correlation ≈ 0 → structural primitive.
+Validated universal-law requires cross-fixture + Phase 3b cross-family.
+
+⭐⭐ **partial mechanism** — JAMES S5+S6 disruption via source-file
+injection. 27b C_rag-full audit (24/24 oracle-FN are real
+hallucinations starting with `Source files: multihop_...` injection)
+suggests N source filenames in prompt commit model to answer rather
+than refuse. **Cycle-specific empirical**; mode pattern expected to
+reshape under α-7 graph top-K.
+
+⭐ **operational** — routing rule data:
+- 1b / 4b / 27b: citation-only (S5+S6 hurt or no effect)
+- 12b / e4b: full stack adopt
+- All graded Δs confounded by graph-bug (Phase 1 §3) → α-7 fixes this
+
+❌ **Withdrawn**: "JAMES amplifier", "inverted-U capability floor",
+"capability floor between 4b and e4b", "gemma3-vs-gemma4 family-only".
+
+---
+
+## 2. P3 sequencing preview
+
+```
+α-6 closure ✅ (PR #678 merged)
+    ↓
+α-7 — graph top-K fix (next; this session)
+    [design memo: docs/design/v0.4-alpha-7-graph-topk.md]
+    [scope: core/graph_topk.py (new ~3 KB) + DFS_SCORE_THRESHOLD 0.05→0.08]
+    [+ bucket-(d) phrase add (doesn't link) per alpha-7-bucket-d-oracle-phrase-gap.md]
+    [re-baseline ~107 min, 5-axis QDC]
+    ↓
+α-7 5-tier mode re-measurement (mandatory subtask)
+    [1b/4b/12b/27b/e4b × C_minus + C_rag-full = 10 cells × ~variable]
+    [confirms whether α-6 mode taxonomy survives context reshape]
+    ↓
+Phase 3b pre-work — cross-family refusal phrase inventory
+    [task #10; ~2-3h, can run in parallel with α-7 implementation]
+    [5 families: qwen2.5:7b / llama3.1:8b / deepseek-v2:16b / gemma2:2b / qwen2.5-coder:7b]
+    [oracle phrase add per family if any new patterns]
+    ↓
+Phase 3b proper measurement
+    [5 families × 2 cells × n=3 = 30 cell-runs ≈ ~45h compute]
+    ↓
+α-8 ontology typed-filter
+    [design memo: docs/design/v0.4-alpha-8-ontology-typed-filter.md]
+```
+
+---
+
+## 3. What just landed this session (PR #678, 11 commits)
+
+| # | Commit | Theme |
+|---|---|---|
+| 1 | `ac9670d` | Phase 3a 1b analysis + script choices |
+| 2 | `492b28e` | Phase 3a 12b analysis (honest framing) |
+| 3 | `be2fb64` | bench/matrix timeout env overrides (27b GPU/CPU split) |
+| 4 | `85beb6e` | recovery curve skeleton + 1b reconciliation header |
+| 5 | `0528f27` | CLAUDE.md sync to v0.4.1 + α-6 |
+| 6 | `6ac76dd` | α-7 + α-8 design memos (no code) |
+| 7 | `7250699` | ROADMAP α-6/α-7/α-8 + sequencing |
+| 8 | `4a5a60c` | Phase 3a 27b skeleton (pre-bench) |
+| 9 | `f9938a0` | 4-step audit on 12b (dip → plateau) |
+| 10 | `e340cfe` | cycle PR index + α-7 bucket-(d) sub-finding |
+| 11 | `efa2351` | Phase 3a 27b analysis + recovery curve 5-point closure |
+
+Memory entries saved:
+- `feedback_alpha6_findings_mostly_known_to_literature`
+- `feedback_james_mode_taxonomy_context_dependent`
+- `feedback_graph_layer_top_k_debt`
+- `project_alpha_7_alpha_8_ontology_track_sequencing`
+
+---
+
+## 4. First actions next session (in order)
+
+### Action 0 — Ollama healthcheck (mandatory carry-over)
+
+```powershell
+Restart-Service Ollama
+ollama list  # gemma3:1b/4b/12b/27b + gemma4:e4b should respond
+```
+
+### Action 1 — Read α-7 design memo
+
+`docs/design/v0.4-alpha-7-graph-topk.md` — full scope, 8 open decisions, mechanism rationale.
+
+Decision points to confirm before implementation:
+
+| # | Decision | Recommendation |
+|---|---|---|
+| 1 | DEFAULT_TOP_K value | 10 |
+| 2 | DFS_SCORE_THRESHOLD value | 0.08 |
+| 3 | Per-depth top-K | deferred |
+| 4 | A/B split (K-only / threshold-only / combined) | single PR with combined |
+| 5 | Sub-finding investigation gate | if `graded Δ < +0.015` after combined |
+
+### Action 2 — α-7 implementation (single PR)
+
+Branch: `feat/v0.4-alpha7-graph-topk`. Sequence:
+
+1. Create `core/graph_topk.py` (~3 KB target):
+   ```python
+   from typing import Dict, List, Tuple
+   DEFAULT_TOP_K = 10
+   def top_k_filter(entities, paths, k=DEFAULT_TOP_K) -> Tuple[List[Dict], List[str]]:
+       # rank by _dfs_score descending, keep top-K, drop paths whose tail dropped
+   ```
+
+2. Edit `core/graph_engine.py:expand_dynamic`:
+   ```python
+   - return entities, paths
+   + from core.graph_topk import top_k_filter
+   + return top_k_filter(entities, paths)
+   ```
+
+3. Edit `core/graph_engine.py:38`:
+   ```python
+   - DFS_SCORE_THRESHOLD = 0.05
+   + DFS_SCORE_THRESHOLD = 0.08
+   ```
+
+4. Add bucket-(d) phrase to `eval/qvt/oracle.py:_ABSTENTION_PHRASES`:
+   - `data doesn't link` / `data does not link` / `data doesn't explicitly link` (per `reports/research-runs/alpha-7-bucket-d-oracle-phrase-gap.md`)
+
+5. ARCHITECTURE.md graph subsystem section update (architecture label).
+
+6. Unit tests for `top_k_filter` round-trip (`tests/test_graph_topk.py`).
+
+### Action 3 — α-7 baseline + Quality Delta Card
+
+```powershell
+$env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
+$env:PYTHONIOENCODING = "utf-8"
+
+python scripts/qvt_capture_baseline.py --suite multihop_rag
+# ~107 min compute; writes eval/qvt/baseline_<new-sha>_rescored.json
+```
+
+Then 5-axis Quality Delta Card per PR template. Acceptance band:
+- `graded_answer Δ ≥ +0.030` → adopt
+- `+0.010 ≤ graded Δ < +0.030` → tier-gated
+- `< +0.010` → reject + sub-finding investigation
+
+### Action 4 — α-7 5-tier mode re-measurement
+
+After α-7 lands, re-measure all 5 tiers to test mode stability:
+
+```powershell
+foreach ($tier in 'M_XS', 'M_S', 'M_M', 'M_L', 'M_XL') {
+    $env:JAMES_WORKSPACE = "./workspaces/hotpot_eval"
+    python scripts/qvt_ablation_matrix.py `
+        --tiers $tier --suite multihop_rag --n-runs 1 `
+        --sector-cells C_minus,C_rag-full
+}
+```
+
+Compare against α-6 5-mode picture (recovery curve doc §3). Expected
+mode reshape if mechanism hypothesis (§3.2 of 27b doc) is correct.
+
+### Action 5 — Phase 3b pre-work (parallel)
+
+`task #10`: gather cross-family refusal phrase inventory.
+Per family, 5-10 null query against pure model, audit answers,
+narrowly add any new phrases to oracle (bucket-(d) sub-finding).
+
+### Action 6 — Phase 3b design memo update + Phase 3b proper launch
+
+After α-7 closure + 5-tier re-measurement + pre-work complete:
+- Update `task #11` design memo with concrete cell envs + ETA estimate
+- Launch Phase 3b proper (~45h compute, 30 cell-runs)
+
+### Action 7 — α-7 / Phase 3b closure → α-8 entry
+
+α-8 entry doc + design memo already exists (`docs/design/v0.4-alpha-8-ontology-typed-filter.md`). Implementation gated on Phase 3b closure.
+
+---
+
+## 5. Critical gotchas (carry-over + new)
+
+1. **4-step rule + arithmetic step** — same as before (recovery curve
+   doc §3.1 demonstrates how to apply it).
+
+2. **Per-layer intent verdict, not uniform 5-axis** — CLAUDE.md rule 2
+   layer-intent extension (#652).
+
+3. **Rate-limit env now bypassed in matrix runner** (#672).
+
+4. **DON'T frame methodology as Replayable RAG validation** —
+   position guard `feedback_jameses_positioning_replayable_rag` §정정 2026-05-31.
+
+5. **`fix` label exemption for measurement-side PRs** — CLAUDE.md rule 2.
+
+6. **Matrix runner tier→model hardcoded** (#677) — use `--tiers`, env
+   var override inert. Cell filenames key on tier letter only —
+   backup before same-tier-different-model runs.
+   `feedback_matrix_runner_tier_model_override`.
+
+7. **Mode taxonomy is cycle-specific empirical** — α-7 / α-8 reshape
+   expected. Don't promote 5-mode to universal claim without α-7
+   5-tier remeasurement + Phase 3b cross-family.
+   `feedback_james_mode_taxonomy_context_dependent`.
+
+8. **Honest framing rule** — apply tier (trivial/partial/novel) to
+   every closure / publishable claim.
+   `feedback_finding_size_honest_framing`.
+
+9. **NEW (α-7)**: `core/graph_engine.py` is at 20923 bytes (20.4 KB) —
+   already 0.4 KB over the 20 KB gate. New α-7 logic MUST live in a
+   new module (`core/graph_topk.py`), not extend graph_engine.
+   Or split graph_engine first (1-2 day refactor).
+
+---
+
+## 6. Memory entries to read on entry
+
+- `feedback_oracle_phrase_artifacts` — 4-step rule + arithmetic step
+- `mechanism_layer_intent_axis_alignment` — per-layer intent matrix
+- `feedback_jameses_positioning_replayable_rag` (정정 2026-05-31) —
+  mother framing primary
+- `feedback_intent_vehicle_gap_collective_archival` — Vehicle separation (DOI hold)
+- **NEW** `feedback_finding_size_honest_framing` — every closure must
+  tier-tag findings
+- **NEW** `feedback_matrix_runner_tier_model_override` — measurement
+  infra trap (matrix runner only respects `--tiers`)
+- **NEW** `feedback_alpha6_findings_mostly_known_to_literature` —
+  α-6 발견 학계 매핑 (don't overclaim)
+- **NEW** `feedback_james_mode_taxonomy_context_dependent` — Mode 의
+  context shape 의존성 (don't promote to universal without α-7 + Phase 3b)
+- **NEW** `feedback_graph_layer_top_k_debt` — all graded Δs are
+  graph-bug-confounded; α-7 fixes
+- **NEW** `project_alpha_7_alpha_8_ontology_track_sequencing` —
+  P3 잠정 결정 + trigger 조건
+
+---
+
+## 7. Quick orientation queries
+
+```powershell
+# What's on main?
+git log --oneline -5
+
+# Recovery curve doc (post-α-6 sealed state)
+cat reports/research-runs/alpha-6-phase-3a-recovery-curve-20260601.md
+
+# α-7 design memo (this session's primary read)
+cat docs/design/v0.4-alpha-7-graph-topk.md
+
+# α-7 bucket-(d) sub-finding (oracle phrase add)
+cat reports/research-runs/alpha-7-bucket-d-oracle-phrase-gap.md
+```
+
+---
+
+## 8. Done condition for next session
+
+- [ ] Action 0 (Ollama healthy) confirmed
+- [ ] Action 1 — α-7 design memo read + 5 open decisions confirmed
+- [ ] Action 2 — α-7 implementation PR drafted
+- [ ] Action 3 — α-7 baseline + Quality Delta Card collected
+- [ ] α-7 PR merged into main
+- [ ] Action 4 — 5-tier mode re-measurement complete; recovery curve
+      doc §3 updated with α-7-post mode picture
+- [ ] (optional) Action 5 — cross-family refusal phrase inventory
+      started in parallel
+
+If Actions 0-4 land, α-7 cycle officially closes. α-7 closure PR
+should mirror Phase 3a closure pattern (analysis docs + recovery
+curve update + memory entries + entry doc for next session).
+
+---
+
+## 9. After-cycle follow-up tracks (still gated)
+
+| Track | Trigger |
+|---|---|
+| Phase 3b proper measurement | α-7 closure + 5-tier remeasurement + pre-work done |
+| α-8 ontology typed-filter | Phase 3b closure |
+| T3 Evidence Aging | parallel; can land in any cycle |
+| MultiHop-RAG paper baseline reproduction | independent ~5h; runnable in parallel |
+| Cross-fixture sanity for S4 universal | post-α-7; uses HotpotQA / MuSiQue |
+| DOI bump | T3 ship + mid-June joint piece framing |
+| Joint piece preprint | 6/6+ Ali resume + framing confirmation |
+
+---
+
+## 10. References (single source of truth)
+
+- α-7 design memo: `docs/design/v0.4-alpha-7-graph-topk.md`
+- α-8 design memo: `docs/design/v0.4-alpha-8-ontology-typed-filter.md`
+- α-7 bucket-(d) sub-finding: `reports/research-runs/alpha-7-bucket-d-oracle-phrase-gap.md`
+- α-6 cycle PR index (10 commits + this PR): `reports/research-runs/alpha-6-cycle-pr-index.md`
+- Phase 3a 1b analysis (reconciliation header): `reports/research-runs/alpha-6-phase-3a-gemma3-1b-analysis-20260601.md`
+- Phase 3a 12b analysis (honest framing): `reports/research-runs/alpha-6-phase-3a-gemma3-12b-analysis-20260601.md`
+- Phase 3a 27b analysis (audit + mechanism): `reports/research-runs/alpha-6-phase-3a-gemma3-27b-analysis-20260601.md`
+- Phase 3a recovery curve (5-point S4 series): `reports/research-runs/alpha-6-phase-3a-recovery-curve-20260601.md`
+- ROADMAP α-6/α-7/α-8: `ROADMAP.md` (post-α-5 section)
+- CLAUDE.md sync: §"Where we are right now" + §"Where to look next"
+- 4-step audit script: `scripts/research/audit_12b_null_query_refusal_shape.py`
+- Previous session entry: `docs/handovers/v0.4-next-session-entry-2026-06-01-PM.md` (Phase 3a launch — now sealed)
+
+---
+
+## 11. End-of-session sign-off
+
+α-6 cycle cumulative:
+- **24+ landed PRs** through #678 (#608 → #678)
+- **5 publishable findings tier-tagged** (1 ⭐⭐⭐ candidate + 2 ⭐⭐ partial + 2 ⭐ operational)
+- **4 framing claims withdrawn** with traceability
+- **9 wrong-fix-averted**
+- **0 JAMES code lines changed** against measurement debt
+- **8 memory entries** added across cycle (5 in this session)
+
+α-7 is the natural next launch. Estimated 1-2 days work for the
+implementation PR, ~107 min for re-baseline, ~30 min for QDC.
+5-tier mode re-measurement is ~5-8h compute (single-bench-per-tier,
+mostly fast at think=OFF).
+
+Good handoff. Next session starts cold by reading this file +
+running Action 0.


### PR DESCRIPTION
## Summary

Post-α-6 cycle closure (PR #678), this handover stages α-7 (graph top-K fix) as the next session's launch point per the P3 sequencing decision.

- `docs/handovers/v0.4-next-session-entry-2026-06-02-alpha7.md` — new entry doc
- `CLAUDE.md` — "Where to look next" first row + "Active theme" updated; previous entry preserved as sealed reference

## Content

The entry doc mirrors the 2026-06-01-PM Phase 3a launch doc pattern, with sections for:
- α-6 sealed findings (5 tier-tagged + 4 withdrawn for orientation)
- P3 sequencing preview (α-7 → 5-tier remeasurement → Phase 3b proper → α-8)
- 7 concrete actions (Ollama healthcheck through α-8 entry)
- α-7-specific gotcha — `core/graph_engine.py` already 20.4 KB over the 20 KB gate; new α-7 logic MUST live in `core/graph_topk.py`
- 9 memory entries to read on entry (5 new this session)

## Verification

```powershell
# Confirm the entry doc is reachable from CLAUDE.md
grep "v0.4-next-session-entry-2026-06-02-alpha7" CLAUDE.md
```

## Out of scope

- α-7 implementation (next session's work)
- Cross-fixture / Phase 3b launch
- Architecture changes

Quality delta: exempt (label: docs) — session-handover only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)