### PR TITLE
chore: ruff F-class lint cleanup — unused imports + empty f-strings + dead var

### DIFF
--- a/scripts/hotpot/ingest_corpus.py
+++ b/scripts/hotpot/ingest_corpus.py
@@ -34,9 +34,8 @@ import subprocess
 import sys
 import time
 import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
@@ -298,7 +297,7 @@ def main() -> int:
     print(f"think-off: {os.environ.get('JAMES_GEMMA4_E4B_THINK_OFF', '<unset>')}")
     print(f"embedding: {os.environ.get('JAMES_EMBEDDING_MODEL', '<default>')}")
     if args.dry_run:
-        print(f"[dry-run] first 3 files:")
+        print("[dry-run] first 3 files:")
         for p in files[:3]:
             print(f"  {p.name} ({p.stat().st_size} bytes)")
         return 0

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -1335,7 +1335,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             cost_axes = ("token_cost", "latency_cost")
             quality_d = {ax: round(_med(j5, ax) - _med(j1, ax), 4) for ax in quality_axes}
             cost_d = {ax: round(_med(j5, ax) - _med(j1, ax), 4) for ax in cost_axes}
-            print(f"\n=== T0 smoke verdict (5-axis) ===")
+            print("\n=== T0 smoke verdict (5-axis) ===")
             for ax, d in quality_d.items():
                 print(f"  {ax:15s} L1={_med(j1, ax):.4f} L5={_med(j5, ax):.4f} Δ={d:+.4f}")
             for ax, d in cost_d.items():
@@ -1370,8 +1370,8 @@ def main(argv: Optional[List[str]] = None) -> int:
                     "Proceed to T1 + likely T2 for tier-gating decisions."
                 )
 
-    print(f"\nRender the consolidated report with:\n"
-          f"  python scripts/qvt_ablation_matrix.py --render-report")
+    print("\nRender the consolidated report with:\n"
+          "  python scripts/qvt_ablation_matrix.py --render-report")
     return 0 if n_fail == 0 else 6
 
 

--- a/scripts/qvt_capture_baseline.py
+++ b/scripts/qvt_capture_baseline.py
@@ -51,10 +51,8 @@ sys.path.insert(0, str(ROOT))
 # from any cwd.
 from eval.qvt.oracle import (  # noqa: E402
     FiveAxisResult,
-    ThreeAxisResult,
     score_five_axis,
     score_five_axis_by_question_type,
-    score_three_axis,
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/qvt_promote_findings.py
+++ b/scripts/qvt_promote_findings.py
@@ -258,7 +258,7 @@ def main() -> int:
             summary.append(("written", f.slug, f"-> {dest.relative_to(ROOT) if dest.is_relative_to(ROOT) else dest}"))
 
     # Output summary
-    print(f"\n=== qvt_promote_findings summary ===")
+    print("\n=== qvt_promote_findings summary ===")
     print(f"Findings scanned: {len(findings)}")
     print(f"Promotion tags accepted: {sorted(promote_tags)}")
     print(f"Written: {written}  Skipped: {skipped}  Rejected: {rejected}")

--- a/scripts/qvt_rescore_ablation_cell.py
+++ b/scripts/qvt_rescore_ablation_cell.py
@@ -54,7 +54,7 @@ import statistics
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 ROOT = Path(__file__).resolve().parent.parent
 

--- a/scripts/qvt_rescore_all_cells.py
+++ b/scripts/qvt_rescore_all_cells.py
@@ -44,7 +44,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 ROOT = Path(__file__).resolve().parent.parent
 SINGLE_SCRIPT = ROOT / "scripts" / "qvt_rescore_ablation_cell.py"
@@ -116,7 +116,7 @@ def _write_summary(out_path: Path, expected_suite: str,
     lines.append(f"- Generated: {datetime.now(timezone.utc).isoformat()}")
     lines.append(f"- Expected suite: `{expected_suite}`")
     lines.append(f"- Mode: {'dry-run' if dry_run else 'live'}")
-    lines.append(f"- Tool: `scripts/qvt_rescore_all_cells.py`")
+    lines.append("- Tool: `scripts/qvt_rescore_all_cells.py`")
     lines.append("")
     lines.append("## Per-cell classification")
     lines.append("")

--- a/scripts/qvt_rescore_baseline.py
+++ b/scripts/qvt_rescore_baseline.py
@@ -153,7 +153,7 @@ def main() -> int:
     print(f"=== QVT 5-axis re-score ({len(bench_paths)} run(s)) ===")
     print(f"suite:   {args.suite}")
     print(f"fixture: {fixture_path}")
-    print(f"oracle:  current main (run `git log --oneline -3` to see what's loaded)")
+    print("oracle:  current main (run `git log --oneline -3` to see what's loaded)")
     for i, bp in enumerate(bench_paths, start=1):
         bench = json.loads(bp.read_text(encoding="utf-8"))
         result = score_five_axis(bench, fixture)

--- a/scripts/research/audit_12b_null_query_refusal_shape.py
+++ b/scripts/research/audit_12b_null_query_refusal_shape.py
@@ -79,7 +79,7 @@ def classify(answer):
             return True, f"pattern[{i}]={refusal_patterns[i]} → match='{m.group(0)}'"
     return False, None
 
-print(f'=== Null-query refusal-shape audit ===')
+print('=== Null-query refusal-shape audit ===')
 print(f'bench file: {bench_path}')
 print(f'null queries: {len(nulls)}')
 print()
@@ -114,7 +114,7 @@ print(f'  true hallucinations:         {len(true_halluc)}/{len(oracle_fn)} ({len
 print()
 
 if missed:
-    print(f'=== Oracle-missed refusal patterns (candidates for bucket-(d) phrase add) ===')
+    print('=== Oracle-missed refusal patterns (candidates for bucket-(d) phrase add) ===')
     for idx, qid, pat, ans in missed:
         print(f'  null[{idx}] id={qid}')
         print(f'    matched: {pat}')
@@ -122,12 +122,12 @@ if missed:
         print()
 
 if oracle_tp:
-    print(f'=== Oracle-caught refusals (for comparison) ===')
+    print('=== Oracle-caught refusals (for comparison) ===')
     for idx, qid, ans in oracle_tp[:3]:
         print(f'  null[{idx}] id={qid}: {ans[:200]}')
         print()
 
-print(f'=== Top-3 true hallucinations (no refusal indicator) ===')
+print('=== Top-3 true hallucinations (no refusal indicator) ===')
 for idx, qid, ans in true_halluc[:3]:
     print(f'  null[{idx}] id={qid}: {ans[:200]}')
     print()

--- a/scripts/research/v3prime_a3_think_quality_boundary.py
+++ b/scripts/research/v3prime_a3_think_quality_boundary.py
@@ -267,7 +267,6 @@ def grade_planner(response: str) -> dict:
     except (json.JSONDecodeError, ValueError):
         parsed = None
     subtasks = parsed.get("subtasks", []) if isinstance(parsed, dict) else []
-    has_subtasks = isinstance(subtasks, list) and len(subtasks) > 0
     n_subtasks = len(subtasks) if isinstance(subtasks, list) else 0
     text_lower = response
     conditional_keywords = ("시나리오", "경우", "이면", "조건", "5%", "2%")
@@ -541,12 +540,12 @@ def verdict(stage: str, fixture: str, on: dict, off: dict) -> tuple[str, str]:
 def render_report(results: dict) -> str:
     meta = results["metadata"]
     lines: list[str] = [
-        f"# A3 — think-mode quality boundary (gemma4:e4b, 5 cognitive stages)",
+        "# A3 — think-mode quality boundary (gemma4:e4b, 5 cognitive stages)",
         "",
         f"**Date**: {meta['started_utc']}",
         f"**Model**: {meta['model']}  **Cap**: {meta['cap']}  "
         f"**Temp**: {meta['temperature']}  **n/cell**: {meta['n']}",
-        f"**Closes**: §17.5.3 of v3prime-cross-family-final-2026-05-29.md",
+        "**Closes**: §17.5.3 of v3prime-cross-family-final-2026-05-29.md",
         "",
         "## Per-stage verdicts (feeds A2 per-stage think policy)",
         "",

--- a/scripts/research/v3prime_a3_v2_llm_judge.py
+++ b/scripts/research/v3prime_a3_v2_llm_judge.py
@@ -335,8 +335,8 @@ def render_report(results: dict) -> str:
         f"**Generator**: {GEN_MODEL}  **Judge**: {JUDGE_MODEL}  "
         f"**Cap**: {meta['cap']}  **Temp**: {meta['temperature']}  "
         f"**n pairs/cell**: {meta['n']}",
-        f"**Closes**: A3 (#608) LLM-judge reservation gate; feeds A2 (#609) "
-        f"default-flip follow-up decision.",
+        "**Closes**: A3 (#608) LLM-judge reservation gate; feeds A2 (#609) "
+        "default-flip follow-up decision.",
         "",
         "## Verdicts",
         "",

--- a/scripts/research/v3prime_e4b_7tier_thinking_split.py
+++ b/scripts/research/v3prime_e4b_7tier_thinking_split.py
@@ -122,9 +122,9 @@ def think_false_eval(prompt: str, cap: int = 4096) -> int:
 def main() -> None:
     print("# gemma4:e4b 7-tier budget — thinking-trace decomposition (INTERNAL)\n")
     print("Question: is D1's 7-tier budget gradient workload, or thinking trace?\n")
-    print(f"| Tier | visible tok | eval_count (think ON) | hidden | hidden % | "
-          f"eval (think OFF) | reclaim |")
-    print(f"|---|---|---|---|---|---|---|")
+    print("| Tier | visible tok | eval_count (think ON) | hidden | hidden % | "
+          "eval (think OFF) | reclaim |")
+    print("|---|---|---|---|---|---|---|")
     rows = []
     for tier, prompt in build_tiers():
         on = stream_visible(prompt)

--- a/scripts/research/v3prime_e4b_cap4096_audit.py
+++ b/scripts/research/v3prime_e4b_cap4096_audit.py
@@ -51,7 +51,7 @@ def main() -> None:
             for t in trials:
                 cells[(model, float(temp), cap)].append(t)
 
-    print(f"# v3prime e4b cap=4096 natural-budget audit\n")
+    print("# v3prime e4b cap=4096 natural-budget audit\n")
     print(f"Source files scanned: {len(files)}")
     print(f"Cells found: {len(cells)}\n")
 

--- a/tests/test_qvt_matrix_renderer_sector.py
+++ b/tests/test_qvt_matrix_renderer_sector.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
 import sys
 import tempfile
 import unittest


### PR DESCRIPTION
## Summary

- 30 F-class lint violations 제거 (F401 unused imports, F541 empty f-strings, F841 unused local)
- Auto-fix via \`ruff --fix\` + 1 manual F841 fix (`scripts/research/v3prime_a3_think_quality_boundary.py:270` dead `has_subtasks` local)
- 13 files touched (`scripts/` + `tests/`)
- No behavior change — pure hygiene

## Verification

\`\`\`
$ python -m ruff check scripts/ tests/ --select F
All checks passed!
\`\`\`

## Out of scope

- E/W/I/C 등 다른 ruff class
- Function logic / type hints

## Bench numbers

해당 없음 (no `core/` touch).

\`Quality delta: exempt (label: chore)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)