### PR TITLE
feat(α-8 Phase B): C_rag-ontology sector cell + pipeline_context typed-filter overlay

### DIFF
--- a/core/reasoning/pipeline_context.py
+++ b/core/reasoning/pipeline_context.py
@@ -29,6 +29,15 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, Tuple
 
+# α-8 Phase B — typed entity filter overlay (R1-R5 evidence-of-absence
+# preservation). Default flag OFF (filter ON when wired); set
+# JAMES_DISABLE_TYPED_FILTER=1 to bypass for byte-identical pre-α-8 path
+# during sector cell measurement.
+from core.graph_typed_filter import (
+    apply_typed_filter,
+    is_typed_filter_disabled,
+)
+
 # Relevance gate threshold — mirrors the local constant pre-extraction
 # and the ``_RELEVANCE_THRESHOLD`` in ``core.reasoning.evidence_scope``
 # (kept synchronized; a single-source consolidation refactor would
@@ -97,7 +106,30 @@ def build_unified_context(
             graph_pth,
             unified_score=unified_score,
         )
-        final_context = loop_state["doc_context"] + graph_ctx_str
+
+        # α-8 Phase B — prepend typed entity summary BEFORE the existing
+        # graph context. This is byte-additive (the original block is
+        # preserved verbatim); the typed summary lands as a structural
+        # evidence-of-absence signal per design memo §1.6 / §2.4 R1-R5.
+        # When JAMES_DISABLE_TYPED_FILTER=1 the prefix is skipped, making
+        # the C_rag-graph sector cell byte-identical to pre-α-8.
+        typed_prefix = ""
+        if not is_typed_filter_disabled():
+            expanded_query = loop_state.get("expanded_query", "") or ""
+            try:
+                typed_prefix, _groups = apply_typed_filter(
+                    expanded_query,
+                    graph_ctx,
+                )
+                typed_prefix = "\n" + typed_prefix + "\n"
+            except Exception:
+                # Defensive: never let typed filter formatting fail the
+                # entire context build. Log via engine and fall through
+                # with empty prefix (= byte-identical to pre-α-8).
+                engine._log("typed_filter_overlay_error", None, user_role)
+                typed_prefix = ""
+
+        final_context = loop_state["doc_context"] + typed_prefix + graph_ctx_str
         gate_label = "pass" if avg_vec >= _RELEVANCE_GATE else "fail"
         print(
             f"[CONTEXT] unified={unified_score:.3f} "

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -206,11 +206,26 @@ _SECTOR_CELL_ENVS: Dict[str, Dict[str, str]] = {
     "C_rag-graph": {
         # S1 + S2 + S3 + S4 on; S5 + S6 off.
         # S3 stays ON (row's defaults: ENTITY_ANCHOR=1, QUERY_REWRITE=1).
+        # α-8: typed filter disabled here so the cell is a pure pre-α-8
+        # graph baseline; comparison reference for C_rag-ontology.
         "JAMES_DISABLE_ABSTENTION":       "1",
         "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+        "JAMES_DISABLE_TYPED_FILTER":     "1",
+    },
+    "C_rag-ontology": {
+        # α-8 Phase A/B: C_rag-graph + typed entity filter (R1-R5
+        # evidence-of-absence preservation per design memo §2.4).
+        # All other layers identical to C_rag-graph so Δ measures the
+        # typed filter contribution in isolation.
+        "JAMES_DISABLE_ABSTENTION":       "1",
+        "JAMES_DISABLE_COGNITIVE_STAGES": "1",
+        # JAMES_DISABLE_TYPED_FILTER intentionally NOT set → filter ON.
     },
     "C_rag-full": {
         # Equivalent to α-5 L1 — all sectors on, no routing layers.
+        # α-8: typed filter ON here too (matches default production state
+        # once α-8 is wired; only C_rag-graph keeps the pre-α-8 path for
+        # baseline comparison).
         # No sector disable flag; row's L1 default applies.
     },
     "C_rag-routed": {
@@ -229,8 +244,9 @@ _SECTOR_CELL_LABELS: Dict[str, str] = {
     "C_minus":      "pure LLM (no JAMES)",
     "C_rag-basic":  "+ RAG only",
     "C_rag-cited":  "+ RAG + citation (S4)",
-    "C_rag-graph":  "+ RAG + graph + S3 preproc + citation",
-    "C_rag-full":   "JAMES full stack (= α-5 L1)",
+    "C_rag-graph":  "+ RAG + graph + S3 preproc + citation (pre-α-8)",
+    "C_rag-ontology": "+ typed filter (α-8 R1-R5 evidence-of-absence)",
+    "C_rag-full":   "JAMES full stack (= α-5 L1; α-8 typed filter ON)",
     "C_rag-routed": "JAMES + routing layers (= α-5 L5)",
 }
 

--- a/tests/test_pipeline_typed_filter_overlay.py
+++ b/tests/test_pipeline_typed_filter_overlay.py
@@ -1,0 +1,122 @@
+"""α-8 Phase B — pipeline_context typed-filter overlay integration tests.
+
+Verifies the overlay at `core/reasoning/pipeline_context.build_unified_context`
+behaves correctly under both flag polarities:
+
+- JAMES_DISABLE_TYPED_FILTER unset/0 → typed prefix prepended to graph context
+- JAMES_DISABLE_TYPED_FILTER=1     → prefix skipped, byte-identical pre-α-8 path
+
+The integration is byte-additive (original graph_context preserved verbatim);
+the typed summary lands BEFORE the existing block as a structural evidence-of-
+absence signal.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from core.reasoning.pipeline_context import build_unified_context
+
+
+def _make_fake_engine():
+    """Minimal engine stand-in that exposes the surface build_unified_context calls."""
+
+    class FakeGraph:
+        @staticmethod
+        def build_graph_context_str(graph_entities, graph_paths, unified_score=0.0):
+            return "\n[GRAPH CONTEXT (unified=0.50)]\n[Entity] Alice (person)"
+
+    class FakeEngine:
+        graph = FakeGraph()
+
+        @staticmethod
+        def _log(event, exc, user_role):
+            pass
+
+        @staticmethod
+        def _elapsed(t, label):
+            pass
+
+    return FakeEngine()
+
+
+def _make_loop_state(query="When did Sam Altman join?"):
+    return {
+        "docs": [{"text": "context", "source": "x.txt"}],
+        "graph_context": [
+            {"name": "Alice", "entity_type": "person"},
+        ],
+        "graph_paths": [],
+        "doc_context": "[DOC CONTEXT]\nfoo",
+        "avg_vec_score": 0.55,
+        "expanded_query": query,
+    }
+
+
+class TypedFilterOverlayFlagTests(unittest.TestCase):
+    """Polarity check: typed prefix landed iff filter is enabled."""
+
+    def test_filter_disabled_no_prefix(self):
+        """JAMES_DISABLE_TYPED_FILTER=1 → typed prefix omitted (byte-identical)."""
+        with patch.dict(os.environ, {"JAMES_DISABLE_TYPED_FILTER": "1"}):
+            ctx, _ = build_unified_context(
+                _make_fake_engine(), _make_loop_state(), user_role="internal"
+            )
+        self.assertNotIn("[ENTITIES BY TYPE]", ctx)
+        # Original graph context block must still be present
+        self.assertIn("[GRAPH CONTEXT", ctx)
+
+    def test_filter_enabled_prefix_inserted(self):
+        """JAMES_DISABLE_TYPED_FILTER unset → typed prefix prepended."""
+        env = os.environ.copy()
+        env.pop("JAMES_DISABLE_TYPED_FILTER", None)
+        with patch.dict(os.environ, env, clear=True):
+            ctx, _ = build_unified_context(
+                _make_fake_engine(), _make_loop_state(), user_role="internal"
+            )
+        self.assertIn("[ENTITIES BY TYPE]", ctx)
+        # Original graph context block STILL present (additive)
+        self.assertIn("[GRAPH CONTEXT", ctx)
+
+    def test_filter_enabled_temporal_query_emits_date_empty_row(self):
+        """Temporal query + no Date entity → '(none found)' row visible."""
+        env = os.environ.copy()
+        env.pop("JAMES_DISABLE_TYPED_FILTER", None)
+        with patch.dict(os.environ, env, clear=True):
+            ctx, _ = build_unified_context(
+                _make_fake_engine(),
+                _make_loop_state(query="When did Alice join?"),
+                user_role="internal",
+            )
+        self.assertIn("[Date]: (none found in graph for this query)", ctx)
+
+    def test_filter_enabled_person_query_includes_person_entities(self):
+        """'who' query → person row populated with the entity."""
+        env = os.environ.copy()
+        env.pop("JAMES_DISABLE_TYPED_FILTER", None)
+        with patch.dict(os.environ, env, clear=True):
+            ctx, _ = build_unified_context(
+                _make_fake_engine(),
+                _make_loop_state(query="Who is Alice?"),
+                user_role="internal",
+            )
+        self.assertIn("[Person]: Alice", ctx)
+
+
+class TypedFilterOverlayOrderTests(unittest.TestCase):
+    """Ordering check: typed prefix comes BEFORE the existing graph block."""
+
+    def test_typed_prefix_before_graph_context_block(self):
+        env = os.environ.copy()
+        env.pop("JAMES_DISABLE_TYPED_FILTER", None)
+        with patch.dict(os.environ, env, clear=True):
+            ctx, _ = build_unified_context(
+                _make_fake_engine(), _make_loop_state(), user_role="internal"
+            )
+        typed_idx = ctx.index("[ENTITIES BY TYPE]")
+        graph_idx = ctx.index("[GRAPH CONTEXT")
+        self.assertLess(typed_idx, graph_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qvt_matrix_sector_cells.py
+++ b/tests/test_qvt_matrix_sector_cells.py
@@ -42,14 +42,30 @@ m = _load_module()
 
 
 class SectorCellsRegistryTests(unittest.TestCase):
-    def test_six_standard_sector_cells_exist(self):
+    def test_seven_standard_sector_cells_exist(self):
+        # α-8 Phase B added C_rag-ontology between C_rag-graph and C_rag-full.
         expected = {"C_minus", "C_rag-basic", "C_rag-cited",
-                    "C_rag-graph", "C_rag-full", "C_rag-routed"}
+                    "C_rag-graph", "C_rag-ontology", "C_rag-full",
+                    "C_rag-routed"}
         self.assertEqual(set(m._SECTOR_CELL_ENVS.keys()), expected)
 
     def test_each_sector_cell_has_a_label(self):
         for cell in m._SECTOR_CELL_ENVS:
             self.assertIn(cell, m._SECTOR_CELL_LABELS)
+
+    def test_c_rag_graph_disables_typed_filter(self):
+        """C_rag-graph is the α-7 (pre-α-8) graph baseline — typed filter MUST be off."""
+        self.assertEqual(
+            m._SECTOR_CELL_ENVS["C_rag-graph"].get("JAMES_DISABLE_TYPED_FILTER"),
+            "1",
+        )
+
+    def test_c_rag_ontology_does_not_set_disable_typed_filter(self):
+        """C_rag-ontology is the α-8 cell — typed filter ON (flag intentionally absent)."""
+        self.assertNotIn(
+            "JAMES_DISABLE_TYPED_FILTER",
+            m._SECTOR_CELL_ENVS["C_rag-ontology"],
+        )
 
 
 class CellEnvOverlayTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

α-8 Phase B — wires the Phase A typed filter module into the production pipeline and adds the matrix runner cell for A/B measurement.

**Design memo**: \`docs/design/v0.4-alpha-8-ontology-typed-filter.md\` §2.1 + §4.

## Changes

| File | Change |
|---|---|
| \`scripts/qvt_ablation_matrix.py\` | New cell \`C_rag-ontology\` between \`C_rag-graph\` and \`C_rag-full\`; C_rag-graph now sets \`JAMES_DISABLE_TYPED_FILTER=1\` explicitly (pre-α-8 baseline) |
| \`core/reasoning/pipeline_context.py\` | \`build_unified_context\` prepends typed entity summary BEFORE graph context (byte-additive); reads query from \`loop_state["expanded_query"]\` |
| \`tests/test_pipeline_typed_filter_overlay.py\` | NEW — 5 integration tests (flag polarity + R1-R2 acceptance) |
| \`tests/test_qvt_matrix_sector_cells.py\` | Updated: six → seven cells; new C_rag-graph + C_rag-ontology flag invariant tests |

## Default behavior post-merge

\`JAMES_DISABLE_TYPED_FILTER\` unset → typed filter ACTIVE in /query/:
- LLM sees typed summary `[ENTITIES BY TYPE]` BEFORE the existing graph context block
- R1-R5 evidence-of-absence rows emitted for query-relevant types with no entities
- gemma4 grounding training should detect "Date is empty → null query" pre-α-7 style

Defensive: any exception in typed filter falls through with empty prefix → byte-identical to pre-α-8. Engine logs the error.

## Verification

\`\`\`
$ python -m pytest tests/test_pipeline_typed_filter_overlay.py
5 passed in 0.05s

$ python -m pytest tests/ -k "pipeline or graph_typed_filter or ontology or sector or qvt_matrix"
137 passed, 3350 deselected

$ python -m ruff check core/reasoning/pipeline_context.py scripts/qvt_ablation_matrix.py tests/test_pipeline_typed_filter_overlay.py tests/test_qvt_matrix_sector_cells.py
All checks passed!
\`\`\`

## Bench numbers — DEFERRED to Phase C

Phase B is the **measurement instrument enablement**, not the measurement. Phase C (next PR) runs N=3 baseline at M_M + 5-tier remeasurement. Quality Delta Card values land with Phase C closure.

Per design memo §1.3 honest framing tier:
- ⭐⭐ partial if graded Δ ≥ +0.030
- ⭐ operational if Δ ≤ noise

## Out of scope (Phase C-D)

- Phase C: N=3 baseline + 5-tier remeasurement (cells × tiers × n=3)
- Phase D: closure analysis + \`docs/ARCHITECTURE.md §5.7\` typed filter section + acceptance test (multihop_rag null query + Ali poison_01/04 from Phase 4 sweep)

\`Quality delta: exempt (label: code — A/B oracle infrastructure; measurement deferred to Phase C per design memo §4)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)