### PR TITLE
docs(handover): Phase C restart note — bash tee + python buffering trap

### DIFF
--- a/docs/handovers/v0.4-next-session-entry-2026-06-02-evening.md
+++ b/docs/handovers/v0.4-next-session-entry-2026-06-02-evening.md
@@ -36,17 +36,30 @@ cd C:\Project\James-RAG-Evol-v010
 git status
 git log --oneline -10
 
-# Check Phase C background run status (running or completed?)
-type "C:\Users\karu-\AppData\Local\Temp\claude\C--Project-James-RAG-Evol-v010\c47eaf4c-729a-45b2-a903-1825b34fc205\tasks\bt5gdm2jw.output"
+# Phase C status as of 2026-06-02 session close:
+#   - Background launch attempted, but Python stdout buffered + bash tee
+#     pipeline produced 0-byte log over 30+ min. No per-cell JSON
+#     written. Process group killed at session close (TaskStop).
+#   - No Phase C results yet on main.
+#   - Cell output dir: workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/
+#     (newest existing cell as of 2026-06-02: C_rag-full-M_XL.json from α-7
+#      5-tier work; NO C_rag-graph or C_rag-ontology cells yet)
 
-# Inspect per-cell JSON outputs if completed:
-ls reports\research-runs\qvt-ablation-cells\
-
-# If Phase C run was killed / incomplete, restart:
-python scripts/qvt_ablation_matrix.py `
+# Phase C relaunch — use python -u for unbuffered stdout:
+python -u scripts/qvt_ablation_matrix.py `
     --sector-cells C_rag-graph,C_rag-ontology `
-    --tiers M_M --n-runs 3 --resume
+    --tiers M_M --n-runs 3 2>&1 | Tee-Object reports/research-runs/alpha8-phase-c-sanity.log
+
+# Inspect per-cell JSON outputs after completion:
+ls workspaces\hotpot_eval\reports\research-runs\qvt-ablation-cells\ | findstr "C_rag-graph C_rag-ontology"
 ```
+
+⚠️ **Phase C buffering lesson** (added 2026-06-02 evening): When running
+the matrix runner via bash `| tee` pipeline, Python's default stdout
+buffering held output until process exit, producing a 0-byte log file
+during a long run. Always pass `-u` to python (unbuffered) when piping
+to `tee` for long-running runs. PowerShell's `Tee-Object` works the
+same but with `-u` flag on python.
 
 ## 2. State of α-8 (4-phase plan)
 
@@ -54,7 +67,7 @@ python scripts/qvt_ablation_matrix.py `
 |---|---|---|
 | **A** ontology + typed filter module + flag | ✅ PR #688 merged | core/ontology.py 14.9 KB / core/graph_typed_filter.py 10.7 KB |
 | **B** matrix cell + pipeline_context wiring | ✅ PR #689 merged | C_rag-ontology between C_rag-graph (forced flag=1) and C_rag-full |
-| **C** N=3 baseline (M_M) | ⏳ background launched 2026-06-02 | log/cells in reports/research-runs/; verify completion before next launch |
+| **C** N=3 baseline (M_M) | ❌ NOT STARTED — relaunch needed | bash `tee` pipeline + Python stdout buffering produced 0-byte log; process killed at session close. Relaunch with `python -u` flag. |
 | **C-extend** 5-tier remeasurement | ⏸️ pending | M_XS/M_S/M_M/M_L/M_XL × n=3 × 2 cells = 30 cells ≈ 6-10h compute |
 | **D** closure analysis + ARCHITECTURE.md | ⏸️ pending | Per-question-type cross-tab + R1-R5 acceptance check (multihop null + Ali poison_01/04) |
 


### PR DESCRIPTION
## Summary

Update next-session entry doc with Phase C restart instructions.

## What happened

Phase C N=3 baseline at M_M was launched in background during session 2026-06-02 evening. After 30+ minutes, the log file (`reports/research-runs/alpha8-phase-c-sanity.log`) and the bg task output were both **0 bytes**, despite Python processes consuming significant memory (~2.4 GB resident for the JAMES server). Process killed at session close.

## Root cause (likely)

The launch command was:
\`\`\`bash
python scripts/qvt_ablation_matrix.py ... | tee log
\`\`\`

Python's default stdout buffering holds output until flush/close. When piped to `tee`, the pipe buffer accumulated all matrix runner output but never flushed because Python wasn't told to flush per-line. The matrix runner uses `print()` extensively and likely produced output, but it stayed buffered.

## Fix for next session

Use \`python -u\` (unbuffered):
\`\`\`powershell
python -u scripts/qvt_ablation_matrix.py `
    --sector-cells C_rag-graph,C_rag-ontology `
    --tiers M_M --n-runs 3 2>&1 | Tee-Object reports/research-runs/alpha8-phase-c-sanity.log
\`\`\`

Also corrected the cells output directory in the entry doc — it lives at \`workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/\` not \`reports/research-runs/qvt-ablation-cells/\`.

## Changes

- \`docs/handovers/v0.4-next-session-entry-2026-06-02-evening.md\`:
  - §1 first-commands: -u flag + correct cells dir
  - §2 Phase C row: ⏳ → ❌ NOT STARTED
  - Added "Phase C buffering lesson" note

\`Quality delta: exempt (label: docs)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)