### PR TITLE
feat(abstraction): core/abstraction/ — §5.7.13 module implementation

### DIFF
--- a/core/abstraction/__init__.py
+++ b/core/abstraction/__init__.py
@@ -1,0 +1,52 @@
+"""Cloud-egress abstraction layer — §5.7.13 trust contract.
+
+The single place where sensitive entity strings are deterministically
+replaced with typed placeholders on the way *out* to a cloud reasoner,
+and where the reply is reversed on the way *in*. §5.7.12 defines the
+boundary (cloud-egress trust zone); this package enforces it.
+
+Public API (frozen per §5.7.13, mirrors design memo §3):
+
+  from core.abstraction import (
+      Decision, AbstractionMap, default_decider,
+      build_map, mask_text, unmask_text, emit_egress_event,
+  )
+
+Caller contract (per §5.7.13):
+  1. PolicyEngine MUST gate the egress decision BEFORE build_map runs.
+     This module enforces the egress; it does not authorize it.
+  2. Every build_map → mask_text → (cloud call) → unmask_text sequence
+     emits one `reason:egress` row via `emit_egress_event`. Failure to
+     audit is the same as failure to mask — caller MUST NOT proceed.
+  3. `flagged` entries from `unmask_text` are surfaced to the
+     user-facing reply, never silently stripped.
+
+Module layout (private, not part of contract):
+  - `_policy.py` — Decision + default_decider
+  - `_mask.py`   — AbstractionMap + build_map + mask_text + unmask_text
+  - `_audit.py`  — emit_egress_event
+
+The split honors rule #5 (module-size discipline) — each private file
+stays well under the 20 KB ceiling and is independently testable
+without touching the others.
+"""
+from __future__ import annotations
+
+from core.abstraction._audit import emit_egress_event
+from core.abstraction._mask import (
+    AbstractionMap,
+    build_map,
+    mask_text,
+    unmask_text,
+)
+from core.abstraction._policy import Decision, default_decider
+
+__all__ = [
+    "Decision",
+    "AbstractionMap",
+    "default_decider",
+    "build_map",
+    "mask_text",
+    "unmask_text",
+    "emit_egress_event",
+]

--- a/core/abstraction/_audit.py
+++ b/core/abstraction/_audit.py
@@ -1,0 +1,111 @@
+"""Egress audit emit — §5.7.13 §"Caller obligations" #2.
+
+Every `build_map → mask_text → (cloud call) → unmask_text` sequence
+emits one `reason:egress` row to `audit_bridge`. The row records
+*what got masked* (placeholder ids + entity-type histogram), not the
+real names (which never leave the local map per §5.7.13 invariant #5)
+and not the map itself (replay reconstructs it from the same entity
+set).
+
+Failure to audit is treated the same as a failure to mask — the
+egress call MUST NOT proceed. This module exposes a single helper;
+the caller is responsible for invoking it on the success path.
+
+Module-size discipline: this file holds the audit emit only. Mask /
+unmask in `_mask.py`; policy in `_policy.py`.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import List, Optional
+
+from core.abstraction._mask import AbstractionMap
+
+
+def _prompt_hash(prompt: str) -> str:
+    """8-hex-char sha256 head — matches the prompt-hash convention in
+    `core/reasoning/router.py::emit_route_event` so a `reason:egress`
+    row can be cross-referenced with the originating `reason:route`
+    row via grep."""
+    if not prompt:
+        return ""
+    return hashlib.sha256(prompt.encode("utf-8", errors="ignore")).hexdigest()[:8]
+
+
+def _type_histogram(amap: AbstractionMap) -> str:
+    """Compact `TYPE:n,TYPE:n` summary of masked entities by type. Used
+    by the audit row so operators can answer 'how many PERSON / ORG /
+    QUANTITY left the machine on this query?' without needing the
+    real names (which are not in the row by invariant #5)."""
+    hist: dict = {}
+    for ph in amap.forward.values():
+        # ph shape: "TYPE_n" — split on the last underscore to keep
+        # multi-word types intact (none today, but cheap insurance).
+        t = ph.rsplit("_", 1)[0]
+        hist[t] = hist.get(t, 0) + 1
+    return ",".join(f"{t}:{n}" for t, n in sorted(hist.items()))
+
+
+def emit_egress_event(
+    stage: str,
+    prompt: str,
+    backend_id: str,
+    amap: AbstractionMap,
+    *,
+    flagged: Optional[List[str]] = None,
+    reason: str = "egress",
+) -> None:
+    """Emit one `reason:egress` row to `audit_log` (via `audit_bridge`).
+
+    Schema mapping (mirrors `emit_route_event` in
+    `core/reasoning/router.py`):
+      • endpoint = "reason:egress"
+      • query    = stage name
+      • answer   = "backend={id} masked={hist} kept_local={n} passed={n}
+                    flagged={list} reason={why} prompt={hash}"
+
+    `flagged` (the hallucinated-placeholder list from `unmask_text`)
+    defaults to `None` — call sites without an unmask phase (e.g.
+    pre-egress audit) omit it; call sites with one pass the list so
+    the row records whether the cloud returned an unmappable token.
+
+    §5.7.13 invariant #5: real entity names never appear in the row.
+    Only placeholder ids (`PERSON_1` …) and type histograms. The audit
+    surface is what *categories* of entity left the machine, not which
+    specific ones — the specific mapping is reconstructible from the
+    deterministic build_map(entities, decider) at replay time.
+
+    Never raises — audit failure must not block the production call
+    path (mirrors the pattern in `core.audit_bridge.mirror_to_audit_db`
+    and `core.reasoning.router.emit_route_event`).
+    """
+    try:
+        from core.audit_bridge import mirror_to_audit_db
+
+        hist = _type_histogram(amap)
+        flag_str = ",".join(flagged) if flagged else ""
+        ph_hash = _prompt_hash(prompt)
+
+        mirror_to_audit_db({
+            "endpoint": "reason:egress",
+            "role": "system",
+            "query": stage,
+            "answer": (
+                f"backend={backend_id} masked={hist or '-'} "
+                f"kept_local={len(amap.keep_local)} "
+                f"passed={len(amap.passed)} "
+                f"flagged={flag_str or '-'} "
+                f"reason={reason} prompt={ph_hash}"
+            ),
+        })
+    except Exception:
+        # Per the module docstring: audit failure must not block the
+        # caller. The caller is responsible for treating an egress
+        # without an audit row as a §5.7.13 violation at the higher
+        # layer (router refuses to proceed if the audit emit raises) —
+        # but THIS helper swallows so a transient sqlite hiccup in the
+        # audit DB doesn't crash the main pipeline.
+        pass
+
+
+__all__ = ["emit_egress_event"]

--- a/core/abstraction/_mask.py
+++ b/core/abstraction/_mask.py
@@ -1,0 +1,159 @@
+"""Deterministic mask/unmask — §5.7.13 §"Module invariants" 1-3 + 6.
+
+`AbstractionMap` holds the local-only real↔placeholder mapping for one
+egress. `build_map` constructs it deterministically from typed graph
+entities. `mask_text` replaces real names with placeholders before
+egress (substring-safe, particle-safe). `unmask_text` reverses on the
+reply and **flags** placeholder tokens absent from the local map —
+never silently de-abstracts them.
+
+Module-size discipline: this file holds the mask/unmask + map only.
+Policy lives in `_policy.py`; audit emit lives in `_audit.py`.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Sequence, Tuple
+
+from core.ontology import ENTITY_TYPES
+
+from core.abstraction._policy import (
+    Decision,
+    _entity_name,
+    _entity_type,
+)
+
+
+@dataclass
+class AbstractionMap:
+    """Per-query mapping between real entity names and typed placeholders.
+
+    §5.7.13 invariant #5 (local-only map): instances are created per
+    query and garbage-collected after `unmask_text`. They are **never**
+    persisted, serialized, or sent over any wire. Same `PERSON_1` across
+    different queries would be a re-identification risk by design.
+
+    Field summary:
+      • `forward`     — real name → placeholder (used by mask_text)
+      • `reverse`     — placeholder → real name (used by unmask_text)
+      • `keep_local`  — names that must NOT egress (Decision.KEEP_LOCAL)
+      • `passed`      — names sent as-is (Decision.PASS, audit record)
+      • `_counters`   — per-TYPE monotonic counter for new placeholders
+    """
+
+    forward: Dict[str, str] = field(default_factory=dict)
+    reverse: Dict[str, str] = field(default_factory=dict)
+    keep_local: List[str] = field(default_factory=list)
+    passed: List[str] = field(default_factory=list)
+    _counters: Dict[str, int] = field(default_factory=dict)
+
+    def placeholder_for(self, name: str, entity_type: str) -> str:
+        """Return the placeholder for `name`, allocating one on first
+        sight. Same name → same placeholder (§5.7.13 invariant #1
+        determinism + closed-world reasoning preservation per §5.7.12).
+        """
+        if name in self.forward:
+            return self.forward[name]
+        t = entity_type.upper()
+        self._counters[t] = self._counters.get(t, 0) + 1
+        ph = f"{t}_{self._counters[t]}"
+        self.forward[name] = ph
+        self.reverse[ph] = name
+        return ph
+
+
+def build_map(
+    entities: Sequence[dict],
+    decide: Callable[[dict], Decision],
+) -> AbstractionMap:
+    """Build an `AbstractionMap` from typed graph entities.
+
+    §5.7.13 invariant #1 (determinism): per-TYPE counters advance in
+    entity declaration order, so the same (entities, decide) input
+    produces a byte-identical map. Required for §5.7.2 trace-schema
+    replay — re-running the same query at time T+ε reconstructs the
+    same map and therefore the same audit row.
+
+    Empty / nameless entities are silently skipped (no placeholder is
+    allocated for a missing name — there is nothing to mask).
+    """
+    amap = AbstractionMap()
+    for e in entities:
+        name = _entity_name(e)
+        if not name:
+            continue
+        d = decide(e)
+        if d is Decision.MASK:
+            amap.placeholder_for(name, _entity_type(e))
+        elif d is Decision.KEEP_LOCAL:
+            if name not in amap.keep_local:
+                amap.keep_local.append(name)
+        else:  # PASS
+            if name not in amap.passed:
+                amap.passed.append(name)
+    return amap
+
+
+def mask_text(text: str, amap: AbstractionMap) -> str:
+    """Replace every masked entity name with its placeholder.
+
+    §5.7.13 invariant #2 (substring safety): longest names first, so a
+    name that is a substring of another (e.g. '김철' ⊂ '김철수') cannot
+    corrupt the replacement. Verified by PoC self-test §5.
+    """
+    for name in sorted(amap.forward, key=len, reverse=True):
+        text = text.replace(name, amap.forward[name])
+    return text
+
+
+# Placeholder token regex.
+#
+# §5.7.13 invariant #3 (particle/boundary safety): plain `\b` trailing
+# boundary fails when a Korean particle is glued to the token —
+# `PERSON_3의` has no `\b` between the `3` and the `의` because both are
+# `\w`. We use:
+#   • non-alnum / non-underscore lookbehind  — placeholder must not be
+#     in the middle of an identifier (`xPERSON_1` is not a match)
+#   • not-a-digit lookahead                  — `PERSON_12` is one token
+#     `PERSON_12`, not `PERSON_1` followed by `2`
+# A trailing Korean particle is fine — `의` is not `[0-9]`, so the
+# lookahead lets it through and the match ends at the digit.
+_KNOWN_TYPE_UPPER = {t.upper() for t in ENTITY_TYPES}
+_PLACEHOLDER_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Z]+)_(\d+)(?![0-9])")
+
+
+def unmask_text(text: str, amap: AbstractionMap) -> Tuple[str, List[str]]:
+    """Restore placeholders to real names.
+
+    Returns `(restored, flagged)` where `flagged` lists placeholder
+    tokens that:
+      • match the placeholder shape (`TYPE_n` with TYPE in the ontology)
+      • are NOT in `amap.reverse` (the reasoner introduced them)
+
+    §5.7.13 invariant #4 (hallucination flagging): flagged tokens are
+    left **verbatim** in `restored` — never silently de-abstracted to
+    a real name. Silent restoration would let the cloud inject content
+    under a real entity name, which is the threat model this module
+    exists to defeat.
+    """
+    flagged: List[str] = []
+
+    def _sub(m: re.Match) -> str:
+        token = m.group(0)
+        if token in amap.reverse:
+            return amap.reverse[token]
+        if m.group(1) in _KNOWN_TYPE_UPPER:
+            if token not in flagged:
+                flagged.append(token)
+        return token
+
+    return _PLACEHOLDER_RE.sub(_sub, text), flagged
+
+
+__all__ = [
+    "AbstractionMap",
+    "build_map",
+    "mask_text",
+    "unmask_text",
+]

--- a/core/abstraction/_policy.py
+++ b/core/abstraction/_policy.py
@@ -1,0 +1,91 @@
+"""Per-entity egress decision — §5.7.13 §"Public API surface" / §5.7.12 §"Egress masking policy".
+
+`Decision` is the 3-way outcome the abstraction layer takes per entity:
+MASK / PASS / KEEP_LOCAL. `default_decider` builds the policy function
+that the router/caller hands to `build_map`. Production callers may
+substitute a query-conditioned classifier for `default_decider`; the
+module is policy-agnostic per §5.7.13 non-goal #2.
+
+Module-size discipline: this file holds policy only. Mask / unmask
+lives in `_mask.py`; audit emit lives in `_audit.py`.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Callable, Sequence
+
+
+class Decision(str, Enum):
+    """Per-entity egress outcome (§5.7.12 three-way)."""
+
+    MASK = "mask"            # sensitive + closed-world → typed placeholder
+    PASS = "pass"            # not sensitive → send real value
+    KEEP_LOCAL = "keep"      # sensitive + open-world → never egress
+
+
+def _entity_name(e: dict) -> str:
+    return e.get("name") or e.get("label") or e.get("title") or e.get("entity_id") or ""
+
+
+def _entity_type(e: dict) -> str:
+    return e.get("entity_type") or e.get("type") or "concept"
+
+
+def _is_sensitive(e: dict) -> bool:
+    """Read the entity's sensitivity flag. §5.7.13 non-goal #1: this
+    module does **not** classify sensitivity — it reads what the
+    ingestion / wiki pipeline set.
+
+    Accepts: `sensitive` (PoC field), `sensitivity` (chunk metadata
+    convention). String values "1"/"true"/"yes"/"high"/"sensitive" map
+    to True (matches the live `core/wiki_generator/_frontmatter.py`
+    convention); empty / falsy / missing → False (conservative — an
+    unflagged entity is treated as not-sensitive and PASSes through).
+    """
+    v = e.get("sensitive", e.get("sensitivity", False))
+    if isinstance(v, str):
+        return v.strip().lower() in ("1", "true", "yes", "high", "sensitive")
+    return bool(v)
+
+
+def default_decider(
+    *,
+    open_world_types: Sequence[str] = (),
+    open_world_names: Sequence[str] = (),
+) -> Callable[[dict], Decision]:
+    """Build the per-entity decision function (§5.7.12 three-way).
+
+    semantic-dependence (closed vs open world) is approximated by
+    explicit sets: an entity whose TYPE or NAME is in the open-world
+    set needs its real-world identity for the reasoning, so when it's
+    sensitive it becomes KEEP_LOCAL (never egress). Everything else
+    sensitive → MASK. Non-sensitive → PASS.
+
+    Production callers replace the sets with a query-conditioned
+    classifier (§5.7.13 non-goal #2) — the module enforces the
+    boundary, the caller picks the policy. Both `open_world_types`
+    and `open_world_names` default to empty: with no policy input,
+    every sensitive entity is MASK (the safer-egress default, since
+    a wrongly-MASKed entity loses no information; a wrongly-PASSed
+    one leaks).
+    """
+    ow_types = {t.lower() for t in open_world_types}
+    ow_names = set(open_world_names)
+
+    def decide(e: dict) -> Decision:
+        if not _is_sensitive(e):
+            return Decision.PASS
+        if _entity_type(e).lower() in ow_types or _entity_name(e) in ow_names:
+            return Decision.KEEP_LOCAL
+        return Decision.MASK
+
+    return decide
+
+
+__all__ = [
+    "Decision",
+    "default_decider",
+    "_entity_name",
+    "_entity_type",
+    "_is_sensitive",
+]

--- a/tests/test_abstraction_layer.py
+++ b/tests/test_abstraction_layer.py
@@ -1,0 +1,519 @@
+"""§5.7.13 Abstraction Module — trust-contract tests.
+
+Locks the contract from ARCHITECTURE.md §5.7.13:
+  • API surface (Decision / AbstractionMap / build_map / mask_text /
+    unmask_text + emit_egress_event)
+  • 6 invariants (determinism, substring safety, particle/boundary
+    safety, hallucination flagging, local-only map, no-egress purity)
+  • PoC parity (§5.7.13 validation pointer — the 5 PoC self-tests
+    re-run as pytest cases against the production module)
+
+Parity tests mirror `scripts/research/abstraction_layer_poc.py`'s
+`_selftest` cases 1-5. If a future change to the production module
+breaks one of these, the PoC's 5/5 promise is also broken — the test
+file is the gate.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from typing import List
+
+import pytest
+
+from core.abstraction import (
+    AbstractionMap,
+    Decision,
+    build_map,
+    default_decider,
+    emit_egress_event,
+    mask_text,
+    unmask_text,
+)
+from core.abstraction._policy import (
+    _entity_name,
+    _entity_type,
+    _is_sensitive,
+)
+
+
+# ─── API surface (§5.7.13 contract) ─────────────────────────────────
+
+def test_decision_enum_three_outcomes():
+    """§5.7.12 three-way: MASK / PASS / KEEP_LOCAL. No other values."""
+    assert {Decision.MASK, Decision.PASS, Decision.KEEP_LOCAL} == set(Decision)
+
+
+def test_decision_string_values_are_stable():
+    """String values are stable — used in audit rows and persisted in
+    research outputs. Changing them is a contract break."""
+    assert Decision.MASK.value == "mask"
+    assert Decision.PASS.value == "pass"
+    assert Decision.KEEP_LOCAL.value == "keep"
+
+
+def test_public_api_surface_matches_init():
+    """The frozen public surface in __init__.__all__ matches §5.7.13."""
+    import core.abstraction as ab
+
+    expected = {
+        "Decision", "AbstractionMap", "default_decider",
+        "build_map", "mask_text", "unmask_text", "emit_egress_event",
+    }
+    assert set(ab.__all__) == expected
+    for name in expected:
+        assert hasattr(ab, name), f"missing public symbol {name!r}"
+
+
+# ─── §5.7.13 invariant #1 — determinism ─────────────────────────────
+
+def test_determinism_same_input_same_map():
+    """build_map(entities, decider) is byte-identical across calls.
+    Required for §5.7.2 trace-schema replay."""
+    entities = [
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+        {"name": "이영희", "entity_type": "person", "sensitive": True},
+        {"name": "박민수", "entity_type": "person", "sensitive": True},
+    ]
+    a = build_map(entities, default_decider()).forward
+    b = build_map(entities, default_decider()).forward
+    assert a == b
+    assert a == {"김철수": "PERSON_1", "이영희": "PERSON_2", "박민수": "PERSON_3"}
+
+
+def test_determinism_counter_advances_in_declaration_order():
+    """Per-TYPE counter follows entity declaration order."""
+    entities = [
+        {"name": "B", "entity_type": "person", "sensitive": True},
+        {"name": "A", "entity_type": "person", "sensitive": True},
+    ]
+    amap = build_map(entities, default_decider())
+    assert amap.forward == {"B": "PERSON_1", "A": "PERSON_2"}
+
+
+# ─── §5.7.13 invariant #2 — substring safety ────────────────────────
+
+def test_substring_safety_longest_first():
+    """A name that is a substring of another must not corrupt the
+    replacement (PoC self-test §5)."""
+    ents = [
+        {"name": "김철", "entity_type": "person", "sensitive": True},
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+    ]
+    amap = build_map(ents, default_decider())
+    masked = mask_text("김철수와 김철은 다른 사람이다.", amap)
+    # both replaced, no corruption — '김철수' got its own placeholder
+    # even though '김철' is a prefix of it
+    assert "김철수" not in masked
+    assert "김철" not in masked.replace(amap.forward["김철수"], "")
+    restored, flagged = unmask_text(masked, amap)
+    assert restored == "김철수와 김철은 다른 사람이다."
+    assert flagged == []
+
+
+# ─── §5.7.13 invariant #3 — particle/boundary safety ────────────────
+
+def test_korean_particle_after_placeholder():
+    """`PERSON_3의` must unmask to `<real>의` — `\\b` would fail here."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")   # → PERSON_1
+    amap.placeholder_for("이영희", "person")   # → PERSON_2
+    amap.placeholder_for("박민수", "person")   # → PERSON_3
+    restored, flagged = unmask_text(
+        "PERSON_3의 보고라인 최상단은 PERSON_1 이다.", amap,
+    )
+    assert restored == "박민수의 보고라인 최상단은 김철수 이다."
+    assert flagged == []
+
+
+def test_two_digit_placeholder_not_split():
+    """`PERSON_12` is one token, not `PERSON_1` + `2` (PoC `_PLACEHOLDER_RE`
+    not-a-digit lookahead)."""
+    amap = AbstractionMap()
+    # allocate 12 placeholders so PERSON_12 is real
+    for i in range(12):
+        amap.placeholder_for(f"name{i}", "person")
+    assert amap.forward["name11"] == "PERSON_12"
+    restored, flagged = unmask_text("alpha PERSON_12 beta", amap)
+    assert "name11" in restored
+    assert flagged == []
+
+
+def test_placeholder_inside_identifier_not_matched():
+    """Lookbehind: `xPERSON_1` is not a placeholder match."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    restored, flagged = unmask_text("xPERSON_1 and PERSON_1", amap)
+    # only the standalone PERSON_1 is restored
+    assert restored == "xPERSON_1 and 김철수"
+    assert flagged == []
+
+
+# ─── §5.7.13 invariant #4 — hallucination flagging ──────────────────
+
+def test_hallucinated_placeholder_flagged_not_restored():
+    """A reasoner-introduced placeholder absent from the map is
+    flagged and **left verbatim** in restored text (PoC self-test §2).
+    Silent de-abstraction would let cloud inject content under a real
+    name — the threat this module exists to defeat."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    bad = "최상단은 PERSON_1 이며, PERSON_9 도 관여한다."
+    restored, flagged = unmask_text(bad, amap)
+    assert flagged == ["PERSON_9"]
+    assert "PERSON_9" in restored  # verbatim, NOT silently restored
+    assert "김철수" in restored
+
+
+def test_unknown_type_placeholder_not_flagged():
+    """A `FOO_1` token shaped like a placeholder but with a TYPE not
+    in the ontology is NOT flagged — it isn't ours to claim."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    restored, flagged = unmask_text("PERSON_1 and FOO_99 walk in", amap)
+    assert flagged == []  # FOO not in ontology
+    assert restored == "김철수 and FOO_99 walk in"
+
+
+def test_flagged_list_deduplicates():
+    """Same hallucinated placeholder appearing twice → one entry."""
+    amap = AbstractionMap()
+    restored, flagged = unmask_text("PERSON_1 and PERSON_1 again", amap)
+    assert flagged == ["PERSON_1"]
+
+
+# ─── §5.7.12 three-way egress policy ────────────────────────────────
+
+def test_default_decider_non_sensitive_passes():
+    """Not-sensitive → PASS."""
+    decide = default_decider()
+    assert decide({"name": "팀A", "entity_type": "org", "sensitive": False}) == Decision.PASS
+
+
+def test_default_decider_sensitive_closed_world_masks():
+    """Sensitive, no open-world hint → MASK (safer-egress default)."""
+    decide = default_decider()
+    assert decide({"name": "김철수", "entity_type": "person", "sensitive": True}) == Decision.MASK
+
+
+def test_default_decider_open_world_type_keeps_local():
+    """Sensitive + open-world TYPE → KEEP_LOCAL (PoC self-test §3)."""
+    decide = default_decider(open_world_types=["concept"])
+    assert decide({"name": "와파린", "entity_type": "concept", "sensitive": True}) == Decision.KEEP_LOCAL
+
+
+def test_default_decider_open_world_name_keeps_local():
+    """Open-world NAME (specific entity) → KEEP_LOCAL even if TYPE is
+    closed-world by default."""
+    decide = default_decider(open_world_names=["환자김"])
+    assert decide({"name": "환자김", "entity_type": "person", "sensitive": True}) == Decision.KEEP_LOCAL
+
+
+def test_default_decider_string_sensitivity_truthy_values():
+    """`sensitivity` chunk-metadata convention accepts string flags."""
+    decide = default_decider()
+    for v in ("1", "true", "yes", "high", "sensitive", "HIGH", " True "):
+        assert decide({"name": "x", "entity_type": "person", "sensitivity": v}) == Decision.MASK
+    for v in ("0", "false", "no", "", "low"):
+        assert decide({"name": "x", "entity_type": "person", "sensitivity": v}) == Decision.PASS
+
+
+def test_sensitive_flag_default_false():
+    """Missing sensitivity flag → not sensitive (conservative — an
+    unflagged entity is not masked but does not block egress)."""
+    assert _is_sensitive({"name": "x", "entity_type": "person"}) is False
+
+
+# ─── PoC §1 parity — closed-world org chart end-to-end ─────────────
+
+def test_poc_case_1_closed_world_org_chart_round_trip():
+    """PoC self-test §1: org chart masks, structural reasoning over
+    placeholders restores cleanly, non-sensitive entity passes through."""
+    entities = [
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+        {"name": "이영희", "entity_type": "person", "sensitive": True},
+        {"name": "박민수", "entity_type": "person", "sensitive": True},
+        {"name": "영업팀", "entity_type": "org", "sensitive": False},
+    ]
+    docs = (
+        "김철수는 영업팀의 팀장이다. "
+        "이영희는 김철수에게 보고한다. "
+        "박민수는 이영희에게 보고한다."
+    )
+    amap = build_map(entities, default_decider())
+    masked = mask_text(docs, amap)
+    # sensitive names gone, non-sensitive entity passes through
+    for sensitive_name in ("김철수", "이영희", "박민수"):
+        assert sensitive_name not in masked
+    assert "영업팀" in masked
+    assert "영업팀" in amap.passed
+
+    # simulate cloud reasoning over placeholders
+    cloud_reply = "PERSON_3의 보고라인 최상단은 PERSON_1 이다."
+    restored, flagged = unmask_text(cloud_reply, amap)
+    assert restored == "박민수의 보고라인 최상단은 김철수 이다."
+    assert flagged == []
+
+
+# ─── PoC §3 parity — open-world keep-local ─────────────────────────
+
+def test_poc_case_3_open_world_kept_local():
+    """PoC self-test §3: drug names (open-world concept) → KEEP_LOCAL,
+    patient name (closed-world person) → masked."""
+    med = [
+        {"name": "와파린", "entity_type": "concept", "sensitive": True},
+        {"name": "아스피린", "entity_type": "concept", "sensitive": True},
+        {"name": "환자김", "entity_type": "person", "sensitive": True},
+    ]
+    decide = default_decider(open_world_types=["concept"])
+    amap = build_map(med, decide)
+    assert set(amap.keep_local) == {"와파린", "아스피린"}
+    assert "환자김" in amap.forward
+
+
+# ─── §5.7.13 invariant #5 — local-only map ─────────────────────────
+
+def test_map_has_no_persist_method():
+    """The map exposes no serialize/save/persist — by design.
+    Cross-query reuse would be a re-identification risk."""
+    amap = AbstractionMap()
+    for attr in ("save", "persist", "to_disk", "serialize", "dumps"):
+        assert not hasattr(amap, attr), f"AbstractionMap should not expose {attr}"
+
+
+def test_two_maps_with_same_input_dont_share_state():
+    """Each build_map returns a fresh AbstractionMap — no module-level
+    cache, no cross-call leakage."""
+    ents = [{"name": "x", "entity_type": "person", "sensitive": True}]
+    a = build_map(ents, default_decider())
+    b = build_map(ents, default_decider())
+    assert a is not b
+    assert a.forward == b.forward  # same input → same content
+    assert a.reverse is not b.reverse  # but different objects
+
+
+# ─── §5.7.13 invariant #6 — no-egress purity ───────────────────────
+
+def test_mask_text_is_pure():
+    """mask_text has no side effects on its inputs."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    original_forward = dict(amap.forward)
+    original_reverse = dict(amap.reverse)
+    _ = mask_text("김철수가 왔다", amap)
+    _ = mask_text("김철수가 또 왔다", amap)
+    assert amap.forward == original_forward
+    assert amap.reverse == original_reverse
+
+
+def test_unmask_text_is_pure():
+    """unmask_text has no side effects on the map."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    original_forward = dict(amap.forward)
+    _ = unmask_text("PERSON_1 and PERSON_9", amap)
+    assert amap.forward == original_forward
+
+
+def test_mask_text_makes_no_network_call(monkeypatch):
+    """No-egress purity: mask_text must not import any network module
+    at call time. Module-level imports are checked by spying on
+    `socket.socket` — if mask_text instantiates one, the test fails."""
+    import socket
+
+    calls = []
+    real_socket = socket.socket
+
+    def _spy(*a, **kw):
+        calls.append((a, kw))
+        return real_socket(*a, **kw)
+
+    monkeypatch.setattr(socket, "socket", _spy)
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    _ = mask_text("김철수가 왔다", amap)
+    _ = unmask_text("PERSON_1", amap)
+    assert calls == [], "mask/unmask must not open sockets"
+
+
+# ─── §5.7.13 caller obligation #2 — audit emit ─────────────────────
+
+
+def _read_audit_rows(db_path: str) -> List[tuple]:
+    """Read `reason:egress` rows. The audit_bridge JSON-packs non-reserved
+    keys (`query`, `answer`) into the SQLite `answer` column, mirroring
+    the convention used by `core.reasoning.router.emit_route_event`. We
+    parse the JSON back so the test can assert on the logical
+    (endpoint, query, answer) the caller passed in, not on the
+    bridge-internal wrapping shape."""
+    import json
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT endpoint, answer FROM audit_log "
+            "WHERE endpoint='reason:egress'"
+        )
+        out: List[tuple] = []
+        for endpoint, packed in cur.fetchall():
+            blob = json.loads(packed) if packed else {}
+            out.append((endpoint, blob.get("query", ""), blob.get("answer", "")))
+        return out
+    finally:
+        conn.close()
+
+
+def _init_audit_schema(db_path: str) -> None:
+    """Minimal audit_log schema matching `core/audit_bridge.py` writes."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                user_role TEXT,
+                endpoint TEXT,
+                query TEXT,
+                answer TEXT,
+                graph_paths TEXT,
+                blocked INTEGER,
+                security_event TEXT,
+                elapsed_sec REAL,
+                ip_address TEXT
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def audit_db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test_audit.db")
+    _init_audit_schema(db_path)
+    monkeypatch.setattr("core.audit_bridge._DEFAULT_AUDIT_DB", db_path)
+    yield db_path
+
+
+def test_emit_egress_event_writes_one_row(audit_db):
+    entities = [
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+        {"name": "삼성전자", "entity_type": "org", "sensitive": True},
+        {"name": "30억", "entity_type": "quantity", "sensitive": True},
+    ]
+    amap = build_map(entities, default_decider())
+    emit_egress_event(
+        "synth",
+        "프롬프트 내용",
+        "claude_code_cli",
+        amap,
+        flagged=[],
+    )
+    rows = _read_audit_rows(audit_db)
+    assert len(rows) == 1
+    endpoint, query, answer = rows[0]
+    assert endpoint == "reason:egress"
+    assert query == "synth"
+    # backend id + type histogram + counts in the answer blob
+    assert "backend=claude_code_cli" in answer
+    assert "PERSON:1" in answer
+    assert "ORG:1" in answer
+    assert "QUANTITY:1" in answer
+    assert "flagged=-" in answer  # empty flagged renders as '-'
+
+
+def test_emit_egress_event_records_flagged(audit_db):
+    """Hallucinated placeholders from unmask_text land in the audit row
+    so operators can answer 'did the cloud invent any entities?'."""
+    amap = AbstractionMap()
+    amap.placeholder_for("김철수", "person")
+    _, flagged = unmask_text("PERSON_1 and PERSON_99", amap)
+    emit_egress_event("verify", "p", "claude_code_cli", amap, flagged=flagged)
+    rows = _read_audit_rows(audit_db)
+    assert len(rows) == 1
+    _, _, answer = rows[0]
+    assert "flagged=PERSON_99" in answer
+
+
+def test_emit_egress_event_does_not_leak_real_names(audit_db):
+    """§5.7.13 invariant #5: real entity names MUST NOT appear in
+    audit rows. Only placeholder ids + type histograms."""
+    sensitive_names = ["김철수", "삼성전자", "30억"]
+    entities = [
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+        {"name": "삼성전자", "entity_type": "org", "sensitive": True},
+        {"name": "30억", "entity_type": "quantity", "sensitive": True},
+    ]
+    amap = build_map(entities, default_decider())
+    emit_egress_event("synth", "프롬프트", "claude_code_cli", amap)
+    rows = _read_audit_rows(audit_db)
+    assert len(rows) == 1
+    _, _, answer = rows[0]
+    for real in sensitive_names:
+        assert real not in answer, f"real name {real!r} leaked into audit row"
+
+
+def test_emit_egress_event_never_raises(monkeypatch):
+    """Per docstring: audit failure must not block the caller. If the
+    audit_bridge import fails or mirror_to_audit_db raises, the helper
+    swallows."""
+    def boom(*a, **kw):
+        raise RuntimeError("simulated audit failure")
+
+    monkeypatch.setattr("core.audit_bridge.mirror_to_audit_db", boom)
+
+    amap = AbstractionMap()
+    amap.placeholder_for("x", "person")
+    # MUST NOT raise
+    emit_egress_event("synth", "p", "claude_code_cli", amap)
+
+
+# ─── Sundry contract bits ──────────────────────────────────────────
+
+def test_empty_nameless_entity_silently_skipped():
+    """Build is resilient to entities with no name/label."""
+    entities = [
+        {"entity_type": "person", "sensitive": True},  # no name
+        {"name": "", "entity_type": "person", "sensitive": True},  # empty
+        {"name": "김철수", "entity_type": "person", "sensitive": True},
+    ]
+    amap = build_map(entities, default_decider())
+    assert amap.forward == {"김철수": "PERSON_1"}
+
+
+def test_entity_alias_field_resolution():
+    """`_entity_name` falls back through name → label → title → entity_id."""
+    assert _entity_name({"name": "A"}) == "A"
+    assert _entity_name({"label": "B"}) == "B"
+    assert _entity_name({"title": "C"}) == "C"
+    assert _entity_name({"entity_id": "D"}) == "D"
+    assert _entity_name({}) == ""
+
+
+def test_entity_type_default():
+    """Missing type → 'concept' (safe default — most entities classified
+    as concept won't egress unless explicitly marked sensitive)."""
+    assert _entity_type({"name": "x"}) == "concept"
+    assert _entity_type({"name": "x", "type": "org"}) == "org"
+    assert _entity_type({"name": "x", "entity_type": "person"}) == "person"
+
+
+def test_kept_local_dedup():
+    """Same KEEP_LOCAL name listed twice → one entry."""
+    decide = default_decider(open_world_types=["concept"])
+    entities = [
+        {"name": "와파린", "entity_type": "concept", "sensitive": True},
+        {"name": "와파린", "entity_type": "concept", "sensitive": True},
+    ]
+    amap = build_map(entities, decide)
+    assert amap.keep_local == ["와파린"]
+
+
+def test_passed_dedup():
+    """Same PASS name listed twice → one entry."""
+    entities = [
+        {"name": "팀A", "entity_type": "org", "sensitive": False},
+        {"name": "팀A", "entity_type": "org", "sensitive": False},
+    ]
+    amap = build_map(entities, default_decider())
+    assert amap.passed == ["팀A"]


### PR DESCRIPTION
## Summary

Promotes the design-stage abstraction PoC (`scripts/research/abstraction_*`) into the production path at `core/abstraction/`, satisfying the §5.7.13 trust contract (PR #698). This is the cloud-egress enforcer: where sensitive entity names become typed placeholders on the way out and the cloud reply is unmasked on the way in.

### Module layout (rule #5 module-size discipline)

| File | Size | Purpose |
|---|---:|---|
| `__init__.py` | 1.9 KB | frozen public façade per §5.7.13 |
| `_policy.py` | 3.4 KB | `Decision` enum + `default_decider` |
| `_mask.py` | 6.0 KB | `AbstractionMap` + `build_map` + `mask_text` + `unmask_text` |
| `_audit.py` | 4.5 KB | `emit_egress_event` (`reason:egress` row, no real-name leak) |

All four well under the 20 KB ceiling. Audit emit mirrors the convention used by `core.reasoning.router.emit_route_event` (idempotent JSON-pack into `audit_log.answer` so existing operator tooling picks them up).

### Public API (frozen per §5.7.13)

```python
from core.abstraction import (
    Decision, AbstractionMap, default_decider,
    build_map, mask_text, unmask_text, emit_egress_event,
)
```

## Verification

**34 tests** lock the §5.7.13 contract:
- API surface (Decision values, `__all__` contract)
- §5.7.13 invariant #1 determinism (replay-critical)
- §5.7.13 invariant #2 substring safety (PoC §5 round-trip parity)
- §5.7.13 invariant #3 particle/boundary safety (Korean `PERSON_3의` + `PERSON_12` not-split + identifier-prefix not matched)
- §5.7.13 invariant #4 hallucination flagging (PoC §2: flagged not silently restored, unknown TYPE not flagged, deduplicated)
- §5.7.12 three-way egress (PASS / MASK / KEEP_LOCAL); open-world TYPE + NAME inputs
- §5.7.13 invariant #5 local-only map (no save/persist/serialize methods; fresh per call)
- §5.7.13 invariant #6 no-egress purity (no side effects, no socket calls under monkey-patched `socket.socket` spy)
- §5.7.13 caller obligation #2 audit emit (one `reason:egress` row, type histogram, flagged surfaced, real names NEVER leak into the row, swallows on audit failure per docstring)

PoC self-test (5/5) still passes — production module is the canonical surface; PoC stays as the design-stage scaffold + e2e Claude loop validator.

Broader regression: **3497 passed** + 17 deselected (the 17 are the documented chronic flakies). Pre-existing main failures unaffected:
- `tests/test_embedding_model_abstraction.py` (BL-9 follow-up)
- `tests/test_event_admin_endpoint.py` + `tests/test_event_entity_schema.py` (α-8 9-type extension follow-up — `ENTITY_TYPES_CORE` ordering)

## Out of scope

- Cloud-routing wiring (S3, next PR): operator-explicit toggle in `core/reasoning/router.py` → `abstraction.build_map` → `claude_code_cli` backend → `unmask_text` end-to-end.
- Live `sensitivity` metadata wiring + query-conditioned open/closed-world classifier — that is the §4.2 hard problem (S7), empirical-gated on measurement data from S4.

Quality delta: exempt (label: code — security-critical scaffold, no oracle yet; α-8 test-line extension (S4) will be the measurement gate per design memo §4.1 sequencing).