### PR TITLE
feat(reasoning): JAMES_FORCE_CLOUD wire at trace_synth_call (S5)

### DIFF
--- a/core/reasoning/router.py
+++ b/core/reasoning/router.py
@@ -85,6 +85,27 @@ def _auto_router_enabled() -> bool:
     return os.getenv("JAMES_AUTO_ROUTER", "0").strip().lower() in _FLAG_ON_VALUES
 
 
+def force_cloud_enabled() -> bool:
+    """Direction α — operator-explicit cloud routing gate.
+
+    Default OFF — `JAMES_FORCE_CLOUD=1` (or `true` / `yes` / `on`)
+    instructs `trace_synth_call` (and any other call site that opts in)
+    to wrap synth-stage egress through `core.abstraction.run_cloud_egress`
+    instead of calling `backend.complete` directly.
+
+    Self-policing: when the flag is ON but the resolved backend's
+    capability is not `provider="cloud"`, the caller logs a warning and
+    proceeds with the normal `backend.complete` path — wrapping a local
+    backend in abstraction would be a confusing no-op.
+
+    Public (unprefixed) name so external callers — e.g. the planner /
+    verify / reflect call sites — can opt in symmetrically once the
+    end-to-end shape is proven on synth. Mirrors the public surface of
+    `core.retrieval.query_rewriter.adaptive_budget_enabled`.
+    """
+    return os.getenv("JAMES_FORCE_CLOUD", "0").strip().lower() in _FLAG_ON_VALUES
+
+
 def _legacy_backend_id() -> str:
     """Return the registry backend ID for the pre-D5 default path.
 

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -7,6 +7,16 @@ site through the registered backend instead of calling
 the default backend (``ollama_local``) runs — that backend wraps
 ``RouterWrapper.call_gemma`` with the same kwargs.
 
+S5 (Direction α, 2026-06-03): when `JAMES_FORCE_CLOUD=1` AND the
+resolved backend is `provider="cloud"`, the synth call is wrapped
+through `core.abstraction.run_cloud_egress` — mask→complete→unmask→
+audit per §5.7.12 / §5.7.13. The wrap is self-policing: flag-on with a
+non-cloud backend logs a warning and proceeds with the normal path
+(wrapping local in abstraction would be a confusing no-op). Optional
+`entities` kwarg lets call sites that have typed graph entities pipe
+them in for actual masking; default `entities=()` makes the wrap a
+mask-no-op but exercises the audit + call path end-to-end.
+
 Call shape:
 
     raw = trace_synth_call(
@@ -44,6 +54,7 @@ from typing import Any, Dict, Optional
 from core.reasoning.backends import (
     CompletionResult,
     get_backend,
+    get_backend_capability,
     resolve_backend_for_stage,
 )
 from core.reasoning.trace_schema import (
@@ -97,6 +108,7 @@ def trace_synth_call(
     model: Optional[str] = None,
     temperature: Optional[float] = None,
     extras: Optional[Dict[str, Any]] = None,
+    entities: Optional[Any] = None,
     **opts: Any,
 ) -> str:
     """Run one synth call through the registered backend, emit one
@@ -213,16 +225,72 @@ def trace_synth_call(
         evidence_scope=scope_breakdown,
     )
 
-    result: CompletionResult = backend.complete(
-        prompt,
-        system=system,
-        max_tokens=max_tokens,
-        timeout=timeout,
-        model=model,
-        use_cache=use_cache,
-        temperature=temperature,
-        **opts,
-    )
+    # S5 — Direction α cloud routing. When JAMES_FORCE_CLOUD=1 AND the
+    # resolved backend is provider="cloud", wrap the egress through
+    # `core.abstraction.run_cloud_egress` (§5.7.12 / §5.7.13). Flag OFF
+    # → byte-identical to pre-S5 main (no abstraction import, no extra
+    # audit row, no runner overhead).
+    #
+    # Self-policing: flag ON + non-cloud backend → log + fall through.
+    # Wrapping a local backend in abstraction would be a no-op (mask
+    # never leaves the machine on the local route by construction) and
+    # would mislead operators reading the audit log.
+    result: Optional[CompletionResult] = None
+    try:
+        from core.reasoning.router import force_cloud_enabled
+        if force_cloud_enabled():
+            cap = get_backend_capability(backend_id)
+            if cap.provider == "cloud":
+                from core.abstraction import (
+                    default_decider,
+                    run_cloud_egress,
+                )
+                # Future S7 will pass a query-conditioned decider;
+                # default_decider() with empty open-world sets is the
+                # safer-egress default (every sensitive entity → MASK).
+                result, _flagged = run_cloud_egress(
+                    backend=backend,
+                    prompt=prompt,
+                    entities=list(entities or ()),
+                    decider=default_decider(),
+                    stage=stage,
+                    system=system,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    model=model,
+                    use_cache=use_cache,
+                    temperature=temperature,
+                    **opts,
+                )
+            else:
+                print(
+                    f"[FORCE_CLOUD] backend {backend_id!r} is provider="
+                    f"{cap.provider!r}, not 'cloud' — JAMES_FORCE_CLOUD=1 "
+                    f"falling through to direct backend.complete. "
+                    f"Set JAMES_BACKEND_SYNTH to a cloud-tier backend "
+                    f"(e.g. claude_code_cli) to enable cloud routing."
+                )
+    except Exception as e:  # noqa: BLE001
+        # The force-cloud wrap is best-effort. Any failure (import,
+        # capability lookup, runner-side refusal in a future change)
+        # should NOT take down the synth path — log to stderr and fall
+        # through to the normal backend.complete so the user query still
+        # gets an answer.
+        print(f"[FORCE_CLOUD] wrap failed ({type(e).__name__}: {e}) "
+              f"— falling through to direct backend.complete")
+        result = None
+
+    if result is None:
+        result = backend.complete(
+            prompt,
+            system=system,
+            max_tokens=max_tokens,
+            timeout=timeout,
+            model=model,
+            use_cache=use_cache,
+            temperature=temperature,
+            **opts,
+        )
 
     text_str = result.text if isinstance(result.text, str) else ""
     err = result.error or ""

--- a/tests/test_trace_synth_force_cloud.py
+++ b/tests/test_trace_synth_force_cloud.py
@@ -1,0 +1,354 @@
+"""S5 — `JAMES_FORCE_CLOUD` synth wiring tests.
+
+Locks the contract added in `core/reasoning/trace_helpers.py`:
+
+  • flag OFF                  → byte-identical to pre-S5 (direct backend.complete)
+  • flag ON  + cloud backend  → routes through core.abstraction.run_cloud_egress
+                                (abstraction audit fires, restored text returned)
+  • flag ON  + local backend  → logs + falls through (no abstraction wrap;
+                                wrapping local would be a confusing no-op)
+  • flag ON  + abstraction import explodes → caught + falls through to
+                                backend.complete (synth path stays alive)
+
+Entities kwarg parity: passing `entities=[]` is the same as omitting
+(default `None` → `()` → empty mask), and passing real entities exercises
+the mask. Caller-site PRs (S7 etc.) opt in by passing entities; existing
+callers stay unchanged.
+"""
+from __future__ import annotations
+
+import sqlite3
+import json
+from typing import Any, List, Tuple
+
+import pytest
+
+from core.reasoning.backends import (
+    BackendCapability,
+    CompletionResult,
+    _clear_for_tests,
+    register_backend,
+)
+from core.reasoning.trace_helpers import trace_synth_call
+
+
+# ─── Stub backends ─────────────────────────────────────────────────
+
+
+class _CloudBackend:
+    """Records what reached complete + canned reply.
+
+    `tier="large", provider="cloud"` — the capability that
+    `force_cloud_enabled()` looks for in trace_synth_call's wrap branch.
+    """
+
+    backend_id = "stub_cloud"
+    capability = BackendCapability(tier="large", provider="cloud")
+
+    def __init__(self, reply: str = "ok") -> None:
+        self.reply = reply
+        self.calls: List[Tuple[str, str, dict]] = []
+
+    def complete(self, prompt, *, system="", max_tokens=1024,
+                 timeout=60.0, **opts) -> CompletionResult:
+        self.calls.append((prompt, system, dict(opts)))
+        return CompletionResult(
+            text=self.reply, backend_id=self.backend_id,
+            model="claude-stub", latency_ms=42, error="",
+        )
+
+
+class _LocalBackend:
+    """Local-tier stub. force_cloud=on with this backend resolved
+    must NOT wrap (mismatch → fall through)."""
+
+    backend_id = "stub_local"
+    capability = BackendCapability(tier="small", provider="local")
+
+    def __init__(self, reply: str = "ok") -> None:
+        self.reply = reply
+        self.calls: List[Tuple[str, str, dict]] = []
+
+    def complete(self, prompt, *, system="", max_tokens=1024,
+                 timeout=60.0, **opts) -> CompletionResult:
+        self.calls.append((prompt, system, dict(opts)))
+        return CompletionResult(
+            text=self.reply, backend_id=self.backend_id,
+            model="local-stub", latency_ms=10, error="",
+        )
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry():
+    """Each test starts with a clean backend registry to avoid
+    cross-test bleed from the autoregistered ollama_local."""
+    _clear_for_tests()
+    yield
+    _clear_for_tests()
+
+
+def _init_audit_schema(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT, user_role TEXT, endpoint TEXT,
+                query TEXT, answer TEXT, graph_paths TEXT,
+                blocked INTEGER, security_event TEXT,
+                elapsed_sec REAL, ip_address TEXT
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def audit_db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test_audit.db")
+    _init_audit_schema(db_path)
+    monkeypatch.setattr("core.audit_bridge._DEFAULT_AUDIT_DB", db_path)
+    yield db_path
+
+
+def _read_egress_endpoints(db_path: str) -> List[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT endpoint FROM audit_log WHERE endpoint='reason:egress'"
+        )
+        return [r[0] for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def _read_egress_payloads(db_path: str) -> List[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT answer FROM audit_log WHERE endpoint='reason:egress'"
+        )
+        out = []
+        for (packed,) in cur.fetchall():
+            blob = json.loads(packed) if packed else {}
+            out.append(blob.get("answer", ""))
+        return out
+    finally:
+        conn.close()
+
+
+# ─── Flag OFF — byte-identical (regression guard) ──────────────────
+
+
+def test_flag_off_calls_backend_directly_no_egress_row(audit_db, monkeypatch):
+    """Default state: JAMES_FORCE_CLOUD unset → trace_synth_call goes
+    straight to backend.complete. No reason:egress row, no abstraction
+    import overhead."""
+    monkeypatch.delenv("JAMES_FORCE_CLOUD", raising=False)
+    cloud = _CloudBackend(reply="local-style-answer")
+    register_backend("ollama_local", cloud)  # fallback name resolve_backend uses
+
+    out = trace_synth_call("hello", applied_rule="test.rule")
+
+    assert out == "local-style-answer"
+    assert len(cloud.calls) == 1
+    sent_prompt, _, _ = cloud.calls[0]
+    assert sent_prompt == "hello"  # NOT masked
+    # No egress audit row
+    assert _read_egress_endpoints(audit_db) == []
+
+
+def test_flag_off_with_entities_kwarg_ignored(audit_db, monkeypatch):
+    """Passing entities= when flag is OFF → entities are silently
+    ignored (no mask, no audit). Forward-compatible signature; doesn't
+    light up until the operator opts in."""
+    monkeypatch.delenv("JAMES_FORCE_CLOUD", raising=False)
+    cloud = _CloudBackend()
+    register_backend("ollama_local", cloud)
+
+    trace_synth_call(
+        "김철수가 등장한다",
+        applied_rule="test.rule",
+        entities=[{"name": "김철수", "entity_type": "person", "sensitive": True}],
+    )
+
+    sent_prompt, _, _ = cloud.calls[0]
+    assert "김철수" in sent_prompt  # unmasked — flag was off
+    assert _read_egress_endpoints(audit_db) == []
+
+
+# ─── Flag ON + cloud backend → wrapped through run_cloud_egress ────
+
+
+def test_flag_on_cloud_backend_routes_through_abstraction(audit_db, monkeypatch):
+    """JAMES_FORCE_CLOUD=1 + provider='cloud' backend → wrap fires.
+    backend.complete still happens (the runner calls it) but the prompt
+    has been masked first when entities are supplied, and a
+    reason:egress audit row lands."""
+    monkeypatch.setenv("JAMES_FORCE_CLOUD", "1")
+    monkeypatch.setenv("JAMES_REASONING_BACKEND", "stub_cloud")
+    cloud = _CloudBackend(reply="PERSON_1의 보고는 양호")
+    register_backend("stub_cloud", cloud)
+
+    out = trace_synth_call(
+        "김철수의 보고는?",
+        applied_rule="test.rule",
+        entities=[{"name": "김철수", "entity_type": "person", "sensitive": True}],
+    )
+
+    # backend was called with the MASKED prompt
+    assert len(cloud.calls) == 1
+    sent_prompt, _, _ = cloud.calls[0]
+    assert "김철수" not in sent_prompt
+    assert "PERSON_1" in sent_prompt
+    # returned text is UNMASKED
+    assert out == "김철수의 보고는 양호"
+    # audit row exists
+    endpoints = _read_egress_endpoints(audit_db)
+    assert endpoints == ["reason:egress"]
+    payloads = _read_egress_payloads(audit_db)
+    assert "backend=stub_cloud" in payloads[0]
+    assert "PERSON:1" in payloads[0]  # type histogram
+
+
+def test_flag_on_cloud_backend_no_entities_mask_is_noop(audit_db, monkeypatch):
+    """Flag ON + cloud + no entities (or empty) → wrap still fires (audit
+    row lands, backend gets prompt unchanged because empty mask). Proves
+    operator can flip the flag and immediately see audit traces even
+    before entity wiring lands at call sites."""
+    monkeypatch.setenv("JAMES_FORCE_CLOUD", "1")
+    monkeypatch.setenv("JAMES_REASONING_BACKEND", "stub_cloud")
+    cloud = _CloudBackend(reply="cloud answer")
+    register_backend("stub_cloud", cloud)
+
+    out = trace_synth_call("hello", applied_rule="test.rule")
+
+    assert out == "cloud answer"
+    # mask was a no-op (empty entities)
+    sent_prompt, _, _ = cloud.calls[0]
+    assert sent_prompt == "hello"
+    # audit row still lands → proves wrap fired
+    assert _read_egress_endpoints(audit_db) == ["reason:egress"]
+
+
+# ─── Flag ON + non-cloud backend → fallthrough + warning ──────────
+
+
+def test_flag_on_local_backend_falls_through(audit_db, monkeypatch, capsys):
+    """JAMES_FORCE_CLOUD=1 with a local backend resolved → log a
+    warning + fall through to backend.complete. No abstraction wrap
+    (wrapping local would be a confusing no-op). No egress audit row."""
+    monkeypatch.setenv("JAMES_FORCE_CLOUD", "1")
+    monkeypatch.setenv("JAMES_REASONING_BACKEND", "stub_local")
+    local = _LocalBackend(reply="direct local")
+    register_backend("stub_local", local)
+
+    out = trace_synth_call("hello", applied_rule="test.rule")
+
+    assert out == "direct local"
+    # backend called directly, no mask
+    assert len(local.calls) == 1
+    sent_prompt, _, _ = local.calls[0]
+    assert sent_prompt == "hello"
+    # no abstraction audit row
+    assert _read_egress_endpoints(audit_db) == []
+    # warning printed
+    captured = capsys.readouterr()
+    assert "FORCE_CLOUD" in captured.out
+    assert "stub_local" in captured.out
+
+
+# ─── Flag ON wrap explosion → graceful fallthrough ─────────────────
+
+
+def test_flag_on_wrap_failure_falls_through(audit_db, monkeypatch):
+    """If anything in the force_cloud wrap path raises (import error,
+    capability lookup glitch, runner exception), the synth path stays
+    alive — the helper logs + falls through to backend.complete.
+
+    Simulated by monkeypatching `core.abstraction.run_cloud_egress` to
+    raise. The user query must still get an answer (the normal backend
+    path runs)."""
+    monkeypatch.setenv("JAMES_FORCE_CLOUD", "1")
+    monkeypatch.setenv("JAMES_REASONING_BACKEND", "stub_cloud")
+    cloud = _CloudBackend(reply="fallback reply")
+    register_backend("stub_cloud", cloud)
+
+    def boom(*a, **kw):
+        raise RuntimeError("abstraction explosion")
+
+    monkeypatch.setattr("core.abstraction.run_cloud_egress", boom)
+
+    out = trace_synth_call("hello", applied_rule="test.rule")
+
+    assert out == "fallback reply"
+    # backend called directly (fallthrough path)
+    assert len(cloud.calls) == 1
+
+
+# ─── Self-policing: capability missing → not wrapped ───────────────
+
+
+class _NoCapBackend:
+    """Backend without a capability attribute — `get_backend_capability`
+    returns UNKNOWN. Flag ON should fall through (not wrap)."""
+
+    backend_id = "stub_nocap"
+
+    def __init__(self, reply: str = "ok") -> None:
+        self.reply = reply
+        self.calls: List[Tuple[str, str, dict]] = []
+
+    def complete(self, prompt, *, system="", max_tokens=1024,
+                 timeout=60.0, **opts) -> CompletionResult:
+        self.calls.append((prompt, system, dict(opts)))
+        return CompletionResult(
+            text=self.reply, backend_id=self.backend_id, error="",
+        )
+
+
+def test_flag_on_unknown_capability_falls_through(audit_db, monkeypatch, capsys):
+    """Backend without capability declared → cap.provider == 'unknown'
+    → wrap does NOT fire (only `provider='cloud'` triggers it)."""
+    monkeypatch.setenv("JAMES_FORCE_CLOUD", "1")
+    monkeypatch.setenv("JAMES_REASONING_BACKEND", "stub_nocap")
+    no_cap = _NoCapBackend(reply="direct")
+    register_backend("stub_nocap", no_cap)
+
+    out = trace_synth_call("hello", applied_rule="test.rule")
+
+    assert out == "direct"
+    assert len(no_cap.calls) == 1
+    sent_prompt, _, _ = no_cap.calls[0]
+    assert sent_prompt == "hello"
+    assert _read_egress_endpoints(audit_db) == []
+    captured = capsys.readouterr()
+    assert "FORCE_CLOUD" in captured.out
+    assert "unknown" in captured.out
+
+
+# ─── Public function exposed correctly ─────────────────────────────
+
+
+def test_force_cloud_enabled_public_callable():
+    """`force_cloud_enabled` is unprefixed so external callers (planner,
+    verify, reflect) can opt in symmetrically once synth proves the
+    end-to-end shape."""
+    from core.reasoning import router
+    assert callable(router.force_cloud_enabled)
+
+
+def test_force_cloud_enabled_reads_env(monkeypatch):
+    from core.reasoning.router import force_cloud_enabled
+    monkeypatch.delenv("JAMES_FORCE_CLOUD", raising=False)
+    assert force_cloud_enabled() is False
+    for truthy in ("1", "true", "yes", "on", "TRUE", "On"):
+        monkeypatch.setenv("JAMES_FORCE_CLOUD", truthy)
+        assert force_cloud_enabled() is True, f"truthy {truthy!r} not recognized"
+    for falsy in ("0", "false", "no", "off", "", "  "):
+        monkeypatch.setenv("JAMES_FORCE_CLOUD", falsy)
+        assert force_cloud_enabled() is False, f"falsy {falsy!r} not recognized as off"


### PR DESCRIPTION
## Summary

Wires the §5.7.12 cloud route into the **production synth path**. `JAMES_FORCE_CLOUD=1` → `trace_synth_call` routes through `core.abstraction.run_cloud_egress` when the resolved backend declares `provider="cloud"` (claude_code_cli today; future cloud backends opt in by declaring the same capability).

**Default OFF — byte-identical to pre-S5 main.** The wrap path is opt-in via env, self-policing on capability mismatch, and graceful on import failure.

### Decision tree (post-resolve, pre-complete)

| force_cloud | cap.provider | Action |
|---|---|---|
| OFF | any | `backend.complete` direct (no abstraction import) |
| ON | `"cloud"` | `run_cloud_egress` wraps the call |
| ON | not `"cloud"` | print warning + fall through |
| ON | wrap raises | print error + fall through |

The wrap-failure fallthrough is **deliberate**: a problem in the cloud egress path must not take down the synth path — the user still gets an answer rather than a 500.

### Surfaces added

| Symbol | Type | Purpose |
|---|---|---|
| `core.reasoning.router.force_cloud_enabled()` | public | unprefixed so planner/verify/reflect can opt in symmetrically. Mirrors the public `adaptive_budget_enabled` surface from D1 |
| `trace_synth_call(..., entities=None, ...)` | new kwarg | purely additive. Existing callers stay unchanged; pipeline call sites with typed graph entities (post-α-8) can opt in by passing them — S7 wires that |

## Verification

**9 new tests** (`tests/test_trace_synth_force_cloud.py`):
- flag OFF + no entities → direct call, no egress row (regression guard)
- flag OFF + entities kwarg → entities silently ignored (forward-compat)
- flag ON + cloud + entities → mask fires, audit row, unmask returns
- flag ON + cloud + empty entities → audit row, mask no-op (proves operator can flip flag immediately and see traces even before entity wiring)
- flag ON + local backend → fallthrough + warning printed
- flag ON + wrap raises → fallthrough, user query still answered
- flag ON + unknown capability → fallthrough (only `"cloud"` wraps)
- `force_cloud_enabled()` public callable
- `force_cloud_enabled()` env parsing (truthy/falsy sweep)

**Broader regression**: 3504 passed (+9 from S4), no new failures. Pre-existing main failures unchanged.

## Notes

- **`core/reasoning/router.py` is now 19.1 KB / 20 KB ceiling.** Future router additions need a split before they land (CLAUDE.md rule #5).
- **CLAUDE.md briefing update intentionally NOT in this PR.** A docs-prefixed update lands after operator runs S4 measurement against the live wire — premature briefing of a flag with no validation data risks misleading future sessions per `feedback_finding_size_honest_framing`.
- **UI picker still pending** — separate PR (S5b). Operators today flip via env; picker is purely UX, doesn't affect the contract.

## Out of scope

- UI picker cloud-tier surface (deferred — env-flag operator pattern is sufficient until measurement gates the UX investment)
- Entity wiring at pipeline call sites (S7 — when the §4.2 query-conditioned classifier replaces `default_decider`)
- Planner/verify/reflect cloud-routing (each opts in symmetrically by reading `force_cloud_enabled()` once synth proves the shape)

Quality delta: exempt (label: code — security-critical scaffold, flag default-OFF, byte-identical pre-flip; α-8 test-line extension (S4 harness) is the measurement gate for the cloud-tier quality claim per design memo §4.1 sequencing).