### PR TITLE
fix(claude_cli): Windows env + neutral cwd + harness n_runs aggregate (S5c)

### DIFF
--- a/core/reasoning/backends/claude_code_cli.py
+++ b/core/reasoning/backends/claude_code_cli.py
@@ -11,11 +11,28 @@ Security posture (L0 MVP):
      reach the subprocess argv.
   2. Argv is a fixed list — `[cli_path, "-p", "--output-format", "text"]`.
      No user-controlled string ever joins argv.
-  3. Environment passed to the child is a **whitelist** — PATH, HOME,
-     and the explicit ``ANTHROPIC_API_KEY`` / ``CLAUDE_CONFIG_DIR``
-     forwards. os.environ is not handed over wholesale.
-  4. Output is size-capped (1 MiB) and the child is killed on timeout.
-  5. Cli path can be overridden via ``JAMES_CLAUDE_CLI_PATH`` (defaults
+  3. Environment passed to the child is a **whitelist**. The whitelist
+     splits into:
+       * Cross-platform Claude-specific: ``PATH``, ``HOME``,
+         ``ANTHROPIC_API_KEY``, ``CLAUDE_CONFIG_DIR``.
+       * Windows essentials: ``SystemRoot``, ``APPDATA``,
+         ``LOCALAPPDATA``, ``USERPROFILE``, ``TEMP``, ``TMP``.
+         Without these the Node-based ``claude.CMD`` wrapper exits
+         with returncode 1 + empty stderr on Windows (caught by S4
+         smoke 2026-06-03). The list is conservative — only Windows
+         baseline runtime vars, no app-specific secrets.
+     ``os.environ`` is not handed over wholesale; secrets stashed in
+     other env vars (``JAMES_API_KEY`` / ``AWS_*`` / ``GCP_*`` etc.)
+     stay local.
+  4. Default working directory is a **neutral temp dir**
+     (``tempfile.gettempdir()``), NOT the project directory. Spawning
+     ``claude -p`` inside the project loads the project ``CLAUDE.md``
+     and puts the CLI into coding-agent mode, where it responds to
+     the briefing instead of the prompt (caught by S4 smoke).
+     Operators wanting a project-context call pass an explicit
+     ``cwd=`` to ``complete``.
+  5. Output is size-capped (1 MiB) and the child is killed on timeout.
+  6. Cli path can be overridden via ``JAMES_CLAUDE_CLI_PATH`` (defaults
      to looking up ``claude`` on PATH); a missing CLI surfaces as
      ``error="cli not found"`` rather than a crash.
 """
@@ -24,6 +41,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 from typing import List, Optional
 
@@ -31,7 +49,22 @@ from core.reasoning.backends import BackendCapability, CompletionResult
 
 
 _MAX_OUTPUT_BYTES = 1 * 1024 * 1024   # 1 MiB
-_ENV_WHITELIST = ("PATH", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CONFIG_DIR")
+
+# Cross-platform Claude-specific env passthrough.
+_ENV_WHITELIST_CORE = ("PATH", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CONFIG_DIR")
+
+# Windows runtime essentials. Empirically required on Windows (S4 smoke
+# 2026-06-03): without `SystemRoot` the Node-based `claude.CMD` wrapper
+# exits with returncode 1 and empty stderr. The others (APPDATA et al.)
+# are Claude's config / cache lookup paths. Cross-platform — these are
+# Windows-only names, but reading them on POSIX is harmless (empty
+# value → dropped by _build_env).
+_ENV_WHITELIST_WINDOWS = (
+    "SystemRoot", "APPDATA", "LOCALAPPDATA",
+    "USERPROFILE", "TEMP", "TMP",
+)
+
+_ENV_WHITELIST = _ENV_WHITELIST_CORE + _ENV_WHITELIST_WINDOWS
 
 
 def _resolve_cli_path() -> Optional[str]:
@@ -93,6 +126,7 @@ class ClaudeCodeCliBackend:
         timeout: float = 60.0,
         model: Optional[str] = None,
         temperature: Optional[float] = None,   # accepted per R4, ignored — CLI no flag
+        cwd: Optional[str] = None,
         **opts,
     ) -> CompletionResult:
         t0 = time.time()
@@ -114,6 +148,12 @@ class ClaudeCodeCliBackend:
         # avoids handing a pathological prompt to the subprocess
         composed = composed[: _MAX_OUTPUT_BYTES]
 
+        # Neutral cwd default (§"Security posture" #4): spawn in temp,
+        # not the project dir, so `claude -p` doesn't pick up the
+        # project CLAUDE.md and switch to coding-agent mode. Operators
+        # wanting a project-context call pass `cwd=` explicitly.
+        spawn_cwd = cwd if cwd is not None else tempfile.gettempdir()
+
         try:
             proc = subprocess.Popen(
                 argv,
@@ -121,6 +161,7 @@ class ClaudeCodeCliBackend:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=_build_env(),
+                cwd=spawn_cwd,
                 # text mode with utf-8 to match JAMES's encoding convention
                 text=True,
                 encoding="utf-8",

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -364,9 +364,13 @@ def aggregate(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     def rate(field: str, value: str) -> float:
         return sum(1 for q in per_q if q[field] == value) / n_q
 
+    # n_runs_per_question: max(run_idx) + 1, since run_idx is 0-based.
+    # Old form `rows[0].get("run", 0) and max(...) + 1` short-circuited
+    # to 0 whenever run_idx=0 (every --n-runs=1 invocation), printing
+    # `n_runs/q=0` in the summary header. Caught by S4 smoke 2026-06-03.
     summary = {
         "n_questions": n_q,
-        "n_runs_per_question": rows[0].get("run", 0) and max(r["run"] for r in rows) + 1,
+        "n_runs_per_question": max(r["run"] for r in rows) + 1,
         "local_correct_rate": round(rate("local_majority", "CORRECT"), 3),
         "cloud_correct_rate": round(rate("cloud_majority", "CORRECT"), 3),
         "local_abstain_rate": round(rate("local_majority", "ABSTAINED"), 3),

--- a/tests/test_local_vs_cloud_paired.py
+++ b/tests/test_local_vs_cloud_paired.py
@@ -192,6 +192,29 @@ def test_aggregate_empty_rows_safe(harness):
     assert agg["summary"] == {}
 
 
+def test_aggregate_n_runs_per_question_correct_with_single_run(harness):
+    """S5c regression — aggregate reported `n_runs/q=0` whenever
+    --n-runs=1 because the old form `rows[0].get("run", 0) and max(...)+1`
+    short-circuited on the falsy run_idx=0. Caught by S4 smoke
+    2026-06-03; fixed in same PR."""
+    rows = [
+        _row("q1", "inference_query", 0, "CORRECT", "CORRECT"),
+        _row("q2", "comparison_query", 0, "CORRECT", "CORRECT"),
+    ]
+    agg = harness.aggregate(rows)
+    assert agg["summary"]["n_runs_per_question"] == 1
+
+
+def test_aggregate_n_runs_per_question_correct_with_three_runs(harness):
+    rows = [
+        _row("q1", "inference_query", 0, "CORRECT", "CORRECT"),
+        _row("q1", "inference_query", 1, "CORRECT", "CORRECT"),
+        _row("q1", "inference_query", 2, "CORRECT", "CORRECT"),
+    ]
+    agg = harness.aggregate(rows)
+    assert agg["summary"]["n_runs_per_question"] == 3
+
+
 # ─── Caveat block presence ──────────────────────────────────────────
 
 

--- a/tests/test_reasoning_backends.py
+++ b/tests/test_reasoning_backends.py
@@ -197,15 +197,17 @@ class ClaudeCliSubprocessTests(unittest.TestCase):
         self.assertIn(evil, stdin_arg)
 
     def test_env_whitelist_does_not_leak_secrets(self):
-        """SECURITY: only PATH / HOME / ANTHROPIC_API_KEY /
-        CLAUDE_CONFIG_DIR pass through. A secret stashed in some other
-        env var must NOT reach the child.
+        """SECURITY: only the whitelist passes through. A secret stashed
+        in some other env var (`JAMES_API_KEY`, `AWS_*`, `GCP_*`) must
+        NOT reach the child. The whitelist is documented in the
+        module docstring §"Security posture" #3.
         """
         b = self._backend()
         proc = self._mock_popen()
         secret_env = {
             "JAMES_API_KEY": "leak-me",
             "AWS_SECRET_ACCESS_KEY": "also-leak",
+            "GCP_CREDENTIALS_JSON": "also-also-leak",
             "ANTHROPIC_API_KEY": "ok-to-forward",
             "PATH": os.environ.get("PATH", ""),
         }
@@ -215,8 +217,67 @@ class ClaudeCliSubprocessTests(unittest.TestCase):
         env_passed = p.call_args.kwargs.get("env", {})
         self.assertIn("ANTHROPIC_API_KEY", env_passed)
         self.assertIn("PATH", env_passed)
-        self.assertNotIn("JAMES_API_KEY", env_passed)
-        self.assertNotIn("AWS_SECRET_ACCESS_KEY", env_passed)
+        for leaked in ("JAMES_API_KEY", "AWS_SECRET_ACCESS_KEY",
+                       "GCP_CREDENTIALS_JSON"):
+            self.assertNotIn(leaked, env_passed,
+                             f"{leaked!r} leaked through whitelist")
+
+    def test_env_whitelist_includes_windows_essentials(self):
+        """S5c — Windows runtime essentials are forwarded so claude.CMD
+        wrapper actually runs. Without `SystemRoot` on Windows the Node
+        wrapper exits with returncode 1 + empty stderr (caught by S4
+        smoke 2026-06-03). The list (SystemRoot, APPDATA, LOCALAPPDATA,
+        USERPROFILE, TEMP, TMP) is a Windows baseline runtime set, not
+        app-specific secrets.
+        """
+        b = self._backend()
+        proc = self._mock_popen()
+        windows_env = {
+            "SystemRoot": "C:\\Windows",
+            "APPDATA": "C:\\Users\\test\\AppData\\Roaming",
+            "LOCALAPPDATA": "C:\\Users\\test\\AppData\\Local",
+            "USERPROFILE": "C:\\Users\\test",
+            "TEMP": "C:\\Users\\test\\AppData\\Local\\Temp",
+            "TMP": "C:\\Users\\test\\AppData\\Local\\Temp",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        with patch.dict(os.environ, windows_env, clear=False), \
+             patch("subprocess.Popen", return_value=proc) as p:
+            b.complete("x")
+        env_passed = p.call_args.kwargs.get("env", {})
+        for required in ("SystemRoot", "APPDATA", "LOCALAPPDATA",
+                         "USERPROFILE", "TEMP", "TMP"):
+            self.assertIn(required, env_passed,
+                          f"Windows essential {required!r} not forwarded")
+
+    def test_default_cwd_is_neutral_not_project(self):
+        """S5c — default cwd is `tempfile.gettempdir()`, NOT the project
+        directory. Spawning `claude -p` inside the project loads the
+        project CLAUDE.md and puts the CLI into coding-agent mode
+        (responds to the briefing, not the prompt). Caught by S4 smoke
+        2026-06-03.
+        """
+        import tempfile
+        b = self._backend()
+        proc = self._mock_popen()
+        with patch("subprocess.Popen", return_value=proc) as p:
+            b.complete("x")
+        cwd_passed = p.call_args.kwargs.get("cwd")
+        self.assertEqual(cwd_passed, tempfile.gettempdir())
+        # And cwd is definitely NOT the project root or current dir
+        self.assertNotEqual(cwd_passed, os.getcwd())
+
+    def test_explicit_cwd_kwarg_overrides_default(self):
+        """Operators wanting a project-context call pass `cwd=` explicitly.
+        Default neutral cwd is the safe default; explicit override is
+        the documented escape hatch."""
+        b = self._backend()
+        proc = self._mock_popen()
+        custom = "C:\\some\\other\\path" if os.name == "nt" else "/some/other/path"
+        with patch("subprocess.Popen", return_value=proc) as p:
+            b.complete("x", cwd=custom)
+        cwd_passed = p.call_args.kwargs.get("cwd")
+        self.assertEqual(cwd_passed, custom)
 
     def test_model_flag_passed_to_argv(self):
         """User-selected model string DOES appear in argv (after the


### PR DESCRIPTION
## Summary

S4 smoke (2026-06-03) caught **three production wiring bugs** that pre-dated this cycle but landed in the cloud path the moment S5 (PR #702) wired `JAMES_FORCE_CLOUD` to `trace_synth_call`. All three were caught by a single 3-question smoke run that S4 was designed to enable — exactly the integration value the design memo §4.1 sequencing predicted.

### Bug 1 — Windows env whitelist missing `SystemRoot` (+5)

`ClaudeCodeCliBackend` env whitelist was `{PATH, HOME, ANTHROPIC_API_KEY, CLAUDE_CONFIG_DIR}` — sufficient on POSIX, **broken on Windows**. Without `SystemRoot` the Node-based `claude.CMD` wrapper exits returncode 1 with **empty stderr** (silent failure, the worst kind).

```
cloud_err: RuntimeError: cloud backend error: exit code 1
cloud_ans: ''
```

**Fix**: split into `_ENV_WHITELIST_CORE` + `_ENV_WHITELIST_WINDOWS` (`SystemRoot`, `APPDATA`, `LOCALAPPDATA`, `USERPROFILE`, `TEMP`, `TMP`). Windows list is baseline runtime vars only — no app secrets. Security contract preserved.

### Bug 2 — default cwd was project dir → coding-agent mode

Backend spawned `claude -p` with subprocess's inherited cwd. When that's the JAMES project root, `claude -p` loads the project `CLAUDE.md` and switches into **coding-agent mode**: replies *"Based on the briefing, the natural next step is..."* instead of answering the prompt — unusable as a reasoning backend.

Memory anchor: `feedback_direction_alpha_max_plan_research_cloud` (*"gotcha: neutral cwd + stdin prompt"*) — recorded for the v2 PoC (which set `cwd=tempfile.gettempdir()`) but the lesson never made it to the production backend.

**Fix**: default `cwd=tempfile.gettempdir()`. New `cwd=` kwarg for operators wanting explicit project-context call.

### Bug 3 — `n_runs/q` aggregate reports 0 on `--n-runs=1`

`local_vs_cloud_paired.py`:
```python
"n_runs_per_question": rows[0].get("run", 0) and max(...) + 1
```
With `run_idx` 0-based, `rows[0]["run"]==0` (falsy) → short-circuits to 0 → summary header prints `n_runs/q=0` for every `--n-runs=1` invocation.

**Fix**: `(max(r["run"] for r in rows) + 1) if rows else 0` (parens-grouped, no `and`).

## Verification

### Smoke (before vs after)

| | Pre-fix | Post-fix |
|---|---|---|
| Local CORRECT | 0/3 | 3/3 |
| Cloud CORRECT | 0/3 | 3/3 |
| Cloud error | `exit code 1` on all | none |
| Latency / Q | 1.5–7.3s (never reached Claude) | ~22.5s (real reasoning + judge) |
| n_runs/q header | `0` | `1` |

Δ = 0 on the post-fix smoke matches the v2 §4.1 reasoning-isolated baseline — premise re-examination data point holds.

### Tests

- **+3 in `tests/test_reasoning_backends.py`**: Windows essentials forwarded / default cwd is tempdir / explicit `cwd=` override
- Existing `test_env_whitelist_does_not_leak_secrets` extended to sweep `JAMES_API_KEY` + `AWS_SECRET_ACCESS_KEY` + `GCP_CREDENTIALS_JSON` — all still excluded
- **+2 in `tests/test_local_vs_cloud_paired.py`**: n_runs aggregate with single-run + three-run cases

**108 tests pass** across all 5 cloud-tier test files. **Broader regression: 3509 pass** (+5 from S5 baseline), no new failures.

## Out of scope

- Operator-run S4 measurement at full `--n-per-type 3 --n-runs 3` — the harness is now genuinely live, but burning 243+ Max-plan calls is the operator's decision (per `feedback_direction_alpha_max_plan_research_cloud`)
- S6/S7 design work — still measurement-gated per the 2026-06-03 user decision

Quality delta: exempt (label: fix — production-wiring bug caught by S4 smoke, no oracle applies; the bug WAS the oracle gate for the live wire).