### PR TITLE
feat(qvt): P3 metric precision + answer-format mismatch 발견

### DIFF
--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -569,6 +569,45 @@ class AbstentionF1Axis:
     per_query: List[AbstentionQueryRow] = field(default_factory=list)
 
 
+_YESNO_RE = {
+    "yes": _re.compile(r"\byes\b"),
+    "no": _re.compile(r"\bno\b"),
+}
+# Where to look for the yes/no verdict — the lead of the answer. MultiHop-RAG
+# answers are simple ("Yes, ...", "No. ..."); the verdict is at the front.
+# A trailing "no" buried in prose ("...there is no doubt") shouldn't flip a
+# "Yes"-gold answer. 60 chars covers "Yes/No" + a short clause.
+_YESNO_LEAD_CHARS = 60
+
+
+def _primary_answer_match(
+    answer_lower: str,
+    primary_signal: Dict[str, Any],
+    question_type: str,
+) -> bool:
+    """P3 precision matcher for the PRIMARY (canonical) answer signal.
+
+    The fixture's gold_signals[0] is the paper's single canonical answer:
+      - inference_query  → an entity name  ("Sam Bankman-Fried")
+      - comparison_query → "Yes" / "No"
+      - temporal_query   → "Yes" / "No" (fixture uses yes/no, not before/after)
+
+    Entity answers keep the substring+negation matcher (`_matches_signal`).
+    Yes/No answers use a **word-boundary match restricted to the answer
+    lead** so substring noise ("no" inside "not"/"now"/"nothing"; a "yes"
+    buried deep in prose) doesn't create false hits — this is the main
+    precision gain over the generic matcher (closes the wide [strict,
+    primary] band toward the paper's exact-match metric).
+    """
+    term = (primary_signal.get("term") or "").strip().lower()
+    if term in ("yes", "no"):
+        lead = answer_lower[:_YESNO_LEAD_CHARS]
+        return bool(_YESNO_RE[term].search(lead))
+    # Entity / other — generic substring + negation-aware matcher.
+    ok, _ = _matches_signal(answer_lower, primary_signal)
+    return ok
+
+
 def score_paper_aligned_accuracy(
     bench_results: Dict[str, Any],
     fixture: Dict[str, Any],
@@ -637,7 +676,16 @@ def score_paper_aligned_accuracy(
         hits = 0
         primary_hit = False
         for i, sig in enumerate(signals):
-            ok, _ = _matches_signal(answer_lower, sig)
+            if i == 0:
+                # P3 precision — primary signal IS the paper's canonical
+                # single answer (inference→entity, comparison/temporal→
+                # yes/no, confirmed by fixture inspection). Use a
+                # question-type-aware matcher so a yes/no answer isn't
+                # falsely hit by substring noise ("no" in "not"/"now"/
+                # "nothing", or a "yes" buried mid-answer).
+                ok = _primary_answer_match(answer_lower, sig, qtype)
+            else:
+                ok, _ = _matches_signal(answer_lower, sig)
             if ok:
                 hits += 1
                 if i == 0:

--- a/reports/research-runs/alpha-8-paper-aligned-comparison-20260604.md
+++ b/reports/research-runs/alpha-8-paper-aligned-comparison-20260604.md
@@ -109,6 +109,60 @@ ChatGPT급. 확실한 것 = **자메스가 70b open 모델과 비교 가능한 l
 P1 결론: **자메스 general-news 경쟁력 입증 (작은 모델로 open 70b league).
 품질 lever는 모델 아니라 도메인 데이터/온톨로지. 다음 = domain pack.**
 
+## 9. P3 — metric 정밀화 + answer-format mismatch 발견 (2026-06-04 추가)
+
+P1의 0.44 (ChatGPT급) 결론이 metric 정밀화 후 흔들림. **진짜 confound는
+metric이 아니라 answer-format mismatch** 발견.
+
+### P3.1 — yes/no word-boundary 정밀화
+
+P1 `accuracy_primary`의 yes/no 매칭이 substring이라 거짓 hit 위험
+("no" in "not"/"now"/"nothing", "yes" 답 중간 등장). word-boundary +
+answer-lead(60자) 정밀화 (`_primary_answer_match`):
+
+| System | primary (substring, P1) | primary (word-boundary, P3) |
+|---|---:|---:|
+| JAMES+gemma4:e4b (n=3) | 0.44-0.45 | **0.29-0.35** |
+| JAMES+Claude(Opus) | 0.47 | **0.26** |
+| Claude RAW (leak) | 0.72 | 0.56 |
+
+→ P1 0.44는 yes/no substring 거짓 hit 과대평가. 정밀하면 0.29-0.35.
+
+### P3.2 — 진짜 원인: answer-format mismatch
+
+자메스 comparison 답 실제 형태 (서술형, 1400-2000자):
+- "Source files: ... [분석] ..." 로 시작
+- "We cannot definitively compare..." / "do not necessarily align..."
+- **yes/no를 명시 안 함**
+
+논문 모델 = 단답 ("Yes"/"No"). → **같은 metric 비교가 자메스 서술형 답에
+부당** (yes/no 앞에 없으니 word-boundary lead에서 miss).
+
+= P1 substring (0.44) = 과대 / P3 word-boundary (0.29) = 과소. 진실은
+**answer-format 통제 후**.
+
+### P3.3 — 단답 모드 일시 적용 가능 확정 (코드 0)
+
+측정용 fixture suffix ("Answer with ONLY 'Yes'/'No', no explanation")
+smoke (comparison 3Q, gemma4:e4b):
+
+| id | gold | 자메스 답 (단답 모드) |
+|---|---|---|
+| 26/27/28 | Yes | "No" / "No" / "No." (ans_len 2-3) |
+
+→ **fixture suffix만으로 자메스 단답 produce 확정** (production 코드 0
+변경, NATURAL preset 무시하고 단답). 단 comparison 3개 다 틀림 (gold
+Yes, 답 No) = **자메스 comparison query 약점이 단답 모드로 명확히 드러남**.
+
+### P3 결론
+
+- P3 precision metric (`score_paper_aligned_accuracy` + `_primary_answer_match`)
+  은 **단답 모드 답에 적용해야 정확**. 서술형 답에 적용하면 과소평가.
+- **fair 우수성 확정 = 단답 모드 full 측정 (100Q) 필수** (fixture suffix
+  로 일시, 코드 0). + 모델 통제 (Mixtral 또는 gemma4:e4b).
+- answer-format mismatch = measurement-side 신규 confound
+  (`feedback_evidence_grounded_validity_check` 계열 확장).
+
 ## 8. 재현
 
 ```

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -840,6 +840,55 @@ class PaperAlignedAccuracyTests(unittest.TestCase):
         self.assertEqual(axis.n_answerable, 2)
         self.assertEqual(axis.n_null, 1)
 
+    def test_yesno_precision_no_substring_false_positive(self):
+        """P3 precision — gold 'no' must NOT match 'nothing'/'not'/'now'
+        substring. Word-boundary + answer-lead restriction."""
+        fixture = {
+            "version": "test",
+            "queries": [
+                {"id": 1, "question_type": "comparison_query",
+                 "abstention_truth": "present",
+                 "gold_signals": [{"term": "No", "aliases": []}]},
+            ],
+        }
+        # answer says "nothing" — substring 'no' present but NOT a 'No' verdict
+        bench = self._bench({1: "There is nothing conclusive in the sources."})
+        axis = score_paper_aligned_accuracy(bench, fixture)
+        self.assertEqual(axis.correct_primary, 0)   # 'nothing' != 'No' verdict
+
+    def test_yesno_precision_lead_window(self):
+        """P3 precision — a 'Yes' verdict at the front counts; a stray
+        'yes' buried deep in prose does not flip a different verdict."""
+        fixture = {
+            "version": "test",
+            "queries": [
+                {"id": 1, "question_type": "comparison_query",
+                 "abstention_truth": "present",
+                 "gold_signals": [{"term": "Yes", "aliases": []}]},
+            ],
+        }
+        # 'Yes' at front → hit
+        b1 = self._bench({1: "Yes, both reports confirm the increase."})
+        self.assertEqual(score_paper_aligned_accuracy(b1, fixture).correct_primary, 1)
+        # 'yes' only deep in long prose past the lead window → no hit
+        filler = "The provided documents discuss many topics in detail. " * 3
+        b2 = self._bench({1: filler + "so the answer would be yes eventually."})
+        self.assertEqual(score_paper_aligned_accuracy(b2, fixture).correct_primary, 0)
+
+    def test_entity_answer_keeps_substring_match(self):
+        """P3 precision applies word-boundary ONLY to yes/no; entity
+        answers (inference) keep the substring+negation matcher."""
+        fixture = {
+            "version": "test",
+            "queries": [
+                {"id": 1, "question_type": "inference_query",
+                 "abstention_truth": "present",
+                 "gold_signals": [{"term": "Sam Bankman-Fried", "aliases": []}]},
+            ],
+        }
+        bench = self._bench({1: "The trial concerns Sam Bankman-Fried and FTX."})
+        self.assertEqual(score_paper_aligned_accuracy(bench, fixture).correct_primary, 1)
+
     def test_real_fixture_smoke(self):
         # Runs against the real multihop fixture + a trivial all-miss bench;
         # just ensures no crash + sane partition (75 answerable / 25 null).


### PR DESCRIPTION
## Summary

P1의 paper-aligned primary metric을 정밀화하다 **진짜 confound = answer-format mismatch** 발견.

### P3.1 — yes/no word-boundary 정밀화

P1 primary가 yes/no를 substring 매칭 → 거짓 hit 과대평가. word-boundary + answer-lead(60자) 정밀화:

| System | P1 substring | P3 word-boundary |
|---|---:|---:|
| JAMES+gemma4:e4b (n=3) | 0.44-0.45 | **0.29-0.35** |
| JAMES+Claude(Opus) | 0.47 | 0.26 |
| Claude RAW (leak) | 0.72 | 0.56 |

### P3.2 — 진짜 원인: answer-format mismatch

자메스 comparison 답 = 서술형 (1400-2000자, "Source files:" 시작, yes/no 명시 X). 논문 = 단답 ("Yes"/"No"). **같은 metric 비교가 자메스 서술형 답에 부당.**
- P1 substring 0.44 = 과대 ("no" in "nothing")
- P3 word-boundary 0.29 = 과소 (자메스 yes/no 앞에 안 둠)
- 진실 = answer-format 통제 후

### P3.3 — 단답 모드 일시 적용 가능 확정 (코드 0)

fixture suffix smoke (comparison 3Q, gemma4:e4b):

| id | gold | 자메스 답 (단답) |
|---|---|---|
| 26/27/28 | Yes | "No"/"No"/"No." (len 2-3) |

→ **fixture suffix만으로 자메스 단답 produce** (production 코드 0, NATURAL preset 무시). 단 3개 다 틀림 = comparison 약점 단답으로 드러남.

## Verification

- **+3 tests** (yes/no substring false-positive 방지 / lead window / entity substring 유지). 59 pass.
- smoke cleanup 완료 (mini fixture + overwrite cell 제거, gitignore라 git 영향 0)

## 결론

fair 우수성 확정 = **단답 모드 full 측정 (100Q, fixture suffix 일시) + 모델 통제 (Mixtral/gemma4:e4b) 필수**. P3 precision metric은 단답 모드 답에 적용해야 정확 (서술형에 적용하면 과소).

## Out of scope (다음)

- 단답 모드 full 100Q 측정 (fair 비교)
- 모델 통제 (Mixtral-8x7B 받기 또는 gemma4:e4b)

Quality delta: exempt (label: code — measurement metric precision).