### PR TITLE
fix(response_style): answer-format를 옵션 층으로 (platform 정상화) + 단답 측정 인프라

### DIFF
--- a/core/gemma_client.py
+++ b/core/gemma_client.py
@@ -300,7 +300,19 @@ class GemmaClient:
                                 if temperature is not None
                                 else __import__("config").LLM_TEMPERATURE
                             ),
-                            "num_ctx":     8192,   # [#A8-5] 4096 → 8192 (긴 답변 토큰까지 수용)
+                            # [#A8-5] 4096 → 8192 (긴 답변 토큰까지 수용).
+                            # JAMES_NUM_CTX env override (default 8192 =
+                            # production byte-identical). Benchmark eval may
+                            # raise it (e.g. 16384) so large retrieval
+                            # evidence + a full CoT answer both fit without
+                            # truncating the answer — gemma4:e4b supports
+                            # up to 131072. Measurement-only; production
+                            # unchanged when the env is unset.
+                            "num_ctx": int(
+                                __import__("os").environ.get(
+                                    "JAMES_NUM_CTX", "8192"
+                                )
+                            ),
                         }
                 resp = requests.post(
                     OLLAMA_API_URL,

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -193,7 +193,7 @@ class ReasoningEngine:
         # ``kwargs["session_language"]``).
         from core.reasoning.engine_memory import build_memory_context
         memory_context, system_prompt, hist_ctx = build_memory_context(
-            self, safe_query, user_role, kwargs,
+            self, safe_query, user_role, kwargs, response_style=response_style,
         )
 
         # ── Query Router (STEP 0.5a) ─────────────────────────

--- a/core/reasoning/engine_memory.py
+++ b/core/reasoning/engine_memory.py
@@ -37,6 +37,7 @@ def build_memory_context(
     safe_query: str,
     user_role: str,
     kwargs: Dict[str, Any],
+    response_style: str = "",
 ) -> Tuple[str, str, str]:
     """Build the (memory_context, system_prompt, hist_ctx) triple that
     feeds the rest of ReasoningEngine.query().
@@ -102,15 +103,25 @@ def build_memory_context(
         engine._log("memory_context", e, user_role)
 
     # ── [P1-10] 성향 캐릭터 modifier → system_prompt 주입 ─
+    # 2026-06-04: gated on the resolved style's answer-format contract.
+    # NATURAL (default) → inject (production byte-identical). TERSE and
+    # any future single-answer style → skip, so the 16-trait persona
+    # does not re-introduce verbose scaffolding the user opted out of.
     try:
-        from core.character_profile import CharacterProfile
-        cp = CharacterProfile()
-        modifier = cp.get_prompt_modifiers()
-        if modifier and modifier.strip():
-            system_prompt = (system_prompt + "\n\n" + modifier).strip()
-            print(f"[CHARACTER] 성향 주입: {modifier[:60]}")
-    except Exception as e:
-        engine._log("character_profile", e, user_role)
+        from core.response_style import resolve_style
+        _inject_character = resolve_style(response_style).inject_character_directives
+    except Exception:
+        _inject_character = True
+    if _inject_character:
+        try:
+            from core.character_profile import CharacterProfile
+            cp = CharacterProfile()
+            modifier = cp.get_prompt_modifiers()
+            if modifier and modifier.strip():
+                system_prompt = (system_prompt + "\n\n" + modifier).strip()
+                print(f"[CHARACTER] 성향 주입: {modifier[:60]}")
+        except Exception as e:
+            engine._log("character_profile", e, user_role)
 
     # ── [P1-5] 페르소나 명령 감지 → 장기기억 즉시 저장 ──
     try:

--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -203,6 +203,7 @@ def run_retrieval_pipeline(
     )
     safe_context = apply_post_check_and_sources_header(
         engine, loop_state, final_context, user_role,
+        response_style=response_style,
     )
 
     # ── LEO L.C — evidence-scope measurement + scope-context bind ───

--- a/core/reasoning/pipeline_context.py
+++ b/core/reasoning/pipeline_context.py
@@ -150,6 +150,7 @@ def apply_post_check_and_sources_header(
     loop_state: Dict[str, Any],
     final_context: str,
     user_role: str,
+    response_style: str = "",
 ) -> str:
     """Security post_check + [관련 자료 목록] sources-header prepend.
 
@@ -182,7 +183,18 @@ def apply_post_check_and_sources_header(
             s_disp = s.split("/")[-1].split("\\")[-1]
             source_names.append(s_disp[:60])
             seen_sources.add(s)
-    if safe_context.strip() and source_names:
+    # 2026-06-04: header gated on the resolved style's answer-format
+    # contract. NATURAL (default) → prepend (byte-identical). TERSE and
+    # any future single-answer style → omit, since the header pushes the
+    # LLM toward the verbose "Source files:" opening the user opted out
+    # of. Header omission does not change retrieval — only the citation
+    # hint injected into context.
+    try:
+        from core.response_style import resolve_style
+        _inject_header = resolve_style(response_style).inject_sources_header
+    except Exception:
+        _inject_header = True
+    if _inject_header and safe_context.strip() and source_names:
         sources_header = (
             "[관련 자료 목록]\n"
             + "\n".join(f"- {s}" for s in source_names)

--- a/core/response_style.py
+++ b/core/response_style.py
@@ -71,6 +71,20 @@ class StylePreset:
     force_two_sections: bool
     rule_text_ko:       str
     rule_text_en:       str
+    # ── Answer-format contract (2026-06-04) ──────────────────────────
+    # The preset is the single source of truth for the *whole* answer
+    # shape, not just the synth-layer rule_text. Two upstream layers
+    # also force verbose output and must honor the resolved style:
+    #   inject_character_directives — L1: the 16-trait character-profile
+    #       persona/directive block (engine_memory.build_memory_context).
+    #   inject_sources_header       — L3: the "[관련 자료 목록]" header
+    #       prepended to context (pipeline_context.apply_post_check_…).
+    # Default True/True = NATURAL = production byte-identical. TERSE sets
+    # both False so a single style request ("terse") collapses all three
+    # layers to single-answer mode. See memory
+    # feedback_response_style_hardcode_platform_defect.
+    inject_character_directives: bool = True
+    inject_sources_header:       bool = True
 
 
 # The one natural-flow preset. All public ids resolve to this.
@@ -153,21 +167,80 @@ NATURAL_PRESET = StylePreset(
 )
 
 
+# Terse preset — single canonical answer, no NATURAL flow scaffolding.
+# Added 2026-06-04 to (a) restore user style override (the v2 hardcode
+# blocked it — platform defect, see memory
+# feedback_response_style_hardcode_platform_defect) and (b) enable
+# benchmark single-answer measurement (paper-aligned exact-match).
+#
+# Opt-in only: default (no explicit / no env) stays NATURAL =
+# production byte-identical. Operators/users request terse via the
+# QueryRequest.response_style field or JAMES_RESPONSE_STYLE=terse.
+TERSE = "terse"
+
+TERSE_PRESET = StylePreset(
+    name="terse",
+    max_tokens=8192,
+    force_two_sections=False,
+    rule_text_ko=(
+        "답변 작성 가이드 (간결 모드):\n"
+        "- 추론은 자유롭게 하되, 마지막 줄에 'ANSWER:' 뒤에 직접 답만 "
+        "쓰세요 (개체명, 또는 'Yes'/'No').\n"
+        "- '관련 자료:' / 'Source files:' 헤더, 다음 작업 제안, 보고서 "
+        "형식(## 섹션)을 쓰지 마세요.\n"
+        "- 제공된 자료에 답이 없으면 'ANSWER: insufficient information'.\n"
+    ),
+    rule_text_en=(
+        "Answer guide (terse mode):\n"
+        "- Reason freely, but on the LAST line write 'ANSWER:' followed "
+        "by ONLY the direct answer (entity name, or 'Yes'/'No').\n"
+        "- Do NOT add a 'Source files:' header, next-action suggestions, "
+        "or report-format (## sections).\n"
+        "- If the context lacks the answer: 'ANSWER: insufficient information'.\n"
+    ),
+    # Collapse the two upstream verbose layers too — otherwise the
+    # character persona (L1) and sources header (L3) re-introduce the
+    # scaffolding the terse rule_text (L2) just forbade.
+    inject_character_directives=False,
+    inject_sources_header=False,
+)
+
+
+# Style id → preset registry. default (unmatched / empty) → NATURAL.
+_STYLE_REGISTRY = {
+    "terse": TERSE_PRESET,
+    "natural": NATURAL_PRESET,
+    # brief / standard / detailed keep resolving to NATURAL (v2 decision:
+    # the v1 token-cutting presets were rejected by user feedback; we
+    # do NOT resurrect token-cut behavior, only style/format variants).
+    "brief": NATURAL_PRESET,
+    "standard": NATURAL_PRESET,
+    "detailed": NATURAL_PRESET,
+}
+
+
 def resolve_style(explicit: str = "") -> StylePreset:
-    """Resolve the active style preset.
+    """Resolve the active style preset, honoring user/operator override.
 
-    v2: ignores `explicit` (and the `JAMES_RESPONSE_STYLE` env) — all
-    inputs resolve to NATURAL_PRESET. Kept as a function so the call
-    sites don't need to change. The signature also documents that
-    explicit style ids are accepted (for forward compat if a future
-    pack-level override resurrects the preset distinction).
+    Resolution order:
+      1. ``explicit`` arg (QueryRequest.response_style API field)
+      2. ``JAMES_RESPONSE_STYLE`` env
+      3. default → NATURAL_PRESET (production byte-identical)
 
-    The env var is still read so an unrecognised value here doesn't
-    silently differ from the v1 behavior — but since all values now
-    map to NATURAL, the read is informational only.
+    2026-06-04 fix — restore override (the v2 hardcode ignored both
+    inputs and forced NATURAL, blocking any user style request = mother
+    platform defect, see memory
+    feedback_response_style_hardcode_platform_defect). Default behavior
+    is unchanged: with no explicit and no env, returns NATURAL exactly
+    as before. Only an explicit/env style id (e.g. "terse") diverges.
+
+    Unrecognized ids fall through to NATURAL (forgiving — a typo
+    shouldn't break the answer path). The v1 token-cutting presets
+    (brief/standard/detailed) are NOT resurrected; they map to NATURAL.
     """
-    # Read but ignore — preserves the v1 API surface for any caller
-    # that introspects this function's behavior.
-    _ = (explicit or "").strip().lower()
-    _ = (os.getenv("JAMES_RESPONSE_STYLE", "") or "").strip().lower()
-    return NATURAL_PRESET
+    requested = (explicit or "").strip().lower()
+    if not requested:
+        requested = (os.getenv("JAMES_RESPONSE_STYLE", "") or "").strip().lower()
+    if not requested:
+        return NATURAL_PRESET
+    return _STYLE_REGISTRY.get(requested, NATURAL_PRESET)

--- a/eval/qvt/oracle.py
+++ b/eval/qvt/oracle.py
@@ -579,6 +579,24 @@ _YESNO_RE = {
 # "Yes"-gold answer. 60 chars covers "Yes/No" + a short clause.
 _YESNO_LEAD_CHARS = 60
 
+# CoT terse-mode marker. The CoT+final-answer fixture variant
+# (scripts/research/build_terse_fixture.py) asks the model to reason
+# freely then put the canonical answer on a final "ANSWER:" line. When
+# present, only that line is the answer for scoring (reasoning preserved
+# for the model, single answer extracted for the paper-aligned metric).
+# Absent → whole answer is used (back-compat with verbose/non-terse runs).
+_ANSWER_LINE_RE = _re.compile(r"ANSWER:\s*(.+?)\s*$", _re.IGNORECASE | _re.MULTILINE)
+
+
+def _extract_terse_answer(answer_text: str) -> str:
+    """Return the CoT 'ANSWER:' line content if present, else the whole
+    answer. Uses the LAST ANSWER: line (model may write the marker mid-
+    reasoning; the final one is the verdict)."""
+    matches = _ANSWER_LINE_RE.findall(answer_text or "")
+    if matches:
+        return matches[-1].strip()
+    return answer_text or ""
+
 
 def _primary_answer_match(
     answer_lower: str,
@@ -645,6 +663,11 @@ def score_paper_aligned_accuracy(
         by_type.setdefault(qtype, [0, 0, 0])
         by_type[qtype][2] += 1
 
+        # Terse-mode extraction: if the answer carries a CoT 'ANSWER:'
+        # line, score only that line (reasoning kept for the model,
+        # canonical answer extracted). Absent → whole answer (back-compat).
+        terse_answer = _extract_terse_answer(_answer_text(r))
+
         # Null query (no answer exists) — correct iff system abstained.
         if truth == "absent":
             n_null += 1
@@ -653,7 +676,7 @@ def score_paper_aligned_accuracy(
             elif r.get("blocked") is True:
                 abstained = True
             else:
-                abstained = detect_abstention(_answer_text(r))
+                abstained = detect_abstention(terse_answer)
             is_correct = bool(abstained)
             rows.append(PaperAlignedRow(
                 id=qid, question_type=qtype, correct=is_correct,
@@ -672,7 +695,7 @@ def score_paper_aligned_accuracy(
             # No gold to score against — skip (not counted in either bucket).
             continue
         n_answerable += 1
-        answer_lower = _answer_text(r).lower()
+        answer_lower = terse_answer.lower()
         hits = 0
         primary_hit = False
         for i, sig in enumerate(signals):

--- a/reports/research-runs/alpha-8-paper-comparison-experiment-log-20260604.md
+++ b/reports/research-runs/alpha-8-paper-comparison-experiment-log-20260604.md
@@ -1,0 +1,164 @@
+# JAMES vs MultiHop-RAG Paper — Experiment Log (2026-06-04)
+
+> 목적: 자메스 retrieval/reasoning 품질을 외부 benchmark (MultiHop-RAG,
+> Tang & Yang 2024, COLM) Table 6과 **fair 비교**해 우수성 확정 논리 구축.
+> 사용자 framing 요구: ① 모델 통제 (같은 모델) ② metric 정밀.
+>
+> 이 문서는 시간순 실험 로그 — 각 시도의 방법 / 결과 / confound / 다음
+> 결정. confound chain이 핵심 발견.
+
+## 0. 외부 baseline (MultiHop-RAG 논문 Table 6, retrieved chunks)
+
+| Model | retrieved | ground-truth |
+|---|---:|---:|
+| GPT-4 | 0.56 | 0.89 |
+| Claude-2.1 | 0.52 | 0.56 |
+| Google-PaLM | 0.47 | 0.74 |
+| ChatGPT/3.5 | 0.44 | 0.57 |
+| Mixtral-8x7B | 0.32 | 0.36 |
+| Llama-2-70b | 0.28 | 0.32 |
+
+- Metric: exact match on simple responses (entity / yes-no / before-after).
+  null query = "insufficient information" 류면 correct. **정확한 matching
+  logic은 논문 미공개.**
+- 논문 결론: "existing RAG methods perform unsatisfactorily" — GPT-4 0.56
+  조차 unsatisfactory. multi-hop RAG는 field-wide 어려운 문제.
+
+## 1. 실험 시간순 로그
+
+### Exp 1 — P1: paper-aligned binary (substring) [PR #709]
+
+- 방법: `eval/qvt/oracle.py::score_paper_aligned_accuracy`. 기존 multihop
+  bench JSON 재채점 (새 측정 없음). answerable=gold_signals match
+  (primary=signal[0] substring), null=abstain. [strict, primary] band.
+- 결과: JAMES+gemma4:e4b **primary 0.44** / strict 0.11-0.17.
+  JAMES+Claude(Opus) 0.47. Claude RAW 0.72.
+- 해석 (당시): e4b 0.44 = ChatGPT(0.44) 동급, Mixtral(0.32)/Llama-70b(0.28) 초과.
+- **confound 발견**: yes/no를 substring 매칭 → 거짓 hit ("no" in "not"/
+  "nothing", "yes" 답 중간 등장) → **과대평가 의심**.
+
+### Exp 2 — P3: yes/no word-boundary precision [PR #710]
+
+- 방법: primary 매칭을 question-type-aware로. yes/no는 word-boundary +
+  answer-lead(60자) (`_primary_answer_match`). entity는 substring 유지.
+- 결과: JAMES+gemma4:e4b **0.29-0.35** (P1 0.44에서 하락). Opus 0.26.
+- **핵심 confound 발견 — answer-format mismatch**: 자메스 답 = 서술형
+  (1400-2000자, "Source files:" 시작, yes/no 명시 안 함). 논문 = 단답.
+  P1 substring 0.44 = 과대, P3 word-boundary 0.29 = 과소 (자메스 yes/no
+  앞에 안 둠). **진실 = answer-format 통제 후.**
+
+### Exp 3 — 순수 단답 smoke (fixture suffix)
+
+- 방법: comparison 3Q에 "Answer with ONLY Yes/No" suffix. gemma4:e4b.
+- 결과: 자메스 "No"/"No"/"No." 단답 produce (서술형 아님, 코드 0 변경).
+  단 **3개 다 틀림** (gold Yes).
+- confound: 단답 강제 → e4b **reasoning 생략** → comparison 틀림. 작은
+  모델 불리 변수.
+- cell overwrite 발견: cell 이름 = `<cell>-<tier>` (suite 미포함). terse
+  측정이 기존 α-8 cell 덮어씀 → 이후 백업/복구 의무화.
+
+### Exp 4 — 모델 통제 시도: Mixtral-8x7B
+
+- 동기: framing 엄밀 — 논문 같은 모델로 통제. 논문 open 모델 중 최소 =
+  Mixtral-8x7B (47B, 26GB). Llama-70b는 39GB.
+- pull: `ollama pull mixtral:8x7b` (26GB, ~12분).
+- 속도 smoke: 직접 ollama "Paris" 정답, **33초** (cold load + 짧은 답).
+  RTX 4070 SUPER 12GB VRAM → CPU offload. multihop (긴 context + CoT) =
+  **per query 1-3분 추정, 100Q = 1.5-5시간.** matrix runner는 cell마다
+  server boot → Mixtral 로드 느려 boot timeout ("bench output 실패").
+- 부작용: Mixtral 26GB 다운로드 후 **numba DLL quarantine** (Windows
+  Defender 추정) → pytest conftest 차단 + server import 실패. `pip
+  install --force-reinstall numba`로 복구.
+- 결정: **모델 통제 포기.** 논문에 작은 모델 baseline 없어 동일-모델
+  통제는 Mixtral 26GB 외 불가. 대안 = **handicap framing** ("더 작은
+  모델 e4b로 논문 큰 모델 47B league 도전" — 동일-모델보다 강한 주장).
+
+### Exp 5 — CoT+ANSWER 단답 (변수 통제 design)
+
+- 동기: 순수 단답(Exp 3)이 e4b reasoning 생략시킴. 논문 큰 모델은 단답
+  강제해도 내부 reasoning; 작은 모델은 reasoning 막힘. **CoT 허용 +
+  마지막 ANSWER 줄 추출**로 reasoning 유지 + 단답 추출.
+- 방법: fixture suffix = "Reason ... THEN last line 'ANSWER:' + 단답".
+  oracle `_extract_terse_answer` ("ANSWER:" 줄 추출, last-wins, 없으면
+  전체). gemma4:e4b, terse fixture 100Q, num_ctx=8192.
+- 결과 (paper-aligned): primary **0.25**.
+  - null_query **0.84** (abstention 강함, 신뢰 가능)
+  - inference 0.16, comparison **0.00**, temporal **0.00**
+- **confound 발견 — CoT 잘림**: e4b가 ANSWER 줄 안 만듦. 답 1308자에서
+  잘림 ("...FTX and the"). comparison/temporal 0.00 = yes/no 결론 도달
+  전 잘림 (gold no 케이스도 miss → 자메스 답이 yes/no 아예 안 냄).
+
+### Exp 6 — 잘림 원인 진단
+
+- num_predict = 8192 (max, 충분). think = OFF (workspace .env, thinking
+  trace 흔적 없음). 둘 다 잘림 원인 아님.
+- **진짜 원인 = num_ctx 8192 포화**: retrieval evidence (multihop 3개
+  기사 ~6000자) + 질문이 context window 채움 → 답 토큰 부족 → 잘림.
+- gemma4:e4b context length = **131072 (128K)** — 자메스 num_ctx 8192는
+  1/16. 늘릴 여유 충분.
+
+### Exp 7 — 측정 전용 환경: num_ctx=16384 [진행 중]
+
+- 방법: `core/gemma_client.py`에 `JAMES_NUM_CTX` env override 추가
+  (production default 8192 유지, 측정 시 16384). evidence + CoT 답 둘 다
+  수용 → 잘림 해소 기대. terse fixture, gemma4:e4b.
+- 상태: **background 측정 진행 중** (task bqtd1pqca, ~25-40min).
+- 기대: comparison/temporal 0.00이 회복되면 잘림이 원인이었음 → fair
+  측정. 여전히 0이면 자메스 comparison 진짜 약점.
+
+## 2. confound chain (핵심 발견)
+
+측정 시도마다 새 confound 등장:
+```
+P1 substring (과대)
+  → P3 word-boundary (과소, answer-format mismatch)
+    → 순수 단답 (reasoning 생략)
+      → CoT 단답 (잘림)
+        → think (이미 OFF)
+        → num_predict (이미 8192 max)
+        → num_ctx (포화 — 8192→16384 시도 중)
+          → evidence size (?)
+```
+
+**근본**: 자메스 production pipeline (서술형 grounded RAG, 8192 context,
+자체 retrieval, 큰 evidence) ≠ benchmark 단답 exact-match 설계. 깔끔한
+점수 비교 = 자메스를 benchmark 형식으로 변환 (측정 전용 설정) + confound
+하나씩 제거.
+
+## 3. 신뢰 가능한 발견 (confound 영향 적음)
+
+| 발견 | 근거 |
+|---|---|
+| **abstention 강점** | null_query 0.84 (모든 측정에서 일관) — hallucination 회피 |
+| **모델 무관** | JAMES+e4b ≈ JAMES+Opus (paper-aligned 둘 다 ~0.25-0.47) — JAMES 위에서 모델 차이 작음 |
+| **학습-지식 leak** | Claude RAW (no JAMES) 0.72 > GPT-4 retrieved 0.56 = multihop(2023 뉴스) Claude 학습 분포 포함 |
+| **품질 lever = 도메인** | 모델 scaling (1b~27b~cloud) general에서 평탄 → lever는 데이터/온톨로지 |
+
+## 4. 측정-side 룰 (이번 cycle 박힘)
+
+- `feedback_methodological_chain_before_plan` — plan 전 verdict/diagnostic/role/순서 4질문
+- `feedback_fixture_fitness_before_verdict` — fixture가 verdict-grade인지
+- `feedback_evidence_grounded_validity_check` — evidence 전달 + 학습-leak 분리
+- (신규 후보) **answer-format mismatch + confound chain** — production
+  pipeline vs benchmark format은 confound 연쇄. 하나 제거하면 다음 등장.
+- (신규 후보) **작은 모델 + 작은 토큰 예산은 단답 benchmark 부적합** —
+  순수 단답이면 reasoning 생략, CoT면 토큰 소진/잘림.
+
+## 5. 잠정 결론 (Exp 7 pending)
+
+- 자메스 general-multihop 경쟁력은 **abstention(0.84)에서 명확**, 단답
+  정답률은 confound chain으로 깔끔한 "확정" 미완.
+- handicap framing (작은 e4b로 논문 큰 모델 league)이 측정 가능하면
+  강한 입증. Exp 7 (num_ctx 16384)이 잘림 해소하면 fair 측정.
+- Exp 7도 안 되면 → Mixtral 동일-모델 측정 (PC 부담 1.5-5h 감수).
+- 어느 경우든 핵심 차별화 lever = **도메인 데이터 + 온톨로지** (general
+  benchmark는 모든 시스템 retrieval bottleneck — 자메스 v0.5 도메인 pilot 방향).
+
+## 6. 재현
+
+- oracle: `eval/qvt/oracle.py::score_paper_aligned_accuracy` + `_extract_terse_answer`
+- 재채점: `scripts/research/paper_aligned_rescore.py`
+- terse fixture 생성: `scripts/research/build_terse_fixture.py` (CoT+ANSWER suffix)
+- num_ctx override: `JAMES_NUM_CTX=16384`
+- Mixtral tier: `--tiers M_MIXTRAL` (opt-in, 26GB CPU-offload 느림)
+- tests: `tests/test_qvt_oracle.py::PaperAlignedAccuracyTests` (CoT 추출 + yes/no precision)

--- a/scripts/qvt_ablation_matrix.py
+++ b/scripts/qvt_ablation_matrix.py
@@ -265,8 +265,16 @@ _TIER_MODELS: Dict[str, str] = {
     "M_M": "gemma4:e4b",   # production default; α-3 baseline tier
     "M_L": "gemma3:12b",
     "M_XL": "gemma3:27b",  # α-6 Phase 3a — large (saturation point probe)
+    "M_MIXTRAL": "mixtral:8x7b",  # paper-baseline control (MultiHop-RAG
+                                  # Table 6: Mixtral-8x7B retrieved 0.32)
     "M_CLOUD": "",         # α-8 cloud tier — Claude default model (CLI picks)
 }
+
+# Default tier universe when --tiers is omitted = the 5 gemma scale
+# ladder only. M_MIXTRAL (paper-baseline control, ~26GB CPU-offload slow)
+# and M_CLOUD (cloud, Max-plan quota) are **opt-in** via explicit
+# --tiers so a stray run doesn't pull a 26GB model or burn cloud quota.
+_DEFAULT_TIERS: Tuple[str, ...] = ("M_XS", "M_S", "M_M", "M_L", "M_XL")
 
 
 # α-8 cloud tier (2026-06-04) — tiers that route through a non-Ollama
@@ -1322,13 +1330,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     #     LOCAL tiers only (M_CLOUD requires explicit opt-in to avoid
     #     a stray "run everything" command burning the operator's Max-
     #     plan quota).
-    _local_tier_universe = [
-        t for t in _TIER_MODELS if t not in _TIER_BACKEND_OVERRIDE
-    ]
     if args.tiers:
         tiers = _parse_subset(args.tiers, list(_TIER_MODELS.keys()), "tiers")
     else:
-        tiers = _local_tier_universe
+        # Default = 5 gemma scale ladder. M_MIXTRAL / M_CLOUD opt-in only.
+        tiers = list(_DEFAULT_TIERS)
     sha = _current_git_sha() or "unknown"
     fixture_path = _resolve_fixture(args.suite)
     out_dir = _resolve_output_dir()

--- a/scripts/research/_terse_live_proof.py
+++ b/scripts/research/_terse_live_proof.py
@@ -1,0 +1,50 @@
+"""Live proof: response_style override now collapses all 3 forcing
+layers end-to-end (2026-06-04 platform-defect fix).
+
+Runs the SAME query under default (NATURAL) and "terse" and prints
+both answers + lengths. Terse should be markedly shorter, with no
+"[관련 자료 목록]"/"Source files:" header and no character-persona
+scaffolding ("보안 위험성", "다음 작업", report ## sections).
+"""
+from __future__ import annotations
+import os, sys, io
+# Force UTF-8 stdout so Windows cp949 console doesn't crash on ⚠ etc.
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from core.reasoning.engine import ReasoningEngine
+
+# Neutral retrieval query — no self_evolve/coding/wiki/meta trigger words.
+Q = "재순위화(reranking)는 검색 결과 품질에 어떤 역할을 하는가?"
+MODEL = os.environ.get("PROOF_MODEL", "qwen2.5:7b")
+
+
+def run(style: str) -> str:
+    eng = ReasoningEngine()
+    out = eng.query(Q, user_role="admin", response_style=style,
+                    selected_model=MODEL, session_id=f"proof-{style or 'def'}",
+                    mode_override="retrieval")
+    if isinstance(out, dict):
+        return out.get("answer") or out.get("response") or str(out)
+    return str(out)
+
+
+def report(label: str, ans: str) -> None:
+    print(f"\n===== {label} (len={len(ans)}) =====")
+    print(ans[:1200])
+    flags = {
+        "관련자료헤더(L3)": ("[관련 자료" in ans) or ("Source files:" in ans) or ("관련 자료:" in ans),
+        "보고서섹션(##)": "##" in ans,
+        "다음작업(L2)": ("다음 작업" in ans) or ("Next actions" in ans),
+        "ANSWER:라인": "ANSWER:" in ans,
+    }
+    print("  flags:", flags)
+
+
+if __name__ == "__main__":
+    print(f"model={MODEL}")
+    nat = run("")          # default → NATURAL
+    report("DEFAULT/NATURAL", nat)
+    ter = run("terse")     # override → TERSE
+    report("TERSE override", ter)
+    print(f"\n>>> length ratio terse/natural = {len(ter)/max(1,len(nat)):.2f}")

--- a/scripts/research/build_terse_fixture.py
+++ b/scripts/research/build_terse_fixture.py
@@ -1,0 +1,63 @@
+"""Build a terse-answer variant of a multihop_rag fixture.
+
+The base fixture's queries elicit JAMES's natural verbose grounded
+answers ("Source files: ... [analysis]"). The MultiHop-RAG paper metric
+expects single-word answers (entity / yes-no). To compare like-for-like
+we append a terse instruction suffix so JAMES emits a paper-shaped
+short answer — a measurement-only transform (production answer style is
+unchanged; this fixture exists solely for benchmark comparison).
+
+The output fixture is gitignored (workspaces/*/eval/), so this script
+is the reproducible source.
+
+Usage:
+  python scripts/research/build_terse_fixture.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+SRC = ROOT / "workspaces" / "hotpot_eval" / "eval" / "multihop_rag_queries.json"
+DST = ROOT / "workspaces" / "hotpot_eval" / "eval" / "multihop_rag_terse_queries.json"
+
+# Terse instruction — CoT-preserving variant.
+#
+# Pure "answer with only Yes/No" suppresses small-model chain-of-thought
+# (gemma4:e4b drops reasoning → wrong, observed in the comparison smoke:
+# 3/3 'No' on Yes-gold). The paper's large models reason internally even
+# under single-word answers; a small model needs the reasoning step kept.
+# So we ALLOW reasoning and require the canonical answer on a final
+# ANSWER: line — the oracle extracts that line (reasoning preserved +
+# paper-shaped single answer extractable). Covers all 4 types
+# (inference→entity, comparison/temporal→yes-no, null→insufficient).
+SUFFIX = (
+    " /// Reason through the evidence, THEN on the LAST line write"
+    " 'ANSWER:' followed by ONLY the direct answer — the entity name,"
+    " or 'Yes' / 'No'. If the context lacks the answer, write"
+    " 'ANSWER: insufficient information'."
+)
+
+
+def main() -> int:
+    src = json.loads(SRC.read_text(encoding="utf-8"))
+    out = {"version": "multihop-rag-terse-v1", "queries": []}
+    for q in src["queries"]:
+        qq = dict(q)
+        qq["text"] = q["text"] + SUFFIX
+        out["queries"].append(qq)
+    DST.write_text(
+        json.dumps(out, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    from collections import Counter
+    types = Counter(q["question_type"] for q in out["queries"])
+    print(f"wrote {DST.relative_to(ROOT)} — {len(out['queries'])} queries")
+    print(f"types: {dict(types)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_max_tokens_relax.py
+++ b/tests/test_max_tokens_relax.py
@@ -55,13 +55,18 @@ class GemmaClientDefaultsTests(unittest.TestCase):
             f"num_predict fallback {fallback} — must be ≥4096")
 
     def test_num_ctx_increased(self):
-        # Context window must be at least as large as the default
-        # max_tokens, otherwise tokens get clamped.
-        m = re.search(r'"num_ctx":\s*(\d+)', self.src)
-        self.assertIsNotNone(m, "couldn't locate num_ctx literal")
+        # Context window default must be ≥8192 (else tokens clamp).
+        # 2026-06-04: num_ctx became env-overridable
+        # (JAMES_NUM_CTX, default "8192") for benchmark eval — the
+        # default literal is the fallback string in os.environ.get.
+        m = re.search(r'JAMES_NUM_CTX",\s*"(\d+)"', self.src)
+        if m is None:
+            # back-compat: plain literal form
+            m = re.search(r'"num_ctx":\s*(\d+)', self.src)
+        self.assertIsNotNone(m, "couldn't locate num_ctx default")
         ctx = int(m.group(1))
         self.assertGreaterEqual(ctx, 8192,
-            f"num_ctx {ctx} — must be ≥8192 to fit the longer answers")
+            f"num_ctx default {ctx} — must be ≥8192 to fit longer answers")
 
 
 class CallSiteUnchangedTests(unittest.TestCase):

--- a/tests/test_qvt_matrix_cloud_tier.py
+++ b/tests/test_qvt_matrix_cloud_tier.py
@@ -184,12 +184,12 @@ def test_default_tiers_excludes_m_cloud_opt_in_safety(monkeypatch):
         # printed planning instead — but easier to test the logic
         # directly through a synthetic argv.
 
-    # Direct test: simulate the branch by checking that
-    # _local_tier_universe equals all non-cloud tiers.
-    expected_local = {"M_XS", "M_S", "M_M", "M_L", "M_XL"}
-    actual = set(t for t in runner._TIER_MODELS
-                 if t not in runner._TIER_BACKEND_OVERRIDE)
-    assert actual == expected_local
+    # Direct test: default tier universe (--tiers omitted) = 5 gemma
+    # scale ladder. M_MIXTRAL (paper control) and M_CLOUD (cloud) are
+    # opt-in only, so neither is in the default set.
+    assert set(runner._DEFAULT_TIERS) == {"M_XS", "M_S", "M_M", "M_L", "M_XL"}
+    assert "M_CLOUD" not in runner._DEFAULT_TIERS
+    assert "M_MIXTRAL" not in runner._DEFAULT_TIERS
 
 
 def test_explicit_tiers_m_cloud_passes_through():

--- a/tests/test_qvt_oracle.py
+++ b/tests/test_qvt_oracle.py
@@ -875,6 +875,52 @@ class PaperAlignedAccuracyTests(unittest.TestCase):
         b2 = self._bench({1: filler + "so the answer would be yes eventually."})
         self.assertEqual(score_paper_aligned_accuracy(b2, fixture).correct_primary, 0)
 
+    def test_cot_answer_line_extracted(self):
+        """CoT 'ANSWER:' line is extracted; reasoning before it ignored.
+        A 'No' buried in reasoning must not flip a final 'ANSWER: Yes'."""
+        from eval.qvt.oracle import _extract_terse_answer
+        cot = ("Looking at the evidence, there is no clear contradiction "
+               "between the two sources, so the comparison holds.\n"
+               "ANSWER: Yes")
+        self.assertEqual(_extract_terse_answer(cot), "Yes")
+
+        fixture = {
+            "version": "test",
+            "queries": [
+                {"id": 1, "question_type": "comparison_query",
+                 "abstention_truth": "present",
+                 "gold_signals": [{"term": "Yes", "aliases": []}]},
+            ],
+        }
+        # reasoning has 'no' but final ANSWER is Yes → correct
+        bench = self._bench({1: cot})
+        self.assertEqual(score_paper_aligned_accuracy(bench, fixture).correct_primary, 1)
+
+    def test_cot_last_answer_line_wins(self):
+        from eval.qvt.oracle import _extract_terse_answer
+        s = "ANSWER: maybe\nactually reconsidering\nANSWER: No"
+        self.assertEqual(_extract_terse_answer(s), "No")
+
+    def test_no_answer_line_uses_whole_text(self):
+        from eval.qvt.oracle import _extract_terse_answer
+        s = "Sam Bankman-Fried was the person."
+        self.assertEqual(_extract_terse_answer(s), s)
+
+    def test_cot_null_abstain_extracted(self):
+        """CoT 'ANSWER: insufficient information' → abstain correct."""
+        fixture = {
+            "version": "test",
+            "queries": [
+                {"id": 1, "question_type": "null_query",
+                 "abstention_truth": "absent",
+                 "gold_signals": [{"term": "x", "aliases": []}]},
+            ],
+        }
+        cot = "The documents discuss X but not the asked relation.\nANSWER: insufficient information"
+        bench = self._bench({1: cot})
+        axis = score_paper_aligned_accuracy(bench, fixture)
+        self.assertEqual(axis.correct_primary, 1)
+
     def test_entity_answer_keeps_substring_match(self):
         """P3 precision applies word-boundary ONLY to yes/no; entity
         answers (inference) keep the substring+negation matcher."""

--- a/tests/test_response_style.py
+++ b/tests/test_response_style.py
@@ -178,5 +178,99 @@ class ChatParagraphPreservationTests(unittest.TestCase):
                       "v2 must collapse 3+ newlines to 2, preserving paragraphs")
 
 
+class StyleOverrideTests(unittest.TestCase):
+    """2026-06-04 — restore user/operator style override (v2 hardcode
+    blocked it = platform defect). default stays NATURAL byte-identical;
+    explicit/env 'terse' diverges to TERSE_PRESET."""
+
+    def setUp(self):
+        from core import response_style
+        self.rs = response_style
+        self._saved_env = os.environ.get("JAMES_RESPONSE_STYLE")
+        os.environ.pop("JAMES_RESPONSE_STYLE", None)
+
+    def tearDown(self):
+        if self._saved_env is None:
+            os.environ.pop("JAMES_RESPONSE_STYLE", None)
+        else:
+            os.environ["JAMES_RESPONSE_STYLE"] = self._saved_env
+
+    def test_default_is_natural_byte_identical(self):
+        # No explicit, no env → NATURAL (production unchanged).
+        self.assertIs(self.rs.resolve_style(), self.rs.NATURAL_PRESET)
+        self.assertIs(self.rs.resolve_style(""), self.rs.NATURAL_PRESET)
+        self.assertIs(self.rs.resolve_style(None or ""), self.rs.NATURAL_PRESET)
+
+    def test_explicit_terse_resolves_terse(self):
+        self.assertIs(self.rs.resolve_style("terse"), self.rs.TERSE_PRESET)
+        self.assertIs(self.rs.resolve_style("TERSE"), self.rs.TERSE_PRESET)
+        self.assertIs(self.rs.resolve_style(" terse "), self.rs.TERSE_PRESET)
+
+    def test_env_terse_resolves_terse(self):
+        os.environ["JAMES_RESPONSE_STYLE"] = "terse"
+        self.assertIs(self.rs.resolve_style(), self.rs.TERSE_PRESET)
+
+    def test_explicit_overrides_env(self):
+        os.environ["JAMES_RESPONSE_STYLE"] = "natural"
+        # explicit terse wins over env natural
+        self.assertIs(self.rs.resolve_style("terse"), self.rs.TERSE_PRESET)
+
+    def test_v1_presets_still_natural(self):
+        # brief/standard/detailed NOT resurrected (no token-cut) → NATURAL
+        for s in ("brief", "standard", "detailed"):
+            self.assertIs(self.rs.resolve_style(s), self.rs.NATURAL_PRESET)
+
+    def test_unknown_falls_back_to_natural(self):
+        self.assertIs(self.rs.resolve_style("nonsense-style"), self.rs.NATURAL_PRESET)
+
+    def test_terse_preset_rule_text_demands_answer_line(self):
+        # TERSE rule_text must instruct ANSWER: line + forbid Source files
+        for rt in (self.rs.TERSE_PRESET.rule_text_ko, self.rs.TERSE_PRESET.rule_text_en):
+            self.assertIn("ANSWER:", rt)
+        # forbids the NATURAL scaffolding
+        self.assertIn("Source files", self.rs.TERSE_PRESET.rule_text_en)  # mentioned as "do NOT"
+
+
+class AnswerFormatContractTests(unittest.TestCase):
+    """2026-06-04 — the StylePreset is the single source of truth for the
+    *whole* answer shape across all 3 forcing layers (L1 character
+    directives, L2 rule_text, L3 sources header). NATURAL keeps every
+    layer ON (byte-identical); TERSE collapses all three."""
+
+    def test_natural_keeps_all_layers_on(self):
+        from core.response_style import NATURAL_PRESET
+        self.assertTrue(NATURAL_PRESET.inject_character_directives,
+                        "NATURAL must keep L1 character injection (default)")
+        self.assertTrue(NATURAL_PRESET.inject_sources_header,
+                        "NATURAL must keep L3 sources header (default)")
+
+    def test_terse_collapses_all_layers(self):
+        from core.response_style import TERSE_PRESET
+        self.assertFalse(TERSE_PRESET.inject_character_directives,
+                         "TERSE must suppress L1 character persona")
+        self.assertFalse(TERSE_PRESET.inject_sources_header,
+                         "TERSE must suppress L3 sources header")
+
+    def test_l1_callsite_gates_on_contract(self):
+        # build_memory_context must read the resolved style's
+        # inject_character_directives flag (not inject unconditionally).
+        import core.reasoning.engine_memory as em
+        import inspect
+        src = inspect.getsource(em.build_memory_context)
+        self.assertIn("inject_character_directives", src)
+        self.assertIn("response_style", src,
+                      "L1 must receive response_style to resolve the style")
+
+    def test_l3_callsite_gates_on_contract(self):
+        # apply_post_check_and_sources_header must read the resolved
+        # style's inject_sources_header flag.
+        import core.reasoning.pipeline_context as pc
+        import inspect
+        src = inspect.getsource(pc.apply_post_check_and_sources_header)
+        self.assertIn("inject_sources_header", src)
+        self.assertIn("response_style", src,
+                      "L3 must receive response_style to resolve the style")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_source_files_first.py
+++ b/tests/test_source_files_first.py
@@ -145,8 +145,11 @@ class PipelineSourcePrependTests(unittest.TestCase):
     def test_skip_when_no_context(self):
         # If safe_context is empty (no retrieval result), prepending
         # the header would mislead the model. Source prepend is gated
-        # on safe_context.strip().
-        self.assertIn("if safe_context.strip() and source_names", self.src,
+        # on safe_context.strip() AND a non-empty source list. (As of
+        # 2026-06-04 the condition also includes an _inject_header style
+        # gate — TERSE suppresses the header — so match the substring
+        # that survives the added gate rather than the whole if-line.)
+        self.assertIn("safe_context.strip() and source_names", self.src,
                       "source-prepend must be gated on non-empty context "
                       "AND non-empty source list")
 


### PR DESCRIPTION
## Summary
- **Platform 결함 수정**: 답변 장황화 강제가 3개 layer(L1 캐릭터 / L2 스타일룰 / L3 자료헤더)에 hardcode + 사용자 override 봉쇄 → 사용자가 단답 요청해도 못 하는 구조. `StylePreset`을 답변 형식 계약의 단일 진실원천으로 만들어 옵션화. NATURAL(기본)=production byte-identical, `terse` 1요청 = 3 layer 동시 collapse.
- **단답 측정 인프라**: paper-aligned exact-match oracle + M_CLOUD/M_MIXTRAL tier + `JAMES_NUM_CTX` env + terse fixture builder.

## Verification
- 463 reasoning/style 테스트 pass. 신규 `AnswerFormatContractTests` 4개 (preset 계약 + L1/L3 콜사이트 게이트 lock).
- 라이브 e2e (qwen2.5:7b, retrieval): terse=348자 vs natural=1764자 (0.20배), L1 캐릭터 persona 억제 확인 (`[CHARACTER]` 로그 사라짐), default byte-identical.

## Quality delta
exempt (label: fix) — answer-format 결함 정정 + measurement-side 인프라. retrieval/graph/reasoning 품질 변경 아님.

## Out of scope
- terse 모드 본 측정 (gemma4부터 재개 — 별도)
- UI picker에 style 노출 (S5b deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)