### PR TITLE
fix(research): runner sources count → list (cycle β #7 path coverage prerequisite)

### DIFF
--- a/reports/research-runs/alpha-8-paper-comparison-experiment-log-20260604.md
+++ b/reports/research-runs/alpha-8-paper-comparison-experiment-log-20260604.md
@@ -3136,6 +3136,97 @@ cycle β #2 closure 후 진입 sequence:
 총 cost = ~1-2 주. design-planned 인프라 다 갖춘 후 publication-grade
 evidence 확보.
 
+
+## 41. Cycle β #7 — multihop_terse_run.py sources field count → list (path coverage prerequisite, 2026-06-06)
+
+cycle β #2 closure 직후 Path 1 sequence 의 첫 step. runner 가 sources
+를 `int (count)` 만 저장하던 것을 `list of citation names` 로 변경.
+`score_path_coverage` 의 `via_sources` 가 항상 0 이었던 platform-wide
+defect 차단 — cycle γ 의 MuSiQue / 2WikiMultiHopQA support fact
+accuracy 측정 prerequisite.
+
+### Phase A 진단
+
+- `scripts/research/multihop_terse_run.py:94` — `"sources": n_src`
+  (int count 만)
+- `eval/qvt/oracle.py:301-303` `score_path_coverage` 의 `r.get("sources")`
+  → string list 필요 (`if isinstance(s, str)`)
+- 결과: `via_sources` 항상 0 → `path_recall` 가 graph-only 한정
+
+### Phase B 코드 변경
+
+```python
+# Before
+"sources": n_src   # int
+
+# After
+source_names = []
+for s in srcs:
+    if isinstance(s, dict):
+        name = (s.get("source") or s.get("title") or
+                s.get("filename") or s.get("file") or "")
+    elif isinstance(s, str):
+        name = s
+    name = (name or "").strip()
+    if name:
+        source_names.append(name)
+"sources": source_names,     # list of strings
+"sources_count": len(source_names),  # 호환 (evidence-retrieved print)
+```
+
+호환성:
+- `score_path_coverage` legacy fallback (line 272 `if not fq` branch) =
+  historic JSON 의 `sources: int` 호환 유지
+- `multihop_score_axes.py` 의 evidence-retrieved 출력 = `sources_count`
+  사용으로 갱신
+
+### Phase C smoke 검증 (PM-22 n=5 e4b)
+
+`workspaces/hotpot_eval/eval/multihop_rag_queries_smoke5.json` 신규
+(첫 5 inference_query). 측정 cost ~4-5min.
+
+**sources field shape check**:
+
+| qid | type | len | sample (first 2) |
+|---|---|---|---|
+| 1 | list | 3 | `['multihop_0175_The-FTX-trial...', 'multihop_0086_Sam-Bankman-Fried...']` |
+| 2 | list | 3 | `['multihop_0530_The-777-million-surprise...', 'multihop_0530_The-777-million-surprise...']` |
+| 3 | list | 3 | `['multihop_0332_OpenAI-s-ex-chairman...', 'multihop_0516_Sam-Altman-ousted...']` |
+| 4 | list | 3 | `['multihop_0072_Vermont-Sportsbook-Promos...', 'multihop_0072_Vermont-Sportsbook-Promos...']` |
+| 5 | list | 3 | `['multihop_0031_Is-Sam-Bankman-Fried...', 'multihop_0010_SBF-s-trial-starts-soon...']` |
+
+→ 모두 `list of strings`, 정상 ✅
+
+**score_path_coverage check (via_sources 0 → positive 변환)**:
+
+| qid | expected | hits | recall | via_graph | **via_sources** |
+|---|---|---|---|---|---|
+| 1 | 3 | 1 | 0.333 | 0 | **1** |
+| 2 | 2 | 1 | 0.500 | 0 | **1** |
+| **3** | **2** | **2** | **1.000** | **0** | **2** |
+| 4 | 3 | 1 | 0.333 | 0 | **1** |
+| 5 | 2 | 1 | 0.500 | 0 | **1** |
+
+→ mean_recall = **0.5333**, queries_at_full_recall = 1/5.
+**via_sources 0 → positive 정상 변환 ✅**. qid=3 full recall (2/2) 달성.
+
+### Mechanism verdict
+
+| 변경 전 | 변경 후 |
+|---|---|
+| `sources: int` | `sources: list of strings` + `sources_count: int` 호환 |
+| `via_sources` 항상 0 | `via_sources` positive (1-2/expected) |
+| `path_recall` = graph-only | `path_recall` = graph + source union |
+| MuSiQue/2Wiki 측정 불가 | MuSiQue/2Wiki support fact accuracy 측정 가능 |
+
+→ cycle β #7 = measurement infra prerequisite 완료. cycle γ 의 외부
+벤치 측정 prerequisite 첫 항목 ✅.
+
+### Path 1 sequence 다음 step
+
+cycle β #6 (Hidden defect audit) — cap[:1000] 같은 1-line hardcoded
+defect 추가 발굴. ~2-4h.
+
 ### Mother-platform 6 원칙 매핑
 
 | 원칙 | 평가 |

--- a/scripts/research/multihop_terse_run.py
+++ b/scripts/research/multihop_terse_run.py
@@ -78,6 +78,7 @@ def main():
     _eff_style = "" if _runner_style.lower() == "auto" else _runner_style
 
     for i, q in enumerate(queries, 1):
+        source_names: list = []
         try:
             session_id = (_shared_session if _session_mode == "fixed-shared"
                           else f"pm-terse-q{q['id']}")
@@ -86,12 +87,39 @@ def main():
                             session_id=session_id)
             ans = out.get("answer", "") if isinstance(out, dict) else str(out)
             srcs = (out.get("sources") or out.get("docs") or []) if isinstance(out, dict) else []
-            n_src = len(srcs) if isinstance(srcs, (list, tuple)) else 0
+            # cycle β #7 (2026-06-06) — emit sources as a list of
+            # citation names (was an int count) so the unified
+            # `score_path_coverage` axis can credit source-side hits
+            # against `fixture.expected_path.nodes`. Without this, the
+            # scorer's `r.get("sources")` slug set is always empty and
+            # `via_sources` is always 0, leaving MuSiQue / 2WikiMultiHopQA
+            # support-fact accuracy unmeasurable.
+            #
+            # Each `srcs` entry can be a dict (engine path) or a string
+            # (legacy / web path). Extract the most filename-like field
+            # available; preserve insertion order; drop empties.
+            if isinstance(srcs, (list, tuple)):
+                for s in srcs:
+                    if isinstance(s, dict):
+                        name = (s.get("source") or s.get("title") or
+                                s.get("filename") or s.get("file") or "")
+                    elif isinstance(s, str):
+                        name = s
+                    else:
+                        name = ""
+                    name = (name or "").strip()
+                    if name:
+                        source_names.append(name)
             status = "ok"
         except Exception as e:
-            ans, n_src, status = f"[ERROR] {e}", 0, "error"
+            ans, status = f"[ERROR] {e}", "error"
         results.append({"id": q["id"], "status": status, "answer": ans,
-                        "question_type": q["question_type"], "sources": n_src})
+                        "question_type": q["question_type"],
+                        # list of citation names — score_path_coverage uses this
+                        "sources": source_names,
+                        # int count preserved for back-compat with the
+                        # evidence-retrieved print + any legacy reader
+                        "sources_count": len(source_names)})
         if i % 10 == 0 or i == len(queries):
             json.dump({"model": MODEL, "results": results},
                       open(OUT, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
@@ -105,7 +133,7 @@ def main():
     print(f"accuracy_strict            : {axis.accuracy_strict:.3f}  "
           f"({axis.correct_strict}/{axis.n_queries})")
     print(f"answerable / null          : {axis.n_answerable} / {axis.n_null}")
-    print(f"evidence-retrieved         : {sum(1 for r in results if r['sources']>0)}/{len(results)} "
+    print(f"evidence-retrieved         : {sum(1 for r in results if r.get('sources_count', len(r.get('sources') or []))>0)}/{len(results)} "
           f"(null queries expected 0)")
     print("\nby question_type:")
     for t, d in sorted(axis.by_question_type.items()):


### PR DESCRIPTION
## Summary

Cycle β #2 closure 직후 Path 1 sequence 의 첫 step. runner 가 sources 를
`int (count)` 만 저장하던 것을 `list of citation names` 로 변경.
`score_path_coverage` 의 `via_sources` 가 항상 0 이었던 platform-wide
defect 차단 — cycle γ 의 MuSiQue / 2WikiMultiHopQA support fact accuracy
측정 prerequisite.

## Verification (PM-22 smoke n=5 e4b, ~4-5min cost)

### sources field shape

| qid | type | len | sample |
|---|---|---|---|
| 1 | list | 3 | `['multihop_0175_The-FTX-trial...', 'multihop_0086_Sam-Bankman-Fried...']` |
| 3 | list | 3 | `['multihop_0332_OpenAI-s-ex-chairman...', 'multihop_0516_Sam-Altman-ousted...']` |

→ list of citation names (string list) ✅

### score_path_coverage via_sources 0 → positive 변환

| qid | expected | hits | recall | via_graph | **via_sources** |
|---|---|---|---|---|---|
| 1 | 3 | 1 | 0.333 | 0 | **1** |
| 2 | 2 | 1 | 0.500 | 0 | **1** |
| **3** | **2** | **2** | **1.000** | **0** | **2** |
| 4 | 3 | 1 | 0.333 | 0 | **1** |
| 5 | 2 | 1 | 0.500 | 0 | **1** |

→ mean_recall = **0.5333**, qid=3 full recall (2/2) 달성. via_sources
positive 변환 정상 작동 ✅

## Quality Delta Card

**Exempt** (label: `fix`) — runner/measurement-infra correction, not
a quality dial. score_path_coverage 가 본래 의도대로 작동하도록
wiring 수정. CLAUDE.md rule #2 exemption 의 `fix` 항목 정합.

## Compatibility

- `score_path_coverage` legacy fallback (`oracle.py:272` `if not fq`
  branch) = historic JSON 의 `sources: int` 호환 유지
- evidence-retrieved print (line 108) = `sources_count` 사용 (back-compat)

## Out of scope

- 전체 fixture (n=100) full measurement = cycle γ 측정에서 활용
- cycle β #6 (Hidden defect audit) — Path 1 다음 step

## Closes / related

- Cycle β #2 closure: `e2491e4` (#715)
- Path 1 sequence: `docs/handovers/v0.4-cycle-beta-closure-2026-06-06.md`
- Cycle γ prerequisite: `docs/design/v0.4-cycle-gamma-external-
  benchmark-integration.md` §7 (`#7 runner sources count → list`)
- §41 doc: `reports/research-runs/alpha-8-paper-comparison-experiment-
  log-20260604.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)