### PR TITLE
feat(v0.4.2): T5.A — event taxonomy + emit helper + audit_log migration

### DIFF
--- a/core/lifecycle/replay_audit.py
+++ b/core/lifecycle/replay_audit.py
@@ -1,0 +1,213 @@
+"""T5.A — Lifecycle event taxonomy + emit helpers (write side).
+
+This module is the write-side infrastructure for v0.4.2 T5's
+**audit-only invariant** (``reconstruct_graph_at(t)`` will depend
+solely on the audit_log row stream up to ``t`` — design memo §2 +
+§4 invariant I1). Every lifecycle mutation that produces a
+read-side graph state change must emit one audit_log row with
+``event_type`` in :data:`LIFECYCLE_EVENT_TYPES` so the read-side
+reconstruction can replay the mutation deterministically.
+
+Design memo: ``docs/design/v0.4.2-t5-replayable-audit-graph.md``.
+
+Decision LOCKs (memo §7):
+
+* LOCK 1 — ``event_payload`` is a JSON string column on ``audit_log``,
+  not a separate table. Keeps the migration to ``ALTER TABLE … ADD
+  COLUMN`` (idempotent, no row rewrite).
+* LOCK 2 — emit is **synchronous in-transaction**: ``emit_lifecycle_event``
+  inserts on the calling thread; lifecycle code must call it before
+  returning from the mutation site.
+
+API surface
+-----------
+
+  * :data:`LIFECYCLE_EVENT_TYPES` — frozen tuple of every valid
+    lifecycle event type.
+  * :func:`emit_lifecycle_event` — write a lifecycle row to
+    ``audit_log``. Never raises; returns ``True`` on insert,
+    ``False`` on any failure (matches ``audit_bridge.mirror_to_audit_db``
+    contract).
+  * :func:`is_lifecycle_event` — boolean predicate for routing
+    reads back to lifecycle replay vs reasoning trace replay.
+
+Read-side (``reconstruct_graph_at(t)``) lands in PR-T5.B
+(``core/lifecycle/replay_graph.py``).
+
+Wiring (PR-T5.A.b or follow-up): every existing mutation site
+listed in :data:`LIFECYCLE_EVENT_TYPES` calls
+:func:`emit_lifecycle_event` exactly once per state change. The
+release-gating "every mutation → audit row" invariant (memo §11
+risk table) pins that contract.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+# ─── Event-type taxonomy (LOCK with design memo §3) ────────────────
+#
+# Every lifecycle mutation that the read-side replay must observe to
+# reconstruct graph state at an arbitrary ``t`` must use one of these
+# event types. The names match the design memo §3 table 1:1.
+#
+# Adding a new entry here is a public API change: the migration
+# script does not need to know the entries (event_type is a free
+# TEXT column), but ``reconstruct_graph_at`` (PR-T5.B) dispatches
+# on these strings, and every entry must have a corresponding
+# decoder there.
+
+# T7 — supersede chain mutations
+EVT_SUPERSEDE_EDGE_CREATED  = "lifecycle.supersede.edge_created"
+EVT_SUPERSEDE_CHAIN_EXTENDED = "lifecycle.supersede.chain_extended"
+
+# T6 — causality chain cascade
+EVT_CASCADE_INVALIDATE = "lifecycle.cascade.invalidate"
+
+# T1 — temporal validity expiration
+EVT_T1_EXPIRATION_CASCADE = "lifecycle.t1.expiration_cascade"
+
+# T2 — deterministic contradiction arbitration
+EVT_T2_DISPATCH_CONTRADICTION = "lifecycle.t2.dispatch_contradiction"
+
+# T2.D — ingestion-time pre-merge contradiction routing
+EVT_T2D_INGEST_DISPATCH = "lifecycle.t2d.ingest_dispatch"
+
+# Migration marker — rows emitted by ``migrate_v042_replay_audit.py``
+# when the historic wiki state was snapshot-reverse-derived because
+# the original mutation predates audit_log capture. Replay treats
+# these as a one-shot bootstrap event.
+EVT_BACKFILL_SNAPSHOT = "lifecycle.backfill.snapshot"
+
+
+LIFECYCLE_EVENT_TYPES: tuple[str, ...] = (
+    EVT_SUPERSEDE_EDGE_CREATED,
+    EVT_SUPERSEDE_CHAIN_EXTENDED,
+    EVT_CASCADE_INVALIDATE,
+    EVT_T1_EXPIRATION_CASCADE,
+    EVT_T2_DISPATCH_CONTRADICTION,
+    EVT_T2D_INGEST_DISPATCH,
+    EVT_BACKFILL_SNAPSHOT,
+)
+
+
+_LIFECYCLE_PREFIX = "lifecycle."
+
+
+def is_lifecycle_event(event_type: Optional[str]) -> bool:
+    """True iff ``event_type`` is one of :data:`LIFECYCLE_EVENT_TYPES`.
+
+    The check is exact-equality against the registered set rather
+    than a ``startswith("lifecycle.")`` prefix, so a typo in a
+    mutation site (``lifecycle.cascadx.invalidate``) does not
+    silently slip into the replay stream.
+    """
+    return isinstance(event_type, str) and event_type in LIFECYCLE_EVENT_TYPES
+
+
+# ─── DB path resolution (matches audit_bridge) ──────────────────────
+
+
+def _default_db_path() -> str:
+    """Resolve the production audit_log SQLite path.
+
+    Mirrors the resolution order used by ``audit_bridge`` so a
+    lifecycle event lands in the same database as the reasoning
+    rows — replay reads them back from one place.
+    """
+    env = (os.environ.get("JAMES_AUDIT_DB") or "").strip()
+    if env:
+        return env
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "audit.db",
+    )
+
+
+# ─── emit (write side) ─────────────────────────────────────────────
+
+
+def emit_lifecycle_event(
+    event_type: str,
+    payload: Dict[str, Any],
+    *,
+    user_role: str = "system",
+    timestamp: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Insert one ``audit_log`` row with the given lifecycle
+    ``event_type`` + JSON-encoded ``payload``.
+
+    Args:
+        event_type: one of :data:`LIFECYCLE_EVENT_TYPES`. Validated.
+        payload: any JSON-serializable dict describing the mutation
+            (edge ids, ``mutation_type``, validity window, etc.).
+            Encoded with ``ensure_ascii=False`` so Korean / mixed
+            text round-trips without escape clutter.
+        user_role: who triggered the mutation. Defaults to
+            ``"system"`` because most lifecycle mutations originate
+            from CASCADE / EVENT machinery, not from an HTTP role.
+        timestamp: ISO-8601 string. Defaults to ``datetime.now()``.
+        db_path: optional override. Production code omits it.
+
+    Returns:
+        ``True`` on insert, ``False`` on any failure. **Never raises**
+        — matches ``audit_bridge.mirror_to_audit_db`` so a lifecycle
+        bug cannot block the cascade or supersede path.
+
+    Notes:
+        * The ``audit_log`` schema must have ``event_type`` and
+          ``event_payload`` columns (``migrate_v042_replay_audit.py``
+          adds them). On a pre-migration DB this function returns
+          ``False`` instead of crashing.
+        * ``endpoint`` is set to ``event_type`` so existing operator
+          audit views (``/admin/audit/list``) surface lifecycle rows
+          without a separate filter.
+    """
+    if not is_lifecycle_event(event_type):
+        return False
+    if not isinstance(payload, dict):
+        return False
+
+    ts = timestamp or datetime.now().isoformat()
+    try:
+        payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return False
+
+    path = db_path or _default_db_path()
+    try:
+        conn = sqlite3.connect(path, check_same_thread=False)
+        try:
+            conn.execute(
+                "INSERT INTO audit_log "
+                "(timestamp, user_role, endpoint, query, answer, "
+                " graph_paths, blocked, security_event, elapsed_sec, "
+                " ip_address, event_type, event_payload) "
+                "VALUES (?, ?, ?, NULL, NULL, NULL, 0, NULL, NULL, NULL, ?, ?)",
+                (ts, user_role, event_type, event_type, payload_json),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+    except Exception:
+        return False
+
+
+__all__ = [
+    "LIFECYCLE_EVENT_TYPES",
+    "EVT_SUPERSEDE_EDGE_CREATED",
+    "EVT_SUPERSEDE_CHAIN_EXTENDED",
+    "EVT_CASCADE_INVALIDATE",
+    "EVT_T1_EXPIRATION_CASCADE",
+    "EVT_T2_DISPATCH_CONTRADICTION",
+    "EVT_T2D_INGEST_DISPATCH",
+    "EVT_BACKFILL_SNAPSHOT",
+    "is_lifecycle_event",
+    "emit_lifecycle_event",
+]

--- a/scripts/migrate_v042_replay_audit.py
+++ b/scripts/migrate_v042_replay_audit.py
@@ -1,0 +1,209 @@
+"""v0.4.2 PR-T5.A — audit_log schema migration (T5 replay audit columns).
+
+v0.4.2 T5 design memo §3 PR-T5.A scope. Adds two columns to the
+``audit_log`` SQLite table so lifecycle mutation events can be
+captured for the audit-only replay invariant (memo §2):
+
+  * ``event_type`` (TEXT, nullable)    — one of
+    :data:`core.lifecycle.replay_audit.LIFECYCLE_EVENT_TYPES`,
+    or NULL on existing reasoning rows.
+  * ``event_payload`` (TEXT, nullable) — JSON-encoded mutation
+    payload (edge ids, validity, mutation_type, …).
+
+Pre-existing rows (reasoning trace, security, etc.) keep both new
+columns NULL — they remain readable by the existing replay
+(``test_replay_trace.py`` §5.7.2). New lifecycle rows use the
+columns; the read-side primitive (PR-T5.B) routes by
+``event_type IS NOT NULL`` + :func:`is_lifecycle_event`.
+
+Properties (every one pinned by
+``tests/test_migrate_v042_replay_audit.py``):
+
+* **Idempotent.** Running ``--apply`` twice is a no-op after the
+  first run. ``ALTER TABLE … ADD COLUMN`` is wrapped in an
+  introspection check (``PRAGMA table_info``) so a re-run does
+  not raise.
+* **v0.4.1-equivalent behavior.** Existing reasoning / security
+  rows are byte-identical. Existing replay
+  (``tests/test_replay_trace.py``) keeps reading the historic
+  columns only.
+* **Snapshot first.** ``--apply`` defaults to copying the audit DB
+  to ``<db>.pre-v042-migration`` so the operator has a one-step
+  rollback path. ``--no-snapshot`` skips when the operator has
+  already taken one.
+
+Operator workflow::
+
+    # 1. Dry-run (default) — report which columns are missing
+    python scripts/migrate_v042_replay_audit.py --db audit.db
+
+    # 2. Apply with snapshot (creates audit.db.pre-v042-migration)
+    python scripts/migrate_v042_replay_audit.py --db audit.db --apply
+
+    # 3. Verify (re-introspect — should report no missing columns)
+    python scripts/migrate_v042_replay_audit.py --db audit.db --verify
+
+Design memo: ``docs/design/v0.4.2-t5-replayable-audit-graph.md`` §3.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from utils.console import ensure_utf8_console  # noqa: E402
+    ensure_utf8_console()
+except Exception:
+    pass
+
+
+# Columns the migration adds. (column_name, sql_type) tuples — kept
+# small so a future T5.A.b can extend the list without rewriting the
+# add/verify loops.
+NEW_COLUMNS: Tuple[Tuple[str, str], ...] = (
+    ("event_type",    "TEXT"),
+    ("event_payload", "TEXT"),
+)
+
+
+def _existing_columns(conn: sqlite3.Connection, table: str) -> List[str]:
+    """Return the column names already present on ``table``.
+
+    Uses ``PRAGMA table_info`` so the introspection works on any
+    SQLite version and does not require write access.
+    """
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk)
+    return [r[1] for r in rows]
+
+
+def _missing_columns(conn: sqlite3.Connection) -> List[Tuple[str, str]]:
+    existing = set(_existing_columns(conn, "audit_log"))
+    return [(name, sql_type) for name, sql_type in NEW_COLUMNS
+            if name not in existing]
+
+
+def _snapshot(db_path: Path) -> Path:
+    """Copy the DB file to ``<db>.pre-v042-migration``.
+
+    Returns the snapshot path. Raises ``FileExistsError`` if a
+    snapshot already exists — operator must ``--no-snapshot`` or
+    rename the existing one explicitly.
+    """
+    snap = db_path.with_name(db_path.name + ".pre-v042-migration")
+    if snap.exists():
+        raise FileExistsError(
+            f"Snapshot already exists at {snap}. Pass --no-snapshot to skip "
+            "or rename it before re-running --apply."
+        )
+    shutil.copy2(db_path, snap)
+    return snap
+
+
+def migrate(
+    db_path: Path,
+    *,
+    apply: bool = False,
+    snapshot: bool = True,
+    verify: bool = False,
+) -> int:
+    """Run the migration. Returns 0 on success, non-zero on failure
+    (for CLI exit codes).
+
+    Modes:
+      * ``apply=False, verify=False`` (default): dry-run — report
+        missing columns, no write.
+      * ``apply=True``: add missing columns. Snapshots first unless
+        ``snapshot=False``.
+      * ``verify=True``: re-introspect and exit non-zero if any
+        column is still missing.
+    """
+    if not db_path.exists():
+        print(f"[T5.A migrate] FATAL: db not found: {db_path}")
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        existing = _existing_columns(conn, "audit_log")
+        if "id" not in existing:
+            print("[T5.A migrate] FATAL: audit_log table missing — "
+                  "this DB has no v0.3+ audit schema.")
+            return 2
+
+        missing = _missing_columns(conn)
+        if verify:
+            if missing:
+                print(f"[T5.A migrate] VERIFY FAIL: missing columns: "
+                      f"{[name for name, _ in missing]}")
+                return 1
+            print("[T5.A migrate] VERIFY OK: every T5 column is present.")
+            return 0
+
+        if not missing:
+            print("[T5.A migrate] No-op: every T5 column is already present.")
+            return 0
+
+        if not apply:
+            print(f"[T5.A migrate] DRY-RUN: would add columns: "
+                  f"{[(name, sql_type) for name, sql_type in missing]}")
+            print("[T5.A migrate]   Re-run with --apply to perform the migration.")
+            return 0
+
+        if snapshot:
+            snap = _snapshot(db_path)
+            print(f"[T5.A migrate] Snapshot: {snap}")
+        else:
+            print("[T5.A migrate] Snapshot: skipped (--no-snapshot)")
+
+        for name, sql_type in missing:
+            conn.execute(f"ALTER TABLE audit_log ADD COLUMN {name} {sql_type}")
+            print(f"[T5.A migrate] Added column: {name} {sql_type}")
+        conn.commit()
+
+        # Post-write verification — re-introspect.
+        post = set(_existing_columns(conn, "audit_log"))
+        for name, _ in NEW_COLUMNS:
+            if name not in post:
+                print(f"[T5.A migrate] FATAL: column {name} did not land")
+                return 2
+        print("[T5.A migrate] APPLY OK")
+        return 0
+    finally:
+        conn.close()
+
+
+def main(argv: List[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="v0.4.2 PR-T5.A: add event_type + event_payload "
+                    "columns to audit_log (idempotent, snapshots first)."
+    )
+    ap.add_argument("--db", required=True,
+                    help="Path to the audit_log SQLite database.")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true",
+                      help="Perform the migration. Snapshots first by default.")
+    mode.add_argument("--verify", action="store_true",
+                      help="Re-introspect and exit non-zero if columns are "
+                           "missing. No write.")
+    ap.add_argument("--no-snapshot", action="store_true",
+                    help="Skip the .pre-v042-migration snapshot. Use only "
+                         "when an external backup is already in place.")
+    args = ap.parse_args(argv)
+
+    return migrate(
+        Path(args.db),
+        apply=args.apply,
+        snapshot=not args.no_snapshot,
+        verify=args.verify,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_t5_event_taxonomy.py
+++ b/tests/test_t5_event_taxonomy.py
@@ -1,0 +1,406 @@
+"""v0.4.2 PR-T5.A — event taxonomy + emit + migration contract tests.
+
+Pins the write-side contract for the T5 audit-only replay invariant
+(``docs/design/v0.4.2-t5-replayable-audit-graph.md`` §2 + §4 I1):
+
+  1. ``LIFECYCLE_EVENT_TYPES`` covers every existing lifecycle
+     mutation path (T1 / T2 / T2.D / T6 / T7 + migration backfill).
+  2. ``is_lifecycle_event`` is exact-match (no prefix lookalikes).
+  3. ``emit_lifecycle_event`` round-trips on a real SQLite (post-
+     migration schema), never raises on bad input, and refuses to
+     write non-lifecycle event types.
+  4. The migration script is idempotent, snapshots once, and verify
+     mode exits non-zero against an un-migrated DB.
+
+Tests pin the design memo's Decision LOCKs (§7):
+  LOCK 1 — event_payload is a JSON string column on audit_log
+  LOCK 2 — emit is synchronous in-transaction
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# Pre-migration audit_log schema (v0.4.1) — matches
+# ``tests/test_replay_trace.py``'s _AUDIT_SCHEMA so we exercise the
+# real upgrade path.
+_PRE_MIGRATION_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_pre_migration_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_PRE_MIGRATION_SCHEMA)
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+def _fresh_post_migration_db() -> str:
+    """A DB with the T5.A columns already applied — used by the
+    emit / round-trip tests so they don't depend on the migration
+    script's correctness."""
+    path = _fresh_pre_migration_db()
+    conn = sqlite3.connect(path)
+    conn.execute("ALTER TABLE audit_log ADD COLUMN event_type TEXT")
+    conn.execute("ALTER TABLE audit_log ADD COLUMN event_payload TEXT")
+    conn.commit()
+    conn.close()
+    return path
+
+
+class EventTypeTaxonomyTests(unittest.TestCase):
+    """LIFECYCLE_EVENT_TYPES covers every mutation path the design memo
+    enumerates, exposes a stable name set, and rejects lookalikes."""
+
+    def test_taxonomy_covers_every_design_memo_mutation(self):
+        from core.lifecycle import replay_audit as ra
+        # Memo §3 table: T7 supersede (2), T6 cascade (1), T1 expiration (1),
+        # T2 contradiction (1), T2.D ingest (1), migration backfill (1) = 7.
+        self.assertEqual(len(ra.LIFECYCLE_EVENT_TYPES), 7)
+        # Each entry must be a string starting with 'lifecycle.'.
+        for evt in ra.LIFECYCLE_EVENT_TYPES:
+            self.assertIsInstance(evt, str)
+            self.assertTrue(evt.startswith("lifecycle."),
+                            f"non-lifecycle name in taxonomy: {evt!r}")
+
+    def test_taxonomy_constants_match_strings(self):
+        from core.lifecycle import replay_audit as ra
+        # Each EVT_* constant must equal its design-memo name.
+        self.assertEqual(ra.EVT_SUPERSEDE_EDGE_CREATED,
+                         "lifecycle.supersede.edge_created")
+        self.assertEqual(ra.EVT_SUPERSEDE_CHAIN_EXTENDED,
+                         "lifecycle.supersede.chain_extended")
+        self.assertEqual(ra.EVT_CASCADE_INVALIDATE,
+                         "lifecycle.cascade.invalidate")
+        self.assertEqual(ra.EVT_T1_EXPIRATION_CASCADE,
+                         "lifecycle.t1.expiration_cascade")
+        self.assertEqual(ra.EVT_T2_DISPATCH_CONTRADICTION,
+                         "lifecycle.t2.dispatch_contradiction")
+        self.assertEqual(ra.EVT_T2D_INGEST_DISPATCH,
+                         "lifecycle.t2d.ingest_dispatch")
+        self.assertEqual(ra.EVT_BACKFILL_SNAPSHOT,
+                         "lifecycle.backfill.snapshot")
+
+    def test_taxonomy_is_frozen_tuple(self):
+        from core.lifecycle import replay_audit as ra
+        self.assertIsInstance(ra.LIFECYCLE_EVENT_TYPES, tuple)
+        # Tuple of distinct strings (no duplicate aliases).
+        self.assertEqual(len(set(ra.LIFECYCLE_EVENT_TYPES)),
+                         len(ra.LIFECYCLE_EVENT_TYPES))
+
+
+class IsLifecycleEventTests(unittest.TestCase):
+    """is_lifecycle_event is exact-match — a typo or prefix-only
+    lookalike must NOT slip through."""
+
+    def test_known_event_types_return_true(self):
+        from core.lifecycle import replay_audit as ra
+        for evt in ra.LIFECYCLE_EVENT_TYPES:
+            self.assertTrue(ra.is_lifecycle_event(evt),
+                            f"registered type rejected: {evt!r}")
+
+    def test_typo_in_event_type_returns_false(self):
+        from core.lifecycle.replay_audit import is_lifecycle_event
+        # Typo / lookalike — must not silently slip in.
+        for bad in (
+            "lifecycle.cascadx.invalidate",
+            "lifecycle.supersede.edge_create",   # missing trailing 'd'
+            "lifecycle.t1.expiration",            # missing _cascade
+            "Lifecycle.cascade.invalidate",       # capital L
+            "lifecycle..cascade.invalidate",      # double dot
+        ):
+            self.assertFalse(is_lifecycle_event(bad),
+                             f"lookalike accepted: {bad!r}")
+
+    def test_non_lifecycle_endpoints_return_false(self):
+        from core.lifecycle.replay_audit import is_lifecycle_event
+        # Reasoning trace + security events live in the same table
+        # but must not be confused with lifecycle events.
+        for non in (
+            "reasoning.synth.rag",
+            "reasoning.synth.web_fallback",
+            "reasoning.verify.security",
+            "tool:wiki:write",
+            "",
+            None,
+            0,
+            object(),
+        ):
+            self.assertFalse(is_lifecycle_event(non))
+
+
+class EmitLifecycleEventTests(unittest.TestCase):
+    """emit_lifecycle_event writes a row with the expected fields and
+    never raises on bad input (matches audit_bridge contract)."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_emit_round_trips_event_type_and_payload(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        payload = {
+            "head_id":      "edge-abc-001",
+            "new_edge_id":  "edge-abc-002",
+            "supersede_ts": "2026-06-06T12:00:00",
+            "validity":     {"from": "2026-06-06T12:00:00", "to": None},
+        }
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED, payload, db_path=self.db,
+        )
+        self.assertTrue(ok)
+
+        conn = sqlite3.connect(self.db)
+        try:
+            rows = conn.execute(
+                "SELECT event_type, event_payload, endpoint, user_role "
+                "FROM audit_log"
+            ).fetchall()
+        finally:
+            conn.close()
+        self.assertEqual(len(rows), 1)
+        evt, payload_json, endpoint, role = rows[0]
+        self.assertEqual(evt, EVT_SUPERSEDE_EDGE_CREATED)
+        # LOCK 1: payload is JSON string.
+        self.assertEqual(json.loads(payload_json), payload)
+        # endpoint mirrors event_type so legacy /admin/audit/list shows it.
+        self.assertEqual(endpoint, EVT_SUPERSEDE_EDGE_CREATED)
+        # default user_role is 'system'.
+        self.assertEqual(role, "system")
+
+    def test_emit_accepts_korean_in_payload_without_escape(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_CASCADE_INVALIDATE,
+        )
+        payload = {"reason": "출처 모두 빈 상태에서 도출된 사실 → 무효화"}
+        ok = emit_lifecycle_event(
+            EVT_CASCADE_INVALIDATE, payload, db_path=self.db,
+        )
+        self.assertTrue(ok)
+        conn = sqlite3.connect(self.db)
+        try:
+            (raw,) = conn.execute(
+                "SELECT event_payload FROM audit_log"
+            ).fetchone()
+        finally:
+            conn.close()
+        # ensure_ascii=False — Korean stays readable, no \uXXXX clutter.
+        self.assertIn("출처", raw)
+
+    def test_emit_rejects_unknown_event_type(self):
+        from core.lifecycle.replay_audit import emit_lifecycle_event
+        ok = emit_lifecycle_event(
+            "lifecycle.cascadx.invalidate",
+            {"x": 1},
+            db_path=self.db,
+        )
+        self.assertFalse(ok)
+        conn = sqlite3.connect(self.db)
+        try:
+            (n,) = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(n, 0,
+                         "unknown event type must not produce a row")
+
+    def test_emit_rejects_non_dict_payload(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_CASCADE_INVALIDATE,
+        )
+        for bad in ("string", 123, ["list"], None):
+            ok = emit_lifecycle_event(
+                EVT_CASCADE_INVALIDATE, bad, db_path=self.db,
+            )
+            self.assertFalse(ok, f"non-dict payload accepted: {bad!r}")
+
+    def test_emit_never_raises_on_bad_db_path(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_CASCADE_INVALIDATE,
+        )
+        # Unwritable path — must return False, not raise. Matches
+        # audit_bridge.mirror_to_audit_db contract.
+        ok = emit_lifecycle_event(
+            EVT_CASCADE_INVALIDATE,
+            {"x": 1},
+            db_path="/nonexistent/dir/does/not/exist/audit.db",
+        )
+        self.assertFalse(ok)
+
+    def test_emit_writes_to_pre_migration_db_returns_false(self):
+        """A DB without the event_type column must return False
+        rather than raising — operators sometimes start the engine
+        before running the migration."""
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_CASCADE_INVALIDATE,
+        )
+        pre = _fresh_pre_migration_db()
+        try:
+            ok = emit_lifecycle_event(
+                EVT_CASCADE_INVALIDATE, {"x": 1}, db_path=pre,
+            )
+            self.assertFalse(ok)
+        finally:
+            try:
+                os.unlink(pre)
+            except OSError:
+                pass
+
+    def test_emit_uses_explicit_timestamp_when_provided(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_T1_EXPIRATION_CASCADE,
+        )
+        ts = "2026-06-06T15:30:00"
+        ok = emit_lifecycle_event(
+            EVT_T1_EXPIRATION_CASCADE, {"edge_id": "e1"},
+            timestamp=ts, db_path=self.db,
+        )
+        self.assertTrue(ok)
+        conn = sqlite3.connect(self.db)
+        try:
+            (got,) = conn.execute(
+                "SELECT timestamp FROM audit_log"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(got, ts)
+
+
+class MigrationScriptTests(unittest.TestCase):
+    """migrate_v042_replay_audit is idempotent, snapshots once, and
+    verify mode exits non-zero on a pre-migration DB."""
+
+    def setUp(self):
+        self.db = _fresh_pre_migration_db()
+        # Path for the snapshot the script creates.
+        self.snap = self.db + ".pre-v042-migration"
+
+    def tearDown(self):
+        for p in (self.db, self.snap):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+    def _run(self, *args):
+        from scripts import migrate_v042_replay_audit as m
+        return m.main(["--db", self.db, *args])
+
+    def test_dry_run_reports_missing_columns_no_write(self):
+        rc = self._run()
+        self.assertEqual(rc, 0)
+        # DB column list unchanged.
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = [r[1] for r in conn.execute(
+                "PRAGMA table_info(audit_log)"
+            ).fetchall()]
+        finally:
+            conn.close()
+        self.assertNotIn("event_type", cols)
+        self.assertNotIn("event_payload", cols)
+
+    def test_apply_adds_columns_and_snapshots(self):
+        rc = self._run("--apply")
+        self.assertEqual(rc, 0)
+        # Both columns landed.
+        conn = sqlite3.connect(self.db)
+        try:
+            cols = [r[1] for r in conn.execute(
+                "PRAGMA table_info(audit_log)"
+            ).fetchall()]
+        finally:
+            conn.close()
+        self.assertIn("event_type", cols)
+        self.assertIn("event_payload", cols)
+        # Snapshot exists.
+        self.assertTrue(os.path.exists(self.snap))
+
+    def test_apply_idempotent_after_first_run(self):
+        rc1 = self._run("--apply")
+        self.assertEqual(rc1, 0)
+        # Pre-existing snapshot must block the second snapshot attempt
+        # — operator runs --no-snapshot to re-apply.
+        rc2 = self._run("--apply", "--no-snapshot")
+        self.assertEqual(rc2, 0)
+
+    def test_verify_fails_on_pre_migration_db(self):
+        rc = self._run("--verify")
+        self.assertEqual(rc, 1)
+
+    def test_verify_succeeds_after_apply(self):
+        self.assertEqual(self._run("--apply"), 0)
+        self.assertEqual(self._run("--verify"), 0)
+
+
+class PreMigrationCompatibilityTests(unittest.TestCase):
+    """Existing reasoning rows (no event_type) keep working — replay
+    trace at §5.7.2 stays green after the migration."""
+
+    def test_existing_rows_keep_null_in_new_columns(self):
+        db = _fresh_pre_migration_db()
+        try:
+            # Insert a v0.4.1-style reasoning row.
+            conn = sqlite3.connect(db)
+            try:
+                conn.execute(
+                    "INSERT INTO audit_log "
+                    "(timestamp, user_role, endpoint, query, answer) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    ("2026-06-06T10:00:00", "admin",
+                     "reasoning.synth.rag", "Q?", "A."),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            # Migrate.
+            from scripts import migrate_v042_replay_audit as m
+            self.assertEqual(m.main(["--db", db, "--apply"]), 0)
+            # The pre-existing row keeps NULL on both new columns.
+            conn = sqlite3.connect(db)
+            try:
+                rows = conn.execute(
+                    "SELECT event_type, event_payload FROM audit_log"
+                ).fetchall()
+            finally:
+                conn.close()
+            self.assertEqual(rows, [(None, None)])
+        finally:
+            for p in (db, db + ".pre-v042-migration"):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-T5.A (design memo Phase B). Write-side infrastructure for the v0.4.2 T5 audit-only replay invariant — \`∀ t. reconstruct_graph_at(t) = replay of audit_log events ≤ t\` (memo §2).

## Files

- \`core/lifecycle/replay_audit.py\` (NEW) — 7 event types + \`is_lifecycle_event\` + \`emit_lifecycle_event\`. Decisions LOCK 1 (event_payload = JSON column) + LOCK 2 (synchronous in-transaction emit).
- \`scripts/migrate_v042_replay_audit.py\` (NEW) — Idempotent ALTER TABLE adding \`event_type\` + \`event_payload\` columns. \`--dry-run\` / \`--apply\` / \`--verify\` / \`--no-snapshot\`. Snapshots first at \`<db>.pre-v042-migration\`.
- \`tests/test_t5_event_taxonomy.py\` (NEW, 19 tests, all pass) — Taxonomy / is_lifecycle_event / emit round-trip / migration / pre-migration compatibility.

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_t5_event_taxonomy\` | 19 | 19/19 PASS |
| \`tests/test_replay_trace\` (§5.7.2 regression) | 16 | 16/16 PASS |

## Quality Delta Card

**Exempt** (label: \`feat\`, lifecycle write-side schema/infra; no \`core/retrieval\`, \`core/graph\`, \`core/reasoning\` quality dial. Read-side replay invariant lands in T5.B and will paste step7 bench numbers per CLAUDE.md rule 2).

## Decision LOCKs (memo §7)

- LOCK 1 — event_payload = JSON string column (vs separate table) ✅
- LOCK 2 — emit = synchronous in-transaction (vs async queue) ✅

## Out of scope

- Mutation site wiring (T1/T2/T2.D/T6/T7 → \`emit_lifecycle_event\`) — T5.A.b or T5.B integration
- \`reconstruct_graph_at\` primitive — T5.B
- Cross-chain consistency vs \`reconstruct_view_at\` — T5.C
- 5 release-gating invariants + closure — T5.D

## Closes / related

- Design memo: \`docs/design/v0.4.2-t5-replayable-audit-graph.md\` (#719)
- Next: PR-T5.B \`reconstruct_graph_at\` primitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)