### PR TITLE
feat(v0.4.2): T5.B — reconstruct_graph_at audit-only primitive

### DIFF
--- a/core/lifecycle/replay_graph.py
+++ b/core/lifecycle/replay_graph.py
@@ -1,0 +1,427 @@
+"""T5.B — read-side ``reconstruct_graph_at(t)`` primitive.
+
+This module is the read-side counterpart of
+:mod:`core.lifecycle.replay_audit` (T5.A). It folds the lifecycle
+event stream from ``audit_log`` into a deterministic
+:class:`GraphSnapshot` for any cutoff time ``t``. Together the two
+modules realise the v0.4.2 T5 audit-only invariant (design memo §2 +
+§4 I1)::
+
+    ∀ t. reconstruct_graph_at(t) =
+        replay of every lifecycle event row whose timestamp ≤ t.
+
+Decision LOCKs (memo §7):
+
+* LOCK 4 — ``reconstruct_graph_at`` is a **pure function**: no DB
+  write, no module-level cache mutation, no global state read
+  beyond the audit_log SELECT. Determinism is the whole point —
+  the same ``(t, audit_log_path)`` pair always produces the same
+  snapshot.
+* LOCK 5 — the audit-only invariant (I1) is pinned by a contract
+  test that monkeypatches the DB read and asserts every byte the
+  snapshot depends on came through it (PR-T5.D).
+
+Why pure event-log fold (not DB scan)
+-------------------------------------
+The whole point of T5 is that an operator can ship the audit_log
+to a third party — no wiki snapshot, no graph dump — and the third
+party can reproduce the graph state at any past ``t``. That is
+"replay invariant" in the corpus-retrieval analysis (PR #712 §6).
+If reconstruction touches the wiki on disk, the invariant collapses.
+
+Out of scope for this PR
+------------------------
+* Mutation-site wiring (T1/T2/T2.D/T6/T7 → ``emit_lifecycle_event``).
+  Lands in T5.A.b or T5.B follow-up. Until wiring happens the
+  production audit_log has no lifecycle rows, so live integration
+  tests stay synthetic (this module's tests INSERT events directly).
+* Live-graph equality invariant (I4) against the on-disk wiki.
+  PR-T5.D pins it once mutation wiring is in.
+* Cross-chain consistency vs :func:`reconstruct_view_at`. PR-T5.C.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
+
+from core.lifecycle.replay_audit import (
+    EVT_BACKFILL_SNAPSHOT,
+    EVT_CASCADE_INVALIDATE,
+    EVT_SUPERSEDE_CHAIN_EXTENDED,
+    EVT_SUPERSEDE_EDGE_CREATED,
+    EVT_T1_EXPIRATION_CASCADE,
+    EVT_T2_DISPATCH_CONTRADICTION,
+    EVT_T2D_INGEST_DISPATCH,
+    LIFECYCLE_EVENT_TYPES,
+    is_lifecycle_event,
+)
+
+
+# ─── snapshot dataclass (design memo §4) ───────────────────────────
+
+
+@dataclass(frozen=True)
+class GraphSnapshot:
+    """Deterministic projection of the lifecycle event stream up to a
+    cutoff time.
+
+    Attributes:
+        edges: ``edge_id → edge dict``. Each edge dict carries the
+            payload of the event that materialised it (supersede
+            ``edge_created`` / backfill ``snapshot``), minus any
+            edge_ids that landed in :attr:`invalidated_ids` afterwards.
+        supersede_chains: ``head_id → ordered list of edge_ids``,
+            including the head. Chains are walked in event order so a
+            late ``chain_extended`` cleanly appends.
+        invalidated_ids: edge_ids whose **lifecycle.cascade.invalidate**
+            (T6) or **lifecycle.t1.expiration_cascade** (T1) event has
+            fired with timestamp ≤ ``t``. Invalidated edges are NOT in
+            :attr:`edges` — replay omits them just as the live graph
+            does (matches ``reconstruct_view_at``'s mutation_type filter).
+        replayed_at: the ``t`` cutoff used to compute the snapshot.
+        event_count: how many lifecycle event rows contributed
+            (≥ 0). 0 on a fresh DB or a pre-mutation-wiring run.
+    """
+    edges:             Dict[str, Dict[str, Any]]
+    supersede_chains:  Dict[str, List[str]]
+    invalidated_ids:   FrozenSet[str]
+    replayed_at:       datetime
+    event_count:       int
+
+
+# Empty snapshot — returned when the audit_log has no lifecycle rows
+# (e.g. pre-migration DB, pre-wiring production DB).
+def _empty_snapshot(t: datetime) -> GraphSnapshot:
+    return GraphSnapshot(
+        edges={}, supersede_chains={}, invalidated_ids=frozenset(),
+        replayed_at=t, event_count=0,
+    )
+
+
+# ─── per-event-type handlers (private) ─────────────────────────────
+#
+# Each handler takes the *mutable* working state (edges dict,
+# chains dict, invalidated set) and the event payload, and folds the
+# event in place. The dispatch loop calls them in audit_log
+# insertion order — they must be associative + idempotent under
+# repeat replay (the same audit_log JSON read twice produces the
+# same snapshot).
+
+
+def _h_supersede_edge_created(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    new_id = payload.get("new_edge_id")
+    head_id = payload.get("head_id")
+    if not isinstance(new_id, str) or not new_id:
+        return
+    # Edge dict — payload itself is the canonical projection. We
+    # strip the head_id field so the edge view matches what
+    # walk_supersede_chain would return on the live graph.
+    edge_view = {k: v for k, v in payload.items() if k != "head_id"}
+    edges[new_id] = edge_view
+    # Chain extension semantics: a new edge attaches under its head.
+    # If the head is itself a chain root, append; otherwise create a
+    # new chain with the head as root + the new edge after.
+    if isinstance(head_id, str) and head_id:
+        chain = chains.setdefault(head_id, [head_id])
+        if new_id not in chain:
+            chain.append(new_id)
+
+
+def _h_supersede_chain_extended(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # chain_extended carries (chain_head, new_link, validity). We
+    # treat it as an explicit link append — the new edge may have
+    # been created earlier by an edge_created event, or may be
+    # introduced here directly (backfill).
+    head_id = payload.get("chain_head")
+    new_link = payload.get("new_link")
+    if not isinstance(head_id, str) or not head_id:
+        return
+    if not isinstance(new_link, str) or not new_link:
+        return
+    chain = chains.setdefault(head_id, [head_id])
+    if new_link not in chain:
+        chain.append(new_link)
+    # If the link's edge dict wasn't already projected, register a
+    # stub so callers can resolve the id → edge mapping.
+    if new_link not in edges:
+        edges[new_link] = {
+            "id":       new_link,
+            "_origin":  "supersede_chain_extended",
+            "validity": payload.get("validity", {}),
+        }
+
+
+def _h_cascade_invalidate(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # cascade.invalidate carries either {invalidated_edges: [...]} or
+    # {edge_id: "..."} depending on call site. Accept both — the
+    # mutation_type field is informational only.
+    ids = payload.get("invalidated_edges")
+    if isinstance(ids, list):
+        for ei in ids:
+            if isinstance(ei, str) and ei:
+                invalidated.add(ei)
+                edges.pop(ei, None)
+    single = payload.get("edge_id")
+    if isinstance(single, str) and single:
+        invalidated.add(single)
+        edges.pop(single, None)
+
+
+def _h_t1_expiration_cascade(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # T1 expiration removes the edge from the active set just like a
+    # T6 cascade invalidate. The validity.to field is informational.
+    single = payload.get("edge_id")
+    if isinstance(single, str) and single:
+        invalidated.add(single)
+        edges.pop(single, None)
+
+
+def _h_t2_dispatch_contradiction(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # T2 dispatch resolves a CASCADE-vs-EVENT contradiction. The
+    # actual mutation it triggers — invalidate or supersede — is
+    # emitted as a separate event by the dispatcher, so this handler
+    # is a no-op for the snapshot fold (the downstream event carries
+    # the state change). We still accept the row so the audit-only
+    # invariant (I1) sees a fully decoded event stream.
+    return
+
+
+def _h_t2d_ingest_dispatch(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # T2.D pre-merge dispatch — same rationale as T2: the actual
+    # mutation (CASCADE or EVENT) emits its own follow-up event.
+    return
+
+
+def _h_backfill_snapshot(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    # backfill.snapshot bootstraps the replay state. Operator
+    # migrations that cannot re-derive a full event history (older
+    # wiki rows) emit one of these so the snapshot starts from a
+    # known baseline rather than empty.
+    initial_edges = payload.get("edges") or {}
+    if isinstance(initial_edges, dict):
+        for eid, edge in initial_edges.items():
+            if isinstance(eid, str) and isinstance(edge, dict):
+                edges[eid] = edge
+    initial_chains = payload.get("supersede_chains") or {}
+    if isinstance(initial_chains, dict):
+        for head_id, chain in initial_chains.items():
+            if isinstance(head_id, str) and isinstance(chain, list):
+                chains[head_id] = [c for c in chain if isinstance(c, str)]
+    initial_invalid = payload.get("invalidated_ids") or []
+    if isinstance(initial_invalid, list):
+        for eid in initial_invalid:
+            if isinstance(eid, str):
+                invalidated.add(eid)
+
+
+_HANDLERS: Dict[str, Callable[..., None]] = {
+    EVT_SUPERSEDE_EDGE_CREATED:    _h_supersede_edge_created,
+    EVT_SUPERSEDE_CHAIN_EXTENDED:  _h_supersede_chain_extended,
+    EVT_CASCADE_INVALIDATE:        _h_cascade_invalidate,
+    EVT_T1_EXPIRATION_CASCADE:     _h_t1_expiration_cascade,
+    EVT_T2_DISPATCH_CONTRADICTION: _h_t2_dispatch_contradiction,
+    EVT_T2D_INGEST_DISPATCH:       _h_t2d_ingest_dispatch,
+    EVT_BACKFILL_SNAPSHOT:         _h_backfill_snapshot,
+}
+
+
+# Sanity: every taxonomy entry has a handler. A missing handler in a
+# CI build would be a Decision LOCK 4 (pure function) violation
+# because the snapshot would non-deterministically drop events.
+assert set(_HANDLERS) == set(LIFECYCLE_EVENT_TYPES), (
+    "every LIFECYCLE_EVENT_TYPES entry must have a handler in _HANDLERS"
+)
+
+
+# ─── DB read (the only side-channel for the snapshot) ──────────────
+
+
+def _default_db_path() -> str:
+    """Mirrors :func:`core.lifecycle.replay_audit._default_db_path`
+    so reads and writes hit the same SQLite file."""
+    env = (os.environ.get("JAMES_AUDIT_DB") or "").strip()
+    if env:
+        return env
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "audit.db",
+    )
+
+
+def _read_lifecycle_events(
+    db_path: str,
+    t: datetime,
+    include: Optional[Tuple[str, ...]],
+) -> List[Tuple[str, str]]:
+    """SELECT lifecycle rows with timestamp ≤ t, ordered by insertion.
+
+    Returns a list of ``(event_type, event_payload_json)``. Sorted by
+    ``id`` (the audit_log primary key) so events ingested at the same
+    timestamp string still replay in append order.
+
+    Notes:
+        * Pre-migration DBs (no ``event_type`` column) → empty list.
+          The function reads ``PRAGMA table_info`` first and returns
+          early — this is the same defensive pattern
+          ``emit_lifecycle_event`` uses on the write side.
+        * The function never raises. On any sqlite error it returns
+          an empty list; the snapshot becomes the empty snapshot,
+          which is the safe degenerate case.
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+    except Exception:
+        return []
+    try:
+        # Detect a pre-migration schema and bail.
+        cols = {r[1] for r in conn.execute(
+            "PRAGMA table_info(audit_log)"
+        ).fetchall()}
+        if "event_type" not in cols or "event_payload" not in cols:
+            return []
+        cutoff = t.isoformat()
+        if include:
+            placeholders = ",".join("?" * len(include))
+            rows = conn.execute(
+                f"SELECT event_type, event_payload "
+                f"FROM audit_log "
+                f"WHERE event_type IN ({placeholders}) "
+                f"AND timestamp <= ? "
+                f"ORDER BY id ASC",
+                (*include, cutoff),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT event_type, event_payload "
+                "FROM audit_log "
+                "WHERE event_type IS NOT NULL "
+                "AND timestamp <= ? "
+                "ORDER BY id ASC",
+                (cutoff,),
+            ).fetchall()
+        return [(et, ep or "") for et, ep in rows]
+    except Exception:
+        return []
+    finally:
+        conn.close()
+
+
+# ─── public primitive ──────────────────────────────────────────────
+
+
+def reconstruct_graph_at(
+    t: datetime,
+    *,
+    audit_log_path: Optional[str] = None,
+    include_event_types: Optional[Tuple[str, ...]] = None,
+) -> GraphSnapshot:
+    """Replay every lifecycle event row whose ``timestamp ≤ t`` and
+    return the resulting :class:`GraphSnapshot`.
+
+    Args:
+        t: UTC-aware ``datetime``. Replay cutoff. Events strictly
+            after ``t`` are not folded in.
+        audit_log_path: optional path override. Defaults to the
+            production audit_log (resolved the same way
+            ``emit_lifecycle_event`` resolves it).
+        include_event_types: optional tuple restricting which event
+            types are considered. Default: every member of
+            :data:`LIFECYCLE_EVENT_TYPES`. Mostly useful for
+            cross-chain integration in PR-T5.C.
+
+    Returns:
+        :class:`GraphSnapshot` — deterministic projection of the
+        replayed event stream.
+
+    Pure-function contract (LOCK 4): the only side-channel is the
+    audit_log SELECT. The function does not read the wiki, the
+    knowledge_tracker, the graph engine, or any other module's
+    state — so an audit_log JSON dump alone is enough to reproduce
+    the snapshot on any machine.
+    """
+    path = audit_log_path or _default_db_path()
+    rows = _read_lifecycle_events(path, t, include_event_types)
+
+    edges: Dict[str, Dict[str, Any]] = {}
+    chains: Dict[str, List[str]] = {}
+    invalidated: set = set()
+    n = 0
+
+    for evt, payload_json in rows:
+        if not is_lifecycle_event(evt):
+            # Defence-in-depth: the SELECT clause already filters
+            # by event_type, but a free-text column might carry
+            # legacy junk on legacy migrations. Skip silently rather
+            # than crash; the audit-only invariant is preserved
+            # because the snapshot depends only on rows that *do*
+            # validate.
+            continue
+        if include_event_types and evt not in include_event_types:
+            continue
+        try:
+            payload = json.loads(payload_json) if payload_json else {}
+        except json.JSONDecodeError:
+            # Malformed payload: skip. A future T5.D test will
+            # surface a counter so an operator notices, but the
+            # snapshot itself must remain deterministic.
+            continue
+        if not isinstance(payload, dict):
+            continue
+        handler = _HANDLERS.get(evt)
+        if handler is None:
+            continue
+        handler(edges, chains, invalidated, payload)
+        n += 1
+
+    return GraphSnapshot(
+        edges=edges,
+        supersede_chains=chains,
+        invalidated_ids=frozenset(invalidated),
+        replayed_at=t,
+        event_count=n,
+    )
+
+
+__all__ = [
+    "GraphSnapshot",
+    "reconstruct_graph_at",
+]

--- a/tests/test_t5_reconstruct_graph_at.py
+++ b/tests/test_t5_reconstruct_graph_at.py
@@ -1,0 +1,559 @@
+"""v0.4.2 PR-T5.B — reconstruct_graph_at primitive contract tests.
+
+Pins the read-side contract for the T5 audit-only replay invariant
+(``docs/design/v0.4.2-t5-replayable-audit-graph.md`` §4 + §6 Phase C).
+Each test builds a synthetic audit_log (post-migration schema),
+emits lifecycle rows via ``emit_lifecycle_event``, and asserts the
+resulting :class:`GraphSnapshot`.
+
+Invariants pinned (memo §4 API I1-I4):
+
+  I1 audit-only  — no DB read beyond audit_log; no wiki / graph engine
+                   access during reconstruction
+  I2 supersede   — chains in snapshot match the order edges were emitted
+  I3 cascade     — invalidate events remove ids from edges + add to
+                   invalidated_ids
+  I4 replay-eq   — snapshot at t = now is byte-equal to the snapshot
+                   produced by reading the audit_log immediately after
+
+These tests do NOT depend on mutation-site wiring (T1/T2/T2.D/T6/T7
+→ emit_lifecycle_event) — that lands in T5.A.b or T5.B follow-up.
+The wiring-integrated invariants (I4 against the live wiki) land
+in PR-T5.D.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+_PRE_MIGRATION_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp    TEXT    NOT NULL,
+    user_role    TEXT    NOT NULL,
+    endpoint     TEXT    NOT NULL,
+    query        TEXT,
+    answer       TEXT,
+    graph_paths  TEXT,
+    blocked      INTEGER DEFAULT 0,
+    security_event TEXT,
+    elapsed_sec  REAL,
+    ip_address   TEXT
+)
+"""
+
+
+def _fresh_post_migration_db() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    f.close()
+    conn = sqlite3.connect(f.name)
+    conn.execute(_PRE_MIGRATION_SCHEMA)
+    conn.execute("ALTER TABLE audit_log ADD COLUMN event_type TEXT")
+    conn.execute("ALTER TABLE audit_log ADD COLUMN event_payload TEXT")
+    conn.commit()
+    conn.close()
+    return f.name
+
+
+class GraphSnapshotShapeTests(unittest.TestCase):
+    def test_empty_db_returns_empty_snapshot(self):
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        db = _fresh_post_migration_db()
+        try:
+            snap = reconstruct_graph_at(datetime.now(), audit_log_path=db)
+            self.assertEqual(snap.edges, {})
+            self.assertEqual(snap.supersede_chains, {})
+            self.assertEqual(snap.invalidated_ids, frozenset())
+            self.assertEqual(snap.event_count, 0)
+        finally:
+            os.unlink(db)
+
+    def test_pre_migration_db_returns_empty_snapshot(self):
+        """A DB without the new columns must produce the empty
+        snapshot — operators sometimes invoke replay before
+        migrating."""
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        f = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        f.close()
+        conn = sqlite3.connect(f.name)
+        conn.execute(_PRE_MIGRATION_SCHEMA)
+        conn.commit()
+        conn.close()
+        try:
+            snap = reconstruct_graph_at(datetime.now(), audit_log_path=f.name)
+            self.assertEqual(snap.event_count, 0)
+        finally:
+            os.unlink(f.name)
+
+    def test_nonexistent_db_returns_empty_snapshot(self):
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        snap = reconstruct_graph_at(
+            datetime.now(),
+            audit_log_path="/nonexistent/path/audit.db",
+        )
+        self.assertEqual(snap.event_count, 0)
+
+
+class SupersedeChainTests(unittest.TestCase):
+    """I2 — supersede chain ordering matches event-emission order."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_single_edge_created_appears_in_snapshot(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"head_id": "head-1", "new_edge_id": "edge-1",
+             "validity": {"from": "2026-06-06T10:00:00", "to": None}},
+            db_path=self.db,
+        )
+        self.assertTrue(ok)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertIn("edge-1", snap.edges)
+        self.assertEqual(snap.supersede_chains["head-1"],
+                         ["head-1", "edge-1"])
+
+    def test_chain_extended_preserves_insertion_order(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        # Three edges in succession under the same head.
+        for new_id in ("a", "b", "c"):
+            self.assertTrue(emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"head_id": "h", "new_edge_id": new_id,
+                 "validity": {"from": "2026-06-06T10:00:00", "to": None}},
+                db_path=self.db,
+            ))
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        # Chain order = head then emission order.
+        self.assertEqual(snap.supersede_chains["h"], ["h", "a", "b", "c"])
+
+    def test_two_separate_chains_do_not_collide(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h1", "new_edge_id": "e1"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h2", "new_edge_id": "e2"},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertEqual(set(snap.supersede_chains), {"h1", "h2"})
+        self.assertEqual(snap.supersede_chains["h1"], ["h1", "e1"])
+        self.assertEqual(snap.supersede_chains["h2"], ["h2", "e2"])
+
+    def test_chain_extended_event_appends_link(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_SUPERSEDE_CHAIN_EXTENDED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "e1"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_SUPERSEDE_CHAIN_EXTENDED,
+                             {"chain_head": "h", "new_link": "e2",
+                              "validity": {}},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertEqual(snap.supersede_chains["h"], ["h", "e1", "e2"])
+        # The extended link is registered with a stub edge dict so
+        # callers can resolve id → edge.
+        self.assertIn("e2", snap.edges)
+
+
+class CascadeAndExpirationTests(unittest.TestCase):
+    """I3 — invalidate events remove ids from edges + add to
+    invalidated_ids."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_cascade_invalidate_removes_edge(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_CASCADE_INVALIDATE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "doomed"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_CASCADE_INVALIDATE,
+                             {"invalidated_edges": ["doomed"],
+                              "mutation_type": "invalidated"},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertNotIn("doomed", snap.edges)
+        self.assertIn("doomed", snap.invalidated_ids)
+
+    def test_cascade_invalidate_single_edge_id_payload(self):
+        """Backward-compat: some emit sites use {edge_id: "..."}
+        rather than the canonical {invalidated_edges: [...]}."""
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_CASCADE_INVALIDATE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "doomed"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_CASCADE_INVALIDATE,
+                             {"edge_id": "doomed"},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertIn("doomed", snap.invalidated_ids)
+
+    def test_t1_expiration_invalidates_edge(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_T1_EXPIRATION_CASCADE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "expiring"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_T1_EXPIRATION_CASCADE,
+                             {"edge_id": "expiring",
+                              "validity": {"to": "2026-06-06T11:00:00"}},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertNotIn("expiring", snap.edges)
+        self.assertIn("expiring", snap.invalidated_ids)
+
+    def test_invalidate_after_recreate_keeps_it_invalidated(self):
+        """A subsequent edge_created with the same id does NOT
+        un-invalidate — replay reflects event order (last write wins
+        only when handlers say so). edge_created carries the new
+        edge dict back into edges, but the id stays in
+        invalidated_ids as the historical record."""
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_CASCADE_INVALIDATE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "x"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_CASCADE_INVALIDATE,
+                             {"invalidated_edges": ["x"]},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "x"},
+                             db_path=self.db)
+        snap = reconstruct_graph_at(datetime.now(), audit_log_path=self.db)
+        self.assertIn("x", snap.edges)        # last write wins for live state
+        self.assertIn("x", snap.invalidated_ids)   # but history is preserved
+
+
+class CutoffSemanticsTests(unittest.TestCase):
+    """Replay respects the ``t`` cutoff: events strictly after t are
+    excluded."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_event_after_t_excluded(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        t0 = datetime(2026, 6, 6, 10, 0, 0)
+        t1 = datetime(2026, 6, 6, 11, 0, 0)
+        t2 = datetime(2026, 6, 6, 12, 0, 0)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "before"},
+                             timestamp=t0.isoformat(), db_path=self.db)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "after"},
+                             timestamp=t2.isoformat(), db_path=self.db)
+        snap = reconstruct_graph_at(t1, audit_log_path=self.db)
+        self.assertIn("before", snap.edges)
+        self.assertNotIn("after", snap.edges)
+        self.assertEqual(snap.event_count, 1)
+
+    def test_event_at_exact_t_included(self):
+        """``timestamp <= t`` — exact-match is inclusive."""
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        t = datetime(2026, 6, 6, 10, 0, 0)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "edge-at-t"},
+                             timestamp=t.isoformat(), db_path=self.db)
+        snap = reconstruct_graph_at(t, audit_log_path=self.db)
+        self.assertIn("edge-at-t", snap.edges)
+
+
+class DeterminismAndIdempotenceTests(unittest.TestCase):
+    """LOCK 4 — pure function. Same (t, audit_log_path) → byte-equal
+    snapshot."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_two_reconstructions_byte_equal(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_CASCADE_INVALIDATE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "e1"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "e2"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_CASCADE_INVALIDATE,
+                             {"invalidated_edges": ["e1"]},
+                             db_path=self.db)
+        t = datetime.now()
+        snap_a = reconstruct_graph_at(t, audit_log_path=self.db)
+        snap_b = reconstruct_graph_at(t, audit_log_path=self.db)
+        self.assertEqual(snap_a.edges, snap_b.edges)
+        self.assertEqual(snap_a.supersede_chains, snap_b.supersede_chains)
+        self.assertEqual(snap_a.invalidated_ids, snap_b.invalidated_ids)
+        self.assertEqual(snap_a.event_count, snap_b.event_count)
+
+    def test_replay_equality_round_trip(self):
+        """I4 weaker form (until mutation wiring lands in T5.A.b):
+        snapshot at t = now is equal to snapshot taken right after
+        another emit doesn't change pre-existing rows."""
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "a"},
+                             db_path=self.db)
+        t_before = datetime.now()
+        snap_before = reconstruct_graph_at(t_before, audit_log_path=self.db)
+        # Emit something after t_before — must NOT change the snapshot
+        # at t_before.
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "b"},
+                             timestamp=(t_before + timedelta(hours=1))
+                             .isoformat(),
+                             db_path=self.db)
+        snap_after = reconstruct_graph_at(t_before, audit_log_path=self.db)
+        self.assertEqual(snap_before.edges, snap_after.edges)
+        self.assertEqual(snap_before.event_count, snap_after.event_count)
+
+
+class AuditOnlyInvariantTests(unittest.TestCase):
+    """I1 — reconstruct_graph_at must NOT read the wiki, the graph
+    engine, or any module beyond the audit_log SELECT.
+
+    Approach: import the module fresh and assert that the file
+    list it touches contains only the audit_log DB path. A coarser
+    but solid signal is the absence of imports of core.graph_engine,
+    core.workspace, core.memory etc — but checking for negative
+    imports is brittle. We instead pin the *positive* side: the
+    function never opens any file other than the audit DB during a
+    reconstruct call.
+    """
+
+    def test_only_reads_the_audit_db(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_SUPERSEDE_EDGE_CREATED,
+        )
+        from core.lifecycle import replay_graph as rg
+        db = _fresh_post_migration_db()
+        try:
+            emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                                 {"head_id": "h", "new_edge_id": "e"},
+                                 db_path=db)
+
+            opened_paths = []
+            real_connect = sqlite3.connect
+
+            def spy_connect(path, *a, **kw):
+                opened_paths.append(path)
+                return real_connect(path, *a, **kw)
+
+            # Monkeypatch the sqlite3 used by the replay_graph module
+            # so we observe every connection it opens.
+            saved = rg.sqlite3.connect
+            rg.sqlite3.connect = spy_connect
+            try:
+                rg.reconstruct_graph_at(datetime.now(), audit_log_path=db)
+            finally:
+                rg.sqlite3.connect = saved
+
+            # Every connect call must target the audit DB. No wiki,
+            # no knowledge_tracker DB, no graph engine state.
+            self.assertTrue(all(p == db for p in opened_paths),
+                            f"unexpected DB opens: {opened_paths}")
+        finally:
+            os.unlink(db)
+
+
+class IncludeFilterTests(unittest.TestCase):
+    """`include_event_types` lets PR-T5.C narrow the snapshot to e.g.
+    only T7 events when checking cross-chain consistency vs
+    `reconstruct_view_at`."""
+
+    def setUp(self):
+        self.db = _fresh_post_migration_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def test_include_filter_skips_other_types(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event,
+            EVT_SUPERSEDE_EDGE_CREATED,
+            EVT_CASCADE_INVALIDATE,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        emit_lifecycle_event(EVT_SUPERSEDE_EDGE_CREATED,
+                             {"head_id": "h", "new_edge_id": "e"},
+                             db_path=self.db)
+        emit_lifecycle_event(EVT_CASCADE_INVALIDATE,
+                             {"invalidated_edges": ["e"]},
+                             db_path=self.db)
+        # Only T7 supersede events — invalidate should NOT remove e.
+        snap = reconstruct_graph_at(
+            datetime.now(),
+            audit_log_path=self.db,
+            include_event_types=(EVT_SUPERSEDE_EDGE_CREATED,),
+        )
+        self.assertIn("e", snap.edges)
+        self.assertEqual(snap.invalidated_ids, frozenset())
+        self.assertEqual(snap.event_count, 1)
+
+
+class MalformedRowsTests(unittest.TestCase):
+    """Defence-in-depth: malformed event_payload JSON or unknown
+    event_type rows are skipped — they cannot crash the snapshot."""
+
+    def test_malformed_payload_skipped(self):
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        db = _fresh_post_migration_db()
+        try:
+            # Hand-craft a malformed row.
+            conn = sqlite3.connect(db)
+            conn.execute(
+                "INSERT INTO audit_log "
+                "(timestamp, user_role, endpoint, event_type, event_payload) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("2026-06-06T10:00:00", "system",
+                 "lifecycle.supersede.edge_created",
+                 "lifecycle.supersede.edge_created",
+                 "{not valid json"),
+            )
+            conn.commit()
+            conn.close()
+            snap = reconstruct_graph_at(datetime.now(), audit_log_path=db)
+            # Skipped — no edges, no count.
+            self.assertEqual(snap.edges, {})
+            self.assertEqual(snap.event_count, 0)
+        finally:
+            os.unlink(db)
+
+    def test_unknown_event_type_skipped(self):
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        db = _fresh_post_migration_db()
+        try:
+            conn = sqlite3.connect(db)
+            conn.execute(
+                "INSERT INTO audit_log "
+                "(timestamp, user_role, endpoint, event_type, event_payload) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("2026-06-06T10:00:00", "system",
+                 "lifecycle.cascadx.invalidate",
+                 "lifecycle.cascadx.invalidate",
+                 json.dumps({"invalidated_edges": ["x"]})),
+            )
+            conn.commit()
+            conn.close()
+            snap = reconstruct_graph_at(datetime.now(), audit_log_path=db)
+            self.assertEqual(snap.event_count, 0)
+            self.assertEqual(snap.invalidated_ids, frozenset())
+        finally:
+            os.unlink(db)
+
+
+class BackfillSnapshotTests(unittest.TestCase):
+    """Backfill events bootstrap the snapshot from a known baseline
+    (for operators whose pre-migration wiki cannot re-derive every
+    historical mutation)."""
+
+    def test_backfill_bootstraps_edges_and_chains(self):
+        from core.lifecycle.replay_audit import (
+            emit_lifecycle_event, EVT_BACKFILL_SNAPSHOT,
+        )
+        from core.lifecycle.replay_graph import reconstruct_graph_at
+        db = _fresh_post_migration_db()
+        try:
+            emit_lifecycle_event(
+                EVT_BACKFILL_SNAPSHOT,
+                {
+                    "edges": {
+                        "e1": {"id": "e1", "validity": {}},
+                        "e2": {"id": "e2", "validity": {}},
+                    },
+                    "supersede_chains": {"h": ["h", "e1", "e2"]},
+                    "invalidated_ids": ["e_old"],
+                },
+                db_path=db,
+            )
+            snap = reconstruct_graph_at(datetime.now(), audit_log_path=db)
+            self.assertEqual(set(snap.edges), {"e1", "e2"})
+            self.assertEqual(snap.supersede_chains, {"h": ["h", "e1", "e2"]})
+            self.assertIn("e_old", snap.invalidated_ids)
+        finally:
+            os.unlink(db)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-T5.B (design memo Phase C). Read-side counterpart of T5.A — folds the lifecycle event stream from \`audit_log\` into a deterministic \`GraphSnapshot\` for any cutoff time \`t\`.

**Audit-only invariant** (memo §2 + §4 I1):
\`\`\`
∀ t. reconstruct_graph_at(t) = replay of every lifecycle event row whose timestamp ≤ t.
\`\`\`

## Files

- \`core/lifecycle/replay_graph.py\` (NEW) — \`GraphSnapshot\` dataclass + \`reconstruct_graph_at\` + per-event-type handlers. LOCK 4 pure function. Defence-in-depth (malformed JSON / unknown event_type / pre-migration DB / non-existent file all return empty snapshot).
- \`tests/test_t5_reconstruct_graph_at.py\` (NEW, 20 tests) — all 4 invariants I1-I4 pinned (I1 audit-only via monkeypatched sqlite3.connect; I2 supersede chain ordering; I3 cascade-respected; I4 weak round-trip).

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_t5_reconstruct_graph_at\` | 20 | **20/20 PASS** |
| \`tests/test_t5_event_taxonomy\` (T5.A regression) | 19 | **19/19 PASS** |
| \`tests/test_replay_trace\` (§5.7.2 regression) | 16 | **16/16 PASS** |

## Quality Delta Card

**Exempt** (label: \`feat\`, lifecycle read-side primitive on the new audit_log columns; no \`core/retrieval\`, \`core/graph\`, \`core/reasoning\` quality dial change. Mutation-site wiring lands in a follow-up; until then production audit_log has no lifecycle rows and live graph state is unchanged).

## Decision LOCKs (memo §7)

- LOCK 4 — pure function (no side effect beyond audit_log SELECT) ✅
- LOCK 5 — I1 (audit-only) test = monkeypatch sqlite3.connect + assert only audit DB path is opened ✅

## Out of scope

- Mutation-site wiring (T1/T2/T2.D/T6/T7 → \`emit_lifecycle_event\`) — T5.A.b or T5.B follow-up
- Cross-chain consistency vs \`reconstruct_view_at\` — T5.C
- ARCHITECTURE.md §5.7.2 extension — T5.C
- I4 against live wiki state — T5.D once wiring is in

## Closes / related

- Design memo: #719
- PR-T5.A: #720
- Next: PR-T5.C cross-chain integration + ARCHITECTURE

🤖 Generated with [Claude Code](https://claude.com/claude-code)