### PR TITLE
feat(cycle γ A.0): eval/external base + ExternalQuery schema + tests

### DIFF
--- a/eval/external/__init__.py
+++ b/eval/external/__init__.py
@@ -1,0 +1,42 @@
+"""``eval.external`` — Cycle γ external-benchmark integration.
+
+Cycle γ measures JAMES against 4 external academic benchmarks
+(RGB / ALCE / MuSiQue / 2WikiMultiHopQA) to produce publication-grade
+cross-bench evidence beyond the single MultiHop-RAG baseline used
+through v0.4.2. Design memo:
+``docs/design/v0.4-cycle-gamma-external-benchmark-integration.md``.
+
+This package is the integration layer:
+
+* Phase A.0 (this file + ``base.py``) — abstract ``ExternalBenchFixture``
+  + unified ``ExternalQuery`` schema. Dependency-free.
+* Phase A.1 — RGB loader.
+* Phase A.2 — ALCE (ASQA + QAMPARI) loader.
+* Phase A.3 — MuSiQue + 2WikiMultiHopQA loaders.
+* Phase A.4 — per-bench scorers (RGB negative-rejection F1, ALCE
+  NLI-based citation precision/recall, MuSiQue/2Wiki EM-F1 +
+  support fact accuracy).
+* Phase A.5 — unified ``external_bench_run.py`` runner.
+
+The base class deliberately does **not** depend on the HuggingFace
+``datasets`` library — that decision lives at Phase A.1 (per-loader)
+so we can swap to raw HTTP downloads or an offline cache without
+re-touching the abstract interface.
+
+Self-eval trap rule applies (memory
+``feedback_self_evaluation_trap``): JAMES does NOT write its own
+fixtures or its own oracle for these benchmarks. Each loader pulls
+the original published fixture; each scorer implements the
+benchmark's official scoring formula (or a documented faithful
+approximation).
+"""
+from eval.external.base import (
+    ExternalBenchFixture,
+    ExternalQuery,
+)
+
+
+__all__ = [
+    "ExternalBenchFixture",
+    "ExternalQuery",
+]

--- a/eval/external/base.py
+++ b/eval/external/base.py
@@ -1,0 +1,212 @@
+"""Cycle γ Phase A.0 — abstract ``ExternalBenchFixture`` + unified
+``ExternalQuery`` schema.
+
+Every external benchmark loader (RGB, ALCE, MuSiQue, 2WikiMultiHopQA)
+implements :class:`ExternalBenchFixture` and emits
+:class:`ExternalQuery` records. The unified schema lets one runner
+(Phase A.5) drive JAMES across all four benchmarks without per-bench
+branching in the answer path — the bench-specific scoring lives in
+the per-bench :class:`ExternalScorer` (Phase A.4).
+
+Schema design notes
+-------------------
+
+The query record is a frozen dataclass so loaders can cache it
+without worrying about downstream mutation. Bench-specific fields
+that don't map onto the unified columns are preserved under
+``metadata`` verbatim, so the scorer can still see them.
+
+The schema is deliberately small. We do NOT pre-emptively add fields
+for "answer aliases" / "support fact ids" / "citation labels" /
+"abstention truth" — those land at the per-loader PRs (A.1 - A.3) so
+each addition is justified by an actual benchmark requirement. The
+abstract base stays tiny; loaders are where the real per-bench shape
+lives.
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+each loader pulls the original published fixture rows — no
+JAMES-authored prompts, no JAMES-curated subset, no quietly modified
+gold labels. The point of cycle γ is external evidence; bending the
+fixture invalidates it.
+"""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ─── Unified query schema (frozen) ─────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExternalQuery:
+    """One question from an external benchmark, in the unified shape
+    the cycle γ runner consumes.
+
+    Attributes:
+        id: Benchmark-namespaced identifier (e.g. ``"rgb-0001"``,
+            ``"alce-asqa-train-42"``). Stable across runs; the per-
+            benchmark loader chooses the format so downstream code
+            can grep for "rgb-" / "alce-" / "musique-" / "2wiki-".
+        benchmark: Short benchmark id — one of ``"rgb"``,
+            ``"alce-asqa"``, ``"alce-qampari"``, ``"alce-eli5"``,
+            ``"musique"``, ``"2wiki"``. Stable per-loader contract.
+        question: The natural-language question text as published in
+            the original fixture. NOT rewritten by JAMES.
+        context: Supporting passages the benchmark expects the model
+            to ground its answer on (Wikipedia paragraphs, news
+            articles, …). Empty tuple if the benchmark is
+            closed-book.
+        gold_answer: The benchmark's primary answer string. For
+            yes/no benchmarks (RGB negative rejection) this is
+            ``"Yes"`` / ``"No"`` / ``"insufficient"``; for
+            entity-extraction benchmarks (MuSiQue / 2Wiki) it's the
+            canonical entity name; for citation benchmarks (ALCE)
+            it's a long-form answer.
+        metadata: Bench-specific fields preserved verbatim from the
+            source row. Loaders MUST round-trip the fixture row
+            through here so scorers have everything they need
+            (alias lists, support-fact ids, abstention truth,
+            citation spans, etc.). Treat as opaque dict-of-strings
+            for downstream code.
+    """
+    id:          str
+    benchmark:   str
+    question:    str
+    context:     Tuple[str, ...]
+    gold_answer: str
+    metadata:    Dict[str, Any] = field(default_factory=dict)
+
+    def to_bench_row(self) -> Dict[str, Any]:
+        """Project to the dict shape the JAMES bench JSON uses
+        elsewhere — so the existing scoring helpers (``score_paper_
+        aligned_accuracy``, ``score_path_coverage``) can still read
+        the row alongside the per-bench scorers.
+
+        The cycle γ scorers also use this projection so behaviour
+        across benchmarks stays uniform: every scorer reads a dict,
+        not a dataclass.
+        """
+        return {
+            "id":         self.id,
+            "benchmark":  self.benchmark,
+            "question":   self.question,
+            "text":       self.question,
+            "context":    list(self.context),
+            "gold":       self.gold_answer,
+            "metadata":   dict(self.metadata),
+        }
+
+
+# ─── Abstract benchmark fixture (per-loader contract) ───────────────
+
+
+class ExternalBenchFixture(abc.ABC):
+    """Abstract base every Phase-A.1+ loader inherits from.
+
+    A loader subclass is responsible for:
+
+    1. Pulling the original published fixture (HuggingFace ``datasets``,
+       raw HTTP, or a local cache directory — the loader chooses).
+    2. Yielding :class:`ExternalQuery` records via :meth:`iter_queries`.
+    3. Reporting its benchmark id via :attr:`benchmark_id` for the
+       unified runner's per-bench dispatch.
+
+    The base does NOT prescribe downloading, caching, or batching —
+    those are loader-specific concerns. The base only pins the
+    minimum interface every loader must satisfy so the runner stays
+    benchmark-agnostic.
+    """
+
+    # ── Subclass contract ──────────────────────────────────────────
+
+    @property
+    @abc.abstractmethod
+    def benchmark_id(self) -> str:
+        """Short benchmark id (e.g. ``"rgb"``, ``"alce-asqa"``).
+        Must match the ``benchmark`` field on the queries this loader
+        yields — runtime check at :meth:`iter_queries` enforces it.
+        """
+
+    @abc.abstractmethod
+    def iter_queries(
+        self,
+        *,
+        split: str = "dev",
+        n_samples: Optional[int] = None,
+    ) -> "List[ExternalQuery]":
+        """Yield the fixture's queries.
+
+        Args:
+            split: Benchmark split id (``"train"`` / ``"dev"`` /
+                ``"test"``). Each loader decides which splits it
+                supports and raises ``ValueError`` for an unknown
+                split.
+            n_samples: Optional cap. ``None`` returns the whole split
+                (useful for full measurement runs); a positive integer
+                returns the first ``n_samples`` rows (useful for the
+                Phase B smoke + cost-validation runs the design memo
+                §6 recommends).
+        """
+
+    # ── Shared helpers (loaders inherit these unchanged) ───────────
+
+    def take_sample(
+        self,
+        queries: "List[ExternalQuery]",
+        n_samples: Optional[int],
+    ) -> "List[ExternalQuery]":
+        """Slice the front of a query list according to ``n_samples``.
+
+        Loaders call this from :meth:`iter_queries` so the
+        ``None`` / positive-int semantics stay uniform across
+        benchmarks. Centralising it here also means the test for
+        n_samples semantics lives in one place (Phase A.0 tests),
+        not duplicated per loader.
+        """
+        if n_samples is None:
+            return list(queries)
+        if not isinstance(n_samples, int) or n_samples < 0:
+            raise ValueError(
+                f"n_samples must be None or a non-negative int; got "
+                f"{n_samples!r}"
+            )
+        return list(queries[:n_samples])
+
+    def validate_queries(
+        self,
+        queries: "List[ExternalQuery]",
+    ) -> None:
+        """Cross-check the yielded queries against the loader's
+        :attr:`benchmark_id` and the unified-schema invariants.
+
+        Loaders SHOULD call this before returning from
+        :meth:`iter_queries` — it catches misconfigured fixture rows
+        early (loader emits ``"rgb-001"`` but ``benchmark`` field
+        says ``"musique"``, etc.).
+
+        Raises:
+            ValueError: when a query's ``benchmark`` does not match
+                ``self.benchmark_id``, or when an id is empty / a
+                duplicate within the batch.
+        """
+        seen_ids: set = set()
+        for q in queries:
+            if q.benchmark != self.benchmark_id:
+                raise ValueError(
+                    f"query {q.id!r} has benchmark={q.benchmark!r} "
+                    f"but this loader's benchmark_id is "
+                    f"{self.benchmark_id!r}"
+                )
+            if not q.id:
+                raise ValueError("empty query id")
+            if q.id in seen_ids:
+                raise ValueError(f"duplicate query id: {q.id!r}")
+            seen_ids.add(q.id)
+
+
+__all__ = [
+    "ExternalBenchFixture",
+    "ExternalQuery",
+]

--- a/tests/test_cycle_gamma_external_base.py
+++ b/tests/test_cycle_gamma_external_base.py
@@ -1,0 +1,238 @@
+"""Cycle γ Phase A.0 — ``eval.external.base`` contract tests.
+
+Pins the abstract-base / unified-schema invariants every Phase A.1+
+loader will inherit:
+
+  * ``ExternalQuery`` is frozen + serialises to the bench JSON shape
+    (``to_bench_row``) the existing scoring helpers consume.
+  * ``ExternalBenchFixture`` is genuinely abstract — the bare class
+    cannot be instantiated, and ``benchmark_id`` + ``iter_queries``
+    are required overrides.
+  * ``take_sample`` semantics: ``None`` → full split, positive int →
+    front slice, negative / non-int → ``ValueError``.
+  * ``validate_queries`` catches benchmark-id mismatch + empty id +
+    duplicate id.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class ExternalQuerySchemaTests(unittest.TestCase):
+    """Schema is frozen + projects to the bench dict shape."""
+
+    def test_is_frozen(self):
+        from eval.external import ExternalQuery
+        q = ExternalQuery(
+            id="rgb-001", benchmark="rgb",
+            question="Q?", context=("ctx",), gold_answer="A",
+        )
+        with self.assertRaises(Exception):
+            q.id = "mutated"   # type: ignore[misc]
+
+    def test_to_bench_row_round_trip(self):
+        from eval.external import ExternalQuery
+        q = ExternalQuery(
+            id="rgb-001", benchmark="rgb",
+            question="Who is X?",
+            context=("para A", "para B"),
+            gold_answer="X",
+            metadata={"aliases": ["x", "the X"]},
+        )
+        row = q.to_bench_row()
+        # Required JAMES bench JSON columns:
+        self.assertEqual(row["id"],   "rgb-001")
+        self.assertEqual(row["benchmark"], "rgb")
+        self.assertEqual(row["question"], "Who is X?")
+        # `text` alias for compatibility with multihop_terse_run.py
+        # which keys on q["text"]:
+        self.assertEqual(row["text"], row["question"])
+        self.assertEqual(row["context"], ["para A", "para B"])
+        self.assertEqual(row["gold"], "X")
+        self.assertEqual(row["metadata"], {"aliases": ["x", "the X"]})
+
+    def test_metadata_defaults_to_empty_dict(self):
+        from eval.external import ExternalQuery
+        q = ExternalQuery(
+            id="x", benchmark="rgb",
+            question="Q?", context=(), gold_answer="A",
+        )
+        # Distinct dataclass instances must NOT share the same default
+        # dict (classic mutable-default trap).
+        q2 = ExternalQuery(
+            id="y", benchmark="rgb",
+            question="Q2?", context=(), gold_answer="B",
+        )
+        self.assertEqual(q.metadata, {})
+        self.assertEqual(q2.metadata, {})
+        self.assertIsNot(q.metadata, q2.metadata)
+
+    def test_context_is_a_tuple(self):
+        """The dataclass declares ``context: Tuple[str, ...]`` so a
+        loader emitting a list will lock down to a tuple at the
+        constructor; pinning the type explicitly here protects against
+        a future loader relaxing it to a list (which would break
+        hashability for caching)."""
+        from eval.external import ExternalQuery
+        q = ExternalQuery(
+            id="x", benchmark="rgb",
+            question="?", context=("a", "b"), gold_answer="c",
+        )
+        self.assertIsInstance(q.context, tuple)
+
+
+class ExternalBenchFixtureContractTests(unittest.TestCase):
+    """The abstract base enforces its contract."""
+
+    def test_cannot_instantiate_abstract_base(self):
+        from eval.external import ExternalBenchFixture
+        with self.assertRaises(TypeError):
+            ExternalBenchFixture()   # type: ignore[abstract]
+
+    def test_subclass_without_overrides_still_abstract(self):
+        from eval.external import ExternalBenchFixture
+
+        class Half(ExternalBenchFixture):
+            # Only one override — still abstract.
+            @property
+            def benchmark_id(self) -> str:
+                return "x"
+
+        with self.assertRaises(TypeError):
+            Half()   # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiable(self):
+        from eval.external import ExternalBenchFixture, ExternalQuery
+
+        class Tiny(ExternalBenchFixture):
+            @property
+            def benchmark_id(self) -> str:
+                return "tiny"
+
+            def iter_queries(self, *, split="dev", n_samples=None):
+                qs = [ExternalQuery(
+                    id="tiny-1", benchmark="tiny",
+                    question="?", context=(), gold_answer="a",
+                )]
+                return self.take_sample(qs, n_samples)
+
+        t = Tiny()
+        self.assertEqual(t.benchmark_id, "tiny")
+        out = t.iter_queries()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].id, "tiny-1")
+
+
+class TakeSampleTests(unittest.TestCase):
+    """``take_sample`` semantics are uniform across all loaders."""
+
+    def _make(self):
+        from eval.external import ExternalBenchFixture, ExternalQuery
+
+        class L(ExternalBenchFixture):
+            @property
+            def benchmark_id(self) -> str:
+                return "L"
+
+            def iter_queries(self, *, split="dev", n_samples=None):
+                qs = [ExternalQuery(id=f"L-{i}", benchmark="L",
+                                    question="?", context=(),
+                                    gold_answer="a")
+                      for i in range(5)]
+                return self.take_sample(qs, n_samples)
+        return L()
+
+    def test_none_returns_full_split(self):
+        loader = self._make()
+        out = loader.iter_queries(n_samples=None)
+        self.assertEqual(len(out), 5)
+
+    def test_zero_returns_empty(self):
+        loader = self._make()
+        out = loader.iter_queries(n_samples=0)
+        self.assertEqual(out, [])
+
+    def test_positive_n_returns_front_slice(self):
+        loader = self._make()
+        out = loader.iter_queries(n_samples=3)
+        self.assertEqual([q.id for q in out],
+                         ["L-0", "L-1", "L-2"])
+
+    def test_n_larger_than_split_returns_whole_split(self):
+        loader = self._make()
+        out = loader.iter_queries(n_samples=100)
+        self.assertEqual(len(out), 5)
+
+    def test_negative_raises(self):
+        loader = self._make()
+        with self.assertRaises(ValueError):
+            loader.iter_queries(n_samples=-1)
+
+    def test_non_int_raises(self):
+        loader = self._make()
+        with self.assertRaises(ValueError):
+            loader.iter_queries(n_samples="3")   # type: ignore[arg-type]
+
+
+class ValidateQueriesTests(unittest.TestCase):
+    """``validate_queries`` catches loader misconfiguration early."""
+
+    def _make_loader(self, bid="X"):
+        from eval.external import ExternalBenchFixture
+
+        class L(ExternalBenchFixture):
+            @property
+            def benchmark_id(self) -> str:
+                return bid
+
+            def iter_queries(self, *, split="dev", n_samples=None):
+                return []
+        return L()
+
+    def test_wrong_benchmark_id_raises(self):
+        from eval.external import ExternalQuery
+        loader = self._make_loader(bid="X")
+        bad = [ExternalQuery(id="X-1", benchmark="OTHER",
+                             question="?", context=(), gold_answer="a")]
+        with self.assertRaises(ValueError):
+            loader.validate_queries(bad)
+
+    def test_empty_id_raises(self):
+        from eval.external import ExternalQuery
+        loader = self._make_loader(bid="X")
+        bad = [ExternalQuery(id="", benchmark="X",
+                             question="?", context=(), gold_answer="a")]
+        with self.assertRaises(ValueError):
+            loader.validate_queries(bad)
+
+    def test_duplicate_id_raises(self):
+        from eval.external import ExternalQuery
+        loader = self._make_loader(bid="X")
+        dup = [
+            ExternalQuery(id="X-1", benchmark="X", question="?",
+                          context=(), gold_answer="a"),
+            ExternalQuery(id="X-1", benchmark="X", question="?",
+                          context=(), gold_answer="b"),
+        ]
+        with self.assertRaises(ValueError):
+            loader.validate_queries(dup)
+
+    def test_valid_batch_passes_silently(self):
+        from eval.external import ExternalQuery
+        loader = self._make_loader(bid="X")
+        ok = [
+            ExternalQuery(id="X-1", benchmark="X", question="?",
+                          context=(), gold_answer="a"),
+            ExternalQuery(id="X-2", benchmark="X", question="??",
+                          context=(), gold_answer="b"),
+        ]
+        # Returns None — silent pass.
+        self.assertIsNone(loader.validate_queries(ok))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.0 — abstract \`ExternalBenchFixture\` + unified \`ExternalQuery\` schema. Dependency-free scaffolding for the four external-benchmark loaders (RGB / ALCE / MuSiQue / 2WikiMultiHopQA) that land in A.1+.

Design memo: \`docs/design/v0.4-cycle-gamma-external-benchmark-integration.md\` §6 Phase A.

## Files

- \`eval/external/__init__.py\` (NEW) — package entry, public re-export
- \`eval/external/base.py\` (NEW)
  - \`ExternalQuery\` frozen dataclass + \`to_bench_row()\` projection to JAMES bench dict shape (uniform with \`score_paper_aligned_accuracy\` / \`score_path_coverage\`)
  - \`ExternalBenchFixture\` abstract base with \`benchmark_id\` + \`iter_queries(*, split, n_samples)\`
  - \`take_sample\` helper (uniform None / positive-int / negative semantics)
  - \`validate_queries\` helper (catches benchmark-id mismatch, empty id, duplicate id)
- \`tests/test_cycle_gamma_external_base.py\` (NEW, 17 tests, all pass)

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_external_base\` | 17 | **17/17 PASS** |

## Self-eval trap rule reaffirmed

Per \`memory/feedback_self_evaluation_trap.md\`: each loader pulls the original published fixture; no JAMES-authored prompts, no JAMES-curated subset, no quietly modified gold labels. Base docstring + package docstring both pin this.

## Quality Delta Card

**Exempt** (label: \`feat\`, integration-layer scaffolding; no \`core/retrieval\`, \`core/graph\`, \`core/reasoning\` quality dial change).

## Why dependency-free

The base deliberately does NOT depend on HuggingFace \`datasets\`. That decision lives at A.1 (per-loader) so we can swap to raw HTTP downloads or an offline cache without re-touching the abstract interface.

## Closes / related

- Design memo: \`docs/design/v0.4-cycle-gamma-external-benchmark-integration.md\`
- Self-eval trap: \`memory/feedback_self_evaluation_trap.md\`
- Path 1 closure: \`docs/handovers/v0.4-cycle-beta-closure-2026-06-06.md\`

## Next step

A.1 — RGB loader (Chen et al. 2024 EMNLP, arXiv:2309.01431). JAMES-unique abstention F1 strength → first benchmark to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)