### PR TITLE
feat(cycle γ A.1): RGB loader (Chen et al. 2024 EMNLP, arXiv:2309.01431)

### DIFF
--- a/eval/external/rgb_loader.py
+++ b/eval/external/rgb_loader.py
@@ -1,0 +1,330 @@
+"""Cycle γ Phase A.1 — RGB (Chen et al. 2024 EMNLP) loader.
+
+Pulls the RGB benchmark fixture directly from the published GitHub
+repository (https://github.com/chen700564/RGB) and yields
+:class:`ExternalQuery` records in the unified cycle γ schema.
+
+RGB is the JAMES-unique strength validation point: its **negative
+rejection** axis maps 1:1 onto the JAMES abstention F1 metric
+(``score_abstention_f1`` in ``eval/qvt/oracle.py``), and the
+corpus-retrieval analysis (PR #712 §6) flagged RGB as the
+strongest external evidence path for the abstention claim.
+
+Source files (raw GitHub URLs)
+------------------------------
+
+The benchmark publishes 4 variants × 2 languages:
+
+* ``en.json`` / ``zh.json``                 — base benchmark
+* ``en_refine.json`` / ``zh_refine.json``   — refined positives + corrected answers
+* ``en_int.json`` / ``zh_int.json``         — information integration
+* ``en_fact.json`` / ``zh_fact.json``       — counterfactual robustness
+
+Each entry has the following primary keys (verified against the
+official ``evalue.py``):
+
+* ``id``       — unique identifier
+* ``query``    — question text
+* ``answer``   — gold answer (string OR list of acceptable strings)
+* ``positive`` — list of supporting passages
+* ``negative`` — list of distractor passages
+* ``positive_wrong``  — incorrect passages (``_fact`` variant only)
+
+Schema mapping (RGB → :class:`ExternalQuery`)
+---------------------------------------------
+
+* ``id``         → ``"rgb-<variant>-<orig_id>"``  (namespaced)
+* ``benchmark``  → ``"rgb-<variant>"``
+* ``question``   → ``entry["query"]``
+* ``context``    → ``tuple(positive + negative)``  (loader preserves
+                  both so the scorer can identify negative-rejection
+                  cases via ``len(positive) == 0``)
+* ``gold_answer`` → flatten ``answer`` to a single string; the
+                  original list is preserved under
+                  ``metadata["answer_aliases"]`` for alias matching
+* ``metadata``   → ``{
+    "positive_count":  int,
+    "negative_count":  int,
+    "positive_wrong":  list[str],  # _fact variant only
+    "answer_aliases":  list[str],
+    "variant":         str,
+    "language":        "en" | "zh",
+  }``
+
+Dependency strategy
+-------------------
+
+Raw HTTP download via stdlib ``urllib`` — no HuggingFace ``datasets``
+package, no extra dependency. The fixture is cached under
+``eval/external/_fixtures/rgb/<variant>.json`` so a second run is
+offline. Production callers can pre-populate the cache directory
+without involving the loader; the loader only downloads when the
+cache is absent.
+
+The download itself is opt-in: ``iter_queries`` accepts a
+``cache_dir`` argument. Tests pass a tmpdir with a hand-written
+synthetic fixture so they neither download anything nor depend on
+the live RGB repo.
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the loader does NOT rewrite queries, does NOT curate a subset, and
+does NOT modify gold answers. Every byte of the source fixture
+either lands in :class:`ExternalQuery` directly or under
+``metadata`` for the scorer to consume.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from eval.external.base import ExternalBenchFixture, ExternalQuery
+
+
+# ─── Source registry ───────────────────────────────────────────────
+
+
+# Published variants. Order matches the original GitHub repo's
+# ``data/`` listing. Adding a new entry here is the only change
+# needed to ship a new variant.
+RGB_VARIANTS: Tuple[str, ...] = (
+    "en",
+    "zh",
+    "en_refine",
+    "zh_refine",
+    "en_int",
+    "zh_int",
+    "en_fact",
+    "zh_fact",
+)
+
+
+_GITHUB_RAW_BASE = (
+    "https://raw.githubusercontent.com/chen700564/RGB/master/data/"
+)
+
+
+def _default_cache_dir() -> Path:
+    """Resolve the package-local cache directory.
+
+    ``eval/external/_fixtures/rgb/`` — same tree as the loader so a
+    git-cloned checkout can ship pre-populated fixtures without an
+    environment-variable dance.
+    """
+    return (Path(__file__).resolve().parent / "_fixtures" / "rgb")
+
+
+# ─── Fixture download / cache ───────────────────────────────────────
+
+
+def _variant_url(variant: str) -> str:
+    if variant not in RGB_VARIANTS:
+        raise ValueError(
+            f"unknown RGB variant: {variant!r}. "
+            f"Valid: {RGB_VARIANTS}"
+        )
+    return f"{_GITHUB_RAW_BASE}{variant}.json"
+
+
+def _cache_path(variant: str, cache_dir: Optional[Path]) -> Path:
+    base = Path(cache_dir) if cache_dir else _default_cache_dir()
+    return base / f"{variant}.json"
+
+
+def _ensure_fixture(
+    variant: str,
+    cache_dir: Optional[Path],
+    *,
+    allow_download: bool,
+) -> Path:
+    """Return the on-disk path to ``<variant>.json``. Downloads it
+    from GitHub if absent and ``allow_download`` is True.
+
+    Raises:
+        FileNotFoundError: when the cached fixture is missing and
+            downloads are disabled (test path).
+        urllib.error.URLError: when the download fails.
+    """
+    path = _cache_path(variant, cache_dir)
+    if path.exists():
+        return path
+    if not allow_download:
+        raise FileNotFoundError(
+            f"RGB {variant!r} fixture not in cache at {path} and "
+            f"download disabled (pass allow_download=True to fetch)."
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    url = _variant_url(variant)
+    # Stream-write so a 10+ MB fixture doesn't sit in memory twice.
+    with urllib.request.urlopen(url) as resp, open(path, "wb") as f:
+        while True:
+            chunk = resp.read(64 * 1024)
+            if not chunk:
+                break
+            f.write(chunk)
+    return path
+
+
+# ─── Schema mapping ────────────────────────────────────────────────
+
+
+def _flatten_answer(raw: Any) -> Tuple[str, List[str]]:
+    """RGB ``answer`` may be a string or a list of acceptable strings.
+
+    Returns ``(primary_answer, aliases)`` where ``primary_answer`` is
+    a single string suitable for ``ExternalQuery.gold_answer`` and
+    ``aliases`` is the rest of the list (empty if the source already
+    was a single string).
+    """
+    if isinstance(raw, str):
+        return raw, []
+    if isinstance(raw, list):
+        flat: List[str] = []
+        for item in raw:
+            if isinstance(item, list):
+                # Sometimes nested (alias groups). Flatten one level.
+                flat.extend(str(x) for x in item)
+            else:
+                flat.append(str(item))
+        if not flat:
+            return "", []
+        return flat[0], flat[1:]
+    # Anything else (None / int / dict) → str() fallback, no aliases.
+    return ("" if raw is None else str(raw)), []
+
+
+def _entry_to_query(
+    entry: Dict[str, Any],
+    *,
+    variant: str,
+) -> ExternalQuery:
+    orig_id = str(entry.get("id", "")).strip()
+    if not orig_id:
+        # Fall back to a positional id only when the source row truly
+        # omits it; raises in validate_queries if it stays empty.
+        orig_id = "noid"
+    primary, aliases = _flatten_answer(entry.get("answer"))
+    positive = list(entry.get("positive") or [])
+    negative = list(entry.get("negative") or [])
+    positive_wrong = list(entry.get("positive_wrong") or [])
+
+    metadata: Dict[str, Any] = {
+        "positive_count":  len(positive),
+        "negative_count":  len(negative),
+        "answer_aliases":  aliases,
+        "variant":         variant,
+        "language":        ("zh" if variant.startswith("zh") else "en"),
+    }
+    # _fact variant carries an extra distractor list.
+    if positive_wrong:
+        metadata["positive_wrong"] = positive_wrong
+
+    return ExternalQuery(
+        id=f"rgb-{variant}-{orig_id}",
+        benchmark=f"rgb-{variant}",
+        question=str(entry.get("query", "")),
+        context=tuple(str(p) for p in (positive + negative)),
+        gold_answer=primary,
+        metadata=metadata,
+    )
+
+
+# ─── Loader ────────────────────────────────────────────────────────
+
+
+class RGBLoader(ExternalBenchFixture):
+    """Loader for one RGB variant (``en`` / ``zh`` / ``en_refine`` /
+    ``en_int`` / ``en_fact`` / Chinese counterparts).
+
+    Usage::
+
+        loader = RGBLoader(variant="en", allow_download=True)
+        queries = loader.iter_queries(n_samples=20)   # Phase B smoke
+        # later, after caching:
+        queries = loader.iter_queries()               # full split
+
+    Notes:
+        * ``allow_download=False`` (the default) is the safe mode for
+          test environments — it raises ``FileNotFoundError`` if the
+          cache is absent rather than hitting the network silently.
+        * ``cache_dir`` lets tests redirect to a tmpdir; production
+          callers should pass ``None`` so the loader uses
+          ``eval/external/_fixtures/rgb/``.
+    """
+
+    def __init__(
+        self,
+        *,
+        variant: str = "en",
+        cache_dir: Optional[Path] = None,
+        allow_download: bool = False,
+    ):
+        if variant not in RGB_VARIANTS:
+            raise ValueError(
+                f"unknown RGB variant: {variant!r}. "
+                f"Valid: {RGB_VARIANTS}"
+            )
+        self._variant = variant
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+        self._allow_download = allow_download
+
+    @property
+    def benchmark_id(self) -> str:
+        return f"rgb-{self._variant}"
+
+    @property
+    def variant(self) -> str:
+        return self._variant
+
+    @property
+    def cache_path(self) -> Path:
+        return _cache_path(self._variant, self._cache_dir)
+
+    def iter_queries(
+        self,
+        *,
+        split: str = "dev",
+        n_samples: Optional[int] = None,
+    ) -> List[ExternalQuery]:
+        """Load + parse the cached (or freshly-downloaded) fixture and
+        yield queries in the unified schema.
+
+        Args:
+            split: Accepted purely for interface uniformity with
+                other loaders. RGB does not publish train/dev/test
+                splits — every variant is one flat list. The argument
+                is recorded but not used.
+            n_samples: see :meth:`ExternalBenchFixture.take_sample`.
+
+        Raises:
+            FileNotFoundError: cache missing + downloads disabled.
+            ValueError: validation failed (empty id / dup id /
+                benchmark mismatch).
+            json.JSONDecodeError: cached file is corrupt.
+        """
+        path = _ensure_fixture(
+            self._variant,
+            self._cache_dir,
+            allow_download=self._allow_download,
+        )
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"RGB {self._variant!r} fixture must be a JSON list; "
+                f"got {type(raw).__name__}"
+            )
+
+        queries = [_entry_to_query(e, variant=self._variant)
+                   for e in raw if isinstance(e, dict)]
+        self.validate_queries(queries)
+        return self.take_sample(queries, n_samples)
+
+
+__all__ = [
+    "RGB_VARIANTS",
+    "RGBLoader",
+]

--- a/tests/test_cycle_gamma_rgb_loader.py
+++ b/tests/test_cycle_gamma_rgb_loader.py
@@ -1,0 +1,270 @@
+"""Cycle γ Phase A.1 — RGB loader contract tests.
+
+Every test runs against a hand-written synthetic fixture written to
+a tmpdir so the suite never touches the network and never depends
+on the live RGB GitHub repo.
+
+The synthetic rows mirror the published schema verified against the
+official ``evalue.py`` (``id`` / ``query`` / ``answer`` /
+``positive`` / ``negative`` / ``positive_wrong``) so the schema
+mapping is exercised end-to-end. Real measurement runs (Phase B+)
+will populate the cache from the live repo via ``allow_download=
+True``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _write_synthetic(
+    cache_dir: Path,
+    variant: str,
+    entries: list,
+) -> Path:
+    """Write a synthetic <variant>.json into the loader's cache dir
+    layout (``<cache_dir>/<variant>.json``)."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / f"{variant}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False)
+    return path
+
+
+class VariantRegistryTests(unittest.TestCase):
+    """RGB_VARIANTS covers every published variant. Constructor
+    rejects unknown variants."""
+
+    def test_variant_registry_complete(self):
+        from eval.external.rgb_loader import RGB_VARIANTS
+        self.assertEqual(set(RGB_VARIANTS), {
+            "en", "zh",
+            "en_refine", "zh_refine",
+            "en_int", "zh_int",
+            "en_fact", "zh_fact",
+        })
+
+    def test_constructor_rejects_unknown_variant(self):
+        from eval.external.rgb_loader import RGBLoader
+        with self.assertRaises(ValueError):
+            RGBLoader(variant="bogus")
+
+    def test_default_variant_is_english_base(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader()
+        self.assertEqual(loader.variant, "en")
+        self.assertEqual(loader.benchmark_id, "rgb-en")
+
+
+class CacheBehaviourTests(unittest.TestCase):
+    """Cache absence + downloads disabled = FileNotFoundError."""
+
+    def test_missing_cache_no_download_raises(self):
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = RGBLoader(variant="en", cache_dir=Path(td),
+                                allow_download=False)
+            with self.assertRaises(FileNotFoundError):
+                loader.iter_queries()
+
+    def test_cache_path_respects_cache_dir(self):
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = RGBLoader(variant="en", cache_dir=Path(td))
+            self.assertEqual(loader.cache_path,
+                              Path(td) / "en.json")
+
+
+class SchemaMappingTests(unittest.TestCase):
+    """Synthetic fixture → ExternalQuery shape."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic_entry_maps_correctly(self):
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [
+            {
+                "id": "0001",
+                "query": "Who founded OpenAI?",
+                "answer": "Sam Altman",
+                "positive": ["Sam Altman co-founded OpenAI in 2015."],
+                "negative": ["FTX is a cryptocurrency exchange."],
+            },
+        ])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        q = out[0]
+        self.assertEqual(q.id,         "rgb-en-0001")
+        self.assertEqual(q.benchmark,  "rgb-en")
+        self.assertEqual(q.question,   "Who founded OpenAI?")
+        # positive + negative are concatenated into context.
+        self.assertEqual(len(q.context), 2)
+        self.assertEqual(q.gold_answer, "Sam Altman")
+        self.assertEqual(q.metadata["positive_count"], 1)
+        self.assertEqual(q.metadata["negative_count"], 1)
+        self.assertEqual(q.metadata["language"], "en")
+        self.assertEqual(q.metadata["variant"], "en")
+        self.assertEqual(q.metadata["answer_aliases"], [])
+        # _fact-only field absent on base variant
+        self.assertNotIn("positive_wrong", q.metadata)
+
+    def test_zh_variant_marks_language(self):
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "zh", [
+            {"id": "z1", "query": "中国首都是哪里？",
+             "answer": "北京",
+             "positive": ["北京是中国首都。"], "negative": []},
+        ])
+        loader = RGBLoader(variant="zh", cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(out[0].metadata["language"], "zh")
+        self.assertEqual(out[0].benchmark, "rgb-zh")
+
+    def test_list_answer_flattens_with_aliases(self):
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [
+            {"id": "a1", "query": "Capital of the United States?",
+             "answer": ["Washington, D.C.", "Washington DC",
+                        "Washington"],
+             "positive": ["The U.S. capital is Washington, D.C."],
+             "negative": []},
+        ])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        # First element is the primary answer; the rest are aliases.
+        self.assertEqual(q.gold_answer, "Washington, D.C.")
+        self.assertEqual(q.metadata["answer_aliases"],
+                         ["Washington DC", "Washington"])
+
+    def test_nested_list_answer_flattens_one_level(self):
+        """Some RGB rows wrap aliases in a list-of-lists; loader
+        flattens one level so the scorer sees a flat alias list."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [
+            {"id": "a2", "query": "Who?",
+             "answer": [["Sam Bankman-Fried", "SBF"], "Bankman-Fried"],
+             "positive": ["doc"], "negative": []},
+        ])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.gold_answer, "Sam Bankman-Fried")
+        self.assertEqual(q.metadata["answer_aliases"],
+                         ["SBF", "Bankman-Fried"])
+
+    def test_fact_variant_preserves_positive_wrong(self):
+        """The _fact variant carries an extra distractor list that the
+        counterfactual-robustness scorer needs."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en_fact", [
+            {"id": "f1", "query": "Capital?", "answer": "Paris",
+             "positive": ["Paris is the capital of France."],
+             "negative": ["Berlin is in Germany."],
+             "positive_wrong": ["The capital of France is Lyon."]},
+        ])
+        loader = RGBLoader(variant="en_fact", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.benchmark, "rgb-en_fact")
+        self.assertEqual(q.metadata["positive_wrong"],
+                         ["The capital of France is Lyon."])
+
+    def test_negative_rejection_case_has_zero_positives(self):
+        """RGB encodes negative-rejection (abstention) cases as rows
+        whose positive list is empty — the scorer (Phase A.4) checks
+        ``metadata['positive_count'] == 0``. The loader must preserve
+        that flag faithfully."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [
+            {"id": "neg1",
+             "query": "Who is the next CEO of nonexistent company?",
+             "answer": "",
+             "positive": [],
+             "negative": ["distractor 1", "distractor 2"]},
+        ])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.metadata["positive_count"], 0)
+        # context = positive ∪ negative; even with 0 positives the
+        # negative docs are still there for the scorer to inspect.
+        self.assertEqual(len(q.context), 2)
+
+
+class TakeSampleIntegrationTests(unittest.TestCase):
+    """``n_samples`` slices the front of the fixture without
+    altering the schema."""
+
+    def test_n_samples_returns_front_slice(self):
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            entries = [
+                {"id": f"r{i}", "query": "?", "answer": "a",
+                 "positive": [], "negative": []}
+                for i in range(10)
+            ]
+            _write_synthetic(Path(td), "en", entries)
+            loader = RGBLoader(variant="en", cache_dir=Path(td))
+            out = loader.iter_queries(n_samples=3)
+            self.assertEqual(len(out), 3)
+            self.assertEqual([q.id for q in out],
+                             ["rgb-en-r0", "rgb-en-r1", "rgb-en-r2"])
+
+
+class CorruptFixtureTests(unittest.TestCase):
+    """Malformed JSON / non-list root / non-dict rows surface cleanly."""
+
+    def test_non_list_root_raises_value_error(self):
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            with open(cache / "en.json", "w", encoding="utf-8") as f:
+                json.dump({"not": "a list"}, f)
+            loader = RGBLoader(variant="en", cache_dir=cache)
+            with self.assertRaises(ValueError):
+                loader.iter_queries()
+
+    def test_corrupt_json_raises_json_decode_error(self):
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            with open(cache / "en.json", "w", encoding="utf-8") as f:
+                f.write("{not valid json")
+            loader = RGBLoader(variant="en", cache_dir=cache)
+            with self.assertRaises(json.JSONDecodeError):
+                loader.iter_queries()
+
+    def test_non_dict_rows_silently_skipped(self):
+        """A misformatted row inside an otherwise valid list is
+        skipped rather than crashing the whole fixture — keeps the
+        loader resilient to one bad upstream commit."""
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            with open(cache / "en.json", "w", encoding="utf-8") as f:
+                json.dump([
+                    {"id": "ok", "query": "?", "answer": "a",
+                     "positive": [], "negative": []},
+                    "this is not a dict",
+                    {"id": "ok2", "query": "??", "answer": "b",
+                     "positive": [], "negative": []},
+                ], f)
+            loader = RGBLoader(variant="en", cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual(len(out), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.1 — first per-bench loader. Pulls the RGB benchmark fixture from the published GitHub repository (chen700564/RGB) and yields \`ExternalQuery\` records in the unified cycle γ schema.

**RGB is the JAMES-unique strength validation point**: its negative rejection axis maps 1:1 onto the JAMES abstention F1 metric (\`score_abstention_f1\` in \`eval/qvt/oracle.py\`), and the corpus-retrieval analysis (PR #712 §6) flagged RGB as the strongest external evidence path for the abstention claim.

## Files

- \`eval/external/rgb_loader.py\` (NEW)
  - \`RGB_VARIANTS\` — every published variant (en/zh × base/refine/int/fact = 8 entries)
  - \`RGBLoader\` class (subclasses \`ExternalBenchFixture\`)
  - \`allow_download\` flag — production callers opt in (True); tests stay offline (default False)
  - Raw HTTP download via stdlib \`urllib\` — no \`datasets\` package dependency
  - Schema mapping verified against the official \`evalue.py\`

- \`tests/test_cycle_gamma_rgb_loader.py\` (NEW, 15 tests, all pass)
  - All tests run against a hand-written synthetic fixture in a tmpdir — network-free, repo-free

## Schema mapping (RGB → ExternalQuery)

| RGB key | ExternalQuery |
|---|---|
| \`id\` | namespaced to \`"rgb-<variant>-<orig_id>"\` |
| \`query\` | \`question\` |
| \`positive + negative\` | \`context\` tuple (preserves both for the scorer to identify negative-rejection cases via \`metadata.positive_count == 0\`) |
| \`answer\` (str or list) | flattened to primary string + \`metadata.answer_aliases\` |
| \`positive_wrong\` (_fact only) | \`metadata.positive_wrong\` |

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_rgb_loader\` | 15 | **15/15 PASS** |

## Self-eval trap rule reaffirmed

The loader does NOT rewrite queries, does NOT curate a subset, does NOT modify gold answers. Every byte of the source fixture either lands in \`ExternalQuery\` directly or under \`metadata\` for the scorer to consume.

## Quality Delta Card

**Exempt** (label: \`feat\`, integration-layer loader; no \`core/retrieval\`, \`core/graph\`, \`core/reasoning\` quality dial change).

## Cycle γ progress

| Phase | Status |
|---|---|
| A.0 abstract base + schema | ✅ #724 |
| **A.1 RGB loader (this PR)** | **✅** |
| A.2 ALCE loader (ASQA + QAMPARI) | ⏳ next |
| A.3 MuSiQue + 2WikiMultiHopQA loaders | ⏳ |
| A.4 4 scorers | ⏳ |
| A.5 unified runner | ⏳ |

## Next step

A.2 — ALCE loader (Gao et al. 2023, arXiv:2305.14627). ASQA + QAMPARI variants. Citation precision/recall scoring (NLI-based) lands in A.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)