### PR TITLE
feat(cycle γ A.2): ALCE loader — ASQA + QAMPARI + ELI5 (Gao et al. 2023)

### DIFF
--- a/eval/external/alce_loader.py
+++ b/eval/external/alce_loader.py
@@ -1,0 +1,347 @@
+"""Cycle γ Phase A.2 — ALCE (Gao et al. 2023) loader.
+
+ALCE = Automatic LLM Citation Evaluation. Three sub-benchmarks:
+
+* **ASQA**    — ambiguous QA with multiple acceptable short answers
+                + a reference long answer + annotated QA pairs.
+* **QAMPARI** — list-based answers (each question has multiple
+                acceptable answer groups).
+* **ELI5**    — long-form explanation with atomic claims for
+                NLI-based citation verification.
+
+Citation precision/recall is the headline metric (the per-bench
+scorer in A.4 implements it). The loader's job is just to lift the
+published fixture rows into the unified :class:`ExternalQuery`
+shape without rewriting any of them — the citation-eval logic lives
+downstream.
+
+Source
+------
+
+ALCE publishes the fixtures as a single tarball on HuggingFace:
+
+    https://huggingface.co/datasets/princeton-nlp/ALCE-data/resolve/main/ALCE-data.tar
+
+The tarball expands into a ``data/`` directory with one JSON per
+variant + retriever. The loader doesn't unpack tarballs itself —
+that adds non-trivial code for a one-time bootstrap. Operators run
+the official ``download_data.sh`` (or unpack the tarball manually)
+and point ``cache_dir`` at the resulting directory. The loader then
+reads ``<cache_dir>/<expected_filename>``.
+
+Per-variant expected filenames (verified against ALCE's ``eval.py``
+default flags):
+
+* ASQA    → ``asqa_eval_gtr_top100.json``
+* QAMPARI → ``qampari_eval_gtr_top100.json``
+* ELI5    → ``eli5_eval_bm25_top100.json``
+
+Schema mapping (per variant)
+----------------------------
+
+The three variants have different gold-answer shapes; the unified
+schema absorbs them with a per-variant ``_entry_to_query_*`` helper
+and routes the remainder under ``metadata``:
+
+* ASQA:
+    ``id``         → ``"alce-asqa-<sample_id>"``
+    ``benchmark``  → ``"alce-asqa"``
+    ``question``   → ``entry["question"]``
+    ``context``    → tuple(doc["text"] for doc in entry["docs"])
+    ``gold_answer`` → primary short answer (first qa_pair's first
+                     ``short_answers`` entry)
+    ``metadata``   → ``qa_pairs`` / ``annotations`` /
+                    ``docs_titles`` / variant / retriever
+
+* QAMPARI:
+    ``id``         → ``"alce-qampari-<sample_id>"``
+    ``benchmark``  → ``"alce-qampari"``
+    ``question``   → ``entry["question"]``
+    ``context``    → tuple(doc["text"])
+    ``gold_answer`` → first answer of the first answer group
+    ``metadata``   → ``answers`` (list of lists, preserved) /
+                    ``docs_titles`` / variant / retriever
+
+* ELI5:
+    ``id``         → ``"alce-eli5-<sample_id>"``
+    ``benchmark``  → ``"alce-eli5"``
+    ``question``   → ``entry["question"]``
+    ``context``    → tuple(doc["text"])
+    ``gold_answer`` → ``entry["answer"]`` (the reference long answer)
+    ``metadata``   → ``claims`` (atomic claims for NLI scoring) /
+                    ``docs_titles`` / variant / retriever
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the loader does NOT rewrite questions, does NOT curate a subset,
+does NOT recompute gold labels. Every byte of the source row
+either lands in :class:`ExternalQuery` directly or under
+``metadata`` for the A.4 scorer.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from eval.external.base import ExternalBenchFixture, ExternalQuery
+
+
+# ─── Variant registry (mirrors ALCE's eval.py default flags) ─────────
+
+
+@dataclass(frozen=True)
+class _AlceVariantConfig:
+    """Per-variant filename + retriever id.
+
+    The filename is what ``download_data.sh`` writes to ``data/``;
+    the retriever id is recorded under ``metadata.retriever`` so a
+    cross-bench analysis can group results by retrieval setup.
+    """
+    filename:  str
+    retriever: str
+
+
+_VARIANTS: Dict[str, _AlceVariantConfig] = {
+    "asqa":    _AlceVariantConfig("asqa_eval_gtr_top100.json",    "gtr"),
+    "qampari": _AlceVariantConfig("qampari_eval_gtr_top100.json", "gtr"),
+    "eli5":    _AlceVariantConfig("eli5_eval_bm25_top100.json",   "bm25"),
+}
+
+ALCE_VARIANTS: Tuple[str, ...] = tuple(_VARIANTS.keys())
+
+
+# ─── Shared helpers ────────────────────────────────────────────────
+
+
+def _extract_docs(entry: Dict[str, Any]) -> Tuple[Tuple[str, ...],
+                                                    List[str]]:
+    """Return ``(context_texts, titles)`` for one entry.
+
+    The loader keeps the doc *texts* under ``context`` (so the scorer
+    can resolve a citation ``[1]`` back to its passage) and the
+    *titles* under ``metadata["docs_titles"]`` (for forensic
+    inspection / by-source aggregation downstream).
+    """
+    docs = entry.get("docs") or []
+    if not isinstance(docs, list):
+        return (), []
+    texts: List[str] = []
+    titles: List[str] = []
+    for d in docs:
+        if not isinstance(d, dict):
+            continue
+        # ALCE's eval.py accepts both 'text' (passage body) and
+        # 'sent' (QA-extracted sentence) — prefer the longer body.
+        body = d.get("text") or d.get("sent") or ""
+        title = d.get("title") or ""
+        texts.append(str(body))
+        titles.append(str(title))
+    return tuple(texts), titles
+
+
+def _resolve_id(entry: Dict[str, Any]) -> str:
+    """ALCE rows usually carry ``sample_id`` (ASQA / QAMPARI /
+    ELI5 all share this key). Fall back to ``question_id`` or a
+    positional placeholder if the source row lacks it — validate_
+    queries surfaces the rest."""
+    for key in ("sample_id", "question_id", "id"):
+        val = entry.get(key)
+        if val is not None:
+            return str(val)
+    return "noid"
+
+
+# ─── Per-variant mappers ───────────────────────────────────────────
+
+
+def _entry_to_query_asqa(entry: Dict[str, Any]) -> ExternalQuery:
+    sid = _resolve_id(entry)
+    qa_pairs = entry.get("qa_pairs") or []
+    # Primary short answer = first qa_pair's first short_answers entry.
+    primary = ""
+    if isinstance(qa_pairs, list) and qa_pairs:
+        first = qa_pairs[0] if isinstance(qa_pairs[0], dict) else {}
+        shorts = first.get("short_answers") or []
+        if isinstance(shorts, list) and shorts:
+            primary = str(shorts[0])
+    texts, titles = _extract_docs(entry)
+    cfg = _VARIANTS["asqa"]
+    metadata: Dict[str, Any] = {
+        "qa_pairs":    qa_pairs,
+        "annotations": entry.get("annotations") or [],
+        "docs_titles": titles,
+        "variant":     "asqa",
+        "retriever":   cfg.retriever,
+    }
+    return ExternalQuery(
+        id=f"alce-asqa-{sid}",
+        benchmark="alce-asqa",
+        question=str(entry.get("question", "")),
+        context=texts,
+        gold_answer=primary,
+        metadata=metadata,
+    )
+
+
+def _entry_to_query_qampari(entry: Dict[str, Any]) -> ExternalQuery:
+    sid = _resolve_id(entry)
+    answers = entry.get("answers") or []
+    primary = ""
+    # QAMPARI answers are a list of answer-groups; each group is a list
+    # of acceptable strings for one "slot" in the list-answer. We pick
+    # the first group's first string for the primary; the full
+    # structure stays under metadata for the scorer.
+    if isinstance(answers, list) and answers:
+        first_group = answers[0]
+        if isinstance(first_group, list) and first_group:
+            primary = str(first_group[0])
+        elif isinstance(first_group, str):
+            primary = first_group
+    texts, titles = _extract_docs(entry)
+    cfg = _VARIANTS["qampari"]
+    metadata: Dict[str, Any] = {
+        "answers":     answers,
+        "docs_titles": titles,
+        "variant":     "qampari",
+        "retriever":   cfg.retriever,
+    }
+    return ExternalQuery(
+        id=f"alce-qampari-{sid}",
+        benchmark="alce-qampari",
+        question=str(entry.get("question", "")),
+        context=texts,
+        gold_answer=primary,
+        metadata=metadata,
+    )
+
+
+def _entry_to_query_eli5(entry: Dict[str, Any]) -> ExternalQuery:
+    sid = _resolve_id(entry)
+    texts, titles = _extract_docs(entry)
+    cfg = _VARIANTS["eli5"]
+    metadata: Dict[str, Any] = {
+        "claims":      entry.get("claims") or [],
+        "docs_titles": titles,
+        "variant":     "eli5",
+        "retriever":   cfg.retriever,
+    }
+    return ExternalQuery(
+        id=f"alce-eli5-{sid}",
+        benchmark="alce-eli5",
+        question=str(entry.get("question", "")),
+        context=texts,
+        gold_answer=str(entry.get("answer") or ""),
+        metadata=metadata,
+    )
+
+
+_MAPPERS: Dict[str, Callable[[Dict[str, Any]], ExternalQuery]] = {
+    "asqa":    _entry_to_query_asqa,
+    "qampari": _entry_to_query_qampari,
+    "eli5":    _entry_to_query_eli5,
+}
+
+
+# Sanity at import time: every variant has a mapper. A future
+# _VARIANTS entry that forgets to register a mapper here becomes a
+# load-time error rather than silently dropping rows.
+assert set(_MAPPERS) == set(_VARIANTS), (
+    "every ALCE variant must have an entry in _MAPPERS"
+)
+
+
+# ─── Loader ────────────────────────────────────────────────────────
+
+
+def _default_cache_dir() -> Path:
+    """Loader-local cache (``eval/external/_fixtures/alce/``).
+    Operators normally point at ALCE's ``data/`` directory instead;
+    this default just exists for the rare git-cloned-fixtures case.
+    """
+    return Path(__file__).resolve().parent / "_fixtures" / "alce"
+
+
+class ALCELoader(ExternalBenchFixture):
+    """Loader for one ALCE variant (``asqa`` / ``qampari`` / ``eli5``).
+
+    Usage::
+
+        loader = ALCELoader(variant="asqa", cache_dir=Path("data"))
+        queries = loader.iter_queries(n_samples=20)   # Phase B smoke
+        # or:
+        queries = loader.iter_queries()               # full split
+
+    The loader expects ``cache_dir/<filename>`` to exist on disk —
+    typically populated by running ALCE's official ``download_data.
+    sh`` and pointing ``cache_dir`` at the resulting ``data/``
+    directory. Auto-download from the HuggingFace tarball is NOT
+    implemented here (the bootstrap is a single ``bash``
+    invocation; pulling + unpacking a tarball would just duplicate
+    that with more failure modes).
+    """
+
+    def __init__(
+        self,
+        *,
+        variant: str = "asqa",
+        cache_dir: Optional[Path] = None,
+    ):
+        if variant not in _VARIANTS:
+            raise ValueError(
+                f"unknown ALCE variant: {variant!r}. "
+                f"Valid: {ALCE_VARIANTS}"
+            )
+        self._variant = variant
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+
+    @property
+    def benchmark_id(self) -> str:
+        return f"alce-{self._variant}"
+
+    @property
+    def variant(self) -> str:
+        return self._variant
+
+    @property
+    def cache_path(self) -> Path:
+        base = self._cache_dir or _default_cache_dir()
+        return base / _VARIANTS[self._variant].filename
+
+    def iter_queries(
+        self,
+        *,
+        split: str = "dev",
+        n_samples: Optional[int] = None,
+    ) -> List[ExternalQuery]:
+        path = self.cache_path
+        if not path.exists():
+            raise FileNotFoundError(
+                f"ALCE {self._variant!r} fixture not at {path}. "
+                f"Run ALCE's `bash download_data.sh` and point "
+                f"cache_dir at the resulting data/ directory."
+            )
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+
+        if isinstance(raw, dict) and "data" in raw:
+            # ALCE wraps the actual rows under a top-level "data" key
+            # in some variants; unwrap so the mapper sees the flat list.
+            raw = raw["data"]
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"ALCE {self._variant!r} fixture must be a JSON list "
+                f"(or a dict with a 'data' list); got "
+                f"{type(raw).__name__}"
+            )
+
+        mapper = _MAPPERS[self._variant]
+        queries = [mapper(e) for e in raw if isinstance(e, dict)]
+        self.validate_queries(queries)
+        return self.take_sample(queries, n_samples)
+
+
+__all__ = [
+    "ALCE_VARIANTS",
+    "ALCELoader",
+]

--- a/tests/test_cycle_gamma_alce_loader.py
+++ b/tests/test_cycle_gamma_alce_loader.py
@@ -1,0 +1,338 @@
+"""Cycle γ Phase A.2 — ALCE loader contract tests.
+
+Every test runs against a hand-written synthetic fixture written to
+a tmpdir so the suite never touches the network and never depends
+on the live ALCE GitHub / HuggingFace data tarball.
+
+The synthetic rows mirror the published per-variant schema verified
+against ALCE's official ``eval.py``:
+
+* ASQA   — ``question`` / ``qa_pairs[].short_answers`` /
+           ``annotations[].long_answer`` / ``docs[].text``
+* QAMPARI — ``question`` / ``answers`` (list of acceptable answer
+           groups) / ``docs[].text``
+* ELI5   — ``question`` / ``answer`` (reference long answer) /
+           ``claims`` / ``docs[].text``
+
+Real measurement runs (Phase B+) populate the cache by pointing
+``cache_dir`` at the directory ALCE's ``download_data.sh`` creates.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _write_fixture(
+    cache_dir: Path,
+    variant: str,
+    entries: list,
+) -> Path:
+    """Write a synthetic ALCE fixture under ``cache_dir`` using the
+    expected filename for the variant."""
+    from eval.external import alce_loader as al
+    cfg = al._VARIANTS[variant]
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / cfg.filename
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False)
+    return path
+
+
+class VariantRegistryTests(unittest.TestCase):
+    def test_variant_registry_complete(self):
+        from eval.external.alce_loader import ALCE_VARIANTS
+        self.assertEqual(set(ALCE_VARIANTS), {"asqa", "qampari", "eli5"})
+
+    def test_constructor_rejects_unknown_variant(self):
+        from eval.external.alce_loader import ALCELoader
+        with self.assertRaises(ValueError):
+            ALCELoader(variant="bogus")
+
+    def test_default_variant_is_asqa(self):
+        from eval.external.alce_loader import ALCELoader
+        loader = ALCELoader()
+        self.assertEqual(loader.variant, "asqa")
+        self.assertEqual(loader.benchmark_id, "alce-asqa")
+
+    def test_each_variant_has_distinct_filename(self):
+        from eval.external import alce_loader as al
+        files = [cfg.filename for cfg in al._VARIANTS.values()]
+        self.assertEqual(len(files), len(set(files)))
+
+    def test_each_variant_has_a_mapper(self):
+        """Import-time invariant — every _VARIANTS entry has a mapper."""
+        from eval.external import alce_loader as al
+        self.assertEqual(set(al._MAPPERS), set(al._VARIANTS))
+
+
+class CacheBehaviourTests(unittest.TestCase):
+    def test_missing_cache_raises_file_not_found(self):
+        from eval.external.alce_loader import ALCELoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = ALCELoader(variant="asqa", cache_dir=Path(td))
+            with self.assertRaises(FileNotFoundError):
+                loader.iter_queries()
+
+    def test_cache_path_uses_variant_filename(self):
+        from eval.external.alce_loader import ALCELoader
+        with tempfile.TemporaryDirectory() as td:
+            asqa = ALCELoader(variant="asqa", cache_dir=Path(td))
+            qampari = ALCELoader(variant="qampari", cache_dir=Path(td))
+            eli5 = ALCELoader(variant="eli5", cache_dir=Path(td))
+            # Each variant resolves to its own filename in the same
+            # directory.
+            self.assertNotEqual(asqa.cache_path, qampari.cache_path)
+            self.assertNotEqual(asqa.cache_path, eli5.cache_path)
+            self.assertEqual(asqa.cache_path.parent, Path(td))
+
+
+class ASQAMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic_entry_maps_correctly(self):
+        from eval.external.alce_loader import ALCELoader
+        _write_fixture(self.cache, "asqa", [
+            {
+                "sample_id": "asqa-001",
+                "question": "When was OpenAI founded?",
+                "qa_pairs": [
+                    {"question": "Founding year?",
+                     "short_answers": ["2015", "in 2015"]},
+                ],
+                "annotations": [
+                    {"long_answer": "OpenAI was founded in December 2015 …"},
+                ],
+                "docs": [
+                    {"title": "OpenAI", "text": "OpenAI founded 2015."},
+                    {"title": "Sam Altman", "text": "co-founder."},
+                ],
+            },
+        ])
+        loader = ALCELoader(variant="asqa", cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        q = out[0]
+        self.assertEqual(q.id, "alce-asqa-asqa-001")
+        self.assertEqual(q.benchmark, "alce-asqa")
+        self.assertEqual(q.question, "When was OpenAI founded?")
+        self.assertEqual(q.gold_answer, "2015")
+        self.assertEqual(q.context,
+                         ("OpenAI founded 2015.", "co-founder."))
+        self.assertEqual(q.metadata["docs_titles"],
+                         ["OpenAI", "Sam Altman"])
+        self.assertEqual(q.metadata["retriever"], "gtr")
+        self.assertEqual(q.metadata["variant"], "asqa")
+        # qa_pairs / annotations preserved verbatim.
+        self.assertEqual(len(q.metadata["qa_pairs"]), 1)
+        self.assertEqual(len(q.metadata["annotations"]), 1)
+
+    def test_missing_short_answers_yields_empty_gold(self):
+        from eval.external.alce_loader import ALCELoader
+        _write_fixture(self.cache, "asqa", [
+            {"sample_id": "asqa-002", "question": "?",
+             "qa_pairs": [], "annotations": [], "docs": []},
+        ])
+        loader = ALCELoader(variant="asqa", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.gold_answer, "")
+
+
+class QAMPARIMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_list_of_lists_answers_round_trip(self):
+        from eval.external.alce_loader import ALCELoader
+        _write_fixture(self.cache, "qampari", [
+            {
+                "sample_id": "q-001",
+                "question": "Name the founders of OpenAI.",
+                "answers": [
+                    ["Sam Altman", "Altman"],
+                    ["Elon Musk"],
+                    ["Greg Brockman"],
+                ],
+                "docs": [{"title": "OpenAI", "text": "Founders: Altman, Musk, Brockman."}],
+            },
+        ])
+        loader = ALCELoader(variant="qampari", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.benchmark, "alce-qampari")
+        # Primary = first group's first string.
+        self.assertEqual(q.gold_answer, "Sam Altman")
+        # Full list-of-lists preserved for the scorer.
+        self.assertEqual(q.metadata["answers"],
+                         [["Sam Altman", "Altman"], ["Elon Musk"],
+                          ["Greg Brockman"]])
+
+    def test_first_group_as_flat_string_accepted(self):
+        """Some QAMPARI rows store the first answer as a bare string
+        instead of a single-element list — the loader handles both."""
+        from eval.external.alce_loader import ALCELoader
+        _write_fixture(self.cache, "qampari", [
+            {"sample_id": "q-002", "question": "?",
+             "answers": ["Solo answer", ["Other"]],
+             "docs": []},
+        ])
+        loader = ALCELoader(variant="qampari", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.gold_answer, "Solo answer")
+
+
+class ELI5MappingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic_entry_maps_correctly(self):
+        from eval.external.alce_loader import ALCELoader
+        _write_fixture(self.cache, "eli5", [
+            {
+                "sample_id": "eli5-001",
+                "question": "Why is the sky blue?",
+                "answer": "Rayleigh scattering …",
+                "claims": [
+                    "Air molecules scatter blue light more than red.",
+                    "Shorter wavelengths scatter more.",
+                ],
+                "docs": [
+                    {"title": "Rayleigh scattering",
+                     "text": "Rayleigh scattering causes blue sky."},
+                ],
+            },
+        ])
+        loader = ALCELoader(variant="eli5", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.benchmark, "alce-eli5")
+        self.assertEqual(q.gold_answer, "Rayleigh scattering …")
+        # claims preserved for the NLI-based citation scorer.
+        self.assertEqual(len(q.metadata["claims"]), 2)
+        self.assertEqual(q.metadata["retriever"], "bm25")
+
+
+class DocsFallbackTests(unittest.TestCase):
+    """The ``docs`` field may carry ``text`` (passage body) or
+    ``sent`` (QA-extracted sentence). The loader prefers ``text``
+    but falls back to ``sent``."""
+
+    def test_text_field_preferred_over_sent(self):
+        from eval.external.alce_loader import ALCELoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_fixture(cache, "asqa", [
+                {"sample_id": "x", "question": "?",
+                 "qa_pairs": [{"short_answers": ["a"]}],
+                 "annotations": [],
+                 "docs": [{"title": "T",
+                           "text": "body wins",
+                           "sent": "snippet loses"}]},
+            ])
+            loader = ALCELoader(variant="asqa", cache_dir=cache)
+            q = loader.iter_queries()[0]
+            self.assertEqual(q.context, ("body wins",))
+
+    def test_sent_used_when_text_absent(self):
+        from eval.external.alce_loader import ALCELoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_fixture(cache, "asqa", [
+                {"sample_id": "y", "question": "?",
+                 "qa_pairs": [{"short_answers": ["a"]}],
+                 "annotations": [],
+                 "docs": [{"title": "T", "sent": "snippet OK"}]},
+            ])
+            loader = ALCELoader(variant="asqa", cache_dir=cache)
+            q = loader.iter_queries()[0]
+            self.assertEqual(q.context, ("snippet OK",))
+
+
+class TakeSampleAndCorruptTests(unittest.TestCase):
+    def test_n_samples_front_slice_across_variants(self):
+        from eval.external.alce_loader import ALCELoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_fixture(cache, "qampari", [
+                {"sample_id": f"q{i}", "question": "?",
+                 "answers": [["x"]], "docs": []}
+                for i in range(10)
+            ])
+            loader = ALCELoader(variant="qampari", cache_dir=cache)
+            out = loader.iter_queries(n_samples=3)
+            self.assertEqual([q.id for q in out],
+                             ["alce-qampari-q0", "alce-qampari-q1",
+                              "alce-qampari-q2"])
+
+    def test_non_list_root_raises_value_error(self):
+        from eval.external.alce_loader import ALCELoader
+        from eval.external import alce_loader as al
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            path = cache / al._VARIANTS["asqa"].filename
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"not": "data wrapper"}, f)
+            loader = ALCELoader(variant="asqa", cache_dir=cache)
+            with self.assertRaises(ValueError):
+                loader.iter_queries()
+
+    def test_top_level_data_key_unwrapped(self):
+        """Some ALCE variants wrap rows under {'data': [...]}; the
+        loader unwraps so callers see a flat list."""
+        from eval.external.alce_loader import ALCELoader
+        from eval.external import alce_loader as al
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            path = cache / al._VARIANTS["asqa"].filename
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"data": [
+                    {"sample_id": "w1", "question": "?",
+                     "qa_pairs": [{"short_answers": ["yes"]}],
+                     "annotations": [], "docs": []},
+                ]}, f)
+            loader = ALCELoader(variant="asqa", cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0].id, "alce-asqa-w1")
+
+    def test_non_dict_rows_silently_skipped(self):
+        from eval.external.alce_loader import ALCELoader
+        from eval.external import alce_loader as al
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            path = cache / al._VARIANTS["eli5"].filename
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump([
+                    {"sample_id": "ok", "question": "?",
+                     "answer": "a", "claims": [], "docs": []},
+                    "garbage row",
+                    {"sample_id": "ok2", "question": "??",
+                     "answer": "b", "claims": [], "docs": []},
+                ], f)
+            loader = ALCELoader(variant="eli5", cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual(len(out), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.2 — second per-bench loader. Pulls the three ALCE sub-benchmark fixtures (ASQA / QAMPARI / ELI5) and yields \`ExternalQuery\` records in the unified cycle γ schema.

ALCE (Gao et al. 2023, \`arXiv:2305.14627\`) is the **citation-evidence** path: precision/recall of citations against retrieved passages. The A.4 scorer (NLI-based) implements official scoring; this loader only lifts published rows into the unified shape.

## Files

- \`eval/external/alce_loader.py\` (NEW) — 3 variants × per-variant mapper. \`_AlceVariantConfig\` mirrors ALCE's \`eval.py\` default flags. Top-level \`{"data": [...]}\` wrapper accepted.
- \`tests/test_cycle_gamma_alce_loader.py\` (NEW, 18 tests, all pass)

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_alce_loader\` | 18 | **18/18 PASS** |

## Schema mappings per variant

- **ASQA**: gold = first qa_pair's first short_answers entry; qa_pairs + annotations preserved under metadata
- **QAMPARI**: gold = first answer-group's first string (or bare string if flat); full list-of-lists preserved
- **ELI5**: gold = entry["answer"] (reference long answer); claims preserved under metadata for NLI-based citation scorer

## Cycle γ progress

| Phase | Status |
|---|---|
| A.0 abstract base + schema | ✅ #724 |
| A.1 RGB loader | ✅ #725 |
| **A.2 ALCE loader (this PR)** | **✅** |
| A.3 MuSiQue + 2WikiMultiHopQA loaders | ⏳ next |
| A.4 4 scorers | ⏳ |
| A.5 unified runner | ⏳ |

## Next step

A.3 — MuSiQue (Trivedi et al. 2022) + 2WikiMultiHopQA (Ho et al. 2020) loaders. Multi-hop EM/F1 + support-fact accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)