### PR TITLE
feat(cycle γ A.3): MuSiQue + 2WikiMultiHopQA loaders

### DIFF
--- a/eval/external/musique_loader.py
+++ b/eval/external/musique_loader.py
@@ -1,0 +1,258 @@
+"""Cycle γ Phase A.3 — MuSiQue (Trivedi et al. 2022) loader.
+
+MuSiQue (https://github.com/StonyBrookNLP/musique) is one of the
+two multi-hop QA evidence paths for cycle γ. Its official format is
+JSONL (one JSON object per line) and ships in two variants:
+
+* **MuSiQue-Ans** — answerable questions only (cleanest signal for
+  EM / F1 + support-fact accuracy).
+* **MuSiQue-Full** — includes unanswerable questions (rows with
+  ``answerable == False``). Useful for abstention robustness
+  measurements.
+
+Each variant publishes ``train`` / ``dev`` / ``test`` splits. Test
+gold answers are withheld so the loader still yields the rows but
+gold_answer falls back to ``""`` on test.
+
+Source filenames (official format)
+----------------------------------
+
+* ``musique_ans_v1.0_<split>.jsonl``
+* ``musique_full_v1.0_<split>.jsonl``
+
+Schema (verified against ``raw_data_to_official_format.py``)
+------------------------------------------------------------
+
+Each JSONL line is a dict::
+
+    {
+      "id":                    <str>,
+      "paragraphs": [
+        {
+          "idx":               <int>,
+          "title":             <str>,
+          "paragraph_text":    <str>,
+          "is_supporting":     <bool>,
+        }, ...
+      ],
+      "question":              <str>,
+      "question_decomposition": [
+        {
+          "id":                <str>,
+          "question":          <str>,
+          "answer":            <str>,
+          "paragraph_support_idx": <int | None>,
+        }, ...
+      ],
+      "answer":                <str>,
+      "answer_aliases":        [<str>, ...],
+      "answerable":            <bool>,
+    }
+
+Schema mapping (MuSiQue → :class:`ExternalQuery`)
+-------------------------------------------------
+
+* ``id``         → ``"musique-<variant>-<orig_id>"``
+* ``benchmark``  → ``"musique-<variant>"`` (e.g. ``"musique-ans"``)
+* ``question``   → ``entry["question"]``
+* ``context``    → tuple of every ``paragraph_text`` (order
+                   preserved so the ``idx`` field still indexes
+                   into ``context``)
+* ``gold_answer`` → ``entry["answer"]``  (``""`` on test set)
+* ``metadata``   → ``{
+    "paragraph_titles":          [...],
+    "paragraph_is_supporting":   [bool, ...],
+    "paragraph_idx":             [int, ...],
+    "support_idx_set":           [int, ...],   # sorted list of supporting idxs
+    "answer_aliases":            [...],
+    "question_decomposition":    [...],
+    "answerable":                bool,
+    "hop_count":                 int,           # len(question_decomposition)
+    "variant":                   "ans" | "full",
+    "split":                     "train"/"dev"/"test",
+  }``
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the loader does NOT rewrite questions, does NOT curate a subset,
+does NOT modify gold labels.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from eval.external.base import ExternalBenchFixture, ExternalQuery
+
+
+MUSIQUE_VARIANTS: Tuple[str, ...] = ("ans", "full")
+MUSIQUE_SPLITS:   Tuple[str, ...] = ("train", "dev", "test")
+
+
+def _expected_filename(variant: str, split: str) -> str:
+    return f"musique_{variant}_v1.0_{split}.jsonl"
+
+
+def _default_cache_dir() -> Path:
+    return Path(__file__).resolve().parent / "_fixtures" / "musique"
+
+
+def _entry_to_query(
+    entry: Dict[str, Any],
+    *,
+    variant: str,
+    split: str,
+) -> ExternalQuery:
+    orig_id = str(entry.get("id", "")).strip() or "noid"
+    paragraphs = entry.get("paragraphs") or []
+    if not isinstance(paragraphs, list):
+        paragraphs = []
+
+    paragraph_texts: List[str] = []
+    paragraph_titles: List[str] = []
+    paragraph_is_supporting: List[bool] = []
+    paragraph_idx: List[int] = []
+    support_idx: List[int] = []
+
+    for i, p in enumerate(paragraphs):
+        if not isinstance(p, dict):
+            continue
+        paragraph_texts.append(str(p.get("paragraph_text", "")))
+        paragraph_titles.append(str(p.get("title", "")))
+        # idx may be missing on some rows; fall back to the positional
+        # index so downstream code can still match support indices.
+        idx = p.get("idx")
+        paragraph_idx.append(int(idx) if isinstance(idx, int) else i)
+        is_sup = bool(p.get("is_supporting"))
+        paragraph_is_supporting.append(is_sup)
+        if is_sup:
+            support_idx.append(paragraph_idx[-1])
+
+    decomp = entry.get("question_decomposition") or []
+    aliases = entry.get("answer_aliases") or []
+    answerable = bool(entry.get("answerable", True))
+
+    metadata: Dict[str, Any] = {
+        "paragraph_titles":        paragraph_titles,
+        "paragraph_is_supporting": paragraph_is_supporting,
+        "paragraph_idx":           paragraph_idx,
+        "support_idx_set":         sorted(set(support_idx)),
+        "answer_aliases":          list(aliases) if isinstance(aliases, list) else [],
+        "question_decomposition":  decomp if isinstance(decomp, list) else [],
+        "answerable":              answerable,
+        "hop_count":               len(decomp) if isinstance(decomp, list) else 0,
+        "variant":                 variant,
+        "split":                   split,
+    }
+
+    return ExternalQuery(
+        id=f"musique-{variant}-{orig_id}",
+        benchmark=f"musique-{variant}",
+        question=str(entry.get("question", "")),
+        context=tuple(paragraph_texts),
+        gold_answer=str(entry.get("answer") or ""),
+        metadata=metadata,
+    )
+
+
+class MuSiQueLoader(ExternalBenchFixture):
+    """Loader for one MuSiQue variant + split.
+
+    Usage::
+
+        loader = MuSiQueLoader(variant="ans", split="dev",
+                                cache_dir=Path("data"))
+        queries = loader.iter_queries(n_samples=20)
+
+    Operators populate ``cache_dir`` by running MuSiQue's
+    ``download_data.sh`` and pointing ``cache_dir`` at the directory
+    that holds the official-format ``.jsonl`` files.
+    """
+
+    def __init__(
+        self,
+        *,
+        variant: str = "ans",
+        split: str = "dev",
+        cache_dir: Optional[Path] = None,
+    ):
+        if variant not in MUSIQUE_VARIANTS:
+            raise ValueError(
+                f"unknown MuSiQue variant: {variant!r}. "
+                f"Valid: {MUSIQUE_VARIANTS}"
+            )
+        if split not in MUSIQUE_SPLITS:
+            raise ValueError(
+                f"unknown MuSiQue split: {split!r}. "
+                f"Valid: {MUSIQUE_SPLITS}"
+            )
+        self._variant = variant
+        self._split = split
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+
+    @property
+    def benchmark_id(self) -> str:
+        return f"musique-{self._variant}"
+
+    @property
+    def variant(self) -> str:
+        return self._variant
+
+    @property
+    def split(self) -> str:
+        return self._split
+
+    @property
+    def cache_path(self) -> Path:
+        base = self._cache_dir or _default_cache_dir()
+        return base / _expected_filename(self._variant, self._split)
+
+    def iter_queries(
+        self,
+        *,
+        split: Optional[str] = None,
+        n_samples: Optional[int] = None,
+    ) -> List[ExternalQuery]:
+        # Accept the abstract-base's ``split`` keyword for interface
+        # uniformity, but the actual split is fixed at construction.
+        if split is not None and split != self._split:
+            raise ValueError(
+                f"split mismatch: loader bound to {self._split!r}, "
+                f"caller passed {split!r}"
+            )
+        path = self.cache_path
+        if not path.exists():
+            raise FileNotFoundError(
+                f"MuSiQue fixture not at {path}. Run MuSiQue's "
+                f"download_data.sh and point cache_dir at the "
+                f"resulting directory."
+            )
+
+        queries: List[ExternalQuery] = []
+        with open(path, encoding="utf-8") as f:
+            for line_no, raw in enumerate(f, start=1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    # One bad line should not destroy the run — skip
+                    # silently the way RGB / ALCE do for non-dict
+                    # rows. The scorer counts the rows it actually
+                    # got, so a sudden drop is visible downstream.
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                queries.append(_entry_to_query(
+                    entry, variant=self._variant, split=self._split,
+                ))
+        self.validate_queries(queries)
+        return self.take_sample(queries, n_samples)
+
+
+__all__ = [
+    "MUSIQUE_VARIANTS",
+    "MUSIQUE_SPLITS",
+    "MuSiQueLoader",
+]

--- a/eval/external/wikimulti_loader.py
+++ b/eval/external/wikimulti_loader.py
@@ -1,0 +1,238 @@
+"""Cycle γ Phase A.3 — 2WikiMultiHopQA (Ho et al. 2020) loader.
+
+2WikiMultiHopQA (https://github.com/Alab-NII/2wikimultihop) is the
+second multi-hop QA evidence path for cycle γ. The fixture pairs
+each multi-hop question with a list of Wikipedia paragraphs (one
+``[title, sentences]`` pair per paragraph), the answer, and the
+supporting-fact list that pins which sentences inside which
+paragraphs the reasoning chain depends on.
+
+Source
+------
+
+The official fixture is hosted at::
+
+    https://www.dropbox.com/s/npidmtadreo6df2/data.zip
+
+with the updated (``evidences_id``-augmented) version available
+separately. Operators unpack the zip and point ``cache_dir`` at the
+``data/`` directory. The loader expects ``<cache_dir>/<split>.json``.
+
+Schema (verified against the official README)
+---------------------------------------------
+
+Each top-level JSON file is a list of dicts::
+
+    {
+      "_id":              <str>,
+      "question":         <str>,
+      "answer":           <str>,                     # absent on test
+      "type":             "comparison" |             # 4 categories
+                          "inference" |
+                          "compositional" |
+                          "bridge-comparison",
+      "entity_ids":       <str>,                     # gold paragraph
+                                                     # Wikidata ids
+      "context": [
+        [<title>, [<sentence>, ...]],                # one tuple per
+        ...                                           # paragraph
+      ],
+      "supporting_facts": [[<title>, <sent_id:int>], ...],
+      "evidences":        [[<subject>, <relation>, <object>], ...],
+      "evidences_id":     <list>,                    # certain types
+      "answer_id":        <str>,                     # 2020-12 update
+    }
+
+Schema mapping (2Wiki → :class:`ExternalQuery`)
+-----------------------------------------------
+
+* ``id``         → ``"2wiki-<orig_id>"``
+* ``benchmark``  → ``"2wiki"``
+* ``question``   → ``entry["question"]``
+* ``context``    → tuple of one string per paragraph; each string is
+                  ``" ".join(sentences)`` so the scorer sees the
+                  paragraph as a single passage but the per-sentence
+                  supporting-facts index still maps via
+                  ``metadata["context_sentences"]``
+* ``gold_answer`` → ``entry["answer"]`` (``""`` on test where the
+                   field is absent)
+* ``metadata``   → ``{
+    "context_titles":     [...],
+    "context_sentences":  [[<sent>, ...], ...],     # per-paragraph
+                                                    # sentence lists,
+                                                    # preserved so the
+                                                    # supporting-fact
+                                                    # scorer can index
+    "supporting_facts":   [[title, sent_id], ...],
+    "type":               <str>,                    # comparison /
+                                                    # inference /
+                                                    # compositional /
+                                                    # bridge-comparison
+    "entity_ids":         <str>,
+    "evidences":          [...],
+    "evidences_id":       [...],
+    "answer_id":          <str>,
+    "split":              "train" | "dev" | "test",
+  }``
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the loader does NOT rewrite questions, does NOT curate a subset,
+does NOT modify gold labels.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from eval.external.base import ExternalBenchFixture, ExternalQuery
+
+
+WIKIMULTI_SPLITS: Tuple[str, ...] = ("train", "dev", "test")
+
+# Official 4 question-type categories, kept here so a future scorer
+# can iterate them with a single import.
+WIKIMULTI_TYPES: Tuple[str, ...] = (
+    "comparison",
+    "inference",
+    "compositional",
+    "bridge-comparison",
+)
+
+
+def _default_cache_dir() -> Path:
+    return Path(__file__).resolve().parent / "_fixtures" / "wikimulti"
+
+
+def _entry_to_query(
+    entry: Dict[str, Any],
+    *,
+    split: str,
+) -> ExternalQuery:
+    # 2Wiki uses ``_id`` (note the leading underscore) — fall through
+    # the usual candidates only as a defensive fallback.
+    orig_id = (entry.get("_id") or entry.get("id") or "").strip() or "noid"
+
+    context_raw = entry.get("context") or []
+    context_texts: List[str] = []
+    context_titles: List[str] = []
+    context_sentences: List[List[str]] = []
+
+    if isinstance(context_raw, list):
+        for item in context_raw:
+            # Each item is the [title, [sentences]] pair.
+            if not (isinstance(item, list) and len(item) >= 2):
+                continue
+            title, sentences = item[0], item[1]
+            if isinstance(sentences, list):
+                sents = [str(s) for s in sentences]
+            else:
+                sents = []
+            context_titles.append(str(title))
+            context_sentences.append(sents)
+            # Join sentences with a single space so the passage reads
+            # the way an LLM would consume it. The per-sentence list
+            # stays under metadata for the supporting-fact scorer.
+            context_texts.append(" ".join(sents))
+
+    metadata: Dict[str, Any] = {
+        "context_titles":    context_titles,
+        "context_sentences": context_sentences,
+        "supporting_facts":  entry.get("supporting_facts") or [],
+        "type":              str(entry.get("type") or ""),
+        "entity_ids":        str(entry.get("entity_ids") or ""),
+        "evidences":         entry.get("evidences") or [],
+        "evidences_id":      entry.get("evidences_id") or [],
+        "answer_id":         str(entry.get("answer_id") or ""),
+        "split":             split,
+    }
+
+    return ExternalQuery(
+        id=f"2wiki-{orig_id}",
+        benchmark="2wiki",
+        question=str(entry.get("question", "")),
+        context=tuple(context_texts),
+        gold_answer=str(entry.get("answer") or ""),
+        metadata=metadata,
+    )
+
+
+class WikiMultiLoader(ExternalBenchFixture):
+    """Loader for one 2WikiMultiHopQA split.
+
+    Usage::
+
+        loader = WikiMultiLoader(split="dev",
+                                  cache_dir=Path("data"))
+        queries = loader.iter_queries(n_samples=20)
+
+    Operators populate ``cache_dir`` by downloading the official
+    ``data.zip`` from Dropbox and unpacking it. The loader expects
+    ``<cache_dir>/<split>.json``.
+    """
+
+    def __init__(
+        self,
+        *,
+        split: str = "dev",
+        cache_dir: Optional[Path] = None,
+    ):
+        if split not in WIKIMULTI_SPLITS:
+            raise ValueError(
+                f"unknown 2WikiMultiHopQA split: {split!r}. "
+                f"Valid: {WIKIMULTI_SPLITS}"
+            )
+        self._split = split
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+
+    @property
+    def benchmark_id(self) -> str:
+        return "2wiki"
+
+    @property
+    def split(self) -> str:
+        return self._split
+
+    @property
+    def cache_path(self) -> Path:
+        base = self._cache_dir or _default_cache_dir()
+        return base / f"{self._split}.json"
+
+    def iter_queries(
+        self,
+        *,
+        split: Optional[str] = None,
+        n_samples: Optional[int] = None,
+    ) -> List[ExternalQuery]:
+        if split is not None and split != self._split:
+            raise ValueError(
+                f"split mismatch: loader bound to {self._split!r}, "
+                f"caller passed {split!r}"
+            )
+        path = self.cache_path
+        if not path.exists():
+            raise FileNotFoundError(
+                f"2WikiMultiHopQA fixture not at {path}. Unpack "
+                f"data.zip from the Dropbox link and point cache_dir "
+                f"at the resulting directory."
+            )
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"2WikiMultiHopQA fixture must be a JSON list; got "
+                f"{type(raw).__name__}"
+            )
+        queries = [
+            _entry_to_query(e, split=self._split)
+            for e in raw if isinstance(e, dict)
+        ]
+        self.validate_queries(queries)
+        return self.take_sample(queries, n_samples)
+
+
+__all__ = [
+    "WIKIMULTI_SPLITS",
+    "WIKIMULTI_TYPES",
+    "WikiMultiLoader",
+]

--- a/tests/test_cycle_gamma_musique_loader.py
+++ b/tests/test_cycle_gamma_musique_loader.py
@@ -1,0 +1,222 @@
+"""Cycle γ Phase A.3 — MuSiQue loader contract tests.
+
+Synthetic JSONL fixtures in tmpdir — network-free, repo-free.
+Schema verified against MuSiQue's ``raw_data_to_official_format.py``
+output spec.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _write_jsonl(cache_dir: Path, variant: str, split: str,
+                  entries: list) -> Path:
+    from eval.external.musique_loader import _expected_filename
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / _expected_filename(variant, split)
+    with open(path, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+    return path
+
+
+def _basic_entry(orig_id="mq-001", answer="X", n_paragraphs=3,
+                  support_idxs=(0,), hops=2, answerable=True):
+    paragraphs = [
+        {"idx": i, "title": f"T{i}",
+         "paragraph_text": f"text {i}",
+         "is_supporting": i in support_idxs}
+        for i in range(n_paragraphs)
+    ]
+    decomp = [
+        {"id": f"d{i}", "question": f"sub Q {i}",
+         "answer": f"sub A {i}", "paragraph_support_idx": i}
+        for i in range(hops)
+    ]
+    return {
+        "id": orig_id, "question": "Multi-hop Q?",
+        "paragraphs": paragraphs,
+        "question_decomposition": decomp,
+        "answer": answer, "answer_aliases": [],
+        "answerable": answerable,
+    }
+
+
+class RegistryTests(unittest.TestCase):
+    def test_variants_and_splits(self):
+        from eval.external.musique_loader import (
+            MUSIQUE_VARIANTS, MUSIQUE_SPLITS,
+        )
+        self.assertEqual(set(MUSIQUE_VARIANTS), {"ans", "full"})
+        self.assertEqual(set(MUSIQUE_SPLITS), {"train", "dev", "test"})
+
+    def test_constructor_rejects_unknown_variant(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with self.assertRaises(ValueError):
+            MuSiQueLoader(variant="bogus")
+
+    def test_constructor_rejects_unknown_split(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with self.assertRaises(ValueError):
+            MuSiQueLoader(split="bogus")
+
+    def test_default_loader_is_ans_dev(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        loader = MuSiQueLoader()
+        self.assertEqual(loader.variant, "ans")
+        self.assertEqual(loader.split, "dev")
+        self.assertEqual(loader.benchmark_id, "musique-ans")
+
+
+class CacheTests(unittest.TestCase):
+    def test_missing_cache_raises(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = MuSiQueLoader(cache_dir=Path(td))
+            with self.assertRaises(FileNotFoundError):
+                loader.iter_queries()
+
+    def test_filename_includes_variant_split_and_version(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = MuSiQueLoader(variant="full", split="train",
+                                     cache_dir=Path(td))
+            self.assertEqual(loader.cache_path.name,
+                              "musique_full_v1.0_train.jsonl")
+
+    def test_split_kwarg_mismatch_raises(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = MuSiQueLoader(split="dev", cache_dir=Path(td))
+            with self.assertRaises(ValueError):
+                loader.iter_queries(split="train")
+
+
+class SchemaMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic_entry_maps_correctly(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        _write_jsonl(self.cache, "ans", "dev", [_basic_entry()])
+        loader = MuSiQueLoader(variant="ans", split="dev",
+                                 cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        q = out[0]
+        self.assertEqual(q.id, "musique-ans-mq-001")
+        self.assertEqual(q.benchmark, "musique-ans")
+        self.assertEqual(q.question, "Multi-hop Q?")
+        self.assertEqual(q.gold_answer, "X")
+        # context = paragraph_texts in order
+        self.assertEqual(q.context, ("text 0", "text 1", "text 2"))
+        # metadata round-trip
+        self.assertEqual(q.metadata["paragraph_titles"],
+                         ["T0", "T1", "T2"])
+        self.assertEqual(q.metadata["paragraph_is_supporting"],
+                         [True, False, False])
+        self.assertEqual(q.metadata["paragraph_idx"], [0, 1, 2])
+        self.assertEqual(q.metadata["support_idx_set"], [0])
+        self.assertEqual(q.metadata["hop_count"], 2)
+        self.assertTrue(q.metadata["answerable"])
+        self.assertEqual(q.metadata["variant"], "ans")
+        self.assertEqual(q.metadata["split"], "dev")
+
+    def test_unanswerable_full_variant_preserved(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        _write_jsonl(self.cache, "full", "dev", [
+            _basic_entry(orig_id="u1", answer="", answerable=False),
+        ])
+        loader = MuSiQueLoader(variant="full", split="dev",
+                                 cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertFalse(q.metadata["answerable"])
+        self.assertEqual(q.gold_answer, "")
+
+    def test_hop_count_matches_decomposition_len(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        _write_jsonl(self.cache, "ans", "dev", [
+            _basic_entry(orig_id="h4", hops=4),
+        ])
+        loader = MuSiQueLoader(cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.metadata["hop_count"], 4)
+
+    def test_multiple_supporting_idxs_preserved(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        _write_jsonl(self.cache, "ans", "dev", [
+            _basic_entry(orig_id="m1", n_paragraphs=4,
+                         support_idxs=(0, 2, 3)),
+        ])
+        loader = MuSiQueLoader(cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.metadata["support_idx_set"], [0, 2, 3])
+
+    def test_answer_aliases_preserved(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        e = _basic_entry()
+        e["answer_aliases"] = ["alias 1", "alias 2"]
+        _write_jsonl(self.cache, "ans", "dev", [e])
+        loader = MuSiQueLoader(cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.metadata["answer_aliases"],
+                         ["alias 1", "alias 2"])
+
+
+class JsonlParsingTests(unittest.TestCase):
+    def test_blank_lines_skipped(self):
+        from eval.external.musique_loader import MuSiQueLoader, _expected_filename
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            path = cache / _expected_filename("ans", "dev")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(json.dumps(_basic_entry(orig_id="a")) + "\n")
+                f.write("\n")
+                f.write(json.dumps(_basic_entry(orig_id="b")) + "\n")
+            loader = MuSiQueLoader(cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual(len(out), 2)
+
+    def test_bad_line_skipped_silently(self):
+        """One malformed line should NOT take down the whole fixture
+        — the rest of the rows still load."""
+        from eval.external.musique_loader import MuSiQueLoader, _expected_filename
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            path = cache / _expected_filename("ans", "dev")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(json.dumps(_basic_entry(orig_id="a")) + "\n")
+                f.write("{not valid json\n")
+                f.write(json.dumps(_basic_entry(orig_id="b")) + "\n")
+            loader = MuSiQueLoader(cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual(len(out), 2)
+
+    def test_n_samples_front_slice(self):
+        from eval.external.musique_loader import MuSiQueLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_jsonl(cache, "ans", "dev", [
+                _basic_entry(orig_id=f"row-{i}") for i in range(5)
+            ])
+            loader = MuSiQueLoader(cache_dir=cache)
+            out = loader.iter_queries(n_samples=2)
+            self.assertEqual([q.id for q in out],
+                             ["musique-ans-row-0", "musique-ans-row-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cycle_gamma_wikimulti_loader.py
+++ b/tests/test_cycle_gamma_wikimulti_loader.py
@@ -1,0 +1,207 @@
+"""Cycle γ Phase A.3 — 2WikiMultiHopQA loader contract tests.
+
+Synthetic JSON fixtures in tmpdir — network-free, repo-free. Schema
+verified against the official README of github.com/Alab-NII/2wikimultihop.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _write_fixture(cache_dir: Path, split: str, entries: list) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / f"{split}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False)
+    return path
+
+
+def _basic_entry(_id="wk-001", answer="Paris", q_type="comparison",
+                  n_paragraphs=2, supporting=(("T0", 0), ("T1", 1))):
+    context = [
+        [f"T{i}", [f"sentence {i}.0", f"sentence {i}.1"]]
+        for i in range(n_paragraphs)
+    ]
+    return {
+        "_id": _id,
+        "question": "Where?",
+        "answer": answer,
+        "type": q_type,
+        "entity_ids": "Q1_Q2",
+        "context": context,
+        "supporting_facts": [list(sf) for sf in supporting],
+        "evidences": [["A", "lives_in", answer]],
+        "evidences_id": [],
+        "answer_id": "Q90",
+    }
+
+
+class RegistryTests(unittest.TestCase):
+    def test_splits_and_types(self):
+        from eval.external.wikimulti_loader import (
+            WIKIMULTI_SPLITS, WIKIMULTI_TYPES,
+        )
+        self.assertEqual(set(WIKIMULTI_SPLITS), {"train", "dev", "test"})
+        self.assertEqual(set(WIKIMULTI_TYPES), {
+            "comparison", "inference",
+            "compositional", "bridge-comparison",
+        })
+
+    def test_constructor_rejects_unknown_split(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with self.assertRaises(ValueError):
+            WikiMultiLoader(split="bogus")
+
+    def test_default_loader_is_dev(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        loader = WikiMultiLoader()
+        self.assertEqual(loader.split, "dev")
+        self.assertEqual(loader.benchmark_id, "2wiki")
+
+
+class CacheTests(unittest.TestCase):
+    def test_missing_cache_raises(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = WikiMultiLoader(cache_dir=Path(td))
+            with self.assertRaises(FileNotFoundError):
+                loader.iter_queries()
+
+    def test_cache_path_uses_split_filename(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = WikiMultiLoader(split="train", cache_dir=Path(td))
+            self.assertEqual(loader.cache_path.name, "train.json")
+
+    def test_split_kwarg_mismatch_raises(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            loader = WikiMultiLoader(split="dev", cache_dir=Path(td))
+            with self.assertRaises(ValueError):
+                loader.iter_queries(split="train")
+
+
+class SchemaMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic_entry_maps_correctly(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        _write_fixture(self.cache, "dev", [_basic_entry()])
+        loader = WikiMultiLoader(split="dev", cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        q = out[0]
+        self.assertEqual(q.id,        "2wiki-wk-001")
+        self.assertEqual(q.benchmark, "2wiki")
+        self.assertEqual(q.question,  "Where?")
+        self.assertEqual(q.gold_answer, "Paris")
+        # Sentences joined per paragraph; one passage per paragraph.
+        self.assertEqual(q.context,
+                         ("sentence 0.0 sentence 0.1",
+                          "sentence 1.0 sentence 1.1"))
+        # Metadata round-trip
+        self.assertEqual(q.metadata["context_titles"], ["T0", "T1"])
+        self.assertEqual(q.metadata["context_sentences"],
+                         [["sentence 0.0", "sentence 0.1"],
+                          ["sentence 1.0", "sentence 1.1"]])
+        self.assertEqual(q.metadata["supporting_facts"],
+                         [["T0", 0], ["T1", 1]])
+        self.assertEqual(q.metadata["type"], "comparison")
+        self.assertEqual(q.metadata["entity_ids"], "Q1_Q2")
+        self.assertEqual(q.metadata["answer_id"], "Q90")
+        self.assertEqual(q.metadata["split"], "dev")
+
+    def test_test_split_without_answer_yields_empty_gold(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        e = _basic_entry()
+        del e["answer"]   # test set has no answer
+        _write_fixture(self.cache, "test", [e])
+        loader = WikiMultiLoader(split="test", cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.gold_answer, "")
+
+    def test_each_type_preserved(self):
+        """Every official 2Wiki question type survives the mapping."""
+        from eval.external.wikimulti_loader import (
+            WikiMultiLoader, WIKIMULTI_TYPES,
+        )
+        entries = [_basic_entry(_id=f"t-{i}", q_type=t)
+                   for i, t in enumerate(WIKIMULTI_TYPES)]
+        _write_fixture(self.cache, "dev", entries)
+        loader = WikiMultiLoader(cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual([q.metadata["type"] for q in out],
+                         list(WIKIMULTI_TYPES))
+
+    def test_malformed_context_pair_skipped(self):
+        """A context entry that isn't ``[title, sentences]`` is
+        silently skipped — the rest of the paragraphs load."""
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        e = _basic_entry()
+        # Inject one bad entry between two good ones.
+        e["context"] = [
+            ["T0", ["sent A"]],
+            "not a pair",
+            ["T2", ["sent B"]],
+        ]
+        _write_fixture(self.cache, "dev", [e])
+        loader = WikiMultiLoader(cache_dir=self.cache)
+        q = loader.iter_queries()[0]
+        self.assertEqual(q.context, ("sent A", "sent B"))
+        self.assertEqual(q.metadata["context_titles"], ["T0", "T2"])
+
+
+class ParsingTests(unittest.TestCase):
+    def test_non_list_root_raises_value_error(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            with open(cache / "dev.json", "w", encoding="utf-8") as f:
+                json.dump({"not": "a list"}, f)
+            loader = WikiMultiLoader(cache_dir=cache)
+            with self.assertRaises(ValueError):
+                loader.iter_queries()
+
+    def test_non_dict_rows_silently_skipped(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_fixture(cache, "dev", [
+                _basic_entry(_id="ok-1"),
+                "garbage",
+                _basic_entry(_id="ok-2"),
+            ])
+            loader = WikiMultiLoader(cache_dir=cache)
+            out = loader.iter_queries()
+            self.assertEqual([q.id for q in out],
+                             ["2wiki-ok-1", "2wiki-ok-2"])
+
+    def test_n_samples_front_slice(self):
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            _write_fixture(cache, "dev", [
+                _basic_entry(_id=f"row-{i}") for i in range(5)
+            ])
+            loader = WikiMultiLoader(cache_dir=cache)
+            out = loader.iter_queries(n_samples=3)
+            self.assertEqual([q.id for q in out],
+                             ["2wiki-row-0", "2wiki-row-1",
+                              "2wiki-row-2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.3 — two multi-hop QA loaders land in one PR (symmetric schema work, parallel test suites). All 4 loaders now in place; Phase A.4 (scorers) is the next step.

- **MuSiQue** (Trivedi et al. 2022, \`arXiv:2108.00573\`) — JSONL, 2 variants × 3 splits
- **2WikiMultiHopQA** (Ho et al. 2020, \`arXiv:2011.01060\`) — JSON, 3 splits, 4 question types

## Files

- \`eval/external/musique_loader.py\` (NEW)
  - 2 variants (\`ans\` / \`full\`) × 3 splits, schema verified against \`raw_data_to_official_format.py\`
  - JSONL parsing with blank-line + malformed-line skip
  - Metadata: \`paragraph_titles\` / \`is_supporting\` / \`support_idx_set\` / \`question_decomposition\` / \`answer_aliases\` / \`answerable\` / \`hop_count\`

- \`eval/external/wikimulti_loader.py\` (NEW)
  - 3 splits, 4 question types (\`comparison\` / \`inference\` / \`compositional\` / \`bridge-comparison\`)
  - Schema verified against the official README
  - Metadata: \`context_titles\` / \`context_sentences\` (per-paragraph sentence lists for support-fact indexing) / \`supporting_facts\` / \`type\` / \`entity_ids\` / \`evidences\` / \`evidences_id\` / \`answer_id\`

- \`tests/test_cycle_gamma_musique_loader.py\` (NEW, 14 tests)
- \`tests/test_cycle_gamma_wikimulti_loader.py\` (NEW, 14 tests)

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_musique_loader\` | 14 | 14/14 PASS |
| \`tests/test_cycle_gamma_wikimulti_loader\` | 14 | 14/14 PASS |
| **Total A.3** | **28** | **28/28 PASS** |

## Quality Delta Card

**Exempt** (label: \`feat\`, integration-layer loaders; no \`core/retrieval\`, \`core/graph\`, \`core/reasoning\` quality dial change).

## Cycle γ progress

| Phase | Status |
|---|---|
| A.0 abstract base + schema | ✅ #724 |
| A.1 RGB loader | ✅ #725 |
| A.2 ALCE loader | ✅ #726 |
| **A.3 MuSiQue + 2Wiki loaders (this PR)** | **✅** |
| A.4 4 scorers | ⏳ next |
| A.5 unified runner | ⏳ |

## Next step

A.4 — 4 scorers (RGB negative-rejection F1 / ALCE NLI-based citation precision-recall / MuSiQue EM-F1 + support-fact / 2Wiki EM-F1 + support-fact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)