### PR TITLE
feat(cycle γ A.4.0): ExternalScorer abstract base + ScoreAxis dataclass

### DIFF
--- a/eval/external/__init__.py
+++ b/eval/external/__init__.py
@@ -34,9 +34,15 @@ from eval.external.base import (
     ExternalBenchFixture,
     ExternalQuery,
 )
+from eval.external.scorer_base import (
+    ExternalScorer,
+    ScoreAxis,
+)
 
 
 __all__ = [
     "ExternalBenchFixture",
     "ExternalQuery",
+    "ExternalScorer",
+    "ScoreAxis",
 ]

--- a/eval/external/scorer_base.py
+++ b/eval/external/scorer_base.py
@@ -1,0 +1,185 @@
+"""Cycle γ Phase A.4.0 — abstract ``ExternalScorer`` + unified
+``ScoreAxis`` dataclass.
+
+Every per-benchmark scorer (RGB / ALCE / MuSiQue / 2Wiki) inherits
+:class:`ExternalScorer` and emits one or more :class:`ScoreAxis`
+records. The unified runner (Phase A.5) collects these axes into a
+single cross-bench table without per-bench branching.
+
+Design philosophy
+-----------------
+
+* **One scorer per benchmark**: each scorer implements that
+  benchmark's *official* scoring formula (or a documented faithful
+  approximation). The scorer reads :class:`eval.external.base.
+  ExternalQuery` records side-by-side with the model's bench-output
+  rows and emits aggregate scores.
+
+* **Pluggable verifier backends**: the ALCE scorer (A.4.4) needs an
+  NLI model to verify citation entailment. The base does NOT pick
+  one — it exposes the *interface* and lets each scorer accept a
+  callable. The default is a documented string-matching fallback
+  (with a clearly-flagged ``score_axis.notes`` warning); operators
+  who care about ALCE-grade precision pass a HuggingFace NLI
+  callable. This keeps the runtime dependency optional.
+
+* **Honest framing**: every axis carries a ``notes`` field. When a
+  scorer falls back to an approximation (e.g. ALCE without NLI), the
+  notes record that and the cycle γ report must surface it. The
+  self-eval trap rule (memory ``feedback_self_evaluation_trap``)
+  applies: a JAMES-internal approximation of an external metric is
+  worth less than the metric itself, and we must say so.
+
+API surface
+-----------
+
+  * :class:`ScoreAxis` — frozen dataclass with name / score /
+    n_queries / per_query / notes.
+  * :class:`ExternalScorer` — abstract base. Subclasses override
+    ``benchmark_id`` and ``score``.
+"""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+
+# ─── ScoreAxis (frozen) ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ScoreAxis:
+    """One scored axis for one benchmark.
+
+    Attributes:
+        name: Stable short identifier (e.g. ``"em"``, ``"f1"``,
+            ``"citation_precision"``, ``"negative_rejection_f1"``).
+            Used as a column key in the cross-bench table.
+        score: Aggregate score over all queries. Range and meaning
+            are axis-specific (F1 ∈ [0, 1]; EM ∈ {0, 1} per query
+            averaged ∈ [0, 1]; etc.).
+        n_queries: How many queries contributed to the aggregate.
+            Zero is a legitimate value (no applicable rows in the
+            input) and indicates "axis not measured here" rather
+            than "score is zero".
+        per_query: Optional per-query breakdown. Loaders that need
+            sub-aggregates (e.g. MuSiQue F1 by hop count) recompute
+            from this field; the runner persists it to the bench
+            JSON so downstream analysis is possible.
+        notes: Free-text honest-framing field. Approximation
+            warnings, missing-backend disclaimers, fixture caveats.
+            Empty string means "scored per the official formula
+            with no caveats".
+    """
+    name:       str
+    score:      float
+    n_queries:  int
+    per_query:  Dict[str, float] = field(default_factory=dict)
+    notes:      str = ""
+
+
+# ─── Abstract scorer base ──────────────────────────────────────────
+
+
+class ExternalScorer(abc.ABC):
+    """Abstract base every Phase-A.4.1+ scorer inherits from.
+
+    A scorer subclass is responsible for:
+
+    1. Declaring its :attr:`benchmark_id` so the runner can route
+       bench rows to the right scorer.
+    2. Implementing :meth:`score` against an iterable of
+       :class:`eval.external.base.ExternalQuery` records (fixture)
+       and a list of bench rows (model output rows in the JAMES bench
+       JSON shape).
+
+    The base does NOT prescribe answer-normalisation, NLI back-ends,
+    or aggregation strategies — those are per-benchmark concerns.
+    The base only pins the minimum interface every scorer must
+    satisfy so the runner stays benchmark-agnostic.
+    """
+
+    # ── Subclass contract ──────────────────────────────────────────
+
+    @property
+    @abc.abstractmethod
+    def benchmark_id(self) -> str:
+        """Short benchmark id (e.g. ``"rgb-en"``, ``"alce-asqa"``,
+        ``"musique-ans"``, ``"2wiki"``). Must match the
+        ``benchmark`` field on the :class:`ExternalQuery` records
+        the scorer consumes (runtime check at :meth:`score` enforces
+        it)."""
+
+    @abc.abstractmethod
+    def score(
+        self,
+        queries: Iterable["Any"],
+        bench_rows: List[Dict[str, Any]],
+    ) -> List[ScoreAxis]:
+        """Compute every axis the benchmark publishes.
+
+        Args:
+            queries: Iterable of :class:`eval.external.base.
+                ExternalQuery`. Iterated once.
+            bench_rows: List of model-output rows in the JAMES bench
+                JSON shape — typically ``[{"id": ..., "answer": ...,
+                ...}]``. The runner pairs each query with the row
+                whose ``id`` matches ``query.id``.
+
+        Returns:
+            A list of :class:`ScoreAxis`. Empty list is legitimate
+            (no rows / no applicable axes for this input).
+        """
+
+    # ── Shared helpers ─────────────────────────────────────────────
+
+    def index_rows_by_id(
+        self,
+        bench_rows: List[Dict[str, Any]],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return ``{row_id: row}`` for fast pairing with queries.
+
+        Rows without an ``id`` field are skipped silently — the
+        scorer's per-query loop simply will not find a match for
+        the corresponding query, which surfaces as a non-aggregate
+        count drop.
+        """
+        out: Dict[str, Dict[str, Any]] = {}
+        for r in bench_rows:
+            if not isinstance(r, dict):
+                continue
+            rid = r.get("id")
+            if isinstance(rid, str) and rid:
+                out[rid] = r
+        return out
+
+    def validate_queries(
+        self,
+        queries: List["Any"],
+    ) -> None:
+        """Cross-check that every query has the expected
+        ``benchmark`` field.
+
+        Subclasses call this from :meth:`score` so a misrouted query
+        (e.g. an ALCE row fed to the MuSiQue scorer) surfaces as a
+        clean ValueError instead of producing a meaningless score.
+
+        Raises:
+            ValueError: when any query's ``benchmark`` does not
+                match this scorer's :attr:`benchmark_id`.
+        """
+        bid = self.benchmark_id
+        for q in queries:
+            qb = getattr(q, "benchmark", None)
+            if qb != bid:
+                raise ValueError(
+                    f"query benchmark mismatch: scorer is {bid!r} "
+                    f"but query has benchmark={qb!r}"
+                )
+
+
+__all__ = [
+    "ExternalScorer",
+    "ScoreAxis",
+]

--- a/tests/test_cycle_gamma_scorer_base.py
+++ b/tests/test_cycle_gamma_scorer_base.py
@@ -1,0 +1,165 @@
+"""Cycle γ Phase A.4.0 — scorer base contract tests.
+
+Pins the abstract-base / score-axis invariants every Phase A.4.1+
+scorer will inherit:
+
+  * ``ScoreAxis`` is frozen + carries an honest-framing ``notes``
+    field that defaults to empty.
+  * ``ExternalScorer`` is genuinely abstract — bare class cannot be
+    instantiated, ``benchmark_id`` + ``score`` are required
+    overrides.
+  * ``index_rows_by_id`` skips non-dict rows + rows without a
+    string id without raising.
+  * ``validate_queries`` catches benchmark-id mismatch.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class ScoreAxisSchemaTests(unittest.TestCase):
+    def test_is_frozen(self):
+        from eval.external import ScoreAxis
+        axis = ScoreAxis(name="em", score=0.5, n_queries=10)
+        with self.assertRaises(Exception):
+            axis.name = "mutated"   # type: ignore[misc]
+
+    def test_defaults(self):
+        from eval.external import ScoreAxis
+        axis = ScoreAxis(name="em", score=0.5, n_queries=10)
+        # per_query defaults to an empty dict; notes defaults to empty string.
+        self.assertEqual(axis.per_query, {})
+        self.assertEqual(axis.notes, "")
+
+    def test_per_query_default_not_shared_between_instances(self):
+        """Classic mutable-default trap — every instance must get its
+        own dict, not a class-level shared singleton."""
+        from eval.external import ScoreAxis
+        a = ScoreAxis(name="em", score=0.0, n_queries=0)
+        b = ScoreAxis(name="f1", score=0.0, n_queries=0)
+        self.assertIsNot(a.per_query, b.per_query)
+
+    def test_notes_field_records_honest_framing_warning(self):
+        from eval.external import ScoreAxis
+        axis = ScoreAxis(
+            name="citation_precision", score=0.4, n_queries=100,
+            notes="string-matching fallback (no NLI backend); "
+                  "score is NOT ALCE-grade",
+        )
+        self.assertIn("not alce-grade", axis.notes.lower())
+
+
+class ExternalScorerContractTests(unittest.TestCase):
+    def test_cannot_instantiate_abstract_base(self):
+        from eval.external import ExternalScorer
+        with self.assertRaises(TypeError):
+            ExternalScorer()   # type: ignore[abstract]
+
+    def test_subclass_missing_score_still_abstract(self):
+        from eval.external import ExternalScorer
+
+        class Half(ExternalScorer):
+            @property
+            def benchmark_id(self) -> str:
+                return "x"
+
+        with self.assertRaises(TypeError):
+            Half()   # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiable(self):
+        from eval.external import ExternalScorer, ScoreAxis
+
+        class Tiny(ExternalScorer):
+            @property
+            def benchmark_id(self) -> str:
+                return "tiny"
+
+            def score(self, queries, bench_rows):
+                return [ScoreAxis(name="em", score=1.0, n_queries=1)]
+
+        scorer = Tiny()
+        out = scorer.score([], [])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].name, "em")
+
+
+class IndexRowsByIdTests(unittest.TestCase):
+    def _make(self):
+        from eval.external import ExternalScorer, ScoreAxis
+
+        class T(ExternalScorer):
+            @property
+            def benchmark_id(self) -> str:
+                return "T"
+
+            def score(self, queries, bench_rows):
+                return []
+        return T()
+
+    def test_basic_indexing(self):
+        scorer = self._make()
+        idx = scorer.index_rows_by_id([
+            {"id": "a", "answer": "A"},
+            {"id": "b", "answer": "B"},
+        ])
+        self.assertEqual(set(idx), {"a", "b"})
+        self.assertEqual(idx["a"]["answer"], "A")
+
+    def test_non_dict_rows_skipped(self):
+        scorer = self._make()
+        idx = scorer.index_rows_by_id([
+            {"id": "a", "answer": "A"},
+            "garbage row",
+            42,
+            {"id": "b", "answer": "B"},
+        ])
+        self.assertEqual(set(idx), {"a", "b"})
+
+    def test_rows_without_id_skipped(self):
+        scorer = self._make()
+        idx = scorer.index_rows_by_id([
+            {"id": "a"},
+            {"answer": "no id here"},
+            {"id": "", "answer": "empty id"},
+            {"id": 42, "answer": "int id"},   # non-string id skipped
+            {"id": "b"},
+        ])
+        self.assertEqual(set(idx), {"a", "b"})
+
+
+class ValidateQueriesTests(unittest.TestCase):
+    def _make(self, bid="X"):
+        from eval.external import ExternalScorer
+
+        class T(ExternalScorer):
+            @property
+            def benchmark_id(self) -> str:
+                return bid
+
+            def score(self, queries, bench_rows):
+                return []
+        return T()
+
+    def test_matching_benchmark_passes(self):
+        from eval.external import ExternalQuery
+        scorer = self._make(bid="X")
+        ok = [ExternalQuery(id="X-1", benchmark="X", question="?",
+                             context=(), gold_answer="a")]
+        # Returns None — silent pass.
+        self.assertIsNone(scorer.validate_queries(ok))
+
+    def test_mismatched_benchmark_raises(self):
+        from eval.external import ExternalQuery
+        scorer = self._make(bid="X")
+        bad = [ExternalQuery(id="Y-1", benchmark="Y", question="?",
+                              context=(), gold_answer="a")]
+        with self.assertRaises(ValueError):
+            scorer.validate_queries(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.4.0 — scoring-layer scaffolding. Sets the contract every per-benchmark scorer (RGB / ALCE / MuSiQue / 2Wiki) in A.4.1-A.4.4 will inherit. Dependency-free.

## Files

- \`eval/external/scorer_base.py\` (NEW)
  - \`ScoreAxis\` (frozen) — name / score / n_queries / per_query / **notes** (honest-framing channel for fallback/approximation warnings)
  - \`ExternalScorer\` abstract — \`benchmark_id\` + \`score(queries, bench_rows)\`
  - \`index_rows_by_id\` helper (non-dict / no-id rows silently skipped)
  - \`validate_queries\` helper (benchmark-id mismatch raises)
- \`eval/external/__init__.py\` — re-exports \`ExternalScorer\` + \`ScoreAxis\`
- \`tests/test_cycle_gamma_scorer_base.py\` (NEW, 12 tests)

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_scorer_base\` | 12 | **12/12 PASS** |
| \`tests/test_cycle_gamma_external_base\` (A.0 regression) | 17 | 17/17 PASS |

## Pluggable verifier backend design (deferred to A.4.4)

ALCE official scoring needs an NLI model. The base does NOT pick one — exposes the interface and lets the ALCE scorer accept a callable. Default = documented string-matching fallback with \`ScoreAxis.notes\` warning; production = HuggingFace NLI callable. Keeps the runtime dependency optional.

## Quality Delta Card

**Exempt** (label: \`feat\`, integration-layer scaffolding).

## Cycle γ progress

| Phase | Status |
|---|---|
| A.0 base + schema | ✅ #724 |
| A.1 RGB loader | ✅ #725 |
| A.2 ALCE loader | ✅ #726 |
| A.3 MuSiQue + 2Wiki loaders | ✅ #727 |
| **A.4.0 scorer base (this PR)** | **✅** |
| A.4.1 RGB scorer | ⏳ next |
| A.4.2 MuSiQue scorer | ⏳ |
| A.4.3 2Wiki scorer | ⏳ |
| A.4.4 ALCE scorer (pluggable NLI) | ⏳ |
| A.5 unified runner | ⏳ |

## Next step

A.4.1 — RGB scorer (string-based, JAMES abstention F1 external evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)