### PR TITLE
feat(cycle γ A.4.3): 2WikiMultiHopQA scorer — EM/F1/support_fact_f1/f1_by_type

### DIFF
--- a/eval/external/wikimulti_scorer.py
+++ b/eval/external/wikimulti_scorer.py
@@ -1,0 +1,288 @@
+"""Cycle γ Phase A.4.3 — 2WikiMultiHopQA scorer.
+
+Four axes, faithful to Ho et al. 2020's official evaluation:
+
+* ``em`` / ``f1`` — SQuAD-normalised answer match. Reuses the
+  exact helpers the MuSiQue scorer uses (``_normalize_answer`` /
+  ``_f1`` / ``_max_em`` / ``_max_f1``) so the two multi-hop
+  benchmarks share one normalisation pipeline. The bench's
+  ``answer_aliases`` field is empty on 2Wiki — alias lifting is
+  still wired in case a future release adds it.
+
+* ``support_fact_f1`` — F1 of the predicted vs gold
+  ``[title, sent_id]`` set. 2Wiki's official scorer reports
+  precision / recall / F1 over this set; the cycle γ table needs
+  one summary number so we expose F1 with the per-row breakdown
+  under ``per_query`` (id → sf_f1).
+
+* ``f1_by_type`` — per-question-type token-F1 averages
+  (``comparison`` / ``inference`` / ``compositional`` /
+  ``bridge-comparison``) recorded as ``per_query``. The aggregate
+  ``score`` on this axis is the mean of the per-type means, so a
+  table reader sees both the headline and the breakdown.
+
+The supporting-fact axis is only emitted when at least one bench
+row carries a ``predicted_supporting_facts`` (or alias) list — the
+runner in Phase A.5 will translate JAMES citation outputs into
+``[title, sent_id]`` pairs. Until then the axis surfaces with
+``n_queries=0`` and a "not measured" note rather than silently
+scoring 0.
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the helpers reused from MuSiQue are SQuAD v1.1 verbatim, not
+JAMES-internal inventions. The 4 question types come straight
+from the published fixture.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from eval.external import ScoreAxis
+from eval.external.scorer_base import ExternalScorer
+from eval.external.wikimulti_loader import WIKIMULTI_TYPES
+# Private helpers reused — SQuAD v1.1 normalisation is the same
+# across multi-hop QA benches. Keeping the helpers in one place
+# (musique_scorer) avoids drift; a future refactor may pull them
+# into eval/external/_squad_norm.py.
+from eval.external.musique_scorer import (
+    _f1 as _squad_f1,
+    _max_em,
+    _max_f1,
+    _resolve_model_answer,
+)
+
+
+# ─── Supporting-facts helpers ──────────────────────────────────────
+
+
+def _normalize_sf_pair(item: Any) -> Optional[Tuple[str, int]]:
+    """Coerce a single ``[title, sent_id]`` entry to a hashable
+    ``(str, int)`` tuple.
+
+    The fixture emits lists; the runner may also emit tuples. Both
+    are accepted. Returns ``None`` on malformed input so the caller
+    can silently drop one bad pair without losing the rest.
+    """
+    if isinstance(item, (list, tuple)) and len(item) >= 2:
+        title, sid = item[0], item[1]
+        # Accept string ints from upstream serialisers.
+        if isinstance(sid, str) and sid.strip().lstrip("-").isdigit():
+            sid = int(sid)
+        if isinstance(title, str) and isinstance(sid, int):
+            return (title, sid)
+    return None
+
+
+def _normalize_sf_list(items: Any) -> Set[Tuple[str, int]]:
+    out: Set[Tuple[str, int]] = set()
+    if not isinstance(items, list):
+        return out
+    for it in items:
+        norm = _normalize_sf_pair(it)
+        if norm is not None:
+            out.add(norm)
+    return out
+
+
+def _extract_predicted_supporting_facts(
+    row: Dict[str, Any],
+) -> Optional[Set[Tuple[str, int]]]:
+    """Pull the predicted supporting-facts set out of a bench row.
+
+    Accepted keys (priority):
+
+      * ``predicted_supporting_facts``
+      * ``supporting_facts`` (rare — model side rather than gold side)
+      * ``predicted_support``
+
+    Returns ``None`` when no key is present, signalling "not measured"
+    rather than the empty set (which would otherwise score every row
+    as a complete miss).
+    """
+    for key in ("predicted_supporting_facts",
+                "supporting_facts", "predicted_support"):
+        if key in row:
+            return _normalize_sf_list(row[key])
+    return None
+
+
+def _set_f1(predicted: Set, gold: Set) -> float:
+    """Set-level F1. Empty / empty → 1.0; one empty → 0.0; otherwise
+    standard harmonic mean of precision and recall."""
+    if not predicted and not gold:
+        return 1.0
+    if not predicted or not gold:
+        return 0.0
+    tp = len(predicted & gold)
+    if tp == 0:
+        return 0.0
+    precision = tp / len(predicted)
+    recall = tp / len(gold)
+    return 2 * precision * recall / (precision + recall)
+
+
+# ─── Scorer ────────────────────────────────────────────────────────
+
+
+class WikiMultiScorer(ExternalScorer):
+    """Single scorer (no variants — 2WikiMultiHopQA is one benchmark
+    with one split-per-loader). Constructor takes no required args
+    so the runner can ``WikiMultiScorer()`` without dispatch."""
+
+    @property
+    def benchmark_id(self) -> str:
+        return "2wiki"
+
+    def score(
+        self,
+        queries: Iterable["Any"],
+        bench_rows: List[Dict[str, Any]],
+    ) -> List[ScoreAxis]:
+        queries = list(queries)
+        self.validate_queries(queries)
+        idx = self.index_rows_by_id(bench_rows)
+
+        em_total = 0
+        f1_total = 0.0
+        n_answer = 0
+
+        # Per-question-type accumulators.
+        type_f1_sum: Dict[str, float] = {t: 0.0 for t in WIKIMULTI_TYPES}
+        type_n:      Dict[str, int]   = {t: 0   for t in WIKIMULTI_TYPES}
+
+        # Support-fact bookkeeping (set-F1 over [title, sent_id] pairs).
+        sf_total = 0.0
+        n_sf_rows = 0
+        sf_per_query: Dict[str, float] = {}
+
+        per_query_f1: Dict[str, float] = {}
+
+        for q in queries:
+            row = idx.get(q.id)
+            if row is None:
+                # Missing bench row → 0 on EM/F1, support skipped.
+                em_total += 0
+                f1_total += 0.0
+                n_answer += 1
+                per_query_f1[q.id] = 0.0
+                q_type = str(q.metadata.get("type") or "")
+                if q_type in type_n:
+                    type_n[q_type] += 1
+                    # type_f1_sum += 0.0 (no-op)
+                continue
+
+            n_answer += 1
+            model_text = _resolve_model_answer(row)
+            aliases = q.metadata.get("answer_aliases") or []
+            gold = q.gold_answer or ""
+
+            em = _max_em(model_text, gold, aliases)
+            f1 = _max_f1(model_text, gold, aliases)
+            em_total += em
+            f1_total += f1
+            per_query_f1[q.id] = round(f1, 4)
+
+            q_type = str(q.metadata.get("type") or "")
+            if q_type in type_n:
+                type_n[q_type] += 1
+                type_f1_sum[q_type] += f1
+
+            # Support-fact axis.
+            predicted_sf = _extract_predicted_supporting_facts(row)
+            if predicted_sf is not None:
+                gold_sf = _normalize_sf_list(
+                    q.metadata.get("supporting_facts") or []
+                )
+                if gold_sf:
+                    n_sf_rows += 1
+                    sf_f1 = _set_f1(predicted_sf, gold_sf)
+                    sf_total += sf_f1
+                    sf_per_query[q.id] = round(sf_f1, 4)
+
+        axes: List[ScoreAxis] = []
+
+        if n_answer > 0:
+            axes.append(ScoreAxis(
+                name="em",
+                score=round(em_total / n_answer, 4),
+                n_queries=n_answer,
+                notes="SQuAD v1.1 normalisation (reused from MuSiQue "
+                      "scorer); max over gold + answer_aliases.",
+            ))
+            axes.append(ScoreAxis(
+                name="f1",
+                score=round(f1_total / n_answer, 4),
+                n_queries=n_answer,
+                per_query=per_query_f1,
+                notes="token-level F1 on SQuAD-normalised tokens; max "
+                      "over gold + answer_aliases.",
+            ))
+        else:
+            axes.append(ScoreAxis(
+                name="em", score=0.0, n_queries=0,
+                notes="no queries in fixture; EM not measured",
+            ))
+            axes.append(ScoreAxis(
+                name="f1", score=0.0, n_queries=0,
+                notes="no queries in fixture; F1 not measured",
+            ))
+
+        # Per-type axis: aggregate score = mean of the per-type
+        # means (so the headline isn't dominated by the largest type),
+        # per_query exposes the per-type means as a dict.
+        type_means: Dict[str, float] = {}
+        contributing_types: List[float] = []
+        for t in WIKIMULTI_TYPES:
+            n = type_n[t]
+            if n > 0:
+                mean = type_f1_sum[t] / n
+                type_means[t] = round(mean, 4)
+                contributing_types.append(mean)
+        if contributing_types:
+            axes.append(ScoreAxis(
+                name="f1_by_type",
+                score=round(
+                    sum(contributing_types) / len(contributing_types),
+                    4,
+                ),
+                n_queries=sum(type_n[t] for t in WIKIMULTI_TYPES
+                                if type_n[t] > 0),
+                per_query=type_means,
+                notes="mean of per-type F1 means (so the headline isn't "
+                      "dominated by the largest type); per_query = "
+                      "{type: mean_f1}.",
+            ))
+        else:
+            axes.append(ScoreAxis(
+                name="f1_by_type", score=0.0, n_queries=0,
+                notes="no queries carried a 'type' metadata field; "
+                      "per-type axis not measured",
+            ))
+
+        if n_sf_rows > 0:
+            axes.append(ScoreAxis(
+                name="support_fact_f1",
+                score=round(sf_total / n_sf_rows, 4),
+                n_queries=n_sf_rows,
+                per_query=sf_per_query,
+                notes="set-F1 over [title, sent_id] pairs; rows whose "
+                      "bench row lacked predicted_supporting_facts are "
+                      "skipped.",
+            ))
+        else:
+            axes.append(ScoreAxis(
+                name="support_fact_f1",
+                score=0.0,
+                n_queries=0,
+                notes="no bench row carried a predicted_supporting_facts "
+                      "list; support-fact axis not measured (the unified "
+                      "runner in A.5 will translate JAMES citations into "
+                      "[title, sent_id] pairs).",
+            ))
+
+        return axes
+
+
+__all__ = [
+    "WikiMultiScorer",
+]

--- a/tests/test_cycle_gamma_wikimulti_scorer.py
+++ b/tests/test_cycle_gamma_wikimulti_scorer.py
@@ -1,0 +1,224 @@
+"""Cycle γ Phase A.4.3 — 2WikiMultiHopQA scorer contract tests."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _query(
+    *,
+    qid: str = "2wiki-1",
+    gold: str = "Paris",
+    aliases=None,
+    q_type: str = "comparison",
+    supporting_facts=None,
+):
+    from eval.external import ExternalQuery
+    return ExternalQuery(
+        id=qid,
+        benchmark="2wiki",
+        question="?",
+        context=(),
+        gold_answer=gold,
+        metadata={
+            "answer_aliases":   aliases or [],
+            "type":             q_type,
+            "supporting_facts": supporting_facts or [],
+            "split":            "dev",
+        },
+    )
+
+
+def _row(qid: str, answer: str, **kwargs):
+    return {"id": qid, "answer": answer, **kwargs}
+
+
+class ConstructorAndValidationTests(unittest.TestCase):
+    def test_benchmark_id_is_2wiki(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        self.assertEqual(WikiMultiScorer().benchmark_id, "2wiki")
+
+    def test_validate_queries_catches_mismatch(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        with self.assertRaises(ValueError):
+            s.score([_query(qid="x")._replace(benchmark="other")
+                     if hasattr(_query(qid="x"), "_replace") else
+                     None] if False else [
+                # ExternalQuery is frozen — build a fresh wrong-benchmark
+                # one directly:
+                __import__("eval.external", fromlist=["ExternalQuery"])
+                .ExternalQuery(id="x", benchmark="other", question="?",
+                                context=(), gold_answer="a")
+            ], [])
+
+
+class EmF1AxesTests(unittest.TestCase):
+    def test_perfect_hit(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="Paris"),
+                    _query(qid="w2", gold="Tokyo")]
+        rows = [_row("w1", "Paris"), _row("w2", "Tokyo")]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        self.assertEqual(axes["em"].score, 1.0)
+        self.assertEqual(axes["f1"].score, 1.0)
+        self.assertEqual(axes["em"].n_queries, 2)
+
+    def test_missing_bench_row_counts_as_miss(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="Paris"),
+                    _query(qid="w2", gold="Tokyo")]
+        rows = [_row("w1", "Paris")]   # w2 missing
+        axes = {a.name: a for a in s.score(queries, rows)}
+        # 1 hit / 2 queries
+        self.assertEqual(axes["em"].score, 0.5)
+
+    def test_alias_lifts_match(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="United States",
+                            aliases=["USA", "U.S."])]
+        rows = [_row("w1", "USA")]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        self.assertEqual(axes["em"].score, 1.0)
+
+    def test_no_queries_axis_not_measured(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        axes = {a.name: a for a in s.score([], [])}
+        self.assertEqual(axes["em"].n_queries, 0)
+        self.assertEqual(axes["em"].score, 0.0)
+        self.assertIn("not measured", axes["em"].notes)
+
+
+class PerTypeStratificationTests(unittest.TestCase):
+    def test_aggregate_is_mean_of_per_type_means(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        # 2 comparison rows (one hit, one miss) + 1 inference (hit)
+        # → comparison mean F1 = 0.5, inference mean F1 = 1.0
+        # → aggregate = mean(0.5, 1.0) = 0.75
+        queries = [
+            _query(qid="c1", gold="Paris", q_type="comparison"),
+            _query(qid="c2", gold="Berlin", q_type="comparison"),
+            _query(qid="i1", gold="Tokyo", q_type="inference"),
+        ]
+        rows = [
+            _row("c1", "Paris"),
+            _row("c2", "London"),
+            _row("i1", "Tokyo"),
+        ]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        ax = axes["f1_by_type"]
+        self.assertAlmostEqual(ax.score, 0.75, places=3)
+        # per_query exposes the per-type means.
+        self.assertEqual(ax.per_query["comparison"], 0.5)
+        self.assertEqual(ax.per_query["inference"], 1.0)
+        # Only types with rows appear in per_query.
+        self.assertNotIn("compositional", ax.per_query)
+        self.assertNotIn("bridge-comparison", ax.per_query)
+
+    def test_no_type_queries_axis_not_measured(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        # All four types empty → per-type axis not measured.
+        queries = [_query(qid="w1", gold="X", q_type="")]
+        rows = [_row("w1", "X")]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        ax = axes["f1_by_type"]
+        self.assertEqual(ax.score, 0.0)
+        self.assertEqual(ax.n_queries, 0)
+
+
+class SupportFactAxisTests(unittest.TestCase):
+    def test_perfect_support_fact_match(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        sf = [["T0", 0], ["T1", 2]]
+        queries = [_query(qid="w1", gold="X", supporting_facts=sf)]
+        rows = [_row("w1", "X", predicted_supporting_facts=sf)]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        self.assertEqual(axes["support_fact_f1"].score, 1.0)
+
+    def test_partial_support_fact_yields_set_f1(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        gold = [["T0", 0], ["T1", 1]]
+        pred = [["T0", 0], ["T2", 5]]   # 1 overlap, 1 extra
+        queries = [_query(qid="w1", gold="X", supporting_facts=gold)]
+        rows = [_row("w1", "X", predicted_supporting_facts=pred)]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        # precision = 1/2, recall = 1/2 → F1 = 0.5
+        self.assertAlmostEqual(axes["support_fact_f1"].score, 0.5,
+                                 places=3)
+
+    def test_string_int_sent_id_accepted(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="X",
+                            supporting_facts=[["T0", 0]])]
+        # Upstream serialiser emits sent_id as a string.
+        rows = [_row("w1", "X",
+                      predicted_supporting_facts=[["T0", "0"]])]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        self.assertEqual(axes["support_fact_f1"].score, 1.0)
+
+    def test_malformed_pair_dropped_silently(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        gold = [["T0", 0], ["T1", 1]]
+        # One good, one malformed (missing sent_id), one good.
+        pred = [["T0", 0], ["T_bad"], ["T1", 1]]
+        queries = [_query(qid="w1", gold="X", supporting_facts=gold)]
+        rows = [_row("w1", "X", predicted_supporting_facts=pred)]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        # Predicted set ends up as {(T0, 0), (T1, 1)} after the
+        # malformed pair is dropped → perfect match against gold.
+        self.assertEqual(axes["support_fact_f1"].score, 1.0)
+
+    def test_axis_not_measured_when_no_predicted_field(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="X",
+                            supporting_facts=[["T0", 0]])]
+        rows = [_row("w1", "X")]   # no predicted_supporting_facts
+        axes = {a.name: a for a in s.score(queries, rows)}
+        ax = axes["support_fact_f1"]
+        self.assertEqual(ax.n_queries, 0)
+        self.assertIn("not measured", ax.notes)
+
+    def test_axis_skipped_when_gold_supporting_facts_empty(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = WikiMultiScorer()
+        queries = [_query(qid="w1", gold="X", supporting_facts=[])]
+        rows = [_row("w1", "X", predicted_supporting_facts=[])]
+        axes = {a.name: a for a in s.score(queries, rows)}
+        # Gold is empty so the row doesn't contribute; n_queries=0.
+        self.assertEqual(axes["support_fact_f1"].n_queries, 0)
+
+
+class HelperTests(unittest.TestCase):
+    def test_set_f1_empty_sets(self):
+        from eval.external.wikimulti_scorer import _set_f1
+        # Both empty = perfect (degenerate case but SQuAD convention).
+        self.assertEqual(_set_f1(set(), set()), 1.0)
+
+    def test_set_f1_one_empty(self):
+        from eval.external.wikimulti_scorer import _set_f1
+        self.assertEqual(_set_f1({("T", 0)}, set()), 0.0)
+        self.assertEqual(_set_f1(set(), {("T", 0)}), 0.0)
+
+    def test_normalize_sf_pair_rejects_malformed(self):
+        from eval.external.wikimulti_scorer import _normalize_sf_pair
+        self.assertIsNone(_normalize_sf_pair(["only-title"]))
+        self.assertIsNone(_normalize_sf_pair([42, 0]))   # title not str
+        self.assertIsNone(_normalize_sf_pair("not a pair"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cycle γ Phase A.4.3 — four axes faithful to Ho et al. 2020's official evaluation. Reuses MuSiQue scorer's SQuAD v1.1 helpers so both multi-hop benchmarks share one normalisation pipeline.

## Axes

- **\`em\` / \`f1\`** — SQuAD-normalised match, maxed over gold + aliases (private import from \`musique_scorer\`)
- **\`support_fact_f1\`** — set-F1 over predicted vs gold \`[title, sent_id]\` pairs (2Wiki's supporting_facts structure)
- **\`f1_by_type\`** — aggregate = mean of per-type means (so the headline isn't dominated by the largest type); \`per_query\` exposes per-type means (comparison / inference / compositional / bridge-comparison)

## Verification

| Suite | Tests | Result |
|---|---|---|
| \`tests/test_cycle_gamma_wikimulti_scorer\` | 17 | **17/17 PASS** |

## Quality Delta Card

**Exempt** (label: \`feat\`, integration-layer scorer).

## Cycle γ Phase A progress

| Phase | Status |
|---|---|
| A.0-A.4.2 | ✅ #724-#730 |
| **A.4.3 2Wiki scorer (this PR)** | **✅** |
| A.4.4 ALCE scorer (pluggable NLI) | ⏳ next |
| A.5 unified runner | ⏳ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)