### PR TITLE
feat(cycle γ A.5): unified external_bench_run runner — final A-phase deliverable

### DIFF
--- a/eval/external/runner.py
+++ b/eval/external/runner.py
@@ -1,0 +1,482 @@
+"""Cycle γ Phase A.5 — unified external-benchmark runner core.
+
+This module is the *engine* the ``scripts/external_bench_run.py``
+CLI dispatches to. Keeping the engine in ``eval/external/`` (pure
+Python, no ``argparse``, no ``sys.exit``) means the same code path
+can be unit-tested without a subprocess shell-out and reused from
+notebook / orchestrator code if a future phase needs to.
+
+Three pluggable parts
+---------------------
+
+1. **Loader dispatch** — :func:`build_loader` maps
+   ``("rgb"|"alce"|"musique"|"2wiki", <variant_or_split>, cache_dir)``
+   to a concrete :class:`ExternalBenchFixture` subclass. Cycle γ
+   already shipped four loaders (A.1 – A.3); this dispatch is the
+   one-stop import surface for the CLI.
+
+2. **Scorer dispatch** — :func:`build_scorer` mirrors the loader
+   side for the four :class:`ExternalScorer` subclasses (A.4.1 –
+   A.4.4). The dispatch makes the runner benchmark-agnostic.
+
+3. **Answer producer** — the runner does NOT prescribe how an
+   answer is produced. Production callers wire one of:
+
+   * :class:`ClosedCorpusGemmaProducer` — passes ``query.context``
+     as evidence to a local Ollama Gemma call (mirrors the Phase
+     B / Layer B paper-aligned baseline pattern from
+     ``scripts/research/multihop_raw_run.py``).
+   * :class:`JamesEngineProducer` — full JAMES stack via
+     :class:`ReasoningEngine`, using JAMES's own retrieval rather
+     than the fixture context. The cycle γ premise (production-mirror
+     evaluation) is *both* are valid measurement modes, so both
+     ship.
+   * A test stub conforming to the :class:`AnswerProducer` Protocol.
+     The unit tests use one so the engine is exercised end-to-end
+     without an LLM dependency.
+
+The :func:`run_external_bench` function plumbs queries from a
+loader, through a producer, into a scorer, and returns one
+JSON-serialisable result dict. The dict shape is the cross-bench
+table the Phase C / D analysis consumes.
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+the runner is *only* plumbing — it does not write fixtures, oracles,
+or scoring logic. Every fact the runner emits is either (a) a row
+straight from a published fixture, (b) a model's free-text answer,
+or (c) a number a published scorer computed. JAMES-internal logic
+is confined to the producer (system under test), never the oracle.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+import traceback
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
+
+from eval.external import (
+    ExternalBenchFixture,
+    ExternalQuery,
+    ExternalScorer,
+    ScoreAxis,
+)
+
+
+# ─── Loader dispatch ───────────────────────────────────────────────
+
+
+# Stable benchmark IDs accepted by ``build_loader`` and the CLI.
+SUPPORTED_BENCHES: Tuple[str, ...] = ("rgb", "alce", "musique", "2wiki")
+
+
+def build_loader(
+    bench: str,
+    *,
+    variant: Optional[str] = None,
+    split: Optional[str] = None,
+    cache_dir: Optional[Path] = None,
+    allow_download: bool = False,
+) -> ExternalBenchFixture:
+    """Construct one of the four cycle γ loaders by name.
+
+    Args:
+        bench: One of ``SUPPORTED_BENCHES``.
+        variant: Required for benches with variants (rgb/alce/musique);
+            ignored for 2wiki.
+        split: Required for benches with splits (musique/2wiki);
+            ignored for rgb/alce (single-split).
+        cache_dir: Optional cache directory; loader-specific.
+        allow_download: Only honoured by the RGB loader (the rest
+            require the fixture to be pre-downloaded).
+
+    Raises:
+        ValueError: unknown bench / missing required variant or split.
+    """
+    bench = bench.strip().lower()
+    if bench == "rgb":
+        from eval.external.rgb_loader import RGBLoader
+        return RGBLoader(
+            variant=variant or "en",
+            cache_dir=cache_dir,
+            allow_download=allow_download,
+        )
+    if bench == "alce":
+        from eval.external.alce_loader import ALCELoader
+        return ALCELoader(
+            variant=variant or "asqa",
+            cache_dir=cache_dir,
+        )
+    if bench == "musique":
+        from eval.external.musique_loader import MuSiQueLoader
+        return MuSiQueLoader(
+            variant=variant or "ans",
+            split=split or "dev",
+            cache_dir=cache_dir,
+        )
+    if bench == "2wiki":
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        return WikiMultiLoader(
+            split=split or "dev",
+            cache_dir=cache_dir,
+        )
+    raise ValueError(
+        f"unknown bench: {bench!r}. Valid: {SUPPORTED_BENCHES}"
+    )
+
+
+# ─── Scorer dispatch ───────────────────────────────────────────────
+
+
+def build_scorer(
+    bench: str,
+    *,
+    variant: Optional[str] = None,
+    verifier: Optional[Any] = None,
+) -> ExternalScorer:
+    """Construct the matching scorer for a benchmark.
+
+    The variant must align with the loader's variant — the runner
+    enforces this implicitly via ``ExternalScorer.validate_queries``
+    on the first :meth:`score` call.
+
+    ``verifier`` is the ALCE-specific NLI verifier callable
+    (:class:`eval.external.alce_scorer.NLIVerifier`); ignored by
+    the other scorers.
+    """
+    bench = bench.strip().lower()
+    if bench == "rgb":
+        from eval.external.rgb_scorer import RGBScorer
+        return RGBScorer(variant=variant or "en")
+    if bench == "alce":
+        from eval.external.alce_scorer import ALCEScorer
+        return ALCEScorer(
+            variant=variant or "asqa",
+            verifier=verifier,
+        )
+    if bench == "musique":
+        from eval.external.musique_scorer import MuSiQueScorer
+        return MuSiQueScorer(variant=variant or "ans")
+    if bench == "2wiki":
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        return WikiMultiScorer()
+    raise ValueError(
+        f"unknown bench: {bench!r}. Valid: {SUPPORTED_BENCHES}"
+    )
+
+
+# ─── AnswerProducer interface ──────────────────────────────────────
+
+
+class AnswerProducer(Protocol):
+    """Every producer maps one :class:`ExternalQuery` to one bench
+    row in the JAMES bench-JSON shape.
+
+    The minimum row keys are ``id`` (mirrors ``query.id``) and
+    ``answer`` (the model's free-text output). Producers MAY emit
+    additional keys the scorer reads — e.g.
+    ``predicted_supporting_facts`` for 2Wiki, ``predicted_support_idx``
+    for MuSiQue. The runner does not interpret these keys; it
+    just hands the row to the scorer verbatim.
+    """
+
+    name: str
+
+    def produce(self, query: ExternalQuery) -> Dict[str, Any]: ...
+
+
+class StubProducer:
+    """Test producer — answers via a caller-supplied callable.
+
+    Used by the cycle γ unit tests so the runner is exercised
+    end-to-end without an LLM. Also useful for ablation runs that
+    replay a fixed answer per query id.
+    """
+
+    name = "stub"
+
+    def __init__(self, answer_fn: Callable[[ExternalQuery], Dict[str, Any]]):
+        if not callable(answer_fn):
+            raise TypeError("answer_fn must be callable")
+        self._fn = answer_fn
+
+    def produce(self, query: ExternalQuery) -> Dict[str, Any]:
+        row = self._fn(query) or {}
+        if not isinstance(row, dict):
+            raise TypeError(
+                f"answer_fn must return a dict; got {type(row).__name__}"
+            )
+        return row
+
+
+class ClosedCorpusGemmaProducer:
+    """Closed-corpus producer — feeds ``query.context`` as evidence to
+    a local Ollama Gemma call.
+
+    Closed-corpus mode is the publishable baseline: every model sees
+    the *same* gold context the benchmark publishes, so cross-model
+    deltas are not confounded by retrieval differences. The cycle γ
+    paper-aligned table uses this mode.
+
+    The producer does NOT import :mod:`core.gemma_client` at module
+    import time — it imports inside :meth:`produce` so the runner
+    module stays importable in environments without Ollama (the
+    unit-test environment, for instance).
+    """
+
+    name = "closed-corpus-gemma"
+
+    def __init__(
+        self,
+        *,
+        model: str = "gemma4:e4b",
+        max_tokens: int = 8192,
+        timeout: int = 180,
+        think: bool = False,
+        use_cache: bool = False,
+        context_separator: str = "\n\n",
+    ):
+        self._model = model
+        self._max_tokens = max_tokens
+        self._timeout = timeout
+        self._think = think
+        self._use_cache = use_cache
+        self._sep = context_separator
+
+    def _prompt(self, query: ExternalQuery) -> str:
+        ctx = self._sep.join(query.context)
+        return (
+            "Answer the question using only the provided context. "
+            "If the context is insufficient, answer "
+            "'Insufficient Information'.\n\n"
+            f"Context:\n{ctx}\n\n"
+            f"Question: {query.question}\n"
+        )
+
+    def produce(self, query: ExternalQuery) -> Dict[str, Any]:
+        from core.gemma_client import GemmaClient   # late import
+        client = GemmaClient()
+        ans = client.call_gemma(
+            self._prompt(query),
+            model=self._model,
+            max_tokens=self._max_tokens,
+            think=self._think,
+            use_cache=self._use_cache,
+            timeout=self._timeout,
+        )
+        return {
+            "id":       query.id,
+            "answer":   ans,
+            "sources":  list(query.context[:1]) if query.context else [],
+            "mode":     "closed-corpus",
+            "model":    self._model,
+        }
+
+
+class JamesEngineProducer:
+    """Full-JAMES producer — routes the question through
+    :class:`core.reasoning.engine.ReasoningEngine`.
+
+    Ignores ``query.context``: JAMES uses its own retrieval against
+    the corpus configured by ``JAMES_WORKSPACE``. Cycle γ Phase B/C
+    operators are responsible for building a JAMES corpus that
+    mirrors the benchmark's source documents — that's a separate
+    operator task; this producer just plumbs the engine call.
+
+    Like the closed-corpus producer, the engine import is deferred to
+    :meth:`produce` so the runner module is importable in the
+    test environment.
+    """
+
+    name = "james-engine"
+
+    def __init__(
+        self,
+        *,
+        model: str = "gemma4:e4b",
+        response_style: str = "",
+        user_role: str = "admin",
+        mode_override: str = "retrieval",
+        session_prefix: str = "external-bench",
+    ):
+        self._model = model
+        self._response_style = response_style
+        self._user_role = user_role
+        self._mode_override = mode_override
+        self._session_prefix = session_prefix
+
+    def produce(self, query: ExternalQuery) -> Dict[str, Any]:
+        from core.reasoning.engine import ReasoningEngine   # late import
+        eng = ReasoningEngine()
+        out = eng.query(
+            query.question,
+            user_role=self._user_role,
+            response_style=self._response_style,
+            selected_model=self._model,
+            mode_override=self._mode_override,
+            session_id=f"{self._session_prefix}-{query.id}",
+        )
+        ans = out.get("answer", "") if isinstance(out, dict) else str(out)
+        srcs = ((out.get("sources") or out.get("docs") or [])
+                if isinstance(out, dict) else [])
+        source_names: List[str] = []
+        if isinstance(srcs, (list, tuple)):
+            for s in srcs:
+                if isinstance(s, dict):
+                    name = (s.get("source") or s.get("title")
+                            or s.get("filename") or s.get("file") or "")
+                elif isinstance(s, str):
+                    name = s
+                else:
+                    name = ""
+                name = (name or "").strip()
+                if name:
+                    source_names.append(name)
+        return {
+            "id":           query.id,
+            "answer":       ans,
+            "sources":      source_names,
+            "sources_count": len(source_names),
+            "mode":         "james-engine",
+            "model":        self._model,
+        }
+
+
+# ─── Core run loop ─────────────────────────────────────────────────
+
+
+def _axis_to_dict(axis: ScoreAxis) -> Dict[str, Any]:
+    """Serialise one ``ScoreAxis`` for JSON output.
+
+    Floats round to 4 decimals — the publishable tables only carry
+    that many significant digits and round-tripping deeper precision
+    encourages over-reading noise.
+    """
+    return {
+        "name":      axis.name,
+        "score":     round(float(axis.score), 4),
+        "n_queries": int(axis.n_queries),
+        "per_query": dict(axis.per_query),
+        "notes":     axis.notes,
+    }
+
+
+def run_external_bench(
+    *,
+    loader: ExternalBenchFixture,
+    scorer: ExternalScorer,
+    producer: AnswerProducer,
+    split: str = "dev",
+    n_samples: Optional[int] = None,
+    progress_every: int = 10,
+    on_progress: Optional[Callable[[int, int, float], None]] = None,
+) -> Dict[str, Any]:
+    """Drive ``loader → producer → scorer`` end-to-end and return one
+    cross-bench result dict.
+
+    The returned shape::
+
+        {
+          "benchmark":  "<scorer.benchmark_id>",
+          "loader":     "<loader.benchmark_id>",
+          "producer":   "<producer.name>",
+          "split":      "<split>",
+          "n_queries":  <int>,
+          "n_rows":     <int>,
+          "n_errors":   <int>,
+          "elapsed_s":  <float>,
+          "started_at": "<ISO-8601 UTC>",
+          "axes":       [<axis-dict>, ...],
+          "rows":       [<bench-row>, ...]
+        }
+
+    The axes list IS the publishable table. The rows list is the
+    raw per-query bench output — Phase D analysis reads it for
+    per-row breakdowns, per-question-type cross-tabs, etc.
+    """
+    # Loader / scorer benchmark id must match — catch a misrouted
+    # CLI call before the LLM-cost run starts.
+    if loader.benchmark_id != scorer.benchmark_id:
+        raise ValueError(
+            f"loader/scorer benchmark id mismatch: "
+            f"loader={loader.benchmark_id!r}, "
+            f"scorer={scorer.benchmark_id!r}"
+        )
+
+    queries = loader.iter_queries(split=split, n_samples=n_samples)
+    rows: List[Dict[str, Any]] = []
+    n_errors = 0
+    t0 = time.time()
+    started = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    for i, q in enumerate(queries, 1):
+        try:
+            row = producer.produce(q)
+            if not isinstance(row, dict):
+                raise TypeError(
+                    f"producer.produce returned {type(row).__name__}, "
+                    f"expected dict"
+                )
+            row.setdefault("id", q.id)
+            row.setdefault("status", "ok")
+        except Exception as exc:                       # one bad query
+            n_errors += 1                              # must not kill
+            row = {                                    # the whole run
+                "id":     q.id,
+                "answer": f"[ERROR] {exc!r}",
+                "status": "error",
+                "error":  "".join(
+                    traceback.format_exception_only(type(exc), exc)
+                ).strip(),
+            }
+        rows.append(row)
+
+        if (on_progress is not None
+                and (i % max(progress_every, 1) == 0 or i == len(queries))):
+            on_progress(i, len(queries), time.time() - t0)
+
+    axes = scorer.score(queries, rows)
+
+    return {
+        "benchmark":  scorer.benchmark_id,
+        "loader":     loader.benchmark_id,
+        "producer":   getattr(producer, "name", type(producer).__name__),
+        "split":      split,
+        "n_queries":  len(queries),
+        "n_rows":     len(rows),
+        "n_errors":   n_errors,
+        "elapsed_s":  round(time.time() - t0, 3),
+        "started_at": started,
+        "axes":       [_axis_to_dict(a) for a in axes],
+        "rows":       rows,
+    }
+
+
+def write_result(result: Dict[str, Any], out_path: Path) -> Path:
+    """Atomic-ish JSON write: write to ``<out>.tmp`` then rename.
+
+    Returns the final path so callers can log it.
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, out_path)
+    return out_path
+
+
+__all__ = [
+    "SUPPORTED_BENCHES",
+    "AnswerProducer",
+    "ClosedCorpusGemmaProducer",
+    "JamesEngineProducer",
+    "StubProducer",
+    "build_loader",
+    "build_scorer",
+    "run_external_bench",
+    "write_result",
+]

--- a/scripts/external_bench_run.py
+++ b/scripts/external_bench_run.py
@@ -1,0 +1,178 @@
+"""Cycle γ Phase A.5 — unified external-benchmark runner (CLI shim).
+
+Thin argparse wrapper around :mod:`eval.external.runner`. All the
+plumbing logic lives in the module (testable, importable); this file
+only translates CLI arguments into runner kwargs and emits the
+result JSON.
+
+Examples
+--------
+
+Phase B smoke (20 queries through closed-corpus Gemma)::
+
+    JAMES_WORKSPACE=./workspaces/cycle_gamma_eval \\
+    python scripts/external_bench_run.py \\
+        --bench rgb --variant en \\
+        --mode closed-corpus --model gemma4:e4b \\
+        --n-samples 20 \\
+        --out reports/cycle_gamma/rgb-en-smoke.json
+
+Full closed-corpus ALCE-ASQA run::
+
+    python scripts/external_bench_run.py \\
+        --bench alce --variant asqa \\
+        --mode closed-corpus --model gemma4:e4b \\
+        --out reports/cycle_gamma/alce-asqa-closed.json
+
+Full JAMES-stack 2WikiMultiHopQA dev run::
+
+    JAMES_WORKSPACE=./workspaces/cycle_gamma_eval \\
+    python scripts/external_bench_run.py \\
+        --bench 2wiki --split dev \\
+        --mode james --model gemma4:e4b \\
+        --out reports/cycle_gamma/2wiki-james.json
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import time
+from pathlib import Path
+
+# Stream-safe UTF-8 on Windows consoles.
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8",
+                                errors="replace")
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from eval.external.runner import (
+    ClosedCorpusGemmaProducer,
+    JamesEngineProducer,
+    SUPPORTED_BENCHES,
+    build_loader,
+    build_scorer,
+    run_external_bench,
+    write_result,
+)
+
+
+def _build_producer(args: argparse.Namespace):
+    if args.mode == "closed-corpus":
+        return ClosedCorpusGemmaProducer(
+            model=args.model,
+            max_tokens=args.max_tokens,
+            timeout=args.timeout,
+            think=args.think,
+        )
+    if args.mode == "james":
+        return JamesEngineProducer(
+            model=args.model,
+            response_style=args.response_style,
+        )
+    raise SystemExit(f"unknown mode: {args.mode!r}")
+
+
+def _progress_printer(i: int, n: int, elapsed: float) -> None:
+    print(f"  [{i}/{n}] {elapsed:.0f}s elapsed", flush=True)
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="external_bench_run",
+        description=(
+            "Cycle γ unified runner: dispatch one external benchmark "
+            "through JAMES (or a closed-corpus baseline) and emit one "
+            "cross-bench JSON result."
+        ),
+    )
+    p.add_argument("--bench", required=True, choices=SUPPORTED_BENCHES,
+                    help="external benchmark to run")
+    p.add_argument("--variant", default=None,
+                    help="benchmark variant (rgb: en/zh/..., alce: asqa/"
+                          "qampari/eli5, musique: ans/full); 2wiki has "
+                          "no variant")
+    p.add_argument("--split", default="dev",
+                    help="benchmark split (musique/2wiki); ignored "
+                          "elsewhere. Default: dev.")
+    p.add_argument("--cache-dir", default=None,
+                    help="loader cache directory (default: each loader's "
+                          "_fixtures/ tree)")
+    p.add_argument("--allow-download", action="store_true",
+                    help="permit live GitHub download (RGB only); other "
+                          "benches must be pre-downloaded by the operator")
+    p.add_argument("--mode", choices=("closed-corpus", "james"),
+                    default="closed-corpus",
+                    help="producer mode (default: closed-corpus)")
+    p.add_argument("--model", default=os.environ.get("PROOF_MODEL",
+                                                      "gemma4:e4b"),
+                    help="model id (Ollama tag for closed-corpus; "
+                          "JAMES selected_model for james)")
+    p.add_argument("--response-style", default="",
+                    help="JAMES response style override (james mode only)")
+    p.add_argument("--n-samples", type=int, default=None,
+                    help="cap on the number of queries (Phase B smoke)")
+    p.add_argument("--max-tokens", type=int, default=8192,
+                    help="closed-corpus max_tokens (default 8192)")
+    p.add_argument("--timeout", type=int, default=180,
+                    help="closed-corpus per-call timeout in seconds")
+    p.add_argument("--think", action="store_true",
+                    help="closed-corpus think=True (default False)")
+    p.add_argument("--out", required=True,
+                    help="output JSON path (parents created if needed)")
+    p.add_argument("--progress-every", type=int, default=10,
+                    help="print progress every N queries (default 10)")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    loader = build_loader(
+        args.bench,
+        variant=args.variant,
+        split=args.split,
+        cache_dir=Path(args.cache_dir) if args.cache_dir else None,
+        allow_download=args.allow_download,
+    )
+    scorer = build_scorer(args.bench, variant=args.variant)
+    producer = _build_producer(args)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"=== cycle γ external bench: bench={args.bench} "
+        f"variant={args.variant or '(default)'} split={args.split} "
+        f"mode={args.mode} model={args.model} "
+        f"n_samples={args.n_samples or 'ALL'} ===",
+        flush=True,
+    )
+
+    t0 = time.time()
+    result = run_external_bench(
+        loader=loader,
+        scorer=scorer,
+        producer=producer,
+        split=args.split,
+        n_samples=args.n_samples,
+        progress_every=args.progress_every,
+        on_progress=_progress_printer,
+    )
+    elapsed = time.time() - t0
+
+    final = write_result(result, out_path)
+    print(f"\n=== RESULT (bench={result['benchmark']}, "
+            f"n={result['n_queries']}, errors={result['n_errors']}, "
+            f"elapsed={elapsed:.1f}s) ===")
+    for axis in result["axes"]:
+        notes = (axis["notes"] or "").strip().splitlines()[0] if axis["notes"] else ""
+        notes_tail = f"  // {notes[:80]}" if notes else ""
+        print(f"  {axis['name']:24s} {axis['score']:.4f}  "
+                f"(n={axis['n_queries']}){notes_tail}")
+    print(f"\nsaved: {os.path.relpath(final, ROOT)}")
+    return 0 if result["n_errors"] == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cycle_gamma_runner.py
+++ b/tests/test_cycle_gamma_runner.py
@@ -1,0 +1,373 @@
+"""Cycle γ Phase A.5 — unified runner contract tests.
+
+Pins:
+  * build_loader dispatch covers all 4 SUPPORTED_BENCHES.
+  * build_scorer dispatch matches the loader benchmark_id.
+  * StubProducer integration: the runner threads queries through
+    a producer and into the scorer without touching an LLM.
+  * Producer-raises errors do NOT kill the run; they surface as
+    one row per failure with status=error.
+  * Loader/scorer benchmark-id mismatch is caught before producer
+    work starts.
+  * Result dict shape is stable + JSON-serialisable.
+  * write_result is atomic (final file appears all at once).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ─── Helpers ──────────────────────────────────────────────────────
+
+
+def _write_rgb_fixture(tmp: Path) -> Path:
+    """Write a tiny synthetic RGB fixture so RGBLoader can read it
+    without hitting the network."""
+    cache = tmp / "rgb"
+    cache.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "id":       1,
+            "query":    "What is the capital of France?",
+            "answer":   "Paris",
+            "positive": ["Paris is the capital of France."],
+            "negative": [],
+        },
+        {
+            "id":       2,
+            "query":    "What is the population of Atlantis?",
+            "answer":   "[Insufficient Information]",
+            "positive": [],
+            "negative": ["Atlantis is a mythical city."],
+        },
+    ]
+    (cache / "en.json").write_text(json.dumps(rows), encoding="utf-8")
+    return cache
+
+
+def _write_2wiki_fixture(tmp: Path) -> Path:
+    """Write a tiny synthetic 2WikiMultiHopQA fixture so WikiMultiLoader
+    can read it without hitting the network."""
+    cache = tmp / "2wiki"
+    cache.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "_id":      "w1",
+            "question": "Who composed Symphony X?",
+            "context":  [["Title A", ["s0", "s1"]]],
+            "supporting_facts": [["Title A", 0]],
+            "answer":   "Beethoven",
+            "type":     "comparison",
+        },
+        {
+            "_id":      "w2",
+            "question": "Who painted Painting Y?",
+            "context":  [["Title B", ["s0"]]],
+            "supporting_facts": [["Title B", 0]],
+            "answer":   "Van Gogh",
+            "type":     "inference",
+        },
+    ]
+    (cache / "dev.json").write_text(json.dumps(rows), encoding="utf-8")
+    return cache
+
+
+# ─── Dispatch tests ────────────────────────────────────────────────
+
+
+class BuildLoaderTests(unittest.TestCase):
+    def test_rgb_dispatch(self):
+        from eval.external.runner import build_loader
+        from eval.external.rgb_loader import RGBLoader
+        loader = build_loader("rgb", variant="en")
+        self.assertIsInstance(loader, RGBLoader)
+        self.assertEqual(loader.benchmark_id, "rgb-en")
+
+    def test_alce_dispatch(self):
+        from eval.external.runner import build_loader
+        from eval.external.alce_loader import ALCELoader
+        loader = build_loader("alce", variant="asqa")
+        self.assertIsInstance(loader, ALCELoader)
+        self.assertEqual(loader.benchmark_id, "alce-asqa")
+
+    def test_musique_dispatch(self):
+        from eval.external.runner import build_loader
+        from eval.external.musique_loader import MuSiQueLoader
+        loader = build_loader("musique", variant="ans", split="dev")
+        self.assertIsInstance(loader, MuSiQueLoader)
+        self.assertEqual(loader.benchmark_id, "musique-ans")
+
+    def test_2wiki_dispatch(self):
+        from eval.external.runner import build_loader
+        from eval.external.wikimulti_loader import WikiMultiLoader
+        loader = build_loader("2wiki", split="dev")
+        self.assertIsInstance(loader, WikiMultiLoader)
+        self.assertEqual(loader.benchmark_id, "2wiki")
+
+    def test_unknown_bench_raises(self):
+        from eval.external.runner import build_loader
+        with self.assertRaises(ValueError):
+            build_loader("bogus")
+
+
+class BuildScorerTests(unittest.TestCase):
+    def test_rgb_scorer_dispatch(self):
+        from eval.external.runner import build_scorer
+        from eval.external.rgb_scorer import RGBScorer
+        s = build_scorer("rgb", variant="en")
+        self.assertIsInstance(s, RGBScorer)
+        self.assertEqual(s.benchmark_id, "rgb-en")
+
+    def test_alce_scorer_dispatch_with_verifier(self):
+        from eval.external.runner import build_scorer
+        from eval.external.alce_scorer import (
+            ALCEScorer, StringContainmentVerifier,
+        )
+        verifier = StringContainmentVerifier(min_overlap=0.7)
+        s = build_scorer("alce", variant="asqa", verifier=verifier)
+        self.assertIsInstance(s, ALCEScorer)
+        # Custom verifier honoured.
+        self.assertIs(s.verifier, verifier)
+
+    def test_musique_scorer_dispatch(self):
+        from eval.external.runner import build_scorer
+        from eval.external.musique_scorer import MuSiQueScorer
+        s = build_scorer("musique", variant="ans")
+        self.assertIsInstance(s, MuSiQueScorer)
+        self.assertEqual(s.benchmark_id, "musique-ans")
+
+    def test_2wiki_scorer_dispatch(self):
+        from eval.external.runner import build_scorer
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        s = build_scorer("2wiki")
+        self.assertIsInstance(s, WikiMultiScorer)
+        self.assertEqual(s.benchmark_id, "2wiki")
+
+    def test_unknown_bench_raises(self):
+        from eval.external.runner import build_scorer
+        with self.assertRaises(ValueError):
+            build_scorer("bogus")
+
+
+# ─── StubProducer + run_external_bench end-to-end ──────────────────
+
+
+class StubProducerTests(unittest.TestCase):
+    def test_stub_requires_callable(self):
+        from eval.external.runner import StubProducer
+        with self.assertRaises(TypeError):
+            StubProducer("not callable")
+
+    def test_stub_must_return_dict(self):
+        from eval.external.runner import StubProducer
+        from eval.external import ExternalQuery
+        sp = StubProducer(lambda q: "not a dict")
+        with self.assertRaises(TypeError):
+            sp.produce(ExternalQuery(
+                id="x", benchmark="rgb-en", question="?",
+                context=(), gold_answer="",
+            ))
+
+
+class EndToEndStubRunTests(unittest.TestCase):
+    """The big one: drive a real loader + real scorer through a
+    StubProducer that answers from the fixture's gold so the scorer
+    has something concrete to grade."""
+
+    def test_rgb_perfect_stub_yields_one(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_rgb_fixture(tmp)
+            loader = build_loader("rgb", variant="en",
+                                   cache_dir=cache,
+                                   allow_download=False)
+            scorer = build_scorer("rgb", variant="en")
+
+            # Answer with the gold so RGB's negative-rejection
+            # F1 axis can both score the positive case and the
+            # abstention case.
+            def answer(q):
+                return {"answer": q.gold_answer}
+            sp = StubProducer(answer)
+
+            result = run_external_bench(
+                loader=loader, scorer=scorer, producer=sp,
+            )
+            self.assertEqual(result["benchmark"], "rgb-en")
+            self.assertEqual(result["n_queries"], 2)
+            self.assertEqual(result["n_rows"], 2)
+            self.assertEqual(result["n_errors"], 0)
+            self.assertEqual(result["producer"], "stub")
+            self.assertIn("axes", result)
+            self.assertIn("rows", result)
+            self.assertIn("started_at", result)
+            self.assertIn("elapsed_s", result)
+            # Result must be JSON-serialisable end-to-end.
+            self.assertIsInstance(json.dumps(result), str)
+
+    def test_2wiki_perfect_stub_emits_em_f1(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_2wiki_fixture(tmp)
+            loader = build_loader("2wiki", split="dev",
+                                   cache_dir=cache)
+            scorer = build_scorer("2wiki")
+
+            def answer(q):
+                return {"answer": q.gold_answer}
+            sp = StubProducer(answer)
+
+            result = run_external_bench(
+                loader=loader, scorer=scorer, producer=sp,
+            )
+            self.assertEqual(result["benchmark"], "2wiki")
+            self.assertEqual(result["n_queries"], 2)
+            axes = {a["name"]: a for a in result["axes"]}
+            # Perfect-answer stub → EM = F1 = 1.0
+            self.assertEqual(axes["em"]["score"], 1.0)
+            self.assertEqual(axes["f1"]["score"], 1.0)
+
+    def test_n_samples_caps_the_run(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_2wiki_fixture(tmp)
+            loader = build_loader("2wiki", split="dev",
+                                   cache_dir=cache)
+            scorer = build_scorer("2wiki")
+            sp = StubProducer(lambda q: {"answer": "anything"})
+            result = run_external_bench(
+                loader=loader, scorer=scorer, producer=sp,
+                n_samples=1,
+            )
+            self.assertEqual(result["n_queries"], 1)
+
+    def test_producer_raises_surface_as_error_rows(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_2wiki_fixture(tmp)
+            loader = build_loader("2wiki", split="dev",
+                                   cache_dir=cache)
+            scorer = build_scorer("2wiki")
+
+            def explode(q):
+                raise RuntimeError(f"boom for {q.id}")
+            sp = StubProducer(explode)
+            result = run_external_bench(
+                loader=loader, scorer=scorer, producer=sp,
+            )
+            self.assertEqual(result["n_errors"], 2)
+            self.assertTrue(all(r["status"] == "error"
+                                  for r in result["rows"]))
+            self.assertTrue(any("boom" in r["answer"]
+                                  for r in result["rows"]))
+
+
+class BenchmarkIdMismatchTests(unittest.TestCase):
+    def test_runner_catches_loader_scorer_mismatch(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_2wiki_fixture(tmp)
+            loader = build_loader("2wiki", split="dev",
+                                   cache_dir=cache)
+            scorer = build_scorer("musique", variant="ans")
+            sp = StubProducer(lambda q: {"answer": "x"})
+            with self.assertRaises(ValueError):
+                run_external_bench(
+                    loader=loader, scorer=scorer, producer=sp,
+                )
+
+
+# ─── Progress callback + write_result ──────────────────────────────
+
+
+class ProgressCallbackTests(unittest.TestCase):
+    def test_on_progress_fires_at_each_threshold(self):
+        from eval.external.runner import (
+            StubProducer, build_loader, build_scorer,
+            run_external_bench,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cache = _write_2wiki_fixture(tmp)
+            loader = build_loader("2wiki", split="dev",
+                                   cache_dir=cache)
+            scorer = build_scorer("2wiki")
+            sp = StubProducer(lambda q: {"answer": "x"})
+
+            calls: list = []
+            def cb(i, n, e):
+                calls.append((i, n))
+            run_external_bench(
+                loader=loader, scorer=scorer, producer=sp,
+                progress_every=1, on_progress=cb,
+            )
+            # Fires once per row + final == 2 queries → 2 calls
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(calls[-1][1], 2)
+
+
+class WriteResultTests(unittest.TestCase):
+    def test_write_creates_dir_and_atomic_rename(self):
+        from eval.external.runner import write_result
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "nested" / "deep" / "result.json"
+            payload: Dict[str, Any] = {"hello": "world", "n": 7}
+            final = write_result(payload, out)
+            self.assertEqual(final, out)
+            self.assertTrue(out.exists())
+            # Tmp side-file must not remain.
+            self.assertFalse(
+                out.with_suffix(out.suffix + ".tmp").exists()
+            )
+            self.assertEqual(json.loads(out.read_text(encoding="utf-8")),
+                              payload)
+
+
+# ─── Producer defaults ─────────────────────────────────────────────
+
+
+class ProducerDefaultsTests(unittest.TestCase):
+    """Pin the .name attribute and constructor surface so a config
+    file can rely on the public API."""
+
+    def test_closed_corpus_producer_name(self):
+        from eval.external.runner import ClosedCorpusGemmaProducer
+        p = ClosedCorpusGemmaProducer(model="gemma4:e4b")
+        self.assertEqual(p.name, "closed-corpus-gemma")
+
+    def test_james_engine_producer_name(self):
+        from eval.external.runner import JamesEngineProducer
+        p = JamesEngineProducer(model="gemma4:e4b")
+        self.assertEqual(p.name, "james-engine")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Cycle γ Phase A.5 — closes Phase A. One CLI dispatches any of {RGB, ALCE, MuSiQue, 2Wiki} through {closed-corpus Gemma, full JAMES stack} and emits one cross-bench JSON aligned with `ScoreAxis`.
- Three pluggable parts: `build_loader` / `build_scorer` (benchmark dispatch) + `AnswerProducer` Protocol (3 producers: `StubProducer` for tests, `ClosedCorpusGemmaProducer`, `JamesEngineProducer`).
- Errors surface as per-row `status=error` so one bad query does not torpedo a Phase C overnight run.
- 21 contract tests, all pass; cross-suite (83 cycle γ tests) green.

## Verification

- `python -m unittest tests.test_cycle_gamma_runner` → 21/21 OK
- `python -m unittest tests.test_cycle_gamma_runner tests.test_cycle_gamma_alce_scorer tests.test_cycle_gamma_wikimulti_scorer tests.test_cycle_gamma_musique_scorer` → 83/83 OK
- `python scripts/external_bench_run.py --help` lists every dispatch knob
- Self-eval trap rule preserved — the runner is plumbing-only; every emitted fact is either a published fixture row, a model free-text answer, or a published scorer's number.

## Out of scope

- Phase B smoke (live LLM, `--n-samples 20` per bench × producer mode)
- Phase C full measurement (~80h CPU, 양 모델 × 4 벤치)
- Phase D cross-bench analysis report

## Cycle γ Phase A status (CLOSED)

| Sub-phase | PR |
|---|---|
| A.0 base + schema | #724 |
| A.1 RGB loader | #725 |
| A.2 ALCE loader | #726 |
| A.3 MuSiQue + 2Wiki loaders | #727 |
| A.4.0 scorer base | #728 |
| A.4.1 RGB scorer | #729 |
| A.4.2 MuSiQue scorer | #730 |
| A.4.3 2Wiki scorer | #731 |
| A.4.4 ALCE scorer | #732 |
| A.5 unified runner | this PR |

Quality delta: exempt (label: feat — integration-layer runner; no `core/retrieval` / `core/graph` / `core/reasoning` quality dial change. Actual cross-bench numbers land at Phase C.)

Next: Phase B smoke → Phase C full → Phase D report → v0.5 entry gate evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)