### PR TITLE
fix(cycle γ Phase B smoke #1): RGB loader handles JSONL format

### DIFF
--- a/eval/external/rgb_loader.py
+++ b/eval/external/rgb_loader.py
@@ -167,6 +167,44 @@ def _ensure_fixture(
     return path
 
 
+# The published RGB fixtures are JSONL (one JSON object per line) —
+# not a top-level JSON array — for the ``en`` / ``zh`` / ``*_int`` /
+# ``*_fact`` variants. The ``*_refine`` variants are a single JSON
+# list. Phase B smoke (2026-06-08) caught this: the loader's
+# original ``json.load`` raised ``Extra data`` on the first newline.
+# This helper accepts both formats so the loader stays oblivious to
+# the per-variant wire shape.
+def _load_rgb_fixture(path: Path, *, variant: str) -> List[Dict[str, Any]]:
+    """Return a list of dict entries from an RGB fixture file.
+
+    Detection rule (cheap, no second pass): strip leading whitespace
+    and look at the first non-whitespace character. ``[`` → JSON
+    array; anything else → JSONL (one object per non-empty line).
+
+    Empty / whitespace-only lines are skipped silently so a trailing
+    newline does not raise.
+    """
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    head = text.lstrip()[:1]
+    if head == "[":
+        raw = json.loads(text)
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"RGB {variant!r} fixture must be a JSON list; "
+                f"got {type(raw).__name__}"
+            )
+        return raw
+    # JSONL fallback.
+    out: List[Dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
 # ─── Schema mapping ────────────────────────────────────────────────
 
 
@@ -309,14 +347,7 @@ class RGBLoader(ExternalBenchFixture):
             self._cache_dir,
             allow_download=self._allow_download,
         )
-        with open(path, encoding="utf-8") as f:
-            raw = json.load(f)
-
-        if not isinstance(raw, list):
-            raise ValueError(
-                f"RGB {self._variant!r} fixture must be a JSON list; "
-                f"got {type(raw).__name__}"
-            )
+        raw = _load_rgb_fixture(path, variant=self._variant)
 
         queries = [_entry_to_query(e, variant=self._variant)
                    for e in raw if isinstance(e, dict)]

--- a/tests/test_cycle_gamma_rgb_loader.py
+++ b/tests/test_cycle_gamma_rgb_loader.py
@@ -223,16 +223,55 @@ class TakeSampleIntegrationTests(unittest.TestCase):
 class CorruptFixtureTests(unittest.TestCase):
     """Malformed JSON / non-list root / non-dict rows surface cleanly."""
 
-    def test_non_list_root_raises_value_error(self):
+    def test_dict_root_treated_as_single_jsonl_entry(self):
+        """Phase B smoke (2026-06-08) showed the published RGB
+        fixtures are JSONL (one JSON object per line), not a JSON
+        array. The loader now accepts either shape. A bare dict
+        therefore becomes a 1-entry JSONL stream rather than an
+        error — and the per-row validation (id, benchmark match,
+        etc.) is what catches malformed entries downstream."""
         from eval.external.rgb_loader import RGBLoader
         with tempfile.TemporaryDirectory() as td:
             cache = Path(td)
             cache.mkdir(parents=True, exist_ok=True)
+            entry = {
+                "id":       99,
+                "query":    "smoke?",
+                "answer":   "smoke",
+                "positive": ["evidence"],
+                "negative": [],
+            }
             with open(cache / "en.json", "w", encoding="utf-8") as f:
-                json.dump({"not": "a list"}, f)
+                json.dump(entry, f)
             loader = RGBLoader(variant="en", cache_dir=cache)
-            with self.assertRaises(ValueError):
-                loader.iter_queries()
+            queries = loader.iter_queries()
+            self.assertEqual(len(queries), 1)
+            self.assertEqual(queries[0].id, "rgb-en-99")
+
+    def test_jsonl_file_loads_one_query_per_line(self):
+        """The on-disk format for the official ``en`` / ``zh`` /
+        ``*_int`` / ``*_fact`` variants is JSONL; round-trip pin."""
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            cache.mkdir(parents=True, exist_ok=True)
+            entries = [
+                {"id": 0, "query": "a?", "answer": "a",
+                 "positive": ["p"], "negative": []},
+                {"id": 1, "query": "b?", "answer": "b",
+                 "positive": [], "negative": ["n"]},
+                {"id": 2, "query": "c?", "answer": "c",
+                 "positive": ["p"], "negative": []},
+            ]
+            with open(cache / "en.json", "w", encoding="utf-8") as f:
+                for e in entries:
+                    f.write(json.dumps(e) + "\n")
+                f.write("\n")    # trailing blank line — must be tolerated
+            loader = RGBLoader(variant="en", cache_dir=cache)
+            queries = loader.iter_queries()
+            self.assertEqual(len(queries), 3)
+            self.assertEqual([q.id for q in queries],
+                              ["rgb-en-0", "rgb-en-1", "rgb-en-2"])
 
     def test_corrupt_json_raises_json_decode_error(self):
         from eval.external.rgb_loader import RGBLoader


### PR DESCRIPTION
## Summary

Phase B smoke #1 (RGB-en n=20 closed-corpus gemma4:e4b, 2026-06-08) crashed immediately because the published RGB fixtures for the \`en\` / \`zh\` / \`*_int\` / \`*_fact\` variants are JSONL (one JSON object per line), not a JSON array. The loader's \`json.load\` only accepts a single top-level value → \`Extra data: line 2\`.

Synthetic test fixtures used \`json.dump([...], f)\` (array shape) so round-trip was fine. A.1 #725 shipped against synthetic only — the real on-disk shape was not exercised until the live download landed at Phase B.

Direct evidence for [\`feedback_measurement_smoke_caught_wiring_bugs\`](https://github.com/Hashevolution/James-RAG-Evol/blob/main/CLAUDE.md): unit-test mocks miss format invariants that only show up against the published fixture.

## Verification

- 37/37 RGB loader + runner tests pass after fix
- Re-launched smoke succeeded: RGB-en n=20 → noise_robustness 0.700, 0 errors, 25.4s

## Out of scope

- ALCE / MuSiQue / 2Wiki loaders use \`json.load\` of the whole file but the published shape for those is JSON-with-data-wrapper or standalone JSON — no fix needed. If a fresh smoke against those catches another invariant, it lands as its own \`fix(cycle γ Phase B smoke #N)\` PR.

Quality delta: exempt (label: fix — measurement-side wiring correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)