### PR TITLE
feat(cycle γ Phase B #3): RGB loader emits dual-axis (noise + negrej) per row

### DIFF
--- a/eval/external/rgb_loader.py
+++ b/eval/external/rgb_loader.py
@@ -238,6 +238,11 @@ def _entry_to_query(
     *,
     variant: str,
 ) -> ExternalQuery:
+    """Single-query mapping — produces ONLY the noise-robustness
+    query for one fixture entry. Kept for back-compat (callers that
+    construct queries directly) and re-used internally by
+    :func:`_entries_to_queries`.
+    """
     orig_id = str(entry.get("id", "")).strip()
     if not orig_id:
         # Fall back to a positional id only when the source row truly
@@ -254,19 +259,102 @@ def _entry_to_query(
         "answer_aliases":  aliases,
         "variant":         variant,
         "language":        ("zh" if variant.startswith("zh") else "en"),
+        "setting":         "noise_robustness",
     }
     # _fact variant carries an extra distractor list.
     if positive_wrong:
         metadata["positive_wrong"] = positive_wrong
 
     return ExternalQuery(
-        id=f"rgb-{variant}-{orig_id}",
+        id=f"rgb-{variant}-{orig_id}-noise",
         benchmark=f"rgb-{variant}",
         question=str(entry.get("query", "")),
         context=tuple(str(p) for p in (positive + negative)),
         gold_answer=primary,
         metadata=metadata,
     )
+
+
+def _entry_to_negative_rejection_query(
+    entry: Dict[str, Any],
+    *,
+    variant: str,
+) -> ExternalQuery:
+    """Negative-rejection variant of one fixture entry — strips the
+    positive passages so the model sees only distractors.
+
+    Implements the RGB paper's negative-rejection setting (Chen et
+    al. 2024 EMNLP, §3.2): given irrelevant docs only, does the
+    model abstain? ``positive_count=0`` in metadata routes the row
+    onto the scorer's abstention branch automatically.
+
+    Cycle γ Phase B smoke (2026-06-08) discovered the published
+    fixture has no rows with ``positive=[]`` natively — the
+    negative-rejection axis is a *setting* the runner constructs,
+    not a class of rows in the file. This helper builds that
+    setting per row.
+    """
+    orig_id = str(entry.get("id", "")).strip() or "noid"
+    primary, aliases = _flatten_answer(entry.get("answer"))
+    negative = list(entry.get("negative") or [])
+
+    metadata: Dict[str, Any] = {
+        "positive_count":  0,         # → scorer routes to abstention
+        "negative_count":  len(negative),
+        # The original gold + aliases stay under metadata so a
+        # downstream forensic step can confirm whether the model
+        # somehow guessed the right answer from negative docs
+        # alone (a learning-leak signal).
+        "answer_aliases":  aliases,
+        "variant":         variant,
+        "language":        ("zh" if variant.startswith("zh") else "en"),
+        "setting":         "negative_rejection",
+        # Cross-link back to the paired noise-robustness query for
+        # per-question analysis downstream.
+        "paired_id":       f"rgb-{variant}-{orig_id}-noise",
+    }
+
+    return ExternalQuery(
+        id=f"rgb-{variant}-{orig_id}-negrej",
+        benchmark=f"rgb-{variant}",
+        question=str(entry.get("query", "")),
+        context=tuple(str(n) for n in negative),
+        # Empty gold so the scorer's noise-robustness branch (which
+        # is gated on positive_count > 0 anyway) cannot accidentally
+        # score this row.
+        gold_answer="",
+        metadata=metadata,
+    )
+
+
+def _entries_to_queries(
+    entry: Dict[str, Any],
+    *,
+    variant: str,
+    abstention_mode: bool,
+) -> List[ExternalQuery]:
+    """Emit one or two queries per fixture entry.
+
+    Always emits the noise-robustness query. When
+    ``abstention_mode=True`` AND the entry has at least one positive
+    passage to strip, also emits the negative-rejection variant — so
+    the same fixture row drives both axes of the cycle γ table.
+
+    The negative-rejection variant is suppressed when there are no
+    positive passages to remove (the resulting query would be
+    identical to the noise-robustness one, doubling cost without
+    new evidence).
+    """
+    noise_q = _entry_to_query(entry, variant=variant)
+    if not abstention_mode:
+        return [noise_q]
+    positive = entry.get("positive") or []
+    if not positive:
+        # Nothing to strip — negative-rejection would be a clone.
+        return [noise_q]
+    return [noise_q, _entry_to_negative_rejection_query(
+        entry, variant=variant,
+    )]
 
 
 # ─── Loader ────────────────────────────────────────────────────────
@@ -298,7 +386,15 @@ class RGBLoader(ExternalBenchFixture):
         variant: str = "en",
         cache_dir: Optional[Path] = None,
         allow_download: bool = False,
+        abstention_mode: bool = True,
     ):
+        """``abstention_mode`` controls whether the loader emits the
+        negative-rejection variant alongside the noise-robustness
+        query (default: True, which mirrors the RGB paper's dual-axis
+        evaluation). Set to False to halve cost when only
+        noise-robustness is needed (e.g. a cost-sensitive smoke run
+        or a single-axis ablation).
+        """
         if variant not in RGB_VARIANTS:
             raise ValueError(
                 f"unknown RGB variant: {variant!r}. "
@@ -307,6 +403,11 @@ class RGBLoader(ExternalBenchFixture):
         self._variant = variant
         self._cache_dir = Path(cache_dir) if cache_dir else None
         self._allow_download = allow_download
+        self._abstention_mode = abstention_mode
+
+    @property
+    def abstention_mode(self) -> bool:
+        return self._abstention_mode
 
     @property
     def benchmark_id(self) -> str:
@@ -349,9 +450,21 @@ class RGBLoader(ExternalBenchFixture):
         )
         raw = _load_rgb_fixture(path, variant=self._variant)
 
-        queries = [_entry_to_query(e, variant=self._variant)
-                   for e in raw if isinstance(e, dict)]
+        queries: List[ExternalQuery] = []
+        for e in raw:
+            if not isinstance(e, dict):
+                continue
+            queries.extend(_entries_to_queries(
+                e,
+                variant=self._variant,
+                abstention_mode=self._abstention_mode,
+            ))
         self.validate_queries(queries)
+        # ``n_samples`` is applied to the *output* query stream — so a
+        # caller asking for 50 queries gets 50 queries, regardless of
+        # whether the loader expanded each fixture row 1× or 2×. This
+        # matches the rest of the cycle γ runners' semantics (the cap
+        # is on producer calls, not fixture rows).
         return self.take_sample(queries, n_samples)
 
 

--- a/tests/test_cycle_gamma_rgb_loader.py
+++ b/tests/test_cycle_gamma_rgb_loader.py
@@ -104,9 +104,13 @@ class SchemaMappingTests(unittest.TestCase):
         ])
         loader = RGBLoader(variant="en", cache_dir=self.cache)
         out = loader.iter_queries()
-        self.assertEqual(len(out), 1)
-        q = out[0]
-        self.assertEqual(q.id,         "rgb-en-0001")
+        # Default abstention_mode=True emits BOTH the
+        # noise-robustness query AND the negative-rejection variant
+        # for every row with positive evidence (cycle γ Phase B #3,
+        # 2026-06-08). One fixture row → two queries.
+        self.assertEqual(len(out), 2)
+        q = out[0]   # noise-robustness query
+        self.assertEqual(q.id,         "rgb-en-0001-noise")
         self.assertEqual(q.benchmark,  "rgb-en")
         self.assertEqual(q.question,   "Who founded OpenAI?")
         # positive + negative are concatenated into context.
@@ -116,6 +120,7 @@ class SchemaMappingTests(unittest.TestCase):
         self.assertEqual(q.metadata["negative_count"], 1)
         self.assertEqual(q.metadata["language"], "en")
         self.assertEqual(q.metadata["variant"], "en")
+        self.assertEqual(q.metadata["setting"], "noise_robustness")
         self.assertEqual(q.metadata["answer_aliases"], [])
         # _fact-only field absent on base variant
         self.assertNotIn("positive_wrong", q.metadata)
@@ -129,8 +134,12 @@ class SchemaMappingTests(unittest.TestCase):
         ])
         loader = RGBLoader(variant="zh", cache_dir=self.cache)
         out = loader.iter_queries()
+        # zh row has positive → noise + negrej both emitted (2 queries)
+        self.assertEqual(len(out), 2)
         self.assertEqual(out[0].metadata["language"], "zh")
         self.assertEqual(out[0].benchmark, "rgb-zh")
+        # Both queries inherit the language tag.
+        self.assertEqual(out[1].metadata["language"], "zh")
 
     def test_list_answer_flattens_with_aliases(self):
         from eval.external.rgb_loader import RGBLoader
@@ -142,7 +151,8 @@ class SchemaMappingTests(unittest.TestCase):
              "negative": []},
         ])
         loader = RGBLoader(variant="en", cache_dir=self.cache)
-        q = loader.iter_queries()[0]
+        out = loader.iter_queries()
+        q = out[0]   # noise-robustness query (first emitted)
         # First element is the primary answer; the rest are aliases.
         self.assertEqual(q.gold_answer, "Washington, D.C.")
         self.assertEqual(q.metadata["answer_aliases"],
@@ -158,7 +168,7 @@ class SchemaMappingTests(unittest.TestCase):
              "positive": ["doc"], "negative": []},
         ])
         loader = RGBLoader(variant="en", cache_dir=self.cache)
-        q = loader.iter_queries()[0]
+        q = loader.iter_queries()[0]   # noise-robustness query
         self.assertEqual(q.gold_answer, "Sam Bankman-Fried")
         self.assertEqual(q.metadata["answer_aliases"],
                          ["SBF", "Bankman-Fried"])
@@ -174,16 +184,17 @@ class SchemaMappingTests(unittest.TestCase):
              "positive_wrong": ["The capital of France is Lyon."]},
         ])
         loader = RGBLoader(variant="en_fact", cache_dir=self.cache)
-        q = loader.iter_queries()[0]
+        q = loader.iter_queries()[0]   # noise-robustness query
         self.assertEqual(q.benchmark, "rgb-en_fact")
         self.assertEqual(q.metadata["positive_wrong"],
                          ["The capital of France is Lyon."])
 
-    def test_negative_rejection_case_has_zero_positives(self):
-        """RGB encodes negative-rejection (abstention) cases as rows
-        whose positive list is empty — the scorer (Phase A.4) checks
-        ``metadata['positive_count'] == 0``. The loader must preserve
-        that flag faithfully."""
+    def test_native_zero_positive_row_emits_only_one_query(self):
+        """A row whose published positive list is already empty
+        cannot have its positives stripped — the negative-rejection
+        variant would be a clone of the noise-robustness one. The
+        loader skips the duplicate so cost stays predictable.
+        """
         from eval.external.rgb_loader import RGBLoader
         _write_synthetic(self.cache, "en", [
             {"id": "neg1",
@@ -193,8 +204,13 @@ class SchemaMappingTests(unittest.TestCase):
              "negative": ["distractor 1", "distractor 2"]},
         ])
         loader = RGBLoader(variant="en", cache_dir=self.cache)
-        q = loader.iter_queries()[0]
+        out = loader.iter_queries()
+        # Only the noise-robustness query is emitted (negrej clone
+        # skipped).
+        self.assertEqual(len(out), 1)
+        q = out[0]
         self.assertEqual(q.metadata["positive_count"], 0)
+        self.assertEqual(q.metadata["setting"], "noise_robustness")
         # context = positive ∪ negative; even with 0 positives the
         # negative docs are still there for the scorer to inspect.
         self.assertEqual(len(q.context), 2)
@@ -209,7 +225,10 @@ class TakeSampleIntegrationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             entries = [
                 {"id": f"r{i}", "query": "?", "answer": "a",
-                 "positive": [], "negative": []}
+                 "positive": [], "negative": []}   # no positives →
+                                                    # only 1 query per
+                                                    # row (no negrej
+                                                    # clone)
                 for i in range(10)
             ]
             _write_synthetic(Path(td), "en", entries)
@@ -217,7 +236,123 @@ class TakeSampleIntegrationTests(unittest.TestCase):
             out = loader.iter_queries(n_samples=3)
             self.assertEqual(len(out), 3)
             self.assertEqual([q.id for q in out],
-                             ["rgb-en-r0", "rgb-en-r1", "rgb-en-r2"])
+                             ["rgb-en-r0-noise",
+                              "rgb-en-r1-noise",
+                              "rgb-en-r2-noise"])
+
+    def test_n_samples_counts_emitted_queries_not_fixture_rows(self):
+        """When abstention_mode=True doubles rows that carry positive
+        evidence, n_samples must still mean "return N queries", not
+        "return N fixture rows worth of queries". This keeps the cost
+        accounting predictable for the runner."""
+        from eval.external.rgb_loader import RGBLoader
+        with tempfile.TemporaryDirectory() as td:
+            entries = [
+                {"id": f"r{i}", "query": "?", "answer": "a",
+                 "positive": ["p"], "negative": ["n"]}   # each row → 2 queries
+                for i in range(10)
+            ]
+            _write_synthetic(Path(td), "en", entries)
+            loader = RGBLoader(variant="en", cache_dir=Path(td))
+            out = loader.iter_queries(n_samples=3)
+            self.assertEqual(len(out), 3)
+            # First two queries are the first row's noise + negrej.
+            self.assertEqual(out[0].id, "rgb-en-r0-noise")
+            self.assertEqual(out[1].id, "rgb-en-r0-negrej")
+            self.assertEqual(out[2].id, "rgb-en-r1-noise")
+
+
+class AbstentionModeTests(unittest.TestCase):
+    """Phase B #3 (2026-06-08) — the loader emits noise-robustness +
+    negative-rejection queries for every row with positives. These
+    tests pin the dual-axis contract end-to-end."""
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.cache = Path(self._td.name)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def _entry(self):
+        return {
+            "id":       "x1",
+            "query":    "Who founded OpenAI?",
+            "answer":   "Sam Altman",
+            "positive": ["Sam Altman co-founded OpenAI in 2015."],
+            "negative": ["FTX is a cryptocurrency exchange.",
+                          "Mars rover Perseverance."],
+        }
+
+    def test_dual_mode_emits_two_queries_when_positives_exist(self):
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            abstention_mode=True)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0].metadata["setting"], "noise_robustness")
+        self.assertEqual(out[1].metadata["setting"], "negative_rejection")
+
+    def test_negrej_query_has_positive_count_zero(self):
+        """The whole point of the negrej variant: scorer routes on
+        positive_count=0 → abstention axis."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        out = loader.iter_queries()
+        negrej = out[1]
+        self.assertEqual(negrej.metadata["positive_count"], 0)
+        self.assertEqual(negrej.id, "rgb-en-x1-negrej")
+
+    def test_negrej_context_excludes_positives(self):
+        """The model must see only distractors — otherwise it would
+        trivially answer correctly and the abstention test would be
+        invalid."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        out = loader.iter_queries()
+        negrej_context = list(out[1].context)
+        # Two negatives, zero positives.
+        self.assertEqual(len(negrej_context), 2)
+        self.assertNotIn(
+            "Sam Altman co-founded OpenAI in 2015.",
+            negrej_context,
+        )
+
+    def test_negrej_query_empty_gold_so_noise_axis_skips_it(self):
+        """The negrej query's gold_answer is empty so the
+        noise-robustness branch (gated on positive_count > 0 too)
+        cannot accidentally credit a match."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        out = loader.iter_queries()
+        self.assertEqual(out[1].gold_answer, "")
+
+    def test_paired_id_links_negrej_back_to_noise(self):
+        """For per-question forensic analysis."""
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache)
+        out = loader.iter_queries()
+        negrej = out[1]
+        self.assertEqual(negrej.metadata["paired_id"], out[0].id)
+
+    def test_abstention_mode_false_emits_only_noise_query(self):
+        from eval.external.rgb_loader import RGBLoader
+        _write_synthetic(self.cache, "en", [self._entry()])
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            abstention_mode=False)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["setting"], "noise_robustness")
+
+    def test_abstention_mode_default_is_true(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en")
+        self.assertTrue(loader.abstention_mode)
 
 
 class CorruptFixtureTests(unittest.TestCase):
@@ -245,8 +380,10 @@ class CorruptFixtureTests(unittest.TestCase):
                 json.dump(entry, f)
             loader = RGBLoader(variant="en", cache_dir=cache)
             queries = loader.iter_queries()
-            self.assertEqual(len(queries), 1)
-            self.assertEqual(queries[0].id, "rgb-en-99")
+            # 1 noise + 1 negrej because positive=["evidence"] exists.
+            self.assertEqual(len(queries), 2)
+            self.assertEqual(queries[0].id, "rgb-en-99-noise")
+            self.assertEqual(queries[1].id, "rgb-en-99-negrej")
 
     def test_jsonl_file_loads_one_query_per_line(self):
         """The on-disk format for the official ``en`` / ``zh`` /
@@ -257,21 +394,27 @@ class CorruptFixtureTests(unittest.TestCase):
             cache.mkdir(parents=True, exist_ok=True)
             entries = [
                 {"id": 0, "query": "a?", "answer": "a",
-                 "positive": ["p"], "negative": []},
+                 "positive": ["p"], "negative": []},     # → 2 queries
                 {"id": 1, "query": "b?", "answer": "b",
-                 "positive": [], "negative": ["n"]},
+                 "positive": [], "negative": ["n"]},     # → 1 (no neg-rej clone)
                 {"id": 2, "query": "c?", "answer": "c",
-                 "positive": ["p"], "negative": []},
+                 "positive": ["p"], "negative": []},     # → 2 queries
             ]
             with open(cache / "en.json", "w", encoding="utf-8") as f:
                 for e in entries:
                     f.write(json.dumps(e) + "\n")
                 f.write("\n")    # trailing blank line — must be tolerated
-            loader = RGBLoader(variant="en", cache_dir=cache)
+            # Use abstention_mode=False to keep this JSONL parsing
+            # test isolated from the dual-axis expansion (covered by
+            # its own AbstentionModeTests suite).
+            loader = RGBLoader(variant="en", cache_dir=cache,
+                                abstention_mode=False)
             queries = loader.iter_queries()
             self.assertEqual(len(queries), 3)
             self.assertEqual([q.id for q in queries],
-                              ["rgb-en-0", "rgb-en-1", "rgb-en-2"])
+                              ["rgb-en-0-noise",
+                               "rgb-en-1-noise",
+                               "rgb-en-2-noise"])
 
     def test_corrupt_json_raises_json_decode_error(self):
         from eval.external.rgb_loader import RGBLoader

--- a/tests/test_cycle_gamma_runner.py
+++ b/tests/test_cycle_gamma_runner.py
@@ -206,8 +206,14 @@ class EndToEndStubRunTests(unittest.TestCase):
                 loader=loader, scorer=scorer, producer=sp,
             )
             self.assertEqual(result["benchmark"], "rgb-en")
-            self.assertEqual(result["n_queries"], 2)
-            self.assertEqual(result["n_rows"], 2)
+            # Phase B #3 (2026-06-08): the loader now emits two
+            # queries per row that carries positive evidence (one
+            # noise-robustness + one negative-rejection). The first
+            # fixture row has positive=["Paris..."] → 2 queries; the
+            # second has positive=[] → 1 query (negrej clone
+            # skipped). Total = 3.
+            self.assertEqual(result["n_queries"], 3)
+            self.assertEqual(result["n_rows"], 3)
             self.assertEqual(result["n_errors"], 0)
             self.assertEqual(result["producer"], "stub")
             self.assertIn("axes", result)


### PR DESCRIPTION
## Summary

Phase B smoke #2 measured noise_robustness=0.600 cleanly but reported negative_rejection_f1 as "not measured" across all 300 RGB-en rows — the published fixture has ZERO rows with positive=[]. RGB paper (Chen et al. 2024 EMNLP §3.2) tests negative rejection by stripping positives at runner time, not by fixture-row class.

This PR closes that gap: the loader now emits 2 queries per row (noise-robustness + negative-rejection), so the abstention axis — which maps 1:1 onto JAMES's abstention F1 strength — becomes measurable end-to-end.

## Loader change

- `_entry_to_query`: ID gets `-noise` suffix, metadata.setting="noise_robustness". No other surface change.
- NEW `_entry_to_negative_rejection_query`: context = negative passages only (positives stripped). metadata.positive_count=0 → scorer auto-routes to abstention branch. gold_answer="" so noise branch cannot accidentally credit a match. metadata.paired_id cross-links back to the noise query.
- NEW `_entries_to_queries` plural helper: 1 query when row has no positives to strip OR abstention_mode=False, 2 otherwise.
- `RGBLoader.__init__` takes new `abstention_mode` kwarg (default True). False halves cost when only noise-robustness is needed.
- `iter_queries` applies `n_samples` to OUTPUT query stream so `--n-samples 50` = 50 producer calls regardless of expansion ratio.

Scorer side: NO change. RGBScorer already routes on `positive_count==0`.

## Verification

- 128/128 cycle γ tests pass (24 RGB loader + 26 RGB scorer + 21 runner + 24 ALCE + 25 MuSiQue + 24 2Wiki + 5 prompt-cap, with overlap)
- Smoke re-run in flight at time of PR (`reports/cycle_gamma/rgb-en-dual-axis-20260608.json`)
- No `core/` files touched

## Out of scope

- ALCE / MuSiQue / 2Wiki loaders (different fixture shapes; no parallel issue)
- JAMES-engine mode (Phase C operator-side)
- 7 other RGB variants (en/zh × refine/int/fact) — same loader path, abstention_mode applies if needed

Quality delta: exempt (label: feat — integration-layer loader expansion; no core/retrieval/graph/reasoning quality dial change. Actual numbers land at the smoke re-run + Phase C).

Self-eval trap discipline: the negrej setting is the published RGB paper's evaluation methodology, not a JAMES-internal contrivance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)