### PR TITLE
feat(cycle γ Phase B Option A): RGB setting_filter + 2-workspace corpus builder

### DIFF
--- a/eval/external/rgb_loader.py
+++ b/eval/external/rgb_loader.py
@@ -387,6 +387,7 @@ class RGBLoader(ExternalBenchFixture):
         cache_dir: Optional[Path] = None,
         allow_download: bool = False,
         abstention_mode: bool = True,
+        setting_filter: Optional[str] = None,
     ):
         """``abstention_mode`` controls whether the loader emits the
         negative-rejection variant alongside the noise-robustness
@@ -394,20 +395,43 @@ class RGBLoader(ExternalBenchFixture):
         evaluation). Set to False to halve cost when only
         noise-robustness is needed (e.g. a cost-sensitive smoke run
         or a single-axis ablation).
+
+        ``setting_filter`` (``None`` / ``"noise_robustness"`` /
+        ``"negative_rejection"``) post-filters the emitted query
+        stream to one axis only. Cycle γ Phase B JAMES-engine
+        experiments need this so each measurement can target the
+        workspace tuned for that axis: workspace #1 has full
+        positive+negative ingestion (run with
+        ``setting_filter="noise_robustness"``); workspace #2 has
+        negative-only ingestion (run with
+        ``setting_filter="negative_rejection"``). When ``None``,
+        every emitted query passes through unchanged.
         """
         if variant not in RGB_VARIANTS:
             raise ValueError(
                 f"unknown RGB variant: {variant!r}. "
                 f"Valid: {RGB_VARIANTS}"
             )
+        if setting_filter is not None and setting_filter not in (
+            "noise_robustness", "negative_rejection",
+        ):
+            raise ValueError(
+                f"setting_filter must be None / 'noise_robustness' / "
+                f"'negative_rejection'; got {setting_filter!r}"
+            )
         self._variant = variant
         self._cache_dir = Path(cache_dir) if cache_dir else None
         self._allow_download = allow_download
         self._abstention_mode = abstention_mode
+        self._setting_filter = setting_filter
 
     @property
     def abstention_mode(self) -> bool:
         return self._abstention_mode
+
+    @property
+    def setting_filter(self) -> Optional[str]:
+        return self._setting_filter
 
     @property
     def benchmark_id(self) -> str:
@@ -459,6 +483,11 @@ class RGBLoader(ExternalBenchFixture):
                 variant=self._variant,
                 abstention_mode=self._abstention_mode,
             ))
+        # Apply setting_filter BEFORE id-uniqueness validation so a
+        # narrow run does not need both halves of every paired row.
+        if self._setting_filter is not None:
+            queries = [q for q in queries
+                        if q.metadata.get("setting") == self._setting_filter]
         self.validate_queries(queries)
         # ``n_samples`` is applied to the *output* query stream — so a
         # caller asking for 50 queries gets 50 queries, regardless of

--- a/eval/external/runner.py
+++ b/eval/external/runner.py
@@ -80,6 +80,8 @@ def build_loader(
     split: Optional[str] = None,
     cache_dir: Optional[Path] = None,
     allow_download: bool = False,
+    setting_filter: Optional[str] = None,
+    abstention_mode: bool = True,
 ) -> ExternalBenchFixture:
     """Construct one of the four cycle γ loaders by name.
 
@@ -92,6 +94,14 @@ def build_loader(
         cache_dir: Optional cache directory; loader-specific.
         allow_download: Only honoured by the RGB loader (the rest
             require the fixture to be pre-downloaded).
+        setting_filter: RGB-only — restrict the emitted query stream
+            to one axis (``"noise_robustness"`` or
+            ``"negative_rejection"``). Cycle γ Phase B JAMES-engine
+            experiments use this to pair an axis-specific workspace
+            with an axis-specific query slice.
+        abstention_mode: RGB-only — emit the negative-rejection
+            variant alongside the noise-robustness query (default
+            True; the dual-axis evaluation).
 
     Raises:
         ValueError: unknown bench / missing required variant or split.
@@ -103,6 +113,8 @@ def build_loader(
             variant=variant or "en",
             cache_dir=cache_dir,
             allow_download=allow_download,
+            abstention_mode=abstention_mode,
+            setting_filter=setting_filter,
         )
     if bench == "alce":
         from eval.external.alce_loader import ALCELoader

--- a/scripts/external_bench_run.py
+++ b/scripts/external_bench_run.py
@@ -124,6 +124,16 @@ def _parse_args(argv=None) -> argparse.Namespace:
                     help="output JSON path (parents created if needed)")
     p.add_argument("--progress-every", type=int, default=10,
                     help="print progress every N queries (default 10)")
+    p.add_argument("--setting-filter", default=None,
+                    choices=(None, "noise_robustness",
+                              "negative_rejection"),
+                    help="RGB only — restrict emitted queries to one "
+                          "axis. Cycle γ Phase B JAMES-engine "
+                          "experiments pair an axis-specific workspace "
+                          "with an axis-specific query slice.")
+    p.add_argument("--no-abstention-mode", action="store_true",
+                    help="RGB only — suppress negative-rejection "
+                          "variant queries (default: dual-axis on)")
     return p.parse_args(argv)
 
 
@@ -135,6 +145,8 @@ def main(argv=None) -> int:
         split=args.split,
         cache_dir=Path(args.cache_dir) if args.cache_dir else None,
         allow_download=args.allow_download,
+        setting_filter=args.setting_filter,
+        abstention_mode=not args.no_abstention_mode,
     )
     scorer = build_scorer(args.bench, variant=args.variant)
     producer = _build_producer(args)

--- a/scripts/research/cycle_gamma_rgb_corpus_build.py
+++ b/scripts/research/cycle_gamma_rgb_corpus_build.py
@@ -1,0 +1,222 @@
+"""Cycle γ Phase B Option A — build a JAMES workspace whose corpus
+mirrors the RGB-en docs, so the JAMES-engine producer can be
+measured on the same 50 queries the closed-corpus baseline ran.
+
+Two modes (matching the 2-workspace experiment design the operator
+chose 2026-06-08):
+
+* ``--mode full``    — ingest every row's positive + negative
+                       passages. Pairs with the noise-robustness
+                       JAMES measurement.
+* ``--mode negrej``  — ingest every row's negative passages only.
+                       Pairs with the negative-rejection JAMES
+                       measurement (the workspace has no gold for
+                       any query, so the JAMES abstention layer
+                       drives the result).
+
+The script sets ``JAMES_WORKSPACE`` *before* importing core.config
+so the workspace path the operator chose is the path the
+VectorStore writes to. Each (row, kind) pair lands under a single
+deterministic source id (``rgb-en-<row_id>-{pos|neg}``) so a
+re-run that bumps the fixture deletes + re-ingests the matching
+slice cleanly (via VectorStore.delete_by_source).
+
+Usage (operator)::
+
+    # Workspace #1 — full (positive + negative)
+    JAMES_WORKSPACE=./workspaces/cycle_gamma_rgb_full \
+    python scripts/research/cycle_gamma_rgb_corpus_build.py \
+        --mode full \
+        --workspace ./workspaces/cycle_gamma_rgb_full
+
+    # Workspace #2 — negrej-only (negative only)
+    JAMES_WORKSPACE=./workspaces/cycle_gamma_rgb_negrej \
+    python scripts/research/cycle_gamma_rgb_corpus_build.py \
+        --mode negrej \
+        --workspace ./workspaces/cycle_gamma_rgb_negrej
+
+Self-eval trap rule (memory ``feedback_self_evaluation_trap``):
+this script reads the published RGB fixture verbatim and routes
+the published passages into the JAMES vector store without
+rewriting / curating / re-labelling. The "negrej" mode is the
+published RGB paper's experimental setting (strip positives), not
+a JAMES-internal trick.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _resolve_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _read_rgb_fixture(path: Path) -> list:
+    """Accept either JSONL (the published ``en.json`` shape) or a
+    JSON array (the ``*_refine.json`` shape). Mirrors
+    ``eval.external.rgb_loader._load_rgb_fixture``."""
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    head = text.lstrip()[:1]
+    if head == "[":
+        return json.loads(text)
+    out: list = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+def _ingest_row(
+    vector_store,
+    row: dict,
+    *,
+    mode: str,
+) -> tuple:
+    """Ingest one row's passages. Returns ``(n_pos_ingested,
+    n_neg_ingested)``."""
+    row_id = str(row.get("id", "noid"))
+    positives = [p for p in (row.get("positive") or [])
+                  if isinstance(p, str) and p.strip()]
+    negatives = [n for n in (row.get("negative") or [])
+                  if isinstance(n, str) and n.strip()]
+
+    n_pos_ingested = 0
+    n_neg_ingested = 0
+
+    if mode == "full" and positives:
+        vector_store.add_documents_with_meta(
+            positives,
+            source=f"rgb-en-{row_id}-pos",
+            metadata={
+                "category":     "rgb-en-positive",
+                "source_type":  "prod",
+            },
+        )
+        n_pos_ingested = len(positives)
+
+    if negatives:
+        vector_store.add_documents_with_meta(
+            negatives,
+            source=f"rgb-en-{row_id}-neg",
+            metadata={
+                "category":     "rgb-en-negative",
+                "source_type":  "prod",
+            },
+        )
+        n_neg_ingested = len(negatives)
+
+    return (n_pos_ingested, n_neg_ingested)
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="cycle_gamma_rgb_corpus_build",
+        description=(
+            "Build a JAMES workspace whose corpus mirrors RGB-en "
+            "(full or negrej-only mode). Sets JAMES_WORKSPACE so the "
+            "VectorStore writes to the chosen workspace path."
+        ),
+    )
+    p.add_argument("--mode", required=True,
+                    choices=("full", "negrej"),
+                    help="full = positive + negative; negrej = "
+                          "negative only")
+    p.add_argument("--workspace", required=True,
+                    help="absolute or relative path to the workspace "
+                          "root (chroma_db lives at "
+                          "<workspace>/chroma_db/)")
+    p.add_argument("--fixture", default=None,
+                    help="path to RGB en.json (default: "
+                          "eval/external/_fixtures/rgb/en.json)")
+    p.add_argument("--max-rows", type=int, default=None,
+                    help="cap on rows ingested (smoke convenience)")
+    p.add_argument("--progress-every", type=int, default=25,
+                    help="print progress every N rows (default 25)")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+
+    root = _resolve_root()
+    workspace = Path(args.workspace).resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    # Set JAMES_WORKSPACE BEFORE importing core/config. The resolver
+    # in core.plugins.workspace reads it at import time.
+    os.environ["JAMES_WORKSPACE"] = str(workspace)
+
+    fixture_path = (Path(args.fixture).resolve() if args.fixture
+                    else root / "eval" / "external" / "_fixtures"
+                         / "rgb" / "en.json")
+    if not fixture_path.exists():
+        print(f"!! fixture not found: {fixture_path}", file=sys.stderr)
+        print("   download via:", file=sys.stderr)
+        print("   python -c \"from eval.external.runner import "
+                "build_loader; build_loader('rgb', variant='en', "
+                "allow_download=True).iter_queries(n_samples=1)\"",
+                file=sys.stderr)
+        return 2
+
+    # UTF-8 console safety on Windows.
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8",
+                                    errors="replace")
+
+    rows = _read_rgb_fixture(fixture_path)
+    if args.max_rows is not None:
+        rows = rows[:args.max_rows]
+
+    print(f"=== cycle γ RGB-en corpus build ===")
+    print(f"  workspace : {workspace}")
+    print(f"  fixture   : {fixture_path}  (rows={len(rows)})")
+    print(f"  mode      : {args.mode}")
+    print()
+
+    # Late import so JAMES_WORKSPACE is honoured.
+    sys.path.insert(0, str(root))
+    from core.vector_store import VectorStore
+
+    vector_store = VectorStore()
+    n_pos_total = 0
+    n_neg_total = 0
+    t0 = time.time()
+
+    for i, row in enumerate(rows, 1):
+        if not isinstance(row, dict):
+            continue
+        n_pos, n_neg = _ingest_row(
+            vector_store, row, mode=args.mode,
+        )
+        n_pos_total += n_pos
+        n_neg_total += n_neg
+        if (i % max(args.progress_every, 1) == 0
+                or i == len(rows)):
+            elapsed = time.time() - t0
+            print(f"  [{i}/{len(rows)}] {elapsed:.0f}s — "
+                    f"pos={n_pos_total} neg={n_neg_total}",
+                    flush=True)
+
+    elapsed = time.time() - t0
+    final_count = vector_store.count()
+    print()
+    print(f"=== INGESTION COMPLETE ({args.mode}) ===")
+    print(f"  rows processed         : {len(rows)}")
+    print(f"  positive passages added: {n_pos_total}")
+    print(f"  negative passages added: {n_neg_total}")
+    print(f"  vector store count     : {final_count}")
+    print(f"  elapsed                : {elapsed:.1f}s")
+    print(f"  workspace              : {workspace}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cycle_gamma_rgb_loader.py
+++ b/tests/test_cycle_gamma_rgb_loader.py
@@ -355,6 +355,71 @@ class AbstentionModeTests(unittest.TestCase):
         self.assertTrue(loader.abstention_mode)
 
 
+class SettingFilterTests(unittest.TestCase):
+    """Phase B Option A (2026-06-08) — the JAMES-engine experiment
+    needs to pair an axis-specific workspace (full vs negrej-only)
+    with an axis-specific query slice. setting_filter does that
+    routing without re-loading the fixture twice."""
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.cache = Path(self._td.name)
+        _write_synthetic(self.cache, "en", [
+            {"id": "x1", "query": "Q?", "answer": "A",
+             "positive": ["p"], "negative": ["n"]},
+        ])
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def test_filter_none_emits_both(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            setting_filter=None)
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 2)
+
+    def test_filter_noise_keeps_only_noise(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            setting_filter="noise_robustness")
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["setting"],
+                          "noise_robustness")
+
+    def test_filter_negrej_keeps_only_negrej(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            setting_filter="negative_rejection")
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["setting"],
+                          "negative_rejection")
+
+    def test_filter_invalid_raises(self):
+        from eval.external.rgb_loader import RGBLoader
+        with self.assertRaises(ValueError):
+            RGBLoader(variant="en", setting_filter="bogus")
+
+    def test_filter_default_is_none(self):
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en")
+        self.assertIsNone(loader.setting_filter)
+
+    def test_filter_negrej_with_abstention_mode_false_emits_zero(self):
+        """When abstention_mode is False AND filter requests negrej,
+        nothing comes through (the negrej variant isn't emitted in
+        the first place). This is a degenerate but defensible
+        combination — the loader doesn't crash on it."""
+        from eval.external.rgb_loader import RGBLoader
+        loader = RGBLoader(variant="en", cache_dir=self.cache,
+                            abstention_mode=False,
+                            setting_filter="negative_rejection")
+        out = loader.iter_queries()
+        self.assertEqual(len(out), 0)
+
+
 class CorruptFixtureTests(unittest.TestCase):
     """Malformed JSON / non-list root / non-dict rows surface cleanly."""
 


### PR DESCRIPTION
## Summary

Phase B Option A wiring — operator chose "제대로 측정 — 2 workspace (full + negrej-only)" from the handover §4 decision tree. This PR ships both halves of that wiring:

1. **Loader-side setting_filter**: post-filters the dual-axis query stream to one axis. Lets a single workspace pair with a single axis (no cross-axis bleed).
2. **2-workspace corpus builder script**: `--mode {full,negrej}` ingests RGB-en passages into a JAMES_WORKSPACE-isolated chroma_db.

Together these unlock the JAMES-engine RGB measurement that closes the framing of the ⭐⭐ candidate finding from Phase B #3 (raw `negative_rejection_f1=0.000`).

## Verification

- 51/51 cycle γ tests pass
- CLI help lists `--setting-filter` and `--no-abstention-mode`
- Corpus builder sanity smoke OK on 5 rows (46 pos + 153 neg = 199 chunks ingested)

## Out of scope (operator-gated next steps)

- Full 300-row ingestion for both modes (~50 min combined)
- JAMES-engine measurement runs (live LLM)
- Comparison against the 0.000 raw baseline

Quality delta: exempt (label: feat — integration-layer addition; no `core/retrieval/graph/reasoning` quality dial change).

Self-eval trap discipline (memory `feedback_self_evaluation_trap`): the corpus builder reads the published RGB fixture verbatim. The "negrej" mode is the published RGB paper's experimental setting (strip positives), not a JAMES-internal contrivance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)