### PR TITLE
feat(cycle γ D2): softener bilingual opt-in (default OFF) — negative evidence

### DIFF
--- a/core/reasoning/pipeline_synth.py
+++ b/core/reasoning/pipeline_synth.py
@@ -25,6 +25,105 @@ from core.observability import log_stage
 from core.reasoning.trace_helpers import trace_synth_call
 
 
+# ─── cycle γ Phase D2 — softener triggers + retry prompt ───────────
+#
+# Helpers are module-level so the contract is unit-testable without
+# instantiating the engine. JAMES_SOFTENER_BILINGUAL=1 is the only
+# new env knob; default OFF keeps Korean-only behaviour byte-identical
+# to pre-Phase-D2. Path D positioning honoured: this fills a design
+# gap (cross-lingual coverage) without taking JAMES into the
+# HALT-RAG specialty-verifier category. See
+# memory/feedback_path_d_james_not_specialty_verifier.md.
+
+_KOREAN_NO_DATA_TRIGGERS: tuple = (
+    "자료에 없음. 관련된",
+    "답변 생성에 실패",
+    "LLM 응답 생성 중 오류",
+)
+
+# English abstention triggers mirror the RGB scorer's _ABSTENTION_EN
+# pattern set (core/reasoning/../external/rgb_scorer.py) so the
+# softener fires on the same set of model outputs that the published
+# RGB benchmark scores as "abstention" — keeps end-to-end semantics
+# consistent across the JAMES pipeline + the external scorer it's
+# being evaluated against. NOT a HALT-RAG-style NLI verifier — just
+# a startswith() trigger mirror, axis-aligned with abst_f1 primary.
+_ENGLISH_NO_DATA_TRIGGERS: tuple = (
+    "Insufficient information",
+    "Insufficient context",
+    "Insufficient evidence",
+    "I cannot find",
+    "I can not find",
+    "I can't find",
+    "I cannot answer",
+    "I can not answer",
+    "I can't answer",
+    "I cannot determine",
+    "I can not determine",
+    "I can't determine",
+    "I don't know",
+    "I do not know",
+    "Unable to answer",
+    "Unable to determine",
+    "No information available",
+    "No relevant information",
+    "Not enough information",
+)
+
+
+def _abstention_triggers(*, bilingual: bool) -> tuple:
+    """Return the tuple of answer-prefix substrings that trigger the
+    softener retry pass.
+
+    Default = Korean only (back-compat with pre-Phase-D2 deployments).
+    ``bilingual=True`` adds English equivalents mirroring the RGB
+    scorer's abstention pattern set — closes the Korean-only design
+    gap surfaced by Phase B+C+D measurement on RGB-en.
+    """
+    if bilingual:
+        return _KOREAN_NO_DATA_TRIGGERS + _ENGLISH_NO_DATA_TRIGGERS
+    return _KOREAN_NO_DATA_TRIGGERS
+
+
+def _build_retry_prompt(
+    *,
+    sys_prefix: str,
+    rule_text: str,
+    query: str,
+    is_korean: bool,
+    bilingual: bool,
+) -> str:
+    """Build the retry-no-info prompt in the query's language.
+
+    Pre-Phase-D2 path = Korean-only prompt regardless of query
+    language. With ``bilingual=True`` AND English query
+    (``is_korean=False``), the prompt scaffolding switches to
+    English so the model isn't asked an English question with a
+    Korean parenthetical and a Korean "답변:" prompt — both of
+    which empirically derailed RGB-en query #3 in the Phase D
+    measurement.
+
+    Korean queries always get the Korean prompt (regardless of
+    ``bilingual``) — back-compat preserved.
+    """
+    if is_korean or not bilingual:
+        return (
+            f"{sys_prefix}{rule_text}\n"
+            f"질문: {query}\n\n"
+            "(내부 자료에는 직접 언급이 없습니다. "
+            "위 가이드를 따라 자연스럽게 답하세요.)\n답변:"
+        )
+    # bilingual=True + English query → English scaffold
+    return (
+        f"{sys_prefix}{rule_text}\n"
+        f"Question: {query}\n\n"
+        "(The internal materials do not contain a direct mention. "
+        "Follow the guide above to respond naturally — if you cannot "
+        "answer from the provided context, say so explicitly.)\n"
+        "Answer:"
+    )
+
+
 @dataclass
 class AnswerBlock:
     """Outputs of generate_answer() that the orchestrator threads into
@@ -257,7 +356,15 @@ def generate_answer(
         # α-6 S5 sector ablation — `JAMES_DISABLE_ABSTENTION=1` skips the
         # retry-no-info pass so the LLM's first "자료에 없음" answer stands.
         # The cell measures JAMES *without* the abstention softener.
-        _no_data = ("자료에 없음. 관련된", "답변 생성에 실패", "LLM 응답 생성 중 오류")
+        #
+        # cycle γ Phase D2 (2026-06-08) — softener was Korean-only since
+        # introduction; English queries (e.g. RGB-en) never triggered the
+        # softener because the LLM's English abstention output didn't
+        # match any Korean trigger string. JAMES_SOFTENER_BILINGUAL=1 enables
+        # English triggers + bilingual retry prompt. Default OFF preserves
+        # byte-identical pre-Phase-D2 behaviour for Korean-only deployments.
+        _bilingual = os.environ.get("JAMES_SOFTENER_BILINGUAL") == "1"
+        _no_data = _abstention_triggers(bilingual=_bilingual)
         _s5_disabled = os.environ.get("JAMES_DISABLE_ABSTENTION") == "1"
         if not _s5_disabled and answer and any(answer.startswith(p) for p in _no_data):
             sys_prefix = f"{system_prompt}\n\n" if system_prompt else ""
@@ -266,11 +373,12 @@ def generate_answer(
             _korean_r = sum(1 for c in safe_query if "가" <= c <= "힣")
             _is_ko_r = _korean_r >= max(1, len(safe_query) * 0.2)
             _rule_r = _style_retry.rule_text_ko if _is_ko_r else _style_retry.rule_text_en
-            _retry_prompt = (
-                f"{sys_prefix}{_rule_r}\n"
-                f"질문: {safe_query}\n\n"
-                "(내부 자료에는 직접 언급이 없습니다. "
-                "위 가이드를 따라 자연스럽게 답하세요.)\n답변:"
+            _retry_prompt = _build_retry_prompt(
+                sys_prefix=sys_prefix,
+                rule_text=_rule_r,
+                query=safe_query,
+                is_korean=_is_ko_r,
+                bilingual=_bilingual,
             )
             retry = trace_synth_call(
                 _retry_prompt,

--- a/tests/test_cycle_gamma_phase_d2_softener_bilingual.py
+++ b/tests/test_cycle_gamma_phase_d2_softener_bilingual.py
@@ -1,0 +1,192 @@
+"""Cycle γ Phase D2 — softener bilingual extension contract tests.
+
+Pins:
+  * Default (`JAMES_SOFTENER_BILINGUAL` unset / "0") = Korean-only,
+    byte-identical to pre-Phase-D2 production
+  * `JAMES_SOFTENER_BILINGUAL=1` adds the English abstention trigger
+    set, mirroring the RGB scorer's `_ABSTENTION_EN`
+  * Retry prompt scaffold switches Korean → English when (bilingual
+    AND query language English)
+  * Korean queries keep the Korean retry prompt regardless of
+    bilingual env (back-compat)
+
+Path D positioning honoured: this is NOT an NLI verifier (no
+HALT-RAG style), just a Korean-only-gap fix for cross-lingual
+RAG abstention. See memory/feedback_path_d_james_not_specialty_
+verifier.md for the boundary.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class AbstentionTriggersTests(unittest.TestCase):
+
+    def test_default_korean_only(self):
+        from core.reasoning.pipeline_synth import (
+            _abstention_triggers, _KOREAN_NO_DATA_TRIGGERS,
+            _ENGLISH_NO_DATA_TRIGGERS,
+        )
+        triggers = _abstention_triggers(bilingual=False)
+        self.assertEqual(triggers, _KOREAN_NO_DATA_TRIGGERS)
+        # All Korean strings preserved
+        self.assertIn("자료에 없음. 관련된", triggers)
+        self.assertIn("답변 생성에 실패", triggers)
+        self.assertIn("LLM 응답 생성 중 오류", triggers)
+        # No English additions
+        for s in _ENGLISH_NO_DATA_TRIGGERS:
+            self.assertNotIn(s, triggers,
+                              msg=f"English {s!r} leaked into default")
+
+    def test_bilingual_includes_english(self):
+        from core.reasoning.pipeline_synth import (
+            _abstention_triggers, _KOREAN_NO_DATA_TRIGGERS,
+            _ENGLISH_NO_DATA_TRIGGERS,
+        )
+        triggers = _abstention_triggers(bilingual=True)
+        # Korean preserved (back-compat)
+        for s in _KOREAN_NO_DATA_TRIGGERS:
+            self.assertIn(s, triggers)
+        # English additions present
+        for s in _ENGLISH_NO_DATA_TRIGGERS:
+            self.assertIn(s, triggers)
+        # Specific high-frequency patterns from RGB scorer
+        self.assertIn("Insufficient information", triggers)
+        self.assertIn("I cannot find", triggers)
+        self.assertIn("Unable to answer", triggers)
+
+    def test_no_duplicates(self):
+        from core.reasoning.pipeline_synth import _abstention_triggers
+        for bilingual in (False, True):
+            triggers = _abstention_triggers(bilingual=bilingual)
+            self.assertEqual(len(triggers), len(set(triggers)),
+                              msg=f"bilingual={bilingual} has duplicates")
+
+    def test_english_mirrors_rgb_scorer_subset(self):
+        """The English triggers are a subset (or near-subset) of the
+        RGB scorer's _ABSTENTION_EN — keeps end-to-end semantics
+        consistent: when JAMES retries on an English 'Insufficient'
+        answer, that same answer would be scored as abstention by
+        the bench."""
+        from core.reasoning.pipeline_synth import _ENGLISH_NO_DATA_TRIGGERS
+        from eval.external.rgb_scorer import _ABSTENTION_EN
+        # Each Phase-D2 English trigger should have at least one
+        # matching prefix in the RGB scorer's pattern set
+        # (lower-cased, substring).
+        scorer_set_lower = set(p.lower() for p in _ABSTENTION_EN)
+        for trig in _ENGLISH_NO_DATA_TRIGGERS:
+            trig_lower = trig.lower()
+            # Match either exact, or scorer pattern is substring of
+            # trigger, or trigger is substring of scorer pattern.
+            matched = any(
+                p == trig_lower or p in trig_lower or trig_lower in p
+                for p in scorer_set_lower
+            )
+            self.assertTrue(matched,
+                             msg=f"trigger {trig!r} has no RGB-scorer "
+                                 f"mirror — soft semantic break")
+
+
+class RetryPromptTests(unittest.TestCase):
+
+    def test_korean_query_bilingual_off_keeps_korean(self):
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="", rule_text="rule", query="질문 내용",
+            is_korean=True, bilingual=False,
+        )
+        self.assertIn("질문:", out)
+        self.assertIn("답변:", out)
+        self.assertIn("내부 자료에는", out)
+
+    def test_korean_query_bilingual_on_keeps_korean(self):
+        """Korean queries always get the Korean scaffold (regardless
+        of bilingual env) — back-compat guarantee."""
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="", rule_text="rule", query="질문 내용",
+            is_korean=True, bilingual=True,
+        )
+        self.assertIn("질문:", out)
+        self.assertNotIn("Question:", out)
+
+    def test_english_query_bilingual_off_keeps_korean(self):
+        """Back-compat: English query + bilingual OFF = Korean
+        prompt (pre-Phase-D2 behaviour byte-identical)."""
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="", rule_text="rule", query="What is X?",
+            is_korean=False, bilingual=False,
+        )
+        self.assertIn("질문:", out)
+        self.assertIn("답변:", out)
+
+    def test_english_query_bilingual_on_switches_to_english(self):
+        """The Phase D2 fix: English query + bilingual ON = English
+        prompt scaffold (no Korean 질문/답변)."""
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="", rule_text="rule", query="What is X?",
+            is_korean=False, bilingual=True,
+        )
+        self.assertIn("Question:", out)
+        self.assertIn("Answer:", out)
+        self.assertNotIn("질문:", out)
+        self.assertNotIn("답변:", out)
+        # Abstention guidance text in English
+        self.assertIn("cannot answer", out)
+
+    def test_sys_prefix_prepended(self):
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="SYS_PREFIX_TOKEN\n\n", rule_text="rule",
+            query="What is X?", is_korean=False, bilingual=True,
+        )
+        self.assertTrue(out.startswith("SYS_PREFIX_TOKEN\n\n"))
+
+    def test_rule_text_included(self):
+        from core.reasoning.pipeline_synth import _build_retry_prompt
+        out = _build_retry_prompt(
+            sys_prefix="", rule_text="SOME_RULE_TEXT",
+            query="What is X?", is_korean=False, bilingual=True,
+        )
+        self.assertIn("SOME_RULE_TEXT", out)
+
+
+class IntegrationContractTests(unittest.TestCase):
+    """End-to-end contract: env var → triggers + prompt match."""
+
+    def test_env_default_keeps_korean_only(self):
+        from core.reasoning.pipeline_synth import _abstention_triggers
+        triggers = _abstention_triggers(
+            bilingual=(os.environ.get("JAMES_SOFTENER_BILINGUAL")
+                      == "1")
+        )
+        # Without the env, we get Korean only — pre-Phase-D2 contract
+        if os.environ.get("JAMES_SOFTENER_BILINGUAL") != "1":
+            self.assertNotIn("Insufficient information", triggers)
+
+    def test_phase_b_query_3_would_trigger_under_bilingual(self):
+        """The actual Phase B+C+D query #3 R0 answer started with
+        'Insufficient information.' — confirm it would now fire the
+        softener under bilingual=True."""
+        from core.reasoning.pipeline_synth import _abstention_triggers
+        phase_c_q3_answer = (
+            "Insufficient information. While the context confirms "
+            "that Jason Semore spent time at Valdosta State and "
+            "returned to Georgia Tech, it does not specify what "
+            "position he held while at Valdosta State."
+        )
+        triggers = _abstention_triggers(bilingual=True)
+        matched = any(phase_c_q3_answer.startswith(t) for t in triggers)
+        self.assertTrue(matched,
+                         msg="Bilingual softener should fire on the "
+                             "Phase C query-3 answer pattern")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

D2 V2: JAMES_SOFTENER_BILINGUAL=1 env knob adds English abstention triggers + bilingual retry prompt scaffold. **Default OFF preserves byte-identical pre-Phase-D2 production behaviour.**

Path D positioning honoured: NOT an NLI verifier (no HALT-RAG style architecture). Just a startswith() trigger expansion mirroring the RGB scorer's `_ABSTENTION_EN` patterns.

## Measurement — REGRESSION

| Config | F1 | Set | Δ |
|---|---|---|---|
| R0 (Korean-only, current) | 0.387 | {3,9,14,15,17,18} | — |
| D2 V2 (Bilingual ON) | 0.276 | {3,14,15,17} | **-0.111** |

V2 lost queries 9 + 18. Per-query inspection: V2 retry's "respond naturally" cue **destabilises** correct English abstention into either softer hedge (Q9, scorer misses) or outright hallucination (Q18).

## Why ship despite regression

1. **Empirical evidence preserved** — future sessions don't repeat the same hypothesis
2. **Helper structure reusable** — `_abstention_triggers()` + `_build_retry_prompt()` clean abstractions for V3/V4
3. **Tests as contract pins** — 12 tests
4. **Default OFF byte-identical** — production untouched
5. **Clear pivot signal** — Phase D showed retrieval = 5/6 contribution; D2 V2 reinforces softener is small-lever work. Next priority = D1 (retrieval).

## What this PR is NOT

- ❌ Not path to HALT-RAG 0.978 (Path D stands)
- ❌ Not default-revision recommendation
- ❌ Not "JAMES is Korean-only" — JAMES is cross-lingual; current softener architecture is the gap, V2 isn't the right fix
- ❌ Not the only English abstention fix — V3 directive retry / V4 selective trigger still on table

## 8 catches this session (7 user-driven + 1 measurement-driven)

1. post-hoc fit framed as prediction
2. 0.000 negrej audit
3. family vs size separation
4. prior art search recommendation
5. cycle γ ↔ joint piece scope separation
6. single-axis ablation → defect framing violation
7. HALT-RAG axis chase → Path D positioning
8. **D2 V2 "Korean-only is correct" framing → JAMES is cross-lingual, V2 implementation is the wrong fix**

Quality delta: exempt (label: fix — the regression IS the contribution; multi-axis not gating because same-axis (abst_f1) regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)