### PR TITLE
fix(security): starlette 1.0.1 floor pin + chromadb risk-accept (Dependabot 4-alert P0)

### DIFF
--- a/docs/security/dependabot-2026-06-10-risk-assessment.md
+++ b/docs/security/dependabot-2026-06-10-risk-assessment.md
@@ -1,0 +1,119 @@
+# Dependabot risk assessment — 2026-06-10
+
+Open alerts on `main` at the time of this assessment:
+
+| # | Package | Severity | CVE | Manifest | Disposition |
+|---|---|---|---|---|---|
+| 16 | starlette | medium | CVE-2026-48710 | `requirements.txt` | **Fix** (floor pin → 1.0.1) |
+| 15 | starlette | medium | CVE-2026-48710 | `requirements_pinned.txt` | **Fix** (pin 1.0.0 → 1.0.1) |
+| 14 | chromadb | critical | CVE-2026-45829 | `requirements.txt` | **Risk-accept** (not exploitable; awaiting upstream patch) |
+| 13 | chromadb | critical | CVE-2026-45829 | `requirements_pinned.txt` | **Risk-accept** (same) |
+
+Two distinct advisories; each fires once per manifest.
+
+---
+
+## 1. starlette — CVE-2026-48710 (badhost)
+
+**GHSA-86qp-5c8j-p5mr.** Affected versions (≤ 1.0.0) did not validate
+the HTTP `Host` header before reconstructing `request.url`. A
+malformed `Host` such as `example.com/abc?bar=` shifts the
+path/query boundary during URL re-parsing, so
+`request.url.path` becomes `/abc` even when routing dispatched to
+the real path `/foo`. Middleware that gates path prefixes on
+`request.url.path` (rather than the raw ASGI scope path) can be
+bypassed.
+
+### JAMES exposure
+
+Direct dependency surface — FastAPI / Uvicorn ASGI app
+(`server_llmwiki.py`). The repository does not use the affected
+attribute in security-critical decisions today (a quick grep finds
+no middleware that gates on `request.url.path`), but the
+deployment runs an ASGI app behind no consistently-configured
+reverse-proxy normalisation, so the latent risk warrants the
+mechanical fix even at the medium-severity level.
+
+### Disposition
+
+**Fix.** Patched in starlette 1.0.1. Pulled in transitively by
+FastAPI; explicit floor pin added in `requirements.txt` mirroring
+the existing pattern for urllib3 / idna / python-multipart so a
+fresh install with a stale wheel cache cannot regress us.
+`requirements_pinned.txt` bumped to 1.0.1.
+
+---
+
+## 2. chromadb — CVE-2026-45829 (chromatoast)
+
+**GHSA-f4j7-r4q5-qw2c.** Pre-authentication remote code execution
+in the ChromaDB HTTP server. An unauthenticated attacker POSTs a
+collection-creation request to
+`/api/v2/tenants/{tenant}/databases/{db}/collections` whose body
+points at a malicious model repository with `trust_remote_code=true`
+set; the server then executes attacker-controlled Python during
+model loading. Vulnerable range: chromadb 1.0.0 – 1.5.9. **No
+patched version is published as of 2026-06-10.** Upstream tracker:
+`chroma-core/chroma#6717`.
+
+### JAMES exposure — risk-accept rationale
+
+The CVE attack surface is **not reachable** in this deployment:
+
+1. **No HTTP server.** `core/vector_store.py` constructs the client
+   as `chromadb.PersistentClient(path=self.db_path)` (line 75) —
+   the embedded local mode. The chromadb HTTP server module
+   (which exposes the vulnerable `/api/v2/.../collections`
+   endpoint) is not started by any JAMES code path. A repo-wide
+   grep for `chromadb.HttpClient` / `chromadb.AsyncHttpClient` /
+   `chroma_server` returns zero matches.
+2. **No trust_remote_code call sites.** Grep for
+   `trust_remote_code` across the codebase returns zero matches.
+   No JAMES module passes user-controlled values into a chromadb
+   collection-construction payload that could enable the gadget.
+3. **Local-first architecture.** CLAUDE.md headline ("A local-first,
+   auditable knowledge reasoning system") and `docs/ARCHITECTURE.md`
+   non-goals exclude multi-tenant network surface as a v0.4 target.
+   v0.5 enterprise-internal-knowledge pilot (the candidate
+   v0.5 domain, gated) does not change this — the chromadb client
+   stays embedded; ingestion / retrieval flow through the JAMES
+   API surface (`routes/`), not chromadb's own HTTP layer.
+
+The vulnerable code path exists in the installed library but is
+unreferenced from JAMES call sites. An attacker would need to
+either (a) compromise the JAMES Python process directly (a higher
+bar than the CVE describes), or (b) get JAMES code to import and
+start chromadb's HTTP server with a user-controlled payload (no
+such code path exists, and adding one would be a separate review).
+
+### Disposition
+
+**Risk-accept until upstream patch ships.** Concrete action:
+
+- Floor in `requirements.txt` stays at `chromadb>=0.4.22`. No
+  meaningful upper bound to add (no patched version exists; the
+  pre-1.0 versions are missing features the project needs).
+- `requirements_pinned.txt` stays at `chromadb==1.5.7`.
+- Track `chroma-core/chroma#6717`; bump on first patched release.
+- **Re-evaluation trigger**: any PR that introduces
+  `chromadb.HttpClient`, `chromadb.AsyncHttpClient`, a
+  `chroma_server` import, or anything that lets external input
+  influence collection-creation payloads MUST revisit this
+  assessment in the same PR. The chromadb advisory becomes live
+  exposure the moment any of those land.
+- Dependabot alerts #13 and #14 will be dismissed as
+  `not_used` with this document URL as the comment, following the
+  review's guidance to keep the alerts queue actionable.
+
+---
+
+## 3. Auditability note
+
+This assessment lives in the repository at
+`docs/security/dependabot-2026-06-10-risk-assessment.md` and is
+referenced from the relevant requirements.txt comment block. The
+goal is the property described in
+`docs/research/project-direction-review-2026-06-09.md` R1 — that
+JAMES's moat axis is **replayable audit**, and risk-acceptance
+decisions on dependencies are exactly the kind of thing that has
+to be reproducible from the repo, not from operator memory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,13 @@
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
 python-multipart>=0.0.27  # GHSA / Dependabot alerts #5,#6 (DoS via unbounded multipart headers; 0.0.27 raises the floor past the newer disclosure)
+# Dependabot alerts #15/#16 — GHSA-86qp-5c8j-p5mr / CVE-2026-48710
+# (badhost): unvalidated Host header poisons request.url.path,
+# bypassing path-based security middleware. Patched in starlette
+# 1.0.1. Pulled in transitively by fastapi; pin the floor here so a
+# fresh install with a stale wheel cache cannot regress us, matching
+# the urllib3 / python-multipart / idna approach above.
+starlette>=1.0.1
 pydantic>=2.5.0
 
 # ── Authentication / Security ──────────────────────────────────
@@ -31,6 +38,24 @@ urllib3>=2.7.0
 idna>=3.15
 
 # ── Vector DB / Embeddings / Search ────────────────────────────
+# Dependabot alerts #13/#14 — GHSA-f4j7-r4q5-qw2c / CVE-2026-45829
+# (chromatoast): pre-auth code injection in the chromadb HTTP server's
+# /api/v2/tenants/{tenant}/databases/{db}/collections endpoint when
+# the request body sets trust_remote_code=true on a malicious model
+# repository. Vulnerable range 1.0.0–1.5.9 with NO patched version
+# published as of 2026-06-10.
+#
+# JAMES risk acceptance: not exploitable in this deployment.
+#   - core/vector_store.py uses chromadb.PersistentClient (embedded
+#     local mode); the HTTP server is never started.
+#   - No JAMES code path calls trust_remote_code or constructs
+#     chromadb collections from user-controlled model repositories.
+#   - JAMES is local-first per CLAUDE.md / docs/ARCHITECTURE.md.
+# Floor kept at 0.4.22 (no advisory ≥ patched version exists to
+# raise to). Track upstream chroma-core/chroma#6717 and bump when
+# a fixed release ships. See
+# docs/security/dependabot-2026-06-10-risk-assessment.md for the
+# full assessment + dismissal rationale.
 chromadb>=0.4.22
 sentence-transformers>=2.5.0
 rank-bm25>=0.2.2

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -125,7 +125,7 @@ six==1.17.0
 sniffio==1.3.1
 sounddevice==0.5.5
 soupsieve==2.8.3
-starlette==1.0.0
+starlette==1.0.1
 sympy==1.14.0
 tenacity==9.1.4
 threadpoolctl==3.6.0


### PR DESCRIPTION
## Summary
- **starlette**: floor pin → 1.0.1 (CVE-2026-48710 *badhost* — Host header validation bypass in path-based middleware). Closes Dependabot #15 / #16.
- **chromadb**: risk-accept (CVE-2026-45829 *chromatoast* — pre-auth RCE in chromadb HTTP server; **no upstream patch yet**). Documented non-exploitability + dismissal plan for Dependabot #13 / #14.
- New: \`docs/security/dependabot-2026-06-10-risk-assessment.md\` (auditability — R1 moat-axis material).

## Verification

### starlette (mechanical)
- Pulled in transitively by FastAPI; explicit floor pin in \`requirements.txt\` follows the same pattern as urllib3 / idna / python-multipart so a stale wheel cache cannot regress.
- \`requirements_pinned.txt\`: 1.0.0 → 1.0.1.

### chromadb (risk-accept rationale)
- Attack vector = HTTP endpoint \`/api/v2/tenants/{tenant}/databases/{db}/collections\` with \`trust_remote_code=true\` in body.
- \`core/vector_store.py:75\` uses \`chromadb.PersistentClient(path=self.db_path)\` — **embedded local mode**, HTTP server not started.
- Repo-wide grep for \`chromadb.HttpClient\` / \`chromadb.AsyncHttpClient\` / \`chroma_server\` / \`trust_remote_code\` returns **zero matches**.
- Local-first architecture per CLAUDE.md / docs/ARCHITECTURE.md.
- Re-evaluation trigger documented (any future PR that introduces those imports MUST revisit).
- Action after merge: dismiss alerts #13 / #14 with reason=\`not_used\` and comment URL pointing at the risk-assessment doc.

## Out of scope
- Upstream chromadb patch (tracking chroma-core/chroma#6717; will bump on first patched release).
- Dependabot dismissals via \`gh api -X PATCH ... /alerts/{13,14}\` — to be run after merge.

P0 of the 2026-06-09 project-direction review (#750 closed the docs half: R2 rules + R5 pre-registration).

Quality delta: exempt (label: chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)