### PR TITLE
feat(cycle γ C.2): MuSiQue → retrieval is the dominant multi-hop bottleneck

### DIFF
--- a/core/reasoning/pipeline_loops.py
+++ b/core/reasoning/pipeline_loops.py
@@ -29,6 +29,21 @@ from typing import Any, Dict
 from core.observability import log_stage
 
 
+def _env_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to
+    ``default`` on unset / malformed / non-positive values. Used for
+    the retrieval / rerank breadth knobs so production stays at 8/5
+    unless an operator explicitly overrides for a measurement."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return val if val > 0 else default
+
+
 def run_loop_0_retrieve(
     engine,
     loop_state: Dict[str, Any],
@@ -59,6 +74,14 @@ def run_loop_0_retrieve(
                   source_type=source_type, sector_disabled=True)
         print("  docs=0 (S1 disabled — JAMES_DISABLE_RAG_RETRIEVAL=1)")
         return
+    # Retrieval / rerank breadth. Default 8/5 (byte-identical to prior
+    # behaviour when the env vars are unset). Cycle γ Phase C.2 uses
+    # these to test whether widening retrieval lifts multi-hop
+    # supporting-paragraph coverage (MuSiQue R0 floor diagnosis,
+    # 2026-06-10). Production default is unchanged until a multi-axis
+    # measurement (MuSiQue gain vs RGB abstention loss) licenses a flip.
+    retrieve_top_k = _env_int("JAMES_RETRIEVE_TOP_K", 8)
+    rerank_top_k = _env_int("JAMES_RERANK_TOP_K", 5)
     try:
         from core.orchestrator import retrieve as orch_retrieve
         docs = orch_retrieve(
@@ -67,13 +90,13 @@ def run_loop_0_retrieve(
             hybrid_search_fn= engine.retrieval.hybrid_search,
             user_role       = user_role,
             source_type     = source_type,
-            top_k           = 8,
+            top_k           = retrieve_top_k,
         )
     except Exception as e:
         engine._log("loop0_orchestrator", e, user_role)
         # fallback: 기존 방식
         docs = engine.retrieval.hybrid_search(
-            safe_query, top_k=8,
+            safe_query, top_k=retrieve_top_k,
             user_role=user_role,
             source_type=source_type,
         )
@@ -90,10 +113,10 @@ def run_loop_0_retrieve(
     pre_rerank_count = len(docs)
     try:
         from core.retrieval.rerank import get_reranker
-        docs = get_reranker().rerank(safe_query, docs, top_k=5)
+        docs = get_reranker().rerank(safe_query, docs, top_k=rerank_top_k)
     except Exception as e:
         engine._log("loop0_rerank", e, user_role)
-        docs = docs[:5]
+        docs = docs[:rerank_top_k]
     rerank_ms = int((time.time() - t_rerank) * 1000)
 
     # Emit one trace step for the rerank stage so the replay

--- a/docs/handovers/v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md
+++ b/docs/handovers/v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md
@@ -1,0 +1,161 @@
+# Cycle γ Phase C.2 — MuSiQue paired ablation → retrieval bottleneck
+
+**Date**: 2026-06-10
+**Status**: Phase C.2 **closed as honest negative + diagnostic finding**.
+The pre-registered tradeoff measurement (hyp2) could NOT be run — MuSiQue
+R0 floored — but the floor diagnosis produced a **stronger** result: a
+decisive, externally-grounded confirmation that **retrieval (not the
+component knobs, not the model) is the dominant multi-hop bottleneck**.
+
+---
+
+## 1. Headline
+
+Pre-registration (`docs/research/cycle-gamma-phase-c2-preregistration-2026-06-10.md`)
+set out to measure the GAIN half of the rerank / cognitive_stages
+tradeoff on MuSiQue-ans (n=25, 3 models). The R0 cell-validity gate
+(§5) caught a floor and we entered diagnostic mode. Three measurements
+**isolated the cause**:
+
+| Measurement | Result | What it rules out |
+|---|---|---|
+| R0 (top_k 8/5, full JAMES) | em=0, f1≈0.06, **abstain 76%** | — (floor observed) |
+| R0 (top_k 16/10, env-gated) | em=0, f1≈0.06, **abstain 80%** | retrieval **breadth** ❌ (2× wider = no change) |
+| **oracle (supporting paras only)** | **gold-in-answer 72%**, abstain 24% | model **ceiling** ❌ (model solves with evidence) |
+
+**Conclusion: JAMES's single-shot dense retrieval fails to surface the
+2nd-hop supporting paragraph. That is the floor. Not breadth, not the
+model, not rerank/cog_stages.**
+
+---
+
+## 2. The measurement chain (logical order)
+
+### 2.1 Setup
+- Data: MuSiQue-ans dev, downloaded from HF mirror `dgslibisey/MuSiQue`
+  (2417 rows) via new `scripts/research/download_musique.py`.
+- Workspace: `workspaces/cycle_gamma_musique_ans`, first-25 rows
+  ingested per-paragraph (`musique-ans-<rowid>-p<idx>`), 500 paragraphs.
+- All 25 queries are **2-hop**.
+
+### 2.2 R0 cell-validity gate (pre-registration §5)
+- 3 models (mixtral:8x7b / gemma4:e4b / llama3.1:8b), n=25 each.
+- f1 = 0.060 / 0.085 / 0.071 — **barely** over the §5 "≤ 0.05 on all 3 =
+  wiring suspicion" line, but **em = 0.000 on all 75 queries** forced a
+  diagnostic read rather than a pass.
+- mxtral raw-answer inspection: **19/25 abstain** ("insufficient
+  information"), answers explicitly say *"context states A but does not
+  provide B"* → 2nd hop evidence missing.
+- Retrieval coverage of gold supporting paragraphs (sources top-3
+  shown): **0.60**; both-supporting-caught only **5/25**.
+
+### 2.3 Breadth test (env-gate, exploratory)
+- New env-gate `JAMES_RETRIEVE_TOP_K` / `JAMES_RERANK_TOP_K` in
+  `core/reasoning/pipeline_loops.py`. **Default 8/5 byte-identical**
+  (verified: unset → 8/5; malformed/negative → default).
+- mxtral R0 at 16/10: abstain **80%** (vs 76%), f1 0.057 (vs 0.060),
+  em 0. **Widening retrieval 2× changed nothing** → breadth is not the
+  cause.
+
+### 2.4 Oracle-retrieval test (the decider)
+- `scripts/research/_phase_c2_oracle_diag.py`: feed each query ONLY its
+  gold supporting paragraphs (perfect evidence, retrieval bypassed),
+  score em/f1 + abstention.
+- mxtral, n=25: **gold-substring-in-answer 18/25 (72%)** vs R0's 2/25
+  (8%) — a **9× jump**. abstain 6/25 (24%) vs 76%.
+- → The model solves the 2-hop **once it has the evidence**. The gap is
+  retrieval, not the LLM.
+
+---
+
+## 3. What this means
+
+### 3.1 Pre-registered hyp2 (tradeoff) — not measurable here
+The rerank/cognitive_stages GAIN cannot be measured on this fixture:
+`cognitive_stages` (multi-step reasoning) needs the evidence delivered
+to fire, and 80% of queries never get the 2nd-hop supporting paragraph.
+Per `mechanism_layer_intent_axis_alignment`, the layer is **"not in
+evidence"** — running the 6 ablation cells on the floor would measure
+noise. This is an **honest negative**, and the pre-registration §5 gate
+worked exactly as designed (it stopped us before the knob runs).
+
+The RGB-en LOSS half (Phase E-min cross-model) stays locked but
+**unpaired** — the MuSiQue GAIN half is structurally unavailable until
+retrieval can surface multi-hop evidence. **No cycle β default revision
+is licensed** (unchanged from the Phase E handover).
+
+### 3.2 The real finding — retrieval is the dominant multi-hop lever
+Three independent measurements converge:
+- breadth 2× → no change (not a top_k problem)
+- oracle evidence → 9× gold-in-answer jump (not a model problem)
+- ∴ **single-shot dense retrieval structurally misses the 2nd hop**.
+  MuSiQue's 2-hop shape ("Who is the spouse of the Green performer?" →
+  hop1 Green→Steve Hillage is query-similar; hop2 Steve
+  Hillage→spouse is NOT query-similar) is exactly the case single-shot
+  retrieval cannot reach.
+
+This **externally confirms Phase D's "retrieval = dominant lever
+(−0.173)"** on a published standard benchmark with an official scorer
+(passes the self-eval-trap bar). Honest tier: ⭐⭐ (externally
+confirmed, single model on the oracle leg — gemma4/llama oracle
+replication would lift to cross-model).
+
+### 3.3 Secondary — em=0 is a response-style artifact
+Even with oracle evidence em=0 while gold-in-answer=72%: the model knows
+the answer but replies in NATURAL prose (173–410 chars), so SQuAD-style
+EM/F1 collapse. This re-confirms cycle β's "short-answer penalty" — a
+terse response_style would be needed for EM-graded short-answer benches.
+**Not** a JAMES defect; a measurement-mode mismatch.
+
+---
+
+## 4. Artifacts
+
+| Purpose | Path |
+|---|---|
+| Pre-registration (decision thresholds, LOCKED) | `docs/research/cycle-gamma-phase-c2-preregistration-2026-06-10.md` |
+| MuSiQue downloader (HF mirror → official JSONL) | `scripts/research/download_musique.py` |
+| Corpus build (per-paragraph ingest) | `scripts/research/cycle_gamma_musique_corpus_build.py` |
+| R0 gate runner | `scripts/research/_phase_c2_r0_gate.sh` |
+| Oracle diagnostic | `scripts/research/_phase_c2_oracle_diag.py` |
+| Verdict combiner (RGB LOSS + MuSiQue GAIN) | `scripts/research/_phase_c2_verdict.py` (unused — GAIN unmeasurable) |
+| retrieval/rerank env-gate | `core/reasoning/pipeline_loops.py` (`JAMES_RETRIEVE_TOP_K` / `JAMES_RERANK_TOP_K`) |
+| Result JSONs | `reports/cycle_gamma/phase-c2/musique-ans-mxtral-{R0,R0-topk16,ORACLE}.json` + gemma4/llama R0 |
+
+---
+
+## 5. Next session — D1 multi-hop-aware retrieval
+
+The lever is now identified and externally grounded. The next work is
+**D1: make retrieval reach the 2nd hop** — single-shot dense retrieval
+is the wrong tool for multi-hop. Candidate approaches (all local-first,
+no new cloud dep):
+- **iterative / multi-step retrieval** (retrieve → read → re-query with
+  hop1 answer → retrieve hop2). JAMES already has a query-rewrite layer
+  (`core/reasoning/pipeline_query_expansion.py`) — the question is
+  whether an answer-conditioned 2nd retrieval round lands hop2.
+- **query decomposition** (MuSiQue's own `question_decomposition` field
+  shows the 2 sub-questions — a decomposer that splits then retrieves
+  each sub-q is the textbook fix).
+- Compare against **LazyGraphRAG / iterative-RAG** baselines (review R7)
+  before committing build effort.
+
+Measurement design for D1 (pre-register again): R0 (single-shot) vs
+D1 (iterative/decomposed) on the SAME 25 MuSiQue queries, primary axis
+= **gold-substring-in-answer** (em/f1 are response-style-confounded —
+use the substring metric or add terse mode). Target: lift R0's 8% toward
+the oracle ceiling of 72%.
+
+Also worth pairing: terse response_style on MuSiQue so em/f1 become
+usable (secondary, cycle β follow-up).
+
+### Carry-forward rules
+- env-gate default 8/5 stays until a multi-axis measurement (MuSiQue
+  gain vs RGB abstention loss) licenses a flip — top_k↑ pulls more noise
+  docs into abstention-prone queries (the same tradeoff this whole cycle
+  studies).
+- `feedback_evidence_grounded_validity_check` (oracle test = the clean
+  separator of evidence-delivery vs model-capability) — reuse this
+  pattern whenever a RAG floor appears.
+- Honest framing held: hyp2 reported as **unmeasurable**, not as a
+  fabricated verdict.

--- a/scripts/research/_phase_c2_oracle_diag.py
+++ b/scripts/research/_phase_c2_oracle_diag.py
@@ -1,0 +1,123 @@
+"""Cycle γ Phase C.2 — oracle-retrieval diagnostic.
+
+Splits "JAMES retrieval is the bottleneck" from "model multi-hop
+ceiling". Feeds each MuSiQue-ans 2-hop query ONLY its gold supporting
+paragraphs (perfect evidence, no distractors, retrieval fully
+bypassed) straight to the model and scores em/f1 + abstention.
+
+Interpretation (vs JAMES R0 floor em=0 / abstain ~76-80%):
+  - oracle SOLVES (em/f1 up, abstain down)  => retrieval is the
+    bottleneck; the model can do the 2-hop once it has the evidence
+    => D1 retrieval pivot is justified.
+  - oracle ALSO floors                       => model multi-hop
+    ceiling; D1 won't help, the gap is the LLM.
+
+Rule basis: feedback_evidence_grounded_validity_check (separate
+"evidence delivered" from "model capability"). Reads only; no
+production mutation.
+
+Usage:
+    PYTHONIOENCODING=utf-8 python scripts/research/_phase_c2_oracle_diag.py \
+        --model mixtral:8x7b --n 25 \
+        --out reports/cycle_gamma/phase-c2/musique-ans-mxtral-ORACLE.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="_phase_c2_oracle_diag")
+    p.add_argument("--model", default="mixtral:8x7b")
+    p.add_argument("--n", type=int, default=25)
+    p.add_argument("--out", required=True)
+    args = p.parse_args(argv)
+
+    from eval.external.musique_loader import MuSiQueLoader
+    from eval.external.musique_scorer import MuSiQueScorer
+    from core.gemma_client import GemmaClient
+
+    loader = MuSiQueLoader(variant="ans", split="dev",
+                            cache_dir=ROOT / "eval" / "external"
+                                     / "_fixtures" / "musique")
+    queries = loader.iter_queries(n_samples=args.n)
+
+    # Lift the prompt cap so multi-paragraph evidence is not truncated.
+    os.environ["JAMES_GEMMA_MAX_PROMPT_CHARS"] = "200000"
+    client = GemmaClient()
+
+    rows = []
+    t0 = time.time()
+    for i, q in enumerate(queries, 1):
+        support = set(q.metadata.get("support_idx_set") or [])
+        pidx = q.metadata.get("paragraph_idx") or list(range(len(q.context)))
+        oracle_ctx = [q.context[j] for j, idx in enumerate(pidx)
+                      if idx in support and j < len(q.context)]
+        ctx = "\n\n".join(oracle_ctx)
+        prompt = (
+            "Answer the question using only the provided context. "
+            "If the context is insufficient, answer "
+            "'Insufficient Information'.\n\n"
+            f"Context:\n{ctx}\n\n"
+            f"Question: {q.question}\n"
+        )
+        ans = client.call_gemma(
+            prompt, model=args.model, max_tokens=8192,
+            think=False, use_cache=False, timeout=180,
+        )
+        rows.append({"id": q.id, "answer": ans,
+                     "n_support_paragraphs": len(oracle_ctx)})
+        if i % 5 == 0 or i == len(queries):
+            print(f"  [{i}/{len(queries)}] {time.time()-t0:.0f}s", flush=True)
+
+    scorer = MuSiQueScorer(variant="ans")
+    axes = scorer.score(queries, rows)
+    axes_out = {a.name: a.score for a in axes}
+
+    abst = sum(1 for r in rows
+               if "insufficient" in r["answer"].lower()
+               or not r["answer"].strip())
+    gold_in = sum(1 for q, r in zip(queries, rows)
+                  if q.gold_answer
+                  and q.gold_answer.lower() in r["answer"].lower())
+
+    result = {
+        "mode": "oracle-retrieval (supporting paragraphs only)",
+        "model": args.model,
+        "n": len(rows),
+        "axes": axes_out,
+        "abstain": abst,
+        "gold_substring_in_answer": gold_in,
+        "avg_support_paragraphs": round(
+            sum(r["n_support_paragraphs"] for r in rows) / max(len(rows), 1), 2),
+        "rows": rows,
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2),
+                        encoding="utf-8")
+
+    print()
+    print("=== ORACLE-RETRIEVAL DIAGNOSTIC ===")
+    print(f"  model: {args.model}  n={len(rows)}")
+    print(f"  em={axes_out.get('em',0):.4f}  f1={axes_out.get('f1',0):.4f}")
+    print(f"  abstain: {abst}/{len(rows)} ({abst/max(len(rows),1)*100:.0f}%)")
+    print(f"  gold-substring-in-answer: {gold_in}/{len(rows)}")
+    print(f"  avg support paragraphs fed: {result['avg_support_paragraphs']}")
+    print(f"  saved: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/research/_phase_c2_r0_gate.sh
+++ b/scripts/research/_phase_c2_r0_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Cycle γ Phase C.2 — R0 cell-validity gate (pre-registration §5).
+# Runs R0 (full JAMES, no knob) on MuSiQue-ans n=25 for all 3 models.
+# If R0 f1 <= 0.05 on ALL 3 models => wiring suspicion, stop + diagnose
+# before spending the knob runs.
+set -u
+
+ROOT="$(pwd)"
+WS="$ROOT/workspaces/cycle_gamma_musique_ans"
+OUTDIR="$ROOT/reports/cycle_gamma/phase-c2"
+mkdir -p "$OUTDIR"
+N=25
+
+for spec in "mixtral:8x7b mxtral" "gemma4:e4b gemma4" "llama3.1:8b llama"; do
+  set -- $spec
+  MODEL="$1"; TAG="$2"
+  OUT="$OUTDIR/musique-ans-$TAG-R0.json"
+  echo ">>> R0 [$TAG] $MODEL -> $OUT"
+  env "JAMES_WORKSPACE=$WS" \
+    python scripts/external_bench_run.py --bench musique --variant ans \
+    --mode james --model "$MODEL" --n-samples "$N" \
+    --out "$OUT" 2>&1 | tail -8
+  echo "<<< R0 [$TAG] done (exit ${PIPESTATUS[0]})"
+done
+
+echo "=== R0 GATE DONE ==="

--- a/scripts/research/_phase_c2_verdict.py
+++ b/scripts/research/_phase_c2_verdict.py
@@ -1,0 +1,120 @@
+"""Cycle γ Phase C.2 — tradeoff verdict combiner.
+
+Reads the MuSiQue paired-ablation result JSONs (R0 + DISABLE_RERANK +
+DISABLE_COGNITIVE_STAGES per model) and combines the MuSiQue Δ (the
+GAIN half) with the Phase E-min RGB-en Δ (the LOSS half, hardcoded
+from the cross-model handover) to apply the pre-registered §5 verdict
+table.
+
+Δ convention (pre-registration §5): Δ = score(R0) − score(component OFF).
+Δ > 0 ⇒ the component contributes on this axis.
+
+Reads only; prints a verdict table. No mutation of any measurement.
+
+Pre-registration: docs/research/cycle-gamma-phase-c2-preregistration-2026-06-10.md
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+OUTDIR = Path("reports/cycle_gamma/phase-c2")
+MODELS = [("mixtral:8x7b", "mxtral"), ("gemma4:e4b", "gemma4"),
+          ("llama3.1:8b", "llama")]
+KNOBS = ["rerank", "cognitive_stages"]
+
+# Noise bands (pre-registration §4).
+BAND_EM = 0.04
+BAND_F1 = 0.03
+
+# RGB-en LOSS half (Phase E-min cross-model handover, Δnoise / Δnegrej
+# when the component is DISABLED — positive = disabling HELPS RGB
+# abstention, i.e. the component HURTS RGB abstention).
+RGB_LOSS = {
+    "rerank":           {"mxtral": (+0.040, +0.050),
+                          "gemma4": (+0.040, +0.209),
+                          "llama":  (+0.040, +0.098)},
+    "cognitive_stages": {"mxtral": (+0.160, +0.050),
+                          "gemma4": (+0.040, +0.111),
+                          "llama":  (+0.120, +0.050)},
+}
+
+
+def _load_axes(tag: str, label: str) -> dict:
+    """Return {axis_name: score} for one result JSON, or {} if missing."""
+    path = OUTDIR / f"musique-ans-{tag}-{label}.json"
+    if not path.exists():
+        return {}
+    d = json.loads(path.read_text(encoding="utf-8"))
+    out = {}
+    for ax in d.get("axes", []):
+        out[ax["name"]] = ax.get("score")
+    return out
+
+
+def main() -> int:
+    print("=== Cycle γ Phase C.2 — tradeoff verdict ===\n")
+    print("Δ = score(R0) − score(component OFF); Δ>0 ⇒ component helps the axis.")
+    print(f"Noise band: |Δem| ≤ {BAND_EM}, |Δf1| ≤ {BAND_F1}\n")
+
+    any_missing = False
+    for knob in KNOBS:
+        print(f"\n### Component: {knob}")
+        print(f"{'model':<8} {'R0_f1':>7} {'OFF_f1':>7} {'Δf1':>8} "
+              f"{'R0_em':>7} {'OFF_em':>7} {'Δem':>8}   "
+              f"{'RGB Δnoise/Δnegrej (LOSS)':>26}")
+        gain_dirs = []
+        for model_id, tag in MODELS:
+            r0 = _load_axes(tag, "R0")
+            off = _load_axes(tag, knob)
+            if not r0 or not off:
+                print(f"{tag:<8}  (missing result JSON — run not complete)")
+                any_missing = True
+                continue
+            d_f1 = (r0.get("f1", 0.0) or 0.0) - (off.get("f1", 0.0) or 0.0)
+            d_em = (r0.get("em", 0.0) or 0.0) - (off.get("em", 0.0) or 0.0)
+            rgb = RGB_LOSS[knob].get(tag, (None, None))
+            rgb_str = f"+{rgb[0]:.3f} / +{rgb[1]:.3f}" if rgb[0] is not None else "n/a"
+            # GAIN direction: Δf1 > band ⇒ helps multihop (+); < -band ⇒ hurts (−)
+            if d_f1 > BAND_F1:
+                gain_dirs.append("+")
+            elif d_f1 < -BAND_F1:
+                gain_dirs.append("-")
+            else:
+                gain_dirs.append("0")
+            print(f"{tag:<8} {r0.get('f1',0):>7.3f} {off.get('f1',0):>7.3f} "
+                  f"{d_f1:>+8.3f} {r0.get('em',0):>7.3f} {off.get('em',0):>7.3f} "
+                  f"{d_em:>+8.3f}   {rgb_str:>26}")
+
+        # Per-component verdict (pre-registration §5).
+        print(f"  MuSiQue GAIN directions (Δf1): {gain_dirs}")
+        n_help = gain_dirs.count("+")
+        n_hurt = gain_dirs.count("-")
+        n_flat = gain_dirs.count("0")
+        if len(gain_dirs) < 3:
+            verdict = "PENDING (need all 3 models)"
+        elif n_help >= 2:
+            verdict = ("HYP 2 PROVEN (tradeoff) — component helps multi-hop "
+                       "while hurting RGB abstention → KEEP + harmonize "
+                       "(query-type routing). Default-off FORBIDDEN.")
+        elif n_flat == 3 or (n_flat >= 2 and n_hurt == 0 and n_help == 0):
+            verdict = ("HYP 1 PROVEN (deadweight) — flat on home turf + "
+                       "hurts RGB → default-off PR LICENSED (R4 registry).")
+        elif n_hurt >= 2:
+            verdict = ("HYP 1 strengthened — OFF better on home turf too "
+                       "→ default-off LICENSED (prior-art check before "
+                       "novelty claim).")
+        else:
+            verdict = ("SPLIT (model-dependent) — no global default change; "
+                       "route to R10 model-capability-tier profile.")
+        print(f"  >>> VERDICT [{knob}]: {verdict}")
+
+    if any_missing:
+        print("\n(some cells missing — re-run after all 9 runs complete)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/research/download_musique.py
+++ b/scripts/research/download_musique.py
@@ -1,0 +1,206 @@
+"""Cycle γ Phase C.2 — MuSiQue dataset downloader.
+
+Pulls the MuSiQue dataset (Trivedi et al. 2022, TACL) from a public
+HuggingFace mirror and writes it to disk in the official JSONL format
+the loader expects (``eval/external/musique_loader.py``).
+
+The official upstream is https://github.com/StonyBrookNLP/musique
+which distributes via Google Drive (their ``download_data.sh`` uses
+``gdown``). That path works but is operator-heavy on Windows. This
+script uses HuggingFace ``datasets`` instead — the same library
+``scripts/hotpot/download_multihop_rag.py`` already uses for
+MultiHop-RAG, so no new dep.
+
+Default mirror: ``dgslibisey/MuSiQue``. If that ever moves, override
+with ``--hf-repo <new/repo>``.
+
+Idempotent: skips files that already exist at the destination.
+
+Usage::
+
+    python scripts/research/download_musique.py \\
+        --variant ans --split dev \\
+        --dest eval/external/_fixtures/musique
+
+After it lands, ``MuSiQueLoader`` (variant=ans, split=dev) will
+find the file at the path it expects.
+
+Citation
+--------
+
+Trivedi, Harsh and Balasubramanian, Niranjan and Khot, Tushar and
+Sabharwal, Ashish. "MuSiQue: Multihop Questions via Single-hop
+Question Composition." Transactions of the Association for
+Computational Linguistics (TACL), 2022.
+https://github.com/StonyBrookNLP/musique  (Apache-2.0)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+DEFAULT_HF_REPO = "dgslibisey/MuSiQue"
+VARIANTS = ("ans", "full")
+# Official split name (what the loader / filename use) → HF split name.
+# The HF mirror exposes ['train', 'validation']; "dev" is the official
+# name for what HF calls "validation".
+OFFICIAL_TO_HF_SPLIT = {
+    "train": "train",
+    "dev":   "validation",
+    "test":  "test",
+}
+
+
+def _expected_filename(variant: str, split: str) -> str:
+    return f"musique_{variant}_v1.0_{split}.jsonl"
+
+
+def _hf_config_name(variant: str) -> str:
+    # dgslibisey/MuSiQue uses "answerable" / "full" as config names.
+    return "answerable" if variant == "ans" else "full"
+
+
+def _row_to_official_format(row: dict) -> dict:
+    """Project an HF row back to the official MuSiQue JSONL schema.
+
+    The HF mirror generally preserves the original fields verbatim
+    (id, paragraphs, question, question_decomposition, answer,
+    answer_aliases, answerable). Some configs flatten paragraphs into
+    parallel arrays, which we re-zip back into the expected list of
+    dicts.
+    """
+    # Already-official shape: just pass through.
+    if isinstance(row.get("paragraphs"), list) and (
+        not row["paragraphs"] or isinstance(row["paragraphs"][0], dict)
+    ):
+        return dict(row)
+
+    # Flattened-array shape: zip parallel lists back together.
+    titles = row.get("paragraphs", {}).get("title") or []
+    texts = row.get("paragraphs", {}).get("paragraph_text") or []
+    is_supp = row.get("paragraphs", {}).get("is_supporting") or []
+    idxs = row.get("paragraphs", {}).get("idx") or list(range(len(titles)))
+    paragraphs = []
+    for i, (t, txt, sup) in enumerate(zip(titles, texts, is_supp)):
+        paragraphs.append({
+            "idx":            idxs[i] if i < len(idxs) else i,
+            "title":          str(t),
+            "paragraph_text": str(txt),
+            "is_supporting":  bool(sup),
+        })
+
+    out = dict(row)
+    out["paragraphs"] = paragraphs
+
+    # Question decomposition can be similarly flattened.
+    qd = row.get("question_decomposition")
+    if isinstance(qd, dict):
+        ids = qd.get("id") or []
+        questions = qd.get("question") or []
+        answers = qd.get("answer") or []
+        psi = qd.get("paragraph_support_idx") or []
+        decomp = []
+        for i, q in enumerate(questions):
+            decomp.append({
+                "id":                    ids[i] if i < len(ids) else f"step{i}",
+                "question":              str(q),
+                "answer":                answers[i] if i < len(answers) else "",
+                "paragraph_support_idx": psi[i] if i < len(psi) else None,
+            })
+        out["question_decomposition"] = decomp
+
+    return out
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="download_musique",
+        description=(
+            "Download MuSiQue from a HuggingFace mirror and write "
+            "the official JSONL format that MuSiQueLoader expects."
+        ),
+    )
+    p.add_argument("--variant", default="ans", choices=VARIANTS,
+                    help="MuSiQue variant (default: ans)")
+    p.add_argument("--split", default="dev",
+                    choices=("train", "dev", "test"),
+                    help="dataset split (default: dev)")
+    p.add_argument("--dest", required=True,
+                    help="destination directory (file lands at "
+                          "<dest>/musique_<variant>_v1.0_<split>.jsonl)")
+    p.add_argument("--hf-repo", default=DEFAULT_HF_REPO,
+                    help=f"HuggingFace dataset id (default: "
+                          f"{DEFAULT_HF_REPO})")
+    p.add_argument("--force", action="store_true",
+                    help="overwrite if the destination file exists")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+
+    dest_dir = Path(args.dest).resolve()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out_path = dest_dir / _expected_filename(args.variant, args.split)
+
+    if out_path.exists() and not args.force:
+        print(f"=== EXISTS (skip): {out_path}")
+        print(f"    pass --force to overwrite.")
+        return 0
+
+    print(f"=== Loading MuSiQue from HF mirror ===")
+    print(f"  hf_repo : {args.hf_repo}")
+    print(f"  config  : {_hf_config_name(args.variant)}")
+    print(f"  split   : {args.split}")
+    print(f"  dest    : {out_path}")
+    print()
+
+    try:
+        from datasets import load_dataset  # type: ignore
+    except ImportError:
+        print("!! 'datasets' package missing. Install via "
+                "'pip install datasets>=2.14.0' "
+                "(already pinned in requirements.txt).",
+                file=sys.stderr)
+        return 2
+
+    # Map the official split name to the HF mirror's split name
+    # ("dev" → "validation"). Fall back to the given name if unknown.
+    hf_split = OFFICIAL_TO_HF_SPLIT.get(args.split, args.split)
+
+    config = _hf_config_name(args.variant)
+    try:
+        ds = load_dataset(args.hf_repo, config, split=hf_split)
+    except Exception as e:
+        # Some mirrors use no-config layout. Retry.
+        try:
+            ds = load_dataset(args.hf_repo, split=hf_split)
+        except Exception as e2:
+            print(f"!! HuggingFace load failed: {e2}", file=sys.stderr)
+            print(f"   Tried: {args.hf_repo} / config={config} / "
+                    f"split={hf_split}", file=sys.stderr)
+            print(f"   Manual fallback: clone "
+                    f"https://github.com/StonyBrookNLP/musique "
+                    f"and run bash download_data.sh, then copy "
+                    f"the matching .jsonl into --dest.",
+                    file=sys.stderr)
+            return 3
+
+    n_written = 0
+    with open(out_path, "w", encoding="utf-8") as f:
+        for row in ds:
+            entry = _row_to_official_format(dict(row))
+            f.write(json.dumps(entry, ensure_ascii=False))
+            f.write("\n")
+            n_written += 1
+
+    size = out_path.stat().st_size
+    print(f"=== WROTE {n_written} rows ({size:,} bytes) → {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Pre-registered rerank/cognitive_stages tradeoff (hyp2) on MuSiQue-ans **could not be measured** — R0 floored (em=0, abstain 76%). The pre-registration §5 cell-validity gate caught it and we entered diagnostic mode, which produced a **stronger** result: a 3-measurement isolation of the cause.

| Measurement | Result | Rules out |
|---|---|---|
| R0 (top_k 8/5, full JAMES) | em=0, f1≈0.06, **abstain 76%** | — (floor) |
| R0 (top_k 16/10, env-gated) | em=0, f1≈0.06, **abstain 80%** | retrieval **breadth** (2× = no change) |
| **oracle (supporting paras only)** | **gold-in-answer 72%** (vs R0 8%), abstain 24% | model **ceiling** (solves with evidence) |

**Finding**: single-shot dense retrieval structurally misses the 2nd hop of MuSiQue's 2-hop questions. Externally confirms Phase D "retrieval = dominant lever (−0.173)" on a published standard benchmark + official scorer (self-eval-trap pass). Honest tier ⭐⭐ (oracle leg single-model).

## Verification
- **env-gate default 8/5 byte-identical** — verified: unset → 8/5, malformed/negative → default. `tests/test_reranker.py` + `tests/test_feature_flags.py` 36 passed.
- `core/reasoning/pipeline_loops.py` = 11.36 KB (< 20 KB gate).
- Honest negative on hyp2 (RGB LOSS half stays unpaired; **no cycle β default revision licensed** — unchanged from Phase E handover).
- Secondary: oracle em=0 while gold-in-answer=72% = response-style artifact (NATURAL prose), re-confirms cycle β short-answer penalty. Not a defect.

## Out of scope
- **D1 multi-hop-aware retrieval** (iterative / query-decomposition) — next session, target lifting R0's 8% toward oracle ceiling 72%. Pre-register again.
- top_k default flip — gated on multi-axis (MuSiQue gain vs RGB abstention loss); top_k↑ pulls noise docs into abstention-prone queries (the same tradeoff this cycle studies).
- terse response_style on MuSiQue (em/f1 usability) — cycle β follow-up.

Handover: `docs/handovers/v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md`

Quality delta: exempt (label: chore — measurement infra + env-gate, production default byte-identical; the floor finding IS the measurement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)