### PR TITLE
feat(cycle γ D1): query decomposition — INSUFFICIENT (honest negative), iterative pivot

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -72,6 +72,7 @@ def retrieve(
     user_role:       str  = "external",
     source_type:     Optional[str] = "prod",
     top_k:           int  = 8,
+    extra_queries:   Optional[List[str]] = None,
 ) -> List[Dict]:
     """
     multi-path 수집 → 단순 merge → dedup.
@@ -80,6 +81,10 @@ def retrieve(
       1. original_query  → hybrid_search
       2. expanded_query  → hybrid_search (query_expander 성공 시 다름, 실패 시 동일)
       3. keyword_query   → hybrid_search
+      4. extra_queries   → hybrid_search (cycle γ D1 query-decomposition
+         sub-questions; ``None`` / ``[]`` → byte-identical to the 3-path
+         behaviour. Each sub-question becomes a "subq{i}" path so the
+         hop-2 query surfaces what the original cannot.)
 
     결과 merge: 단순 concat → deduplicate
     ❌ rerank 없음 / ❌ 점수 재계산 없음 / ❌ 순서 변경 없음
@@ -89,6 +94,9 @@ def retrieve(
         ("expanded",  expanded_query),
         ("keyword",   _extract_keywords(original_query)),
     ]
+    for i, sq in enumerate(extra_queries or []):
+        if isinstance(sq, str) and sq.strip():
+            queries.append((f"subq{i+1}", sq))
 
     # expanded == original인 경우 중복 쿼리 제거
     seen_queries, unique_queries = set(), []

--- a/core/reasoning/pipeline_loops.py
+++ b/core/reasoning/pipeline_loops.py
@@ -82,6 +82,25 @@ def run_loop_0_retrieve(
     # measurement (MuSiQue gain vs RGB abstention loss) licenses a flip.
     retrieve_top_k = _env_int("JAMES_RETRIEVE_TOP_K", 8)
     rerank_top_k = _env_int("JAMES_RERANK_TOP_K", 5)
+
+    # Cycle γ D1 — multi-hop query decomposition (opt-in). Flag off →
+    # decompose returns [] → orch_retrieve sees no extra paths → the
+    # retrieval query set is byte-identical to pre-D1 behaviour. The
+    # sub-questions add hop-2 retrieval paths the original query cannot
+    # reach (Phase C.2 bottleneck finding).
+    sub_questions = []
+    try:
+        from core.retrieval.query_decomposer import (
+            decompose, query_decomp_enabled,
+        )
+        if query_decomp_enabled():
+            sub_questions = decompose(safe_query)
+            if sub_questions:
+                print(f"  [D1] decomposed into {len(sub_questions)} "
+                      f"sub-question(s)")
+    except Exception as e:
+        engine._log("query_decompose", e, user_role)
+
     try:
         from core.orchestrator import retrieve as orch_retrieve
         docs = orch_retrieve(
@@ -91,6 +110,7 @@ def run_loop_0_retrieve(
             user_role       = user_role,
             source_type     = source_type,
             top_k           = retrieve_top_k,
+            extra_queries   = sub_questions,
         )
     except Exception as e:
         engine._log("loop0_orchestrator", e, user_role)

--- a/core/retrieval/query_decomposer.py
+++ b/core/retrieval/query_decomposer.py
@@ -1,0 +1,111 @@
+"""Cycle γ D1 — multi-hop query decomposition.
+
+Phase C.2 proved single-shot dense retrieval misses the 2nd hop of
+multi-hop questions (the model solves MuSiQue 2-hop given the gold
+supporting paragraphs — oracle gold-in-answer 72% — but JAMES R0
+retrieval surfaces them only 8% of the time). D1 decomposes a
+multi-hop question into ordered sub-questions and feeds each as an
+extra retrieval path, so the hop-2 sub-question ("Who is the spouse of
+Steve Hillage?") surfaces what the original query ("Who is the spouse
+of the Green performer?") cannot.
+
+Pre-registration: docs/research/cycle-gamma-d1-query-decomposition-preregistration-2026-06-10.md
+
+Opt-in only. ``JAMES_ENABLE_QUERY_DECOMP`` unset / not "1" → ``decompose``
+returns ``[]`` and the retrieval query set is byte-identical to today.
+Default OFF is deliberate (mother-platform principle 3: specialised
+behaviour is an option layer; a default flip is gated on a later
+multi-axis cost measurement, not on this single benchmark).
+
+Model selection: ``JAMES_DECOMP_MODEL`` → ``JAMES_LLM_MODEL`` →
+``gemma4:e4b``. The measurement harness sets ``JAMES_DECOMP_MODEL`` so
+the decomposer uses the same model as synth.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import List
+
+
+def query_decomp_enabled() -> bool:
+    """True iff ``JAMES_ENABLE_QUERY_DECOMP`` == "1". Read per-call so a
+    runtime toggle takes effect immediately (mirrors the cognitive
+    feature-flag convention)."""
+    return os.environ.get("JAMES_ENABLE_QUERY_DECOMP") == "1"
+
+
+def _decomp_model() -> str:
+    return (os.environ.get("JAMES_DECOMP_MODEL")
+            or os.environ.get("JAMES_LLM_MODEL")
+            or "gemma4:e4b")
+
+
+_PROMPT = (
+    "Break the following question into the minimal ordered sub-questions "
+    "needed to answer it step by step. Output one sub-question per line, "
+    "no numbering, no explanation. If it is already a single-hop "
+    "question, output it unchanged.\n\n"
+    "Question: {q}\n"
+    "Sub-questions:"
+)
+
+# Strip leading list markers the model sometimes emits despite the
+# instruction ("1. ", "1) ", "- ", "* ").
+_LEADING_MARKER = re.compile(r"^\s*(?:\d+[.)]\s*|[-*]\s*)")
+
+
+def decompose(
+    query: str,
+    *,
+    model: str | None = None,
+    max_sub: int = 4,
+    timeout: int = 60,
+) -> List[str]:
+    """Return ordered sub-questions for ``query``, or ``[]``.
+
+    ``[]`` is returned (no-op, byte-identical retrieval) when:
+      - the flag is off,
+      - the query is empty,
+      - the LLM call fails,
+      - the model echoes the question unchanged (single-hop),
+      - the output is empty/garbage.
+
+    Never raises — decomposition must not block retrieval.
+    """
+    if not query_decomp_enabled():
+        return []
+    q = (query or "").strip()
+    if not q:
+        return []
+    try:
+        from core.gemma_client import GemmaClient
+        client = GemmaClient()
+        out = client.call_gemma(
+            _PROMPT.format(q=q),
+            model=model or _decomp_model(),
+            max_tokens=256,
+            think=False,
+            use_cache=False,
+            timeout=timeout,
+        )
+    except Exception:
+        return []
+
+    subs: List[str] = []
+    seen = {q.lower()}
+    for line in (out or "").splitlines():
+        line = _LEADING_MARKER.sub("", line).strip()
+        if not line or len(line) < 6:
+            continue
+        low = line.lower()
+        if low in seen:
+            continue
+        seen.add(low)
+        subs.append(line)
+        if len(subs) >= max_sub:
+            break
+    return subs
+
+
+__all__ = ["decompose", "query_decomp_enabled"]

--- a/docs/handovers/v0.4-cycle-gamma-d1-query-decomposition-results-2026-06-10.md
+++ b/docs/handovers/v0.4-cycle-gamma-d1-query-decomposition-results-2026-06-10.md
@@ -1,0 +1,120 @@
+# Cycle γ D1 — query-decomposition results: INSUFFICIENT → iterative pivot
+
+**Date**: 2026-06-10 (same session as Phase C.2)
+**Status**: D1 (static query decomposition) **closed as INSUFFICIENT**
+(honest negative). Pre-registration §3 verdict reached without post-hoc
+fit. Root cause identified (hop-2 anaphora). Next = iterative retrieval.
+
+---
+
+## 1. Headline
+
+Phase C.2 proved single-shot dense retrieval misses the 2nd hop. D1
+added **query decomposition** (LLM splits the multi-hop question into
+sub-questions, each becomes an extra retrieval path). Pre-registered
+(`docs/research/cycle-gamma-d1-query-decomposition-preregistration-2026-06-10.md`,
+commit hash before implementation = post-hoc-fit barred).
+
+**Result: D1 does not lift multi-hop retrieval.** The decomposer fires
+correctly (25/25 queries, 59 sub-question paths added) but the hop-2
+sub-question is an **anaphora** ("Who is the spouse of *that person*?")
+that cannot retrieve the hop-2 supporting paragraph.
+
+| Metric (mxtral n=25) | R0 single-shot | D1 decomposed | Δ | §3 threshold |
+|---|---|---|---|---|
+| **gold-in-answer** | 8% (2/25) | 12% (3/25) | +1 (noise) | <15% → INSUFFICIENT |
+| **supporting recall** | 0.600 | 0.600 | **flat** | ≤0.65 → INSUFFICIENT |
+| both-supporting caught | 5/25 | 5/25 | 0 | |
+| abstain | 19/25 | 20/25 | +1 | |
+| f1 (confounded) | 0.060 | 0.048 | −0.012 | not verdict-bearing |
+
+Pre-registration §3 verdict: **D1 INSUFFICIENT → iterative retrieval
+pivot** (gold-in-answer < 15% AND supporting recall flat).
+
+---
+
+## 2. Why it failed — hop-2 anaphora
+
+The decomposer output is correct *as decomposition* but useless *as
+retrieval queries* for the 2nd hop:
+
+```
+"Who is the spouse of the Green performer?"
+ → hop1: "Who is referred to as the Green performer?"   ← retrievable
+ → hop2: "Who is the spouse of that person?"            ← "that person" = dead query
+
+"Who is the founder of the company that distributed UHF?"
+ → hop1: "Who distributed the film UHF?"                ← retrievable
+ → hop2/3: "...of that company?"                        ← "that company" = dead query
+```
+
+Static decomposition splits **before** hop1 is answered, so every 2nd+
+hop carries an unresolved pronoun. The hop-1 sub-question helps (it is
+query-similar to hop-1 supporting), but the hop-2 sub-question retrieves
+noise, and the final answer does not improve. This is **exactly** the
+failure mode the pre-registration anticipated (§3 "supporting recall
+flat → iterative pivot").
+
+Wiring was verified live (`_d1_run.log`: 25 `[D1] decomposed` lines, 59
+`[ORCH] subq` paths) — this is a genuine mechanism limit, not a bug.
+
+---
+
+## 3. What's preserved + what's next
+
+### Preserved infrastructure (reused by iterative)
+- `core/retrieval/query_decomposer.py` — LLM decompose, env-gate,
+  `[]`-on-failure no-op.
+- `core/orchestrator.py` `extra_queries` param — multi-path merge for
+  sub-questions (`None`/`[]` byte-identical).
+- `core/reasoning/pipeline_loops.py` STEP 0.5c wiring +
+  `JAMES_ENABLE_QUERY_DECOMP` gate (**default OFF byte-identical**,
+  verified).
+
+All default-OFF; production behaviour unchanged. This is negative
+evidence, permanently recorded (cf. D2 V2 / PR #746 pattern).
+
+### Next = iterative retrieval (separate pre-registration)
+The fix for hop-2 anaphora is to **resolve the pronoun before
+retrieving hop-2**:
+
+```
+round 1: retrieve hop-1 sub-q → synth/extract hop-1 answer ("Steve Hillage")
+round 2: substitute "that person" → "Steve Hillage" in hop-2 sub-q
+         → retrieve hop-2 supporting → union → final synth
+```
+
+This is the textbook iterative-RAG / self-ask / IRCoT pattern (prior
+art — JAMES contribution = reproducible measurement on its own stack,
+⭐⭐ ceiling, not mechanism novelty). Pre-register again:
+- Primary axis: gold-in-answer (target: lift R0's 8% toward oracle 72%)
+- Secondary: supporting recall (does round-2 land hop-2 supporting?)
+- Cost axis: 2 retrieval rounds + 1 extra synth/extract call — must be
+  weighed before any default flip.
+
+Build note: the decomposer already produces ordered sub-questions; the
+new piece is (a) an intermediate extract step after round-1 retrieve,
+(b) pronoun/entity substitution into later sub-questions, (c) a 2nd
+retrieve round. The query-rewrite layer
+(`core/reasoning/pipeline_query_expansion.py`) is the natural host.
+
+---
+
+## 4. Artifacts
+
+| Purpose | Path |
+|---|---|
+| Pre-registration (LOCKED before impl) | `docs/research/cycle-gamma-d1-query-decomposition-preregistration-2026-06-10.md` |
+| Decomposer | `core/retrieval/query_decomposer.py` |
+| Orchestrator extra_queries | `core/orchestrator.py` |
+| Wiring + gate | `core/reasoning/pipeline_loops.py` |
+| Result JSONs | `reports/cycle_gamma/phase-c2/musique-ans-mxtral-{R0,D1}.json` |
+| Phase C.2 handover (retrieval bottleneck) | `docs/handovers/v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md` |
+
+### Carry-forward
+- `feedback_oracle_phrase_artifacts` 4-step rule caught the "is this a
+  wiring no-op or a real negative?" question — log inspection confirmed
+  decompose fired, so the negative is genuine.
+- Honest framing held: D1 reported as INSUFFICIENT (not spun as "+4pp
+  improvement"). The +1 query is inside the noise band.
+- env-gate default-OFF discipline: no flip without multi-axis + cost.

--- a/docs/research/cycle-gamma-d1-query-decomposition-preregistration-2026-06-10.md
+++ b/docs/research/cycle-gamma-d1-query-decomposition-preregistration-2026-06-10.md
@@ -1,0 +1,147 @@
+# Cycle γ D1 — query-decomposition retrieval: design + pre-registration
+
+**Date**: 2026-06-10 (written BEFORE D1 is implemented — post-hoc fit
+barred, same discipline as Phase C.2 pre-registration)
+**Status**: LOCKED before any D1 measurement run. Thresholds / verdict
+rules below do not change after measurement; if they must, the run is
+demoted to exploratory.
+
+> **Why D1**: Phase C.2 (`v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md`)
+> proved with 3 measurements that **single-shot dense retrieval is the
+> dominant multi-hop bottleneck** — the model solves MuSiQue 2-hop when
+> given the supporting paragraphs (oracle gold-in-answer 72%) but JAMES
+> R0 retrieval only surfaces them 8% of the time. D1 makes retrieval
+> reach the 2nd hop.
+
+---
+
+## 1. Design
+
+### 1.1 Mechanism (MVP = query decomposition)
+
+JAMES's `orchestrator.retrieve` already runs a **multi-query** merge:
+`original` + `expanded` + `keyword`, each through `hybrid_search`, then
+concat + dedup. All three are variants of the *same* question, so the
+2nd hop (query-dissimilar) is never reached.
+
+D1 adds **sub-question paths** to that query set:
+
+```
+multi-hop query
+   │
+   ├─ (D1) LLM decomposer → [sub_q1, sub_q2, ...]   ← NEW
+   │
+   └─ orchestrator.retrieve(queries = original + expanded + keyword + sub_q*)
+        → hybrid_search each → merge → dedup → rerank → synth
+```
+
+`sub_q2` ("Who is the spouse of Steve Hillage?") is query-similar to the
+hop-2 supporting paragraph, so it surfaces what `original` cannot.
+
+### 1.2 Wiring
+
+- New module `core/retrieval/query_decomposer.py` (LLM decompose via
+  `GemmaClient`, the model passed through from the engine call).
+- Pipeline STEP 0.5c (after entity-anchor + query-rewrite, before
+  `run_loop_0_retrieve`): if enabled, decompose and stash sub-questions
+  on `loop_state` so `run_loop_0_retrieve` adds them to the retrieve
+  query list.
+- **env-gate `JAMES_ENABLE_QUERY_DECOMP`** (opt-in). Unset → no
+  decompose call, retrieve query set byte-identical to today
+  (mother-platform principle 3: short-answer/specialised behaviour is an
+  opt-in option layer, not a default flip — flip is gated on a later
+  multi-axis measurement, same as the top_k env-gate).
+- Failure isolation: decompose exception → fall back to the original
+  query set (D1 must never block retrieval).
+
+### 1.3 Decompose prompt (fixed for the measurement)
+
+> "Break the following question into the minimal ordered sub-questions
+> needed to answer it step by step. Output one sub-question per line, no
+> numbering, no explanation. If it is already a single-hop question,
+> output it unchanged."
+
+Cap: ≤ 4 sub-questions; on empty/garbage output fall back to the
+original query (no-op).
+
+---
+
+## 2. Measurement design (methodological-chain labelling)
+
+- **Verdict Q**: Does query decomposition (D1) lift gold-supporting
+  retrieval coverage and gold-in-answer on MuSiQue-ans 2-hop, vs
+  single-shot R0, toward the oracle ceiling (72%)?
+- **Diagnostic Q**: If it does NOT lift, why? — (a) decomposer produces
+  bad sub-questions, (b) sub-q retrieval still misses hop2, (c) coverage
+  rises but synth still abstains. Inspect raw sub-questions + per-query
+  supporting recall.
+- **Fixture**: same 25 MuSiQue-ans queries, same workspace
+  (`cycle_gamma_musique_ans`), paired against the existing R0 JSONs.
+  Verdict-grade (external standard bench + official scorer, self-eval
+  trap pass).
+- **Primary axis**: **gold-substring-in-answer** (em/f1 are
+  response-style-confounded per Phase C.2 §3.3 — the model answers in
+  NATURAL prose; substring is the honest capability signal).
+- **Secondary axis**: **supporting-paragraph recall** (does decompose
+  surface the hop-2 supporting paragraph? the direct mechanism check).
+- **Tertiary (diagnostic only)**: abstain rate, em, f1 (reported, not
+  verdict-bearing).
+
+### 2.1 Baselines (already measured, Phase C.2)
+
+| Metric | R0 single-shot (mxtral) | oracle ceiling (mxtral) |
+|---|---|---|
+| gold-in-answer | 8% (2/25) | 72% (18/25) |
+| abstain | 76% | 24% |
+| supporting recall (top-3 shown) | 0.60 | — (all support fed) |
+
+---
+
+## 3. Decision rule (LOCKED)
+
+Δ = D1 − R0 on the **same 25 queries**, mxtral first.
+
+| Result | Verdict | Follow-up |
+|---|---|---|
+| gold-in-answer **≥ 30%** (≥ +22pp over R0's 8%) AND supporting recall **≥ 0.75** | **D1 WORKS** — decomposition reaches hop2 | cross-model (gemma4/llama) → if holds, design D1 as an option layer + measure cost (latency/token) for a default-flip case |
+| gold-in-answer 15–30% | **PARTIAL** — decompose helps but incompletely | diagnose which hop2s still miss; consider iterative round 2 |
+| gold-in-answer < 15% OR supporting recall flat (≤ 0.65) | **D1 INSUFFICIENT** | decomposition is not enough; pivot to iterative retrieval (retrieve→read→re-query) — separate pre-registration |
+| supporting recall ↑ but gold-in-answer flat | **retrieval fixed, synth/abstention is now the limiter** | re-point to synth/abstention layer, not retrieval |
+
+### Noise / honesty guards (pre-stated)
+
+1. n=25, mxtral single model for the first verdict; **no cross-model
+   claim until gemma4+llama replicate** (`feedback_n1_verdict_inflation`,
+   cross-model rule).
+2. **em/f1 forbidden as standalone headline** (response-style artifact).
+   gold-in-answer + supporting recall are the verdict axes.
+3. **default-OFF stays** until a multi-axis measurement (MuSiQue gain vs
+   RGB abstention loss vs latency/token cost) licenses a flip. D1 adds
+   an LLM call + N extra retrievals — cost is real and must be weighed.
+4. No post-hoc threshold movement. No joint-piece framing
+   (`feedback_eval_cycle_vs_collab_arc_separation`).
+5. Honest tier ceiling: ⭐⭐ (external bench), ⭐⭐⭐ barred — iterative /
+   decomposed multi-hop RAG is prior art (IRCoT, self-ask, decomp-RAG);
+   JAMES contribution = reproducible measurement on its own stack, not
+   mechanism novelty.
+
+---
+
+## 4. Execution order
+
+```
+0. live smoke: 1 query with JAMES_ENABLE_QUERY_DECOMP=1 — confirm
+   sub-questions are generated + added to retrieve set (wiring, not verdict)
+1. implement core/retrieval/query_decomposer.py + STEP 0.5c wiring + env-gate
+2. unit test: flag-OFF byte-identical query set; flag-ON adds sub-q paths
+3. D1 run: mxtral n=25 on cycle_gamma_musique_ans
+4. compare vs R0 (gold-in-answer, supporting recall) → §3 verdict
+5. if D1 WORKS → cross-model; else → diagnose / iterative pivot
+6. handover + PR (env-gate default OFF)
+```
+
+Estimated: implementation ~1–2h; measurement ~15 min/run.
+
+---
+
+*Committed before implementation. Commit hash = pre-registration evidence.*


### PR DESCRIPTION
## Summary
Pre-registered (commit e3ed9a9, **before** implementation) static query-decomposition retrieval to fix the multi-hop bottleneck Phase C.2 identified. **Result: INSUFFICIENT** — the decomposer fires correctly but the hop-2 sub-question is an anaphora that can't retrieve hop-2 evidence.

| Metric (mxtral n=25) | R0 | D1 | Δ | §3 threshold |
|---|---|---|---|---|
| **gold-in-answer** | 8% | 12% | +1 (noise) | <15% → INSUFFICIENT |
| **supporting recall** | 0.600 | 0.600 | flat | ≤0.65 → INSUFFICIENT |

Pre-registration §3 verdict reached **without post-hoc fit**: D1 INSUFFICIENT → iterative retrieval pivot.

## Root cause — hop-2 anaphora
```
"Who is the spouse of the Green performer?"
 → hop1: "Who is referred to as the Green performer?"   ← retrievable
 → hop2: "Who is the spouse of that person?"            ← dead query
```
Static decomposition splits **before** hop1 is answered → 2nd+ hops carry unresolved pronouns. Verified live (`_d1_run.log`: 25 decompose lines, 59 subq paths) — genuine mechanism limit, not a bug.

## Verification
- **default-OFF byte-identical**: `JAMES_ENABLE_QUERY_DECOMP` unset → decompose `[]` no-op; `extra_queries` None/[] identical to 3-path. `tests/test_reranker.py` 14 passed.
- Module sizes < 20KB (orchestrator 6.71 / pipeline_loops 12.18 / decomposer 3.52).
- Honest framing: reported as INSUFFICIENT, not spun as "+4pp". The +1 query is inside the noise band.

## Out of scope — next = iterative retrieval (separate pre-reg)
```
round 1: retrieve hop-1 → extract hop-1 answer ("Steve Hillage")
round 2: substitute "that person" → "Steve Hillage" → retrieve hop-2 → synth
```
Prior art (self-ask / IRCoT); JAMES contribution = reproducible measurement (⭐⭐ ceiling). Cost axis (2 rounds + extract call) weighed before any default flip.

Infrastructure preserved (decomposer + extra_queries reused by iterative), all default-OFF.

Handover: `docs/handovers/v0.4-cycle-gamma-d1-query-decomposition-results-2026-06-10.md`

Quality delta: exempt (label: chore — measurement infra + env-gate, production default-OFF byte-identical; the negative result IS the finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)