### PR TITLE
docs(R1): replayable-audit benchmark design — external-recognition first

### DIFF
--- a/docs/design/v0.4-r1-replayable-audit-benchmark.md
+++ b/docs/design/v0.4-r1-replayable-audit-benchmark.md
@@ -1,0 +1,175 @@
+# R1 — Replayable-Audit Benchmark: design memo (외부 객관 인정 설계)
+
+**Date**: 2026-06-10
+**Status**: DRAFT — design + external-anchoring plan. Prior-art web
+verification **PENDING** (classifier outage at draft time; §2 must be
+re-verified online before the spec is frozen).
+**Origin**: 2026-06-09 project-direction review R1 — "측정 에너지가
+모트가 아닌 축에 쓰이고, 모트(replayable audit)는 측정되지 않고 있다."
+User constraint (2026-06-10): **"외부에서도 객관적으로 인정받을 수 있는
+기준"** — the benchmark must not be a self-eval trap.
+
+---
+
+## 0. The self-eval-trap problem, stated honestly
+
+JAMES defining a benchmark for JAMES's own moat is exactly the "엄마
+100점" pattern (`feedback_self_evaluation_trap`) unless the design
+**externalises every source of authority**:
+
+| Authority | Self-eval trap | This design |
+|---|---|---|
+| What is measured (criteria) | JAMES decides | **External standards decide** — EU AI Act articles, W3C PROV, NIST AI RMF (§1) |
+| How it is scored | LLM judge / JAMES oracle | **Deterministic only** — byte-diff, event counts. No LLM judge anywhere (§3) |
+| Who can run it | only JAMES | **Generic spec** — any system that emits an audit log can be scored; baselines included (§4) |
+| Who validates it | JAMES | **Publication + external replication** — spec/scorer/fixtures public (Zenodo DOI), third-party can re-run (§5) |
+
+AbstentionBench (facebookresearch 2025) is the worked precedent: a lab
+defined a benchmark for an under-measured axis and earned recognition by
+publishing data + deterministic scorers + measuring *many* systems, not
+just its own.
+
+---
+
+## 1. External anchoring — the criteria come from outside
+
+Each metric maps 1:1 to clauses of external standards, so the *bar*
+is not JAMES's invention (knowledge-cutoff 2026-01; exact article
+text to be re-verified online):
+
+| Metric | EU AI Act anchor | Other anchors |
+|---|---|---|
+| **Audit Completeness** | **Art. 12 (record-keeping)**: high-risk AI must automatically log events over the system lifetime; traceability adequate for post-hoc analysis. Art. 19 (log retention) | NIST AI RMF "Measure" (accountability); ISO/IEC 42001 audit-trail requirement |
+| **Replay Fidelity** | Art. 12's purpose clause — logs must enable *reconstruction* of system operation for post-market monitoring + incident investigation | Event-sourcing literature (deterministic fold); ML reproducibility checklists |
+| **Provenance Coverage** | **Art. 10 (data governance)** — training/input data traceability; Art. 11 + Annex IV (technical documentation must describe data provenance) | **W3C PROV-DM** (entity/activity/agent, `wasDerivedFrom` chains) — the de-facto provenance standard |
+
+The pitch to an external reviewer is therefore: *"these are the
+regulation's own requirements, operationalised into deterministic,
+runnable metrics"* — not "JAMES's idea of quality".
+
+## 2. Prior art (MUST re-verify online before freezing)
+
+Known landscape at knowledge cutoff (2026-01):
+- Quality benches exist (HELM, RGB, ALCE, AbstentionBench…) — none
+  measure audit/replay/provenance of the *system*.
+- Tracing **tools** exist (LangSmith, MLflow, W&B, OpenTelemetry GenAI
+  semantic conventions) — they *produce* logs but there is no
+  benchmark scoring *log completeness / replayability*.
+- W3C PROV has conformance notions but no RAG/agent benchmark.
+- EU AI Act conformity assessment is procedural (notified bodies), not
+  a quantitative benchmark.
+
+**Hypothesis (to verify)**: a deterministic replay/audit benchmark for
+RAG/agent systems does not yet exist → defining one is a genuine
+methodological contribution (the review's claim). If verification finds
+prior art, **adopt it** instead — adoption is stronger external
+recognition than invention.
+
+## 3. The three metrics — deterministic definitions
+
+### 3.1 Audit Completeness (AC)
+> Of the decision-bearing events the system actually executed, what
+> fraction emitted an audit row sufficient to identify the event?
+
+- Ground truth: an **instrumented run** — hooks at each pipeline stage
+  record the events that actually happened (retrieve, rerank, synth,
+  verify, lifecycle mutations…). The hook list is published in the spec.
+- Score = |audited events ∩ executed events| / |executed events|.
+- Deterministic: event-id set intersection. No judgement calls.
+- JAMES surface: `audit_bridge` rows (§5.7.2 trace schema) vs pipeline
+  hooks.
+
+### 3.2 Replay Fidelity (RF)
+> Given ONLY the audit log, how exactly can a third party reconstruct
+> the system's state and decision path at any past time t?
+
+- Protocol: run a published **event scenario** (a fixed sequence of
+  ingests / updates / supersedes / deletes / queries). At each step k,
+  snapshot the live state (ground truth S_k). Then, *from the audit log
+  alone*, reconstruct R_k = `reconstruct_graph_at(t_k)`.
+- Score = fraction of checkpoints where R_k ≡ S_k (canonical-form
+  byte-identical), plus a graded edge/node overlap (Jaccard) for
+  partial credit.
+- Deterministic: canonical serialisation + diff.
+- JAMES surface: `core/lifecycle/replay_graph.py` (already implemented +
+  112 tests); the benchmark turns the existing invariant into a *score*.
+
+### 3.3 Provenance Coverage (PC)
+> Of the claims in the system's answers, what fraction is traceable to
+> a source through an unbroken machine-readable chain?
+
+- Each answer's cited sources must chain back (answer → synth context →
+  retrieved doc → ingested artifact) expressible as W3C PROV
+  `wasDerivedFrom` edges from the logs.
+- Score = traceable-citation count / citation count (deterministic:
+  follow ids through the log; a break = untraceable).
+- Caution: "claims" segmentation can drift toward judgement — v1 scopes
+  to **cited sources only** (ids in the answer), which is fully
+  deterministic. Claim-level coverage is a v2 extension with its own
+  honesty review.
+
+### Scale axis (from cycle γ's finding)
+Graph build O(N²) (2026-06-10 finding) means replay **cost** matters at
+scale. Report RF with a **cost column** (events/sec folded, wall-time
+per 1k events) so the benchmark captures moat-at-scale, not just
+correctness on toy logs.
+
+## 4. Generic + comparable — not a JAMES-only yardstick
+
+The spec defines an **abstract audit-log interface** (event row: id,
+ts, type, inputs-hash, outputs-summary, parent) and scores ANY system
+that can export it:
+
+- **Baseline 0**: vanilla RAG (LangChain/LlamaIndex quickstart, default
+  logging) — expected to score near-zero on RF (no event-sourced state)
+  and low on AC. This is the honest contrast that quantifies the moat.
+- **Baseline 1**: same stack + LangSmith/OTel tracing — measures how far
+  *tracing tools* get you (likely: AC mid, RF still near-zero — traces
+  ≠ replayable state).
+- **JAMES**: full pipeline.
+
+Publishing scores for systems *we don't own* is what makes the bench a
+benchmark rather than a brochure.
+
+## 5. External-recognition path (the user's constraint)
+
+1. **Spec + scorer + fixtures public** (GitHub + Zenodo DOI) — anyone
+   can re-run; scoring is deterministic so re-runs reproduce.
+2. **Standards mapping table** (§1) published in the spec — reviewers
+   check the mapping against the regulation text, not against JAMES.
+3. **Third-party replication invite** — Robin/Ali (existing
+   collaborators) run the scorer on their stacks; their numbers appear
+   in the release. (Collab-arc rule: this is an *invitation with its own
+   scope*, NOT folded into the mid-June joint piece —
+   `feedback_eval_cycle_vs_collab_arc_separation`.)
+4. **Honest tier**: the benchmark itself is the contribution
+   (methodology). JAMES scoring well on its own bench is expected and
+   NOT the headline; the headline is the *measurable gap* between
+   audit-native and bolt-on-tracing architectures, reproducible by
+   anyone.
+
+## 6. Work plan (each step pre-registered before its measurement)
+
+```
+R1.0  prior-art online verification (§2)            — blocks spec freeze
+R1.1  spec freeze: 3 metric definitions + standards mapping + abstract
+      log interface (this memo → versioned spec doc)
+R1.2  fixture: published event scenario (ingest/update/supersede/delete/
+      query sequence) — synthetic but public + deterministic
+R1.3  scorer implementation (deterministic; no LLM) + unit tests
+R1.4  pre-register thresholds → measure JAMES + Baseline 0 (+1)
+R1.5  release: spec + scorer + fixtures + all scores (Zenodo DOI)
+R1.6  replication invites (separate collab scope)
+```
+
+Estimated: R1.1–R1.3 ≈ 1–2 days; R1.4 ≈ hours (deterministic, no LLM
+calls in scoring); R1.5–R1.6 operator-paced.
+
+## 7. What this is NOT (scope guards)
+
+- NOT a MuSiQue/quality bench — quality axes are covered elsewhere.
+- NOT a conformity-assessment substitute — it *operationalises* Art.
+  10/12 concepts; it does not certify compliance (say so explicitly in
+  the spec to stay honest).
+- NOT joint-piece content (separate arc; 4-question check applies).
+- NOT frozen until §2 prior-art verification runs online.


### PR DESCRIPTION
## Summary
Design memo for the **moat-axis benchmark** (review R1). User constraint: **외부에서도 객관적으로 인정받을 수 있는 기준** — must not be a self-eval trap.

### Authority externalized on all four axes
| Authority | Self-eval trap | This design |
|---|---|---|
| Criteria | JAMES decides | **EU AI Act Art.10/12 + W3C PROV + NIST AI RMF** mapping |
| Scoring | LLM judge | **Deterministic only** (byte-diff, event counts) |
| Applicability | JAMES-only | **Generic audit-log interface** — vanilla-RAG + tracing-tool baselines scored alongside; the gap IS the moat |
| Validation | JAMES | **Public spec/scorer/fixtures (Zenodo DOI)** + third-party replication |

### 3 metrics (deterministic)
- **Audit Completeness** — executed events vs audited events (Art.12 record-keeping)
- **Replay Fidelity** — `reconstruct_graph_at(t)` vs ground-truth snapshots + **cost column** (the O(N²) scale finding feeds in)
- **Provenance Coverage** — v1 = cited-source chains only (W3C PROV `wasDerivedFrom`), fully deterministic

### Honest framing
- The benchmark itself is the contribution; JAMES scoring well on its own bench is NOT the headline — the reproducible **gap between audit-native and bolt-on-tracing** is.
- NOT a conformity-assessment substitute (operationalises Art.10/12 concepts; does not certify).
- NOT joint-piece content (separate collab scope, 4-question check).

## Status — DRAFT
**R1.0 (prior-art online verification) BLOCKS spec freeze** — classifier outage at draft time prevented web search. If prior art exists → ADOPT it (stronger recognition than invention). Work plan R1.0–R1.6 in the memo, each measurement pre-registered.

JAMES replay functionality already implemented (112 tests pass) — R1 measures existing capability; no new core code.

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)