### PR TITLE
chore(release): v0.4.3 — RAB v0.1.1 + Cycle γ multi-hop arc closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,11 @@ james_attack_log.jsonl
 tmp/
 temp/
 
+# RAB SPEC §4 re-verification artifacts MUST be tracked — they are
+# part of every released RAB result triple (result.json + log.jsonl
+# + mapping.json). Override the global *.jsonl rule for reports/rab/.
+!reports/rab/*.jsonl
+
 # ── IDE / OS ───────────────────────────────────────────────────
 .vscode/
 .idea/

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
-  "title": "PROJECT JAMES — v0.4.2 (T5 Replayable Audit Graph — full event-sourced graph-wide reconstruction; audit-only invariant; cross-chain integration)",
-  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.2 ships the T5 Replayable Audit Graph — full event-sourced graph-wide reconstruction. v0.4.0 shipped reconstruct_view_at (single-supersede-chain replay primitive); v0.4.2 extends it to graph-wide reconstruct_graph_at(t) — a pure-function rebuild of the graph snapshot at any past time using only audit_log event rows, with no wiki / knowledge_tracker / graph-engine read. That is the audit-only invariant — the foundation that makes the ABAC + replay claim (corpus retrieval analysis, PR #712 §6) externally demonstrable: ship the audit_log JSON → third party reproduces the graph state at any past t and the answer's decision tree on top, with no other artifact.\n\nT5 5-PR sequence:\n- #719 T5 design memo — 15 sections covering partial-vs-full scope, audit-only invariant, event-type taxonomy, API design, cross-chain integration, 5-PR phase plan, 5 Decision LOCKs, cross-cutting impact analysis, closure conditions.\n- #720 PR-T5.A — event taxonomy + emit helper + audit_log migration. core/lifecycle/replay_audit.py (LIFECYCLE_EVENT_TYPES with 7 entries: T7 supersede ×2, T6 cascade, T1 expiration, T2 dispatch, T2.D ingest dispatch, migration backfill; EVT_* constants; is_lifecycle_event exact-match predicate; emit_lifecycle_event synchronous in-transaction insert — never raises). LOCK 1 (event_payload = JSON string column) + LOCK 2 (synchronous in-transaction emit). scripts/migrate_v042_replay_audit.py (idempotent ALTER TABLE adding event_type + event_payload columns; --dry-run/--apply/--verify/--no-snapshot; pre-write snapshot at <db>.pre-v042-migration). 19 contract tests.\n- #721 PR-T5.B — reconstruct_graph_at audit-only primitive. core/lifecycle/replay_graph.py (frozen GraphSnapshot dataclass: edges / supersede_chains / invalidated_ids / replayed_at / event_count; reconstruct_graph_at(t, *, audit_log_path=None, include_event_types=None)). Per-event-type handlers for every LIFECYCLE_EVENT_TYPES entry; import-time assert set(_HANDLERS) == set(LIFECYCLE_EVENT_TYPES) makes any drift a load-time error. LOCK 4 (pure function — only side-channel is the audit_log SELECT). Defence-in-depth (malformed JSON / unknown event_type / pre-migration DB / non-existent file all return the empty snapshot). 20 contract tests + 4 invariants (I1 audit-only / I2 supersede-preserved / I3 cascade-respected / I4 replay-equality weak form).\n- #722 PR-T5.C — cross-chain integration + ARCHITECTURE §5.7.2 extension. view_from_snapshot(snap, head_id, t) snapshot-side equivalent of reconstruct_view_at. Same iterate-forward + last-match + validity-window + invalidated-edge-skip semantics as the live primitive; _validity_contains private helper mirrors the live primitive byte-for-byte on edge selection. Cross-chain consistency contract: view_from_snapshot(snap, head, t) ∈ snap.edges.values() ∪ {None}. ARCHITECTURE.md §5.7.2 gets a \"Graph replay invariant\" subsection alongside the trace replay invariant. 11 contract tests.\n- PR-T5.D — release-gating invariants + closure. tests/test_t5_release_gating_invariants.py (5 release-gating tests against in-memory SQLite fixtures with real emit/reconstruct code: test_graph_replay_at_t_matches_event_log, test_replay_audit_only_no_db_scan, test_replay_preserves_supersede_chain, test_replay_respects_cascade_invalidate, test_reasoning_trace_replay_invariant). CHANGELOG [0.4.2], .zenodo.json v0.4.2, docs/release_notes_v0.4.2.md.\n\nDefault-off invariant preserved. No new env flag in this cycle. The two new audit_log columns (event_type / event_payload) default NULL on existing rows; mutation-site wiring (T1/T2/T2.D/T6/T7 call sites → emit_lifecycle_event) is intentionally a follow-up cycle (cross-cutting change kept out of v0.4.2 so the read-side primitive can land independently). Production audit_log keeps emitting only reasoning trace rows until wiring lands.\n\nVerification: tests/test_t5_event_taxonomy 19/19 PASS; tests/test_t5_reconstruct_graph_at 20/20 PASS; tests/test_t5_cross_chain_consistency 11/11 PASS; tests/test_t5_release_gating_invariants 5/5 PASS; tests/test_replay_trace (§5.7.2 v0.4.1 regression) 16/16 PASS. T5 lifecycle suite + replay regression: 71/71 PASS.\n\nWhat v0.4.2 does NOT do: no mutation-site wiring (T1/T2/T2.D/T6/T7 → emit_lifecycle_event), so production audit_log keeps emitting only reasoning trace rows and reconstruct_graph_at(now) returns the empty snapshot until wiring lands; no I4 against the live wiki (strong form requires wiring + live-state fixture); no T3 Evidence Aging, no T4 Reviewer Authority Hierarchy (both stay deferred to v0.4.3+).",
-  "version": "v0.4.2",
+  "title": "PROJECT JAMES — v0.4.3 (RAB v0.1.1: Replayable-Audit Benchmark + Cycle γ multi-hop arc closure)",
+  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.3 ships RAB v0.1.1 (Replayable-Audit Benchmark) — the first replayable-audit benchmark for RAG / agent systems whose 3 metrics (AC / RF / PC) are operationalisations of EU AI Act Articles 10, 12, 19 (in force 2026-08-02). Companion track: Cycle γ multi-hop arc closure (7 probes, 6 honest nulls, 2 self-corrections — multi-hop improvement reframed out of the JAMES roadmap; the graph build O(N²) finding lifted into RAB as the RF-cost axis). No JAMES production runtime change — RAB measures the existing audit / lifecycle / graph paths via a workspace-scoped adapter; production audit.db is untouched.\n\nRAB v0.1.1 — frozen spec + scenario fixture + deterministic scorer + reference / JAMES / Baseline-0 adapters + first gap-table measurement. Authority externalised across 4 axes: (1) Anchors — EU AI Act Art. 10(2)(b) + 12(1)(2)(b) + 19 verbatim + W3C PROV + NIST AI RMF + Mathkar et al. agent-trace survey (arXiv 2606.04990) which explicitly names execution-trace benchmarks as an open challenge → RAB responds to a published gap. (2) Scoring — deterministic only; no LLM judge anywhere in the scorer. (3) Application — generic audit-log JSONL interface; any system that can export an append-only log is scoreable; Baseline-0 (vanilla quickstart + Python logging) scored alongside JAMES; the gap structure across SUTs is the headline (SPEC §5 / §6.5). (4) Verification — every result ships with the SPEC §4 re-verification triple (result.json, exported audit log JSONL, mapping table JSON), committed to reports/rab/ for bit-for-bit re-runs.\n\nR1.0 → R1.5 sequence:\n- #758 / #760 / #761 R1.0 prior-art + EU AI Act anchors — vacancy confirmed; ActiveGraph (arXiv 2605.21997) is independent co-invention of the audit-native architecture → contribution is the benchmark, not the architecture.\n- #762 R1.1 SPEC v0.1.1 FROZEN — eval/rab/SPEC-v0.1.md. v0.1.1 = v0.1.0 + PC's origin-bearing event widened from INGEST only to INGEST | SUPERSEDE (defect caught by reference adapter before any measurement; changelog in the SPEC itself).\n- #763 R1.2 scenario-S1 fixture — eval/rab/scenarios/s1_lifecycle_small.json (40 ops + 10 checkpoints, synthetic Northbridge Labs lifecycle, public domain).\n- #764 R1.3 driver + scorer + reference adapter — eval/rab/{driver,scorer}.py + adapters/reference.py + tests/test_rab_benchmark.py (14 tests pinning reference 1.0×3 self-verification + 3 fault-injection variants).\n- #766 R1.4 pre-registration LOCKED before any adapter code or measurement (R5 rule).\n- #767 R1.4 JAMES adapter (workspace-isolated; SUPERSEDE calls real core.lifecycle.replay_audit.emit_lifecycle_event; cross-verified against core.lifecycle.replay_graph.reconstruct_graph_at — production code path actually exercised) + Baseline-0 adapter (vanilla in-memory RAG + Python-logging-style records = the floor) + scripts/research/rab_run.py CLI writing the SPEC §4 re-verification triple + 17 new tests + 9 measurement artifacts committed to reports/rab/.\n- R1.5 = this release.\n\nGap table (RAB SPEC v0.1.1 / scenario-S1): reference 1.000 / 1.000,1.000 / 1.000; JAMES 1.000 / 1.000,1.000 / 1.000; Baseline-0 0.275 / 0.000,0.000 / 0.000. AC INGEST = 1.0 across all three (default logging covers add-doc); AC UPDATE/SUPERSEDE/DELETE/ANSWER = 0 for Baseline-0 (vanilla logger has no lifecycle taxonomy); RF = 0 for Baseline-0 (logs carry strings, not payload — replay has nothing to fold); PC = 0 for Baseline-0 (no parent_id chain). JAMES = reference on S1 is expected per SPEC §6.5 — the headline is the audit-native vs default-logging gap, not JAMES's score. Honest tier ⭐⭐ scenario-S1 audit-native vs floor gap confirmed; ⭐⭐⭐ cross-scenario remains ungated until additional scenarios ship.\n\nCycle γ multi-hop arc closure (companion track, PRs #752 → #757): MuSiQue probes concluded that multi-hop improvement is not a JAMES roadmap item — the wall is unsupervised supporting-paragraph selection, not retrieval breadth, not model ceiling. Top-8 retrieval recall is 0.76 (both R0 and ablated); oracle-grounded performance jumps 8% → 72% (9×) when supporting paragraphs are given directly. The secondary finding — graph build O(N²) — lifted out of MuSiQue scope (where it had no leverage) into RAB as the RF-cost axis (SPEC §2.2 cost_s_per_1k_events). Env-gates JAMES_RETRIEVE_TOP_K + JAMES_RERANK_TOP_K added (defaults 8 / 5; byte-identical when unset). Selector-tuning rabbit hole closed.\n\nVerification: tests/test_rab_benchmark 14/14 PASS, tests/test_rab_baseline0 8/8 PASS, tests/test_rab_james_adapter 9/9 PASS — RAB test suite 31/31 PASS. No JAMES core test regression — no core/ change in this cycle.\n\nWhat v0.4.3 does NOT do: no production runtime change in JAMES core; no cross-scenario RAB result (S1 only); no Baseline-1 (LangSmith/OTel adapter — separate SUT, future cycle); no mutation-site wiring follow-up to v0.4.2 (T1/T2/T2.D/T6/T7 → emit_lifecycle_event still deferred); no multi-hop retrieval improvement (cycle γ closure re-framed it as not a JAMES roadmap item); no regulatory compliance certification claim (SPEC §6.3).",
+  "version": "v0.4.3",
   "upload_type": "software",
   "creators": [
     {
@@ -57,7 +57,18 @@
     "foundational-vs-corroborative",
     "non-saturating-quality-oracle",
     "pr-gate-quality-delta-card",
-    "replayable-rag"
+    "replayable-rag",
+    "rab",
+    "replayable-audit-benchmark",
+    "eu-ai-act",
+    "audit-completeness",
+    "replay-fidelity",
+    "provenance-coverage",
+    "audit-native",
+    "deterministic-scorer",
+    "pre-registration",
+    "gap-table",
+    "event-sourced-log"
   ],
   "license": "MIT",
   "access_right": "open",
@@ -69,8 +80,13 @@
       "resource_type": "software"
     },
     {
-      "identifier": "10.5281/zenodo.20411354",
+      "identifier": "10.5281/zenodo.20426719",
       "relation": "isNewVersionOf",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "10.5281/zenodo.20411354",
+      "relation": "isDerivedFrom",
       "resource_type": "software"
     },
     {
@@ -94,100 +110,65 @@
       "resource_type": "software"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/548",
+      "identifier": "arXiv:2606.04990",
+      "relation": "cites",
+      "resource_type": "publication-article"
+    },
+    {
+      "identifier": "arXiv:2605.21997",
+      "relation": "cites",
+      "resource_type": "publication-article"
+    },
+    {
+      "identifier": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj",
+      "relation": "references",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://www.w3.org/TR/prov-overview/",
+      "relation": "references",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/758",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/549",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/760",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/550",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/761",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/551",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/762",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/552",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/763",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/553",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/764",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/554",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/766",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     },
     {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/555",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/556",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/557",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/558",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/559",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/560",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/561",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/562",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/563",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/564",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/565",
-      "relation": "isDocumentedBy",
-      "resource_type": "publication-other"
-    },
-    {
-      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/566",
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/767",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
     }
   ],
-  "notes": "v0.4.1 closes the CASCADE pillar v0.4.0 only half-finished. T6 Causality Chain ships as a 5-PR sequence (T6.A schema + cycle validator + migration → T6.B derivation extraction → T6.C invalidate_derived_facts cascade → T6.C.b foundational-vs-corroborative refinement → T6.D cascade integration + 4 release-gating invariants). Plus the v0.4.0 carry-over dispatch_contradiction wiring (T2.D-1/2/2.b/3) lands as flag-gated default-OFF. Plus the QVT α track ships end-to-end (3-axis non-saturating oracle + canonical baseline_2a31b20.json + PR-gate template + ARCHITECTURE §5.7.10). All decisions back-traceable to the T6.C.b user-clarified semantics during T6.C review. The isNewVersionOf chain back to v0.4.0 (10.5281/zenodo.20411354) makes the DOI lineage explicit; the chain back to v0.4.0-alpha.3 (10.5281/zenodo.20391100) and v0.3.x stays via isDerivedFrom. Three-author joint-piece collaboration with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the mid-June trajectory."
+  "notes": "v0.4.3 ships RAB v0.1.1 — the first replayable-audit benchmark for RAG / agent systems with 3 deterministic metrics (AC / RF / PC) operationalising EU AI Act Articles 10, 12, 19. Companion track closes the cycle γ multi-hop arc with 6 honest nulls (multi-hop improvement reframed out of the JAMES roadmap). The full RAB SPEC + scenario + scorer + adapters + 9 measurement artifacts are committed to this repo. The headline is the AUDIT-NATIVE vs DEFAULT-LOGGING gap on scenario-S1 (JAMES = reference = 1.0×3 / Baseline-0 = 0.275, 0.0, 0.0), not JAMES's score — SPEC §6.5 explicitly disclaims JAMES-wins framing. The benchmark, not the architecture, is the contribution: ActiveGraph (arXiv 2605.21997) is independent co-invention of the event-sourced log + deterministic replay. The isNewVersionOf chain pins v0.4.1 (10.5281/zenodo.20426719) as immediate predecessor; v0.4.0 (10.5281/zenodo.20411354) and earlier chained via isDerivedFrom. Three-author joint-piece with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the mid-June trajectory (separate collab arc — not auto-linked to this release per feedback_eval_cycle_vs_collab_arc_separation)."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.3] — 2026-06-10 — RAB v0.1.1 (Replayable-Audit Benchmark) + Cycle γ multi-hop arc closure
+
+**Theme**: v0.4.3 ships **RAB v0.1.1** — the first replayable-audit benchmark for RAG / agent systems whose 3 metrics (AC / RF / PC) are operationalisations of EU AI Act Articles 10, 12, 19 (in force 2026-08-02). Same cycle closes the cycle γ multi-hop arc (7 probes, 6 honest nulls, 2 self-corrections — `multi-hop improvement` reframed out of the JAMES roadmap; **graph build O(N²) finding** lifted into RAB as the RF-cost axis). No JAMES production runtime change — RAB measures the existing audit / lifecycle / graph paths via a workspace-scoped adapter; production `audit.db` is untouched.
+
+**Default-off invariant preserved**. The cycle γ measurement gates (`JAMES_RETRIEVE_TOP_K`, `JAMES_RERANK_TOP_K`) default to the existing values (8 / 5) and are byte-identical when unset.
+
+### RAB v0.1.1 — R1.0 → R1.5 sequence
+
+- **R1.0 prior-art + EU AI Act anchors (#758 / #760 / #761)** — vacancy confirmed (no replayable-audit benchmark exists); arXiv 2606.04990 (Mathkar et al.) names "realistic execution-trace benchmarks" as an open challenge → RAB responds to a published gap. ActiveGraph (arXiv 2605.21997, 2026-05-21) is independent co-invention of the event-sourced log + replay architecture → **contribution is the benchmark, not the architecture**. EU AI Act Art. 12(1) + 12(2)(b) + 10(2)(b) + 19 verbatim verified; Art. 113 fixes effective date 2026-08-02.
+- **R1.1 SPEC v0.1.1 FROZEN (#762)** — `eval/rab/SPEC-v0.1.md`. Abstract log interface (§1, JSONL + canonical event types), three deterministic metrics (§2: AC / RF / PC), scenario contract (§3), reporting format (§4 incl. log_sha + mapping_table_sha for re-verification), 5 baselines (§5: reference / Baseline-0 / Baseline-1 / JAMES / invited audit-native runtimes), 6 honesty clauses (§6). v0.1.1 = v0.1.0 + PC's origin-bearing event rule widened from `INGEST` only to `INGEST | SUPERSEDE` (defect caught by the reference adapter implementation before any measurement was taken; changelog in the SPEC itself).
+- **R1.2 scenario-S1 fixture (#763)** — `eval/rab/scenarios/s1_lifecycle_small.json`. 40 ops (11 INGEST / 4 UPDATE / 3 SUPERSEDE / 2 DELETE / 20 QUERY) + 10 checkpoints over a synthetic Northbridge Labs lifecycle. Public-domain content, deterministic ids.
+- **R1.3 driver + scorer + reference adapter (#764)** — `eval/rab/{driver,scorer}.py` + `eval/rab/adapters/reference.py` + `tests/test_rab_benchmark.py` (14 tests pinning reference 1.0×3 self-verification + 3 fault-injection variants that drop exactly the targeted metric).
+- **R1.4 pre-registration + JAMES adapter + Baseline-0 adapter + measurement (#766 / #767)** — pre-registration `docs/research/r1-4-preregistration-2026-06-10.md` LOCKED before any adapter code or measurement ran (R5 rule). `eval/rab/adapters/baseline0.py` (vanilla in-memory RAG + Python-logging-style records — the floor). `eval/rab/adapters/james.py` (workspace-isolated; SUPERSEDE calls real `core.lifecycle.replay_audit.emit_lifecycle_event` and is cross-verified against `core.lifecycle.replay_graph.reconstruct_graph_at` — JAMES's production code path is actually exercised). `scripts/research/rab_run.py` CLI writes the SPEC §4 re-verification triple (`result.json` + `log.jsonl` + `mapping.json`) per SUT. **31 tests green** across all three test files. Gap-table handover: `docs/handovers/v0.4-r1-4-gap-table-2026-06-10.md`.
+- **R1.5 = this release** — packaged for external review (CHANGELOG, `.zenodo.json` v0.4.3, README RAB section, release notes).
+
+### Gap table (RAB SPEC v0.1.1 / scenario-S1)
+
+| SUT | AC | AC INGEST | AC UPDATE | AC SUPERSEDE | AC DELETE | AC ANSWER | RF-exact | RF-graded | PC | events |
+|---|---|---|---|---|---|---|---|---|---|---|
+| reference (self-verify gate) | **1.000** | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | **1.000** | 1.000 | **1.000** | 80 |
+| **JAMES** | **1.000** | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | **1.000** | 1.000 | **1.000** | 80 |
+| **Baseline-0** (floor) | **0.275** | 1.00 | 0.00 | 0.00 | 0.00 | 0.00 | **0.000** | 0.000 | **0.000** | 40 |
+
+Honest tier: **⭐⭐ scenario-S1 audit-native vs floor gap confirmed** (deterministic, re-runnable from artifacts under `reports/rab/`). ⭐⭐⭐ cross-scenario remains ungated until a future cycle ships additional scenarios. JAMES = reference on S1 is **expected** per SPEC §6.5 — the headline is the gap structure across SUTs, not any single system's score.
+
+### Cycle γ multi-hop arc closure (companion track)
+
+PRs #752 → #757. Cycle γ's MuSiQue probes concluded that "multi-hop improvement" is not a JAMES roadmap item: the wall is unsupervised supporting-paragraph selection, not retrieval breadth and not model ceiling. Top-8 retrieval recall is 0.76 (both R0 and ablated); oracle-grounded performance jumps 8% → 72% (9×) when supporting paragraphs are given directly. The cycle's secondary finding — **graph build O(N²)** — has been lifted out of MuSiQue scope (where it had no leverage) into RAB as the RF-cost axis (SPEC §2.2 `cost_s_per_1k_events`). Memory: `project_cycle_gamma_phase_c2_retrieval_bottleneck`. ★ selector-tuning rabbit hole closed.
+
+Env-gate hooks added: `JAMES_RETRIEVE_TOP_K`, `JAMES_RERANK_TOP_K` (defaults 8 / 5; byte-identical when unset).
+
+### R0 P0 (cycle-pre disciplinary + security)
+
+- **#750** — R5 pre-registration rules + R2 measurement-discipline rules checked into `docs/rules/` as repo-side audit trail (previously memory-only — bus-factor + auditability fix from 2026-06-09 external review action R2).
+- **#751** — `starlette` 1.0.1 (CVE) + `chromadb` risk-accept note (`docs/security/`).
+
+### Verification
+
+- `tests/test_rab_benchmark.py` — 14/14 PASS (reference 1.0×3 + 3 fault-injection variants)
+- `tests/test_rab_baseline0.py` — 8/8 PASS (floor pinned: AC 0.275 / RF 0 / PC 0)
+- `tests/test_rab_james_adapter.py` — 9/9 PASS (audit-native 1.0×3 + workspace isolation + real `emit_lifecycle_event` bridge + `reconstruct_graph_at` agreement + log-only replay invariant)
+- **RAB test suite: 31/31 PASS**
+- No JAMES core test regression — no `core/` change.
+- RAB measurement artifacts committed under `reports/rab/`:
+  - `reference-S1-*.{result.json,log.jsonl,mapping.json}`
+  - `james-S1-*.{result.json,log.jsonl,mapping.json}`
+  - `baseline0-S1-*.{result.json,log.jsonl,mapping.json}`
+
+### What v0.4.3 does NOT do
+
+- No production runtime change in JAMES core.
+- No cross-scenario RAB result (S1 only).
+- No Baseline-1 (LangSmith/OTel adapter) — separate SUT, future cycle.
+- No mutation-site wiring follow-up to v0.4.2 (T1/T2/T2.D/T6/T7 → `emit_lifecycle_event` still deferred).
+- No multi-hop retrieval improvement (cycle γ closure re-framed it as not a JAMES roadmap item).
+- No regulatory compliance certification claim (SPEC §6.3).
+
+---
+
 ## [0.4.2] — 2026-06-06 — T5 Replayable Audit Graph (full event-sourced reconstruction)
 
 **Theme**: v0.4.0 shipped `reconstruct_view_at` — a single-supersede-chain replay primitive. v0.4.2 extends that to **graph-wide event-sourced reconstruction**: a pure-function `reconstruct_graph_at(t)` that rebuilds the full graph snapshot at any past time using only `audit_log` event rows, with no wiki / knowledge_tracker / graph-engine read. That is the **audit-only invariant** — the foundation that makes the "ABAC + replay" claim (corpus retrieval analysis, PR #712 §6) externally demonstrable: ship the `audit_log` JSON → third party reproduces the graph state at any past `t` and the answer's decision tree on top, with no other artifact.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@
 > API, and the deterministic 4-rule contradiction tree.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
+[![Status](https://img.shields.io/badge/Status-v0.4.3-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.3)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20426719.svg)](https://doi.org/10.5281/zenodo.20426719)
+[![RAB SPEC](https://img.shields.io/badge/RAB%20SPEC-v0.1.1-green.svg)](eval/rab/SPEC-v0.1.md)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)
 
@@ -42,14 +43,23 @@ The numbers below come from the current `main` branch — not aspirational, not 
 | **Module size discipline** | 20 KB cap enforced on every `core/` file. Largest current: `core/lifecycle/schema.py` at 18.9 KB | CLAUDE.md rule 5 + module-size CI gate |
 | **Default-off invariant** | Every routing layer added since v0.3 (D5 / LEO / D1 / T2.D / T6 LLM) defaults OFF — production fleets pulling v0.4.1 see byte-identical retrieval to v0.3.3 unless they opt in | `JAMES_*` env audit (CHANGELOG `[0.4.x]` table) |
 | **Deterministic contradiction arbitration** | `classify_contradiction` is an LLM-free 4-rule decision tree (~10.2 KB pure function). Audit-replay-safe by construction. | `core/lifecycle/contradiction_arbiter.py` |
+| **RAB v0.1.1 — Replayable-Audit Benchmark** | **JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 (vanilla quickstart + default logging) = 0.275 / 0.000 / 0.000** on scenario-S1. Deterministic scorer (no LLM judge); 3 metrics map to EU AI Act Art. 10/12/19 (in force 2026-08-02). | `eval/rab/SPEC-v0.1.md` + `python scripts/research/rab_run.py --sut {reference,baseline0,james}` |
 
 **What is NOT yet headline-verified**: a single-page ablation card showing **Graph-RAG vs flat RAG** on the same fixture. The infrastructure to produce it (`scripts/qvt_capture_baseline.py` + the 18-cell ablation matrix design from QVT memo §5) is wired; the operator-run capture is the late-June deliverable. Until then, the graph contribution is measurable via `graph_paths_count` per query in any STEP 7 bench output, but not summarized in one table.
 
 ---
 
-## Project Status: v0.4.1 — T6 Causality Chain (CASCADE extension)
+## Project Status: v0.4.3 — RAB v0.1.1 (Replayable-Audit Benchmark) + Cycle γ multi-hop arc closure
 
-Released **2026-05-28**. v0.4.1 closes the CASCADE pillar that v0.4.0 only half-finished: when a base fact's sources are fully removed, edges whose `derived_from` references that base now auto-invalidate via `invalidate_derived_facts` — the derivation chain stays internally consistent without manual operator intervention. Per-derivation-type semantics (T6.C.b refinement): `transitive` / `inferred` are structural chain links (any base empty → invalidate); `operator` is corroborative (only invalidates when no hard deps AND all operator bases empty).
+Released **2026-06-10**. v0.4.3 ships **RAB v0.1.1** — the first replayable-audit benchmark for RAG / agent systems whose 3 deterministic metrics (AC / RF / PC) are operationalisations of EU AI Act Articles 10, 12, 19 (in force 2026-08-02). The full SPEC, scenario fixture, scorer, reference / JAMES / Baseline-0 adapters, and 9 measurement artifacts (reports/rab/) are committed. Headline = the **gap structure** across SUTs (JAMES audit-native = 1.000 / 1.000 / 1.000 vs Baseline-0 default-logging floor = 0.275 / 0.000 / 0.000 on scenario-S1), not JAMES's score — SPEC §6.5 explicitly disclaims JAMES-wins framing. Honest framing: **the benchmark is the contribution, not the architecture** — ActiveGraph (arXiv 2605.21997) is independent co-invention of the audit-native runtime; the unfilled gap was the measurement, not the system.
+
+Companion track in the same cycle closes the **Cycle γ multi-hop arc** (PRs #752 → #757) with 6 honest nulls: multi-hop improvement reframed out of the JAMES roadmap; the **graph build O(N²)** secondary finding lifted into RAB as the RF-cost axis.
+
+No JAMES production runtime change — RAB measures the existing audit / lifecycle / graph paths via a workspace-scoped adapter; production `audit.db` is untouched. Default-off invariant preserved.
+
+Pre-v0.4.3: **v0.4.2** (2026-06-06) shipped T5 Replayable Audit Graph — full event-sourced graph-wide reconstruction (`reconstruct_graph_at(t)` audit-only primitive, the building block RAB measures the quality of).
+
+Pre-v0.4.2: **v0.4.1** (2026-05-28) closed the CASCADE pillar that v0.4.0 only half-finished: when a base fact's sources are fully removed, edges whose `derived_from` references that base now auto-invalidate via `invalidate_derived_facts` — the derivation chain stays internally consistent without manual operator intervention. Per-derivation-type semantics (T6.C.b refinement): `transitive` / `inferred` are structural chain links (any base empty → invalidate); `operator` is corroborative (only invalidates when no hard deps AND all operator bases empty).
 
 Pre-v0.4.1: **v0.4.0** (2026-05-27) shipped the Layer 4 first
 bundle — **T1 Temporal Validity + T7 Supersede Chain + T2
@@ -91,6 +101,56 @@ travel, etc.) can branch off **only at v1.0**. Until then:
 See [`docs/PLATFORM_READINESS.md`](docs/PLATFORM_READINESS.md) for
 the 6 dimensions, 4 gates (v0.2 / v0.3 / v0.4 / v1.0), and 3
 branching forms (Domain Pack / Distribution / Vertical Product).
+
+---
+
+## RAB — Replayable-Audit Benchmark (new in v0.4.3)
+
+**RAB v0.1.1** is a frozen benchmark spec + scenario fixture +
+deterministic scorer + adapter contract for systems that claim
+audit-replayable RAG / agent state. Three metrics, all deterministic
+(no LLM judge anywhere):
+
+* **AC — Audit Completeness** (EU AI Act Art. 12(1)/(2))
+* **RF — Replay Fidelity** (Art. 12(2)(b) post-market reconstruction)
+* **PC — Provenance Coverage** (Art. 10(2)(b) + W3C PROV)
+
+**Why a new benchmark**: the Mathkar et al. 2026 agent-trace survey
+(arXiv 2606.04990) names "realistic execution-trace benchmarks" as
+an open challenge; RAB responds to that gap. The benchmark — not the
+audit-native runtime — is the contribution: ActiveGraph (arXiv
+2605.21997) independently published the event-sourced log + replay
+architecture; **RAB is what was missing**.
+
+**Headline = gap structure**, not JAMES's score. Scenario-S1 v0.4.3
+result:
+
+| SUT | AC | RF-exact | RF-graded | PC |
+|---|---|---|---|---|
+| reference (self-verify gate) | 1.000 | 1.000 | 1.000 | 1.000 |
+| **JAMES** (audit-native) | **1.000** | **1.000** | 1.000 | **1.000** |
+| **Baseline-0** (vanilla quickstart + default logging) | **0.275** | **0.000** | 0.000 | **0.000** |
+
+JAMES = reference on S1 is **expected** (SPEC §6.5). The audit-native
+vs default-logging delta is the finding. Honest tier: ⭐⭐
+scenario-S1 confirmed. Re-verification triple committed to
+`reports/rab/` (SPEC §4 bit-for-bit determinism).
+
+**Not a regulatory certification.** RAB operationalises the AI Act's
+*concepts* into measurable form; SPEC §6.3 says so wherever scores
+are published.
+
+Reproduce:
+
+```bash
+python scripts/research/rab_run.py --sut reference  # 1.000 / 1.000 / 1.000 (gate)
+python scripts/research/rab_run.py --sut james      # 1.000 / 1.000 / 1.000
+python scripts/research/rab_run.py --sut baseline0  # 0.275 / 0.000 / 0.000
+```
+
+See [`eval/rab/SPEC-v0.1.md`](eval/rab/SPEC-v0.1.md),
+[`docs/handovers/v0.4-r1-4-gap-table-2026-06-10.md`](docs/handovers/v0.4-r1-4-gap-table-2026-06-10.md),
+[`docs/research/r1-4-preregistration-2026-06-10.md`](docs/research/r1-4-preregistration-2026-06-10.md).
 
 ---
 

--- a/docs/release_notes_v0.4.3.md
+++ b/docs/release_notes_v0.4.3.md
@@ -1,0 +1,230 @@
+# v0.4.3 — RAB (Replayable-Audit Benchmark) v0.1.1 + Cycle γ multi-hop arc closure
+
+**Released**: 2026-06-10 (R1 trace: PR sequence #758 → #760 → #761 →
+#762 → #763 → #764 → #766 → #767; Cycle γ multi-hop arc trace: PRs
+#752 → #753 → #754 → #755 → #756 → #757).
+
+**Theme**: v0.4.3 ships **RAB v0.1.1** — the first replayable-audit
+benchmark for RAG / agent systems whose 3 metrics (AC / RF / PC) are
+operationalisations of EU AI Act Articles 10, 12, 19 (in force
+2026-08-02). Same cycle closes the cycle γ multi-hop arc (7 probes,
+6 honest nulls, 2 self-corrections — `multi-hop improvement` reframed
+out of the JAMES roadmap; **graph build O(N²) finding** lifted into RAB
+as the RF-cost axis).
+
+Two tracks closed; no production runtime change. JAMES production
+audit / lifecycle / graph code paths are unchanged byte-for-byte —
+**RAB measures what was already there**, it does not modify it. The
+adapter (`eval/rab/adapters/james.py`) calls the existing
+`core.lifecycle.replay_audit.emit_lifecycle_event` and
+`core.lifecycle.replay_graph.reconstruct_graph_at` against a
+workspace-scoped audit.db; production audit.db is untouched.
+
+## RAB v0.1.1 — the headline
+
+A frozen benchmark spec + scenario fixture + deterministic scorer +
+reference / JAMES / Baseline-0 adapters + the first gap-table
+measurement.
+
+### Authority axes externalised (4 axes, locked before any
+measurement)
+
+1. **Anchors**: EU AI Act Art. 10(2)(b) / 12(1)(2)(b) / 19 verbatim
+   + W3C PROV `wasDerivedFrom` + NIST AI RMF + Mathkar et al. agent
+   trace survey (arXiv 2606.04990) which explicitly names
+   "realistic execution-trace benchmarks" as an open challenge → RAB
+   responds to a published gap, not a self-defined one.
+2. **Scoring**: deterministic only. No LLM judge anywhere in the
+   scorer (SPEC §6.1, pinned by test).
+3. **Application**: generic audit-log JSONL interface — any system
+   that can export an append-only log per SPEC §1 is scoreable.
+   Baseline-0 (vanilla quickstart + Python-logging) is scored
+   alongside JAMES; the **gap structure across SUTs is the headline**
+   (SPEC §5 / §6.5).
+4. **Verification**: every result ships with the SPEC §4
+   re-verification triple — `result.json`, exported audit log
+   JSONL, mapping table JSON — committed to `reports/rab/`. Re-running
+   the deterministic scorer on the same artifacts must reproduce the
+   numbers bit-for-bit.
+
+### Honest framing — what RAB is not
+
+* Not a regulatory compliance certification. RAB operationalises
+  Art. 10 / 12 / 19 *concepts*; SPEC §6.3 says this wherever scores
+  are published.
+* Not an architecture novelty claim. ActiveGraph (arXiv 2605.21997,
+  2026-05-21) independently published event-sourced log +
+  deterministic replay + log-only reconstruction. **The contribution
+  is the benchmark**, not the audit-native runtime (R1.0 prior-art
+  finding, memory `project_r1_replayable_audit_benchmark`).
+* Not a JAMES-wins announcement. JAMES = reference on scenario-S1 is
+  *expected* per SPEC §6.5. The bolt-on-vs-audit-native gap is the
+  finding.
+
+### R1.0 → R1.5 sequence
+
+- **R1.0 prior-art + EU AI Act anchors (#758/#760/#761)** —
+  benchmark-vacancy confirmed; Art. 12/10/19 mapping verbatim; AI
+  Act effective date 2026-08-02 confirmed via Art. 113.
+- **R1.1 SPEC v0.1.1 FROZEN (#762)** — `eval/rab/SPEC-v0.1.md`. The
+  abstract log interface (SPEC §1), three metrics (§2), scenario
+  contract (§3), reporting format (§4), 5 baselines (§5), 6
+  honesty clauses (§6). Spec changes never retro-apply; results
+  carry their spec version (SPEC §6.6).
+- **R1.2 scenario-S1 fixture (#763)** —
+  `eval/rab/scenarios/s1_lifecycle_small.json`. 40 ops (11 INGEST /
+  4 UPDATE / 3 SUPERSEDE / 2 DELETE / 20 QUERY) + 10 checkpoints +
+  Northbridge Labs synthetic prose. Public-domain content,
+  deterministic ids.
+- **R1.3 driver + scorer + reference adapter (#764)** —
+  `eval/rab/{driver,scorer}.py` + `eval/rab/adapters/reference.py` +
+  `tests/test_rab_benchmark.py` (14 tests). The reference adapter
+  caught a SPEC v0.1.0 defect during implementation (supersede-born
+  docs untraceable under INGEST-only PC rule), corrected to v0.1.1
+  before any measurement was taken — adapter-as-spec-validation
+  worked.
+- **R1.4 pre-registration + JAMES adapter + Baseline-0 adapter +
+  scenario-S1 measurement (#766 / #767)** — see gap table below.
+  31 tests green (reference 14 + Baseline-0 8 + JAMES 9).
+- **R1.5 = this release** — packaged for external review.
+
+### Gap table (RAB SPEC v0.1.1 / scenario-S1, deterministic,
+re-runnable from `reports/rab/`)
+
+| SUT | AC overall | AC INGEST | AC UPDATE | AC SUPERSEDE | AC DELETE | AC ANSWER | RF-exact | RF-graded | PC | log events |
+|---|---|---|---|---|---|---|---|---|---|---|
+| reference (self-verify gate) | **1.000** | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | **1.000** | 1.000 | **1.000** | 80 |
+| **JAMES** | **1.000** | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | **1.000** | 1.000 | **1.000** | 80 |
+| **Baseline-0** (floor) | **0.275** | 1.00 | 0.00 | 0.00 | 0.00 | 0.00 | **0.000** | 0.000 | **0.000** | 40 |
+
+* AC INGEST = 1.0 across all three (default logging covers add-doc).
+* AC UPDATE / SUPERSEDE / DELETE / ANSWER = 0 for Baseline-0 (vanilla
+  logger doesn't distinguish them, has no supersede taxonomy, often
+  doesn't log deletes, emits no ANSWER event).
+* RF = 0 for Baseline-0 (logs carry strings, not payload — replay
+  has nothing to fold).
+* PC = 0 for Baseline-0 (no `parent_id` chain).
+* JAMES = reference on S1 is expected (SPEC §6.5); the headline is
+  the audit-native vs default-logging gap.
+
+Honest tier: **⭐⭐ scenario-S1 audit-native vs floor gap confirmed**
+(deterministic, re-runnable from artifacts). ⭐⭐⭐ cross-scenario
+remains ungated until R1.5+ ships additional scenarios.
+
+### Reproduce the table
+
+```bash
+git checkout v0.4.3
+python -m pytest tests/test_rab_benchmark.py \
+                 tests/test_rab_baseline0.py \
+                 tests/test_rab_james_adapter.py    # 31 tests, all green
+python scripts/research/rab_run.py --sut reference  # AC 1.0 / RF 1.0,1.0 / PC 1.0 (gate)
+python scripts/research/rab_run.py --sut james      # AC 1.0 / RF 1.0,1.0 / PC 1.0
+python scripts/research/rab_run.py --sut baseline0  # AC 0.275 / RF 0.0,0.0 / PC 0.0
+# inspect reports/rab/*.result.json — values match
+# the committed v0.4.3 artifacts bit-for-bit (SPEC §4 determinism).
+```
+
+The driver + scorer is deterministic over a fixed artifact set. The
+adapter step has wall-clock-dependent timestamps but the AC/RF/PC
+values are stable across re-runs (`test_baseline0_deterministic`,
+`test_james_deterministic_mode_repeat`).
+
+## Cycle γ multi-hop arc closure (companion track)
+
+Cycle γ's MuSiQue probes concluded that **"multi-hop improvement"
+is not a JAMES roadmap item**. The wall is unsupervised supporting-
+selection, not retrieval breadth and not model ceiling. Retrieval
+recall on the top-8 set is 0.76 (both R0 and ablated); the gap to
+oracle-grounded performance is the selection step. Memory:
+`project_cycle_gamma_phase_c2_retrieval_bottleneck`.
+
+7-probe trace (PRs #752 → #757):
+
+* **#752** MuSiQue → retrieval-bottleneck hypothesis (later corrected
+  by #754)
+* **#753** D1 static decompose → INSUFFICIENT (hop-2 anaphora)
+* **#754** D1b iterative → INSUFFICIENT + sources-top3 artifact
+  isolation: `retrieve(top-8)` 13/25 both arms — the diagnosis pivot.
+* **#755** D2 rerank-OFF → synth-noise is the actual lever
+  (oracle 72% vs noisy 12%, a 9× jump when supporting paragraphs are
+  given directly).
+* **#756** D3 evidence-select → INSUFFICIENT → **multi-hop arc
+  closure**.
+* **#757** D4 graph: feature already verified (250+ tests); Path-D
+  over-investment PASS; **★ graph build O(N²) finding** — folded
+  into RAB as the RF-cost axis (SPEC §2.2 `cost_s_per_1k_events`).
+  Lifted out of MuSiQue scope where it had no leverage, lifted into
+  RAB scope where it has structural meaning.
+
+Operator-facing artifacts: env-gate `JAMES_RETRIEVE_TOP_K` /
+`JAMES_RERANK_TOP_K` (defaults 8 / 5; byte-identical when unset).
+**Default-off invariant preserved.**
+
+## R0 P0 (pre-cycle disciplinary + security)
+
+* **#750** R5 pre-registration rules + R2 measurement-discipline rules
+  (`docs/rules/`) checked in as repo-side audit trail of CLAUDE.md
+  rules previously memory-only. Bus-factor + auditability fix
+  (R2 external review action item).
+* **#751** `starlette` 1.0.1 (CVE) + `chromadb` risk-accept note
+  (`docs/security/`).
+
+## Verification
+
+* RAB test suite (this release): **31/31 PASS**
+  - `tests/test_rab_benchmark.py` — 14 (reference adapter + scorer +
+    fault injection)
+  - `tests/test_rab_baseline0.py` — 8 (floor pinned)
+  - `tests/test_rab_james_adapter.py` — 9 (audit-native demo +
+    workspace isolation + lifecycle bridge + reconstruct_graph_at
+    agreement + log-only replay invariant)
+* RAB measurement artifacts committed under `reports/rab/`:
+  - `reference-S1-*.{result.json,log.jsonl,mapping.json}`
+  - `james-S1-*.{result.json,log.jsonl,mapping.json}`
+  - `baseline0-S1-*.{result.json,log.jsonl,mapping.json}`
+  Each result.json carries `scenario_sha`, `log_sha`,
+  `mapping_table_sha`, `sut_version`, `runner_env` for SPEC §4
+  re-verification.
+* JAMES core test suite: no regression (no `core/` change).
+
+## What v0.4.3 does NOT do
+
+* **No production runtime change in JAMES core**. The audit / lifecycle
+  / graph paths are unchanged byte-for-byte. RAB measures the existing
+  paths via a workspace-scoped adapter; production `audit.db` is never
+  touched.
+* **No cross-scenario RAB result**. S1 is the only scenario in v0.1.1.
+  Additional scenarios (S2 cross-lingual / S3 larger graph / etc.)
+  unlock the ⭐⭐⭐ cross-scenario ceiling in a future cycle.
+* **No Baseline-1**. SPEC §5 names Baseline-1 as
+  "default-quickstart + LangSmith/OTel tracing mapped to SPEC §1".
+  It is a separate SUT in a future cycle; this release is the
+  default-vs-native gap only.
+* **No mutation-site wiring follow-up**. v0.4.2's audit-only invariant
+  (I4 strong form) still depends on the mutation-site wiring cross-
+  cutting cycle (T1/T2/T2.D/T6/T7 call sites → `emit_lifecycle_event`).
+  Out of scope for v0.4.3.
+* **No multi-hop retrieval improvement**. Cycle γ closure explicitly
+  re-framed this as NOT a JAMES roadmap item (memory
+  `project_cycle_gamma_phase_c2_retrieval_bottleneck`).
+* **No regulatory compliance certification claim**. SPEC §6.3.
+
+## Out of scope (deferred)
+
+* Baseline-1 (LangSmith / OTel adapter).
+* RAB scenario-S2 + cross-scenario gating.
+* Replication invites to ActiveGraph + other audit-native runtimes
+  (R1.6, separate collab scope —
+  `feedback_eval_cycle_vs_collab_arc_separation`).
+* Mutation-site wiring (T1/T2/T2.D/T6/T7 → `emit_lifecycle_event`)
+  carried forward from v0.4.2.
+
+## Sources
+
+* RAB SPEC: `eval/rab/SPEC-v0.1.md`
+* Pre-registration: `docs/research/r1-4-preregistration-2026-06-10.md`
+* Gap-table handover: `docs/handovers/v0.4-r1-4-gap-table-2026-06-10.md`
+* Cycle γ closure handover (companion track):
+  `docs/handovers/v0.4-cycle-gamma-phase-c2-musique-retrieval-bottleneck-2026-06-10.md`
+* Session entry: `docs/handovers/v0.4-next-session-entry-2026-06-10-r1-rab.md`


### PR DESCRIPTION
## Summary

R1.5 — packages v0.4.3 for external review. **No code changes**, only
release metadata + release notes + README + CHANGELOG + .gitignore
exception for the RAB SPEC §4 re-verification artifacts already
committed under \`reports/rab/\` (PR #767).

**Headline**: RAB v0.1.1 — the first replayable-audit benchmark for
RAG / agent systems, 3 deterministic metrics (AC / RF / PC)
operationalising EU AI Act Articles 10, 12, 19 (in force 2026-08-02).
Same cycle closes the cycle γ multi-hop arc with 6 honest nulls.

## Honest framing (pinned in release notes, CHANGELOG, README, and .zenodo.json)

- The **benchmark is the contribution**, not the audit-native runtime.
  ActiveGraph (arXiv 2605.21997) independently published event-sourced
  log + replay; RAB is what was missing.
- JAMES = reference on scenario-S1 is **expected** per SPEC §6.5. The
  audit-native vs default-logging gap is the finding (not JAMES's score).
- Not a regulatory compliance certification — RAB operationalises Art.
  10/12/19 *concepts* into measurable form (SPEC §6.3).
- Honest tier: **⭐⭐ scenario-S1 audit-native vs floor gap confirmed**.
  ⭐⭐⭐ cross-scenario remains ungated until additional scenarios ship.

## Gap table (RAB SPEC v0.1.1 / scenario-S1)

| SUT | AC | RF-exact | RF-graded | PC |
|---|---|---|---|---|
| reference (self-verify gate) | 1.000 | 1.000 | 1.000 | 1.000 |
| **JAMES** | **1.000** | **1.000** | 1.000 | **1.000** |
| **Baseline-0** (vanilla quickstart + Python logging) | **0.275** | **0.000** | 0.000 | **0.000** |

All three artifact triples (\`result.json\` + \`log.jsonl\` +
\`mapping.json\`) committed under \`reports/rab/\` (PR #767). SPEC §4
re-verification: re-running the deterministic scorer on the same
artifacts reproduces the numbers bit-for-bit.

## Verification

- RAB test suite: \`pytest tests/test_rab_benchmark.py tests/test_rab_baseline0.py tests/test_rab_james_adapter.py\` → **31/31 PASS**
- No \`core/\` change → no JAMES core regression possible.
- gitignore exception verified: \`git check-ignore reports/rab/*.jsonl\` exit 1 (not ignored).

## Changes in this PR

- \`docs/release_notes_v0.4.3.md\` — full release notes (R1.0 → R1.5
  sequence, gap table, cycle γ companion, what does NOT change)
- \`CHANGELOG.md\` [0.4.3] entry
- \`.zenodo.json\` v0.4.3 — description, version, RAB keywords,
  related_identifiers (arXiv 2606.04990 / 2605.21997 + EUR-Lex AI Act
  + W3C PROV + PRs #758–#767), isNewVersionOf chain back to v0.4.1
  DOI 10.5281/zenodo.20426719
- \`README.md\` status badge → v0.4.3, new RAB SPEC badge,
  \"What's Verified\" row for RAB, full \"RAB — Replayable-Audit
  Benchmark\" section
- \`.gitignore\` exception: \`!reports/rab/*.jsonl\` so the SPEC §4
  re-verification triple stays tracked in future operator runs

## Next step after merge (operator action)

\`\`\`bash
gh release create v0.4.3 --notes-file docs/release_notes_v0.4.3.md \
    --title \"v0.4.3 — RAB v0.1.1 + Cycle γ closure\"
# Zenodo auto-archives via the existing GitHub-Zenodo webhook and
# issues the new DOI under the isNewVersionOf chain.
\`\`\`

## Out of scope

- Baseline-1 (LangSmith / OTel adapter) — separate SUT, future cycle
- RAB scenario-S2 / cross-scenario ⭐⭐⭐ gate — future cycle
- R1.6 replication invites — separate collab arc (\`feedback_eval_cycle_vs_collab_arc_separation\`)
- Mutation-site wiring carried over from v0.4.2

Quality delta: exempt (label: docs — release packaging only, no \`core/\` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)