### PR TITLE
chore(release): v0.4.3 post-mint — README DOI badges → 10.5281/zenodo.20625533

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,18 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 
 ## Where we are right now
 
-- **Current version**: **v0.4.1 closed** (2026-05-28, DOI
-  `10.5281/zenodo.20426719`) — T6 Causality Chain + T2.D ingestion +
-  QVT α track. v0.2.0 (Foundation Hardening) and v0.3.0
-  (Platform Skeleton) both fully closed; v0.4.0 (Layer 4 Lifecycle:
-  T1+T7+T2 first bundle) shipped 2026-05-27.
+- **Current version**: **v0.4.3 closed** (2026-06-10, DOI
+  `10.5281/zenodo.20625533`) — RAB v0.1.1 (Replayable-Audit Benchmark
+  for RAG / agent systems; 3 deterministic metrics AC/RF/PC mapped to
+  EU AI Act Art. 10/12/19 in force 2026-08-02) + Cycle γ multi-hop arc
+  closure (multi-hop improvement reframed out of the JAMES roadmap;
+  graph build O(N²) finding lifted into RAB as the RF-cost axis).
+  v0.4.2 (T5 Replayable Audit Graph, 2026-06-06) shipped the
+  `reconstruct_graph_at(t)` primitive that RAB measures the quality
+  of. v0.4.1 (2026-05-28, DOI `10.5281/zenodo.20426719`) closed T6
+  Causality Chain + T2.D ingestion + QVT α track. v0.2.0 / v0.3.0
+  fully closed; v0.4.0 (Layer 4 Lifecycle: T1+T7+T2 first bundle)
+  shipped 2026-05-27.
 - **Active theme**: **Direction α — hybrid cloud reasoning tier**
   (entered 2026-06-03). The α-measurement cycle (α-6/7/8) is closed and
   the **forced discovery hunt has ended** (see memory

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,7 +17,7 @@
 [![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20426719.svg)](https://doi.org/10.5281/zenodo.20426719)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20625533.svg)](https://doi.org/10.5281/zenodo.20625533)
 
 ![PROJECT JAMES — 3D 온톨로지 그래프 시각화](reports/promo-assets/screenshots/06-3d-graph.jpg)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Status](https://img.shields.io/badge/Status-v0.4.3-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.3)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20426719.svg)](https://doi.org/10.5281/zenodo.20426719)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20625533.svg)](https://doi.org/10.5281/zenodo.20625533)
 [![RAB SPEC](https://img.shields.io/badge/RAB%20SPEC-v0.1.1-green.svg)](eval/rab/SPEC-v0.1.md)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)


### PR DESCRIPTION
## Summary

Zenodo auto-mint of v0.4.3 succeeded — DOI **10.5281/zenodo.20625533**.

Mirrors the v0.4.1 post-mint pattern (PR #569): bumps the README DOI
shields in both \`README.md\` and \`README.ko.md\`, plus the CLAUDE.md
\"Current version\" line that still named v0.4.1 closed.

## DOI lineage (most recent first)

| Version | DOI |
|---|---|
| **v0.4.3** | **10.5281/zenodo.20625533** ← this PR |
| v0.4.1 | 10.5281/zenodo.20426719 (\`.zenodo.json\` \`isNewVersionOf\`) |
| v0.4.0 | 10.5281/zenodo.20411354 |
| v0.4.0-alpha.3 | 10.5281/zenodo.20391100 |
| v0.3.3 | 10.5281/zenodo.20374227 |
| v0.3.2 | 10.5281/zenodo.20372649 |
| v0.3.1 | 10.5281/zenodo.20363998 |

(v0.4.2 has no DOI — release tag was not created at the time. The
\`.zenodo.json\` v0.4.3 description includes v0.4.2's T5 work as the
substrate RAB measures, so the record has no archive gap.)

## Verification

- README DOI badge points to https://doi.org/10.5281/zenodo.20625533
  in both EN + KO files
- Zenodo landing page lists JAMES v0.4.3 with the SPEC §4
  re-verification artifacts (handover, gap table, RAB SPEC, scenario,
  scorer, adapters, measurement triples) all included in the zip

## Out of scope

- arXiv preprint (separate publication track, R1.5+ option)
- Baseline-1 / scenario-S2 (future cycle to unlock ⭐⭐⭐
  cross-scenario)
- R1.6 replication invites (separate collab arc per
  \`feedback_eval_cycle_vs_collab_arc_separation\`)

Quality delta: exempt (label: docs — post-mint badge update only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)