### PR TITLE
docs(handover): arXiv submit progress memo — B/C/D re-entry doc

### DIFF
--- a/docs/handovers/v0.4-arxiv-submit-progress-2026-06-11.md
+++ b/docs/handovers/v0.4-arxiv-submit-progress-2026-06-11.md
@@ -1,0 +1,196 @@
+# arXiv Submit — 진행 상태 + 다음 단계 가이드 (2026-06-11)
+
+> **이 doc 으로 다시 시작.** 운영자가 휴식 후 재개할 때, 또는 새
+> Claude 세션이 시작할 때 entry point. 한 줄로 위치만 파악하려면 § "현재
+> 위치", 곧장 작업 재개하려면 § "[B] PDF 빌드부터 시작" 으로.
+
+## 현재 위치 (한 줄)
+
+```
+[A] arXiv 가입         ✅  완료 (2026-06-11 오후)
+[B] PDF 빌드           ⏸  다음 (Overleaf, ~10분)
+[C] Endorsement        ⏸  대기 (B 후 진행, 컨택 + 24-96h 대기)
+[D] Paper submit       ⏸  대기 (C 승인 후, ~15분)
+[E] arXiv 처리         —   arXiv 가 자동 처리 (~24h)
+[F] Post-mint PR       —   Claude 자동 (README + .zenodo.json + Zenodo cross-link)
+```
+
+## 이번 세션 (2026-06-11) 누적
+
+| # | 작업 | 결과 |
+|---|---|---|
+| 1 | scenario-S2 사전등록 | PR #774 머지 / locking commit `d21c680` |
+| 2 | S2 fixture + 9 tests + Zenodo prereg deposit bundle | PR #775 머지 |
+| 3 | 4 SUT × S2 측정 + handover (⭐⭐ cross-scenario partial) | PR #776 머지 |
+| 4 | **Phase 3 prereg Zenodo deposit DOI 발급** | `10.5281/zenodo.20635130` (concept `20635129`) |
+| 5 | paper v1.3 (S2 evidence + new DOI 통합) | PR #777 머지 |
+| 6 | arXiv 계정 가입 [A] | ✅ |
+
+main HEAD: `0ade610` (커밋 #777 머지 시점).
+
+## [B] PDF 빌드부터 시작 (Overleaf, ~10분)
+
+> 로컬 `pdflatex` 미설치 확인 완료 → 브라우저 기반 Overleaf 가 정답.
+> 무료 회원 충분 (single project).
+
+### B-1. Overleaf 가입 (없으시면)
+
+URL: https://www.overleaf.com/register
+
+`karu-7@hanmail.net` 또는 자주 쓰시는 메일. 가입 후 verify.
+이미 계정 있으면 https://www.overleaf.com/login.
+
+### B-2. 로컬 폴더 zip 만들기 (PowerShell 한 줄)
+
+```powershell
+! Compress-Archive -Path papers\rab-preprint\* -DestinationPath rab-preprint.zip -Force
+```
+
+→ `C:\Project\James-RAG-Evol-v010\rab-preprint.zip` 생성 (~20-30 KB).
+
+### B-3. Overleaf 새 프로젝트
+
+1. Overleaf 메인 → 좌상단 **녹색 New Project** → **Upload Project**
+2. zip 선택 → 업로드 → `main.tex` 자동 인식
+
+### B-4. 컴파일
+
+1. (필요 시) Menu (햄버거) → Settings → Compiler = **pdfLaTeX**
+2. 상단 녹색 **Recompile** 클릭 → 우측에 PDF
+3. 첫 빌드는 인용이 "?" 일 수 있음 → 한 번 더 Recompile (bibtex 자동 처리)
+
+### B-5. 확인 항목
+
+- 제목: `RAB: A Replayable-Audit Benchmark for RAG and Agent Systems Operationalising EU AI Act Articles 10, 12, 19`
+- 저자: `Jiwon Seo` (ORCID `0009-0002-0007-7860`)
+- 날짜: `2026-06-11`
+- **Table 1** (S1 gap) + **Table 2** (S2 gap) 둘 다 존재
+- 참고문헌 ~16개
+- 총 페이지 11-13
+
+### B-6. 다운로드
+
+우측 PDF panel 위 다운로드 아이콘 → `main.pdf` 저장.
+
+## [C] Endorsement (B 완료 후, ~15분 + 대기)
+
+### C-1. endorsement 코드 발급
+
+arXiv 로그인 → 우상단 username → **Account** → 좌측 메뉴 **Endorsement Requests** → "Get an endorsement"
+
+또는 직접 URL: https://arxiv.org/auth/show-endorsers
+
+- 카테고리 선택: **cs.SE** primary (또는 시도해 보고 cs.AI 가 더 통과 가능성 높으면 변경)
+- arXiv 가 즉시 **endorsement code** (보통 6자리) 발급 → 복사
+
+### C-2. Endorser 후보 (paper refs.bib 에서 자연스러운 인용)
+
+| 후보 | 이유 | 컨택 채널 |
+|---|---|---|
+| **Yohei Nakajima** (ActiveGraph, arXiv 2605.21997, cs.AI) | paper §1/§2/Conclusion 에 "independent co-invention" 명시. BabyAGI 창시자, X 활동 활발. **1순위.** | X (@yoheinakajima), GitHub issue 가능. https://yoheinakajima.com |
+| **Mathkar et al.** (Survey arXiv 2606.04990, cs.AI) | "realistic execution-trace benchmarks" open challenge 라고 명시한 저자. RAB 가 응답. | arXiv paper 첫 페이지 corresponding author 메일 |
+| **DFAH / Reflow Research** (arXiv 2601.15322, cs.AI) | "replayable"/"audit" 용어 겹침. paper §2 disambiguation paragraph 가짐. | Reflow Research 회사 컨택 폼 |
+| **COMPL-AI / INSAIT** (arXiv 2410.07959, cs.CY) | AI Act benchmarking precedent. system-level vs model-level 보완 관계. | 첫 저자 학교 이메일 (INSAIT / ETH) |
+
+### C-3. Endorser 컨택 메일 (영문, copy-paste 후 약간 수정)
+
+```
+Subject: arXiv endorsement request — Replayable-Audit Benchmark (RAB)
+         operationalising EU AI Act Art. 10/12/19
+
+Dear Dr. <Name>,
+
+I have completed a single-author benchmark paper titled "RAB: A
+Replayable-Audit Benchmark for RAG and Agent Systems Operationalising
+EU AI Act Articles 10, 12, 19" and am preparing to submit to arXiv
+(cs.SE primary, cs.AI + cs.CY cross-list). The work is operationally
+complete: spec frozen (v0.1.1), scorer pure-functional and
+deterministic, TWO scenarios (S1 40 ops, S2 400 ops) pre-registered
+before measurement, four SUTs reported (Reference / JAMES /
+Baseline-1 OpenTelemetry-GenAI / Baseline-0 default-logging), and
+Zenodo DOIs minted for both the v0.4.3 software archive
+(10.5281/zenodo.20625533) and the Phase 3 scenario-S2 pre-registration
+(10.5281/zenodo.20635130) with full re-verification artifacts.
+
+I am writing because <your work / your paper> is cited in this paper
+as <reason: independent co-invention of event-sourced replay / named
+the open challenge that RAB responds to / shared "replayable"
+terminology with explicit disambiguation / precedent for AI-Act
+operationalisation>, which makes you a natural endorser. There is no
+expectation of co-authorship — this is solely a category-endorsement
+request.
+
+My arXiv endorsement code is <CODE>.
+
+The paper source (LaTeX + bib + submission guide) is at
+https://github.com/Hashevolution/James-RAG-Evol/tree/main/papers/rab-preprint
+and I attach the compiled PDF. The pre-registration DOIs below are
+the timestamped evidence that nothing in the manuscript was modified
+after measurement:
+
+- Phase 3 pre-registration (Zenodo): https://doi.org/10.5281/zenodo.20635130
+- Software archive (Zenodo):          https://doi.org/10.5281/zenodo.20625533
+
+Best regards,
+Seo Ji Won
+ORCID: 0009-0002-0007-7860
+karu-7@hanmail.net
+```
+
+### C-4. 컨택 정책
+
+- **1순위 (Nakajima) 먼저 컨택, 24h 응답 없으면 2순위 (Mathkar) 추가 컨택**
+- 동시에 4명 한 번에 보내는 것은 over-engagement — 1-2명씩 순차
+- 96시간 = arXiv 의 endorsement code 만료 시간 (만료되면 새 코드 재발급)
+
+## [D] Paper Submit (Endorsement 승인 후, ~15분)
+
+승인되면 arXiv 가 이메일 알림 발송. 그 후:
+
+1. arXiv 로그인 → **Submit** 클릭
+2. **Step 1 (License)**: CC BY 4.0 권장 (refs.bib 의 MIT 와 정합. 또는 arXiv 영구 비독점 라이센스도 OK)
+3. **Step 2 (Categories)**: primary = cs.SE, cross-list = cs.AI, cs.CY
+4. **Step 3 (Metadata)**:
+   - Title (paper 와 동일)
+   - Authors: `Seo, Jiwon`
+   - Abstract: paper abstract 복붙
+   - Comments: `12 pages, 2 tables. Spec v0.1.1, two pre-registered scenarios (S1 40 ops, S2 400 ops), deterministic scorer, four adapters, 12 re-verification artefacts at https://doi.org/10.5281/zenodo.20625533 (software) + https://doi.org/10.5281/zenodo.20635130 (Phase 3 pre-registration). Both measurements pre-registered before fixture/measurement.`
+   - MSC class / ACM class: 비워 둠 (해당 없음)
+5. **Step 4 (Files)**: zip 업로드
+   - 권장: `main.tex` + `refs.bib` + `main.bbl` (bibtex 결과물; Overleaf 의 Logs 에서 `.bbl` 파일 다운로드 가능)
+   - 또는 main.pdf 만 단독 업로드 (arXiv 가 받기는 하나 LaTeX source 권장)
+6. **Step 5 (Preview)**: arXiv 가 빌드한 PDF 확인
+7. **Submit** → arXiv 가 처리 (~24h 이내 ID 발급, 보통 다음 발표 cycle)
+
+다음 발표 cycle (Announce schedule): https://info.arxiv.org/help/submit/index.html
+- 미국 동부시간 기준 평일 매일 14:00 EST 까지 제출 → 익일 20:00 EST 발표
+
+## [F] Post-mint 자동화 (arXiv ID 발급되면 Claude 진행)
+
+arXiv ID (예: `2606.NNNNN`) 받으면 알려주세요. Claude 가 자동:
+
+1. JAMES README 에 arXiv badge 추가 (`![arXiv](https://img.shields.io/badge/arXiv-NNNN.NNNNN-b31b1b.svg)`)
+2. `.zenodo.json` 의 `related_identifiers` 에 `isSupplementedBy: arXiv:NNNN.NNNNN` 추가
+3. Zenodo records (v0.4.3 + prereg deposit) 양쪽 metadata 에 arXiv ID cross-link 추가 (Zenodo API 호출)
+4. `papers/rab-preprint/main.tex` footnote 또는 abstract 에 arXiv ID 자기인용 (선택)
+5. memory + MEMORY.md + CLAUDE.md "Where to look next" 업데이트
+6. 단일 post-mint PR (PR #769 패턴)
+
+## 운영자 보안 후속 (잊지 마세요)
+
+**Zenodo personal access token revoke**:
+- https://zenodo.org/account/settings/applications/tokens/
+- `rab-prereg-phase-3-deposit` (이름) → **Revoke** 클릭
+- 토큰은 한 번 발급 + 한 번 사용 + 즉시 폐기 가 정석. 노출 없었지만 원칙적 폐기.
+
+## 참고 (변경 없음)
+
+- v0.4.3 software DOI: https://doi.org/10.5281/zenodo.20625533
+- Phase 3 prereg DOI:   https://doi.org/10.5281/zenodo.20635130
+- paper source path: `papers/rab-preprint/{main.tex, refs.bib, README.md}`
+- arXiv submission guide: `papers/rab-preprint/README.md` (이번 v1.3 에서 갱신된 checklist 포함)
+
+## 관련 메모리
+
+- [[project_r1_replayable_audit_benchmark]] — R1 트랙 상태 (Phase 3 prereg DOI 추가됨)
+- [[feedback_eval_cycle_vs_collab_arc_separation]] — joint piece 와의 자동 연결 금지 (이 paper 는 internal RAB arc, joint piece 별개)


### PR DESCRIPTION
## Summary

Single re-entry document for the arXiv submission track. The operator pauses after step A (arXiv account created) and resumes in the evening; this doc is the entry point.

Inlined sections:
- [B] PDF build via Overleaf (~10 min)
- [C] endorsement code + 4 candidate endorsers + paste-ready email template (~15 min + 24-96h wait)
- [D] arXiv submit form walkthrough (~15 min after endorsement)
- [F] post-mint automation Claude will run once arXiv ID lands
- Security follow-up (Zenodo personal access token revoke)

Records this session's state:
- arXiv account created (A ✅)
- Zenodo prereg DOI 10.5281/zenodo.20635130 minted
- paper v1.3 with both Zenodo DOIs landed at \`0ade610\`

## Out of scope

- [B] / [C] / [D] execution — operator actions, evening session.
- arXiv ID — gated on operator submission + arXiv processing (~24h).

## Labels

\`Quality delta: exempt (label: docs)\` — handover only, no \`core/\` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)