### PR TITLE
chore(ci): fix entity vocabulary tests + ruff F-class (restore CI as gate)

### DIFF
--- a/core/lifecycle/replay_graph.py
+++ b/core/lifecycle/replay_graph.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
 

--- a/eval/external/rgb_loader.py
+++ b/eval/external/rgb_loader.py
@@ -75,7 +75,6 @@ either lands in :class:`ExternalQuery` directly or under
 from __future__ import annotations
 
 import json
-import os
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/eval/external/rgb_scorer.py
+++ b/eval/external/rgb_scorer.py
@@ -43,8 +43,7 @@ prompts ("I cannot find" / "I don't know" / 中文 "无法回答" etc.).
 """
 from __future__ import annotations
 
-import re
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 from eval.external import ScoreAxis
 from eval.external.scorer_base import ExternalScorer

--- a/eval/external/runner.py
+++ b/eval/external/runner.py
@@ -54,7 +54,6 @@ import json
 import os
 import time
 import traceback
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
 

--- a/eval/external/scorer_base.py
+++ b/eval/external/scorer_base.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List
 
 
 # ─── ScoreAxis (frozen) ────────────────────────────────────────────

--- a/eval/external/wikimulti_scorer.py
+++ b/eval/external/wikimulti_scorer.py
@@ -45,7 +45,6 @@ from eval.external.wikimulti_loader import WIKIMULTI_TYPES
 # (musique_scorer) avoids drift; a future refactor may pull them
 # into eval/external/_squad_norm.py.
 from eval.external.musique_scorer import (
-    _f1 as _squad_f1,
     _max_em,
     _max_f1,
     _resolve_model_answer,

--- a/eval/rab/adapters/baseline0.py
+++ b/eval/rab/adapters/baseline0.py
@@ -36,7 +36,7 @@ reference adapter as the "what bolt-on minimum looks like" data point.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 
 def _now() -> str:

--- a/eval/rab/adapters/baseline1.py
+++ b/eval/rab/adapters/baseline1.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 
 _MAPPING_PATH = Path(__file__).resolve().parents[1] / "mappings" \

--- a/scripts/research/_r1_prior_art_detail.py
+++ b/scripts/research/_r1_prior_art_detail.py
@@ -1,6 +1,5 @@
 """R1.0 step 2 — fetch full abstracts of the candidate prior-art papers."""
 import sys
-import urllib.parse
 import xml.etree.ElementTree as ET
 
 import requests

--- a/scripts/research/abstraction_layer_poc.py
+++ b/scripts/research/abstraction_layer_poc.py
@@ -28,7 +28,7 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Sequence, Tuple
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))

--- a/scripts/research/build_terse_fixture.py
+++ b/scripts/research/build_terse_fixture.py
@@ -16,7 +16,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent

--- a/scripts/research/compare_paired_cells.py
+++ b/scripts/research/compare_paired_cells.py
@@ -239,7 +239,7 @@ def main(argv=None):
         if rescued:
             add("### Rescued queries (candidate caught what baseline missed)")
             add("")
-            add(f"| id | intent | Δrefusals | query |")
+            add("| id | intent | Δrefusals | query |")
             add("|---:|---|---:|---|")
             for qid, delta, d in rescued[:15]:
                 add(f"| {qid} | `{d['intent']}` | +{delta} | {d['label']!r} |")
@@ -247,7 +247,7 @@ def main(argv=None):
         if regressed:
             add("### Regressed queries (candidate broke what baseline caught)")
             add("")
-            add(f"| id | intent | Δrefusals | query |")
+            add("| id | intent | Δrefusals | query |")
             add("|---:|---|---:|---|")
             for qid, delta, d in regressed[:15]:
                 add(f"| {qid} | `{d['intent']}` | {delta} | {d['label']!r} |")

--- a/scripts/research/cycle_gamma_musique_corpus_build.py
+++ b/scripts/research/cycle_gamma_musique_corpus_build.py
@@ -162,7 +162,7 @@ def main(argv=None) -> int:
 
     rows = _read_musique_fixture(fixture_path, max_rows=args.max_rows)
 
-    print(f"=== cycle γ MuSiQue corpus build ===")
+    print("=== cycle γ MuSiQue corpus build ===")
     print(f"  workspace : {workspace}")
     print(f"  fixture   : {fixture_path}  (rows={len(rows)})")
     print(f"  variant   : {args.variant}  split: {args.split}")
@@ -189,7 +189,7 @@ def main(argv=None) -> int:
     elapsed = time.time() - t0
     final_count = vector_store.count()
     print()
-    print(f"=== INGESTION COMPLETE ===")
+    print("=== INGESTION COMPLETE ===")
     print(f"  rows processed   : {len(rows)}")
     print(f"  paragraphs added : {n_para_total}")
     print(f"  vector store count: {final_count}")

--- a/scripts/research/cycle_gamma_musique_graph_build.py
+++ b/scripts/research/cycle_gamma_musique_graph_build.py
@@ -83,7 +83,7 @@ def main(argv=None) -> int:
     g = GraphEngine()
     wg = g.wiki_generator
 
-    print(f"=== cycle γ MuSiQue graph build ===")
+    print("=== cycle γ MuSiQue graph build ===")
     print(f"  workspace : {os.environ['JAMES_WORKSPACE']}")
     print(f"  fixture   : {fixture}  (rows={len(rows)})")
     print(f"  model     : {os.environ.get('JAMES_LLM_MODEL', 'default')}")
@@ -124,7 +124,7 @@ def main(argv=None) -> int:
 
     el = time.time() - t0
     print()
-    print(f"=== GRAPH BUILD COMPLETE ===")
+    print("=== GRAPH BUILD COMPLETE ===")
     print(f"  rows={len(rows)}  paragraphs={n_para}  entities={n_entities}")
     print(f"  elapsed={el:.0f}s ({el/60:.1f} min)")
     return 0

--- a/scripts/research/cycle_gamma_phase_d_ablate.py
+++ b/scripts/research/cycle_gamma_phase_d_ablate.py
@@ -143,7 +143,7 @@ def _run_one_ablation(
         print(f"  cmd  : {' '.join(cmd)}", flush=True)
         print(f"  env  : JAMES_WORKSPACE={env['JAMES_WORKSPACE']} "
               f"{knob}=1", flush=True)
-        print(f"  DRY RUN — not executed.", flush=True)
+        print("  DRY RUN — not executed.", flush=True)
         return out_path
 
     t0 = time.time()
@@ -272,7 +272,7 @@ def main(argv=None) -> int:
     ref_path = _reference_path(args.model)
     if not ref_path.exists() and not args.dry_run:
         print(f"!! Reference file missing: {ref_path}", file=sys.stderr)
-        print(f"   Run Phase C full-JAMES negrej first:",
+        print("   Run Phase C full-JAMES negrej first:",
               file=sys.stderr)
         print(f"   JAMES_WORKSPACE={workspace} python scripts/"
               f"external_bench_run.py --bench rgb --variant en --mode "
@@ -281,7 +281,7 @@ def main(argv=None) -> int:
               file=sys.stderr)
         return 2
 
-    print(f"=== cycle γ Phase D ablation matrix ===")
+    print("=== cycle γ Phase D ablation matrix ===")
     print(f"  model     : {args.model}")
     print(f"  workspace : {workspace}")
     print(f"  out_dir   : {out_dir}")

--- a/scripts/research/cycle_gamma_rgb_compare.py
+++ b/scripts/research/cycle_gamma_rgb_compare.py
@@ -30,10 +30,9 @@ from __future__ import annotations
 import argparse
 import io
 import json
-import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 
 def _load(path: Path) -> Dict[str, Any]:

--- a/scripts/research/cycle_gamma_rgb_corpus_build.py
+++ b/scripts/research/cycle_gamma_rgb_corpus_build.py
@@ -175,7 +175,7 @@ def main(argv=None) -> int:
     if args.max_rows is not None:
         rows = rows[:args.max_rows]
 
-    print(f"=== cycle γ RGB-en corpus build ===")
+    print("=== cycle γ RGB-en corpus build ===")
     print(f"  workspace : {workspace}")
     print(f"  fixture   : {fixture_path}  (rows={len(rows)})")
     print(f"  mode      : {args.mode}")

--- a/scripts/research/download_musique.py
+++ b/scripts/research/download_musique.py
@@ -148,10 +148,10 @@ def main(argv=None) -> int:
 
     if out_path.exists() and not args.force:
         print(f"=== EXISTS (skip): {out_path}")
-        print(f"    pass --force to overwrite.")
+        print("    pass --force to overwrite.")
         return 0
 
-    print(f"=== Loading MuSiQue from HF mirror ===")
+    print("=== Loading MuSiQue from HF mirror ===")
     print(f"  hf_repo : {args.hf_repo}")
     print(f"  config  : {_hf_config_name(args.variant)}")
     print(f"  split   : {args.split}")
@@ -174,7 +174,7 @@ def main(argv=None) -> int:
     config = _hf_config_name(args.variant)
     try:
         ds = load_dataset(args.hf_repo, config, split=hf_split)
-    except Exception as e:
+    except Exception:
         # Some mirrors use no-config layout. Retry.
         try:
             ds = load_dataset(args.hf_repo, split=hf_split)
@@ -182,10 +182,10 @@ def main(argv=None) -> int:
             print(f"!! HuggingFace load failed: {e2}", file=sys.stderr)
             print(f"   Tried: {args.hf_repo} / config={config} / "
                     f"split={hf_split}", file=sys.stderr)
-            print(f"   Manual fallback: clone "
-                    f"https://github.com/StonyBrookNLP/musique "
-                    f"and run bash download_data.sh, then copy "
-                    f"the matching .jsonl into --dest.",
+            print("   Manual fallback: clone "
+                    "https://github.com/StonyBrookNLP/musique "
+                    "and run bash download_data.sh, then copy "
+                    "the matching .jsonl into --dest.",
                     file=sys.stderr)
             return 3
 

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -463,7 +463,7 @@ def main() -> int:
     print(f"local={args.local_model} (num_ctx={NUM_CTX})  "
           f"cloud=claude-cli-abstraction-wired  judge=claude-blinded-AB  "
           f"queries={len(queries)}  n_runs={args.n_runs}")
-    print(f"design=reasoning-isolated  fixture=multihop_rag\n")
+    print("design=reasoning-isolated  fixture=multihop_rag\n")
 
     rows: List[Dict[str, Any]] = []
     for i, q in enumerate(queries, 1):

--- a/scripts/research/multihop_raw_run.py
+++ b/scripts/research/multihop_raw_run.py
@@ -119,7 +119,7 @@ def main():
     # ── Evidence-grounded validity guard (the Stage 4b lesson) ──
     answerable = [r for r in results if r["question_type"] != "null_query"]
     ans_no_ev = [r["id"] for r in answerable if r["sources"] == 0]
-    print(f"\n=== VALIDITY GUARD ===")
+    print("\n=== VALIDITY GUARD ===")
     print(f"answerable with evidence: {len(answerable)-len(ans_no_ev)}/{len(answerable)}")
     if ans_no_ev:
         print(f"!! WARNING: {len(ans_no_ev)} answerable queries got NO evidence "
@@ -136,7 +136,7 @@ def main():
     print("\nby question_type:")
     for t, d in sorted(axis.by_question_type.items()):
         print(f"  {t:18s} primary={d['accuracy_primary']:.2f} strict={d['accuracy_strict']:.2f} (n={d['n']})")
-    print(f"\nRAW vs JAMES-full vs paper — fill from multihop_terse_run.py result")
+    print("\nRAW vs JAMES-full vs paper — fill from multihop_terse_run.py result")
     print(f"  {'paper-Mixtral':16s} 0.32")
     print(f"  {'RAW '+MODEL:16s} {axis.accuracy_primary:.2f} (primary)")
     print(f"\nsaved: {os.path.relpath(OUT, ROOT)}")

--- a/scripts/research/ontology_gap_report.py
+++ b/scripts/research/ontology_gap_report.py
@@ -349,7 +349,7 @@ def format_report(
         add("No UNRESOLVED relation targets found.")
     else:
         add(f"**Total distinct unresolved targets: {len(unresolved)}**  ")
-        add(f"Top 30 by reference count:")
+        add("Top 30 by reference count:")
         add("")
         add("| Target name | Ref count | Referenced by (sample) |")
         add("|---|---:|---|")
@@ -396,7 +396,7 @@ def format_report(
         add("No type-relation mismatches found. Ingest layer respects ")
         add("`ALLOWED_RELATIONS` per entity_type.")
     else:
-        add(f"Entities using a relation not in `ALLOWED_RELATIONS` for ")
+        add("Entities using a relation not in `ALLOWED_RELATIONS` for ")
         add(f"their `entity_type`. Sample of {len(mismatches)}:")
         add("")
         add("| Entity | Type | Relation (not allowed) | Target | Path |")

--- a/scripts/research/paper_aligned_rescore.py
+++ b/scripts/research/paper_aligned_rescore.py
@@ -57,7 +57,7 @@ def main() -> int:
     reports = ROOT / "reports"
 
     print(f"fixture: {FIXTURE.name} ({len(fixture['queries'])} queries)")
-    print(f"metric: paper-aligned binary accuracy [strict, primary] band")
+    print("metric: paper-aligned binary accuracy [strict, primary] band")
     print("=" * 78)
 
     results = []

--- a/scripts/research/persona_leak_diagnostic.py
+++ b/scripts/research/persona_leak_diagnostic.py
@@ -223,7 +223,7 @@ def diagnose_sample_answers(json_paths: list[str]) -> None:
                 print(f"    {label:18s} → 0")
 
         # Pick 3 representative answer samples (first non-empty)
-        section(f"  → 3 answer samples")
+        section("  → 3 answer samples")
         shown = 0
         for r in results:
             ans = r.get("answer", "")

--- a/scripts/research/restore_chroma_from_snapshot.py
+++ b/scripts/research/restore_chroma_from_snapshot.py
@@ -44,7 +44,7 @@ def main(argv=None):
     before = coll.count()
     print(f"[chroma] current count: {before}")
 
-    print(f"[wipe] deleting collection…")
+    print("[wipe] deleting collection…")
     client.delete_collection(name=CHROMA_COLLECTION)
     coll = client.get_or_create_collection(
         name=CHROMA_COLLECTION, metadata={"hnsw:space": "cosine"}

--- a/scripts/research/retrieval_quality.py
+++ b/scripts/research/retrieval_quality.py
@@ -51,10 +51,9 @@ import json
 import math
 import re
 import sys
-from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
@@ -267,7 +266,7 @@ def render_single(bench_path: str, fixture_path: str, k: int = 5) -> str:
     add("")
     add("## Per-query")
     add("")
-    add(f"| id | ndcg | rr | hits | gold | retrieved |")
+    add("| id | ndcg | rr | hits | gold | retrieved |")
     add("|---:|---:|---:|---:|---:|---:|")
     for pq in result["per_query"]:
         if pq.get("skipped"):
@@ -327,7 +326,7 @@ def render_compare(
         elif d_ndcg < -0.05:
             regressed.append((qid, d_ndcg, pq_b[qid], pq_c[qid]))
 
-    add(f"## Per-query Δ (NDCG threshold ±0.05)")
+    add("## Per-query Δ (NDCG threshold ±0.05)")
     add("")
     add(f"- ✅ improved (NDCG+0.05+): **{len(improved)}** queries")
     add(f"- ❌ regressed (NDCG−0.05+): **{len(regressed)}** queries")
@@ -336,7 +335,7 @@ def render_compare(
     if improved:
         add("### Top improved")
         add("")
-        add(f"| id | Δndcg | base ndcg | cand ndcg | base rr | cand rr |")
+        add("| id | Δndcg | base ndcg | cand ndcg | base rr | cand rr |")
         add("|---:|---:|---:|---:|---:|---:|")
         for qid, d, b, c in sorted(improved, key=lambda x: -x[1])[:10]:
             add(f"| {qid} | {d:+.3f} | {b['ndcg']:.3f} | {c['ndcg']:.3f} | "
@@ -345,7 +344,7 @@ def render_compare(
     if regressed:
         add("### Top regressed")
         add("")
-        add(f"| id | Δndcg | base ndcg | cand ndcg | base rr | cand rr |")
+        add("| id | Δndcg | base ndcg | cand ndcg | base rr | cand rr |")
         add("|---:|---:|---:|---:|---:|---:|")
         for qid, d, b, c in sorted(regressed, key=lambda x: x[1])[:10]:
             add(f"| {qid} | {d:+.3f} | {b['ndcg']:.3f} | {c['ndcg']:.3f} | "

--- a/scripts/research/zenodo_deposit_prereg.py
+++ b/scripts/research/zenodo_deposit_prereg.py
@@ -160,7 +160,7 @@ def main(argv=None) -> int:
 
     metadata = _load_metadata()
 
-    print(f"[zenodo] creating draft deposit …")
+    print("[zenodo] creating draft deposit …")
     r = _post(token, "/deposit/depositions", json_body={})
     _check(r, expected_status=201, step="create draft")
     dep = r.json()
@@ -169,7 +169,7 @@ def main(argv=None) -> int:
     print(f"[zenodo]   deposit id: {deposit_id}")
     print(f"[zenodo]   bucket    : {bucket_url}")
 
-    print(f"[zenodo] setting metadata …")
+    print("[zenodo] setting metadata …")
     r = _put(token, f"/deposit/depositions/{deposit_id}",
              json_body=metadata)
     _check(r, expected_status=200, step="set metadata")
@@ -205,7 +205,7 @@ def main(argv=None) -> int:
         print(f"[zenodo] audit record: {AUDIT_PATH}")
         return 0
 
-    print(f"[zenodo] publishing …")
+    print("[zenodo] publishing …")
     r = _post(token, f"/deposit/depositions/{deposit_id}/actions/publish")
     _check(r, expected_status=202, step="publish")
     pub = r.json()
@@ -238,10 +238,10 @@ def main(argv=None) -> int:
     print(f"[zenodo] Audit:     {AUDIT_PATH}")
     print()
     print("Next steps (semi-automated):")
-    print(f"  - replace <PREREG_DOI> placeholders in papers/rab-preprint/")
+    print("  - replace <PREREG_DOI> placeholders in papers/rab-preprint/")
     print(f"    with: {doi}")
-    print(f"  - update memory + MEMORY.md with the prereg DOI")
-    print(f"  - revoke the access token at "
+    print("  - update memory + MEMORY.md with the prereg DOI")
+    print("  - revoke the access token at "
           "https://zenodo.org/account/settings/applications/tokens/")
     return 0
 

--- a/tests/test_abstraction_layer.py
+++ b/tests/test_abstraction_layer.py
@@ -15,9 +15,7 @@ file is the gate.
 """
 from __future__ import annotations
 
-import os
 import sqlite3
-import tempfile
 from typing import List
 
 import pytest

--- a/tests/test_abstraction_runner.py
+++ b/tests/test_abstraction_runner.py
@@ -19,7 +19,6 @@ from typing import Any, List, Tuple
 import pytest
 
 from core.abstraction import (
-    Decision,
     default_decider,
     run_cloud_egress,
 )

--- a/tests/test_cycle_gamma_scorer_base.py
+++ b/tests/test_cycle_gamma_scorer_base.py
@@ -89,7 +89,7 @@ class ExternalScorerContractTests(unittest.TestCase):
 
 class IndexRowsByIdTests(unittest.TestCase):
     def _make(self):
-        from eval.external import ExternalScorer, ScoreAxis
+        from eval.external import ExternalScorer
 
         class T(ExternalScorer):
             @property

--- a/tests/test_event_admin_endpoint.py
+++ b/tests/test_event_admin_endpoint.py
@@ -232,17 +232,24 @@ class IdentityCollisionTests(unittest.TestCase):
 
 
 class WikiGeneratorLiftTests(unittest.TestCase):
-    """Sanity check: after the lift, the production class's entity_types
-    starts with the legacy 4 and ends with `event`. This is the contract
-    create_event_node relies on (event directory pre-created)."""
+    """Sanity check: after the PR-11a-2 lift, the production class's
+    entity_types starts with the legacy 4 and contains `event`. This is
+    the contract create_event_node relies on (event directory
+    pre-created). α-8 (2026-06-03) extended the tuple with 4 more
+    horizontal types after `event`, so `event` is no longer the last
+    element — what matters for create_event_node is membership and the
+    ordering vs the legacy 4."""
 
-    def test_production_entity_types_includes_event_last(self):
+    def test_production_entity_types_legacy_four_then_event(self):
         # Import the production class directly. Construction is
         # heavyweight, so just assert the constant at the wire-up site.
         from core.relations_schema import ENTITY_TYPES_CORE
         # This is what wiki_generator.py:132 lifts to (post-PR-11a-2):
         self.assertIn("event", ENTITY_TYPES_CORE)
-        self.assertEqual(ENTITY_TYPES_CORE[-1], "event")
+        # `event` is the 5th type, directly after the legacy 4.
+        self.assertEqual(ENTITY_TYPES_CORE[4], "event")
+        legacy_four = ("person", "concept", "org", "document")
+        self.assertEqual(ENTITY_TYPES_CORE[: len(legacy_four)], legacy_four)
 
 
 if __name__ == "__main__":

--- a/tests/test_event_entity_schema.py
+++ b/tests/test_event_entity_schema.py
@@ -32,18 +32,33 @@ from core.relations_schema import (  # noqa: E402
 
 
 class EntityTypeVocabularyTests(unittest.TestCase):
-    """The 5-element tuple is the truth source for graph-valid entity
-    types. wiki_generator.py still uses a 4-element literal at this
-    point in the rollout — that drift is intentional and removed in
-    PR-11a-2."""
-
-    def test_entity_types_core_has_five_members_event_last(self):
-        self.assertEqual(len(ENTITY_TYPES_CORE), 5)
-        self.assertEqual(ENTITY_TYPES_CORE[-1], "event")
+    """The truth source for graph-valid entity types. PR-11a-1 shipped
+    a 5-element tuple (legacy 4 + `event`); α-8 (2026-06-03,
+    `project_alpha_8_phase_a_b_landed`) extended it with 4 more
+    horizontal types (date, location, quantity, project) to give the
+    extractor enough type slots for evidence-of-absence preservation
+    (R1-R5 rules). `wiki_generator.py` was lifted to the constant at
+    PR-11a-2, so production and schema agree on whatever the tuple
+    holds today."""
 
     def test_entity_types_core_preserves_legacy_four(self):
         legacy_four = ("person", "concept", "org", "document")
         self.assertEqual(ENTITY_TYPES_CORE[: len(legacy_four)], legacy_four)
+
+    def test_entity_types_core_has_event_immediately_after_legacy_four(self):
+        # PR-11a-1 contract: `event` is the 5th element (first non-legacy
+        # type). α-8's later additions sit after `event`.
+        self.assertEqual(ENTITY_TYPES_CORE[4], "event")
+
+    def test_entity_types_core_matches_alpha8_horizontal_extension(self):
+        # α-8 added 4 horizontal (non-vertical) types after event; the
+        # ordering matters because evidence-of-absence row emission
+        # walks ENTITY_TYPES_CORE in declaration order.
+        self.assertEqual(
+            ENTITY_TYPES_CORE,
+            ("person", "concept", "org", "document",
+             "event", "date", "location", "quantity", "project"),
+        )
 
     def test_event_like_entity_types_baseline_is_just_event(self):
         # OntologyPack loader (PR-11e) extends this set at startup.

--- a/tests/test_planner_terse_skip.py
+++ b/tests/test_planner_terse_skip.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import inspect
 import re
-import textwrap
 
 
 def _read_pipeline_synth() -> str:

--- a/tests/test_qvt_matrix_cloud_tier.py
+++ b/tests/test_qvt_matrix_cloud_tier.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_rab_james_adapter.py
+++ b/tests/test_rab_james_adapter.py
@@ -97,7 +97,6 @@ def test_james_reconstruct_graph_at_agrees_on_supersede_chain(tmp_path):
     must agree on the chain shape (the JSONL replay's edges set must be
     a superset; reconstruct_graph_at only sees lifecycle events, RAB
     JSONL also has INGEST/UPDATE/DELETE)."""
-    import os
     adapter = JamesAdapter(workspace=tmp_path / "ws", use_engine=False)
     adapter.ingest("d1", "Original", "Body")
     adapter.supersede("d1", "d2", "Replacement", "Body2")

--- a/tests/test_reflect_meta_narration_strip.py
+++ b/tests/test_reflect_meta_narration_strip.py
@@ -385,7 +385,7 @@ def test_revise_prompt_v2_frames_as_fresh_answer_task():
     exactly what invites revision-speak. It must frame as 'write the
     best answer to the question', with the earlier draft as a
     reference rather than the subject of edit."""
-    from core.reasoning.reflect import REVISE_PROMPT_V2_EN, REVISE_PROMPT_V2_KO
+    from core.reasoning.reflect import REVISE_PROMPT_V2_EN
     en = REVISE_PROMPT_V2_EN.lower()
     # Must NOT say "revise the draft" / "address the review"
     assert "revise the" not in en, (

--- a/tests/test_t5_cross_chain_consistency.py
+++ b/tests/test_t5_cross_chain_consistency.py
@@ -104,16 +104,16 @@ class ViewFromSnapshotMatchesReconstructViewAtTests(unittest.TestCase):
         return {e["new_edge_id"]: e for e in chain_edges}
 
     def test_single_edge_chain_t_inside_window(self):
-        from core.lifecycle.supersede_chain import (
-            reconstruct_view_at, T7_EDGE_FIELD_VALIDITY,
-        )
         from core.lifecycle.replay_graph import (
             reconstruct_graph_at, view_from_snapshot,
         )
         from datetime import datetime as DT
         # Single edge valid from 10:00 onwards (open ended).
         t0 = DT(2026, 6, 6, 10, 0, 0)
-        edge_payload = {
+        # _edge_payload documents the payload shape the live primitive
+        # would emit; we don't drive that path end-to-end in this test,
+        # but keep the literal as inline contract documentation.
+        _edge_payload = {  # noqa: F841 — intentional inline contract doc
             "head_id":     "h",
             "new_edge_id": "e1",
             "validity":    {"from": t0.isoformat(), "to": None},
@@ -130,12 +130,12 @@ class ViewFromSnapshotMatchesReconstructViewAtTests(unittest.TestCase):
         self.assertEqual(snap_edge.get("new_edge_id"), "e1")
         # live primitive path — same chain, same t
         # Build the head + lookup the way walk_supersede_chain expects.
-        head_dict = {
+        # We don't drive the live primitive end-to-end here — the
+        # comparison is structural: the same edge_id is the answer.
+        _head_dict = {  # noqa: F841 — intentional inline contract doc
             "new_edge_id": "h",
             "_supersede_chain": {"successor_id": "e1"},
         }
-        # We don't drive the live primitive end-to-end here — the
-        # comparison is structural: the same edge_id is the answer.
 
     def test_t_before_chain_start_returns_none(self):
         from core.lifecycle.replay_graph import (

--- a/tests/test_t5_release_gating_invariants.py
+++ b/tests/test_t5_release_gating_invariants.py
@@ -27,13 +27,12 @@ fold step in the snapshot.
 """
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import sys
 import tempfile
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/test_trace_synth_force_cloud.py
+++ b/tests/test_trace_synth_force_cloud.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import sqlite3
 import json
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import pytest
 


### PR DESCRIPTION
## Summary

Resolves the two long-standing CI failures that R1 PRs (#772-#778) all self-merged through. After this PR, \`ruff check . --select F\` is green on main and the entity vocabulary tests pin the current α-8 ontology shape — CI becomes a real gate again instead of ambient noise.

### Fix 1 — ENTITY_TYPES_CORE tests refresh

α-8 (PR #688, 2026-06-03) extended the entity vocabulary from 5 to 9 elements (legacy 4 + event + α-8 horizontal: date / location / quantity / project) per the evidence-of-absence R1-R5 rules in [\`project_alpha_8_phase_a_b_landed\`](https://github.com/Hashevolution/James-RAG-Evol). Two tests still asserted the pre-α-8 length and \"event last\" shape, so every CI run after α-8 has been failing on the same two assertions.

- \`test_event_entity_schema.py\`: the length-5 assertion is dropped; legacy-4 + event-as-5th + the full α-8 ordering are pinned instead.
- \`test_event_admin_endpoint.py\`: the \"event last\" assertion is replaced with \"event at position 5\" + legacy-4 prefix — matching the actual contract \`create_event_node\` needs.

### Fix 2 — ruff F-class cleanup (67 → 0)

- **65 auto-fixed**: \`ruff check --fix --select F\` removed unused imports (F401) and bare f-strings (F541).
- **2 manually addressed**: \`tests/test_t5_cross_chain_consistency.py\` has two locals (\`edge_payload\`, \`head_dict\`) that are intentional inline contract documentation for the live-primitive payload shape. Renamed with \`_\` prefix + \`# noqa: F841\` with explanatory comment so the intent survives.

## Verification

\`\`\`text
\$ python -m pytest tests/test_event_entity_schema.py tests/test_event_admin_endpoint.py -q
34 passed

\$ PYTHONIOENCODING=utf-8 ruff check . --select F
All checks passed!

\$ python -m pytest tests/test_rab_benchmark.py tests/test_rab_baseline0.py \
                   tests/test_rab_baseline1.py tests/test_rab_james_adapter.py \
                   tests/test_rab_scenario_s2.py tests/test_event_entity_schema.py \
                   tests/test_event_admin_endpoint.py tests/test_t5_cross_chain_consistency.py -q
96 passed
\`\`\`

## Why this matters

R1 PRs (#772, #773, #774, #775, #776, #777, #778) all merged with the same two CI failures showing as red. Each merge was a judgement call (\"the failures are not from my PR, they're pre-existing\"). That judgement is correct each individual time, but the cumulative effect is that CI stopped being a meaningful signal. After this PR, a red ruff or pytest run is again actionable evidence that the proposing PR has a real problem.

## Out of scope

- Other CI failures we have not investigated yet (none currently surface; this PR clears the two known long-standing ones).
- Test suite coverage gaps and async test warnings — separate hygiene PRs.
- The 2 \`pytest\` warnings about \`asyncio.iscoroutinefunction\` (Python 3.16 deprecation) and FastAPI \`on_event\` — third-party.

## Labels

\`Quality delta: exempt (label: chore)\` — hygiene only (lint + dead test assertion refresh), no production behavior change. The single \`core/lifecycle/replay_graph.py\` change is one unused-import removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)