### PR TITLE
docs(design): LRB (Lifecycle Retrieval Benchmark) — RAB sibling axis

### DIFF
--- a/docs/design/v0.4-lrb-lifecycle-retrieval-benchmark-design.md
+++ b/docs/design/v0.4-lrb-lifecycle-retrieval-benchmark-design.md
@@ -1,0 +1,240 @@
+# LRB — Lifecycle Retrieval Benchmark — design memo (2026-06-11)
+
+> **Status**: design memo (pre-pre-registration). 다음 step = Phase A
+> 사전 등록 lock 결정 (별도 PR).
+>
+> **Why**: 외부 평가자(2026-06-11)가 정확히 짚은 axis — RAG 시스템이
+> **시간에 따라 진화하는 corpus** 위에서 retrieval/answer quality 가
+> 어떻게 변하는가. 이건 RAB v0.1.1 의 sibling axis (RAB = audit-side,
+> LRB = retrieval-side / answer-side). 둘은 **보완, 대체 아님**.
+>
+> **Scope discipline**: 이 doc 은 *측정 protocol* 의 design 만. 측정
+> magnitude / SUT 결과 / "JAMES 가 이긴다" claim 는 후속 사전등록 +
+> 측정 후에만. honest framing rule 적용 (cycle γ Phase B+C 의 prior
+> art 정리 + 9th catch).
+
+---
+
+## 1. RAB 와의 관계 — sibling 두 axis
+
+RAB v0.1.1 + LRB 가 결합되어야 mother-platform 가치의 **두 dimension**
+이 publish-ready 가 됨.
+
+| Axis | RAB v0.1.1 | LRB (proposed) |
+|---|---|---|
+| 측정 대상 | exported audit log 의 quality | RAG system 의 retrieval + answer quality |
+| EU AI Act 정합 | Art. 10 (origin) / 12 (logs) / 19 (retention) | (Art. 정합 없음 — operational evidence) |
+| Scoring discipline | deterministic, no LLM judge anywhere (H1) | mixed — deterministic where possible, NLI/LLM-judge only for hallucination axis (H1 변형) |
+| Headline | gap structure 가 headline; JAMES 점수 자체 아님 | 동일 — gap structure (Vanilla RAG / Graph RAG / Audit-native) |
+| Honest tier ceiling | $\star\star\star$ 4-bench cross-scenario + replication | $\star\star\star$ multi-fixture cross-vocabulary + cross-model |
+| Industry framing | "auditability moat — EU AI Act 대비" | "operational moat — temporally-evolving corpus 위 quality" |
+
+**둘은 독립 가능**:
+- RAB 만 있고 LRB 없음 = 감사 가능하지만 답 quality 모름
+- LRB 만 있고 RAB 없음 = 답 잘 나오는데 추적 불가능 = 기업 EU AI Act 위반 risk
+
+→ 두 표를 *함께* 내는 게 mother-platform 의 full value.
+
+## 2. Prior art — honest framing 의무
+
+cycle γ Phase B+C 의 prior-art search 결과 + RAB R1.0 의 결과를 LRB
+에 그대로 이식:
+
+| 시스템 | 무엇 | LRB 와의 관계 |
+|---|---|---|
+| **Microsoft GraphRAG** | community summary + LLM-extracted entities + hierarchical retrieval | **첫 번째 직접 비교 대상**. Graph-RAG SUT 의 기본 candidate. |
+| **ActiveGraph** (Nakajima 2026, arXiv 2605.21997) | event-sourced log + deterministic replay + log-only reconstruction. **lifecycle architecture 의 independent co-invention** (RAB paper §1/§2 명시) | second audit-native SUT candidate. LRB 의 self-eval-trap mitigation 직접 자원 (within-class replication). |
+| **LlamaIndex / Lewis 2020 RAG** | append-only vector DB + retrieval | vanilla-RAG baseline (floor). |
+| **AbstentionBench 2025** (Meta, 35k query, 20 dataset) | abstention quality benchmark, convergent finding | LRB 의 hallucination axis prior art. 직접 비교 아님 (axis 다름) — "lifecycle 운영 하 retrieval/answer" 이 LRB scope. |
+| **HALT-RAG 2025** (F1 0.978) | post-hoc verification specialty | LRB 와 axis 다름 (HALT-RAG = answer post-verification, LRB = retrieval/answer **on evolving corpus**). |
+| **Schapire 1990 boosting / KD capacity gap** | 학계 기지 mechanism (RAG cheat-sheet effect 등) | LRB 가 mechanism discovery 주장 안 함 — "empirical reproducibility on a temporally-evolving fixture" 만. |
+
+**LRB 의 contribution claim**:
+- ✗ **NOT** "lifecycle-aware retrieval 이 새 mechanism"
+- ✗ **NOT** "JAMES 가 vanilla RAG 보다 좋다"
+- ✓ "**ActiveGraph 가 음시한 architectural class** (event-sourced log) 의 retrieval-quality dimension 을 deterministic 측정으로 표면화" — 측정 instrument 의 contribution. 결과 자체는 측정 후에만.
+
+이 framing 이 cycle γ Phase B+C 의 "prior art 후 narrowed" + 9th catch
+("measurement-driven discovery") 정신과 정합.
+
+## 3. Metrics — deterministic-first, NLI 는 분리된 H1-변형
+
+RAB 의 H1 (no LLM judge anywhere) 룰을 LRB 에 그대로 가져오면
+hallucination axis 가 측정 불가. 따라서 **H1-variant** 로 분리:
+
+### 3.1 Deterministic axes (H1 strict — RAB 동등)
+
+| Axis | 정의 | 의무 |
+|---|---|---|
+| **R@k (Recall at k)** | gold supporting docs ∩ top-k retrieved / |gold| | gold supporting list 필수 → fixture 의 sf-label 의무 |
+| **P@k (Precision at k)** | gold supporting docs ∩ top-k retrieved / k | 동일 |
+| **Latency** | retrieval + generation 의 wall-clock time | 인프라 axis (RAB RF-cost 와 정합) |
+| **Token cost** | total tokens generated | 인프라 axis |
+
+이 4개는 LLM judge 없이 측정 가능 → RAB H1 룰 정합.
+
+### 3.2 NLI-grounded axis (H1-variant)
+
+| Axis | 정의 | H1-variant 정당화 |
+|---|---|---|
+| **HR (Hallucination Resistance)** | 답 안의 atomic claims 중 retrieved context 가 entail 하는 비율 (ALCE 의 claim entailment 변형) | LLM judge 가 retrieval / answer 단계엔 작용 안 함 — *scoring step* 에만. 그리고 NLI verifier (T5-XXL 또는 RoBERTa-NLI) 가 deterministic given fixed checkpoint. RAB H1 의 정신 (scoring 결정성) 유지. |
+
+→ LRB v0.1 = deterministic axes only (R@k / P@k / Latency / Token cost).
+HR = LRB v0.2 candidate (NLI verifier 통합 후).
+
+### 3.3 측정 안 하는 axis (out of scope, LOCK)
+
+- **"User satisfaction" / "LLM-as-judge quality score"** — RAB H1 정신
+  위반, self-eval trap 직접
+- **F1 / EM on free-text answer** — SQuAD-norm 이 정합 안 됨
+  (lifecycle corpus 의 답이 다양)
+- **JAMES-specific routing axis (auto_router / cog_stages 등)** —
+  `feedback_path_d_james_not_specialty_verifier` 룰 적용. 단일-axis
+  chase 금지.
+
+## 4. Scenario shape — temporally-evolving corpus
+
+### 4.1 Scenario S1 (smoke) — "lifecycle-quarterly"
+
+| 항목 | 값 |
+|---|---|
+| 도메인 | RAB scenario-S2 재사용 (city operations). License friction 0. |
+| 초기 corpus | 100 docs (departments + projects + contracts) |
+| Evolution | 12 weeks 시뮬, 매주 10-20 lifecycle event (INGEST/UPDATE/SUPERSEDE/DELETE) |
+| Total events | ~200 (RAB S2 의 400 op 의 절반, scope manageable) |
+| Query set | 60 queries × 3 timestamps each (T=0 / T=6w / T=12w) = 180 evaluations |
+| Gold | 각 query × timestamp 에 대해 manually-curated supporting doc list + atomic claim list |
+
+### 4.2 핵심 질문 — "temporal evaluation"
+
+같은 query 가 다른 timestamp 에 대해 다른 답을 expect:
+- T=0: "Who directs the public-works department?" → Lena Ortiz
+- T=6w: SUPERSEDE event 후 → Marcus Chen
+- T=12w: 또 다른 SUPERSEDE → 다른 사람
+
+→ **각 SUT 가 "T 시점의 정확한 답" 을 retrieve 할 수 있는가** 가 LRB
+의 핵심 측정 axis. Vanilla append-only RAG 는 T=0 의 stale fact 도
+retrieve → 잘못된 답 가능. Graph RAG 는 supersede chain 일부 다룸. Audit-
+native (ActiveGraph / JAMES) 는 `validity` window + supersede status 로
+T-시점 정확.
+
+### 4.3 Scenario S2 (publication, deferred) — "lifecycle-yearly"
+
+| 항목 | 값 |
+|---|---|
+| 초기 corpus | 1000 docs (제언자 제안 그대로) |
+| Evolution | 6 months 시뮬, 10K events |
+| Query set | 500 queries × 5 timestamps = 2500 evaluations |
+| 비용 | full N-SUT × 측정 = ~100h CPU + LLM 호출 |
+
+LRB v0.2 candidate. v0.1 = S1 smoke, v0.2 = S2 publication.
+
+## 5. SUTs — 4-row gap table (locked)
+
+| SUT | 정체 | 예상 결과 |
+|---|---|---|
+| **Vanilla in-memory RAG** (Baseline-0) | append-only vector store, no supersede 처리 | R@k 떨어지는 axis = T-시점 정확도; 답에 stale fact 포함 |
+| **Microsoft GraphRAG** (Baseline-1) | community summary + entity extract, partial lifecycle | 중간; supersede chain 부재 |
+| **ActiveGraph** (Audit-native reference) | event-sourced log, deterministic replay | high-quality; **JAMES 와 within-class 비교 가능** |
+| **JAMES** (audit-native, this system) | 5-layer lifecycle + CASCADE + EVENT/TEMPORAL | RAB Phase 3 의 self-eval trap 룰 그대로 — gap structure 가 headline, JAMES 점수 자체 아님 |
+
+**self-eval trap mitigation**: ActiveGraph 가 within-class second
+audit-native point 로 들어가야 "JAMES 만 잘함" 의 confound 가 제거됨.
+이건 RAB Phase 4 replication invite 와 정합 — ActiveGraph collab arc.
+
+## 6. Honest tier ladder (locked)
+
+| Result shape | Tier |
+|---|---|
+| 4 SUT 모두 R@k / P@k / Latency / Token cost emit + Vanilla < JAMES < ActiveGraph 또는 Vanilla < (Graph RAG, ActiveGraph, JAMES) 가 cluster | **$\star\star$ infrastructure validated + temporal-quality gap reproduced** |
+| Vanilla ≈ JAMES (no gap) | **honest negative** — temporal-evaluation axis 가 SUT 차이 못 jam (paper headline 으로 무게 없음) |
+| 한 SUT exception / no axes | **exploratory**, fix-PR, results unused |
+
+**Magnitude framing 금지**: scenario-S1 (smoke) 의 magnitude 는 cross-
+scenario / cross-model 확인 전 publication-tier claim 금지 (RAB Phase 3
+ladder 와 정합).
+
+## 7. RAB H1 호환성 — strict
+
+LRB 의 deterministic axes (§3.1) 는 RAB H1 (no LLM judge) 와 동등.
+LRB v0.1 의 4 axes 모두 deterministic — **LRB v0.1 self-publish 가능
+without NLI dep**.
+
+HR axis (§3.2) 가 LRB v0.2 로 옮겨가는 이유. v0.2 = NLI 통합 후
+publication tier.
+
+## 8. JAMES 코드 reuse
+
+기존 `eval/external/runner.py` 의 producer pattern 그대로 사용:
+- `ClosedCorpusGemmaProducer` → Vanilla RAG SUT
+- `JamesEngineProducer` → JAMES SUT
+- 새 producer 2개 = `GraphRAGProducer` + `ActiveGraphProducer` (각각
+  공식 implementation reference)
+
+LRB 의 인프라 = `eval/external/lrb_*.py` (loader / scorer / runner) +
+새 producers. RAB 의 코드와 완전 별도, dispatch layer 만 reuse.
+
+## 9. 의무 reading
+
+이 design memo 의 사전등록 step 진입 전 의무:
+
+1. **RAB SPEC v0.1.1** — H1 룰 + scoring discipline
+2. **RAB Phase 3 handover** — cross-scenario partial honest tier landing
+3. **`docs/architecture/memory-lifecycle-architecture.md`** — 5-layer +
+   CASCADE vs EVENT axiom (= LRB 가 측정할 axis 의 정의)
+4. **memory `project_cycle_gamma_phase_b_rgb_baseline`** — prior art
+   narrowed framing rule
+5. **memory `feedback_self_evaluation_trap`** — fixture / oracle / SUT
+   discipline
+6. **memory `feedback_finding_size_honest_framing`** — magnitude framing
+7. **memory `feedback_eval_cycle_vs_collab_arc_separation`** — joint
+   piece linkage 금지 룰
+
+## 10. 다음 step — 결정 분기
+
+### (A) 사전등록 lock 진행 (이번 또는 다음 세션)
+
+이 design memo 의 §4-7 (scenario shape + SUTs + metrics + tier) 을
+사전등록 doc 으로 lock. 그 후:
+- corpus generator (RAB S2 generator 보다 복잡 — temporal evolution)
+- producer 4개 wire
+- scorer (deterministic R@k / P@k / Latency / Token cost)
+- smoke 측정
+
+예상 비용: 2-3 주 단일-track 작업 (corpus generator + 측정).
+
+### (B) RAB v0.2 sibling 으로 통합
+
+LRB 를 별도 benchmark 가 아니라 RAB v0.2 의 새 axis 로 통합. SPEC
+v0.2 bump + scenario S3 + scoring discipline 의 H1-variant.
+
+trade-off: 통합 framing 강하지만 RAB SPEC frozen 룰 위반 risk.
+
+### (C) 미루기 (defer)
+
+D-2wiki / D-alce / mutation-site wiring 트랙 closure 우선. LRB =
+이 design memo 만 archive + 다음 cycle.
+
+## 11. Cross-link
+
+- RAB v0.1.1: `eval/rab/SPEC-v0.1.md`
+- RAB Phase 3 handover: `docs/handovers/v0.4-r1-phase-3-s2-gap-table-2026-06-11.md`
+- Memory Lifecycle Architecture: `docs/architecture/memory-lifecycle-architecture.md`
+- Cycle γ design memo (4-bench): `docs/design/v0.4-cycle-gamma-external-benchmark-integration.md`
+- Cycle γ Phase B+C prior art (narrowed framing): `docs/research/cycle-gamma-prior-art-positioning.md`
+- ActiveGraph: arXiv 2605.21997 (Nakajima 2026) — RAB paper §1/§2 의 "independent co-invention" 명시 대상
+
+## 12. 외부 평가 (2026-06-11) — honest 반응
+
+외부 평가자가 정확히 짚은 axis 가 이 design memo 의 출발점. 그러나
+평가자의 *framing* 일부는 prior art (특히 ActiveGraph) 의 정보 부족
+에서 비롯한 over-claim 위험이 있었음 (cycle γ Phase B+C 의 narrowed
+framing rule 가 직접 적용). 평가자의 핵심 통찰 — "측정이 axis" — 은
+LRB design memo 의 motivation 으로 그대로 채택. magnitude / novelty
+주장은 측정 후로 보류.
+
+이 design memo 가 lock 되면 외부 평가자에게 답신 시: "내부 framing
+= Memory Lifecycle Architecture (architecture) + RAB (audit-side) +
+LRB (retrieval-side, design memo this PR). ActiveGraph 가 architecturally
+같은 class — independent co-invention" 정확 framing 공유. magnitude
+claim 은 사전등록 후 측정 결과 받은 뒤에만.


### PR DESCRIPTION
## Summary

External evaluator (2026-06-11) correctly named the axis RAB v0.1.1 does NOT measure: how does a RAG system's **retrieval/answer quality** behave on a **temporally-evolving corpus**?

This design memo defines LRB as a **sibling track** to RAB (audit-side vs retrieval-side), reusing the RAB pattern (pre-reg → fixture → SUTs → honest tier ladder) and the cycle γ rules (prior-art narrowed framing, self-eval trap mitigation, no JAMES-wins headline).

| Axis | RAB v0.1.1 | **LRB (proposed)** |
|---|---|---|
| Object | exported audit log quality | RAG retrieval + answer quality on evolving corpus |
| Scoring | deterministic, no LLM judge (H1) | deterministic axes only in v0.1; NLI/HR in v0.2 |
| Industry framing | "auditability moat — EU AI Act" | "operational moat — temporally-evolving corpus" |

Two independent tables; mother-platform value is **both**.

## Locked design decisions

- **LRB v0.1 deterministic axes only** (R@k / P@k / Latency / Token cost) → RAB-H1-compatible (no LLM judge in scoring). Hallucination Resistance (NLI-grounded) is LRB v0.2 candidate.
- **Scenario S1 smoke** = reuse RAB's city-operations vocabulary (license friction 0) at 100 docs / 12 weeks / ~200 events / 60 queries × 3 timestamps.
- **Scenario S2 publication** (1000 docs / 6 months / 10K events — exactly the external evaluator's number) = LRB v0.2 candidate, deferred.
- **4-SUT row**: Vanilla in-memory RAG / Microsoft GraphRAG / **ActiveGraph** / JAMES. ActiveGraph as the within-class second audit-native point mitigates the self-eval trap directly.
- **Honest tier ladder**: ⭐⭐ infrastructure validated + temporal-quality gap reproduced as smoke ceiling; honest negative (Vanilla ≈ JAMES no gap) is an acceptable landing per the cycle γ rule.

## Prior art mapping (cycle γ Phase B+C rules applied)

- **ActiveGraph** (Nakajima 2026, arXiv 2605.21997) = same architectural class as JAMES Layer 4 lifecycle. RAB paper §1/§2 already states \"independent co-invention\"; LRB inherits this framing.
- **Microsoft GraphRAG / LlamaIndex / AbstentionBench 2025 / HALT-RAG 2025 / Schapire 1990 boosting** — all named with their actual relation to LRB.
- **LRB contribution claim is the measurement instrument**, not a novel mechanism. Magnitude / \"JAMES wins\" framing is forbidden pre-measurement (cycle γ Phase B+C lessons; 9th catch).

## Honest response to the external evaluation

The evaluator's core insight (\"measurement is the missing axis\") is correct and is the motivation of this memo. The evaluator's framing of \"CAP\" as a novel concept is over-claimed (cycle γ prior art search rule applies); the internal precise framing is **5-layer Memory Lifecycle Architecture + CASCADE vs EVENT axiom** (`docs/architecture/memory-lifecycle-architecture.md` §1.5), measured by **RAB (audit-side) + LRB (retrieval-side)** as siblings.

## Next-step decision (§10) — operator chooses

| Path | When | Trade-off |
|---|---|---|
| **(A) Lock the pre-reg now, start the corpus generator** | Immediate | Direct evidence path; 2-3 weeks single-track work |
| **(B) Merge LRB into RAB v0.2** | After SPEC v0.2 bump | Unified framing; SPEC frozen rule risk + H1-variant needed |
| **(C) Defer** | After D-2wiki / D-alce / mutation-site close | Lowest churn; LRB stays as an archived design memo |

## Out of scope

- The pre-registration itself — separate PR after the operator picks A/B/C.
- The corpus generator — separate cycle.
- Any magnitude claim about Vanilla RAG vs JAMES — forbidden pre-measurement.
- arXiv submission of the RAB paper — separate track (B-C-D), unaffected by this memo.

## Labels

\`Quality delta: exempt (label: docs)\` — design memo only, no \`core/\` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)