### PR TITLE
docs(R5-LRB+v0.5): cross-model prereg + v0.5 domain ranking + pilot scope spec

### DIFF
--- a/docs/research/lrb-v021-cross-model-preregistration-2026-06-11.md
+++ b/docs/research/lrb-v021-cross-model-preregistration-2026-06-11.md
@@ -1,0 +1,224 @@
+# LRB v0.2.1 — Cross-Model 사전 등록 (Pre-registration)
+
+**Date**: 2026-06-11 (cross-model producer 구현 + 측정 실행 **전** 커밋)
+**Status**: LOCKED. 이 doc commit 후 모델 lineup / producer interface /
+honest tier ladder / 측정 axes 변경 금지.
+
+**Bench under test**: LRB v0.2.1 — Phase B 의 LRB-S1 / S2 fixture 위에
+**LLM-grounded retrieval producer** 를 추가하여 cross-model 측정. v0.2
+publication tier 의 첫 번째 step.
+
+**Predecessors**:
+- LRB design memo (PR #782)
+- LRB Phase A prereg (PR #783) + 측정 (PR #784)
+- LRB Phase B prereg (PR #785) + 측정 (PR #786, ⭐⭐⭐ tier landed)
+
+**Why pre-register**: Phase A+B 가 token-overlap deterministic only.
+"LRB 가 LLM 영향 없는 axis 만 측정" 비판이 외부 인정 ❌ 항목 (cross-
+model). v0.2.1 은 LLM-grounded retrieval producer 를 도입하여 retrieval
+quality 가 model size / family 에 따라 어떻게 변하는지 측정. cross-
+model gap reproduction = self-eval trap mitigation 강화.
+
+**Why now (전체 트랙과의 정합)**: Track A v0.2 publication tier 의
+첫 milestone. 외부 인정 7/10 → 8/10 진입.
+
+---
+
+## 1. Scope — v0.2.1 가 측정할 것과 측정하지 않을 것
+
+### 1.1 측정 (LOCK)
+
+| 항목 | 값 |
+|---|---|
+| Scenario | **LRB-S1 + LRB-S2** (Phase B 와 동일 fixture, 동일 sha) |
+| SUTs | **3 (Phase B 와 동일)** — Vanilla + Naive-supersede + JAMES |
+| **Models (cross-model lineup)** | **4 family** — `gemma4:e4b` (Phase A/B baseline) + `gemma3:12b` (mid-size) + `mxtral` (mid-large) + `claude-haiku-4-5` (cloud, abstraction layer) |
+| Retrieval modes | **2** — (a) token-overlap-only (Phase B baseline) + (b) **LLM-grounded retrieval** (model-rerank top-20 by token-overlap → LLM scores top-20 → top-k by LLM score) |
+| n_runs | 1 per (model, mode, SUT, scenario) — deterministic 단일 run |
+| Honest tier | **⭐⭐ infra validated + cross-model gap reproduction → ⭐⭐⭐ candidate (if gap rank-order survives cross-model)** |
+
+### 1.2 핵심 신규 axis — cross-model reproduction
+
+| Question | Test |
+|---|---|
+| (Q1) Token-overlap 결과가 LLM grounding 으로 바뀌나? | 4 model × 2 mode × 3 SUT × 2 scenario = 48 cells. mode delta (LLM − token-only) per SUT |
+| (Q2) Cross-model gap rank-order 가 유지되나? | S2 R@1 ranking: Vanilla < Naive < JAMES — 모든 model 에서 reproduce 되어야 ⭐⭐⭐ |
+| (Q3) Model size 가 retrieval quality 결정하나? | gemma4:e4b (~4B) < gemma3:12b < mxtral (~47B) < claude — strict ordering 시 size 효과; tied 면 architecture 효과 |
+
+### 1.3 측정 axes (Phase B 와 동일 LOCK)
+
+deterministic-first; LLM 은 **scoring 단계가 아니라 retrieval 단계 only**
+(RAB H1 정신 유지 — scoring 여전 deterministic):
+
+- R@5 / R@10 / P@5 / P@10
+- Latency / Token cost (LLM call 포함 시 retrieval latency 가 token-only 대비 크게 증가 예상)
+- temporal_accuracy
+- [exp] R@1 / P@1 / temporal_accuracy_strict_top1
+
+### 1.4 honest-tier ladder (LOCK)
+
+| Result shape | Tier |
+|---|---|
+| 4 model × 3 SUT axes emit + S2 R@1 rank-order (V < N < J) 가 **모든 model 에서 reproduce** | **⭐⭐⭐ cross-model gap structure validated** |
+| 4 model × 3 SUT axes emit + S2 rank-order 가 일부 model 에서 partial (3 of 4 reproduce) | ⭐⭐ partial cross-model reproduction |
+| Rank-order 가 절반 이하 model 에서 reproduce | ⭐ cross-model reverse — root-cause cycle 별도 |
+| 한 model exception / no axes | exploratory |
+
+**Magnitude framing 금지**: v0.2.1 cross-model 의 magnitude 는 v0.2.3
+S3 publication-scale 확인 전 publication-tier claim 금지.
+
+### 1.5 측정하지 **않음** (v0.2.1 — LOCK)
+
+| 항목 | 사유 |
+|---|---|
+| LLM-graded **answer quality** axis | v0.2.4 HR (NLI) axis 별도 |
+| GraphRAG SUT | v0.2.2 별도 |
+| ActiveGraph SUT | v0.2 publication collab arc |
+| S3 publication-scale (1000+ docs) | v0.2.3 별도 |
+| Korean / cross-lingual | LRB v0.3 candidate |
+
+## 2. Cross-model producer 설계
+
+기존 token-overlap retrieve_at() 를 **두 모드**로 분리:
+
+```python
+class CrossModelAdapter:
+    def retrieve_at(self, q, k, query_time, valid_time, *,
+                    mode: Literal["token", "llm-grounded"],
+                    model: str):
+        if mode == "token":
+            return token_overlap_top_k(q, k, vt)
+        else:
+            top_20 = token_overlap_top_k(q, 20, vt)
+            llm_scores = llm_rerank(top_20, q, model=model)
+            return top_k_by_score(top_20, llm_scores, k)
+```
+
+LLM rerank prompt (deterministic JSON output):
+```
+Given query: "{q}"
+Score each candidate doc 0-10 by relevance:
+1. {title} — {first 200 chars of text}
+2. ...
+Return JSON: {{"scores": [0..10, ...]}}
+```
+
+3 adapter (Vanilla / Naive / JAMES) 모두 이 layer 위에 build — 즉
+**모드 + 모델은 SUT 외부의 cross-cutting concern**. SUT 자체 코드는
+변경 0 (retrieve_at signature 만 model/mode keyword).
+
+## 3. Models lineup (locked)
+
+| Model | Family | 사용 방식 | 의무 |
+|---|---|---|---|
+| `gemma4:e4b` | Google Gemma | Ollama local | Phase A/B baseline reuse |
+| `gemma3:12b` | Google Gemma | Ollama local | mid-size in-family |
+| `mxtral` (= `mixtral:8x7b`) | Mistral | Ollama local | mid-large cross-family |
+| `claude-haiku-4-5` | Anthropic | abstraction layer (Direction α §5.7.13) | cloud cross-family |
+
+→ 1 local-small + 1 local-mid + 1 local-large + 1 cloud = 4-family
+spread. Family / size 효과 분리 가능.
+
+**Operator action 요건**:
+- Ollama service 가동 + 3 model 다운로드 (`ollama pull gemma3:12b`,
+  `ollama pull mixtral:8x7b`)
+- Claude API key (또는 Max-plan headless `claude -p` per
+  `feedback_direction_alpha_max_plan_research_cloud`)
+- abstraction layer (`core/abstraction/`) 가용성 확인
+
+## 4. 보고 프로토콜 (LOCK)
+
+### 4.1 산출물 (per (scenario, sut, model, mode))
+
+48 cells = 2 scenario × 3 SUT × 4 model × 2 mode. 각 cell:
+- `reports/external/lrb/v021-<scn>-<model>-<mode>-<ts>.<sut>.result.json`
+- `reports/external/lrb/v021-<scn>-<model>-<mode>-<ts>.<sut>.bench.jsonl`
+
+Cross-cell handover: `docs/handovers/v0.4-lrb-v021-cross-model-<date>.md`
+
+### 4.2 보고 시 의무
+
+1. ⭐⭐⭐ / ⭐⭐ / ⭐ tier 명시 (§1.4 의 verdict 그대로)
+2. cross-model gap rank-order 4-cell summary 표
+3. Phase A finding (naive ≈ JAMES on S1) + Phase B finding (J > N on S2)
+   보존 — cross-model 측정이 부정 아닌 보완
+4. NOT publication framing
+5. mid-June joint piece 자동 연결 금지
+6. operator action evidence (어떤 model 이 어떤 hardware 에서, 어떤
+   prompt 로) 명시
+
+### 4.3 금지 사항
+
+1. Phase A/B finding 의 retroactive 덮기
+2. token-overlap 결과를 LLM-grounded 결과로 overwrite (post-hoc fit)
+3. 4 model 중 1-2 cells exception 발생 시 결과 cherry-pick
+4. magnitude claim ("12b 가 4b 의 X 배") without v0.2.3 publication-scale
+
+## 5. 인프라 reuse
+
+기존 LRB Phase A/B 인프라 그대로 + 다음 확장:
+
+| 위치 | 역할 |
+|---|---|
+| `eval/external/lrb/adapters/*.py` | 동일 (변경 0) |
+| `eval/external/lrb/driver_phase_b.py` | retrieve_at signature 에 mode + model keyword 추가 |
+| `eval/external/lrb/llm_rerank.py` | 신규 — Ollama + abstraction layer dispatch |
+| `eval/external/lrb/scorer.py` | 동일 (axes 동일) |
+| `scripts/research/lrb_run_v021_cross_model.py` | 신규 — CLI runner |
+
+v0.2.1 신규 코드 surface ≈ 500 줄 (llm_rerank + runner + handover).
+
+## 6. 실행 순서 (logical chain)
+
+```
+0. 이 사전 등록 commit                      ← P0 (이 단계, 솔로)
+1. retrieve_at signature 확장 (mode/model)  ← 솔로
+2. llm_rerank.py 모듈 + Ollama + abstraction dispatch ← 솔로
+3. CLI runner + tests                        ← 솔로
+4. 단일 cell smoke (gemma4:e4b, token-mode)  ← 솔로 (baseline reproduction)
+5. operator 의존: full sweep 48 cells (3-5h overnight batch)
+6. cross-cell analysis + handover + PR        ← 솔로 분석
+```
+
+예상 비용:
+- 사전 등록 + signature 확장 + llm_rerank 모듈: 2-3h
+- CLI runner + tests: 1-2h
+- smoke (1 cell): 5-10분
+- full 48-cell sweep: 3-5h (operator-attended, overnight 권장)
+- handover + 분석: 2-3h
+- 총 ~10-15h 단일-cycle 작업
+
+## 7. ⭐⭐⭐ tier 진입 의미
+
+v0.2.1 ⭐⭐⭐ 진입 시:
+- 외부 인정 7/10 → **8/10** (외부 model ❌ → ✅ 해소)
+- 다음 step = v0.2.2 GraphRAG SUT → 9/10 (external SUT ❌ → ✅)
+- v0.2.6 reproducer invite → 10/10 (collab arc 별도)
+
+⭐⭐⭐ 후 publication 요건 추가:
+- v0.2.3 S3 publication scale
+- v0.2.4 HR NLI axis
+- v0.2.5 arXiv preprint
+
+## 8. 관련
+
+- [[project_lrb_phase_a_smoke]] — Phase A+B 결과
+- [[project_r1_replayable_audit_benchmark]] — RAB sibling axis
+- [[feedback_self_evaluation_trap]] — fixture / oracle discipline
+- [[feedback_finding_size_honest_framing]] — magnitude framing 룰
+- [[feedback_single_axis_ablation_misframing]] — 단일 axis chase 금지
+- [[feedback_eval_cycle_vs_collab_arc_separation]] — joint piece 자동 연결 금지
+- [[feedback_direction_alpha_max_plan_research_cloud]] — cloud abstraction 정합
+- design memo: `docs/design/v0.4-lrb-lifecycle-retrieval-benchmark-design.md`
+- Phase B prereg: `docs/research/lrb-phase-b-time-travel-preregistration-2026-06-11.md`
+- Phase B handover: `docs/handovers/v0.4-lrb-phase-b-cross-scenario-2026-06-11.md`
+
+## 9. 사전 등록 commit hash = evidence
+
+이 doc 의 첫 commit hash 가 사전 등록 timestamped evidence.
+llm_rerank.py / cross-model runner / 측정 실행 **전** PR 머지.
+
+---
+
+*v0.2.1 = LRB v0.2 publication tier 의 첫 milestone. Token-overlap
+결과의 cross-model reproduction 이 본 cycle 의 핵심 측정.*

--- a/docs/strategy/v0.5-domain-candidate-evaluation-2026-06-11.md
+++ b/docs/strategy/v0.5-domain-candidate-evaluation-2026-06-11.md
@@ -1,0 +1,243 @@
+# v0.5 First-Domain Candidate Evaluation (2026-06-11)
+
+> **Purpose**: v0.5 first-domain pilot 의 후보 도메인을 self-eval-trap-
+> averse 방식으로 평가하고 ranked list 산출. 본 doc 은 *내부 평가만*
+> — 외부 customer outreach 는 v0.5.3 (별도 cycle).
+>
+> **Constraint**: CLAUDE.md rule #1 "v1.0 까지 도메인 features 금지" 의
+> 예외 = **v0.5 first pilot 1개 도메인 only**. 본 doc 의 ranking 이
+> pilot 선택 의사결정 입력.
+
+---
+
+## 1. 평가 framework — 6 차원 weighted score
+
+각 도메인을 6 차원으로 점수화 (1-5 scale, 높을수록 적합):
+
+| Dim | 차원 | 측정-evidence 정합 | 가중치 |
+|---|---|---|---|
+| **R** | Regulatory anchor (RAB Art 정합) | RAB AC/RF/PC publishable 가치 | 3.0 |
+| **T** | Temporal reasoning 필요성 (LRB time-travel 정합) | LRB ⭐⭐⭐ publishable 가치 | 3.0 |
+| **S** | Data sensitivity / audit pressure | mother-platform 강점 (audit-side) | 2.5 |
+| **M** | Market size (한국) | 운영 viability + pilot 회수 | 1.5 |
+| **C** | Cold-start cost (initial corpus 확보) | pilot 6개월 안에 측정 가능 | 1.5 |
+| **N** | Network access (pilot customer 발견 난이도) | LOI 도달까지의 거리 | 1.5 |
+
+**총점 만점**: 1.5 + 1.5 + 1.5 + 2.5 + 3.0 + 3.0 = 13.0 × 5 = **65.0**
+
+**Tier 컷오프**:
+- ≥ 52 (80%): **Strong candidate** — outreach 우선순위
+- 39-51 (60-79%): Mid candidate — secondary outreach
+- < 39: Reject (v1.0 후로 deferred)
+
+## 2. 도메인 후보 평가
+
+### 2.1 Legal contract review (법무 / 법률 검토)
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **5** | 계약법 / 한국 전자문서법 / 변호사법 — audit trail 의무. RAB Art.10/12/19 직접 매칭. |
+| T | **5** | "체결 시점 정책본문 vs 현재" — LRB time-travel 직접 use case |
+| S | **5** | 영업비밀 / 변호사-의뢰인 비밀특권 — audit + 격리 강함 |
+| M | **3** | 한국 legal tech 시장 ~5천억대, 성장 중. 대형 로펌 50+ + 인하우스 법무팀 다수 |
+| C | **3** | initial corpus = 계약서/판례/법령. 공공 corpus (open law DB) + 회사 내부 계약서. |
+| N | **3** | Korean legal tech 회사 (LawTalk, 로톡 등) + 대형 로펌 KM 부서. 직접 콜드 가능, 단 의사결정 슬로우. |
+| **Weighted total** | **56.0 / 65 = 86%** | R(5×3) + T(5×3) + S(5×2.5) + M(3×1.5) + C(3×1.5) + N(3×1.5) = 15 + 15 + 12.5 + 4.5 + 4.5 + 4.5 = 56.0 / 65 = **86%** Strong |
+
+★★★ **첫 번째 strong candidate.**
+
+### 2.2 Compliance & internal audit (내부 감사 / 컴플라이언스)
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **5** | 자본시장법 / 금융감독 / SOX (글로벌 자회사) — 감사 추적 의무. RAB Art.10/12/19 정밀 매칭 |
+| T | **4** | "결재 시점의 internal control rule" — LRB time-travel 강한 use case. 다만 legal 만큼 dramatic 하지 않음 |
+| S | **5** | 비공개 감사 보고 / 임원 결재 / 회계 처리 — audit 강함, leak risk 최고 |
+| M | **3** | 대기업 50+ 그룹 감사실 + 금융사 50+ 컴플라이언스 부서. 시장 small but high-value |
+| C | **3** | initial corpus = 내부 규정 / 매뉴얼 / 감사보고 history. 회사 의존 (공공 corpus 없음) |
+| N | **2** | 감사실은 외부 PoC 매우 conservative. 의사결정 → CFO/감사위. 슬로우 + skeptical. |
+| **Weighted total** | **53.0/65** | R(15) + T(12) + S(12.5) + M(4.5) + C(4.5) + N(3) = **51.5 / 65 = 79%** Mid → Strong border |
+
+★★ Mid-Strong candidate. R+S+T 가 매우 높음, N 이 낮음.
+
+### 2.3 Records management (기록물 관리 / 공공 records)
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **5** | 공공기록물법 / 행정전자문서법 — 30년 보존 / replayability 법적 의무. RAB Art.10/12/19 + 한국법 정합. |
+| T | **5** | "X년 X월 등록 정보는?" — LRB time-travel core use case |
+| S | **4** | 공공기록 = 비밀 vs 공개 혼재. audit pressure 높음 (감사원) |
+| M | **2** | 공공 + 일부 대기업. 시장 small + 가격 sensitivity 높음 (B2G) |
+| C | **4** | 공공 records open data (국가기록원 등) 풍부. 초기 corpus 확보 쉬움. |
+| N | **2** | B2G 조달 절차 = 6-12개월. PoC 진입 어려움 (수의 = 한계, 정식 입찰 = 시간) |
+| **Weighted total** | **47.0/65** | R(15) + T(15) + S(10) + M(3) + C(6) + N(3) = **52.0 / 65 = 80%** Strong border |
+
+★★★ Strong candidate, **단 N (조달 난이도)** 가 LOI 진입 속도를 약화.
+
+### 2.4 HR / employee records (인사 / 발령 / 평가)
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **4** | 근로기준법 / 개인정보보호법 / 노동위 — audit 의무 (단 legal 만큼 verbatim Art 정합 약함) |
+| T | **5** | "이 발령 시점 부서장은?" / "당시 평가 룰은?" — LRB time-travel 강한 use case |
+| S | **5** | 개인정보 + 평가/연봉 — leak risk 최고급. audit 압박 (노동위 진정 시) |
+| M | **3** | 모든 회사가 HRIS 보유. 단 기존 HRIS (SAP/Oracle/Workday/Flex/Saramin) 경쟁 강함 |
+| C | **2** | initial corpus = 내부 인사 history. 외부 reference 없음 + 민감 데이터 = pilot 초기 ingest 가 정치적 부담 |
+| N | **3** | 인사팀 의사결정 비교적 빠름. 단 임원 sign-off 필요 (개인정보 외부 처리). |
+| **Weighted total** | **44.5/65** | R(12) + T(15) + S(12.5) + M(4.5) + C(3) + N(4.5) = **51.5 / 65 = 79%** Mid → Strong border |
+
+★★ Mid candidate. T+S 강함, M (경쟁) + C (민감 데이터 ingest) 약점.
+
+### 2.5 Healthcare clinical records (의료기록 / 임상 결정)
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **5** | 의료법 + 개인정보보호법 — 진료기록 10년 보존 / replayability 법적 의무 |
+| T | **5** | "당시 진단 시점의 가이드라인은?" — LRB time-travel 강력 use case |
+| S | **5** | 환자정보 = 한국 개인정보보호법 민감정보. audit 강함 (보건복지부) |
+| M | **3** | 대형 병원 + EMR vendor 경쟁 (EzCaretech, BIT Computer 등). 진입 어렵지만 시장 large |
+| C | **1** | initial corpus = 의료기록 — pilot 초기 ingest 가 IRB / 환자 동의 필요. 6개월 안에 evidence 어려움 |
+| N | **2** | 병원 IT 의사결정 = 보수적 + 슬로우. PoC 라도 IRB 통과 필요. |
+| **Weighted total** | **40.5/65** | R(15) + T(15) + S(12.5) + M(4.5) + C(1.5) + N(3) = **51.5 / 65 = 79%** Mid border |
+
+★ Mid candidate. R+T+S 강함, C (IRB) + N (병원 보수) 가 v0.5 pilot 6개월 spec 와 conflict.
+
+### 2.6 Customer support / CRM 결정 history
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **2** | 일반 통신 / 개인정보 외엔 regulatory pressure 약함 |
+| T | **3** | "당시 응대 정책은?" — useful 하지만 dramatic 하지 않음 |
+| S | **3** | 고객정보 + 응대 history — moderate |
+| M | **4** | B2B SaaS 시장 large + customer support tool 경쟁 (Zendesk, Channeltalk, Freshdesk) |
+| C | **4** | 회사 자체 CRM history — 비교적 풍부 |
+| N | **4** | 마케팅/CS 부서 의사결정 빠름. PoC 진입 쉬움 |
+| **Weighted total** | **45.0/65** | R(6) + T(9) + S(7.5) + M(6) + C(6) + N(6) = **40.5 / 65 = 62%** Mid border |
+
+★ Mid candidate. N+M+C 강함, R+T 약함 → mother-platform 측정-evidence 정합 약함 → reject 권고.
+
+### 2.7 Engineering / DevOps 의사결정 history
+
+| Dim | Score | 근거 |
+|---|---|---|
+| R | **1** | regulatory anchor 거의 없음 (보안 사고 시 사후 조사 정도) |
+| T | **4** | "당시 인프라 룰은?" — RCA 시 매우 유용 |
+| S | **3** | source code / infra config — moderate |
+| M | **5** | 모든 tech 회사 + DevX 시장 성장. 시장 huge |
+| C | **5** | GitHub / Jira / Confluence — corpus 풍부 |
+| N | **5** | 엔지니어링 부서 의사결정 fastest. PoC 가장 쉬움 |
+| **Weighted total** | **44.0/65** | R(3) + T(12) + S(7.5) + M(7.5) + C(7.5) + N(7.5) = **45.0 / 65 = 69%** Mid border |
+
+★ Mid candidate. N/M/C 최고, 단 R 부재 → mother-platform 의 audit-side 강점이 안 살아남 → reject 권고 (v1.0 이후 Domain Pack).
+
+## 3. Ranked candidate list
+
+| Rank | Domain | Total | Tier | Recommended |
+|---|---|---|---|---|
+| **1** | **Legal contract review** | **56.0 / 86%** | **Strong** | **PRIMARY outreach** |
+| 2 | Records management (공공기록) | 52.0 / 80% | Strong | Strong outreach (B2G 조달 long) |
+| 3 | Compliance & internal audit | 51.5 / 79% | Strong-Mid | Strong outreach |
+| 3 | HR / employee records | 51.5 / 79% | Strong-Mid | Mid outreach |
+| 3 | Healthcare clinical records | 51.5 / 79% | Mid-Strong | Mid outreach (IRB 시간) |
+| 6 | Engineering / DevOps | 45.0 / 69% | Mid | Reject for v0.5 |
+| 7 | Customer support / CRM | 40.5 / 62% | Mid | Reject for v0.5 |
+
+### Score 재정렬 (정확 순서)
+
+```
+86% Legal contract review              ← PRIMARY
+80% Records management
+79% Compliance & internal audit
+79% HR / employee records
+79% Healthcare clinical records
+69% Engineering / DevOps
+62% Customer support / CRM
+```
+
+## 4. 권고 (top-2 outreach)
+
+### 4.1 Primary: Legal contract review
+
+**Why**:
+- 모든 측정-evidence 강점 (RAB Art / LRB time-travel / audit pressure)
+  이 직접 use case 와 매칭
+- 한국 legal tech 시장 큼 + 대형 로펌 KM (knowledge management) 부서
+  성장 중
+- PoC 진입 비교적 빠름 (대형 로펌 IT 팀 + 인하우스 법무 양쪽 가능)
+- 회사 결재 자료 framing 강함 ("계약 체결 시점 정책본문 정확 보존")
+
+**PoC 시나리오 예시**:
+```
+회사 = 대형 로펌 또는 대기업 인하우스 법무팀 (사용자 50-200명)
+부서 = KM (knowledge management) + 1 practice area (e.g., M&A or 노동)
+기간 = 6 개월
+Scope = (1) 계약서 / 판례 / 내부 의견서 ingest
+        (2) LRB time-travel: "체결 시점 회사 정책 본문 / 표준 조항 retrieval"
+        (3) RAB audit: 모든 retrieval/answer chain 자체 감사 log
+Success metric = (a) audit completeness ≥ 99% (RAB AC)
+                (b) temporal retrieval R@1 ≥ 0.7 (LRB)
+                (c) user satisfaction NPS ≥ 30
+```
+
+### 4.2 Secondary: Records management (공공기록)
+
+**Why**:
+- 한국 공공기록물법 / 행정전자문서법 = RAB anchor 강도 maximum
+- LRB time-travel 의 "30년 보존 + 시점 정확 retrieval" 이 법적 의무
+- B2G 조달 시 RAB DOI + EU AI Act anchor 가 기술 신뢰성 강한 evidence
+
+**Risk**:
+- 조달 6-12개월 — v0.5 timeline 슬립 risk
+- 가격 sensitivity 높음 (B2G 통상)
+- 의사결정 슬로우
+
+**Mitigation**:
+- B2G 조달 전에 **공공기관 R&D 협력** 형태로 진입 (KISTI / NIA / 국가기록원 R&D)
+- 정식 조달은 v1.0 이후
+
+### 4.3 Tertiary (병행 outreach): Compliance & internal audit + HR records
+
+- 양쪽 모두 R+T+S 강하지만 N 약점
+- Primary (Legal) 의 outreach 시 같은 회사 내 다른 부서로 confluence
+  가능 → 별도 콜드 outreach 비용 saving
+
+## 5. Reject 도메인 (v1.0 이후로 deferred)
+
+- **Engineering / DevOps**: R 부재 → mother-platform audit-side 강점 안 살아남.
+  v1.0 후 Domain Pack 으로 가능.
+- **Customer support / CRM**: R+T 약함 + 기존 SaaS 경쟁 강함 → 차별 어려움.
+  v1.0 후 Domain Pack 으로 가능.
+- **Travel / 여행 ticketing**: PLATFORM_READINESS §7 의 informal eval
+  도 medium-high (v1.0+) — v0.5 scope 밖.
+- **Retail / 유통**: PLATFORM_READINESS §7 medium (v1.0+) — v0.5 scope 밖.
+
+## 6. Next step (v0.5.1 Pilot scope spec)
+
+본 doc 의 Primary (Legal) + Secondary (Records mgmt) 두 도메인에 대해
+다음 cycle (v0.5.1):
+- 각 도메인의 6개월 pilot scope spec 작성
+- Dim F production proof 측정 metric 정의
+- 기술 통합 spec (workspace 격리 / audit_bridge / abstraction trust)
+- Success criteria + risk mitigation
+
+본 doc 의 ranked list 는 **outreach 진행 시 priority guide**.
+실제 LOI 받는 도메인이 ranked list 와 다를 수 있음 (operator 의
+network access 의존). 그 경우 LOI 받은 도메인을 first pilot 로
+진행하되, 본 doc 의 평가 framework 로 measurement-evidenced 정합성
+re-validate.
+
+## 7. 관련
+
+- `docs/PLATFORM_READINESS.md` (6-dim framework, §7 informal eval)
+- `docs/ARCHITECTURE.md` (non-goals, trust zones)
+- memory `project_r1_replayable_audit_benchmark` (RAB 측정-evidence)
+- memory `project_lrb_phase_a_smoke` (LRB Phase A+B 측정-evidence)
+- handover `v0.4-lrb-phase-b-cross-scenario-2026-06-11.md`
+- (다음 cycle) `docs/strategy/v0.5-pilot-scope-spec-2026-06-11.md`
+
+---
+
+*평가는 measurement-evidenced moat (audit + lifecycle/time-travel)
+정합을 가중치 high 로 둠. "JAMES reasoning superiority" 는 측정-data
+없음으로 평가 axis 에서 제외. 실제 outreach 결과에 따라 LOI 받은
+도메인을 first pilot 로 진행하되, 본 framework 로 정합성 재검증.*

--- a/docs/strategy/v0.5-pilot-scope-spec-2026-06-11.md
+++ b/docs/strategy/v0.5-pilot-scope-spec-2026-06-11.md
@@ -1,0 +1,270 @@
+# v0.5 Pilot Scope Specification (2026-06-11)
+
+> **Purpose**: v0.5 first-domain pilot 의 scope / goal / metric / spec
+> 정의. Dim F (Production proof) gate 충족 조건 = 본 doc 의 success
+> criteria 모두 6 개월 안에 측정-evidenced.
+>
+> **Scope discipline**: 본 doc 은 *generic pilot spec* (도메인 무관).
+> 도메인-specific 작업 (legal pack 등) 은 LOI 받은 후 별도 cycle.
+>
+> **Predecessors**: `v0.5-domain-candidate-evaluation-2026-06-11.md`
+> (도메인 ranked list) — Primary = Legal contract review (86%).
+
+---
+
+## 1. Pilot 목표 (Dim F production proof gate 정합)
+
+`docs/PLATFORM_READINESS.md` Gate v0.4 의 F 차원 통과 기준:
+
+```
+F: One external customer runs the pilot for ≥ 6 months
+F: Zero core regressions caused by the pack during the pilot
+```
+
+이를 정량 spec 으로 매핑:
+
+| Pilot 목표 | 측정 기준 | Pass threshold |
+|---|---|---|
+| **F.1** Customer pilot ≥ 6 개월 | 계약 시작-종료 일자 | ≥ 180 days uninterrupted |
+| **F.2** Core regression 0 | core/ 모듈 PR 머지 후 RAB AC/RF/PC 측정 | regression Δ ≤ −0.01 in any cycle |
+| **F.3** User-base 의미있음 | active users / 부서 size | ≥ 50 weekly active users in pilot dept |
+| **F.4** Audit completeness | RAB AC (production traffic 대상) | ≥ 0.99 |
+| **F.5** Temporal retrieval accuracy | LRB-style time-travel R@1 (production samples) | ≥ 0.65 (baseline) |
+| **F.6** No prod incident causing data loss | incident log | 0 P1, ≤ 2 P2 |
+| **F.7** Customer NPS / 재계약 의향 | exit survey | NPS ≥ 30 OR 재계약 의향 ≥ 70% |
+
+**Pilot pass = F.1-F.6 모두 충족 + F.7 ≥ 1개 충족**.
+
+본 pilot 의 목적은 *제품 검증* + *Dim F gate clearance*. 매출
+규모는 secondary.
+
+## 2. 기술 scope (LOCK)
+
+### 2.1 통합 architecture (변경 0)
+
+```
+Customer infra
+   ├─ JAMES instance (workspace-isolated)
+   │    ├─ core/ (변경 0 — mother platform contract 유지)
+   │    ├─ audit_log + audit_bridge (RAB evidence 생성)
+   │    └─ validity-window retrieval (LRB evidence 생성)
+   ├─ Data ingest (도메인-specific connector — LOI 후 별도 cycle)
+   └─ UI (web — 기존 server_llmwiki + 도메인-specific extension)
+```
+
+**핵심 제약**:
+- **core/ 코드 변경 0** (CLAUDE.md rule #1 "도메인 features 금지" 정합)
+- 도메인-specific 코드 = `packs/<domain>/` (v0.3 plugin API 가 v0.5
+  pilot 의 dogfood — pilot evidence 가 v0.3 packs/general/ 로 환원)
+- workspace 격리 = `JAMES_WORKSPACE` env var 로 customer 데이터 완전 분리
+- audit log 격리 = audit_bridge 가 customer-side 저장
+
+### 2.2 기능 scope (LOCK)
+
+| 카테고리 | Included | Excluded |
+|---|---|---|
+| Retrieval | validity-window 시간 인지 + token-overlap + (option) LLM rerank | full GraphRAG / ActiveGraph |
+| Audit | RAB SPEC v0.1.1 적합 + replayable log + reconstruct_graph_at(t) | NIST AI RMF full 정합 |
+| UI | server_llmwiki extend + 도메인 panel | 자체 브랜드 / 마케팅 |
+| Auth | JWT / SSO (customer IdP) | SAML / LDAP full (Dim D v1.0) |
+| Observability | OpenTelemetry exporter | full Prometheus (Dim D v1.0) |
+| Backup/restore | CLI + snapshot | live multi-region (Dim D v1.0) |
+| Multi-tenancy | single-customer instance | full SaaS multi-tenant (Dim D v1.0) |
+
+### 2.3 Out of scope (Pilot)
+
+- v1.0 vertical product features
+- 마케팅 / 영업 자료 통합
+- 외부 marketplace
+- Public plugin distribution
+- 다른 도메인 동시 pilot (CLAUDE.md rule = 1 도메인만)
+
+## 3. Pilot timeline (6 개월 baseline)
+
+```
+Week 1-2   : Kickoff
+  - NDA / DPA / 보안 검토 (customer 측)
+  - Workspace 격리 spec 합의
+  - 초기 corpus 정의 (사이즈 / 카테고리 / 민감 등급)
+  - Success metric 합의 (§1 의 7 항목 + 도메인-specific 항목)
+
+Week 3-6   : Setup & ingest
+  - JAMES instance 배포 (customer infra OR JAMES-hosted dedicated)
+  - 초기 corpus ingest + audit log baseline
+  - 사용자 onboarding (10-20 pilot user, friendly first)
+  - Baseline 측정 (RAB AC / LRB R@1 / latency)
+
+Week 7-12  : Expansion
+  - User base 확장 (50+ active)
+  - 일상 사용 + 피드백 수집
+  - Weekly retro + small adjustments
+
+Week 13-20 : Stabilization
+  - 정상 운영 phase
+  - 월간 RAB / LRB measurement
+  - Core regression watch
+
+Week 21-24 : Closure + measurement
+  - F.1-F.7 측정 finalize
+  - Customer exit interview
+  - 결과 handover + 재계약 협상 (or end)
+```
+
+## 4. Success metric 측정 방법 (deterministic-first)
+
+### 4.1 RAB AC (audit completeness) — F.4
+
+**측정**:
+- 매월 1회 production audit log dump
+- 각 day 의 핵심 op (INGEST/UPDATE/SUPERSEDE/DELETE/ANSWER) ground-truth
+  driver 와 매칭
+- RAB SPEC v0.1.1 scorer 그대로 적용
+
+**Pass threshold**: 0.99 (RAB Phase 3 의 JAMES 1.000 보다 보수적
+threshold; production noise 허용)
+
+**계측 인프라 reuse**: `eval/rab/driver.py` + `eval/rab/scorer.py` +
+`eval/rab/adapters/james.py` (production audit log 형식이 SPEC §1 과
+매칭 의무 — pilot kickoff 시 합의)
+
+### 4.2 LRB temporal retrieval R@1 — F.5
+
+**측정**:
+- 매월 1회 production query log 에서 historical 쿼리 추출 ("X 시점의 Y는?"
+  형 + 시간 표현 포함)
+- 도메인 expert (customer 측 변호사 / 컴플 담당 / 기록사) 가 gold valid_time +
+  gold doc 라벨링 (월 30 쿼리)
+- LRB Phase B scorer 적용
+
+**Pass threshold**: 0.65 (LRB Phase B S2 의 JAMES 0.713 보다 보수적;
+production query distribution 이 fixture 보다 hard 할 수 있음)
+
+### 4.3 Core regression 측정 — F.2
+
+**측정**:
+- Pilot 기간 동안 main 에 머지된 모든 core/ PR 에 대해 RAB Phase 3
+  S2 측정 자동 실행 (CI)
+- AC/RF/PC 각각 baseline 대비 Δ 계산
+- Δ ≤ -0.01 in any axis = regression
+
+**Pass threshold**: Δ ≤ −0.01 발생 PR 0개. 발생 시 → 같은 cycle 안에
+revert OR fix.
+
+### 4.4 User-base / NPS — F.3, F.7
+
+**측정**:
+- Weekly active users = audit_log 의 사용자 별 ANSWER 호출 횟수 ≥ 5 회/주
+- NPS = 6 개월 exit survey (한국 기준 0-10 scale, 9-10 promoter, 0-6
+  detractor; NPS = % promoter − % detractor)
+
+### 4.5 Incident tracking — F.6
+
+**측정**:
+- Severity 정의: P1 = 서비스 중단 또는 데이터 손실; P2 = 기능 제한 또는
+  성능 저하; P3 = minor
+- Incident log = customer + JAMES 양쪽 보유
+
+**Pass threshold**: P1 = 0, P2 ≤ 2.
+
+## 5. Risk + mitigation matrix
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **R.1** Customer 데이터 leak (외부) | low | catastrophic | Workspace 격리 + audit_bridge 격리 + DPA 사전 합의 + 정기 보안 audit |
+| **R.2** Customer core/ 수정 요청 | high | high | CLAUDE.md rule #1 enforced — packs/<domain>/ 로 분리. 거부 가능. |
+| **R.3** Pilot 기간 중 core/ 머지로 regression | medium | high | F.2 CI 자동 측정 + revert 절차 사전 합의 |
+| **R.4** 6 개월 내 pilot 중단 (customer 측 사유) | medium | catastrophic | Pilot 시작 시 6 개월 commit clause + monthly checkpoint |
+| **R.5** 측정 baseline 측정 불가 (corpus 불완전 / 동의 부족) | medium | high | Kickoff 시 corpus 사이즈 / 동의 명시 + 측정 가능 minimum 보장 |
+| **R.6** RAB / LRB metric 이 도메인 reality 와 mismatch | medium | medium | Pilot kickoff 시 도메인-specific 보완 metric (도메인 expert 가 정의) |
+| **R.7** Customer staff turnover → pilot momentum 상실 | low | medium | Pilot sponsor + 백업 sponsor 양측 commit |
+| **R.8** 가격 협상 결렬 | medium | high | Pilot 가격 = 진입 friction 최소화 (cost-recovery 기반); 정식 v1.0 후 가격 협상 |
+| **R.9** LRB / RAB 의 외부 발표가 customer 데이터 노출 | low | high | Customer 데이터 = pilot evidence 의 anonymized aggregate 만 외부 발표; 사전 합의 |
+| **R.10** Pilot 결과 negative → 모체 platform credibility 손상 | low | medium | Honest framing rule (cycle γ 패턴) — negative 결과도 publish, "what we learned" framing |
+
+## 6. Customer responsibility vs JAMES responsibility
+
+### 6.1 Customer 측
+
+- Pilot sponsor 임원 + 부서장 + 운영 PIC 3-tier 책임자 지정
+- 초기 corpus 제공 + 분류 + ingest 권한
+- 사용자 onboarding 협조 (50+ active)
+- Monthly retro 참여
+- 도메인 expert 의 monthly gold labeling (LRB R@1 측정 용)
+- 보안 / compliance 검토 (DPA / NDA / IRB if applicable)
+
+### 6.2 JAMES 측 (operator)
+
+- Workspace 격리 instance 배포 + 운영
+- Monthly RAB / LRB measurement + report
+- Weekly office hour + incident response
+- 도메인-specific UI extension (packs/<domain>/) 개발
+- Pilot 종료 후 handover doc + 데이터 export (customer 보유)
+
+### 6.3 공동 책임
+
+- Success metric 합의 + 측정 protocol lock (kickoff week)
+- Monthly checkpoint
+- Risk register 공동 관리
+
+## 7. Pricing model (cost-recovery baseline)
+
+Pilot 의 목표는 *제품 검증* (Dim F gate). Pricing 은 friction 최소화 우선.
+
+**옵션**:
+- **A. Free pilot** (6 개월 무료, 결과 공동 발표권) — 외부 인정 가속 +
+  publication evidence 강함
+- **B. Cost-recovery** (인프라 + operator 시간 실비) — JAMES 측 부담 최소
+- **C. Discounted commercial** (정상 가격의 30-50%) — customer commit 강함
+
+권고: **B (cost-recovery) + 옵션 A 의 발표권 별도 협상**. Pilot 종료
+시 정식 가격 = v1.0 진입 후 별도 협상.
+
+**예상 cost-recovery 견적**:
+- 인프라 (cloud or on-prem hosting): 월 50-200 만원
+- Operator 시간 (월 40-60 시간): 월 400-600 만원
+- 총: 월 450-800 만원 × 6 = **2,700-4,800 만원** (pilot 전체)
+
+## 8. Pilot 시작 prerequisite
+
+진입 전 확인:
+
+- [ ] LOI 서명 (customer 측, 6 개월 commit + 가격 모델 합의)
+- [ ] NDA + DPA 양방 서명
+- [ ] Pilot sponsor 3-tier 지정
+- [ ] 초기 corpus 정의 + 동의 (사이즈 / 카테고리 / 민감등급)
+- [ ] Success metric 합의 + 측정 protocol lock (이 doc §4 + 도메인-specific 보완)
+- [ ] Workspace 격리 spec 합의 (배포 위치 / 데이터 흐름 / 백업)
+- [ ] 보안 검토 통과 (customer 측 정책 정합)
+- [ ] Pilot 가격 모델 confirm
+- [ ] (도메인-specific) IRB / 법적 검토 통과 (Healthcare / Legal 등)
+
+진입 후 첫 30일 내:
+- [ ] JAMES instance 배포 완료
+- [ ] 초기 corpus ingest 완료
+- [ ] 10-20 명 friendly user onboarding
+- [ ] Baseline RAB / LRB 측정 완료
+- [ ] Monthly checkpoint 첫 회의
+
+## 9. Pilot 종료 후 path
+
+| Outcome | 다음 step |
+|---|---|
+| **Pass (F.1-F.7 충족)** | (a) 재계약 협상 + v0.5 → v1.0 진행 (b) Pilot evidence + customer attestation 외부 발표 |
+| **Partial pass (5-6 of 7)** | 부족 차원 root-cause + v0.5.x 추가 cycle 후 재측정 |
+| **Fail (< 5 of 7)** | Honest framing handover + measurement-driven discovery 재정렬. v0.5 first-domain 후보 재선정. |
+
+## 10. 관련
+
+- `docs/PLATFORM_READINESS.md` (6-dim framework, Gate v0.4)
+- `docs/strategy/v0.5-domain-candidate-evaluation-2026-06-11.md` (도메인 ranked)
+- `docs/ARCHITECTURE.md` §5.7 (trust zones / abstraction)
+- `eval/rab/SPEC-v0.1.md` (RAB SPEC — F.4 측정 기준)
+- `docs/handovers/v0.4-lrb-phase-b-cross-scenario-2026-06-11.md` (LRB — F.5 측정 baseline)
+- memory `project_r1_replayable_audit_benchmark` (RAB evidence)
+- memory `project_lrb_phase_a_smoke` (LRB evidence)
+
+---
+
+*본 doc 은 generic pilot spec. 도메인-specific 작업 = LOI 받은 후
+별도 cycle. v0.5.2 (pre-LOI customer-facing material) 가 본 doc 을
+customer-facing summary 로 변환.*


### PR DESCRIPTION
## Summary

3 solo-doable strategy/prereg docs landed in parallel:

* **Track A v0.2.1 prereg** — LRB cross-model 4-model lineup LOCK (gemma4:e4b + gemma3:12b + mxtral + claude-haiku-4-5) × 2-mode (token / LLM-grounded) × 3-SUT × 2-scenario = 48 cells. Honest tier ladder §1.4 LOCK before producer implementation.
* **Track B v0.5.0 domain ranking** — 6-dim weighted score framework. Top 1: **Legal contract review 56.0/86%** (PRIMARY). Top 5: Records mgmt 80%, Compliance 79%, HR 79%, Healthcare 79%. Reject: DevOps 69%, CRM 62%.
* **Track B v0.5.1 pilot scope spec** — Generic spec (도메인 무관). 7 success metrics → Dim F production proof gate. 6-month timeline. RAB AC / LRB R@1 / core regression CI 측정 protocol. Risk matrix 10-row. Cost-recovery pricing ~₩2.7-4.8M total.

## Why all 3 in one PR

Pre-execution docs (no code, no measurement). Cohesive strategy narrative without code-PR collision risk.

## Out of scope

* LRB cross-model producer impl + measurement — separate PR(s) after prereg merge
* v0.5.2 pre-LOI customer-facing material — next cycle
* Customer outreach — operator-led, separate cycle

Quality delta: exempt (label: docs).

## Test plan

- [x] Prereg ladder §1.4 thresholds enumerable
- [x] Domain framework dims map to measurement-evidenced moat (RAB + LRB)
- [x] Pilot spec success metrics map to Dim F gate (PLATFORM_READINESS.md)
- [x] No domain-specific implementation prematurely promised

🤖 Generated with [Claude Code](https://claude.com/claude-code)