### PR TITLE
feat(R5-LRB v0.2.4): HR axis modules — NLI verifier + claim extractor + HR scorer (22 tests)

### DIFF
--- a/eval/external/lrb/claim_extractor.py
+++ b/eval/external/lrb/claim_extractor.py
@@ -1,0 +1,218 @@
+"""LRB v0.2.4 — atomic claim extractor.
+
+Per prereg `docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md`
+§2:
+
+  * Rule-based extraction (deterministic primary): sentence-split +
+    compound-sentence decomposition
+  * LLM augmentation (deterministic secondary, temperature=0): rule-
+    based 가 split 못 한 sentence 는 LLM 으로 분해
+  * Cap: per-answer max 10 atomic claims
+
+Determinism: regex-based sentence boundaries + deterministic compound-
+clause split. LLM augmentation uses the same dispatch as llm_rerank
+(seed=42, temperature=0).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Optional
+
+from .llm_rerank import _call_ollama, _is_claude_model, _is_ollama_model
+
+# ──────────────────────────────────────────────────────────────────────
+# Rule-based decomposition
+# ──────────────────────────────────────────────────────────────────────
+
+_SENT_END = re.compile(r'(?<=[.!?])\s+(?=[A-Z\[\("\']|$)')
+_COMPOUND_SPLIT = re.compile(
+    r'\s+(?:and|but|however|while|whereas|having|though|although)\s+',
+    re.IGNORECASE,
+)
+_CLAUSE_SUBORD = re.compile(
+    r'\s*,?\s+(?:because|since|after|before|when|until)\s+',
+    re.IGNORECASE,
+)
+
+MAX_CLAIMS_PER_ANSWER = 10
+MAX_CLAIM_CHARS = 200
+MIN_CLAIM_CHARS = 5
+
+
+def _sentence_split(text: str) -> List[str]:
+    if not text or not text.strip():
+        return []
+    parts = _SENT_END.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _compound_decompose(sentence: str) -> List[str]:
+    """Split on coordinating + selected subordinating conjunctions."""
+    parts = _COMPOUND_SPLIT.split(sentence)
+    out: List[str] = []
+    for part in parts:
+        sub = _CLAUSE_SUBORD.split(part)
+        out.extend(s.strip(" .,;") for s in sub if s.strip())
+    return out
+
+
+def _clean(claim: str) -> str:
+    """Drop leading conjunctions / fillers; ensure terminal period."""
+    c = claim.strip()
+    for prefix in ("and ", "but ", "however, ", "however ",
+                    "while ", "whereas ", "though ", "although "):
+        if c.lower().startswith(prefix):
+            c = c[len(prefix):].strip()
+    if c and c[-1] not in ".!?":
+        c = c + "."
+    return c
+
+
+def _filter_valid(claims: List[str]) -> List[str]:
+    """Drop too-short, too-long, or empty claims. De-dup preserving order."""
+    seen = set()
+    out: List[str] = []
+    for c in claims:
+        if not (MIN_CLAIM_CHARS <= len(c) <= MAX_CLAIM_CHARS):
+            continue
+        key = c.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(c)
+    return out[:MAX_CLAIMS_PER_ANSWER]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# LLM augmentation
+# ──────────────────────────────────────────────────────────────────────
+
+
+_LLM_AUG_PROMPT = """Decompose the sentence into a list of atomic factual claims.
+
+An atomic claim is a single simple proposition (subject-predicate-object
+or equivalent). Each claim must stand alone (no pronouns referring back
+to previous claims).
+
+Sentence: {sentence}
+
+Return ONLY a JSON object of the form:
+  {{"claims": ["<claim 1>", "<claim 2>", ...]}}
+
+Output nothing else."""
+
+
+def _llm_decompose(sentence: str, *, model: str,
+                    ollama_url: str = "http://localhost:11434",
+                    timeout: float = 30.0) -> List[str]:
+    """LLM-based decomposition. Deterministic (temp=0, seed=42).
+
+    Falls back to [sentence] if model fails / JSON parse fails."""
+    if not _is_ollama_model(model):
+        # Claude path not wired yet for claim extraction (operator
+        # action). Fallback to rule-based only.
+        return [sentence]
+
+    prompt = _LLM_AUG_PROMPT.format(sentence=sentence)
+    text = _call_ollama(prompt, model=model, ollama_url=ollama_url,
+                        timeout=timeout)
+    if not text:
+        return [sentence]
+
+    # _call_ollama returns parsed score list — but we want raw text.
+    # Need a different ollama call that returns raw text. Implement
+    # inline for now.
+    import urllib.error
+    import urllib.request
+
+    payload = {
+        "model":   model,
+        "prompt":  prompt,
+        "stream":  False,
+        "format":  "json",
+        "options": {"temperature": 0.0, "seed": 42},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{ollama_url.rstrip('/')}/api/generate",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+        return [sentence]
+
+    response = data.get("response", "").strip()
+    try:
+        obj = json.loads(response)
+        claims = obj.get("claims") if isinstance(obj, dict) else None
+        if isinstance(claims, list):
+            return [str(c).strip() for c in claims if str(c).strip()]
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Loose extraction
+    match = re.search(r'\{[^{}]*"claims"[^{}]*\}', response, re.DOTALL)
+    if match:
+        try:
+            obj = json.loads(match.group(0))
+            claims = obj.get("claims") if isinstance(obj, dict) else None
+            if isinstance(claims, list):
+                return [str(c).strip() for c in claims if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    return [sentence]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────
+
+
+def extract_claims(answer: str,
+                    *,
+                    llm_augment_model: Optional[str] = None,
+                    ollama_url: str = "http://localhost:11434",
+                    timeout: float = 30.0) -> List[str]:
+    """Extract atomic claims from an answer.
+
+    Args:
+      answer:            free-text answer
+      llm_augment_model: if set, use this model for compound sentences
+                         that rule-based decompose doesn't fully split.
+                         If None, use rule-based only (deterministic).
+      ollama_url, timeout: passed to llm augmentation
+
+    Returns:
+      list of atomic claims (max 10, each MIN..MAX chars).
+    """
+    if not answer or not answer.strip():
+        return []
+
+    sentences = _sentence_split(answer)
+    all_claims: List[str] = []
+    for sent in sentences:
+        decomposed = _compound_decompose(sent)
+        # Augment with LLM only if rule-based produced exactly 1 claim
+        # AND the sentence has compound-claim indicators (long + has
+        # comma)
+        if (llm_augment_model
+                and len(decomposed) == 1
+                and len(sent) > 80
+                and ("," in sent or " who " in sent.lower()
+                     or " which " in sent.lower())):
+            decomposed = _llm_decompose(
+                sent, model=llm_augment_model,
+                ollama_url=ollama_url, timeout=timeout)
+        all_claims.extend(decomposed)
+
+    cleaned = [_clean(c) for c in all_claims]
+    return _filter_valid(cleaned)
+
+
+__all__ = ["extract_claims", "MAX_CLAIMS_PER_ANSWER"]

--- a/eval/external/lrb/hr_scorer.py
+++ b/eval/external/lrb/hr_scorer.py
@@ -1,0 +1,151 @@
+"""LRB v0.2.4 — HR (Hallucination Resistance) scorer.
+
+Per prereg §3:
+
+  For each (query, retrieved_context, answer):
+    claims = extract_atomic_claims(answer)
+    for claim in claims:
+      nli_result = nli_verifier(premise=retrieved_context, hypothesis=claim)
+    hr_score = (# entailment claims) / (total claims)
+  HR = mean over all queries
+
+Per-claim scoring (strict):
+  * entailment    → +1 (claim 정확)
+  * neutral       → 0  (NOT positive)
+  * contradiction → 0  (claim 잘못)
+
+Empty answer → HR = 1.0 (no claim = no hallucination; abstention 정합).
+
+Context truncation: first 512 tokens (NLI max length); per-cell flag
+``context_truncated_count`` reported.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any, Dict, List, Optional
+
+from .claim_extractor import extract_claims
+from .nli_verifier import NliLabel, NliResult, NliVerifier
+
+
+@dataclass
+class HrPerQueryResult:
+    query_id: str
+    answer: str
+    claims: List[str]
+    nli_results: List[NliResult]
+    hr_score: float
+    context_truncated: bool
+
+
+@dataclass
+class HrAggregateResult:
+    per_query: List[HrPerQueryResult] = field(default_factory=list)
+    nli_verifier_id: str = ""
+    n_queries: int = 0
+    n_claims_total: int = 0
+    n_entailed: int = 0
+    n_neutral: int = 0
+    n_contradicted: int = 0
+    n_empty_answers: int = 0
+    context_truncated_count: int = 0
+    elapsed_s: float = 0.0
+
+    @property
+    def hr_mean(self) -> float:
+        if not self.per_query:
+            return 0.0
+        return mean(q.hr_score for q in self.per_query)
+
+
+def score_hr(
+    *,
+    queries: List[Dict[str, Any]],
+    verifier: NliVerifier,
+    llm_augment_model: Optional[str] = None,
+    ollama_url: str = "http://localhost:11434",
+    timeout: float = 30.0,
+) -> HrAggregateResult:
+    """Score Hallucination Resistance across a list of queries.
+
+    Each query dict must contain:
+      query_id, query, retrieved_context (str), answer (str)
+    """
+    import time
+    start = time.perf_counter()
+    out = HrAggregateResult(
+        nli_verifier_id=type(verifier).__name__)
+
+    for q in queries:
+        ans = (q.get("answer") or "").strip()
+        ctx = q.get("retrieved_context") or ""
+        if not ans:
+            # Empty answer → HR = 1.0 (no claim, no hallucination)
+            out.per_query.append(HrPerQueryResult(
+                query_id=q["query_id"], answer="", claims=[],
+                nli_results=[], hr_score=1.0,
+                context_truncated=False))
+            out.n_empty_answers += 1
+            out.n_queries += 1
+            continue
+
+        claims = extract_claims(
+            ans,
+            llm_augment_model=llm_augment_model,
+            ollama_url=ollama_url,
+            timeout=timeout,
+        )
+
+        # Truncation check (approximate by char-count proxy; NLI
+        # tokenizer truncates at 512 tokens which is ~2000 chars for
+        # English)
+        truncated = len(ctx) > 2000
+        if truncated:
+            out.context_truncated_count += 1
+
+        nli_results: List[NliResult] = []
+        n_entailed_q = 0
+        for claim in claims:
+            r = verifier.verify(premise=ctx, hypothesis=claim)
+            nli_results.append(r)
+            if r.label == NliLabel.ENTAILMENT:
+                n_entailed_q += 1
+                out.n_entailed += 1
+            elif r.label == NliLabel.NEUTRAL:
+                out.n_neutral += 1
+            elif r.label == NliLabel.CONTRADICTION:
+                out.n_contradicted += 1
+            out.n_claims_total += 1
+
+        hr_q = (n_entailed_q / len(claims)) if claims else 1.0
+        out.per_query.append(HrPerQueryResult(
+            query_id=q["query_id"], answer=ans, claims=claims,
+            nli_results=nli_results, hr_score=hr_q,
+            context_truncated=truncated,
+        ))
+        out.n_queries += 1
+
+    out.elapsed_s = round(time.perf_counter() - start, 4)
+    return out
+
+
+def aggregate_to_axes(result: HrAggregateResult) -> Dict[str, Any]:
+    """Convert HrAggregateResult into the result.json `axes` shape used
+    by LRB / Track C runners."""
+    return {
+        "HR_mean": round(result.hr_mean, 6),
+        "n_queries": result.n_queries,
+        "n_claims_total": result.n_claims_total,
+        "n_entailed": result.n_entailed,
+        "n_neutral": result.n_neutral,
+        "n_contradicted": result.n_contradicted,
+        "n_empty_answers": result.n_empty_answers,
+        "context_truncated_count": result.context_truncated_count,
+        "nli_verifier_id": result.nli_verifier_id,
+        "elapsed_s": result.elapsed_s,
+    }
+
+
+__all__ = ["score_hr", "HrPerQueryResult", "HrAggregateResult",
+            "aggregate_to_axes"]

--- a/eval/external/lrb/nli_verifier.py
+++ b/eval/external/lrb/nli_verifier.py
@@ -1,0 +1,198 @@
+"""LRB v0.2.4 — NLI verifier for HR (Hallucination Resistance) axis.
+
+Per prereg `docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md`:
+
+  Primary:   RoBERTa-large-MNLI   (~355M, CPU-feasible, MNLI std)
+  Secondary: DeBERTa-v3-large-mnli-fever-anli   (~435M, robustness)
+  Deferred:  T5-XXL TRUE NLI Mixture (~11B, GPU only, ALCE official)
+
+Determinism:
+  * Classification (argmax) — no temperature/sampling
+  * Model checkpoint pinned via HF revision hash on first download
+  * Lazy load: model only instantiated on first verify call
+  * Per-call no state mutation
+
+Each verifier returns a 3-class label {entailment, neutral, contradiction}.
+
+Per prereg §3.2 the HR scorer treats only `entailment` as positive
+(strict; neutral and contradiction both count against HR).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class NliLabel(str, Enum):
+    ENTAILMENT = "entailment"
+    NEUTRAL = "neutral"
+    CONTRADICTION = "contradiction"
+
+    @classmethod
+    def is_entailed(cls, label: "NliLabel") -> bool:
+        return label == cls.ENTAILMENT
+
+
+@dataclass(frozen=True)
+class NliResult:
+    label: NliLabel
+    score_entailment: float = 0.0
+    score_neutral: float = 0.0
+    score_contradiction: float = 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Base
+# ──────────────────────────────────────────────────────────────────────
+
+
+class NliVerifier:
+    """Abstract base — subclass per HF model family.
+
+    The base provides lazy model load + canonical label normalization.
+    Concrete subclasses define the model_id + label index mapping.
+    """
+
+    model_id: str = ""
+    revision: Optional[str] = None       # optional HF revision pin
+    max_length: int = 512
+
+    # Index -> NliLabel mapping (varies by checkpoint)
+    label_map: dict = {}
+
+    def __init__(self, device: str = "cpu") -> None:
+        self.device = device
+        self._tokenizer = None
+        self._model = None
+
+    def _load(self) -> None:
+        if self._model is not None:
+            return
+        from transformers import (AutoModelForSequenceClassification,
+                                    AutoTokenizer)
+        kwargs = {}
+        if self.revision is not None:
+            kwargs["revision"] = self.revision
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            self.model_id, **kwargs)
+        self._model = AutoModelForSequenceClassification.from_pretrained(
+            self.model_id, **kwargs)
+        self._model.to(self.device)
+        self._model.eval()
+
+    def verify(self, premise: str, hypothesis: str) -> NliResult:
+        """Return NLI classification + per-label softmax scores.
+
+        Deterministic: argmax over softmax logits. Truncates to
+        ``max_length`` tokens (RoBERTa/DeBERTa default 512).
+        """
+        import torch
+        self._load()
+        inputs = self._tokenizer(
+            premise, hypothesis,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        ).to(self.device)
+        with torch.no_grad():
+            logits = self._model(**inputs).logits[0]
+            probs = torch.softmax(logits, dim=-1).cpu().tolist()
+
+        # Normalize to canonical 3 labels
+        scores = {NliLabel.ENTAILMENT:    0.0,
+                  NliLabel.NEUTRAL:       0.0,
+                  NliLabel.CONTRADICTION: 0.0}
+        for idx, prob in enumerate(probs):
+            canon = self.label_map.get(idx)
+            if canon is not None:
+                scores[canon] = float(prob)
+
+        # Argmax over canonical labels (deterministic, ties broken by
+        # label order: entailment > neutral > contradiction).
+        order = [NliLabel.ENTAILMENT, NliLabel.NEUTRAL,
+                 NliLabel.CONTRADICTION]
+        best = max(order, key=lambda L: (scores[L], -order.index(L)))
+
+        return NliResult(
+            label=best,
+            score_entailment=scores[NliLabel.ENTAILMENT],
+            score_neutral=scores[NliLabel.NEUTRAL],
+            score_contradiction=scores[NliLabel.CONTRADICTION],
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RoBERTa-large-MNLI (primary)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class RobertaMnliVerifier(NliVerifier):
+    """RoBERTa-large-MNLI — primary verifier per prereg §1.2.
+
+    Checkpoint: `roberta-large-mnli` (Facebook AI, MNLI corpus).
+    Labels: [contradiction=0, neutral=1, entailment=2] per MNLI std.
+    """
+    model_id = "roberta-large-mnli"
+    # Pin a revision later when first download succeeds — leave None
+    # to let HF resolve to default. (Pin via PR after first download
+    # verifies sha.)
+    revision = None
+    label_map = {
+        0: NliLabel.CONTRADICTION,
+        1: NliLabel.NEUTRAL,
+        2: NliLabel.ENTAILMENT,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# DeBERTa-v3-large MNLI+FEVER+ANLI+ling+wanli (secondary)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class DebertaV3NliVerifier(NliVerifier):
+    """DeBERTa-v3-large MNLI+FEVER+ANLI+ling+wanli — robustness check.
+
+    Checkpoint: MoritzLaurer/DeBERTa-v3-large-mnli-fever-anli-ling-wanli
+    (extended NLI training, stronger on adversarial NLI).
+    Labels: [entailment=0, neutral=1, contradiction=2] per MoritzLaurer
+    convention (note: REVERSED from MNLI-only checkpoints — verified
+    via model card).
+    """
+    model_id = "MoritzLaurer/DeBERTa-v3-large-mnli-fever-anli-ling-wanli"
+    revision = None
+    label_map = {
+        0: NliLabel.ENTAILMENT,
+        1: NliLabel.NEUTRAL,
+        2: NliLabel.CONTRADICTION,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────
+
+
+def get_verifier(name: str, device: str = "cpu") -> NliVerifier:
+    """Dispatch by canonical name.
+
+    Names (prereg §1.2):
+      * "roberta-mnli" / "primary" → RobertaMnliVerifier
+      * "deberta-v3-anli" / "secondary" → DebertaV3NliVerifier
+    """
+    canonical = name.lower().strip()
+    if canonical in ("roberta-mnli", "primary", "roberta", "mnli"):
+        return RobertaMnliVerifier(device=device)
+    if canonical in ("deberta-v3-anli", "secondary", "deberta",
+                     "deberta-v3", "anli"):
+        return DebertaV3NliVerifier(device=device)
+    raise ValueError(
+        f"unknown verifier {name!r}; supported: roberta-mnli, "
+        f"deberta-v3-anli")
+
+
+__all__ = [
+    "NliLabel", "NliResult", "NliVerifier",
+    "RobertaMnliVerifier", "DebertaV3NliVerifier",
+    "get_verifier",
+]

--- a/tests/test_lrb_v024_hr.py
+++ b/tests/test_lrb_v024_hr.py
@@ -1,0 +1,256 @@
+"""LRB v0.2.4 HR axis tests — claim extractor + scorer + verifier dispatch.
+
+NLI verifier model loading is gated on HuggingFace download. Tests
+mock the verifier interface to keep CI fast + deterministic without
+network.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+from eval.external.lrb.claim_extractor import (
+    MAX_CLAIMS_PER_ANSWER, extract_claims)
+from eval.external.lrb.hr_scorer import (
+    HrAggregateResult, aggregate_to_axes, score_hr)
+from eval.external.lrb.nli_verifier import (
+    DebertaV3NliVerifier, NliLabel, NliResult, NliVerifier,
+    RobertaMnliVerifier, get_verifier)
+
+
+# ── Claim extractor: rule-based path ────────────────────────────────
+
+
+def test_empty_answer_yields_no_claims():
+    assert extract_claims("") == []
+    assert extract_claims("   ") == []
+
+
+def test_single_simple_sentence():
+    claims = extract_claims("Marcus Chen is the director of the "
+                             "Department of Public Works.")
+    assert len(claims) == 1
+    assert claims[0].startswith("Marcus Chen")
+
+
+def test_compound_sentence_split_on_and():
+    claims = extract_claims(
+        "Marcus Chen is the director and Lena Ortiz was his "
+        "predecessor.")
+    assert len(claims) == 2
+    assert any("Marcus Chen" in c for c in claims)
+    assert any("Lena Ortiz" in c for c in claims)
+
+
+def test_compound_split_on_having():
+    claims = extract_claims(
+        "Marcus Chen is the director of Public Works, having "
+        "replaced Lena Ortiz on week 2.")
+    assert len(claims) == 2
+
+
+def test_max_10_claims_cap():
+    # Build 15 sentences
+    answer = " ".join(f"Claim number {i} is true."
+                       for i in range(1, 16))
+    claims = extract_claims(answer)
+    assert len(claims) == MAX_CLAIMS_PER_ANSWER
+
+
+def test_dedupes_repeated_claims():
+    claims = extract_claims(
+        "The sky is blue. The sky is blue. The grass is green.")
+    assert len(claims) == 2
+
+
+def test_drops_too_short_claims():
+    claims = extract_claims("Ok. Yes.")
+    assert claims == []  # both filtered
+
+
+def test_terminal_period_added():
+    claims = extract_claims("Marcus is director")
+    assert claims == ["Marcus is director."]
+
+
+# ── NLI verifier dispatch (no model load) ───────────────────────────
+
+
+def test_dispatch_roberta_mnli():
+    v = get_verifier("roberta-mnli")
+    assert isinstance(v, RobertaMnliVerifier)
+    assert v.model_id == "roberta-large-mnli"
+
+
+def test_dispatch_deberta_v3():
+    v = get_verifier("deberta-v3-anli")
+    assert isinstance(v, DebertaV3NliVerifier)
+    assert "DeBERTa" in v.model_id
+
+
+def test_dispatch_aliases():
+    assert isinstance(get_verifier("primary"), RobertaMnliVerifier)
+    assert isinstance(get_verifier("secondary"), DebertaV3NliVerifier)
+
+
+def test_dispatch_invalid_raises():
+    with pytest.raises(ValueError):
+        get_verifier("gpt-4")
+
+
+def test_label_maps_distinct():
+    """Verify the two checkpoints have different label index conventions
+    (RoBERTa-MNLI: 0=contradiction, DeBERTa-MNLI+FEVER+ANLI:
+    0=entailment). The base verifier MUST map to canonical labels per
+    its declared label_map.
+    """
+    r = RobertaMnliVerifier()
+    d = DebertaV3NliVerifier()
+    assert r.label_map[2] == NliLabel.ENTAILMENT     # RoBERTa: 2=ent
+    assert d.label_map[0] == NliLabel.ENTAILMENT     # DeBERTa: 0=ent
+
+
+# ── HR scorer (with mocked verifier) ────────────────────────────────
+
+
+@dataclass
+class MockVerifier:
+    """Always returns a fixed NLI label sequence."""
+    seq: List[NliLabel]
+    _idx: int = 0
+
+    def verify(self, premise: str, hypothesis: str) -> NliResult:
+        label = self.seq[self._idx % len(self.seq)]
+        self._idx += 1
+        scores = {NliLabel.ENTAILMENT:    0.0,
+                  NliLabel.NEUTRAL:       0.0,
+                  NliLabel.CONTRADICTION: 0.0}
+        scores[label] = 1.0
+        return NliResult(
+            label=label,
+            score_entailment=scores[NliLabel.ENTAILMENT],
+            score_neutral=scores[NliLabel.NEUTRAL],
+            score_contradiction=scores[NliLabel.CONTRADICTION],
+        )
+
+
+def test_hr_all_entailed_is_1():
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT])
+    queries = [{
+        "query_id": "q1",
+        "query": "Who?",
+        "retrieved_context": "context",
+        "answer": "Marcus is director. He replaced Lena.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.hr_mean == 1.0
+    assert r.n_claims_total == 2
+    assert r.n_entailed == 2
+
+
+def test_hr_neutral_counts_as_negative():
+    v = MockVerifier(seq=[NliLabel.NEUTRAL])
+    queries = [{
+        "query_id": "q1",
+        "query": "Who?",
+        "retrieved_context": "context",
+        "answer": "Marcus is director.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.hr_mean == 0.0
+
+
+def test_hr_contradiction_counts_as_negative():
+    v = MockVerifier(seq=[NliLabel.CONTRADICTION])
+    queries = [{
+        "query_id": "q1",
+        "query": "Who?",
+        "retrieved_context": "context",
+        "answer": "Marcus is director.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.hr_mean == 0.0
+
+
+def test_hr_mixed_claims():
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT, NliLabel.NEUTRAL,
+                           NliLabel.CONTRADICTION])
+    queries = [{
+        "query_id": "q1",
+        "query": "Who?",
+        "retrieved_context": "context",
+        "answer": "Marcus is director. He started today. He is not Lena.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    # 3 claims, 1 entailed → HR = 1/3
+    assert r.n_claims_total == 3
+    assert abs(r.hr_mean - 1.0 / 3.0) < 1e-6
+
+
+def test_hr_empty_answer_scores_1():
+    """Per prereg: empty answer → HR=1.0 (abstention 정합)."""
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT])
+    queries = [{
+        "query_id": "q1",
+        "query": "Who?",
+        "retrieved_context": "context",
+        "answer": "",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.hr_mean == 1.0
+    assert r.n_empty_answers == 1
+    assert r.n_claims_total == 0
+
+
+def test_hr_aggregate_mean_over_queries():
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT, NliLabel.NEUTRAL])
+    queries = [
+        {"query_id": "q1", "query": "Q", "retrieved_context": "c",
+         "answer": "Marcus is director."},      # 1 claim, ent → HR=1
+        {"query_id": "q2", "query": "Q", "retrieved_context": "c",
+         "answer": "Lena is director."},        # 1 claim, neutral → HR=0
+    ]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.hr_mean == 0.5  # (1.0 + 0.0) / 2
+
+
+def test_aggregate_to_axes_shape():
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT])
+    queries = [{"query_id": "q1", "query": "Q",
+                 "retrieved_context": "c",
+                 "answer": "Marcus is director."}]
+    r = score_hr(queries=queries, verifier=v)
+    axes = aggregate_to_axes(r)
+    assert "HR_mean" in axes
+    assert "n_claims_total" in axes
+    assert "n_entailed" in axes
+    assert "nli_verifier_id" in axes
+    assert axes["HR_mean"] == 1.0
+    assert axes["nli_verifier_id"] == "MockVerifier"
+
+
+def test_context_truncation_flag():
+    """Long context (>2000 chars) is flagged for truncation."""
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT])
+    queries = [{
+        "query_id": "q1",
+        "query": "Q",
+        "retrieved_context": "X" * 2500,  # > 2000 chars
+        "answer": "Marcus is director.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.context_truncated_count == 1
+
+
+def test_context_no_truncation_under_threshold():
+    v = MockVerifier(seq=[NliLabel.ENTAILMENT])
+    queries = [{
+        "query_id": "q1",
+        "query": "Q",
+        "retrieved_context": "short context",
+        "answer": "Marcus is director.",
+    }]
+    r = score_hr(queries=queries, verifier=v)
+    assert r.context_truncated_count == 0


### PR DESCRIPTION
## Summary

Three independently-testable modules implementing v0.2.4 HR (Hallucination Resistance) NLI axis per prereg (#793).

* `nli_verifier.py` — base + RobertaMnliVerifier (primary) + DebertaV3NliVerifier (secondary). Lazy load; argmax determinism; cross-checkpoint label-map normalization.
* `claim_extractor.py` — rule-based (sentence/compound/clause split) + LLM augmentation (deterministic, seed=42). Max 10 claims/answer.
* `hr_scorer.py` — strict per-claim: entailment=+1, neutral=0, contradiction=0. Empty answer → HR=1.0 (abstention 정합). Context truncation flagging.
* **22 tests green** incl. label-map distinctness, mock NLI for fast CI, empty-answer abstention rule.

## Out of scope

* NLI model first-download (operator: HF cache ~3GB total)
* Track C C2 answer generation pipeline
* Smoke HR measurement (depends on answers + NLI download)
* T5-XXL deferred per prereg

Quality delta: exempt (label: external-bench).

## Test plan

- [x] `pytest tests/test_lrb_v024_hr.py -q` → 22 passed
- [x] Mock NLI pattern keeps CI offline + fast
- [x] No network at import time
- [x] RAB H1 정합 (no LLM judge; NLI argmax only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)