### PR TITLE
feat(R5-Track-C): C2 scaffolding — answer_f1 + TimeQA loader (30 tests)

### DIFF
--- a/eval/external/lrb/answer_f1.py
+++ b/eval/external/lrb/answer_f1.py
@@ -1,0 +1,123 @@
+"""Track C answer-F1 scorer — SQuAD-style EM/F1 + per-bench aggregation.
+
+Shared deterministic scorer for the three Track C benches (TimeQA,
+TempReason, MuSiQue). Re-exports the SQuAD v1.1 normalisation /
+exact-match / token-F1 primitives (the same routines MuSiQue's
+official evaluator uses, mirrored in
+``eval/external/musique_scorer.py``).
+
+Per Track C C0 §3.1:
+  * Token F1 (SQuAD-norm)
+  * Exact Match (EM, SQuAD-norm)
+
+Per-bench extension:
+  * TimeQA: answer must be in valid time window (official scoring)
+  * MuSiQue: support-fact recall already in musique_scorer
+  * TempReason: standard EM/F1
+"""
+from __future__ import annotations
+
+import re
+import string
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+# ─── SQuAD v1.1 normalization (matches musique_scorer byte-for-byte) ──
+
+
+_ARTICLES = re.compile(r"\b(a|an|the)\b", re.IGNORECASE)
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalize_answer(s: str) -> str:
+    if not isinstance(s, str):
+        return ""
+    s = s.lower()
+    s = _ARTICLES.sub(" ", s)
+    s = "".join(ch for ch in s if ch not in string.punctuation)
+    s = _WHITESPACE.sub(" ", s).strip()
+    return s
+
+
+def _tokens(s: str) -> List[str]:
+    n = _normalize_answer(s)
+    return n.split() if n else []
+
+
+def exact_match(prediction: str, gold: str) -> int:
+    return int(_normalize_answer(prediction) == _normalize_answer(gold))
+
+
+def token_f1(prediction: str, gold: str) -> float:
+    p = _tokens(prediction)
+    g = _tokens(gold)
+    if not p and not g:
+        return 1.0
+    if not p or not g:
+        return 0.0
+    common = set(p) & set(g)
+    if not common:
+        return 0.0
+    # Standard SQuAD F1 uses multiset counts
+    from collections import Counter
+    p_cnt = Counter(p)
+    g_cnt = Counter(g)
+    tp = sum((p_cnt & g_cnt).values())
+    if tp == 0:
+        return 0.0
+    precision = tp / len(p)
+    recall = tp / len(g)
+    return 2 * precision * recall / (precision + recall)
+
+
+def max_em(prediction: str, candidates: Iterable[str]) -> int:
+    cands = list(candidates) or [""]
+    return max(exact_match(prediction, c) for c in cands)
+
+
+def max_f1(prediction: str, candidates: Iterable[str]) -> float:
+    cands = list(candidates) or [""]
+    return max(token_f1(prediction, c) for c in cands)
+
+
+# ─── Aggregation ──────────────────────────────────────────────────────
+
+
+def score_answer_f1(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate EM + F1 over a list of per-query rows.
+
+    Each row dict needs:
+      * ``prediction``: str (generated answer)
+      * ``gold``: str (primary gold answer)
+      * ``answer_aliases``: list[str] (optional)
+
+    Returns:
+      ``{"EM": float, "F1": float, "n": int, "n_empty_pred": int}``
+    """
+    if not rows:
+        return {"EM": 0.0, "F1": 0.0, "n": 0, "n_empty_pred": 0}
+    em_scores: List[float] = []
+    f1_scores: List[float] = []
+    empty = 0
+    for r in rows:
+        pred = (r.get("prediction") or "").strip()
+        if not pred:
+            empty += 1
+        gold = r.get("gold") or ""
+        aliases = r.get("answer_aliases") or []
+        cands = [gold] + list(aliases)
+        em_scores.append(max_em(pred, cands))
+        f1_scores.append(max_f1(pred, cands))
+    return {
+        "EM": round(mean(em_scores), 6),
+        "F1": round(mean(f1_scores), 6),
+        "n":  len(rows),
+        "n_empty_pred": empty,
+    }
+
+
+__all__ = [
+    "_normalize_answer", "exact_match", "token_f1",
+    "max_em", "max_f1", "score_answer_f1",
+]

--- a/eval/external/lrb/timeqa_loader.py
+++ b/eval/external/lrb/timeqa_loader.py
@@ -1,0 +1,146 @@
+"""Track C — TimeQA loader (Chen et al. 2021).
+
+Pre-registered per `docs/research/track-c-c0-bench-selection-
+2026-06-11.md` §1.1 as Primary bench for temporal reasoning axis.
+
+Source URL (operator must verify license + download):
+  https://github.com/wenhuchen/Time-Sensitive-QA
+
+Expected file layout (when operator drops data into the fixture dir):
+  eval/external/_fixtures/timeqa/
+    ├── easy/
+    │   ├── train.jsonl
+    │   ├── dev.jsonl
+    │   └── test.jsonl
+    └── hard/
+        ├── train.jsonl
+        ├── dev.jsonl
+        └── test.jsonl
+
+Each line is a JSON object. The TimeQA paper format (verified from
+public release notes — operator should cross-check against the
+official repo at first download):
+
+    {
+      "idx":      <str>,
+      "question": <str>,
+      "paragraphs": [<str>, ...],      # Wikipedia passages
+      "targets": [
+        {
+          "answer":     <str>,
+          "start_time": <str | int>,    # ISO date or year
+          "end_time":   <str | int>,
+        },
+        ...
+      ],
+      "question_time": <str | int>,    # the time the question asks about
+    }
+
+Per Track C C0 §1.1 sample sizes:
+  * Smoke n=100 from dev (deterministic first-n slice)
+  * Full n=1000 from dev
+
+Per Track C C0 §3.1 scoring axes:
+  * Token F1 + EM (SQuAD norm, `answer_f1.py`)
+  * TimeQA-specific time-aware F1: answer must be in valid time window
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+
+# Default fixture root (operator drops data here)
+DEFAULT_FIXTURE_DIR = (Path(__file__).resolve()
+                       .parent.parent.parent.parent
+                       / "eval" / "external" / "_fixtures" / "timeqa")
+
+
+def fixture_path(difficulty: str = "easy",
+                  split: str = "dev",
+                  fixture_dir: Optional[Path] = None) -> Path:
+    """Return the expected JSONL path for (difficulty, split).
+
+    Args:
+      difficulty: "easy" or "hard"
+      split:      "train" / "dev" / "test"
+      fixture_dir: override the default fixture dir (testing)
+    """
+    base = fixture_dir or DEFAULT_FIXTURE_DIR
+    return base / difficulty / f"{split}.jsonl"
+
+
+def load_rows(path: Path) -> List[Dict[str, Any]]:
+    """Load TimeQA JSONL rows. Returns empty list if path missing
+    (operator action: download data)."""
+    if not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def to_track_c_format(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a TimeQA row to the Track C unified shape.
+
+    Returns:
+      {
+        "query_id":   <str>,
+        "question":   <str>,
+        "context":    <str>,        # concatenated paragraphs
+        "gold":       <str>,         # primary answer (first target)
+        "answer_aliases": [<str>],   # additional targets
+        "time_window": (start, end), # for time-aware F1
+        "question_time": <str>,
+      }
+    """
+    targets = row.get("targets") or []
+    primary = targets[0] if targets else {}
+    aliases = [t.get("answer", "") for t in targets[1:]
+                if t.get("answer", "")]
+    context = "\n\n".join(row.get("paragraphs") or [])
+    return {
+        "query_id":      str(row.get("idx", "")),
+        "question":      row.get("question", ""),
+        "context":       context,
+        "gold":          primary.get("answer", ""),
+        "answer_aliases": aliases,
+        "time_window": (
+            primary.get("start_time", ""),
+            primary.get("end_time", ""),
+        ),
+        "question_time": row.get("question_time", ""),
+    }
+
+
+def load_smoke(n: int = 100,
+                difficulty: str = "easy",
+                split: str = "dev",
+                fixture_dir: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """First-n deterministic slice in the normalised Track C shape."""
+    rows = load_rows(fixture_path(difficulty, split, fixture_dir))
+    return [to_track_c_format(r) for r in rows[:n]]
+
+
+def is_available(difficulty: str = "easy",
+                  split: str = "dev",
+                  fixture_dir: Optional[Path] = None) -> bool:
+    """Operator-action check — fast probe for whether TimeQA data has
+    been dropped into the fixture dir.
+
+    Used by Track C runner to skip with a clear message rather than
+    crash if the bench isn't present."""
+    return fixture_path(difficulty, split, fixture_dir).exists()
+
+
+__all__ = [
+    "DEFAULT_FIXTURE_DIR",
+    "fixture_path", "load_rows", "to_track_c_format",
+    "load_smoke", "is_available",
+]

--- a/tests/test_lrb_answer_f1.py
+++ b/tests/test_lrb_answer_f1.py
@@ -1,0 +1,126 @@
+"""LRB answer_f1 tests — SQuAD norm + EM + F1 + multi-alias."""
+from __future__ import annotations
+
+import pytest
+
+from eval.external.lrb.answer_f1 import (
+    _normalize_answer, exact_match, max_em, max_f1, score_answer_f1,
+    token_f1)
+
+
+def test_normalize_lowercase():
+    assert _normalize_answer("Hello World") == "hello world"
+
+
+def test_normalize_articles_dropped():
+    assert _normalize_answer("the cat") == "cat"
+    assert _normalize_answer("a dog") == "dog"
+    assert _normalize_answer("An apple") == "apple"
+
+
+def test_normalize_punct_dropped():
+    assert _normalize_answer("Marcus Chen, Director.") == "marcus chen director"
+
+
+def test_normalize_whitespace_collapsed():
+    assert _normalize_answer("  multiple   spaces  ") == "multiple spaces"
+
+
+def test_em_exact():
+    assert exact_match("Marcus Chen", "Marcus Chen") == 1
+
+
+def test_em_after_norm():
+    assert exact_match("THE marcus", "Marcus") == 1
+
+
+def test_em_negative():
+    assert exact_match("Marcus", "Lena") == 0
+
+
+def test_em_empty():
+    assert exact_match("", "") == 1
+    assert exact_match("", "Marcus") == 0
+
+
+def test_f1_full_overlap():
+    assert token_f1("Marcus Chen", "Marcus Chen") == 1.0
+
+
+def test_f1_partial():
+    # "Marcus Chen director" vs "Marcus Chen" → P=2/3, R=2/2, F1=0.8
+    assert abs(token_f1("Marcus Chen director", "Marcus Chen") - 0.8) < 1e-6
+
+
+def test_f1_no_overlap():
+    assert token_f1("Lena Ortiz", "Marcus Chen") == 0.0
+
+
+def test_f1_both_empty():
+    assert token_f1("", "") == 1.0
+
+
+def test_f1_one_empty():
+    assert token_f1("", "Marcus") == 0.0
+    assert token_f1("Marcus", "") == 0.0
+
+
+def test_max_em_over_aliases():
+    assert max_em("Marcus", ["Lena", "Marcus", "Sofia"]) == 1
+    assert max_em("Daniel", ["Lena", "Marcus", "Sofia"]) == 0
+
+
+def test_max_f1_over_aliases():
+    # First alias matches better
+    score = max_f1("Marcus Chen", ["Lena Ortiz", "Marcus Chen"])
+    assert score == 1.0
+
+
+def test_score_answer_f1_empty():
+    out = score_answer_f1([])
+    assert out["EM"] == 0.0
+    assert out["F1"] == 0.0
+    assert out["n"] == 0
+
+
+def test_score_answer_f1_perfect():
+    rows = [
+        {"prediction": "Marcus Chen", "gold": "Marcus Chen"},
+        {"prediction": "Lena", "gold": "Lena"},
+    ]
+    out = score_answer_f1(rows)
+    assert out["EM"] == 1.0
+    assert out["F1"] == 1.0
+    assert out["n"] == 2
+
+
+def test_score_answer_f1_partial():
+    rows = [
+        {"prediction": "Marcus", "gold": "Marcus Chen"},   # EM=0, F1=0.667
+        {"prediction": "Lena Ortiz", "gold": "Lena Ortiz"},  # both 1.0
+    ]
+    out = score_answer_f1(rows)
+    assert out["EM"] == 0.5
+    # F1 mean = (0.6666... + 1.0) / 2 = 0.8333...
+    assert abs(out["F1"] - 0.833333) < 1e-4
+
+
+def test_score_answer_f1_aliases():
+    rows = [
+        {"prediction": "Marcus C", "gold": "Marcus Chen",
+         "answer_aliases": ["Marcus C", "M. Chen"]},
+    ]
+    out = score_answer_f1(rows)
+    # "Marcus C" matches alias #1 exactly
+    assert out["EM"] == 1.0
+    assert out["F1"] == 1.0
+
+
+def test_score_answer_f1_empty_prediction_counts():
+    rows = [
+        {"prediction": "", "gold": "Marcus Chen"},
+        {"prediction": "Marcus Chen", "gold": "Marcus Chen"},
+    ]
+    out = score_answer_f1(rows)
+    assert out["n_empty_pred"] == 1
+    assert out["EM"] == 0.5

--- a/tests/test_lrb_timeqa_loader.py
+++ b/tests/test_lrb_timeqa_loader.py
@@ -1,0 +1,129 @@
+"""TimeQA loader tests — fixture path resolution + JSONL parse +
+normalization to Track C shape + is_available probe."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.external.lrb.timeqa_loader import (
+    fixture_path, is_available, load_rows, load_smoke,
+    to_track_c_format)
+
+
+@pytest.fixture
+def fake_fixture_dir(tmp_path):
+    """Build a fake TimeQA fixture dir with 3 rows."""
+    easy_dev = tmp_path / "easy" / "dev.jsonl"
+    easy_dev.parent.mkdir(parents=True)
+    rows = [
+        {
+            "idx": "q-001",
+            "question": "Who was mayor of Paris in 2010?",
+            "paragraphs": ["Bertrand Delanoë was mayor of Paris from "
+                            "2001 to 2014.", "irrelevant passage"],
+            "targets": [
+                {"answer": "Bertrand Delanoë",
+                 "start_time": 2001, "end_time": 2014},
+                {"answer": "Delanoë",
+                 "start_time": 2001, "end_time": 2014},
+            ],
+            "question_time": 2010,
+        },
+        {
+            "idx": "q-002",
+            "question": "Who held position X in 2015?",
+            "paragraphs": ["Alice held X from 2010 to 2016."],
+            "targets": [
+                {"answer": "Alice",
+                 "start_time": 2010, "end_time": 2016},
+            ],
+            "question_time": 2015,
+        },
+        {
+            "idx": "q-003",
+            "question": "Empty target case?",
+            "paragraphs": ["nothing relevant"],
+            "targets": [],
+            "question_time": 2020,
+        },
+    ]
+    with easy_dev.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    return tmp_path
+
+
+def test_fixture_path_default_easy_dev():
+    p = fixture_path()
+    assert p.name == "dev.jsonl"
+    assert p.parent.name == "easy"
+
+
+def test_fixture_path_hard_test():
+    p = fixture_path("hard", "test")
+    assert p.name == "test.jsonl"
+    assert p.parent.name == "hard"
+
+
+def test_is_available_returns_false_when_missing(tmp_path):
+    assert is_available("easy", "dev", fixture_dir=tmp_path) is False
+
+
+def test_is_available_returns_true_when_present(fake_fixture_dir):
+    assert is_available("easy", "dev",
+                         fixture_dir=fake_fixture_dir) is True
+
+
+def test_load_rows_missing_returns_empty(tmp_path):
+    rows = load_rows(fixture_path("easy", "dev", fixture_dir=tmp_path))
+    assert rows == []
+
+
+def test_load_rows_parses_jsonl(fake_fixture_dir):
+    rows = load_rows(fixture_path("easy", "dev",
+                                    fixture_dir=fake_fixture_dir))
+    assert len(rows) == 3
+    assert rows[0]["idx"] == "q-001"
+
+
+def test_to_track_c_format():
+    row = {
+        "idx": "q-001",
+        "question": "Who was mayor?",
+        "paragraphs": ["Para A", "Para B"],
+        "targets": [
+            {"answer": "Bertrand", "start_time": 2001, "end_time": 2014},
+            {"answer": "Delanoë",  "start_time": 2001, "end_time": 2014},
+        ],
+        "question_time": 2010,
+    }
+    norm = to_track_c_format(row)
+    assert norm["query_id"] == "q-001"
+    assert norm["question"] == "Who was mayor?"
+    assert norm["context"] == "Para A\n\nPara B"
+    assert norm["gold"] == "Bertrand"
+    assert norm["answer_aliases"] == ["Delanoë"]
+    assert norm["time_window"] == (2001, 2014)
+    assert norm["question_time"] == 2010
+
+
+def test_to_track_c_empty_targets():
+    row = {"idx": "x", "question": "?", "paragraphs": [],
+            "targets": [], "question_time": ""}
+    norm = to_track_c_format(row)
+    assert norm["gold"] == ""
+    assert norm["answer_aliases"] == []
+
+
+def test_load_smoke_n_slice(fake_fixture_dir):
+    rows = load_smoke(n=2, difficulty="easy", split="dev",
+                       fixture_dir=fake_fixture_dir)
+    assert len(rows) == 2
+    assert rows[0]["query_id"] == "q-001"
+
+
+def test_load_smoke_n_larger_than_data(fake_fixture_dir):
+    rows = load_smoke(n=100, fixture_dir=fake_fixture_dir)
+    assert len(rows) == 3


### PR DESCRIPTION
## Summary

Track C C2/C3 scaffolding. Both modules pure Python, no network at import.

* `answer_f1.py` — SQuAD v1.1 normalization (mirrors `musique_scorer`), EM/F1 primitives, `score_answer_f1(rows)` aggregation. Shared across TimeQA / TempReason / MuSiQue re-run. Deterministic, no LLM judge.
* `timeqa_loader.py` — fixture path resolution + JSONL parse + `to_track_c_format` normalization + `is_available()` probe for operator-action gating.

## Operator action remaining

* Download TimeQA from https://github.com/wenhuchen/Time-Sensitive-QA + license confirm
* Drop `dev.jsonl` into `eval/external/_fixtures/timeqa/easy/dev.jsonl`

`is_available()` returns False when fixture missing → runner skips with explicit message.

## Out of scope

* TempReason loader — separate PR
* Track C unified smoke runner — separate PR
* Actual TimeQA measurement — operator action

Quality delta: exempt (label: external-bench).

## Test plan

- [x] `pytest tests/test_lrb_answer_f1.py tests/test_lrb_timeqa_loader.py -q` → 30 passed
- [x] No network at import time
- [x] Deterministic scoring (RAB H1 정합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)