### PR TITLE
feat(R5-Track-C): TempReason loader skeleton (Track C bench #2, 15 tests)

### DIFF
--- a/eval/external/lrb/tempreason_loader.py
+++ b/eval/external/lrb/tempreason_loader.py
@@ -1,0 +1,138 @@
+"""Track C — TempReason loader (Tan et al. 2023).
+
+Pre-registered per `docs/research/track-c-c0-bench-selection-
+2026-06-11.md` §1.2 as Secondary bench for multi-hop + temporal axis.
+
+Source URL (operator must verify license + download):
+  https://github.com/DAMO-NLP-SG/TempReason
+
+Expected file layout (when operator drops data into the fixture dir):
+  eval/external/_fixtures/tempreason/
+    ├── l1_train.json
+    ├── l1_val.json
+    ├── l1_test.json
+    ├── l2_train.json
+    ├── l2_val.json
+    ├── l2_test.json
+    ├── l3_train.json
+    ├── l3_val.json
+    └── l3_test.json
+
+Each file is a JSON list (verify format at first download — operator
+should cross-check). Per Track C C0 §1.2, the format is roughly:
+
+    [
+      {
+        "id":       <str>,
+        "question": <str>,
+        "context":  <str>,           # paragraph(s)
+        "answer":   <str>,
+        "level":    "L1" | "L2" | "L3",  # difficulty
+      },
+      ...
+    ]
+
+Per Track C C0 sample sizes:
+  * Smoke n=100 from val (L1+L2+L3 균등 분포 — 34/33/33)
+  * Full n=600 (L1/L2/L3 × 200 each)
+
+Per Track C C0 scoring axes:
+  * Token F1 + EM (SQuAD norm, shared `answer_f1.py`)
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Default fixture root (operator drops data here)
+DEFAULT_FIXTURE_DIR = (Path(__file__).resolve()
+                       .parent.parent.parent.parent
+                       / "eval" / "external" / "_fixtures"
+                       / "tempreason")
+
+LEVELS = ("l1", "l2", "l3")
+SPLITS = ("train", "val", "test")
+
+
+def fixture_path(level: str = "l1",
+                  split: str = "val",
+                  fixture_dir: Optional[Path] = None) -> Path:
+    """Return the expected JSON path for (level, split)."""
+    base = fixture_dir or DEFAULT_FIXTURE_DIR
+    return base / f"{level}_{split}.json"
+
+
+def load_rows(path: Path) -> List[Dict[str, Any]]:
+    """Load TempReason JSON rows. Returns empty list if missing."""
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    if isinstance(data, list):
+        return data
+    # Some releases wrap in {"data": [...]}; handle gracefully
+    if isinstance(data, dict) and "data" in data:
+        return data["data"]
+    return []
+
+
+def to_track_c_format(row: Dict[str, Any],
+                       *, default_level: str = "") -> Dict[str, Any]:
+    """Normalize a TempReason row to Track C unified shape.
+
+    Returns:
+      {
+        "query_id":      <str>,
+        "question":      <str>,
+        "context":       <str>,
+        "gold":          <str>,
+        "answer_aliases": [],
+        "level":         "L1" | "L2" | "L3",
+      }
+    """
+    level = row.get("level", default_level) or default_level
+    return {
+        "query_id":       str(row.get("id", "")),
+        "question":       row.get("question", ""),
+        "context":        row.get("context", "") or row.get("paragraph", ""),
+        "gold":           row.get("answer", ""),
+        "answer_aliases": row.get("answer_aliases", []) or [],
+        "level":          level.upper(),
+    }
+
+
+def load_smoke_balanced(n: int = 100,
+                          split: str = "val",
+                          fixture_dir: Optional[Path] = None
+                          ) -> List[Dict[str, Any]]:
+    """Load n queries balanced across L1/L2/L3.
+
+    n=100 → 34 L1 + 33 L2 + 33 L3.
+    """
+    per_level = [n // 3 + (1 if i < n % 3 else 0) for i in range(3)]
+    out: List[Dict[str, Any]] = []
+    for level, k in zip(LEVELS, per_level):
+        rows = load_rows(fixture_path(level, split, fixture_dir))
+        for r in rows[:k]:
+            out.append(to_track_c_format(r, default_level=level))
+    return out
+
+
+def is_available(level: str = "l1",
+                  split: str = "val",
+                  fixture_dir: Optional[Path] = None) -> bool:
+    return fixture_path(level, split, fixture_dir).exists()
+
+
+def all_levels_available(split: str = "val",
+                          fixture_dir: Optional[Path] = None) -> bool:
+    return all(is_available(L, split, fixture_dir) for L in LEVELS)
+
+
+__all__ = [
+    "DEFAULT_FIXTURE_DIR", "LEVELS", "SPLITS",
+    "fixture_path", "load_rows", "to_track_c_format",
+    "load_smoke_balanced", "is_available", "all_levels_available",
+]

--- a/tests/test_lrb_tempreason_loader.py
+++ b/tests/test_lrb_tempreason_loader.py
@@ -1,0 +1,137 @@
+"""TempReason loader tests — same shape as TimeQA: path / parse /
+normalize / balanced smoke."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.external.lrb.tempreason_loader import (
+    LEVELS, all_levels_available, fixture_path, is_available,
+    load_rows, load_smoke_balanced, to_track_c_format)
+
+
+@pytest.fixture
+def fake_fixture_dir(tmp_path):
+    """Build a fake TempReason fixture dir with 3 rows per level."""
+    for level in LEVELS:
+        path = tmp_path / f"{level}_val.json"
+        rows = [
+            {
+                "id":       f"{level}-{i:03d}",
+                "question": f"Q{i} for {level}",
+                "context":  f"Context for {level} {i}",
+                "answer":   f"Answer-{level}-{i}",
+                "level":    level.upper(),
+            }
+            for i in range(1, 5)
+        ]
+        path.write_text(json.dumps(rows), encoding="utf-8")
+    return tmp_path
+
+
+def test_fixture_path_default():
+    p = fixture_path()
+    assert p.name == "l1_val.json"
+
+
+def test_fixture_path_level_split():
+    assert fixture_path("l3", "test").name == "l3_test.json"
+
+
+def test_is_available_missing(tmp_path):
+    assert is_available("l1", "val", fixture_dir=tmp_path) is False
+
+
+def test_is_available_present(fake_fixture_dir):
+    assert is_available("l1", "val",
+                         fixture_dir=fake_fixture_dir) is True
+
+
+def test_all_levels_available_true(fake_fixture_dir):
+    assert all_levels_available("val",
+                                  fixture_dir=fake_fixture_dir) is True
+
+
+def test_all_levels_available_false_partial(tmp_path):
+    # Only l1 present
+    (tmp_path / "l1_val.json").write_text("[]", encoding="utf-8")
+    assert all_levels_available("val", fixture_dir=tmp_path) is False
+
+
+def test_load_rows_missing_returns_empty(tmp_path):
+    assert load_rows(fixture_path("l1", "val",
+                                    fixture_dir=tmp_path)) == []
+
+
+def test_load_rows_list_form(fake_fixture_dir):
+    rows = load_rows(fixture_path("l1", "val",
+                                    fixture_dir=fake_fixture_dir))
+    assert len(rows) == 4
+
+
+def test_load_rows_dict_data_form(tmp_path):
+    """Some TempReason releases wrap in {"data": [...]}."""
+    path = tmp_path / "l1_val.json"
+    payload = {"data": [{"id": "a", "question": "q",
+                          "context": "c", "answer": "x"}]}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert len(load_rows(path)) == 1
+
+
+def test_to_track_c_format():
+    row = {
+        "id": "001",
+        "question": "Q",
+        "context": "C",
+        "answer": "A",
+        "level": "L2",
+    }
+    norm = to_track_c_format(row)
+    assert norm["query_id"] == "001"
+    assert norm["question"] == "Q"
+    assert norm["context"] == "C"
+    assert norm["gold"] == "A"
+    assert norm["level"] == "L2"
+
+
+def test_to_track_c_default_level():
+    row = {"id": "x", "question": "?", "context": "",
+            "answer": ""}  # no level
+    norm = to_track_c_format(row, default_level="l3")
+    assert norm["level"] == "L3"
+
+
+def test_to_track_c_paragraph_field():
+    """Some releases use `paragraph` instead of `context`."""
+    row = {"id": "y", "question": "?", "paragraph": "p body",
+            "answer": "a"}
+    norm = to_track_c_format(row)
+    assert norm["context"] == "p body"
+
+
+def test_load_smoke_balanced_distribution(fake_fixture_dir):
+    smoke = load_smoke_balanced(n=9, split="val",
+                                  fixture_dir=fake_fixture_dir)
+    # 9 = 3 + 3 + 3 across L1/L2/L3
+    assert len(smoke) == 9
+    levels = [r["level"] for r in smoke]
+    assert levels.count("L1") == 3
+    assert levels.count("L2") == 3
+    assert levels.count("L3") == 3
+
+
+def test_load_smoke_balanced_uneven(fake_fixture_dir):
+    smoke = load_smoke_balanced(n=10, split="val",
+                                  fixture_dir=fake_fixture_dir)
+    # 10 = 4 + 3 + 3 (first level gets extra)
+    levels = [r["level"] for r in smoke]
+    assert levels.count("L1") == 4
+    assert levels.count("L2") == 3
+    assert levels.count("L3") == 3
+
+
+def test_load_smoke_balanced_missing_fixture(tmp_path):
+    smoke = load_smoke_balanced(n=9, fixture_dir=tmp_path)
+    assert smoke == []


### PR DESCRIPTION
## Summary

`tempreason_loader.py` mirrors `timeqa_loader.py` for Track C bench #2 (Tan et al. 2023). Pure Python, no network at import.

* L1/L2/L3 difficulty levels supported
* `load_smoke_balanced(n)` distributes across levels (n=100 → 34/33/33)
* `all_levels_available()` + `is_available()` probes for operator-action gating
* Handles list/dict-data wrapping + context/paragraph field alternatives

## Out of scope

* Track C unified smoke runner — separate PR
* MuSiQue answer F1 axis — separate PR
* Actual measurement — operator action (license + download)

Quality delta: exempt (label: external-bench).

## Test plan

- [x] `pytest tests/test_lrb_tempreason_loader.py -q` → 15 passed
- [x] Mirrors timeqa_loader interface
- [x] Balanced smoke distribution verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)