### PR TITLE
docs(R5-v0.5.3): customer outreach playbook (framework + templates, solo-doable portion)

### DIFF
--- a/docs/strategy/v0.5-customer-outreach-playbook-2026-06-12.md
+++ b/docs/strategy/v0.5-customer-outreach-playbook-2026-06-12.md
@@ -1,0 +1,373 @@
+# v0.5 Customer Outreach Playbook (2026-06-12 draft)
+
+> **Solo-doable portion only**. 실제 outreach 실행 (contact list 작성,
+> 첫 콜드 message 발송, intro 미팅 진행, NDA 협상) 은 모두 operator
+> action. 본 doc 은 outreach 의 **전략 framework + segment analysis +
+> template** 만 제공.
+>
+> **Predecessors**:
+> - `v0.5-domain-candidate-evaluation-2026-06-11.md` (Legal contract review
+>   86% Primary; Records mgmt 80%; Compliance 79%)
+> - `v0.5-pilot-scope-spec-2026-06-11.md` (Dim F 7 metrics)
+> - `v0.5-pre-loi-materials/*` (7-doc 자료 pack)
+>
+> **Constraint**: outreach 자체는 operator 의 네트워크 / 시간 / 의사결정.
+> 본 doc 은 그 outreach 의 효율성 위한 framework + scripts 만.
+
+---
+
+## 1. Outreach 의 전략 framework
+
+### 1.1 4-단계 funnel
+
+```
+Step 1: Cold introduction      → 100 contacts/month
+Step 2: Initial interest        → 10-15 responses (10-15%)
+Step 3: Technical brief 공유   → 3-5 qualified leads
+Step 4: LOI / pilot 협상        → 1-2 LOIs / 6 months
+```
+
+→ **Conservative target: 2 LOIs in 6 months**. Aggressive target: 4-5
+LOIs. Realistic for solo operator = 1-2 LOIs (focus on quality).
+
+### 1.2 Quality > quantity
+
+Cold outreach 의 ROI 는 채널 + segment + messaging match 에 크게 의존.
+운영자 의 한정 시간 (월 ~20-30시간 outreach 가능) 을 **targeted 100
+contacts** 에 집중 권장 (mass 1000+ 비추천).
+
+### 1.3 채널 우선순위 (한국 시장)
+
+| 채널 | Effort | Response rate | Recommended for |
+|---|---|---|---|
+| **개인 네트워크 / referral** | low | 30-50% | **★ 최우선** — operator 의 기존 변호사 / IT 인맥 |
+| LinkedIn 직접 메시지 | medium | 5-10% | Decision-maker (CTO / CLO / 부서장) direct |
+| 컨퍼런스 / 세미나 발표 후 contact | high | 20-30% | 다수 contact + brand 구축 |
+| 이메일 cold | medium | 1-3% | last resort |
+| Web inquiry form | low | 5-10% | inbound (외부 marketing 후) |
+
+권장 mix: 개인 네트워크 (40%) + LinkedIn (30%) + 컨퍼런스 (20%) +
+inbound (10%).
+
+## 2. Customer segments (한국 시장, ranked)
+
+### 2.1 Tier S: Mid-size firms / in-house teams (~50 users)
+
+**Primary target for first pilot.** 의사결정 빠르고 (sponsor 임원 1-2명
+설득), 가격 sensitivity 적정.
+
+**Sub-segments**:
+- **법무 specialty 로펌** (20-100 변호사): IP / 노동 / M&A 전문
+- **중견 기업 인하우스 법무팀** (10-50명): 제조 / IT 대기업의 자회사
+- **공공기관 R&D 협력 부서** (10-30명): KISTI / NIA / 등 R&D 협력 가능
+
+**Why first pilot**:
+- 의사결정 chain 짧음 (CEO / 임원 1-2명)
+- IT 인프라 control 가능 (Option A deployment 적합)
+- Pilot evidence 가 다음 segment 진입의 backup
+
+**Outreach channel**: 개인 네트워크 + LinkedIn + 변호사 협회 세미나.
+
+### 2.2 Tier M: Large firms / 대기업 법무팀 (~200 users)
+
+**Secondary target.** 의사결정 chain 길지만 (CFO + CTO + CLO + 임원회의),
+계약 size 크고 retention 강함.
+
+**Sub-segments**:
+- **Top-10 한국 로펌** (김앤장 / 광장 / 율촌 / 세종 등): 의사결정
+  보수적, IT 도입 슬로우. Brand 구축 후 진입 권장.
+- **그룹 인하우스 법무팀** (삼성 / SK / LG / 현대 / 한화 등): 그룹 전체
+  의 표준화 추구. M&A / regulatory 부서 우선.
+
+**Outreach channel**: 개인 네트워크 + 컨퍼런스 (Korean Bar Association,
+한국법학회) + 이미 도입 사례 reference (Tier S pilot 완료 후).
+
+### 2.3 Tier L: Top-5 로펌 / 대기업 그룹 법무본부 (500+ users)
+
+**Long-term target.** Tier S/M pilot 완료 후 진입 권장. 의사결정 매우
+slow (12-24개월), 가격 협상 강함.
+
+**Why long-term**:
+- Pilot evidence 가 다수 있어야 진입 가능
+- Vertical product / SLA / 보안 요구사항 엄격
+- v1.0 platform maturity 후 진입 권장
+
+### 2.4 Adjacent segments (시간 가능 시)
+
+| Segment | 우선순위 | 이유 |
+|---|---|---|
+| Records management (공공기관) | 2nd | 80% domain score; B2G 조달 느림 (12-18mo) |
+| Compliance / internal audit (대기업) | 3rd | 79% score; 의사결정 conservative |
+| HR records (모든 회사) | 4th | 79% score; 개인정보 민감 |
+| Healthcare clinical (병원) | 5th | 79% score; IRB / 변호사 검토 6-12mo |
+
+Tier S 첫 pilot 완료 후 results 기반으로 segment 확장 결정.
+
+## 3. Outreach 우선순위 mapping
+
+```
+Month 1-2:  개인 네트워크 (Tier S 중심) → ~30 contacts
+            Conference 발표 1-2회 (Korean Bar / 한국법학회)
+            
+Month 3-4:  LinkedIn cold (Tier S 보충) → ~20 contacts
+            First 2-3 intro 미팅
+            
+Month 5-6:  Initial response 분석 → qualified leads 3-5건
+            Technical brief 공유 + pilot 협상 시작
+            
+Target: Month 6 by → 1-2 LOI signed
+```
+
+만약 Month 3까지 response 없음 → channel mix 재조정.
+
+## 4. Cold message templates (한국어)
+
+### 4.1 개인 네트워크 referral request
+
+```
+[보내는 사람]: Jiwon Seo (Hashevolution)
+[받는 사람]: 인맥 (이미 알고 있는 변호사 / IT / 컨설팅 분)
+[제목]: 법무 도메인 AI 시스템 pilot — 소개 가능한 분?
+
+[내용]:
+[Name] 안녕하세요. 
+
+저는 최근 6 개월간 JAMES 라는 법무 도메인 RAG 시스템 개발 중입니다.
+일반 RAG 와 가장 큰 차이는:
+- **시간 인지 검색**: 계약 체결 시점의 정확한 정책 본문 retrieval
+- **감사 추적**: 모든 검색 / 답변 chain 자동 기록 + 재생 가능
+EU AI Act 발효 (2026-08-02) 대비.
+
+외부 벤치마크 (RAB / LRB) 측정 결과 publication tier:
+- 감사 완전성 1.000 (vs 일반 RAG 0.275)
+- 시간 정확 retrieval 0.975 (vs 일반 RAG 0.225)
+- Zenodo DOI 10.5281/zenodo.20625533 공개 archive
+
+6 개월 pilot 진행 가능한 중견 로펌 / 인하우스 법무팀 의 IT / KM /
+혹은 임원 분 알고 계시면 소개 부탁드립니다.
+
+자료 pack (exec summary / technical brief / pilot proposal / ROI /
+risk) 첨부합니다. 시간 가능하시면 30분 정도 만나 인사 드리고 자세히
+설명 드리고 싶습니다.
+
+감사합니다.
+Jiwon Seo
+karu-7@hanmail.net
+https://github.com/Hashevolution/James-RAG-Evol
+```
+
+### 4.2 LinkedIn direct message (Decision-maker)
+
+```
+[Subject 없음 — LinkedIn 메시지]
+
+[Name] 님, 안녕하세요.
+
+[Customer Company] 의 법무 / KM / IT 부서장 으로 활동 하시는 것 보고
+연락 드립니다.
+
+저는 법무 도메인 RAG 시스템 JAMES 개발 중인 Hashevolution 의 Jiwon
+Seo 입니다. 
+
+기존 RAG 와 자메스 의 차이는 "시간 시점 정확 retrieval" + "감사 추적"
+입니다. 외부 벤치마크 측정 결과 publication tier (Zenodo DOI:
+10.5281/zenodo.20625533).
+
+EU AI Act 발효 (8/2) 후 audit chain 요구사항 대비 + 계약 체결 시점
+의 정확한 정책 / 표준 조항 retrieval 이 가능한 시스템 입니다.
+
+6 개월 pilot (50-200 명 사용자, cost-recovery 가격) 협의 가능 하시면
+1-pager exec summary 보내 드리겠습니다.
+
+소중한 시간 내 주셔 감사합니다.
+Jiwon Seo
+karu-7@hanmail.net
+```
+
+### 4.3 Conference 후 후속
+
+```
+[보내는 사람]: Jiwon Seo
+[제목]: [Conference Name] 후 follow-up — JAMES pilot
+
+[Name] 님, 안녕하세요.
+
+지난 주 [Conference Name] 에서 인사 드린 Jiwon Seo 입니다. 발표 중
+언급한 JAMES (시간 인지 + 감사 추적 RAG) 의 자료 pack 첨부 드립니다.
+
+귀 사 의 [observed pain point — 예: contract amendment 추적 어려움]
+에 직접 도움 될 수 있는 axis 측정-evidence 가 publication tier 까지
+완성 되어 있습니다.
+
+다음 주 30분 미팅 가능하실까요? 시간대 알려 주시면 맞춰 가겠습니다.
+
+감사합니다.
+Jiwon Seo
+```
+
+## 5. Cold message templates (English, for foreign-affiliate stakeholders)
+
+### 5.1 LinkedIn direct (multinational firms)
+
+```
+[Subject: JAMES — audit-traceable temporally-aware RAG for legal teams]
+
+Hi [Name],
+
+I noticed your work as [Title] at [Company]. I'm reaching out about
+JAMES, a local-first RAG system I've developed for legal teams.
+
+Two distinctive measurement-evidenced advantages over typical RAG:
+- **Temporally-aware retrieval**: retrieves the policy/contract version
+  valid at a historical point in time
+- **Audit traceability**: every retrieval+answer chain is automatically
+  logged and replayable from log alone
+
+External benchmark measurements (RAB / LRB) are at publication tier
+(Zenodo DOI 10.5281/zenodo.20625533). Aligned with EU AI Act effective
+2026-08-02.
+
+If you're exploring AI tools for your legal team's contract review or
+KM workflow, I'd love to share a 1-pager exec summary + 30-min intro.
+
+Thanks for your time.
+Jiwon Seo
+karu-7@hanmail.net
+https://github.com/Hashevolution/James-RAG-Evol
+```
+
+## 6. First meeting agenda template (30분)
+
+```
+Time 00:00-00:05  Operator self-intro (Hashevolution / JAMES 배경)
+Time 00:05-00:10  Customer 측 자기 소개 + 현재 RAG / KM 상황 듣기
+                  - 어떤 use case? 어떤 시스템 사용 중?
+                  - 어떤 pain point?
+Time 00:10-00:20  JAMES 소개 + measurement evidence (3 axes 우위 표)
+                  - Audit chain (RAB 1.000)
+                  - Temporal retrieval (LRB 0.975)
+                  - Local-first + workspace 격리
+Time 00:20-00:25  Pilot proposal 개요
+                  - 6 개월 / cost-recovery base / Dim F 7 metrics
+                  - 자료 pack 공유 (5 docs)
+Time 00:25-00:30  Q&A + 다음 step 결정
+                  - Technical brief 검토 → 다음 미팅 잡기 (2 주 안)
+                  - 거절 시 reason + future 가능성 ask
+```
+
+핵심 규칙:
+- 첫 미팅 = listen 60%, talk 40%
+- 측정 evidence 강조 (over-claim 금지)
+- 거절도 honest 학습 — feedback collect
+
+## 7. Qualified vs unqualified lead 식별
+
+| Sign | Qualified? |
+|---|---|
+| 1-2 개 specific use case 언급 | ✓ |
+| 가격 / 일정 / 보안 검토 의 구체 질문 | ✓ |
+| Internal sponsor (CTO / CLO) 존재 확인 | ✓ |
+| 6 개월 pilot 가능 timeline | ✓ |
+| "재미 있네요" / "나중에 보겠습니다" 만 | ✗ unqualified |
+| 가격 = 무료 만 가능 | ✗ unqualified (cost-recovery 불가) |
+| Decision-maker 미접 (junior 만 응답) | △ keep nurture, but low priority |
+
+Qualified leads = pilot proposal template 공유 + 협상 시작.
+Unqualified = quarterly check-in (1-2회), 그 후 drop.
+
+## 8. Risk + ethics in outreach
+
+### 8.1 Honest framing 의무
+
+- "추론 우수" framing 금지 (measurement-evidence 없음)
+- "EU AI Act compliance certification" framing 금지 (descriptive only)
+- "다른 시스템 보다 무조건 우수" framing 금지 (axes 분리)
+- Pilot 가격 = cost-recovery 명시 (할인 / 무료 미끼 금지)
+
+### 8.2 NDA / confidentiality 우선
+
+- 첫 미팅 = 일반 publicly available 정보 만
+- Customer 측 specific 정보 (계약 / use case / 데이터) 는 NDA 이전 까지
+  공유 X
+- LinkedIn / 이메일 공개 채널 에서는 customer name + use case 언급 X
+
+### 8.3 거절 의 honest 처리
+
+- 첫 미팅 후 거절 = 자연. 강압 X.
+- "잘 부탁드립니다" / "검토 하시고 연락 주세요" 정도 로 종결
+- 6 개월 후 1회 nurture follow-up (새 measurement evidence 등)
+- 그 후 drop
+
+## 9. Tracking spreadsheet (operator personal use)
+
+| Field | Type |
+|---|---|
+| Contact name | text |
+| Company | text |
+| Title | text |
+| Channel | enum (network/linkedin/conf/email/inbound) |
+| Outreach date | date |
+| First reply date | date / blank |
+| Status | enum (sent/replied/meeting-scheduled/met/qualified/proposal/loi/declined/nurture) |
+| Notes | text |
+| Next action date | date |
+
+Spreadsheet 는 operator personal — 본 repo 에 commit X (개인정보 / 영업
+비밀). Operator side 에 별도 시트.
+
+## 10. 6 개월 outreach campaign budget
+
+| Item | Monthly | 6mo Total |
+|---|---|---|
+| Operator time (~20-30h) | (sunk cost) | — |
+| Conference 등록 / 발표 | ₩100-200K | ₩600K-1.2M |
+| 미팅 식대 / 교통 | ₩50-150K | ₩300K-900K |
+| Customer 자료 pack 인쇄 (선택) | ₩30K | ₩180K |
+| 총 outreach 직접 비용 | ~₩200-380K | ~₩1.1-2.3M |
+
+→ outreach campaign 자체 비용 = ~₩1-2M. 1 LOI 만 얻어도 ROI 매우 높음.
+
+## 11. 측정 지표 (outreach 효과)
+
+매월 다음 metric tracking:
+
+| Metric | Target | Action if below target |
+|---|---|---|
+| Contacts sent | 15-20/month | Channel mix 재조정 |
+| Response rate | ≥ 5% | Cold message 재작성 |
+| Meeting scheduled | ≥ 2/month | 자료 pack 개선 / referral 강화 |
+| Qualified leads | ≥ 1/month | 잘 못 segment 선택 — re-target |
+| LOI conversion | ≥ 1/quarter | proposal template / pricing 재검토 |
+
+Pilot LOI = 6 개월 target 2건. 1건도 honest 학습.
+
+## 12. 다음 step (operator action)
+
+본 doc commit 후:
+
+1. Operator 측 personal tracking spreadsheet 구축 (Notion / Excel /
+   Airtable / etc.)
+2. Tier S 첫 contact list 작성 (개인 네트워크 우선 ~30명)
+3. Conference / 세미나 등록 (Korean Bar / 한국법학회 next quarter)
+4. LinkedIn 프로필 업데이트 (JAMES 강조)
+5. 첫 cold outreach 1주 안에 ~10명 (개인 네트워크 referral request)
+6. 응답 분석 → channel mix 조정
+
+각 step 의 timing + 효과 는 operator 의 시간 / 네트워크 / 우선순위 에
+의존. 본 doc 의 framework 는 그 결정 의 base.
+
+## 13. 관련
+
+- v0.5.0 domain ranking: `v0.5-domain-candidate-evaluation-2026-06-11.md`
+- v0.5.1 pilot scope: `v0.5-pilot-scope-spec-2026-06-11.md`
+- v0.5.2 pre-LOI materials: `v0.5-pre-loi-materials/*` (7 docs)
+- CLAUDE.md mother-platform discipline rule #1
+- PLATFORM_READINESS.md Dim F gate
+- Memory `feedback_build_dont_broadcast` (2026-05-25) — outreach 의
+  build-don't-broadcast 정신 적용
+
+---
+
+*Outreach playbook 의 framework + template 만 제공. 실제 outreach 는
+operator action — 시간 / 네트워크 / 우선순위 의 본인 결정. 첫 LOI
+서명 시 본 doc 의 framework 가 어느 부분 효과 있었는지 post-mortem.*


### PR DESCRIPTION
## Summary

v0.5.3 customer outreach playbook — framework + segments + templates. Actual outreach execution remains operator action.

* §1 4-stage funnel (conservative 1-2 LOIs in 6mo target)
* §2 Korean market segments (Tier S/M/L + 4 adjacent)
* §3 6mo campaign timeline
* §4 Korean cold message templates (network/LinkedIn/conference)
* §5 English template (multinational firms)
* §6 First meeting agenda
* §7 Qualified vs unqualified lead identification
* §8 Risk + ethics (honest framing, NDA discipline, decline handling)
* §9 Tracking spreadsheet schema (operator personal, NOT in repo)
* §10 Budget (~₩1-2M for 6mo)
* §11 Monthly metrics + corrective actions
* §12 Operator next-step checklist

## Discipline preserved

* No "JAMES reasoning superiority" framing
* No "EU AI Act certification" framing
* Cost-recovery pricing explicit (no free-trial baiting)
* Decline handling = honest, no aggressive nurture

## Out of scope

* Actual contact list (operator personal, PII)
* Real execution (operator action)
* Conference registration / LinkedIn profile (operator)

Quality delta: exempt (label: docs).

## Test plan

- [x] Framework derives from measurement-evidenced moats
- [x] Templates use only publicly-verifiable claims
- [x] Segments map to v0.5.0 ranking
- [x] CLAUDE.md mother-platform discipline preserved
- [x] No PII in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)