### PR TITLE
docs(R5): session closure — update FINAL handover with PR #817 mxtral cross-model k=20

### DIFF
--- a/docs/handovers/v0.4-autonomous-loop-FINAL-2026-06-12.md
+++ b/docs/handovers/v0.4-autonomous-loop-FINAL-2026-06-12.md
@@ -55,9 +55,14 @@ family) LOCKED.
                             k=5 LLM rerank 0.150 (F1+0.036)
                             k=5 CoT 0.000 (REGRESSION -0.150)
                             k=10 0.100 (REGRESSION -0.05)
-                            k=20 0.200 (+0.05 BEST)
-                          k=20 = general-model lift, NOT JAMES specific
-                          ⭐ honest negative SATURATED
+                            k=20 0.200 (+0.05 BEST at gemma3:12b)
+                          + cross-model k=20 verification (PR #817):
+                            mxtral 47B × k=20 = EM 0.000 (NO lift!)
+                            (SR 0.55 → 0.80 but mxtral verbose
+                             abstention + missing hop-2 chain)
+                          k=20 lift is model-specific (gemma3:12b only)
+                          ⭐ honest negative SATURATED + cross-model
+                          robust check done (improvement lever NOT robust)
 ```
 
 ## 3. PR 누적 (이 session: 17 PR / autonomous loop 시작 후)
@@ -83,6 +88,8 @@ family) LOCKED.
 | #813 | v0.5.2 pre-LOI batch 1 (README + 4 docs) |
 | #814 | v0.5.2 batch 2 + arXiv 11-item checklist |
 | #815 | v0.5.3 customer outreach playbook |
+| #816 | 6h autonomous loop FINAL session handover (이 doc) + CLAUDE.md first row update |
+| #817 | MuSiQue mxtral × k=20 cross-model verification — k=20 lift gemma3:12b-only (post-summary) |
 
 ## 4. Solo-doable 모두 완료 — Operator action remaining
 


### PR DESCRIPTION
## Summary

Session closure update. PR #817 landed mxtral × k=20 cross-model verification AFTER initial FINAL handover (PR #816). This PR brings the next-session entry doc into sync.

## Updates

* §2 Multi-hop reasoning block — adds cross-model k=20 verification (mxtral 47B × k=20 = EM 0, no lift) and notes k=20 lift is gemma3:12b-only
* §3 PR list — adds #816 + #817

## Why this matters

CLAUDE.md `Where to look next` first row points at the FINAL handover. PR #817 strengthens multi-hop honest negative from "saturated" to "saturated + cross-model robustness check done". Next session reads this correctly.

## Memory updates (out-of-band)

Memory files at `~/.claude/projects/.../memory/` updated separately by harness:
* `project_track_c_musique_honest_negative.md` — body extended with PR #817 + 4-lines-of-evidence summary
* `MEMORY.md` — index entry updated (35-PR session, cross-model verification)

## Out of scope

* PR #817 artifacts (already merged)
* CLAUDE.md update (already done in #816)
* Operator action items (same 8 items)

Quality delta: exempt (label: docs).

## Test plan

- [x] §2 reflects #817 finding
- [x] PR list includes #816 + #817
- [x] No double-count
- [x] CLAUDE.md unchanged (still correct)
- [x] Memory reflects PR #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)