### PR TITLE
feat(R5-cycle-γ D-2wiki): supporting-fact-aware producer for 2WikiMultiHopQA

### DIFF
--- a/docs/research/cycle-gamma-d-2wiki-supporting-fact-preregistration-2026-06-12.md
+++ b/docs/research/cycle-gamma-d-2wiki-supporting-fact-preregistration-2026-06-12.md
@@ -1,0 +1,150 @@
+# Cycle γ Phase D-2wiki — supporting-fact 사전 등록 (Pre-registration)
+
+**Date**: 2026-06-12 (인프라 구현 + 측정 **전** 커밋 — R5 의무)
+**Status**: LOCKED. 이 문서 commit 이후 producer 종류 / prompt 형식 /
+n / honest-tier 게이트 변경 금지. 변경이 필요하면 사유를 본 문서에
+append 하고 그 cycle 의 결과는 exploratory 로 강등.
+
+**Bench under test**: 2WikiMultiHopQA (Ho et al. 2020, COLING) —
+`eval/external/wikimulti_loader.py` + `eval/external/wikimulti_scorer.py`
++ `eval/external/wikimulti_cited_producer.py` (이 PR 신규).
+
+**Predecessors**:
+- Cycle γ Phase C.4 sealed (closed-corpus producer, em/f1/f1_by_type
+  measured, support_fact_f1 "not measured by design")
+- cycle γ design memo §C.1 4-벤치 promise 의 **2Wiki cell 의 마지막
+  infra-only 잔여물** = supporting-fact axis
+- D-alce sibling cycle (PR #820 직전) 가 ALCE citation axis 를
+  infra-only → research-tier 격상 — D-2wiki 는 2Wiki supporting-fact
+  axis 의 동일 격상
+
+**Why pre-register**: cycle γ design memo §C.1 4-벤치 promise 의 2Wiki
+cell `support_fact_f1` axis 를 "infra-only" 에서 "research-tier
+producer-emitted" 로 격상. 작은 open 모델 (gemma4:e4b 등) citation
+정확도 자체는 RAG citations literature 의 known weak axis — 본 cycle
+이 측정하는 것은 *infrastructure / pipeline 작동*, 절대 정확도 score
+publish-ready claim 아님.
+
+---
+
+## 1. Scope — Phase D-2wiki 가 측정할 것과 측정하지 않을 것
+
+### 1.1 측정 (LOCK)
+
+| 항목 | 값 |
+|---|---|
+| Bench | 2WikiMultiHopQA dev split (Phase C.4 와 동일 fixture, sha pinned) |
+| Producer | `WikiMultiCitedProducer` (이 PR 신규, supporting-fact 출력 prompt) |
+| Scorer | `WikiMultiScorer` (Phase A.3 기존, 변경 없음 — `support_fact_f1` axis 가 producer-emit `predicted_supporting_facts` 를 소비) |
+| Model | `gemma4:e4b` (C.4 baseline 과 동일) |
+| n_samples | 20 (C.4 와 동일 — research-tier 인프라 검증 smoke) |
+| max_tokens | 1024 |
+| Honest tier | **⭐ research-tier infra validation — NOT publication-grade citation quality** |
+| Determinism | producer-side: stable prompt + parser; LLM-side: ollama temperature default |
+
+### 1.2 측정 안 함 (Phase D-2wiki OUT of scope)
+
+| 항목 | 사유 |
+|---|---|
+| 큰 모델 / instruction-tuned cited models | E-2wiki 별도 cycle (gemma3:12b / mxtral / claude 가 citation 정확도 본 cycle 의 단순 분기 → 모델-cross 별도) |
+| qampari / eli5 / 추가 변형 | 2Wiki 는 단일 bench; ALCE variants 와 무관 |
+| Full N=300-1000 | research-tier smoke 우선 — 결과 보고 paper publish-ready 게이트 통과 시에만 N 확대 |
+| Cross-bench 표 publish-ready ranking | research-tier 점수는 publish ready 아니므로 ranking 표 갱신 보류 |
+| paper v1.4 § "2Wiki supporting-fact outer validation" | D-2wiki 결과 보고 별도 cycle |
+
+## 2. Pre-registered verdict matrix
+
+| support_fact_f1 결과 | answer EM/F1 vs C.4 비교 | Verdict | 후속 |
+|---|---|---|---|
+| support_fact_f1 > 0 AND answer EM/F1 within ±0.05 of C.4 baseline | infra OK + answer 안정 | ⭐ research-tier infra validated + citation emission working at small model | E-2wiki 모델 ladder cycle prereq 통과 (publish-ready 가능성 평가) |
+| support_fact_f1 > 0 AND answer EM/F1 regression > 0.10 vs C.4 | infra OK BUT citation prompt 가 answer quality 깎음 | ⭐ research-tier infra validated + small-model prompt tradeoff finding | prompt design 별도 cycle (cited vs uncited 의 answer tax 정량화) |
+| support_fact_f1 = 0 AND `predicted_supporting_facts` 전부 비어있음 | 모델이 SUPPORTING_FACTS 형식 못 따라옴 | ⭐ research-tier infra validated (parser working) + small-model citation-emission ceiling finding | E-2wiki larger-model cycle prerequisite 직접 evidence |
+| 측정 0건 / pipeline crash | 인프라 결함 | NOT infra-validated | producer/parser 디버그, re-prereg 없이 retry 가능 (config 변경 없을 시) |
+
+## 3. Honest framing 의무
+
+`result.json` 에 다음 field 의무 (이 PR 의 wiki2_smoke_run.py 가 emit):
+
+```json
+{
+  "producer_grade":  "research-tier-cited",
+  "honest_tier":     "research-tier: ... STRONGER than C.4 ... NOT publication-grade ... E-2wiki ...",
+  "fixture_sha":     "<sha256>",
+  "scope": {
+    "producer_emits_supporting_facts": true,
+    "support_fact_f1_axis":            "measured (research-tier)",
+    "comparable_to_musique_magnitude": false,
+    "cross_bench_claim":               "..."
+  }
+}
+```
+
+본 cycle 결과는 paper publish-ready claim 으로 인용 **금지**.
+"Research-tier 2Wiki citation infra working at small model" /
+"small-model citation-emission ceiling" / "prompt-induced answer
+tradeoff" finding 으로만 paper methods robustness 행 inform.
+
+## 4. Cross-bench 표 update 룰
+
+cross-bench 표 (cycle γ 4-벤치 summary) 에 2Wiki row 가 갱신될 때:
+
+```
+| Bench    | Producer grade            | Axes (em / f1 / f1_by_type / support_fact_f1) | N | Honest tier |
+| 2Wiki    | infra-only-uncited        | 0.10 / 0.16 / 0.22 / --                       | 20 | infra-only |
+| 2Wiki    | research-tier-cited       | <TBD> / <TBD> / <TBD> / <TBD>                 | 20 | research-tier |
+| 2Wiki    | publication-grade-cited   | DEFERRED                                      | -- | NOT YET RUN |
+```
+
+`producer_grade` column 필수. 단일 모델 / 단일 producer 점수 인용 금지
+— research-tier 결과는 항상 C.4 baseline 과 페어로 표시 (answer-axis
+tradeoff 정량화).
+
+## 5. 측정 실행 절차 (operator action)
+
+```powershell
+# D-2wiki research-tier smoke
+python scripts/research/wiki2_smoke_run.py `
+  --cited `
+  --n 20 `
+  --model gemma4:e4b
+```
+
+C.4 baseline 결과 (`reports/external/2wiki/dev-smoke-20260611T071605Z.*`)
+와 paired 비교. 동일 fixture_sha 확인 후 axis 비교.
+
+## 6. 인프라 완성 후 (Phase D-2wiki 측정 후, 다음 cycle prerequisite)
+
+| Phase | 작업 |
+|---|---|
+| D-2wiki+ | gemma3:12b / mxtral citation prompt 응답 측정 (모델-cross robustness) |
+| E-2wiki | claude / instruction-tuned 큰 모델 citation 정확도 (publication-grade prereq) |
+| F-2wiki | full N=300-1000 (publication-grade), 모든 모델 |
+| G-2wiki | paper v1.4 § "2Wiki supporting-fact outer validation" reverse-publish |
+
+D-2wiki 측정 자체는 본 prereg 게이트 안에서 진행; D-2wiki 측정 후
+follow-up cycle 들은 별도 prereg 의무.
+
+## 7. 사전 등록 commit hash = evidence
+
+이 doc 의 첫 commit hash 가 사전 등록의 timestamped evidence.
+측정 실행 전 PR 머지 + main 동기화 후 시작.
+
+## 8. 관련
+
+- `docs/research/cycle-gamma-c4-2wiki-smoke-preregistration-2026-06-11.md`
+  — Phase C.4 (preceding) 인프라 only prereg.
+- `docs/research/cycle-gamma-d-alce-research-tier-nli-preregistration-2026-06-12.md`
+  — sibling cycle (ALCE citation axis 의 동일 격상 패턴).
+- `eval/external/wikimulti_cited_producer.py` — 본 cycle 구현 모듈.
+- `eval/external/wikimulti_scorer.py` — Phase A.3 NLI-free set-F1
+  scorer (변경 없음; `predicted_supporting_facts` consumption 그대로).
+- `eval/external/wikimulti_loader.py` — Phase A.3 fixture loader
+  (변경 없음; metadata.context_titles + context_sentences 가 producer
+  prompt 의 ground).
+- `tests/test_wikimulti_cited_producer.py` — 24 단위 테스트 (LLM 없이
+  parser + prompt + bench row shape + scorer round-trip 검증).
+- [[project_cycle_gamma_phase_c4_2wiki_smoke]] — preceding cycle state.
+- [[feedback_self_evaluation_trap]] — fixture / scoring authority 외부
+  = self-eval trap 통과 (gold supporting_facts 는 2Wiki 공식 fixture).
+- [[feedback_finding_size_honest_framing]] — research-tier ≠
+  publication-grade, paper publish-ready claim 금지.

--- a/eval/external/wikimulti_cited_producer.py
+++ b/eval/external/wikimulti_cited_producer.py
@@ -1,0 +1,249 @@
+"""Cycle γ D-2wiki — supporting-fact-aware closed-corpus producer.
+
+The C.4 smoke producer (`ClosedCorpusGemmaProducer`) emits answer text only;
+the existing `WikiMultiScorer.support_fact_f1` axis therefore reports
+"not measured by design". D-2wiki promotes the cell to research-tier by
+prompting the model for citation markers AND parsing them into the
+``predicted_supporting_facts: [[title, sent_id], …]`` shape the scorer
+already consumes.
+
+**Honest tier**: ⭐ research-tier (small open model citation accuracy
+gate). NOT publication-grade — small-model citation precision is a known
+weak axis (RAG citations literature 2024+). The producer measures
+*citation emission infrastructure*, not state-of-the-art citation
+quality. Larger / instruction-tuned cited models are a separate cycle
+(E-2wiki).
+
+**Prompt design** (small-model-friendly):
+  * Paragraphs are enumerated with title + zero-indexed sentence numbers.
+  * Answer + `SUPPORTING_FACTS: [Title #N], [Title #N]` line.
+  * Tolerant parser: drops invalid citations, no fail-hard.
+
+**Self-eval trap rule** (memory ``feedback_self_evaluation_trap``):
+the producer parses the model's own citations against an external
+fixture's gold supporting facts; the scorer's set-F1 is the external
+authority, not the model's confidence in its own citations.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, List, Tuple
+
+from eval.external.base import ExternalQuery
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Citation parser (LLM-free; testable without GemmaClient)
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Captures `[Title text #42]` / `[Title text   #  42]` / `[ Title #0 ]`.
+# Title is anything that's not a closing bracket, trimmed; sent_id is
+# the first non-negative integer immediately after `#`.
+_CITATION_RE = re.compile(r"\[\s*([^\]]+?)\s*#\s*(\d+)\s*\]")
+
+# Locates the supporting-facts section anchor. Tolerant of small case /
+# punctuation variants the model may emit. Anchored at line start to
+# avoid matching the phrase inside the prompt echo.
+_SF_ANCHOR_RE = re.compile(
+    r"(?im)^\s*supporting[\s_]?facts\s*:?\s*",
+)
+
+
+def _split_at_supporting_facts(text: str) -> Tuple[str, str]:
+    """Splits the model completion into (answer_segment, sf_segment).
+
+    If no anchor is found, the whole text is the answer and the SF
+    segment is empty. The anchor line itself is stripped from the
+    answer side so the answer-axis EM/F1 isn't polluted by the
+    citation list.
+    """
+    if not isinstance(text, str):
+        return "", ""
+    m = _SF_ANCHOR_RE.search(text)
+    if m is None:
+        return text.strip(), ""
+    answer = text[:m.start()].rstrip()
+    sf_segment = text[m.end():]
+    return answer, sf_segment
+
+
+def parse_supporting_facts(
+    completion: str,
+    *,
+    context_titles: List[str],
+    context_sentences: List[List[str]],
+) -> List[List[Any]]:
+    """Returns the validated list of ``[title, sent_id:int]`` pairs.
+
+    Validation rules (tolerant, drop-on-fail, no exceptions):
+      * Title must appear in ``context_titles`` (case-sensitive — the
+        prompt feeds exact titles, so this catches hallucinated names).
+      * ``sent_id`` must be an int in ``[0, len(context_sentences[i]))``
+        for the matching paragraph index.
+      * Duplicates are deduplicated (set semantics — the scorer's
+        ``_set_f1`` collapses repeats anyway).
+
+    The deduped list preserves first-occurrence order so the bench
+    row's audit trail mirrors the model's emission order.
+    """
+    if not isinstance(completion, str):
+        return []
+    _, sf_segment = _split_at_supporting_facts(completion)
+    if not sf_segment:
+        return []
+
+    title_to_idx = {t: i for i, t in enumerate(context_titles)}
+    seen = set()
+    out: List[List[Any]] = []
+
+    for m in _CITATION_RE.finditer(sf_segment):
+        title = m.group(1).strip()
+        try:
+            sent_id = int(m.group(2))
+        except ValueError:
+            continue
+        idx = title_to_idx.get(title)
+        if idx is None:
+            continue
+        sentences = context_sentences[idx] if 0 <= idx < len(
+            context_sentences) else []
+        if sent_id < 0 or sent_id >= len(sentences):
+            continue
+        key = (title, sent_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append([title, sent_id])
+
+    return out
+
+
+def _format_paragraph(idx: int, title: str, sentences: List[str]) -> str:
+    """Single paragraph block: title + 0-indexed sentences."""
+    lines = [f"[{idx}] Title: {title}"]
+    for sid, sent in enumerate(sentences):
+        lines.append(f"  #{sid}: {sent}")
+    return "\n".join(lines)
+
+
+def build_cited_prompt(query: ExternalQuery) -> str:
+    """Build the supporting-fact-aware prompt.
+
+    Reads `metadata.context_titles` + `metadata.context_sentences`; if
+    either is absent the producer falls back to numbered paragraphs
+    with empty title (the parser will drop all citations, axis goes to
+    0 — honest under-attribution rather than a crash).
+    """
+    titles = list(query.metadata.get("context_titles") or [])
+    sentences = list(query.metadata.get("context_sentences") or [])
+    n = max(len(titles), len(sentences))
+
+    paragraphs: List[str] = []
+    for i in range(n):
+        title = titles[i] if i < len(titles) else f"Paragraph {i+1}"
+        sents = sentences[i] if i < len(sentences) else []
+        paragraphs.append(_format_paragraph(i + 1, title, sents))
+
+    paragraph_block = "\n\n".join(paragraphs)
+
+    return (
+        "You are answering a multi-hop question using the provided "
+        "paragraphs. Each paragraph has a Title and zero-indexed "
+        "sentences (#0, #1, ...).\n\n"
+        f"Paragraphs:\n{paragraph_block}\n\n"
+        f"Question: {query.question}\n\n"
+        "Answer the question concisely on the first line. If the "
+        "context is insufficient, answer 'Insufficient Information'.\n\n"
+        "Then on a NEW line, list every paragraph-sentence that "
+        "supported your answer in this EXACT format:\n"
+        "SUPPORTING_FACTS: [<Title> #<sent_id>], [<Title> #<sent_id>]\n"
+        "If your answer is 'Insufficient Information', emit "
+        "'SUPPORTING_FACTS:' with no citations.\n"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Producer
+# ──────────────────────────────────────────────────────────────────────
+
+
+class WikiMultiCitedProducer:
+    """Closed-corpus 2Wiki producer that emits ``predicted_supporting_facts``.
+
+    The producer is structurally identical to
+    `eval.external.runner.ClosedCorpusGemmaProducer` (lazy `GemmaClient`
+    import, env-var prompt cap), but:
+
+      * the prompt is supporting-fact-aware (`build_cited_prompt`), and
+      * the bench row carries ``predicted_supporting_facts``,
+        ``raw_completion``, and ``mode = closed-corpus-cited``.
+
+    The answer-axis EM/F1 reads from the stripped-of-citations answer
+    segment so the existing answer scorer isn't polluted by the
+    `SUPPORTING_FACTS:` line.
+    """
+
+    name = "closed-corpus-cited-2wiki"
+
+    def __init__(
+        self,
+        *,
+        model: str = "gemma4:e4b",
+        max_tokens: int = 1024,
+        timeout: int = 180,
+        think: bool = False,
+        use_cache: bool = False,
+        max_prompt_chars: int = 200_000,
+    ):
+        self._model = model
+        self._max_tokens = max_tokens
+        self._timeout = timeout
+        self._think = think
+        self._use_cache = use_cache
+        self._max_prompt_chars = max_prompt_chars
+
+    def produce(self, query: ExternalQuery) -> Dict[str, Any]:
+        from core.gemma_client import GemmaClient   # late import
+
+        prompt = build_cited_prompt(query)
+
+        os.environ["JAMES_GEMMA_MAX_PROMPT_CHARS"] = str(
+            self._max_prompt_chars
+        )
+        client = GemmaClient()
+        raw = client.call_gemma(
+            prompt,
+            model=self._model,
+            max_tokens=self._max_tokens,
+            think=self._think,
+            use_cache=self._use_cache,
+            timeout=self._timeout,
+        )
+
+        answer_segment, _ = _split_at_supporting_facts(raw)
+        supporting_facts = parse_supporting_facts(
+            raw,
+            context_titles=list(query.metadata.get("context_titles") or []),
+            context_sentences=list(
+                query.metadata.get("context_sentences") or []),
+        )
+
+        return {
+            "id":                          query.id,
+            "answer":                      answer_segment,
+            "predicted_supporting_facts":  supporting_facts,
+            "raw_completion":              raw,
+            "sources":                     list(query.context[:1])
+                                           if query.context else [],
+            "mode":                        "closed-corpus-cited",
+            "model":                       self._model,
+        }
+
+
+__all__ = [
+    "WikiMultiCitedProducer",
+    "build_cited_prompt",
+    "parse_supporting_facts",
+]

--- a/scripts/research/wiki2_smoke_run.py
+++ b/scripts/research/wiki2_smoke_run.py
@@ -35,6 +35,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
 
+from eval.external.wikimulti_cited_producer import WikiMultiCitedProducer
 from eval.external.wikimulti_loader import WikiMultiLoader
 from eval.external.wikimulti_scorer import WikiMultiScorer
 from eval.external.runner import (
@@ -61,16 +62,35 @@ def main(argv=None) -> int:
     p.add_argument("--max-tokens", type=int, default=1024)
     p.add_argument("--out-dir",
                    default=str(ROOT / "reports" / "external" / "2wiki"))
+    p.add_argument(
+        "--cited", action="store_true",
+        help=("Use the D-2wiki supporting-fact-aware producer "
+              "(WikiMultiCitedProducer) instead of the C.4 closed-"
+              "corpus baseline. Emits predicted_supporting_facts so "
+              "the support_fact_f1 axis is measured (research-tier; "
+              "NOT publication-grade -- small-model citation accuracy "
+              "is a known weak axis). See "
+              "docs/research/cycle-gamma-d-2wiki-supporting-fact-"
+              "preregistration-2026-06-12.md"),
+    )
     args = p.parse_args(argv)
 
     loader = WikiMultiLoader(split="dev")
     scorer = WikiMultiScorer()
-    producer = ClosedCorpusGemmaProducer(
-        model=args.model,
-        max_tokens=args.max_tokens,
-        # 2Wiki's 10 paragraphs total well under the 100k char cap
-        # already in the base producer; no need to override.
-    )
+    if args.cited:
+        producer = WikiMultiCitedProducer(
+            model=args.model,
+            max_tokens=args.max_tokens,
+        )
+        producer_grade = "research-tier-cited"
+    else:
+        producer = ClosedCorpusGemmaProducer(
+            model=args.model,
+            max_tokens=args.max_tokens,
+            # 2Wiki's 10 paragraphs total well under the 100k char cap
+            # already in the base producer; no need to override.
+        )
+        producer_grade = "infrastructure-only-uncited"
 
     fixture_sha = _fixture_sha(loader.cache_path)
 
@@ -98,19 +118,40 @@ def main(argv=None) -> int:
     )
 
     # Pre-reg-annotated metadata so the result JSON is self-describing.
-    result["honest_tier"] = (
-        "infrastructure-only: smoke n=" + str(args.n) + " with "
-        "ClosedCorpusGemmaProducer. NOT publication. "
-        "Pre-reg: docs/research/cycle-gamma-c4-2wiki-smoke-"
-        "preregistration-2026-06-11.md"
-    )
+    if args.cited:
+        result["honest_tier"] = (
+            "research-tier: smoke n=" + str(args.n) + " with "
+            "WikiMultiCitedProducer (supporting-fact emission). "
+            "STRONGER than C.4 closed-corpus baseline (support_fact_f1 "
+            "now measured), but NOT publication-grade — small-model "
+            "citation accuracy is a known weak axis (E-2wiki cycle "
+            "will measure larger / instruction-tuned cited models). "
+            "Pre-reg: docs/research/cycle-gamma-d-2wiki-supporting-"
+            "fact-preregistration-2026-06-12.md"
+        )
+        result["scope"] = {
+            "producer_emits_supporting_facts": True,
+            "support_fact_f1_axis": "measured (research-tier)",
+            "comparable_to_musique_magnitude": False,
+            "cross_bench_claim": ("multi-hop floor pattern qualitative "
+                                  "agreement + 2Wiki citation-emission "
+                                  "validated for small open model"),
+        }
+    else:
+        result["honest_tier"] = (
+            "infrastructure-only: smoke n=" + str(args.n) + " with "
+            "ClosedCorpusGemmaProducer. NOT publication. "
+            "Pre-reg: docs/research/cycle-gamma-c4-2wiki-smoke-"
+            "preregistration-2026-06-11.md"
+        )
+        result["scope"] = {
+            "producer_emits_supporting_facts": False,
+            "support_fact_f1_axis": "not measured by design",
+            "comparable_to_musique_magnitude": False,
+            "cross_bench_claim": "multi-hop floor pattern qualitative agreement only",
+        }
     result["fixture_sha"] = fixture_sha
-    result["scope"] = {
-        "producer_emits_supporting_facts": False,
-        "support_fact_f1_axis": "not measured by design",
-        "comparable_to_musique_magnitude": False,
-        "cross_bench_claim": "multi-hop floor pattern qualitative agreement only",
-    }
+    result["producer_grade"] = producer_grade
 
     stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     out_dir = Path(args.out_dir)

--- a/tests/test_wikimulti_cited_producer.py
+++ b/tests/test_wikimulti_cited_producer.py
@@ -1,0 +1,373 @@
+"""Cycle γ D-2wiki — WikiMultiCitedProducer parser contract tests.
+
+The producer's LLM-touching half is tested by smoke runs; the parser
+half (which converts a noisy LLM completion into the validated
+``predicted_supporting_facts`` list the scorer reads) must be
+contract-pinned without an LLM in the loop.
+
+Pins:
+  * Anchor splitting (`SUPPORTING_FACTS:` line in any case / spacing).
+  * Citation regex captures `[Title #N]` / `[ Title  #  N ]`.
+  * Validation: title-in-context + sent_id-in-range; out-of-range
+    drops, hallucinated titles drop, non-int sent_id drops.
+  * Deduplication preserves first-occurrence order.
+  * `build_cited_prompt` reads loader metadata correctly.
+  * Producer bench row shape (`predicted_supporting_facts`,
+    `raw_completion`, `mode=closed-corpus-cited`).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _query(*, qid="2wiki-q1", question="Q?", titles=None, sentences=None):
+    from eval.external import ExternalQuery
+    titles = titles or ["Alice", "Wonderland"]
+    sentences = sentences or [["A0.", "A1."], ["W0.", "W1.", "W2."]]
+    context_texts = tuple(" ".join(s) for s in sentences)
+    return ExternalQuery(
+        id=qid,
+        benchmark="2wiki",
+        question=question,
+        context=context_texts,
+        gold_answer="",
+        metadata={
+            "context_titles":    titles,
+            "context_sentences": sentences,
+            "supporting_facts":  [],
+            "type":              "comparison",
+            "entity_ids":        "",
+            "evidences":         [],
+            "evidences_id":      [],
+            "answer_id":         "",
+            "split":             "dev",
+        },
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+
+
+class AnchorSplitTests(unittest.TestCase):
+    def test_split_returns_full_text_when_no_anchor(self):
+        from eval.external.wikimulti_cited_producer import \
+            _split_at_supporting_facts
+        ans, sf = _split_at_supporting_facts("Just an answer.")
+        self.assertEqual(ans, "Just an answer.")
+        self.assertEqual(sf, "")
+
+    def test_split_at_canonical_anchor(self):
+        from eval.external.wikimulti_cited_producer import \
+            _split_at_supporting_facts
+        ans, sf = _split_at_supporting_facts(
+            "Final answer.\nSUPPORTING_FACTS: [Alice #0]"
+        )
+        self.assertEqual(ans, "Final answer.")
+        self.assertIn("[Alice #0]", sf)
+
+    def test_split_tolerates_case_and_underscore(self):
+        from eval.external.wikimulti_cited_producer import \
+            _split_at_supporting_facts
+        ans, sf = _split_at_supporting_facts(
+            "Answer.\nsupporting facts: [Alice #0]"
+        )
+        self.assertEqual(ans, "Answer.")
+        self.assertIn("[Alice #0]", sf)
+
+    def test_split_returns_empty_on_non_string(self):
+        from eval.external.wikimulti_cited_producer import \
+            _split_at_supporting_facts
+        ans, sf = _split_at_supporting_facts(None)        # type: ignore
+        self.assertEqual((ans, sf), ("", ""))
+
+
+class CitationRegexTests(unittest.TestCase):
+    def test_basic_citation(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Alice #0]",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [["Alice", 0]])
+
+    def test_multiple_citations(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Alice #0], [Wonderland #2]",
+            context_titles=["Alice", "Wonderland"],
+            context_sentences=[["s0"], ["s0", "s1", "s2"]],
+        )
+        self.assertEqual(sf, [["Alice", 0], ["Wonderland", 2]])
+
+    def test_spaces_inside_brackets(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [ Alice  #  0 ]",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [["Alice", 0]])
+
+    def test_multi_word_title(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Lewis Carroll #0]",
+            context_titles=["Lewis Carroll"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [["Lewis Carroll", 0]])
+
+
+class ValidationTests(unittest.TestCase):
+    def test_hallucinated_title_dropped(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Ghost #0], [Alice #0]",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [["Alice", 0]])
+
+    def test_out_of_range_sent_id_dropped(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Alice #99], [Alice #0]",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [["Alice", 0]])
+
+    def test_negative_sent_id_dropped(self):
+        # Regex `\d+` rejects '-' so this is effectively no-citation.
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Alice #-1]",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [])
+
+    def test_no_anchor_returns_empty_even_with_brackets(self):
+        # `[Alice #0]` outside the SUPPORTING_FACTS segment is ignored
+        # — citations leaking into the answer text don't pollute the SF
+        # axis.
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Some answer [Alice #0] inline.",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [])
+
+    def test_duplicates_collapse_preserving_first_order(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Wonderland #1], [Alice #0], "
+            "[Wonderland #1]",
+            context_titles=["Alice", "Wonderland"],
+            context_sentences=[["s0"], ["s0", "s1"]],
+        )
+        self.assertEqual(sf, [["Wonderland", 1], ["Alice", 0]])
+
+    def test_empty_sentences_for_title_drops_all_sf_for_it(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Ans.\nSUPPORTING_FACTS: [Alice #0]",
+            context_titles=["Alice"],
+            context_sentences=[[]],
+        )
+        self.assertEqual(sf, [])
+
+
+class EmptyInputTests(unittest.TestCase):
+    def test_empty_completion(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [])
+
+    def test_non_string_completion(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            None,                                        # type: ignore
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [])
+
+    def test_anchor_only_no_citations(self):
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+        sf = parse_supporting_facts(
+            "Insufficient Information.\nSUPPORTING_FACTS:",
+            context_titles=["Alice"],
+            context_sentences=[["s0"]],
+        )
+        self.assertEqual(sf, [])
+
+
+class PromptBuilderTests(unittest.TestCase):
+    def test_prompt_contains_question(self):
+        from eval.external.wikimulti_cited_producer import \
+            build_cited_prompt
+        q = _query(question="Who founded Wonderland?")
+        prompt = build_cited_prompt(q)
+        self.assertIn("Who founded Wonderland?", prompt)
+
+    def test_prompt_enumerates_titles_and_zero_indexed_sentences(self):
+        from eval.external.wikimulti_cited_producer import \
+            build_cited_prompt
+        q = _query(
+            titles=["Alpha", "Beta"],
+            sentences=[["A0.", "A1."], ["B0."]],
+        )
+        prompt = build_cited_prompt(q)
+        self.assertIn("Title: Alpha", prompt)
+        self.assertIn("Title: Beta", prompt)
+        self.assertIn("#0: A0.", prompt)
+        self.assertIn("#1: A1.", prompt)
+        self.assertIn("#0: B0.", prompt)
+
+    def test_prompt_advertises_exact_supporting_facts_format(self):
+        from eval.external.wikimulti_cited_producer import \
+            build_cited_prompt
+        q = _query()
+        prompt = build_cited_prompt(q)
+        self.assertIn("SUPPORTING_FACTS:", prompt)
+        # The exact citation format must be in the prompt so small
+        # models don't have to guess.
+        self.assertIn("[<Title> #<sent_id>]", prompt)
+
+    def test_prompt_handles_missing_metadata_gracefully(self):
+        from eval.external.wikimulti_cited_producer import \
+            build_cited_prompt
+        from eval.external import ExternalQuery
+        q = ExternalQuery(
+            id="2wiki-q1", benchmark="2wiki", question="Q?",
+            context=("ctx",), gold_answer="",
+            metadata={},                                  # no titles/sentences
+        )
+        prompt = build_cited_prompt(q)
+        # No crash; prompt still well-formed.
+        self.assertIn("Question: Q?", prompt)
+        self.assertIn("SUPPORTING_FACTS:", prompt)
+
+
+class ProducerBenchRowShapeTests(unittest.TestCase):
+    """Stubs the GemmaClient so the bench-row shape is exercised
+    end-to-end without an LLM."""
+
+    def test_row_carries_predicted_supporting_facts(self):
+        from eval.external.wikimulti_cited_producer import \
+            WikiMultiCitedProducer
+
+        producer = WikiMultiCitedProducer()
+        q = _query(question="Who founded Alice?")
+        # Stub the GemmaClient with a callable inside the produce path.
+        # Because the producer late-imports core.gemma_client, we
+        # monkey-patch on its module object after import.
+        import core.gemma_client as gc
+
+        class _StubClient:
+            def call_gemma(self, prompt, **_kw):
+                # Honor the prompt format the producer published.
+                return ("Alice was founded by Carroll.\n"
+                        "SUPPORTING_FACTS: [Alice #1]")
+
+        original = gc.GemmaClient
+        try:
+            gc.GemmaClient = _StubClient
+            row = producer.produce(q)
+        finally:
+            gc.GemmaClient = original
+
+        self.assertEqual(row["id"], q.id)
+        self.assertEqual(row["mode"], "closed-corpus-cited")
+        self.assertEqual(row["predicted_supporting_facts"],
+                         [["Alice", 1]])
+        # Answer segment stripped of the SUPPORTING_FACTS line.
+        self.assertNotIn("SUPPORTING_FACTS", row["answer"])
+        self.assertIn("Alice was founded by Carroll.", row["answer"])
+        # raw_completion preserves the full LLM output for audit.
+        self.assertIn("SUPPORTING_FACTS:", row["raw_completion"])
+
+    def test_row_handles_no_citations_gracefully(self):
+        from eval.external.wikimulti_cited_producer import \
+            WikiMultiCitedProducer
+
+        producer = WikiMultiCitedProducer()
+        q = _query()
+        import core.gemma_client as gc
+
+        class _StubClient:
+            def call_gemma(self, prompt, **_kw):
+                return "Insufficient Information.\nSUPPORTING_FACTS:"
+
+        original = gc.GemmaClient
+        try:
+            gc.GemmaClient = _StubClient
+            row = producer.produce(q)
+        finally:
+            gc.GemmaClient = original
+
+        self.assertEqual(row["predicted_supporting_facts"], [])
+        self.assertEqual(row["answer"], "Insufficient Information.")
+
+
+class ScorerEndToEndTests(unittest.TestCase):
+    """The producer's output round-trips through `WikiMultiScorer`
+    such that `support_fact_f1` is non-zero when citations match gold.
+    """
+
+    def test_support_fact_f1_round_trip(self):
+        from eval.external.wikimulti_scorer import WikiMultiScorer
+        from eval.external.wikimulti_cited_producer import \
+            parse_supporting_facts
+
+        q = _query()
+        # Force gold supporting_facts so the axis becomes measurable
+        # (without modifying loader semantics).
+        q.metadata["supporting_facts"] = [["Alice", 0], ["Wonderland", 1]]
+
+        completion = ("Some answer.\n"
+                      "SUPPORTING_FACTS: [Alice #0], [Wonderland #1]")
+        predicted = parse_supporting_facts(
+            completion,
+            context_titles=q.metadata["context_titles"],
+            context_sentences=q.metadata["context_sentences"],
+        )
+        bench_row = {
+            "id": q.id,
+            "answer": "Some answer.",
+            "predicted_supporting_facts": predicted,
+        }
+        scorer = WikiMultiScorer()
+        axes = scorer.score([q], [bench_row])
+        sf_axis = next(a for a in axes if a.name == "support_fact_f1")
+        # Perfect match → support_fact_f1 = 1.0.
+        self.assertEqual(sf_axis.score, 1.0)
+        self.assertEqual(sf_axis.n_queries, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Promotes 2Wiki from "infrastructure-only" (em/f1 measured, support_fact_f1 NOT) to research-tier supporting-fact-emitting smoke by adding `WikiMultiCitedProducer` — prompts the model for `[Title #sent_id]` citations and parses them into the `predicted_supporting_facts` list the existing `WikiMultiScorer` already consumes
- Closes the last "infra-only" cell of cycle γ 4-bench promise §C.1 (sibling to D-alce #820 that just landed for ALCE citation axis)
- `producer_grade=research-tier-cited` explicitly does NOT claim publication-grade — small-model citation accuracy is a known weak axis (E-2wiki larger/instruction-tuned model cycle separate)

## Why now

- D-alce (#820) just shipped same-format cycle for ALCE; parallel landing closes both cycle γ infra-only cells at once
- `WikiMultiScorer.support_fact_f1` axis already implemented; the bottleneck was a producer that emits `predicted_supporting_facts` — this PR is the minimum-scope fix
- Closes cycle γ design memo §C.1 4-bench promise from "3/4 measured + 1 partial" to "4/4 measured" (research-tier honest tier on both upgrades)

## Verification

- ✓ 24 new unit tests (`tests/test_wikimulti_cited_producer.py`) — contract pinned: anchor splitting, citation regex (multi-word titles, whitespace tolerance), validation (hallucinated title drop, range drop, negative drop), dedup preserving first-occurrence order, empty/non-string edge cases, prompt builder shape, bench row shape with stubbed `GemmaClient`, scorer round-trip (perfect citation → support_fact_f1=1.0)
- ✓ 21 existing cycle γ runner tests still pass (0 regression)
- ✓ ruff F-class clean on all new files
- ✓ CLI `--cited` flag wired; `honest_tier` / `scope` / `producer_grade` fields differ per branch
- ✓ Prereg LOCK doc `docs/research/cycle-gamma-d-2wiki-supporting-fact-preregistration-2026-06-12.md` (scope, verdict matrix, honest-tier gate, cross-bench update rule)

## Operator action (post-merge, per prereg §5)

```powershell
python scripts/research/wiki2_smoke_run.py --cited --n 20 --model gemma4:e4b
```

Compare against C.4 baseline at `reports/external/2wiki/dev-smoke-20260611T071605Z.*` (same fixture_sha). Verdict matrix: support_fact_f1 score AND answer EM/F1 delta vs C.4 both inform the next gate.

## Out of scope

- Actual measurement (operator-gated per prereg §5)
- Larger / instruction-tuned cited models (E-2wiki, separate prereg)
- Full N=300-1000 publication-grade (F-2wiki, separate)
- paper v1.4 §"2Wiki supporting-fact outer validation" reverse-publish (G-2wiki, gated on D-2wiki results)
- 2Wiki test split / train split — dev only this cycle (matches C.4)

Quality delta: exempt (label: feat — new producer module; no `core/` retrieval/graph/reasoning changes). Measurement bench numbers in operator-gated PR per prereg §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)