### PR TITLE
chore(R5): ruff F-class CI hygiene — remove dead imports and unused locals

### DIFF
--- a/eval/external/lrb/answer_f1.py
+++ b/eval/external/lrb/answer_f1.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import re
 import string
 from statistics import mean
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List
 
 
 # ─── SQuAD v1.1 normalization (matches musique_scorer byte-for-byte) ──

--- a/eval/external/lrb/claim_extractor.py
+++ b/eval/external/lrb/claim_extractor.py
@@ -19,7 +19,7 @@ import json
 import re
 from typing import List, Optional
 
-from .llm_rerank import _call_ollama, _is_claude_model, _is_ollama_model
+from .llm_rerank import _call_ollama, _is_ollama_model
 
 # ──────────────────────────────────────────────────────────────────────
 # Rule-based decomposition

--- a/eval/external/lrb/cross_model.py
+++ b/eval/external/lrb/cross_model.py
@@ -19,7 +19,7 @@ pure rerank — scoring math stays in the deterministic scorer.
 """
 from __future__ import annotations
 
-from typing import List, Sequence, Tuple
+from typing import List, Tuple
 
 from .llm_rerank import rerank
 

--- a/eval/external/lrb/driver.py
+++ b/eval/external/lrb/driver.py
@@ -21,7 +21,7 @@ import json
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from typing import Callable, List, Optional, Protocol
 
 from .scorer import score_axes
 

--- a/eval/external/lrb/driver_phase_b.py
+++ b/eval/external/lrb/driver_phase_b.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Callable, Dict, List
 
-from .driver import LrbAdapter, QueryResult, SutRunResult, fixture_sha
+from .driver import LrbAdapter, QueryResult, SutRunResult
 from .scorer import score_axes
 
 

--- a/eval/external/lrb/llm_rerank.py
+++ b/eval/external/lrb/llm_rerank.py
@@ -26,10 +26,9 @@ from __future__ import annotations
 import json
 import re
 import subprocess
-import time
 import urllib.error
 import urllib.request
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 # ──────────────────────────────────────────────────────────────────────
 # Public API

--- a/eval/external/lrb/timeqa_loader.py
+++ b/eval/external/lrb/timeqa_loader.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 # Default fixture root (operator drops data here)

--- a/scripts/research/build_lrb_scenario_s1.py
+++ b/scripts/research/build_lrb_scenario_s1.py
@@ -402,7 +402,6 @@ def evolution_events() -> List[dict]:
     # updates don't perturb temporal-accuracy gold.
     for week in range(1, 13):
         for i, (app_id, app_title, dep_key) in enumerate(APPOINTMENTS):
-            person = PERSONS[i]
             base = _app_body(app_id, app_title, dep_key, i)
             new_text = base + f" Weekly review note: week {week}; status active."
             emit(week, "UPDATE", {

--- a/scripts/research/build_lrb_scenario_s2.py
+++ b/scripts/research/build_lrb_scenario_s2.py
@@ -554,7 +554,6 @@ def build_scenario() -> dict:
 
     # Gold reachability check (each gold doc_id must exist at its valid_time)
     initial_ids = {d["doc_id"] for d in initial}
-    by_event_t: Dict[int, set] = {0: set(initial_ids)}
     state = set(initial_ids)
     # Walk events in order tracking which doc_ids exist at each week
     sorted_events = sorted(events, key=lambda e: (e["week"], e["event_id"]))
@@ -581,7 +580,6 @@ def build_scenario() -> dict:
     week_states[0] = set(initial_ids)
 
     for q in queries:
-        vt = q["valid_time"]
         # JAMES validity-window keeps superseded versions alive at
         # earlier valid_time, so for the gold check we expand the
         # reachable set with all doc_ids that existed at any time

--- a/scripts/research/lrb_run_phase_b.py
+++ b/scripts/research/lrb_run_phase_b.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
 
 from eval.external.lrb.adapters import (
     JamesValidityAdapter, NaiveSupersedeAdapter, VanillaRagAdapter)
@@ -231,14 +231,14 @@ def main() -> None:
         s2_v = cross["S2"]["vanilla"]["axes"]["overall"][ts_axis]
         s2_n = cross["S2"]["naive-supersede"]["axes"]["overall"][ts_axis]
         s2_j = cross["S2"]["james"]["axes"]["overall"][ts_axis]
-        print(f"\n  temporal_accuracy:")
+        print("\n  temporal_accuracy:")
         print(f"    S1: V={s1_v:.4f}  N={s1_n:.4f}  J={s1_j:.4f}  "
               f"(J-N={s1_j - s1_n:+.4f})")
         print(f"    S2: V={s2_v:.4f}  N={s2_n:.4f}  J={s2_j:.4f}  "
               f"(J-N={s2_j - s2_n:+.4f})")
 
         # Per-category S2 historical (the differentiator)
-        print(f"\n  S2 historical-* categories (time-travel diff):")
+        print("\n  S2 historical-* categories (time-travel diff):")
         s2_cats = cross["S2"]["james"]["axes"]["per_category"]
         for cat in sorted(c for c in s2_cats if c.startswith("historical")):
             v_c = cross["S2"]["vanilla"]["axes"]["per_category"][cat]["R@10"]

--- a/scripts/research/lrb_run_v021_cross_model.py
+++ b/scripts/research/lrb_run_v021_cross_model.py
@@ -319,8 +319,6 @@ def main() -> None:
                 effective_model = ("token-baseline"
                                    if mode == "token" else model)
                 # Skip duplicate token cells across models
-                seen_key = (scn, "_token_only_"
-                            if mode == "token" else model, mode)
                 if mode == "token" and any(
                         c["model"] == "token-baseline" and
                         c["scenario"] == scn and c["mode"] == "token"

--- a/scripts/research/lrb_v024_hr_rescore.py
+++ b/scripts/research/lrb_v024_hr_rescore.py
@@ -22,7 +22,7 @@ import glob
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from eval.external.lrb.hr_scorer import (
     HrAggregateResult, HrPerQueryResult, aggregate_to_axes)
@@ -156,7 +156,7 @@ def main() -> None:
         print(f"    HR={s['HR_mean']:.4f}  claims={s['n_claims']}  "
               f"entailed={s['n_entailed']}  elapsed={s['elapsed_s']}s")
 
-    print(f"\n=== SUMMARY ===")
+    print("\n=== SUMMARY ===")
     for s in summary:
         print(f"  {s['input']:60s} → HR={s['HR_mean']:.4f}")
 

--- a/scripts/research/lrb_v024_hr_smoke.py
+++ b/scripts/research/lrb_v024_hr_smoke.py
@@ -27,7 +27,7 @@ import argparse
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from eval.external.lrb.adapters import (
     JamesValidityAdapter, NaiveSupersedeAdapter, VanillaRagAdapter)

--- a/scripts/research/track_c_musique_smoke.py
+++ b/scripts/research/track_c_musique_smoke.py
@@ -187,7 +187,7 @@ def main() -> None:
     ts = utc_stamp()
 
     rows = load_musique_dev(args.n)
-    print(f"\n=== Track C MuSiQue smoke ===")
+    print("\n=== Track C MuSiQue smoke ===")
     print(f"  fixture: {FIXTURE.name}  n={len(rows)}  k={args.k}  "
           f"model={args.model}")
 
@@ -238,7 +238,7 @@ def main() -> None:
 
     # Cross-SUT comparison
     if len(summary) > 1:
-        print(f"\n=== CROSS-SUT GAP (MuSiQue smoke) ===")
+        print("\n=== CROSS-SUT GAP (MuSiQue smoke) ===")
         for sut, axes in summary:
             print(f"  {sut:15s}  EM={axes['EM']:.4f}  F1={axes['F1']:.4f}  "
                   f"support_recall={axes['support_recall_mean']:.4f}")

--- a/tests/test_lrb_answer_f1.py
+++ b/tests/test_lrb_answer_f1.py
@@ -1,7 +1,6 @@
 """LRB answer_f1 tests — SQuAD norm + EM + F1 + multi-alias."""
 from __future__ import annotations
 
-import pytest
 
 from eval.external.lrb.answer_f1 import (
     _normalize_answer, exact_match, max_em, max_f1, score_answer_f1,

--- a/tests/test_lrb_answer_gen.py
+++ b/tests/test_lrb_answer_gen.py
@@ -1,12 +1,10 @@
 """LRB answer generation tests — prompt build + dispatch + adapter wiring."""
 from __future__ import annotations
 
-from typing import List, Tuple
 
-import pytest
 
 from eval.external.lrb.adapters import (
-    JamesValidityAdapter, NaiveSupersedeAdapter, VanillaRagAdapter)
+    JamesValidityAdapter, VanillaRagAdapter)
 from eval.external.lrb.answer_gen import (
     GenerationResult, _is_claude_model, _is_ollama_model,
     answer_from_adapter, build_prompt, generate_answer)

--- a/tests/test_lrb_phase_b.py
+++ b/tests/test_lrb_phase_b.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from eval.external.lrb.adapters import (
     JamesValidityAdapter, NaiveSupersedeAdapter, VanillaRagAdapter)

--- a/tests/test_lrb_smoke.py
+++ b/tests/test_lrb_smoke.py
@@ -2,10 +2,8 @@
 scorer math."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-import pytest
 
 from eval.external.lrb.adapters import (
     JamesValidityAdapter, VanillaRagAdapter)

--- a/tests/test_lrb_tempreason_loader.py
+++ b/tests/test_lrb_tempreason_loader.py
@@ -3,7 +3,6 @@ normalize / balanced smoke."""
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_lrb_timeqa_loader.py
+++ b/tests/test_lrb_timeqa_loader.py
@@ -3,7 +3,6 @@ normalization to Track C shape + is_available probe."""
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_lrb_v021_cross_model.py
+++ b/tests/test_lrb_v021_cross_model.py
@@ -11,10 +11,9 @@ from eval.external.lrb.adapters import (
 from eval.external.lrb.cross_model import retrieve_at_cross_model
 from eval.external.lrb.driver import fixture_sha, load_scenario
 from eval.external.lrb.driver_phase_b import (
-    run_sut_phase_b, score_run)
+    score_run)
 from eval.external.lrb.llm_rerank import (
-    _build_prompt, _is_claude_model, _is_ollama_model, _parse_scores,
-    rerank)
+    _build_prompt, _is_claude_model, _is_ollama_model, _parse_scores)
 
 ROOT = Path(__file__).resolve().parent.parent
 FIXTURE_S1 = ROOT / "eval" / "external" / "_fixtures" / "lrb" / \

--- a/tests/test_lrb_v024_hr.py
+++ b/tests/test_lrb_v024_hr.py
@@ -14,10 +14,9 @@ import pytest
 from eval.external.lrb.claim_extractor import (
     MAX_CLAIMS_PER_ANSWER, extract_claims)
 from eval.external.lrb.hr_scorer import (
-    HrAggregateResult, aggregate_to_axes, score_hr)
+    aggregate_to_axes, score_hr)
 from eval.external.lrb.nli_verifier import (
-    DebertaV3NliVerifier, NliLabel, NliResult, NliVerifier,
-    RobertaMnliVerifier, get_verifier)
+    DebertaV3NliVerifier, NliLabel, NliResult, RobertaMnliVerifier, get_verifier)
 
 
 # ── Claim extractor: rule-based path ────────────────────────────────


### PR DESCRIPTION
## Summary

- Cleans up 39 pre-existing F-class violations (F401 unused imports, F541 f-string without placeholders, F841 assigned-but-unused locals) across LRB / Track C / cycle γ scripts and tests
- After this PR, the ruff CI step on future PRs reports only NEW violations from that PR's changes — current state is ~30 inherited violations swamping the signal

## Effort

- 35 F401/F541 fixed by \`ruff check --fix --select F401,F541\` (autofix)
- 4 F841 (unused locals) fixed manually after reading surrounding code to confirm dead binding:
  - \`scripts/research/build_lrb_scenario_s1.py:405\` — \`person\` (line was vestigial; \`_app_body\` reads \`i\` directly)
  - \`scripts/research/build_lrb_scenario_s2.py:557\` — \`by_event_t\` (replaced by \`week_states\` later in the function)
  - \`scripts/research/build_lrb_scenario_s2.py:584\` — \`vt\` (never referenced)
  - \`scripts/research/lrb_run_v021_cross_model.py:322\` — \`seen_key\` (never referenced)

## Verification

- ✓ \`python -m ruff check --select F .\` → "All checks passed!"
- ✓ 178 tests green across all LRB / cycle γ / D-alce / D-2wiki test modules touched
- ✓ All touched modules import cleanly via \`importlib.import_module\`
- ✓ No removed import was actually being used at runtime (autofix is sound)

## Why now

PR #818-#821 inherited these same F-class failures and merged despite ruff CI failing on main. Cleaning them up lets the next PR's ruff CI output be a true signal about that PR's diff, not noise from existing hygiene debt.

## Out of scope

- E-class (pycodestyle) violations — separate cleanup if needed
- W-class (warnings) — separate
- Type hints / mypy — separate
- \`rab-preprint.zip\` (operator's arXiv bundle, intentionally NOT staged)

Quality delta: exempt (label: chore — hygiene-only; no behavior change; no \`core/\` retrieval/graph/reasoning changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)