### PR TITLE
chore(R5-v0.4.4): Zenodo mint prep — .zenodo.json + release notes

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
-  "title": "PROJECT JAMES — v0.4.3 (RAB v0.1.1: Replayable-Audit Benchmark + Cycle γ multi-hop arc closure)",
-  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.3 ships RAB v0.1.1 (Replayable-Audit Benchmark) — the first replayable-audit benchmark for RAG / agent systems whose 3 metrics (AC / RF / PC) are operationalisations of EU AI Act Articles 10, 12, 19 (in force 2026-08-02). Companion track: Cycle γ multi-hop arc closure (7 probes, 6 honest nulls, 2 self-corrections — multi-hop improvement reframed out of the JAMES roadmap; the graph build O(N²) finding lifted into RAB as the RF-cost axis). No JAMES production runtime change — RAB measures the existing audit / lifecycle / graph paths via a workspace-scoped adapter; production audit.db is untouched.\n\nRAB v0.1.1 — frozen spec + scenario fixture + deterministic scorer + reference / JAMES / Baseline-0 adapters + first gap-table measurement. Authority externalised across 4 axes: (1) Anchors — EU AI Act Art. 10(2)(b) + 12(1)(2)(b) + 19 verbatim + W3C PROV + NIST AI RMF + Mathkar et al. agent-trace survey (arXiv 2606.04990) which explicitly names execution-trace benchmarks as an open challenge → RAB responds to a published gap. (2) Scoring — deterministic only; no LLM judge anywhere in the scorer. (3) Application — generic audit-log JSONL interface; any system that can export an append-only log is scoreable; Baseline-0 (vanilla quickstart + Python logging) scored alongside JAMES; the gap structure across SUTs is the headline (SPEC §5 / §6.5). (4) Verification — every result ships with the SPEC §4 re-verification triple (result.json, exported audit log JSONL, mapping table JSON), committed to reports/rab/ for bit-for-bit re-runs.\n\nR1.0 → R1.5 sequence:\n- #758 / #760 / #761 R1.0 prior-art + EU AI Act anchors — vacancy confirmed; ActiveGraph (arXiv 2605.21997) is independent co-invention of the audit-native architecture → contribution is the benchmark, not the architecture.\n- #762 R1.1 SPEC v0.1.1 FROZEN — eval/rab/SPEC-v0.1.md. v0.1.1 = v0.1.0 + PC's origin-bearing event widened from INGEST only to INGEST | SUPERSEDE (defect caught by reference adapter before any measurement; changelog in the SPEC itself).\n- #763 R1.2 scenario-S1 fixture — eval/rab/scenarios/s1_lifecycle_small.json (40 ops + 10 checkpoints, synthetic Northbridge Labs lifecycle, public domain).\n- #764 R1.3 driver + scorer + reference adapter — eval/rab/{driver,scorer}.py + adapters/reference.py + tests/test_rab_benchmark.py (14 tests pinning reference 1.0×3 self-verification + 3 fault-injection variants).\n- #766 R1.4 pre-registration LOCKED before any adapter code or measurement (R5 rule).\n- #767 R1.4 JAMES adapter (workspace-isolated; SUPERSEDE calls real core.lifecycle.replay_audit.emit_lifecycle_event; cross-verified against core.lifecycle.replay_graph.reconstruct_graph_at — production code path actually exercised) + Baseline-0 adapter (vanilla in-memory RAG + Python-logging-style records = the floor) + scripts/research/rab_run.py CLI writing the SPEC §4 re-verification triple + 17 new tests + 9 measurement artifacts committed to reports/rab/.\n- R1.5 = this release.\n\nGap table (RAB SPEC v0.1.1 / scenario-S1): reference 1.000 / 1.000,1.000 / 1.000; JAMES 1.000 / 1.000,1.000 / 1.000; Baseline-0 0.275 / 0.000,0.000 / 0.000. AC INGEST = 1.0 across all three (default logging covers add-doc); AC UPDATE/SUPERSEDE/DELETE/ANSWER = 0 for Baseline-0 (vanilla logger has no lifecycle taxonomy); RF = 0 for Baseline-0 (logs carry strings, not payload — replay has nothing to fold); PC = 0 for Baseline-0 (no parent_id chain). JAMES = reference on S1 is expected per SPEC §6.5 — the headline is the audit-native vs default-logging gap, not JAMES's score. Honest tier ⭐⭐ scenario-S1 audit-native vs floor gap confirmed; ⭐⭐⭐ cross-scenario remains ungated until additional scenarios ship.\n\nCycle γ multi-hop arc closure (companion track, PRs #752 → #757): MuSiQue probes concluded that multi-hop improvement is not a JAMES roadmap item — the wall is unsupervised supporting-paragraph selection, not retrieval breadth, not model ceiling. Top-8 retrieval recall is 0.76 (both R0 and ablated); oracle-grounded performance jumps 8% → 72% (9×) when supporting paragraphs are given directly. The secondary finding — graph build O(N²) — lifted out of MuSiQue scope (where it had no leverage) into RAB as the RF-cost axis (SPEC §2.2 cost_s_per_1k_events). Env-gates JAMES_RETRIEVE_TOP_K + JAMES_RERANK_TOP_K added (defaults 8 / 5; byte-identical when unset). Selector-tuning rabbit hole closed.\n\nVerification: tests/test_rab_benchmark 14/14 PASS, tests/test_rab_baseline0 8/8 PASS, tests/test_rab_james_adapter 9/9 PASS — RAB test suite 31/31 PASS. No JAMES core test regression — no core/ change in this cycle.\n\nWhat v0.4.3 does NOT do: no production runtime change in JAMES core; no cross-scenario RAB result (S1 only); no Baseline-1 (LangSmith/OTel adapter — separate SUT, future cycle); no mutation-site wiring follow-up to v0.4.2 (T1/T2/T2.D/T6/T7 → emit_lifecycle_event still deferred); no multi-hop retrieval improvement (cycle γ closure re-framed it as not a JAMES roadmap item); no regulatory compliance certification claim (SPEC §6.3).",
-  "version": "v0.4.3",
+  "title": "PROJECT JAMES — v0.4.4 (LRB v0.2.3 S3 publication-scale + cycle γ 4-bench infrastructure closure)",
+  "description": "JAMES is a local-first, auditable knowledge reasoning system. v0.4.4 extends the v0.4.3 software archive with the v0.2.3 release of LRB (Lifecycle Retrieval Benchmark) — the temporal-validity-axis sibling to RAB v0.1.1 — plus the cycle γ 4-bench measurement infrastructure closure. No JAMES core runtime change; this release adds benchmark code, scenario fixtures, measurement artefacts, and a pre-registration trail for an LRB arXiv preprint that cites this DOI for data availability.\n\nLRB v0.2.3 — cross-scale reproducibility extension. The v0.2.1 cross-model leg-clear (gemma4:e4b 4B / gemma3:12b 12B / mixtral:8x7b 47B / claude-haiku-4-5 cloud) demonstrated that R@1 V<N<J on Phase B (S2 time-travel) is not a single-model artefact. v0.2.3 adds the SCALE axis: a programmatic-vocabulary S3 scenario generator producing three preset scales (smoke 100 docs / 282 events / 100 queries, dev 300 / ~1.2k / 300, publication 1000 / ~5.6k / 1000) and a 4-point measurement ladder spanning a 12.5× scale jump (S2 N=80 → S3 publication N=1000). R@1 V<N<J inequality is preserved at every cell of the ladder (J = 0.7125 → 0.930 → 0.913 → 0.845); the JAMES − Naive gap remains above +0.10 at every cell (+0.175 / +0.200 / +0.176 / +0.124). Pattern + gap are scale-robust (⭐⭐⭐); absolute magnitudes are scenario-sensitive (⭐⭐; synthetic templated vocabulary has lower retrieval ambiguity than hand-curated S2 city-operations text, producing higher absolute R@1 ceilings). Cross-scenario claims are therefore limited to ordering and gap structure, not absolute magnitude — this honest framing is locked in the §5 Discussion of the preprint.\n\nA pre-S3.1 measurement (PR #824) reported an apparent ‘within ±0.05 magnitude band' claim, which a per-category audit caught as an artefact of one broken category (current-contract R@10 = 0 across all 3 SUTs from single-template title cluster collapse). PR #825 fixed the generator vocabulary (30 contract domains × 7 contract types = 210 unique title pairs, distinguishable for BM25 / embedding retrieval), restored the broken category, revealed the honest magnitude (J = 0.845 at S3 publication, +0.132 vs S2 token), and retracted the over-tight verdict. This is the 12th wrong-fix-averted in the JAMES cycle history and the first self-catch (the prior 11 were all user-catches). The S3.1 fix → preprint §5 honest framing → arXiv abstract update self-correction loop is the strongest applied evidence of the feedback_oracle_phrase_artifacts measurement-side artefact rule.\n\nCycle γ 4-bench promise — infrastructure closure. The v0.4.3 release closed RGB and MuSiQue measurement; ALCE and 2Wiki were ⭐ infra-only (string-containment fallback citation scoring for ALCE; em/f1/f1_by_type-only for 2Wiki). v0.4.4 ships the D-alce research-tier NLI adapter (RoBERTa-large-MNLI + DeBERTa-v3-large-mnli-fever-anli-ling-wanli, 19 unit tests; T5-XXL TRUE NLI Mixture remains deferred to GPU-attended cycle) and the D-2wiki supporting-fact-aware producer (WikiMultiCitedProducer with [Title #sent_id] citation prompt + parser + 24 unit tests). Both prereg-LOCKED before any measurement, both operator-gated on the actual run (HF model cache + Ollama). After v0.4.4 the cycle γ 4-bench promise is research-tier-ready infrastructure for 4 of 4 cells; the v0.4.3 ⭐ infra-only caveat is closed.\n\nLLM-grounded S3 cross-model runner. PR #827 ships scripts/research/lrb_run_v023b_s3_cross_model.py — a pure-reuse wrapper of the v0.2.1 cross-model run_cell pointed at S3 fixtures. Token-mode smoke verified (V=0.51 / N=0.73 / J=0.93 matches PR #825 ladder cell exactly). LLM-grounded execution operator-gated (~4-6h wall for 12 cells × 4 models). Pre-reg LOCKED.\n\nRepository health. PR #822 closed 39 pre-existing F-class ruff violations across LRB / Track C / cycle γ scripts and tests. 178 tests green across all LRB + cycle γ + D-alce + D-2wiki test modules.\n\nThe headline of v0.4.4 is the SCALE-axis extension of the V<N<J finding (LRB), not a JAMES win — gap structure is the headline per LRB SPEC §4.6. ActiveGraph (arXiv 2605.21997) is independent co-invention of the audit-native validity-window architecture; LRB does not claim novelty of the architecture, only of the benchmark and the cross-scale measurement.\n\nWhat v0.4.4 does NOT do: no JAMES core runtime change; no LLM-grounded S3 publication measurement (operator-gated, separate cycle); no T5-XXL ALCE-official-grade NLI (separate cycle); no HR full sweep n=100 (operator-attended); no TimeQA / TempReason / GraphRAG SUT (operator data-download gated). The arXiv preprint LRB v0.2.5 is a separate artefact and not yet submitted (pre-flight in progress).",
+  "version": "v0.4.4",
   "upload_type": "software",
   "creators": [
     {
@@ -68,7 +68,17 @@
     "deterministic-scorer",
     "pre-registration",
     "gap-table",
-    "event-sourced-log"
+    "event-sourced-log",
+    "lifecycle-retrieval-benchmark",
+    "lrb",
+    "cross-scale-reproducibility",
+    "validity-window",
+    "time-travel-retrieval",
+    "temporal-rag",
+    "alce",
+    "2wikimultihop",
+    "nli-citation-verification",
+    "supporting-fact-citation"
   ],
   "license": "MIT",
   "access_right": "open",
@@ -80,8 +90,13 @@
       "resource_type": "software"
     },
     {
-      "identifier": "10.5281/zenodo.20426719",
+      "identifier": "10.5281/zenodo.20625533",
       "relation": "isNewVersionOf",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "10.5281/zenodo.20426719",
+      "relation": "isDerivedFrom",
       "resource_type": "software"
     },
     {
@@ -168,7 +183,62 @@
       "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/767",
       "relation": "isDocumentedBy",
       "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/819",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/820",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/821",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/822",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/823",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/824",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/825",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/826",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/827",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/828",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
+    },
+    {
+      "identifier": "https://github.com/Hashevolution/James-RAG-Evol/pull/829",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-other"
     }
   ],
-  "notes": "v0.4.3 ships RAB v0.1.1 — the first replayable-audit benchmark for RAG / agent systems with 3 deterministic metrics (AC / RF / PC) operationalising EU AI Act Articles 10, 12, 19. Companion track closes the cycle γ multi-hop arc with 6 honest nulls (multi-hop improvement reframed out of the JAMES roadmap). The full RAB SPEC + scenario + scorer + adapters + 9 measurement artifacts are committed to this repo. The headline is the AUDIT-NATIVE vs DEFAULT-LOGGING gap on scenario-S1 (JAMES = reference = 1.0×3 / Baseline-0 = 0.275, 0.0, 0.0), not JAMES's score — SPEC §6.5 explicitly disclaims JAMES-wins framing. The benchmark, not the architecture, is the contribution: ActiveGraph (arXiv 2605.21997) is independent co-invention of the event-sourced log + deterministic replay. The isNewVersionOf chain pins v0.4.1 (10.5281/zenodo.20426719) as immediate predecessor; v0.4.0 (10.5281/zenodo.20411354) and earlier chained via isDerivedFrom. Three-author joint-piece with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains the mid-June trajectory (separate collab arc — not auto-linked to this release per feedback_eval_cycle_vs_collab_arc_separation)."
+  "notes": "v0.4.4 extends v0.4.3 with the LRB v0.2.3 release (cross-scale reproducibility: 4-point S2→S3 ladder spanning 12.5× scale, R@1 V<N<J preserved at every cell, J−N gap > +0.10 throughout) plus the cycle γ 4-bench measurement infrastructure closure (D-alce research-tier NLI adapter; D-2wiki supporting-fact-aware producer). The S3.1 contract-vocabulary fix retracted a pre-S3.1 over-tight ‘within ±0.05 magnitude band' verdict (broken-category artefact) — this is the 12th wrong-fix-averted in the JAMES cycle history and the first self-catch (the prior 11 were user-catches). Pattern + gap are scale-robust ⭐⭐⭐; absolute magnitudes are scenario-sensitive ⭐⭐ (honest framing locked in preprint §5). The arXiv preprint LRB v0.2.5 (papers/lrb-preprint/main.tex) cites this v0.4.4 DOI for data availability; the LLM-grounded S3 cross-model 12-cell sweep is operator-gated and runs in a separate cycle. The isNewVersionOf chain pins v0.4.3 (10.5281/zenodo.20625533) as immediate predecessor; v0.4.1 (10.5281/zenodo.20426719) and earlier chained via isDerivedFrom. The mid-June joint-piece collab arc with Robin Converse (Triava Labs) and Ali Afana (Provia) on the substitution/synthesis cost-asymmetry finding remains a separate trajectory (not auto-linked to this release per feedback_eval_cycle_vs_collab_arc_separation rule)."
 }

--- a/RELEASE_NOTES_v0.4.4.md
+++ b/RELEASE_NOTES_v0.4.4.md
@@ -1,0 +1,179 @@
+# v0.4.4 — LRB v0.2.3 S3 publication-scale + cycle γ 4-bench infrastructure closure
+
+**Date**: 2026-06-12
+**Predecessor**: v0.4.3 — `10.5281/zenodo.20625533` (deposited 2026-06-10)
+**Concept DOI**: see Zenodo "Versions" tab of the parent record (chain-anchor across all versions)
+**Tag**: `v0.4.4`
+**Commit**: (this release tag)
+
+---
+
+## What's new (11 PRs since v0.4.3)
+
+### LRB v0.2.3 — cross-scale reproducibility extension (6 PRs)
+
+| PR | Type | Summary |
+|---|---|---|
+| #823 | feat | S3 publication-scale generator (smoke / dev / publication presets; 100 / 300 / 1000 docs; deterministic-SHA programmatic vocabulary; 25 unit tests) |
+| #824 | feat | S3 token-mode 4-point ladder measurement (V<N<J preserved across smoke / dev / publication) |
+| #825 | fix | S3.1 contract title diversity (30 domains × 7 types = 210 unique pairs) + honest-framing self-correction (retracts pre-S3.1 over-tight ±0.05 verdict) |
+| #826 | docs | preprint §4.6 Cross-scale + §5 pattern-vs-magnitude framing + §6.1 Limitations + §7.4 Future Work updates |
+| #827 | feat | v0.2.3b cross-model LLM-grounded runner (operator-gated execution; pre-reg LOCKED) |
+| #829 | fix | preprint typo corrections (leg 1 deltas + line 213 narrative) + abstract S3 integration (4 fixes) |
+
+**Headline finding**: R@1 V<N<J inequality preserved at every cell of a 4-point scale ladder spanning a **12.5× scale jump** (S2 N=80 → S3 publication N=1000). JAMES − Naive gap remains above +0.10 at every cell.
+
+| Scenario | N (init/events/queries) | V R@1 | N R@1 | J R@1 | J−N gap |
+|---|---|---|---|---|---|
+| S2 token (frozen v0.2.1) | 200 / 564 / 80 | 0.225 | 0.5375 | 0.7125 | +0.175 |
+| S3 smoke | 100 / 282 / 100 | 0.510 | 0.730 | 0.930 | +0.200 |
+| S3 dev | 300 / 1206 / 300 | 0.530 | 0.737 | 0.913 | +0.176 |
+| **S3 publication** | **1000 / 5620 / 1000** | **0.502** | **0.721** | **0.845** | **+0.124** |
+
+Pattern + gap are scale-robust (⭐⭐⭐). Absolute magnitudes are scenario-sensitive (⭐⭐; synthetic templated vocabulary has lower retrieval ambiguity than hand-curated S2 city-operations text). Cross-scenario claims are therefore limited to ordering and gap structure, not absolute magnitude.
+
+### Cycle γ 4-bench promise — infrastructure closure (3 PRs)
+
+| PR | Type | Summary |
+|---|---|---|
+| #819 | chore | LRB v0.2.1 claude S2 vanilla audit-trail closure (canonical R@1=0.6125 + reproducibility band ⭐ finding: claude API non-determinism produces ~10pp variance between two 1.5min-apart runs) |
+| #820 | feat | D-alce research-tier NLI adapter (RoBERTa-large-MNLI primary + DeBERTa-v3-large-mnli-fever-anli-ling-wanli secondary; 19 unit tests; T5-XXL TRUE NLI Mixture deferred to GPU-attended cycle) |
+| #821 | feat | D-2wiki supporting-fact-aware producer (`WikiMultiCitedProducer` with `[Title #sent_id]` citation prompt + tolerant parser; 24 unit tests) |
+
+After v0.4.4, the cycle γ 4-bench promise has **research-tier-ready infrastructure for 4 of 4 cells** (RGB + MuSiQue + ALCE + 2Wiki). v0.4.3's ⭐ infra-only caveat for ALCE / 2Wiki is closed.
+
+### Repository health (2 PRs)
+
+| PR | Type | Summary |
+|---|---|---|
+| #822 | chore | ruff F-class CI hygiene — 39 pre-existing F401/F541/F841 violations closed; 178 tests green |
+| #828 | docs | Next-session entry handover doc + CLAUDE.md "Where to look next" pointer update |
+
+---
+
+## Self-correction example (12th wrong-fix-averted, **first self-catch**)
+
+PR #824 originally claimed ⭐⭐⭐ "JAMES R@1 within ±0.05 of S2 token reference" (J = 0.673 at S3 publication vs J = 0.713 at S2 token, delta = 0.040). A per-category audit revealed `current-contract R@10 = 0.0 across all 3 SUTs` from single-template contract-title cluster collapse — the broken category coincidentally pulled J magnitude down to match S2.
+
+PR #825 fixed the generator vocabulary, restored the broken category (R@10 = 1.0), revealed the honest J magnitude (0.845, delta +0.132 vs S2 token), and re-graded the verdict (⭐⭐⭐ pattern preserved + ⭐⭐ magnitude scenario-sensitive). PR #826 propagated the honest framing into preprint §5; PR #829 corrected residual abstract / leg 1 typos.
+
+This is the **12th wrong-fix-averted** in the JAMES cycle history and the **first self-catch** (the prior 11 were all user-catches). The S3.1 → preprint §5 → arXiv abstract self-correction loop is the strongest applied evidence of the `feedback_oracle_phrase_artifacts` measurement-side artefact rule: when overall magnitude looks like a coincidence, audit per-category before declaring ⭐⭐⭐.
+
+---
+
+## What's NOT included (separate cycles)
+
+- **LLM-grounded S3 publication run** (v0.2.3b operator-gated; ~4-6h wall for 12 cells × 4 models)
+- **D-alce research-tier measurement** (operator-gated; HF cache ~1.5GB × 2, CPU ~3-5min × 2)
+- **D-2wiki research-tier measurement** (operator-gated; ~3-5min on local gemma4:e4b)
+- **T5-XXL TRUE NLI Mixture integration** (ALCE-official-grade verifier; GPU-attended)
+- **HR full sweep n=100** (operator-attended)
+- **TimeQA / TempReason / Microsoft GraphRAG SUT** (operator data-download + license gated)
+- **arXiv preprint LRB v0.2.5 submission** (pre-flight in progress; this DOI will be cited in Acknowledgements)
+- **Joint-piece collab arc with Robin Converse / Ali Afana** (separate trajectory, not auto-linked per the eval-cycle-vs-collab-arc-separation rule)
+
+---
+
+## Reproducing the results
+
+```bash
+# 1. Generate scenario fixtures (deterministic; no LLM; SHA-pinned)
+python scripts/research/build_lrb_scenario_s1.py
+python scripts/research/build_lrb_scenario_s2.py
+python scripts/research/build_lrb_scenario_s3.py --scale smoke
+python scripts/research/build_lrb_scenario_s3.py --scale dev
+python scripts/research/build_lrb_scenario_s3.py --scale publication
+
+# 2. Phase A (S1 current-only) + Phase B (S2 time-travel) token-mode
+python scripts/research/lrb_run_phase_b.py --scenarios S1,S2 --k 10
+
+# 3. v0.2.1 cross-model (S1+S2 × 4 models × token + llm-grounded)
+PYTHONPATH=. python scripts/research/lrb_run_v021_cross_model.py \
+  --scenarios S1,S2 \
+  --modes token,llm-grounded \
+  --models gemma4:e4b,gemma3:12b,mixtral:8x7b,claude-haiku-4-5
+
+# 4. v0.2.3 S3 token-mode ladder (this release; deterministic; no LLM)
+python scripts/research/lrb_run_s3.py --scale smoke
+python scripts/research/lrb_run_s3.py --scale dev
+python scripts/research/lrb_run_s3.py --scale publication
+
+# 5. v0.2.3b S3 cross-model LLM-grounded (this release infrastructure;
+#    operator-gated; expensive)
+PYTHONPATH=. python scripts/research/lrb_run_v023b_s3_cross_model.py \
+  --scale publication \
+  --modes llm-grounded \
+  --models gemma4:e4b,gemma3:12b,mixtral:8x7b,claude-haiku-4-5
+
+# 6. v0.2.4 HR axis (RoBERTa primary + DeBERTa rescore)
+PYTHONPATH=. python scripts/research/lrb_v024_hr_smoke.py
+PYTHONPATH=. python scripts/research/lrb_v024_hr_rescore.py
+
+# 7. Cycle γ 4-bench (RGB + MuSiQue + ALCE + 2Wiki)
+python scripts/research/alce_smoke_run.py --verifier roberta-mnli --n 20
+python scripts/research/alce_smoke_run.py --verifier deberta-v3-anli --n 20
+python scripts/research/wiki2_smoke_run.py --cited --n 20
+```
+
+All result.json + bench.jsonl files land in `reports/external/lrb/` and `reports/external/{alce,2wiki,musique}/` deterministically (SHA-pinned per fixture; LLM-grounded mode inherits the ~10pp claude-API reproducibility band documented in PR #819).
+
+---
+
+## Citation
+
+```bibtex
+@software{seo2026james044,
+  author    = {Seo, Jiwon},
+  title     = {PROJECT JAMES — v0.4.4 (LRB v0.2.3 S3 publication-scale +
+               cycle γ 4-bench infrastructure closure)},
+  year      = {2026},
+  month     = {6},
+  doi       = {10.5281/zenodo.XXXXXXXX},
+  url       = {https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.4},
+  version   = {v0.4.4},
+  publisher = {Zenodo}
+}
+```
+
+(DOI populated by Zenodo after release publish.)
+
+---
+
+## Pre-registrations (LOCKED before measurement, R5 rule)
+
+| Cycle | Pre-reg doc |
+|---|---|
+| LRB Phase A (S1 current-only) | `docs/research/lrb-phase-a-smoke-preregistration-2026-06-11.md` |
+| LRB Phase B (S2 time-travel) | `docs/research/lrb-phase-b-time-travel-preregistration-2026-06-11.md` |
+| LRB v0.2.1 cross-model | `docs/research/lrb-v021-cross-model-preregistration-2026-06-11.md` |
+| LRB v0.2.4 HR axis | `docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md` |
+| **LRB v0.2.3 S3 scale** (new) | `docs/research/lrb-v023-s3-publication-scale-preregistration-2026-06-12.md` |
+| **LRB v0.2.3b S3 cross-model** (new) | `docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md` |
+| **D-alce research-tier NLI** (new) | `docs/research/cycle-gamma-d-alce-research-tier-nli-preregistration-2026-06-12.md` |
+| **D-2wiki supporting-fact** (new) | `docs/research/cycle-gamma-d-2wiki-supporting-fact-preregistration-2026-06-12.md` |
+
+Each pre-reg is a Markdown LOCK doc committed before any measurement code or result.json artefact. All eight pre-regs (including the four inherited from v0.4.3) are committed in this repository and accessible at the v0.4.4 tag commit.
+
+---
+
+## Test suite
+
+After this release: **~200+ tests pass**. Touched in v0.4.4:
+- `tests/test_alce_nli_adapter.py` — 19 tests (D-alce contract)
+- `tests/test_wikimulti_cited_producer.py` — 24 tests (D-2wiki parser + scorer round-trip)
+- `tests/test_lrb_s3_generator.py` — 27 tests (S3 vocabulary primitives + determinism + scale invariants)
+- Existing tests: 0 regression from any of the 11 PRs
+
+---
+
+## Honest framing summary
+
+The headline of v0.4.4 is the **SCALE-axis extension of the V<N<J finding** (LRB), not a JAMES win. Gap structure is the headline per LRB SPEC §4.6.
+
+- ✓ Pattern + gap scale-robust (publication-tier evidence)
+- ⚠ Absolute magnitudes scenario-sensitive (honest caveat; not a JAMES claim)
+- ✗ ActiveGraph (arXiv 2605.21997) is independent co-invention of the audit-native validity-window architecture; LRB does NOT claim novelty of the architecture, only of the benchmark and the cross-scale measurement
+- ✗ Multi-hop reasoning is saturated honest negative (3-SUT identical on MuSiQue)
+- ✗ EU AI Act references are anchor / framing, not compliance certification
+
+This release is the data-availability anchor for the LRB v0.2.5 arXiv preprint. The preprint's Acknowledgements section will cite the v0.4.4 DOI assigned at Zenodo mint.


### PR DESCRIPTION
## Summary

Prep for Zenodo v0.4.4 mint. Updates .zenodo.json metadata to trigger a new version DOI via GitHub-Zenodo webhook on next GitHub Release publish event, and drafts the release notes for the GitHub Release UI.

## Changes

### .zenodo.json
- title: v0.4.3 → v0.4.4 (LRB v0.2.3 + cycle γ closure)
- description: extended ~2500 → ~4600 chars covering this session's 11 PRs
- version: v0.4.3 → v0.4.4
- related_identifiers:
  - 10.5281/zenodo.20625533 (v0.4.3) added as isNewVersionOf
  - v0.4.1's 10.5281/zenodo.20426719 demoted from isNewVersionOf to isDerivedFrom (now ancestor)
  - PRs #819-#829 (11 new PRs) added as isDocumentedBy
- keywords: 10 new (lrb / cross-scale-reproducibility / validity-window / time-travel-retrieval / temporal-rag / alce / 2wikimultihop / nli-citation-verification / supporting-fact-citation / lifecycle-retrieval-benchmark)
- notes: extended with v0.4.4 narrative

### RELEASE_NOTES_v0.4.4.md (new)
GitHub Release body draft covering:
- 11 PRs grouped by track (LRB v0.2.3 / cycle γ / repo health)
- 4-point scale ladder table (V/N/J at S2 / S3 smoke / S3 dev / S3 publication)
- Self-correction narrative (12th wrong-fix-averted, first self-catch)
- What's NOT included (operator-gated separate cycles)
- Reproducibility instructions (7-step CLI sequence)
- Citation BibTeX template (DOI placeholder)
- Pre-registration list (8 LOCKed docs)
- Test suite summary
- Honest framing rules applied

## Verification

- ✓ .zenodo.json validates as JSON (title 97 chars, description 4636 chars, 61 keywords, 31 related_identifiers, version v0.4.4)
- ✓ All PR URLs use Hashevolution/James-RAG-Evol/pull/<N> format (consistent with v0.4.3 convention)
- ✓ isNewVersionOf chain: v0.4.4 → v0.4.3 (20625533) → v0.4.1 (20426719) → v0.4.0 (20411354) → earlier

## Operator action remaining (post-merge)

1. \`git tag -a v0.4.4 -m "LRB v0.2.3 S3 publication-scale + cycle γ closure"\`
2. \`git push origin v0.4.4\`
3. \`gh release create v0.4.4 --notes-file RELEASE_NOTES_v0.4.4.md --latest\` (or GitHub UI)
4. Wait for Zenodo webhook (1-15 min)
5. Verify new DOI at https://zenodo.org/account/settings/github/
6. Update preprint Acknowledgements with new DOI string (separate PR)
7. Final preprint rebuild + arXiv submission proceeds

## Out of scope

- git tag + push (operator action 1-2)
- GitHub Release publish (operator action 3)
- Preprint Acknowledgements DOI insertion (post-mint, separate PR)
- arXiv submission itself (operator action, separate)

Quality delta: exempt (label: chore — metadata + release notes; no \`core/\` change; no measurement axes; no test changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)