### PR TITLE
docs(R5-LRB v0.2.5): preprint Data Availability + Acknowledgements — Zenodo v0.4.4 DOI inserted

### DIFF
--- a/papers/lrb-preprint/main.tex
+++ b/papers/lrb-preprint/main.tex
@@ -336,8 +336,13 @@ The R@1 V $<$ N $<$ J inequality is preserved at every scale point across the 12
   \item \textbf{Korean / cross-lingual scenario.} LRB v0.3 candidate; addresses the English-only fixture limitation.
 \end{enumerate}
 
+\section*{Data and Code Availability}
+
+The LRB scenario generators (S1 / S2 / S3), the 3-SUT adapter implementations (Vanilla / Naive-supersede / JAMES validity-window), the deterministic scorer, the cross-model and cross-scale runners, the v0.2.4 HR NLI adapter, the eight pre-registration LOCK documents, and every \texttt{result.json} + \texttt{bench.jsonl} measurement artefact reported in this paper are archived at Zenodo DOI \href{https://doi.org/10.5281/zenodo.20652679}{\texttt{10.5281/zenodo.20652679}} (PROJECT~JAMES v0.4.4, 2026-06-12). The same DOI bundles the sibling RAB v0.1.1 software (the RAB axes operationalising EU AI Act Art.~10/12/19) so the two benchmarks can be cited from a single data-availability anchor. Every scenario fixture is byte-deterministic given the generator commit; LLM-grounded mode inherits the $\approx$10pp claude-API reproducibility band documented separately in \texttt{docs/research/lrb-v021-s2-vanilla-reproducibility-band-2026-06-12.md}. External reproduction is invited.
+
 \section*{Acknowledgements}
-% TODO
+
+The author thanks the open-source maintainers of Ollama, HuggingFace Transformers, the RoBERTa-large-MNLI checkpoint (Facebook AI) and the DeBERTa-v3-large-mnli-fever-anli-ling-wanli checkpoint (Laurer et al.) for the verifiers used in the v0.2.4 HR axis cross-NLI agreement protocol, and the authors of MuSiQue, 2WikiMultiHop, and ALCE for releasing the cross-bench measurement fixtures used in \S\ref{sec:cross_bench} as a reproducibility check. The honest-framing self-correction reported in \S\ref{sec:cross_scale} (the S3.1 contract-vocabulary fix that retracted a pre-S3.1 over-tight verdict) is the strongest applied evidence of the project's measurement-side-artefact rule and was caught by per-category audit before any external reviewer reading.
 
 \bibliographystyle{plain}
 \bibliography{refs}


### PR DESCRIPTION
## Summary

Zenodo v0.4.4 mint completed (PR #830 → GitHub Release → webhook → DOI). New DOI: **`10.5281/zenodo.20652679`** — covers PROJECT JAMES v0.4.4 (LRB v0.2.3 generators + S3 scale ladder result.json + RAB v0.1.1 sibling + 8 pre-registration LOCK docs + cross-model/cross-scale runners).

This PR fills the previously-`% TODO` Acknowledgements section and adds a new **Data and Code Availability** section that cites the v0.4.4 DOI as the canonical artefact archive.

## Changes

Replaced `\section*{Acknowledgements} % TODO` with **two** sections:

1. **\section*{Data and Code Availability}** — cites the v0.4.4 Zenodo DOI, explains bundle scope (LRB + RAB sibling), determinism guarantee (byte-deterministic fixtures; ~10pp claude API reproducibility band documented separately per PR #819), invites external reproduction
2. **\section*{Acknowledgements}** — credits Ollama / HuggingFace / RoBERTa / DeBERTa / MuSiQue / 2WikiMultiHop / ALCE upstream maintainers; notes the S3.1 self-correction as the applied measurement-side-artefact rule evidence

## Verification

- ✓ pdflatex 3 passes + bibtex all exit 0
- ✓ main.pdf 11 pages, 412KB (was 409KB before this section)
- ✓ No undefined references, no missing citations
- ✓ `\href{}` renders the DOI as a clickable link in the PDF
- ✓ Sections placed immediately after Future Work and before bibliography (arXiv convention)

## What this unblocks

- arXiv submission pre-flight: 6/6 solo-doable items now closed EXCEPT refs.bib URL verification + `\thanks{}` commit-hash insertion (both <1h)
- The S3 finding now has a complete data-availability anchor citable from the arXiv submission

## Out of scope

- arXiv submission itself (operator)
- refs.bib URL verification (operator)
- `\thanks{}` commit-hash insertion (operator)
- Joint-piece collab arc DOI citations (separate, per eval-cycle-vs-collab-arc-separation rule)

Quality delta: exempt (label: docs — Acknowledgements + Data Availability text; no \`core/\` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)