### PR TITLE
chore(R5-v0.4.4): README + CHANGELOG sync to v0.4.4 (Phase 1 enterprise polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.4] — 2026-06-12 — LRB v0.2.3 S3 publication-scale + cycle γ 4-bench infrastructure closure
+
+**Theme**: v0.4.4 extends v0.4.3 with **LRB v0.2.3** — the *Lifecycle Retrieval Benchmark*'s cross-scale reproducibility extension and a sibling axis to RAB v0.1.1. The v0.2.1 cross-model leg-clear (gemma4:e4b 4B / gemma3:12b 12B / mixtral:8x7b 47B / claude-haiku-4-5 cloud) established that **R@1 V<N<J on Phase B (S2 time-travel)** is not a single-model artefact; **v0.2.3 adds the scale axis**: a 4-point ladder spanning a **12.5× scale jump** (S2 N=80 → S3 publication N=1000) preserves the V<N<J inequality at every cell with JAMES − Naive gap above +0.10 throughout. **Pattern + gap are scale-robust ⭐⭐⭐; absolute magnitudes are scenario-sensitive ⭐⭐** (honest framing locked in preprint §5).
+
+Same cycle ships the **cycle γ 4-bench measurement infrastructure closure**: D-alce research-tier NLI adapter + D-2wiki supporting-fact-aware producer promote ALCE and 2Wiki cells from ⭐ infra-only (v0.4.3) to research-tier-ready infrastructure for 4-of-4 cycle γ benches.
+
+**No JAMES production runtime change** — v0.4.4 ships generators, scorers, runners, NLI adapters, 8 pre-registration LOCK documents, and 2 arXiv preprints (papers/rab-preprint, papers/lrb-preprint). The arXiv preprints cite Zenodo DOI [`10.5281/zenodo.20652679`](https://doi.org/10.5281/zenodo.20652679) for data availability.
+
+### LRB v0.2.3 — cross-scale reproducibility extension
+
+- **#823 S3 publication-scale generator** — programmatic vocabulary; three presets (smoke 100 docs / 282 events / 100 queries; dev 300 / 1.2k / 300; publication 1000 / 5.6k / 1000); SHA-deterministic; 25 unit tests.
+- **#824 S3 token-mode 4-point ladder measurement** — initial verdict.
+- **#825 S3.1 contract-vocabulary fix + honest-framing self-correction** — broken `current-contract` category caught via per-category audit; generator fix → honest J magnitude 0.845 (delta +0.132 vs S2 token); re-graded verdict ⭐⭐⭐ pattern + gap / ⭐⭐ magnitude. **First self-catch in the JAMES cycle history's 12 wrong-fix-averted instances**.
+- **#826 preprint integration** — papers/lrb-preprint/main.tex §4.6 + §5 + §6.1 + §7.4.
+- **#827 v0.2.3b cross-model LLM-grounded runner** — pure-reuse wrapper; operator-gated; pre-reg LOCKED.
+- **#829 preprint typo + abstract S3 integration** — 4 fixes.
+
+### Cycle γ 4-bench infrastructure closure
+
+- **#819 audit-trail closure** — canonical claude S2 vanilla R@1=0.6125 committed + ⭐ reproducibility band finding (~10pp claude API non-determinism between ~1.5min-apart runs).
+- **#820 D-alce research-tier NLI adapter** — RoBERTa-MNLI + DeBERTa-v3-large-mnli-fever-anli-ling-wanli; T5-XXL deferred; 19 tests.
+- **#821 D-2wiki supporting-fact-aware producer** — `[Title #sent_id]` citation prompt + tolerant parser; 24 tests.
+
+### Repository health + papers pre-flight
+
+- **#822 ruff F-class CI hygiene** — 39 → 0 violations; 178 tests green.
+- **#828 next-session entry handover**.
+- **#830 Zenodo v0.4.4 mint prep** → DOI `10.5281/zenodo.20652679` minted via GitHub Release webhook.
+- **#831 preprint Data Availability + Acknowledgements** — DOI inserted.
+- **#832 refs.bib citation corrections + LRB \thanks{} commit-hash insertion** — 6 LLM-fabricated citation patterns caught (4 wrong-author + 2 fabricated URLs).
+- **#833 Stage-2 deep audit cleanup** — EU AI Act precision, "JAMES T5" → "JAMES", attribution fix.
+
+### Self-correction narrative (12th wrong-fix-averted, first self-catch)
+
+PR #824 originally claimed ⭐⭐⭐ "JAMES R@1 within ±0.05 of S2 token reference". A per-category audit revealed `current-contract R@10 = 0.0` across all 3 SUTs from single-template title cluster collapse. PR #825 fixed the generator, revealed the honest J magnitude (0.845, delta +0.132), and re-graded the verdict. **Strongest applied evidence of the `feedback_oracle_phrase_artifacts` measurement-side-artefact rule**. The prior 11 wrong-fix-averted instances were all user-catches; this is the first self-catch.
+
+### What v0.4.4 does NOT include (separate cycles)
+
+- LLM-grounded S3 publication run (v0.2.3b operator-gated)
+- D-alce / D-2wiki research-tier measurement (operator-gated)
+- T5-XXL TRUE NLI Mixture integration (GPU-attended)
+- HR full sweep n=100 (operator-attended)
+- TimeQA / TempReason / GraphRAG SUT (operator data-download gated)
+- arXiv preprint submission (pre-flight complete; endorsement = operator-gated last step)
+
+### Verification
+
+After v0.4.4: **~200+ tests pass**. New: `test_alce_nli_adapter.py` (19), `test_wikimulti_cited_producer.py` (24), `test_lrb_s3_generator.py` (27). Existing: 0 regressions.
+
+---
+
 ## [0.4.3] — 2026-06-10 — RAB v0.1.1 (Replayable-Audit Benchmark) + Cycle γ multi-hop arc closure
 
 **Theme**: v0.4.3 ships **RAB v0.1.1** — the first replayable-audit benchmark for RAG / agent systems whose 3 metrics (AC / RF / PC) are operationalisations of EU AI Act Articles 10, 12, 19 (in force 2026-08-02). Same cycle closes the cycle γ multi-hop arc (7 probes, 6 honest nulls, 2 self-corrections — `multi-hop improvement` reframed out of the JAMES roadmap; **graph build O(N²) finding** lifted into RAB as the RF-cost axis). No JAMES production runtime change — RAB measures the existing audit / lifecycle / graph paths via a workspace-scoped adapter; production `audit.db` is untouched.

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,10 +14,12 @@
 > 모순 트리 등도 모두 first-class 차별점.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.1-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.1)
+[![Status](https://img.shields.io/badge/Status-v0.4.4-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.4)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20625533.svg)](https://doi.org/10.5281/zenodo.20625533)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20652679.svg)](https://doi.org/10.5281/zenodo.20652679)
+[![RAB SPEC](https://img.shields.io/badge/RAB%20SPEC-v0.1.1-green.svg)](eval/rab/SPEC-v0.1.md)
+[![LRB Benchmark](https://img.shields.io/badge/LRB-v0.2.3-green.svg)](papers/lrb-preprint/main.pdf)
 
 ![PROJECT JAMES — 3D 온톨로지 그래프 시각화](reports/promo-assets/screenshots/06-3d-graph.jpg)
 
@@ -26,9 +28,29 @@
 
 ---
 
-## 프로젝트 상태: v0.4.1 — T6 Causality Chain (CASCADE extension)
+## 프로젝트 상태: v0.4.4 — LRB v0.2.3 S3 publication-scale + cycle γ 4-벤치 인프라 마감
 
-**2026-05-28 릴리스**. v0.4.1 은 v0.4.0 이 절반만 마친 CASCADE
+**2026-06-12 릴리스**. v0.4.4 는 v0.4.3 (RAB v0.1.1) 에 **LRB v0.2.3** — *Lifecycle Retrieval Benchmark* 의 cross-scale 재현성 확장 + RAB 의 sibling axis — 을 더합니다. v0.2.1 cross-model (gemma4:e4b 4B / gemma3:12b 12B / mixtral:8x7b 47B / claude-haiku-4-5) 가 Phase B (S2 time-travel) 의 **R@1 V<N<J** 가 single-model artefact 가 아님을 입증했고, **v0.2.3 가 scale 축을 추가**: **12.5× 스케일 점프** (S2 N=80 → S3 publication N=1000) 의 4-point ladder 모든 cell 에서 V<N<J 부등호 + JAMES − Naive gap +0.10 이상 유지. **Pattern + gap 은 scale-robust ⭐⭐⭐, 절대 magnitude 는 scenario-sensitive ⭐⭐** (honest framing 은 preprint §5 에 lock — 12번째 wrong-fix-averted 이자 **첫 self-catch** 의 S3.1 contract-vocabulary fix 가 pre-S3.1 over-tight verdict 를 retract).
+
+같은 cycle 에서 **cycle γ 4-벤치 measurement 인프라 마감**: D-alce research-tier NLI adapter (RoBERTa-MNLI + DeBERTa-v3-ANLI) + D-2wiki supporting-fact-aware producer 가 ALCE / 2Wiki 셀을 v0.4.3 의 ⭐ infra-only 에서 4-of-4 research-tier-ready 로 격상.
+
+**Papers 제출 준비 완료** (pre-flight 마감, arXiv endorsement 대기):
+- **RAB preprint** (10페이지): [papers/rab-preprint/main.pdf](papers/rab-preprint/main.pdf) — *EU AI Act Art. 10/12/19 를 측정 가능 audit-quality 벤치마크로 operationalise.*
+- **LRB preprint** (11페이지): [papers/lrb-preprint/main.pdf](papers/lrb-preprint/main.pdf) — *RAG 의 temporal validity 축; 4 모델 × 4 스케일에서 V<N<J 보존.*
+
+JAMES production runtime 변경 없음 — v0.4.4 는 generator, scorer, runner, NLI adapter, 8 pre-registration LOCK 문서 만 ship. arXiv preprint 는 Zenodo DOI [10.5281/zenodo.20652679](https://doi.org/10.5281/zenodo.20652679) 를 data availability 로 인용.
+
+---
+
+## 프로젝트 상태: v0.4.3 — RAB v0.1.1 (Replayable-Audit Benchmark) + Cycle γ multi-hop arc 마감
+
+**2026-06-10 릴리스**. v0.4.3 는 **RAB v0.1.1** 출시 — RAG / agent 시스템의 audit log 품질을 측정하는 최초 replayable-audit benchmark. 3 결정론적 metric (AC / RF / PC) 는 EU AI Act Art. 10/12/19 (Art. 113 에 따라 2026-08-02 부터 적용) 의 operationalisation. JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 (vanilla quickstart + default logging) = 0.275 / 0.000 / 0.000 (scenario-S1). Headline 은 SUT 간 **gap structure** — JAMES 점수 자체가 아님 (SPEC §6.5 가 JAMES-wins framing 명시 거부). Honest framing: **벤치마크 자체가 contribution, 아키텍처 아님** — ActiveGraph (arXiv 2605.21997) 가 audit-native runtime 의 독립 co-invention; 빈 곳은 측정이지 시스템이 아님.
+
+같은 cycle 의 companion track 이 **Cycle γ multi-hop arc** 마감 (PR #752 → #757) — 6 honest null: multi-hop improvement 가 JAMES 로드맵에서 reframe out; **graph build O(N²)** secondary finding 이 RAB 의 RF-cost 축으로 lift.
+
+이전: **v0.4.2** (2026-06-06) 가 T5 Replayable Audit Graph 출시 — 전체 event-sourced graph-wide 재구성 (`reconstruct_graph_at(t)` audit-only primitive, RAB 가 측정하는 품질의 building block).
+
+이전: **v0.4.1** (2026-05-28) 가 v0.4.0 이 절반만 마친 CASCADE
 pillar 를 마감합니다. base fact 의 sources 가 모두 제거되면,
 `derived_from` 이 그 base 를 가리키는 edge 들이
 `invalidate_derived_facts` 로 자동 무효화 — 파생 체인이 운영자

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@
 > API, and the deterministic 4-rule contradiction tree.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.3-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.3)
+[![Status](https://img.shields.io/badge/Status-v0.4.4-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.4)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20625533.svg)](https://doi.org/10.5281/zenodo.20625533)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20652679.svg)](https://doi.org/10.5281/zenodo.20652679)
 [![RAB SPEC](https://img.shields.io/badge/RAB%20SPEC-v0.1.1-green.svg)](eval/rab/SPEC-v0.1.md)
+[![LRB Benchmark](https://img.shields.io/badge/LRB-v0.2.3-green.svg)](papers/lrb-preprint/main.pdf)
 
 ![PROJECT JAMES — 3D ontology graph visualizer](reports/promo-assets/screenshots/06-3d-graph.jpg)
 
@@ -43,9 +44,24 @@ The numbers below come from the current `main` branch — not aspirational, not 
 | **Module size discipline** | 20 KB cap enforced on every `core/` file. Largest current: `core/lifecycle/schema.py` at 18.9 KB | CLAUDE.md rule 5 + module-size CI gate |
 | **Default-off invariant** | Every routing layer added since v0.3 (D5 / LEO / D1 / T2.D / T6 LLM) defaults OFF — production fleets pulling v0.4.1 see byte-identical retrieval to v0.3.3 unless they opt in | `JAMES_*` env audit (CHANGELOG `[0.4.x]` table) |
 | **Deterministic contradiction arbitration** | `classify_contradiction` is an LLM-free 4-rule decision tree (~10.2 KB pure function). Audit-replay-safe by construction. | `core/lifecycle/contradiction_arbiter.py` |
-| **RAB v0.1.1 — Replayable-Audit Benchmark** | **JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 (vanilla quickstart + default logging) = 0.275 / 0.000 / 0.000** on scenario-S1. Deterministic scorer (no LLM judge); 3 metrics map to EU AI Act Art. 10/12/19 (in force 2026-08-02). | `eval/rab/SPEC-v0.1.md` + `python scripts/research/rab_run.py --sut {reference,baseline0,james}` |
+| **RAB v0.1.1 — Replayable-Audit Benchmark** | **JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 (vanilla quickstart + default logging) = 0.275 / 0.000 / 0.000** on scenario-S1. Deterministic scorer (no LLM judge); 3 metrics map to EU AI Act Art. 10/12/19 (applies from 2026-08-02 per Art. 113). | `eval/rab/SPEC-v0.1.md` + `python scripts/research/rab_run.py --sut {reference,baseline0,james}` |
+| **LRB v0.2.3 — Lifecycle Retrieval Benchmark** | **R@1 V<N<J preserved across a 4-point scale ladder** (S2 N=80 → S3 publication N=1000, **12.5× scale**) and **across 4 model families** (gemma4:e4b / gemma3:12b / mixtral / claude). S3 publication R@1: V/N/J = 0.502 / 0.721 / **0.845**. JAMES − Naive gap > +0.10 at every scale point. Pattern + gap scale-robust ⭐⭐⭐; absolute magnitude scenario-sensitive ⭐⭐. | `papers/lrb-preprint/main.pdf` + `python scripts/research/lrb_run_s3.py --scale publication` |
 
 **What is NOT yet headline-verified**: a single-page ablation card showing **Graph-RAG vs flat RAG** on the same fixture. The infrastructure to produce it (`scripts/qvt_capture_baseline.py` + the 18-cell ablation matrix design from QVT memo §5) is wired; the operator-run capture is the late-June deliverable. Until then, the graph contribution is measurable via `graph_paths_count` per query in any STEP 7 bench output, but not summarized in one table.
+
+---
+
+## Project Status: v0.4.4 — LRB v0.2.3 S3 publication-scale + cycle γ 4-bench infrastructure closure
+
+Released **2026-06-12**. v0.4.4 extends v0.4.3 with **LRB v0.2.3** — the *Lifecycle Retrieval Benchmark*'s cross-scale reproducibility extension and a sibling axis to RAB v0.1.1. v0.2.1 cross-model (gemma4:e4b 4B / gemma3:12b 12B / mixtral:8x7b 47B / claude-haiku-4-5) established that **R@1 V<N<J on Phase B (S2 time-travel)** is not a single-model artefact; **v0.2.3 adds the scale axis**: a 4-point ladder spanning a **12.5× scale jump** (S2 N=80 → S3 publication N=1000) preserves the V<N<J inequality at every cell with the JAMES − Naive gap above +0.10 throughout. **Pattern + gap are scale-robust ⭐⭐⭐; absolute magnitudes are scenario-sensitive ⭐⭐** (honest framing locked in preprint §5; the S3.1 contract-vocabulary fix retracted a pre-S3.1 over-tight verdict — first **self-catch** in the JAMES cycle history's 12 wrong-fix-averted instances).
+
+Same cycle ships the **cycle γ 4-bench measurement infrastructure closure**: D-alce research-tier NLI adapter (RoBERTa-MNLI + DeBERTa-v3-ANLI) and D-2wiki supporting-fact-aware producer promote ALCE and 2Wiki cells from ⭐ infra-only (v0.4.3) to research-tier-ready infrastructure for 4-of-4 cycle γ benches.
+
+**Papers ready for submission** (pre-flight complete, arXiv endorsement pending):
+- **RAB preprint** (10 pages): [papers/rab-preprint/main.pdf](papers/rab-preprint/main.pdf) — *Operationalising EU AI Act Articles 10/12/19 into a measurable audit-quality benchmark.*
+- **LRB preprint** (11 pages): [papers/lrb-preprint/main.pdf](papers/lrb-preprint/main.pdf) — *Temporal validity axis for RAG; V<N<J across 4 model families × 4 scale points.*
+
+No JAMES production runtime change — v0.4.4 ships generators, scorers, runners, NLI adapters, and 8 pre-registration LOCK documents. The arXiv preprints cite Zenodo DOI [10.5281/zenodo.20652679](https://doi.org/10.5281/zenodo.20652679) for data availability.
 
 ---
 


### PR DESCRIPTION
## Summary

Enterprise-polish Phase 1: GitHub repo first-page presentation reflects v0.4.4 (was v0.4.3 EN / v0.4.1 KO). Visitors see current status badge, current DOI link, RAB + LRB benchmark badges, and a section pointing at both preprints.

## Changes

### README.md
- Status badge v0.4.3 → v0.4.4
- DOI badge 20625533 (v0.4.3) → 20652679 (v0.4.4)
- New LRB Benchmark badge → papers/lrb-preprint/main.pdf
- New "Project Status: v0.4.4" section (LRB v0.2.3 S3 ladder + cycle γ 4-bench closure + papers ready)
- "What's Verified" table: new row for LRB v0.2.3 (S3 publication V/N/J = 0.502/0.721/0.845, 12.5× scale ladder)
- RAB row: Art. 113 precision ("in force" → "applies from")

### README.ko.md
- 3-version jump catch-up (v0.4.1 → v0.4.4)
- Korean translation matching EN narrative
- v0.4.4 / v0.4.3 / v0.4.2 sections added; v0.4.1 / v0.4.0 preserved as chain

### CHANGELOG.md
- New [0.4.4] entry covering all 11 PRs (#819-#833)
- Self-correction narrative (12th wrong-fix-averted, first self-catch)
- "What v0.4.4 does NOT include" list

## Verification

- All 3 files render correctly
- All badge URLs valid
- All cited DOIs / PRs / refs resolve
- v0.4.3 → v0.4.4 chain preserved

## Out of scope (Phase 2 + 3 follow-up)

- Phase 2: "Papers & Citations" section with BibTeX + reproduction one-liner
- Phase 3: Hero / "Why JAMES vs LangChain / LlamaIndex" enterprise-scanner first impression

Quality delta: exempt (label: chore — README + CHANGELOG only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)