### PR TITLE
feat(v0.5-B.5.d): document subtype filter — typed-filter integration

### DIFF
--- a/core/graph_typed_filter.py
+++ b/core/graph_typed_filter.py
@@ -37,7 +37,7 @@ import os
 import re
 from typing import Dict, Iterable, List, Sequence, Tuple
 
-from core.ontology import ENTITY_TYPES
+from core.ontology import DOCUMENT_SUBTYPES, ENTITY_TYPES
 
 
 # ─── Runtime flag ──────────────────────────────────────────────────────
@@ -283,10 +283,246 @@ def apply_typed_filter(
     return rendered, groups
 
 
+# ─── v0.5 B.5.d — Document-subtype intent layer ───────────────────────
+#
+# Parallel to the entity-type classifier above, but operating on
+# DOCUMENT_SUBTYPES (10 horizontal subtypes added in B.5.b). For
+# enterprise queries like "which policy is in force?", the
+# entity-type-level classifier would return ["org"] or fall through to
+# "concept" — losing the structural cue that the user is asking about a
+# specific document KIND. This layer fills that gap with the same
+# R1-R5 contract preserved at the subtype level.
+#
+# This layer is additive — existing callers of `classify_query_intent`
+# / `apply_typed_filter` are unchanged. Callers that ingest document
+# entities can opt in to `apply_document_subtype_filter` for an extra
+# typed-context block. The same `JAMES_DISABLE_TYPED_FILTER` env var
+# disables both layers.
+#
+# Vertical-agnostic per CLAUDE.md rule #1 — keywords are generic
+# horizontal terms (no NDA / recipe / 10-K / treatment-protocol).
+
+_SUBTYPE_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "contract": (
+        "contract", "agreement", "sla", "service agreement", "mou",
+        "계약", "계약서", "협약", "서비스 계약",
+    ),
+    "policy": (
+        "policy", "policies", "guideline", "guidelines", "rule book",
+        "정책", "지침", "방침",
+    ),
+    "procedure": (
+        "procedure", "process", "sop", "workflow", "how to",
+        "절차", "프로세스", "업무 절차", "표준 작업",
+    ),
+    "memo": (
+        "memo", "memorandum", "internal note", "announcement",
+        "메모", "공지", "사내 공지", "안내",
+    ),
+    "report": (
+        "report", "summary", "review document", "analysis",
+        "보고서", "리포트", "분석 보고",
+    ),
+    "specification": (
+        "specification", "spec", "design doc", "design document",
+        "requirements", "api spec",
+        "명세", "사양", "스펙", "설계 문서", "요구사항",
+    ),
+    "meeting_minutes": (
+        "minutes", "meeting minutes", "meeting notes", "회의록",
+        "회의 기록", "회의 메모",
+    ),
+    "standard": (
+        "standard", "convention", "norm", "baseline document",
+        "표준", "규약", "규격", "준칙",
+    ),
+    "form": (
+        "form", "template", "request form", "intake form",
+        "양식", "서식", "신청서", "템플릿",
+    ),
+    "record": (
+        "record", "log", "logbook", "ledger", "decision log",
+        "기록", "이력", "로그", "장부",
+    ),
+}
+
+
+def classify_document_subtype_intent(query: str) -> List[str]:
+    """Heuristic classifier → ranked list of expected DOCUMENT_SUBTYPES.
+
+    Mirror of `classify_query_intent` but operating on the v0.5 document
+    subtype layer. Returns subtypes whose keywords appear in the query
+    (case-insensitive substring match), ordered by keyword-count
+    descending. Ties broken by DOCUMENT_SUBTYPES declaration order.
+
+    No fallback: if no subtype keyword matches, returns ``[]`` (the
+    document-subtype layer is OPT-IN per-query — the entity-type
+    classifier has its own "concept" fallback for general queries).
+
+    Cap: at most 10 subtypes (R5). The 10 horizontal subtypes registered
+    in B.5.b naturally fit under the cap.
+    """
+    if not query:
+        return []
+
+    q_lower = query.lower()
+    counts: Dict[str, int] = {}
+    for subtype_name, keywords in _SUBTYPE_KEYWORDS.items():
+        for kw in keywords:
+            if kw.lower() in q_lower:
+                counts[subtype_name] = counts.get(subtype_name, 0) + 1
+
+    if not counts:
+        return []
+
+    declaration_order = {t: i for i, t in enumerate(DOCUMENT_SUBTYPES)}
+    ranked = sorted(
+        counts.items(),
+        key=lambda kv: (-kv[1], declaration_order.get(kv[0], 999)),
+    )
+    return [t for t, _ in ranked[:10]]
+
+
+def _document_subtype_of(doc: dict) -> str:
+    """Recover a document's subtype using the conventional field names."""
+    return (
+        doc.get("subtype")
+        or doc.get("document_subtype")
+        or ""
+    )
+
+
+def group_documents_by_subtype(
+    documents: Iterable[dict],
+    query_subtypes: Sequence[str],
+    cap: int = 10,
+) -> List[Tuple[str, List[dict], bool]]:
+    """Group documents by SUBTYPE, emitting empty rows per R1-R5.
+
+    Subtype-level parallel of `group_entities_by_type`. Same R1-R5
+    contract:
+
+      R1. Never silently drop a query-relevant subtype slot.
+      R2. Empty subtype rows are first-class context.
+      R3. Documents whose subtype is not in ``query_subtypes`` are
+          ONLY included as non-empty extra slots (no empty extras).
+      R4. Subtype slots are ordered by query intent rank first.
+      R5. Total slots capped at ``cap`` (default 10).
+
+    Documents with an empty / unknown subtype are silently skipped at
+    bucketing time (they cannot anchor a subtype slot).
+    """
+    if cap < 1:
+        cap = 1
+
+    buckets: Dict[str, List[dict]] = {}
+    for doc in documents:
+        if not isinstance(doc, dict):
+            continue
+        sub = _document_subtype_of(doc)
+        if not sub:
+            continue
+        buckets.setdefault(sub, []).append(doc)
+
+    out: List[Tuple[str, List[dict], bool]] = []
+    used: set = set()
+
+    # Phase 1 — query-relevant subtypes in intent order (R1+R4)
+    for s in query_subtypes:
+        if len(out) >= cap:
+            break
+        docs = buckets.get(s, [])
+        out.append((s, docs, bool(docs)))
+        used.add(s)
+
+    # Phase 2 — non-empty registered subtypes not yet covered (R3 inverse)
+    for s in DOCUMENT_SUBTYPES:
+        if len(out) >= cap:
+            break
+        if s in used:
+            continue
+        docs = buckets.get(s, [])
+        if docs:
+            out.append((s, docs, True))
+
+    return out
+
+
+def _document_label(doc: dict) -> str:
+    """Pick a readable label for a document dict."""
+    return (
+        doc.get("title")
+        or doc.get("name")
+        or doc.get("doc_id", "")
+        or "?"
+    )
+
+
+def format_subtype_context(
+    groups: List[Tuple[str, List[dict], bool]],
+    *,
+    none_phrase: str = "(none found in graph for this query)",
+    header: str = "[DOCUMENTS BY SUBTYPE]",
+    entity_separator: str = ", ",
+) -> str:
+    """Render subtype-grouped documents to the LLM-readable string.
+
+    Format:
+        [DOCUMENTS BY SUBTYPE]
+          [Policy]:    Data retention policy
+          [Procedure]: (none found in graph for this query)
+          [Report]:    Annual report 2025
+          ...
+
+    Empty-slot phrase is the structural evidence-of-absence signal (R2).
+    """
+    lines: List[str] = [header]
+    for subtype_name, docs, present in groups:
+        if present:
+            labels = [_document_label(d) for d in docs]
+            rendered = entity_separator.join(labels)
+        else:
+            rendered = none_phrase
+        # Title-case multi-word subtypes (meeting_minutes → Meeting_Minutes)
+        # using simple capitalize on each '_'-separated part for readability.
+        display = " ".join(p.capitalize() for p in subtype_name.split("_"))
+        lines.append(f"  [{display}]: {rendered}")
+    return "\n".join(lines)
+
+
+def apply_document_subtype_filter(
+    query: str,
+    documents: Iterable[dict],
+    cap: int = 10,
+) -> Tuple[str, List[Tuple[str, List[dict], bool]]]:
+    """Subtype-level convenience: classify + group + render in one call.
+
+    Returns ``(rendered_string, groups)``. When the query contains no
+    subtype keywords, returns ``("", [])`` — the caller should fall back
+    to the existing entity-type-level context.
+
+    Disabled-state behaviour: same as `apply_typed_filter` — callers
+    check `is_typed_filter_disabled()` at the call site rather than this
+    function auto-disabling, so the A/B comparison stays clean at the
+    integration layer.
+    """
+    query_subtypes = classify_document_subtype_intent(query)
+    if not query_subtypes:
+        return "", []
+    groups = group_documents_by_subtype(documents, query_subtypes, cap=cap)
+    rendered = format_subtype_context(groups)
+    return rendered, groups
+
+
 __all__ = (
     "is_typed_filter_disabled",
     "classify_query_intent",
     "group_entities_by_type",
     "format_typed_context",
     "apply_typed_filter",
+    # v0.5 B.5.d — document subtype layer
+    "classify_document_subtype_intent",
+    "group_documents_by_subtype",
+    "format_subtype_context",
+    "apply_document_subtype_filter",
 )

--- a/tests/test_v05_document_subtype_filter.py
+++ b/tests/test_v05_document_subtype_filter.py
@@ -1,0 +1,260 @@
+"""v0.5 B.5.d — tests for the document-subtype intent layer.
+
+Covers:
+
+  * `classify_document_subtype_intent` — keyword routing into the 10
+    horizontal DOCUMENT_SUBTYPES, ranking, fallback behaviour.
+  * `group_documents_by_subtype` — R1-R5 contract preserved at the
+    subtype level (empty slots for query-relevant subtypes, no empty
+    extras for non-query subtypes).
+  * `format_subtype_context` — explicit `(none found ...)` evidence-of-
+    absence phrase + readable display labels.
+  * `apply_document_subtype_filter` — end-to-end against the
+    `tests/fixtures/v0.5_enterprise_documents.json` corpus.
+  * Existing `classify_query_intent` / `apply_typed_filter` regression
+    check — adding the subtype layer must NOT change entity-type-level
+    behaviour.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from core.graph_typed_filter import (
+    apply_document_subtype_filter,
+    apply_typed_filter,
+    classify_document_subtype_intent,
+    classify_query_intent,
+    format_subtype_context,
+    group_documents_by_subtype,
+)
+from core.ontology import DOCUMENT_SUBTYPES
+
+_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "v0.5_enterprise_documents.json"
+)
+
+
+def _load_documents() -> list:
+    with _FIXTURE.open(encoding="utf-8") as f:
+        return json.load(f)["documents"]
+
+
+class ClassifyDocumentSubtypeIntentTests(unittest.TestCase):
+    def test_empty_query_returns_empty(self):
+        self.assertEqual(classify_document_subtype_intent(""), [])
+
+    def test_no_subtype_keyword_returns_empty(self):
+        # Unlike `classify_query_intent` which falls back to ['concept'],
+        # the subtype layer is opt-in per-query and returns [].
+        self.assertEqual(
+            classify_document_subtype_intent("what is the capital of France?"),
+            [],
+        )
+
+    def test_single_keyword_routes_to_subtype(self):
+        self.assertEqual(
+            classify_document_subtype_intent("which policy applies?"),
+            ["policy"],
+        )
+
+    def test_korean_keyword_routes(self):
+        self.assertIn("policy",
+                      classify_document_subtype_intent("우리 정책이 뭐야?"))
+
+    def test_two_distinct_keywords_outrank_one(self):
+        # Policy matches via 2 distinct keywords ('policy' + 'guideline');
+        # contract matches via 1 keyword. Policy must rank first.
+        # (The classifier counts distinct matched keywords, not repetitions
+        # — same behaviour as the entity-type-level classifier.)
+        result = classify_document_subtype_intent(
+            "is the policy aligned with our guideline and contract?"
+        )
+        self.assertEqual(result[0], "policy")
+        self.assertIn("contract", result)
+
+    def test_meeting_minutes_multiword(self):
+        self.assertIn(
+            "meeting_minutes",
+            classify_document_subtype_intent("show me the meeting minutes"),
+        )
+
+    def test_cap_at_10(self):
+        # All-keyword query — result still capped at 10.
+        big = " ".join(["contract policy procedure memo report",
+                        "specification meeting minutes standard form record"])
+        self.assertLessEqual(len(classify_document_subtype_intent(big)), 10)
+
+    def test_every_registered_subtype_has_at_least_one_keyword(self):
+        # Every subtype in DOCUMENT_SUBTYPES must be matchable via at
+        # least one English keyword equal to its name.
+        from core.graph_typed_filter import _SUBTYPE_KEYWORDS
+        for sub in DOCUMENT_SUBTYPES:
+            with self.subTest(subtype=sub):
+                self.assertIn(sub, _SUBTYPE_KEYWORDS,
+                              f"{sub!r} has no keyword entry")
+                self.assertTrue(len(_SUBTYPE_KEYWORDS[sub]) >= 2,
+                                f"{sub!r} should have ≥2 keywords")
+
+
+class GroupDocumentsBySubtypeTests(unittest.TestCase):
+    def setUp(self):
+        self.docs = [
+            {"doc_id": "d1", "subtype": "policy",   "title": "P1"},
+            {"doc_id": "d2", "subtype": "policy",   "title": "P2"},
+            {"doc_id": "d3", "subtype": "contract", "title": "C1"},
+            {"doc_id": "d4", "subtype": "form",     "title": "F1"},
+            {"doc_id": "d5",                        "title": "no-subtype"},
+        ]
+
+    def test_query_subtype_with_documents_emits_present_row(self):
+        groups = group_documents_by_subtype(self.docs, ["policy"])
+        names = {g[0]: g for g in groups}
+        self.assertIn("policy", names)
+        sub, docs, present = names["policy"]
+        self.assertEqual(len(docs), 2)
+        self.assertTrue(present)
+
+    def test_query_subtype_with_no_documents_emits_empty_row_r1(self):
+        # R1: never silently drop a query-relevant subtype.
+        groups = group_documents_by_subtype(self.docs, ["report"])
+        report_rows = [g for g in groups if g[0] == "report"]
+        self.assertEqual(len(report_rows), 1)
+        sub, docs, present = report_rows[0]
+        self.assertEqual(docs, [])
+        self.assertFalse(present)
+
+    def test_query_subtypes_ordered_first_r4(self):
+        # R4: intent-rank order honoured.
+        groups = group_documents_by_subtype(
+            self.docs, ["form", "policy"]
+        )
+        self.assertEqual(groups[0][0], "form")
+        self.assertEqual(groups[1][0], "policy")
+
+    def test_non_query_non_empty_subtypes_emit_as_extras_r3(self):
+        # 'contract' and 'form' weren't queried but exist non-empty.
+        groups = group_documents_by_subtype(self.docs, ["policy"])
+        subtypes_in_out = [g[0] for g in groups]
+        self.assertIn("policy", subtypes_in_out)
+        self.assertIn("contract", subtypes_in_out)
+        self.assertIn("form", subtypes_in_out)
+
+    def test_no_empty_extras_r3_inverse(self):
+        # 'report' was NOT queried and has no documents — must not appear.
+        groups = group_documents_by_subtype(self.docs, ["policy"])
+        names = [g[0] for g in groups]
+        self.assertNotIn("report", names)
+
+    def test_documents_without_subtype_silently_skipped(self):
+        groups = group_documents_by_subtype(self.docs, ["policy"])
+        all_doc_ids = [d.get("doc_id") for _, docs, _ in groups for d in docs]
+        self.assertNotIn("d5", all_doc_ids)
+
+    def test_cap_r5(self):
+        # 12 query subtypes asked but cap=3 → at most 3 slots out.
+        query_subs = list(DOCUMENT_SUBTYPES.keys())[:12]
+        groups = group_documents_by_subtype(self.docs, query_subs, cap=3)
+        self.assertLessEqual(len(groups), 3)
+
+
+class FormatSubtypeContextTests(unittest.TestCase):
+    def test_renders_present_and_empty_slots(self):
+        groups = [
+            ("policy", [{"title": "Data retention"}], True),
+            ("report", [], False),
+        ]
+        text = format_subtype_context(groups)
+        self.assertIn("[Policy]:", text)
+        self.assertIn("[Report]:", text)
+        self.assertIn("Data retention", text)
+        self.assertIn("(none found", text)
+
+    def test_multiword_subtype_display(self):
+        groups = [("meeting_minutes", [{"title": "Q2 review"}], True)]
+        text = format_subtype_context(groups)
+        self.assertIn("[Meeting Minutes]:", text)
+
+    def test_header_present(self):
+        groups = [("policy", [{"title": "X"}], True)]
+        text = format_subtype_context(groups)
+        self.assertTrue(text.startswith("[DOCUMENTS BY SUBTYPE]"))
+
+
+class ApplyDocumentSubtypeFilterFixtureTests(unittest.TestCase):
+    """End-to-end against the v0.5 enterprise fixture."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.docs = _load_documents()
+
+    def test_policy_query_finds_data_retention(self):
+        rendered, groups = apply_document_subtype_filter(
+            "which policy is in force?", self.docs
+        )
+        self.assertIn("Data retention policy", rendered)
+        policy_rows = [g for g in groups if g[0] == "policy"]
+        self.assertEqual(len(policy_rows), 1)
+        self.assertTrue(policy_rows[0][2])  # present
+
+    def test_specification_query_finds_both_versions(self):
+        rendered, groups = apply_document_subtype_filter(
+            "show me the api spec", self.docs
+        )
+        spec_rows = [g for g in groups if g[0] == "specification"]
+        self.assertEqual(len(spec_rows), 1)
+        spec_docs = spec_rows[0][1]
+        # Fixture has v1 (SUPERSEDED) and v2 (PUBLISHED)
+        self.assertEqual(len(spec_docs), 2)
+
+    def test_no_subtype_keyword_returns_empty(self):
+        # Generic query without a subtype keyword falls through.
+        rendered, groups = apply_document_subtype_filter(
+            "what is the capital of France?", self.docs
+        )
+        self.assertEqual(rendered, "")
+        self.assertEqual(groups, [])
+
+    def test_unmatched_subtype_emits_empty_slot_against_fixture(self):
+        # Force a query for a subtype the fixture exercises:
+        # 'record' exists in fixture (decision log). Verify present row.
+        rendered, groups = apply_document_subtype_filter(
+            "show me the decision log", self.docs
+        )
+        self.assertIn("Decision log", rendered)
+
+    def test_empty_subtype_slot_for_missing_kind(self):
+        # The fixture has exactly one 'meeting_minutes' doc. Construct a
+        # smaller subset that contains no meeting_minutes and query for it.
+        no_minutes = [d for d in self.docs if d["subtype"] != "meeting_minutes"]
+        rendered, _ = apply_document_subtype_filter(
+            "show me the meeting minutes", no_minutes
+        )
+        self.assertIn("[Meeting Minutes]:", rendered)
+        self.assertIn("(none found", rendered)
+
+
+class RegressionEntityTypeLayerUnchangedTests(unittest.TestCase):
+    """Adding the subtype layer must not change entity-type behaviour."""
+
+    def test_classify_query_intent_concept_fallback(self):
+        self.assertEqual(classify_query_intent(""), ["concept"])
+        self.assertEqual(
+            classify_query_intent("what is the capital of France?"),
+            ["concept"],
+        )
+
+    def test_classify_query_intent_who_routes_to_person(self):
+        result = classify_query_intent("who founded this company?")
+        self.assertIn("person", result)
+
+    def test_apply_typed_filter_still_works(self):
+        entities = [{"entity_type": "person", "name": "Alice"}]
+        rendered, groups = apply_typed_filter("who is the author?", entities)
+        self.assertIn("[ENTITIES BY TYPE]", rendered)
+        self.assertIn("Alice", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **B.5.d** of the v0.5 enterprise document ontology design. Extends `core/graph_typed_filter.py` with a document-subtype intent layer that parallels the existing 7-intent entity-type classifier.

For enterprise queries like \"which policy is in force?\", the entity-type-level classifier would fall through to \"concept\" — losing the structural cue that the user is asking about a specific document **KIND**. This layer fills that gap with the same R1-R5 contract preserved at the subtype level.

### New surfaces

| Symbol | Purpose |
|---|---|
| `_SUBTYPE_KEYWORDS` | 10 horizontal subtypes × ~5–8 keywords each (English + Korean). No vertical content. |
| `classify_document_subtype_intent(query)` | Heuristic classifier → ranked list of matched DOCUMENT_SUBTYPES. Returns `[]` if no subtype keyword matched (opt-in per-query, unlike the entity-type-level `'concept'` fallback). |
| `group_documents_by_subtype(docs, query_subtypes, cap=10)` | R1-R5 contract at the subtype level (query slots never silently dropped, empty rows first-class, no empty extras for non-query subtypes, intent rank first, total slots capped). |
| `format_subtype_context(groups)` | Title-cases multi-word subtypes (`meeting_minutes` → `Meeting Minutes`). Same `(none found ...)` evidence-of-absence phrase as the entity-type layer. |
| `apply_document_subtype_filter(query, documents, cap=10)` | Convenience: classify + group + render. Returns `('', [])` when no subtype keyword matched — caller falls back to entity-type layer cleanly. |

### Disabled-state behaviour

Same `JAMES_DISABLE_TYPED_FILTER` env var governs both layers. This function does NOT auto-disable — call sites check at the integration layer for clean A/B comparison (same pattern as existing `apply_typed_filter`).

### Tests (`tests/test_v05_document_subtype_filter.py`)

26 tests across 5 classes:

- `ClassifyDocumentSubtypeIntentTests` (8) — including a coverage check that every DOCUMENT_SUBTYPE has ≥2 keywords
- `GroupDocumentsBySubtypeTests` (7) — covering all of R1, R2, R3 (forward + inverse), R4, R5
- `FormatSubtypeContextTests` (3) — multi-word display, header, empty/present mix
- `ApplyDocumentSubtypeFilterFixtureTests` (5) — end-to-end against `tests/fixtures/v0.5_enterprise_documents.json` (B.5.c corpus): policy query, spec query finds both v1 + v2, no-keyword query returns empty, decision-log query, missing meeting_minutes emits empty slot
- `RegressionEntityTypeLayerUnchangedTests` (3) — existing `classify_query_intent` / `apply_typed_filter` behaviour bit-identical to pre-B.5.d

## Verification

- `pytest tests/test_v05_document_subtype_filter.py`: **26 passed**
- Full B.5 + typed_filter regression sweep: **116 passed** (33 existing typed_filter + 36 B.5.b + 21 B.5.c + 26 B.5.d)
- `ruff check core/graph_typed_filter.py`: clean
- Module size: **19,485 bytes** (under 20 KB cap, CLAUDE.md rule 5)

## Out of scope

- Wiring `apply_document_subtype_filter` into the engine's context assembly path — deferred until measurement gates value (no production caller yet; B.5.d is the primitive that future enterprise queries will consume)
- Stream A operator work (Hashevolution dogfooding, Tier S outreach) — paused per operator decision
- Vertical-specific subtypes — BLOCKED until v1.0 or signed LOI per CLAUDE.md rule #1

Quality delta: exempt (label: external-mother-platform — additive ontology surface; no `core/retrieval`, `core/graph` traversal, or `core/reasoning` paths changed; entity-type-level layer bit-identical to pre-PR)