### PR TITLE
feat(v0.5-G7): etag optimistic concurrency on T7 supersede edges

### DIFF
--- a/core/lifecycle/etag.py
+++ b/core/lifecycle/etag.py
@@ -1,0 +1,203 @@
+"""v0.5 G7 — optimistic-concurrency etag for T7 supersede mutations.
+
+Per `docs/reviews/v0.5-b1-ontology-surface-audit.md` G7: two concurrent
+writers can both read the same `old_edge`, both produce a supersede
+event, both write back, and the second silently overwrites the first
+— losing one supersede.
+
+This module adds an **optimistic-concurrency token** ("etag", same
+naming as HTTP) computed deterministically over the edge's stable
+identity fields. Writers compare the expected etag against the
+current edge's etag before mutating; mismatch raises
+`EtagMismatchError`. The caller retries with the fresh head — the
+standard optimistic-concurrency pattern.
+
+## Why optimistic, not pessimistic
+
+A pessimistic lock would force the wiki I/O layer to acquire a
+process-wide mutex around every edge mutation. That has correctness
+appeal but ties JAMES's mutation model to a single-process world,
+which contradicts the multi-tenant SaaS direction B.1 flagged.
+
+Optimistic locking lets concurrent readers proceed without
+coordination, and only the WRITE step needs to verify the etag is
+still current. The caller's retry loop is short because supersede
+events are rare per edge (chain length stays small).
+
+## What's hashed
+
+The etag is a SHA-256 hex digest (first 12 hex chars; 48 bits of
+entropy is overkill for an in-flight-collision check but matches
+the existing `e_edge_<10-hex>` id shape for legibility) computed
+over a JSON-canonicalised projection of:
+
+  - `id` — the edge's synthetic id
+  - `type` — the relation type
+  - `validity.from` / `validity.to` — the temporal window
+  - `status.active` / `status.superseded_by` / `status.superseded_at`
+  - `mutation_type` — the lifecycle label
+  - `sources` — the source-list (each source's `doc_id` + `weight`)
+
+Excluded fields (the etag intentionally does not change when these
+mutate):
+  - `etag` itself (would self-reference)
+  - `confidence` — derived from sources at read time; not load-bearing
+  - `label` — display-side; not part of identity
+  - Any caller-added unknown keys — robust under schema evolution
+
+## Public API
+
+  - `EtagMismatchError` — raised by `check_edge_etag` and
+    `supersede_edge` when the optimistic check fails.
+  - `compute_edge_etag(edge) → str` — deterministic hash, no
+    side effects.
+  - `assign_edge_etag(edge) → str` — populates `edge["etag"]`
+    in-place from `compute_edge_etag`, returns the value.
+  - `check_edge_etag(edge, expected) → None` — raises
+    `EtagMismatchError` if `edge["etag"]` != `expected`.
+
+The supersede integration lives in `core/lifecycle/supersede_chain.py`
+— this module is the primitive layer, no T7 logic of its own.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict
+
+from core.lifecycle.schema import (
+    T7_EDGE_FIELD_ETAG,
+    T7_EDGE_FIELD_MUTATION_TYPE,
+    T7_EDGE_FIELD_STATUS,
+    T7_EDGE_FIELD_VALIDITY,
+)
+
+
+# Number of hex chars in the etag prefix. 12 hex = 48 bits = collision
+# probability < 2^-24 for 1k concurrent mutations to one edge, well
+# beyond any realistic concurrent-writer count for one edge.
+_ETAG_PREFIX_LEN: int = 12
+
+
+class EtagMismatchError(RuntimeError):
+    """Raised when an optimistic-concurrency etag check fails.
+
+    The caller should re-fetch the current edge head and retry the
+    mutation. This is not a programming bug — it is the expected
+    signal that a concurrent writer mutated the edge first.
+    """
+
+    def __init__(self, expected: str, actual: str, edge_id: str = "?"):
+        self.expected = expected
+        self.actual = actual
+        self.edge_id = edge_id
+        super().__init__(
+            f"etag mismatch on edge {edge_id!r}: "
+            f"expected {expected!r}, actual {actual!r}"
+        )
+
+
+def _canonical_projection(edge: dict) -> Dict[str, Any]:
+    """Project an edge dict to the etag-hashable identity subset.
+
+    See module docstring 'What's hashed' for the field list. Missing
+    fields normalise to None (NOT empty dict) so a `None` validity
+    and an `{}` validity hash identically — they have the same
+    semantic ("no temporal window known").
+    """
+    validity = edge.get(T7_EDGE_FIELD_VALIDITY) or {}
+    status = edge.get(T7_EDGE_FIELD_STATUS) or {}
+
+    sources = []
+    for src in edge.get("sources") or ():
+        if not isinstance(src, dict):
+            continue
+        sources.append({
+            "doc_id": src.get("doc_id"),
+            "weight": src.get("weight"),
+        })
+
+    return {
+        "id":           edge.get("id"),
+        "type":         edge.get("type"),
+        "validity":     {
+            "from": validity.get("from"),
+            "to":   validity.get("to"),
+        },
+        "status":       {
+            "active":         status.get("active", True),
+            "superseded_by":  status.get("superseded_by"),
+            "superseded_at":  status.get("superseded_at"),
+        },
+        "mutation_type": edge.get(T7_EDGE_FIELD_MUTATION_TYPE),
+        "sources":       sources,
+    }
+
+
+def compute_edge_etag(edge: dict) -> str:
+    """Deterministic etag for an edge dict.
+
+    Returns a SHA-256 hex prefix of the canonicalised projection.
+    Pure function — no side effects. Two structurally-equal edges
+    return the same etag.
+
+    Raises ValueError if ``edge`` is not a dict (matches the rest of
+    the lifecycle module surface).
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    canonical = _canonical_projection(edge)
+    serialised = json.dumps(canonical, sort_keys=True,
+                            ensure_ascii=False, separators=(",", ":"))
+    digest = hashlib.sha256(serialised.encode("utf-8")).hexdigest()
+    return digest[:_ETAG_PREFIX_LEN]
+
+
+def assign_edge_etag(edge: dict) -> str:
+    """Populate ``edge["etag"]`` from ``compute_edge_etag``.
+
+    Mutates ``edge`` in place; returns the assigned value. Idempotent
+    in the sense that calling it twice on an unchanged edge produces
+    the same value — but the second call DOES reassign the field
+    (so callers can use it as a "force-refresh" primitive too).
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    value = compute_edge_etag(edge)
+    edge[T7_EDGE_FIELD_ETAG] = value
+    return value
+
+
+def check_edge_etag(edge: dict, expected: str) -> None:
+    """Raise ``EtagMismatchError`` if ``edge["etag"]`` != ``expected``.
+
+    The check uses the edge's STORED etag (i.e., the field), not a
+    recomputed hash. This means a caller that hasn't yet called
+    `assign_edge_etag` on the edge will see ``None`` and trigger
+    a mismatch — that's the intended behaviour, since "no etag
+    stored" means the edge hasn't been through the optimistic-
+    concurrency layer and the caller should re-fetch.
+    """
+    if not isinstance(edge, dict):
+        raise ValueError(
+            f"edge must be a dict, got {type(edge).__name__}"
+        )
+    actual = edge.get(T7_EDGE_FIELD_ETAG)
+    if actual != expected:
+        raise EtagMismatchError(
+            expected=str(expected),
+            actual=str(actual) if actual is not None else "<absent>",
+            edge_id=str(edge.get("id", "?")),
+        )
+
+
+__all__ = (
+    "EtagMismatchError",
+    "compute_edge_etag",
+    "assign_edge_etag",
+    "check_edge_etag",
+)

--- a/core/lifecycle/schema.py
+++ b/core/lifecycle/schema.py
@@ -72,6 +72,13 @@ T7_EDGE_FIELD_VALIDITY:      Final[str] = "validity"
 T7_EDGE_FIELD_STATUS:        Final[str] = "status"
 T7_EDGE_FIELD_MUTATION_TYPE: Final[str] = "mutation_type"
 
+# v0.5 G7 — optimistic-concurrency etag on edge mutations. Optional;
+# absence means "no etag tracking" (backwards-compatible with v0.4
+# edges that were never touched by the etag layer). When set, must
+# be a non-empty string. See ``core/lifecycle/etag.py`` for the
+# canonical hash recipe.
+T7_EDGE_FIELD_ETAG: Final[str] = "etag"
+
 # ─── T6 Causality Chain (v0.4.1, 2026-05-28) ─────────────────────
 #
 # Edge-level ``derived_from`` field tracks the base facts that an
@@ -226,6 +233,19 @@ def validate_edge_v04_fields(edge: dict) -> None:
             f"edge.mutation_type must be one of "
             f"{sorted(VALID_MUTATION_TYPES)}, got {mt!r}"
         )
+
+    # ─── v0.5 G7 etag (optimistic concurrency token) ─────────────
+    # Optional. Absence = "no etag tracking" (v0.4-compatible).
+    # When present, must be a non-empty string.
+    etag = edge.get(T7_EDGE_FIELD_ETAG)
+    if etag is not None:
+        if not isinstance(etag, str):
+            raise ValueError(
+                f"edge.etag must be str or absent, got "
+                f"{type(etag).__name__}"
+            )
+        if not etag:
+            raise ValueError("edge.etag must be a non-empty string")
 
     # ─── Cross-field consistency (T7 invariant) ──────────────────
     if isinstance(status, dict) and mt is not None:

--- a/core/lifecycle/supersede_chain.py
+++ b/core/lifecycle/supersede_chain.py
@@ -56,6 +56,10 @@ import uuid
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
+from core.lifecycle.etag import (
+    assign_edge_etag,
+    check_edge_etag,
+)
 from core.lifecycle.schema import (
     T1_MUTATION_INVALIDATED,
     T1_MUTATION_SUPERSEDED,
@@ -109,6 +113,8 @@ def supersede_edge(
     old_edge: dict,
     new_fact: dict,
     supersede_ts: datetime,
+    *,
+    expected_old_etag: Optional[str] = None,
 ) -> tuple[dict, dict]:
     """Create the new edge from ``new_fact`` + mark ``old_edge`` as
     superseded by it.
@@ -127,16 +133,28 @@ def supersede_edge(
         supersede_ts: UTC-aware ``datetime`` of the supersede event.
             Written into ``old_edge.status.superseded_at`` AND used
             as the new edge's ``validity.from``.
+        expected_old_etag: **optimistic-concurrency token** (v0.5 G7,
+            keyword-only). When set, the caller asserts that
+            ``old_edge["etag"]`` equals this value at the moment of
+            supersede. If the stored etag differs (a concurrent writer
+            mutated the edge first), raises :class:`EtagMismatchError`
+            BEFORE any mutation — the old edge is untouched and the
+            caller can safely retry with the fresh head. Default
+            ``None`` preserves byte-identical pre-G7 behaviour.
 
     Returns:
         ``(new_edge, old_edge)`` — both mutated. ``new_edge`` is a
         fresh dict (built from ``new_fact``), ``old_edge`` is the
-        same object passed in.
+        same object passed in. Both carry a freshly-assigned ``etag``
+        field reflecting their post-mutation state.
 
     Raises:
         ValueError if either dict fails ``validate_edge_v04_fields``
         after mutation — defends against the caller passing partial
         v0.4 shapes that would produce an inconsistent chain.
+        :class:`EtagMismatchError` if ``expected_old_etag`` is set
+        and does not match ``old_edge["etag"]`` — the supersede did
+        NOT happen, no fields were mutated.
 
     What this function does NOT do:
         - **No I/O.** Caller writes both edges back to the wiki.
@@ -155,6 +173,11 @@ def supersede_edge(
         raise ValueError(
             f"supersede_ts must be datetime, got {type(supersede_ts).__name__}"
         )
+
+    # v0.5 G7 — optimistic-concurrency check FIRST (before any mutation).
+    # Raises EtagMismatchError on mismatch; old_edge stays untouched.
+    if expected_old_etag is not None:
+        check_edge_etag(old_edge, expected_old_etag)
 
     # Build the new edge. apply_v04_edge_defaults is idempotent so the
     # caller may pass either a raw v0.3 dict or a partially-v0.4 dict.
@@ -187,6 +210,12 @@ def supersede_edge(
     status["superseded_at"] = supersede_ts.isoformat()
     old_edge[T7_EDGE_FIELD_STATUS] = status
     old_edge[T7_EDGE_FIELD_MUTATION_TYPE] = T1_MUTATION_SUPERSEDED
+
+    # v0.5 G7 — assign fresh etag to BOTH edges so the next caller
+    # has an up-to-date concurrency token. Assigned BEFORE validation
+    # so the etag field is part of the validated shape.
+    assign_edge_etag(new_edge)
+    assign_edge_etag(old_edge)
 
     # Validate both — surface a partial-shape caller bug immediately.
     validate_edge_v04_fields(new_edge)

--- a/tests/test_v05_etag_optimistic_locking.py
+++ b/tests/test_v05_etag_optimistic_locking.py
@@ -1,0 +1,320 @@
+"""v0.5 G7 — etag optimistic-concurrency tests.
+
+Covers:
+
+  * `compute_edge_etag` — determinism, field-sensitivity (which mutations
+    DO change the etag and which DON'T), validation.
+  * `assign_edge_etag` — populates the field, idempotent on unchanged
+    edges, force-refresh semantic.
+  * `check_edge_etag` — raises on mismatch, no-stored-etag treated as
+    mismatch.
+  * `EtagMismatchError` — fields populated, descriptive message.
+  * `supersede_edge` integration — opt-in via `expected_old_etag`,
+    raises before mutation on mismatch, succeeds on match, default
+    behaviour (`expected_old_etag=None`) byte-identical to pre-G7
+    except for the newly-assigned etag field on both edges.
+  * Schema regression — `validate_edge_v04_fields` accepts edges with
+    and without etag; rejects empty-string or non-str etag.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from core.lifecycle.etag import (
+    EtagMismatchError,
+    assign_edge_etag,
+    check_edge_etag,
+    compute_edge_etag,
+)
+from core.lifecycle.schema import (
+    T7_EDGE_FIELD_ETAG,
+    validate_edge_v04_fields,
+)
+from core.lifecycle.supersede_chain import supersede_edge
+
+
+def _fresh_edge() -> dict:
+    """Build a minimal v0.4-shaped edge for testing."""
+    return {
+        "id": "e_edge_aaaaaaaaaa",
+        "type": "RELATED_TO",
+        "validity": {
+            "from": "2026-01-01T00:00:00+00:00",
+            "to": None,
+        },
+        "status": {
+            "active": True,
+            "superseded_by": None,
+            "superseded_at": None,
+        },
+        "mutation_type": "active",
+        "sources": [
+            {"doc_id": "doc_x", "weight": 0.9, "role": "primary",
+             "ts": "2026-01-01T00:00:00+00:00",
+             "valid_from": None, "valid_until": None},
+        ],
+        "confidence": 0.9,
+    }
+
+
+def _fresh_new_fact() -> dict:
+    """Build a v0.4 'new fact' shape for supersede tests."""
+    return {
+        "type": "RELATED_TO",
+        "validity": {"from": None, "to": None},
+        "status": {"active": True, "superseded_by": None,
+                   "superseded_at": None},
+        "mutation_type": "active",
+        "sources": [
+            {"doc_id": "doc_y", "weight": 0.95, "role": "primary",
+             "ts": "2026-06-01T00:00:00+00:00",
+             "valid_from": None, "valid_until": None},
+        ],
+        "confidence": 0.95,
+    }
+
+
+class ComputeEdgeEtagTests(unittest.TestCase):
+    def test_deterministic(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        self.assertEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_changes_with_validity_to(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["validity"]["to"] = "2026-12-31T00:00:00+00:00"
+        self.assertNotEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_changes_with_status_active(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["status"]["active"] = False
+        self.assertNotEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_changes_with_superseded_by(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["status"]["superseded_by"] = "e_edge_xxxxxxxxxx"
+        self.assertNotEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_changes_with_sources_doc_id(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["sources"][0]["doc_id"] = "doc_different"
+        self.assertNotEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_changes_with_sources_weight(self):
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["sources"][0]["weight"] = 0.5
+        self.assertNotEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_invariant_to_confidence(self):
+        # confidence is derived; not part of identity → etag unchanged.
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["confidence"] = 0.1
+        self.assertEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_invariant_to_label(self):
+        # label is display-side; not part of identity → etag unchanged.
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["label"] = "display name"
+        self.assertEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_invariant_to_unknown_fields(self):
+        # Future caller-added fields don't poison the etag.
+        e1 = _fresh_edge()
+        e2 = _fresh_edge()
+        e2["some_future_field"] = "anything"
+        self.assertEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_invariant_to_etag_self_reference(self):
+        # The etag must NOT include itself in the hash (would
+        # self-reference and prevent stable comparison).
+        e1 = _fresh_edge()
+        before = compute_edge_etag(e1)
+        e1[T7_EDGE_FIELD_ETAG] = "tampered_value"
+        after = compute_edge_etag(e1)
+        self.assertEqual(before, after)
+
+    def test_validity_none_vs_empty_dict_equivalent(self):
+        # 'no temporal window known' has one canonical representation.
+        e1 = _fresh_edge()
+        e1["validity"] = None
+        e2 = _fresh_edge()
+        e2["validity"] = {}
+        self.assertEqual(compute_edge_etag(e1), compute_edge_etag(e2))
+
+    def test_returns_12_hex(self):
+        etag = compute_edge_etag(_fresh_edge())
+        self.assertEqual(len(etag), 12)
+        # All hex chars
+        int(etag, 16)
+
+    def test_rejects_non_dict(self):
+        with self.assertRaises(ValueError):
+            compute_edge_etag("not an edge")  # type: ignore[arg-type]
+
+
+class AssignEdgeEtagTests(unittest.TestCase):
+    def test_populates_field(self):
+        e = _fresh_edge()
+        self.assertNotIn(T7_EDGE_FIELD_ETAG, e)
+        value = assign_edge_etag(e)
+        self.assertEqual(e[T7_EDGE_FIELD_ETAG], value)
+
+    def test_value_matches_compute(self):
+        e = _fresh_edge()
+        expected = compute_edge_etag(e)
+        actual = assign_edge_etag(e)
+        self.assertEqual(actual, expected)
+
+    def test_idempotent_on_unchanged_edge(self):
+        e = _fresh_edge()
+        v1 = assign_edge_etag(e)
+        v2 = assign_edge_etag(e)
+        self.assertEqual(v1, v2)
+
+    def test_force_refresh_after_mutation(self):
+        e = _fresh_edge()
+        assign_edge_etag(e)
+        e["status"]["active"] = False
+        # New compute would differ; assign refreshes the stored value.
+        new_value = assign_edge_etag(e)
+        self.assertEqual(e[T7_EDGE_FIELD_ETAG], new_value)
+
+
+class CheckEdgeEtagTests(unittest.TestCase):
+    def test_match_returns_none(self):
+        e = _fresh_edge()
+        value = assign_edge_etag(e)
+        self.assertIsNone(check_edge_etag(e, value))
+
+    def test_mismatch_raises(self):
+        e = _fresh_edge()
+        assign_edge_etag(e)
+        with self.assertRaises(EtagMismatchError):
+            check_edge_etag(e, "wrong_value")
+
+    def test_no_stored_etag_treated_as_mismatch(self):
+        # An edge that never went through the etag layer raises on
+        # check — the caller must call `assign_edge_etag` first.
+        e = _fresh_edge()
+        with self.assertRaises(EtagMismatchError) as ctx:
+            check_edge_etag(e, "anything")
+        self.assertEqual(ctx.exception.actual, "<absent>")
+
+    def test_error_carries_expected_and_actual(self):
+        e = _fresh_edge()
+        assign_edge_etag(e)
+        with self.assertRaises(EtagMismatchError) as ctx:
+            check_edge_etag(e, "expected_value")
+        self.assertEqual(ctx.exception.expected, "expected_value")
+        self.assertEqual(ctx.exception.actual, e[T7_EDGE_FIELD_ETAG])
+        self.assertIn("e_edge_aaaaaaaaaa", str(ctx.exception))
+
+
+class SupersedeEdgeEtagIntegrationTests(unittest.TestCase):
+    def test_default_no_expected_etag_works_as_before(self):
+        old = _fresh_edge()
+        new_fact = _fresh_new_fact()
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        new_edge, returned_old = supersede_edge(old, new_fact, ts)
+        # Pre-G7 behaviour preserved + etag now populated on both.
+        self.assertEqual(returned_old["status"]["active"], False)
+        self.assertEqual(returned_old["mutation_type"], "superseded")
+        self.assertIn(T7_EDGE_FIELD_ETAG, new_edge)
+        self.assertIn(T7_EDGE_FIELD_ETAG, returned_old)
+
+    def test_matching_expected_etag_succeeds(self):
+        old = _fresh_edge()
+        # Caller computes etag BEFORE mutation.
+        assign_edge_etag(old)
+        snapshot = old[T7_EDGE_FIELD_ETAG]
+        new_fact = _fresh_new_fact()
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        # Match → supersede proceeds.
+        new_edge, returned_old = supersede_edge(
+            old, new_fact, ts, expected_old_etag=snapshot,
+        )
+        # Etag was refreshed on both edges post-mutation.
+        self.assertNotEqual(returned_old[T7_EDGE_FIELD_ETAG], snapshot)
+        self.assertIn(T7_EDGE_FIELD_ETAG, new_edge)
+
+    def test_mismatched_expected_etag_raises_before_mutation(self):
+        old = _fresh_edge()
+        assign_edge_etag(old)
+        # Snapshot the pre-mutation status to verify rollback semantics.
+        pre_status_active = old["status"]["active"]
+        pre_mutation_type = old["mutation_type"]
+        new_fact = _fresh_new_fact()
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        with self.assertRaises(EtagMismatchError):
+            supersede_edge(
+                old, new_fact, ts, expected_old_etag="stale_etag",
+            )
+        # Old edge must be untouched.
+        self.assertEqual(old["status"]["active"], pre_status_active)
+        self.assertEqual(old["mutation_type"], pre_mutation_type)
+
+    def test_concurrent_supersede_race_simulation(self):
+        """Two writers read the same edge; only the first supersede
+        succeeds. The second sees an etag mismatch and refuses."""
+        old = _fresh_edge()
+        assign_edge_etag(old)
+        snapshot_a = old[T7_EDGE_FIELD_ETAG]
+        snapshot_b = old[T7_EDGE_FIELD_ETAG]  # Same snapshot both readers
+
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        # Writer A wins.
+        supersede_edge(old, _fresh_new_fact(), ts,
+                       expected_old_etag=snapshot_a)
+        # Old now has a new etag.
+        self.assertNotEqual(old[T7_EDGE_FIELD_ETAG], snapshot_a)
+
+        # Writer B retries with the stale snapshot → loses cleanly.
+        with self.assertRaises(EtagMismatchError):
+            supersede_edge(old, _fresh_new_fact(), ts,
+                           expected_old_etag=snapshot_b)
+
+    def test_post_supersede_etag_is_valid_per_schema(self):
+        old = _fresh_edge()
+        new_fact = _fresh_new_fact()
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        new_edge, returned_old = supersede_edge(old, new_fact, ts)
+        # Both edges must validate (etag included).
+        validate_edge_v04_fields(new_edge)
+        validate_edge_v04_fields(returned_old)
+
+
+class SchemaValidationTests(unittest.TestCase):
+    def test_edge_without_etag_validates(self):
+        e = _fresh_edge()
+        # Sanity: pre-G7 v0.4 shape still valid.
+        validate_edge_v04_fields(e)
+
+    def test_edge_with_str_etag_validates(self):
+        e = _fresh_edge()
+        e[T7_EDGE_FIELD_ETAG] = "abc123def456"
+        validate_edge_v04_fields(e)
+
+    def test_edge_with_empty_etag_rejected(self):
+        e = _fresh_edge()
+        e[T7_EDGE_FIELD_ETAG] = ""
+        with self.assertRaises(ValueError):
+            validate_edge_v04_fields(e)
+
+    def test_edge_with_non_str_etag_rejected(self):
+        e = _fresh_edge()
+        e[T7_EDGE_FIELD_ETAG] = 123
+        with self.assertRaises(ValueError):
+            validate_edge_v04_fields(e)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses **G7** from `docs/reviews/v0.5-b1-ontology-surface-audit.md` — the most natural must-address gap for v0.5 cycle (concurrent supersede race becomes reachable as soon as any scheduled-job ingest path lands).

Adds an **optimistic-concurrency token** (\"etag\", HTTP-style naming) to the T7 supersede primitive. Two concurrent writers can no longer silently overwrite each other's supersede event — the second writer sees an `EtagMismatchError` and can retry cleanly with the fresh head.

### Changes

| File | Change |
|---|---|
| `core/lifecycle/schema.py` | New `T7_EDGE_FIELD_ETAG = \"etag\"` constant + validation rule (optional, str-or-absent). Pre-G7 edges still valid. |
| `core/lifecycle/etag.py` | **NEW** — `EtagMismatchError`, `compute_edge_etag`, `assign_edge_etag`, `check_edge_etag`. Pure functions over a canonical projection of the edge's identity fields. |
| `core/lifecycle/supersede_chain.py` | `supersede_edge(..., *, expected_old_etag=None)`. Optimistic check fires **before** any mutation; mismatch leaves `old_edge` untouched. On success, both edges get a fresh etag. |
| `tests/test_v05_etag_optimistic_locking.py` | **30 new tests** (compute / assign / check / supersede integration / schema validation). |

### What's hashed

The etag is a SHA-256 hex prefix (12 hex chars = 48 bits) over a canonical projection of:

- `id`, `type`
- `validity.{from, to}`
- `status.{active, superseded_by, superseded_at}`
- `mutation_type`
- `sources[*].{doc_id, weight}`

**Excluded** (so they can mutate without etag churn): `etag` itself (no self-reference), `confidence` (derived at read), `label` (display), unknown caller fields (schema-evolution-robust).

### Why optimistic, not pessimistic

A pessimistic lock would force a process-wide mutex around every mutation — fine for single-process, incompatible with the multi-tenant SaaS direction B.1 flagged. Optimistic locking lets readers proceed without coordination; only the WRITE step verifies. Supersede events are rare per edge, so retry loops stay short.

### Backwards compatibility

- Default `expected_old_etag=None` preserves pre-G7 supersede behaviour byte-identical, except that both edges now carry a freshly-populated `etag` field (no caller relied on its absence; field is forward-compatible).
- Edges without an etag field still validate per `validate_edge_v04_fields`.

## Verification

- `pytest tests/test_v05_etag_optimistic_locking.py`: **30 passed**
- Full lifecycle + B.5 regression sweep (T7 supersede + T7 release-gating invariants + T6 release-gating invariants + B.5.b + B.5.c + B.5.d + typed_filter): **171 passed**
- `ruff check`: clean
- Module size cap (CLAUDE.md rule 5, 20 KB):
  - `schema.py` 19.8 KB
  - `etag.py` 7.4 KB (new)
  - `supersede_chain.py` 15.6 KB

## Out of scope

- Wiki I/O integration — the engine-side write path doesn't yet pass `expected_old_etag`. The primitive is ready; wiring lands alongside the scheduled-job ingest pipeline whose race condition motivates G7. **No `core/retrieval` / `core/reasoning` path changed by this PR.**
- G1 / G2 / G3-G6 / G8 from the B.1 audit — each lands as a separate cycle (G1 / G2 fold into B.2 + future approval-evidence work; G3-G6 are nice-to-haves; G8 lands in B.3 v0.6 design memo).
- Vertical-specific edge types — BLOCKED per CLAUDE.md rule #1.

Quality delta: exempt (label: external-mother-platform — additive lifecycle primitive; `core/retrieval`, `core/graph` traversal, `core/reasoning` paths untouched; default-off behaviour byte-identical to pre-PR)