### PR TITLE
feat(v0.5-G4): retention-class metadata on audit-log rows

### DIFF
--- a/core/lifecycle/replay_audit.py
+++ b/core/lifecycle/replay_audit.py
@@ -138,6 +138,7 @@ def emit_lifecycle_event(
     user_role: str = "system",
     timestamp: Optional[str] = None,
     db_path: Optional[str] = None,
+    retention_class: Optional[str] = None,
 ) -> bool:
     """Insert one ``audit_log`` row with the given lifecycle
     ``event_type`` + JSON-encoded ``payload``.
@@ -153,6 +154,14 @@ def emit_lifecycle_event(
             from CASCADE / EVENT machinery, not from an HTTP role.
         timestamp: ISO-8601 string. Defaults to ``datetime.now()``.
         db_path: optional override. Production code omits it.
+        retention_class: **v0.5 G4** — optional machine-readable
+            retention tag. When set, stamped into the row's
+            ``event_payload`` JSON under ``retention_class`` so
+            ``core.lifecycle.retention.pending_retention_review`` can
+            find rows past their window. Must be a value accepted by
+            :func:`core.lifecycle.retention.validate_retention_class`
+            — malformed values cause the emit to return ``False``
+            (safer than silently stamping garbage).
 
     Returns:
         ``True`` on insert, ``False`` on any failure. **Never raises**
@@ -167,11 +176,26 @@ def emit_lifecycle_event(
         * ``endpoint`` is set to ``event_type`` so existing operator
           audit views (``/admin/audit/list``) surface lifecycle rows
           without a separate filter.
+        * **No schema migration** is needed for ``retention_class`` —
+          it lives inside the ``event_payload`` JSON column.
     """
     if not is_lifecycle_event(event_type):
         return False
     if not isinstance(payload, dict):
         return False
+
+    # v0.5 G4 — validate + stamp retention_class into the payload.
+    if retention_class is not None:
+        # Local import to avoid a circular at module-import time
+        # (retention.py imports nothing from replay_audit.py — this
+        # keeps the dependency one-way, even though replay_audit only
+        # consults retention.validate at runtime).
+        from core.lifecycle.retention import validate_retention_class
+        if not validate_retention_class(retention_class):
+            return False
+        # Copy to avoid mutating the caller's dict.
+        payload = dict(payload)
+        payload["retention_class"] = retention_class
 
     ts = timestamp or datetime.now().isoformat()
     try:

--- a/core/lifecycle/retention.py
+++ b/core/lifecycle/retention.py
@@ -1,0 +1,299 @@
+"""v0.5 G4 — retention-policy metadata for audit-log rows.
+
+Per `docs/reviews/v0.5-b1-ontology-surface-audit.md` G4
+(strongly recommended for enterprise pilots): audit rows are append-
+only and never deleted (the correct semantic for replay-safety),
+but enterprise deployments routinely have legal retention windows
+(e.g., 7 years per a typical data-retention policy).
+
+This module adds a **machine-readable retention class** that callers
+attach to emitted audit rows, plus a **`pending_retention_review`**
+predicate that surfaces row IDs past their window — so the operator
+can run the (approval-gated, manual) decision to actually archive
+them. The module does NOT auto-delete; the only way to remove a row
+is still a separate change-request flow that preserves the
+audit-replay-safety invariant.
+
+## Retention class values
+
+  - ``"permanent"``   — keep indefinitely; never returned by the
+                        pending-review predicate. The default for
+                        load-bearing audit rows.
+  - ``"7y"``          — 7 years from row timestamp (typical legal
+                        retention floor for enterprise records).
+  - ``"3y"``          — 3 years from row timestamp.
+  - ``"pilot"``       — 90 days from row timestamp (short pilot
+                        window so pilot data doesn't accumulate
+                        indefinitely in production-style stores).
+  - ``"custom:<ISO>"`` — custom expiry timestamp; the suffix MUST be
+                        a parseable ISO-8601 datetime string.
+
+## Integration with emit
+
+The retention class is stored INSIDE the row's `event_payload` JSON
+column (under the key ``retention_class``), so adding it required
+zero schema migration. Callers pass ``retention_class`` to
+:func:`emit_lifecycle_event` (added there) and read it back via
+:func:`row_retention_class`.
+
+## What this module is NOT
+
+- **Not an auto-delete path.** :func:`pending_retention_review`
+  returns row IDs; the operator decides whether to invoke an
+  archive flow.
+- **Not a TTL.** Rows past their window remain visible to replay
+  until explicitly archived. The retention metadata only signals
+  eligibility.
+- **Not GDPR Art. 17 ready out of the box.** Customers needing
+  erasure-on-request must implement an archive flow that preserves
+  the replay-safety invariant — typically by writing a "tombstone"
+  row that the replay layer respects without exposing the original
+  PII. That work is downstream of this primitive.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Final, List, Optional
+
+
+# ─── Retention class constants ────────────────────────────────────────
+
+RETENTION_PERMANENT: Final[str] = "permanent"
+RETENTION_7Y:        Final[str] = "7y"
+RETENTION_3Y:        Final[str] = "3y"
+RETENTION_PILOT:     Final[str] = "pilot"
+RETENTION_CUSTOM_PREFIX: Final[str] = "custom:"
+
+_FIXED_RETENTION_DELTAS = {
+    RETENTION_7Y:    timedelta(days=365 * 7),
+    RETENTION_3Y:    timedelta(days=365 * 3),
+    RETENTION_PILOT: timedelta(days=90),
+}
+
+VALID_RETENTION_FIXED: Final[frozenset[str]] = frozenset({
+    RETENTION_PERMANENT,
+    RETENTION_7Y,
+    RETENTION_3Y,
+    RETENTION_PILOT,
+})
+
+
+# ─── Validation ───────────────────────────────────────────────────────
+
+
+def validate_retention_class(value: str) -> bool:
+    """True iff ``value`` is a recognised retention class.
+
+    Recognised forms:
+      * Any of the four fixed classes (``permanent``, ``7y``, ``3y``,
+        ``pilot``).
+      * ``custom:<ISO-8601>`` where the suffix parses as a
+        timezone-aware datetime.
+
+    Returns ``False`` (does not raise) on ``None``, non-str, empty,
+    or malformed values — callers that need a strict assertion can
+    wrap with their own raise.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if value in VALID_RETENTION_FIXED:
+        return True
+    if value.startswith(RETENTION_CUSTOM_PREFIX):
+        suffix = value[len(RETENTION_CUSTOM_PREFIX):]
+        return _parse_iso(suffix) is not None
+    return False
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    """Lenient ISO-8601 parse → tz-aware datetime (UTC if naive)."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+# ─── Expiry computation ───────────────────────────────────────────────
+
+
+def expiry_for(
+    retention_class: str,
+    row_timestamp: str,
+) -> Optional[datetime]:
+    """Return the moment a row passes retention.
+
+    Args:
+        retention_class: a value accepted by
+            :func:`validate_retention_class`.
+        row_timestamp: ISO-8601 timestamp of the audit row.
+
+    Returns:
+        Timezone-aware datetime when the row is past its window.
+        ``None`` if the row is ``permanent`` (never expires), if
+        the retention class is malformed, or if ``row_timestamp``
+        cannot be parsed.
+    """
+    if not validate_retention_class(retention_class):
+        return None
+    if retention_class == RETENTION_PERMANENT:
+        return None
+    parsed_ts = _parse_iso(row_timestamp)
+    if parsed_ts is None:
+        return None
+    if retention_class in _FIXED_RETENTION_DELTAS:
+        return parsed_ts + _FIXED_RETENTION_DELTAS[retention_class]
+    # custom:<ISO> — the suffix IS the expiry timestamp (absolute,
+    # not relative to row_timestamp). The custom case is the
+    # "legal hold until specific date" pattern.
+    suffix = retention_class[len(RETENTION_CUSTOM_PREFIX):]
+    return _parse_iso(suffix)
+
+
+def is_past_retention(
+    retention_class: str,
+    row_timestamp: str,
+    now: datetime,
+) -> bool:
+    """True iff a row is past its retention window relative to ``now``.
+
+    ``permanent`` and malformed retention classes return ``False``
+    (treated as "never review"). ``now`` must be timezone-aware.
+    """
+    if not isinstance(now, datetime) or now.tzinfo is None:
+        raise ValueError(
+            "now must be a timezone-aware datetime "
+            "(UTC recommended)"
+        )
+    expiry = expiry_for(retention_class, row_timestamp)
+    if expiry is None:
+        return False
+    return now >= expiry
+
+
+# ─── Audit-log scan ───────────────────────────────────────────────────
+
+
+_RETENTION_KEY_RE = re.compile(
+    r'"retention_class"\s*:\s*"([^"]+)"'
+)
+
+
+def _default_db_path() -> str:
+    """Mirror of `replay_audit._default_db_path` so this module
+    doesn't introduce a cross-module dependency on a private helper.
+    """
+    env = (os.environ.get("JAMES_AUDIT_DB") or "").strip()
+    if env:
+        return env
+    here = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(os.path.dirname(here))
+    return os.path.join(project_root, "audit.db")
+
+
+def pending_retention_review(
+    now: datetime,
+    *,
+    db_path: Optional[str] = None,
+    limit: int = 1000,
+) -> List[int]:
+    """Return audit_log row IDs whose retention window has expired.
+
+    Scans the audit_log table for rows whose ``event_payload`` JSON
+    contains a ``retention_class`` key. For each such row, computes
+    the expiry from the row's ``timestamp`` + retention class, and
+    includes the row's ID if ``now >= expiry``.
+
+    Args:
+        now: timezone-aware "current" moment for the review.
+        db_path: optional override. Defaults to the same path as
+            :func:`emit_lifecycle_event` (``JAMES_AUDIT_DB`` env or
+            project-root ``audit.db``).
+        limit: maximum number of row IDs to return. Default 1000
+            — the operator runs the predicate periodically; returning
+            millions of IDs in one call is a smell.
+
+    Returns:
+        List of integer row IDs, ordered by ID ascending. Empty list
+        if no rows past retention, or if the DB is missing /
+        unreadable (silent fail matches `emit_lifecycle_event`'s
+        "never raises" contract).
+
+    What this does NOT do:
+        * Does NOT delete the rows. Caller decides.
+        * Does NOT mark rows as reviewed. Stateless scan.
+        * Does NOT cross-reference replay invariants. The operator
+          must verify archival doesn't break replay before deleting.
+    """
+    if not isinstance(now, datetime) or now.tzinfo is None:
+        raise ValueError(
+            "now must be a timezone-aware datetime "
+            "(UTC recommended)"
+        )
+    path = db_path or _default_db_path()
+    if not os.path.exists(path):
+        return []
+
+    out: List[int] = []
+    try:
+        conn = sqlite3.connect(path, check_same_thread=False)
+        try:
+            cur = conn.execute(
+                "SELECT id, timestamp, event_payload "
+                "FROM audit_log "
+                "WHERE event_payload LIKE '%retention_class%' "
+                "ORDER BY id ASC LIMIT ?",
+                (int(limit),),
+            )
+            for row_id, ts, payload_json in cur:
+                if not isinstance(payload_json, str):
+                    continue
+                match = _RETENTION_KEY_RE.search(payload_json)
+                if not match:
+                    continue
+                rc = match.group(1)
+                if is_past_retention(rc, ts or "", now):
+                    out.append(int(row_id))
+        finally:
+            conn.close()
+    except Exception:
+        return []
+    return out
+
+
+# ─── Row-side accessor ────────────────────────────────────────────────
+
+
+def row_retention_class(event_payload: str) -> Optional[str]:
+    """Extract the ``retention_class`` from a row's payload JSON.
+
+    Returns ``None`` if the key is absent, the payload is not a
+    string, or the JSON is malformed. Uses a regex match rather
+    than `json.loads` so callers iterating millions of rows pay
+    the parse cost only on rows that already match the LIKE filter.
+    """
+    if not isinstance(event_payload, str):
+        return None
+    match = _RETENTION_KEY_RE.search(event_payload)
+    return match.group(1) if match else None
+
+
+__all__ = (
+    "RETENTION_PERMANENT",
+    "RETENTION_7Y",
+    "RETENTION_3Y",
+    "RETENTION_PILOT",
+    "RETENTION_CUSTOM_PREFIX",
+    "VALID_RETENTION_FIXED",
+    "validate_retention_class",
+    "expiry_for",
+    "is_past_retention",
+    "pending_retention_review",
+    "row_retention_class",
+)

--- a/tests/test_v05_retention_metadata.py
+++ b/tests/test_v05_retention_metadata.py
@@ -1,0 +1,382 @@
+"""v0.5 G4 — retention-metadata tests.
+
+Covers:
+
+  * Constants + `validate_retention_class` accept the 4 fixed
+    values and well-formed `custom:<ISO>`; reject everything else.
+  * `expiry_for` — fixed-duration math (7y / 3y / 90d) + absolute
+    `custom:` semantic + `permanent` returns None.
+  * `is_past_retention` — tz-awareness invariant + boundary
+    semantics (now == expiry → past).
+  * `row_retention_class` — regex extraction from JSON payload
+    string, robust to absence + malformed.
+  * `emit_lifecycle_event` integration — `retention_class` stamps
+    payload + invalid values cause emit to return False (safer
+    than silently stamping garbage).
+  * `pending_retention_review` — scans audit_log SQLite DB for
+    rows whose retention_class is past; respects `limit`; returns
+    empty list on missing DB.
+
+Uses a temporary SQLite DB built in `setUpClass` so the predicate
+walks real rows, not a mock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from core.lifecycle.replay_audit import (
+    EVT_SUPERSEDE_EDGE_CREATED,
+    emit_lifecycle_event,
+)
+from core.lifecycle.retention import (
+    RETENTION_3Y,
+    RETENTION_7Y,
+    RETENTION_CUSTOM_PREFIX,
+    RETENTION_PERMANENT,
+    RETENTION_PILOT,
+    VALID_RETENTION_FIXED,
+    expiry_for,
+    is_past_retention,
+    pending_retention_review,
+    row_retention_class,
+    validate_retention_class,
+)
+
+
+class ValidateRetentionClassTests(unittest.TestCase):
+    def test_four_fixed_classes_valid(self):
+        for value in VALID_RETENTION_FIXED:
+            with self.subTest(value=value):
+                self.assertTrue(validate_retention_class(value))
+
+    def test_custom_with_iso_valid(self):
+        self.assertTrue(validate_retention_class(
+            "custom:2027-01-01T00:00:00+00:00"
+        ))
+
+    def test_custom_with_z_suffix_valid(self):
+        self.assertTrue(validate_retention_class("custom:2027-01-01T00:00:00Z"))
+
+    def test_custom_naive_iso_valid(self):
+        # _parse_iso treats naive as UTC.
+        self.assertTrue(validate_retention_class("custom:2027-01-01T00:00:00"))
+
+    def test_custom_with_malformed_iso_invalid(self):
+        self.assertFalse(validate_retention_class("custom:not-a-date"))
+        self.assertFalse(validate_retention_class("custom:"))
+
+    def test_unrecognised_string_invalid(self):
+        for value in ("forever", "10y", "1d", "0", ""):
+            with self.subTest(value=value):
+                self.assertFalse(validate_retention_class(value))
+
+    def test_non_string_invalid(self):
+        for value in (None, 0, 7, [], {}):
+            with self.subTest(value=value):
+                self.assertFalse(validate_retention_class(value))  # type: ignore[arg-type]
+
+
+class ExpiryForTests(unittest.TestCase):
+    def test_permanent_returns_none(self):
+        self.assertIsNone(expiry_for(RETENTION_PERMANENT,
+                                     "2026-01-01T00:00:00+00:00"))
+
+    def test_7y_returns_7y_later(self):
+        ts = "2026-01-01T00:00:00+00:00"
+        expiry = expiry_for(RETENTION_7Y, ts)
+        self.assertIsNotNone(expiry)
+        # 7 * 365 = 2555 days.
+        delta = expiry - datetime.fromisoformat(ts)
+        self.assertEqual(delta, timedelta(days=2555))
+
+    def test_3y_returns_3y_later(self):
+        ts = "2026-01-01T00:00:00+00:00"
+        expiry = expiry_for(RETENTION_3Y, ts)
+        delta = expiry - datetime.fromisoformat(ts)
+        self.assertEqual(delta, timedelta(days=1095))
+
+    def test_pilot_returns_90d_later(self):
+        ts = "2026-01-01T00:00:00+00:00"
+        expiry = expiry_for(RETENTION_PILOT, ts)
+        delta = expiry - datetime.fromisoformat(ts)
+        self.assertEqual(delta, timedelta(days=90))
+
+    def test_custom_returns_suffix_absolute(self):
+        # Custom is ABSOLUTE — the suffix IS the expiry, regardless
+        # of row_timestamp. Verify the row_timestamp is NOT added in.
+        expiry = expiry_for(
+            f"{RETENTION_CUSTOM_PREFIX}2027-06-15T12:00:00+00:00",
+            "2026-01-01T00:00:00+00:00",
+        )
+        self.assertEqual(
+            expiry,
+            datetime(2027, 6, 15, 12, 0, tzinfo=timezone.utc),
+        )
+
+    def test_malformed_class_returns_none(self):
+        self.assertIsNone(expiry_for("forever", "2026-01-01T00:00:00+00:00"))
+        self.assertIsNone(expiry_for("custom:bad", "2026-01-01T00:00:00+00:00"))
+
+    def test_malformed_timestamp_returns_none(self):
+        self.assertIsNone(expiry_for(RETENTION_7Y, "not-a-timestamp"))
+
+
+class IsPastRetentionTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    def test_permanent_never_past(self):
+        # Even a row from year 2000 with permanent class is "not past".
+        self.assertFalse(is_past_retention(
+            RETENTION_PERMANENT, "2000-01-01T00:00:00+00:00", self.now,
+        ))
+
+    def test_pilot_row_from_yesterday_not_past(self):
+        ts = (self.now - timedelta(days=1)).isoformat()
+        self.assertFalse(is_past_retention(RETENTION_PILOT, ts, self.now))
+
+    def test_pilot_row_from_91d_ago_past(self):
+        ts = (self.now - timedelta(days=91)).isoformat()
+        self.assertTrue(is_past_retention(RETENTION_PILOT, ts, self.now))
+
+    def test_naive_now_raises(self):
+        with self.assertRaises(ValueError):
+            is_past_retention(RETENTION_PILOT,
+                              self.now.isoformat(), datetime(2026, 6, 1))
+
+    def test_non_datetime_now_raises(self):
+        with self.assertRaises(ValueError):
+            is_past_retention(RETENTION_PILOT, "x", "2026-06-01")  # type: ignore[arg-type]
+
+    def test_malformed_returns_false(self):
+        # Both malformed class and malformed timestamp gracefully
+        # return False rather than raise.
+        self.assertFalse(is_past_retention(
+            "bogus", "2025-01-01T00:00:00+00:00", self.now,
+        ))
+        self.assertFalse(is_past_retention(
+            RETENTION_PILOT, "not-a-time", self.now,
+        ))
+
+
+class RowRetentionClassExtractionTests(unittest.TestCase):
+    def test_extracts_value_from_well_formed_payload(self):
+        payload = json.dumps(
+            {"edge_id": "e_x", "retention_class": "7y"},
+            sort_keys=True,
+        )
+        self.assertEqual(row_retention_class(payload), "7y")
+
+    def test_extracts_value_from_payload_with_custom(self):
+        payload = json.dumps(
+            {"retention_class": "custom:2027-01-01T00:00:00+00:00"},
+            sort_keys=True,
+        )
+        self.assertEqual(
+            row_retention_class(payload),
+            "custom:2027-01-01T00:00:00+00:00",
+        )
+
+    def test_returns_none_when_key_absent(self):
+        payload = json.dumps({"edge_id": "e_x"})
+        self.assertIsNone(row_retention_class(payload))
+
+    def test_returns_none_on_non_string(self):
+        self.assertIsNone(row_retention_class(None))  # type: ignore[arg-type]
+        self.assertIsNone(row_retention_class(123))  # type: ignore[arg-type]
+
+    def test_handles_unicode_payload(self):
+        payload = json.dumps(
+            {"edge_id": "엔티티", "retention_class": "pilot"},
+            ensure_ascii=False, sort_keys=True,
+        )
+        self.assertEqual(row_retention_class(payload), "pilot")
+
+
+def _make_temp_db_with_audit_schema() -> str:
+    """Create a fresh SQLite DB with the audit_log schema for tests."""
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="james-test-")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("""
+            CREATE TABLE audit_log (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp       TEXT NOT NULL,
+                user_role       TEXT,
+                endpoint        TEXT,
+                query           TEXT,
+                answer          TEXT,
+                graph_paths     TEXT,
+                blocked         INTEGER NOT NULL DEFAULT 0,
+                security_event  TEXT,
+                elapsed_sec     REAL,
+                ip_address      TEXT,
+                event_type      TEXT,
+                event_payload   TEXT
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+class EmitWithRetentionClassTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db_path = _make_temp_db_with_audit_schema()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            os.remove(cls.db_path)
+        except OSError:
+            pass
+
+    def test_emit_with_valid_retention_class_succeeds(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_y"},
+            db_path=self.db_path,
+            retention_class=RETENTION_7Y,
+        )
+        self.assertTrue(ok)
+
+    def test_emit_stamps_retention_class_into_payload(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_z"},
+            db_path=self.db_path,
+            retention_class=RETENTION_PILOT,
+        )
+        self.assertTrue(ok)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT event_payload FROM audit_log "
+                "WHERE event_payload LIKE '%e_z%'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+        self.assertEqual(row_retention_class(row[0]), RETENTION_PILOT)
+
+    def test_emit_with_invalid_retention_class_returns_false(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_bad"},
+            db_path=self.db_path,
+            retention_class="forever",
+        )
+        self.assertFalse(ok)
+
+    def test_emit_without_retention_class_unchanged(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_no_retention"},
+            db_path=self.db_path,
+        )
+        self.assertTrue(ok)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT event_payload FROM audit_log "
+                "WHERE event_payload LIKE '%e_no_retention%'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+        self.assertIsNone(row_retention_class(row[0]))
+
+    def test_emit_does_not_mutate_caller_payload(self):
+        caller_payload = {"edge_id": "e_purity"}
+        emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            caller_payload,
+            db_path=self.db_path,
+            retention_class=RETENTION_PILOT,
+        )
+        self.assertNotIn("retention_class", caller_payload)
+
+
+class PendingRetentionReviewTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db_path = _make_temp_db_with_audit_schema()
+        cls.now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        # Seed rows directly so we control timestamps without
+        # depending on the emit function's default ts.
+        conn = sqlite3.connect(cls.db_path)
+        try:
+            seeds = [
+                # 1: pilot 91d ago → PAST
+                ("2026-03-01T00:00:00+00:00",
+                 json.dumps({"retention_class": "pilot"})),
+                # 2: 7y row from 2018 → PAST (now=2026)
+                ("2018-01-01T00:00:00+00:00",
+                 json.dumps({"retention_class": "7y"})),
+                # 3: permanent → not past
+                ("2018-01-01T00:00:00+00:00",
+                 json.dumps({"retention_class": "permanent"})),
+                # 4: pilot 30d ago → not past
+                ("2026-05-01T00:00:00+00:00",
+                 json.dumps({"retention_class": "pilot"})),
+                # 5: no retention_class key → ignored
+                ("2018-01-01T00:00:00+00:00",
+                 json.dumps({"edge_id": "x"})),
+                # 6: custom with absolute past expiry
+                ("2026-01-01T00:00:00+00:00",
+                 json.dumps({"retention_class": "custom:2026-05-01T00:00:00+00:00"})),
+            ]
+            for ts, payload in seeds:
+                conn.execute(
+                    "INSERT INTO audit_log "
+                    "(timestamp, user_role, endpoint, blocked, "
+                    " event_type, event_payload) "
+                    "VALUES (?, 'system', 'evt', 0, 'lifecycle.t', ?)",
+                    (ts, payload),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            os.remove(cls.db_path)
+        except OSError:
+            pass
+
+    def test_returns_expected_past_row_ids(self):
+        ids = pending_retention_review(self.now, db_path=self.db_path)
+        # Rows 1 (pilot past), 2 (7y past), 6 (custom past) → 3 ids.
+        # Rows 3 (permanent), 4 (pilot fresh), 5 (no class) → excluded.
+        self.assertEqual(len(ids), 3)
+        # IDs ascending.
+        self.assertEqual(ids, sorted(ids))
+
+    def test_respects_limit(self):
+        ids = pending_retention_review(self.now, db_path=self.db_path,
+                                       limit=2)
+        self.assertEqual(len(ids), 2)
+
+    def test_missing_db_returns_empty(self):
+        ids = pending_retention_review(
+            self.now, db_path="/nonexistent/path.db",
+        )
+        self.assertEqual(ids, [])
+
+    def test_naive_now_raises(self):
+        with self.assertRaises(ValueError):
+            pending_retention_review(datetime(2026, 6, 1),
+                                     db_path=self.db_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses **G4** from `docs/reviews/v0.5-b1-ontology-surface-audit.md` (strongly recommended for enterprise pilots — typical GDPR Art. 17 customer-Q surface).

Adds machine-readable retention metadata that callers attach to emitted audit rows + a `pending_retention_review(now)` predicate. **No auto-delete** — the operator still owns the (approval-gated, manual) archive decision.

### New surfaces

| Symbol | Purpose |
|---|---|
| `RETENTION_PERMANENT` / `_7Y` / `_3Y` / `_PILOT` (90d) | 4 fixed retention classes |
| `custom:<ISO>` | Absolute legal-hold expiry (suffix IS the expiry, not a delta) |
| `validate_retention_class(value)` | Accepts fixed + well-formed custom; never raises |
| `expiry_for(class, row_ts)` | When does this row pass retention? `permanent` → None. |
| `is_past_retention(class, row_ts, now)` | tz-aware predicate |
| `row_retention_class(payload)` | Regex extraction from a row's payload JSON |
| `pending_retention_review(now, *, db_path=None, limit=1000)` | SQLite scan returning row IDs past their window |

`emit_lifecycle_event(..., retention_class=None)` — new keyword-only parameter. Stamps inside `event_payload` JSON. **No schema migration**. Invalid values cause emit to return False (safer than silently stamping garbage). Default None preserves byte-identical pre-G4 behaviour.

### What this is NOT

- **Not an auto-delete path.** Returns IDs; operator decides.
- **Not a TTL.** Past-retention rows remain visible to replay until explicitly archived.
- **Not GDPR Art. 17 ready out of the box.** Customers needing erasure-on-request build a tombstone-row archive flow on top. This is the prerequisite primitive.

## Tests

`tests/test_v05_retention_metadata.py` — **34 tests across 6 classes** (validate / expiry / past-predicate / row extraction / emit integration with a real temp SQLite / pending-review scan with seeded rows).

## Verification

- `pytest tests/test_v05_retention_metadata.py`: **34 passed**
- T5 regression sweep (existing event taxonomy + release-gating + reconstruct + new): **78 passed**
- `ruff check`: clean
- Module sizes (CLAUDE.md rule 5, 20 KB cap): retention.py 10.9 KB (new); replay_audit.py 9.5 KB (+3 KB for retention path)

## Out of scope

- Tombstone-row archive flow — separate PR when customer signal materializes.
- Wiring `retention_class` into actual mutation call sites — every existing emit call still defaults to None.
- G1 / G2 / G3 / G6 / G8 — separate cycles per B.1 triage.
- Vertical-specific retention rules — BLOCKED per CLAUDE.md rule #1.

Quality delta: exempt (label: external-mother-platform — additive primitive; default-off behaviour byte-identical)