### PR TITLE
feat(v0.5-G3): corpus-wide reconstruct_view_at streaming generator

### DIFF
--- a/core/lifecycle/supersede_chain.py
+++ b/core/lifecycle/supersede_chain.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 from core.lifecycle.etag import (
     assign_edge_etag,
@@ -356,6 +356,76 @@ def _validity_contains(validity: dict, t: datetime) -> bool:
         if t >= vt:
             return False
     return True
+
+
+# ─── v0.5 G3 — corpus-wide replay convenience (streaming) ─────────────
+
+
+def reconstruct_corpus_view_at(
+    heads: Iterable[dict],
+    lookup: Callable[[str], Optional[dict]],
+    t: datetime,
+    *,
+    limit: Optional[int] = None,
+) -> Iterator[Tuple[str, Optional[dict]]]:
+    """Stream the entire corpus state at time ``t``.
+
+    Per `docs/reviews/v0.5-b1-ontology-surface-audit.md` G3: the
+    edge-level :func:`reconstruct_view_at` answers "what was edge
+    X at time T?" — replaying an entire corpus requires the caller
+    to enumerate all chain heads and call it for each. This
+    convenience yields one tuple per head so an auditor can ask
+    "show me the entire corpus state at audit cutoff T" without
+    materializing the full result set in memory first.
+
+    Args:
+        heads: iterable of chain links — typically the result of
+            the caller's enumeration over the wiki's currently-
+            active edges (chain heads), but any chain link works
+            (this function walks via ``walk_supersede_chain``
+            internally). Generator-friendly; consumed lazily.
+        lookup: same id-to-edge resolver used by
+            :func:`reconstruct_view_at` and
+            :func:`walk_supersede_chain`. Receives chain-link IDs
+            and returns the corresponding edge dict, or ``None``
+            if the link is missing from the caller's snapshot.
+        t: UTC-aware ``datetime`` — the moment to reconstruct.
+        limit: maximum number of heads to yield. ``None`` (default)
+            means "yield all". The cap is a hygiene guard for
+            unbounded enumerations; production callers should pick
+            a page size that fits their downstream buffer.
+
+    Yields:
+        ``(head_id, edge_at_t_or_None)`` tuples in the order the
+        ``heads`` iterable produced them. ``head_id`` is the
+        ``id`` field of the input head dict — useful for caller-
+        side deduplication. ``edge_at_t`` is the chain edge whose
+        ``validity`` window contained ``t`` (per
+        :func:`reconstruct_view_at`), or ``None`` if no chain
+        edge matched (e.g., ``t`` is before the chain began, or
+        every link was CASCADE-invalidated).
+
+    Asymptotic cost (operator hint):
+        O(N × avg_chain_length) where N = number of heads yielded.
+        Each per-head reconstruction is O(chain_length). The
+        function does NOT cache walks across heads — a head that
+        appears twice in ``heads`` will be walked twice.
+
+    Why generator: at corpus > 10⁵ heads the materialized result
+    set is hundreds of MB. Streaming lets the caller page into
+    its downstream buffer (file write, HTTP response, archive
+    table) without holding the full result in memory.
+    """
+    count = 0
+    for head in heads:
+        if limit is not None and count >= limit:
+            return
+        if not isinstance(head, dict):
+            continue
+        head_id = head.get("id") or ""
+        edge_at_t = reconstruct_view_at(head, lookup, t)
+        yield (str(head_id), edge_at_t)
+        count += 1
 
 
 __all__ = [

--- a/tests/test_v05_corpus_reconstruct.py
+++ b/tests/test_v05_corpus_reconstruct.py
@@ -1,0 +1,196 @@
+"""v0.5 G3 — corpus-wide reconstruct_view_at tests.
+
+Covers:
+
+  * Equivalence — per-head reconstruction matches `reconstruct_view_at`
+    on a single chain.
+  * Order preservation — yields in the order the heads iterable
+    produced them.
+  * Lazy / streaming — generator semantics; consumers can stop early.
+  * `limit` — respects the cap; default `None` yields all.
+  * Skips non-dict entries silently (defensive against caller's
+    iterator producing junk).
+  * Empty / no-match — yields `(head_id, None)` for chain heads whose
+    chain has no edge containing `t`.
+  * Handles dangling chains (lookup returns None mid-walk).
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from core.lifecycle.supersede_chain import (
+    reconstruct_corpus_view_at,
+    reconstruct_view_at,
+)
+
+
+def _chain_head(head_id: str, vf: str, vt: str = None,
+                superseded_by: str = None,
+                mutation_type: str = "active") -> dict:
+    """Build a chain-link edge dict for testing."""
+    return {
+        "id": head_id,
+        "type": "RELATED_TO",
+        "validity": {"from": vf, "to": vt},
+        "status": {
+            "active": superseded_by is None,
+            "superseded_by": superseded_by,
+            "superseded_at": vt if superseded_by else None,
+        },
+        "mutation_type": mutation_type,
+        "sources": [{"doc_id": "doc_x", "weight": 0.9, "role": "primary",
+                     "ts": vf, "valid_from": None, "valid_until": None}],
+    }
+
+
+class CorpusReconstructEquivalenceTests(unittest.TestCase):
+    """Per-head outputs must match single-head reconstruct_view_at."""
+
+    def setUp(self):
+        # Two chain heads, each a single edge (no supersede).
+        self.head_a = _chain_head("e_a", "2026-01-01T00:00:00+00:00")
+        self.head_b = _chain_head("e_b", "2026-03-01T00:00:00+00:00")
+        self.lookup = lambda eid: None  # No chain extensions
+
+    def test_equivalence_for_each_head(self):
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        per_head = {
+            "e_a": reconstruct_view_at(self.head_a, self.lookup, t),
+            "e_b": reconstruct_view_at(self.head_b, self.lookup, t),
+        }
+        corpus = dict(reconstruct_corpus_view_at(
+            [self.head_a, self.head_b], self.lookup, t,
+        ))
+        self.assertEqual(corpus, per_head)
+
+
+class CorpusReconstructOrderTests(unittest.TestCase):
+    def test_output_order_matches_input_order(self):
+        h1 = _chain_head("e_1", "2026-01-01T00:00:00+00:00")
+        h2 = _chain_head("e_2", "2026-02-01T00:00:00+00:00")
+        h3 = _chain_head("e_3", "2026-03-01T00:00:00+00:00")
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            [h2, h3, h1], lookup=lambda _: None, t=t,
+        ))
+        self.assertEqual([head_id for head_id, _ in out],
+                         ["e_2", "e_3", "e_1"])
+
+
+class CorpusReconstructStreamingTests(unittest.TestCase):
+    def test_generator_can_be_stopped_early(self):
+        heads = [_chain_head(f"e_{i}", "2026-01-01T00:00:00+00:00")
+                 for i in range(100)]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        gen = reconstruct_corpus_view_at(heads, lookup=lambda _: None, t=t)
+        # Pull the first 3, then drop the generator.
+        first_three = [next(gen) for _ in range(3)]
+        self.assertEqual(len(first_three), 3)
+        self.assertEqual([h for h, _ in first_three],
+                         ["e_0", "e_1", "e_2"])
+
+    def test_returns_generator_not_list(self):
+        gen = reconstruct_corpus_view_at(
+            [], lookup=lambda _: None,
+            t=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        # Generator/iterator protocol: has __iter__ + __next__.
+        self.assertTrue(hasattr(gen, "__iter__"))
+        self.assertTrue(hasattr(gen, "__next__"))
+
+
+class CorpusReconstructLimitTests(unittest.TestCase):
+    def test_limit_caps_output(self):
+        heads = [_chain_head(f"e_{i}", "2026-01-01T00:00:00+00:00")
+                 for i in range(10)]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            heads, lookup=lambda _: None, t=t, limit=3,
+        ))
+        self.assertEqual(len(out), 3)
+
+    def test_limit_none_yields_all(self):
+        heads = [_chain_head(f"e_{i}", "2026-01-01T00:00:00+00:00")
+                 for i in range(5)]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            heads, lookup=lambda _: None, t=t, limit=None,
+        ))
+        self.assertEqual(len(out), 5)
+
+    def test_limit_zero_yields_nothing(self):
+        heads = [_chain_head("e_a", "2026-01-01T00:00:00+00:00")]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            heads, lookup=lambda _: None, t=t, limit=0,
+        ))
+        self.assertEqual(out, [])
+
+    def test_limit_larger_than_heads_yields_all(self):
+        heads = [_chain_head(f"e_{i}", "2026-01-01T00:00:00+00:00")
+                 for i in range(3)]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            heads, lookup=lambda _: None, t=t, limit=999,
+        ))
+        self.assertEqual(len(out), 3)
+
+
+class CorpusReconstructRobustnessTests(unittest.TestCase):
+    def test_non_dict_entries_silently_skipped(self):
+        head = _chain_head("e_real", "2026-01-01T00:00:00+00:00")
+        # The iterable produces some junk entries; the function
+        # should skip them and continue with the real head.
+        heads = ["not a dict", None, head, 42]
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            heads, lookup=lambda _: None, t=t,
+        ))
+        head_ids = [h for h, _ in out]
+        self.assertEqual(head_ids, ["e_real"])
+
+    def test_no_match_yields_none(self):
+        # Head's validity starts AFTER t → no chain edge matches.
+        head = _chain_head("e_future",
+                           vf="2027-01-01T00:00:00+00:00")
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            [head], lookup=lambda _: None, t=t,
+        ))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0], "e_future")
+        self.assertIsNone(out[0][1])
+
+    def test_dangling_chain_yields_partial(self):
+        # Head points at a missing chain link via supersede; lookup
+        # returns None mid-walk. The chain ends at the head dict;
+        # reconstruct_view_at returns the head when its validity
+        # window contains t.
+        head = _chain_head(
+            "e_dangling",
+            vf="2026-01-01T00:00:00+00:00",
+            superseded_by="e_missing",
+            mutation_type="superseded",
+        )
+        # Force the head's validity to extend through t — verify
+        # that supersede→dangling still returns the head edge.
+        head["validity"]["to"] = "2027-01-01T00:00:00+00:00"
+        t = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        out = list(reconstruct_corpus_view_at(
+            [head], lookup=lambda _: None, t=t,
+        ))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0], "e_dangling")
+        self.assertIs(out[0][1], head)
+
+    def test_empty_heads_yields_empty(self):
+        out = list(reconstruct_corpus_view_at(
+            [], lookup=lambda _: None,
+            t=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        ))
+        self.assertEqual(out, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses **G3** from `docs/reviews/v0.5-b1-ontology-surface-audit.md` — EU AI Act Article 12 evidence ergonomics.

The edge-level `reconstruct_view_at(head, lookup, t)` answers \"what was edge X at time T?\" Replaying an entire corpus required the caller to enumerate all chain heads and call the primitive for each. Adds `reconstruct_corpus_view_at(heads, lookup, t, *, limit=None)` as a streaming generator over that enumeration, so an auditor can ask \"show me the entire corpus state at audit cutoff T\" without holding the full result set in memory.

### New surface

```python
def reconstruct_corpus_view_at(
    heads: Iterable[dict],
    lookup: Callable[[str], Optional[dict]],
    t: datetime,
    *,
    limit: Optional[int] = None,
) -> Iterator[Tuple[str, Optional[dict]]]:
```

Yields `(head_id, edge_at_t_or_None)` tuples in the order the iterable produced them. Per-head reconstruction delegates to the existing edge-level primitive — zero semantic divergence. Respects `limit` for paged enumeration; skips non-dict entries defensively.

### Asymptotic cost (operator hint)

`O(N × avg_chain_length)`. The function does NOT cache walks across heads — duplicate heads are walked twice.

## Tests (`tests/test_v05_corpus_reconstruct.py`)

12 tests across 5 classes:

- Equivalence (1) — per-head output matches single-head primitive
- Order preservation (1)
- Streaming (2) — generator protocol; early-stop semantics
- Limit (4) — cap respected; None yields all; 0 yields nothing; oversized N yields all
- Robustness (4) — non-dict entries skipped; no-match yields `None`; dangling chain handled; empty input → empty output

## Verification

- `pytest tests/test_v05_corpus_reconstruct.py`: **12 passed**
- T7 regression sweep (existing T7 supersede + release-gating + G7 etag + G3): **62 passed**
- `ruff check`: clean
- Module size: **18.8 KB** (was 15.6 KB; +3.2 KB) — under 20 KB cap.

## Out of scope

- Wiring into operator audit endpoints — separate PR when an auditor-facing surface materializes (primitive ready; wiring belongs with UX layer).
- Walk-cache across heads — out-of-scope micro-optimization; operator hint documents the trade-off.
- G1 / G2 / G6 / G8 — separate cycles per B.1 triage.
- Vertical-specific reconstruct rules — BLOCKED per CLAUDE.md rule #1.

Quality delta: exempt (label: external-mother-platform — additive generator over existing primitive; edge-level `reconstruct_view_at` byte-identical)