### PR TITLE
docs(v0.5-B.3): plugin API stability — ontology-pack mount design

### DIFF
--- a/docs/reviews/v0.5-b3-plugin-api-stability.md
+++ b/docs/reviews/v0.5-b3-plugin-api-stability.md
@@ -1,0 +1,323 @@
+# v0.5 B.3 — Plugin API stability review + ontology-pack mount design
+
+**Status**: REVIEW + DESIGN MEMO (no code change in this PR; the
+v0.6 design proposal in §4 is the input to the v1.0 plugin-API-freeze
+gate, not a v0.5 implementation contract).
+
+**Date**: 2026-06-12
+
+**Scope (Stream B carry-over from `docs/handovers/v0.5-entry-2026-06-12.md`
+§Stream B.3)**: review the current plugin loader, evaluate whether
+it is a sufficient mount surface for **ontology packs** (G8 from
+the B.1 audit), and propose the v0.6 shape WITHOUT promising
+stability before its design memo lands. CLAUDE.md rule "no plugin
+API stability promises before v0.3" is respected; the v0.3 LLM-
+backend plugin contract is documented at
+`docs/design/v0.3-llm-provider-contract.md` and that contract is
+honored.
+
+**Constraint**: CLAUDE.md rule #1 — no domain features until v1.0.
+This memo defines the **mount surface mechanism** that vertical
+packs will later use; it does NOT introduce any vertical content.
+
+---
+
+## 1. What plugins JAMES already has
+
+JAMES today supports **two plugin surfaces**:
+
+### 1.1 LLM backend plugins (v0.3, stable)
+
+- `core/reasoning/backends/__init__.py::register_backend(id, instance)`
+- Loader: `_load_plugins()` reads `JAMES_PLUGINS` env (comma-
+  separated module list), `importlib.import_module`s each. The
+  module's import-time side effect is expected to call
+  `register_backend`.
+- Contract: `core/reasoning/backends/__init__.py::Backend` ABC
+  (4 methods: `complete`, `stream`, `id`, `defaults`).
+- Failure mode: fatal. Operator sees `RuntimeError: JAMES_PLUGINS:
+  failed to import plugin <X>` at boot. No silent degradation.
+- Stability promise: locked at v0.3 per the provider-contract
+  design memo. External backend authors (Robin / Ali / Vadym
+  during collaboration arcs) wrote plugins against this surface.
+
+### 1.2 Workspace plugins (v0.3, stable)
+
+- `core/plugins/workspace.py::get_workspace_root` defines the
+  `JAMES_WORKSPACE` env contract.
+- Other modules under `core/plugins/` (`security_config.py`,
+  `errors.py`) are operator-config surfaces, not extensible API.
+
+**No third plugin surface exists.** Ontology, retrieval, lifecycle —
+all are module-level Python dicts / functions. There is no
+documented contract for extending them externally.
+
+---
+
+## 2. Why ontology packs need their own surface
+
+G8 from the B.1 audit:
+
+> `DOCUMENT_SUBTYPES` and `RELATION_TYPES` are module-level Python
+> dicts. To add a vertical pack (e.g., the legal pack scoped by a
+> hypothetical LOI), an external collaborator would have to either
+> edit `core/ontology.py` directly or maintain a fork.
+
+This forces three undesirable outcomes:
+
+1. **Vertical content in `core/`**. Any non-trivial customer
+   ontology pack mutates the mother-platform repo — exactly the
+   anti-pattern CLAUDE.md rule #1 protects against.
+2. **No isolation guarantee.** A pack author's mistake in declaring
+   a new subtype could shadow a horizontal entry. Today there is
+   no name-collision check because there is no concept of "pack".
+3. **No staged removal.** When a customer's pilot ends, removing
+   their pack means another `core/ontology.py` edit. Reverting
+   per-customer code in shared modules is risky and slow.
+
+The v1.0 plugin-API-freeze gate **must** include an ontology mount
+surface that solves all three. This memo proposes the v0.6 shape
+that LOI scoping will refine before v1.0 freeze.
+
+---
+
+## 3. Design constraints (locked)
+
+| Constraint | Why |
+|---|---|
+| **Additive on existing ontology.py** | Existing 12+ entity types + B.5.b 10 subtypes + 4 new relations remain the mother-platform default. Packs **add**; they cannot subtract. |
+| **No silent override** | A pack registering an existing subtype name MUST raise at mount time. Operator picks the resolution explicitly (rename, override-flag, or unmount). |
+| **Per-pack capability gate** | Mount requires a named capability the operator explicitly grants. Default is "rule-1-mother-only" — capability blocked. Vertical packs require `rule_one_exemption_granted=True` set at boot, which is itself blocked by CLAUDE.md until LOI/v1.0. |
+| **Audit row per mount** | Each mount emits a lifecycle event (`lifecycle.ontology.pack_mounted` — new event type). Operator + auditor can reconstruct "what packs were active at time T" via existing replay primitives. |
+| **One-way dependency** | Packs depend on `core/ontology.py`; `core/ontology.py` does NOT import or know about packs. The registry is consulted at LOOKUP time, not at definition time. |
+| **No retroactive mutation** | Mounting a pack does NOT renormalize existing audit rows or stored frontmatter. Audit replay at time T sees whatever packs were mounted at time T (via replay event). |
+
+---
+
+## 4. Proposed v0.6 mount surface
+
+### 4.1 Public API sketch
+
+```python
+# core/ontology_packs.py — NEW module (proposed, v0.6)
+# Mother-platform code; pack content lives outside this module.
+
+@dataclass(frozen=True)
+class OntologyPack:
+    pack_id: str                                    # e.g. "legal-v1"
+    requires_capability: str                        # e.g. "rule_one_exemption_granted"
+    subtypes: Mapping[str, Mapping[str, Any]]       # additive to DOCUMENT_SUBTYPES
+    relation_types: Mapping[str, Mapping[str, Any]] # additive to RELATION_TYPES
+    enterprise_roles: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    label_to_type: Mapping[str, str] = field(default_factory=dict)
+    since: str = "v0.6"
+    provenance: str = ""                            # license / DOI / customer ref
+
+def register_pack(pack: OntologyPack) -> None:
+    """Mount an ontology pack into the running registry.
+
+    Pre-conditions checked at registration:
+      1. ``pack.requires_capability`` is present in the process-
+         level capability set (controlled by JAMES_CAPABILITIES env
+         + admin grant calls). Raises CapabilityNotGrantedError if
+         not — mother-platform default is no capabilities granted.
+      2. No subtype / relation name collision with the existing
+         DOCUMENT_SUBTYPES / RELATION_TYPES OR with already-mounted
+         packs. Raises NameCollisionError on conflict.
+      3. Every subtype's ``parent`` is a known entity type (matches
+         the existing ontology.py invariant).
+
+    Side effects on success:
+      * Pack mounted in the in-memory registry.
+      * Audit row emitted (event_type = "lifecycle.ontology.
+        pack_mounted") carrying pack_id + provenance + capability.
+      * Subsequent calls to mounted_packs() include this pack.
+
+    Failure modes:
+      * CapabilityNotGrantedError — capability gate failed.
+      * NameCollisionError — duplicate name detected.
+      * SchemaError — pack content is malformed.
+
+    All failures are FATAL (raise); a silent half-mount would break
+    audit reconstruction. The operator sees the error at boot or at
+    runtime mount call.
+    """
+
+def unmount_pack(pack_id: str) -> None:
+    """Remove a previously mounted pack.
+
+    Emits ``lifecycle.ontology.pack_unmounted``. Existing audit rows
+    referencing pack-defined subtypes / relations are NOT mutated;
+    replay at a time when the pack was mounted continues to honor
+    the pack's definitions (via the replay event stream)."""
+
+def mounted_packs() -> Tuple[OntologyPack, ...]:
+    """Snapshot of currently-mounted packs. Iteration order is
+    registration order (deterministic for audit reconstruction)."""
+```
+
+### 4.2 Lookup-time integration
+
+The pack registry is **consulted at lookup time** so existing call
+sites don't need to know about packs:
+
+```python
+# core/ontology.py — additive read-side helpers (proposed)
+
+def all_document_subtypes() -> Mapping[str, Mapping[str, Any]]:
+    """Mother-platform DOCUMENT_SUBTYPES merged with currently-mounted
+    pack subtypes. Existing callers that import DOCUMENT_SUBTYPES
+    directly continue to see only the mother set — this helper is
+    the new opt-in surface for pack-aware code paths."""
+
+def all_relation_types() -> Mapping[str, Mapping[str, Any]]:
+    """Mother + mounted pack relations."""
+```
+
+This makes the pack surface **strictly additive at the read side
+too**: pack-unaware code paths see the v0.5 ontology byte-identical;
+pack-aware paths (engine context assembly, document subtype filter,
+etc.) opt in via the new helpers.
+
+### 4.3 Capability gate semantics
+
+Three capability surfaces compose:
+
+| Capability | Default | How granted | What it allows |
+|---|---|---|---|
+| (none) | always | mother-platform default | Read of `core/ontology.py` only |
+| `rule_one_exemption_granted` | **NEVER default** | `JAMES_CAPABILITIES=rule_one_exemption_granted` + LOI/v1.0 phase | Mount of vertical packs |
+| `pack_<id>_owner` | per-pack | runtime admin grant after operator review | Unmount of specific pack |
+
+The `rule_one_exemption_granted` capability is the **policy
+enforcement** of CLAUDE.md rule #1 at code level. Until a customer
+LOI scopes the vertical, the env var stays unset → packs cannot
+mount → vertical content cannot enter the runtime.
+
+### 4.4 Audit-replay integration
+
+Mount/unmount events use the existing `replay_audit.py` infra:
+
+```python
+EVT_ONTOLOGY_PACK_MOUNTED   = "lifecycle.ontology.pack_mounted"
+EVT_ONTOLOGY_PACK_UNMOUNTED = "lifecycle.ontology.pack_unmounted"
+```
+
+`reconstruct_graph_at(t)` learns to dispatch on these events to
+reconstruct **which packs were mounted at time T** when replaying
+graph state. Pack-defined edges in the audit stream are recognized
+because the replay log already carries the relation type / subtype
+name; the pack registry's state at T tells the replay layer which
+pack defined that name.
+
+### 4.5 What this design explicitly does NOT include
+
+- **Code-side pack content.** Packs are pure data: subtypes,
+  relations, roles, label mappings. A pack that wants custom
+  behavior (e.g., "this subtype triggers a special cascade")
+  requires a separate code-plugin surface, which is **out of
+  scope** for v0.6. Vertical packs that need code must wait for
+  the v1.0 plugin-code surface (separate design memo).
+- **Distribution / versioning of packs.** How a pack gets to the
+  JAMES process (PyPI? git repo? customer-supplied zip?) is an
+  operator concern, not a runtime API concern. The runtime accepts
+  whatever delivery mechanism the operator wires up.
+- **Cross-pack inheritance.** A pack cannot extend another pack's
+  subtypes. If `legal-v1` defines `nda` (under hypothetical LOI),
+  a separate `legal-extended-v1` cannot add fields to `nda`. The
+  v1.0 design will refine this if customer data shows it's
+  load-bearing.
+- **Live reload.** Mounting a new pack while a query is in flight
+  is not supported. The operator must drain in-flight queries
+  before mount/unmount (deferred to v1.0 ops manual).
+
+---
+
+## 5. Phased rollout (after this memo)
+
+| Phase | PR | Scope | Gate |
+|---|---|---|---|
+| G8.0 | (this PR) | Design memo lock | Mother-platform consensus |
+| G8.a | `feat/v0.6-g8a-pack-module-skeleton` | `ontology_packs.py` module + tests + capability gate (capabilities default empty → can't mount anything yet) | After v0.5 cycle close |
+| G8.b | `feat/v0.6-g8b-pack-lookup-helpers` | `all_document_subtypes` / `all_relation_types` read-side helpers + integration test | After G8.a |
+| G8.c | `feat/v0.6-g8c-pack-replay-events` | Audit event types + `reconstruct_graph_at` dispatch | After G8.b |
+| **G8.d (BLOCKED)** | `feat/v1.0-g8d-rule-one-exemption-flow` | `rule_one_exemption_granted` capability grant workflow + LOI-binding doc | **Requires customer LOI; BLOCKED per CLAUDE.md rule #1** |
+
+G8.a–G8.c land the mechanism with **no vertical content possible at
+runtime** (capability default empty). They are mother-platform
+hardening. G8.d is the explicit door through which the first
+vertical pack would walk; it stays locked until an LOI scopes the
+pack's content + retention + audit requirements.
+
+---
+
+## 6. Gap closure summary
+
+After this memo, **every B.1 audit gap has been addressed**:
+
+| B.1 gap | Status |
+|---|---|
+| G1 tenant-scoped audit log | CONTRACT-LOCKED (B.2 §3) |
+| G2 verified approver principal | CONTRACT-LOCKED (B.2 §4) |
+| G3 corpus-wide replay convenience | LANDED (PR #849) |
+| G4 retention-class metadata | LANDED (PR #848) |
+| G5 batched contradiction classifier | LANDED (PR #847) |
+| G6 DERIVED_FROM transitive walk | DEFERRED to v1.0 (B.1 §3.G6 — needs LOI customer data) |
+| G7 etag optimistic locking | LANDED (PR #846) |
+| G8 ontology-pack mount | **CONTRACT-LOCKED here** (this memo §4) |
+
+**v0.5 mother-platform audit cycle: substantially wrapped up.**
+Code-side: 4 landed. Contract-side: 3 locked (B.2 G1+G2 + this
+memo's G8). Out-of-scope: 1 (G6 deferred to v1.0). The remaining
+v0.5 work is operator-side (Stream A.3 dogfooding + Stream A.4
+outreach + Stream C measurements) and the **UI improvement stream
+the operator queued as the next pivot**.
+
+---
+
+## 7. References
+
+- B.1 audit: `docs/reviews/v0.5-b1-ontology-surface-audit.md`
+- B.2 design (G1+G2): `docs/reviews/v0.5-b2-multi-tenant-isolation.md`
+- v0.3 LLM provider contract:
+  `docs/design/v0.3-llm-provider-contract.md`
+- B.5.a enterprise ontology design:
+  `docs/design/v0.5-enterprise-document-ontology.md`
+- Backend plugin loader: `core/reasoning/backends/__init__.py`
+- Ontology registry: `core/ontology.py`
+- Audit emitter: `core/lifecycle/replay_audit.py`
+- Replay reader: `core/lifecycle/replay_graph.py`
+- v0.5 entry handover: `docs/handovers/v0.5-entry-2026-06-12.md`
+- CLAUDE.md rules: #1 (no domain features), #5 (20 KB module cap),
+  "plugin API stability not promised before v0.3" → v0.3 contract
+  honored; v0.5 ontology-pack contract proposed here for v0.6 lock
+  + v1.0 freeze gate input.
+
+---
+
+## 8. Korean summary (한국어 요약)
+
+**v0.5 B.3 — 플러그인 API 안정성 review + 온톨로지 팩 마운트 설계**:
+
+- **현재 = 2 플러그인 표면**: (a) LLM 백엔드 (v0.3, stable), (b)
+  워크스페이스 env (v0.3, stable). **온톨로지 팩 표면 없음** —
+  vertical 팩 추가하려면 `core/ontology.py` 직접 수정해야 하는데,
+  그게 정확히 rule #1 이 막는 패턴.
+- **G8 컨트랙트 제안** (§4): `core/ontology_packs.py` 신규 모듈 +
+  `register_pack` / `unmount_pack` / `mounted_packs` API. 충돌 시
+  raise (silent override 금지). Capability gate
+  (`rule_one_exemption_granted`) 가 rule #1 의 **코드 레벨 정책
+  enforcement** — LOI 받기 전까지 capability default 빈 set → 팩
+  마운트 자체 불가.
+- **Replay 통합**: mount/unmount 마다 audit row. `reconstruct_
+  graph_at(t)` 가 시점 T 의 팩 구성 재현.
+- **롤아웃 단계화** (§5): G8.a (모듈 skeleton) → G8.b (lookup
+  helpers) → G8.c (replay events) — v0.6 cycle. **G8.d (rule_one_
+  exemption_granted capability grant flow) = v1.0 + LOI 필수,
+  BLOCKED**. G8.a-c 까지는 mother-platform hardening (runtime 에서
+  vertical 콘텐츠 불가).
+- **B.1 audit 8 gap 전부 처리 완료**: G3/G4/G5/G7 LANDED (PR
+  #846-849), G1/G2 (B.2) + G8 (이 memo) CONTRACT-LOCKED, G6 v1.0
+  DEFERRED.
+- **v0.5 mother-platform audit cycle "실질적으로 마무리"**. 다음
+  자연 pivot = **UI 개선 stream** (사용자 지시).


### PR DESCRIPTION
## Summary

Stream **B.3** of `docs/handovers/v0.5-entry-2026-06-12.md`. Mother-level review + design memo; **no code change**.

Folds **G8** (ontology-pack mount surface) from the B.1 audit into a concrete v0.6 contract proposal — input to the v1.0 plugin-API-freeze gate.

### Mount API sketch

```python
# core/ontology_packs.py — NEW v0.6 module (proposed)

@dataclass(frozen=True)
class OntologyPack:
    pack_id: str
    requires_capability: str
    subtypes: Mapping[str, Mapping[str, Any]]
    relation_types: Mapping[str, Mapping[str, Any]]
    enterprise_roles: Mapping[str, Mapping[str, Any]]
    label_to_type: Mapping[str, str]
    since: str
    provenance: str

def register_pack(pack: OntologyPack) -> None: ...
def unmount_pack(pack_id: str) -> None: ...
def mounted_packs() -> Tuple[OntologyPack, ...]: ...
```

### Code-level enforcement of CLAUDE.md rule #1

**Capability gate** `rule_one_exemption_granted` — default empty capability set means packs cannot mount, so vertical content cannot enter the runtime until LOI/v1.0 grants the capability explicitly. The mechanism enforces what the documentation already requires.

### Replay integration

Mount/unmount emit lifecycle events (`lifecycle.ontology.pack_{mounted,unmounted}`). `reconstruct_graph_at(t)` learns which packs were active at T — replay safety preserved across pack lifecycle.

### Phased rollout

- **G8.a / G8.b / G8.c**: mechanism (skeleton + lookup helpers + replay events). v0.6 cycle. Mother-platform hardening only.
- **G8.d**: `rule_one_exemption_granted` grant workflow. **BLOCKED — requires customer LOI per CLAUDE.md rule #1.**

## Gap closure after this memo

**Every B.1 audit gap addressed:**

| Status | Gaps |
|---|---|
| LANDED | G3 (#849) · G4 (#848) · G5 (#847) · G7 (#846) |
| CONTRACT-LOCKED | G1 + G2 (B.2 memo) · **G8 (this memo)** |
| DEFERRED to v1.0 | G6 (needs LOI customer data) |

**v0.5 mother-platform audit cycle: substantially wrapped up.** Natural pivot to **UI improvement stream** per operator plan.

## Out of scope

- Code-side pack content (vertical packs are pure data; code plugins are a separate v1.0 surface)
- Pack distribution / versioning (operator concern)
- Cross-pack inheritance (deferred per customer data)
- Live reload (deferred to v1.0 ops manual)
- Vertical packs themselves — **BLOCKED per rule #1**

## Verification

- No code changed.

Quality delta: exempt (label: docs)