### PR TITLE
feat(v0.5-ui-1): a11y pass — skip link + focus-visible + main landmark

### DIFF
--- a/docs/reviews/v0.5-ui-1-accessibility-pass.md
+++ b/docs/reviews/v0.5-ui-1-accessibility-pass.md
@@ -1,0 +1,195 @@
+# v0.5 UI #1 — Accessibility pass (mother-platform)
+
+**Status**: REVIEW + IMPLEMENTATION (this PR ships the first batch
+of fixes; remaining gaps are listed in §3 for follow-up PRs).
+
+**Date**: 2026-06-12
+
+**Scope**: per `frontend/HANDOVER_WEB_UI.md` §4 task #4 (handover doc
+written 2026-05-11). First UI improvement PR after the v0.5 mother-
+platform audit cycle wrapped up (B.1 / B.2 / B.3 memos + G3/G4/G5/G7
+landed). No domain features, no visual identity changes — pure
+keyboard / screen-reader / contrast hygiene.
+
+**Constraints**: CLAUDE.md rules #1 (no domain features), #5 (20 KB
+module cap), and the frontend handover's "tokens single-source"
+rule (no per-page `:root` overrides).
+
+---
+
+## 1. What this PR lands
+
+### 1.1 Skip-to-main link (WCAG 2.4.1 "Bypass Blocks", Level A)
+
+Every full-page UI (`index` / `admin` / `workspace` / `graph`) gets
+an `<a class="skip-link" href="#main">` as the **first focusable
+element** in `<body>`. Visually hidden by default; pops into the
+top-left corner when a keyboard user Tabs into it. Activating it
+jumps focus to the page's `<main id="main">` landmark, skipping
+header + nav.
+
+CSS lives in `frontend/static/tokens.css` (`.skip-link` rule); the
+HTML mounts the link + an `id="main"` on each page's main landmark.
+i18n key `a11y.skip_to_main` added with English + Korean strings.
+
+### 1.2 Global `:focus-visible` ring (WCAG 2.4.7 "Focus Visible", AA)
+
+Every keyboard-focusable element gets a **2 px mint-cyan outline +
+2 px offset** when reached via keyboard (`:focus-visible` selector).
+Mouse-driven focus does NOT trigger the ring — the pointer UX stays
+clean, only Tab / Shift+Tab / arrow keys surface the indicator.
+
+Inputs that already paint their own `:focus` border keep precedence
+— the outline is a separate layer (not `border`) so the two don't
+collide.
+
+### 1.3 `<main id="main">` landmark added to every page
+
+Required by §1.1's skip-link anchor target. Each page now has
+exactly one `<main id="main">` wrapping its primary content:
+
+| Page | Before | After |
+|---|---|---|
+| `index.html` | `<main style="position:relative">` | `<main id="main" style="position:relative">` |
+| `admin.html` | `<div class="content">` | `<main id="main" class="content">` |
+| `workspace.html` | `<main>` | `<main id="main">` |
+| `graph.html` | `<div class="main">` | `<main id="main" class="main">` |
+
+`admin.html` and `graph.html` previously used `<div>` where
+semantics call for `<main>` — corrected. CSS class selectors that
+target `.content` / `.main` keep working unchanged (the class
+attribute is preserved).
+
+### 1.4 i18n keys
+
+| Key | English | Korean |
+|---|---|---|
+| `a11y.skip_to_main` | "Skip to main content" | "본문으로 건너뛰기" |
+
+---
+
+## 2. What the existing baseline already covers (verified)
+
+Before this PR, the frontend was already in solid shape on several
+a11y dimensions. Documenting here so the next reviewer doesn't
+re-do the work:
+
+| Surface | Status | Evidence |
+|---|---|---|
+| `<html lang="ko">` | ✅ all 4 pages | `grep '<html' frontend/*.html` |
+| Modal `role="dialog" aria-modal="true"` | ✅ all 15 modals | inline attribute |
+| Modal `aria-labelledby` | ✅ all 15 modals | each points to an `id` heading |
+| Focus trap inside open modals | ✅ | `frontend/static/a11y-modal.js` (WCAG 2.1 dialog pattern) |
+| Escape closes topmost modal | ✅ | same JS — fires the `.modal-btn.cancel` click |
+| Focus restoration on modal close | ✅ | same JS |
+| `prefers-reduced-motion` gate | ✅ | `tokens.css` `cyber-pulse` / `cyber-scan` blocks |
+| Token contrast on `--bg #04060a` | ✅ AA pass | `--text` 18.7:1 / `--muted` 6.14:1 / `--muted-2` 4.83:1 (commented in tokens.css) |
+| Icon-only close button `aria-label` | ✅ | `workspace.html:392` `aria-label="상세 패널 닫기"` |
+| Icon-glyph buttons w/ adjacent text | ✅ decorative | "❌ 거부" / "🌐 Search & Learn" — emoji is supplementary, not sole label |
+
+---
+
+## 3. Remaining gaps (follow-up PRs)
+
+The handover doc listed 5 remaining UI tasks (after this PR closes
+#4). They fall into three layers:
+
+### 3.1 Same-cycle (v0.5 UI follow-ups, solo-doable)
+
+- **Live regions for dynamic content** — chat answers, status
+  updates, and the workspace's data refresh region should carry
+  `aria-live="polite"` so a screen reader announces new content
+  without yanking focus. Scope: `index.html` chat output +
+  `workspace.html` data list. ~1h.
+- **Visible heading hierarchy audit** — every page's heading
+  levels (`<h1>` → `<h2>` → `<h3>`) should form a contiguous
+  outline. Some current pages skip levels for visual reasons.
+  ~1h.
+- **Form-control `<label for>` audit** — every `<input>` should
+  have either a `<label for="<id>">` OR an `aria-label`. Most do;
+  a handful of inline-styled inputs may lack one. ~1h.
+
+### 3.2 Cross-cutting (touches a11y + responsive + JS)
+
+- **Inline `onclick` → event delegation** (handover #5). Removes
+  inline handlers in favour of `data-action` + a single delegated
+  listener per page. Improves CSP and a11y (inline handlers can't
+  carry `aria-*` cues as cleanly). ~3h.
+- **Mobile responsive expansion** (handover #2). `mobile.css` is
+  currently chat-only; admin / workspace / graph need analogous
+  rules. ~2-3h.
+
+### 3.3 High-impact, deferred
+
+- **Reasoning panel enhancement** (handover #3). Retrieve →
+  expand → verify timeline + citation node + confidence bar +
+  sensitivity badge. ~4-6h. JAMES's Graph-RAG differentiator
+  visualised — natural next high-impact UI work after the small
+  a11y/responsive/CSP wins land.
+
+---
+
+## 4. Verification
+
+This PR changes **only** frontend assets (HTML + CSS + JS i18n).
+No `core/` code touched. Quality delta exempt per
+`.github/PULL_REQUEST_TEMPLATE.md` rule (the changed files don't
+touch retrieval / graph / reasoning).
+
+**Manual verification checklist** (operator runs after merge — UI
+changes need a browser session the model can't run):
+
+1. **Skip link visible on Tab**: load each of `/`, `/admin`,
+   `/workspace`, `/graph`. Press `Tab` once on a freshly-loaded
+   page. The "Skip to main content" link should pop into the
+   top-left corner. Pressing `Enter` should jump focus to the
+   first focusable element inside `<main>`.
+2. **Focus ring on Tab**: cycle through interactive elements with
+   `Tab`. Every button / link / input should show a 2 px mint-cyan
+   outline. Inputs with their own `:focus` border still get the
+   border AND the outline (two layers, no collision).
+3. **Pointer click does NOT show focus ring**: click a button.
+   The ring should NOT appear (because `:focus-visible` is
+   keyboard-only).
+4. **Skip link i18n**: toggle language. The skip link label should
+   switch between "Skip to main content" and "본문으로 건너뛰기".
+5. **No visual regression**: header / nav / content layout should
+   look identical to pre-PR. The CSS only ADDS rules; nothing was
+   removed.
+
+---
+
+## 5. Why this is mother-platform work
+
+a11y is increasingly a hard requirement in enterprise procurement
+(European Accessibility Act, ADA Title III adjacent jurisdictions,
+EN 301 549 for EU public-sector). Shipping mother-platform a11y
+hygiene **before** the first customer pilot kickoff means:
+
+- No vertical-pack (legal / medical / etc.) needs to re-do this
+  work per customer.
+- The same skip-link / focus-ring contract applies to every page,
+  forever — extending packs ship UI elements that inherit the
+  baseline.
+- The remaining gaps in §3 are bounded; the customer-facing
+  procurement question "is this VPAT-clean?" becomes answerable
+  by reference to this audit doc + the handover doc.
+
+This audit pairs naturally with the B.1-B.3 mother-platform memos
+(EU AI Act audit-evidence surface, multi-tenant isolation, plugin
+API stability) that landed alongside it. v0.5 enterprise-readiness
+is now substantially wrapped.
+
+---
+
+## 6. References
+
+- v0.5 entry handover: `docs/handovers/v0.5-entry-2026-06-12.md`
+- Web UI handover: `frontend/HANDOVER_WEB_UI.md`
+- B.1 audit: `docs/reviews/v0.5-b1-ontology-surface-audit.md`
+- B.2 multi-tenant memo: `docs/reviews/v0.5-b2-multi-tenant-isolation.md`
+- B.3 plugin API memo: `docs/reviews/v0.5-b3-plugin-api-stability.md`
+- Existing modal a11y helper: `frontend/static/a11y-modal.js`
+- WCAG 2.1: 2.4.1 (Bypass Blocks) / 2.4.7 (Focus Visible) / 1.4.3
+  (Contrast Minimum, AA)
+- CLAUDE.md rule #1 (no domain features), rule #5 (20 KB module cap)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -12,6 +12,10 @@
 <link rel="stylesheet" href="/static/mobile.css">
 </head>
 <body>
+
+<!-- v0.5 UI #4 — WCAG 2.4.1 skip link (first focusable element) -->
+<a href="#main" class="skip-link" data-i18n="a11y.skip_to_main">Skip to main content</a>
+
 <header>
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
@@ -125,7 +129,7 @@
   </nav>
 
   <!-- ── 콘텐츠 ── -->
-  <div class="content">
+  <main id="main" class="content">
 
     <!-- 대시보드 -->
     <div class="page active" id="page-dashboard">
@@ -1043,7 +1047,7 @@
       </div>
     </div>
 
-  </div>
+  </main>
 </div>
 
 <script src="/static/i18n.js"></script>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -13,6 +13,9 @@
 </head>
 <body>
 
+<!-- v0.5 UI #4 — WCAG 2.4.1 skip link (first focusable element) -->
+<a href="#main" class="skip-link" data-i18n="a11y.skip_to_main">Skip to main content</a>
+
 <header>
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
@@ -28,7 +31,7 @@
   </div>
 </header>
 
-<div class="main">
+<main id="main" class="main">
   <aside>
     <div class="ctrl">
       <span class="panel-title" data-i18n="graph.filter.source">Source</span>
@@ -121,7 +124,7 @@
          JS 가 prepend (renderEntitySummary). 질문 입력은 /chat 으로 이관. -->
     <div class="neighbor-panel" id="neighbor-panel"></div>
   </div>
-</div>
+</main>
 
 <!-- Admin login modal — same flow as admin.html -->
 <div class="modal-overlay" id="login-modal"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,9 @@
 </head>
 <body>
 
+<!-- v0.5 UI #4 — WCAG 2.4.1 skip link (first focusable element) -->
+<a href="#main" class="skip-link" data-i18n="a11y.skip_to_main">Skip to main content</a>
+
 <!-- ── 헤더 ── -->
 <header>
   <!-- [#A8-9] brand mark + tagline. JAMES is the product name;
@@ -99,7 +102,7 @@
      #session-list / #session-count-badge ID는 그대로 보존 — chat.js의
      loadSessionList() / 배지 갱신 로직 그대로 작동. -->
 
-<main style="position:relative">
+<main id="main" style="position:relative">
   <button class="sidebar-open-btn" id="sidebar-open-btn"
           data-action="toggle-sidebar" data-i18n-title="upload.open" title="업로드 열기"
           aria-label="사이드바 열기">▶</button>

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -14,6 +14,8 @@ const TRANSLATIONS = {
     'common.error':          'Error',
     'common.success':        'Success',
     'common.cancel':         'Cancel',
+    // v0.5 UI #4 — WCAG 2.4.1 skip link
+    'a11y.skip_to_main':     'Skip to main content',
     'common.confirm':        'Confirm',
     'common.save':           'Save',
     'common.delete':         'Delete',
@@ -853,6 +855,8 @@ const TRANSLATIONS = {
     'common.error':          '오류',
     'common.success':        '성공',
     'common.cancel':         '취소',
+    // v0.5 UI #4 — WCAG 2.4.1 skip link
+    'a11y.skip_to_main':     '본문으로 건너뛰기',
     'common.confirm':        '확인',
     'common.save':           '저장',
     'common.delete':         '삭제',

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -235,6 +235,63 @@ body {
   }
 }
 
+/* ── A11y — skip to main content link (v0.5 UI #4) ──
+ * First focusable element on every page. Visually hidden until the
+ * user Tabs into it; then it pops into the top-left corner with a
+ * high-contrast accent fill so a keyboard / screen-reader user can
+ * skip the header + nav and jump straight to <main id="main">.
+ *
+ * WCAG 2.4.1 "Bypass Blocks" (Level A). Used by index / admin /
+ * workspace / graph as the first child of <body>. Anchor target is
+ * the page's <main id="main"> landmark. */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: var(--accent);
+  color: var(--on-accent);
+  padding: 8px 14px;
+  font-weight: 600;
+  font-size: 14px;
+  border-radius: 0 0 var(--radius) 0;
+  text-decoration: none;
+  z-index: 9999;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  left: 0;
+  outline: 2px solid var(--accent-fg);
+  outline-offset: 2px;
+}
+
+/* ── A11y — global :focus-visible ring (v0.5 UI #4) ──
+ * Every keyboard-focusable element gets a 2px mint-cyan outline +
+ * 2px offset when reached via keyboard navigation. WCAG 2.4.7
+ * "Focus Visible" (Level AA). Browser default is suppressed for
+ * mouse focus (`:focus-visible` only triggers on keyboard) so the
+ * pointer-driven UX stays clean — only Tab / Shift+Tab / arrow keys
+ * surface the ring.
+ *
+ * Inputs that already have a :focus rule painting their own border
+ * keep that rule precedence — `:focus-visible` adds an OUTLINE
+ * (separate from border) so the two don't collide.
+ *
+ * Excludes .skip-link which paints its own (above) and the
+ * body itself (which would draw a viewport-edge ring). */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+button:focus-visible,
+a:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:focus-visible {
+  outline-color: var(--accent);
+}
+body:focus-visible {
+  outline: none;
+}
+
 /* ── Top accent rail ──
  * Thin 2px stripe along the very top of every page — gives the app
  * a subtle "system header" feel like enterprise dashboards. Fixed

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -13,6 +13,9 @@
 </head>
 <body>
 
+<!-- v0.5 UI #4 — WCAG 2.4.1 skip link (first focusable element) -->
+<a href="#main" class="skip-link" data-i18n="a11y.skip_to_main">Skip to main content</a>
+
 <header>
   <div class="logo">
     <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
@@ -35,7 +38,7 @@
   </div>
 </header>
 
-<main>
+<main id="main">
   <nav class="sidebar">
     <div class="nav-item active" data-tab="data" data-action="select-tab">
       <span class="nav-icon">📦</span>


### PR DESCRIPTION
## Summary

First UI improvement PR after the v0.5 mother-platform audit cycle wrapped up. Per `frontend/HANDOVER_WEB_UI.md` §4 task #4. Pure keyboard / screen-reader / contrast hygiene — **no domain features, no visual identity changes**.

### Three additive changes

| Change | WCAG | Where |
|---|---|---|
| **Skip-to-main link** as first focusable element | 2.4.1 (Level A) | 4 pages + tokens.css `.skip-link` |
| **Global `:focus-visible` ring** (2 px mint-cyan, keyboard-only) | 2.4.7 (Level AA) | tokens.css `:focus-visible` |
| **`<main id="main">` landmark** on every page | 2.4.1 anchor target | 4 pages (admin / graph upgraded from `<div>`) |

i18n key `a11y.skip_to_main` added with English ("Skip to main content") + Korean ("본문으로 건너뛰기").

### What was already there (verified, not changed)

- `<html lang="ko">` ✅
- 15/15 modals: `role="dialog" aria-modal="true" aria-labelledby=...` ✅
- Focus trap + ESC close + focus restoration via `a11y-modal.js` ✅
- `prefers-reduced-motion` gates on cyber animations ✅
- All token contrasts on `--bg` AA-pass (commented in tokens.css) ✅
- Icon-glyph buttons all have adjacent text labels ✅

### Why mother-platform

a11y is increasingly a hard requirement in enterprise procurement (European Accessibility Act, EN 301 549 EU public-sector, ADA Title III adjacent). Shipping mother-platform a11y hygiene **before** the first customer pilot kickoff means the same skip-link / focus-ring contract applies to every future vertical pack without per-customer re-work. Pairs naturally with the B.1-B.3 audit memos that landed alongside.

## Out of scope (follow-up PRs)

Listed in `docs/reviews/v0.5-ui-1-accessibility-pass.md` §3:

- Live regions for dynamic content (`aria-live`)
- Heading hierarchy audit
- Form-control `<label for>` audit
- Inline `onclick` → event delegation (handover #5)
- Mobile responsive expansion (handover #2)
- Reasoning panel enhancement (handover #3)

## Verification

- `core/` **untouched** → no test / ruff / size impact on the audit tree.
- Module size cap (20 KB rule #5): tokens.css +57 lines, +1.8 KB to ~7.5 KB total. No module touched the cap.
- Manual browser checklist in audit doc §4 (operator-run, post-merge).

Quality delta: exempt (label: docs — UI a11y only, no `core/retrieval`, `core/graph` traversal, or `core/reasoning` paths changed)