### PR TITLE
feat(v0.5-ui-2): aria-live regions on dynamic content

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -134,13 +134,22 @@
     <!-- 대시보드 -->
     <div class="page active" id="page-dashboard">
       <div class="page-title"><span data-i18n="dash.page_title">📊 대시보드</span> <span class="badge" data-i18n="dash.live">LIVE</span></div>
-      <div class="cards" id="dash-cards">
+      <!-- v0.5 UI #2 — aria-live polite for dashboard refresh
+           announcements (WCAG 4.1.3). -->
+      <div class="cards" id="dash-cards"
+           aria-live="polite" aria-atomic="false"
+           aria-label="Dashboard cards">
         <div class="loading" data-i18n="common.loading">로딩 중...</div>
       </div>
       <!-- [3-A] 응답 시간 그래프 -->
       <div id="dash-chart"></div>
       <div class="section-title" style="margin-top:16px">▸ <span data-i18n="dash.recent_logs">최근 쿼리 로그</span></div>
-      <div class="log-box" id="dash-logs"><div class="loading" data-i18n="common.loading">로딩 중...</div></div>
+      <!-- v0.5 UI #2 — aria-live polite so screen readers
+           announce new log entries on refresh (WCAG 4.1.3). -->
+      <div class="log-box" id="dash-logs"
+           aria-live="polite" aria-relevant="additions"
+           aria-atomic="false"
+           aria-label="Recent query log"><div class="loading" data-i18n="common.loading">로딩 중...</div></div>
     </div>
 
     <!-- 사용자 -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -244,7 +244,11 @@
 
   <!-- ── 챗 영역 ── -->
   <section class="chat-area">
-    <div class="messages" id="messages">
+    <!-- v0.5 UI #2 — aria-live polite so screen readers announce
+         new chat messages without yanking focus (WCAG 4.1.3). -->
+    <div class="messages" id="messages"
+         aria-live="polite" aria-relevant="additions"
+         aria-atomic="false" aria-label="Chat conversation">
       <div class="welcome" id="welcome">
         <!-- [#A8-9] welcome reframed: knowledge + security + report
              intelligence (was generic "Graph-RAG 지식 추론 엔진"). -->

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -435,7 +435,10 @@
   </div>
 </div>
 
-<div class="toast" id="toast"></div>
+<!-- v0.5 UI #2 — role=status + aria-live polite so screen readers
+     announce toast notifications (success / error). WCAG 4.1.3. -->
+<div class="toast" id="toast" role="status" aria-live="polite"
+     aria-atomic="true"></div>
 
 <script src="/static/i18n.js"></script>
 <script src="/static/auth.js"></script>


### PR DESCRIPTION
## Summary

Follow-up to PR #852 (UI #1 a11y pass). Per `docs/reviews/v0.5-ui-1-accessibility-pass.md` §3.1.

**WCAG 4.1.3 (Status Messages, Level AA)**. Screen readers now announce new content in four dynamic surfaces without yanking focus:

| Surface | Page | aria-live | Why |
|---|---|---|---|
| `#messages` (chat conversation) | index.html | `polite` + `additions` + `non-atomic` | New bubbles announced as they arrive; transcript not re-read |
| `#toast` (toast notifications) | workspace.html | `polite` + `role=status` + `atomic` | Whole notification string announced |
| `#dash-cards` (dashboard cards) | admin.html | `polite` + `non-atomic` | Refresh announces additions |
| `#dash-logs` (recent query logs) | admin.html | `polite` + `additions` + `non-atomic` | New log entries streamed |

### Why polite (not assertive)

`polite` waits for the SR's current utterance to finish — appropriate for chat / dashboards that aren't time-critical. `assertive` interrupts and is reserved for genuinely urgent surfaces (session timeouts), which JAMES doesn't currently expose.

## Out of scope

- `#dash-chart` (canvas response-time graph) — needs paired `aria-describedby` text summary; separate PR.
- Domain-specific announcements — BLOCKED per CLAUDE.md rule #1.

## Verification

- `core/` **untouched** → no test / ruff / size impact.
- Manual: NVDA / VoiceOver should announce new content on chat send, toast show, and dashboard refresh.

Quality delta: exempt (label: docs — UI a11y attribute additions)