### PR TITLE
feat(v0.5-ui-5): reasoning panel — sensitivity badge + ARIA labels

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1485,6 +1485,50 @@ function appendJamesMsg(data) {
     }
   }
 
+  // v0.5 UI #5 — Sensitivity badge.
+  //
+  // Mother-platform surface for the existing ontology `sensitive`
+  // field (5 long-standing sensitive relations: HAS_SECRET /
+  // KNOWS_PASSWORD / HAS_CREDENTIAL / OWNS_PRIVATE — plus v0.5
+  // B.5.b APPROVED_BY). When the backend marks the answer as
+  // having traversed any sensitive relation OR carrying sensitive
+  // source content, the bubble surfaces a red-tinted badge so the
+  // operator immediately sees the EU AI Act Art. 19 evidence cue.
+  //
+  // Reads ANY of these fields (back-compat with future server work):
+  //   data.sensitive                  (top-level bool)
+  //   data.sensitive_path_used        (graph traversal touched a
+  //                                    sensitive relation)
+  //   data.sensitivity_level == 'high'
+  //
+  // Default off: when none are set, no badge. UI is ready;
+  // backend can wire any one of the field names without further
+  // frontend work. ARIA live=polite + role=note so screen readers
+  // announce the cue without yanking focus.
+  let sensitivityBadge = '';
+  const sens = data.sensitive === true
+            || data.sensitive_path_used === true
+            || data.sensitivity_level === 'high';
+  if (sens) {
+    const sensLabel = (typeof t === 'function')
+      ? t('badge.sensitive') : 'Sensitive content referenced';
+    const sensTitle = (typeof t === 'function')
+      ? t('badge.sensitive_title')
+      : 'This answer references sensitive content tracked by JAMES ontology.';
+    sensitivityBadge = `
+      <div role="note" aria-live="polite"
+           style="display:inline-flex;align-items:center;gap:6px;
+                  margin-top:6px;padding:4px 10px;border-radius:6px;
+                  background:rgba(239,68,68,.10);
+                  border:1px solid rgba(239,68,68,.45);
+                  font-size:11px;color:#fca5a5;
+                  font-family:var(--font-mono);letter-spacing:.3px"
+           title="${escHtml(sensTitle)}">
+        <span aria-hidden="true">🔒</span>
+        <span>${escHtml(sensLabel)}</span>
+      </div>`;
+  }
+
   // [3-B] unified_score → 신뢰도 배지 ([#A8-6 통합] score는 위에서 이미 읽음)
   let confidenceBadge = '';
   if (score != null) {
@@ -1642,6 +1686,7 @@ function appendJamesMsg(data) {
       <div class="bubble">${formatAnswerWithParagraphs(cleanAnswer)}${pathsHtml}</div>
       ${webBadge}
       ${saveWikiChip}
+      ${sensitivityBadge}
       ${confidenceBadge}
       ${metaHtml}
       ${forceWebChip}
@@ -2092,7 +2137,12 @@ function appendTyping(traceId) {
   div.innerHTML = `
     <div class="avatar james">🧠</div>
     <div class="bubble" style="min-width:220px">
-      <div id="thinking-${traceId}" class="thinking-stream">
+      <!-- v0.5 UI #5 — aria-live=polite + role=log so screen readers
+           announce reasoning stages as they arrive without yanking
+           focus. aria-label gives context for what's being streamed. -->
+      <div id="thinking-${traceId}" class="thinking-stream"
+           role="log" aria-live="polite" aria-atomic="false"
+           aria-label="Reasoning timeline (retrieve → expand → verify)">
         <div class="thinking-placeholder">
           ${brainPulseSvg(true)}
           <span class="thinking-shimmer-text thinking-label thinking-placeholder-text"
@@ -2177,8 +2227,12 @@ function appendTyping(traceId) {
     phase.className = 'thinking-phase thinking-phase-active';
     phase.setAttribute('data-phase', phaseKey);
     phase.setAttribute('data-order', String(meta.order));
+    // v0.5 UI #5 — role=region + aria-label for SR phase navigation.
+    phase.setAttribute('role', 'region');
+    phase.setAttribute('aria-label',
+      'Reasoning phase ' + String(meta.order) + ': ' + meta.label);
     phase.innerHTML = `
-      <div class="thinking-phase-header">
+      <div class="thinking-phase-header" aria-hidden="true">
         <span class="thinking-phase-icon">${meta.icon}</span>
         <span class="thinking-phase-label">${escHtml(meta.label)}</span>
       </div>

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -16,6 +16,9 @@ const TRANSLATIONS = {
     'common.cancel':         'Cancel',
     // v0.5 UI #4 — WCAG 2.4.1 skip link
     'a11y.skip_to_main':     'Skip to main content',
+    // v0.5 UI #5 — sensitivity badge (surfaces ontology sensitive=True)
+    'badge.sensitive':       'Sensitive content referenced',
+    'badge.sensitive_title': 'This answer references sensitive content tracked by JAMES ontology (HAS_SECRET / KNOWS_PASSWORD / HAS_CREDENTIAL / OWNS_PRIVATE / APPROVED_BY).',
     'common.confirm':        'Confirm',
     'common.save':           'Save',
     'common.delete':         'Delete',
@@ -857,6 +860,9 @@ const TRANSLATIONS = {
     'common.cancel':         '취소',
     // v0.5 UI #4 — WCAG 2.4.1 skip link
     'a11y.skip_to_main':     '본문으로 건너뛰기',
+    // v0.5 UI #5 — sensitivity badge
+    'badge.sensitive':       '민감 정보 포함',
+    'badge.sensitive_title': '이 답변은 JAMES 온톨로지가 추적하는 민감 관계(HAS_SECRET / KNOWS_PASSWORD / HAS_CREDENTIAL / OWNS_PRIVATE / APPROVED_BY)를 참조합니다.',
     'common.confirm':        '확인',
     'common.save':           '저장',
     'common.delete':         '삭제',


### PR DESCRIPTION
## Summary

Per handover doc §4 task #3 (reasoning panel enhancement) + `docs/reviews/v0.5-ui-1-accessibility-pass.md` §3.1 follow-up.

Mother-platform — surfaces JAMES's existing ontology `sensitive` contract (5 long-standing sensitive relations + v0.5 B.5.b APPROVED_BY) as a user-visible cue.

### Sensitivity badge

Chat bubble now surfaces a red-tinted **🔒 Sensitive content referenced** badge when the backend marks an answer as touching any of these ontology-tracked sensitive relations:

| Relation | Since |
|---|---|
| `HAS_SECRET` / `KNOWS_PASSWORD` / `HAS_CREDENTIAL` / `OWNS_PRIVATE` | v0.3 |
| `APPROVED_BY` | v0.5 B.5.b |

Reads ANY of the following data fields (back-compat with future server wiring):
- `data.sensitive` (top-level bool)
- `data.sensitive_path_used` (graph traversal touched a sensitive relation)
- `data.sensitivity_level === 'high'`

**Default off**: when none are set, no badge — current behaviour byte-identical. UI is ready; backend can wire any field name as the audit-evidence track surfaces.

ARIA: `role="note" aria-live="polite"`; emoji `aria-hidden`; explanatory `title`. i18n keys `badge.sensitive` + `badge.sensitive_title` (English + Korean).

### Reasoning panel ARIA

The existing 3-phase timeline (retrieve → expand → verify) was visual-only. Added:

- `#thinking-...` → `role="log" aria-live="polite" aria-atomic="false" aria-label="Reasoning timeline (retrieve → expand → verify)"`
- Each phase container → `role="region" aria-label="Reasoning phase N: <Label>"`. Phase header `aria-hidden` so visual icon+label isn't double-read.

Screen readers now announce stage progress as it arrives and can navigate by phase.

## Why mother-platform

The sensitive-relation contract was added at v0.3 and extended at v0.5 B.5.b. Until now the frontend had no surface that read it back. Adding the badge maps the existing data contract to the user-visible audit-evidence cue **EU AI Act Article 19** / customer procurement question \"how do I see when an answer touches sensitive material?\" needs.

No backend change in this PR — UI is ready to render whatever the server emits.

## Out of scope (follow-up)

- Per-source sensitivity drill-down (needs paired backend payload)
- Citation node anchors in answer text (handover #3) — needs server-side per-claim spans
- Confidence bar refinement (already exists; no change here)
- Domain-specific sensitivity rules — BLOCKED per rule #1

## Verification

- `core/` **untouched**.
- Manual: trigger answer with `data.sensitive === true`; verify badge renders + SR announces. Normal answers; verify no badge.

Quality delta: exempt (label: docs — UI surface only; behaviour byte-identical when data fields absent)