### PR TITLE
docs(v0.5): evaluation coverage mapping — standard metrics ↔ JAMES surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ What JAMES does **not** claim:
 
 If your use case is *audit / lifecycle / time-travel / on-prem* — JAMES is built for it, measured for it, and citeable for it. If your use case is *fastest possible answer on a fixed corpus* — use LangChain.
 
+> **Looking for MRR / NDCG / RAGAS / hallucination-rate coverage?** See [`docs/evaluation/v0.5-evaluation-coverage-mapping.md`](docs/evaluation/v0.5-evaluation-coverage-mapping.md) — a full mapping of standard RAG / IR metrics to what JAMES measures (and what it deliberately doesn't), including code paths and procurement-ready answers.
+
 ---
 
 ## 📑 Papers & Reproducibility

--- a/docs/evaluation/v0.5-evaluation-coverage-mapping.md
+++ b/docs/evaluation/v0.5-evaluation-coverage-mapping.md
@@ -1,0 +1,255 @@
+# JAMES Evaluation Coverage — Standard-Metric Mapping
+
+**Status**: External-facing evaluation reference. Mother-platform
+disclosure of where standard RAG / IR metrics live in the JAMES
+codebase and where they deliberately don't.
+
+**Date**: 2026-06-12 (v0.5 cycle)
+
+**Why this document exists**: external reviewers (enterprise RFPs,
+academic referees, due-diligence analysts) approach JAMES expecting
+the standard IR / RAG metric vocabulary (MRR, NDCG, RAGAS, hallucination
+reduction, multi-hop QA accuracy, …). The headline JAMES vocabulary
+is different — AC/RF/PC (RAB), R@1 V<N<J (LRB), Abstention F1 (QVT),
+HR axis (NLI verifier). A reviewer who maps standard names to "blank
+cells" without reading the codebase will undercount the actual
+coverage.
+
+This document closes that gap. For every standard metric, it states:
+where in the code (if any), what JAMES headlines instead, and **why**
+the headline choice is deliberate.
+
+---
+
+## 1. The framing — what JAMES claims and what it does NOT
+
+Direct quote from `README.md:43-44`:
+
+> What JAMES does **not** claim:
+> - **Better answer quality on closed-book QA** — verified equivalent
+>   on MuSiQue (3-SUT identical EM/F1 by construction; *§ honest
+>   negative* in [LRB preprint](papers/lrb-preprint/main.pdf) §5)
+
+JAMES's **two headline benchmarks** are deliberately custom:
+
+| Benchmark | Axis | DOI |
+|---|---|---|
+| **RAB v0.1.1** (Replayable-Audit Benchmark) | Audit Completeness / Replay Fidelity / Provenance Coverage — EU AI Act Art. 10 / 12 / 19 anchor | [10.5281/zenodo.20625533](https://doi.org/10.5281/zenodo.20625533) |
+| **LRB v0.2.3** (Lifecycle Retrieval Benchmark) | Time-valid retrieval at `(query_time, valid_time)`; V<N<J pattern across 4 model families × 4 scale points | [10.5281/zenodo.20652679](https://doi.org/10.5281/zenodo.20652679) |
+
+The position: JAMES competes on **audit-evidence + lifecycle retrieval**,
+not on closed-book QA leaderboards or graded ranking. Standard ranking
+metrics (MRR / NDCG) are out-of-scope-by-design **for headline numbers**,
+not out-of-codebase.
+
+---
+
+## 2. Standard-metric coverage matrix
+
+Rows are **standard RAG / IR metrics** an external reviewer might
+look for. The "Coverage" column is one of:
+
+- **Headline**: appears in `README.md`, preprints, or `SUMMARY.md`
+  as a measured number that JAMES advertises.
+- **Research tooling**: implemented in `scripts/research/` for
+  internal investigation; not part of the canonical bench output;
+  not a JAMES claim.
+- **Adjacent**: JAMES measures a structurally-equivalent surface
+  under a different name (see §2.1).
+- **Out-of-scope (by design)**: not measured; see why.
+
+| Standard metric | Coverage | Where in code | Headline number | Why this choice |
+|---|---|---|---|---|
+| **Recall@K** | Headline | `eval/external/lrb/scorer.py::_recall_at_k` | LRB v0.2.3 R@1 / R@5 / R@10; S3 publication R@1 V/N/J = 0.502 / 0.721 / **0.845** | LRB measures *temporal* retrieval — Recall@K against per-T gold supporting docs is the natural axis. R@1 is the V<N<J gap structure; R@5/R@10 stay near-identical (the gap is at top-1, not in top-5 set inclusion) |
+| **MRR** (Mean Reciprocal Rank) | Research tooling | `scripts/research/retrieval_quality.py::reciprocal_rank` | None | Implemented in δ-1 cycle (2026-06-03) for retrieval-quality investigations on step7 / multihop / null_v1 fixtures. NOT headlined: MRR's "first relevant doc" framing assumes graded ranking is the goal — JAMES headlines V<N<J presence/absence of validity-window matches, not rank position |
+| **NDCG@K** | Research tooling | `scripts/research/retrieval_quality.py::ndcg_at_k` | None | Same δ-1 cycle. **Binary-relevance NDCG only** (no graded labels in the fixtures). Reviewer expecting graded-NDCG won't find it — the fixtures don't carry graded relevance scores because JAMES's source-of-truth axis is "valid at time T" (boolean), not "more vs less relevant" |
+| **Recall / Precision / F1** (answer-side) | Headline | `eval/external/musique_scorer.py::_f1` / `_exact_match`<br>`eval/external/wikimulti_scorer.py` (delegates to musique scorer) | MuSiQue 3-SUT identical EM/F1 (honest negative — see §1) | SQuAD-style normalised F1 + EM. Used for closed-book QA cross-bench reproducibility; result is a honest negative on MuSiQue (3 SUT identical by construction) — surfaced explicitly to head off "why don't you headline MuSiQue?" |
+| **RAGAS** (Context Precision / Recall / Faithfulness / Answer Relevancy) | Headline | `eval/ragas/run_ragas.py` + `eval/ragas/fixture_v0.2.json` (3-query hand-crafted) | STEP 7 + RAGAS regression suite; baseline-gated (PR fails if metrics regress vs `eval/ragas/baseline.json`) | RAGAS is the standard closed-book RAG correctness baseline. Used as a regression gate (`v0.2 Axis 2`), not as a JAMES *claim* — JAMES doesn't argue it beats anyone on RAGAS, but it argues it doesn't regress under audit-trail / lifecycle additions |
+| **Multi-hop QA accuracy** | Headline | `eval/external/musique_scorer.py`<br>`eval/external/wikimulti_scorer.py`<br>(per-question-type F1 in 2Wiki) | MuSiQue 3-SUT IDENTICAL (k=10) + cycle γ Phase C.2 retrieval bottleneck finding | Measured; result is honest negative (no JAMES uplift). Framed positively as evidence that JAMES's audit-trail / lifecycle additions don't *break* multi-hop, not as a claim that JAMES *wins* multi-hop |
+| **Hallucination rate / reduction %** | Adjacent (different name) | `eval/qvt/oracle.py::detect_abstention` + abstention_f1 axis<br>`eval/external/lrb/hr_scorer.py` (NLI-based HR axis)<br>`eval/external/lrb/nli_verifier.py` | QVT abstention_f1 = 0.67 (median, N=3 paired); LRB v0.2.4 HR axis cross-NLI validated | "Reduction rate" as a single percentage is a misleading framing for a system that the operator can dial. JAMES instead measures **abstention calibration**: did the system abstain when it should have? Two surfaces: (a) phrase-detector + truth label → F1; (b) claim-level NLI entailment. Both are publicly reproducible; "hallucination reduction %" is operator-tunable from any baseline once these are measured |
+| **Citation precision / recall** | Headline | `eval/external/alce_scorer.py::citation_precision` / `citation_recall` | ALCE-smoke (cycle γ Phase C.3, 2026-06-11): precision 0.8168 / recall 0.9067 with StringContainment fallback (**not** ALCE-grade NLI; infrastructure validated only — see [Phase C.3 memory](../../memory/project_cycle_gamma_phase_c3_alce_smoke.md)) | Infrastructure ready; real ALCE NLI verifier (D-alce track) deferred |
+| **Audit log completeness / fidelity / provenance** | **Unique to JAMES (RAB axis)** | `eval/rab/SPEC-v0.1.md` + scoring code | RAB v0.1.1 JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 = 0.275 / 0.000 / 0.000 on scenario-S1 | This is the *load-bearing* JAMES claim. Three deterministic metrics, EU AI Act Art. 10 / 12 / 19 mapped 1:1, scoreable by any RAG / agent system that can dump its append-only audit log |
+| **Time-valid / temporal retrieval** | **Unique to JAMES (LRB axis)** | `eval/external/lrb/scorer.py` + 3 scenarios (S1 quarterly / S2 yearly-with-time-travel / S3 publication-scale) | LRB v0.2.3 R@1 V<N<J preserved across 4 model families × 4 scale points (12.5× scale span) | The second load-bearing claim. Deliberately constructed so V (append-only) and N (naive supersede) are the comparison SUTs — i.e. the gap is *between* lifecycle architectures, not against an external opaque baseline |
+| **Latency p50 / p95** | Headline | `scripts/bench.py --suite=step7 --mode=retrieval` | STEP 7 regression baseline (17-query fixture) | Required by every PR touching `core/{retrieval,graph,reasoning}` per `.github/PULL_REQUEST_TEMPLATE.md` Quality Delta Card |
+| **Token cost** | Adjacent (different name) | `eval/qvt/oracle.py` 5-axis Pareto + `scripts/qvt_ablation_matrix.py::_classify_five_axis_delta` | QVT Pareto axis "Token Cost" | Reported in the per-PR Quality Delta Card. NOT reported as a public benchmark; ablation-matrix internal |
+
+### 2.1 What "adjacent" means
+
+For two metrics in the table (**Hallucination rate**, **Token cost**),
+JAMES measures a structurally-equivalent surface under a different
+name. The name difference is not arbitrary:
+
+- **Abstention F1** (instead of "hallucination reduction %") because
+  hallucination is a **calibration** problem, not a single-rate
+  problem. A system that abstains on everything has 0% hallucinations
+  but 0% useful answers. F1 over (should-abstain × did-abstain)
+  pairs captures the trade-off; a single "reduction %" hides it.
+- **HR axis** (LRB v0.2.4) extends this with NLI-claim-level
+  entailment so the abstention decision is grounded in retrieved
+  context, not just keyword phrases.
+
+If a reviewer's checklist literally says "Hallucination reduction
+%", the answer is: "JAMES measures the same property as abstention
+F1 + HR axis; for a single percentage, compute (1 − incorrect-
+abstention rate) over the QVT baseline".
+
+---
+
+## 3. Out-of-scope-by-design
+
+The following metrics are **deliberately not measured**:
+
+### 3.1 Graded relevance ranking (MRR / NDCG-graded / TREC-style)
+
+- **Why not**: JAMES's source-of-truth is "valid at time T" (boolean),
+  not "more vs less relevant". Graded labels would require an external
+  human-annotated graded-relevance corpus that does not exist for the
+  temporal-validity axis JAMES headlines.
+- **What JAMES does instead**: V<N<J pattern presence (R@1 binary)
+  across 4 models × 4 scales. The gap is the claim, not the rank
+  position.
+- **If you need it anyway**: `scripts/research/retrieval_quality.py`
+  has MRR + binary-NDCG already; build a fixture with graded
+  relevance and the script extends naturally. **Not a v0.5 cycle
+  deliverable.**
+
+### 3.2 Closed-book QA leaderboard scores (MMLU / GSM8K / HumanEval)
+
+- **Why not**: JAMES is a RAG / agent runtime, not a base LLM.
+  Closed-book scores reflect the underlying LLM (gemma4:e4b /
+  gemma3:12b / mxtral / claude), not the JAMES architecture.
+- **What JAMES does instead**: pins the model and measures the
+  *delta* JAMES introduces (audit trail, lifecycle retrieval).
+  Across the LRB cross-model results, V<N<J is preserved at every
+  model — i.e. the JAMES architecture's contribution is model-
+  independent.
+- **If you need it anyway**: run the closed-book benchmark of
+  your choice against the underlying LLM with and without the
+  JAMES wrapper. Per MuSiQue 3-SUT IDENTICAL, the answer is "no
+  closed-book accuracy delta" — JAMES's value is the audit /
+  lifecycle axis, not closed-book uplift.
+
+### 3.3 Cross-tenant query isolation / leak rate
+
+- **Why not yet**: v0.5 is single-tenant by env (`JAMES_WORKSPACE`).
+  Multi-tenant isolation contract (G1) is **proposed** in
+  `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §3 but not yet
+  measured because the contract isn't yet wired into the audit
+  emitter.
+- **Roadmap**: G1.a / G1.b / G1.c phases land tenant-id stamping
+  → tenant-id replay filtering → enforcement. Leak-rate measurement
+  becomes meaningful once G1.b lands (replay-side filtering).
+- **If a customer needs it sooner**: the proposed G1 contract is
+  the surface to wire and measure.
+
+### 3.4 GDPR Art. 17 erasure-on-request rate
+
+- **Why not yet**: G4 retention-class metadata landed (PR #848) as
+  the **prerequisite primitive** for erasure flows. The
+  tombstone-row archive flow that actually erases data while
+  preserving replay safety is a separate cycle, gated on a
+  customer with an active erasure SLA.
+- **What JAMES does today**: surfaces `pending_retention_review(now)`
+  → returns row IDs past their declared retention window. The
+  operator-side archive decision is approval-gated.
+- **If you need it sooner**: G4 documents the design path; the
+  archive flow is ~1 sprint of work once the customer SLA is
+  scoped.
+
+---
+
+## 4. Procurement-readiness checklist
+
+For an enterprise procurement question of the form **"how does
+your system measure X?"**, this is the canonical answer table:
+
+| Procurement question | Answer | Reference |
+|---|---|---|
+| Do you measure retrieval recall? | Yes — LRB R@1 / R@5 / R@10 across 3 SUTs × 4 models × 4 scales | LRB preprint + `eval/external/lrb/scorer.py` |
+| Do you measure MRR? | Yes (research tooling, not headline) | `scripts/research/retrieval_quality.py` |
+| Do you measure NDCG? | Yes (binary-relevance, research tooling) | `scripts/research/retrieval_quality.py` |
+| Do you measure RAGAS? | Yes — used as a regression gate, not a claim | `eval/ragas/run_ragas.py` + `eval/ragas/baseline.json` |
+| Do you measure answer F1 / EM? | Yes (MuSiQue + 2Wiki); result is honest-negative across SUTs (deliberate framing) | `eval/external/musique_scorer.py` + LRB preprint §5 |
+| Do you measure hallucination? | Yes — Abstention F1 (QVT) + HR axis (NLI verifier) | `eval/qvt/oracle.py` + `eval/external/lrb/hr_scorer.py` |
+| Do you measure citation quality? | Infrastructure ready (ALCE smoke, StringContainment); real NLI grading deferred | `eval/external/alce_scorer.py` |
+| Do you measure multi-hop QA accuracy? | Yes — MuSiQue + 2Wiki; result is honest-negative (no JAMES uplift) | `eval/external/musique_scorer.py` |
+| Do you measure audit-log completeness? | **Yes — this is the JAMES headline (RAB v0.1.1)** | `eval/rab/SPEC-v0.1.md` + DOI [10.5281/zenodo.20625533](https://doi.org/10.5281/zenodo.20625533) |
+| Do you measure time-valid retrieval? | **Yes — this is the JAMES headline (LRB v0.2.3)** | LRB preprint + DOI [10.5281/zenodo.20652679](https://doi.org/10.5281/zenodo.20652679) |
+| Do you measure cross-tenant isolation? | Not yet (G1 contract proposed; pre-pilot) | `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §3 |
+| Do you measure GDPR Art. 17 erasure? | Prerequisite primitive landed (G4); tombstone flow gated on customer SLA | `docs/reviews/v0.5-b1-ontology-surface-audit.md` G4 |
+| Do you have a VPAT / EN 301 549 statement? | UI a11y baseline shipped (v0.5 UI cycle); VPAT generation is operator task | `docs/reviews/v0.5-ui-1-accessibility-pass.md` |
+
+---
+
+## 5. What this document does NOT do
+
+- It does **not** introduce any new measurement. Every "Yes" in §4
+  references already-committed code; every "Not yet" references a
+  documented design proposal with a phased rollout.
+- It does **not** change the JAMES headline claims. RAB + LRB
+  remain the two load-bearing benchmarks.
+- It does **not** create any vertical-pack-specific evaluation
+  (CLAUDE.md rule #1 preserved).
+
+---
+
+## 6. References
+
+- `README.md` §"What JAMES does not claim" (lines 43-44) — the
+  identity framing this doc operationalises.
+- `SUMMARY.md` §"What's measured" — current measured numbers
+  surface for external evaluators.
+- `docs/PLATFORM_READINESS.md` — 6-dimension readiness framework.
+- `docs/ARCHITECTURE.md` — architecture and non-goals.
+- `docs/reviews/v0.5-b1-ontology-surface-audit.md` — enterprise
+  readiness gap triage (3 LANDED / 3 CONTRACT-LOCKED / 1
+  v1.0-deferred).
+- `docs/reviews/v0.5-b2-multi-tenant-isolation.md` — G1 tenant-id +
+  G2 approver evidence contract.
+- `docs/reviews/v0.5-b3-plugin-api-stability.md` — G8 ontology-pack
+  mount surface.
+- `papers/rab-preprint/main.pdf` — RAB v0.1.1 preprint (10 pp).
+- `papers/lrb-preprint/main.pdf` — LRB v0.2.3 preprint (11 pp).
+- `eval/qvt/oracle.py` — QVT abstention oracle.
+- `eval/external/lrb/{scorer,hr_scorer,nli_verifier}.py` — LRB
+  scoring + HR axis + claim-level NLI.
+- `eval/external/{musique,wikimulti,alce}_scorer.py` — external
+  multi-hop + citation benches.
+- `eval/ragas/run_ragas.py` — RAGAS regression suite.
+- `scripts/research/retrieval_quality.py` — MRR / binary-NDCG /
+  Hits@k research tooling (δ-1 cycle, 2026-06-03).
+
+---
+
+## 7. Korean summary (한국어 요약)
+
+**JAMES 평가 커버리지 매핑** — 외부 평가자(엔터프라이즈 RFP /
+학술 리뷰어)가 표준 IR/RAG 지표 어휘(MRR / NDCG / RAGAS / 환각
+감소율 / multi-hop 정확도)로 JAMES 를 점검할 때 "빈칸" 으로
+오독되는 위험을 막는 매핑 문서.
+
+**핵심 framing** (README:43-44 직접 인용): JAMES 는 closed-book
+QA answer-quality 로 경쟁하지 **않는다고 명시함**. 대신 RAB v0.1.1
+(audit-evidence — EU AI Act Art.10/12/19) + LRB v0.2.3 (시점 유효
+retrieval) 두 자체 벤치로 차별점 측정.
+
+**6개 표준 지표 실제 상태** (사용자 조사 + 코드 확인):
+
+| 지표 | 실제 |
+|---|---|
+| Recall@K | LRB headline (R@1/R@5/R@10) |
+| MRR | research tooling at `scripts/research/retrieval_quality.py` — headline 아님 |
+| NDCG | 같은 파일 binary-relevance — headline 아님 |
+| RAGAS | regression gate (`eval/ragas/run_ragas.py`) |
+| Hallucination "감소율" | adjacent — Abstention F1 (QVT) + HR axis (NLI) |
+| Multi-hop QA 정확도 | MuSiQue/2Wiki F1+EM (honest negative) |
+
+**Out-of-scope-by-design** (§3): graded-relevance ranking, closed-
+book leaderboard 점수, 멀티테넌트 격리 (G1 미배선 단계), GDPR Art.
+17 erasure (G4 primitive 만 ready).
+
+**procurement-readiness 체크리스트** (§4): 13개 표준 procurement
+질문 × answer + 코드 reference. 외부 RFP 답변시 그대로 사용 가능.
+
+**이 문서가 하지 않는 것**: 새 측정 도입 0, JAMES headline 변경 0,
+vertical-pack 측정 (rule #1 보존).


### PR DESCRIPTION
## Summary

Closes the **external-reviewer blank-cell misread risk** flagged by the operator's investigation: enterprise RFPs + academic referees approach JAMES expecting the standard IR / RAG metric vocabulary (MRR / NDCG / RAGAS / hallucination reduction / multi-hop accuracy). The headline JAMES vocabulary is different (AC/RF/PC = RAB · R@1 V<N<J = LRB · Abstention F1 = QVT · HR axis = NLI).

A reviewer who maps standard names to "blank cells" without reading the codebase **undercounts the actual coverage**.

This PR ships `docs/evaluation/v0.5-evaluation-coverage-mapping.md` (7 sections) — disclosure only, no new measurement, no JAMES headline change, no `core/` code touched.

### Key corrections vs the initial reviewer investigation

The initial investigation said "MRR / NDCG: 진짜 없음" (grep-scoped to `eval/`). Code verification found:

| Metric | Initial finding | Actual |
|---|---|---|
| **MRR** | 없음 | **Present** at `scripts/research/retrieval_quality.py::reciprocal_rank` (δ-1 cycle, 2026-06-03). Research tooling, not headline. |
| **NDCG** | 없음 | **Present** at same file. Binary-relevance only (graded labels would require a graded corpus that doesn't exist for the temporal-validity axis JAMES headlines). |
| **RAGAS** | 있음 | ✓ `eval/ragas/run_ragas.py` — regression gate (not a claim). |
| **Recall@K** | 있음 | ✓ `eval/external/lrb/scorer.py::_recall_at_k` — LRB headline. |
| **Hallucination 감소율** | 부분적 | ✓ Adjacent — measured as Abstention F1 (QVT) + HR axis (LRB v0.2.4 NLI). The "single reduction %" framing is deliberately rejected; calibration is the better surface. |
| **Multi-hop QA 정확도** | 있음 | ✓ MuSiQue + 2Wiki F1/EM (honest negative across SUTs; deliberate framing). |

### Doc structure

| § | Content |
|---|---|
| 1 | Framing — README:43-44 \"What JAMES does not claim\" + RAB+LRB DOIs |
| 2 | 13-row coverage matrix: standard metric × coverage tier × code path × why this choice |
| 3 | Out-of-scope-by-design — graded-relevance ranking, closed-book leaderboard, cross-tenant isolation (G1 pre-pilot), GDPR Art. 17 erasure (G4 ready) |
| 4 | **Procurement-readiness checklist** — 13 typical questions × canonical answer × file reference. Drop-in for RFP responses |
| 5 | What this doc does NOT do |
| 6 | References — code paths + preprints + design memos |
| 7 | Korean summary |

### README integration

Added a one-line link block immediately after the README's "What JAMES does not claim" section so any reviewer following the anti-claim trail finds the coverage mapping in their next scroll-down.

## Why mother-platform

Disclosure-only doc. No new measurement; no headline change. The work is making the **existing** measurement surfaces readable by a reviewer using standard vocabulary. This is the lowest-cost lever to close the gap ("explain why we don't use those names" beats "add the names" because adding rank-position metrics would conflict with JAMES's deliberate non-competition on closed-book QA — a CLAUDE.md-rule-1-adjacent decision).

Pairs naturally with the v0.5 B.1-B.3 enterprise-readiness audit docs.

## Out of scope

- New benchmarks — RAB + LRB remain headline.
- Backend wiring of any metric — disclosure only.
- Vertical-pack evaluation — BLOCKED per CLAUDE.md rule #1.
- VPAT / EN 301 549 / ISO 42001 statement generation — operator tasks using this doc + B.1-B.3 as inputs.

## Verification

- **No code changed** → no test / ruff impact.
- All code paths cited in the doc verified by grep before writing.
- README MuSiQue "3-SUT identical EM/F1" claim verified at README:44.

Quality delta: exempt (label: docs)