### PR TITLE
feat(v0.5): enterprise security headers middleware

### DIFF
--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -1,0 +1,20 @@
+"""v0.5 — security primitives module.
+
+Mother-platform surface for security-related primitives that the
+B.1/B.2/B.3 audit cycle identified as enterprise-procurement
+check-items:
+
+  * `headers` — HTTP response security headers (CSP, X-Frame-Options,
+    Strict-Transport-Security, X-Content-Type-Options,
+    Referrer-Policy, Permissions-Policy) with env-driven config
+    and a default report-only CSP mode.
+
+Future additions (B.2 design memo):
+  * `approval_evidence` — verified-approver-principal binding for
+    self-evolution change requests (G2; deferred to v0.6).
+"""
+from __future__ import annotations
+
+from core.security import headers
+
+__all__ = ["headers"]

--- a/core/security/headers.py
+++ b/core/security/headers.py
@@ -1,0 +1,234 @@
+"""v0.5 — HTTP security headers builder.
+
+Pure-function module that builds the security-header dict applied
+by `server_llmwiki.py`'s `security_headers_middleware`. Each header
+is the answer to a specific enterprise procurement / OWASP /
+EN-301-549 check-item:
+
+  * **Content-Security-Policy** — XSS / injection defense
+    (CSP Level 3). Three modes: `off`, `report-only`, `enforce`.
+    Default = `report-only` (ships the policy as a Report-Only
+    header so the browser logs violations without breaking the
+    existing inline-style usage; operator graduates to `enforce`
+    once `docs/reviews/v0.5-ui-6-inline-style-audit.md` Option A
+    nonce middleware OR Option B mass conversion lands).
+  * **X-Frame-Options: DENY** — clickjacking defense.
+    Belt-and-suspenders with CSP `frame-ancestors 'none'`.
+  * **X-Content-Type-Options: nosniff** — MIME-sniffing defense.
+  * **Referrer-Policy: strict-origin-when-cross-origin** — limits
+    leaked referrer URLs while keeping same-origin Refer for
+    legitimate analytics.
+  * **Permissions-Policy** — disables sensors (geolocation,
+    camera, microphone, payment, USB) that JAMES does not use.
+  * **Strict-Transport-Security** — HSTS preload-ready when
+    operator opts in via `JAMES_HSTS_MAX_AGE` env. Default unset
+    so a non-HTTPS dev/local deploy isn't poisoned by a stuck
+    HSTS pin.
+
+## Env-driven config
+
+| Env var | Default | Effect |
+|---|---|---|
+| `JAMES_CSP_MODE` | `report-only` | One of `off`, `report-only`, `enforce`. `off` omits the CSP header entirely (local-dev). |
+| `JAMES_CSP_REPORT_URI` | `""` | Optional. URL the browser POSTs CSP violation reports to. Empty = no `report-uri` directive. |
+| `JAMES_HSTS_MAX_AGE` | `0` | Seconds. `0` = HSTS header omitted (default for dev / non-HTTPS). Production sets `31536000` (1 year) or `63072000` (2 years for preload). |
+| `JAMES_HSTS_INCLUDE_SUBDOMAINS` | `0` | `1` to add `includeSubDomains` directive. |
+| `JAMES_HSTS_PRELOAD` | `0` | `1` to add `preload` directive (operator must register with hstspreload.org separately). |
+
+## What this module is NOT
+
+- **Not a CSP nonce generator.** Nonces are a separate primitive
+  (`docs/reviews/v0.5-ui-6-inline-style-audit.md` §4.1 Option A);
+  this module ships the policy headers, the nonce middleware
+  lands as a separate PR when operator scopes the SaaS-pilot CSP.
+- **Not a request-bound state machine.** Headers are response-
+  scoped only. The middleware applies them per-response without
+  reading any request state beyond the path (for static-file
+  caching alignment).
+- **Not a CSRF protector.** CSRF is a request-side defense (token
+  validation in routes), orthogonal to response headers.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, Final, Literal
+
+
+# ─── CSP policy (report-only by default) ──────────────────────────────
+#
+# Source-list rationale:
+#
+#   default-src 'self'      — local-first floor
+#   script-src 'self'       — v0.5 UI #4 PR #855 extracted last inline
+#                             script → strict mode safe
+#   style-src 'self'
+#     'unsafe-inline'       — 409 inline `style="..."` attributes still
+#                             remain; report-only mode lets us SEE
+#                             violations without breaking the UI.
+#                             Removed once nonce middleware OR mass
+#                             conversion lands.
+#   img-src 'self' data:    — `data:` for inline SVG icons + brand-pulse
+#                             icons (chat.js `brainPulseSvg`)
+#   font-src 'self'
+#     https://fonts.gstatic.com — Inter + JetBrains Mono loaded by
+#                                  tokens.css from Google Fonts CDN
+#   connect-src 'self'      — XHR + fetch to same-origin only
+#   frame-ancestors 'none'  — clickjacking defense (belt-and-suspenders
+#                             with X-Frame-Options: DENY)
+#   base-uri 'self'         — limit <base href> abuse
+#   form-action 'self'      — limit form post targets
+#   object-src 'none'       — disable <object> / <embed> / <applet>
+#   upgrade-insecure-requests — auto-upgrade http → https on browsers
+#                               that support it; safe when served over
+#                               HTTPS, no-op on HTTP
+
+CSP_DIRECTIVES_DEFAULT: Final[Dict[str, str]] = {
+    "default-src":     "'self'",
+    "script-src":      "'self'",
+    "style-src":       "'self' 'unsafe-inline' "
+                       "https://fonts.googleapis.com",
+    "img-src":         "'self' data:",
+    "font-src":        "'self' https://fonts.gstatic.com",
+    "connect-src":     "'self'",
+    "frame-ancestors": "'none'",
+    "base-uri":        "'self'",
+    "form-action":     "'self'",
+    "object-src":      "'none'",
+}
+
+
+CspMode = Literal["off", "report-only", "enforce"]
+
+
+def _read_csp_mode() -> CspMode:
+    """Resolve `JAMES_CSP_MODE` to one of three modes."""
+    raw = (os.environ.get("JAMES_CSP_MODE") or "report-only").strip().lower()
+    if raw in ("off", "disable", "disabled", "0", "false", "no"):
+        return "off"
+    if raw in ("enforce", "enforced", "strict", "on", "1", "true", "yes"):
+        return "enforce"
+    return "report-only"
+
+
+def _build_csp_value(report_uri: str = "") -> str:
+    """Compose the CSP directive string from `CSP_DIRECTIVES_DEFAULT`.
+
+    Directives are joined `key value; key value; ...`. Trailing
+    `upgrade-insecure-requests` is appended (it has no source list).
+    If `report_uri` is non-empty, a `report-uri <uri>` directive is
+    appended too.
+    """
+    parts = [
+        f"{k} {v}" for k, v in CSP_DIRECTIVES_DEFAULT.items()
+    ]
+    parts.append("upgrade-insecure-requests")
+    if report_uri:
+        parts.append(f"report-uri {report_uri}")
+    return "; ".join(parts)
+
+
+def _csp_header_name(mode: CspMode) -> str:
+    """Resolve the header name for the active CSP mode.
+
+    Report-only mode uses `Content-Security-Policy-Report-Only` so
+    the browser emits violation reports without enforcing the policy
+    (the UI keeps working through any current inline-style usage).
+    """
+    if mode == "enforce":
+        return "Content-Security-Policy"
+    return "Content-Security-Policy-Report-Only"
+
+
+# ─── HSTS ─────────────────────────────────────────────────────────────
+
+
+def _build_hsts() -> str:
+    """Build the Strict-Transport-Security value from env.
+
+    Returns the empty string when `JAMES_HSTS_MAX_AGE` is `0` or
+    unset — the caller then omits the header entirely (the right
+    behaviour for dev / non-HTTPS deploys).
+    """
+    max_age = (os.environ.get("JAMES_HSTS_MAX_AGE") or "0").strip()
+    try:
+        max_age_int = int(max_age)
+    except ValueError:
+        return ""
+    if max_age_int <= 0:
+        return ""
+    parts = [f"max-age={max_age_int}"]
+    if _truthy(os.environ.get("JAMES_HSTS_INCLUDE_SUBDOMAINS")):
+        parts.append("includeSubDomains")
+    if _truthy(os.environ.get("JAMES_HSTS_PRELOAD")):
+        parts.append("preload")
+    return "; ".join(parts)
+
+
+def _truthy(value: str) -> bool:
+    """True iff value is a recognised truthy env-flag string."""
+    if not value:
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on", "enabled")
+
+
+# ─── Permissions-Policy ───────────────────────────────────────────────
+#
+# JAMES does not use any of these sensor / device APIs — explicitly
+# denying them shrinks the attack surface and signals to enterprise
+# evaluators that sensor-leak is not a JAMES concern. Permissions-
+# Policy syntax: `feature=()` blocks the feature on this origin.
+
+_PERMISSIONS_POLICY: Final[str] = ", ".join([
+    "accelerometer=()",
+    "camera=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "magnetometer=()",
+    "microphone=()",
+    "payment=()",
+    "usb=()",
+])
+
+
+# ─── Public API ───────────────────────────────────────────────────────
+
+
+def build_security_headers() -> Dict[str, str]:
+    """Return the security-header dict for the current env config.
+
+    Caller (the FastAPI middleware) iterates the dict and writes
+    each `(name, value)` pair onto the response. The caller is
+    responsible for not overwriting existing headers — but this
+    function never returns header names that a route handler would
+    legitimately set itself, so collisions are not expected.
+
+    Empty values are returned for headers that env config has
+    disabled (e.g., HSTS with `max-age=0`); the caller is expected
+    to skip headers whose value is empty.
+    """
+    out: Dict[str, str] = {}
+
+    # CSP (default report-only)
+    mode = _read_csp_mode()
+    if mode != "off":
+        report_uri = (os.environ.get("JAMES_CSP_REPORT_URI") or "").strip()
+        out[_csp_header_name(mode)] = _build_csp_value(report_uri)
+
+    # Belt-and-suspenders / always-on
+    out["X-Frame-Options"] = "DENY"
+    out["X-Content-Type-Options"] = "nosniff"
+    out["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    out["Permissions-Policy"] = _PERMISSIONS_POLICY
+
+    # HSTS — opt-in via env
+    hsts = _build_hsts()
+    if hsts:
+        out["Strict-Transport-Security"] = hsts
+
+    return out
+
+
+__all__ = (
+    "build_security_headers",
+    "CSP_DIRECTIVES_DEFAULT",
+)

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -151,6 +151,36 @@ async def no_cache_static(request: Request, call_next):
     return response
 
 
+# v0.5 — enterprise security headers (CSP report-only by default +
+# X-Frame-Options / X-Content-Type-Options / Referrer-Policy /
+# Permissions-Policy). HSTS opt-in via env. See
+# `core/security/headers.py` for the env-driven config table and
+# `docs/reviews/v0.5-ui-6-inline-style-audit.md` §4 for the CSP
+# graduation path.
+from core.security.headers import build_security_headers  # noqa: E402
+
+
+@app.middleware("http")
+async def security_headers_middleware(request: Request, call_next):
+    """Apply enterprise security headers to every response.
+
+    Headers are computed once per request via
+    `core.security.headers.build_security_headers()` (which reads
+    env config). The middleware does NOT overwrite headers that
+    earlier middleware / route handlers have already set — this
+    keeps the API contract additive (existing /healthz responses
+    etc. don't see Content-Type rewrites).
+    """
+    response = await call_next(request)
+    for name, value in build_security_headers().items():
+        # `Response.headers` is a MutableHeaders — `setdefault` is
+        # the safe primitive (no overwrite if a downstream layer
+        # already set the same header).
+        if name not in response.headers:
+            response.headers[name] = value
+    return response
+
+
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def serve_index():
     index = os.path.join(FRONTEND_DIR, "index.html")

--- a/tests/test_v05_security_headers.py
+++ b/tests/test_v05_security_headers.py
@@ -1,0 +1,276 @@
+"""v0.5 — security headers contract tests.
+
+Covers:
+
+  * Default CSP mode = report-only → header name is
+    `Content-Security-Policy-Report-Only`.
+  * `JAMES_CSP_MODE=enforce` → header name flips to
+    `Content-Security-Policy`.
+  * `JAMES_CSP_MODE=off` → no CSP header at all.
+  * CSP directive list — every required directive present + value
+    matches the documented contract.
+  * Always-on headers (X-Frame-Options / X-Content-Type-Options /
+    Referrer-Policy / Permissions-Policy) present regardless of
+    CSP mode.
+  * HSTS opt-in semantics — absent by default, present when
+    `JAMES_HSTS_MAX_AGE` is set, includes `includeSubDomains` /
+    `preload` when their respective env flags are set.
+  * `JAMES_CSP_REPORT_URI` appears as `report-uri` directive when
+    set.
+  * Env-flag truthiness parser — covers `1` / `true` / `yes` /
+    `on` plus the falsy variants.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+
+@contextmanager
+def _patched_env(**env: str):
+    """Temporarily override env vars; restore afterwards.
+
+    Variables passed as `None` are unset (instead of set to the
+    string "None"). This is the operator-facing test ergonomic.
+    """
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+        for k in env:
+            if k not in saved and k not in unset_keys:
+                os.environ.pop(k, None)
+
+
+def _headers(**env: str) -> Dict[str, str]:
+    """Build headers under a patched env, no module import order
+    side effects."""
+    from core.security.headers import build_security_headers
+    with _patched_env(**env):
+        return build_security_headers()
+
+
+class CspModeTests(unittest.TestCase):
+    def test_default_mode_report_only(self):
+        # No env set → defaults to report-only.
+        h = _headers(JAMES_CSP_MODE=None)
+        self.assertIn("Content-Security-Policy-Report-Only", h)
+        self.assertNotIn("Content-Security-Policy", h)
+
+    def test_explicit_report_only(self):
+        h = _headers(JAMES_CSP_MODE="report-only")
+        self.assertIn("Content-Security-Policy-Report-Only", h)
+
+    def test_enforce_mode_flips_header_name(self):
+        h = _headers(JAMES_CSP_MODE="enforce")
+        self.assertIn("Content-Security-Policy", h)
+        self.assertNotIn("Content-Security-Policy-Report-Only", h)
+
+    def test_off_mode_omits_csp_entirely(self):
+        h = _headers(JAMES_CSP_MODE="off")
+        self.assertNotIn("Content-Security-Policy", h)
+        self.assertNotIn("Content-Security-Policy-Report-Only", h)
+
+    def test_off_synonyms(self):
+        for value in ("disable", "disabled", "0", "false", "no"):
+            with self.subTest(value=value):
+                h = _headers(JAMES_CSP_MODE=value)
+                self.assertNotIn("Content-Security-Policy", h)
+                self.assertNotIn("Content-Security-Policy-Report-Only", h)
+
+    def test_enforce_synonyms(self):
+        for value in ("enforced", "strict", "on", "1", "true", "yes"):
+            with self.subTest(value=value):
+                h = _headers(JAMES_CSP_MODE=value)
+                self.assertIn("Content-Security-Policy", h)
+
+    def test_unrecognised_value_falls_through_to_report_only(self):
+        h = _headers(JAMES_CSP_MODE="bogus")
+        self.assertIn("Content-Security-Policy-Report-Only", h)
+
+
+class CspContentTests(unittest.TestCase):
+    def setUp(self):
+        self.h = _headers(JAMES_CSP_MODE="enforce")
+        self.csp = self.h["Content-Security-Policy"]
+
+    def test_default_src_self(self):
+        self.assertIn("default-src 'self'", self.csp)
+
+    def test_script_src_self_only(self):
+        # Strict-mode-ready: no unsafe-inline / unsafe-eval.
+        self.assertIn("script-src 'self'", self.csp)
+        # No 'unsafe-inline' / 'unsafe-eval' in script-src directive.
+        script_part = next(
+            (p for p in self.csp.split(";") if "script-src" in p), "",
+        )
+        self.assertNotIn("unsafe-inline", script_part)
+        self.assertNotIn("unsafe-eval", script_part)
+
+    def test_style_src_has_unsafe_inline_for_now(self):
+        # Documented in audit doc §3 — 409 inline `style="..."`
+        # attributes still present; style-src needs 'unsafe-inline'
+        # until nonce middleware OR mass conversion lands.
+        self.assertIn("style-src", self.csp)
+        style_part = next(
+            (p for p in self.csp.split(";") if "style-src" in p), "",
+        )
+        self.assertIn("'unsafe-inline'", style_part)
+
+    def test_frame_ancestors_none(self):
+        self.assertIn("frame-ancestors 'none'", self.csp)
+
+    def test_object_src_none(self):
+        self.assertIn("object-src 'none'", self.csp)
+
+    def test_base_uri_self(self):
+        self.assertIn("base-uri 'self'", self.csp)
+
+    def test_form_action_self(self):
+        self.assertIn("form-action 'self'", self.csp)
+
+    def test_upgrade_insecure_requests(self):
+        self.assertIn("upgrade-insecure-requests", self.csp)
+
+    def test_img_src_allows_data(self):
+        # Brain-pulse SVG icons use data: URLs.
+        self.assertIn("img-src 'self' data:", self.csp)
+
+    def test_font_src_allows_google_fonts(self):
+        # tokens.css @import URL.
+        self.assertIn("font-src 'self' https://fonts.gstatic.com", self.csp)
+
+    def test_report_uri_set_when_env_set(self):
+        h = _headers(
+            JAMES_CSP_MODE="enforce",
+            JAMES_CSP_REPORT_URI="https://example.com/csp-report",
+        )
+        self.assertIn(
+            "report-uri https://example.com/csp-report",
+            h["Content-Security-Policy"],
+        )
+
+    def test_report_uri_absent_by_default(self):
+        self.assertNotIn("report-uri", self.csp)
+
+
+class AlwaysOnHeadersTests(unittest.TestCase):
+    """Headers that are present regardless of CSP mode."""
+
+    def test_x_frame_options_deny(self):
+        for mode in ("off", "report-only", "enforce"):
+            with self.subTest(mode=mode):
+                h = _headers(JAMES_CSP_MODE=mode)
+                self.assertEqual(h["X-Frame-Options"], "DENY")
+
+    def test_x_content_type_options_nosniff(self):
+        for mode in ("off", "report-only", "enforce"):
+            with self.subTest(mode=mode):
+                h = _headers(JAMES_CSP_MODE=mode)
+                self.assertEqual(h["X-Content-Type-Options"], "nosniff")
+
+    def test_referrer_policy_strict_origin(self):
+        h = _headers(JAMES_CSP_MODE="off")
+        self.assertEqual(
+            h["Referrer-Policy"], "strict-origin-when-cross-origin",
+        )
+
+    def test_permissions_policy_blocks_sensors(self):
+        h = _headers(JAMES_CSP_MODE="off")
+        pp = h["Permissions-Policy"]
+        for sensor in ("accelerometer", "camera", "geolocation",
+                       "gyroscope", "magnetometer", "microphone",
+                       "payment", "usb"):
+            with self.subTest(sensor=sensor):
+                self.assertIn(f"{sensor}=()", pp)
+
+
+class HstsTests(unittest.TestCase):
+    def test_absent_by_default(self):
+        h = _headers(JAMES_HSTS_MAX_AGE=None)
+        self.assertNotIn("Strict-Transport-Security", h)
+
+    def test_zero_max_age_omits_header(self):
+        h = _headers(JAMES_HSTS_MAX_AGE="0")
+        self.assertNotIn("Strict-Transport-Security", h)
+
+    def test_negative_max_age_omits_header(self):
+        h = _headers(JAMES_HSTS_MAX_AGE="-1")
+        self.assertNotIn("Strict-Transport-Security", h)
+
+    def test_malformed_max_age_omits_header(self):
+        h = _headers(JAMES_HSTS_MAX_AGE="not-a-number")
+        self.assertNotIn("Strict-Transport-Security", h)
+
+    def test_positive_max_age_emits_header(self):
+        h = _headers(JAMES_HSTS_MAX_AGE="31536000")
+        self.assertEqual(
+            h["Strict-Transport-Security"], "max-age=31536000",
+        )
+
+    def test_include_subdomains_flag(self):
+        h = _headers(
+            JAMES_HSTS_MAX_AGE="31536000",
+            JAMES_HSTS_INCLUDE_SUBDOMAINS="1",
+        )
+        self.assertIn("includeSubDomains", h["Strict-Transport-Security"])
+
+    def test_preload_flag(self):
+        h = _headers(
+            JAMES_HSTS_MAX_AGE="63072000",
+            JAMES_HSTS_PRELOAD="1",
+        )
+        self.assertIn("preload", h["Strict-Transport-Security"])
+
+    def test_full_preload_ready(self):
+        h = _headers(
+            JAMES_HSTS_MAX_AGE="63072000",
+            JAMES_HSTS_INCLUDE_SUBDOMAINS="1",
+            JAMES_HSTS_PRELOAD="1",
+        )
+        self.assertEqual(
+            h["Strict-Transport-Security"],
+            "max-age=63072000; includeSubDomains; preload",
+        )
+
+    def test_truthy_synonyms_for_flags(self):
+        for value in ("1", "true", "yes", "on", "enabled"):
+            with self.subTest(value=value):
+                h = _headers(
+                    JAMES_HSTS_MAX_AGE="31536000",
+                    JAMES_HSTS_INCLUDE_SUBDOMAINS=value,
+                )
+                self.assertIn(
+                    "includeSubDomains", h["Strict-Transport-Security"],
+                )
+
+    def test_falsy_flags_omit_directive(self):
+        for value in ("0", "false", "no", "off", ""):
+            with self.subTest(value=value):
+                h = _headers(
+                    JAMES_HSTS_MAX_AGE="31536000",
+                    JAMES_HSTS_INCLUDE_SUBDOMAINS=value,
+                )
+                self.assertNotIn(
+                    "includeSubDomains", h["Strict-Transport-Security"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Mother-level enterprise procurement check-item. Pure-additive middleware that ships **CSP (report-only by default)** + **clickjacking / MIME / Referrer / Permissions-Policy** headers on every response. No domain content; no `core/retrieval` / `core/graph` / `core/reasoning` touched.

### New module — `core/security/`

- `core/security/__init__.py` — package skeleton
- `core/security/headers.py` (~9.6 KB) — `build_security_headers()` pure function + `CSP_DIRECTIVES_DEFAULT` locked contract

### Headers shipped

| Header | Mode | Default value |
|---|---|---|
| `Content-Security-Policy-Report-Only` | env: `JAMES_CSP_MODE=report-only` (default) | strict directives; `style-src` still has `'unsafe-inline'` until UI #6 nonce/conversion path lands |
| `Content-Security-Policy` | env: `JAMES_CSP_MODE=enforce` | same directives, enforced |
| `X-Frame-Options` | always | `DENY` (clickjacking) |
| `X-Content-Type-Options` | always | `nosniff` |
| `Referrer-Policy` | always | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | always | blocks 8 sensor/device APIs JAMES does not use |
| `Strict-Transport-Security` | env: `JAMES_HSTS_MAX_AGE > 0` | omitted by default (dev/non-HTTPS) |

### Server wiring (`server_llmwiki.py`)

New `security_headers_middleware` after the existing `no_cache_static` middleware. **`setdefault` semantics** — never overwrites a header an earlier middleware or route handler has already set, so the API contract is additive.

### Why default = report-only

The 409 inline `style="..."` attributes documented in `docs/reviews/v0.5-ui-6-inline-style-audit.md` §3 still exist. Report-only mode ships the CSP for **browser violation reporting** without breaking the UI. Operator graduates to `JAMES_CSP_MODE=enforce` once the UI #6 nonce middleware OR mass conversion lands.

### Env config

| Env var | Default | Effect |
|---|---|---|
| `JAMES_CSP_MODE` | `report-only` | `off` / `report-only` / `enforce` (+ documented synonyms) |
| `JAMES_CSP_REPORT_URI` | `""` | URL for browser CSP violation POSTs |
| `JAMES_HSTS_MAX_AGE` | `0` | Seconds; `0` omits HSTS header |
| `JAMES_HSTS_INCLUDE_SUBDOMAINS` | `0` | `1` to add |
| `JAMES_HSTS_PRELOAD` | `0` | `1` to add |

## Tests (`tests/test_v05_security_headers.py`)

**33 tests across 4 classes**:

- CspModeTests (7) — defaults / explicit / off+enforce synonyms / unrecognised fallback
- CspContentTests (12) — every directive present + script-src has no `unsafe-inline`/`unsafe-eval` + style-src retains `unsafe-inline` (documented exception) + frame-ancestors / object-src none + img-src data: / font-src google fonts + report-uri
- AlwaysOnHeadersTests (4) — X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy regardless of CSP mode
- HstsTests (10) — absent by default; zero/negative/malformed max-age omit; positive emits; includeSubDomains+preload flag semantics; full preload-ready; truthy/falsy synonyms

## Verification

- `pytest tests/test_v05_security_headers.py`: **33 passed**
- `ruff check`: clean
- Module size: **9.6 KB** (under 20 KB cap, CLAUDE.md rule 5)
- Live `/healthz` FastAPI TestClient smoke: all 5 always-on headers present + Content-Security-Policy-Report-Only injected

## Out of scope

- CSP nonce generator (UI #6 Option A) — separate cycle at SaaS-pilot.
- Inline `style="..."` mass conversion (UI #6 Option B) — deferred.
- CSRF token validation — request-side concern, orthogonal.
- Vertical-pack-specific headers — BLOCKED per CLAUDE.md rule #1.

Quality delta: exempt (label: external-mother-platform — additive response-header middleware; default report-only mode does not break any existing UI behaviour)