### PR TITLE
feat(v0.5-G1.a): tenant-id primitive + emit-side wire-in

### DIFF
--- a/core/lifecycle/replay_audit.py
+++ b/core/lifecycle/replay_audit.py
@@ -139,6 +139,7 @@ def emit_lifecycle_event(
     timestamp: Optional[str] = None,
     db_path: Optional[str] = None,
     retention_class: Optional[str] = None,
+    tenant_id: Optional[str] = None,
 ) -> bool:
     """Insert one ``audit_log`` row with the given lifecycle
     ``event_type`` + JSON-encoded ``payload``.
@@ -196,6 +197,28 @@ def emit_lifecycle_event(
         # Copy to avoid mutating the caller's dict.
         payload = dict(payload)
         payload["retention_class"] = retention_class
+
+    # v0.5 G1.a — resolve + stamp tenant_id into the payload.
+    # Resolution order: explicit kwarg → with_tenant_id() override →
+    # JAMES_TENANT_ID env. When `is_tenant_isolation_enforced()` is
+    # true AND resolution yields no tenant_id, emit fails fast
+    # (returns False without inserting) — keeps a multi-tenant
+    # deploy from accidentally writing tenant-anonymous rows.
+    from core.lifecycle.tenant import (
+        current_tenant_id,
+        is_tenant_isolation_enforced,
+    )
+    resolved_tenant = (
+        tenant_id if tenant_id is not None else current_tenant_id()
+    )
+    if is_tenant_isolation_enforced() and not resolved_tenant:
+        return False
+    if resolved_tenant:
+        # Defensive copy if we haven't already (the G4 branch above
+        # may already have copied). dict() on a dict is cheap; the
+        # invariant is "never mutate the caller's dict in place".
+        payload = dict(payload)
+        payload["tenant_id"] = resolved_tenant
 
     ts = timestamp or datetime.now().isoformat()
     try:

--- a/core/lifecycle/tenant.py
+++ b/core/lifecycle/tenant.py
@@ -1,0 +1,147 @@
+"""v0.5 G1.a — tenant identifier primitive for audit-log rows.
+
+Per `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §3.2. Mother-
+platform: the contract surface only. Default-off → byte-identical
+pre-G1.a behaviour when no env var is set and no `with_tenant_id`
+override is active.
+
+## What this module ships
+
+  * `JAMES_TENANT_ID_ENV` — name of the env var (constant, for tests).
+  * `JAMES_REQUIRE_TENANT_ID_ENV` — name of the enforcement env var.
+  * `current_tenant_id()` → ``Optional[str]`` — resolves the active
+    tenant from (1) thread-local override stack, (2) the
+    `JAMES_TENANT_ID` env var. ``None`` if neither.
+  * `with_tenant_id(tenant_id)` — context-manager that pushes a
+    thread-local override for the duration of the `with` block.
+    Used by admin tooling that writes audit rows on behalf of a
+    specific tenant from a process without a single ambient
+    tenant.
+  * `is_tenant_isolation_enforced()` → ``bool`` — true iff
+    `JAMES_REQUIRE_TENANT_ID` is set to a recognised truthy value.
+    The audit-emitter consults this to decide whether emit
+    requires a resolved tenant_id (enforce mode) or treats absence
+    as "single-tenant mode" (default).
+
+## Integration
+
+The corresponding emit-side wire-in lives in
+`core/lifecycle/replay_audit.py::emit_lifecycle_event` (extended
+in the same PR). When `tenant_id` is resolvable (override OR env),
+the value is stamped into the row's `event_payload` JSON under
+the key `tenant_id` — no schema migration. Pattern mirrors the G4
+retention_class field (landed PR #848).
+
+## What this module is NOT
+
+- **Not a routing token.** The downstream replay-side filter
+  (G1.b) reads the stamped field to scope queries; that lands
+  in a separate PR. This module only writes.
+- **Not an RBAC layer.** Tenant_id is an audit-trail correlation
+  primitive. Cross-tenant query prevention is handled at the
+  HTTP layer (reverse proxy + per-tenant routes), not here.
+- **Not thread-safe across asyncio tasks.** The override stack
+  uses `threading.local`, which carries per-thread but does NOT
+  carry per-asyncio-task. Admin tooling using `with_tenant_id`
+  inside an `async def` should either (a) use it at thread-pool
+  call sites only, or (b) wait for the asyncio-aware variant
+  scheduled in G1.b.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager
+from typing import Final, Iterator, Optional
+
+
+JAMES_TENANT_ID_ENV:         Final[str] = "JAMES_TENANT_ID"
+JAMES_REQUIRE_TENANT_ID_ENV: Final[str] = "JAMES_REQUIRE_TENANT_ID"
+
+
+# Thread-local override stack. `with_tenant_id` pushes; on exit,
+# pops. The stack supports nested overrides (the innermost wins).
+_local = threading.local()
+
+
+def _stack() -> list:
+    """Lazily-initialise + return the per-thread override stack."""
+    stack = getattr(_local, "stack", None)
+    if stack is None:
+        stack = []
+        _local.stack = stack
+    return stack
+
+
+def current_tenant_id() -> Optional[str]:
+    """Resolve the active tenant id.
+
+    Resolution order (first match wins):
+      1. Innermost `with_tenant_id(...)` override on the current
+         thread, if any.
+      2. `JAMES_TENANT_ID` env var, if set + non-empty.
+      3. ``None``.
+
+    Returns the empty string as ``None`` so callers don't accidentally
+    stamp an empty-string tenant_id (which is a different audit-row
+    state from "no tenant scope known").
+    """
+    stack = _stack()
+    if stack:
+        return stack[-1]
+    raw = os.environ.get(JAMES_TENANT_ID_ENV)
+    if raw and raw.strip():
+        return raw.strip()
+    return None
+
+
+@contextmanager
+def with_tenant_id(tenant_id: Optional[str]) -> Iterator[None]:
+    """Override the active tenant id for the `with` block.
+
+    Pushes ``tenant_id`` onto the thread-local override stack on
+    entry; pops on exit (even if the block raised).
+
+    Pass ``None`` to explicitly NULL the override for the block —
+    this is the "admin tooling running unscoped over the entire
+    audit-log" case. Calling ``current_tenant_id()`` inside such a
+    block returns ``None`` even if ``JAMES_TENANT_ID`` is set.
+
+    Nesting is supported — innermost wins, outer overrides restore
+    naturally on exit.
+    """
+    stack = _stack()
+    stack.append(tenant_id)
+    try:
+        yield
+    finally:
+        # Defensive pop — never trust the stack length if the
+        # caller did something exotic (e.g., manually mutated
+        # the local). Pop the last element only if it matches.
+        if stack and stack[-1] is tenant_id:
+            stack.pop()
+
+
+def is_tenant_isolation_enforced() -> bool:
+    """True iff `JAMES_REQUIRE_TENANT_ID` is set to a truthy value.
+
+    Recognised truthy values: ``1``, ``true``, ``yes``, ``on``,
+    ``enabled``. Everything else (empty / unset / ``0`` / ``false``
+    / arbitrary other string) is falsy.
+
+    The audit-emitter calls this to decide whether the absence of
+    a resolvable tenant_id should cause emit to return ``False``
+    (enforce mode) or proceed unstamped (single-tenant mode, the
+    v0.5 default).
+    """
+    raw = (os.environ.get(JAMES_REQUIRE_TENANT_ID_ENV) or "").strip().lower()
+    return raw in ("1", "true", "yes", "on", "enabled")
+
+
+__all__ = (
+    "JAMES_TENANT_ID_ENV",
+    "JAMES_REQUIRE_TENANT_ID_ENV",
+    "current_tenant_id",
+    "with_tenant_id",
+    "is_tenant_isolation_enforced",
+)

--- a/tests/test_v05_tenant_id.py
+++ b/tests/test_v05_tenant_id.py
@@ -1,0 +1,311 @@
+"""v0.5 G1.a — tenant_id primitive contract tests.
+
+Covers:
+
+  * `current_tenant_id()` resolution order — override > env > None.
+  * `with_tenant_id()` push/pop semantics + nesting + exception
+    safety + explicit None override.
+  * `is_tenant_isolation_enforced()` truthy / falsy parsing.
+  * Emit integration — explicit kwarg / override / env all stamp;
+    enforce mode rejects unstamped emits; emit returns False when
+    enforce + no tenant resolvable; payload not mutated in place.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+from core.lifecycle.replay_audit import (
+    EVT_SUPERSEDE_EDGE_CREATED,
+    emit_lifecycle_event,
+)
+from core.lifecycle.tenant import (
+    current_tenant_id,
+    is_tenant_isolation_enforced,
+    with_tenant_id,
+)
+
+
+@contextmanager
+def _patched_env(**env: str):
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+
+
+def _make_temp_db_with_audit_schema() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="james-test-")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("""
+            CREATE TABLE audit_log (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp       TEXT NOT NULL,
+                user_role       TEXT,
+                endpoint        TEXT,
+                query           TEXT,
+                answer          TEXT,
+                graph_paths     TEXT,
+                blocked         INTEGER NOT NULL DEFAULT 0,
+                security_event  TEXT,
+                elapsed_sec     REAL,
+                ip_address      TEXT,
+                event_type      TEXT,
+                event_payload   TEXT
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _last_payload(db_path: str, marker: str) -> str:
+    """Fetch the most recent audit_log payload matching `marker`."""
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT event_payload FROM audit_log "
+            "WHERE event_payload LIKE ? "
+            "ORDER BY id DESC LIMIT 1",
+            (f"%{marker}%",),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else ""
+
+
+class CurrentTenantIdResolutionTests(unittest.TestCase):
+    def test_returns_none_when_unset(self):
+        with _patched_env(JAMES_TENANT_ID=None):
+            self.assertIsNone(current_tenant_id())
+
+    def test_env_var_resolved(self):
+        with _patched_env(JAMES_TENANT_ID="tenant_acme"):
+            self.assertEqual(current_tenant_id(), "tenant_acme")
+
+    def test_empty_env_treated_as_none(self):
+        with _patched_env(JAMES_TENANT_ID=""):
+            self.assertIsNone(current_tenant_id())
+
+    def test_whitespace_env_treated_as_none(self):
+        with _patched_env(JAMES_TENANT_ID="   "):
+            self.assertIsNone(current_tenant_id())
+
+    def test_env_whitespace_trimmed(self):
+        with _patched_env(JAMES_TENANT_ID="  acme  "):
+            self.assertEqual(current_tenant_id(), "acme")
+
+
+class WithTenantIdTests(unittest.TestCase):
+    def test_override_takes_precedence_over_env(self):
+        with _patched_env(JAMES_TENANT_ID="env_tenant"):
+            with with_tenant_id("override_tenant"):
+                self.assertEqual(current_tenant_id(), "override_tenant")
+            # After exit, falls back to env.
+            self.assertEqual(current_tenant_id(), "env_tenant")
+
+    def test_nested_override_innermost_wins(self):
+        with with_tenant_id("outer"):
+            with with_tenant_id("inner"):
+                self.assertEqual(current_tenant_id(), "inner")
+            self.assertEqual(current_tenant_id(), "outer")
+
+    def test_explicit_none_override_nulls_env(self):
+        with _patched_env(JAMES_TENANT_ID="env_tenant"):
+            with with_tenant_id(None):
+                self.assertIsNone(current_tenant_id())
+            self.assertEqual(current_tenant_id(), "env_tenant")
+
+    def test_exception_safe_pop(self):
+        # Stack must restore even if the with-block raises.
+        try:
+            with with_tenant_id("doomed"):
+                raise RuntimeError("simulated")
+        except RuntimeError:
+            pass
+        self.assertIsNone(current_tenant_id())
+
+
+class IsTenantIsolationEnforcedTests(unittest.TestCase):
+    def test_default_false(self):
+        with _patched_env(JAMES_REQUIRE_TENANT_ID=None):
+            self.assertFalse(is_tenant_isolation_enforced())
+
+    def test_truthy_values(self):
+        for value in ("1", "true", "yes", "on", "enabled"):
+            with self.subTest(value=value):
+                with _patched_env(JAMES_REQUIRE_TENANT_ID=value):
+                    self.assertTrue(is_tenant_isolation_enforced())
+
+    def test_falsy_values(self):
+        for value in ("0", "false", "no", "off", "disabled", ""):
+            with self.subTest(value=value):
+                with _patched_env(JAMES_REQUIRE_TENANT_ID=value):
+                    self.assertFalse(is_tenant_isolation_enforced())
+
+    def test_arbitrary_value_falsy(self):
+        with _patched_env(JAMES_REQUIRE_TENANT_ID="maybe"):
+            self.assertFalse(is_tenant_isolation_enforced())
+
+
+class EmitIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db_path = _make_temp_db_with_audit_schema()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            os.remove(cls.db_path)
+        except OSError:
+            pass
+
+    def test_explicit_kwarg_stamps_payload(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_k1_" + str(time.time())},
+            db_path=self.db_path,
+            tenant_id="kwarg_tenant",
+        )
+        self.assertTrue(ok)
+        payload = _last_payload(self.db_path, "e_k1_")
+        self.assertIn("kwarg_tenant", payload)
+        self.assertEqual(
+            json.loads(payload)["tenant_id"], "kwarg_tenant",
+        )
+
+    def test_override_stamps_payload_when_kwarg_absent(self):
+        with with_tenant_id("override_tenant"):
+            ok = emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"edge_id": "e_o1_" + str(time.time())},
+                db_path=self.db_path,
+            )
+        self.assertTrue(ok)
+        payload = _last_payload(self.db_path, "e_o1_")
+        self.assertEqual(
+            json.loads(payload)["tenant_id"], "override_tenant",
+        )
+
+    def test_env_stamps_payload_when_kwarg_and_override_absent(self):
+        with _patched_env(JAMES_TENANT_ID="env_tenant"):
+            ok = emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"edge_id": "e_e1_" + str(time.time())},
+                db_path=self.db_path,
+            )
+        self.assertTrue(ok)
+        payload = _last_payload(self.db_path, "e_e1_")
+        self.assertEqual(
+            json.loads(payload)["tenant_id"], "env_tenant",
+        )
+
+    def test_no_stamp_when_nothing_set(self):
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_n1_" + str(time.time())},
+            db_path=self.db_path,
+        )
+        self.assertTrue(ok)
+        payload = _last_payload(self.db_path, "e_n1_")
+        self.assertNotIn("tenant_id", payload)
+
+    def test_enforce_mode_rejects_when_no_tenant_resolvable(self):
+        with _patched_env(JAMES_REQUIRE_TENANT_ID="1",
+                          JAMES_TENANT_ID=None):
+            ok = emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"edge_id": "e_reject"},
+                db_path=self.db_path,
+            )
+        self.assertFalse(ok)
+
+    def test_enforce_mode_succeeds_with_explicit_kwarg(self):
+        with _patched_env(JAMES_REQUIRE_TENANT_ID="1",
+                          JAMES_TENANT_ID=None):
+            ok = emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"edge_id": "e_enforce_kwarg"},
+                db_path=self.db_path,
+                tenant_id="explicit",
+            )
+        self.assertTrue(ok)
+
+    def test_enforce_mode_succeeds_with_env(self):
+        with _patched_env(JAMES_REQUIRE_TENANT_ID="1",
+                          JAMES_TENANT_ID="env_t"):
+            ok = emit_lifecycle_event(
+                EVT_SUPERSEDE_EDGE_CREATED,
+                {"edge_id": "e_enforce_env"},
+                db_path=self.db_path,
+            )
+        self.assertTrue(ok)
+
+    def test_caller_payload_not_mutated(self):
+        caller_payload = {"edge_id": "e_purity_" + str(time.time())}
+        emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            caller_payload,
+            db_path=self.db_path,
+            tenant_id="t",
+        )
+        self.assertNotIn("tenant_id", caller_payload)
+
+    def test_tenant_id_composes_with_retention_class(self):
+        from core.lifecycle.retention import RETENTION_7Y
+        ok = emit_lifecycle_event(
+            EVT_SUPERSEDE_EDGE_CREATED,
+            {"edge_id": "e_combo_" + str(time.time())},
+            db_path=self.db_path,
+            retention_class=RETENTION_7Y,
+            tenant_id="combo_tenant",
+        )
+        self.assertTrue(ok)
+        payload = _last_payload(self.db_path, "e_combo_")
+        parsed = json.loads(payload)
+        self.assertEqual(parsed["retention_class"], RETENTION_7Y)
+        self.assertEqual(parsed["tenant_id"], "combo_tenant")
+
+
+class ThreadLocalIsolationTests(unittest.TestCase):
+    def test_override_does_not_leak_across_threads(self):
+        results = {}
+
+        def worker():
+            results["thread"] = current_tenant_id()
+
+        with with_tenant_id("main_thread_tenant"):
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+        # Main thread set override; worker thread should NOT see it.
+        self.assertIsNone(results["thread"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §3 — **first sub-PR of the G1 SaaS-readiness contract**. Mother-level, additive, env-driven, **default-off → byte-identical pre-G1.a behaviour**.

### New module — `core/lifecycle/tenant.py` (~5.4 KB)

| Symbol | Purpose |
|---|---|
| `current_tenant_id() → Optional[str]` | Resolves from thread-local override stack OR `JAMES_TENANT_ID` env. None if neither. |
| `with_tenant_id(tenant_id)` | Context manager. Thread-local override stack. Nests (innermost wins). Explicit `None` nulls env. Exception-safe pop. |
| `is_tenant_isolation_enforced() → bool` | True iff `JAMES_REQUIRE_TENANT_ID` is set to `1`/`true`/`yes`/`on`/`enabled`. |

### Emit-side wire-in (`replay_audit.py`)

`emit_lifecycle_event(..., tenant_id=None)` — new keyword-only parameter. Resolution order:

1. Explicit kwarg
2. `with_tenant_id()` override stack
3. `JAMES_TENANT_ID` env var
4. None (single-tenant mode, v0.5 default)

When `is_tenant_isolation_enforced()` AND resolution yields no tenant_id → emit returns False (no row written). Pattern mirrors G4 retention_class (PR #848). **No schema migration** — stamped inside `event_payload` JSON. Composes with retention_class.

### What this PR does NOT do

- **No replay-side filter** — G1.b separate PR after dogfooding signal.
- **No asyncio-task-aware override** — `threading.local` only. Documented in module docstring; asyncio variant in G1.b.
- **No HTTP-layer RBAC** — JAMES still defers to reverse proxy.

## Tests (`tests/test_v05_tenant_id.py`)

**23 tests across 5 classes**:

- CurrentTenantIdResolutionTests (5) — None / env / empty / whitespace
- WithTenantIdTests (4) — override precedence + nesting + explicit None + exception-safe pop
- IsTenantIsolationEnforcedTests (4) — default / truthy / falsy / arbitrary
- EmitIntegrationTests (9) — all 3 resolution paths stamp; enforce-mode reject; payload not mutated; composes with retention_class
- ThreadLocalIsolationTests (1) — override does not leak across threads

## Verification

- `pytest tests/test_v05_tenant_id.py`: **23 passed**
- Full v0.5 + lifecycle regression sweep: **213 passed**
- `ruff check`: clean
- Module sizes: tenant.py 5.4 KB (new); replay_audit.py 10.6 KB (+1.1 KB)

## Out of scope

- G1.b replay-side filter — separate PR.
- G1.c enforce-by-default in SaaS deployment doc — post-LOI.
- G2 approver evidence (B.2 §4) — separate cycle.
- Asyncio-task-aware override — G1.b candidate.
- Vertical-pack-specific tenant rules — BLOCKED per CLAUDE.md rule #1.

Quality delta: exempt (label: external-mother-platform — additive audit-emitter primitive; default-off behaviour byte-identical to pre-PR)