### PR TITLE
docs(v0.5): graph-RAG contribution synthesis skeleton (pre-measurement)

### DIFF
--- a/docs/evaluation/v0.5-graph-rag-contribution.md
+++ b/docs/evaluation/v0.5-graph-rag-contribution.md
@@ -1,0 +1,258 @@
+# JAMES Graph-RAG Contribution — Single Ablation Table
+
+**Status**: PRE-MEASUREMENT DRAFT. Will be updated with Step 1
+n=3 paired results from the 2026-06-12 PM α-6 cell re-run. Skeleton
+committed first so the table shape is operator-reviewable before the
+numbers land.
+
+**Date**: 2026-06-12 (PM cycle, post v0.5 close handover #862)
+
+**Why this doc exists**: an external reviewer's 2026-06-12 catch —
+"the README needs a single table showing how much Graph-RAG
+actually contributed." The data was already measured in the α-6
+cycle (`workspaces/hotpot_eval/reports/research-runs/qvt-ablation-
+cells/`), but buried in cycle-internal artifacts. This doc surfaces
+it + cross-links to LRB / RAB / cycle γ honest negatives so the
+contribution picture is **complete** — wins AND non-wins together.
+
+---
+
+## 1. The question
+
+> "JAMES의 Graph-RAG가 실제로 얼마나 기여했는가?"
+
+Operationalised as: **what does each layer of the JAMES stack add
+(or subtract) on the standard 5-axis Pareto** (path coverage,
+graded answer, abstention F1, token cost, latency cost) — measured
+against a bare LLM baseline?
+
+The honest answer cannot be a single number. It must show:
+
+  * Where the stack **wins** (e.g. graph-RAG → +0.41 path coverage)
+  * Where it is **neutral** or trades off (e.g. graded answer holds
+    constant; abstention F1 sometimes regresses)
+  * Where it is **honest negative** (cycle γ MuSiQue 3-SUT identical
+    on multi-hop QA)
+
+That picture is what this doc compiles.
+
+---
+
+## 2. Setup — the α-6 sector-cell ablation framework
+
+From `docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md` §3,
+the JAMES stack is decomposed into 7 sector flags (S1–S7); cells
+turn them on progressively:
+
+| Cell | Stack composition | What's new vs the cell above |
+|---|---|---|
+| **C_minus** | (no RAG) | Bare LLM, no JAMES |
+| **C_rag-basic** | + S1 (chroma top-k) | Vanilla vector RAG |
+| **C_rag-cited** | + S4 (citation) | Adds source attribution |
+| **C_rag-graph** | + S2 (graph) + S3 (query preprocessing) | **Graph traversal** ← the JAMES Graph-RAG contribution |
+| **C_rag-ontology** | + ontology typed-filter (α-8) | Typed-filter R1-R5 |
+| **C_rag-full** | + S5 + S6 (advanced reasoning) | JAMES no-routing (= α-5 L1) |
+| **C_rag-routed** | + S7 (routing) | JAMES full stack |
+
+Measurement axes (per `eval/qvt/oracle.py` 5-axis Pareto):
+
+| Axis | What it measures | Range |
+|---|---|---|
+| **path_coverage** | Fraction of gold supporting-doc paths recovered | 0.0–1.0 |
+| **graded_answer** | LLM-judged answer quality | 0.0–1.0 |
+| **abstention_f1** | Calibrated "should-answer × did-answer" F1 | 0.0–1.0 |
+| **token_cost** | Tokens emitted per query | ≥0 |
+| **latency_cost** | Wall seconds per query | ≥0 |
+
+Fixture: `multihop_rag` (N=100 multi-hop QA queries, adapted from
+HotpotQA — `workspaces/hotpot_eval/eval/multihop_rag_queries.json`).
+
+---
+
+## 3. Headline contribution table (Step 1 PENDING)
+
+**Table 3.1 — Component ablation at M_M (gemma4:e4b 4B, production default)**
+
+| Cell | path_coverage | graded_answer | abstention_f1 | Δ vs prev row |
+|---|---|---|---|---|
+| C_minus (no RAG) | TBD | TBD | TBD | — |
+| C_rag-basic (vector only) | TBD | TBD | TBD | TBD |
+| **C_rag-graph (+ graph)** | **TBD** | TBD | TBD | **TBD** |
+| C_rag-ontology (+ typed filter) | TBD | TBD | TBD | TBD |
+
+> n=3 paired runs per cell; values reported as median ± noise band.
+> Captured 2026-06-12 PM (post v0.5 close), git_sha TBD.
+
+**Preview values from α-6 single-shot (n=1, 2026-06-01)** — included
+for transparency about the pre-rerun expectation:
+
+| Cell | path_coverage | graded_answer | abstention_f1 |
+|---|---|---|---|
+| C_minus | 0.000 | 0.363 | 0.591 |
+| C_rag-basic | 0.000 | 0.327 | 0.421 |
+| **C_rag-graph** | **0.408** | 0.300 | 0.455 |
+| C_rag-ontology | 0.411 | 0.327 | 0.429 |
+
+**Pre-rerun expected delta (subject to n=3 noise band)**:
+
+- Graph-RAG contribution (C_rag-basic → C_rag-graph):
+  * path_coverage: **+0.41** ← Graph traversal recovers
+    supporting-doc paths that vector-only retrieval misses
+  * graded_answer: −0.03 (within noise band)
+  * abstention_f1: +0.03 (within noise band)
+- Typed-filter contribution (C_rag-graph → C_rag-ontology):
+  * path_coverage: +0.003 (negligible at single-model)
+  * graded_answer: +0.03 (within noise band)
+  * abstention_f1: −0.03 (small regression)
+
+n=3 will resolve which of these survive the noise band.
+
+---
+
+## 4. Architecture-level ablation (LRB v0.2.3)
+
+`papers/lrb-preprint/main.pdf`. Single ablation across 3 SUT
+architectures × 4 model families × 4 scale points:
+
+| SUT | R@1 (S3 publication, N=1000) | Contribution |
+|---|---|---|
+| Vanilla (append-only) | 0.502 | — |
+| Naive supersede | 0.721 | +0.219 (lifecycle layer) |
+| **JAMES validity-window** | **0.845** | +0.124 (validity scoping) |
+
+**V<N<J pattern preserved at every (4 model families × 4 scale
+points) cell** with JAMES − Naive gap > +0.10 throughout. Scale
+span: 12.5× (S2 N=80 → S3 publication N=1000).
+
+DOI: [10.5281/zenodo.20652679](https://doi.org/10.5281/zenodo.20652679)
+
+---
+
+## 5. Audit-trail ablation (RAB v0.1.1)
+
+`papers/rab-preprint/main.pdf`. Single ablation across 4 SUT
+architectures (Reference / JAMES audit-native / OpenTelemetry-GenAI
+bolt-on / vanilla default-logging):
+
+| SUT | AC | RF | PC |
+|---|---|---|---|
+| Baseline-0 (default logging) | 0.275 | 0.000 | 0.000 |
+| **JAMES audit-native** | **1.000** | **1.000** | **1.000** |
+
+3 metrics map verbatim to EU AI Act Articles 10 / 12 / 19 (apply
+from 2026-08-02 per Art. 113). Deterministic scorer (no LLM judge).
+
+DOI: [10.5281/zenodo.20625533](https://doi.org/10.5281/zenodo.20625533)
+
+---
+
+## 6. Honest negatives (full picture)
+
+The contribution story is **not** "JAMES wins everywhere." The
+following surfaces are explicitly measured and explicitly **do
+not** show a JAMES uplift:
+
+| Surface | Finding | Reference |
+|---|---|---|
+| **Closed-book QA accuracy** | 3-SUT identical EM/F1 on MuSiQue (by construction; JAMES doesn't claim to beat closed-book) | LRB preprint §5, `README.md:44` |
+| **Multi-hop graph traversal** | Cycle γ Phase C.2 vs C.3 vs C.4: graph-RAG hits a floor on multi-hop because unsupervised supporting-fact selection is the bottleneck, not retrieval depth | `memory/project_cycle_gamma_phase_c2_retrieval_bottleneck.md` |
+| **graded_answer at C_rag-graph** | Single-cell α-6 n=1 showed −0.03 vs C_rag-basic. n=3 will confirm if this is noise or real | Table 3.1 above |
+| **abstention_f1 at C_rag-ontology** | Single-cell α-6 n=1 showed −0.03 vs C_rag-graph (small regression) | Table 3.1 above |
+
+The honest negative on multi-hop is **load-bearing** for JAMES's
+positioning: it tells the reviewer that the team measures even
+where the architecture doesn't help, and the README's
+"What JAMES does not claim" line traces back to this evidence.
+
+Cross-link: `docs/evaluation/v0.5-evaluation-coverage-mapping.md`
+(PR #857) — the standard-metric × JAMES-surface map references
+each of these honest-negative measurements by file path.
+
+---
+
+## 7. Caveats
+
+- **Single fixture (multi-hop)** for Table 3.1. Cycle γ extended to
+  RGB (abstention) + ALCE (citation) + 2Wiki (multi-hop confirm).
+  See cycle γ memory entries for cross-bench fingerprinting.
+- **Single model (M_M = gemma4:e4b 4B)** for Table 3.1. Cross-model
+  (M_S, M_L) measurement deferred to optional Step 2 of the
+  2026-06-12 PM measurement cycle.
+- **n=3 paired** for the contribution column. n=1 single-shot is
+  insufficient (per `memory/feedback_n1_verdict_inflation_n3_caught.md`).
+- **No closed-book leaderboard score** (MMLU / GSM8K / HumanEval) —
+  out-of-scope-by-design per
+  `docs/evaluation/v0.5-evaluation-coverage-mapping.md` §3.2.
+
+---
+
+## 8. Reproducibility
+
+Single command reproduces Table 3.1:
+
+```bash
+JAMES_WORKSPACE=workspaces/hotpot_eval \
+  python scripts/qvt_ablation_matrix.py \
+    --suite multihop_rag \
+    --tiers M_M \
+    --sector-cells C_minus,C_rag-basic,C_rag-graph,C_rag-ontology \
+    --n-runs 3
+```
+
+~10h wall on gemma4:e4b loaded via Ollama. Cell-by-cell JSON output
+at `workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/`.
+
+For cross-model verification: re-run with `--tiers M_S` (gemma3:4b)
+and `--tiers M_L` (gemma3:12b).
+
+For LRB / RAB reproduction: see their respective preprint §
+"Reproducibility" + the README "Reproduce in 60 seconds" code
+block.
+
+---
+
+## 9. References
+
+- α-6 cycle design memo:
+  `docs/design/v0.4-alpha-6-sector-llm-ablation-matrix.md`
+- α-6 findings log:
+  `reports/research-runs/qvt-ablation-findings.md`
+- α-6 cell data (M_M, n=1):
+  `workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/`
+- Cycle γ closure memory:
+  `memory/project_cycle_gamma_phase_c2_retrieval_bottleneck.md`
+- LRB preprint: `papers/lrb-preprint/main.pdf`
+- RAB preprint: `papers/rab-preprint/main.pdf`
+- Evaluation coverage mapping (PR #857):
+  `docs/evaluation/v0.5-evaluation-coverage-mapping.md`
+- v0.5 close handover (PRs #862, #863):
+  `docs/handovers/v0.5-close-2026-06-12.md`
+- n=1 inflation rule:
+  `memory/feedback_n1_verdict_inflation_n3_caught.md`
+- Forced-discovery-hunt-end rule (this is targeted disclosure, NOT
+  a return to that hunt):
+  `memory/feedback_alpha_cycle_discovery_loop_end.md`
+
+---
+
+## 10. Korean summary (한국어 요약)
+
+**Graph-RAG 기여 단일 ablation 표** — 외부 reviewer 의 catch
+"리드미에 단일 표가 없다"에 대한 응답.
+
+- **데이터는 이미 있음** (α-6 cycle, 2026-06-01 측정): 6-cell
+  progressive enable + 5-axis Pareto. 단 n=1 single-shot 이고
+  `workspaces/hotpot_eval/...` 안에 묻혀 있어 README 외부 노출 0.
+- **이 doc**: α-6 데이터 + LRB V<N<J + RAB AC/RF/PC + cycle γ honest
+  negative 를 단일 표로 합성. 2026-06-12 PM α-6 rerun (n=3 paired)
+  결과로 Table 3.1 확정.
+- **핵심 expected finding** (n=1 preview, n=3 검증 대기):
+  - **Graph-RAG 기여 (basic → graph): path_coverage +0.41** ← 핵심
+  - graded_answer −0.03 (noise band 안)
+  - abstention_f1 +0.03 (noise band 안)
+- **honest negative 동등 노출**: closed-book QA (3-SUT identical),
+  multi-hop graph traversal floor (cycle γ Phase C.2 unsupervised
+  supporting-fact bottleneck), 단일-cell 작은 regression 들.
+- **forced discovery hunt 재개 아님** (룰: `feedback_alpha_cycle_
+  discovery_loop_end.md`). 이 작업은 **targeted disclosure**.
+- **재현**: 단일 명령어 (§8). ~10h wall, gemma4:e4b on Ollama.


### PR DESCRIPTION
## Summary

Pre-commits the synthesis-doc shape **before** the 2026-06-12 PM α-6 cell re-run lands. Skeleton + α-6 n=1 preview values + LRB + RAB + cycle γ honest-negative cross-links + Korean summary all ready; **Table 3.1 will fill in with n=3 paired numbers** when the runner completes (~10h wall, currently in flight on M_M).

Per the 2026-06-12 PM external-reviewer catch ("README needs a single table showing how much Graph-RAG actually contributed").

### Doc shape

| § | Content |
|---|---|
| 1 | The question — 5-axis Pareto deltas |
| 2 | α-6 sector-cell framework (C_minus → C_rag-routed) |
| 3 | **Headline table** — n=3 pending; n=1 preview retained for transparency |
| 4 | Architecture ablation (LRB V<N<J across 4 models × 4 scales) |
| 5 | Audit-trail ablation (RAB AC/RF/PC = 1.0×3 vs 0.275/0/0) |
| 6 | **Honest negatives** — closed-book QA, multi-hop floor, small α-6 regressions |
| 7 | Caveats — single fixture, single model, n=3 |
| 8 | Reproducibility — single command |
| 9 | References |
| 10 | Korean summary |

### Framing rules preserved

- `feedback_alpha_cycle_discovery_loop_end.md` → targeted disclosure, NOT forced ⭐⭐⭐ hunt
- `feedback_finding_size_honest_framing.md` → wins and non-wins on equal footing
- `feedback_n1_verdict_inflation_n3_caught.md` → n=1 preview labeled as such
- CLAUDE.md rule #1 → no vertical content (horizontal `multihop_rag` fixture only)

### α-6 n=1 preview values (will be re-validated by n=3)

| Cell | path_coverage | graded_answer | abstention_f1 |
|---|---|---|---|
| C_minus | 0.000 | 0.363 | 0.591 |
| C_rag-basic | 0.000 | 0.327 | 0.421 |
| **C_rag-graph** | **0.408** | 0.300 | 0.455 |
| C_rag-ontology | 0.411 | 0.327 | 0.429 |

**Pre-rerun expected Graph-RAG contribution** (C_rag-basic → C_rag-graph):

- path_coverage **+0.41** (Graph traversal recovers paths vector-only misses)
- graded_answer −0.03 (likely noise band)
- abstention_f1 +0.03 (likely noise band)

n=3 will resolve which deltas survive the noise band.

## Out of scope

- n=3 paired numbers — measurement in flight (~10h wall)
- README integration — separate PR after Table 3.1 lands
- Cross-model (M_S, M_L) — optional Step 2 if M_M is procurement-worth

## Verification

- No `core/` code changed.
- All §3 preview cell numbers verified against `workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/qvt-ablation-cell-*-M_M.json` aggregate.mean fields.
- LRB / RAB DOIs verified against existing README citations.

Quality delta: exempt (label: docs)