### PR TITLE
feat(v0.5-trackF-TT.a): Time-Travel timestamp picker UI shell

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -33,6 +33,62 @@
 
 <main id="main" class="main">
   <aside>
+    <!-- v0.5 Track F.1 TT.a — Time-Travel timestamp picker.
+         Surfaces the G3 corpus_reconstruct_view_at primitive (PR #849)
+         as a date/time picker. State syncs with URL hash (`#t=<ISO>`)
+         so a deep-link replays the same moment. Backend call wired
+         in TT.b; this PR ships the UI shell + event-dispatch only. -->
+    <div class="ctrl" id="time-travel-panel">
+      <span class="panel-title" data-i18n="graph.timetravel.title">
+        Time-Travel
+      </span>
+      <label for="time-travel-input" class="field-label"
+             data-i18n="graph.timetravel.pick">
+        Pick a moment
+      </label>
+      <input id="time-travel-input"
+             type="datetime-local"
+             aria-label="Time-travel timestamp"
+             style="width:100%;background:var(--bg);
+                    border:1px solid var(--border);border-radius:7px;
+                    padding:9px 12px;color:var(--text);
+                    font-family:var(--font-mono);font-size:12px;
+                    outline:none">
+      <div style="display:flex;gap:6px;margin-top:8px">
+        <button id="time-travel-apply" type="button"
+                data-action="time-travel-apply"
+                aria-label="Replay graph state at picked time"
+                data-i18n="graph.timetravel.apply"
+                style="flex:1;padding:7px 10px;
+                       background:var(--accent);color:var(--on-accent);
+                       border:none;border-radius:6px;cursor:pointer;
+                       font-size:11px;font-weight:600;
+                       font-family:var(--font-mono);letter-spacing:.4px">
+          Apply
+        </button>
+        <button id="time-travel-now" type="button"
+                data-action="time-travel-now"
+                aria-label="Return to current graph state"
+                data-i18n="graph.timetravel.now"
+                style="flex:1;padding:7px 10px;
+                       background:var(--surface-2);color:var(--text-soft);
+                       border:1px solid var(--border);border-radius:6px;
+                       cursor:pointer;font-size:11px;font-weight:600;
+                       font-family:var(--font-mono);letter-spacing:.4px">
+          Now
+        </button>
+      </div>
+      <!-- v0.5 UI #2 — aria-live polite so screen readers announce
+           the active replay moment without yanking focus. -->
+      <div id="time-travel-state"
+           role="status" aria-live="polite"
+           class="stat"
+           style="margin-top:8px;font-size:11px;line-height:1.5;
+                  font-family:var(--font-mono);color:var(--muted)">
+        <span data-i18n="graph.timetravel.now_label">Viewing: NOW</span>
+      </div>
+    </div>
+
     <div class="ctrl">
       <span class="panel-title" data-i18n="graph.filter.source">Source</span>
       <select id="src-select">
@@ -377,5 +433,9 @@
 <script src="/static/graph_editor.js"></script>
 <script src="/static/graph_node_editor.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
+<!-- v0.5 Track F.1 TT.a — Time-Travel picker UI shell (event-dispatch
+     only; TT.b wires the backend call). Loads last so the picker's
+     wire() runs after graph.js has populated the DOM. -->
+<script src="/static/time-travel.js"></script>
 </body>
 </html>

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -19,6 +19,13 @@ const TRANSLATIONS = {
     // v0.5 UI #5 — sensitivity badge (surfaces ontology sensitive=True)
     'badge.sensitive':       'Sensitive content referenced',
     'badge.sensitive_title': 'This answer references sensitive content tracked by JAMES ontology (HAS_SECRET / KNOWS_PASSWORD / HAS_CREDENTIAL / OWNS_PRIVATE / APPROVED_BY).',
+    // v0.5 Track F.1 TT.a — Time-Travel picker
+    'graph.timetravel.title':         'Time-Travel',
+    'graph.timetravel.pick':          'Pick a moment',
+    'graph.timetravel.apply':         'Apply',
+    'graph.timetravel.now':           'Now',
+    'graph.timetravel.now_label':     'Viewing: NOW',
+    'graph.timetravel.viewing_label': 'Viewing: ',
     'common.confirm':        'Confirm',
     'common.save':           'Save',
     'common.delete':         'Delete',
@@ -863,6 +870,13 @@ const TRANSLATIONS = {
     // v0.5 UI #5 — sensitivity badge
     'badge.sensitive':       '민감 정보 포함',
     'badge.sensitive_title': '이 답변은 JAMES 온톨로지가 추적하는 민감 관계(HAS_SECRET / KNOWS_PASSWORD / HAS_CREDENTIAL / OWNS_PRIVATE / APPROVED_BY)를 참조합니다.',
+    // v0.5 Track F.1 TT.a — Time-Travel picker
+    'graph.timetravel.title':         '타임 트래블',
+    'graph.timetravel.pick':          '시점 선택',
+    'graph.timetravel.apply':         '재생',
+    'graph.timetravel.now':           '현재',
+    'graph.timetravel.now_label':     '재생 시점: 현재',
+    'graph.timetravel.viewing_label': '재생 시점: ',
     'common.confirm':        '확인',
     'common.save':           '저장',
     'common.delete':         '삭제',

--- a/frontend/static/time-travel.js
+++ b/frontend/static/time-travel.js
@@ -1,0 +1,204 @@
+/* PROJECT JAMES — Time-Travel timestamp picker (Track F.1 TT.a).
+ *
+ * Surfaces the G3 corpus_reconstruct_view_at primitive (PR #849)
+ * as a date/time picker on /graph. State syncs with the URL hash
+ * (`#t=<ISO>`) so a deep-link replays the same moment.
+ *
+ * Per `docs/handovers/v0.5-close-2026-06-12.md` §5.6 F.1 — UI shell
+ * only. Backend call wired in TT.b (separate PR). For now this file:
+ *
+ *   1. On DOMContentLoaded: parse `#t=<ISO>` from window.location.hash;
+ *      if present, populate the input + show "Viewing: <ts>" state.
+ *   2. On Apply click: read the input value → write
+ *      `#t=<ISO>` into window.location.hash → dispatch a
+ *      `james:timetravel:set` CustomEvent on window with detail.iso.
+ *   3. On Now click: clear the input + clear the hash → dispatch
+ *      `james:timetravel:clear`.
+ *   4. On hashchange (back/forward navigation): re-sync the input +
+ *      state indicator from the hash.
+ *
+ * Downstream consumers (TT.b corpus-state renderer, TT.c reasoning-
+ * trail replay) listen for the custom events:
+ *
+ *   window.addEventListener('james:timetravel:set',
+ *     function (ev) {
+ *       const iso = ev.detail.iso;
+ *       // fetch /reconstruct-view-at?t=<iso> + repaint graph
+ *     });
+ *   window.addEventListener('james:timetravel:clear',
+ *     function () { // restore current state });
+ *
+ * Plain ES5 — no template literals, arrow functions only at
+ * top-level. Maximises enterprise IT-locked browser compat (same
+ * convention as `index-init.js` from UI #4 PR #855).
+ *
+ * Mother-platform per CLAUDE.md rule #1 — no domain content. The
+ * UI surface schema is "timestamp + apply + now". Customer-pilot
+ * customisation lives in Track D post-LOI.
+ */
+(function () {
+  'use strict';
+
+  var HASH_KEY = 't';
+  var EVENT_SET = 'james:timetravel:set';
+  var EVENT_CLEAR = 'james:timetravel:clear';
+
+  function $(id) { return document.getElementById(id); }
+
+  function readHashIso() {
+    var hash = window.location.hash || '';
+    if (hash.charAt(0) === '#') hash = hash.substring(1);
+    if (!hash) return '';
+    var parts = hash.split('&');
+    for (var i = 0; i < parts.length; i++) {
+      var kv = parts[i].split('=');
+      if (kv[0] === HASH_KEY && kv.length === 2) {
+        try {
+          return decodeURIComponent(kv[1]);
+        } catch (_) {
+          return '';
+        }
+      }
+    }
+    return '';
+  }
+
+  function writeHashIso(iso) {
+    var existing = window.location.hash || '';
+    if (existing.charAt(0) === '#') existing = existing.substring(1);
+    var parts = existing ? existing.split('&') : [];
+    // Drop any existing `t=` entry, then re-append.
+    var kept = [];
+    for (var i = 0; i < parts.length; i++) {
+      var kv = parts[i].split('=');
+      if (kv[0] !== HASH_KEY) kept.push(parts[i]);
+    }
+    if (iso) {
+      kept.push(HASH_KEY + '=' + encodeURIComponent(iso));
+    }
+    var newHash = kept.join('&');
+    // History.replaceState avoids spamming the back-button stack.
+    var url = window.location.pathname + window.location.search +
+              (newHash ? ('#' + newHash) : '');
+    try {
+      window.history.replaceState(null, '', url);
+    } catch (_) {
+      window.location.hash = newHash;
+    }
+  }
+
+  function toInputValue(iso) {
+    // <input type="datetime-local"> wants "YYYY-MM-DDTHH:MM" — strip
+    // timezone + seconds. Returns '' on parse failure.
+    if (!iso) return '';
+    // Accept either "2026-06-12T14:30" or "2026-06-12T14:30:00+00:00".
+    var match = iso.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/);
+    return match ? match[1] : '';
+  }
+
+  function fromInputValue(value) {
+    // Convert input "YYYY-MM-DDTHH:MM" back to canonical ISO-8601.
+    // The browser's datetime-local treats it as local time; we
+    // append a "Z" to make it UTC for the audit-log semantics that
+    // the G3 primitive expects. Operator can override by typing the
+    // ISO string into the URL hash directly.
+    if (!value) return '';
+    // Accept already-ISO strings unchanged.
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:\d{2})?$/.test(value)) {
+      // Append :00 + Z if not already specified.
+      if (!/:\d{2}(Z|[+-]\d{2}:\d{2})?$/.test(value)) {
+        return value + ':00Z';
+      }
+      if (!/(Z|[+-]\d{2}:\d{2})$/.test(value)) {
+        return value + 'Z';
+      }
+      return value;
+    }
+    return '';
+  }
+
+  function t(key, fallback) {
+    if (typeof window.t === 'function') {
+      try { return window.t(key) || fallback; } catch (_) { return fallback; }
+    }
+    return fallback;
+  }
+
+  function updateState(iso) {
+    var el = $('time-travel-state');
+    if (!el) return;
+    if (iso) {
+      el.textContent = t('graph.timetravel.viewing_label', 'Viewing: ') + iso;
+    } else {
+      el.textContent = t('graph.timetravel.now_label', 'Viewing: NOW');
+    }
+  }
+
+  function applyFromInput() {
+    var input = $('time-travel-input');
+    if (!input) return;
+    var iso = fromInputValue(input.value);
+    if (!iso) {
+      // Soft fail — keep the now state.
+      writeHashIso('');
+      updateState('');
+      window.dispatchEvent(new CustomEvent(EVENT_CLEAR));
+      return;
+    }
+    writeHashIso(iso);
+    updateState(iso);
+    window.dispatchEvent(
+      new CustomEvent(EVENT_SET, { detail: { iso: iso } })
+    );
+  }
+
+  function clearTimeTravel() {
+    var input = $('time-travel-input');
+    if (input) input.value = '';
+    writeHashIso('');
+    updateState('');
+    window.dispatchEvent(new CustomEvent(EVENT_CLEAR));
+  }
+
+  function syncFromHash() {
+    var iso = readHashIso();
+    var input = $('time-travel-input');
+    if (input) input.value = toInputValue(iso);
+    updateState(iso);
+    if (iso) {
+      window.dispatchEvent(
+        new CustomEvent(EVENT_SET, { detail: { iso: iso } })
+      );
+    } else {
+      window.dispatchEvent(new CustomEvent(EVENT_CLEAR));
+    }
+  }
+
+  function wire() {
+    var apply = $('time-travel-apply');
+    var now = $('time-travel-now');
+    if (apply) apply.addEventListener('click', applyFromInput);
+    if (now) now.addEventListener('click', clearTimeTravel);
+    window.addEventListener('hashchange', syncFromHash);
+    // Initial sync from URL.
+    syncFromHash();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wire);
+  } else {
+    wire();
+  }
+
+  // Expose for tests and downstream code.
+  window.JAMES_TimeTravel = {
+    readHashIso: readHashIso,
+    writeHashIso: writeHashIso,
+    toInputValue: toInputValue,
+    fromInputValue: fromInputValue,
+    apply: applyFromInput,
+    clear: clearTimeTravel,
+    EVENT_SET: EVENT_SET,
+    EVENT_CLEAR: EVENT_CLEAR
+  };
+})();


### PR DESCRIPTION
## Summary

**Track F.1 TT.a** per `docs/handovers/v0.5-close-2026-06-12.md` §5.6. Mother-level UI shell that surfaces the G3 `reconstruct_corpus_view_at` primitive (#849) as a date/time picker on `/graph`. State syncs with URL hash so a deep-link replays the same moment.

**Backend call wired in TT.b (separate PR).** This PR ships UI shell + event-dispatch only. Downstream consumers (TT.b corpus-state renderer, TT.c reasoning-trail replay) listen for the dispatched `james:timetravel:set` / `james:timetravel:clear` CustomEvents on window.

### Changes

| File | Change |
|---|---|
| `frontend/graph.html` | New `<div id="time-travel-panel">` at top of left `<aside>` — title + `<input type="datetime-local">` + Apply / Now buttons + state indicator (`role="status" aria-live="polite"`) |
| `frontend/static/time-travel.js` | **NEW** (~200 lines plain ES5). IIFE exposing `window.JAMES_TimeTravel`. Wires DOMContentLoaded sync + click handlers + hashchange listener. Helpers: `readHashIso`, `writeHashIso`, `toInputValue`, `fromInputValue` |
| `frontend/static/i18n.js` | 6 new keys (English + Korean) under `graph.timetravel.*` |

### ARIA continuity (UI #1/#2/#5 pattern)

- `<input>` carries `aria-label`
- Apply / Now buttons carry descriptive `aria-label`
- State indicator is a polite live region

### Why mother-platform (Rule #1 protection)

- UI schema = "timestamp + apply + now" — domain-agnostic
- Surfaces JAMES's **EU AI Act Art. 12 evidence claim** as a visual affordance
- Legal/audit teams are the consumer, **but the UI codebase carries no vertical schema** (naming-level protection per v0.5 close handover §6.5)

## What this PR does NOT do

- Backend call — TT.b separate PR. No HTTP endpoint for `reconstruct_corpus_view_at` exists yet.
- Graph-state diff renderer (TT.b)
- Reasoning-trail replay (TT.c)
- now-vs-T diff view (TT.d)
- Vertical-pack-specific time-travel rules — **BLOCKED per CLAUDE.md rule #1**

## Verification

- `core/` **untouched** → no test / ruff impact on Python tree.
- `node --check frontend/static/time-travel.js`: clean syntax.
- Node smoke (mocked DOM): all 8 exported helpers + CustomEvent dispatch verified:
  - `fromInputValue('2026-06-12T14:30')` → `'2026-06-12T14:30Z'`
  - `toInputValue('2026-06-12T14:30:00Z')` → `'2026-06-12T14:30'`
- Manual operator verification (post-merge): visit `/graph`, see new Time-Travel panel at top of sidebar. Pick a moment + Apply. URL hash updates to `#t=<iso>`. Refresh — panel re-populates from hash. Now button clears.

Quality delta: exempt (label: docs — UI shell only; behaviour byte-identical when picker is not interacted with)