### PR TITLE
feat(v0.6-G8.a): ontology pack mount skeleton + capability gate

### DIFF
--- a/core/ontology_packs.py
+++ b/core/ontology_packs.py
@@ -1,0 +1,361 @@
+"""v0.6 G8.a — ontology pack mount mechanism (mother-platform).
+
+Per `docs/reviews/v0.5-b3-plugin-api-stability.md` §4. Mother-level
+implementation of the B.3 design memo's pack mount surface. Ships
+the **mechanism only** — `rule_one_exemption_granted` capability is
+default empty so packs cannot mount, and `core/ontology.py` stays
+the runtime ontology source until an explicit operator grant + LOI
+scoping unlocks the gate (G8.d, separate PR).
+
+## What this module ships
+
+  * `OntologyPack` — frozen dataclass describing a pack
+    (pack_id, capability requirement, subtypes, relation_types,
+    enterprise_roles, label_to_type, since, provenance).
+  * `register_pack(pack)` — mount a pack into the in-memory
+    registry. Raises `CapabilityNotGrantedError` /
+    `NameCollisionError` / `SchemaError` on contract violations.
+  * `unmount_pack(pack_id)` — remove a previously-mounted pack.
+  * `mounted_packs()` — deterministic snapshot of currently-
+    mounted packs (registration order).
+  * `granted_capabilities()` — operator-grantable capability set
+    (driven by `JAMES_CAPABILITIES` env). Default empty.
+
+## What this module does NOT do (deferred to G8.b / G8.c / G8.d)
+
+- **No read-side lookup helpers** — `all_document_subtypes()` /
+  `all_relation_types()` lookup merging mother + mounted packs
+  lands in G8.b.
+- **No audit-replay event types** — `lifecycle.ontology.pack_
+  mounted` / `_unmounted` + `reconstruct_graph_at` dispatch lands
+  in G8.c.
+- **No capability grant workflow** — interactive `grant_capability`
+  CLI with operator confirmation + audit-row writing lands in
+  G8.d. **G8.d is LOI-conditional** — until a customer LOI scopes
+  the vertical pack, the capability grant flow cannot ship without
+  bypassing CLAUDE.md rule #1.
+
+## Rule #1 protection (per v0.5 close handover §6.5)
+
+1. **Code-level**: this module's `_resolve_granted_capabilities()`
+   returns the EMPTY frozenset by default. `register_pack`
+   refuses to mount any pack whose `requires_capability` is not
+   in that set.
+2. **Doc-level**: this module's docstring + `register_pack`'s
+   docstring explicitly state vertical content is BLOCKED until
+   v1.0 / LOI.
+3. **Naming-level**: nothing in this module references vertical
+   names. `OntologyPack` is a generic dataclass; the test fixtures
+   use only horizontal stub packs.
+4. **Trigger-level**: G8.d (the grant workflow that unlocks
+   verticals) is explicitly listed as LOI-conditional in the
+   v0.5 close handover §5.2 and B.3 §5 — any PR shipping G8.d
+   without LOI evidence is reviewer-rejectable.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Mapping, Tuple
+
+
+JAMES_CAPABILITIES_ENV: str = "JAMES_CAPABILITIES"
+
+
+# ─── Exceptions ───────────────────────────────────────────────────────
+
+
+class CapabilityNotGrantedError(RuntimeError):
+    """Raised when `register_pack` is called with a pack whose
+    `requires_capability` is not in the granted-capability set.
+
+    This is the **code-level enforcement** of CLAUDE.md rule #1 —
+    vertical packs require `rule_one_exemption_granted` capability,
+    which is default empty until G8.d ships the grant workflow.
+    """
+
+
+class NameCollisionError(RuntimeError):
+    """Raised when a pack tries to register a name (subtype /
+    relation / role) that is already in the mother ontology OR in
+    an already-mounted pack. Silent override is forbidden by the
+    B.3 §3 design constraints — the operator must rename the
+    conflicting name or unmount the colliding pack first.
+    """
+
+
+class SchemaError(RuntimeError):
+    """Raised when a pack's content fails B.3 §4.1 invariants:
+    every subtype must declare a `parent` that resolves to a
+    known mother entity type, relation type dicts must carry the
+    required keys, etc.
+    """
+
+
+# ─── Public dataclass ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class OntologyPack:
+    """Per B.3 §4.1 — pure data describing a pack.
+
+    Fields:
+        pack_id: globally unique pack identifier (e.g. ``"legal-v1"``).
+        requires_capability: capability name the operator must have
+            granted via ``JAMES_CAPABILITIES`` before this pack can
+            mount. The mother default is empty → no pack can mount.
+        subtypes: additive document subtypes. Each entry's
+            ``parent`` must resolve to a known mother entity type.
+        relation_types: additive relation types. Same shape as
+            ``core/ontology.py::RELATION_TYPES`` entries.
+        enterprise_roles: additive permission roles. Same shape as
+            ``core/ontology.py::ENTERPRISE_ROLES`` entries.
+        label_to_type: i18n label → canonical relation/subtype
+            name map. Append-only with mother.
+        since: pack-version string (operator's choice).
+        provenance: human-readable license / DOI / customer ref.
+    """
+    pack_id:             str
+    requires_capability: str
+    subtypes:            Mapping[str, Mapping[str, Any]] = field(
+        default_factory=dict
+    )
+    relation_types:      Mapping[str, Mapping[str, Any]] = field(
+        default_factory=dict
+    )
+    enterprise_roles:    Mapping[str, Mapping[str, Any]] = field(
+        default_factory=dict
+    )
+    label_to_type:       Mapping[str, str] = field(
+        default_factory=dict
+    )
+    since:               str = "v0.6"
+    provenance:          str = ""
+
+
+# ─── Capability resolver ──────────────────────────────────────────────
+
+
+def _truthy(value: str) -> bool:
+    """Truthy env-flag parser (mirrors retention.py / tenant.py)."""
+    if not value:
+        return False
+    return value.strip().lower() in (
+        "1", "true", "yes", "on", "enabled",
+    )
+
+
+def granted_capabilities() -> FrozenSet[str]:
+    """Return the set of capabilities the operator has granted.
+
+    Resolved from ``JAMES_CAPABILITIES`` env var (comma-separated).
+    Empty default = mother-platform-only mode = no pack can mount.
+
+    Whitespace around each capability name is stripped. Empty names
+    (e.g. trailing comma) are dropped silently. Names are
+    case-sensitive (an operator who set
+    ``JAMES_CAPABILITIES=Rule_One_Exemption_Granted`` would NOT
+    satisfy a pack requiring ``rule_one_exemption_granted``).
+
+    The function reads the env on every call (not cached) so
+    operator can toggle capabilities during a process lifetime
+    by setting the env + asking the audit system to re-mount.
+    Caching would mask such toggles silently.
+    """
+    raw = os.environ.get(JAMES_CAPABILITIES_ENV, "") or ""
+    names = []
+    for chunk in raw.split(","):
+        name = chunk.strip()
+        if name:
+            names.append(name)
+    return frozenset(names)
+
+
+# ─── Registry ─────────────────────────────────────────────────────────
+
+
+# Ordered registry — registration order is part of the audit-replay
+# contract (G8.c). `_mounted` is the source of truth; the snapshot
+# returned by `mounted_packs()` is a copy.
+_mounted: List[OntologyPack] = []
+
+
+def _claimed_names() -> Dict[str, Tuple[str, str]]:
+    """Map name → (kind, owner) for collision detection.
+
+    `kind` is one of ``"subtype"`` / ``"relation"`` / ``"role"``.
+    `owner` is ``"mother"`` (from `core/ontology.py`) or the
+    `pack_id` of an already-mounted pack.
+
+    Re-read from the mother ontology on every call so a future
+    `core/ontology.py` update extending mother subtypes is picked
+    up without a registry refresh dance.
+    """
+    from core.ontology import (
+        DOCUMENT_SUBTYPES,
+        ENTERPRISE_ROLES,
+        RELATION_TYPES,
+    )
+    claimed: Dict[str, Tuple[str, str]] = {}
+    for name in DOCUMENT_SUBTYPES:
+        claimed[name] = ("subtype", "mother")
+    for name in RELATION_TYPES:
+        claimed[name] = ("relation", "mother")
+    for name in ENTERPRISE_ROLES:
+        claimed[name] = ("role", "mother")
+    for pack in _mounted:
+        for name in pack.subtypes:
+            claimed[name] = ("subtype", pack.pack_id)
+        for name in pack.relation_types:
+            claimed[name] = ("relation", pack.pack_id)
+        for name in pack.enterprise_roles:
+            claimed[name] = ("role", pack.pack_id)
+    return claimed
+
+
+def _validate_schema(pack: OntologyPack) -> None:
+    """Per B.3 §4.1 invariants. Raises SchemaError on violation."""
+    if not isinstance(pack.pack_id, str) or not pack.pack_id.strip():
+        raise SchemaError("pack.pack_id must be a non-empty string")
+    if not isinstance(pack.requires_capability, str) \
+       or not pack.requires_capability.strip():
+        raise SchemaError(
+            "pack.requires_capability must be a non-empty string"
+        )
+    # Every subtype must declare a parent that is a known mother
+    # entity type. We import the mother entity-type registry lazily
+    # to avoid circular imports.
+    if pack.subtypes:
+        from core.ontology import ENTITY_TYPES
+        for sub_name, sub_def in pack.subtypes.items():
+            if not isinstance(sub_def, dict):
+                raise SchemaError(
+                    f"subtype {sub_name!r} must map to a dict"
+                )
+            parent = sub_def.get("parent")
+            if parent not in ENTITY_TYPES:
+                raise SchemaError(
+                    f"subtype {sub_name!r} parent {parent!r} is not "
+                    f"a known mother entity type"
+                )
+
+
+def _check_no_collision(pack: OntologyPack) -> None:
+    """Raises NameCollisionError when the pack overlaps any
+    existing claim (mother or already-mounted pack)."""
+    claimed = _claimed_names()
+    incoming = set(pack.subtypes.keys()) \
+             | set(pack.relation_types.keys()) \
+             | set(pack.enterprise_roles.keys())
+    for name in incoming:
+        if name in claimed:
+            kind, owner = claimed[name]
+            raise NameCollisionError(
+                f"pack {pack.pack_id!r} tried to register {name!r} "
+                f"as {kind}; already claimed by {owner!r}"
+            )
+    # Also: same name MUST NOT appear in two different fields of
+    # the incoming pack (a pack registering a name as both a
+    # subtype AND a relation would create lookup ambiguity).
+    seen: Dict[str, str] = {}
+    for kind, source in (
+        ("subtype",  pack.subtypes),
+        ("relation", pack.relation_types),
+        ("role",     pack.enterprise_roles),
+    ):
+        for name in source:
+            if name in seen:
+                raise NameCollisionError(
+                    f"pack {pack.pack_id!r} declared {name!r} as "
+                    f"both {seen[name]!r} and {kind!r}"
+                )
+            seen[name] = kind
+
+
+def register_pack(pack: OntologyPack) -> None:
+    """Mount a pack into the in-memory registry.
+
+    Pre-conditions (checked in order):
+
+      1. ``pack.requires_capability`` is in
+         ``granted_capabilities()`` — raises
+         :class:`CapabilityNotGrantedError`. **Mother default is
+         empty** → no pack can mount until G8.d ships the grant
+         workflow + an operator LOI evidence scope unlocks the
+         capability.
+      2. Pack schema is valid (subtype parents, required fields) —
+         raises :class:`SchemaError`.
+      3. No name collision with mother or any already-mounted
+         pack — raises :class:`NameCollisionError`.
+
+    Side effects on success:
+      * Pack appended to the in-memory registry (registration
+        order preserved).
+      * G8.c will additionally emit a
+        ``lifecycle.ontology.pack_mounted`` audit row; this G8.a
+        implementation does NOT yet emit (the audit-event type is
+        added in G8.c).
+
+    All failures are fatal — a silent half-mount would break the
+    audit-replay contract (G8.c). The caller catches the exception
+    if the failure is recoverable (e.g. operator typo in
+    ``pack_id``).
+    """
+    if pack.requires_capability not in granted_capabilities():
+        raise CapabilityNotGrantedError(
+            f"pack {pack.pack_id!r} requires capability "
+            f"{pack.requires_capability!r}, which has not been "
+            f"granted via {JAMES_CAPABILITIES_ENV} env. "
+            f"This is the code-level enforcement of CLAUDE.md "
+            f"rule #1 — vertical packs cannot mount without an "
+            f"operator grant + LOI evidence."
+        )
+    _validate_schema(pack)
+    _check_no_collision(pack)
+    _mounted.append(pack)
+
+
+def unmount_pack(pack_id: str) -> None:
+    """Remove a previously-mounted pack from the registry.
+
+    Raises KeyError if no pack with that id is currently mounted.
+
+    Existing audit rows referencing pack-defined subtypes /
+    relations are NOT mutated — replay at a time when the pack was
+    mounted continues to honor the pack's definitions via the G8.c
+    event stream (separate PR).
+    """
+    for i, pack in enumerate(_mounted):
+        if pack.pack_id == pack_id:
+            del _mounted[i]
+            return
+    raise KeyError(f"no mounted pack with pack_id={pack_id!r}")
+
+
+def mounted_packs() -> Tuple[OntologyPack, ...]:
+    """Snapshot of currently-mounted packs in registration order.
+
+    Returns a tuple so callers cannot accidentally mutate the
+    registry. The contained dataclasses are frozen.
+    """
+    return tuple(_mounted)
+
+
+def _reset_for_tests() -> None:
+    """Test-only reset of the in-memory registry. Production code
+    must never call this — it bypasses the audit-replay contract.
+    """
+    _mounted.clear()
+
+
+__all__ = (
+    "JAMES_CAPABILITIES_ENV",
+    "CapabilityNotGrantedError",
+    "NameCollisionError",
+    "SchemaError",
+    "OntologyPack",
+    "granted_capabilities",
+    "register_pack",
+    "unmount_pack",
+    "mounted_packs",
+)

--- a/tests/test_v06_ontology_packs.py
+++ b/tests/test_v06_ontology_packs.py
@@ -1,0 +1,316 @@
+"""v0.6 G8.a — ontology pack mount mechanism tests.
+
+Covers:
+
+  * `granted_capabilities()` — env parsing (empty default, comma-
+    separated, whitespace-stripped, case-sensitive, never cached).
+  * `OntologyPack` dataclass — frozen + defaults populated.
+  * `register_pack` — capability gate; schema validation; collision
+    detection (against mother + against already-mounted packs +
+    within-pack double-claim).
+  * `unmount_pack` — removes; raises KeyError on unknown id.
+  * `mounted_packs` — snapshot is a tuple; preserves registration
+    order; mutating the snapshot doesn't affect the registry.
+  * Mother-platform invariant — at module import, registry is
+    empty + default capability set is empty.
+  * Rule #1 protection — a vertical pack (capability
+    `rule_one_exemption_granted` not granted) cannot mount.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+
+@contextmanager
+def _patched_env(**env: str):
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+
+
+def _make_pack(**overrides):
+    """Build a minimal valid pack for tests.
+
+    Default `requires_capability="cap_x"` aligns with the
+    `JAMES_CAPABILITIES="cap_x"` env most tests patch in, so the
+    capability gate doesn't block the pack at registration. Tests
+    that exercise the capability gate explicitly override one or
+    the other.
+    """
+    from core.ontology_packs import OntologyPack
+    defaults = {
+        "pack_id": "test-pack-v1",
+        "requires_capability": "cap_x",
+        "subtypes": {
+            "test_subtype_horizontal": {
+                "parent": "document",
+                "since": "v0.6",
+            },
+        },
+        "relation_types": {},
+        "enterprise_roles": {},
+        "label_to_type": {},
+        "since": "v0.6",
+        "provenance": "test",
+    }
+    defaults.update(overrides)
+    return OntologyPack(**defaults)
+
+
+class GrantedCapabilitiesTests(unittest.TestCase):
+    def test_default_empty(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES=None):
+            self.assertEqual(granted_capabilities(), frozenset())
+
+    def test_single_capability(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES="cap_a"):
+            self.assertEqual(granted_capabilities(), frozenset({"cap_a"}))
+
+    def test_comma_separated(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES="cap_a,cap_b,cap_c"):
+            self.assertEqual(
+                granted_capabilities(),
+                frozenset({"cap_a", "cap_b", "cap_c"}),
+            )
+
+    def test_whitespace_stripped(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES="  cap_a  , cap_b  "):
+            self.assertEqual(
+                granted_capabilities(),
+                frozenset({"cap_a", "cap_b"}),
+            )
+
+    def test_empty_names_dropped(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES=",cap_a,,,cap_b,"):
+            self.assertEqual(
+                granted_capabilities(),
+                frozenset({"cap_a", "cap_b"}),
+            )
+
+    def test_case_sensitive(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES="Cap_A"):
+            self.assertNotIn("cap_a", granted_capabilities())
+            self.assertIn("Cap_A", granted_capabilities())
+
+    def test_not_cached(self):
+        # Changing the env mid-process must be visible immediately.
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES="initial"):
+            self.assertEqual(granted_capabilities(), frozenset({"initial"}))
+            os.environ["JAMES_CAPABILITIES"] = "changed"
+            self.assertEqual(granted_capabilities(), frozenset({"changed"}))
+
+
+class OntologyPackDataclassTests(unittest.TestCase):
+    def test_frozen(self):
+        pack = _make_pack()
+        with self.assertRaises(Exception):
+            pack.pack_id = "mutated"  # type: ignore[misc]
+
+    def test_default_since(self):
+        from core.ontology_packs import OntologyPack
+        pack = OntologyPack(
+            pack_id="x", requires_capability="cap_x",
+        )
+        self.assertEqual(pack.since, "v0.6")
+
+    def test_default_collections_empty(self):
+        from core.ontology_packs import OntologyPack
+        pack = OntologyPack(
+            pack_id="x", requires_capability="cap_x",
+        )
+        self.assertEqual(pack.subtypes, {})
+        self.assertEqual(pack.relation_types, {})
+        self.assertEqual(pack.enterprise_roles, {})
+        self.assertEqual(pack.label_to_type, {})
+
+
+class RegisterPackCapabilityGateTests(unittest.TestCase):
+    def setUp(self):
+        from core.ontology_packs import _reset_for_tests
+        _reset_for_tests()
+
+    def test_default_empty_capabilities_blocks_mount(self):
+        from core.ontology_packs import CapabilityNotGrantedError, register_pack
+        with _patched_env(JAMES_CAPABILITIES=None):
+            with self.assertRaises(CapabilityNotGrantedError):
+                register_pack(_make_pack(requires_capability="cap_x"))
+
+    def test_granted_capability_allows_mount(self):
+        from core.ontology_packs import register_pack, mounted_packs
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(requires_capability="cap_x"))
+            self.assertEqual(len(mounted_packs()), 1)
+
+    def test_vertical_pack_blocked_by_default(self):
+        # The decisive Rule #1 enforcement test.
+        from core.ontology_packs import CapabilityNotGrantedError, register_pack
+        with _patched_env(JAMES_CAPABILITIES=None):
+            with self.assertRaises(CapabilityNotGrantedError):
+                register_pack(_make_pack(
+                    pack_id="hypothetical-vertical-v1",
+                    requires_capability="rule_one_exemption_granted",
+                ))
+
+
+class RegisterPackSchemaTests(unittest.TestCase):
+    def setUp(self):
+        from core.ontology_packs import _reset_for_tests
+        _reset_for_tests()
+
+    def test_empty_pack_id_rejected(self):
+        from core.ontology_packs import SchemaError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(SchemaError):
+                register_pack(_make_pack(pack_id=""))
+
+    def test_empty_capability_rejected(self):
+        # Empty `requires_capability` is rejected by the capability
+        # gate (it's not in the granted set), not the schema check.
+        # That ordering is the documented contract; an empty string
+        # can never appear in `granted_capabilities()` because the
+        # env parser drops empty tokens.
+        from core.ontology_packs import (
+            CapabilityNotGrantedError,
+            register_pack,
+        )
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(CapabilityNotGrantedError):
+                register_pack(_make_pack(requires_capability=""))
+
+    def test_subtype_unknown_parent_rejected(self):
+        from core.ontology_packs import SchemaError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(SchemaError):
+                register_pack(_make_pack(
+                    subtypes={"bad": {"parent": "no-such-type"}},
+                ))
+
+
+class RegisterPackCollisionTests(unittest.TestCase):
+    def setUp(self):
+        from core.ontology_packs import _reset_for_tests
+        _reset_for_tests()
+
+    def test_collision_with_mother_subtype_rejected(self):
+        from core.ontology_packs import NameCollisionError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(NameCollisionError):
+                # `contract` is a mother DOCUMENT_SUBTYPE per B.5.b.
+                register_pack(_make_pack(
+                    subtypes={"contract": {"parent": "document"}},
+                ))
+
+    def test_collision_with_mother_relation_rejected(self):
+        from core.ontology_packs import NameCollisionError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(NameCollisionError):
+                # `AUTHORED_BY` is a mother RELATION_TYPE per B.5.b.
+                register_pack(_make_pack(
+                    subtypes={},
+                    relation_types={"AUTHORED_BY": {
+                        "label": "x", "inverse": "y", "transitive": False,
+                        "weight": 1.0, "sensitive": False,
+                    }},
+                ))
+
+    def test_collision_with_already_mounted_pack_rejected(self):
+        from core.ontology_packs import NameCollisionError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(
+                pack_id="first",
+                subtypes={"unique_name_1": {"parent": "document"}},
+            ))
+            with self.assertRaises(NameCollisionError):
+                register_pack(_make_pack(
+                    pack_id="second",
+                    subtypes={"unique_name_1": {"parent": "document"}},
+                ))
+
+    def test_within_pack_double_claim_rejected(self):
+        from core.ontology_packs import NameCollisionError, register_pack
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with self.assertRaises(NameCollisionError):
+                # Name 'dual' appears as BOTH subtype and role.
+                register_pack(_make_pack(
+                    subtypes={"dual": {"parent": "document"}},
+                    enterprise_roles={"dual": {"perms_over_doc": []}},
+                ))
+
+
+class UnmountAndSnapshotTests(unittest.TestCase):
+    def setUp(self):
+        from core.ontology_packs import _reset_for_tests
+        _reset_for_tests()
+
+    def test_unmount_removes(self):
+        from core.ontology_packs import register_pack, unmount_pack, mounted_packs
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(pack_id="to-remove"))
+            self.assertEqual(len(mounted_packs()), 1)
+            unmount_pack("to-remove")
+            self.assertEqual(len(mounted_packs()), 0)
+
+    def test_unmount_unknown_raises(self):
+        from core.ontology_packs import unmount_pack
+        with self.assertRaises(KeyError):
+            unmount_pack("does-not-exist")
+
+    def test_snapshot_preserves_registration_order(self):
+        from core.ontology_packs import register_pack, mounted_packs
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            for i in range(3):
+                register_pack(_make_pack(
+                    pack_id=f"pack-{i}",
+                    subtypes={f"subtype_{i}": {"parent": "document"}},
+                ))
+            ids = [p.pack_id for p in mounted_packs()]
+            self.assertEqual(ids, ["pack-0", "pack-1", "pack-2"])
+
+    def test_snapshot_is_tuple_not_list(self):
+        from core.ontology_packs import register_pack, mounted_packs
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack())
+            snap = mounted_packs()
+            self.assertIsInstance(snap, tuple)
+
+
+class MotherPlatformInvariantTests(unittest.TestCase):
+    def test_registry_empty_at_module_import(self):
+        # Re-import the module to simulate a fresh process.
+        from core.ontology_packs import _reset_for_tests, mounted_packs
+        _reset_for_tests()
+        self.assertEqual(mounted_packs(), tuple())
+
+    def test_default_capability_set_empty(self):
+        from core.ontology_packs import granted_capabilities
+        with _patched_env(JAMES_CAPABILITIES=None):
+            self.assertEqual(granted_capabilities(), frozenset())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per `docs/reviews/v0.5-b3-plugin-api-stability.md` §4. **First sub-PR of the v0.6 Track B G8** ontology-pack mount surface. Mother-platform implementation — ships the **mechanism only**. `rule_one_exemption_granted` capability is **default empty** so packs cannot mount. `core/ontology.py` remains the runtime ontology source until G8.d (LOI-conditional).

### New module — `core/ontology_packs.py` (~14 KB)

| Symbol | Purpose |
|---|---|
| `OntologyPack` | Frozen dataclass per B.3 §4.1 (pack_id / capability / subtypes / relation_types / enterprise_roles / label_to_type / since / provenance) |
| `granted_capabilities()` | Reads `JAMES_CAPABILITIES` env (comma-separated, whitespace-stripped, case-sensitive, never cached). **Default empty.** |
| `register_pack(pack)` | Capability gate → schema → collision check (in order). Mounts on success |
| `unmount_pack(pack_id)` | Removes; KeyError on unknown |
| `mounted_packs() → tuple` | Deterministic snapshot in registration order |

### Rule #1 4-layer protection (per v0.5 close handover §6.5)

1. **Code-level**: `granted_capabilities()` returns empty frozenset by default → `register_pack` refuses any pack whose `requires_capability` isn't in that set
2. **Doc-level**: module + `register_pack` docstrings explicitly state vertical content is BLOCKED until v1.0/LOI
3. **Naming-level**: no vertical names in this module. Tests use only horizontal stub packs (`test_subtype_horizontal`)
4. **Trigger-level**: G8.d explicitly tagged LOI-conditional in v0.5 close handover §5.2 + B.3 §5

## Tests (`tests/test_v06_ontology_packs.py`)

**26 tests across 6 classes**:

- GrantedCapabilitiesTests (7) — empty default; comma-separated; whitespace; case-sensitive; not cached
- OntologyPackDataclassTests (3) — frozen; defaults
- RegisterPackCapabilityGateTests (3) — **vertical pack blocked by default** (decisive rule-#1 test)
- RegisterPackSchemaTests (3) — pack_id / capability / parent validation
- RegisterPackCollisionTests (4) — mother subtype (`contract`); mother relation (`AUTHORED_BY`); already-mounted pack; within-pack double-claim
- UnmountAndSnapshotTests (3) — remove / unknown / tuple
- MotherPlatformInvariantTests (2) — registry empty + capabilities empty at import

## What this PR does NOT do

- **G8.b** read-side lookup helpers (`all_document_subtypes()` / `all_relation_types()`) — separate PR
- **G8.c** audit-replay event types + `reconstruct_graph_at` dispatch — separate PR
- **G8.d** capability grant workflow — **LOI required**
- **SDK.a/b/c** CLI scaffolder / PLUGIN_AUTHORING.md / PyPI — Track B SDK series
- Vertical pack content — **BLOCKED per CLAUDE.md rule #1**

## Verification

- `pytest tests/test_v06_ontology_packs.py`: **26 passed**
- `ruff check`: clean
- Module size: **14.2 KB** (under 20 KB cap, CLAUDE.md rule 5)
- `core/ontology.py` **NOT touched** — mother is the runtime default

Quality delta: exempt (label: external-mother-platform — additive mount-mechanism primitive; default-empty capability set guarantees no behaviour change in retrieval/reasoning paths)