### PR TITLE
feat(v0.5-G2.b): CR merge function + approval-evidence gate

### DIFF
--- a/core/change_request_merge.py
+++ b/core/change_request_merge.py
@@ -1,0 +1,172 @@
+"""v0.5 G2.b — CR merge (apply) function with approval-evidence gate.
+
+Per `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §4.3. Lives in
+its own module because `core/change_request.py` is already at the
+20 KB cap (CLAUDE.md rule #5); adding merge_cr to the same file
+would push it over.
+
+Import convention:
+
+  >>> from core.change_request_merge import merge_cr
+  >>> merge_cr(cr_id, reviewer="alex", db_path=path)
+
+The function uses the same `change_requests` table that
+`core/change_request.py` owns — there is one SQLite source of
+truth. This module is a pure consumer: it READs the row state,
+applies the gate logic, mutates one row, and emits one audit
+event via the existing `_audit_event` helper in
+`core/change_request.py`.
+
+## What this function ships (G2.b contract)
+
+  * **Reviewer required + non-self-approve invariant** — reviewer
+    must differ from the proposer.
+  * **Optional principal evidence** — caller may pass
+    ``approval_evidence`` (an
+    :class:`core.security.approval_evidence.ApprovalEvidence`).
+    When provided, evidence.principal must match reviewer.
+  * **Enforcement env** — when
+    :func:`core.security.approval_evidence.require_approval_evidence`
+    returns True AND ``approval_evidence`` is None, the function
+    raises ``ValueError``. Default (env unset) preserves
+    byte-identical pre-G2.b behaviour.
+  * **Audit row fingerprint** — when evidence is present, the
+    audit row carries the principal + source + evidence_hash +
+    captured_at (the fingerprint, NOT the raw evidence blob).
+
+## What this module is NOT
+
+- **Not a state-machine extension** — the same `open → merged`
+  transition that `change_request.py` schema already declares
+  (CHECK constraints + STATUS_MERGED constant). This function
+  just adds the principal-binding wire-in.
+- **Not an HTTP route** — the CR.d UI's approve button (UI shell
+  is PR #867) will call this function in a future PR when the
+  HTTP layer lands.
+- **Not vertical-pack-aware** — the gate applies the same way
+  regardless of CR target_type. Vertical-specific approver rules
+  would live in a separate v1.0 module per CLAUDE.md rule #1.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from typing import Optional
+
+from core.change_request import (
+    STATUS_OPEN,
+    ChangeRequest,
+    _DEFAULT_DB,
+    _audit_event,
+    get_cr,
+)
+
+
+def merge_cr(
+    cr_id:              str,
+    *,
+    reviewer:           str,
+    approval_evidence:  Optional["object"] = None,
+    role:               str = "unknown",
+    db_path:            Optional[str] = None,
+) -> ChangeRequest:
+    """Transition ``open → merged`` (the apply path) with optional
+    G2.b approval-evidence gating.
+
+    Args:
+        cr_id: CR identifier to merge.
+        reviewer: free-form reviewer username (the "who" string).
+            MUST differ from the CR's proposer (no self-approval).
+        approval_evidence: optional
+            :class:`core.security.approval_evidence.ApprovalEvidence`
+            dataclass. When provided, its ``principal`` field must
+            match ``reviewer``. When
+            :func:`core.security.approval_evidence.require_approval_evidence`
+            is True AND this is None, the function raises
+            ``ValueError`` (SaaS-pilot gate; default is unset →
+            no evidence required, byte-identical to pre-G2.b).
+        role: caller role for the audit row. Defaults to
+            ``"unknown"``.
+        db_path: optional override of the change-requests DB path.
+
+    Returns:
+        The merged :class:`ChangeRequest` row (status flipped to
+        ``"merged"``, ``merged_at`` + ``merged_by`` populated).
+
+    Raises:
+        ValueError: missing reviewer; CR not found; CR status not
+            ``"open"``; reviewer == proposer; enforce-mode env set
+            without evidence; evidence-principal != reviewer.
+    """
+    if not reviewer:
+        raise ValueError("reviewer required")
+
+    # G2.b — enforce-mode + evidence-principal-match check (BEFORE
+    # the DB transition so a rejection leaves the CR's status
+    # untouched).
+    from core.security.approval_evidence import require_approval_evidence
+    if require_approval_evidence() and approval_evidence is None:
+        raise ValueError(
+            "approval_evidence required when "
+            "JAMES_REQUIRE_APPROVAL_EVIDENCE is set"
+        )
+    if approval_evidence is not None:
+        principal = getattr(approval_evidence, "principal", None)
+        if principal != reviewer:
+            raise ValueError(
+                f"approval_evidence.principal={principal!r} does "
+                f"not match reviewer={reviewer!r}"
+            )
+
+    path = db_path or _DEFAULT_DB
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT status, proposer FROM change_requests WHERE cr_id = ?",
+            (cr_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"cr not found: {cr_id}")
+        if row["status"] != STATUS_OPEN:
+            raise ValueError(
+                f"cannot merge cr_id={cr_id} from status="
+                f"{row['status']!r}"
+            )
+        if row["proposer"] == reviewer:
+            raise ValueError("reviewer must differ from proposer")
+
+        now = int(time.time())
+        conn.execute(
+            "UPDATE change_requests SET status='merged', "
+            "merged_at = ?, merged_by = ?, updated_at = ? "
+            "WHERE cr_id = ?",
+            (now, reviewer, now, cr_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Audit event — carry evidence fingerprint when present.
+    audit_fields = {"reviewer": reviewer, "role": role}
+    if approval_evidence is not None:
+        audit_fields["evidence_principal"] = getattr(
+            approval_evidence, "principal", "",
+        )
+        audit_fields["evidence_source"] = getattr(
+            approval_evidence, "source", "",
+        )
+        audit_fields["evidence_hash"] = getattr(
+            approval_evidence, "evidence_hash", "",
+        )
+        audit_fields["evidence_captured_at"] = getattr(
+            approval_evidence, "captured_at", "",
+        )
+    _audit_event("merge", cr_id, **audit_fields)
+
+    cr = get_cr(cr_id, db_path=db_path)
+    assert cr is not None
+    return cr
+
+
+__all__ = ("merge_cr",)

--- a/tests/test_v05_g2b_cr_merge.py
+++ b/tests/test_v05_g2b_cr_merge.py
@@ -1,0 +1,297 @@
+"""v0.5 G2.b — CR merge + approval-evidence wire-in tests.
+
+Covers:
+
+  * `merge_cr` happy path — transitions open → merged + writes
+    audit row.
+  * Required-reviewer + self-merge guard.
+  * State-machine invariant — only `open` CRs can merge.
+  * Default-off (no enforce env, no evidence) is byte-identical to
+    pre-G2.b behaviour.
+  * Enforce mode (`JAMES_REQUIRE_APPROVAL_EVIDENCE=1`) rejects
+    when evidence is None.
+  * Principal-match check — evidence.principal must match reviewer.
+  * Audit row carries evidence fingerprint when present.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+from unittest import mock
+
+from core.change_request import (
+    STATUS_MERGED,
+    STATUS_OPEN,
+    TARGET_WIKI_ENTITY,
+    create_cr,
+    get_cr,
+    init_db,
+)
+from core.change_request_merge import merge_cr
+from core.security.approval_evidence import ApprovalEvidence
+
+
+@contextmanager
+def _patched_env(**env: str):
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+
+
+def _tmp_db() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="james-cr-")
+    os.close(fd)
+    init_db(db_path=path)
+    return path
+
+
+def _make_cr(db_path: str, *, proposer: str = "alice") -> str:
+    cr = create_cr(
+        target_type=TARGET_WIKI_ENTITY,
+        target_id="e_test",
+        title="Update test entity",
+        description="desc",
+        proposed_diff='{"op":"set","field":"x","value":"y"}',
+        base_hash="0" * 64,
+        proposer=proposer,
+        labels="",
+        db_path=db_path,
+    )
+    return cr.cr_id
+
+
+class MergeHappyPathTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = _tmp_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_open_to_merged(self):
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            cr = merge_cr(
+                cr_id, reviewer="blair", db_path=self.db_path,
+            )
+            self.assertEqual(cr.status, STATUS_MERGED)
+            self.assertIsNotNone(cr.merged_at)
+            self.assertEqual(cr.merged_by, "blair")
+
+    def test_idempotent_re_merge_rejected(self):
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            merge_cr(cr_id, reviewer="blair", db_path=self.db_path)
+            with self.assertRaises(ValueError):
+                merge_cr(cr_id, reviewer="cam", db_path=self.db_path)
+
+
+class MergeReviewerInvariantTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = _tmp_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_empty_reviewer_rejected(self):
+        cr_id = _make_cr(self.db_path)
+        with self.assertRaises(ValueError):
+            merge_cr(cr_id, reviewer="", db_path=self.db_path)
+
+    def test_self_merge_rejected(self):
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            with self.assertRaises(ValueError):
+                merge_cr(
+                    cr_id, reviewer="alice", db_path=self.db_path,
+                )
+
+    def test_unknown_cr_rejected(self):
+        with self.assertRaises(ValueError):
+            merge_cr(
+                "does-not-exist", reviewer="blair", db_path=self.db_path,
+            )
+
+
+class MergeEnforceModeTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = _tmp_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_enforce_no_evidence_rejected(self):
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE="1"):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            with self.assertRaises(ValueError):
+                merge_cr(
+                    cr_id, reviewer="blair", db_path=self.db_path,
+                )
+        # CR must still be open (rollback semantic — gate fires
+        # before DB transition).
+        cr = get_cr(cr_id, db_path=self.db_path)
+        self.assertEqual(cr.status, STATUS_OPEN)
+
+    def test_enforce_with_evidence_succeeds(self):
+        evidence = ApprovalEvidence(
+            principal="blair",
+            source="posix",
+            evidence_hash="abc123" + "0" * 58,  # 64-hex
+            captured_at="2026-06-12T20:00:00+00:00",
+        )
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE="1"):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            cr = merge_cr(
+                cr_id,
+                reviewer="blair",
+                approval_evidence=evidence,
+                db_path=self.db_path,
+            )
+            self.assertEqual(cr.status, STATUS_MERGED)
+
+    def test_default_off_byte_identical(self):
+        # Without enforce env, missing evidence is fine.
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            cr = merge_cr(cr_id, reviewer="blair", db_path=self.db_path)
+            self.assertEqual(cr.status, STATUS_MERGED)
+
+
+class MergePrincipalMatchTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = _tmp_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_principal_mismatch_rejected(self):
+        evidence = ApprovalEvidence(
+            principal="mallory",
+            source="posix",
+            evidence_hash="x" * 12,
+            captured_at="2026-06-12T20:00:00+00:00",
+        )
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            with self.assertRaises(ValueError):
+                merge_cr(
+                    cr_id,
+                    reviewer="blair",
+                    approval_evidence=evidence,
+                    db_path=self.db_path,
+                )
+        # Rollback — CR still open.
+        cr = get_cr(cr_id, db_path=self.db_path)
+        self.assertEqual(cr.status, STATUS_OPEN)
+
+    def test_principal_match_succeeds(self):
+        evidence = ApprovalEvidence(
+            principal="blair",
+            source="posix",
+            evidence_hash="x" * 12,
+            captured_at="2026-06-12T20:00:00+00:00",
+        )
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            cr = merge_cr(
+                cr_id,
+                reviewer="blair",
+                approval_evidence=evidence,
+                db_path=self.db_path,
+            )
+            self.assertEqual(cr.status, STATUS_MERGED)
+
+
+class MergeAuditEventTests(unittest.TestCase):
+    """Verify the audit row emitted on merge carries the right
+    fingerprint shape — verified by mocking the internal
+    `_audit_event` function so the assertion is independent of
+    the audit_bridge DB plumbing."""
+
+    def setUp(self):
+        self.db_path = _tmp_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_audit_event_called_with_reviewer_no_evidence(self):
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            with mock.patch("core.change_request_merge._audit_event") as m:
+                merge_cr(
+                    cr_id, reviewer="blair", db_path=self.db_path,
+                )
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        # First positional is event_type, second is cr_id.
+        self.assertEqual(args[0], "merge")
+        self.assertEqual(args[1], cr_id)
+        self.assertEqual(kwargs.get("reviewer"), "blair")
+        # No evidence fields when no evidence passed.
+        self.assertNotIn("evidence_hash", kwargs)
+        self.assertNotIn("evidence_principal", kwargs)
+
+    def test_audit_event_called_with_evidence_fingerprint(self):
+        evidence = ApprovalEvidence(
+            principal="blair",
+            source="posix",
+            evidence_hash="evidence-hash-value-xyz",
+            captured_at="2026-06-12T20:00:00+00:00",
+        )
+        with _patched_env(JAMES_REQUIRE_APPROVAL_EVIDENCE=None):
+            cr_id = _make_cr(self.db_path, proposer="alice")
+            with mock.patch("core.change_request_merge._audit_event") as m:
+                merge_cr(
+                    cr_id,
+                    reviewer="blair",
+                    approval_evidence=evidence,
+                    db_path=self.db_path,
+                )
+        m.assert_called_once()
+        _, kwargs = m.call_args
+        self.assertEqual(kwargs.get("evidence_principal"), "blair")
+        self.assertEqual(kwargs.get("evidence_source"), "posix")
+        self.assertEqual(
+            kwargs.get("evidence_hash"), "evidence-hash-value-xyz",
+        )
+        self.assertEqual(
+            kwargs.get("evidence_captured_at"),
+            "2026-06-12T20:00:00+00:00",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §4.3. **Pairs with G2.a** `current_approval_evidence` (PR #861). Default off → byte-identical pre-G2.b behaviour.

### Why a separate file (`core/change_request_merge.py`)

`core/change_request.py` was already at **20.3 KB** (just over the 20 KB cap per CLAUDE.md rule #5 — grandfathered legacy). Adding `merge_cr` (~5 KB) inline would push it materially over. New file isolates the G2.b wire-in:

- Imports existing primitives (`STATUS_OPEN` / `ChangeRequest` / `_DEFAULT_DB` / `_audit_event` / `get_cr`)
- One new function: `merge_cr(cr_id, *, reviewer, approval_evidence=None, role="unknown", db_path=None)`
- Pure consumer of the existing `change_requests` table

### `merge_cr` contract

| Rule | Behaviour |
|---|---|
| Reviewer required + non-self-approve | reviewer must differ from proposer |
| Optional principal evidence | `evidence.principal` must match `reviewer` when provided |
| Enforcement env | `JAMES_REQUIRE_APPROVAL_EVIDENCE=1` + no evidence → ValueError (rollback verified) |
| Audit row fingerprint | principal + source + evidence_hash + captured_at (NOT raw blob) when evidence present |
| State machine | open → merged (existing schema CHECK; merged_at + merged_by populated) |

Default (env unset, no evidence kwarg) = byte-identical to pre-G2.b.

## Tests (`tests/test_v05_g2b_cr_merge.py`)

**12 tests across 5 classes**:

- MergeHappyPathTests (2) — open→merged; idempotent re-merge rejected
- MergeReviewerInvariantTests (3) — empty reviewer; **self-merge**; unknown CR
- MergeEnforceModeTests (3) — enforce + no evidence (rollback); enforce + evidence; default-off byte-identical
- MergePrincipalMatchTests (2) — mismatch (rollback); match
- MergeAuditEventTests (2) — `_audit_event` called with reviewer (no evidence fields); called with fingerprint (mocked to bypass audit_bridge plumbing)

## Verification

- `pytest tests/test_v05_g2b_cr_merge.py`: **12 passed**
- `ruff check`: clean
- Module sizes (CLAUDE.md rule 5, 20 KB cap):
  - `change_request.py` 20.3 KB (**UNCHANGED** — grandfathered)
  - `change_request_merge.py` 6.4 KB (new)
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths **untouched**

## What this PR does NOT do

- HTTP route — CR.d UI approve button (UI shell #867) will call `merge_cr` in a separate PR
- **G2.c** OIDC discovery + token validator — separate PR when customer IdP scoped
- Refactor `change_request.py` to under 20 KB — separate cleanup cycle if needed
- Vertical-pack-specific approver rules — BLOCKED per CLAUDE.md rule #1

Quality delta: exempt (label: external-mother-platform — new function in its own module; existing `change_request.py` untouched; default-off behaviour byte-identical)