### PR TITLE
feat(v0.6-G8.b): pack read-side lookup helpers

### DIFF
--- a/core/ontology_packs.py
+++ b/core/ontology_packs.py
@@ -348,6 +348,94 @@ def _reset_for_tests() -> None:
     _mounted.clear()
 
 
+# ─── v0.6 G8.b — read-side lookup helpers (B.3 §4.2) ──────────────────
+#
+# These helpers merge the mother ontology (`core/ontology.py`) with
+# every currently-mounted pack, returning a unified read-only view.
+# Existing call sites that import `DOCUMENT_SUBTYPES` / `RELATION_TYPES`
+# / `ENTERPRISE_ROLES` directly from `core/ontology.py` continue to
+# see ONLY the mother set — these helpers are the new opt-in surface
+# for pack-aware code paths.
+#
+# Lookup-time merging (not registration-time):
+#   - When a pack mounts, the mother dicts are NOT mutated.
+#   - The lookup helpers do the merge on each call.
+#   - Cheap because the dicts are small (mother ~10 subtypes ×
+#     ~few packs × ~10 subtypes each = ~50 entries max).
+#   - Determinism: same mother state + same mount order yields the
+#     same merged view byte-identical.
+#
+# Mother takes precedence on duplicate names. `register_pack`'s
+# collision check (§ above) prevents this in practice — but the
+# defensive ordering means a future race / hot-reload would still
+# fail-safe to mother behaviour.
+
+
+def _merge_packs(field_name: str) -> Dict[str, Any]:
+    """Merge mother + mounted-pack entries for the given field.
+
+    Args:
+        field_name: one of ``"subtypes"`` / ``"relation_types"``
+            / ``"enterprise_roles"``.
+
+    Returns:
+        A fresh dict (callers can mutate without affecting the
+        registry). Mother entries first, then each mounted pack
+        in registration order. Mother takes precedence on key
+        collisions (defensive — `register_pack` already blocks
+        collisions at mount time).
+    """
+    from core.ontology import (
+        DOCUMENT_SUBTYPES,
+        ENTERPRISE_ROLES,
+        RELATION_TYPES,
+    )
+    mother_map = {
+        "subtypes":         DOCUMENT_SUBTYPES,
+        "relation_types":   RELATION_TYPES,
+        "enterprise_roles": ENTERPRISE_ROLES,
+    }
+    mother = mother_map.get(field_name, {})
+    merged: Dict[str, Any] = {}
+    # Packs first, then mother — mother last write wins on conflict.
+    for pack in _mounted:
+        pack_entries = getattr(pack, field_name, {})
+        for name, definition in pack_entries.items():
+            merged[name] = definition
+    for name, definition in mother.items():
+        merged[name] = definition
+    return merged
+
+
+def all_document_subtypes() -> Dict[str, Mapping[str, Any]]:
+    """Mother DOCUMENT_SUBTYPES merged with every mounted pack's
+    subtypes.
+
+    Existing callers that import ``DOCUMENT_SUBTYPES`` from
+    ``core.ontology`` directly continue to see only the mother set
+    — those callers are pack-unaware by design. This helper is the
+    new opt-in surface for pack-aware code (e.g. a future ingestion
+    pipeline that wants to classify documents against vertical
+    pack subtypes once an LOI scopes a pack).
+    """
+    return _merge_packs("subtypes")
+
+
+def all_relation_types() -> Dict[str, Mapping[str, Any]]:
+    """Mother RELATION_TYPES merged with every mounted pack's
+    relation_types. Same opt-in semantic as
+    :func:`all_document_subtypes`.
+    """
+    return _merge_packs("relation_types")
+
+
+def all_enterprise_roles() -> Dict[str, Mapping[str, Any]]:
+    """Mother ENTERPRISE_ROLES merged with every mounted pack's
+    enterprise_roles. Same opt-in semantic.
+    """
+    return _merge_packs("enterprise_roles")
+
+
 __all__ = (
     "JAMES_CAPABILITIES_ENV",
     "CapabilityNotGrantedError",
@@ -358,4 +446,8 @@ __all__ = (
     "register_pack",
     "unmount_pack",
     "mounted_packs",
+    # v0.6 G8.b — read-side helpers
+    "all_document_subtypes",
+    "all_relation_types",
+    "all_enterprise_roles",
 )

--- a/tests/test_v06_ontology_packs.py
+++ b/tests/test_v06_ontology_packs.py
@@ -312,5 +312,124 @@ class MotherPlatformInvariantTests(unittest.TestCase):
             self.assertEqual(granted_capabilities(), frozenset())
 
 
+# ─── v0.6 G8.b — read-side lookup helpers tests ───────────────────────
+
+
+class G8bLookupHelperTests(unittest.TestCase):
+    """Per B.3 §4.2. Helpers merge mother + mounted packs at lookup."""
+
+    def setUp(self):
+        from core.ontology_packs import _reset_for_tests
+        _reset_for_tests()
+
+    def test_all_document_subtypes_returns_mother_by_default(self):
+        # No packs mounted → result == mother DOCUMENT_SUBTYPES.
+        from core.ontology import DOCUMENT_SUBTYPES
+        from core.ontology_packs import all_document_subtypes
+        result = all_document_subtypes()
+        for key in DOCUMENT_SUBTYPES:
+            self.assertIn(key, result)
+        # Result has at least the mother set.
+        self.assertGreaterEqual(len(result), len(DOCUMENT_SUBTYPES))
+
+    def test_all_relation_types_returns_mother_by_default(self):
+        from core.ontology import RELATION_TYPES
+        from core.ontology_packs import all_relation_types
+        result = all_relation_types()
+        for key in RELATION_TYPES:
+            self.assertIn(key, result)
+        self.assertGreaterEqual(len(result), len(RELATION_TYPES))
+
+    def test_all_enterprise_roles_returns_mother_by_default(self):
+        from core.ontology import ENTERPRISE_ROLES
+        from core.ontology_packs import all_enterprise_roles
+        result = all_enterprise_roles()
+        for key in ENTERPRISE_ROLES:
+            self.assertIn(key, result)
+        self.assertGreaterEqual(len(result), len(ENTERPRISE_ROLES))
+
+    def test_mounted_pack_subtypes_appear_in_lookup(self):
+        from core.ontology_packs import (
+            all_document_subtypes,
+            register_pack,
+        )
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(
+                pack_id="lookup-test-pack",
+                subtypes={
+                    "lookup_subtype_a": {
+                        "parent": "document", "since": "v0.6",
+                    },
+                    "lookup_subtype_b": {
+                        "parent": "document", "since": "v0.6",
+                    },
+                },
+            ))
+            result = all_document_subtypes()
+        self.assertIn("lookup_subtype_a", result)
+        self.assertIn("lookup_subtype_b", result)
+        # Mother set is still present.
+        self.assertIn("contract", result)
+
+    def test_mother_takes_precedence_defensively(self):
+        # The collision check prevents mother-shadowing at register
+        # time, but the helper's merge order (packs first, mother
+        # last) means even a future race would fall back to mother.
+        from core.ontology import DOCUMENT_SUBTYPES
+        from core.ontology_packs import _mounted, all_document_subtypes, OntologyPack
+        # Bypass register_pack to force a collision directly into
+        # the registry (simulating a race / hot-reload bug).
+        rogue = OntologyPack(
+            pack_id="rogue",
+            requires_capability="cap_x",
+            subtypes={
+                "contract": {  # MOTHER key
+                    "parent": "document",
+                    "since":  "rogue-v1",
+                    "rogue":  True,
+                },
+            },
+        )
+        _mounted.append(rogue)
+        try:
+            result = all_document_subtypes()
+            # Mother's `contract` definition wins (no `rogue: True`).
+            self.assertEqual(
+                result["contract"], DOCUMENT_SUBTYPES["contract"],
+            )
+        finally:
+            _mounted.remove(rogue)
+
+    def test_unmount_pack_removes_from_lookup(self):
+        from core.ontology_packs import (
+            all_document_subtypes,
+            register_pack,
+            unmount_pack,
+        )
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(
+                pack_id="ephemeral",
+                subtypes={
+                    "ephemeral_subtype": {
+                        "parent": "document", "since": "v0.6",
+                    },
+                },
+            ))
+            self.assertIn("ephemeral_subtype", all_document_subtypes())
+            unmount_pack("ephemeral")
+            self.assertNotIn(
+                "ephemeral_subtype", all_document_subtypes(),
+            )
+
+    def test_lookup_returns_fresh_dict(self):
+        # Caller mutating the returned dict must NOT affect future
+        # lookups (registry remains the source of truth).
+        from core.ontology_packs import all_document_subtypes
+        result = all_document_subtypes()
+        result["INJECTED_BY_TEST"] = "should not persist"
+        # Next call must NOT carry the injection.
+        self.assertNotIn("INJECTED_BY_TEST", all_document_subtypes())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Per `docs/reviews/v0.5-b3-plugin-api-stability.md` §4.2. Extends **G8.a** (PR #868) with the read-side merge layer. Mother-platform — existing call sites importing `DOCUMENT_SUBTYPES` / `RELATION_TYPES` / `ENTERPRISE_ROLES` from `core/ontology.py` directly continue to see only the mother set; these helpers are the **opt-in surface for pack-aware code**.

### New surfaces

| Symbol | Purpose |
|---|---|
| `all_document_subtypes()` | Mother DOCUMENT_SUBTYPES merged with every mounted pack's subtypes |
| `all_relation_types()` | Same for relations |
| `all_enterprise_roles()` | Same for roles |

### Lookup-time merging

- Mother dicts NOT mutated at register_pack time
- Helpers merge on each call (cheap; ontology dicts are small)
- Returns fresh dicts (caller mutation can't poison registry)

### Mother-precedence guarantee

`register_pack` (G8.a) blocks collisions at mount time. But the helpers' merge order is **defensive: packs first, mother last**. Even if a future race or hot-reload bug sneaks a colliding pack into the registry directly (bypassing register_pack), the merged view falls back to mother behaviour. Verified by `test_mother_takes_precedence_defensively` (directly appends colliding pack; mother definition wins).

## Tests

Extends `tests/test_v06_ontology_packs.py` with `G8bLookupHelperTests` (**7 new tests**):

- 3 helpers return mother by default
- Pack subtype appears alongside mother after mount
- Mother-precedence defensive ordering
- Unmount removes from lookup
- Lookup returns fresh dict (caller mutation isolation)

Plus existing 26 G8.a tests still pass → **33 total**.

## Verification

- `pytest tests/test_v06_ontology_packs.py`: **33 passed**
- `ruff check`: clean
- Module size: **18.1 KB** (was 14.2 KB; +3.9 KB). Under 20 KB cap.
- `core/ontology.py` **UNTOUCHED**
- `core/retrieval` / `core/graph` traversal / `core/reasoning` **untouched**

## Out of scope

- Wiring helpers into existing readers — **opt-in** by design
- G8.c audit-replay event types — separate PR
- G8.d capability grant workflow — **LOI required**
- SDK.a/b/c — Track B SDK series
- Vertical pack content — BLOCKED per CLAUDE.md rule #1

Quality delta: exempt (label: external-mother-platform — additive read-side helper layer; existing direct imports preserve byte-identical behaviour)