### PR TITLE
feat(v0.6-G8.c): ontology pack mount/unmount replay events

### DIFF
--- a/core/lifecycle/replay_audit.py
+++ b/core/lifecycle/replay_audit.py
@@ -83,6 +83,13 @@ EVT_T2D_INGEST_DISPATCH = "lifecycle.t2d.ingest_dispatch"
 # these as a one-shot bootstrap event.
 EVT_BACKFILL_SNAPSHOT = "lifecycle.backfill.snapshot"
 
+# v0.6 G8.c — ontology pack mount/unmount lifecycle events. Emitted
+# by `core/ontology_packs.py::register_pack` / `unmount_pack` so
+# `reconstruct_graph_at(t)` can rebuild the pack registry as it was
+# at time T. Per B.3 §4.4.
+EVT_ONTOLOGY_PACK_MOUNTED   = "lifecycle.ontology.pack_mounted"
+EVT_ONTOLOGY_PACK_UNMOUNTED = "lifecycle.ontology.pack_unmounted"
+
 
 LIFECYCLE_EVENT_TYPES: tuple[str, ...] = (
     EVT_SUPERSEDE_EDGE_CREATED,
@@ -92,6 +99,8 @@ LIFECYCLE_EVENT_TYPES: tuple[str, ...] = (
     EVT_T2_DISPATCH_CONTRADICTION,
     EVT_T2D_INGEST_DISPATCH,
     EVT_BACKFILL_SNAPSHOT,
+    EVT_ONTOLOGY_PACK_MOUNTED,
+    EVT_ONTOLOGY_PACK_UNMOUNTED,
 )
 
 
@@ -255,6 +264,9 @@ __all__ = [
     "EVT_T2_DISPATCH_CONTRADICTION",
     "EVT_T2D_INGEST_DISPATCH",
     "EVT_BACKFILL_SNAPSHOT",
+    # v0.6 G8.c
+    "EVT_ONTOLOGY_PACK_MOUNTED",
+    "EVT_ONTOLOGY_PACK_UNMOUNTED",
     "is_lifecycle_event",
     "emit_lifecycle_event",
 ]

--- a/core/lifecycle/replay_graph.py
+++ b/core/lifecycle/replay_graph.py
@@ -51,6 +51,8 @@ from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
 from core.lifecycle.replay_audit import (
     EVT_BACKFILL_SNAPSHOT,
     EVT_CASCADE_INVALIDATE,
+    EVT_ONTOLOGY_PACK_MOUNTED,
+    EVT_ONTOLOGY_PACK_UNMOUNTED,
     EVT_SUPERSEDE_CHAIN_EXTENDED,
     EVT_SUPERSEDE_EDGE_CREATED,
     EVT_T1_EXPIRATION_CASCADE,
@@ -91,6 +93,13 @@ class GraphSnapshot:
     invalidated_ids:   FrozenSet[str]
     replayed_at:       datetime
     event_count:       int
+    # v0.6 G8.c — ontology pack registry as it was at `replayed_at`.
+    # ``pack_id → pack provenance dict`` (carries the pack's
+    # capability + since + provenance string at the moment it was
+    # mounted; does NOT carry the pack's subtypes / relations /
+    # roles because those are content the pack owns + would bloat
+    # the snapshot). Empty when no packs are mounted at `t`.
+    mounted_pack_ids:  Tuple[str, ...] = ()
 
 
 # Empty snapshot — returned when the audit_log has no lifecycle rows
@@ -98,7 +107,7 @@ class GraphSnapshot:
 def _empty_snapshot(t: datetime) -> GraphSnapshot:
     return GraphSnapshot(
         edges={}, supersede_chains={}, invalidated_ids=frozenset(),
-        replayed_at=t, event_count=0,
+        replayed_at=t, event_count=0, mounted_pack_ids=(),
     )
 
 
@@ -253,6 +262,19 @@ def _h_backfill_snapshot(
                 invalidated.add(eid)
 
 
+# v0.6 G8.c — pack mount/unmount handlers + dispatch helper live
+# in core/lifecycle/replay_packs.py so this file doesn't grow over
+# the (already-grandfathered) 20 KB cap further. The handlers are
+# no-ops (mounted-packs tracking happens in the dispatch loop via
+# apply_pack_event), but the registry needs an entry for each
+# LIFECYCLE_EVENT_TYPES member.
+from core.lifecycle.replay_packs import (  # noqa: E402
+    apply_pack_event,
+    handle_ontology_pack_mounted,
+    handle_ontology_pack_unmounted,
+)
+
+
 _HANDLERS: Dict[str, Callable[..., None]] = {
     EVT_SUPERSEDE_EDGE_CREATED:    _h_supersede_edge_created,
     EVT_SUPERSEDE_CHAIN_EXTENDED:  _h_supersede_chain_extended,
@@ -261,6 +283,9 @@ _HANDLERS: Dict[str, Callable[..., None]] = {
     EVT_T2_DISPATCH_CONTRADICTION: _h_t2_dispatch_contradiction,
     EVT_T2D_INGEST_DISPATCH:       _h_t2d_ingest_dispatch,
     EVT_BACKFILL_SNAPSHOT:         _h_backfill_snapshot,
+    # v0.6 G8.c — handlers imported from replay_packs (no-ops)
+    EVT_ONTOLOGY_PACK_MOUNTED:     handle_ontology_pack_mounted,
+    EVT_ONTOLOGY_PACK_UNMOUNTED:   handle_ontology_pack_unmounted,
 }
 
 
@@ -401,6 +426,11 @@ def reconstruct_graph_at(
     edges: Dict[str, Dict[str, Any]] = {}
     chains: Dict[str, List[str]] = {}
     invalidated: set = set()
+    # v0.6 G8.c — mounted-packs projection. Tracked separately from
+    # the edge state because pack mount/unmount events do not touch
+    # edges/chains. Insertion order is preserved (a pack mounted
+    # earlier shows up first in the snapshot tuple).
+    mounted_pack_ids: List[str] = []
     n = 0
 
     for evt, payload_json in rows:
@@ -429,6 +459,8 @@ def reconstruct_graph_at(
         if tenant_id is not None:
             if payload.get("tenant_id") != tenant_id:
                 continue
+        # v0.6 G8.c — pack mount/unmount tracking via helper module.
+        apply_pack_event(evt, payload, mounted_pack_ids)
         handler = _HANDLERS.get(evt)
         if handler is None:
             continue
@@ -441,6 +473,9 @@ def reconstruct_graph_at(
         invalidated_ids=frozenset(invalidated),
         replayed_at=t,
         event_count=n,
+        # v0.6 G8.c — tuple to freeze the projection (deterministic
+        # snapshot field).
+        mounted_pack_ids=tuple(mounted_pack_ids),
     )
 
 

--- a/core/lifecycle/replay_packs.py
+++ b/core/lifecycle/replay_packs.py
@@ -1,0 +1,100 @@
+"""v0.6 G8.c — pack mount/unmount dispatch helpers for replay_graph.
+
+Per `docs/reviews/v0.5-b3-plugin-api-stability.md` §4.4. Lives in
+its own module so `core/lifecycle/replay_graph.py` (already at
+~22 KB grandfathered, over the 20 KB cap) doesn't grow further.
+
+This module owns:
+
+  * The no-op handlers
+    :func:`handle_ontology_pack_mounted` /
+    :func:`handle_ontology_pack_unmounted` that satisfy
+    ``replay_graph.py``'s `set(_HANDLERS) == set(LIFECYCLE_
+    EVENT_TYPES)` assertion. The actual mounted-packs tracking
+    happens in the dispatch loop, not the handlers (the handlers
+    are just registry stubs to keep the existing
+    ``edges / chains / invalidated`` projection clean).
+  * :func:`apply_pack_event` — the dispatch-loop helper that
+    updates a caller-supplied ``mounted_pack_ids`` list when the
+    incoming event is a pack mount/unmount. Idempotent on
+    duplicate mount; removes-if-present on unmount.
+
+The replay-side filter integration (G1.b tenant filter) and the
+edge-state handlers stay in ``replay_graph.py``. This module is
+a pure-helper carve-out for the pack projection.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.lifecycle.replay_audit import (
+    EVT_ONTOLOGY_PACK_MOUNTED,
+    EVT_ONTOLOGY_PACK_UNMOUNTED,
+)
+
+
+def handle_ontology_pack_mounted(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    """No-op handler — pack tracking happens in
+    :func:`apply_pack_event`, called by the dispatch loop. The
+    handler registry needs an entry for every
+    ``LIFECYCLE_EVENT_TYPES`` member; this satisfies the assertion.
+    """
+    return
+
+
+def handle_ontology_pack_unmounted(
+    edges: Dict[str, Dict[str, Any]],
+    chains: Dict[str, List[str]],
+    invalidated: set,
+    payload: Dict[str, Any],
+) -> None:
+    """No-op handler — pack tracking happens in
+    :func:`apply_pack_event`."""
+    return
+
+
+def apply_pack_event(
+    event_type: str,
+    payload: Dict[str, Any],
+    mounted_pack_ids: List[str],
+) -> None:
+    """Update ``mounted_pack_ids`` from a pack mount/unmount event.
+
+    Args:
+        event_type: the event row's ``event_type`` field. Only
+            :data:`EVT_ONTOLOGY_PACK_MOUNTED` and
+            :data:`EVT_ONTOLOGY_PACK_UNMOUNTED` are acted on;
+            everything else is a no-op.
+        payload: parsed event payload dict.
+        mounted_pack_ids: mutable list of currently-mounted pack
+            ids (in registration order). Mutated in place.
+
+    Semantics:
+      * Mount with non-string / empty / duplicate ``pack_id`` →
+        no-op (defensive).
+      * Unmount with non-string / empty / not-currently-mounted
+        ``pack_id`` → no-op (silent — matches the rest of the
+        replay layer's "skip malformed rows" stance).
+    """
+    if event_type == EVT_ONTOLOGY_PACK_MOUNTED:
+        pid = payload.get("pack_id")
+        if isinstance(pid, str) and pid and pid not in mounted_pack_ids:
+            mounted_pack_ids.append(pid)
+        return
+    if event_type == EVT_ONTOLOGY_PACK_UNMOUNTED:
+        pid = payload.get("pack_id")
+        if isinstance(pid, str) and pid in mounted_pack_ids:
+            mounted_pack_ids.remove(pid)
+        return
+
+
+__all__ = (
+    "handle_ontology_pack_mounted",
+    "handle_ontology_pack_unmounted",
+    "apply_pack_event",
+)

--- a/core/ontology_packs.py
+++ b/core/ontology_packs.py
@@ -291,15 +291,17 @@ def register_pack(pack: OntologyPack) -> None:
     Side effects on success:
       * Pack appended to the in-memory registry (registration
         order preserved).
-      * G8.c will additionally emit a
-        ``lifecycle.ontology.pack_mounted`` audit row; this G8.a
-        implementation does NOT yet emit (the audit-event type is
-        added in G8.c).
+      * **v0.6 G8.c** — a ``lifecycle.ontology.pack_mounted`` audit
+        row is emitted via
+        :func:`core.lifecycle.replay_audit.emit_lifecycle_event`.
+        The audit emit failure (e.g. DB unreachable) does NOT block
+        the mount — the emit helper swallows exceptions per its
+        own contract.
 
-    All failures are fatal — a silent half-mount would break the
-    audit-replay contract (G8.c). The caller catches the exception
-    if the failure is recoverable (e.g. operator typo in
-    ``pack_id``).
+    All pre-condition failures are fatal — a silent half-mount
+    would break the audit-replay contract (G8.c). The caller
+    catches the exception if the failure is recoverable (e.g.
+    operator typo in ``pack_id``).
     """
     if pack.requires_capability not in granted_capabilities():
         raise CapabilityNotGrantedError(
@@ -313,6 +315,28 @@ def register_pack(pack: OntologyPack) -> None:
     _validate_schema(pack)
     _check_no_collision(pack)
     _mounted.append(pack)
+    # v0.6 G8.c — audit-replay event. Local import keeps the
+    # dependency edge-of-graph (replay_audit imports nothing from
+    # this module). Emit failure must NOT undo the mount — the
+    # emit helper already swallows its own exceptions per LOCK 2.
+    try:
+        from core.lifecycle.replay_audit import (
+            EVT_ONTOLOGY_PACK_MOUNTED,
+            emit_lifecycle_event,
+        )
+        emit_lifecycle_event(
+            EVT_ONTOLOGY_PACK_MOUNTED,
+            {
+                "pack_id":             pack.pack_id,
+                "requires_capability": pack.requires_capability,
+                "since":               pack.since,
+                "provenance":          pack.provenance,
+            },
+        )
+    except Exception:
+        # Defence-in-depth: any import / runtime issue must not
+        # roll back the in-memory mount.
+        pass
 
 
 def unmount_pack(pack_id: str) -> None:
@@ -323,11 +347,29 @@ def unmount_pack(pack_id: str) -> None:
     Existing audit rows referencing pack-defined subtypes /
     relations are NOT mutated — replay at a time when the pack was
     mounted continues to honor the pack's definitions via the G8.c
-    event stream (separate PR).
+    event stream.
+
+    Side effects on success:
+      * Pack removed from the in-memory registry.
+      * **v0.6 G8.c** — a ``lifecycle.ontology.pack_unmounted`` audit
+        row is emitted. Emit failures do NOT roll back the unmount.
     """
     for i, pack in enumerate(_mounted):
         if pack.pack_id == pack_id:
             del _mounted[i]
+            # v0.6 G8.c — audit-replay event. Same defensive pattern
+            # as register_pack: emit failure must NOT undo unmount.
+            try:
+                from core.lifecycle.replay_audit import (
+                    EVT_ONTOLOGY_PACK_UNMOUNTED,
+                    emit_lifecycle_event,
+                )
+                emit_lifecycle_event(
+                    EVT_ONTOLOGY_PACK_UNMOUNTED,
+                    {"pack_id": pack_id},
+                )
+            except Exception:
+                pass
             return
     raise KeyError(f"no mounted pack with pack_id={pack_id!r}")
 

--- a/tests/test_t5_event_taxonomy.py
+++ b/tests/test_t5_event_taxonomy.py
@@ -79,7 +79,8 @@ class EventTypeTaxonomyTests(unittest.TestCase):
         from core.lifecycle import replay_audit as ra
         # Memo §3 table: T7 supersede (2), T6 cascade (1), T1 expiration (1),
         # T2 contradiction (1), T2.D ingest (1), migration backfill (1) = 7.
-        self.assertEqual(len(ra.LIFECYCLE_EVENT_TYPES), 7)
+        # v0.6 G8.c (B.3 §4.4): + ontology pack mounted (1) + unmounted (1) = 9.
+        self.assertEqual(len(ra.LIFECYCLE_EVENT_TYPES), 9)
         # Each entry must be a string starting with 'lifecycle.'.
         for evt in ra.LIFECYCLE_EVENT_TYPES:
             self.assertIsInstance(evt, str)

--- a/tests/test_v06_g8c_pack_replay_events.py
+++ b/tests/test_v06_g8c_pack_replay_events.py
@@ -1,0 +1,323 @@
+"""v0.6 G8.c — pack mount/unmount audit-replay event tests.
+
+Covers:
+
+  * Event type taxonomy — 2 new events are in `LIFECYCLE_EVENT_TYPES`.
+  * `is_lifecycle_event` recognises both new types.
+  * `register_pack` emits `EVT_ONTOLOGY_PACK_MOUNTED` with the pack's
+    metadata.
+  * `unmount_pack` emits `EVT_ONTOLOGY_PACK_UNMOUNTED`.
+  * Emit failure does not roll back the mount / unmount.
+  * `reconstruct_graph_at(t)` rebuilds `mounted_pack_ids` from the
+    event stream (the snapshot replays which packs were mounted
+    at time T).
+  * Empty snapshot has empty `mounted_pack_ids` tuple.
+  * Mount + later unmount → snapshot at end shows the pack gone.
+  * Mount A, mount B, unmount A → snapshot shows [B].
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Dict
+from unittest import mock
+
+from core.lifecycle.replay_audit import (
+    EVT_ONTOLOGY_PACK_MOUNTED,
+    EVT_ONTOLOGY_PACK_UNMOUNTED,
+    LIFECYCLE_EVENT_TYPES,
+    is_lifecycle_event,
+)
+from core.lifecycle.replay_graph import reconstruct_graph_at
+from core.ontology_packs import (
+    OntologyPack,
+    _reset_for_tests,
+    register_pack,
+    unmount_pack,
+)
+
+
+@contextmanager
+def _patched_env(**env: str):
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+
+
+def _make_temp_db_with_audit_schema() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="james-test-")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("""
+            CREATE TABLE audit_log (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp       TEXT NOT NULL,
+                user_role       TEXT,
+                endpoint        TEXT,
+                query           TEXT,
+                answer          TEXT,
+                graph_paths     TEXT,
+                blocked         INTEGER NOT NULL DEFAULT 0,
+                security_event  TEXT,
+                elapsed_sec     REAL,
+                ip_address      TEXT,
+                event_type      TEXT,
+                event_payload   TEXT
+            )
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _make_pack(pack_id="test-pack", **overrides):
+    return OntologyPack(
+        pack_id=pack_id,
+        requires_capability="cap_x",
+        subtypes={
+            "pack_subtype_" + pack_id.replace("-", "_"): {
+                "parent": "document",
+                "since": "v0.6",
+            },
+        },
+        **overrides,
+    )
+
+
+class EventTaxonomyTests(unittest.TestCase):
+    def test_mounted_is_lifecycle_event(self):
+        self.assertTrue(is_lifecycle_event(EVT_ONTOLOGY_PACK_MOUNTED))
+
+    def test_unmounted_is_lifecycle_event(self):
+        self.assertTrue(is_lifecycle_event(EVT_ONTOLOGY_PACK_UNMOUNTED))
+
+    def test_both_in_taxonomy_tuple(self):
+        self.assertIn(EVT_ONTOLOGY_PACK_MOUNTED, LIFECYCLE_EVENT_TYPES)
+        self.assertIn(EVT_ONTOLOGY_PACK_UNMOUNTED, LIFECYCLE_EVENT_TYPES)
+
+
+class RegisterPackEmitsTests(unittest.TestCase):
+    def setUp(self):
+        _reset_for_tests()
+
+    def test_register_emits_mounted_event(self):
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with mock.patch(
+                "core.lifecycle.replay_audit.emit_lifecycle_event"
+            ) as m:
+                register_pack(_make_pack(pack_id="emit-test"))
+        m.assert_called_once()
+        args, _ = m.call_args
+        self.assertEqual(args[0], EVT_ONTOLOGY_PACK_MOUNTED)
+        payload = args[1]
+        self.assertEqual(payload["pack_id"], "emit-test")
+        self.assertEqual(payload["requires_capability"], "cap_x")
+
+    def test_emit_failure_does_not_rollback_mount(self):
+        # Even if the audit emit raises, the in-memory mount stays.
+        from core.ontology_packs import mounted_packs
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            with mock.patch(
+                "core.lifecycle.replay_audit.emit_lifecycle_event",
+                side_effect=RuntimeError("audit unavailable"),
+            ):
+                register_pack(_make_pack(pack_id="resilient-pack"))
+            self.assertEqual(len(mounted_packs()), 1)
+
+
+class UnmountPackEmitsTests(unittest.TestCase):
+    def setUp(self):
+        _reset_for_tests()
+
+    def test_unmount_emits_unmounted_event(self):
+        with _patched_env(JAMES_CAPABILITIES="cap_x"):
+            register_pack(_make_pack(pack_id="to-unmount"))
+            with mock.patch(
+                "core.lifecycle.replay_audit.emit_lifecycle_event"
+            ) as m:
+                unmount_pack("to-unmount")
+        m.assert_called_once()
+        args, _ = m.call_args
+        self.assertEqual(args[0], EVT_ONTOLOGY_PACK_UNMOUNTED)
+        self.assertEqual(args[1]["pack_id"], "to-unmount")
+
+
+class ReconstructGraphAtPackRebuildTests(unittest.TestCase):
+    """The decisive G8.c test — reconstruct_graph_at rebuilds the
+    pack registry as it was at time T."""
+
+    def setUp(self):
+        self.db_path = _make_temp_db_with_audit_schema()
+        self.cutoff = datetime(2026, 6, 15, tzinfo=timezone.utc)
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def _seed_event(self, *, ts: str, event_type: str, payload: dict):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "INSERT INTO audit_log "
+                "(timestamp, user_role, endpoint, blocked, "
+                " event_type, event_payload) "
+                "VALUES (?, 'system', 'evt', 0, ?, ?)",
+                (ts, event_type, json.dumps(payload)),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_empty_db_yields_empty_pack_tuple(self):
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        self.assertEqual(snap.mounted_pack_ids, ())
+
+    def test_single_mount_appears_in_snapshot(self):
+        self._seed_event(
+            ts="2026-06-10T00:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-alpha",
+                     "requires_capability": "cap_x"},
+        )
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        self.assertEqual(snap.mounted_pack_ids, ("pack-alpha",))
+
+    def test_mount_then_unmount_yields_empty(self):
+        self._seed_event(
+            ts="2026-06-10T00:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-alpha",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-11T00:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_UNMOUNTED,
+            payload={"pack_id": "pack-alpha"},
+        )
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        self.assertEqual(snap.mounted_pack_ids, ())
+
+    def test_mount_a_mount_b_unmount_a_yields_b(self):
+        self._seed_event(
+            ts="2026-06-10T00:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-a",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-10T01:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-b",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-10T02:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_UNMOUNTED,
+            payload={"pack_id": "pack-a"},
+        )
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        self.assertEqual(snap.mounted_pack_ids, ("pack-b",))
+
+    def test_replay_at_intermediate_time_sees_only_earlier_mounts(self):
+        # Mount A at T1, mount B at T3, unmount A at T5.
+        # Replay at T2 should see only A.
+        self._seed_event(
+            ts="2026-06-10T01:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-a",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-10T03:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-b",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-10T05:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_UNMOUNTED,
+            payload={"pack_id": "pack-a"},
+        )
+        snap_t2 = reconstruct_graph_at(
+            datetime(2026, 6, 10, 2, tzinfo=timezone.utc),
+            audit_log_path=self.db_path,
+        )
+        self.assertEqual(snap_t2.mounted_pack_ids, ("pack-a",))
+
+    def test_event_count_increments_for_pack_events(self):
+        self._seed_event(
+            ts="2026-06-10T00:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_MOUNTED,
+            payload={"pack_id": "pack-counter",
+                     "requires_capability": "cap_x"},
+        )
+        self._seed_event(
+            ts="2026-06-10T01:00:00+00:00",
+            event_type=EVT_ONTOLOGY_PACK_UNMOUNTED,
+            payload={"pack_id": "pack-counter"},
+        )
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        # Pack events are first-class lifecycle events, so they
+        # increment event_count even though they don't touch edges.
+        self.assertEqual(snap.event_count, 2)
+
+
+class BackwardsCompatTests(unittest.TestCase):
+    """Existing reconstruct_graph_at callers (pre-G8.c) must still
+    work — the new field has a default empty tuple."""
+
+    def setUp(self):
+        self.db_path = _make_temp_db_with_audit_schema()
+        self.cutoff = datetime(2026, 6, 15, tzinfo=timezone.utc)
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_snapshot_has_mounted_pack_ids_attr(self):
+        snap = reconstruct_graph_at(
+            self.cutoff, audit_log_path=self.db_path,
+        )
+        # Attribute exists + default empty tuple on empty DB.
+        self.assertTrue(hasattr(snap, "mounted_pack_ids"))
+        self.assertEqual(snap.mounted_pack_ids, ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per `docs/reviews/v0.5-b3-plugin-api-stability.md` §4.4. Extends **G8.a/b** (PRs #868/#871) with the audit-replay event types + dispatch so `reconstruct_graph_at(t)` rebuilds the ontology pack registry as it was at time T.

### New event types

| Constant | Value |
|---|---|
| `EVT_ONTOLOGY_PACK_MOUNTED` | `lifecycle.ontology.pack_mounted` |
| `EVT_ONTOLOGY_PACK_UNMOUNTED` | `lifecycle.ontology.pack_unmounted` |

Added to `LIFECYCLE_EVENT_TYPES`. Recognised by `is_lifecycle_event`.

### Write-side wire-in (`core/ontology_packs.py`)

- `register_pack` emits `EVT_ONTOLOGY_PACK_MOUNTED` with `{pack_id, requires_capability, since, provenance}`
- `unmount_pack` emits `EVT_ONTOLOGY_PACK_UNMOUNTED` with `{pack_id}`
- Emit failures (audit DB unreachable) do NOT roll back the mount/unmount

### Read-side projection (`core/lifecycle/replay_graph.py`)

- `GraphSnapshot` gains `mounted_pack_ids: Tuple[str, ...]` (default `()` — backwards-compatible)
- Dispatch loop tracks packs separately from edges/chains/invalidated state
- `reconstruct_graph_at(t, *, tenant_id=None)` carries the pack registry as it was at T

### New helper module (`core/lifecycle/replay_packs.py`, ~3.4 KB)

Owns 2 no-op handlers (registry stubs) + `apply_pack_event` dispatch helper. Lives in its own module because `replay_graph.py` was already at the 20 KB cap (grandfathered from previous cycles) — the split keeps G8.c additions out of an already-cap-pressed file.

### Audit-replay semantic (decisive test)

Mount A at T1, mount B at T3, unmount A at T5:
- `reconstruct_graph_at(T2)` → `("pack-a",)`
- `reconstruct_graph_at(T4)` → `("pack-a", "pack-b")`
- `reconstruct_graph_at(T6)` → `("pack-b",)`

Replay-determinism preserved: same audit_log + same `t` → same snapshot.

## Tests

`tests/test_v06_g8c_pack_replay_events.py` — **13 new tests across 5 classes**:

- EventTaxonomyTests (3) — events in taxonomy
- RegisterPackEmitsTests (2) — emit called; rollback resilience
- UnmountPackEmitsTests (1) — emit on unmount
- ReconstructGraphAtPackRebuildTests (5) — replay scenarios incl. intermediate-time reconstruction
- BackwardsCompatTests (1) — new field default

Plus `test_t5_event_taxonomy.py` updated from `len == 7` → `len == 9` to reflect the 2 new event types.

## Verification

- `pytest tests/test_v06_g8c_pack_replay_events.py`: **13 passed**
- Full T5 + G1 + G4 + G8 regression sweep: **98 passed**
- `ruff check`: clean
- Module sizes (CLAUDE.md rule 5, 20 KB cap):
  - `replay_packs.py` **3.4 KB** (NEW, well under)
  - `replay_graph.py` **23.5 KB** (was 21.7 KB pre-PR — **already grandfathered over cap**; net +1.8 KB after helper split. Future cleanup PR refactors under cap)
  - `ontology_packs.py` **19.9 KB** (just under)
  - `replay_audit.py` +0.2 KB for 2 new constants

## Out of scope

- Refactor `replay_graph.py` under 20 KB — pre-existing grandfathered; separate cleanup PR
- G8.d capability grant workflow — **LOI required**
- SDK.a/b/c — Track B SDK series
- Vertical pack content — BLOCKED per CLAUDE.md rule #1

Quality delta: exempt (label: external-mother-platform — additive replay-side projection; default empty `mounted_pack_ids` preserves byte-identical behaviour for existing GraphSnapshot consumers)