### PR TITLE
docs(v0.5): Step 1 results — Graph-RAG +0.41 path_coverage confirmed (n=3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ If your use case is *audit / lifecycle / time-travel / on-prem* — JAMES is bui
 
 ---
 
+## 🔬 What does Graph-RAG contribute?
+
+A single 4-cell ablation on the `multihop_rag` fixture (N=100, n=3 paired, M_M = gemma4:e4b 4B, git_sha `b686f35`):
+
+| Cell | path_coverage | graded_answer | abstention_f1 | token_cost | latency |
+|---|---|---|---|---|---|
+| C_minus (no RAG) | 0.000 | 0.213 | 0.356 | 675 | 9.8s |
+| C_rag-basic (+ vector) | 0.000 | 0.260 | 0.306 | 783 | 12.5s |
+| **C_rag-graph (+ graph)** | **0.4056** | 0.203 | 0.400 | 1675 | 32.4s |
+| C_rag-ontology (+ typed filter) | 0.4056 | 0.230 | 0.4286 | 1695 | 32.4s |
+
+**Graph-RAG contribution** (C_rag-basic → C_rag-graph):
+- **path_coverage +0.41** (load-bearing win, noise band 0.02) — vector-only retrieval recovers 0% of gold supporting-doc paths on multi-hop queries; graph traversal recovers ~40%.
+- abstention_f1 +0.094 (graph evidence improves "when to say I don't know" calibration).
+- graded_answer −0.057 (honest loss — graph evidence adds noise to short-answer queries; typed-filter recovers +0.027).
+- **2.1× token cost, 2.6× latency** (the path-coverage win is not free).
+
+**Cross-time reproducibility**: the α-6 cycle (2026-06-01, n=1) measured path_coverage 0.408; this Step 1 rerun (2026-06-13, n=3 median) confirms 0.4056. **Stable across 12 days of oracle revisions.**
+
+Full table + LRB V<N<J architecture ablation + RAB AC/RF/PC audit ablation + honest negatives (closed-book QA, cycle γ deep-multi-hop floor, cost trade-offs) all in [`docs/evaluation/v0.5-graph-rag-contribution.md`](docs/evaluation/v0.5-graph-rag-contribution.md).
+
+---
+
 ## 📑 Papers & Reproducibility
 
 Two benchmarks released as a sibling pair, both pre-registered before measurement, both deterministic-scorer-only, both committed in this repository.

--- a/docs/evaluation/v0.5-graph-rag-contribution.md
+++ b/docs/evaluation/v0.5-graph-rag-contribution.md
@@ -1,11 +1,14 @@
 # JAMES Graph-RAG Contribution — Single Ablation Table
 
-**Status**: PRE-MEASUREMENT DRAFT. Will be updated with Step 1
-n=3 paired results from the 2026-06-12 PM α-6 cell re-run. Skeleton
-committed first so the table shape is operator-reviewable before the
-numbers land.
+**Status**: MEASUREMENT COMPLETE. Table 3.1 is the n=3 paired
+result of the 2026-06-12 PM Step 1 ablation run (3 cells × n=3 on
+M_M = gemma4:e4b 4B). Cross-time path_coverage agreement with α-6
+(2026-06-01) preserved. Headline finding: **Graph-RAG contributes
++0.41 path_coverage on multihop_rag** (load-bearing, noise band
+0.02).
 
-**Date**: 2026-06-12 (PM cycle, post v0.5 close handover #862)
+**Date**: 2026-06-12 launch / 2026-06-13 complete (post v0.5 close
+handover #862, git_sha `b686f35`)
 
 **Why this doc exists**: an external reviewer's 2026-06-12 catch —
 "the README needs a single table showing how much Graph-RAG
@@ -73,39 +76,77 @@ HotpotQA — `workspaces/hotpot_eval/eval/multihop_rag_queries.json`).
 
 **Table 3.1 — Component ablation at M_M (gemma4:e4b 4B, production default)**
 
-| Cell | path_coverage | graded_answer | abstention_f1 | Δ vs prev row |
+**Single-model 5-axis Pareto** (M_M = gemma4:e4b 4B, production
+default; multihop_rag fixture N=100; captured 2026-06-12 / 2026-06-13;
+git_sha `b686f35`):
+
+| Cell | path_coverage | graded_answer | abstention_f1 | token_cost | latency |
+|---|---|---|---|---|---|
+| **C_minus** (no RAG) | 0.000 | 0.213 | 0.356 | 675 | 9.8s |
+| **C_rag-basic** (+ vector) | 0.000 | 0.260 | 0.306 | 783 | 12.5s |
+| **C_rag-graph** (+ graph) | **0.4056** | 0.203 | 0.400 | 1675 | 32.4s |
+| **C_rag-ontology** (+ typed filter) | 0.4056 | 0.230 | 0.4286 | 1695 | 32.4s |
+
+> C_minus is n=1 (Step 0 sanity); other 3 cells are **n=3 paired
+> median**. Quality axes (path_coverage / graded_answer /
+> abstention_f1) reported as median of 3 runs; cost axes (token_cost
+> / latency) reported as median over the same 3 runs. Noise band
+> per axis reported in the per-cell JSON
+> (`workspaces/hotpot_eval/reports/research-runs/qvt-ablation-
+> cells/qvt-ablation-cell-*-M_M.json`).
+
+### Δ tables (the contribution view)
+
+**Graph-RAG contribution** (C_rag-basic → C_rag-graph, the
+load-bearing comparison):
+
+| Axis | C_rag-basic | C_rag-graph | Δ | Verdict |
 |---|---|---|---|---|
-| C_minus (no RAG) | TBD | TBD | TBD | — |
-| C_rag-basic (vector only) | TBD | TBD | TBD | TBD |
-| **C_rag-graph (+ graph)** | **TBD** | TBD | TBD | **TBD** |
-| C_rag-ontology (+ typed filter) | TBD | TBD | TBD | TBD |
+| **path_coverage** | 0.000 | **0.4056** | **+0.41** | ⭐⭐⭐ load-bearing win, noise band 0.02 (publication-grade) |
+| graded_answer | 0.260 | 0.203 | −0.057 | Small loss (graph adds noise to short-answer queries) |
+| abstention_f1 | 0.306 | 0.400 | **+0.094** | Real win — graph evidence improves calibration |
+| token_cost | 783 | 1675 | **2.1×** | Graph context inflates prompt |
+| latency | 12.5s | 32.4s | **2.6×** | Graph traversal dominates wall time |
 
-> n=3 paired runs per cell; values reported as median ± noise band.
-> Captured 2026-06-12 PM (post v0.5 close), git_sha TBD.
+**Typed-filter contribution** (C_rag-graph → C_rag-ontology, α-8
+mechanism):
 
-**Preview values from α-6 single-shot (n=1, 2026-06-01)** — included
-for transparency about the pre-rerun expectation:
+| Axis | C_rag-graph | C_rag-ontology | Δ | Verdict |
+|---|---|---|---|---|
+| path_coverage | 0.4056 | 0.4056 | 0.000 | Graph already at top → typed-filter ceiling |
+| graded_answer | 0.203 | 0.230 | +0.027 | Modest improvement |
+| abstention_f1 | 0.400 | 0.4286 | +0.029 | Modest improvement |
+| token_cost | 1675 | 1695 | +1% | Negligible overhead |
+| latency | 32.4s | 32.4s | 0 | No additional latency cost |
 
-| Cell | path_coverage | graded_answer | abstention_f1 |
-|---|---|---|---|
-| C_minus | 0.000 | 0.363 | 0.591 |
-| C_rag-basic | 0.000 | 0.327 | 0.421 |
-| **C_rag-graph** | **0.408** | 0.300 | 0.455 |
-| C_rag-ontology | 0.411 | 0.327 | 0.429 |
+### What this confirms
 
-**Pre-rerun expected delta (subject to n=3 noise band)**:
+1. **Graph-RAG's path_coverage contribution (+0.41) is the load-
+   bearing finding** — vector-only retrieval recovers 0% of gold
+   supporting-doc paths on multi-hop queries, while graph
+   traversal recovers ~40%. The noise band (0.02) is small enough
+   to make this publication-grade.
 
-- Graph-RAG contribution (C_rag-basic → C_rag-graph):
-  * path_coverage: **+0.41** ← Graph traversal recovers
-    supporting-doc paths that vector-only retrieval misses
-  * graded_answer: −0.03 (within noise band)
-  * abstention_f1: +0.03 (within noise band)
-- Typed-filter contribution (C_rag-graph → C_rag-ontology):
-  * path_coverage: +0.003 (negligible at single-model)
-  * graded_answer: +0.03 (within noise band)
-  * abstention_f1: −0.03 (small regression)
+2. **Cross-time reproducibility**: the α-6 cycle (2026-06-01)
+   measured C_rag-graph path_coverage = 0.408 (n=1, single
+   shot); this rerun (2026-06-13) confirms 0.4056 (n=3 median).
+   The path_coverage oracle is **stable across the 12 days of
+   oracle revisions** documented in §7 caveats.
 
-n=3 will resolve which of these survive the noise band.
+3. **Cost-quality trade-off**: graph-RAG is 2.1× the tokens and
+   2.6× the latency of vector-only RAG. The path-coverage win
+   is not free.
+
+4. **Honest negative on graded_answer**: C_rag-graph loses 0.057
+   on graded_answer vs C_rag-basic. The retrieved graph evidence
+   helps the LLM find sources but produces longer, more
+   distracted answers on the multihop_rag fixture's short-answer
+   queries. Typed-filter (C_rag-ontology) recovers +0.027 of
+   this — partial mitigation.
+
+5. **Abstention_f1 is a real win**: +0.094 from graph addition
+   + another +0.029 from typed-filter. JAMES's "knows when to
+   say I don't know" behaviour is graph-driven.
 
 ---
 
@@ -155,9 +196,9 @@ not** show a JAMES uplift:
 | Surface | Finding | Reference |
 |---|---|---|
 | **Closed-book QA accuracy** | 3-SUT identical EM/F1 on MuSiQue (by construction; JAMES doesn't claim to beat closed-book) | LRB preprint §5, `README.md:44` |
-| **Multi-hop graph traversal** | Cycle γ Phase C.2 vs C.3 vs C.4: graph-RAG hits a floor on multi-hop because unsupervised supporting-fact selection is the bottleneck, not retrieval depth | `memory/project_cycle_gamma_phase_c2_retrieval_bottleneck.md` |
-| **graded_answer at C_rag-graph** | Single-cell α-6 n=1 showed −0.03 vs C_rag-basic. n=3 will confirm if this is noise or real | Table 3.1 above |
-| **abstention_f1 at C_rag-ontology** | Single-cell α-6 n=1 showed −0.03 vs C_rag-graph (small regression) | Table 3.1 above |
+| **Multi-hop graph traversal at large N** | Cycle γ Phase C.2 vs C.3 vs C.4: graph-RAG hits a floor at deep multi-hop because unsupervised supporting-fact selection is the bottleneck, not retrieval depth. **NOTE: the +0.41 path_coverage in Table 3.1 above is on `multihop_rag` (a 2-3 hop fixture). Cycle γ's floor is on deeper hops.** | `memory/project_cycle_gamma_phase_c2_retrieval_bottleneck.md` |
+| **graded_answer at C_rag-graph** | **CONFIRMED at n=3**: −0.057 vs C_rag-basic. Graph evidence adds noise to short-answer queries on multihop_rag. Partially mitigated by typed-filter (+0.027). | Table 3.1 |
+| **Cost inflation from graph-RAG** | **CONFIRMED at n=3**: 2.1× token cost, 2.6× latency vs vector-only RAG. The path-coverage win is not free. | Table 3.1 |
 
 The honest negative on multi-hop is **load-bearing** for JAMES's
 positioning: it tells the reviewer that the team measures even
@@ -175,11 +216,33 @@ each of these honest-negative measurements by file path.
 - **Single fixture (multi-hop)** for Table 3.1. Cycle γ extended to
   RGB (abstention) + ALCE (citation) + 2Wiki (multi-hop confirm).
   See cycle γ memory entries for cross-bench fingerprinting.
+  The path_coverage delta (+0.41) is specifically on multihop_rag's
+  2-3 hop queries; deeper-hop multi-hop (e.g. 4+ hop) hits the
+  cycle γ floor per §6.
 - **Single model (M_M = gemma4:e4b 4B)** for Table 3.1. Cross-model
-  (M_S, M_L) measurement deferred to optional Step 2 of the
-  2026-06-12 PM measurement cycle.
-- **n=3 paired** for the contribution column. n=1 single-shot is
-  insufficient (per `memory/feedback_n1_verdict_inflation_n3_caught.md`).
+  (M_S = gemma3:4b, M_L = gemma3:12b) measurement is the
+  immediate next measurement cycle if needed. Cycle γ's Phase
+  E-min already showed `rerank + cognitive_stages` produce
+  similar deltas across 3 models (mxtral / gemma4 / llama),
+  suggesting model-independence is likely but unverified for
+  this specific 4-cell ablation.
+- **n=3 paired** for the contribution column (C_rag-basic /
+  C_rag-graph / C_rag-ontology). C_minus is n=1 (Step 0 sanity).
+  n=1 single-shot is insufficient for headline claims (per
+  `memory/feedback_n1_verdict_inflation_n3_caught.md`); the 3
+  cells whose deltas drive this table's interpretation are all
+  n=3 paired median.
+- **Oracle revisions between α-6 (2026-06-01) and Step 1
+  (2026-06-13)** changed graded_answer + abstention_f1 absolute
+  values substantially (oracle.py grew +268 lines across 5 PRs;
+  AnswerStyleClassifier was added; pipeline_synth cap flipped
+  1000→8000). Cross-time delta comparison is therefore valid
+  for path_coverage (oracle stable for that axis — α-6 0.408
+  ↔ Step 1 0.4056 agree within noise) but NOT for
+  graded_answer / abstention_f1 absolute values. The Δ tables
+  in §3 are within-state (all cells measured at the same
+  git_sha b686f35), so the contribution interpretation is
+  valid.
 - **No closed-book leaderboard score** (MMLU / GSM8K / HumanEval) —
   out-of-scope-by-design per
   `docs/evaluation/v0.5-evaluation-coverage-mapping.md` §3.2.
@@ -199,7 +262,10 @@ JAMES_WORKSPACE=workspaces/hotpot_eval \
     --n-runs 3
 ```
 
-~10h wall on gemma4:e4b loaded via Ollama. Cell-by-cell JSON output
+**Actual wall time (2026-06-12 launch → 2026-06-13 completion)**:
+~5h total for 3 cells × n=3 paired. C_rag-basic runs ~21 min each
+(retrieval enabled); C_rag-graph + C_rag-ontology runs ~55 min
+each (graph traversal). Cell-by-cell JSON output
 at `workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/`.
 
 For cross-model verification: re-run with `--tiers M_S` (gemma3:4b)
@@ -238,21 +304,33 @@ block.
 ## 10. Korean summary (한국어 요약)
 
 **Graph-RAG 기여 단일 ablation 표** — 외부 reviewer 의 catch
-"리드미에 단일 표가 없다"에 대한 응답.
+"리드미에 단일 표가 없다" 에 대한 응답.
 
-- **데이터는 이미 있음** (α-6 cycle, 2026-06-01 측정): 6-cell
-  progressive enable + 5-axis Pareto. 단 n=1 single-shot 이고
-  `workspaces/hotpot_eval/...` 안에 묻혀 있어 README 외부 노출 0.
-- **이 doc**: α-6 데이터 + LRB V<N<J + RAB AC/RF/PC + cycle γ honest
-  negative 를 단일 표로 합성. 2026-06-12 PM α-6 rerun (n=3 paired)
-  결과로 Table 3.1 확정.
-- **핵심 expected finding** (n=1 preview, n=3 검증 대기):
-  - **Graph-RAG 기여 (basic → graph): path_coverage +0.41** ← 핵심
-  - graded_answer −0.03 (noise band 안)
-  - abstention_f1 +0.03 (noise band 안)
-- **honest negative 동등 노출**: closed-book QA (3-SUT identical),
-  multi-hop graph traversal floor (cycle γ Phase C.2 unsupervised
-  supporting-fact bottleneck), 단일-cell 작은 regression 들.
-- **forced discovery hunt 재개 아님** (룰: `feedback_alpha_cycle_
+- **측정 완료** (2026-06-12 launch → 2026-06-13 완료, ~5h wall):
+  3 cells (C_rag-basic / C_rag-graph / C_rag-ontology) × n=3
+  paired at M_M (gemma4:e4b 4B) + Step 0 의 C_minus = 4-cell
+  publication-grade table. git_sha `b686f35`.
+- **핵심 확정 결과** (n=3 median, 노이즈 밴드 0.02):
+  - **Graph-RAG 기여 (basic → graph): path_coverage 0.000 →
+    0.4056 (Δ +0.41)** ⭐⭐⭐ load-bearing win. α-6 (2026-06-01,
+    n=1) 의 0.408 과 cross-time 일치 (oracle 변경에도 path_coverage
+    축은 stable).
+  - graded_answer −0.057 (그래프 evidence 가 short-answer query
+    에 noise 추가)
+  - abstention_f1 **+0.094** (그래프 evidence 가 calibration 개선)
+  - token_cost **2.1×**, latency **2.6×** (graph 비용)
+- **Typed-filter (graph → ontology) 기여**: path 동일,
+  graded +0.027, abstention +0.029, token +1%. Modest 양 axis
+  개선.
+- **Honest negative 동등 노출**: closed-book QA (3-SUT identical),
+  cycle γ deep multi-hop floor (이 표의 +0.41 은 2-3 hop fixture;
+  4+ hop 은 cycle γ floor), graded loss + 2.1× cost.
+- **Cross-time reproducibility**: path_coverage 는 α-6 cycle (12일
+  전, old oracle) 결과와 일치. graded/abstention 절대값은
+  oracle 변경 (oracle.py +268 lines, AnswerStyleClassifier 등)
+  으로 다름 — within-state (같은 git_sha) Δ 만 valid.
+- **Forced discovery hunt 재개 아님** (룰: `feedback_alpha_cycle_
   discovery_loop_end.md`). 이 작업은 **targeted disclosure**.
-- **재현**: 단일 명령어 (§8). ~10h wall, gemma4:e4b on Ollama.
+- **재현**: 단일 명령어 (§8). ~5h wall on gemma4:e4b via Ollama.
+- **Cross-model 확장 후보**: M_S (gemma3:4b) + M_L (gemma3:12b)
+  각각 ~5h. 필요 시 operator action.


### PR DESCRIPTION
## Summary

Updates the synthesis doc (PR #864 skeleton) with the **2026-06-12 Step 1 measurement results** + adds the README **"What does Graph-RAG contribute?"** section per the external reviewer's catch ("리드미에 단일 ablation 표가 없다").

Step 1 launched 2026-06-12 ~21:06 → completed 2026-06-13 ~01:30 (~4.5h wall). 3 cells × n=3 paired at M_M (gemma4:e4b 4B) + Step 0's C_minus = 4-cell publication-grade table. git_sha `b686f35`. Fixture: `multihop_rag` N=100.

### Headline finding

| Cell | path_coverage | graded_answer | abstention_f1 | token_cost | latency |
|---|---|---|---|---|---|
| C_minus       | 0.000  | 0.213 | 0.356  | 675  | 9.8s  |
| C_rag-basic   | 0.000  | 0.260 | 0.306  | 783  | 12.5s |
| **C_rag-graph** | **0.4056** | 0.203 | 0.400  | 1675 | 32.4s |
| C_rag-ontology | 0.4056 | 0.230 | 0.4286 | 1695 | 32.4s |

**Graph-RAG contribution (C_rag-basic → C_rag-graph)**:

- **path_coverage +0.41** ⭐⭐⭐ load-bearing, noise band 0.02
- abstention_f1 **+0.094** (graph evidence improves calibration)
- graded_answer **−0.057** (honest loss; typed-filter recovers +0.027)
- token_cost **2.1×**, latency **2.6×** (cost-quality trade-off)

**Typed-filter contribution (graph → ontology)**: path unchanged (ceiling), graded +0.027, abstention +0.029, token +1%.

### Cross-time reproducibility

α-6 cycle (2026-06-01, n=1) measured path_coverage **0.408**; Step 1 rerun (2026-06-13, n=3 median) confirms **0.4056**. **Stable across 12 days of oracle revisions** (oracle.py +268 lines, AnswerStyleClassifier, pipeline_synth cap flip — all enumerated in §7 caveats).

Note: oracle revisions changed graded_answer + abstention_f1 absolute values substantially. Cross-time comparison is valid for path_coverage but NOT for graded/abstention absolutes. The Δ tables in §3 are within-state (all cells at the same git_sha).

## Changes

### `docs/evaluation/v0.5-graph-rag-contribution.md`

- Status: "PRE-MEASUREMENT DRAFT" → "MEASUREMENT COMPLETE"
- §3 Table 3.1: TBD → confirmed n=3 medians + noise bands + git_sha
- §3: Δ tables added (Graph-RAG + Typed-filter, with verdict columns)
- §3: 5 numbered "what this confirms" findings
- §6 honest negatives: confirmed n=3; α-6 hedging removed
- §7 caveats: cross-time path agreement + oracle-revision impact
- §8 reproducibility: ~5h actual wall time
- §10 Korean summary: confirmed deltas
- Removed obsolete "α-6 n=1 preview" block (only path_coverage agreement preserved)

### `README.md`

New "🔬 What does Graph-RAG contribute?" section with the table + 4-bullet contribution summary + cross-time reproducibility callout + link to full doc.

## Verification

- `core/` **untouched**.
- Cell numbers verified against committed JSONs (medians match).
- α-6 cross-time path_coverage agreement: 0.408 vs 0.4056 (within noise 0.02 → reproducible) ✓

## Out of scope

- Cross-model (M_S, M_L) — operator action (~5h each)
- New benchmarks beyond RAB + LRB — per evaluation coverage mapping
- Vertical-specific ablation — BLOCKED per CLAUDE.md rule #1

Quality delta: exempt (label: docs — measurement disclosure)