### PR TITLE
feat(v0.6-SDK.c): PyPI packaging — pyproject.toml + SemVer policy

### DIFF
--- a/docs/SDK_README.md
+++ b/docs/SDK_README.md
@@ -1,0 +1,67 @@
+# JAMES Pack SDK
+
+Authoring SDK + CLI scaffolder for [PROJECT JAMES](https://github.com/Hashevolution/James-RAG-Evol)
+ontology packs (v0.6 G8 plugin surface).
+
+## What this package gives you
+
+```bash
+pip install james-pack-sdk
+
+# Scaffold a new pack — `legal-demo-v1/` ends up in the cwd:
+james-pack init legal-demo-v1
+
+# Equivalent invocation as a module:
+python -m james.pack init legal-demo-v1
+```
+
+The scaffolder writes:
+
+- `pack.py` — minimal `OntologyPack` stub with commented examples
+  for subtypes, relations, and roles
+- `test_pack.py` — three contract tests (dataclass validity,
+  capability gate, schema-error path) ready to run with `pytest`
+- `LICENSE` — MIT default (replace with your customer-facing one)
+- `README.md` — quickstart pointing at the author guide
+
+## What's in this package
+
+- `james.pack.OntologyPack` — frozen dataclass describing a pack.
+  Re-exported from `core.ontology_packs` (requires the JAMES
+  runtime on your `PYTHONPATH` for actual mounting).
+- `james.pack.register_pack` / `unmount_pack` — runtime mount
+  helpers. Same runtime-requirement note as `OntologyPack`.
+- `james.pack.scaffold` — pure-function template generators
+  (stdlib-only; usable as a library without the JAMES runtime).
+- `python -m james.pack init` / `james-pack init` — CLI
+  scaffolder.
+
+## Important: rule #1 — vertical content is gated
+
+`OntologyPack` requires `requires_capability="rule_one_exemption_granted"`
+by default, and the JAMES runtime ships with `granted_capabilities()`
+returning the empty frozenset. **A pack you write will not mount
+until an operator explicitly grants the capability** — that
+workflow (G8.d) is LOI-conditional and lands when the first
+customer pilot scopes a vertical.
+
+This is the mechanism that protects the mother-platform contract:
+the SDK lets you author, scaffold, and test packs freely; mounting
+in production stays gated.
+
+## Versioning
+
+[`docs/SDK_VERSIONING.md`](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/SDK_VERSIONING.md)
+documents the SemVer policy + 12-month deprecation window
+(`PLATFORM_READINESS.md` §3 v0.3 gate).
+
+## Documentation
+
+- [`ONTOLOGY_PACK_AUTHORING.md`](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/ONTOLOGY_PACK_AUTHORING.md)
+  — the v0.6 G8 author guide
+- [`PLATFORM_READINESS.md`](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/PLATFORM_READINESS.md)
+  — the readiness framework + gate definitions
+
+## License
+
+MIT — see `LICENSE`.

--- a/docs/SDK_VERSIONING.md
+++ b/docs/SDK_VERSIONING.md
@@ -1,0 +1,103 @@
+# `james-pack-sdk` Versioning Policy
+
+Per `PLATFORM_READINESS.md` §3 v0.3 gate ("12-month deprecation
+window for any public-API removal") and v1.0 gate ("Public SDK +
+plugin author guide"). This document is the single source of truth
+for the SDK's compatibility contract.
+
+## SemVer compliance
+
+`james-pack-sdk` follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
+
+> Given a version number `MAJOR.MINOR.PATCH`, increment the:
+> - `MAJOR` when you make incompatible API changes,
+> - `MINOR` when you add functionality in a backwards-compatible
+>   manner,
+> - `PATCH` when you make backwards-compatible bug fixes.
+
+| Change kind | Bump | Example |
+|---|---|---|
+| Bug fix — same call signature, same return type | PATCH | `validate_pack_id("foo bar")` was raising `TypeError` instead of `ValueError` — fixed to match the docstring contract |
+| New optional kwarg, new helper, new pure-function entry | MINOR | Adding `scaffold.render_changelog_md(pack_id)` |
+| Required-kwarg added, signature changed, helper removed, semantics changed | MAJOR | `OntologyPack.__init__` gaining a new required field |
+
+## Public API surface
+
+The public surface as of `0.6.0a1` is:
+
+- `james.__version__`
+- `james.pack.OntologyPack`
+- `james.pack.register_pack`
+- `james.pack.unmount_pack`
+- `james.pack.CapabilityNotGrantedError`
+- `james.pack.NameCollisionError`
+- `james.pack.SchemaError`
+- `james.pack.scaffold.validate_pack_id`
+- `james.pack.scaffold.render_pack_py`
+- `james.pack.scaffold.render_test_pack_py`
+- `james.pack.scaffold.render_license`
+- `james.pack.scaffold.render_readme_md`
+- `james.pack.scaffold.write_scaffold`
+- `python -m james.pack init <pack_id> [--output-dir <path>] [--overwrite]`
+- `james-pack init <pack_id> [--output-dir <path>] [--overwrite]`
+  (entry-point alias)
+
+Names that start with a single underscore (e.g.
+`james.pack.scaffold._PACK_ID_RE`) are **private**. They may
+change in any release.
+
+## Deprecation window
+
+The v0.3 platform gate sets the deprecation window at **12 months**:
+
+> A public symbol marked deprecated stays present for at least one
+> full year before the MAJOR-bump removal release.
+
+Operational checklist for the maintainer who wants to remove a
+public symbol:
+
+1. In release `N.M.P`, decorate the symbol with
+   `warnings.warn(DeprecationWarning(...))` on every call, and
+   add a "Deprecated in `N.M`, removal in next major" note to
+   the docstring. **Do not** change the signature in this
+   release.
+2. Add the symbol to a `DEPRECATIONS.md` table tracking
+   removal target dates (one row per deprecated symbol).
+3. Keep the symbol working for at least 12 months from the
+   release date of step 1.
+4. In the next MAJOR release (after the 12-month window) the
+   symbol can be removed. The MAJOR's release notes must call
+   out the removed symbols explicitly.
+
+The MAJOR-bump grace window is non-negotiable even for symbols
+that turn out to be misnamed or footguns — fix forward with an
+additional well-named symbol in MINOR, deprecate the old one,
+and respect the window.
+
+## Pre-1.0 caveat (alpha-tier)
+
+`0.6.0a1` is alpha. Per SemVer §4:
+
+> Major version zero (0.y.z) is for initial development. Anything
+> MAY change at any time.
+
+We hold ourselves to the deprecation window above even during the
+0.x line — operators relying on the SDK before v1.0 should still
+expect the 12-month grace, with the caveat that the scope of the
+"public API" itself is small (see the surface list above) and may
+grow as v1.0 milestones land.
+
+## Compatibility matrix
+
+| SDK version | JAMES runtime version range | Notes |
+|---|---|---|
+| `0.6.x` | v0.5 — v0.6 cycle (current main) | Runtime API requires `core.ontology_packs` from this branch; pre-G8.a JAMES installs cannot import `OntologyPack` |
+| `1.0.x` (planned) | v1.0+ (post-LOI) | First stable major; capability grant workflow (G8.d) available |
+
+## Reporting incompatible-change regressions
+
+A SemVer regression (a MINOR or PATCH that broke a public symbol)
+is a release-blocker bug. File at
+[github.com/Hashevolution/James-RAG-Evol/issues](https://github.com/Hashevolution/James-RAG-Evol/issues)
+with the `sdk-semver-regression` label. The maintainer's reply
+target is 7 days.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,99 @@
+# v0.6 SDK.c — `james-pack-sdk` packaging metadata.
+#
+# Per `docs/handovers/v0.5-close-2026-06-12.md` §5.2 Track B SDK.c +
+# `PLATFORM_READINESS.md` §3 v1.0 gate "Public SDK + plugin author
+# guide" + the v0.6 strategy review's "JAMES Pack SDK" proposal.
+#
+# What this packages
+# ------------------
+# *Only* the `james/` subtree — the pack-author surface:
+#
+#   * `james.pack` — runtime re-exports of `OntologyPack` + register
+#     / unmount helpers (requires JAMES core on the import path).
+#   * `james.pack.scaffold` — pure-function template generator
+#     (stdlib-only; works standalone after `pip install
+#     james-pack-sdk` without a JAMES install).
+#   * `james.pack.__main__` — the `python -m james.pack init <id>`
+#     CLI entry. Also exposed as `james-pack` console script.
+#
+# What this does NOT package
+# --------------------------
+# The full JAMES application (`server_llmwiki.py`, `core/`,
+# `routes/`, `frontend/`, etc.) is **not** included in this wheel.
+# JAMES ships as a git repo + run-from-source for now; the SDK
+# wheel is a developer-facing build artifact for pack authors who
+# want to import `james.pack` without cloning the full repo.
+#
+# When the JAMES runtime itself ships as a pip package (future
+# milestone, post v1.0), the runtime API re-exports in `james.pack`
+# will gain a dependency on that package. Until then, runtime use
+# requires the user to have the JAMES `core/` modules on PYTHONPATH.
+#
+# Rule #1 alignment
+# -----------------
+# CLAUDE.md rule #1 (no vertical code until v1.0) is preserved by
+# `core.ontology_packs.register_pack` refusing to mount any pack
+# whose `requires_capability` is not in `granted_capabilities()`.
+# Default `granted_capabilities()` is the empty frozenset; G8.d
+# (the capability grant workflow) is LOI-gated. So a third party
+# can `pip install james-pack-sdk`, scaffold a pack, write a
+# vertical schema — and the pack will NOT mount on their JAMES
+# install until an operator explicitly grants the capability.
+# Packaging the SDK does not relax this gate.
+
+[build-system]
+requires      = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "james-pack-sdk"
+# Keep version in lockstep with `james/__init__.py::__version__`
+# so a `pip install` and a `from james import __version__` agree.
+version         = "0.6.0a1"
+description     = "Authoring SDK + CLI scaffolder for JAMES ontology packs (v0.6 G8 surface)."
+readme          = "docs/SDK_README.md"
+requires-python = ">=3.10"
+license         = { file = "LICENSE" }
+keywords        = ["james", "knowledge-graph", "ontology", "rag", "plugin", "sdk"]
+authors         = [
+    { name = "Hashevolution" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    # Stdlib-only. Runtime `from james.pack import OntologyPack`
+    # requires JAMES core on the import path (not yet a separate
+    # pip package — see the module docstring above).
+]
+
+[project.urls]
+Homepage      = "https://github.com/Hashevolution/James-RAG-Evol"
+Documentation = "https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/ONTOLOGY_PACK_AUTHORING.md"
+Versioning    = "https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/SDK_VERSIONING.md"
+Issues        = "https://github.com/Hashevolution/James-RAG-Evol/issues"
+
+[project.scripts]
+# `pip install james-pack-sdk` exposes the CLI as `james-pack
+# init <pack_id>` so authors don't need `python -m james.pack`.
+james-pack = "james.pack.__main__:main"
+
+[tool.setuptools.packages.find]
+# Whitelist only the `james` namespace to keep the full app
+# (`core`, `routes`, `frontend`, `tests`, etc.) OUT of the wheel.
+include = ["james", "james.*"]
+exclude = ["james.__pycache__*", "james.*.__pycache__*"]
+
+[tool.setuptools.package-data]
+# No bundled binary assets yet. If the scaffolder grows file
+# templates that live outside python source modules, add them
+# here with `"james.pack" = ["templates/*.py.in"]`.

--- a/tests/test_v06_sdk_packaging.py
+++ b/tests/test_v06_sdk_packaging.py
@@ -1,0 +1,228 @@
+"""v0.6 SDK.c — `james-pack-sdk` PyPI packaging smoke tests.
+
+Validates the `pyproject.toml` shape, builds a wheel + sdist via the
+`build` library, and verifies the resulting artifacts contain what
+the SDK promises (CLI entry point, the `james.pack` namespace,
+nothing from the wider repo like ``core/`` or ``routes/``).
+
+Coverage:
+
+* `pyproject.toml` parses + carries the canonical [project] keys
+  (name, version, license, requires-python, entry point).
+* The packaged version matches `james.__version__` — packaging
+  drift between the two is a release-blocker.
+* `build` succeeds end-to-end: produces a wheel + sdist.
+* The wheel contains ONLY the `james/` namespace (no `core/`,
+  no `routes/`, no test files).
+* The wheel registers the `james-pack` console script.
+* SemVer policy doc exists + documents the public surface list.
+
+Run:
+  python -m unittest tests.test_v06_sdk_packaging
+
+The build smoke test is skipped if the `build` library is not
+installed (CI environments without it).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _load_pyproject() -> dict:
+    """Parse pyproject.toml using stdlib tomllib (3.11+) or tomli."""
+    try:
+        import tomllib  # Python 3.11+
+        with PYPROJECT.open("rb") as f:
+            return tomllib.load(f)
+    except ImportError:
+        try:
+            import tomli  # Older Python
+            with PYPROJECT.open("rb") as f:
+                return tomli.load(f)
+        except ImportError:
+            raise unittest.SkipTest(
+                "neither tomllib nor tomli available; cannot parse pyproject.toml"
+            )
+
+
+class PyProjectShapeTests(unittest.TestCase):
+    """The pyproject.toml must declare the canonical SDK metadata."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not PYPROJECT.exists():
+            raise unittest.SkipTest("pyproject.toml not present at repo root")
+        cls.cfg = _load_pyproject()
+
+    def test_build_system_uses_setuptools_meta(self):
+        bs = self.cfg.get("build-system", {})
+        self.assertIn("setuptools.build_meta", bs.get("build-backend", ""))
+        self.assertTrue(any("setuptools" in r for r in bs.get("requires", [])))
+
+    def test_project_name_is_james_pack_sdk(self):
+        self.assertEqual(self.cfg["project"]["name"], "james-pack-sdk")
+
+    def test_project_version_matches_james_init(self):
+        from james import __version__ as pkg_version
+        self.assertEqual(self.cfg["project"]["version"], pkg_version,
+                         "pyproject.toml version must match james.__version__")
+
+    def test_python_version_floor_at_least_3_10(self):
+        # Sanity check on the runtime floor. `core/` uses 3.10+ syntax,
+        # so the SDK can't claim broader support without breaking on
+        # the runtime API import path.
+        req = self.cfg["project"]["requires-python"]
+        self.assertTrue(req.startswith(">=3.10") or req.startswith(">=3.11"),
+                        f"unexpected requires-python: {req!r}")
+
+    def test_license_field_points_at_repo_license(self):
+        lic = self.cfg["project"]["license"]
+        self.assertEqual(lic.get("file"), "LICENSE")
+        self.assertTrue((REPO_ROOT / "LICENSE").exists(),
+                        "LICENSE file referenced by pyproject must exist")
+
+    def test_readme_field_points_at_sdk_readme(self):
+        self.assertEqual(self.cfg["project"]["readme"], "docs/SDK_README.md")
+        self.assertTrue((REPO_ROOT / "docs" / "SDK_README.md").exists())
+
+    def test_console_script_entry_point_is_james_pack(self):
+        scripts = self.cfg["project"].get("scripts", {})
+        self.assertEqual(scripts.get("james-pack"),
+                         "james.pack.__main__:main")
+
+    def test_setuptools_find_whitelists_james_only(self):
+        # The wheel must NOT contain `core/`, `routes/`, `frontend/`,
+        # etc. The include list pins this.
+        cfg = self.cfg.get("tool", {}).get("setuptools", {})
+        find_cfg = cfg.get("packages", {}).get("find", {})
+        self.assertIn("james", find_cfg.get("include", []))
+        self.assertIn("james.*", find_cfg.get("include", []))
+
+
+class SemVerDocTests(unittest.TestCase):
+    """SDK_VERSIONING.md must exist + name the public surface."""
+
+    def test_versioning_doc_exists(self):
+        path = REPO_ROOT / "docs" / "SDK_VERSIONING.md"
+        self.assertTrue(path.exists(), "docs/SDK_VERSIONING.md missing")
+
+    def test_versioning_doc_names_public_api_symbols(self):
+        path = REPO_ROOT / "docs" / "SDK_VERSIONING.md"
+        content = path.read_text(encoding="utf-8")
+        # Sanity: doc must enumerate the canonical public-surface
+        # entries so a future contributor can't accidentally remove
+        # one without bumping major.
+        for sym in (
+            "james.pack.OntologyPack",
+            "james.pack.register_pack",
+            "james.pack.unmount_pack",
+            "james.pack.scaffold.validate_pack_id",
+            "james.pack.scaffold.write_scaffold",
+            "james-pack",
+        ):
+            self.assertIn(sym, content,
+                          f"SDK_VERSIONING.md missing public symbol: {sym}")
+
+    def test_versioning_doc_states_12_month_window(self):
+        # The deprecation window is non-negotiable per the v0.3 gate.
+        path = REPO_ROOT / "docs" / "SDK_VERSIONING.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("12 months", content)
+
+
+class BuildArtifactTests(unittest.TestCase):
+    """Build the wheel + sdist and inspect the result."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import build  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest(
+                "build library not available; install with `pip install build`"
+            )
+        cls._tmp = tempfile.mkdtemp(prefix="james_sdk_build_")
+        cls._dist = Path(cls._tmp) / "dist"
+        cls._dist.mkdir()
+        # Invoke `python -m build --wheel --sdist --outdir <tmp>` from
+        # the repo root. We use a subprocess so the build runs in an
+        # isolated environment per the build-system requirement.
+        result = subprocess.run(
+            [sys.executable, "-m", "build", "--wheel", "--sdist",
+             "--outdir", str(cls._dist), str(REPO_ROOT)],
+            capture_output=True, text=True, env={**os.environ},
+        )
+        if result.returncode != 0:
+            shutil.rmtree(cls._tmp, ignore_errors=True)
+            raise unittest.SkipTest(
+                "build failed (likely missing PEP 517 isolation prereqs); "
+                "stdout:\n" + result.stdout + "\nstderr:\n" + result.stderr
+            )
+        cls._build_output = result.stdout + result.stderr
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    def test_wheel_artifact_present(self):
+        wheels = list(self._dist.glob("james_pack_sdk-*.whl"))
+        self.assertEqual(len(wheels), 1,
+                         f"expected exactly one wheel, got: {wheels}")
+
+    def test_sdist_artifact_present(self):
+        sdists = list(self._dist.glob("james_pack_sdk-*.tar.gz")) + \
+                 list(self._dist.glob("james-pack-sdk-*.tar.gz"))
+        self.assertEqual(len(sdists), 1,
+                         f"expected exactly one sdist, got: {sdists}")
+
+    def test_wheel_contains_only_james_namespace(self):
+        wheels = list(self._dist.glob("james_pack_sdk-*.whl"))
+        if not wheels:
+            self.skipTest("wheel not built")
+        with zipfile.ZipFile(wheels[0]) as zf:
+            members = zf.namelist()
+
+        # Every .py member must be under `james/` (with the
+        # exception of `*.dist-info/*` metadata).
+        py_members = [m for m in members
+                      if m.endswith(".py") and ".dist-info/" not in m]
+        for m in py_members:
+            self.assertTrue(m.startswith("james/"),
+                            f"unexpected file in wheel: {m!r}")
+
+        # Affirm: NONE of the bulky repo dirs leak in.
+        for forbidden_prefix in ("core/", "routes/", "frontend/",
+                                  "tests/", "scripts/", "docs/"):
+            offenders = [m for m in members if m.startswith(forbidden_prefix)]
+            self.assertEqual(offenders, [],
+                             f"wheel contains forbidden prefix {forbidden_prefix!r}: "
+                             f"{offenders[:3]}")
+
+    def test_wheel_metadata_declares_entry_point(self):
+        wheels = list(self._dist.glob("james_pack_sdk-*.whl"))
+        if not wheels:
+            self.skipTest("wheel not built")
+        with zipfile.ZipFile(wheels[0]) as zf:
+            entry_members = [m for m in zf.namelist()
+                             if m.endswith("entry_points.txt")]
+            self.assertTrue(entry_members,
+                            "wheel missing entry_points.txt")
+            content = zf.read(entry_members[0]).decode("utf-8")
+        self.assertIn("james-pack", content)
+        self.assertIn("james.pack.__main__:main", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Per v0.5 close handover §5.2 Track B SDK.c + `PLATFORM_READINESS.md`
§3 v1.0 gate \"Public SDK + plugin author guide\". **Completes the v0.6
Pack SDK trio** (SDK.a CLI #876 / SDK.b authoring guide #875 / SDK.c
packaging this PR). Mother-platform packaging metadata.

## Summary

### Packaging — `pyproject.toml` (NEW, repo root)

PEP 517 / 621 metadata for `james-pack-sdk`:

- `[build-system]`: `setuptools.build_meta`
- `[project]`: name=`james-pack-sdk`, version=`0.6.0a1` (in lockstep with `james.__version__`), MIT license, `requires-python>=3.10`
- `[project.scripts]`: `james-pack = james.pack.__main__:main` → `pip install james-pack-sdk` exposes the CLI as `james-pack init <pack_id>` without `python -m`
- `[tool.setuptools.packages.find]`: whitelists ONLY `james` + `james.*` so the wheel never contains `core/`, `routes/`, `frontend/`, `tests/`, `scripts/`, or `docs/`
- `[project.urls]`: Homepage / Documentation / Versioning / Issues all point at the GitHub repo

### SDK README — `docs/SDK_README.md` (NEW)

Referenced by `pyproject.toml`'s `readme` field — this is what PyPI displays on the package page. Quickstart, public-surface enumeration, rule #1 capability-gate explanation, links to ONTOLOGY_PACK_AUTHORING + SDK_VERSIONING.

### SemVer policy — `docs/SDK_VERSIONING.md` (NEW)

Per the v0.3 platform gate (12-month deprecation window for public-API removal):

- SemVer 2.0.0 compliance with bump-kind table (PATCH / MINOR / MAJOR examples)
- Canonical public-API surface enumeration — 13 symbols + 2 CLI entries. `_`-prefixed names are explicitly private.
- 12-month deprecation window mechanism: deprecation warning → DEPRECATIONS.md entry → 12-month grace → MAJOR-bump removal
- Pre-1.0 caveat — SemVer §4 lets 0.x.y change anything, but we hold the 12-month window even during 0.x
- Compatibility matrix: 0.6.x ↔ v0.5–v0.6 runtime; 1.0.x ↔ v1.0+
- `sdk-semver-regression` issue label + 7-day reply target

### Tests — `tests/test_v06_sdk_packaging.py` (NEW, 15 tests)

- **PyProjectShapeTests** (8): build-backend, project name, version-in-lockstep with `james.__version__`, python floor, license/readme references, console script entry, `packages.find` whitelist
- **SemVerDocTests** (3): doc exists, names all 6 canonical symbols, states 12-month window
- **BuildArtifactTests** (4): `python -m build` succeeds, wheel + sdist both present, wheel contains ONLY `james/*` (no `core/`, `routes/`, etc.), wheel registers `james-pack` console script

## Verification

- `pytest tests/test_v06_sdk_packaging.py`: **15 passed**
- `python -m build --wheel --sdist`: produces `james_pack_sdk-0.6.0a1-py3-none-any.whl` + `james_pack_sdk-0.6.0a1.tar.gz` (only `james/` subtree, ~13 KB wheel)
- Existing JAMES runtime untouched — `pyproject.toml` is purely a build artifact descriptor; running from source continues to work as before
- Combined regression sweep on the v0.5 F.1 + SDK tests: **63/63 pass**

## Out of scope

- **Does not upload to PyPI** — operator action when ready (handover §5.2 lists this as a discrete release decision)
- Does not change the runtime mount path — `from james.pack import OntologyPack` still requires JAMES `core/` on `PYTHONPATH`; documented in `pyproject.toml` header + `SDK_README`
- Does not implement G8.d — vertical pack capability grant workflow remains LOI-gated per CLAUDE.md rule #1
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: chore — packaging metadata + author-facing docs over the already-shipped SDK.a/SDK.b code; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)