### PR TITLE
docs(v0.6-G1.c): SaaS tenant-isolation deployment guide

### DIFF
--- a/docs/deployment/v0.6-saas-tenant-isolation.md
+++ b/docs/deployment/v0.6-saas-tenant-isolation.md
@@ -1,0 +1,251 @@
+# SaaS Multi-Tenant Isolation — Operator Deployment Guide (v0.6 G1.c)
+
+> **Status**: Operator-facing config doc. Pairs with the G1.a write-side
+> primitive (PR #860) + G1.b replay-side filter (PR #869) +
+> `docs/reviews/v0.5-b2-multi-tenant-isolation.md` design memo (PR #850).
+>
+> **Audience**: anyone deploying JAMES in a multi-tenant SaaS posture
+> where audit rows from one tenant must never surface under another's
+> tenant filter.
+>
+> **CLAUDE.md rule #1**: this doc is **horizontal** — the isolation
+> primitive is content-agnostic. Vertical pack content remains BLOCKED
+> until v1.0 or signed LOI.
+
+---
+
+## 1. TL;DR — what to set for SaaS
+
+| Env var | Local dev | Single-tenant pilot | Multi-tenant SaaS |
+|---|---|---|---|
+| `JAMES_TENANT_ID` | _unset_ | _unset_ or single value | **set per request** via `with_tenant_id` |
+| `JAMES_REQUIRE_TENANT_ID` | _unset_ | _unset_ | **`1`** |
+| `JAMES_AUDIT_DB` | _unset_ (defaults to `audit.db`) | per-tenant path or shared | **shared path** (rows differentiated by `tenant_id`) |
+| Reverse proxy | none | none required | **per-tenant routing** with header injection |
+
+The two flags that matter most:
+
+- **`JAMES_REQUIRE_TENANT_ID=1`** turns on **enforce mode**: every
+  audit emit must resolve a non-empty `tenant_id` (via env or
+  `with_tenant_id`). If the resolution returns `None`, the emit
+  silently returns `False` (matches `replay_audit`'s "never raises"
+  contract) — the row is dropped on the floor rather than written
+  as an unstamped (and therefore strict-exclusion-invisible) row.
+- **Default off** — production code paths that legitimately don't
+  belong to any tenant (housekeeping, retention sweeps) still need
+  to either (a) `with_tenant_id("system")` or (b) explicitly opt
+  out by leaving `JAMES_REQUIRE_TENANT_ID` unset for the housekeeping
+  process.
+
+---
+
+## 2. Why this exists
+
+`docs/reviews/v0.5-b2-multi-tenant-isolation.md` §2 lays out the
+SaaS pattern: **process-shared, data-isolated**. JAMES today runs
+one process per workspace; SaaS needs N tenants per process.
+
+Without `JAMES_REQUIRE_TENANT_ID=1`:
+
+- A code path that forgets to set `tenant_id` still emits a row.
+- That row carries no `tenant_id` field in its payload.
+- G1.b strict-exclusion replay filter treats "no stamp" as "not my
+  tenant" — so the row is invisible under every tenant filter.
+- That row is now **silently isolated** rather than silently leaking.
+  Good news: no cross-tenant data exposure. Bad news: that row is
+  also invisible to housekeeping, retention sweeps, and audit-trail
+  exports.
+
+With `JAMES_REQUIRE_TENANT_ID=1`:
+
+- The emit fails fast (returns `False`) for unstamped paths.
+- The operator notices the missing row immediately (writes are
+  observable via `audit_log` row count), can trace the call site,
+  and either wire `with_tenant_id` correctly or carve out an
+  explicit "system" tenant for that housekeeping path.
+
+The reason "default off" stays the long-term default: single-tenant
+pilots are the dominant deployment shape pre-v1.0. Enforce mode is
+a footgun outside SaaS.
+
+---
+
+## 3. Setting the env vars
+
+### 3.1 Single-tenant pilot (no SaaS)
+
+Nothing to set. v0.5 single-tenant behaviour is preserved
+byte-identical when neither env is set.
+
+### 3.2 Process-scoped single-tenant SaaS pod
+
+When each pod serves exactly one tenant (the "1 process : 1 tenant"
+fallback pattern), the env-var approach works:
+
+```bash
+export JAMES_TENANT_ID=acme
+export JAMES_REQUIRE_TENANT_ID=1
+uvicorn server_llmwiki:app
+```
+
+Every audit emit in this process resolves `tenant_id="acme"` via
+the env-var path; the enforce flag catches any code path that
+accidentally bypasses the emit helper.
+
+### 3.3 Multi-tenant per-request SaaS (target shape)
+
+When one process serves multiple tenants, **leave `JAMES_TENANT_ID`
+unset** and resolve the tenant per request via `with_tenant_id`:
+
+```python
+from core.lifecycle.tenant import with_tenant_id
+
+async def handle_request(req):
+    tenant_id = req.headers["X-Tenant-Id"]  # set by reverse proxy
+    with with_tenant_id(tenant_id):
+        # Every audit emit inside this block stamps tenant_id.
+        return await dispatch(req)
+```
+
+The reverse proxy (Caddy / Traefik / nginx-plus) is responsible for:
+
+1. Validating the tenant-id header signature (don't trust client
+   headers directly — sign them with a key the proxy + JAMES both
+   know, then validate in middleware before reaching the handler).
+2. Routing per-tenant DNS (`acme.app.example.com` → header
+   `X-Tenant-Id: acme`).
+3. Stripping client-supplied `X-Tenant-Id` headers before injecting
+   the proxy-verified one.
+
+### 3.4 Recognised truthy values for `JAMES_REQUIRE_TENANT_ID`
+
+The flag uses the same truthiness convention as the rest of the
+codebase: `"1"`, `"true"`, `"yes"`, `"on"` (case-insensitive).
+Anything else — including the empty string — counts as off.
+
+```python
+# core/lifecycle/tenant.py::is_tenant_isolation_enforced
+TRUTHY = ("1", "true", "yes", "on")
+```
+
+---
+
+## 4. Threading + asyncio caveat
+
+`with_tenant_id` uses `threading.local`. This means:
+
+- **Thread-pool callers (synchronous, including `BackgroundTasks`)**:
+  the override propagates correctly across the `with` block.
+- **`asyncio` tasks**: `threading.local` does NOT propagate across
+  task switches inside the same OS thread. If your handler awaits
+  inside the `with` block AND spawns a new task that emits an audit
+  row, that task will see the parent thread's tenant state at the
+  time the task scheduler resumes it — which may or may not be the
+  same. **In practice, FastAPI handlers run one task per request
+  on the main loop**, so the simple wrap-the-handler pattern in §3.3
+  works. The footgun is `asyncio.gather` with independent emit-
+  capable subtasks; do not assume they all see the same tenant.
+- **Future**: a `contextvars`-based variant is on the v0.6 roadmap
+  (handover §5.1 "Asyncio-task-aware `with_tenant_id`"). When it
+  lands, the synchronous variant stays for back-compat.
+
+---
+
+## 5. Migrating an existing audit_log
+
+If you turn `JAMES_REQUIRE_TENANT_ID=1` on against a pre-existing
+audit_log that contains unstamped rows, those rows become invisible
+to every tenant filter (strict exclusion per G1.b §3.4). The
+options are:
+
+1. **Backfill** the unstamped rows with a known tenant_id via a
+   one-shot SQL update. The replay-side filter looks at the
+   payload-JSON `tenant_id` field, so:
+
+   ```sql
+   UPDATE audit_log
+   SET event_payload = json_set(event_payload, '$.tenant_id', 'legacy')
+   WHERE json_extract(event_payload, '$.tenant_id') IS NULL;
+   ```
+
+   Then operators querying tenant=`legacy` see the historical rows.
+
+2. **Accept invisibility** for legacy rows and start fresh. The
+   rows stay in the DB (no data loss), they just don't surface
+   under any tenant filter. Audit-trail exports without a
+   tenant filter (`tenant_id=None`) still see them.
+
+3. **Per-tenant separation by DB path** instead of per-row
+   `tenant_id`. Set `JAMES_AUDIT_DB=/var/james/acme/audit.db` per
+   tenant pod. This trades the per-request multi-tenancy shape
+   for the per-pod isolation shape — it loses the "shared model
+   + shared embedder" memory savings but keeps the audit boundary
+   crisper. Pick this when SOC2 review hates the shared-DB shape.
+
+---
+
+## 6. What this gate does NOT promise
+
+Per the design memo §3.6:
+
+- **Not cross-tenant query prevention.** A misconfigured admin
+  caller can still pass `tenant_id="other"` and read another
+  tenant's rows. The contract surfaces the boundary; enforcement
+  is the caller's responsibility (HTTP-layer RBAC).
+- **Not row-level encryption.** Tenant-id is a routing token, not
+  a confidentiality boundary. Confidentiality requires v1.0+
+  encrypted-at-rest with separate keys per tenant.
+- **Not multi-process safety.** One process can serve multiple
+  tenants via `with_tenant_id`; multiple processes still need OS-
+  level mutex on the SQLite file (existing v0.5 limitation).
+- **Not vertical-pack-specific.** Tenant_id and vertical pack
+  mounting are orthogonal contracts. CLAUDE.md rule #1 still
+  applies; the SaaS deployment cannot mount a vertical pack
+  without operator capability grant.
+
+---
+
+## 7. Operational checklist (pre-prod)
+
+Before promoting `JAMES_REQUIRE_TENANT_ID=1` from staging to
+production:
+
+- [ ] Reverse proxy injects a signed `X-Tenant-Id` header — and
+      strips client-supplied ones first.
+- [ ] Handler middleware validates the header signature before any
+      handler logic runs (fail-closed: reject the request, not
+      "fall back to no tenant").
+- [ ] Every FastAPI handler that emits audit rows wraps in
+      `with with_tenant_id(req.state.tenant_id):` — grep
+      `emit_lifecycle_event` to enumerate emit sites; cross-check
+      each one belongs inside such a block.
+- [ ] Housekeeping / retention paths either run in their own
+      process WITHOUT `JAMES_REQUIRE_TENANT_ID=1`, OR use
+      `with_tenant_id("system")` explicitly.
+- [ ] Replay-side queries (`/admin/graph/reconstruct-at`,
+      `/admin/graph/diff-vs-now`) are routed through the same
+      tenant-validated handler so an authenticated operator can't
+      read another tenant's rows by passing `tenant_id=<other>`.
+      (The endpoint accepts the param; the HTTP layer must
+      cross-reference against the proxy-validated identity before
+      forwarding.)
+- [ ] Monitoring: alert on `audit_log` row inserts with
+      `event_type='lifecycle.*'` AND `event_payload` missing a
+      `tenant_id` key in the production DB. With enforce mode on,
+      this count should be 0; non-zero = footgun caught.
+
+---
+
+## 8. References
+
+- Design memo: `docs/reviews/v0.5-b2-multi-tenant-isolation.md`
+  §3 (G1 tenant-id contract)
+- Write-side primitive: `core/lifecycle/tenant.py` (G1.a, PR #860)
+- Replay-side filter: `core/lifecycle/replay_graph.py::reconstruct_graph_at`
+  (G1.b, PR #869)
+- Endpoint surface: `/admin/graph/reconstruct-at?tenant_id=...`
+  (TT.b, PR #878) + `/admin/graph/diff-vs-now?tenant_id=...`
+  (TT.d, PR #880)
+- v0.5 close handover: `docs/handovers/v0.5-close-2026-06-12.md`
+  §5.1 Track A
+- CLAUDE.md rule #1 (no vertical content until v1.0)


### PR DESCRIPTION
Per v0.5 close handover §5.1 Track A G1.c + `docs/reviews/v0.5-b2-multi-tenant-isolation.md` §3.7 phased-rollout table. **Completes the v0.5 G1 tenant-id contract trio**: G1.a write-side (#860) / G1.b replay-side (#869) / G1.c operator deployment doc (this PR). Mother-platform doc.

## Summary

New file: `docs/deployment/v0.6-saas-tenant-isolation.md` — operator-facing config guide for `JAMES_REQUIRE_TENANT_ID=1` in SaaS deployments.

## Structure

| § | Topic |
|---|---|
| 1 | TL;DR env-var matrix (local / single-tenant pilot / multi-tenant SaaS) |
| 2 | Why this exists — strict-exclusion semantics + enforce-mode rationale |
| 3 | Setting the env vars — three deployment shapes including `with_tenant_id` + reverse-proxy header injection |
| 4 | Threading + asyncio caveat — current `threading.local` limitation + v0.6 contextvars roadmap |
| 5 | Migrating an existing audit_log — three options (SQL backfill / accept invisibility / per-tenant DB paths) |
| 6 | What this gate does NOT promise — quotes design memo §3.6 non-promises |
| 7 | Operational checklist — 6-item pre-prod gate |
| 8 | References — design memo + primitives + endpoint surfaces |

## Verification

- No code changed; this is operator documentation
- Cross-references verified against current `main`:
  - `core/lifecycle/tenant.py` (G1.a, PR #860) — truthy convention `(\"1\",\"true\",\"yes\",\"on\")` quoted from the source
  - `core/lifecycle/replay_graph.py::reconstruct_graph_at` (G1.b, PR #869) — `tenant_id` kwarg + strict-exclusion semantic verified
  - `/admin/graph/reconstruct-at` (PR #878) + `/admin/graph/diff-vs-now` (PR #880) — both accept `tenant_id` query param

## Out of scope

- Does NOT change the default — `JAMES_REQUIRE_TENANT_ID` stays off. Single-tenant pilots remain byte-identical
- Does NOT add HTTP-layer RBAC for replay endpoints — that's deployment-side (reverse proxy + middleware), correctly out of scope for the JAMES core
- Does NOT implement `contextvars`-based async-aware `with_tenant_id` — v0.6 G1.c+ follow-up; this doc documents the current `threading.local` limitation explicitly
- Vertical content **BLOCKED** per CLAUDE.md rule #1 — SaaS isolation is horizontal infrastructure

## Quality Delta Card

`Quality delta: exempt (label: docs — operator-facing deployment guide; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)