### PR TITLE
feat(v0.6-G2.c): OIDC resolver surface + async-task-aware tenant variant

### DIFF
--- a/core/lifecycle/tenant.py
+++ b/core/lifecycle/tenant.py
@@ -10,13 +10,18 @@ override is active.
   * `JAMES_TENANT_ID_ENV` — name of the env var (constant, for tests).
   * `JAMES_REQUIRE_TENANT_ID_ENV` — name of the enforcement env var.
   * `current_tenant_id()` → ``Optional[str]`` — resolves the active
-    tenant from (1) thread-local override stack, (2) the
-    `JAMES_TENANT_ID` env var. ``None`` if neither.
-  * `with_tenant_id(tenant_id)` — context-manager that pushes a
+    tenant from (1) the current asyncio task's contextvars-backed
+    override stack, (2) the thread-local override stack, (3) the
+    `JAMES_TENANT_ID` env var. ``None`` if none resolve.
+  * `with_tenant_id(tenant_id)` — sync context-manager that pushes a
     thread-local override for the duration of the `with` block.
     Used by admin tooling that writes audit rows on behalf of a
     specific tenant from a process without a single ambient
     tenant.
+  * `with_tenant_id_async(tenant_id)` — async context-manager (v0.6
+    G2.c) that pushes a contextvars-backed override propagating
+    across `await` points + into child tasks created inside the
+    block. Use this from FastAPI / asyncio handlers.
   * `is_tenant_isolation_enforced()` → ``bool`` — true iff
     `JAMES_REQUIRE_TENANT_ID` is set to a recognised truthy value.
     The audit-emitter consults this to decide whether emit
@@ -40,19 +45,21 @@ retention_class field (landed PR #848).
 - **Not an RBAC layer.** Tenant_id is an audit-trail correlation
   primitive. Cross-tenant query prevention is handled at the
   HTTP layer (reverse proxy + per-tenant routes), not here.
-- **Not thread-safe across asyncio tasks.** The override stack
-  uses `threading.local`, which carries per-thread but does NOT
-  carry per-asyncio-task. Admin tooling using `with_tenant_id`
-  inside an `async def` should either (a) use it at thread-pool
-  call sites only, or (b) wait for the asyncio-aware variant
-  scheduled in G1.b.
+- **Not thread-safe across asyncio tasks (sync API only).** The
+  synchronous `with_tenant_id` override stack uses
+  `threading.local`, which carries per-thread but does NOT
+  carry per-asyncio-task. Async callers should use
+  `with_tenant_id_async` (v0.6 G2.c) — a contextvars-backed
+  variant that DOES propagate across `await` points + into
+  child tasks created inside its `async with` block.
 """
 from __future__ import annotations
 
+import contextvars
 import os
 import threading
-from contextlib import contextmanager
-from typing import Final, Iterator, Optional
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncIterator, Final, Iterator, List, Optional
 
 
 JAMES_TENANT_ID_ENV:         Final[str] = "JAMES_TENANT_ID"
@@ -62,6 +69,21 @@ JAMES_REQUIRE_TENANT_ID_ENV: Final[str] = "JAMES_REQUIRE_TENANT_ID"
 # Thread-local override stack. `with_tenant_id` pushes; on exit,
 # pops. The stack supports nested overrides (the innermost wins).
 _local = threading.local()
+
+# v0.6 G2.c — contextvars-backed override stack for async callers.
+# `with_tenant_id_async` populates this; `current_tenant_id` checks
+# it BEFORE the thread-local stack so an async caller's per-task
+# override wins over an ambient thread-level override.
+#
+# Why a separate stack: `contextvars.ContextVar` propagates across
+# `await` points but not across `threading.Thread.start` boundaries
+# — so mixing one stack risks losing the ambient thread tenant when
+# an async caller spawns a sync worker. Two stacks keep the
+# semantics crisp: thread-local for sync code, contextvars for
+# async code, both readable from `current_tenant_id`.
+_async_stack: contextvars.ContextVar[Optional[List[Optional[str]]]] = (
+    contextvars.ContextVar("james_tenant_async_stack", default=None)
+)
 
 
 def _stack() -> list:
@@ -73,19 +95,37 @@ def _stack() -> list:
     return stack
 
 
+def _async_stack_get() -> Optional[List[Optional[str]]]:
+    """Read the current task's async override stack, or None if no
+    `with_tenant_id_async` is active on this task."""
+    return _async_stack.get()
+
+
 def current_tenant_id() -> Optional[str]:
     """Resolve the active tenant id.
 
     Resolution order (first match wins):
-      1. Innermost `with_tenant_id(...)` override on the current
+      1. Innermost `with_tenant_id_async(...)` override on the
+         current asyncio task (v0.6 G2.c), if any.
+      2. Innermost `with_tenant_id(...)` override on the current
          thread, if any.
-      2. `JAMES_TENANT_ID` env var, if set + non-empty.
-      3. ``None``.
+      3. `JAMES_TENANT_ID` env var, if set + non-empty.
+      4. ``None``.
 
     Returns the empty string as ``None`` so callers don't accidentally
     stamp an empty-string tenant_id (which is a different audit-row
     state from "no tenant scope known").
+
+    Async/sync interaction: the async stack is per-task; the
+    thread-local stack is per-thread. A `with_tenant_id_async` block
+    that internally calls a sync helper (e.g. via
+    `run_in_executor`) carries its tenant scope across the await
+    boundary, then drops back to the thread-local stack when the
+    sync worker runs in a different thread.
     """
+    async_stack = _async_stack_get()
+    if async_stack:
+        return async_stack[-1]
     stack = _stack()
     if stack:
         return stack[-1]
@@ -122,6 +162,51 @@ def with_tenant_id(tenant_id: Optional[str]) -> Iterator[None]:
             stack.pop()
 
 
+@asynccontextmanager
+async def with_tenant_id_async(tenant_id: Optional[str]) -> AsyncIterator[None]:
+    """Async-task-aware override (v0.6 G2.c).
+
+    Pushes ``tenant_id`` onto the current task's contextvars-backed
+    override stack on entry; pops on exit. Designed for FastAPI /
+    asyncio handlers that need the tenant scope to survive ``await``
+    points within the same task — the threading.local-backed
+    :func:`with_tenant_id` does not propagate across awaits in a
+    single thread (see the v0.5 G1.a docstring note).
+
+    Pattern::
+
+        async def handler(req):
+            tenant_id = req.state.tenant_id
+            async with with_tenant_id_async(tenant_id):
+                # Every audit emit inside this block stamps tenant_id,
+                # even after `await` points and across `asyncio.gather`
+                # child tasks (provided they were scheduled inside
+                # the block — contextvars copy on task creation).
+                return await do_work(req)
+
+    `asyncio.gather` semantics: subtasks created inside the block
+    inherit the parent task's contextvars at creation time, so they
+    see the override. Subtasks created OUTSIDE the block do not.
+
+    Nesting is supported — innermost wins, outer overrides restore
+    naturally on exit, mirroring the sync :func:`with_tenant_id`.
+    """
+    stack = list(_async_stack_get() or [])
+    stack.append(tenant_id)
+    token = _async_stack.set(stack)
+    try:
+        yield
+    finally:
+        # Restore the previous stack snapshot. We don't pop in-place
+        # because the ContextVar's value is a list reference; another
+        # task created during the block may still hold a reference to
+        # the longer list. Setting the token back to the prior value
+        # restores the correct visible state for THIS task; siblings
+        # keep their inherited reference unchanged (matches the
+        # `contextvars.Context.copy` semantic).
+        _async_stack.reset(token)
+
+
 def is_tenant_isolation_enforced() -> bool:
     """True iff `JAMES_REQUIRE_TENANT_ID` is set to a truthy value.
 
@@ -143,5 +228,6 @@ __all__ = (
     "JAMES_REQUIRE_TENANT_ID_ENV",
     "current_tenant_id",
     "with_tenant_id",
+    "with_tenant_id_async",
     "is_tenant_isolation_enforced",
 )

--- a/core/security/approval_evidence.py
+++ b/core/security/approval_evidence.py
@@ -43,11 +43,14 @@ deploy will pick.
 
 ## What this module is NOT
 
-- **Not an OIDC verifier.** The OIDC resolution path is documented
-  in §4.4 of the B.2 memo and lands in G2.c when a customer's IdP
-  is in scope. This PR's `current_approval_evidence` returns
-  evidence only when an explicit override OR the POSIX floor
-  resolves.
+- **Not a bundled OIDC verifier.** v0.6 G2.c ships the OIDC
+  *resolution surface* — the env-var contract + the pluggable
+  validator hook (:func:`register_oidc_validator`) — but no
+  built-in JWKS verifier. The signature-checking implementation
+  depends on which crypto library the operator's IdP is friendly
+  with (``python-jose`` / ``authlib`` / ``PyJWT`` / custom shim),
+  so we pin the contract here and the IdP integration ships in
+  the deployment layer.
 - **Not a credential store.** Evidence is stored as a hash, not
   recoverable plaintext. Key rotation is the IdP's concern.
 - **Not an approver-list enforcer.** "Who CAN approve" is RBAC at
@@ -65,7 +68,7 @@ import hashlib
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Final, Literal, Optional
+from typing import Any, Callable, Final, Literal, Mapping, Optional
 
 
 JAMES_APPROVAL_PRINCIPAL_ENV:       Final[str] = "JAMES_APPROVAL_PRINCIPAL"
@@ -73,6 +76,17 @@ JAMES_APPROVAL_EVIDENCE_B64_ENV:    Final[str] = "JAMES_APPROVAL_EVIDENCE_B64"
 JAMES_REQUIRE_APPROVAL_EVIDENCE_ENV: Final[str] = (
     "JAMES_REQUIRE_APPROVAL_EVIDENCE"
 )
+
+# v0.6 G2.c — OIDC discovery surface env vars. The OIDC validator
+# is a pluggable hook (see :func:`register_oidc_validator`) — until
+# a customer IdP is in scope, no built-in validator ships and
+# `_resolve_oidc` returns None even when these env vars are set.
+# That keeps the mother-platform contract free of an IdP dependency
+# while documenting the env surface the operator will wire up at
+# the first SaaS pilot.
+JAMES_OIDC_ISSUER_ENV:    Final[str] = "JAMES_OIDC_ISSUER"
+JAMES_OIDC_TOKEN_ENV:     Final[str] = "JAMES_OIDC_TOKEN"
+JAMES_OIDC_AUDIENCE_ENV:  Final[str] = "JAMES_OIDC_AUDIENCE"
 
 
 # Recognised source labels — locked here because the audit-row
@@ -142,6 +156,125 @@ def require_approval_evidence() -> bool:
 # ─── Resolvers ────────────────────────────────────────────────────────
 
 
+# ─── OIDC validator hook (G2.c) ─────────────────────────────────────
+#
+# `OIDCValidator` receives ``(token, issuer, audience)`` and returns
+# the validated claims dict (carrying at least ``sub`` and optionally
+# ``exp``) when verification succeeds, or ``None`` on any failure
+# (signature mismatch, expired token, audience mismatch, JWKS fetch
+# error). Implementations vary by IdP — Auth0, Okta, Google Workspace
+# all expose ``/.well-known/openid-configuration`` but the JWKS
+# format + claim shape diverges slightly. We pin the contract surface
+# here and ship NO built-in validator until a customer IdP is in
+# scope (per the v0.5 G2.a docstring + B.2 §4.4 design memo). Setting
+# the env vars without registering a validator returns None — the
+# mother-platform contract stays free of an IdP dependency.
+
+OIDCValidator = Callable[[str, str, str], Optional[Mapping[str, Any]]]
+
+_oidc_validator: Optional[OIDCValidator] = None
+
+
+def register_oidc_validator(validator: Optional[OIDCValidator]) -> None:
+    """Install (or remove with ``None``) the OIDC token validator.
+
+    The validator's contract:
+
+        ``validator(token, issuer, audience)`` →
+            ``None`` on any failure
+            ``Mapping[str, Any]`` carrying at minimum ``sub`` (str)
+            and optionally ``exp`` (int — seconds since epoch) on
+            success.
+
+    Why pluggable: the validator MUST do JWKS discovery + signature
+    verification + audience matching, and the implementation depends
+    on which crypto library the operator is willing to install
+    (``python-jose``, ``authlib``, ``PyJWT``, a custom shim for an
+    in-house IdP, ...). Bundling one would force a dependency the
+    mother-platform contract refuses to take until a customer
+    specifies their IdP.
+
+    Default: no validator. ``_resolve_oidc`` returns None until a
+    validator is registered.
+
+    Test/fake validators: pass any callable that returns the right
+    shape. The test suite uses an in-memory fake to exercise the
+    resolution path without HTTP / crypto.
+    """
+    global _oidc_validator
+    _oidc_validator = validator
+
+
+def _resolve_oidc() -> Optional[ApprovalEvidence]:
+    """Resolve from `JAMES_OIDC_ISSUER` + `_TOKEN` + `_AUDIENCE` env.
+
+    Requires (a) all three env vars set, and (b) an OIDC validator
+    registered via :func:`register_oidc_validator`. Without (b),
+    returns None even if (a) is satisfied — see the validator hook
+    docstring for why.
+
+    On success the evidence carries:
+      * principal: the ``sub`` claim
+      * source: ``"oidc"``
+      * evidence_hash: sha256 over the token's signature segment
+        (the third dot-separated segment of a JWS). The token's
+        header + payload are recoverable from the audit log if
+        operators wish; the signature alone is the irrecoverable
+        proof.
+      * captured_at: ISO-8601 now (UTC)
+      * expires_at: ISO-8601 of the ``exp`` claim if present (UTC)
+    """
+    issuer = (os.environ.get(JAMES_OIDC_ISSUER_ENV) or "").strip()
+    token = (os.environ.get(JAMES_OIDC_TOKEN_ENV) or "").strip()
+    audience = (os.environ.get(JAMES_OIDC_AUDIENCE_ENV) or "").strip()
+    if not (issuer and token and audience):
+        return None
+    validator = _oidc_validator
+    if validator is None:
+        return None
+
+    try:
+        claims = validator(token, issuer, audience)
+    except Exception:
+        # Validators may raise on transient JWKS failures. We treat
+        # any exception as "no evidence resolved" — matching the
+        # other resolvers' contract. The caller's enforce-mode gate
+        # decides whether absence is fatal.
+        return None
+    if not isinstance(claims, Mapping):
+        return None
+    principal = claims.get("sub")
+    if not isinstance(principal, str) or not principal:
+        return None
+
+    # Hash the token's signature segment (the third part of a JWS).
+    # When the token isn't dot-segmented in the standard shape, hash
+    # the entire token as a safe fallback.
+    parts = token.split(".")
+    if len(parts) >= 3 and parts[2]:
+        sig_blob = parts[2].encode("utf-8")
+    else:
+        sig_blob = token.encode("utf-8")
+
+    expires_at = ""
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)) and exp > 0:
+        try:
+            expires_at = datetime.fromtimestamp(
+                float(exp), tz=timezone.utc,
+            ).isoformat()
+        except (OverflowError, OSError, ValueError):
+            expires_at = ""
+
+    return ApprovalEvidence(
+        principal=principal,
+        source="oidc",
+        evidence_hash=_sha256_hex(sig_blob),
+        captured_at=_utc_now_iso(),
+        expires_at=expires_at,
+    )
+
+
 def _resolve_explicit() -> Optional[ApprovalEvidence]:
     """Resolve from `JAMES_APPROVAL_PRINCIPAL` + `_EVIDENCE_B64`.
 
@@ -209,12 +342,16 @@ def current_approval_evidence(
 
     Resolution order (first match wins):
 
-      1. **Explicit override** — `JAMES_APPROVAL_PRINCIPAL` + a
+      1. **OIDC** (v0.6 G2.c) — requires `JAMES_OIDC_ISSUER` +
+         `_TOKEN` + `_AUDIENCE` env vars set AND a validator
+         registered via :func:`register_oidc_validator`. Used by
+         SaaS deployments fronted by an enterprise IdP.
+      2. **Explicit override** — `JAMES_APPROVAL_PRINCIPAL` + a
          base64-encoded evidence blob in
          `JAMES_APPROVAL_EVIDENCE_B64`. Used by CI / automation /
          service-account approvals where a signed token is the
          evidence carrier.
-      2. **POSIX floor** — `getpass.getuser()` when
+      3. **POSIX floor** — `getpass.getuser()` when
          `allow_posix_fallback` is True (the default). Used by
          local-dev and single-tenant production where the operator
          is the principal.
@@ -223,11 +360,12 @@ def current_approval_evidence(
     typically a hard-rejection in enforce mode — is the
     `require_approval_evidence` gate's responsibility).
 
-    OIDC + SSH resolution paths land in G2.b / G2.c (separate PRs).
-    They will slot in as resolution steps 0 / 3 (OIDC ahead of
-    explicit; SSH after POSIX) without changing this function's
-    signature.
+    SSH-evidence resolution will slot in as resolution step 4 (after
+    POSIX) when a customer's bastion-host workflow is in scope.
     """
+    oidc = _resolve_oidc()
+    if oidc is not None:
+        return oidc
     explicit = _resolve_explicit()
     if explicit is not None:
         return explicit
@@ -238,8 +376,13 @@ __all__ = (
     "JAMES_APPROVAL_PRINCIPAL_ENV",
     "JAMES_APPROVAL_EVIDENCE_B64_ENV",
     "JAMES_REQUIRE_APPROVAL_EVIDENCE_ENV",
+    "JAMES_OIDC_ISSUER_ENV",
+    "JAMES_OIDC_TOKEN_ENV",
+    "JAMES_OIDC_AUDIENCE_ENV",
     "ApprovalEvidence",
     "ApprovalSource",
+    "OIDCValidator",
     "current_approval_evidence",
+    "register_oidc_validator",
     "require_approval_evidence",
 )

--- a/tests/test_v06_g2c_oidc_async_tenant.py
+++ b/tests/test_v06_g2c_oidc_async_tenant.py
@@ -1,0 +1,301 @@
+"""v0.6 G2.c — OIDC resolver + async-task-aware tenant variant.
+
+Two complementary primitives land in the same PR per v0.5 close
+handover §5.1 Track A:
+
+  * ``core.security.approval_evidence._resolve_oidc`` +
+    ``register_oidc_validator`` — surface OIDC token validation as a
+    pluggable hook. No bundled JWKS verifier yet; the hook is the
+    contract the deployment layer fills in.
+  * ``core.lifecycle.tenant.with_tenant_id_async`` — contextvars-backed
+    async context manager so FastAPI / asyncio handlers can scope a
+    tenant_id across ``await`` points + into child tasks created
+    inside the block.
+
+Coverage:
+
+OIDC:
+  * No env vars → None (resolution doesn't reach the hook)
+  * Env vars set but no validator → None (mother-platform contract:
+    no IdP dependency by default)
+  * Validator returns valid claims → ApprovalEvidence with source=oidc,
+    principal=claims["sub"], expires_at derived from exp claim
+  * Validator returns None → None
+  * Validator raises → None (transient failures don't crash)
+  * OIDC ordered ahead of explicit + POSIX in current_approval_evidence
+  * Signature segment hashed (JWS shape "h.p.s") vs whole-token
+    fallback (non-JWS shape)
+
+Async tenant:
+  * with_tenant_id_async overrides on entry, restores on exit
+  * Override propagates across an `await asyncio.sleep(0)`
+  * Override propagates into a child task created inside the block
+  * A sibling task created OUTSIDE the block does NOT inherit it
+  * Async stack takes precedence over the sync threading.local stack
+  * Nested async overrides — innermost wins
+
+Run:
+  python -m unittest tests.test_v06_g2c_oidc_async_tenant
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ─── OIDC resolver tests ─────────────────────────────────────────────
+
+
+class OIDCResolverTests(unittest.TestCase):
+    def setUp(self):
+        # Snapshot env so each test starts clean. The module-level
+        # validator hook is also snapshotted so test pollution doesn't
+        # leak across cases.
+        from core.security import approval_evidence as ae
+        self._ae = ae
+        self._env_snapshot = {
+            k: os.environ.get(k)
+            for k in (
+                ae.JAMES_OIDC_ISSUER_ENV,
+                ae.JAMES_OIDC_TOKEN_ENV,
+                ae.JAMES_OIDC_AUDIENCE_ENV,
+                ae.JAMES_APPROVAL_PRINCIPAL_ENV,
+                ae.JAMES_APPROVAL_EVIDENCE_B64_ENV,
+            )
+        }
+        for k in self._env_snapshot:
+            os.environ.pop(k, None)
+        self._validator_snapshot = ae._oidc_validator
+        ae.register_oidc_validator(None)
+
+    def tearDown(self):
+        for k, v in self._env_snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self._ae.register_oidc_validator(self._validator_snapshot)
+
+    def _set_oidc_env(self, issuer="https://idp.example.com",
+                     token="hhh.ppp.sssignature",
+                     audience="acme"):
+        os.environ[self._ae.JAMES_OIDC_ISSUER_ENV] = issuer
+        os.environ[self._ae.JAMES_OIDC_TOKEN_ENV] = token
+        os.environ[self._ae.JAMES_OIDC_AUDIENCE_ENV] = audience
+
+    def test_no_env_returns_none(self):
+        self.assertIsNone(self._ae._resolve_oidc())
+
+    def test_env_set_but_no_validator_returns_none(self):
+        self._set_oidc_env()
+        # No validator registered — mother-platform default. Must
+        # NOT fall through to the explicit / POSIX resolvers (the
+        # caller calls _resolve_oidc directly here).
+        self.assertIsNone(self._ae._resolve_oidc())
+
+    def test_validator_returns_claims_yields_oidc_evidence(self):
+        self._set_oidc_env()
+        captured = {}
+
+        def fake_validator(token, issuer, audience):
+            captured["token"] = token
+            captured["issuer"] = issuer
+            captured["audience"] = audience
+            return {"sub": "alice@acme.com", "exp": 9999999999}
+
+        self._ae.register_oidc_validator(fake_validator)
+        ev = self._ae._resolve_oidc()
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev.source, "oidc")
+        self.assertEqual(ev.principal, "alice@acme.com")
+        # captured: validator received the env values verbatim.
+        self.assertEqual(captured["token"], "hhh.ppp.sssignature")
+        self.assertEqual(captured["issuer"], "https://idp.example.com")
+        self.assertEqual(captured["audience"], "acme")
+        # expires_at populated from exp claim.
+        self.assertTrue(ev.expires_at)
+
+    def test_validator_returns_none_yields_no_evidence(self):
+        self._set_oidc_env()
+        self._ae.register_oidc_validator(lambda t, i, a: None)
+        self.assertIsNone(self._ae._resolve_oidc())
+
+    def test_validator_raises_yields_no_evidence(self):
+        self._set_oidc_env()
+
+        def boom(*_):
+            raise RuntimeError("transient JWKS fetch failed")
+
+        self._ae.register_oidc_validator(boom)
+        self.assertIsNone(self._ae._resolve_oidc())
+
+    def test_signature_hash_uses_jws_segment_when_dotted(self):
+        # JWS shape: header.payload.signature → hash the signature.
+        self._set_oidc_env(token="aaa.bbb.SIGSEGMENT")
+        self._ae.register_oidc_validator(lambda t, i, a: {"sub": "x"})
+        ev = self._ae._resolve_oidc()
+        import hashlib
+        expected = hashlib.sha256(b"SIGSEGMENT").hexdigest()
+        self.assertEqual(ev.evidence_hash, expected)
+
+    def test_signature_hash_falls_back_to_whole_token_for_non_jws(self):
+        # Not a JWS — hash the full token bytes.
+        self._set_oidc_env(token="opaque-bearer-token")
+        self._ae.register_oidc_validator(lambda t, i, a: {"sub": "x"})
+        ev = self._ae._resolve_oidc()
+        import hashlib
+        expected = hashlib.sha256(b"opaque-bearer-token").hexdigest()
+        self.assertEqual(ev.evidence_hash, expected)
+
+    def test_resolves_oidc_ahead_of_explicit_and_posix(self):
+        # All three sources available — OIDC wins.
+        self._set_oidc_env()
+        self._ae.register_oidc_validator(
+            lambda t, i, a: {"sub": "oidc-principal"}
+        )
+        os.environ[self._ae.JAMES_APPROVAL_PRINCIPAL_ENV] = "explicit-principal"
+        os.environ[self._ae.JAMES_APPROVAL_EVIDENCE_B64_ENV] = "ZXZpZGVuY2U="
+
+        ev = self._ae.current_approval_evidence()
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev.source, "oidc")
+        self.assertEqual(ev.principal, "oidc-principal")
+
+    def test_falls_through_to_explicit_when_oidc_unavailable(self):
+        # OIDC env vars unset → resolution moves to explicit.
+        os.environ[self._ae.JAMES_APPROVAL_PRINCIPAL_ENV] = "ci-bot"
+        os.environ[self._ae.JAMES_APPROVAL_EVIDENCE_B64_ENV] = "ZXZpZGVuY2U="
+        ev = self._ae.current_approval_evidence(allow_posix_fallback=False)
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev.source, "explicit")
+        self.assertEqual(ev.principal, "ci-bot")
+
+    def test_invalid_validator_return_shape_is_rejected(self):
+        # Validator returns a non-mapping → resolver returns None.
+        self._set_oidc_env()
+        self._ae.register_oidc_validator(lambda t, i, a: ["sub", "alice"])
+        self.assertIsNone(self._ae._resolve_oidc())
+
+    def test_missing_sub_claim_is_rejected(self):
+        self._set_oidc_env()
+        self._ae.register_oidc_validator(lambda t, i, a: {"aud": "acme"})
+        self.assertIsNone(self._ae._resolve_oidc())
+
+
+# ─── async-aware with_tenant_id tests ────────────────────────────────
+
+
+class AsyncTenantTests(unittest.TestCase):
+    """`with_tenant_id_async` must propagate across awaits + child tasks."""
+
+    def setUp(self):
+        from core.lifecycle import tenant
+        self._t = tenant
+        # Clear ambient state — env var, sync stack, async stack.
+        self._env_snapshot = os.environ.get(tenant.JAMES_TENANT_ID_ENV)
+        os.environ.pop(tenant.JAMES_TENANT_ID_ENV, None)
+        tenant._local.stack = []  # sync stack
+        tenant._async_stack.set(None)  # async stack
+
+    def tearDown(self):
+        if self._env_snapshot is None:
+            os.environ.pop(self._t.JAMES_TENANT_ID_ENV, None)
+        else:
+            os.environ[self._t.JAMES_TENANT_ID_ENV] = self._env_snapshot
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_async_override_visible_inside_block(self):
+        async def case():
+            self.assertIsNone(self._t.current_tenant_id())
+            async with self._t.with_tenant_id_async("acme"):
+                self.assertEqual(self._t.current_tenant_id(), "acme")
+            self.assertIsNone(self._t.current_tenant_id())
+        self._run(case())
+
+    def test_async_override_survives_await(self):
+        async def case():
+            async with self._t.with_tenant_id_async("acme"):
+                await asyncio.sleep(0)
+                self.assertEqual(self._t.current_tenant_id(), "acme")
+        self._run(case())
+
+    def test_child_task_inherits_override(self):
+        async def case():
+            seen = []
+
+            async def child():
+                seen.append(self._t.current_tenant_id())
+
+            async with self._t.with_tenant_id_async("acme"):
+                await asyncio.create_task(child())
+            self.assertEqual(seen, ["acme"])
+        self._run(case())
+
+    def test_sibling_task_created_outside_does_not_inherit(self):
+        async def case():
+            seen = []
+
+            async def sibling():
+                # Yield once so the parent has time to enter the
+                # `async with` block — but the sibling was created
+                # before the block opened, so its contextvars
+                # snapshot pre-dates the override.
+                await asyncio.sleep(0)
+                seen.append(self._t.current_tenant_id())
+
+            task = asyncio.create_task(sibling())
+            async with self._t.with_tenant_id_async("acme"):
+                await asyncio.sleep(0)
+            await task
+            self.assertEqual(seen, [None])
+        self._run(case())
+
+    def test_async_override_takes_precedence_over_sync_stack(self):
+        async def case():
+            # Mimic an ambient sync override (this is unusual but
+            # possible — e.g., a wrapping sync helper called from
+            # an async handler via `loop.call_soon`). The async
+            # override must win.
+            self._t._stack().append("sync-tenant")
+            try:
+                self.assertEqual(self._t.current_tenant_id(), "sync-tenant")
+                async with self._t.with_tenant_id_async("async-tenant"):
+                    self.assertEqual(self._t.current_tenant_id(), "async-tenant")
+                self.assertEqual(self._t.current_tenant_id(), "sync-tenant")
+            finally:
+                self._t._stack().pop()
+        self._run(case())
+
+    def test_nested_async_overrides_innermost_wins(self):
+        async def case():
+            async with self._t.with_tenant_id_async("outer"):
+                self.assertEqual(self._t.current_tenant_id(), "outer")
+                async with self._t.with_tenant_id_async("inner"):
+                    self.assertEqual(self._t.current_tenant_id(), "inner")
+                self.assertEqual(self._t.current_tenant_id(), "outer")
+            self.assertIsNone(self._t.current_tenant_id())
+        self._run(case())
+
+    def test_async_override_to_none_blocks_env_fallback(self):
+        async def case():
+            # Set env var so the unscoped read would resolve.
+            os.environ[self._t.JAMES_TENANT_ID_ENV] = "envtenant"
+            self.assertEqual(self._t.current_tenant_id(), "envtenant")
+            async with self._t.with_tenant_id_async(None):
+                # Explicit None override blocks fallback (matches the
+                # sync `with_tenant_id(None)` semantic).
+                self.assertIsNone(self._t.current_tenant_id())
+            # After exit, env fallback restored.
+            self.assertEqual(self._t.current_tenant_id(), "envtenant")
+        self._run(case())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Per v0.5 close handover §5.1 Track A G2.c. **Two complementary primitives** land together because they share the same Track A roadmap row and both lay groundwork for the SaaS-deployment use case the v0.6 G1.c deployment guide (#882) describes.

## Summary

### OIDC resolver surface (`core/security/approval_evidence.py`)

Adds the OIDC resolution path to the `ApprovalEvidence` chain **without bundling a JWKS verifier** — the implementation depends on which crypto library the operator's IdP is friendly with (`python-jose` / `authlib` / `PyJWT` / custom shim), and bundling one would force a dependency the mother-platform contract refuses to take until the first customer specifies their IdP.

New surface:

- Env constants: `JAMES_OIDC_ISSUER` / `JAMES_OIDC_TOKEN` / `JAMES_OIDC_AUDIENCE`
- `OIDCValidator` type alias — `(token, issuer, audience) -> Optional[Mapping[str, Any]]`
- `register_oidc_validator(validator)` — module-level hook that deployments fill in
- `_resolve_oidc()` — calls the validator when both env vars + hook are present; returns `ApprovalEvidence(source=\"oidc\", principal=claims[\"sub\"], expires_at=<from exp claim>, evidence_hash=sha256(signature_segment))`
- Resolution order in `current_approval_evidence`: **OIDC → explicit → POSIX**

Default behaviour unchanged: with no validator registered + no env vars set, `current_approval_evidence` still resolves the explicit override → POSIX floor chain (byte-identical to v0.5 G2.a #861).

### Async-task-aware tenant variant (`core/lifecycle/tenant.py`)

Adds `with_tenant_id_async(tenant_id)` — an `asynccontextmanager` backed by `contextvars.ContextVar` so an override survives `await` points + propagates into child tasks created inside the `async with` block. The synchronous `with_tenant_id` is preserved verbatim for back-compat; both stacks are read by `current_tenant_id` (async stack wins).

Resolution order:

1. Innermost **async** stack (per asyncio task) ← NEW
2. Innermost sync stack (per OS thread)
3. `JAMES_TENANT_ID` env var
4. `None`

The docstring's \"Not thread-safe across asyncio tasks\" caveat is now scoped to the sync API only.

## Tests — `tests/test_v06_g2c_oidc_async_tenant.py` (NEW, 18 tests)

**OIDC (11 tests)**

- No env → None
- Env set, no validator → None
- Validator returns valid claims → oidc evidence with `sub` principal + `exp`-derived `expires_at`
- Validator returns `None` / raises / returns wrong shape / returns claims missing `sub` → None
- Signature hash uses JWS third segment when dot-shaped, falls back to whole-token hash otherwise
- OIDC ordered ahead of explicit + POSIX in resolution chain
- Falls through to explicit when OIDC env not set

**Async tenant (7 tests)**

- Override visible inside the block, cleared on exit
- Survives an `await asyncio.sleep(0)`
- Child task created INSIDE inherits the override
- Sibling task created OUTSIDE does NOT inherit
- Async stack takes precedence over a sync stack override
- Nested async overrides — innermost wins
- `with_tenant_id_async(None)` explicitly blocks env fallback

## Verification

- `pytest tests/test_v06_g2c_oidc_async_tenant.py`: **18 passed**
- Combined G1/G2 family regression sweep (`approval_evidence` + `tenant_id` + `g1b_replay` + this PR's new tests): **67 passed**
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths untouched

## Out of scope

- Does NOT bundle a JWKS verifier — the operator picks their crypto library at deploy time + calls `register_oidc_validator` with the shim. The G1.c deployment doc (#882) can be extended with a canonical IdP example when LOI scopes the SaaS pilot
- Does NOT auto-wire `with_tenant_id_async` into FastAPI handlers — the deployment author wraps their request handler explicitly, following the pattern in `docs/deployment/v0.6-saas-tenant-isolation.md` §3.3
- Does NOT change `current_approval_evidence`'s signature — OIDC slots in as an additional first step; `allow_posix_fallback` kwarg unchanged
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: code — additive resolver hook + async context-manager over existing G1.a/G2.a primitives; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)