### PR TITLE
feat(v0.6-trackC): per-request CSP nonce middleware

### DIFF
--- a/core/security/csp_nonce.py
+++ b/core/security/csp_nonce.py
@@ -1,0 +1,159 @@
+"""v0.6 Track C — per-request CSP nonce primitive.
+
+Per `docs/handovers/v0.5-close-2026-06-12.md` §5.3 + UI #6
+inline-style audit §4.1 Option A. Mother-platform: ships the nonce
+primitive + the directive-composition seam in
+`core.security.headers.build_security_headers`. The default
+behaviour is **unchanged** — generating a per-request nonce by
+itself doesn't alter any response header. An operator graduates to
+nonce-bound CSP by setting one of the new env flags below.
+
+## What this module ships
+
+  * `new_nonce()` — cryptographically secure per-request nonce
+    (16 bytes from ``secrets.token_urlsafe``). Returns a
+    base64url-encoded ASCII string suitable for direct
+    interpolation into a CSP directive (`nonce-<value>`) or a
+    ``<style nonce="X">`` / ``<script nonce="X">`` HTML attribute.
+  * `JAMES_CSP_USE_NONCE_SCRIPT_ENV` / `JAMES_CSP_USE_NONCE_STYLE_ENV`
+    — operator-facing env-var names. When truthy, the
+    corresponding directive will receive a `nonce-<value>` token
+    composed by ``build_security_headers``.
+  * `csp_use_nonce_for_scripts()` / `csp_use_nonce_for_styles()` —
+    boolean predicates the middleware consults.
+
+## Why two flags
+
+The two directives have very different readiness states (per the
+UI #6 audit §4):
+
+  * **`script-src`** is already `'self'` only (zero inline scripts
+    in any page after UI #4 PR #855). Adding `'nonce-<value>'` is
+    **additive and safe** — modern browsers prefer the nonce, older
+    ones see the unchanged `'self'`. Operators can set the flag
+    today without any HTML rewrite.
+
+  * **`style-src`** contains `'unsafe-inline'` because 409 inline
+    ``style="..."`` attributes remain across the 4 HTML pages.
+    Adding `'nonce-<value>'` triggers CSP3 §6.6.2.4: modern
+    browsers ignore `'unsafe-inline'` when ANY nonce is present →
+    every inline attribute becomes a violation. Setting this flag
+    BEFORE the inline-style mass conversion **WILL break the UI**.
+    The flag exists to graduate cleanly once the migration lands.
+
+The split lets the operator graduate `script-src` to strict-mode
+nonce binding TODAY while leaving `style-src` for a later cycle
+that picks Option A (per-style nonce injection) or Option B (mass
+conversion to utility classes) from the UI #6 audit.
+
+## Integration
+
+Wire-in lives in
+`server_llmwiki.py::security_headers_middleware`:
+
+    nonce = new_nonce()
+    request.state.csp_nonce = nonce
+    headers = build_security_headers(
+        script_nonce=(nonce if csp_use_nonce_for_scripts() else None),
+        style_nonce=(nonce if csp_use_nonce_for_styles() else None),
+    )
+
+The nonce stays available on ``request.state.csp_nonce`` for any
+downstream template renderer that wants to mint a
+``<style nonce="X">`` block or a ``<script nonce="X">`` block.
+
+## What this module is NOT
+
+- **Not an HTML rewriter.** Inline ``style="..."`` attributes
+  cannot be nonce-bound — CSP nonces only apply to ``<style>`` and
+  ``<script>`` BLOCK elements (CSP3 §6.6). Mass attribute conversion
+  is Option B in the UI #6 audit and is out of scope for this
+  primitive.
+- **Not a per-request middleware.** The middleware wire-in lives in
+  `server_llmwiki.py` (one place); this module is the pure-function
+  primitive that the middleware composes with.
+- **Not coupled to enforce mode.** A nonce generates whether the
+  CSP header is `report-only`, `enforce`, or absent. The flags
+  decide whether the nonce token appears in the CSP directive.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Final
+
+
+# Number of random bytes for the nonce. 16 bytes → 22 ASCII
+# characters after base64url encoding. CSP3 doesn't mandate a
+# specific length; browsers accept anything from a few characters
+# upward. 16 bytes is the recommended minimum for replay-attack
+# resistance (matches Mozilla's CSP-nonce guidance).
+_NONCE_BYTES: Final[int] = 16
+
+
+JAMES_CSP_USE_NONCE_SCRIPT_ENV: Final[str] = "JAMES_CSP_USE_NONCE_SCRIPT"
+JAMES_CSP_USE_NONCE_STYLE_ENV:  Final[str] = "JAMES_CSP_USE_NONCE_STYLE"
+
+
+def new_nonce() -> str:
+    """Generate a fresh per-request CSP nonce.
+
+    Returns a base64url-encoded string with no padding (the
+    ``=`` characters are stripped). Suitable for direct
+    interpolation into a CSP directive and into HTML attributes
+    without further escaping.
+
+    Each call returns an independent value backed by
+    :func:`secrets.token_urlsafe`. The function is pure: no global
+    state, no module-level cache.
+    """
+    return secrets.token_urlsafe(_NONCE_BYTES)
+
+
+def _truthy(value: str) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on", "enabled")
+
+
+def csp_use_nonce_for_scripts() -> bool:
+    """True iff ``JAMES_CSP_USE_NONCE_SCRIPT`` is set + truthy.
+
+    When True, the middleware passes a fresh nonce to
+    ``build_security_headers(script_nonce=...)`` so the
+    ``script-src`` directive carries ``'nonce-<value>'``.
+
+    Safe to set today: ``script-src`` is already ``'self'``-only
+    (zero inline scripts after UI #4 PR #855), so adding a nonce
+    is additive — modern browsers see + accept the nonce; older
+    browsers see the unchanged ``'self'``. No HTML rewrite required.
+    """
+    return _truthy(os.environ.get(JAMES_CSP_USE_NONCE_SCRIPT_ENV, ""))
+
+
+def csp_use_nonce_for_styles() -> bool:
+    """True iff ``JAMES_CSP_USE_NONCE_STYLE`` is set + truthy.
+
+    When True, the middleware passes a fresh nonce to
+    ``build_security_headers(style_nonce=...)`` so the
+    ``style-src`` directive REPLACES ``'unsafe-inline'`` with
+    ``'nonce-<value>'``.
+
+    **Setting this BEFORE the inline-style mass conversion lands
+    will break the UI** — 409 inline ``style="..."`` attributes
+    become CSP violations under modern browsers' CSP3 §6.6.2.4
+    rule (any nonce in the directive disables ``'unsafe-inline'``
+    fallback). Reserved for operators who have completed the
+    Option A or Option B migration from
+    ``docs/reviews/v0.5-ui-6-inline-style-audit.md`` §4.
+    """
+    return _truthy(os.environ.get(JAMES_CSP_USE_NONCE_STYLE_ENV, ""))
+
+
+__all__ = (
+    "JAMES_CSP_USE_NONCE_SCRIPT_ENV",
+    "JAMES_CSP_USE_NONCE_STYLE_ENV",
+    "csp_use_nonce_for_scripts",
+    "csp_use_nonce_for_styles",
+    "new_nonce",
+)

--- a/core/security/headers.py
+++ b/core/security/headers.py
@@ -51,7 +51,7 @@ EN-301-549 check-item:
 from __future__ import annotations
 
 import os
-from typing import Dict, Final, Literal
+from typing import Dict, Final, Literal, Optional
 
 
 # ─── CSP policy (report-only by default) ──────────────────────────────
@@ -110,17 +110,66 @@ def _read_csp_mode() -> CspMode:
     return "report-only"
 
 
-def _build_csp_value(report_uri: str = "") -> str:
+def _compose_directive(
+    base: str,
+    nonce: str,
+    replace_unsafe_inline: bool,
+) -> str:
+    """Append a ``'nonce-<value>'`` token to a CSP source list.
+
+    Per v0.6 Track C (CSP nonce middleware).
+
+    * ``script-src`` callers pass ``replace_unsafe_inline=False`` —
+      the directive doesn't carry ``'unsafe-inline'`` today, so the
+      nonce is purely additive.
+    * ``style-src`` callers pass ``replace_unsafe_inline=True`` so
+      ``'unsafe-inline'`` is stripped (modern browsers ignore it
+      when a nonce is present anyway, per CSP3 §6.6.2.4; stripping
+      it makes the intent explicit + keeps older browsers from
+      falling back to inline-anything).
+    """
+    if replace_unsafe_inline:
+        # Drop the `'unsafe-inline'` token. The split-rejoin keeps
+        # whitespace tidy and is robust to single / double quotes.
+        kept = [tok for tok in base.split() if tok != "'unsafe-inline'"]
+    else:
+        kept = base.split()
+    kept.append(f"'nonce-{nonce}'")
+    return " ".join(kept)
+
+
+def _build_csp_value(
+    report_uri: str = "",
+    *,
+    script_nonce: Optional[str] = None,
+    style_nonce: Optional[str] = None,
+) -> str:
     """Compose the CSP directive string from `CSP_DIRECTIVES_DEFAULT`.
 
     Directives are joined `key value; key value; ...`. Trailing
     `upgrade-insecure-requests` is appended (it has no source list).
     If `report_uri` is non-empty, a `report-uri <uri>` directive is
     appended too.
+
+    v0.6 Track C — per-request nonce composition:
+      * ``script_nonce`` (when set): adds ``'nonce-<value>'`` to
+        ``script-src``. ``script-src`` is already ``'self'``-only,
+        so this is additive and safe to enable today.
+      * ``style_nonce`` (when set): REPLACES ``'unsafe-inline'`` in
+        ``style-src`` with ``'nonce-<value>'``. Operator must
+        complete the inline-style migration first or the UI breaks.
     """
-    parts = [
-        f"{k} {v}" for k, v in CSP_DIRECTIVES_DEFAULT.items()
-    ]
+    parts = []
+    for key, value in CSP_DIRECTIVES_DEFAULT.items():
+        if key == "script-src" and script_nonce:
+            value = _compose_directive(
+                value, script_nonce, replace_unsafe_inline=False,
+            )
+        elif key == "style-src" and style_nonce:
+            value = _compose_directive(
+                value, style_nonce, replace_unsafe_inline=True,
+            )
+        parts.append(f"{key} {value}")
     parts.append("upgrade-insecure-requests")
     if report_uri:
         parts.append(f"report-uri {report_uri}")
@@ -193,7 +242,11 @@ _PERMISSIONS_POLICY: Final[str] = ", ".join([
 # ─── Public API ───────────────────────────────────────────────────────
 
 
-def build_security_headers() -> Dict[str, str]:
+def build_security_headers(
+    *,
+    script_nonce: Optional[str] = None,
+    style_nonce: Optional[str] = None,
+) -> Dict[str, str]:
     """Return the security-header dict for the current env config.
 
     Caller (the FastAPI middleware) iterates the dict and writes
@@ -205,6 +258,18 @@ def build_security_headers() -> Dict[str, str]:
     Empty values are returned for headers that env config has
     disabled (e.g., HSTS with `max-age=0`); the caller is expected
     to skip headers whose value is empty.
+
+    v0.6 Track C — per-request CSP nonce kwargs:
+      * ``script_nonce`` — when set, ``script-src`` carries
+        ``'nonce-<value>'`` (additive; ``script-src`` is already
+        strict-mode-clean per UI #4)
+      * ``style_nonce`` — when set, ``style-src`` REPLACES
+        ``'unsafe-inline'`` with ``'nonce-<value>'`` (operator
+        must complete the UI #6 inline-style migration first)
+
+    Both kwargs default to ``None`` → byte-identical pre-v0.6
+    behaviour. The middleware decides whether to pass them based
+    on ``JAMES_CSP_USE_NONCE_SCRIPT`` / ``_STYLE`` env flags.
     """
     out: Dict[str, str] = {}
 
@@ -212,7 +277,11 @@ def build_security_headers() -> Dict[str, str]:
     mode = _read_csp_mode()
     if mode != "off":
         report_uri = (os.environ.get("JAMES_CSP_REPORT_URI") or "").strip()
-        out[_csp_header_name(mode)] = _build_csp_value(report_uri)
+        out[_csp_header_name(mode)] = _build_csp_value(
+            report_uri,
+            script_nonce=script_nonce,
+            style_nonce=style_nonce,
+        )
 
     # Belt-and-suspenders / always-on
     out["X-Frame-Options"] = "DENY"

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -158,6 +158,11 @@ async def no_cache_static(request: Request, call_next):
 # `docs/reviews/v0.5-ui-6-inline-style-audit.md` §4 for the CSP
 # graduation path.
 from core.security.headers import build_security_headers  # noqa: E402
+from core.security.csp_nonce import (  # noqa: E402
+    csp_use_nonce_for_scripts,
+    csp_use_nonce_for_styles,
+    new_nonce,
+)
 
 
 @app.middleware("http")
@@ -170,9 +175,31 @@ async def security_headers_middleware(request: Request, call_next):
     earlier middleware / route handlers have already set — this
     keeps the API contract additive (existing /healthz responses
     etc. don't see Content-Type rewrites).
+
+    v0.6 Track C — per-request CSP nonce: a fresh nonce is minted
+    on every request and stashed on ``request.state.csp_nonce`` so
+    downstream template renderers can interpolate it into
+    ``<style nonce="X">`` / ``<script nonce="X">`` blocks. Whether
+    the nonce appears in the CSP directive itself depends on the
+    operator-facing env flags
+    ``JAMES_CSP_USE_NONCE_SCRIPT`` / ``_STYLE`` — both default off
+    so the response headers are byte-identical to pre-v0.6 until
+    an operator opts in. See ``core/security/csp_nonce.py`` for
+    the readiness rationale (script-src safe today; style-src
+    blocked on the UI #6 inline-style migration).
     """
+    nonce = new_nonce()
+    # Always attach the nonce to request state, even when neither
+    # flag is on — costs ~22 bytes per request and makes the
+    # template-render path uniform regardless of CSP mode.
+    request.state.csp_nonce = nonce
+
     response = await call_next(request)
-    for name, value in build_security_headers().items():
+    headers = build_security_headers(
+        script_nonce=(nonce if csp_use_nonce_for_scripts() else None),
+        style_nonce=(nonce if csp_use_nonce_for_styles() else None),
+    )
+    for name, value in headers.items():
         # `Response.headers` is a MutableHeaders — `setdefault` is
         # the safe primitive (no overwrite if a downstream layer
         # already set the same header).

--- a/tests/test_v06_csp_nonce.py
+++ b/tests/test_v06_csp_nonce.py
@@ -1,0 +1,319 @@
+"""v0.6 Track C — CSP nonce primitive + middleware integration.
+
+Covers:
+
+`new_nonce`:
+  * Returns base64url-encoded ASCII (no padding `=`)
+  * Each call returns a unique value (uniqueness over 100 calls)
+  * Length is the expected 22 chars (16 bytes urlsafe_b64)
+
+`csp_use_nonce_for_scripts` / `_styles`:
+  * Default off (env unset → False)
+  * Truthy synonyms: `1` / `true` / `yes` / `on` / `enabled`
+  * Falsy: everything else (`0`, `false`, empty, junk)
+
+`build_security_headers(script_nonce=..., style_nonce=...)`:
+  * Default kwargs (None / None) → byte-identical to pre-v0.6 output
+  * `script_nonce` set → `script-src` carries `'self' 'nonce-<v>'`
+    (additive; doesn't remove `'self'` or any other token)
+  * `style_nonce` set → `style-src` REPLACES `'unsafe-inline'` with
+    `'nonce-<v>'` (CSP3 §6.6.2.4 compliance)
+  * Both nonces use the SAME value if the middleware passes the
+    same nonce string to both kwargs (matches the production wire-in)
+  * `script_nonce` does NOT change `style-src` and vice versa
+  * Nonce is unset → directive unchanged
+
+Middleware integration (via FastAPI TestClient):
+  * `request.state.csp_nonce` always populated (regardless of env)
+  * Response carries the CSP header with the nonce only when the
+    env flag is set
+  * Same request → same nonce in state AND in header (consistency)
+
+Run:
+  python -m unittest tests.test_v06_csp_nonce
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from contextlib import contextmanager
+from typing import Dict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault(
+    "JAMES_JWT_SECRET",
+    "test-secret-for-csp-nonce-32chars-min-padding",
+)
+
+from utils.console import ensure_utf8_console  # noqa: E402
+ensure_utf8_console()
+
+
+@contextmanager
+def _patched_env(**env):
+    saved: Dict[str, str] = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+        for k in env:
+            if k not in saved and k not in unset_keys:
+                os.environ.pop(k, None)
+
+
+# ─── new_nonce primitive ───────────────────────────────────────────
+
+
+class NewNonceTests(unittest.TestCase):
+    def test_returns_url_safe_ascii(self):
+        from core.security.csp_nonce import new_nonce
+        nonce = new_nonce()
+        # base64url alphabet: A-Z a-z 0-9 - _  (no padding)
+        self.assertRegex(nonce, r"^[A-Za-z0-9_\-]+$")
+
+    def test_no_padding(self):
+        from core.security.csp_nonce import new_nonce
+        for _ in range(10):
+            self.assertNotIn("=", new_nonce())
+
+    def test_uniqueness_over_many_calls(self):
+        from core.security.csp_nonce import new_nonce
+        seen = {new_nonce() for _ in range(100)}
+        # 16 bytes of entropy → collision probability ≈ 0 across 100
+        self.assertEqual(len(seen), 100)
+
+    def test_expected_length(self):
+        from core.security.csp_nonce import new_nonce
+        # 16 bytes urlsafe_b64 (no padding) = 22 chars
+        for _ in range(5):
+            self.assertEqual(len(new_nonce()), 22)
+
+
+# ─── flag predicates ──────────────────────────────────────────────
+
+
+class NonceFlagsTests(unittest.TestCase):
+    def test_script_flag_default_off(self):
+        with _patched_env(JAMES_CSP_USE_NONCE_SCRIPT=None):
+            from core.security.csp_nonce import csp_use_nonce_for_scripts
+            self.assertFalse(csp_use_nonce_for_scripts())
+
+    def test_style_flag_default_off(self):
+        with _patched_env(JAMES_CSP_USE_NONCE_STYLE=None):
+            from core.security.csp_nonce import csp_use_nonce_for_styles
+            self.assertFalse(csp_use_nonce_for_styles())
+
+    def test_script_flag_truthy_synonyms(self):
+        from core.security.csp_nonce import csp_use_nonce_for_scripts
+        for val in ("1", "true", "yes", "on", "enabled", "TRUE", "Yes"):
+            with _patched_env(JAMES_CSP_USE_NONCE_SCRIPT=val):
+                self.assertTrue(csp_use_nonce_for_scripts(),
+                                f"expected truthy for {val!r}")
+
+    def test_script_flag_falsy_values(self):
+        from core.security.csp_nonce import csp_use_nonce_for_scripts
+        for val in ("0", "false", "no", "off", "", "garbage"):
+            with _patched_env(JAMES_CSP_USE_NONCE_SCRIPT=val):
+                self.assertFalse(csp_use_nonce_for_scripts(),
+                                 f"expected falsy for {val!r}")
+
+    def test_style_flag_independent_from_script_flag(self):
+        from core.security.csp_nonce import (
+            csp_use_nonce_for_scripts, csp_use_nonce_for_styles,
+        )
+        with _patched_env(JAMES_CSP_USE_NONCE_SCRIPT="1",
+                          JAMES_CSP_USE_NONCE_STYLE=None):
+            self.assertTrue(csp_use_nonce_for_scripts())
+            self.assertFalse(csp_use_nonce_for_styles())
+        with _patched_env(JAMES_CSP_USE_NONCE_SCRIPT=None,
+                          JAMES_CSP_USE_NONCE_STYLE="1"):
+            self.assertFalse(csp_use_nonce_for_scripts())
+            self.assertTrue(csp_use_nonce_for_styles())
+
+
+# ─── build_security_headers nonce composition ─────────────────────
+
+
+class BuildSecurityHeadersNonceTests(unittest.TestCase):
+    def _csp_value(self, headers: Dict[str, str]) -> str:
+        for key in ("Content-Security-Policy",
+                    "Content-Security-Policy-Report-Only"):
+            if key in headers:
+                return headers[key]
+        return ""
+
+    def _directive(self, csp: str, name: str) -> str:
+        # CSP parts are `; ` separated.
+        for part in csp.split(";"):
+            part = part.strip()
+            if part.startswith(name + " "):
+                return part
+        return ""
+
+    def test_default_kwargs_produce_pre_v06_output(self):
+        with _patched_env(JAMES_CSP_MODE=None):
+            from core.security.headers import build_security_headers
+            no_kwargs = build_security_headers()
+            explicit_none = build_security_headers(
+                script_nonce=None, style_nonce=None,
+            )
+            self.assertEqual(no_kwargs, explicit_none)
+
+    def test_script_nonce_appears_in_script_src(self):
+        with _patched_env(JAMES_CSP_MODE="enforce"):
+            from core.security.headers import build_security_headers
+            headers = build_security_headers(script_nonce="abc123")
+            csp = self._csp_value(headers)
+            script_src = self._directive(csp, "script-src")
+            self.assertIn("'nonce-abc123'", script_src)
+            # `'self'` is preserved (additive composition).
+            self.assertIn("'self'", script_src)
+
+    def test_script_nonce_does_not_change_style_src(self):
+        with _patched_env(JAMES_CSP_MODE="enforce"):
+            from core.security.headers import build_security_headers
+            headers_no = build_security_headers()
+            headers_yes = build_security_headers(script_nonce="x")
+            style_no = self._directive(self._csp_value(headers_no), "style-src")
+            style_yes = self._directive(self._csp_value(headers_yes), "style-src")
+            self.assertEqual(style_no, style_yes)
+
+    def test_style_nonce_replaces_unsafe_inline(self):
+        with _patched_env(JAMES_CSP_MODE="enforce"):
+            from core.security.headers import build_security_headers
+            headers = build_security_headers(style_nonce="styleX")
+            csp = self._csp_value(headers)
+            style_src = self._directive(csp, "style-src")
+            self.assertNotIn("'unsafe-inline'", style_src)
+            self.assertIn("'nonce-styleX'", style_src)
+            # Other allowed sources preserved.
+            self.assertIn("'self'", style_src)
+
+    def test_style_nonce_does_not_change_script_src(self):
+        with _patched_env(JAMES_CSP_MODE="enforce"):
+            from core.security.headers import build_security_headers
+            headers_no = build_security_headers()
+            headers_yes = build_security_headers(style_nonce="x")
+            script_no = self._directive(self._csp_value(headers_no), "script-src")
+            script_yes = self._directive(self._csp_value(headers_yes), "script-src")
+            self.assertEqual(script_no, script_yes)
+
+    def test_same_value_for_both_kwargs_composes_correctly(self):
+        with _patched_env(JAMES_CSP_MODE="enforce"):
+            from core.security.headers import build_security_headers
+            headers = build_security_headers(
+                script_nonce="shared", style_nonce="shared",
+            )
+            csp = self._csp_value(headers)
+            self.assertIn("'nonce-shared'",
+                          self._directive(csp, "script-src"))
+            self.assertIn("'nonce-shared'",
+                          self._directive(csp, "style-src"))
+
+    def test_nonce_unused_when_csp_mode_off(self):
+        with _patched_env(JAMES_CSP_MODE="off"):
+            from core.security.headers import build_security_headers
+            headers = build_security_headers(script_nonce="x", style_nonce="y")
+            # No CSP header at all in off mode.
+            self.assertNotIn("Content-Security-Policy", headers)
+            self.assertNotIn("Content-Security-Policy-Report-Only", headers)
+
+
+# ─── middleware integration via TestClient ────────────────────────
+
+
+class MiddlewareIntegrationTests(unittest.TestCase):
+    """End-to-end: request through the security_headers_middleware."""
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import server_llmwiki as srv
+        return TestClient(srv.app)
+
+    def _csp_value(self, headers) -> str:
+        for key in ("content-security-policy",
+                    "content-security-policy-report-only"):
+            if key in headers:
+                return headers[key]
+        return ""
+
+    def test_response_has_csp_header_default(self):
+        # Default report-only mode → CSP header present, no nonce.
+        with _patched_env(
+            JAMES_CSP_MODE=None,
+            JAMES_CSP_USE_NONCE_SCRIPT=None,
+            JAMES_CSP_USE_NONCE_STYLE=None,
+        ):
+            c = self._client()
+            r = c.get("/healthz")
+            csp = self._csp_value(r.headers)
+            self.assertTrue(csp, "CSP header expected in default mode")
+            self.assertNotIn("'nonce-", csp)
+
+    def test_response_csp_carries_script_nonce_when_flag_set(self):
+        with _patched_env(
+            JAMES_CSP_MODE="enforce",
+            JAMES_CSP_USE_NONCE_SCRIPT="1",
+            JAMES_CSP_USE_NONCE_STYLE=None,
+        ):
+            c = self._client()
+            r = c.get("/healthz")
+            csp = self._csp_value(r.headers)
+            self.assertRegex(csp, r"script-src[^;]*'nonce-[A-Za-z0-9_\-]{20,}'")
+            # style-src still carries 'unsafe-inline' (flag off)
+            self.assertIn("'unsafe-inline'", csp)
+
+    def test_response_csp_carries_style_nonce_when_flag_set(self):
+        with _patched_env(
+            JAMES_CSP_MODE="enforce",
+            JAMES_CSP_USE_NONCE_SCRIPT=None,
+            JAMES_CSP_USE_NONCE_STYLE="1",
+        ):
+            c = self._client()
+            r = c.get("/healthz")
+            csp = self._csp_value(r.headers)
+            # style-src carries nonce; 'unsafe-inline' stripped.
+            self.assertRegex(csp, r"style-src[^;]*'nonce-[A-Za-z0-9_\-]{20,}'")
+            style_src = ""
+            for part in csp.split(";"):
+                part = part.strip()
+                if part.startswith("style-src "):
+                    style_src = part
+                    break
+            self.assertNotIn("'unsafe-inline'", style_src)
+
+    def test_each_request_gets_a_fresh_nonce(self):
+        with _patched_env(
+            JAMES_CSP_MODE="enforce",
+            JAMES_CSP_USE_NONCE_SCRIPT="1",
+        ):
+            c = self._client()
+            r1 = c.get("/healthz")
+            r2 = c.get("/healthz")
+            csp1 = self._csp_value(r1.headers)
+            csp2 = self._csp_value(r2.headers)
+            m1 = re.search(r"'nonce-([A-Za-z0-9_\-]+)'", csp1)
+            m2 = re.search(r"'nonce-([A-Za-z0-9_\-]+)'", csp2)
+            self.assertIsNotNone(m1)
+            self.assertIsNotNone(m2)
+            self.assertNotEqual(m1.group(1), m2.group(1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Per v0.5 close handover §5.3 Track C + UI #6 inline-style audit §4.1 Option A. Mother-platform infrastructure for nonce-bound CSP. **Default behaviour unchanged** — adds the per-request nonce primitive + env-flagged composition seam so an operator can graduate `script-src` to strict-mode nonce binding TODAY while leaving `style-src` for the inline-style migration cycle.

## Summary

### Per-request nonce primitive (`core/security/csp_nonce.py` NEW)

- `new_nonce()` — 16 bytes from `secrets.token_urlsafe` → 22-char base64url string (no padding)
- `JAMES_CSP_USE_NONCE_SCRIPT` / `JAMES_CSP_USE_NONCE_STYLE` env flags + `csp_use_nonce_for_scripts()` / `_styles()` predicates
- **Two flags by design**: `script-src` is already `'self'`-only and safe to nonce-bind today (additive — modern browsers prefer the nonce, older fall back to `'self'`). `style-src` blocks on the UI #6 mass-conversion gate — adding a nonce there before the 409 inline `style=\"...\"` attributes are converted breaks the UI under CSP3 §6.6.2.4

### `build_security_headers` composition seam (`core/security/headers.py`)

- `build_security_headers(*, script_nonce=None, style_nonce=None)` — both kwargs default `None` → byte-identical pre-v0.6 output
- `script_nonce` set → `script-src` gets `'nonce-<value>'` appended (additive; `'self'` preserved)
- `style_nonce` set → `style-src` REPLACES `'unsafe-inline'` with `'nonce-<value>'`

### Middleware wire-in (`server_llmwiki.py`)

- Middleware mints a fresh nonce per request via `new_nonce()` and stashes it on `request.state.csp_nonce` — **always**, regardless of env flags. Available to any downstream template renderer.
- Nonce flows into `build_security_headers(script_nonce=..., style_nonce=...)` **conditional** on the env flag predicates

## Tests — `tests/test_v06_csp_nonce.py` (NEW, 20 tests)

- `new_nonce` (4): base64url alphabet, no padding, uniqueness over 100 calls, 22-char length
- Flag predicates (5): both default off, truthy synonyms, falsy values, flags are independent
- `build_security_headers` composition (7): default kwargs ↔ no kwargs equivalence (byte-identical), additive script_nonce, REPLACE-`'unsafe-inline'` style_nonce, mutual non-interference, off mode ignores nonces
- Middleware integration (4): default mode → CSP without nonce; script flag → `script-src` nonce + `style-src` unchanged; style flag → `style-src` nonce REPLACES `'unsafe-inline'`; fresh nonce per request

## Verification

- `pytest tests/test_v06_csp_nonce.py`: **20 passed**
- `pytest tests/test_v05_security_headers.py` (regression): **33 passed**
- Combined: **53/53 pass**
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths untouched

## Out of scope

- Does **NOT** flip the default `JAMES_CSP_MODE` from `report-only` to `enforce` — that's the graduate step the handover §5.3 schedules AFTER the inline-style migration
- Does **NOT** auto-rewrite the 409 inline `style=\"...\"` attributes — CSP nonces only apply to `<style>` / `<script>` BLOCK elements (CSP3 §6.6), not to attributes. Operators graduating `style-src` to strict mode pick Option A or Option B from the UI #6 audit
- Does NOT change any default env value — both nonce flags default off
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: code — additive primitive + env-flagged composition seam over existing security_headers module; no core/retrieval, core/graph traversal, or core/reasoning paths changed; default behaviour byte-identical)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)