### PR TITLE
feat(v0.6): graph-RAG synthesis Step 2 cross-model driver scaffold

### DIFF
--- a/docs/evaluation/v0.5-graph-rag-contribution.md
+++ b/docs/evaluation/v0.5-graph-rag-contribution.md
@@ -150,6 +150,74 @@ mechanism):
 
 ---
 
+## 3.2 Step 2 — cross-model plan + interpretation rules (PENDING measurement)
+
+Step 1 (Table 3.1) measured the contribution at M_M = gemma4:e4b
+(4B, production default) only. Step 2 extends to **M_S = gemma3:4b**
+(smaller 4B different family) + **M_L = gemma3:12b** (larger 12B).
+
+### What Step 2 tests
+
+| Question | Step 2 evidence shape |
+|---|---|
+| Does the +0.41 path_coverage win at M_M reproduce on a smaller model? | M_S `C_rag-basic` → `C_rag-graph` path_coverage Δ |
+| Does the +0.41 path_coverage win at M_M reproduce on a larger model? | M_L `C_rag-basic` → `C_rag-graph` path_coverage Δ |
+| Does the −0.057 graded_answer loss at M_M generalise? | Cross-model graded_answer Δ table |
+| Does the typed-filter +0.027 improvement at M_M generalise? | Cross-model `C_rag-graph` → `C_rag-ontology` Δ table |
+| Are the 2.1× token / 2.6× latency multipliers model-independent? | Cross-model cost ratios |
+
+### Interpretation rules
+
+- **Path_coverage Δ that holds within ±0.05 across all 3 models**:
+  the +0.41 finding upgrades from "load-bearing on M_M" to "load-
+  bearing on the 4B–12B gemma family" (the cycle γ Phase E-min
+  cross-model bar — see `memory/project_cycle_gamma_phase_e_min_mxtral.md`).
+- **Path_coverage Δ that diverges by >0.10 across models**: the
+  finding becomes **model-specific** — the load-bearing claim
+  narrows to M_M and Table 3.2 documents the divergence honestly.
+  This matches `memory/feedback_finding_size_honest_framing.md`.
+- **graded_answer Δ that flips sign across models**: documents a
+  capability-tier interaction with retrieval noise. This would
+  also be a model-specific finding rather than a universal claim.
+- **typed-filter +0.027 holds across models**: typed-filter
+  promoted to ⭐⭐ operational (currently ⭐ operational only per
+  `memory/project_alpha_8_closure_state.md`).
+- **typed-filter Δ goes negative at M_L**: same trade-off rule that
+  cycle γ Phase E-min established (the larger model self-corrects
+  graph noise; typed-filter becomes a small regressor at capability
+  ceiling). Honest negative — typed-filter retained as opt-in but
+  the default-on decision (PR #689) gets a documented caveat.
+
+### Runner readiness
+
+The Step 2 driver script is `scripts/research/graph_rag_synth_step2_cross_model.py`.
+It wraps `scripts.qvt_ablation_matrix` with the pinned scope so the
+operator can launch with a single command. See §8 above for the
+exact invocation.
+
+### Why Step 2 is operator-pending, not solo-runnable
+
+The measurement consumes the operator's local Ollama runtime for
+~14 hours of wall time. This is identical to the v0.2.3b cross-
+model runner status (`docs/handovers/v0.5-close-2026-06-12.md` §5.5
+Track E) — the scaffolding is ready; the operator launches when
+GPU schedule allows.
+
+### Out of scope for Step 2
+
+- **M_XS (gemma3:1b) + M_XL (gemma3:27b)**: extreme-end scale tiers
+  are a Step 3+ decision. The α-6 Phase 3a scale-ladder learnings
+  apply (`memory/feedback_finding_size_honest_framing.md` — small
+  models distort capability claims).
+- **M_MIXTRAL + M_CLOUD**: 26 GB CPU-offload model + cloud quota
+  burn require explicit operator decision. The Step 2 driver does
+  not include them.
+- **C_minus re-run**: the no-RAG floor doesn't shift with model
+  size in the synthesis question (`is JAMES adding value on top of
+  basic RAG?`). Skipping C_minus saves ~30 min wall × 2 tiers.
+
+---
+
 ## 4. Architecture-level ablation (LRB v0.2.3)
 
 `papers/lrb-preprint/main.pdf`. Single ablation across 3 SUT
@@ -268,8 +336,17 @@ JAMES_WORKSPACE=workspaces/hotpot_eval \
 each (graph traversal). Cell-by-cell JSON output
 at `workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/`.
 
-For cross-model verification: re-run with `--tiers M_S` (gemma3:4b)
-and `--tiers M_L` (gemma3:12b).
+For cross-model verification: launch Step 2 via the driver script:
+
+```bash
+python scripts/research/graph_rag_synth_step2_cross_model.py
+```
+
+This wraps `qvt_ablation_matrix.py` with the pinned Step 2 scope
+(3 sector cells × 2 new tiers M_S + M_L × n=3, multihop_rag
+fixture, `JAMES_WORKSPACE=workspaces/hotpot_eval`). Wall time ≈
+14h (operator launches overnight). See §3.2 below for what
+Step 2 will test + how to interpret the cross-model deltas.
 
 For LRB / RAB reproduction: see their respective preprint §
 "Reproducibility" + the README "Reproduce in 60 seconds" code

--- a/scripts/research/graph_rag_synth_step2_cross_model.py
+++ b/scripts/research/graph_rag_synth_step2_cross_model.py
@@ -1,0 +1,229 @@
+"""v0.6 — Graph-RAG synthesis Step 2 cross-model driver.
+
+Per `docs/evaluation/v0.5-graph-rag-contribution.md` §7 ("Single
+model (M_M = gemma4:e4b 4B) for Table 3.1. Cross-model … is the
+immediate next measurement cycle if needed").
+
+This script is a **thin wrapper** around the existing
+:mod:`scripts.qvt_ablation_matrix` runner that pins the Step 2
+scope: 3 sector cells (`C_rag-basic` / `C_rag-graph` /
+`C_rag-ontology`) × 2 new tiers (`M_S` = gemma3:4b, `M_L` =
+gemma3:12b) × n=3 paired, on the `multihop_rag` fixture.
+
+C_minus is intentionally NOT re-run at cross-model — the n=1 sanity
+from Step 0 establishes the no-RAG floor and that floor doesn't
+shift with model size in any meaningful way for the synthesis
+question (the question is "what does the JAMES stack add on top of
+basic RAG?"). Skipping C_minus saves ~30 min of wall time across
+both tiers.
+
+The wrapper exists so the operator can launch Step 2 with a single
+command + a known invocation. It does NOT run the matrix in this
+process — it `subprocess.run`'s `qvt_ablation_matrix` so the
+runner's existing per-cell server-spawn / shutdown / aggregation
+pipeline stays the authoritative path.
+
+## Usage
+
+::
+
+    python scripts/research/graph_rag_synth_step2_cross_model.py
+
+    # Or pick a single new tier:
+    python scripts/research/graph_rag_synth_step2_cross_model.py \\
+        --tiers M_S
+
+    # Dry-run to see the exact subprocess invocation that would run:
+    python scripts/research/graph_rag_synth_step2_cross_model.py --dry-run
+
+## Wall time estimate
+
+Per Step 1's actual time (`docs/evaluation/v0.5-graph-rag-
+contribution.md` §8): 3 cells × n=3 paired ≈ 5h on M_M. M_S is
+~25 % faster (smaller model); M_L is ~2 × slower (12b vs 4b).
+
+Aggregate Step 2 estimate: 5h × 0.75 + 5h × 2 = **~14h wall** for
+both new tiers. Operator should launch overnight + check artifact
+JSONs the next morning.
+
+## Output
+
+Cell JSONs land in the same directory the matrix runner uses:
+``workspaces/hotpot_eval/reports/research-runs/qvt-ablation-cells/
+qvt-ablation-cell-<row>-<tier>.json``
+
+Aggregator (manual step after both tiers complete): compare each
+cell's ``aggregate.mean`` deltas against the Step 1 M_M deltas and
+fill Table 3.2 in the synthesis doc.
+
+## What this script does NOT do
+
+* Does NOT auto-update the synthesis doc — that's a human review
+  step after the operator inspects the cross-model deltas
+* Does NOT run M_XS / M_XL / M_MIXTRAL / M_CLOUD — Step 2 scope
+  is the two interior tiers that bracket M_M (one smaller, one
+  larger). Extreme-end tiers are a Step 3+ decision
+* Does NOT measure C_minus on the cross-model tiers — see the
+  module docstring rationale
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Sequence
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# Step 2 scope — pinned per `docs/evaluation/v0.5-graph-rag-
+# contribution.md` §7. The 3 cells are the load-bearing ones for
+# the "Graph-RAG contribution" comparison (basic → graph) +
+# "typed-filter contribution" (graph → ontology).
+_STEP_2_SECTOR_CELLS = ("C_rag-basic", "C_rag-graph", "C_rag-ontology")
+
+# Cross-model tiers — Step 1 was M_M (4B); Step 2 brackets M_M with
+# M_S (smaller, 4B different family) + M_L (12B). Cycle γ Phase E-min
+# showed 3-model bracketing (mxtral / gemma4 / llama) was sufficient
+# to confirm trade-off stability without burning compute on every
+# scale point.
+_STEP_2_TIERS_DEFAULT = ("M_S", "M_L")
+
+# Fixture — multihop_rag is the same one Step 1 used; the cross-time
+# path_coverage agreement at M_M (α-6 0.408 ↔ Step 1 0.4056) was
+# only demonstrated on this fixture.
+_STEP_2_SUITE = "multihop_rag"
+
+# n=3 paired — locked per the synthesis doc + n=1 inflation rule
+# (`memory/feedback_n1_verdict_inflation_n3_caught.md`).
+_STEP_2_N_RUNS = 3
+
+
+def _build_subprocess_argv(
+    tiers: Sequence[str],
+    sector_cells: Sequence[str],
+    suite: str,
+    n_runs: int,
+) -> List[str]:
+    """Compose the `qvt_ablation_matrix` invocation.
+
+    Returns the argv list ready for ``subprocess.run`` — does NOT
+    actually invoke it (the caller decides whether to dry-run or
+    run).
+    """
+    return [
+        sys.executable,
+        str(ROOT / "scripts" / "qvt_ablation_matrix.py"),
+        "--suite", suite,
+        "--tiers", ",".join(tiers),
+        "--sector-cells", ",".join(sector_cells),
+        "--n-runs", str(n_runs),
+    ]
+
+
+def _build_env(workspace_rel: str) -> dict:
+    """Return an environment dict with `JAMES_WORKSPACE` pinned.
+
+    The synthesis doc §8 reproducibility block scopes the runner to
+    ``workspaces/hotpot_eval`` so the Chroma collection + cell-JSON
+    output directory are the same ones Step 1 used. Pinning it here
+    means an operator who forgets to set the env still gets the
+    right workspace.
+    """
+    env = dict(os.environ)
+    env["JAMES_WORKSPACE"] = str(ROOT / workspace_rel)
+    return env
+
+
+def _parse_args(argv: List[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="graph_rag_synth_step2_cross_model",
+        description=(
+            "Run Step 2 cross-model graph-RAG synthesis ablation. "
+            "Defaults to M_S + M_L × 3 sector cells × n=3 on "
+            "multihop_rag."
+        ),
+    )
+    p.add_argument(
+        "--tiers",
+        default=",".join(_STEP_2_TIERS_DEFAULT),
+        help=(
+            "Comma-separated tier ids (default: M_S,M_L). Pass a "
+            "single tier to launch only one half of Step 2."
+        ),
+    )
+    p.add_argument(
+        "--sector-cells",
+        default=",".join(_STEP_2_SECTOR_CELLS),
+        help=(
+            "Comma-separated sector cells (default: C_rag-basic,"
+            "C_rag-graph,C_rag-ontology — the 3 load-bearing cells "
+            "for the synthesis-doc Table 3.2)."
+        ),
+    )
+    p.add_argument(
+        "--suite",
+        default=_STEP_2_SUITE,
+        help=f"Fixture suite (default: {_STEP_2_SUITE}).",
+    )
+    p.add_argument(
+        "--n-runs",
+        type=int,
+        default=_STEP_2_N_RUNS,
+        help=f"Paired runs per cell (default: {_STEP_2_N_RUNS}).",
+    )
+    p.add_argument(
+        "--workspace",
+        default="workspaces/hotpot_eval",
+        help=(
+            "Relative workspace path under repo root. Pins "
+            "JAMES_WORKSPACE so the runner writes to the same "
+            "cell-JSON directory Step 1 used."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print the subprocess invocation that would run + exit. "
+            "Use this to verify the command shape before launching "
+            "the multi-hour measurement."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: List[str] = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    tiers = [t.strip() for t in args.tiers.split(",") if t.strip()]
+    cells = [c.strip() for c in args.sector_cells.split(",") if c.strip()]
+    if not tiers:
+        print("error: --tiers must be non-empty", file=sys.stderr)
+        return 2
+    if not cells:
+        print("error: --sector-cells must be non-empty", file=sys.stderr)
+        return 2
+
+    cmd = _build_subprocess_argv(tiers, cells, args.suite, args.n_runs)
+    env = _build_env(args.workspace)
+
+    if args.dry_run:
+        print("# Step 2 cross-model invocation (dry-run)")
+        print(f"# JAMES_WORKSPACE={env['JAMES_WORKSPACE']}")
+        print(" ".join(cmd))
+        print()
+        print("# Wall time estimate: ~14h for default 2 tiers × 3 cells × n=3.")
+        print("# Output: workspaces/hotpot_eval/reports/research-runs/")
+        print("#         qvt-ablation-cells/qvt-ablation-cell-<row>-<tier>.json")
+        return 0
+
+    print(f"Launching Step 2 cross-model with tiers={tiers} cells={cells}")
+    print(f"JAMES_WORKSPACE={env['JAMES_WORKSPACE']}")
+    print()
+    return subprocess.run(cmd, env=env).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v06_graph_rag_step2_driver.py
+++ b/tests/test_v06_graph_rag_step2_driver.py
@@ -1,0 +1,170 @@
+"""v0.6 — Graph-RAG synthesis Step 2 driver smoke tests.
+
+Validates the CLI shape + invocation composition of
+``scripts/research/graph_rag_synth_step2_cross_model.py`` WITHOUT
+launching the multi-hour measurement.
+
+Coverage:
+
+  * Default invocation argv: tiers=M_S,M_L / sector cells=basic+graph+
+    ontology / suite=multihop_rag / n-runs=3
+  * --dry-run prints the exact subprocess invocation + exits 0
+  * --tiers M_S only launches M_S
+  * Empty --tiers / empty --sector-cells returns exit code 2
+  * JAMES_WORKSPACE is pinned to the synthesis-doc canonical path
+
+The intent is to lock the driver's API surface so a future PR can't
+silently change the Step 2 scope (e.g. drop typed-filter from the
+cells, or substitute a different fixture) without an explicit
+review of these tests.
+
+Run:
+  python -m unittest tests.test_v06_graph_rag_step2_driver
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DRIVER = REPO_ROOT / "scripts" / "research" / "graph_rag_synth_step2_cross_model.py"
+
+
+class DriverShapeTests(unittest.TestCase):
+    def test_driver_file_exists(self):
+        self.assertTrue(DRIVER.exists(),
+                        f"driver script missing: {DRIVER}")
+
+    def test_module_imports_cleanly(self):
+        # The driver should import without invoking any subprocess.
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "research"))
+        try:
+            import importlib
+            mod = importlib.import_module("graph_rag_synth_step2_cross_model")
+            self.assertTrue(callable(mod.main))
+            self.assertTrue(callable(mod._build_subprocess_argv))
+        finally:
+            sys.path.remove(str(REPO_ROOT / "scripts" / "research"))
+
+    def test_default_scope_constants(self):
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "research"))
+        try:
+            import importlib
+            mod = importlib.import_module("graph_rag_synth_step2_cross_model")
+            # Lock the Step 2 scope so a future PR can't silently
+            # widen / narrow it without reviewing this test.
+            self.assertEqual(
+                mod._STEP_2_SECTOR_CELLS,
+                ("C_rag-basic", "C_rag-graph", "C_rag-ontology"),
+            )
+            self.assertEqual(mod._STEP_2_TIERS_DEFAULT, ("M_S", "M_L"))
+            self.assertEqual(mod._STEP_2_SUITE, "multihop_rag")
+            self.assertEqual(mod._STEP_2_N_RUNS, 3)
+        finally:
+            sys.path.remove(str(REPO_ROOT / "scripts" / "research"))
+
+
+class DriverArgvCompositionTests(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "research"))
+        import importlib
+        self.mod = importlib.import_module(
+            "graph_rag_synth_step2_cross_model"
+        )
+
+    def tearDown(self):
+        try:
+            sys.path.remove(str(REPO_ROOT / "scripts" / "research"))
+        except ValueError:
+            pass
+
+    def test_default_argv_includes_pinned_scope(self):
+        argv = self.mod._build_subprocess_argv(
+            tiers=("M_S", "M_L"),
+            sector_cells=("C_rag-basic", "C_rag-graph", "C_rag-ontology"),
+            suite="multihop_rag",
+            n_runs=3,
+        )
+        # The runner path must point at the canonical
+        # qvt_ablation_matrix script.
+        self.assertTrue(
+            any("qvt_ablation_matrix.py" in str(a) for a in argv),
+            f"missing qvt_ablation_matrix.py in argv: {argv}",
+        )
+        # The pinned-scope arguments must all appear.
+        self.assertIn("--suite", argv)
+        self.assertIn("multihop_rag", argv)
+        self.assertIn("--tiers", argv)
+        self.assertIn("M_S,M_L", argv)
+        self.assertIn("--sector-cells", argv)
+        self.assertIn("C_rag-basic,C_rag-graph,C_rag-ontology", argv)
+        self.assertIn("--n-runs", argv)
+        self.assertIn("3", argv)
+
+    def test_single_tier_argv(self):
+        argv = self.mod._build_subprocess_argv(
+            tiers=("M_S",),
+            sector_cells=("C_rag-graph",),
+            suite="multihop_rag",
+            n_runs=3,
+        )
+        self.assertIn("M_S", argv)
+        self.assertIn("C_rag-graph", argv)
+
+    def test_workspace_pinned_to_hotpot_eval(self):
+        env = self.mod._build_env("workspaces/hotpot_eval")
+        self.assertIn("JAMES_WORKSPACE", env)
+        self.assertTrue(
+            env["JAMES_WORKSPACE"].endswith("workspaces/hotpot_eval") or
+            env["JAMES_WORKSPACE"].endswith("workspaces\\hotpot_eval"),
+            f"unexpected JAMES_WORKSPACE: {env['JAMES_WORKSPACE']}",
+        )
+
+
+class DriverDryRunTests(unittest.TestCase):
+    def _run_driver(self, args):
+        return subprocess.run(
+            [sys.executable, str(DRIVER), *args],
+            capture_output=True, text=True,
+        )
+
+    def test_dry_run_succeeds(self):
+        result = self._run_driver(["--dry-run"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_dry_run_prints_invocation(self):
+        result = self._run_driver(["--dry-run"])
+        self.assertIn("qvt_ablation_matrix.py", result.stdout)
+        self.assertIn("--tiers", result.stdout)
+        self.assertIn("M_S,M_L", result.stdout)
+        self.assertIn("--sector-cells", result.stdout)
+        self.assertIn("C_rag-basic,C_rag-graph,C_rag-ontology", result.stdout)
+        self.assertIn("JAMES_WORKSPACE", result.stdout)
+
+    def test_dry_run_with_single_tier(self):
+        result = self._run_driver(["--dry-run", "--tiers", "M_S"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("M_S", result.stdout)
+        self.assertNotIn("M_S,M_L", result.stdout)
+
+    def test_empty_tiers_returns_2(self):
+        result = self._run_driver(["--tiers", "", "--dry-run"])
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+
+    def test_empty_sector_cells_returns_2(self):
+        result = self._run_driver(
+            ["--sector-cells", "", "--dry-run"]
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Per `docs/evaluation/v0.5-graph-rag-contribution.md` §7 (\"cross-model … is the immediate next measurement cycle\"). Ships the **runner + synthesis-doc §3.2 + smoke tests** so the operator can launch the ~14h cross-model measurement with a single command and the interpretation rules are pre-agreed before the data lands.

Solo-doable scaffolding; the measurement itself stays operator-attended (same posture as v0.2.3b cross-model runner per handover §5.5 Track E).

## Summary

### Driver script — `scripts/research/graph_rag_synth_step2_cross_model.py` (NEW)

Thin wrapper around `scripts.qvt_ablation_matrix` that pins the Step 2 scope:

- **Sector cells**: `C_rag-basic` / `C_rag-graph` / `C_rag-ontology` (3 load-bearing cells; `C_minus` skipped because the no-RAG floor doesn't shift with model size in the synthesis question)
- **Tiers**: `M_S` (gemma3:4b) + `M_L` (gemma3:12b) — brackets M_M around the Step 1 finding
- **Suite**: `multihop_rag` (Step 1's fixture)
- **n=3 paired** — locked per `memory/feedback_n1_verdict_inflation_n3_caught`
- **JAMES_WORKSPACE** pinned to `workspaces/hotpot_eval` so cell JSONs land in the same directory Step 1 used

```bash
python scripts/research/graph_rag_synth_step2_cross_model.py
python scripts/research/graph_rag_synth_step2_cross_model.py --tiers M_S
python scripts/research/graph_rag_synth_step2_cross_model.py --dry-run
```

### Synthesis doc §3.2 — cross-model plan + interpretation rules (UPDATED)

- What Step 2 tests (5-question table)
- **Pre-agreed interpretation rules** (BEFORE data lands so the finding's tier is interpreted by rule, not post-hoc):
  - path_coverage Δ within ±0.05 across 3 models → load-bearing on 4B–12B gemma family
  - path_coverage Δ >0.10 divergence → model-specific, documented honestly
  - typed-filter +0.027 holds across models → ⭐⭐ promote
  - typed-filter flips negative at M_L → cycle γ Phase E-min trade-off pattern reproduced
- Out-of-scope: M_XS / M_XL / M_MIXTRAL / M_CLOUD / C_minus re-run (each with explicit rationale)

## Tests — `tests/test_v06_graph_rag_step2_driver.py` (NEW, 11 tests)

- **Driver shape** (3): file exists, imports cleanly, scope constants locked so a future PR can't silently widen / narrow Step 2 without reviewing these tests
- **Argv composition** (3): default argv includes pinned scope, single-tier argv, `JAMES_WORKSPACE` pinned to `hotpot_eval`
- **Dry-run** (5): succeeds, prints invocation, single-tier works, empty `--tiers` → exit 2, empty `--sector-cells` → exit 2

## Verification

- `pytest tests/test_v06_graph_rag_step2_driver.py`: **11 passed**
- Manual dry-run prints the expected `qvt_ablation_matrix` invocation with correct `JAMES_WORKSPACE` + flags
- No `core/` / `routes/` / `frontend/` changes — purely scaffolding + doc + tests

## Out of scope

- Does **NOT** run the cross-model measurement — that's ~14h wall + consumes the operator's local Ollama GPU
- Does NOT update Table 3.2 — that fills in after the operator launches + the cells land
- Does NOT change `qvt_ablation_matrix` itself — the driver is a thin wrapper
- Does NOT include M_XS / M_XL — Step 3+ decision
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: code — additive measurement driver + synthesis-doc plan section + smoke tests; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)