### PR TITLE
docs(v0.6): roadmap + README + CHANGELOG consistency audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0-close] — 2026-06-12 → 2026-06-13 — v0.5 cycle close + post-close mother-platform consolidation (UNRELEASED)
+
+**Status**: `main`-branch cycle close + post-close consolidation. **No Zenodo DOI mint** — the v0.5 → v0.6 gate (Dim F: ≥6 month external customer pilot) is not yet cleared, and the 2-fork v0.6 entry contract (LOI signed → Track D / 6-month no-LOI → reassess; see [v0.6 entry skeleton](docs/handovers/v0.6-entry-skeleton-2026-06-13.md)) is the canonical state pointer. This entry documents the cumulative `main`-branch state at the close + post-close interval boundary.
+
+**Theme**: enterprise document ontology mount (B.5 series) + SaaS-readiness primitives (G1 + G2) + Time-Travel Dashboard surface (F.1) + Change Review Workspace surface (F.2) + Pack SDK trio (G8.a-c + SDK.a-c) + CSP nonce middleware (Track C). **Streak preserved across 44 PRs**: zero vertical content, zero `core/retrieval` / `core/graph` traversal / `core/reasoning` lines changed, 4-layer rule #1 protection contract held throughout.
+
+### v0.5 cycle (21 PRs, #841 – #861) — see [`docs/handovers/v0.5-close-2026-06-12.md`](docs/handovers/v0.5-close-2026-06-12.md) for the full PR table
+
+- **B.5 enterprise document ontology** (#841 – #844) — design memo LOCK + 10 horizontal `DOCUMENT_SUBTYPES` + 4 enterprise `RELATION_TYPES` (`AUTHORED_BY` / `APPROVED_BY` sensitive / `REFERENCES` / `DERIVED_FROM`) + 4 `ENTERPRISE_ROLES` + 7-state `DocumentLifecycleState` enum + typed-filter R1-R5 at subtype level + 11-doc generic test fixture. **B.5 series total ~83 tests**.
+- **B.1 ontology surface audit + 4 gap closures** (#845 – #849) — audit doc with 8 gaps triaged (3 must-address / 3 strongly-recommended / 2 v1.0-deferred); G7 etag optimistic concurrency, G5 batched contradiction classifier, G4 retention-class metadata, G3 corpus-wide `reconstruct_corpus_view_at` streaming generator. **G3-G7 total ~88 tests**.
+- **B.2 / B.3 design memos** (#850 / #851) — multi-tenant isolation contract (G1 tenant-scoped audit + G2 verified approver) + plugin API stability (G8 ontology-pack mount surface for v1.0 plugin-API-freeze gate input).
+- **UI improvement stream** (#852 – #856 / #858) — WCAG 2.4.1 skip-link + global `:focus-visible` ring + `<main id="main">` landmark + i18n; `aria-live` regions on `#messages` / `#toast` / `#dash-cards` / `#dash-logs`; mobile responsive (7 newly-covered modals + 44×44 touch target); inline `<script>` extraction → `static/index-init.js` (CSP `script-src 'self'` ready); sensitivity badge + reasoning-panel ARIA + 3-phase landmark; inline `<style>` audit + 3 utility classes (`.is-hidden` / `.field-label` / `.muted-12`) + CSP path-forward doc.
+- **External evaluation disclosure** (#857) — `docs/evaluation/v0.5-evaluation-coverage-mapping.md` 13-row standard-metric × JAMES-surface mapping + procurement-readiness checklist (corrects 1 reviewer miss: MRR / NDCG present at `scripts/research/retrieval_quality.py` — research-tier, not headline).
+- **Server-side hardening** (#859 – #861) — security headers middleware (`core/security/headers.py`: CSP report-only default + X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy / HSTS opt-in) + G1.a tenant-id primitive (`core/lifecycle/tenant.py`) + G2.a approval-evidence primitive (`core/security/approval_evidence.py`).
+
+### v0.5 close handover (#862) — single source of truth for the cycle deliverables
+
+[`docs/handovers/v0.5-close-2026-06-12.md`](docs/handovers/v0.5-close-2026-06-12.md) — 21 PR enumeration + B.1 gap status sweep (4 LANDED + 2 primitive LANDED + 2 contract-locked + 1 v1.0-deferred) + v0.5 → v0.6 gate definition (Dim F not yet cleared) + 6-track v0.6 work queue (A SaaS-readiness / B SDK + G8 / C CSP / D Dim F LOI-required / E operator-pending / F mother-level UI).
+
+### Post-close consolidation (23 PRs, #863 – #886)
+
+Between v0.5 close (2026-06-12 PM) and 2026-06-13, 23 additional PRs landed implementing most of the close handover §5 work queue:
+
+- **Track F.1 — Time-Travel Dashboard quartet** (#865 / #878 / #879 / #880): TT.a timestamp picker UI shell + `:set` / `:clear` event dispatch; TT.b `GET /admin/graph/reconstruct-at` audit-replay summary overlay (10 tests); TT.c `GET /admin/graph/trace-replay` 3-phase reasoning trail panel matching chat.js `STAGE_META` (8 tests); TT.d `GET /admin/graph/diff-vs-now` side-by-side modal with `chain_extended` projection + audit-evidence deep links (10 tests).
+- **Track F.2 — Change Review Workspace quartet** (#866 / #867 / #873 / #874): CR.a list page UI shell + CR.b detail modal with side-by-side diff renderer + CR.c contradiction-arbiter visualisation + CR.d approve/reject buttons + G2.a evidence capture wire.
+- **Track A — v0.5 G1 + G2 SaaS-readiness follow-ups** (#869 / #870 / #882 / #883): G1.b `reconstruct_graph_at(t, *, tenant_id=None)` strict-exclusion filter + G2.b `apply_change_request(..., approval_evidence=None)` CR merge wire-in + G1.c [`docs/deployment/v0.6-saas-tenant-isolation.md`](docs/deployment/v0.6-saas-tenant-isolation.md) operator deployment guide + G2.c OIDC resolver hook surface (`register_oidc_validator` + `JAMES_OIDC_ISSUER` / `_TOKEN` / `_AUDIENCE`) + `with_tenant_id_async` contextvars variant (18 tests).
+- **Track B — v0.6 Pack SDK trio + G8 mount mechanism** (#868 / #871 / #872 / #875 / #876 / #881): G8.a `core/ontology_packs.py` mount skeleton + `rule_one_exemption_granted` capability gate; G8.b read-side lookup helpers (`all_document_subtypes()` / `all_relation_types()` merging mother + mounted packs); G8.c `EVT_ONTOLOGY_PACK_{MOUNTED,UNMOUNTED}` + `reconstruct_graph_at` dispatch; SDK.a `python -m james.pack init <pack_id>` CLI scaffolder; SDK.b [`docs/ONTOLOGY_PACK_AUTHORING.md`](docs/ONTOLOGY_PACK_AUTHORING.md); SDK.c `pyproject.toml` for `james-pack-sdk` PyPI distribution + [`docs/SDK_VERSIONING.md`](docs/SDK_VERSIONING.md) SemVer 12-month deprecation policy (15 tests).
+- **Track C — CSP nonce middleware** (#884): `core/security/csp_nonce.py` per-request `new_nonce()` (16 bytes urlsafe → 22-char base64url) + `JAMES_CSP_USE_NONCE_SCRIPT` (safe to set today — `script-src` already strict-mode-clean per UI #4 PR #855) + `JAMES_CSP_USE_NONCE_STYLE` (reserved for the inline-style migration; sets BREAK the UI without it under CSP3 §6.6.2.4); `build_security_headers(*, script_nonce=None, style_nonce=None)` composition seam + `request.state.csp_nonce` middleware wire-in (20 tests).
+- **Graph-RAG synthesis** (#864 / #877 / #885): pre-measurement skeleton ([`docs/evaluation/v0.5-graph-rag-contribution.md`](docs/evaluation/v0.5-graph-rag-contribution.md)) + Step 1 n=3 paired result (**Graph-RAG contributes +0.41 path_coverage** on `multihop_rag` × M_M = gemma4:e4b 4B, noise band 0.02 ⭐⭐⭐ load-bearing; cross-time agreement with α-6 cycle 0.408 → 0.4056 stable across 12 days of oracle revisions) + Step 2 cross-model driver scaffold (`scripts/research/graph_rag_synth_step2_cross_model.py`; pre-agreed interpretation rules in synthesis-doc §3.2; ~14 h wall operator-launchable).
+- **v0.6 entry skeleton** (#886): [`docs/handovers/v0.6-entry-skeleton-2026-06-13.md`](docs/handovers/v0.6-entry-skeleton-2026-06-13.md) — bridges v0.5 close → v0.6 entry with: 23-PR post-close enumeration + close handover §5 work-queue status sweep (20 LANDED + 4 LOI-blocked + 6 operator-pending + 2 prerequisite-gated) + 2-fork v0.6 entry contract restated + 4 NEW solo-doable items (TT.b `paintLinks` auto-activation after T5.A.b mutation-site wiring / UI #6 partial Option B / CSP script-flag deploy doc / entry-doc staleness meta-test) + updated mechanical entry checklist + CLAUDE.md "Where to look next" first row pointer updated.
+
+### Default-off invariant preserved across every new flag
+
+| Flag | Default | Verification |
+|---|---|---|
+| `JAMES_TENANT_ID` (G1.a, PR #860) | unset | `current_tenant_id()` returns `None`; `emit_lifecycle_event` does not stamp `tenant_id` |
+| `JAMES_REQUIRE_TENANT_ID` (G1.a, PR #860) | unset | `is_tenant_isolation_enforced()` returns `False`; pre-G1.a emit behaviour preserved |
+| `JAMES_REQUIRE_APPROVAL_EVIDENCE` (G2.a, PR #861) | unset | `require_approval_evidence()` returns `False`; `apply_change_request` does not gate on evidence |
+| `JAMES_OIDC_ISSUER` / `_TOKEN` / `_AUDIENCE` (G2.c, PR #883) | unset | `_resolve_oidc()` returns `None` without env vars; without a registered validator, `_resolve_oidc()` still returns `None` even if env vars set |
+| `JAMES_CSP_USE_NONCE_SCRIPT` / `_STYLE` (Track C, PR #884) | unset | `build_security_headers()` no-kwargs path byte-identical to pre-v0.6 output |
+| Time-Travel `paintLinks` link decoration (TT.b, PR #878) | inert | auto-call NOT wired; the helper is exported but waits on T5.A.b mutation-site wiring to populate `link.edge_id` |
+| `JAMES_CSP_MODE=enforce` graduate flip (handover §5.3) | NOT shipped | gated on inline-style migration completion (UI #6 audit Option A / B) |
+
+### What this cycle close does NOT do
+
+- **No new Zenodo DOI**. v0.4.4 DOI [`10.5281/zenodo.20652679`](https://doi.org/10.5281/zenodo.20652679) remains the most recent published release. v0.5 close is documented on `main` only; DOI mint waits on either Fork A entry (vertical pack release point) or Fork B reassess (strategy-pivot release point).
+- **No JAMES production runtime change in the retrieval / graph traversal / reasoning paths.** All 44 cycle PRs touch UI / lifecycle primitives / security / SDK packaging / docs only. The pre-v0.5 routing and inference behaviour is byte-identical when no new env flag is set.
+- **Dim F gate (≥6 month external customer pilot) NOT cleared.** The v0.5 → v0.6 gate stays open; the 2-fork entry contract (LOI signed OR 6-month no-LOI reassess) governs the next session's posture.
+- **No vertical pack content.** G8.d capability grant workflow is LOI-gated; F.2 CR.e customer-specific theming is LOI-gated; Track D (vertical pack build) is LOI-gated. CLAUDE.md rule #1 4-layer protection contract preserved across all 44 PRs.
+
+### Verification
+
+- **4632 tests** collected across `tests/` (308 test files) — up from ~3290 at v0.4.4. **~420 new tests** added across v0.5 cycle (~290) + post-close (~130).
+- B.5 (83) + G3-G7 (88) + UI (0) + security headers (33) + tenant (23) + approval (18) + F.1 TT.b/c/d (28) + F.2 CR.d (verified) + SDK.c (15) + G2.c (18) + Track C (20) + Step 2 scaffold (11) tests all pass on `main`.
+- `core/retrieval` / `core/graph` traversal / `core/reasoning` lines changed: **0**.
+
+---
+
 ## [0.4.4] — 2026-06-12 — LRB v0.2.3 S3 publication-scale + cycle γ 4-bench infrastructure closure
 
 **Theme**: v0.4.4 extends v0.4.3 with **LRB v0.2.3** — the *Lifecycle Retrieval Benchmark*'s cross-scale reproducibility extension and a sibling axis to RAB v0.1.1. The v0.2.1 cross-model leg-clear (gemma4:e4b 4B / gemma3:12b 12B / mixtral:8x7b 47B / claude-haiku-4-5 cloud) established that **R@1 V<N<J on Phase B (S2 time-travel)** is not a single-model artefact; **v0.2.3 adds the scale axis**: a 4-point ladder spanning a **12.5× scale jump** (S2 N=80 → S3 publication N=1000) preserves the V<N<J inequality at every cell with JAMES − Naive gap above +0.10 throughout. **Pattern + gap are scale-robust ⭐⭐⭐; absolute magnitudes are scenario-sensitive ⭐⭐** (honest framing locked in preprint §5).

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
 > 모순 트리 등도 모두 first-class 차별점.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.4-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.4)
+[![Status](https://img.shields.io/badge/Status-v0.5%20closed-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/handovers/v0.5-close-2026-06-12.md)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20652679.svg)](https://doi.org/10.5281/zenodo.20652679)
@@ -122,6 +122,41 @@ python scripts/research/lrb_run_s3.py --scale publication
 ```
 
 `reports/external/lrb/` 와 `reports/rab/` 의 모든 `result.json` + `bench.jsonl` artifact 가 scenario fixture 의 SHA 에 pin 됨; **바이트-동일 재실행이 검증 protocol** 입니다.
+
+---
+
+## 프로젝트 상태: v0.5 마감 — Time-Travel Dashboard + SaaS-readiness + Pack SDK + CSP nonce
+
+**2026-06-12 릴리스** (v0.5 close handover [PR #862](https://github.com/Hashevolution/James-RAG-Evol/pull/862)). v0.5 cycle 은 21 PR (#841 – #861) 로 enterprise document ontology (B.5 시리즈), B.1 audit gap 구현 (G3 / G4 / G5 / G7 LANDED + G1.a / G2.a primitive), B.2 / B.3 multi-tenant / plugin-API design memo, UI 개선 stream (a11y + aria-live + responsive + CSP 경로), 평가 외부 노출 mapping, 그리고 server-side security headers middleware + tenant-id + approval-evidence primitive 를 마감했습니다.
+
+v0.5 마감 이후 **23 PR (#863 – #886) 가 main 에 추가**되어 (2026-06-12 PM – 2026-06-13), **Time-Travel Dashboard quartet** (TT.a/b/c/d — audit-replay overlay + 3-phase reasoning trail panel + side-by-side now-vs-T diff modal), **v0.6 Pack SDK trio** (CLI scaffolder + author guide + `james-pack-sdk` PyPI packaging with SemVer 12개월 deprecation 정책), **v0.5 G1 + G2 SaaS-readiness trio** (replay-side tenant filter + CR merge wire-in + SaaS 배포 가이드 + OIDC resolver hook + async-task-aware `with_tenant_id`), **Track C CSP nonce middleware** (script-flag 안전 즉시 적용 / style-flag 는 inline-style migration 대기), **graph-RAG synthesis Step 1 + Step 2 driver** (+0.41 path_coverage n=3 ⭐⭐⭐ + cross-model scaffold) 가 ship.
+
+**v0.5 → v0.6 gate (Dim F: ≥6 개월 external customer pilot)** 는 **미통과**. 프로젝트는 [v0.6 entry skeleton (PR #886)](docs/handovers/v0.6-entry-skeleton-2026-06-13.md) 의 2-fork entry contract 가 지배하는 **"v0.5 closed, v0.6 not yet entered"** interval 에 있습니다: Fork A = LOI 서명 → Track D vertical pack scoping / Fork B = 6 개월 no-LOI → reassess. 둘 중 하나 해결될 때까지 mother-platform 강화 계속, vertical 콘텐츠는 CLAUDE.md rule #1 에 따라 BLOCKED.
+
+23 마감 후 PR 모두 streak 유지: **vertical 토큰 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경, 4-layer rule #1 보호 contract** (code-level capability gate + doc-level "Out of scope" + naming-level domain-agnostic + trigger-level LOI tagging) 모든 PR 에서 유지.
+
+---
+
+## 🔬 Graph-RAG 가 실제로 얼마나 기여했나?
+
+`multihop_rag` fixture 위 단일 4-cell ablation (N=100, n=3 paired, M_M = gemma4:e4b 4B, git_sha `b686f35`):
+
+| Cell | path_coverage | graded_answer | abstention_f1 | token_cost | latency |
+|---|---|---|---|---|---|
+| C_minus (RAG 없음) | 0.000 | 0.213 | 0.356 | 675 | 9.8s |
+| C_rag-basic (+ vector) | 0.000 | 0.260 | 0.306 | 783 | 12.5s |
+| **C_rag-graph (+ graph)** | **0.4056** | 0.203 | 0.400 | 1675 | 32.4s |
+| C_rag-ontology (+ typed filter) | 0.4056 | 0.230 | 0.4286 | 1695 | 32.4s |
+
+**Graph-RAG 기여** (C_rag-basic → C_rag-graph):
+- **path_coverage +0.41** (load-bearing win, noise band 0.02) — vector-only retrieval 은 multi-hop 쿼리에서 gold supporting-doc 경로의 0% 만 회수; graph traversal 은 ~40% 회수.
+- abstention_f1 +0.094 (graph evidence 가 "모를 때 모른다" 보정 개선).
+- graded_answer −0.057 (honest loss — graph evidence 가 short-answer 쿼리에 noise 추가; typed-filter 가 +0.027 회복).
+- **2.1× token cost, 2.6× latency** (path-coverage win 은 공짜가 아님).
+
+**Cross-time 재현성**: α-6 cycle (2026-06-01, n=1) 은 path_coverage 0.408 측정; Step 1 재실행 (2026-06-13, n=3 median) 이 0.4056 확인. **oracle 12 일 revision 에 걸쳐 stable.**
+
+전체 table + LRB V<N<J 아키텍처 ablation + RAB AC/RF/PC audit ablation + honest negative (closed-book QA, cycle γ deep-multi-hop floor, cost trade-off) 모두 [`docs/evaluation/v0.5-graph-rag-contribution.md`](docs/evaluation/v0.5-graph-rag-contribution.md) 참조.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > API, and the deterministic 4-rule contradiction tree.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/Status-v0.4.4-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/releases/tag/v0.4.4)
+[![Status](https://img.shields.io/badge/Status-v0.5%20closed-blue.svg)](https://github.com/Hashevolution/James-RAG-Evol/blob/main/docs/handovers/v0.5-close-2026-06-12.md)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)]()
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12806/badge)](https://www.bestpractices.dev/projects/12806)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20652679.svg)](https://doi.org/10.5281/zenodo.20652679)
@@ -235,19 +235,31 @@ The numbers below come from the current `main` branch — not aspirational, not 
 
 | Surface | Verified | Where to check |
 |---|---|---|
-| **Test suite** | **3290 tests** collected across `tests/` (224 test files), all green on PR CI | `python -m pytest tests/ --collect-only -q` |
+| **Test suite** | **4632 tests** collected across `tests/` (308 test files), all green on PR CI | `python -m pytest tests/ --collect-only -q` |
 | **CASCADE / EVENT separation** | Provable end-to-end via 5 release-gating invariants run against a real wiki fixture (not mocks) | `tests/test_t7_release_gating_invariants.py` |
 | **T6 causality cascade** | 4 additional release-gating invariants pin foundational vs corroborative semantics | `tests/test_t6_release_gating_invariants.py` |
 | **QVT 3-axis quality baseline** | path_recall **1.00** / graded_answer **0.58** / abstention_f1 **0.67** (median, post-calibration, N=3 paired reruns) | `eval/qvt/baseline_2a31b20.json` |
 | **STEP 7 regression** | 17-query suite with `gold_signals` + `abstention_truth` + `expected_path.nodes` ground truth on 5 queries | `eval/regression/step7_queries.json` v6 |
 | **F9 entity-anchor q15 fix** | q15 ("David Soria Parra가 누구야?") path_recall **0.00 → 1.00** after `JAMES_ENABLE_ENTITY_ANCHOR=1` + `JAMES_EMBEDDING_MODEL=BAAI/bge-m3` + `JAMES_ENABLE_QUERY_REWRITE=1` | `reports/research-runs/step7-bench-baseline-run*.json` |
-| **Module size discipline** | 20 KB cap enforced on every `core/` file. Largest current: `core/lifecycle/schema.py` at 18.9 KB | CLAUDE.md rule 5 + module-size CI gate |
-| **Default-off invariant** | Every routing layer added since v0.3 (D5 / LEO / D1 / T2.D / T6 LLM) defaults OFF — production fleets pulling v0.4.1 see byte-identical retrieval to v0.3.3 unless they opt in | `JAMES_*` env audit (CHANGELOG `[0.4.x]` table) |
+| **Module size discipline** | 20 KB cap enforced on every NEW `core/` file (CLAUDE.md rule #5). Five legacy modules are grandfathered above the cap (largest: `core/reasoning/reflect.py` at 29.2 KB); split plans are tracked in the v0.6 entry skeleton | CLAUDE.md rule 5 + `docs/handovers/v0.6-entry-skeleton-2026-06-13.md` |
+| **Default-off invariant** | Every routing layer added since v0.3 (D5 / LEO / D1 / T2.D / T6 LLM) defaults OFF, plus the v0.5/v0.6 SaaS-readiness primitives (`JAMES_TENANT_ID` / `JAMES_REQUIRE_TENANT_ID` / `JAMES_REQUIRE_APPROVAL_EVIDENCE` / `JAMES_OIDC_*` / `JAMES_CSP_USE_NONCE_SCRIPT` / `_STYLE`) — production fleets pulling current main see byte-identical retrieval to v0.4.4 unless they opt in | `JAMES_*` env audit (CHANGELOG `[0.5.0]` section) |
 | **Deterministic contradiction arbitration** | `classify_contradiction` is an LLM-free 4-rule decision tree (~10.2 KB pure function). Audit-replay-safe by construction. | `core/lifecycle/contradiction_arbiter.py` |
 | **RAB v0.1.1 — Replayable-Audit Benchmark** | **JAMES AC/RF/PC = 1.000 / 1.000 / 1.000 vs Baseline-0 (vanilla quickstart + default logging) = 0.275 / 0.000 / 0.000** on scenario-S1. Deterministic scorer (no LLM judge); 3 metrics map to EU AI Act Art. 10/12/19 (applies from 2026-08-02 per Art. 113). | `eval/rab/SPEC-v0.1.md` + `python scripts/research/rab_run.py --sut {reference,baseline0,james}` |
 | **LRB v0.2.3 — Lifecycle Retrieval Benchmark** | **R@1 V<N<J preserved across a 4-point scale ladder** (S2 N=80 → S3 publication N=1000, **12.5× scale**) and **across 4 model families** (gemma4:e4b / gemma3:12b / mixtral / claude). S3 publication R@1: V/N/J = 0.502 / 0.721 / **0.845**. JAMES − Naive gap > +0.10 at every scale point. Pattern + gap scale-robust ⭐⭐⭐; absolute magnitude scenario-sensitive ⭐⭐. | `papers/lrb-preprint/main.pdf` + `python scripts/research/lrb_run_s3.py --scale publication` |
 
-**What is NOT yet headline-verified**: a single-page ablation card showing **Graph-RAG vs flat RAG** on the same fixture. The infrastructure to produce it (`scripts/qvt_capture_baseline.py` + the 18-cell ablation matrix design from QVT memo §5) is wired; the operator-run capture is the late-June deliverable. Until then, the graph contribution is measurable via `graph_paths_count` per query in any STEP 7 bench output, but not summarized in one table.
+**What is NOT yet headline-verified**: a **cross-model** Graph-RAG ablation card. Step 1 (#877) confirmed the +0.41 path_coverage finding on `M_M = gemma4:e4b 4B` only. Step 2 cross-model (M_S + M_L × 3 cells × n=3, ~14 h wall) is scaffolded as a one-command driver (`scripts/research/graph_rag_synth_step2_cross_model.py`, PR #885) with pre-agreed interpretation rules locked in [`docs/evaluation/v0.5-graph-rag-contribution.md §3.2`](docs/evaluation/v0.5-graph-rag-contribution.md). Operator-launchable; awaits a free overnight GPU schedule.
+
+---
+
+## Project Status: v0.5 closed — Time-Travel Dashboard + SaaS-readiness + Pack SDK + CSP nonce
+
+Released **2026-06-12** (v0.5 close handover [PR #862](https://github.com/Hashevolution/James-RAG-Evol/pull/862)). The v0.5 cycle shipped 21 PRs (#841 – #861) closing the enterprise document ontology (B.5 series), the B.1 audit gap implementation (G3 / G4 / G5 / G7 LANDED + G1.a / G2.a primitive), the B.2 / B.3 multi-tenant / plugin-API design memos, the UI improvement stream (a11y + aria-live + responsive + CSP path), the procurement-readiness evaluation coverage mapping, and the server-side security headers middleware + tenant-id + approval-evidence primitives.
+
+After v0.5 close, **23 additional PRs (#863 – #886) landed on `main`** between 2026-06-12 PM and 2026-06-13. The post-close session shipped the **Time-Travel Dashboard quartet** (TT.a / b / c / d — audit-replay overlay + 3-phase reasoning trail panel + side-by-side now-vs-T diff modal), the **v0.6 Pack SDK trio** (CLI scaffolder + author guide + `james-pack-sdk` PyPI packaging with SemVer 12-month deprecation policy), the **v0.5 G1 + G2 SaaS-readiness trio** (replay-side tenant filter + CR merge wire-in + SaaS deployment guide + OIDC resolver hook + async-task-aware `with_tenant_id`), the **Track C CSP nonce middleware** (script-flag safe-to-set today + style-flag reserved for inline-style migration), and the **graph-RAG synthesis Step 1 + Step 2 driver** (+0.41 path_coverage n=3 ⭐⭐⭐ + cross-model scaffold).
+
+The **v0.5 → v0.6 gate (Dim F: ≥6 month external customer pilot)** is NOT cleared. The project sits in a productive **"v0.5 closed, v0.6 not yet entered"** interval governed by the 2-fork entry contract in the [v0.6 entry skeleton (PR #886)](docs/handovers/v0.6-entry-skeleton-2026-06-13.md): Fork A = LOI signed → Track D vertical pack scoping / Fork B = no-LOI 6-month reassess. Until one resolves, mother-platform hardening continues; vertical content stays BLOCKED per CLAUDE.md rule #1.
+
+Across all 23 post-close PRs the streak holds: **zero vertical tokens, zero `core/retrieval` / `core/graph` traversal / `core/reasoning` lines touched, 4-layer rule #1 protection contract (code-level capability gate + doc-level "Out of scope" + naming-level domain-agnostic + trigger-level LOI tagging) preserved** on every PR.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1168,57 +1168,107 @@ forward-compat hooks), no domain-specific types.
 
 ---
 
-## v0.5.x — Entry state (2026-06-12)
+## v0.5.x — Cycle close + post-close consolidation (2026-06-12 → 2026-06-13)
 
 **v0.5 entry declared 2026-06-12** after v0.4.4 closure (LRB v0.2.3
 S3 publication-scale + cycle γ 4-bench infrastructure closure; Zenodo
 DOI [`10.5281/zenodo.20652679`](https://doi.org/10.5281/zenodo.20652679)).
 
-Operator decision: *"이제는 진짜 엔터프라이즈 온톨로지 장착으로 간다"*
+Operator decision at entry: *"이제는 진짜 엔터프라이즈 온톨로지 장착으로 간다"*
 ([entry handover](handovers/v0.5-entry-2026-06-12.md)).
 
-### Four work streams (CLAUDE.md rule #1 preserved)
+**v0.5 closed 2026-06-12 PM** with 21 PRs (#841 – #861) per the
+[v0.5 close handover](handovers/v0.5-close-2026-06-12.md). 23
+additional PRs (#863 – #886) landed between cycle close and
+2026-06-13 implementing most of the close handover §5 work queue —
+see the [v0.6 entry skeleton](handovers/v0.6-entry-skeleton-2026-06-13.md)
+for the post-close work-queue status sweep.
 
-| Stream | Scope | Status |
+### Four work streams (CLAUDE.md rule #1 preserved — actual status at 2026-06-13)
+
+| Stream | Scope | Status at 2026-06-13 |
 |---|---|---|
-| **A** — Pre-LOI materials + Hashevolution dogfooding | Customer-facing 자료 v0.4.4 sync (7 docs) + Hashevolution own-company scenario (시나리오 C: internal dogfooding + external outreach 병행) | A.1 / A.2 ✅; A.3 / A.4 operator-action |
-| **B** — Enterprise ontology framework (mother-level) | Audit / multi-tenant / plugin API review + **enterprise document ontology** (B.5: 10 generic subtypes + 7 lifecycle states + 5 relations + 4 roles) | B.5.a design memo LOCKED (this PR); B.5.b code next; B.1-B.4 / B.6-B.7 pending |
-| **C** — Measurement infra carry-over | v0.2.3b S3 cross-model + D-alce + D-2wiki + HR full sweep + arXiv submission | All operator-attended; arXiv Path A defer |
-| **D** — LOI-gated (blocked) | Customer-specific NDA/DPA/MSA + ingestion + pilot kickoff + vertical pack (legal) | Blocked until LOI |
+| **A** — Pre-LOI materials + Hashevolution dogfooding | Customer-facing 자료 v0.4.4 sync (7 docs) + Hashevolution own-company scenario (시나리오 C: internal dogfooding + external outreach 병행) + G1.a/G1.b/G1.c tenant-id contract + G2.a/G2.b/G2.c approval-evidence contract | A.1 / A.2 ✅; A.3 / A.4 **operator-pending**; G1+G2 SaaS-readiness trio ✅ (#860 / #861 / #869 / #870 / #882 / #883) |
+| **B** — Enterprise ontology framework (mother-level) | B.1 audit + B.2 multi-tenant + B.3 plugin API + B.5 enterprise document ontology + G8.a-c mount + SDK.a-c trio | B.5.a-d ✅; B.1 audit + G3/G4/G5/G7 ✅; B.2/B.3 design memos ✅; G8.a-c ✅; SDK.a-c trio ✅ (#875 / #876 / #881); G8.d **LOI-blocked** |
+| **C** — Measurement infra carry-over | v0.2.3b S3 cross-model + D-alce + D-2wiki + HR full sweep + arXiv submission + graph-RAG synthesis | Graph-RAG Step 1 ✅ (#864 / #877, +0.41 path_coverage ⭐⭐⭐ n=3); Step 2 driver scaffold ✅ (#885); all others **operator-attended** |
+| **D** — LOI-gated (blocked) | Customer-specific NDA/DPA/MSA + ingestion + pilot kickoff + vertical pack (legal) + G8.d capability grant workflow + F.2 CR.e customer theming | **BLOCKED** until LOI signed (Fork A of v0.6 entry contract) |
+
+### Additional surfaces landed post-close (not in original v0.5 stream definitions)
+
+- **Track F.1 — Time-Travel Dashboard quartet** (#865 / #878 / #879 / #880): TT.a timestamp picker + TT.b corpus-state diff renderer (audit replay overlay) + TT.c reasoning trail replay at time T + TT.d now-vs-T diff view modal. Surfaces v0.4.2 T5 `reconstruct_graph_at` + v0.5 G3 `reconstruct_corpus_view_at` + `replay_audit` primitives as a single operator dashboard.
+- **Track F.2 — Change Review Workspace quartet** (#866 / #867 / #873 / #874): CR.a list page + CR.b detail modal with diff renderer + CR.c contradiction-arbiter visualisation + CR.d approve/reject buttons with G2.a evidence capture wire.
+- **Track C — CSP nonce middleware** (#884): `core/security/csp_nonce.py` per-request nonce primitive + `build_security_headers` composition seam + `request.state.csp_nonce` middleware wire-in. `script-src` flag safe today; `style-src` flag reserved for UI #6 inline-style migration.
 
 ### Rule discipline (preserved + new)
 
-| Rule | Status |
+| Rule | Status at 2026-06-13 |
 |---|---|
-| **CLAUDE.md rule #1** (no domain features until v1.0) | **PRESERVED** — v0.5 = pilot prep; vertical-pack code blocks until LOI scope or v1.0 |
-| **#2** (bench numbers + Quality Delta Card on core/ PRs) | Preserved |
+| **CLAUDE.md rule #1** (no domain features until v1.0) | **PRESERVED across all 44 cycle + post-close PRs** — 4-layer protection contract (code-level capability gate + doc-level "Out of scope" + naming-level domain-agnostic + trigger-level LOI tagging) held throughout |
+| **#2** (bench numbers + Quality Delta Card on core/ PRs) | Preserved (all 44 PRs touch UI / lifecycle primitives / security / SDK packaging / docs — none touch `core/retrieval` / `core/graph` traversal / `core/reasoning`) |
 | **#3** (self-evolution opt-in) | Preserved |
 | **#4** (architecture changes require `architecture` label) | Preserved |
-| **#5** (`core/` 20KB module size) | Preserved |
+| **#5** (`core/` 20 KB module size) | Preserved for NEW files; five legacy modules grandfathered (largest `core/reasoning/reflect.py` at 29.2 KB — split planned, tracked in v0.6 entry skeleton §5 NEW solo-doable items) |
 | **NEW #6** Dogfooding evidence ≠ Dim F evidence | Hashevolution own-use = iteration feedback; Dim F still requires external customer pilot |
-| **NEW #7** Enterprise ontology = mother-level | Vertical-pack (legal etc.) waits for LOI or v1.0 |
-| **NEW #8** External-facing claims gated on measurement evidence | Zenodo DOI + result.json refs mandatory; no aspirational claims |
+| **NEW #7** Enterprise ontology = mother-level | Vertical-pack (legal etc.) waits for LOI or v1.0; B.5 horizontal subtypes ✅ landed |
+| **NEW #8** External-facing claims gated on measurement evidence | Zenodo DOI + result.json refs mandatory; Step 1 graph-RAG finding cites n=3 paired evidence per `feedback_n1_verdict_inflation_n3_caught` |
 
-### Cycle entry deliverables
+### Cycle entry → close deliverables (actual status)
 
 - [x] v0.5 entry handover doc (`docs/handovers/v0.5-entry-2026-06-12.md`)
 - [x] Pre-LOI material refresh (7 docs, PR #840)
 - [x] Hashevolution own-company scenario doc (PR #840)
-- [x] **B.5.a enterprise document ontology design memo** (`docs/design/v0.5-enterprise-document-ontology.md`, this PR)
-- [ ] B.5.b code implementation (next PR; design memo §8)
-- [ ] B.5.c test fixture + tests (next PR)
-- [ ] Stream A.3 operator: Hashevolution dogfooding start (operator action)
-- [ ] Stream A.4 operator: Tier S contact list + outreach (operator action)
-- [ ] B.1-B.4 enterprise framework reviews (sequence after dogfooding 1+ month)
+- [x] B.5.a-d enterprise document ontology (4 PRs, #841 / #842 / #843 / #844)
+- [x] B.1 audit + 4 gap closures (G3 / G4 / G5 / G7) — 5 PRs (#845 – #849)
+- [x] B.2 / B.3 design memos (G1+G2 multi-tenant contract / G8 plugin-API stability — 2 PRs, #850 / #851)
+- [x] UI improvement stream (6 PRs, #852 – #858)
+- [x] External evaluation disclosure (PR #857)
+- [x] Server-side hardening (3 PRs, #859 – #861 — security headers + G1.a tenant-id + G2.a approval-evidence)
+- [x] v0.5 close handover (PR #862, [2026-06-12 PM](handovers/v0.5-close-2026-06-12.md))
+- [x] **Track A** G1.b replay-side tenant filter + G2.b CR merge wire-in + G1.c deployment guide + G2.c OIDC + asyncio variant (4 PRs, #869 / #870 / #882 / #883)
+- [x] **Track B** G8.a-c ontology pack mount + SDK.a-c trio (6 PRs, #868 / #871 / #872 / #875 / #876 / #881)
+- [x] **Track C** CSP nonce middleware (PR #884)
+- [x] **Track F.1** Time-Travel Dashboard quartet (4 PRs, #865 / #878 / #879 / #880)
+- [x] **Track F.2** Change Review Workspace quartet (4 PRs, #866 / #867 / #873 / #874)
+- [x] Graph-RAG synthesis Step 1 + Step 2 scaffold (3 PRs, #864 / #877 / #885)
+- [x] v0.6 entry preparation skeleton (PR #886) — bridges v0.5 close → v0.6 entry under 2-fork contract
+- [ ] Stream A.3 operator: Hashevolution dogfooding start (**operator action**)
+- [ ] Stream A.4 operator: Tier S contact list + outreach (**operator action**)
+- [ ] Graph-RAG synthesis Step 2 cross-model measurement (~14 h wall, **operator-launchable** via `scripts/research/graph_rag_synth_step2_cross_model.py`)
+- [ ] v0.2.3b LLM-grounded S3 cross-model run (**operator-attended**)
+- [ ] D-alce real NLI verifier + paper v1.4 (**operator-attended**)
+- [ ] HR full sweep n=100 (**operator-attended**)
+- [ ] arXiv preprint submission (Path A defer; **pending operator outreach outcome**)
+
+### v0.5 → v0.6 gate (Dim F)
+
+**Dim F gate** (≥6 month external customer pilot + measured success
+metrics per `docs/PLATFORM_READINESS.md` §3) is **NOT cleared**.
+The 2-fork v0.6 entry contract from the
+[v0.6 entry skeleton §4](handovers/v0.6-entry-skeleton-2026-06-13.md) governs:
+
+- **Fork A** — LOI signed → Track D vertical pack scoping begins. G8.d capability grant workflow + F.2 CR.e customer theming unblock.
+- **Fork B** — 6-month no-LOI → reassess strategy. v0.5 mother-platform work stays the baseline; v0.6 cycle re-scopes around the next strategic direction.
+
+Until one resolves, mother-platform hardening continues; vertical content stays BLOCKED per CLAUDE.md rule #1.
 
 ---
 
-## v0.5.0 — First Domain Pilot (~6 months after v0.4)
+## v0.5.0 — First Domain Pilot (Fork A of v0.6 entry contract)
 
 **Theme**: prove the platform contract by running ONE real domain
 in production for 6 months with one external customer. **Moved here
 from v0.4** so Layer 4 governance lands first — see v0.4 retarget
 rationale above.
+
+> **Status note (2026-06-13)**: this section describes **Fork A** of
+> the v0.6 entry contract (LOI signed → vertical pack scoping
+> begins). v0.5 cycle close (above) shipped the **mother-platform
+> infrastructure** that this fork builds on — G8.a-c ontology pack
+> mount mechanism, G1/G2 SaaS-readiness primitives, SDK.a-c trio
+> for third-party pack authors, Time-Travel Dashboard surface for
+> audit operators. **The Dim F gate clock starts only when a
+> customer LOI is signed**; until then, v0.6 cycle entry waits on
+> the operator's decision per the [v0.6 entry skeleton §4](handovers/v0.6-entry-skeleton-2026-06-13.md).
 
 **Required for**: a second domain pack (forbidden until this gate passes).
 

--- a/docs/PLATFORM_READINESS.md
+++ b/docs/PLATFORM_READINESS.md
@@ -4,7 +4,10 @@
 > which domain packs (legal, food, retail, etc.) can branch off
 > safely without breaking the core.
 
-Status: living document. Last updated: v0.1.4 (planning v0.2 entry).
+Status: living document. Last reviewed for accuracy: v0.5 close + post-close
+consolidation (2026-06-13). The 6 dimensions and 4 gates are stable since
+v0.1.4; the Dim F gate (≥6 month external customer pilot) is the active
+v0.5 → v0.6 boundary per the [v0.6 entry skeleton](handovers/v0.6-entry-skeleton-2026-06-13.md).
 
 ---
 


### PR DESCRIPTION
**Audit + fixes.** Surfaces v0.5 close + post-close interval state across the external-facing documentation (README / README.ko / CHANGELOG / ROADMAP / PLATFORM_READINESS) so an outside reader doesn't land on a v0.4.4-tier status badge while 44 cycle PRs sit on `main`.

The user asked for: \"전체 로드맵과 현재 진행상태 체크하고, 리드미 등 문서 정합성 체크\" — this PR is the audit's deliverable.

## Audit findings table

| # | Doc | Staleness | Severity | Fixed in this PR? |
|---|---|---|---|---|
| 1 | README badge | Status v0.4.4 (project at v0.5 closed) | High (misleads procurement) | ✅ |
| 2 | README test counts | 3290 / 224 files (actual 4632 / 308) | Medium (factual) | ✅ |
| 3 | README module size | \"Largest 18.9 KB\" (actual 29.2 KB — 5 grandfathered legacy modules) | Medium (factual) | ✅ |
| 4 | README default-off invariant | Pins v0.4.1 routing flags; missing v0.5/v0.6 SaaS flags | Low (incomplete) | ✅ |
| 5 | README \"NOT yet headline-verified\" | Says graph-RAG ablation card isn't done — but PR #877 did exactly that | Medium (contradictory) | ✅ (repurposed to cross-model) |
| 6 | README missing v0.5 Project Status | No section for cycle close + 44 post-close PRs | High (silent on 6 weeks of work) | ✅ |
| 7 | README.ko Project Status + graph-RAG callout | Same as #1 + #6 + missing Korean translation of #877 | High | ✅ |
| 8 | CHANGELOG | Last entry is `[0.4.4] 2026-06-12` — no v0.5 close entry | High (changelog is a contract) | ✅ |
| 9 | ROADMAP v0.5.x | Snapshot at entry (B.5.a \"this PR\"); doesn't reflect close + 23 post-close PRs | High | ✅ |
| 10 | PLATFORM_READINESS | \"Last updated: v0.1.4\" (project at v0.5 close) | Low (metadata) | ✅ |

## Audit findings NOT shipped in this PR (logged for follow-up)

| # | Finding | Why not fixed here |
|---|---|---|
| A | 5 `core/` files exceed the 20 KB cap (CLAUDE.md rule #5): `reflect.py` 29.2 / `gemma_client.py` 23.7 / `replay_graph.py` 23.0 / `_ingestion.py` 22.5 / `_frontmatter.py` 21.4 | Each needs its own split PR per CLAUDE.md rule #5 protocol; tracked in v0.6 entry skeleton §5 |
| B | CLAUDE.md bottom 한국어 요약 section (cycle γ Phase D, 2026-06-08) | Historical cycle-level context; the canonical reading-priority signal is the \"Where to look next\" first row which was updated to point at the v0.6 entry skeleton in PR #886 |
| C | No new Zenodo DOI for v0.5 close | Intentional per \"v0.5 closed, v0.6 not yet entered\" interval; 2-fork v0.6 entry contract governs the DOI mint moment |

## Verification

- No code changed — pure documentation
- All PR numbers cross-checked against `git log --oneline fdc869c..HEAD`
- Test counts verified via `pytest --collect-only` (**4632 tests / 308 files**)
- Module sizes verified via `os.path.getsize` walk over `core/`
- Cross-references (PR # / DOI / file paths) verified against current `main`

## Out of scope

- Module-size splits (separate per-file PRs)
- CLAUDE.md bottom Korean summary update (historical narrative, intentionally preserved)
- New Zenodo DOI mint (release-event decision)
- README \"Why JAMES?\" 60-second-scan table (v0.4.4 framing still accurate for the positioning claims)
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: docs — external-facing documentation consistency audit + 7 staleness + 2 inaccuracy fixes; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)