### PR TITLE
docs(v0.6-P1.1): HTTPS production deployment operator guide

### DIFF
--- a/docs/deployment/v0.6-https-production.md
+++ b/docs/deployment/v0.6-https-production.md
@@ -1,0 +1,469 @@
+# HTTPS Production Deployment — Operator Guide (v0.6 Phase 1)
+
+> **Status**: Operator-facing deployment guide. Pairs with the
+> trusted-forwarded middleware (P1.2, PR #890) + security headers
+> middleware (v0.5 #859) + CSP nonce primitive (v0.6 Track C #884)
+> + HSTS opt-in env (`JAMES_HSTS_MAX_AGE`).
+>
+> **Audience**: anyone deploying JAMES on an internet-facing host
+> who needs HTTPS termination, accurate client IPs in audit/rate-limit
+> rows, and the right CSP + HSTS posture.
+>
+> **CLAUDE.md rule #1**: this guide is **horizontal** — the
+> deployment pattern is content-agnostic. Vertical pack content
+> remains BLOCKED until v1.0 or signed LOI.
+
+---
+
+## 1. TL;DR — minimum production-ready config
+
+If you have a reverse proxy fronting JAMES on a single host:
+
+```bash
+# JAMES env
+export JAMES_TRUSTED_PROXIES="127.0.0.1,10.0.0.0/8"   # peer = your reverse proxy
+export JAMES_HSTS_MAX_AGE=31536000                     # 1 year HSTS
+export JAMES_CSP_MODE=enforce                          # CSP from report-only → enforce
+export JAMES_CSP_USE_NONCE_SCRIPT=1                    # tighten script-src (safe today)
+
+# Reverse proxy: terminate TLS + forward headers
+# nginx / Caddy / Traefik examples in §3
+
+# ASGI: uvicorn workers behind the proxy
+uvicorn server_llmwiki:app --host 127.0.0.1 --port 8000 --workers 4
+```
+
+Three things to get right:
+
+1. **HTTPS termination at the reverse proxy** (LetsEncrypt cert,
+   TLS 1.2+).
+2. **Forward `X-Forwarded-*` headers** to JAMES, AND set
+   `JAMES_TRUSTED_PROXIES` so JAMES honors them.
+3. **Bind JAMES to localhost only** — never expose uvicorn
+   directly on a public interface.
+
+---
+
+## 2. Why HTTPS termination at the proxy (not in uvicorn)
+
+JAMES does NOT ship its own TLS terminator. The supported pattern
+is **reverse-proxy-terminated HTTPS + plaintext localhost to uvicorn**:
+
+- Reverse proxies (nginx / Caddy / Traefik) have battle-tested TLS
+  stacks with automatic cert renewal (LetsEncrypt / ACME) + OCSP
+  stapling + modern cipher selection.
+- uvicorn's own TLS support exists but is not the recommended
+  production posture (no cert management, no rate-limit-of-handshake,
+  no SNI routing).
+- Localhost plaintext is acceptable security boundary when the
+  proxy + JAMES run on the same host (any process that could read
+  the localhost traffic could also read the cert files anyway).
+
+For multi-host SaaS deployments, JAMES + the proxy can be on
+different hosts; in that case the proxy → JAMES leg SHOULD be TLS
+too (mutual-TLS recommended). The same `X-Forwarded-*` semantics
+apply.
+
+---
+
+## 3. Reverse proxy config examples
+
+### 3.1 nginx (LetsEncrypt via certbot)
+
+```nginx
+# /etc/nginx/sites-enabled/james
+server {
+    listen 80;
+    server_name james.example.com;
+    # ACME challenge — certbot writes this on renewal
+    location /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name james.example.com;
+
+    # certbot manages these
+    ssl_certificate /etc/letsencrypt/live/james.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/james.example.com/privkey.pem;
+
+    # Modern TLS (Mozilla intermediate profile)
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    # Forwarded headers — JAMES reads these when peer is in
+    # JAMES_TRUSTED_PROXIES.
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        # WebSocket / SSE upgrade support (if you use streaming
+        # endpoints — JAMES query streaming may benefit)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Read timeout: JAMES query + retrieve + synth can take 30+
+        # seconds on large multi-hop queries; the default 60s is OK
+        # for chat but increase if you observe upstream timeout
+        # errors in the audit log.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 30s;
+    }
+
+    # Health check endpoint — exempt from auth + rate limit
+    location /healthz {
+        proxy_pass http://127.0.0.1:8000/healthz;
+        access_log off;
+    }
+}
+```
+
+JAMES env on the same host:
+
+```bash
+export JAMES_TRUSTED_PROXIES=127.0.0.1
+export JAMES_HSTS_MAX_AGE=31536000
+```
+
+### 3.2 Caddy (automatic LetsEncrypt)
+
+Caddy auto-manages certs; the config below is the minimum:
+
+```caddyfile
+# /etc/caddy/Caddyfile
+james.example.com {
+    # TLS is automatic; Caddy uses LetsEncrypt by default
+
+    # Forward to JAMES
+    reverse_proxy 127.0.0.1:8000 {
+        # Forwarded headers
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+
+        # Increase read timeout for long queries
+        transport http {
+            response_header_timeout 120s
+        }
+    }
+}
+```
+
+JAMES env:
+
+```bash
+export JAMES_TRUSTED_PROXIES=127.0.0.1
+export JAMES_HSTS_MAX_AGE=31536000
+```
+
+### 3.3 Traefik (Docker-compose example)
+
+```yaml
+# docker-compose.yml
+services:
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--providers.docker"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.le.acme.email=admin@example.com"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.le.acme.tlschallenge=true"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "./letsencrypt:/letsencrypt"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  james:
+    image: hashevolution/james:latest
+    environment:
+      # Trust the Traefik container's address — Docker assigns
+      # 172.16.0.0/12 by default; tighten this to the actual subnet
+      # for your compose deployment.
+      JAMES_TRUSTED_PROXIES: "172.16.0.0/12"
+      JAMES_HSTS_MAX_AGE: "31536000"
+      JAMES_CSP_MODE: "enforce"
+      JAMES_CSP_USE_NONCE_SCRIPT: "1"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.james.rule=Host(`james.example.com`)"
+      - "traefik.http.routers.james.entrypoints=websecure"
+      - "traefik.http.routers.james.tls.certresolver=le"
+      - "traefik.http.services.james.loadbalancer.server.port=8000"
+```
+
+Traefik sets `X-Forwarded-*` automatically.
+
+---
+
+## 4. ASGI / uvicorn production setup
+
+### 4.1 Single-host
+
+```bash
+# Bind localhost only — never expose uvicorn directly
+uvicorn server_llmwiki:app \
+    --host 127.0.0.1 \
+    --port 8000 \
+    --workers 4 \
+    --proxy-headers \
+    --forwarded-allow-ips '127.0.0.1' \
+    --log-level info
+```
+
+**Notes**:
+
+- `--workers 4` is a starting point. Each worker holds its own
+  retrieval/graph cache; memory ≈ N × (model + embedder + Chroma
+  client). For an 4B local model + bge-m3 embedder, expect
+  ~3-4 GB resident per worker. Scale down for memory-constrained
+  hosts.
+- `--proxy-headers` + `--forwarded-allow-ips` enable uvicorn's own
+  forwarded-header trust **at the ASGI layer** before JAMES's
+  middleware runs. The two layers are complementary — uvicorn
+  handles the lifespan-scoped `scope["client"]` trust;
+  `TrustedForwardedHeadersMiddleware` (P1.2) re-validates per
+  request against `JAMES_TRUSTED_PROXIES` and also handles the
+  `X-Forwarded-Proto` → `scope["scheme"]` rewrite that uvicorn's
+  flag alone doesn't fully cover.
+- `--log-level info` is the production default. Switch to `warning`
+  in steady-state high-traffic environments to reduce log volume;
+  JAMES's audit log captures security events independently.
+
+### 4.2 systemd unit (Debian / Ubuntu / RHEL)
+
+```ini
+# /etc/systemd/system/james.service
+[Unit]
+Description=PROJECT JAMES — RAG / Graph-RAG / Audit-replayable
+After=network.target
+
+[Service]
+Type=simple
+User=james
+Group=james
+WorkingDirectory=/opt/james
+EnvironmentFile=/etc/james/env
+ExecStart=/opt/james/.venv/bin/uvicorn server_llmwiki:app \
+    --host 127.0.0.1 \
+    --port 8000 \
+    --workers 4 \
+    --proxy-headers \
+    --forwarded-allow-ips '127.0.0.1'
+Restart=on-failure
+RestartSec=5s
+
+# Hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/james /var/log/james
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`/etc/james/env`:
+
+```bash
+# Production env (managed by config-mgmt tool)
+JAMES_TRUSTED_PROXIES=127.0.0.1
+JAMES_HSTS_MAX_AGE=31536000
+JAMES_HSTS_INCLUDE_SUBDOMAINS=1
+JAMES_CSP_MODE=enforce
+JAMES_CSP_USE_NONCE_SCRIPT=1
+JAMES_RATE_LIMIT_MAX=60        # adjust per traffic
+JAMES_AUDIT_DB=/var/lib/james/audit.db
+JAMES_WORKSPACE=/var/lib/james/workspace
+JAMES_API_KEY=<see /etc/james/secrets>
+JAMES_JWT_SECRET=<see /etc/james/secrets>
+```
+
+Apply + start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now james.service
+sudo systemctl status james.service
+```
+
+---
+
+## 5. HSTS — the cliff-edge flag
+
+`JAMES_HSTS_MAX_AGE` is **opt-in** by design:
+
+| Value | Effect |
+|---|---|
+| `0` or unset | No `Strict-Transport-Security` header (default; safe for dev / HTTP) |
+| `31536000` | 1 year HSTS (recommended for production) |
+| `63072000` | 2 years (preload-eligible per hstspreload.org) |
+
+Companion flags:
+
+| Env | Effect |
+|---|---|
+| `JAMES_HSTS_INCLUDE_SUBDOMAINS=1` | Add `includeSubDomains` directive — pins HSTS for every `*.example.com` |
+| `JAMES_HSTS_PRELOAD=1` | Add `preload` directive — operator must separately register with [hstspreload.org](https://hstspreload.org) |
+
+**Why HSTS is a cliff**: once a browser sees a valid HSTS header
+with a non-zero `max-age`, it refuses ALL plaintext connections to
+that host for the duration — even if the cert expires. Mistakes
+are recoverable but visible (users get hard errors). Set
+`max-age=300` (5 minutes) for the first production-cutover window;
+graduate to `31536000` after a week of successful HTTPS-only
+operation.
+
+---
+
+## 6. CSP — graduating from report-only to enforce
+
+The default is `JAMES_CSP_MODE=report-only` per
+[`core/security/headers.py`](../../core/security/headers.py). To
+graduate to `enforce`:
+
+1. Run in `report-only` for at least 2 weeks of production
+   traffic. Monitor `Content-Security-Policy-Report-Only` violation
+   reports (if you configured `JAMES_CSP_REPORT_URI`).
+2. Confirm zero false positives — every violation report should
+   correspond to a known intentional inline-style or an actual
+   policy mismatch.
+3. Flip `JAMES_CSP_MODE=enforce`.
+4. (Optional) Flip `JAMES_CSP_USE_NONCE_SCRIPT=1` — safe today
+   per UI #4 PR #855 (zero inline `<script>` blocks remain).
+5. (NOT YET RECOMMENDED) Flip `JAMES_CSP_USE_NONCE_STYLE=1` — this
+   BREAKS the UI until the inline `style="..."` migration
+   completes (see `docs/reviews/v0.5-ui-6-inline-style-audit.md`
+   §4).
+
+---
+
+## 7. Health check + monitoring
+
+JAMES exposes `/healthz` (no auth required). The reverse proxy
+should bypass rate-limit + auth gates for this endpoint:
+
+```nginx
+location /healthz {
+    proxy_pass http://127.0.0.1:8000/healthz;
+    access_log off;  # don't pollute audit-grade access logs
+}
+```
+
+For deeper monitoring:
+
+| Endpoint | Auth | Purpose |
+|---|---|---|
+| `GET /healthz` | none | Liveness probe — returns 200 if FastAPI is responding |
+| `GET /admin/metrics?window_hours=24` | admin | Per-stage p50/p90/p99/max latency histograms |
+| `GET /admin/audit/list?category=...` | admin | Security event audit feed (rate-limit-exceeded etc.) |
+
+Prometheus / OpenTelemetry exporters are a v1.0 Dim D deliverable
+(not yet shipped). Until then, scrape `/admin/metrics` from a
+trusted internal host on a cron + push to your TSDB.
+
+---
+
+## 8. Multi-host SaaS deployment
+
+For SaaS (multi-tenant, multi-host) deployment, this guide is the
+**floor**. Additional layers land in Phase 3 (per-request tenant
+middleware) and Phase 4 (admin dashboard UX):
+
+| Layer | Guide |
+|---|---|
+| **HTTPS termination + forwarded headers** | This doc (P1.1) |
+| **Per-tenant request routing + signed `X-Tenant-Id`** | Phase 3 (v0.6 entry skeleton §5) |
+| **SSO / OIDC bundled validator** | Phase 2 (v0.6 entry skeleton §5) |
+| **Per-tenant workspace path isolation** | [`docs/deployment/v0.6-saas-tenant-isolation.md`](v0.6-saas-tenant-isolation.md) |
+| **Non-developer operator dashboard UX** | Phase 4 (v0.6 entry skeleton §5) |
+
+---
+
+## 9. Operational checklist (pre-prod)
+
+Before flipping a deployment from staging to production:
+
+- [ ] TLS cert installed + auto-renewal verified (run `certbot
+      renew --dry-run` or equivalent)
+- [ ] HSTS max-age starts at 300 (5 min) for first 24 h, then
+      bumped to 31536000 (1 year) after successful HTTPS-only
+      verification
+- [ ] `JAMES_TRUSTED_PROXIES` set to the reverse proxy's actual
+      address (not a wildcard; not `0.0.0.0/0`)
+- [ ] uvicorn binds to `127.0.0.1` only — verify with
+      `ss -tlnp | grep 8000`
+- [ ] `/healthz` returns 200 from outside (via the proxy) without
+      authentication
+- [ ] `/admin/*` returns 401 from outside without a valid Bearer
+      token
+- [ ] Audit log row for a rate-limit-exceeded test request records
+      the **actual client IP** (not the proxy's IP) — this is the
+      P1.2 trusted-forwarded fix in action; if you see the proxy's
+      IP, `JAMES_TRUSTED_PROXIES` is mis-configured
+- [ ] CSP runs in `report-only` mode for ≥ 2 weeks before flipping
+      to `enforce`
+- [ ] Reverse proxy strips inbound `X-Forwarded-*` headers from
+      external clients before re-setting them (nginx + Caddy do
+      this by default; Traefik requires
+      `--entrypoints.web.forwardedHeaders.trustedIPs`)
+- [ ] Read timeout on the proxy ≥ 90 s — JAMES query+retrieve+synth
+      can hit 30-60 s on multi-hop queries
+- [ ] Backup of `audit.db` configured (operator responsibility;
+      JAMES does not ship its own backup CLI yet — that's a v1.0
+      Dim D deliverable)
+
+---
+
+## 10. What this guide does NOT do
+
+- **Does not ship HTTPS for you.** Cert acquisition + renewal +
+  TLS config are the reverse proxy's job. This guide documents
+  the contract JAMES expects from the proxy.
+- **Does not enforce HSTS automatically.** `JAMES_HSTS_MAX_AGE` is
+  opt-in; mis-configuration is a cliff (see §5).
+- **Does not validate Host header.** Add a host allow-list at the
+  proxy layer (`server_name` in nginx; `host` matcher in Caddy;
+  `Host()` rule in Traefik).
+- **Does not authenticate clients.** Auth is JAMES's job
+  (JWT-based, see [`docs/security/`](../security/)); the proxy
+  passes Bearer tokens through.
+- **Does not implement multi-tenancy per request.** That's
+  Phase 3 of the v0.6 production-readiness sequence.
+- **Does not introduce any vertical content.** BLOCKED per
+  CLAUDE.md rule #1. HTTPS / forwarded headers / HSTS / CSP are
+  all horizontal infrastructure.
+
+---
+
+## 11. References
+
+- P1.2 trusted forwarded middleware: [PR #890](https://github.com/Hashevolution/James-RAG-Evol/pull/890) + [`core/security/forwarded.py`](../../core/security/forwarded.py)
+- Security headers: [`core/security/headers.py`](../../core/security/headers.py) (v0.5 PR #859)
+- CSP nonce primitive: [`core/security/csp_nonce.py`](../../core/security/csp_nonce.py) (v0.6 Track C PR #884)
+- UI inline-style audit (CSP graduation path): [`docs/reviews/v0.5-ui-6-inline-style-audit.md`](../reviews/v0.5-ui-6-inline-style-audit.md)
+- SaaS tenant isolation: [`docs/deployment/v0.6-saas-tenant-isolation.md`](v0.6-saas-tenant-isolation.md) (v0.6 G1.c PR #882)
+- v0.6 entry skeleton (work queue context): [`docs/handovers/v0.6-entry-skeleton-2026-06-13.md`](../handovers/v0.6-entry-skeleton-2026-06-13.md)
+- Mozilla TLS profile generator: [ssl-config.mozilla.org](https://ssl-config.mozilla.org/)
+- hstspreload.org (HSTS preload registration): [hstspreload.org](https://hstspreload.org)
+- HSTS cliff explanation: [Mozilla MDN — Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)


### PR DESCRIPTION
**v0.6 Phase 1 P1.1** per the operator's 4-item production-readiness advice. Companion to **P1.2** ([PR #890](https://github.com/Hashevolution/James-RAG-Evol/pull/890), trusted forwarded middleware). Single doc that walks an operator from \"we want to run JAMES on the internet\" to \"HTTPS + accurate audit IPs + HSTS + CSP enforce + systemd service\" without guessing.

## Why this doc exists

Pre-v0.6 JAMES had no operator-facing answer to \"how do I deploy this safely?\" — the README explained code, ROADMAP explained versions, but the production path (reverse proxy + uvicorn + forwarded headers + HSTS + CSP graduation + health checks) was distributed across 6+ source files. This doc consolidates the posture into a single 11-section guide.

## Structure

| § | Topic |
|---|---|
| 1 | TL;DR — minimum production-ready env vars + binding |
| 2 | Why HTTPS termination at the proxy, not in uvicorn |
| 3 | Reverse proxy config examples — **nginx (LetsEncrypt) + Caddy (auto-LE) + Traefik (docker-compose)** |
| 4 | ASGI / uvicorn production setup — single-host + systemd unit with hardening |
| 5 | HSTS — the cliff-edge flag — cutover-window safety advice (start max-age=300, graduate to 31536000) |
| 6 | CSP — graduating from report-only to enforce — 5-step recipe with script-flag-safe vs style-flag-blocked distinction |
| 7 | Health check + monitoring — /healthz + /admin/metrics + acknowledgment that Prometheus / OpenTelemetry is v1.0 |
| 8 | Multi-host SaaS deployment — pointer to Phases 2/3/4 of the v0.6 production sequence |
| 9 | **Operational checklist (pre-prod)** — 12-item pre-flight list |
| 10 | What this guide does NOT do — explicit non-promises |
| 11 | References — 9 cross-links |

## Verification

- No code changed — pure operator documentation
- All env var names cross-checked against current `main`:
  - `JAMES_TRUSTED_PROXIES` — verified in `core/security/forwarded.py`
  - `JAMES_HSTS_MAX_AGE` / `_INCLUDE_SUBDOMAINS` / `_PRELOAD` — verified in `core/security/headers.py`
  - `JAMES_CSP_MODE` / `_USE_NONCE_SCRIPT` / `_STYLE` — verified
  - `JAMES_RATE_LIMIT_MAX` — verified in `server_llmwiki.py`
- All cross-links verified to existing files / PR URLs
- nginx + Caddy + Traefik configs follow Mozilla intermediate TLS profile + TLS 1.2+
- systemd unit hardening directives verified against systemd 240+

## Out of scope

- Does NOT ship code — pure operator-facing documentation
- Does NOT enforce HTTPS — the doc explains the contract; the operator's reverse proxy executes
- Does NOT introduce a new env var — every flag was already shipped in v0.5 / v0.6 prior PRs
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: docs — operator-facing deployment guide; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)