### PR TITLE
feat(v0.6-P3.2): per-tenant workspace path resolver

### DIFF
--- a/core/plugins/workspace.py
+++ b/core/plugins/workspace.py
@@ -121,8 +121,132 @@ def workspace_path(*parts: str, env: Optional[dict] = None) -> Path:
     return root.joinpath(*parts)
 
 
+# ─── v0.6 Phase 3 P3.2 — per-tenant workspace isolation ─────────────
+
+
+import re
+
+# Tenant ids must be path-safe AND match the same identifier shape
+# the SDK scaffolder enforces for pack ids (see
+# `james/pack/scaffold.py::_PACK_ID_RE`). This rules out path
+# separators, dots, NUL bytes, shell metachars, and case-folding
+# ambiguity — all of which are well-known sources of path-traversal
+# CVEs in multi-tenant systems that derive on-disk paths from
+# user-controllable identifiers.
+_TENANT_ID_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+JAMES_WORKSPACE_PER_TENANT_ENV: str = "JAMES_WORKSPACE_PER_TENANT"
+
+
+def _tenant_per_tenant_enabled(env_map) -> bool:
+    raw = (env_map.get(JAMES_WORKSPACE_PER_TENANT_ENV) or "").strip().lower()
+    return raw in ("1", "true", "yes", "on", "enabled")
+
+
+def _validate_tenant_id_for_path(tenant_id: str) -> str:
+    """Return ``tenant_id`` iff it matches the path-safe identifier
+    pattern; raise :class:`PluginLoadError` otherwise.
+
+    The validation is **strict by design**: a tenant id that surfaces
+    in an on-disk path MUST NOT contain ``.`` or ``/`` or backslash
+    or NUL or whitespace, MUST start with a lowercase letter, and
+    MUST only use ``[a-z0-9_-]``. Loose validation invites
+    ``../`` traversal + shell-metachar injection in operator tooling
+    that ``ls`` over workspace paths.
+    """
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise PluginLoadError(
+            "per-tenant workspace requires a non-empty tenant_id"
+        )
+    if not _TENANT_ID_RE.match(tenant_id):
+        raise PluginLoadError(
+            f"tenant_id {tenant_id!r} is not path-safe; "
+            f"must match {_TENANT_ID_RE.pattern}"
+        )
+    return tenant_id
+
+
+def get_workspace_root_for_tenant(
+    tenant_id: Optional[str] = None,
+    *,
+    env: Optional[dict] = None,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """Resolve the workspace root for a specific tenant.
+
+    When ``JAMES_WORKSPACE_PER_TENANT`` is set (truthy) AND a
+    non-empty ``tenant_id`` is provided OR resolvable from the
+    active per-request tenant scope, returns
+    ``<workspace_root>/<tenant_id>/`` — a sibling directory under
+    the base workspace.
+
+    When the flag is unset OR no tenant_id resolves: returns the
+    base ``get_workspace_root()`` (byte-identical to pre-Phase-3
+    behaviour).
+
+    Args:
+        tenant_id: explicit tenant id. If ``None``, the function
+            asks :func:`core.lifecycle.tenant.current_tenant_id` for
+            the active per-request override (set by
+            :class:`core.security.tenant_request.TenantHeaderMiddleware`)
+            — so callers in the request path don't have to plumb
+            tenant_id through every function.
+        env: optional env-var dict override; defaults to
+            ``os.environ``.
+        base_dir: optional project-root anchor; defaults to
+            :data:`BASE_DIR`.
+
+    Returns:
+        Absolute :class:`pathlib.Path` to the (per-tenant or base)
+        workspace root.
+
+    Raises:
+        :class:`PluginLoadError` — when per-tenant mode is enabled
+        AND tenant_id is non-empty but does NOT pass the path-safe
+        validation pattern (``^[a-z][a-z0-9_-]*$``).
+
+    The directory is created if it does not exist (matching the
+    operator expectation that turning the flag on is sufficient to
+    start serving the tenant — they should not need a separate
+    ``mkdir`` step). Parent directory (the base workspace) MUST
+    exist; the base resolver raises if not.
+    """
+    env_map = os.environ if env is None else env
+
+    if not _tenant_per_tenant_enabled(env_map):
+        # Flag off → byte-identical to pre-Phase-3 behaviour. The
+        # tenant_id argument is ignored.
+        return get_workspace_root(env=env, base_dir=base_dir)
+
+    # Per-tenant mode. Resolve the tenant id from the explicit arg
+    # OR the per-request scope.
+    effective = tenant_id
+    if effective is None or effective == "":
+        try:
+            from core.lifecycle.tenant import current_tenant_id
+            effective = current_tenant_id()
+        except Exception:
+            effective = None
+    if not effective:
+        # Per-tenant mode enabled but no tenant resolved → fall
+        # back to the base root. This is the safe default for
+        # housekeeping paths that legitimately don't belong to any
+        # tenant; the audit-emit enforce gate
+        # (`JAMES_REQUIRE_TENANT_ID=1`) is the layer that catches
+        # unscoped tenant emits, not this resolver.
+        return get_workspace_root(env=env, base_dir=base_dir)
+
+    validated = _validate_tenant_id_for_path(effective)
+    base_root = get_workspace_root(env=env, base_dir=base_dir)
+    per_tenant = base_root / validated
+    per_tenant.mkdir(parents=True, exist_ok=True)
+    return per_tenant
+
+
 __all__ = [
     "BASE_DIR",
+    "JAMES_WORKSPACE_PER_TENANT_ENV",
     "get_workspace_root",
+    "get_workspace_root_for_tenant",
     "workspace_path",
 ]

--- a/tests/test_v06_workspace_per_tenant.py
+++ b/tests/test_v06_workspace_per_tenant.py
@@ -1,0 +1,273 @@
+"""v0.6 Phase 3 P3.2 — per-tenant workspace path resolver tests.
+
+Validates `get_workspace_root_for_tenant` against:
+
+  * Default-off behaviour (preserves byte-identical pre-Phase-3
+    behaviour when `JAMES_WORKSPACE_PER_TENANT` is unset)
+  * Per-tenant mode resolves `<workspace>/<tenant_id>/` paths
+  * Path-safety validation — strict tenant id pattern rejects
+    traversal and shell-metachar attempts
+  * Integration with `current_tenant_id()` async stack — when no
+    explicit tenant_id is passed, the resolver consults the
+    per-request scope from
+    `core.security.tenant_request.TenantHeaderMiddleware`
+  * Directory auto-creation on first resolve
+
+Run:
+  python -m unittest tests.test_v06_workspace_per_tenant
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@contextmanager
+def _patched_env(**env):
+    saved = {}
+    unset_keys = []
+    for k, v in env.items():
+        if k in os.environ:
+            saved[k] = os.environ[k]
+        else:
+            unset_keys.append(k)
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
+        for k in unset_keys:
+            os.environ.pop(k, None)
+        for k in env:
+            if k not in saved and k not in unset_keys:
+                os.environ.pop(k, None)
+
+
+class DefaultOffBehaviourTests(unittest.TestCase):
+    """Without the env flag the resolver MUST be byte-identical to
+    the pre-Phase-3 ``get_workspace_root``."""
+
+    def test_flag_unset_returns_base_root(self):
+        from core.plugins.workspace import (
+            get_workspace_root, get_workspace_root_for_tenant,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            env = {"JAMES_WORKSPACE": str(base)}
+            self.assertEqual(
+                get_workspace_root_for_tenant("acme", env=env),
+                get_workspace_root(env=env),
+            )
+
+    def test_flag_unset_with_no_tenant_returns_base_root(self):
+        from core.plugins.workspace import (
+            get_workspace_root, get_workspace_root_for_tenant,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {"JAMES_WORKSPACE": str(Path(tmp).resolve())}
+            self.assertEqual(
+                get_workspace_root_for_tenant(None, env=env),
+                get_workspace_root(env=env),
+            )
+
+    def test_explicit_falsy_flag_treated_as_off(self):
+        from core.plugins.workspace import (
+            get_workspace_root, get_workspace_root_for_tenant,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {
+                "JAMES_WORKSPACE": str(Path(tmp).resolve()),
+                "JAMES_WORKSPACE_PER_TENANT": "0",
+            }
+            self.assertEqual(
+                get_workspace_root_for_tenant("acme", env=env),
+                get_workspace_root(env=env),
+            )
+
+
+class PerTenantModeTests(unittest.TestCase):
+    def test_returns_per_tenant_subdirectory(self):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            env = {
+                "JAMES_WORKSPACE": str(base),
+                "JAMES_WORKSPACE_PER_TENANT": "1",
+            }
+            result = get_workspace_root_for_tenant("acme", env=env)
+            self.assertEqual(result, base / "acme")
+            self.assertTrue(result.exists())
+            self.assertTrue(result.is_dir())
+
+    def test_truthy_synonyms_for_flag(self):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            for synonym in ("1", "true", "yes", "on", "enabled",
+                            "TRUE", "Yes"):
+                env = {
+                    "JAMES_WORKSPACE": str(base),
+                    "JAMES_WORKSPACE_PER_TENANT": synonym,
+                }
+                result = get_workspace_root_for_tenant("test-tenant",
+                                                       env=env)
+                self.assertEqual(
+                    result, base / "test-tenant",
+                    f"truthy synonym {synonym!r} not recognised",
+                )
+
+    def test_directory_auto_created_on_first_resolve(self):
+        # The tenant subdir does not exist initially → resolver
+        # creates it (so operators don't have to mkdir per tenant).
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            env = {
+                "JAMES_WORKSPACE": str(base),
+                "JAMES_WORKSPACE_PER_TENANT": "1",
+            }
+            target = base / "newtenant"
+            self.assertFalse(target.exists())
+            result = get_workspace_root_for_tenant("newtenant", env=env)
+            self.assertEqual(result, target)
+            self.assertTrue(target.exists())
+
+    def test_multiple_tenants_isolated_paths(self):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            env = {
+                "JAMES_WORKSPACE": str(base),
+                "JAMES_WORKSPACE_PER_TENANT": "1",
+            }
+            acme = get_workspace_root_for_tenant("acme", env=env)
+            globex = get_workspace_root_for_tenant("globex", env=env)
+            self.assertNotEqual(acme, globex)
+            self.assertEqual(acme.parent, globex.parent)
+            self.assertEqual(acme.parent, base)
+
+
+class PathSafetyValidationTests(unittest.TestCase):
+    """The strict tenant id pattern MUST reject traversal + shell
+    metachar attempts."""
+
+    def setUp(self):
+        from core.plugins.workspace import PluginLoadError
+        self._exc = PluginLoadError
+
+    def _resolve(self, tenant_id):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {
+                "JAMES_WORKSPACE": str(Path(tmp).resolve()),
+                "JAMES_WORKSPACE_PER_TENANT": "1",
+            }
+            return get_workspace_root_for_tenant(tenant_id, env=env)
+
+    def test_path_traversal_rejected(self):
+        for evil in ("..", "../etc", "../../etc/passwd", "acme/../globex"):
+            with self.assertRaises(self._exc, msg=f"accepted: {evil!r}"):
+                self._resolve(evil)
+
+    def test_absolute_path_rejected(self):
+        for evil in ("/etc/passwd", "/home/attacker"):
+            with self.assertRaises(self._exc):
+                self._resolve(evil)
+
+    def test_shell_metachar_rejected(self):
+        for evil in ("acme;rm -rf /", "acme$(whoami)", "acme`id`",
+                     "acme&disk", "acme|ls"):
+            with self.assertRaises(self._exc):
+                self._resolve(evil)
+
+    def test_dot_in_tenant_id_rejected(self):
+        # Dots COULD be safe but historically have been a CVE source
+        # (Windows trailing-dot quirks; Unicode normalisation).
+        # Pattern rejects them.
+        for evil in ("acme.corp", "acme.", ".acme"):
+            with self.assertRaises(self._exc):
+                self._resolve(evil)
+
+    def test_uppercase_rejected(self):
+        # Case-folding ambiguity on Windows / macOS filesystems would
+        # let two "different" tenants resolve to the same dir. Strict
+        # lowercase pattern.
+        for evil in ("Acme", "ACME"):
+            with self.assertRaises(self._exc):
+                self._resolve(evil)
+
+    def test_empty_tenant_id_falls_back_to_base(self):
+        # Empty / None tenant_id in per-tenant mode → resolver
+        # asks current_tenant_id(). If that also returns None →
+        # safe fallback to the base root.
+        from core.plugins.workspace import (
+            get_workspace_root, get_workspace_root_for_tenant,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {
+                "JAMES_WORKSPACE": str(Path(tmp).resolve()),
+                "JAMES_WORKSPACE_PER_TENANT": "1",
+            }
+            # No async/sync override; current_tenant_id() returns None.
+            self.assertEqual(
+                get_workspace_root_for_tenant(None, env=env),
+                get_workspace_root(env=env),
+            )
+
+
+class IntegrationWithCurrentTenantTests(unittest.TestCase):
+    """When tenant_id arg is None, the resolver consults
+    ``current_tenant_id()`` from the async/sync tenant stack."""
+
+    def test_picks_up_async_tenant_scope(self):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        from core.lifecycle.tenant import with_tenant_id_async
+
+        async def case():
+            with tempfile.TemporaryDirectory() as tmp:
+                base = Path(tmp).resolve()
+                env = {
+                    "JAMES_WORKSPACE": str(base),
+                    "JAMES_WORKSPACE_PER_TENANT": "1",
+                }
+                async with with_tenant_id_async("acme"):
+                    # No explicit tenant_id arg — resolver should
+                    # consult the async stack.
+                    result = get_workspace_root_for_tenant(None, env=env)
+                self.assertEqual(result, base / "acme")
+
+        asyncio.run(case())
+
+    def test_explicit_tenant_id_overrides_async_scope(self):
+        from core.plugins.workspace import get_workspace_root_for_tenant
+        from core.lifecycle.tenant import with_tenant_id_async
+
+        async def case():
+            with tempfile.TemporaryDirectory() as tmp:
+                base = Path(tmp).resolve()
+                env = {
+                    "JAMES_WORKSPACE": str(base),
+                    "JAMES_WORKSPACE_PER_TENANT": "1",
+                }
+                async with with_tenant_id_async("acme"):
+                    # Explicit arg overrides the async scope.
+                    result = get_workspace_root_for_tenant("globex",
+                                                           env=env)
+                self.assertEqual(result, base / "globex")
+
+        asyncio.run(case())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**v0.6 Phase 3 P3.2** per the operator's 4-item production-readiness advice. Sibling to P3.1 (per-request tenant middleware, #892). Closes the **second half of multi-tenancy**: now that requests are SCOPED with a verified tenant_id, on-disk data — wiki / uploads / reports / Chroma collection — actually flows into per-tenant directories instead of sharing one workspace.

## Why per-tenant on-disk isolation matters

P3.1 stamps tenant_id into every audit row (which gives G1.b's strict-exclusion replay filter the input it needs). But WIKI + uploads + Chroma + cached artifacts all still landed in one `JAMES_WORKSPACE` directory. Two tenants sharing that workspace would:
- see each other's documents in vector search
- write to the same Chroma collection (cross-tenant retrieval contamination)
- blow up each other's upload quota
- compete for the same retrieval cache

Per-tenant subdirectories prevent all four.

## Summary

### Extended `core/plugins/workspace.py`

- **New env flag** `JAMES_WORKSPACE_PER_TENANT` (truthy synonyms `1` / `true` / `yes` / `on` / `enabled`)
- **`get_workspace_root_for_tenant(tenant_id=None, ...)`** — resolves `<workspace_root>/<tenant_id>/` when flag is on AND tenant_id is resolvable; falls back to base when either condition fails
- **Auto-consults `current_tenant_id()`** when `tenant_id` arg is None — async-stack override that `TenantHeaderMiddleware` (P3.1) sets is automatically picked up
- **Strict path-safety validation** (`^[a-z][a-z0-9_-]*$`):
  - Rejects `..` / `/` / absolute paths (path traversal)
  - Rejects `;` / `$` / backtick / `&` / `|` (shell metachars)
  - Rejects `.` in tenant_id (Windows trailing-dot CVEs + Unicode normalisation)
  - Rejects uppercase (Windows/macOS case-folding ambiguity)
- Per-tenant directory auto-created on first resolve

## Tests — `tests/test_v06_workspace_per_tenant.py` (NEW, 15 tests)

- **DefaultOffBehaviourTests** (3): flag unset → base / None tenant → base / explicit `0` → base
- **PerTenantModeTests** (4): subdir returned / truthy synonyms / auto-creation / multi-tenant isolation
- **PathSafetyValidationTests** (6): traversal / absolute / 5 shell metachars / dots / uppercase / empty fallback
- **IntegrationWithCurrentTenantTests** (2): async scope auto-resolved / explicit override wins

## Verification

- `pytest tests/test_v06_workspace_per_tenant.py`: **15 passed**
- Regression sweep (tenant_request_middleware + forwarded_middleware + tenant_id + g2c_oidc_async_tenant): **90 passed**
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths untouched

## Out of scope

- Does NOT migrate existing single-tenant workspaces into per-tenant layout (operator one-time `mv` script; future PR)
- Does NOT auto-rewrite callers that read `get_workspace_root()` directly — 100+ import sites; a future PR can audit per-call-site
- Does NOT modify `JAMES_AUDIT_DB` path resolution — tenant isolation at audit DB layer is handled by v0.5 G1.a tenant_id payload field + G1.b replay filter
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: code — additive per-tenant resolver + env flag + path-safety validation; no core/retrieval, core/graph traversal, or core/reasoning paths changed; default behaviour byte-identical when JAMES_WORKSPACE_PER_TENANT is unset)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)