### PR TITLE
feat(v0.6-P4.4): glossary page + universal tooltip mechanism

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -42,6 +42,11 @@
        data-i18n="admin.flow_link"
        title="Reasoning flow / 추론 흐름"
        style="font-size:12px">🔎 추론 흐름</a>
+    <!-- v0.6 Phase 4 P4.4 — glossary entry point -->
+    <a href="/glossary" class="nav-btn"
+       data-i18n="admin.glossary_link"
+       title="Glossary / 용어 설명"
+       style="font-size:12px">📚 용어 설명</a>
     <a href="/" class="nav-btn" data-i18n="admin.chat_link">← 챗으로</a>
   </div>
 </header>
@@ -1146,6 +1151,8 @@
 <!-- v0.5 Track F.2 CR.a — Change Review list page (UI shell). Loads
      after admin.js so the SPA page-toggle wiring is already in place. -->
 <script src="/static/change-requests.js"></script>
+<!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script. -->
+<script src="/static/glossary.js"></script>
 
 <!-- ── Admin 로그인 모달 ── -->
 <div class="modal-overlay" id="admin-login-modal"

--- a/frontend/glossary.html
+++ b/frontend/glossary.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="theme-color" content="#04060a">
+<title data-i18n="glossary.page_title">JAMES — 용어 설명</title>
+<link rel="stylesheet" href="/static/tokens.css">
+<link rel="stylesheet" href="/static/onboarding.css">
+<link rel="stylesheet" href="/static/glossary.css">
+<link rel="stylesheet" href="/static/mobile.css">
+</head>
+<body>
+
+<a href="#main" class="skip-link" data-i18n="a11y.skip_to_main">Skip to main content</a>
+
+<header>
+  <div class="logo">
+    <span class="brand">Secure Enterprise Knowledge<span class="brand-tail">Operating System</span></span>
+    <span style="color:var(--muted);font-size:11px;margin-left:6px"
+          data-i18n="glossary.header_subtitle">· 용어 설명</span>
+  </div>
+  <div class="header-right">
+    <button class="nav-btn" data-lang-toggle data-action="toggle-lang"
+            title="Language / 언어"
+            aria-label="언어 전환 / Toggle language"
+            style="font-size:12px;font-weight:600;background:var(--surface-2);
+                   border:1px solid var(--border);border-radius:6px;
+                   padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
+    <a href="/admin" class="nav-btn"
+       data-i18n="glossary.back_to_admin">← 관리자 페이지</a>
+  </div>
+</header>
+
+<main id="main" class="glossary-main">
+  <h1 class="glossary-h1" data-i18n="glossary.title">용어 설명</h1>
+  <p class="glossary-intro" data-i18n="glossary.intro">
+    JAMES 의 화면에 등장하는 기술 용어들을 평이한 한국어로 설명합니다.
+    모르는 용어가 보이면 이 페이지에서 검색하거나, 다른 페이지에서 점선 밑줄이
+    그어진 단어 위에 마우스를 올리면 같은 설명이 툴팁으로 나타납니다.
+  </p>
+
+  <div class="glossary-search">
+    <input id="glossary-search-input"
+           type="text"
+           autocomplete="off"
+           placeholder="용어 검색…"
+           data-i18n-placeholder="glossary.search.placeholder"
+           aria-label="용어 검색"
+           class="glossary-input">
+  </div>
+
+  <!-- ── Category: Core concepts ── -->
+  <section class="glossary-section" data-category="core">
+    <h2 data-i18n="glossary.cat.core">기본 개념</h2>
+    <dl class="glossary-list">
+
+      <div class="glossary-entry" data-term="rag" tabindex="0">
+        <dt>RAG <span class="term-en">(Retrieval-Augmented Generation)</span></dt>
+        <dd data-i18n="glossary.def.rag">
+          질문에 답할 때, LLM 이 가진 지식만 쓰지 않고
+          <strong>먼저 사내 문서를 검색</strong>한 뒤 그 결과를 근거로
+          답을 만드는 방식. JAMES 가 기본적으로 동작하는 방식입니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="graph-rag" tabindex="0">
+        <dt>Graph-RAG <span class="term-en">(그래프 기반 RAG)</span></dt>
+        <dd data-i18n="glossary.def.graph_rag">
+          단순 문서 검색에 더해 <strong>온톨로지 그래프 (개념 간 관계망)</strong>
+          를 통해 답을 찾는 방식. 여러 문서에 흩어진 정보를 연결해서
+          답할 수 있습니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="entity" tabindex="0">
+        <dt>Entity <span class="term-en">(엔티티)</span></dt>
+        <dd data-i18n="glossary.def.entity">
+          시스템이 알고 있는 <strong>한 개의 "것"</strong> — 사람, 조직, 개념,
+          문서 등. 예: "앤스로픽" / "휴가 정책 v3" / "김철수".
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="relation" tabindex="0">
+        <dt>Relation <span class="term-en">(관계)</span></dt>
+        <dd data-i18n="glossary.def.relation">
+          엔티티들 사이의 <strong>연결</strong>. 예: "앤스로픽 ─CEO─ 다리오 아모데이",
+          "휴가 정책 v3 ─supersedes─ 휴가 정책 v2".
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="ontology" tabindex="0">
+        <dt>Ontology <span class="term-en">(온톨로지)</span></dt>
+        <dd data-i18n="glossary.def.ontology">
+          엔티티의 <strong>종류 + 관계 종류</strong> 의 정의 체계. 예: 회사 도메인은
+          "사람 / 조직 / 문서 / 정책" 같은 엔티티 종류, "WORKS_AT / SUPERSEDES /
+          APPROVED_BY" 같은 관계 종류로 구성.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="embedding" tabindex="0">
+        <dt>Embedding <span class="term-en">(임베딩)</span></dt>
+        <dd data-i18n="glossary.def.embedding">
+          텍스트를 <strong>숫자 벡터로 변환</strong>한 것. 이를 통해 "비슷한 의미"
+          를 가진 문서를 빠르게 찾을 수 있습니다.
+        </dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <!-- ── Category: Audit + Time ── -->
+  <section class="glossary-section" data-category="audit">
+    <h2 data-i18n="glossary.cat.audit">감사 + 시점</h2>
+    <dl class="glossary-list">
+
+      <div class="glossary-entry" data-term="audit-log" tabindex="0">
+        <dt>Audit log <span class="term-en">(감사 로그)</span></dt>
+        <dd data-i18n="glossary.def.audit_log">
+          시스템에서 일어난 <strong>모든 동작의 기록</strong>. 누가 언제 어떤
+          질문을 했는지, 어떤 문서를 봤는지, 어떤 변경을 했는지 모두 저장됩니다.
+          위조 불가능 (append-only).
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="trace-id" tabindex="0">
+        <dt>trace_id <span class="term-en">(추적 ID)</span></dt>
+        <dd data-i18n="glossary.def.trace_id">
+          한 번의 질문/답변 흐름 전체를 <strong>고유하게 식별하는 ID</strong>.
+          나중에 "이 답이 어떻게 만들어졌지?" 추적할 때 사용. 모든 audit log
+          행에 함께 기록됩니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="replay" tabindex="0">
+        <dt>Replay <span class="term-en">(재생)</span></dt>
+        <dd data-i18n="glossary.def.replay">
+          과거 어떤 시점의 시스템 상태를 <strong>바이트 단위로 똑같이 재구성</strong>
+          하는 기능. audit log 만 있으면 어느 시점이든 재현 가능.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="time-travel" tabindex="0">
+        <dt>Time-travel <span class="term-en">(시점 복원)</span></dt>
+        <dd data-i18n="glossary.def.time_travel">
+          관리자 → 그래프 페이지에서 시점 선택 → 그 시점의 시스템 상태를 보거나
+          되돌리는 기능. 실수 복구 + forensic 분석에 사용.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="supersede" tabindex="0">
+        <dt>Supersede <span class="term-en">(관계 갱신)</span></dt>
+        <dd data-i18n="glossary.def.supersede">
+          예: "휴가 정책 v3 가 v2 를 supersede 한다" = 더 새로운 버전이 이전
+          버전을 대체. <strong>이전 버전은 지워지지 않고</strong> 체인 형태로
+          보존되어, 시점 복원이 가능합니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="cascade" tabindex="0">
+        <dt>Cascade <span class="term-en">(연쇄 무효화)</span></dt>
+        <dd data-i18n="glossary.def.cascade">
+          한 문서를 삭제했을 때 그 문서를 근거로 한 다른 정보들을
+          <strong>자동으로 비활성화</strong>하는 동작. "이 정보의 근거였던 문서가
+          없어졌으니 정보도 의심스러움" 표시.
+        </dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <!-- ── Category: Answer quality ── -->
+  <section class="glossary-section" data-category="quality">
+    <h2 data-i18n="glossary.cat.quality">답변 품질</h2>
+    <dl class="glossary-list">
+
+      <div class="glossary-entry" data-term="abstention" tabindex="0">
+        <dt>Abstention <span class="term-en">(회피)</span></dt>
+        <dd data-i18n="glossary.def.abstention">
+          시스템이 답을 모를 때 <strong>"정보가 없습니다" 라고 솔직하게 답하는 것</strong>.
+          추측해서 잘못된 답을 만드는 것보다 회피가 옳은 행동입니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="hallucination" tabindex="0">
+        <dt>Hallucination <span class="term-en">(환각)</span></dt>
+        <dd data-i18n="glossary.def.hallucination">
+          LLM 이 사실이 아닌 내용을 <strong>그럴듯하게 만들어내는 현상</strong>.
+          JAMES 는 회피 + 근거 표시로 환각을 최소화합니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="citation" tabindex="0">
+        <dt>Citation <span class="term-en">(근거 인용)</span></dt>
+        <dd data-i18n="glossary.def.citation">
+          답변에 <strong>어떤 문서의 어느 부분을 사용했는지</strong> 출처를 함께
+          표시하는 것. 답을 검증 + 재확인할 수 있게 합니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="path-coverage" tabindex="0">
+        <dt>Path coverage <span class="term-en">(경로 적중률)</span></dt>
+        <dd data-i18n="glossary.def.path_coverage">
+          질문에 답하는 데 필요한 <strong>실제 근거 문서를 시스템이 얼마나
+          찾았는지</strong> 측정한 비율. JAMES Graph-RAG = 0.41 (벡터 검색만
+          쓰면 0.00).
+        </dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <!-- ── Category: Security / Auth ── -->
+  <section class="glossary-section" data-category="security">
+    <h2 data-i18n="glossary.cat.security">보안 + 권한</h2>
+    <dl class="glossary-list">
+
+      <div class="glossary-entry" data-term="rbac" tabindex="0">
+        <dt>RBAC <span class="term-en">(역할 기반 접근 제어)</span></dt>
+        <dd data-i18n="glossary.def.rbac">
+          사용자의 <strong>역할에 따라</strong> 무엇을 볼 수 있는지 결정.
+          예: "admin / employee / external" 역할별로 접근 가능 자료가 다름.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="abac" tabindex="0">
+        <dt>ABAC <span class="term-en">(속성 기반 접근 제어)</span></dt>
+        <dd data-i18n="glossary.def.abac">
+          역할 + 문서 속성 (예: "기밀 등급") 의 조합으로 접근을 결정.
+          RBAC 보다 세밀한 통제.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="oidc" tabindex="0">
+        <dt>OIDC <span class="term-en">(OpenID Connect)</span></dt>
+        <dd data-i18n="glossary.def.oidc">
+          회사의 SSO (Single Sign-On) 시스템과 JAMES 를 <strong>연동</strong>
+          하는 표준. JAMES 직접 비밀번호를 받지 않고 회사 IdP 에 위임.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="approval-evidence" tabindex="0">
+        <dt>Approval evidence <span class="term-en">(승인 증거)</span></dt>
+        <dd data-i18n="glossary.def.approval_evidence">
+          변경 승인 시 <strong>운영자의 신원을 암호학적으로 기록</strong>한
+          정보 (SSO 토큰 또는 OS 사용자 ID 의 해시). 사후 위조 불가능.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="csp" tabindex="0">
+        <dt>CSP <span class="term-en">(Content Security Policy)</span></dt>
+        <dd data-i18n="glossary.def.csp">
+          브라우저가 어떤 스크립트/스타일을 실행할 수 있는지 <strong>제한
+          하는 보안 정책</strong>. XSS 공격 방어.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="tenant" tabindex="0">
+        <dt>Tenant <span class="term-en">(테넌트)</span></dt>
+        <dd data-i18n="glossary.def.tenant">
+          한 JAMES 인스턴스에 <strong>여러 고객사가 들어 있을 때 각 고객사</strong>.
+          예: SaaS 운영 시 acme / globex 가 같은 서버를 쓰지만 데이터는 분리.
+        </dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <!-- ── Category: Operator action ── -->
+  <section class="glossary-section" data-category="ops">
+    <h2 data-i18n="glossary.cat.ops">운영자 동작</h2>
+    <dl class="glossary-list">
+
+      <div class="glossary-entry" data-term="change-request" tabindex="0">
+        <dt>Change Request (CR) <span class="term-en">(변경 요청)</span></dt>
+        <dd data-i18n="glossary.def.change_request">
+          직원이 정보를 수정하고 싶을 때 만드는 <strong>"제안" 상태의 변경</strong>.
+          운영자가 검토 후 승인/거부할 때까지 실제 시스템에는 적용되지 않습니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="rollback" tabindex="0">
+        <dt>Rollback <span class="term-en">(롤백)</span></dt>
+        <dd data-i18n="glossary.def.rollback">
+          잘못된 변경을 <strong>되돌리는 동작</strong>. JAMES 에는 (a) "최근 변경
+          되돌리기" + (b) "특정 시점으로 복원" 두 가지가 있습니다.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="contradiction-arbiter" tabindex="0">
+        <dt>Contradiction arbiter <span class="term-en">(모순 중재)</span></dt>
+        <dd data-i18n="glossary.def.contradiction_arbiter">
+          새로 들어온 정보가 기존 정보와 충돌할 때 <strong>4 가지 규칙으로
+          어떻게 처리할지 결정</strong>하는 모듈. LLM 호출 없이 결정론적.
+        </dd>
+      </div>
+
+      <div class="glossary-entry" data-term="reasoning-trace" tabindex="0">
+        <dt>Reasoning trace <span class="term-en">(추론 흔적)</span></dt>
+        <dd data-i18n="glossary.def.reasoning_trace">
+          한 번의 질문/답변에서 시스템이 <strong>어떤 단계들을 거쳤는지</strong>
+          의 기록. 관리자 → 추론 흐름 보기 페이지에서 시각화하여 볼 수 있음.
+        </dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <div id="glossary-no-results"
+       class="empty-state"
+       hidden
+       data-i18n="glossary.search.no_results">
+    검색 결과가 없습니다.
+  </div>
+
+  <p class="glossary-footer-note" data-i18n="glossary.footer_note">
+    💡 다른 페이지에서 <span class="glossary-term-demo">점선 밑줄</span> 이
+    그어진 단어 위에 마우스를 올리면 같은 설명이 툴팁으로 나타납니다.
+  </p>
+</main>
+
+<script src="/static/i18n.js"></script>
+<script src="/static/auth.js"></script>
+<script src="/static/glossary.js"></script>
+</body>
+</html>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -157,7 +157,10 @@
     </div>
 
     <div>
-      <div class="panel-title" style="margin-bottom:8px" data-i18n="graph.legend.title">Legend</div>
+      <div class="panel-title" style="margin-bottom:8px"
+           data-i18n="graph.legend.title">
+        <span data-glossary="entity">Legend</span>
+      </div>
       <div class="legend">
         <div class="legend-row"><span class="legend-dot" style="background:var(--t-person)"></span>   <span data-i18n="graph.legend.person">person</span></div>
         <div class="legend-row"><span class="legend-dot" style="background:var(--t-org)"></span>      <span data-i18n="graph.legend.org">org</span></div>
@@ -510,5 +513,9 @@
      it can hook the picker button + the `james:timetravel:*`
      events the prior shells dispatch. -->
 <script src="/static/time-travel-diff.js"></script>
+<!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script.
+     Scans the page for elements with `data-glossary="<term>"` and
+     attaches hover/focus tooltips with plain-Korean definitions. -->
+<script src="/static/glossary.js"></script>
 </body>
 </html>

--- a/frontend/knowledge-rollback.html
+++ b/frontend/knowledge-rollback.html
@@ -150,5 +150,7 @@
 <script src="/static/i18n.js"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/knowledge-rollback.js"></script>
+<!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script. -->
+<script src="/static/glossary.js"></script>
 </body>
 </html>

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -311,5 +311,7 @@
 <script src="/static/i18n.js"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/onboarding.js"></script>
+<!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script. -->
+<script src="/static/glossary.js"></script>
 </body>
 </html>

--- a/frontend/reasoning-flow.html
+++ b/frontend/reasoning-flow.html
@@ -148,5 +148,7 @@
 <script src="/static/i18n.js"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/reasoning-flow.js"></script>
+<!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script. -->
+<script src="/static/glossary.js"></script>
 </body>
 </html>

--- a/frontend/static/glossary.css
+++ b/frontend/static/glossary.css
@@ -1,0 +1,218 @@
+/* v0.6 Phase 4 P4.4 — glossary page + universal tooltip stylesheet.
+ *
+ * Two surfaces:
+ *   1. /glossary page — searchable entry list grouped by category
+ *   2. Universal hover tooltip — any element with `data-glossary` on
+ *      ANY page across JAMES gets a dotted underline + hover tooltip
+ *      that surfaces the same plain-Korean definition
+ */
+
+/* ── page layout (same shell as onboarding/rollback/flow) ──── */
+
+.glossary-main {
+  max-width: 900px;
+  margin: 32px auto;
+  padding: 0 24px 64px;
+  color: var(--text);
+  font-family: var(--font-body);
+}
+
+.glossary-h1 {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--accent-fg);
+  margin: 0 0 8px;
+  letter-spacing: .2px;
+}
+
+.glossary-intro {
+  color: var(--text-soft);
+  font-size: 15px;
+  line-height: 1.65;
+  margin: 0 0 24px;
+}
+
+.glossary-search {
+  margin-bottom: 24px;
+}
+
+.glossary-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: var(--text);
+  font-size: 15px;
+  outline: none;
+  min-height: 44px;
+  box-sizing: border-box;
+  transition: border-color .15s;
+}
+
+.glossary-input:focus { border-color: var(--accent); }
+
+/* ── section per category ───────────────────────────────────── */
+
+.glossary-section {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.glossary-section h2 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--accent-fg);
+  margin: 0 0 14px;
+  letter-spacing: .3px;
+}
+
+.glossary-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.glossary-entry {
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 14px 18px;
+  border-left: 3px solid transparent;
+  transition: border-left-color .15s, transform .1s;
+  cursor: default;
+}
+
+.glossary-entry:hover,
+.glossary-entry:focus-within {
+  border-left-color: var(--accent);
+  outline: none;
+}
+
+.glossary-entry dt {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 6px;
+}
+
+.glossary-entry .term-en {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  letter-spacing: .2px;
+  margin-left: 6px;
+}
+
+.glossary-entry dd {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-soft);
+}
+
+.glossary-entry dd strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.empty-state {
+  padding: 20px;
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
+  background: var(--bg);
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.glossary-footer-note {
+  margin-top: 36px;
+  padding: 14px 18px;
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-soft);
+  text-align: center;
+}
+
+.glossary-term-demo {
+  border-bottom: 1px dotted var(--accent);
+  cursor: help;
+  padding: 1px 0;
+}
+
+/* ── universal hover-tooltip mechanism (any page) ──────────── */
+
+/* Any element with `data-glossary` gets a dotted underline. The
+ * tooltip itself is a single floating div that glossary.js positions
+ * absolutely on hover. */
+[data-glossary] {
+  border-bottom: 1px dotted var(--accent);
+  cursor: help;
+  text-decoration: none;
+}
+
+[data-glossary]:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.glossary-tooltip {
+  position: absolute;
+  z-index: 100;
+  max-width: 320px;
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-soft);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, .5);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity .12s, transform .12s;
+}
+
+.glossary-tooltip[data-shown="true"] {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.glossary-tooltip strong {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.glossary-tooltip .tooltip-term {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent-fg);
+  margin-bottom: 4px;
+}
+
+.glossary-tooltip .tooltip-link {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+@media (max-width: 600px) {
+  .glossary-main { padding: 0 16px 48px; }
+  .glossary-section { padding: 18px; }
+  .glossary-entry { padding: 12px 14px; }
+  .glossary-tooltip { max-width: 280px; font-size: 12px; }
+}

--- a/frontend/static/glossary.js
+++ b/frontend/static/glossary.js
@@ -1,0 +1,253 @@
+/* PROJECT JAMES — universal glossary tooltip + page search (P4.4).
+ *
+ * Two responsibilities:
+ *
+ *   1. On the `/glossary` page (when present) — provide a search box
+ *      that hides non-matching entries on the fly.
+ *
+ *   2. On ANY page — scan the DOM for elements carrying a
+ *      `data-glossary="<term-slug>"` attribute and attach a hover
+ *      tooltip that surfaces the corresponding glossary entry.
+ *      The tooltip floats above the page (single shared div); no
+ *      per-element node creation.
+ *
+ * Plain ES5 — same convention as the rest of frontend/static/.
+ */
+(function () {
+  'use strict';
+
+  /* The canonical glossary content used by the floating tooltip on
+   * every page. Same term-slugs as the dt entries in
+   * `frontend/glossary.html` — the page itself is the SoT for the
+   * formatted Korean copy; this map is the JS-side cache so the
+   * tooltip works WITHOUT loading the /glossary page first.
+   *
+   * Entries are intentionally short (1-2 sentences). Operators who
+   * want the full explanation click through to /glossary.
+   *
+   * Per CLAUDE.md rule #1 — domain-agnostic. Vertical-pack-specific
+   * terms (e.g. legal "force majeure", medical "ICD-10") would land
+   * in pack-side glossaries post-LOI, not here.
+   */
+  var GLOSSARY = {
+    'rag': '질문에 답할 때 LLM 의 기억만 쓰지 않고 사내 문서를 먼저 검색한 뒤 그 결과를 근거로 답을 만드는 방식.',
+    'graph-rag': '단순 문서 검색에 더해 온톨로지 그래프 (개념 간 관계망) 를 통해 답을 찾는 방식. 여러 문서의 정보를 연결.',
+    'entity': '시스템이 알고 있는 한 개의 "것" — 사람 / 조직 / 개념 / 문서 등.',
+    'relation': '엔티티들 사이의 연결. 예: "앤스로픽 ─CEO─ 다리오 아모데이".',
+    'ontology': '엔티티 종류 + 관계 종류의 정의 체계.',
+    'embedding': '텍스트를 숫자 벡터로 변환한 것. 의미 기반 검색에 사용.',
+    'audit-log': '시스템의 모든 동작 기록. 누가 언제 무엇을 했는지 전부 저장 (위조 불가능).',
+    'trace-id': '한 번의 질문/답변 흐름을 고유하게 식별하는 ID.',
+    'replay': '과거 어떤 시점의 시스템 상태를 바이트 단위로 똑같이 재구성하는 기능.',
+    'time-travel': '관리자 → 그래프 페이지에서 시점 선택 → 그 시점 상태를 보거나 되돌리는 기능.',
+    'supersede': '예: "휴가 정책 v3 가 v2 를 supersede" = 새 버전이 이전을 대체. 이전 버전은 보존됨.',
+    'cascade': '문서 삭제 시 그 문서를 근거로 한 다른 정보들을 자동으로 비활성화하는 동작.',
+    'abstention': '시스템이 답을 모를 때 "정보가 없습니다" 라고 솔직하게 답하는 것.',
+    'hallucination': 'LLM 이 사실이 아닌 내용을 그럴듯하게 만들어내는 현상.',
+    'citation': '답변에 어떤 문서의 어느 부분을 사용했는지 출처를 함께 표시.',
+    'path-coverage': '질문 답에 필요한 실제 근거 문서를 시스템이 얼마나 찾았는지 비율.',
+    'rbac': '사용자 역할에 따라 무엇을 볼 수 있는지 결정 (역할 기반 접근 제어).',
+    'abac': '역할 + 문서 속성 조합으로 접근 결정 (속성 기반 접근 제어).',
+    'oidc': '회사 SSO 와 JAMES 를 연동하는 표준. JAMES 가 비밀번호를 직접 받지 않음.',
+    'approval-evidence': '변경 승인 시 운영자 신원을 암호학적으로 기록한 정보. 사후 위조 불가능.',
+    'csp': '브라우저가 어떤 스크립트/스타일을 실행할 수 있는지 제한하는 보안 정책.',
+    'tenant': '한 JAMES 인스턴스에 여러 고객사가 있을 때 각 고객사.',
+    'change-request': '직원이 정보 수정을 제안한 "Pending" 상태의 변경. 운영자 승인 전까지 미적용.',
+    'rollback': '잘못된 변경을 되돌리는 동작. "최근 변경 되돌리기" + "특정 시점으로 복원" 두 가지.',
+    'contradiction-arbiter': '새 정보가 기존과 충돌할 때 4 가지 규칙으로 결정론적 처리.',
+    'reasoning-trace': '한 질문/답변에서 시스템이 거친 단계들의 기록. 추론 흐름 보기 페이지에서 시각화.'
+  };
+
+  function $(id) { return document.getElementById(id); }
+
+  function escapeHtml(s) {
+    if (s === null || typeof s === 'undefined') return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /* ── universal floating tooltip ──────────────────────────── */
+
+  var tooltipEl = null;
+  var hideTimer = null;
+  var activeTrigger = null;
+
+  function ensureTooltip() {
+    if (tooltipEl) return tooltipEl;
+    tooltipEl = document.createElement('div');
+    tooltipEl.className = 'glossary-tooltip';
+    tooltipEl.setAttribute('role', 'tooltip');
+    tooltipEl.setAttribute('data-shown', 'false');
+    document.body.appendChild(tooltipEl);
+    return tooltipEl;
+  }
+
+  function showTooltip(trigger) {
+    var term = trigger.getAttribute('data-glossary');
+    if (!term) return;
+    var def = GLOSSARY[term];
+    if (!def) return;
+    if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+    activeTrigger = trigger;
+    var tip = ensureTooltip();
+    tip.innerHTML =
+      '<span class="tooltip-term">' + escapeHtml(term.replace(/-/g, ' ')) +
+      '</span>' +
+      '<span>' + escapeHtml(def) + '</span>' +
+      '<a class="tooltip-link" href="/glossary#' +
+      encodeURIComponent(term) + '">전체 용어집 →</a>';
+    // Position next to the trigger.
+    var rect = trigger.getBoundingClientRect();
+    var top = rect.bottom + window.scrollY + 6;
+    var left = rect.left + window.scrollX;
+    // Keep within viewport horizontally
+    var max = window.innerWidth + window.scrollX - 340;
+    if (left > max) left = max;
+    if (left < 8) left = 8;
+    tip.style.top = top + 'px';
+    tip.style.left = left + 'px';
+    tip.setAttribute('data-shown', 'true');
+  }
+
+  function scheduleHide() {
+    if (hideTimer) clearTimeout(hideTimer);
+    hideTimer = setTimeout(function () {
+      if (tooltipEl) tooltipEl.setAttribute('data-shown', 'false');
+      activeTrigger = null;
+    }, 150);
+  }
+
+  function wireTooltips() {
+    // Use event delegation so future-added [data-glossary] elements
+    // (e.g. dynamically rendered) also get the tooltip without
+    // re-wiring.
+    document.addEventListener('mouseover', function (ev) {
+      var el = ev.target;
+      while (el && el !== document.body) {
+        if (el.hasAttribute && el.hasAttribute('data-glossary')) {
+          showTooltip(el);
+          return;
+        }
+        el = el.parentNode;
+      }
+    }, true);
+    document.addEventListener('mouseout', function (ev) {
+      var el = ev.target;
+      while (el && el !== document.body) {
+        if (el.hasAttribute && el.hasAttribute('data-glossary')) {
+          scheduleHide();
+          return;
+        }
+        el = el.parentNode;
+      }
+    }, true);
+    // Keyboard focus also shows the tooltip (a11y).
+    document.addEventListener('focusin', function (ev) {
+      var el = ev.target;
+      if (el && el.hasAttribute && el.hasAttribute('data-glossary')) {
+        showTooltip(el);
+      }
+    });
+    document.addEventListener('focusout', function (ev) {
+      var el = ev.target;
+      if (el && el.hasAttribute && el.hasAttribute('data-glossary')) {
+        scheduleHide();
+      }
+    });
+    // Esc dismisses.
+    document.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Escape' && tooltipEl) {
+        tooltipEl.setAttribute('data-shown', 'false');
+      }
+    });
+  }
+
+  /* ── /glossary page — live search ────────────────────────── */
+
+  function wireSearch() {
+    var input = $('glossary-search-input');
+    var noResults = $('glossary-no-results');
+    if (!input) return;  // not on the glossary page
+
+    function filter(query) {
+      var q = (query || '').trim().toLowerCase();
+      var entries = document.querySelectorAll('.glossary-entry');
+      var visible = 0;
+      for (var i = 0; i < entries.length; i++) {
+        var el = entries[i];
+        var dt = el.querySelector('dt');
+        var dd = el.querySelector('dd');
+        var text = ((dt && dt.textContent) || '') + ' ' +
+                   ((dd && dd.textContent) || '');
+        var slug = el.getAttribute('data-term') || '';
+        var match = !q ||
+                    text.toLowerCase().indexOf(q) !== -1 ||
+                    slug.toLowerCase().indexOf(q) !== -1;
+        if (match) {
+          el.style.display = '';
+          visible++;
+        } else {
+          el.style.display = 'none';
+        }
+      }
+      // Hide empty category sections + show "no results" hint.
+      var sections = document.querySelectorAll('.glossary-section');
+      for (var s = 0; s < sections.length; s++) {
+        var anyVisible = sections[s].querySelector(
+          '.glossary-entry:not([style*="display: none"])');
+        sections[s].style.display = anyVisible ? '' : 'none';
+      }
+      if (noResults) {
+        if (visible === 0 && q) {
+          noResults.removeAttribute('hidden');
+        } else {
+          noResults.setAttribute('hidden', 'hidden');
+        }
+      }
+    }
+
+    input.addEventListener('input', function () {
+      filter(input.value);
+    });
+
+    // Deep-link via URL hash to a specific term (#trace-id etc.).
+    var hash = (window.location.hash || '').replace('#', '');
+    if (hash) {
+      input.value = hash.replace(/-/g, ' ');
+      filter(input.value);
+      var el = document.querySelector(
+        '.glossary-entry[data-term="' + hash + '"]');
+      if (el) {
+        try { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }
+        catch (_) {}
+        el.focus && el.focus();
+      }
+    }
+  }
+
+  function init() {
+    wireTooltips();
+    wireSearch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  // Expose for tests + downstream code (admin pages that want to
+  // dynamically annotate new content).
+  window.JAMES_Glossary = {
+    GLOSSARY: GLOSSARY,
+    showTooltip: showTooltip,
+    annotate: function (el, term) {
+      if (el && term && GLOSSARY[term]) {
+        el.setAttribute('data-glossary', term);
+      }
+    }
+  };
+})();

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -280,6 +280,22 @@ const TRANSLATIONS = {
     'admin.onboarding_link':   'Operator guide',
     'admin.rollback_link':     'Knowledge rollback',
     'admin.flow_link':         'Reasoning flow',
+    'admin.glossary_link':     'Glossary',
+
+    // v0.6 Phase 4 P4.4 — glossary page
+    'glossary.page_title':          'JAMES — Glossary',
+    'glossary.header_subtitle':     '· Glossary',
+    'glossary.back_to_admin':       '← Admin',
+    'glossary.title':               'Glossary',
+    'glossary.intro':               'Plain-language explanations of the technical terms used throughout the JAMES interface. Search or hover over any dotted-underlined term on other pages to see the same tooltip.',
+    'glossary.search.placeholder':  'Search terms…',
+    'glossary.search.no_results':   'No results match your search.',
+    'glossary.cat.core':            'Core concepts',
+    'glossary.cat.audit':           'Audit + time',
+    'glossary.cat.quality':         'Answer quality',
+    'glossary.cat.security':        'Security + access',
+    'glossary.cat.ops':             'Operator actions',
+    'glossary.footer_note':         '💡 On other pages, hover over any dotted-underlined word to see the same explanation as a tooltip.',
 
     // v0.6 Phase 4 P4.3 — reasoning flow visualization
     'flow.page_title':             'JAMES — Reasoning flow',
@@ -1343,6 +1359,22 @@ const TRANSLATIONS = {
     'admin.onboarding_link':   '운영자 안내',
     'admin.rollback_link':     '지식 롤백',
     'admin.flow_link':         '추론 흐름',
+    'admin.glossary_link':     '용어 설명',
+
+    // v0.6 Phase 4 P4.4 — glossary page
+    'glossary.page_title':          'JAMES — 용어 설명',
+    'glossary.header_subtitle':     '· 용어 설명',
+    'glossary.back_to_admin':       '← 관리자 페이지',
+    'glossary.title':               '용어 설명',
+    'glossary.intro':               'JAMES 의 화면에 등장하는 기술 용어들을 평이한 한국어로 설명합니다. 이 페이지에서 검색하거나, 다른 페이지에서 점선 밑줄이 그어진 단어 위에 마우스를 올리면 같은 설명이 툴팁으로 나타납니다.',
+    'glossary.search.placeholder':  '용어 검색…',
+    'glossary.search.no_results':   '검색 결과가 없습니다.',
+    'glossary.cat.core':            '기본 개념',
+    'glossary.cat.audit':           '감사 + 시점',
+    'glossary.cat.quality':         '답변 품질',
+    'glossary.cat.security':        '보안 + 권한',
+    'glossary.cat.ops':             '운영자 동작',
+    'glossary.footer_note':         '💡 다른 페이지에서 점선 밑줄이 그어진 단어 위에 마우스를 올리면 같은 설명이 툴팁으로 나타납니다.',
 
     // v0.6 Phase 4 P4.3 — reasoning flow visualization
     'flow.page_title':             'JAMES — 추론 흐름 보기',

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -254,6 +254,22 @@ async def serve_admin():
     return HTMLResponse("<h1>Admin</h1><p>frontend/admin.html 없음</p>")
 
 
+@app.get("/glossary", response_class=HTMLResponse, include_in_schema=False)
+async def serve_glossary():
+    """v0.6 Phase 4 P4.4 — JAMES technical term glossary.
+
+    Public page (no auth) with plain-Korean explanations of every
+    technical term that appears in the admin / graph / workspace UI
+    surfaces. Also hosts the universal tooltip script
+    (`/static/glossary.js`) that other pages load to auto-attach
+    hover tooltips on elements with `data-glossary="<term-slug>"`.
+    """
+    page = os.path.join(FRONTEND_DIR, "glossary.html")
+    if os.path.exists(page):
+        return FileResponse(page)
+    return HTMLResponse("<h1>Glossary</h1><p>frontend/glossary.html 없음</p>")
+
+
 @app.get("/admin/reasoning-flow", response_class=HTMLResponse, include_in_schema=False)
 async def serve_reasoning_flow():
     """v0.6 Phase 4 P4.3 — non-developer reasoning flow visualization.

--- a/tests/test_v06_glossary.py
+++ b/tests/test_v06_glossary.py
@@ -1,0 +1,211 @@
+"""v0.6 Phase 4 P4.4 — glossary page + universal tooltip tests.
+
+Coverage:
+
+  * `/glossary` page exists at canonical path
+  * 5 categories present (core / audit / quality / security / ops)
+  * Search input + no-results hint present
+  * 26+ canonical term entries (data-term attributes)
+  * Cross-page tooltip wiring: existing pages (admin / graph /
+    onboarding / reasoning-flow / knowledge-rollback) load
+    glossary.js
+  * Universal `data-glossary` attribute pattern present in graph.html
+  * glossary.js exposes window.JAMES_Glossary + canonical GLOSSARY map
+  * glossary.css carries selectors (.glossary-tooltip /
+    [data-glossary] / .glossary-entry)
+  * Server route registered
+  * Admin entry-point link present
+  * i18n keys in BOTH EN and KO blocks
+
+Run:
+  python -m unittest tests.test_v06_glossary
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HTML       = REPO_ROOT / "frontend" / "glossary.html"
+JS         = REPO_ROOT / "frontend" / "static" / "glossary.js"
+CSS        = REPO_ROOT / "frontend" / "static" / "glossary.css"
+I18N       = REPO_ROOT / "frontend" / "static" / "i18n.js"
+ADMIN_HTML = REPO_ROOT / "frontend" / "admin.html"
+GRAPH_HTML = REPO_ROOT / "frontend" / "graph.html"
+ONBOARDING_HTML = REPO_ROOT / "frontend" / "onboarding.html"
+REASONING_HTML  = REPO_ROOT / "frontend" / "reasoning-flow.html"
+ROLLBACK_HTML   = REPO_ROOT / "frontend" / "knowledge-rollback.html"
+SERVER     = REPO_ROOT / "server_llmwiki.py"
+
+
+class GlossaryPageStructureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not HTML.exists():
+            raise unittest.SkipTest("glossary.html missing")
+        cls.body = HTML.read_text(encoding="utf-8")
+
+    def test_five_categories(self):
+        for cat in ("core", "audit", "quality", "security", "ops"):
+            self.assertIn(f'data-category="{cat}"', self.body,
+                          f"missing category section: {cat}")
+
+    def test_search_surface(self):
+        self.assertIn('id="glossary-search-input"', self.body)
+        self.assertIn('id="glossary-no-results"', self.body)
+
+    def test_canonical_term_entries_present(self):
+        # Lock the canonical 26 terms (one per data-term attribute
+        # in glossary.html). A future PR can add MORE terms, but
+        # may not silently drop the canonical set.
+        canonical_terms = [
+            # core
+            "rag", "graph-rag", "entity", "relation", "ontology", "embedding",
+            # audit + time
+            "audit-log", "trace-id", "replay", "time-travel",
+            "supersede", "cascade",
+            # quality
+            "abstention", "hallucination", "citation", "path-coverage",
+            # security
+            "rbac", "abac", "oidc", "approval-evidence", "csp", "tenant",
+            # ops
+            "change-request", "rollback", "contradiction-arbiter",
+            "reasoning-trace",
+        ]
+        for term in canonical_terms:
+            self.assertIn(f'data-term="{term}"', self.body,
+                          f"missing canonical term: {term}")
+        self.assertEqual(
+            len(canonical_terms), 26,
+            "canonical term count drifted — update both the test "
+            "and the doc if intentional",
+        )
+
+    def test_a11y_skip_link(self):
+        self.assertIn('class="skip-link"', self.body)
+
+
+class GlossaryJsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.body = JS.read_text(encoding="utf-8")
+
+    def test_exposes_global(self):
+        self.assertIn("window.JAMES_Glossary", self.body)
+        for name in ("GLOSSARY", "showTooltip", "annotate"):
+            self.assertIn(name, self.body)
+
+    def test_glossary_map_carries_canonical_terms(self):
+        # The JS-side GLOSSARY object MUST contain every term the
+        # page advertises — so cross-page tooltips work without
+        # loading the page.
+        terms = [
+            "rag", "graph-rag", "entity", "relation", "ontology",
+            "audit-log", "trace-id", "replay", "time-travel",
+            "supersede", "cascade", "abstention", "hallucination",
+            "citation", "path-coverage", "rbac", "abac", "oidc",
+            "approval-evidence", "csp", "tenant", "change-request",
+            "rollback", "contradiction-arbiter", "reasoning-trace",
+        ]
+        for term in terms:
+            self.assertIn(f"'{term}'", self.body,
+                          f"GLOSSARY map missing term: {term}")
+
+
+class GlossaryCssTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.body = CSS.read_text(encoding="utf-8")
+
+    def test_tooltip_selectors(self):
+        for sel in (".glossary-tooltip", "[data-glossary]",
+                    ".glossary-entry", ".glossary-section"):
+            self.assertIn(sel, self.body,
+                          f"missing CSS selector: {sel}")
+
+    def test_44px_touch_target_on_search(self):
+        self.assertIn("min-height: 44px", self.body)
+
+
+class CrossPageWiringTests(unittest.TestCase):
+    """All other operator-facing pages must load `glossary.js` so the
+    universal tooltip mechanism works site-wide."""
+
+    def _assert_loads_glossary_js(self, path: Path, label: str):
+        body = path.read_text(encoding="utf-8")
+        self.assertIn(
+            '/static/glossary.js', body,
+            f"{label} does not load glossary.js — tooltips won't work",
+        )
+
+    def test_admin_html_loads_glossary(self):
+        self._assert_loads_glossary_js(ADMIN_HTML, "admin.html")
+
+    def test_graph_html_loads_glossary(self):
+        self._assert_loads_glossary_js(GRAPH_HTML, "graph.html")
+
+    def test_onboarding_html_loads_glossary(self):
+        self._assert_loads_glossary_js(ONBOARDING_HTML, "onboarding.html")
+
+    def test_reasoning_html_loads_glossary(self):
+        self._assert_loads_glossary_js(REASONING_HTML, "reasoning-flow.html")
+
+    def test_rollback_html_loads_glossary(self):
+        self._assert_loads_glossary_js(ROLLBACK_HTML, "knowledge-rollback.html")
+
+    def test_graph_html_has_data_glossary_anchor(self):
+        # Verify at least ONE data-glossary attribute exists in the
+        # graph page — proves the wiring scope reaches that page.
+        body = GRAPH_HTML.read_text(encoding="utf-8")
+        self.assertIn('data-glossary=', body,
+                      "graph.html has no data-glossary anchor — tooltips "
+                      "load but won't activate on any element")
+
+
+class I18nKeysTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.body = I18N.read_text(encoding="utf-8")
+
+    def test_canonical_glossary_keys_in_both_blocks(self):
+        required = [
+            "glossary.page_title",
+            "glossary.title",
+            "glossary.intro",
+            "glossary.search.placeholder",
+            "glossary.search.no_results",
+            "glossary.cat.core",
+            "glossary.cat.audit",
+            "glossary.cat.quality",
+            "glossary.cat.security",
+            "glossary.cat.ops",
+            "admin.glossary_link",
+        ]
+        for key in required:
+            count = self.body.count(f"'{key}'")
+            self.assertGreaterEqual(
+                count, 2,
+                f"i18n key {key!r} missing in EN or KO (count {count})",
+            )
+
+
+class ServerAndEntryPointTests(unittest.TestCase):
+    def test_glossary_route_registered(self):
+        body = SERVER.read_text(encoding="utf-8")
+        self.assertIn('@app.get("/glossary"', body)
+        self.assertIn("async def serve_glossary", body)
+
+    def test_admin_html_link_to_glossary(self):
+        body = ADMIN_HTML.read_text(encoding="utf-8")
+        self.assertIn('href="/glossary"', body)
+        self.assertIn('admin.glossary_link', body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**v0.6 Phase 4 P4.4** per the operator's 4-item production-readiness advice. Closes the gap that P4.1/P4.2/P4.3 left open: the NEW non-developer pages are jargon-free (lock-tests enforce that), but the EXISTING pages (admin / graph / workspace) still expose technical terms — `trace_id`, `supersede`, `audit_log`, `cascade` etc. — that bounce non-developer operators.

P4.4 ships two things:
1. **Canonical glossary page** (`/glossary`) with 26 terms in plain Korean, grouped by 5 categories
2. **Universal hover-tooltip script** (`glossary.js`) that ANY page loads — elements with `data-glossary=\"<term>\"` gain dotted underline + hover/focus tooltip surfacing the same definition

This means existing pages stay intact for power users, but a non-developer hovering over any annotated technical term sees a friendly explanation without leaving the page.

## Summary

### `/glossary` page — 26 terms × 5 categories

| Category | Terms |
|---|---|
| 기본 개념 (Core) | RAG / Graph-RAG / Entity / Relation / Ontology / Embedding |
| 감사 + 시점 (Audit) | Audit log / trace_id / Replay / Time-travel / Supersede / Cascade |
| 답변 품질 (Quality) | Abstention / Hallucination / Citation / Path coverage |
| 보안 + 권한 (Security) | RBAC / ABAC / OIDC / Approval evidence / CSP / Tenant |
| 운영자 동작 (Ops) | Change Request / Rollback / Contradiction arbiter / Reasoning trace |

Each entry: Korean term + English in parens + plain-Korean explanation (1-3 sentences) with `<strong>` highlights on key phrases. Live search filter + URL hash deep-link (`#trace-id`).

### Universal tooltip — `glossary.js`

- `GLOSSARY` JS-side map carrying short version of every page entry — tooltip works WITHOUT loading `/glossary` first
- Event-delegated `mouseover` / `mouseout` / `focusin` / `focusout` on `document` — works for static AND dynamically-rendered `data-glossary` elements
- Single shared floating tooltip div, auto-positions next to trigger, keeps within viewport, Esc dismisses
- Tooltip carries: term + short def + link to `/glossary#<term>`

### Cross-page wiring (5 pages)

All operator-facing pages now load `glossary.js`:
- `admin.html` (NEW)
- `graph.html` (NEW + one `data-glossary=\"entity\"` example anchor)
- `onboarding.html` (NEW)
- `reasoning-flow.html` (NEW)
- `knowledge-rollback.html` (NEW)

Lock-tests assert all 5 load the script.

### Misc

- `GET /glossary` server route (public)
- `📚 용어 설명` link in admin.html header
- 13 new i18n keys (EN + KO)

## Tests — `tests/test_v06_glossary.py` (NEW, 17 tests)

- **GlossaryPageStructureTests** (4): 5 categories present; search surface; **26 canonical terms LOCKED** by name; a11y skip link
- **GlossaryJsTests** (2): JAMES_Glossary global; GLOSSARY map carries all 25 terms
- **GlossaryCssTests** (2): tooltip + entry + section selectors + 44px touch
- **CrossPageWiringTests** (6): admin / graph / onboarding / reasoning-flow / knowledge-rollback ALL load glossary.js; graph.html has ≥1 `data-glossary` anchor
- **I18nKeysTests** (1): 11 keys in BOTH EN and KO
- **ServerAndEntryPointTests** (2): route registered; admin link present

## Verification

- `pytest tests/test_v06_glossary.py`: **17 passed**
- Phase 4 regression sweep (reasoning_flow + knowledge_rollback + onboarding_flow): **52 passed** — adding glossary.js as last script include didn't break existing wiring
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths untouched

## Out of scope

- Does NOT annotate every existing technical term — graph.html gets ONE example anchor; bulk annotation is operator-driven follow-up
- Does NOT cover vertical-specific terms (legal/medical) — packs ship their own glossaries post-LOI
- Does NOT translate to languages other than Korean (English fallback in parens)
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: code — additive page + universal tooltip script + cross-page script-include wiring + lock tests; no core/retrieval, core/graph traversal, or core/reasoning paths changed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)