### PR TITLE
refactor(v0.6): split core/gemma_client.py 24.3KB → 5-file package

### DIFF
--- a/core/gemma_client/__init__.py
+++ b/core/gemma_client/__init__.py
@@ -1,0 +1,70 @@
+"""PROJECT JAMES - Gemma Client (Phase 4)
+
+Phase 3.5 수정 적용:
+  [CACHE-BUG-FIX] 에러 응답 캐시 금지
+    기존: [Gemma 응답 없음] 등 에러도 캐시 저장
+          → 이후 동일 프롬프트 재호출 시 에러가 캐시 히트로 즉시 반환
+    수정: is_cacheable_response() 검증
+          _get_from_cache 조회 시점에도 재검증 (기존 에러 자동 제거)
+
+  [C2-FIX] <think> 블록 제거 후 빈 응답 3단계 복구
+    1단계: <think> 제거 후 내용 있으면 정상 사용
+    2단계: </think> 이후 텍스트 추출
+    3단계: <think> 내부 마지막 문장 추출
+
+  [CACHE-STAT] hit / miss / error 통계 카운터
+
+Phase 4:
+  [SPEED] num_predict=700 (thinking 버퍼 확보), num_ctx=2048, temperature=0.2
+
+## v0.6 package split (CLAUDE.md rule #5)
+
+This package was a single ``core/gemma_client.py`` file (24.3 KB,
+over the 20 KB cap) until the v0.6 oversize-module split. The
+public API surface is byte-identical — all existing imports
+(``from core.gemma_client import GemmaClient`` /
+``ERROR_PREFIXES`` / ``is_cacheable_response`` etc.) keep working
+through this façade:
+
+  * :mod:`core.gemma_client.client` — ``GemmaClient`` class
+  * :mod:`core.gemma_client.errors` — ``ERROR_PREFIXES`` +
+    ``is_cacheable_response`` + ``log_system_event``
+  * :mod:`core.gemma_client.config` — ``_DEFAULT_MAX_PROMPT_LEN`` +
+    ``_resolve_max_prompt_len`` (JAMES_GEMMA_MAX_PROMPT_CHARS env)
+  * :mod:`core.gemma_client.response_parser` — ``<think>`` block
+    3-stage recovery + post-processing
+  * this ``__init__.py`` — re-exports
+
+External callers that imported ``_LLM_OPTIONS`` from this module
+(only :mod:`llm.providers.deepseek_client`) used a try/except
+fallback because the symbol never existed in the pre-split file —
+behaviour preserved.
+"""
+from __future__ import annotations
+
+# ─── re-exports — preserves the pre-split import surface ─────────
+
+from core.gemma_client.config import (  # noqa: F401
+    _DEFAULT_MAX_PROMPT_LEN,
+    _resolve_max_prompt_len,
+)
+from core.gemma_client.errors import (  # noqa: F401
+    ERROR_PREFIXES,
+    is_cacheable_response,
+    log_system_event,
+)
+from core.gemma_client.response_parser import (  # noqa: F401
+    recover_think_block,
+    recover_vision_response,
+)
+from core.gemma_client.client import (  # noqa: F401
+    GemmaClient,
+)
+
+
+__all__ = [
+    "GemmaClient",
+    "ERROR_PREFIXES",
+    "is_cacheable_response",
+    "log_system_event",
+]

--- a/core/gemma_client/client.py
+++ b/core/gemma_client/client.py
@@ -1,109 +1,38 @@
+"""GemmaClient — main LLM client class.
+
+Extracted from the legacy single-file ``core/gemma_client.py``
+during the v0.6 oversize-module split (CLAUDE.md rule #5). Behaviour
+is byte-identical to the pre-split file; only the location moved.
+
+The class encapsulates:
+  * The Ollama HTTP call (``call_gemma``)
+  * The Vision call (``call_gemma_vision``)
+  * The bounded LRU response cache (with error-response rejection)
+  * Cache statistics (hits / misses / errors / total)
+  * The D6 follow-up ``_last_done_reason`` stash that
+    ``OllamaClient.generate_meta`` reads to forward Ollama's native
+    truncation signal upward.
 """
-PROJECT JAMES - Gemma Client (Phase 4)
+from __future__ import annotations
 
-Phase 3.5 수정 적용:
-  [CACHE-BUG-FIX] 에러 응답 캐시 금지
-    기존: [Gemma 응답 없음] 등 에러도 캐시 저장
-          → 이후 동일 프롬프트 재호출 시 에러가 캐시 히트로 즉시 반환
-    수정: is_cacheable_response() 검증
-          _get_from_cache 조회 시점에도 재검증 (기존 에러 자동 제거)
-
-  [C2-FIX] <think> 블록 제거 후 빈 응답 3단계 복구
-    1단계: <think> 제거 후 내용 있으면 정상 사용
-    2단계: </think> 이후 텍스트 추출
-    3단계: <think> 내부 마지막 문장 추출
-
-  [CACHE-STAT] hit / miss / error 통계 카운터
-
-Phase 4:
-  [SPEED] num_predict=700 (thinking 버퍼 확보), num_ctx=2048, temperature=0.2
-"""
-
-import os
-import requests
-import time
-import hashlib
 import base64
-import re
+import hashlib
+import time
 from collections import OrderedDict
-from datetime import datetime
 from typing import Optional
+
+import requests
+
 from config import GEMMA_MODEL, OLLAMA_API_URL
-
-
-# Prompt-length cap. The historical default is 4000 chars, baked in
-# during Phase 4 to keep early-dev runaway prompts bounded. Cycle γ
-# Phase B smoke (2026-06-08) revealed the cap silently truncates
-# multi-doc evidence prompts (RGB en row had 35k-char context
-# truncated to 4k → noise_robustness measured on truncated evidence),
-# the same class of bug as
-# ``feedback_synth_context_1000_truncation_rootcause``. Make the
-# cap configurable via env var so external-bench measurement runs
-# can lift it without touching call sites; the default stays at
-# 4000 so production behaviour is byte-identical for any caller
-# that doesn't set the env var.
-_DEFAULT_MAX_PROMPT_LEN = 4000
-
-
-def _resolve_max_prompt_len() -> int:
-    """Read ``JAMES_GEMMA_MAX_PROMPT_CHARS`` from env each call.
-
-    Reading per-call (not at import) lets a measurement script set the
-    env var after this module has been imported and still take effect.
-    Returns the default on missing / invalid / non-positive values
-    rather than raising — silent fallback matches the rest of this
-    module's behaviour and keeps an env-var typo from crashing
-    production traffic.
-    """
-    raw = os.environ.get("JAMES_GEMMA_MAX_PROMPT_CHARS")
-    if not raw:
-        return _DEFAULT_MAX_PROMPT_LEN
-    try:
-        val = int(raw)
-    except (TypeError, ValueError):
-        return _DEFAULT_MAX_PROMPT_LEN
-    if val <= 0:
-        return _DEFAULT_MAX_PROMPT_LEN
-    return val
-
-
-# ─── 에러 응답 식별자 ────────────────────────────────────────
-
-ERROR_PREFIXES = (
-    "[Gemma 응답 없음]",
-    "[Gemma 오류]",
-    "[Gemma Vision 오류]",
-    "[Gemma Vision 응답 없음]",
+from core.gemma_client.config import _resolve_max_prompt_len
+from core.gemma_client.errors import (
+    is_cacheable_response,
+    log_system_event,
 )
-
-
-def is_cacheable_response(result: str) -> bool:
-    """
-    [CACHE-BUG-FIX] 캐시 저장 가능 여부 판단.
-    에러/빈 응답은 캐시 금지.
-    """
-    if not result or not isinstance(result, str):
-        return False
-    if result.startswith(ERROR_PREFIXES):
-        return False
-    if len(result.strip()) < 5:
-        return False
-    return True
-
-
-def log_system_event(step: str, detail: str, level: str = "ERROR"):
-    """시스템 이벤트 기록"""
-    entry = {
-        "time":   datetime.now().isoformat(),
-        "level":  level,
-        "step":   step,
-        "detail": str(detail)[:300],
-    }
-    try:
-        from core.audit_bridge import mirror_system_event
-        mirror_system_event(entry)
-    except Exception:
-        pass
+from core.gemma_client.response_parser import (
+    recover_think_block,
+    recover_vision_response,
+)
 
 
 class GemmaClient:
@@ -138,8 +67,7 @@ class GemmaClient:
         return hashlib.sha256(str(content).strip().lower().encode()).hexdigest()
 
     def _get_from_cache(self, cache_key: str):
-        """
-        [CACHE-BUG-FIX] 조회 시점에도 에러 응답 재검증.
+        """[CACHE-BUG-FIX] 조회 시점에도 에러 응답 재검증.
         이전 실행에서 잘못 저장된 에러 응답 자동 제거.
         """
         if cache_key in self.cache:
@@ -209,10 +137,11 @@ class GemmaClient:
         temperature: float = None,
         think: Optional[bool] = None,
     ) -> str:
-        """
-        Gemma 모델 호출.
+        """Gemma 모델 호출.
+
         [CACHE-BUG-FIX] 에러 응답 캐시 금지
-        [C2-FIX]        <think> 블록 3단계 복구
+        [C2-FIX]        <think> 블록 3단계 복구 (delegated to
+                        ``response_parser.recover_think_block``)
         [CACHE-STAT]    hit/miss 카운터 업데이트
         [#15]           model override (None이면 config.GEMMA_MODEL 기본)
         [PR plan-1, 2026-05-09] model=None일 때 core.model_resolver로
@@ -369,51 +298,19 @@ class GemmaClient:
                 elapsed_llm = time.time() - t_call
                 print(f"[GEMMA] 응답 수신 ({elapsed_llm:.1f}s) | {len(output)}자")
 
-                # [C2-FIX] <think> 블록 3단계 복구
+                # [C2-FIX] <think> 블록 3단계 복구 — delegated to
+                # ``response_parser.recover_think_block`` (split out
+                # of this method for the v0.6 oversize-module split,
+                # behaviour byte-identical).
                 if not output:
                     result = "[Gemma 응답 없음]"
-                    log_system_event("gemma.empty_response",
-                                     f"timeout={timeout}s elapsed={elapsed_llm:.1f}s", level="WARN")
+                    log_system_event(
+                        "gemma.empty_response",
+                        f"timeout={timeout}s elapsed={elapsed_llm:.1f}s",
+                        level="WARN",
+                    )
                 else:
-                    raw_output = output   # 원본 보존
-
-                    # 1단계: <think>...</think> 제거 후 내용 있으면 정상
-                    cleaned = re.sub(r'<think>.*?</think>', '', output, flags=re.DOTALL).strip()
-
-                    if cleaned:
-                        result = cleaned
-
-                    # 2단계: </think> 이후 텍스트 추출
-                    elif '</think>' in raw_output:
-                        after_think = raw_output.split('</think>', 1)[-1].strip()
-                        if after_think:
-                            print(f"[GEMMA] ⚠️ <think> 이후 복구: {len(after_think)}자")
-                            result = after_think
-                        else:
-                            # 3단계: <think> 내부 마지막 문장 추출
-                            think_match = re.search(r'<think>(.*?)</think>', raw_output, re.DOTALL)
-                            if think_match:
-                                think_body = think_match.group(1).strip()
-                                sentences  = [s.strip() for s in re.split(r'(?<=[.。!?])\s+', think_body) if s.strip()]
-                                recovered  = " ".join(sentences[-2:]) if sentences else think_body[-300:]
-                                print(f"[GEMMA] ⚠️ think 내부 복구: {len(recovered)}자")
-                                result = recovered if recovered else "[Gemma 응답 없음]"
-                            else:
-                                result = "[Gemma 응답 없음]"
-
-                    # <think> 없는데 빈 문자열 → 원본 재시도
-                    else:
-                        result = raw_output.strip() if raw_output.strip() else "[Gemma 응답 없음]"
-
-                    # 공통 후처리
-                    if result and result != "[Gemma 응답 없음]":
-                        result = re.sub(r'</?s>', '', result)
-                        for marker in ["...done thinking.", "done thinking."]:
-                            idx = result.find(marker)
-                            if idx != -1:
-                                result = result[idx + len(marker):]
-                                break
-                        result = result.strip()
+                    result = recover_think_block(output)
 
                 # [CACHE-BUG-FIX] 정상 응답만 캐시 저장
                 if use_cache:
@@ -457,18 +354,7 @@ class GemmaClient:
             resp.raise_for_status()
             output = resp.json().get("response", "").strip()
 
-            if not output:
-                return "[Gemma Vision 응답 없음]"
-
-            cleaned = re.sub(r'<think>.*?</think>', '', output, flags=re.DOTALL).strip()
-            result  = cleaned if cleaned else output.strip()
-            result  = re.sub(r'</?s>', '', result)
-            for marker in ["...done thinking.", "done thinking."]:
-                idx = result.find(marker)
-                if idx != -1:
-                    result = result[idx + len(marker):]
-                    break
-            return result.strip()
+            return recover_vision_response(output)
 
         except requests.exceptions.Timeout:
             return "[Gemma Vision 오류] 응답 시간 초과"
@@ -489,41 +375,6 @@ class GemmaClient:
             print(f"[CACHE] 만료 {len(expired)}개 제거")
 
 
-# ─── 자가 테스트 ─────────────────────────────────────────────
-
-if __name__ == "__main__":
-    print("=== GemmaClient Phase 4 검증 ===\n")
-
-    client = GemmaClient()
-
-    # is_cacheable_response 검증
-    cases = [
-        ("[Gemma 응답 없음]",      False),
-        ("[Gemma 오류] timeout",   False),
-        ("",                       False),
-        ("  ",                     False),
-        ("경제학은 사회과학이다.",   True),
-    ]
-    print("--- is_cacheable_response ---")
-    for v, exp in cases:
-        ok = is_cacheable_response(v) == exp
-        print(f"  {'✅' if ok else '❌'} cacheable={exp}: '{v[:35]}'")
-
-    # 캐시 조회 시점 에러 응답 제거
-    print("\n--- 캐시 조회 시점 에러 제거 ---")
-    key = "test_key"
-    client.cache[key]            = "[Gemma 응답 없음]"
-    client.cache_timestamps[key] = time.time()
-    result = client._get_from_cache(key)
-    ok = result is None and key not in client.cache
-    print(f"  {'✅' if ok else '❌'} 에러 응답 자동 제거: result={result}, key_removed={key not in client.cache}")
-
-    # 정상 응답 캐시 저장
-    client._set_cache(key, "정상 응답입니다.")
-    result = client._get_from_cache(key)
-    ok = result == "정상 응답입니다."
-    print(f"  {'✅' if ok else '❌'} 정상 응답 캐시 저장: {result}")
-
-    # 통계
-    print("\n--- Cache Stats ---")
-    print(f"  {client.get_cache_stats()}")
+__all__ = [
+    "GemmaClient",
+]

--- a/core/gemma_client/config.py
+++ b/core/gemma_client/config.py
@@ -1,0 +1,58 @@
+"""Prompt-length config for the Gemma client.
+
+Extracted from the legacy single-file ``core/gemma_client.py``
+during the v0.6 oversize-module split (CLAUDE.md rule #5). Behaviour
+is byte-identical to the pre-split file; only the location moved.
+
+External callers (tests) import these directly:
+
+    from core.gemma_client import _resolve_max_prompt_len
+
+The re-export façade in ``core.gemma_client.__init__`` preserves
+that import shape.
+"""
+from __future__ import annotations
+
+import os
+
+
+# Prompt-length cap. The historical default is 4000 chars, baked in
+# during Phase 4 to keep early-dev runaway prompts bounded. Cycle γ
+# Phase B smoke (2026-06-08) revealed the cap silently truncates
+# multi-doc evidence prompts (RGB en row had 35k-char context
+# truncated to 4k → noise_robustness measured on truncated evidence),
+# the same class of bug as
+# ``feedback_synth_context_1000_truncation_rootcause``. Make the
+# cap configurable via env var so external-bench measurement runs
+# can lift it without touching call sites; the default stays at
+# 4000 so production behaviour is byte-identical for any caller
+# that doesn't set the env var.
+_DEFAULT_MAX_PROMPT_LEN = 4000
+
+
+def _resolve_max_prompt_len() -> int:
+    """Read ``JAMES_GEMMA_MAX_PROMPT_CHARS`` from env each call.
+
+    Reading per-call (not at import) lets a measurement script set the
+    env var after this module has been imported and still take effect.
+    Returns the default on missing / invalid / non-positive values
+    rather than raising — silent fallback matches the rest of this
+    module's behaviour and keeps an env-var typo from crashing
+    production traffic.
+    """
+    raw = os.environ.get("JAMES_GEMMA_MAX_PROMPT_CHARS")
+    if not raw:
+        return _DEFAULT_MAX_PROMPT_LEN
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_PROMPT_LEN
+    if val <= 0:
+        return _DEFAULT_MAX_PROMPT_LEN
+    return val
+
+
+__all__ = [
+    "_DEFAULT_MAX_PROMPT_LEN",
+    "_resolve_max_prompt_len",
+]

--- a/core/gemma_client/errors.py
+++ b/core/gemma_client/errors.py
@@ -1,0 +1,63 @@
+"""Error response identification + system-event logging for the
+Gemma client.
+
+Extracted from the legacy single-file ``core/gemma_client.py``
+during the v0.6 oversize-module split (CLAUDE.md rule #5). Behaviour
+is byte-identical to the pre-split file; only the location moved.
+
+External callers (`routes/evolution.py`, `scripts/recover_gemma_*`,
+tests) import these directly:
+
+    from core.gemma_client import ERROR_PREFIXES, is_cacheable_response
+
+The re-export façade in ``core.gemma_client.__init__`` preserves
+that import shape so the split is a no-op for callers.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+
+# ─── 에러 응답 식별자 ────────────────────────────────────────
+
+ERROR_PREFIXES = (
+    "[Gemma 응답 없음]",
+    "[Gemma 오류]",
+    "[Gemma Vision 오류]",
+    "[Gemma Vision 응답 없음]",
+)
+
+
+def is_cacheable_response(result: str) -> bool:
+    """[CACHE-BUG-FIX] 캐시 저장 가능 여부 판단.
+    에러/빈 응답은 캐시 금지.
+    """
+    if not result or not isinstance(result, str):
+        return False
+    if result.startswith(ERROR_PREFIXES):
+        return False
+    if len(result.strip()) < 5:
+        return False
+    return True
+
+
+def log_system_event(step: str, detail: str, level: str = "ERROR"):
+    """시스템 이벤트 기록"""
+    entry = {
+        "time":   datetime.now().isoformat(),
+        "level":  level,
+        "step":   step,
+        "detail": str(detail)[:300],
+    }
+    try:
+        from core.audit_bridge import mirror_system_event
+        mirror_system_event(entry)
+    except Exception:
+        pass
+
+
+__all__ = [
+    "ERROR_PREFIXES",
+    "is_cacheable_response",
+    "log_system_event",
+]

--- a/core/gemma_client/response_parser.py
+++ b/core/gemma_client/response_parser.py
@@ -1,0 +1,128 @@
+"""``<think>`` block 3-stage recovery + post-processing for Gemma
+client responses.
+
+Extracted from the legacy single-file ``core/gemma_client.py``
+during the v0.6 oversize-module split (CLAUDE.md rule #5). Behaviour
+is byte-identical to the pre-split file — the same call-order, the
+same regex set, the same "...done thinking." marker handling, the
+same final ``[Gemma 응답 없음]`` fallback when every recovery stage
+collapses.
+
+Used by both ``call_gemma`` (with all 3 stages) and
+``call_gemma_vision`` (with a simpler 1-stage variant). Both code
+paths share the post-processing tail (``</?s>`` strip + "done
+thinking" marker skip).
+"""
+from __future__ import annotations
+
+import re
+
+
+def _strip_response_tail(result: str) -> str:
+    """Common post-processing — remove ``<s>`` / ``</s>`` markers and
+    skip past any "...done thinking." / "done thinking." marker that
+    Gemma occasionally emits at the boundary between the hidden
+    reasoning trace and the visible answer.
+
+    Returns the cleaned string. Returns the input unchanged if it is
+    empty or the canonical ``[Gemma 응답 없음]`` fallback.
+    """
+    if not result or result == "[Gemma 응답 없음]":
+        return result
+    result = re.sub(r'</?s>', '', result)
+    for marker in ["...done thinking.", "done thinking."]:
+        idx = result.find(marker)
+        if idx != -1:
+            result = result[idx + len(marker):]
+            break
+    return result.strip()
+
+
+def recover_think_block(output: str) -> str:
+    """3-stage recovery for Gemma responses that may carry a
+    ``<think>...</think>`` block surrounding (or replacing) the
+    visible answer.
+
+    Stage 1 — strip ``<think>...</think>`` and return the remainder
+    if substantive.
+
+    Stage 2 — if stripping yielded empty AND a closing ``</think>``
+    exists in the raw output, return the text after the closing tag
+    (the LLM resumed the real answer outside the thinking block).
+
+    Stage 3 — if neither succeeded but a ``<think>...</think>`` is
+    present, extract the LAST 2 sentences from inside the thinking
+    block (or the trailing 300 chars when sentence splitting fails)
+    as a best-effort recovery.
+
+    Returns the canonical ``[Gemma 응답 없음]`` string when every
+    stage collapses — the upstream caller treats that as a recognised
+    error response (see ``ERROR_PREFIXES`` / ``is_cacheable_response``)
+    and will refuse to cache it.
+
+    All three stages preserve the call-order + print-side-effects of
+    the pre-split implementation so log lines downstream operators
+    rely on (`[GEMMA] ⚠️ <think> 이후 복구: …자`) stay byte-identical.
+    """
+    if not output:
+        return "[Gemma 응답 없음]"
+
+    raw_output = output
+
+    # Stage 1: <think>...</think> 제거 후 내용 있으면 정상
+    cleaned = re.sub(r'<think>.*?</think>', '', output,
+                     flags=re.DOTALL).strip()
+    if cleaned:
+        return _strip_response_tail(cleaned)
+
+    # Stage 2: </think> 이후 텍스트 추출
+    if '</think>' in raw_output:
+        after_think = raw_output.split('</think>', 1)[-1].strip()
+        if after_think:
+            print(f"[GEMMA] ⚠️ <think> 이후 복구: {len(after_think)}자")
+            return _strip_response_tail(after_think)
+
+        # Stage 3: <think> 내부 마지막 문장 추출
+        think_match = re.search(r'<think>(.*?)</think>', raw_output,
+                                re.DOTALL)
+        if think_match:
+            think_body = think_match.group(1).strip()
+            sentences = [s.strip() for s in
+                         re.split(r'(?<=[.。!?])\s+', think_body)
+                         if s.strip()]
+            recovered = (" ".join(sentences[-2:])
+                         if sentences else think_body[-300:])
+            print(f"[GEMMA] ⚠️ think 내부 복구: {len(recovered)}자")
+            result = recovered if recovered else "[Gemma 응답 없음]"
+            return _strip_response_tail(result)
+
+        return "[Gemma 응답 없음]"
+
+    # <think> 없는데 빈 문자열 → 원본 재시도
+    if raw_output.strip():
+        return _strip_response_tail(raw_output.strip())
+    return "[Gemma 응답 없음]"
+
+
+def recover_vision_response(output: str) -> str:
+    """Simpler 1-stage recovery for ``call_gemma_vision`` — strip
+    ``<think>...</think>`` and apply the post-processing tail.
+
+    Vision responses rarely emit thinking blocks (Gemma's vision
+    pipeline doesn't run the same CoT prompt), so the call_gemma
+    3-stage recovery is overkill; this stage 1 + tail strip is the
+    pre-split behaviour preserved byte-identical.
+    """
+    if not output:
+        return "[Gemma Vision 응답 없음]"
+    cleaned = re.sub(r'<think>.*?</think>', '', output,
+                     flags=re.DOTALL).strip()
+    result = cleaned if cleaned else output.strip()
+    return _strip_response_tail(result)
+
+
+__all__ = [
+    "recover_think_block",
+    "recover_vision_response",
+    "_strip_response_tail",
+]

--- a/tests/test_v06_gemma_client_module_size.py
+++ b/tests/test_v06_gemma_client_module_size.py
@@ -1,0 +1,174 @@
+"""v0.6 — `core/gemma_client/` package size lock-test.
+
+CLAUDE.md rule #5: "no file in `core/` exceeds 20 KB. If your change
+pushes a file over, split first." This test locks the 5 sub-files
+of the post-split gemma_client package at < 20 KB each.
+
+Also asserts the public + private import surface is preserved
+exactly — the v0.6 split is a no-op for callers.
+
+Run:
+  python -m unittest tests.test_v06_gemma_client_module_size
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = REPO_ROOT / "core" / "gemma_client"
+
+CAP_BYTES = 20 * 1024
+
+
+class ModuleSizeCapTests(unittest.TestCase):
+    def test_legacy_single_file_removed(self):
+        legacy = REPO_ROOT / "core" / "gemma_client.py"
+        self.assertFalse(
+            legacy.exists(),
+            "legacy core/gemma_client.py reappeared — both file "
+            "and package can't coexist; revert and pick one",
+        )
+
+    def test_package_dir_exists(self):
+        self.assertTrue(PACKAGE.is_dir())
+
+    def test_canonical_subfiles_present(self):
+        for name in ("__init__.py", "config.py", "errors.py",
+                     "response_parser.py", "client.py"):
+            self.assertTrue(
+                (PACKAGE / name).exists(),
+                f"missing canonical sub-file: {name}",
+            )
+
+    def test_each_subfile_under_20kb(self):
+        for path in PACKAGE.glob("*.py"):
+            size = path.stat().st_size
+            self.assertLess(
+                size, CAP_BYTES,
+                f"{path.name} is {size/1024:.1f} KB — exceeds CLAUDE.md "
+                f"rule #5 20 KB cap. Split it before merging.",
+            )
+
+
+class PublicImportSurfaceTests(unittest.TestCase):
+    def test_canonical_public_imports(self):
+        from core.gemma_client import (
+            GemmaClient,
+            ERROR_PREFIXES,
+            is_cacheable_response,
+            log_system_event,
+        )
+        self.assertTrue(callable(GemmaClient))
+        self.assertIsInstance(ERROR_PREFIXES, tuple)
+        self.assertTrue(callable(is_cacheable_response))
+        self.assertTrue(callable(log_system_event))
+
+    def test_canonical_private_imports(self):
+        from core.gemma_client import (  # noqa: F401
+            _DEFAULT_MAX_PROMPT_LEN,
+            _resolve_max_prompt_len,
+            recover_think_block,
+            recover_vision_response,
+        )
+
+    def test_error_prefixes_content(self):
+        from core.gemma_client import ERROR_PREFIXES
+        # Lock the canonical 4 error prefixes — callers
+        # (routes/evolution.py, scripts/recover_*) match against
+        # these strings to detect Gemma error responses.
+        expected = (
+            "[Gemma 응답 없음]",
+            "[Gemma 오류]",
+            "[Gemma Vision 오류]",
+            "[Gemma Vision 응답 없음]",
+        )
+        self.assertEqual(ERROR_PREFIXES, expected)
+
+    def test_is_cacheable_response_contract(self):
+        from core.gemma_client import is_cacheable_response
+        self.assertTrue(is_cacheable_response("normal answer"))
+        self.assertFalse(is_cacheable_response(""))
+        self.assertFalse(is_cacheable_response(None))
+        self.assertFalse(is_cacheable_response("[Gemma 응답 없음]"))
+        self.assertFalse(is_cacheable_response("[Gemma 오류] timeout"))
+        self.assertFalse(is_cacheable_response("ab"))  # < 5 chars
+
+    def test_default_max_prompt_len_unchanged(self):
+        from core.gemma_client import _DEFAULT_MAX_PROMPT_LEN
+        self.assertEqual(_DEFAULT_MAX_PROMPT_LEN, 4000)
+
+
+class ResponseParserContractTests(unittest.TestCase):
+    """The 3-stage <think> recovery has byte-identical behaviour."""
+
+    def test_stage1_strip_think_block(self):
+        from core.gemma_client import recover_think_block
+        self.assertEqual(
+            recover_think_block("<think>hidden</think>visible answer"),
+            "visible answer",
+        )
+
+    def test_stage1_with_done_thinking_marker(self):
+        from core.gemma_client import recover_think_block
+        # The post-processing tail skips past "...done thinking." /
+        # "done thinking." markers — then .strip() removes leading
+        # whitespace. So "visible answer...done thinking. answer body"
+        # collapses to "answer body" (everything before the marker
+        # is dropped, leading space stripped).
+        result = recover_think_block(
+            "<think>hidden</think>visible answer...done thinking. answer body"
+        )
+        self.assertEqual(result, "answer body")
+
+    def test_empty_output_returns_canonical_fallback(self):
+        from core.gemma_client import recover_think_block
+        self.assertEqual(
+            recover_think_block(""), "[Gemma 응답 없음]",
+        )
+
+    def test_vision_recovery_strips_think(self):
+        from core.gemma_client import recover_vision_response
+        self.assertEqual(
+            recover_vision_response("<think>x</think>image description"),
+            "image description",
+        )
+
+    def test_vision_empty_returns_canonical_fallback(self):
+        from core.gemma_client import recover_vision_response
+        self.assertEqual(
+            recover_vision_response(""), "[Gemma Vision 응답 없음]",
+        )
+
+
+class GemmaClientInstanceContractTests(unittest.TestCase):
+    def test_construction_with_defaults(self):
+        from core.gemma_client import GemmaClient
+        c = GemmaClient()
+        self.assertEqual(c.cache_max_size, 100)
+        self.assertEqual(c.cache_ttl, 600)
+        self.assertEqual(c._last_done_reason, "")
+        # All counters start at zero.
+        self.assertEqual(c._cache_hits, 0)
+        self.assertEqual(c._cache_misses, 0)
+        self.assertEqual(c._cache_errors, 0)
+        self.assertEqual(c._total_calls, 0)
+
+    def test_get_cache_stats_shape(self):
+        from core.gemma_client import GemmaClient
+        c = GemmaClient()
+        stats = c.get_cache_stats()
+        # Lock the 8 canonical fields callers (admin dashboard,
+        # diagnostic scripts) rely on.
+        for key in ("hits", "misses", "errors", "total",
+                    "hit_rate", "hit_rate_%", "cache_size", "ttl"):
+            self.assertIn(key, stats, f"missing stat field: {key}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Refactor 2/5** in the v0.6 oversize-module split series. Per CLAUDE.md rule #5. Sibling to the reflect.py split (#900).

## The split

| File | Pre-split | Post-split |
|---|---|---|
| `core/gemma_client.py` | **24.3 KB / 529 lines** | (deleted) |
| `core/gemma_client/__init__.py` | — | 2.4 KB — re-export façade |
| `core/gemma_client/errors.py` | — | 1.7 KB — ERROR_PREFIXES + is_cacheable_response + log_system_event |
| `core/gemma_client/config.py` | — | 2.0 KB — _DEFAULT_MAX_PROMPT_LEN + _resolve_max_prompt_len |
| `core/gemma_client/response_parser.py` | — | 4.9 KB — `<think>` 3-stage recovery + post-processing tail |
| `core/gemma_client/client.py` | — | 17.0 KB — GemmaClient class + cache + call_gemma + call_gemma_vision |

All 5 sub-files **under the 20 KB cap**. The `<think>` recovery (Stage 1 strip / Stage 2 after-</think> / Stage 3 inside-think sentence extraction) extracts cleanly because it has no class-state dependencies — it operates only on the response string.

## Behaviour preservation

The split is a **no-op for callers**. Every import path the pre-split file supported keeps working through the `__init__.py` façade:

- **Public**: `GemmaClient`, `ERROR_PREFIXES`, `is_cacheable_response`, `log_system_event`
- **Private** (test-only): `_DEFAULT_MAX_PROMPT_LEN`, `_resolve_max_prompt_len`, `recover_think_block`, `recover_vision_response`

`llm/providers/deepseek_client.py` line 28 has a try/except fallback for `_LLM_OPTIONS` that does NOT exist in this module — behaviour preserved (the fallback dict is used as it always was).

## Tests — `tests/test_v06_gemma_client_module_size.py` (NEW, 16 tests)

- **ModuleSizeCapTests** (4): legacy removed; package dir; 5 canonical sub-files; every sub-file under 20 KB
- **PublicImportSurfaceTests** (5): canonical public + private imports; ERROR_PREFIXES locked to 4 canonical strings; is_cacheable_response contract; default cap value
- **ResponseParserContractTests** (5): Stage 1 strip; \"done thinking.\" marker; empty fallback; vision recovery; vision empty
- **GemmaClientInstanceContractTests** (2): defaults (cache_max_size=100, ttl=600, counters zero); get_cache_stats 8-field shape

## Verification

- `pytest tests/test_v06_gemma_client_module_size.py`: **16 passed**
- `pytest tests/test_gemma_client_prompt_cap.py`: **5 passed** (test imports `_resolve_max_prompt_len`)
- Caller import smoke (`llm/providers/deepseek_client` + `routes/evolution`): both pass
- `core/retrieval` / `core/graph` traversal / `core/reasoning` paths untouched

## Out of scope

- Does NOT touch the 3 remaining oversize files (`replay_graph.py` 23.0 KB / `_ingestion.py` 22.5 KB / `_frontmatter.py` 21.4 KB)
- Does NOT change behaviour — pure refactor
- Vertical content **BLOCKED** per CLAUDE.md rule #1

## Quality Delta Card

`Quality delta: exempt (label: refactor — file reorganisation + size-cap lock tests; no core/retrieval, core/graph traversal, or core/reasoning behaviour changes; all 8 import paths preserved)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)