### PR TITLE
refactor(v0.6): split core/wiki_generator/_frontmatter.py 21.4KB → 4-file package

### DIFF
--- a/core/wiki_generator/_frontmatter/__init__.py
+++ b/core/wiki_generator/_frontmatter/__init__.py
@@ -1,0 +1,59 @@
+"""Wiki generator — frontmatter, indexing, single-entity write path.
+
+Holds the ``WikiFrontmatterMixin`` (Layers 0–2 in the dependency
+graph): instance state via ``__init__``, the entity-id index build,
+ID generation, name normalization, frontmatter read, duplicate
+detection, and the single-file ``create_entity_file`` writer.
+
+## v0.6 package split (CLAUDE.md rule #5)
+
+This package was a single ``core/wiki_generator/_frontmatter.py``
+file (21.4 KB, over the 20 KB cap) until the v0.6 oversize-module
+split. The public import surface is byte-identical — every caller
+(``core/wiki_generator/__init__.py`` → ``WikiFrontmatterMixin``)
+keeps working through this façade.
+
+``WikiFrontmatterMixin`` is composed via MRO from 4 sub-mixins. Each
+sub-mixin holds one logical layer of the original file; no method-
+name collisions exist so the MRO is documentation-driven (top-down by
+layer), not load-bearing:
+
+  * :mod:`core.wiki_generator._frontmatter.init_state` —
+    ``WikiInitStateMixin`` (``__init__`` + ``_create_index_template``;
+    holds the late-binding ``WIKI_DIR`` import that the test
+    monkey-patch pattern depends on)
+  * :mod:`core.wiki_generator._frontmatter.id_gen` —
+    ``WikiIdGenMixin`` (``_generate_entity_id`` + ``_normalize_name``)
+  * :mod:`core.wiki_generator._frontmatter.read` —
+    ``WikiReadMixin`` (``_build_entity_id_index``,
+    ``refresh_entity_map``, ``_register_entity_id``,
+    ``_build_overlap_snapshot``, ``_find_existing_entity_id``,
+    ``_read_frontmatter``, ``_default_sensitivity``,
+    ``find_duplicate_entities``)
+  * :mod:`core.wiki_generator._frontmatter.create` —
+    ``WikiCreateMixin`` (``create_entity_file`` — the big one)
+"""
+from __future__ import annotations
+
+from core.wiki_generator._frontmatter.create import WikiCreateMixin
+from core.wiki_generator._frontmatter.id_gen import WikiIdGenMixin
+from core.wiki_generator._frontmatter.init_state import WikiInitStateMixin
+from core.wiki_generator._frontmatter.read import WikiReadMixin
+
+
+class WikiFrontmatterMixin(
+    WikiCreateMixin,
+    WikiReadMixin,
+    WikiIdGenMixin,
+    WikiInitStateMixin,
+):
+    """Frontmatter / index / single-entity write mixin.
+
+    MRO (left → right): Create → Read → IdGen → InitState → object.
+    No method-name collisions, so the order is documentation-driven
+    only.
+    """
+    pass
+
+
+__all__ = ["WikiFrontmatterMixin"]

--- a/core/wiki_generator/_frontmatter/create.py
+++ b/core/wiki_generator/_frontmatter/create.py
@@ -1,236 +1,28 @@
-"""Wiki generator — frontmatter, indexing, single-entity write path.
+"""``create_entity_file`` writer — sub-mixin of
+``WikiFrontmatterMixin``.
 
-Holds the ``WikiFrontmatterMixin`` (Layers 0–2 in the dependency
-graph): instance state via ``__init__``, the entity-id index build,
-ID generation, name normalization, frontmatter read, duplicate
-detection, single-file ``create_entity_file`` writer, the
-``update_index`` summary, ``resolve_pending_relations`` UNRESOLVED
-sweep, and ``get_entity_statistics``.
-
-The ``WIKI_DIR`` binding is late-imported from ``core.wiki_generator``
-inside ``__init__`` so the test pattern
-``import core.wiki_generator as wg_mod; wg_mod.WIKI_DIR = tmp``
-keeps working after the Stage C.1 split.
+Extracted from the legacy single-file
+``core/wiki_generator/_frontmatter.py`` during the v0.6 oversize-module
+split (CLAUDE.md rule #5). Behaviour is byte-identical; only the
+location moved.
 """
 from __future__ import annotations
 
-import hashlib
 import re
 from datetime import datetime
-from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import yaml
 
 from core.relations_schema import (
-    ENTITY_TYPES_CORE,
     compute_confidence_from_sources,
     validate_occurred_at,
 )
-from core.vector_store import VectorStore
-from llm.router import RouterWrapper
-from utils.metadata import MetadataGenerator
 
-from ._aliases import _expand_alias_candidates
+from core.wiki_generator._aliases import _expand_alias_candidates
 
 
-class WikiFrontmatterMixin:
-
-    def __init__(self, source_type: str = "prod"):
-        """
-        [P4.5-1] source_type 분리
-          source_type='prod' → wiki/entity/prod/{type}/
-          source_type='test' → wiki/entity/test/{type}/
-        """
-        # Late-bind WIKI_DIR: tests do ``wg_mod.WIKI_DIR = tmp`` between
-        # instantiations, so reading the binding at __init__ time
-        # (rather than at module import) is the load-bearing invariant.
-        from core.wiki_generator import WIKI_DIR
-
-        self.gemma_client = RouterWrapper("extract")
-        self.metadata_gen = MetadataGenerator()
-        self.vector_store = VectorStore()
-
-        # [P4.5-1] source_type에 따라 entity 경로 분리
-        self.source_type    = source_type if source_type in ("prod", "test") else "prod"
-        self.wiki_base_path = Path(WIKI_DIR)
-        self.entity_path    = self.wiki_base_path / "entity" / self.source_type
-
-        # ENTITY_TYPES_CORE = 5 types (event 5th, PR-11). LLM extraction
-        # prompt below still emits only 3 types (person/org/concept);
-        # `document` is post-processor source-attribution; `event` is
-        # admin POST path (PR-11a-2). Directory listing / index build /
-        # search default to all 5 — empty event/ dir is a no-op until
-        # the first admin event creation.
-        self.entity_types = list(ENTITY_TYPES_CORE)
-
-        for t in self.entity_types:
-            (self.entity_path / t).mkdir(parents=True, exist_ok=True)
-
-        self.index_path = self.wiki_base_path / "index.md"
-        if not self.index_path.exists():
-            self._create_index_template()
-
-        self.entity_id_index: Dict[str, Path] = {}
-        self._build_entity_id_index()
-
-
-    def _create_index_template(self):
-        """index.md 초기 템플릿 생성"""
-
-        content = (
-            "---\n"
-            f'updated_at: "{datetime.now().isoformat()}"\n'
-            "total_entities: 0\n"
-            "---\n\n"
-            "# 자메스 Wiki Index\n\n"
-            "## person (0)\n\n"
-            "## concept (0)\n\n"
-            "## org (0)\n\n"
-            "## document (0)\n\n"
-            "## event (0)\n"
-        )
-
-        self.index_path.write_text(content, encoding="utf-8")
-
-    # =========================
-    # INDEX BUILD
-    # =========================
-
-    def _build_entity_id_index(self):
-        self.entity_id_index.clear()
-
-        for t in self.entity_types:
-            d = self.entity_path / t
-            if not d.exists():
-                continue
-
-            for f in d.glob("*.md"):
-                fm = self._read_frontmatter(f)
-                if fm and fm.get("entity_id"):
-                    self.entity_id_index[fm["entity_id"]] = f
-
-        print(f"[INDEX] {len(self.entity_id_index)} entities loaded")
-
-    def refresh_entity_map(self):
-        self._build_entity_id_index()
-
-    def _register_entity_id(self, entity_id: str, filepath: Path):
-        self.entity_id_index[entity_id] = filepath
-
-    # =========================
-    # ID GENERATION (SECURE)
-    # =========================
-
-    def _generate_entity_id(self, name: str, entity_type: str) -> str:
-        normalized = self._normalize_name(name)
-
-        # 🔐 보안: SALT 추가
-        SALT = "JAMES_SECURE_V1"
-        raw = f"{normalized}_{entity_type}_{SALT}"
-
-        h = hashlib.sha256(raw.encode()).hexdigest()[:8]   # graph_rag_engine 정규식 {8} 일치
-        return f"e_{entity_type}_{h}"
-
-    def _normalize_name(self, name: str) -> str:
-        return re.sub(r"[^\w가-힣]", "_", name.strip().lower())
-
-    def _build_overlap_snapshot(self):
-        """Return `{normalized_name: (canonical_name, entity_id, entity_type)}`
-        for every existing wiki entity (any type), aliases included.
-
-        v0.4 Sprint 1 #1 addition — used by ingestion's entity-name
-        overlap detection (`_infer_overlap_relations` in `_merge.py`)
-        so a newly-ingested event named *"비트코인 spot ETF 11개
-        일괄 승인"* automatically gets a RELATED_TO relation to the
-        existing "비트코인" concept entity when its normalized name
-        appears as a token in the new entity's name.
-
-        First-write-wins: if two entities share a normalized name
-        (e.g. one canonical + one alias on a different entity), the
-        earlier one in `entity_id_index` iteration order takes
-        precedence. Tests pin this — production rarely has the
-        collision because aliases that match another canonical name
-        would already trip `_find_existing_entity_id` during ingest.
-        """
-        from pathlib import Path
-        snapshot = {}
-        for eid, filepath in self.entity_id_index.items():
-            try:
-                fm = self._read_frontmatter(Path(filepath))
-            except Exception:
-                continue
-            if not fm:
-                continue
-            canonical = fm.get("name", "")
-            norm = fm.get("normalized_name", "") or self._normalize_name(canonical)
-            etype = fm.get("entity_type", "concept")
-            if norm and norm not in snapshot:
-                snapshot[norm] = (canonical, eid, etype)
-            for alias in fm.get("aliases", []) or []:
-                alias_norm = self._normalize_name(alias)
-                if alias_norm and alias_norm not in snapshot:
-                    snapshot[alias_norm] = (canonical, eid, etype)
-        return snapshot
-
-    # =========================
-    # ENTITY SEARCH (FIXED)
-    # =========================
-
-    def _find_existing_entity_id(
-        self,
-        name: str,
-        entity_type: Optional[str]
-    ) -> Optional[str]:
-
-        normalized = self._normalize_name(name)
-
-        # 🔥 핵심 FIX: None 대응
-        if entity_type:
-            search_types = [entity_type]
-        else:
-            search_types = self.entity_types
-
-        for t in search_types:
-            d = self.entity_path / t
-            if not d.exists():
-                continue
-
-            for f in d.glob("*.md"):
-                fm = self._read_frontmatter(f)
-                if not fm:
-                    continue
-
-                if fm.get("normalized_name") == normalized:
-                    return fm.get("entity_id")
-
-                for alias in fm.get("aliases", []):
-                    if self._normalize_name(alias) == normalized:
-                        return fm.get("entity_id")
-
-        return None
-
-    # =========================
-    # FRONTMATTER
-    # =========================
-
-    def _read_frontmatter(self, path: Path) -> Optional[Dict]:
-        try:
-            content = path.read_text(encoding="utf-8")
-            if not content.startswith("---"):
-                return None
-
-            end = content.find("---", 3)
-            if end < 0:
-                return None
-
-            return yaml.safe_load(content[3:end]) or {}
-        except Exception:
-            return None
-
-    # =========================
-    # CREATE ENTITY
-    # =========================
+class WikiCreateMixin:
 
     def create_entity_file(
         self,
@@ -492,45 +284,5 @@ class WikiFrontmatterMixin:
 
         return str(path)
 
-    # =========================
-    # SENSITIVITY DEFAULT (ABAC)
-    # =========================
 
-    @staticmethod
-    def _default_sensitivity(entity_type: str) -> str:
-        """entity_type별 기본 민감도 등급 반환"""
-        mapping = {
-            "person":   "confidential",  # 개인정보 → 기밀
-            "org":      "internal",      # 조직정보 → 내부
-            "document": "confidential",  # 문서 → 기밀
-            "concept":  "public",        # 개념/지식 → 공개
-            "event":    "internal",      # 시간 축 사건 → 내부 (PR-11b)
-        }
-        return mapping.get(entity_type, "internal")
-
-    # =========================
-    # DUPLICATE CHECK
-    # =========================
-
-    def find_duplicate_entities(self, entity: Dict) -> Optional[str]:
-
-        name = entity.get("name", "")
-        normalized = self._normalize_name(name)
-
-        t = entity.get("type", "concept")
-        d = self.entity_path / t
-
-        if not d.exists():
-            return None
-
-        for f in d.glob("*.md"):
-            fm = self._read_frontmatter(f)
-            if not fm:
-                continue
-
-            if fm.get("normalized_name") == normalized:
-                return str(f)
-
-        return None
-
-__all__ = ["WikiFrontmatterMixin"]
+__all__ = ["WikiCreateMixin"]

--- a/core/wiki_generator/_frontmatter/id_gen.py
+++ b/core/wiki_generator/_frontmatter/id_gen.py
@@ -1,0 +1,32 @@
+"""ID generation + name normalisation — sub-mixin of
+``WikiFrontmatterMixin``.
+
+Extracted from the legacy single-file
+``core/wiki_generator/_frontmatter.py`` during the v0.6 oversize-module
+split (CLAUDE.md rule #5). Behaviour is byte-identical; only the
+location moved.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+class WikiIdGenMixin:
+
+    def _generate_entity_id(self, name: str, entity_type: str) -> str:
+        normalized = self._normalize_name(name)
+
+        # 보안: SALT 추가
+        SALT = "JAMES_SECURE_V1"
+        raw = f"{normalized}_{entity_type}_{SALT}"
+
+        # graph_rag_engine 정규식 {8} 일치
+        h = hashlib.sha256(raw.encode()).hexdigest()[:8]
+        return f"e_{entity_type}_{h}"
+
+    def _normalize_name(self, name: str) -> str:
+        return re.sub(r"[^\w가-힣]", "_", name.strip().lower())
+
+
+__all__ = ["WikiIdGenMixin"]

--- a/core/wiki_generator/_frontmatter/init_state.py
+++ b/core/wiki_generator/_frontmatter/init_state.py
@@ -1,0 +1,85 @@
+"""Instance state initialiser + index template — sub-mixin of
+``WikiFrontmatterMixin``.
+
+Extracted from the legacy single-file
+``core/wiki_generator/_frontmatter.py`` during the v0.6 oversize-module
+split (CLAUDE.md rule #5). Behaviour is byte-identical to the pre-split
+file; only the location moved.
+
+The ``WIKI_DIR`` binding is late-imported from ``core.wiki_generator``
+inside ``__init__`` so the test pattern
+``import core.wiki_generator as wg_mod; wg_mod.WIKI_DIR = tmp``
+keeps working after the Stage C.1 split.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from core.relations_schema import ENTITY_TYPES_CORE
+from core.vector_store import VectorStore
+from llm.router import RouterWrapper
+from utils.metadata import MetadataGenerator
+
+
+class WikiInitStateMixin:
+
+    def __init__(self, source_type: str = "prod"):
+        """
+        [P4.5-1] source_type 분리
+          source_type='prod' → wiki/entity/prod/{type}/
+          source_type='test' → wiki/entity/test/{type}/
+        """
+        # Late-bind WIKI_DIR: tests do ``wg_mod.WIKI_DIR = tmp`` between
+        # instantiations, so reading the binding at __init__ time
+        # (rather than at module import) is the load-bearing invariant.
+        from core.wiki_generator import WIKI_DIR
+
+        self.gemma_client = RouterWrapper("extract")
+        self.metadata_gen = MetadataGenerator()
+        self.vector_store = VectorStore()
+
+        # [P4.5-1] source_type에 따라 entity 경로 분리
+        self.source_type    = source_type if source_type in ("prod", "test") else "prod"
+        self.wiki_base_path = Path(WIKI_DIR)
+        self.entity_path    = self.wiki_base_path / "entity" / self.source_type
+
+        # ENTITY_TYPES_CORE = 5 types (event 5th, PR-11). LLM extraction
+        # prompt below still emits only 3 types (person/org/concept);
+        # `document` is post-processor source-attribution; `event` is
+        # admin POST path (PR-11a-2). Directory listing / index build /
+        # search default to all 5 — empty event/ dir is a no-op until
+        # the first admin event creation.
+        self.entity_types = list(ENTITY_TYPES_CORE)
+
+        for t in self.entity_types:
+            (self.entity_path / t).mkdir(parents=True, exist_ok=True)
+
+        self.index_path = self.wiki_base_path / "index.md"
+        if not self.index_path.exists():
+            self._create_index_template()
+
+        self.entity_id_index: Dict[str, Path] = {}
+        self._build_entity_id_index()
+
+    def _create_index_template(self):
+        """index.md 초기 템플릿 생성"""
+
+        content = (
+            "---\n"
+            f'updated_at: "{datetime.now().isoformat()}"\n'
+            "total_entities: 0\n"
+            "---\n\n"
+            "# 자메스 Wiki Index\n\n"
+            "## person (0)\n\n"
+            "## concept (0)\n\n"
+            "## org (0)\n\n"
+            "## document (0)\n\n"
+            "## event (0)\n"
+        )
+
+        self.index_path.write_text(content, encoding="utf-8")
+
+
+__all__ = ["WikiInitStateMixin"]

--- a/core/wiki_generator/_frontmatter/read.py
+++ b/core/wiki_generator/_frontmatter/read.py
@@ -1,0 +1,179 @@
+"""Frontmatter read + entity-id index build + search/duplicate detect
++ overlap snapshot + sensitivity default — sub-mixin of
+``WikiFrontmatterMixin``.
+
+Extracted from the legacy single-file
+``core/wiki_generator/_frontmatter.py`` during the v0.6 oversize-module
+split (CLAUDE.md rule #5). Behaviour is byte-identical; only the
+location moved.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+
+
+class WikiReadMixin:
+
+    # =========================
+    # INDEX BUILD
+    # =========================
+
+    def _build_entity_id_index(self):
+        self.entity_id_index.clear()
+
+        for t in self.entity_types:
+            d = self.entity_path / t
+            if not d.exists():
+                continue
+
+            for f in d.glob("*.md"):
+                fm = self._read_frontmatter(f)
+                if fm and fm.get("entity_id"):
+                    self.entity_id_index[fm["entity_id"]] = f
+
+        print(f"[INDEX] {len(self.entity_id_index)} entities loaded")
+
+    def refresh_entity_map(self):
+        self._build_entity_id_index()
+
+    def _register_entity_id(self, entity_id: str, filepath: Path):
+        self.entity_id_index[entity_id] = filepath
+
+    def _build_overlap_snapshot(self):
+        """Return `{normalized_name: (canonical_name, entity_id, entity_type)}`
+        for every existing wiki entity (any type), aliases included.
+
+        v0.4 Sprint 1 #1 addition — used by ingestion's entity-name
+        overlap detection (`_infer_overlap_relations` in `_merge.py`)
+        so a newly-ingested event named *"비트코인 spot ETF 11개
+        일괄 승인"* automatically gets a RELATED_TO relation to the
+        existing "비트코인" concept entity when its normalized name
+        appears as a token in the new entity's name.
+
+        First-write-wins: if two entities share a normalized name
+        (e.g. one canonical + one alias on a different entity), the
+        earlier one in `entity_id_index` iteration order takes
+        precedence. Tests pin this — production rarely has the
+        collision because aliases that match another canonical name
+        would already trip `_find_existing_entity_id` during ingest.
+        """
+        snapshot = {}
+        for eid, filepath in self.entity_id_index.items():
+            try:
+                fm = self._read_frontmatter(Path(filepath))
+            except Exception:
+                continue
+            if not fm:
+                continue
+            canonical = fm.get("name", "")
+            norm = fm.get("normalized_name", "") or self._normalize_name(canonical)
+            etype = fm.get("entity_type", "concept")
+            if norm and norm not in snapshot:
+                snapshot[norm] = (canonical, eid, etype)
+            for alias in fm.get("aliases", []) or []:
+                alias_norm = self._normalize_name(alias)
+                if alias_norm and alias_norm not in snapshot:
+                    snapshot[alias_norm] = (canonical, eid, etype)
+        return snapshot
+
+    # =========================
+    # ENTITY SEARCH (FIXED)
+    # =========================
+
+    def _find_existing_entity_id(
+        self,
+        name: str,
+        entity_type: Optional[str]
+    ) -> Optional[str]:
+
+        normalized = self._normalize_name(name)
+
+        # 핵심 FIX: None 대응
+        if entity_type:
+            search_types = [entity_type]
+        else:
+            search_types = self.entity_types
+
+        for t in search_types:
+            d = self.entity_path / t
+            if not d.exists():
+                continue
+
+            for f in d.glob("*.md"):
+                fm = self._read_frontmatter(f)
+                if not fm:
+                    continue
+
+                if fm.get("normalized_name") == normalized:
+                    return fm.get("entity_id")
+
+                for alias in fm.get("aliases", []):
+                    if self._normalize_name(alias) == normalized:
+                        return fm.get("entity_id")
+
+        return None
+
+    # =========================
+    # FRONTMATTER READ
+    # =========================
+
+    def _read_frontmatter(self, path: Path) -> Optional[Dict]:
+        try:
+            content = path.read_text(encoding="utf-8")
+            if not content.startswith("---"):
+                return None
+
+            end = content.find("---", 3)
+            if end < 0:
+                return None
+
+            return yaml.safe_load(content[3:end]) or {}
+        except Exception:
+            return None
+
+    # =========================
+    # SENSITIVITY DEFAULT (ABAC)
+    # =========================
+
+    @staticmethod
+    def _default_sensitivity(entity_type: str) -> str:
+        """entity_type별 기본 민감도 등급 반환"""
+        mapping = {
+            "person":   "confidential",  # 개인정보 → 기밀
+            "org":      "internal",      # 조직정보 → 내부
+            "document": "confidential",  # 문서 → 기밀
+            "concept":  "public",        # 개념/지식 → 공개
+            "event":    "internal",      # 시간 축 사건 → 내부 (PR-11b)
+        }
+        return mapping.get(entity_type, "internal")
+
+    # =========================
+    # DUPLICATE CHECK
+    # =========================
+
+    def find_duplicate_entities(self, entity: Dict) -> Optional[str]:
+
+        name = entity.get("name", "")
+        normalized = self._normalize_name(name)
+
+        t = entity.get("type", "concept")
+        d = self.entity_path / t
+
+        if not d.exists():
+            return None
+
+        for f in d.glob("*.md"):
+            fm = self._read_frontmatter(f)
+            if not fm:
+                continue
+
+            if fm.get("normalized_name") == normalized:
+                return str(f)
+
+        return None
+
+
+__all__ = ["WikiReadMixin"]

--- a/tests/test_v06_frontmatter_module_size.py
+++ b/tests/test_v06_frontmatter_module_size.py
@@ -1,0 +1,112 @@
+"""v0.6 — `core/wiki_generator/_frontmatter/` package size lock-test.
+
+CLAUDE.md rule #5: "no file in `core/` exceeds 20 KB. If your change
+pushes a file over, split first." This test locks the 4 sub-files
+of the post-split frontmatter package at < 20 KB each.
+
+Also asserts the public import surface is preserved exactly — the v0.6
+split is a no-op for callers (``core/wiki_generator/__init__.py``
+imports ``WikiFrontmatterMixin`` from ``._frontmatter``).
+
+Run:
+  python -m unittest tests.test_v06_frontmatter_module_size
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = REPO_ROOT / "core" / "wiki_generator" / "_frontmatter"
+
+CAP_BYTES = 20 * 1024  # CLAUDE.md rule #5
+
+
+class ModuleSizeCapTests(unittest.TestCase):
+    def test_legacy_single_file_removed(self):
+        legacy = REPO_ROOT / "core" / "wiki_generator" / "_frontmatter.py"
+        self.assertFalse(
+            legacy.exists(),
+            "legacy core/wiki_generator/_frontmatter.py reappeared — "
+            "both file and package can't coexist; revert and pick one",
+        )
+
+    def test_package_dir_exists(self):
+        self.assertTrue(PACKAGE.is_dir())
+
+    def test_canonical_subfiles_present(self):
+        for name in ("__init__.py", "init_state.py", "id_gen.py",
+                     "read.py", "create.py"):
+            self.assertTrue(
+                (PACKAGE / name).exists(),
+                f"missing canonical sub-file: {name}",
+            )
+
+    def test_each_subfile_under_20kb(self):
+        for path in PACKAGE.glob("*.py"):
+            size = path.stat().st_size
+            self.assertLess(
+                size, CAP_BYTES,
+                f"{path.name} is {size/1024:.1f} KB — exceeds CLAUDE.md "
+                f"rule #5 20 KB cap. Split it before merging.",
+            )
+
+
+class PublicImportSurfaceTests(unittest.TestCase):
+    def test_canonical_public_import(self):
+        from core.wiki_generator._frontmatter import WikiFrontmatterMixin
+        self.assertTrue(isinstance(WikiFrontmatterMixin, type))
+
+    def test_mixin_carries_all_canonical_methods(self):
+        from core.wiki_generator._frontmatter import WikiFrontmatterMixin
+        # Methods the merge / ingestion / index_ops mixins call via
+        # ``self`` — losing any of these breaks the package.
+        for name in (
+            "__init__",
+            "_create_index_template",
+            "_build_entity_id_index",
+            "refresh_entity_map",
+            "_register_entity_id",
+            "_build_overlap_snapshot",
+            "_generate_entity_id",
+            "_normalize_name",
+            "_find_existing_entity_id",
+            "_read_frontmatter",
+            "create_entity_file",
+            "_default_sensitivity",
+            "find_duplicate_entities",
+        ):
+            self.assertTrue(
+                hasattr(WikiFrontmatterMixin, name),
+                f"WikiFrontmatterMixin missing canonical method: {name}",
+            )
+
+    def test_top_level_wiki_generator_still_constructs(self):
+        # End-to-end smoke that the MRO composition + WikiGenerator
+        # façade still works post-split.
+        from core.wiki_generator import WikiGenerator
+        # Construction touches every sub-mixin's __init__ path.
+        wg = WikiGenerator(source_type="test")
+        self.assertEqual(wg.source_type, "test")
+        self.assertTrue(hasattr(wg, "entity_id_index"))
+        self.assertTrue(hasattr(wg, "wiki_base_path"))
+
+    def test_id_gen_contract(self):
+        from core.wiki_generator._frontmatter import WikiFrontmatterMixin
+        # _generate_entity_id is deterministic + carries the
+        # e_<type>_<8hex> shape graph_rag_engine regex expects.
+        import re
+        wf = WikiFrontmatterMixin.__new__(WikiFrontmatterMixin)
+        eid = wf._generate_entity_id("Anthropic", "org")
+        self.assertTrue(re.fullmatch(r"e_org_[0-9a-f]{8}", eid), eid)
+        # Same input → same id.
+        self.assertEqual(eid, wf._generate_entity_id("Anthropic", "org"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Split the 21.4 KB single file into a 4-file package via MRO sub-mixin composition. CLAUDE.md rule #5: no file in `core/` exceeds 20 KB.
- Public import surface preserved byte-identically: `core/wiki_generator/__init__.py` still does `from ._frontmatter import WikiFrontmatterMixin`.
- **Refactor 5/5 (FINAL)** of the v0.6 oversize-module cleanup. The 20 KB cap is now satisfied across all of `core/`, and 5 lock-tests (reflect / gemma_client / replay_graph / ingestion / frontmatter) prevent regrowth past the cap on future PRs.

Sub-files (all < 20 KB):

| File | Size | Contents |
|---|---|---|
| `__init__.py` | 2.3 KB | composes `WikiFrontmatterMixin` from 4 sub-mixins via MRO |
| `init_state.py` | 3.0 KB | `WikiInitStateMixin` — `__init__` + `_create_index_template` (late-binding `WIKI_DIR` lives here) |
| `id_gen.py` | 0.9 KB | `WikiIdGenMixin` — `_generate_entity_id` + `_normalize_name` |
| `read.py` | 5.7 KB | `WikiReadMixin` — index build, overlap snapshot, search, frontmatter read, sensitivity default, duplicate detect |
| `create.py` | 12.3 KB | `WikiCreateMixin` — `create_entity_file` (the orchestrator) |

`WikiFrontmatterMixin` is composed from the 4 sub-mixins via MRO: Create → Read → IdGen → InitState → object. No method-name collisions exist, so the MRO order is documentation-driven (top-down by layer), not load-bearing.

## Verification
- `python -m unittest tests.test_v06_frontmatter_module_size` → 8/8 OK (size cap + import surface + canonical method preservation + `WikiGenerator(source_type="test")` end-to-end smoke + `_generate_entity_id` determinism).
- `python -m unittest discover -s tests -p "test_phase_b_*.py"` → 13/13 OK.
- `python -m unittest discover -s tests -p "test_event_*.py"` → 62/62 OK.
- `python -m unittest tests.test_attributes_summary_cleanup tests.test_entity_type_extension` → 13/13 OK.

## Out of scope
- Behaviour change of any kind — pure mechanical split.

Quality delta: exempt (label: chore) — no `core/retrieval`, `core/graph`, or `core/reasoning` behaviour touched.

## v0.6 oversize-module cleanup — final summary

| # | File | Pre-split | PR |
|---|---|---|---|
| 1 | `core/reasoning/reflect.py` | 29.2 KB | #900 |
| 2 | `core/gemma_client.py` | 24.3 KB | #901 |
| 3 | `core/lifecycle/replay_graph.py` | 23.0 KB | #902 |
| 4 | `core/wiki_generator/_ingestion.py` | 22.5 KB | #903 |
| 5 | `core/wiki_generator/_frontmatter.py` | 21.4 KB | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)