### PR TITLE
docs(v0.6): CSP nonce script-flag graduation deployment guide

### DIFF
--- a/docs/deployment/v0.6-csp-nonce-graduation.md
+++ b/docs/deployment/v0.6-csp-nonce-graduation.md
@@ -1,0 +1,254 @@
+# CSP Nonce Graduation — Operator Deployment Guide (v0.6 Track C)
+
+> **Status**: Operator-facing config doc. Pairs with the Track C
+> per-request nonce primitive (PR #884, `core/security/csp_nonce.py`)
+> + the directive-composition seam in
+> `core/security/headers.py::build_security_headers` + the UI #4
+> inline-script removal (PR #855) that makes the script-flag graduation
+> safe.
+>
+> **Audience**: anyone deploying JAMES with strict-mode CSP, or
+> auditing the gap between the current `'unsafe-inline'` posture and
+> the v0.6 nonce-bound target. **No measurement, no behavior change**
+> if you don't set either flag.
+>
+> **CLAUDE.md rule #1**: the nonce primitive is horizontal —
+> content-agnostic, no domain coupling. The `style-src` flag is
+> reserved for after the UI #6 inline-style migration lands.
+
+---
+
+## 1. TL;DR — what to set, and when
+
+| Env var | Local dev | Hardened pilot | Strict-mode SaaS |
+|---|---|---|---|
+| `JAMES_CSP_USE_NONCE_SCRIPT` | _unset_ | **`1`** | **`1`** |
+| `JAMES_CSP_USE_NONCE_STYLE` | _unset_ | _unset_ | _unset_ until UI #6 migration lands |
+
+**The one flag you can safely set TODAY** is
+`JAMES_CSP_USE_NONCE_SCRIPT=1`. The other flag is documented for
+completeness but **WILL break the UI** if you set it before the
+inline-style migration completes.
+
+---
+
+## 2. Why these two flags exist (and why one breaks the UI)
+
+The two CSP directives have very different readiness states. From
+PR #884's module docstring:
+
+- **`script-src`** is already `'self'` only. After UI #4 (PR #855)
+  removed the last inline `<script>` blocks, the only scripts the
+  app loads are plain `.js` files from `/static/`. Adding
+  `'nonce-<value>'` to the directive is **additive and safe** —
+  modern browsers prefer the nonce when present, older browsers
+  see the unchanged `'self'`. No HTML rewrite required.
+
+- **`style-src`** still carries `'unsafe-inline'` because 409
+  inline `style="..."` attributes remain across the 4 admin HTML
+  pages (see `docs/reviews/v0.5-ui-6-inline-style-audit.md` §3).
+  Adding a nonce triggers **CSP3 §6.6.2.4**: modern browsers
+  ignore `'unsafe-inline'` when ANY nonce is present in the same
+  directive. Every one of those 409 inline attributes becomes a
+  blocked CSP violation. **Setting this flag before the migration
+  lands hard-breaks every operator-facing surface**.
+
+The split flag design (PR #884) lets an operator graduate
+`script-src` to nonce-bound TODAY while leaving `style-src` for
+the cycle that picks Option A (per-style nonce injection) or
+Option B (mass attribute → utility-class conversion) from the
+UI #6 audit.
+
+---
+
+## 3. Graduating `script-src` — what to do
+
+### 3.1 Verify your install is on the post-#855 baseline
+
+A 5-second pre-flight: confirm no inline `<script>` block ships
+in any page you serve.
+
+```powershell
+# PowerShell
+Select-String -Path "frontend/*.html" -Pattern "<script>" -CaseSensitive
+```
+
+```bash
+# bash
+grep -RHn "<script>" frontend/*.html
+```
+
+The expected output is empty. If anything matches, that page will
+break the moment a nonce is added because the inline block carries
+no `nonce="..."` attribute. Move that script into a `.js` file
+under `/static/` before graduating.
+
+External `<script src="...">` tags are fine — they're not blocked
+by `'nonce-<value>'`, only by `script-src` not listing their origin.
+
+### 3.2 Set the env var on the production process
+
+Add **one line** to your systemd unit (or Docker compose env, or
+PM2 ecosystem file):
+
+```ini
+# systemd: /etc/systemd/system/james.service.d/override.conf
+[Service]
+Environment="JAMES_CSP_USE_NONCE_SCRIPT=1"
+```
+
+```yaml
+# docker-compose.yml
+services:
+  james:
+    environment:
+      JAMES_CSP_USE_NONCE_SCRIPT: "1"
+```
+
+Reload + restart:
+
+```powershell
+sudo systemctl daemon-reload
+sudo systemctl restart james
+```
+
+### 3.3 Verify the directive lands
+
+```powershell
+curl.exe -sI https://your-deployment/admin/ | Select-String "content-security-policy"
+```
+
+Expected: the `script-src` directive carries a `'nonce-<value>'`
+token alongside `'self'`. The value rotates per request.
+
+```text
+content-security-policy: ...; script-src 'self' 'nonce-A1B2c3D4...'; ...
+```
+
+If the directive does NOT show a nonce, check that:
+
+1. The env var resolves inside the running process:
+   `sudo systemctl show james -p Environment` (systemd) or
+   `docker exec james env | grep CSP` (Docker).
+2. The truthiness check in `csp_use_nonce_for_scripts()` accepts
+   `1`, `true`, `yes`, `on`, or `enabled` (case-insensitive).
+   Anything else (including the empty string) is read as **off**.
+
+### 3.4 Verify there are no script-src violations
+
+Tail the browser console for one round-trip through the admin UI,
+or enable CSP reporting (separate flag, out of scope for this
+doc). No `Refused to execute inline script` warnings means the
+graduation is clean.
+
+---
+
+## 4. Why NOT to graduate `style-src` yet
+
+Setting `JAMES_CSP_USE_NONCE_STYLE=1` on the current baseline
+hard-breaks the UI. The browser refuses every inline attribute
+because the directive now reads roughly:
+
+```text
+style-src 'self' 'nonce-XYZ' 'unsafe-inline';
+```
+
+…and per CSP3 §6.6.2.4 modern browsers IGNORE `'unsafe-inline'`
+when a nonce is present. The 409 inline `style="..."` attributes
+across `frontend/admin*.html`, `frontend/dashboard.html`, etc.,
+have **no `nonce` attribute and cannot have one** — CSP nonces
+attach to `<style>` BLOCK elements, not to per-attribute styles
+(CSP3 §6.6).
+
+The UI #6 audit at `docs/reviews/v0.5-ui-6-inline-style-audit.md`
+§4 documents two migration paths. Either must land BEFORE this
+flag is safe:
+
+| Option | Approach | Effort | Reversibility |
+|---|---|---|---|
+| A | Convert each `style="..."` to a `<style nonce="X">` block in the page head + class hook | High (409× × 4 pages) | Low (touches every page) |
+| B | Convert the top-13 repeated patterns to utility classes in `tokens.css`, leave the long tail | Medium (one screenshot baseline + 13 class additions) | High (additive only) |
+
+The `v0.6-entry-skeleton-2026-06-13.md` §5 lists "UI #6 partial
+Option B (top-13 pattern only)" as a NEW solo-doable item for a
+future session, gated on a visual-regression baseline first.
+
+---
+
+## 5. Rollback — turn the script-flag back off
+
+If anything regresses, unset the env var and restart:
+
+```ini
+[Service]
+Environment="JAMES_CSP_USE_NONCE_SCRIPT="
+```
+
+```powershell
+sudo systemctl daemon-reload
+sudo systemctl restart james
+```
+
+The directive returns to its pre-graduation shape (`script-src 'self'`)
+on the next request. No HTML or template changes are required to
+roll back — the flag is a pure runtime gate.
+
+---
+
+## 6. What this graduation is NOT
+
+- **Not enforce-mode CSP** — the `script-src` nonce graduation
+  works under both `report-only` and `enforce` modes. The
+  `JAMES_CSP_MODE=enforce` flip is a separate decision, gated on
+  the UI #6 migration (per `v0.6-entry-skeleton-2026-06-13.md` §3
+  Track C row).
+- **Not a strict-dynamic** posture — CSP3's
+  `'strict-dynamic'` keyword changes the trust delegation
+  semantics for nonce-loaded scripts. JAMES doesn't load scripts
+  that transitively load other scripts, so the keyword would be
+  a no-op + footgun (an operator setting it would inadvertently
+  trust scripts that `eval`-load helpers). Reserved.
+- **Not an HTML rewriter** — see PR #884 module docstring §"What
+  this module is NOT". The graduation depends on the page baseline
+  (zero inline `<script>` blocks). Verify with §3.1 before
+  graduating, not after.
+
+---
+
+## 7. References
+
+- `core/security/csp_nonce.py` — the per-request nonce primitive
+  + the two predicate functions the middleware consults.
+- `core/security/headers.py::build_security_headers` — directive
+  composition seam.
+- `server_llmwiki.py::security_headers_middleware` — middleware
+  wire-in (the one place this primitive composes with).
+- `docs/reviews/v0.5-ui-6-inline-style-audit.md` — the
+  inline-style audit + the Option A / Option B migration paths
+  that gate the `style-src` flag.
+- `docs/handovers/v0.5-close-2026-06-12.md` §5.3 — Track C work
+  queue + the `JAMES_CSP_MODE=enforce` default-flip rationale.
+- `docs/handovers/v0.6-entry-skeleton-2026-06-13.md` §5 — the
+  "NEW solo-doable items" list this doc resolves one entry of.
+
+---
+
+## 8. Korean summary (한국어 요약)
+
+**CSP nonce graduation (Track C v0.6, PR #884 follow-up)**:
+
+- **오늘 안전하게 설정 가능**: `JAMES_CSP_USE_NONCE_SCRIPT=1` —
+  `script-src` directive 가 per-request nonce 추가. UI #4 (PR #855)
+  이후 inline `<script>` 0 개 → 호환 안전. modern 브라우저는
+  nonce 채택, 구버전은 `'self'` 그대로.
+- **설정 절대 금지** (UI #6 마이그레이션 전): `JAMES_CSP_USE_NONCE_STYLE=1` —
+  409 개 inline `style="..."` 속성이 CSP3 §6.6.2.4 에 의해 모두
+  차단됨. 운영 UI 전체 깨짐.
+- **사전 확인 (§3.1)**: `frontend/*.html` 안에 `<script>` block
+  검색 결과 0 건이어야 함. 한 건이라도 매칭되면 그 페이지가
+  graduation 직후 깨짐.
+- **롤백 (§5)**: env var 빈 문자열 또는 unset 후 재시작. HTML/
+  템플릿 변경 없이 1 회 요청 만에 원상복귀.
+- **enforce mode (`JAMES_CSP_MODE=enforce`) 별개 결정**: UI #6
+  inline-style 마이그레이션 (Option A 또는 B) 완료 후 같은 사이클
+  에서 결정.

--- a/tests/test_v06_csp_graduation_doc.py
+++ b/tests/test_v06_csp_graduation_doc.py
@@ -1,0 +1,149 @@
+"""v0.6 Track C — CSP nonce graduation doc structural test.
+
+Pins the canonical sections + the script-vs-style flag separation
++ the §3.1 pre-flight `grep <script>` instruction. A future PR that
+deletes the per-flag warning OR merges the script flag with the
+style flag would silently let an operator graduate `style-src`
+before the UI #6 migration lands → hard UI break in production.
+This test surfaces such a regression at PR time.
+
+Run:
+  python -m unittest tests.test_v06_csp_graduation_doc
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC = REPO_ROOT / "docs" / "deployment" / "v0.6-csp-nonce-graduation.md"
+
+
+class DocPresenceTests(unittest.TestCase):
+    def test_doc_exists(self):
+        self.assertTrue(DOC.is_file(),
+                        "graduation doc removed — Track C follow-up "
+                        "needs it to land safely")
+
+    def setUp(self):
+        self.body = DOC.read_text(encoding="utf-8")
+
+
+class CanonicalSectionsTests(DocPresenceTests):
+    """The doc must keep its operator-orienting structure."""
+
+    def test_carries_canonical_sections(self):
+        # Match `## N. ` at start of line (allow trailing title text).
+        for n in (1, 2, 3, 4, 5, 6, 7, 8):
+            with self.subTest(section=n):
+                pattern = re.compile(rf"^## {n}\.", re.MULTILINE)
+                self.assertTrue(
+                    pattern.search(self.body),
+                    f"missing section ## {n}.",
+                )
+
+    def test_tldr_table_lists_both_flags(self):
+        # §1 must mention both env vars explicitly so an operator
+        # scanning the TL;DR can't graduate the wrong one.
+        self.assertIn("JAMES_CSP_USE_NONCE_SCRIPT", self.body)
+        self.assertIn("JAMES_CSP_USE_NONCE_STYLE", self.body)
+
+
+class FlagSeparationContractTests(DocPresenceTests):
+    """The whole point of the split-flag design (PR #884) is that
+    one flag is safe today + the other one breaks the UI. The doc
+    MUST carry both halves of that contract verbatim — a future
+    edit that drops the warning would invite a production break."""
+
+    def test_script_flag_marked_safe_today(self):
+        # Look for the canonical safety phrase OR an equivalent
+        # ("safe today", "safely set", "safely TODAY", etc.).
+        head = self.body.lower()
+        safe_phrases = [
+            "safe to set today",
+            "safely set today",
+            "safe to graduate today",
+            "safely set",
+            "안전하게 설정",
+        ]
+        self.assertTrue(
+            any(p in head for p in safe_phrases),
+            "doc must declare the script flag safe-today somewhere — "
+            "otherwise operators won't graduate the one flag that's "
+            "actually ready",
+        )
+
+    def test_style_flag_marked_breaks_ui(self):
+        head = self.body.lower()
+        break_phrases = [
+            "break the ui",
+            "breaks the ui",
+            "hard-break",
+            "hard break",
+            "ui 전체 깨짐",
+            "ui 깨짐",
+            "깨짐",
+        ]
+        self.assertTrue(
+            any(p in head for p in break_phrases),
+            "doc must warn that the style flag breaks the UI today — "
+            "otherwise an operator graduates it and takes prod down",
+        )
+
+    def test_csp3_section_referenced(self):
+        # The mechanism reference matters: an operator who hits the
+        # break wants to grep for "CSP3 §6.6.2.4" to understand why.
+        self.assertIn("CSP3 §6.6.2.4", self.body,
+                      "the §6.6.2.4 reference is the canonical "
+                      "browser-side rule that explains the break")
+
+
+class PreFlightCheckTests(DocPresenceTests):
+    """§3.1 pre-flight verification — without it operators graduate
+    without checking the baseline → script flag breaks pages that
+    still ship an inline <script>."""
+
+    def test_preflight_section_present(self):
+        self.assertIn("3.1", self.body,
+                      "the §3.1 pre-flight check section is required")
+
+    def test_preflight_greps_for_inline_script(self):
+        # Both Powershell + bash hints must include a literal `<script>`
+        # target so an operator copy-pastes the right command.
+        self.assertIn("<script>", self.body,
+                      "the pre-flight grep target is the literal "
+                      "`<script>` open tag")
+
+
+class RollbackPathTests(DocPresenceTests):
+    """A graduation doc without a rollback path is half a doc."""
+
+    def test_rollback_section_present(self):
+        self.assertTrue(
+            re.search(r"^## 5\. Rollback", self.body, re.MULTILINE),
+            "the §5 rollback section must exist — otherwise an "
+            "operator who hits a regression has no documented escape",
+        )
+
+    def test_rollback_returns_to_unflagged_state(self):
+        # The rollback section MUST describe unsetting the env var,
+        # not "leave the flag and patch CSP" or similar.
+        rollback_block = self.body.split("## 5.")[1].split("## 6.")[0]
+        head = rollback_block.lower()
+        self.assertTrue(
+            any(p in head for p in (
+                "unset", "empty string", 'environment=""', "환경 변수"
+            )),
+            "rollback should be unsetting the env var, not patching "
+            "the directive",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `docs/deployment/v0.6-csp-nonce-graduation.md` — the operator-facing guide that pairs with PR #884's per-request nonce primitive.
- Resolves the **"CSP nonce script-flag graduation doc"** entry from `docs/handovers/v0.6-entry-skeleton-2026-06-13.md` §5 NEW solo-doable items.
- Adds `tests/test_v06_csp_graduation_doc.py` — 14 assertions that pin the canonical structure + the safe-today / breaks-the-UI contract.

## Why
PR #884 shipped `JAMES_CSP_USE_NONCE_SCRIPT` + `JAMES_CSP_USE_NONCE_STYLE`. The script flag is safe to set today (zero inline scripts after UI #4 PR #855); the style flag hard-breaks the UI (409 inline `style="..."` attributes trigger CSP3 §6.6.2.4). Without this deployment doc the asymmetry only lives in the module docstring + the close-handover §5.3 — neither of which a production operator naturally finds.

## Doc structure
1. TL;DR table (which flag in which posture)
2. Why the two flags exist (CSP3 §6.6.2.4 mechanism)
3. Graduation procedure with §3.1 5-second pre-flight `grep <script>`
4. Why the style flag is reserved (UI #6 audit + Option A/B paths)
5. Rollback (unset env + restart, no HTML changes)
6. What this graduation is NOT (enforce mode separate)
7. References
8. Korean summary

## Verification
- `python -m unittest tests.test_v06_csp_graduation_doc` → 14/14 OK (structural sections + flag-separation contract + pre-flight check + rollback path).

## Out of scope
- The `JAMES_CSP_MODE=enforce` default flip — separate decision, gated on UI #6 inline-style migration (per `v0.6-entry-skeleton` §3 Track C row).
- The UI #6 Option A/B migration itself — separate NEW solo-doable item, gated on a visual-regression baseline.

Quality delta: exempt (label: docs) — no `core/` behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)