### PR TITLE
docs(v0.6): template-formatting engine session-close handover

### DIFF
--- a/docs/handovers/v0.6-template-engine-close-2026-06-13.md
+++ b/docs/handovers/v0.6-template-engine-close-2026-06-13.md
@@ -1,0 +1,100 @@
+# v0.6 Template-Formatting Engine — Session Close (2026-06-13)
+
+> **Status**: feature **shipped + merged to main** (PR #909, squash
+> `9ef818c`). This closes the Track F mother-level UI item "양식 엔진"
+> (horizontal document-shaping engine). Cycle state unchanged:
+> **v0.5 closed, v0.6 not formally entered** — the Dim F gate (≥6mo
+> external pilot / LOI) is still operator-pending (see
+> `v0.6-entry-skeleton-2026-06-13.md`, which remains the first-read
+> bridge doc).
+>
+> **Audience**: next session. This is a *feature-close* note, not a
+> cycle-entry doc. Nothing here re-opens the two-fork v0.6 entry
+> contract.
+
+---
+
+## 1. What shipped (PR #909, 7-PR series squashed)
+
+A **domain-agnostic** template-formatting engine. Operator registers a
+template/form in the workspace (file, image-OCR, or pasted text),
+pastes raw content, and JAMES runs one LLM reshaping pass that lays the
+content onto the template structure and returns a downloadable file
+(md / txt / html).
+
+| PR | What |
+|----|------|
+| PR-0 | design memo `docs/design/v0.6-template-formatting-ui.md` + `ARCHITECTURE.md` §5.7.14 |
+| PR-1 | `core/templating/` store + spec (placeholder parse, owner-scoped store) |
+| PR-2 | `core/templating/formatter.py` (LLM reshape) + `render.py` (md/txt/html) |
+| PR-3 | `routes/templating.py` (create/list/detail/apply/download/delete), registered in `server_llmwiki.py` |
+| PR-4 | workspace "Templates" tab (`frontend/workspace.html` + `workspace.js`) |
+| PR-5 | image mode — server-side Tesseract OCR ingest (`core/templating/ingest.py`) |
+| PR-6 | chat-page apply modal (`frontend/static/templating-chat.js`, self-contained) |
+
+## 2. Architecture / contract
+
+- **Backend** (`routes/templating.py`, owner-scoped):
+  - `POST /templates/` — register `{name, raw_text, mode}` → `{id, ...}`
+  - `GET  /templates/mine/list` → `{items:[meta]}`
+  - `GET  /templates/{id}` → `{...tpl, spec:{placeholders}, outputs:[...]}`
+  - `POST /templates/{id}/apply` `{raw_content, fmt}` → `{out_id, preview, filename}`
+  - `GET  /templates/{id}/output/{out_id}` → file download (Content-Disposition)
+  - `DELETE /templates/{id}`
+  - `POST /templates/ingest-image` (multipart) → `{raw_text, mode:"image"}` (OCR, returns text for review before register)
+- **Auth**: `api_key` (query or X-API-Key) + JWT Bearer. Owner = JWT
+  sub (`_bearer_username`). Others' resources → **404** (no existence
+  leak). No login → **401**. Bad/traversal id → **400**.
+- **OCR**: lazy `pytesseract` + `PIL`, honours `config.TESSERACT_PATH`,
+  `lang="kor+eng"`, `--psm 6`. `ingest.py` is self-contained (no heavy
+  FileProcessor / RouterWrapper, no cv2/whisper imports).
+- **Frontend**: workspace tab (full register+apply+download) + chat
+  modal (apply-only; registration stays in workspace). `templating-
+  chat.js` reads `james_token`/`james_api_key` from localStorage and
+  registers its **own** click delegation for `tplc-*` actions — chat.js's
+  send pipeline is untouched (both click listeners fire; chat.js ignores
+  unknown actions). EN+KO i18n under `tplchat.*` and `workspace.tpl_*`.
+
+## 3. Rule compliance (all green)
+
+- **Rule #1 (no vertical)**: JAMES ships **zero** templates; every
+  template is runtime workspace user data. Mechanical grep clean — no
+  template content under `core/` / `frontend/` / seed paths. This is
+  the spine of the design (memo §1).
+- **Rule #2 (bench gate)**: touches **no** `core/retrieval` /
+  `core/graph` / `core/reasoning` → `feat` label, Quality Delta Card
+  exempt. Streak of 0 lines changed in those layers is preserved.
+- **Rule #5 (20 KB)**: largest `core/templating` file = `store.py` 8 KB.
+
+## 4. Verification done
+
+- 37 templating tests pass: `python -m unittest
+  tests.test_v06_templating_store_spec
+  tests.test_v06_templating_formatter_render
+  tests.test_v06_templating_routes tests.test_v06_templating_ingest`
+  (store/spec 8 + formatter/render 10 + routes 8 + ingest 11).
+- Route registration confirmed on main (ServerRegistrationTests OK).
+- `node --check` clean on `templating-chat.js` + `i18n.js`.
+- **Not done (no live LLM/UI run this session)**: end-to-end browser
+  click-through (register → paste → format → download) and a real
+  Tesseract OCR pass were **not** exercised live — tests stub the LLM
+  and OCR. First natural next step if touched again = one live smoke in
+  the browser (golden path + a Korean image) before claiming UX-complete.
+
+## 5. Follow-ups / not in scope
+
+- Live e2e smoke (above) — operator-runnable.
+- `git push` surfaced a **Dependabot** alert on the default branch:
+  **2 critical + 2 low**. Unrelated to this feature; worth triaging
+  next session: https://github.com/Hashevolution/James-RAG-Evol/security/dependabot
+- v0.6 cycle entry itself remains gated on the Dim F fork decision —
+  unchanged; see the entry skeleton.
+
+## 6. Where this sits in the bigger picture
+
+This is one more **Track F (mother-level UI)** solo-doable, LOI-
+independent capability landed during the "v0.5 closed, v0.6 not yet
+entered" interval — same posture as the #863–#885 run the entry
+skeleton documents. The four-layer rule #1 protection contract held.
+Next session's first read is still
+`docs/handovers/v0.6-entry-skeleton-2026-06-13.md`.


### PR DESCRIPTION
## Summary
Session-close handover for the v0.6 template-formatting engine (shipped in #909). Backend contract, rule #1/#2/#5 compliance, verification status (no live e2e/OCR smoke yet), Dependabot follow-up, and confirmation the Dim F entry gate is unchanged.

## Out of scope
Docs only — no code changes. `docs` label → Quality delta: exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)