### PR TITLE
docs(v0.6): extend Dependabot triage with torch #17/#18 + guardrail tests

### DIFF
--- a/docs/security/dependabot-2026-06-10-risk-assessment.md
+++ b/docs/security/dependabot-2026-06-10-risk-assessment.md
@@ -1,15 +1,23 @@
 # Dependabot risk assessment — 2026-06-10
 
+> **Update 2026-06-13**: §3 added for two new low-severity torch
+> advisories (#17 / #18, CVE-2025-3000, `torch.jit.script` memory
+> corruption). Same risk-accept pattern as chromadb: no JAMES call
+> site exercises the vulnerable function. Original §1/§2 unchanged.
+
 Open alerts on `main` at the time of this assessment:
 
 | # | Package | Severity | CVE | Manifest | Disposition |
 |---|---|---|---|---|---|
+| 18 | torch | low | CVE-2025-3000 | `requirements.txt` (transitive) | **Risk-accept** (not reachable; awaiting upstream patch) — §3 |
+| 17 | torch | low | CVE-2025-3000 | `requirements_pinned.txt` | **Risk-accept** (same) — §3 |
 | 16 | starlette | medium | CVE-2026-48710 | `requirements.txt` | **Fix** (floor pin → 1.0.1) |
 | 15 | starlette | medium | CVE-2026-48710 | `requirements_pinned.txt` | **Fix** (pin 1.0.0 → 1.0.1) |
 | 14 | chromadb | critical | CVE-2026-45829 | `requirements.txt` | **Risk-accept** (not exploitable; awaiting upstream patch) |
 | 13 | chromadb | critical | CVE-2026-45829 | `requirements_pinned.txt` | **Risk-accept** (same) |
 
-Two distinct advisories; each fires once per manifest.
+Three distinct advisories; each fires once per manifest where the
+package surfaces.
 
 ---
 
@@ -107,7 +115,66 @@ such code path exists, and adding one would be a separate review).
 
 ---
 
-## 3. Auditability note
+## 3. torch — CVE-2025-3000 (jit.script memory corruption)
+
+> Added 2026-06-13. Alerts #17 / #18 surfaced after the original
+> 2026-06-10 assessment.
+
+**GHSA-rrmf-rvhw-rf47.** Memory corruption in `torch.jit.script`
+when passed maliciously crafted input. Severity: **low** (local-host
+attack, requires the attacker to supply Python source / a serialized
+JIT module to a process that calls `torch.jit.script` on it).
+Vulnerable range: torch ≤ 2.12.0. **No patched version published as
+of 2026-06-13.**
+
+### JAMES exposure — risk-accept rationale
+
+The vulnerable function is **not called** from any JAMES code path:
+
+1. **Zero `torch.jit.script` call sites.** Repo-wide grep for
+   `torch.jit.script` / `torch.jit.load` / `jit.script` returns
+   zero matches. No JAMES module compiles or loads a JIT module.
+2. **Single direct torch import** — `eval/external/lrb/nli_verifier.py`
+   uses only `torch.no_grad()` (context manager for inference) and
+   `torch.softmax()` (numeric op). Neither is the vulnerable
+   surface.
+3. **Transitive usage only otherwise.** torch is pulled in by
+   `sentence-transformers` and `transformers` for embedding /
+   reranker model forward passes. Those libraries call the
+   high-level `model(...)` interface, not `torch.jit.script`. They
+   may use JIT *internally* on pretrained weights they bundle, but
+   the attack model (CVE-2025-3000) requires attacker-controlled
+   JIT source to reach the corruption — JAMES never accepts
+   user-controlled JIT input.
+4. **Local-host attack model.** The CVE describes "possible to
+   launch the attack on the local host." An attacker who already
+   has local execution against the JAMES process has higher-
+   privilege paths than corrupting `torch.jit` parser state.
+
+### Disposition
+
+**Risk-accept until upstream patch ships.** Concrete action:
+
+- torch is **transitive only** in `requirements.txt` (pulled in by
+  `sentence-transformers>=2.5.0`); no direct pin to add there. The
+  Dependabot scanner attributes the alert to `requirements.txt`
+  via dependency-graph inference.
+- `requirements_pinned.txt` stays at `torch==2.11.0` /
+  `torchvision==0.26.0`. No patched torch release exists to bump
+  to; bumping forward into the still-vulnerable 2.12.0 range
+  would change nothing.
+- **Re-evaluation trigger**: any PR that introduces
+  `torch.jit.script`, `torch.jit.load`, `torch.jit.trace`, or any
+  code path that passes user-supplied Python source / serialized
+  modules into a JIT call MUST revisit this assessment in the same
+  PR. The torch advisory becomes live exposure the moment any of
+  those land.
+- Dependabot alerts #17 and #18 follow the same dismissal
+  treatment as #13 / #14 (`not_used` with this document URL).
+
+---
+
+## 4. Auditability note
 
 This assessment lives in the repository at
 `docs/security/dependabot-2026-06-10-risk-assessment.md` and is

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -132,6 +132,16 @@ threadpoolctl==3.6.0
 tifffile==2026.3.3
 tiktoken==0.12.0
 tokenizers==0.22.2
+# Dependabot alerts #17/#18 — GHSA-rrmf-rvhw-rf47 / CVE-2025-3000:
+# torch.jit.script memory corruption (low). Vulnerable ≤ 2.12.0
+# with NO patched version published as of 2026-06-13.
+# JAMES risk acceptance: not reachable. Repo-wide grep for
+# torch.jit.script / torch.jit.load / jit.script returns zero
+# matches; the only direct torch import (eval/external/lrb/
+# nli_verifier.py) uses torch.no_grad() + torch.softmax() only.
+# transformers / sentence-transformers consume torch via the
+# high-level model interface, not JIT. See
+# docs/security/dependabot-2026-06-10-risk-assessment.md §3.
 torch==2.11.0
 torchvision==0.26.0
 tqdm==4.67.3

--- a/tests/test_v06_dependabot_triage_invariants.py
+++ b/tests/test_v06_dependabot_triage_invariants.py
@@ -43,7 +43,6 @@ Run:
 from __future__ import annotations
 
 import os
-import re
 import sys
 import unittest
 from pathlib import Path

--- a/tests/test_v06_dependabot_triage_invariants.py
+++ b/tests/test_v06_dependabot_triage_invariants.py
@@ -1,0 +1,208 @@
+"""v0.6 — Dependabot triage re-evaluation guardrails.
+
+`docs/security/dependabot-2026-06-10-risk-assessment.md` accepts
+three live Dependabot advisories as "not exploitable in this
+deployment" because no JAMES call site exercises the vulnerable
+surface. The risk-acceptance is conditional: §2 and §3 both name an
+explicit **re-evaluation trigger** — if a future PR introduces a
+call site that *would* reach the vulnerable surface, the dispositions
+in the doc become stale and the PR must revisit the assessment.
+
+That trigger only works if it's mechanical. A free-floating doc-side
+rule depends on a reviewer remembering to look for the trigger; this
+test makes the trigger fire automatically at PR time.
+
+Three invariants, mapped to the doc sections that justify them:
+
+  §2 chromadb (CVE-2026-45829):
+      - no import of `chromadb.HttpClient` /
+        `chromadb.AsyncHttpClient` (HTTP-server entry the CVE lives
+        on)
+      - no `trust_remote_code=True` call site (the payload-side
+        condition the CVE requires)
+
+  §3 torch (CVE-2025-3000):
+      - no `torch.jit.script` / `torch.jit.load` / `torch.jit.trace`
+        call site (the vulnerable JIT surface)
+
+Scope: production Python sources under `core/`, `routes/`,
+`scripts/`, `eval/`. Excluded: `tests/` (this file's docstring would
+self-match), `docs/` (the assessment doc names the patterns as
+"things we DON'T do"), `requirements*.txt` (comment blocks reference
+the patterns in their rationale), and any `.md` file.
+
+A future PR that legitimately needs one of these patterns must:
+  1. Update `docs/security/dependabot-2026-06-10-risk-assessment.md`
+     with the new exposure analysis.
+  2. Add the file to the per-pattern allow-list below with a
+     comment naming the assessment update.
+
+Run:
+  python -m unittest tests.test_v06_dependabot_triage_invariants
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Production source roots — where a vulnerable call site would
+# actually expose the deployment. Adding a root here widens the
+# guardrail (good); removing one narrows it (review carefully).
+SOURCE_ROOTS = ("core", "routes", "scripts", "eval")
+
+# Per-pattern allow-list. If a legitimate future use-case lands,
+# add the file's repo-relative path here and reference the doc
+# update in the comment. Empty by design — the triage doc claims
+# zero call sites today.
+_ALLOW_LIST: dict[str, frozenset[str]] = {
+    "chromadb.HttpClient":           frozenset(),
+    "chromadb.AsyncHttpClient":      frozenset(),
+    "trust_remote_code":             frozenset(),
+    "torch.jit.script":              frozenset(),
+    "torch.jit.load":                frozenset(),
+    "torch.jit.trace":               frozenset(),
+}
+
+
+def _iter_python_sources():
+    """Yield every `*.py` file under the production source roots.
+
+    Skips `__pycache__/` and any `.venv` / `venv` subtree by virtue
+    of the production-root list — none of those live under the
+    listed roots.
+    """
+    for root in SOURCE_ROOTS:
+        root_path = REPO_ROOT / root
+        if not root_path.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root_path):
+            # Prune cache dirs in place — os.walk respects mutation.
+            dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+            for name in filenames:
+                if name.endswith(".py"):
+                    yield Path(dirpath) / name
+
+
+def _grep_pattern(pattern: str) -> list[tuple[str, int, str]]:
+    """Return (relpath, lineno, line) for every match of `pattern`
+    in any production Python source.
+
+    Matching is **substring** — these are call-shape patterns
+    (`module.func`), not full regex. Substring is sufficient because
+    every pattern in `_ALLOW_LIST` is already a complete, distinctive
+    attribute reference unlikely to collide with unrelated identifiers.
+    """
+    hits: list[tuple[str, int, str]] = []
+    for path in _iter_python_sources():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            # Skip pure-comment lines — they're documenting, not calling.
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if pattern in line:
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                hits.append((rel, lineno, line.rstrip()))
+    return hits
+
+
+class ChromaDbExposureGuardrailTests(unittest.TestCase):
+    """§2 of the triage doc. CVE-2026-45829 (chromatoast) requires
+    BOTH the HTTP server surface AND `trust_remote_code=True` in a
+    user-controlled payload. Either appearing in JAMES sources means
+    the disposition (`not exploitable`) is no longer accurate."""
+
+    def _assert_zero_call_sites(self, pattern: str, section: str):
+        hits = _grep_pattern(pattern)
+        allowed = _ALLOW_LIST[pattern]
+        unexpected = [h for h in hits if h[0] not in allowed]
+        if unexpected:
+            sample = "\n  ".join(
+                f"{rel}:{lineno}: {line}"
+                for rel, lineno, line in unexpected[:5]
+            )
+            self.fail(
+                f"Dependabot triage {section} claims zero call sites "
+                f"for `{pattern}`, but {len(unexpected)} found:\n  "
+                f"{sample}\n\n"
+                f"If this is intentional, update "
+                f"`docs/security/dependabot-2026-06-10-risk-"
+                f"assessment.md` {section} with the new exposure "
+                f"analysis and add the file(s) to `_ALLOW_LIST` in "
+                f"this test."
+            )
+
+    def test_no_http_client_import(self):
+        self._assert_zero_call_sites("chromadb.HttpClient", "§2")
+
+    def test_no_async_http_client_import(self):
+        self._assert_zero_call_sites("chromadb.AsyncHttpClient", "§2")
+
+    def test_no_trust_remote_code_call_site(self):
+        self._assert_zero_call_sites("trust_remote_code", "§2")
+
+
+class TorchJitExposureGuardrailTests(unittest.TestCase):
+    """§3 of the triage doc. CVE-2025-3000 reaches the corruption
+    via `torch.jit.script` (and the related JIT entry points). If
+    any of these surface in JAMES sources, the disposition becomes
+    stale."""
+
+    def _assert_zero_call_sites(self, pattern: str):
+        hits = _grep_pattern(pattern)
+        allowed = _ALLOW_LIST[pattern]
+        unexpected = [h for h in hits if h[0] not in allowed]
+        if unexpected:
+            sample = "\n  ".join(
+                f"{rel}:{lineno}: {line}"
+                for rel, lineno, line in unexpected[:5]
+            )
+            self.fail(
+                f"Dependabot triage §3 claims zero call sites for "
+                f"`{pattern}`, but {len(unexpected)} found:\n  "
+                f"{sample}\n\n"
+                f"If this is intentional, update "
+                f"`docs/security/dependabot-2026-06-10-risk-"
+                f"assessment.md` §3 with the new exposure analysis "
+                f"and add the file(s) to `_ALLOW_LIST` in this test."
+            )
+
+    def test_no_jit_script_call_site(self):
+        self._assert_zero_call_sites("torch.jit.script")
+
+    def test_no_jit_load_call_site(self):
+        self._assert_zero_call_sites("torch.jit.load")
+
+    def test_no_jit_trace_call_site(self):
+        self._assert_zero_call_sites("torch.jit.trace")
+
+
+class TriageDocPresenceTests(unittest.TestCase):
+    """Sanity — the triage doc the other tests reference must be on
+    disk. Renaming it without updating the test would leave the
+    guardrail in a broken-pointer state."""
+
+    def test_triage_doc_exists(self):
+        doc = REPO_ROOT / "docs" / "security" / "dependabot-2026-06-10-risk-assessment.md"
+        self.assertTrue(
+            doc.is_file(),
+            f"Triage doc missing at {doc} — the guardrail's "
+            f"per-section error messages point at a non-existent "
+            f"file. Update both the doc path AND this test if the "
+            f"doc was intentionally renamed.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends `docs/security/dependabot-2026-06-10-risk-assessment.md` with §3 (torch CVE-2025-3000) and adds a mechanical guardrail that fires the assessment's "re-evaluation trigger" automatically at PR time.

Closes the **"2 critical + 2 low Dependabot alerts worth triaging next session"** follow-up from `docs/handovers/v0.6-template-engine-close-2026-06-13.md` §5.

| # | Package | Sev | CVE | Disposition |
|---|---|---|---|---|
| 13 / 14 | chromadb | **critical** | CVE-2026-45829 | Risk-accept (already triaged 2026-06-10, §2 — embedded `PersistentClient` only, no HTTP server, no `trust_remote_code` call) |
| 17 / 18 | torch | low | CVE-2025-3000 | Risk-accept (new §3 — zero `torch.jit.script` / `load` / `trace` call sites; single direct import uses `no_grad` + `softmax` only) |

`fixed_in: null` for all 4 — both upstream patches still pending. Monitor + dismiss-as-`not_used` per existing pattern.

### What landed

- **Doc**: `dependabot-2026-06-10-risk-assessment.md` gets §3 (torch), update banner, expanded header table. Original §1 / §2 unchanged. Filename unchanged (referenced from `requirements.txt`).
- **Pin comment**: `requirements_pinned.txt` torch block mirrors the chromadb comment-rationale pattern.
- **Guardrail**: `tests/test_v06_dependabot_triage_invariants.py` (7 tests) asserts zero call sites for `chromadb.HttpClient` / `AsyncHttpClient` / `trust_remote_code` / `torch.jit.script` / `load` / `trace` across `core/` / `routes/` / `scripts/` / `eval/`. If a future PR adds any, the failure names the assessment section that must be revisited.

## Verification

- chromadb: 5/5 usages = `PersistentClient` (embedded). Zero `HttpClient` / `AsyncHttpClient` grep. Zero `trust_remote_code` grep across production sources.
- torch: zero `torch.jit.*` grep. Single direct import in `eval/external/lrb/nli_verifier.py` uses only `no_grad` + `softmax`.
- 7/7 new guardrail tests pass.
- 46/46 adjacent v0.6 hygiene tests pass (`test_v06_claude_md_entry_pointer` + `test_v06_csp_graduation_doc` + `test_v06_csp_nonce` + this).

## Out of scope

- Dismissing the alerts on GitHub (`gh api ... --method PATCH`) — operator action; the doc + comment block prescribe the `not_used` disposition for the operator to execute.
- Upstream patch tracking automation — manual monitoring of `chroma-core/chroma#6717` continues as-is.
- Any vertical / domain content (Rule #1 unchanged).
- `core/retrieval` / `core/graph` / `core/reasoning` (zero lines touched — Quality Delta Card exempt, label: docs).

Quality delta: exempt (label: docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)