### PR TITLE
chore(v0.6): ignore LaTeX build artifacts under papers/ + preprint zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,23 @@ reports/*.txt
 .pytest_cache/
 htmlcov/
 
+# ── LaTeX 빌드 산출물 (papers/) ───────────────────────────────
+# papers/<id>-preprint/ 내 main.tex / main.pdf / refs.bib / README.md 만
+# 추적. main.log 는 위 *.log 글롭이 이미 차단.
+papers/**/*.aux
+papers/**/*.bbl
+papers/**/*.blg
+papers/**/*.out
+papers/**/*.toc
+papers/**/*.lof
+papers/**/*.lot
+papers/**/*.fls
+papers/**/*.fdb_latexmk
+papers/**/*.synctex.gz
+
+# Preprint 배포 zip (release 트래커가 별도; repo 추적 X)
+*-preprint.zip
+
 # ── 한국어 내부 노트 (개인 작업 파일) ──────────────────────────
 자메스_프로젝트_*
 레이어별_*


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules for LaTeX compile outputs under `papers/` and root-level preprint distribution zips. Closes the 9 untracked files + `rab-preprint.zip` surfaced in session-open `git status`.

## What ignored

Scoped to `papers/**/*` (other directories can still track LaTeX outputs intentionally if a future need arises):

- `*.aux` / `*.bbl` / `*.blg` / `*.out` / `*.toc` / `*.lof` / `*.lot` / `*.fls` / `*.fdb_latexmk` / `*.synctex.gz`

Root pattern:

- `*-preprint.zip` (mirrors the existing `backup_*.zip` shape — release tracker lives outside the repo)

`main.log` was already covered by the top-level `*.log` glob, so no duplicate rule.

## What stays tracked

`papers/<id>-preprint/`:

- `main.tex` — source
- `main.pdf` — release artifact
- `refs.bib` — source
- `README.md` — source

## Verification

- `git status` before: 9 untracked LaTeX artifacts + 1 zip
- `git status` after: clean except `.gitignore` modified
- No `core/` / `routes/` / test files touched
- `papers/**/*` scope means other directories with LaTeX use unaffected

## Out of scope

- Dependabot alerts #13/#14/#17/#18 — all 4 risk-accepted in #911, dismissal is operator action via `gh api ... --method PATCH` (separate from this PR)
- Rule #1 (zero vertical content, unchanged)
- `core/retrieval` / `core/graph` / `core/reasoning` — zero lines touched

Quality delta: exempt (label: chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)