### PR TITLE
docs(v0.6): template-formatting engine live e2e smoke guide

### DIFF
--- a/docs/deployment/v0.6-template-engine-smoke.md
+++ b/docs/deployment/v0.6-template-engine-smoke.md
@@ -1,0 +1,218 @@
+# Template Formatting Engine — Live e2e Smoke Guide (v0.6 Track F)
+
+> **Status**: Operator-runbook for the live verification missed in the
+> shipping session of PR #909 + #910. The 37 unit tests stub the LLM
+> and Tesseract, so this guide covers the three paths that need a real
+> browser + real backend before the feature can be claimed
+> UX-complete:
+>
+> 1. Workspace 골든 패스 (paste → register → apply → download)
+> 2. Korean OCR 이미지 등록 → 적용
+> 3. Chat 페이지 apply 모달
+>
+> **Audience**: anyone who has a JAMES instance up locally with the
+> normal LLM backend (Ollama / Claude CLI). About **5–8 minutes**
+> end-to-end.
+>
+> **CLAUDE.md rule #1**: the templates created during this smoke are
+> *workspace user data*, not shipped content. After the smoke, delete
+> them via the workspace tab or `DELETE /templates/{id}` so nothing
+> domain-specific leaks into a git status by accident.
+
+---
+
+## 1. 사전 조건 체크
+
+| 항목 | 확인 |
+|---|---|
+| JAMES 서버 기동 | `python server_llmwiki.py` (또는 평소 기동 스크립트), `/docs` 열어서 swagger 페이지 뜨면 OK |
+| LLM 백엔드 | 워크스페이스에서 평소처럼 채팅이 도는 상태 (Ollama gemma3:4b 등). `format_content` 가 호출 라우터를 그대로 씀 |
+| 로그인 | 브라우저에서 평소처럼 로그인하고 워크스페이스 페이지에 도달. `localStorage.james_token` 채워져 있어야 함 |
+| Tesseract (OCR 경로용) | `tesseract --version` 통과. 한국어 언어팩 (`kor.traineddata`) 설치. `config.py` 의 `TESSERACT_PATH` 가 해당 바이너리 경로를 가리키면 더 안전 |
+
+`config.TESSERACT_PATH` 미설정이어도 PATH 에 있으면 동작. Windows 에서는 보통 `C:\Program Files\Tesseract-OCR\tesseract.exe` 명시가 안전.
+
+---
+
+## 2. Test #1 — Workspace 골든 패스 (~2 분)
+
+**무엇을 검증**: 텍스트 입력 → 등록 → 적용 → 다운로드 한 사이클이
+`routes/templating.py` + `frontend/workspace.html` + `workspace.js`
+조합에서 동작.
+
+### 2.1 등록
+
+1. 워크스페이스 → **Templates** 탭.
+2. 이름: `smoke-meeting-notes` (또는 아무거나).
+3. 양식 본문 paste — 아무 양식이나 한 장:
+
+   ```
+   # 회의 노트
+
+   ## 일시
+   {{datetime}}
+
+   ## 참석자
+   {{attendees}}
+
+   ## 안건
+   {{agenda}}
+
+   ## 결정사항
+   {{decisions}}
+
+   ## 액션
+   {{actions}}
+   ```
+
+4. "등록" 버튼 → 목록에 `smoke-meeting-notes` 가 나타나고
+   `placeholders: 5` (또는 비슷한 spec 요약) 가 보이면 OK.
+
+### 2.2 적용 + 다운로드
+
+1. 목록에서 방금 만든 행 선택.
+2. **raw 내용** 패널에 비구조 텍스트 paste:
+
+   ```
+   3월 14일 오후 2시 토요일. 김지원, 박철수, 이수영 참석.
+   주제는 v0.6 양식 엔진 smoke 진행. 결정: 운영자가 직접
+   브라우저에서 끝까지 돌리기로. 액션: 김지원 가이드 작성,
+   박철수 OCR 한글팩 확인.
+   ```
+
+3. 출력 형식 = `md` 그대로 두고 "적용".
+4. **검증 신호**:
+   - preview 패널에 위 5 섹션이 채워진 markdown 이 나타남.
+   - "다운로드" 클릭 → 브라우저가 `<out_id>.md` 받음.
+   - 내려받은 파일 열어서 회의 시간 / 참석자 / 결정 / 액션이 *raw
+     내용에서 가져온 사실*만 있고 모델이 새 사실을 만들어내지
+     않았는지 확인 (양식 §5 grounding discipline).
+
+### 2.3 실패 시 1차 진단
+
+| 증상 | 원인 가능성 |
+|---|---|
+| 401 alert | JWT 만료 — 로그아웃 후 재로그인 |
+| 403 alert | role 에 `data.view_own` 없음 — `routes/templating.py::_owner_or_401` |
+| preview 비어 있음 | LLM 백엔드 응답 실패 — 서버 로그에서 `format_content` 예외 확인. 502 면 LLM router timeout |
+| 다운로드 404 | apply 응답에서 `out_id` 가 비어 있음 — DB / `core/templating/store.py` write 실패. workspace 디렉터리 권한 확인 |
+| 양식 본문에 들어간 instruction 이 그대로 실행된 듯한 출력 | 회귀 — prompt injection 가드 깨짐, `core/templating/formatter.py` 즉시 확인 + 운영 중단 |
+
+---
+
+## 3. Test #2 — Korean OCR 이미지 등록 (~3 분)
+
+**무엇을 검증**: `POST /templates/ingest-image` 가 한국어가 섞인
+이미지에서 텍스트 추출 → 그대로 `POST /templates/` 등록.
+
+### 3.1 이미지 준비
+
+테스트용 이미지 한 장 — 본인이 직접 작성한 한국어 양식이 가장
+좋음 (실제 문서 사용 금지: 누수 위험). 빠른 방법: 위 §2.1 의
+회의 노트 본문을 메모장 / 워드에 붙여넣고 화면 캡처 →
+`smoke-tpl-ko.png` 로 저장.
+
+크기 12 MB 이하 (`routes/templating.py::_MAX_IMAGE_BYTES`).
+
+### 3.2 업로드
+
+워크스페이스 Templates 탭의 "이미지에서 양식 가져오기" (또는
+동등한 UI 라벨) → 파일 선택 → 업로드.
+
+**검증 신호**:
+- 업로드 후 review 패널에 OCR 추출 텍스트가 나타남.
+- 한국어가 깨지지 않고 (mojibake X) 자모 분리 없이 보이면
+  Tesseract `kor+eng` 가 제대로 잡힌 것.
+- 추출 텍스트를 그대로 "등록" 누르면 §2 와 같은 등록 흐름으로 진입.
+
+### 3.3 실패 시 1차 진단
+
+| 증상 | 원인 가능성 |
+|---|---|
+| 400 "OCR stack unavailable" | `pytesseract` 또는 `Pillow` 미설치. `pip install pytesseract Pillow` |
+| 400 "OCR produced no text" | 이미지 해상도 낮음 / 텍스트가 손글씨 / 배경 잡음. 더 깨끗한 캡처 필요 |
+| 한국어가 영문 OCR 결과로 나옴 | `kor.traineddata` 미설치. Tesseract 설치 경로의 `tessdata/` 확인 |
+| 413 "이미지가 너무 큽니다" | 12 MB 초과 — 캡처 다시 |
+| 502 / 500 + tesseract 경로 에러 | `config.TESSERACT_PATH` 가 가리키는 바이너리가 실제로 없음. Windows 흔한 케이스 |
+
+---
+
+## 4. Test #3 — Chat 페이지 apply 모달 (~2 분)
+
+**무엇을 검증**: `frontend/static/templating-chat.js` 가 chat.js 의
+send 파이프라인을 건드리지 않고 자체 click delegation 만으로
+양식 적용까지 굴린다.
+
+1. 채팅 페이지로 이동 (`index.html`).
+2. 평소처럼 한두 번 채팅을 주고받아 어시스턴트 응답이 화면에 있는
+   상태를 만든다.
+3. 응답 옆 "양식 적용" 버튼 (또는 `data-action="tplc-apply"`
+   엘리먼트) 클릭 → 모달 열림.
+4. 모달의 양식 선택 드롭다운에서 §2 에서 만든
+   `smoke-meeting-notes` 선택 → 적용.
+5. **검증 신호**:
+   - 모달 안에서 preview 가 채워짐.
+   - 다운로드 링크 정상 동작.
+   - **회귀 체크**: 모달을 그냥 닫고 채팅에서 메시지 한 번 더 보내
+     평소처럼 답이 오면 chat.js 송신 파이프라인이 영향받지
+     않았다는 것 (handover §2 의 "둘 다 click 리스너 발화,
+     chat.js 는 모르는 action 무시" 계약이 살아 있음).
+
+회귀 체크가 실패 (모달 사용 이후 채팅 답이 안 옴) → 즉시
+`templating-chat.js` 의 click delegation 이 `event.stopPropagation()`
+같은 걸 호출하지 않는지 확인. 현재 설계상 양쪽 다 발화해야 함.
+
+---
+
+## 5. 부정 케이스 (선택, ~1 분)
+
+빠르게 한 줄씩 — `curl` 로:
+
+```bash
+# 401 — 로그인 X
+curl -i http://localhost:8000/templates/mine/list
+
+# 404 — 남의 자원 (존재 누수 없음). <other_id> = 다른 사용자가
+# 만든 템플릿 id 또는 무작위 ULID
+curl -i -H "Authorization: Bearer <my_jwt>" \
+     http://localhost:8000/templates/<other_id>
+
+# 400 — traversal 시도
+curl -i -H "Authorization: Bearer <my_jwt>" \
+     "http://localhost:8000/templates/..%2Fetc"
+```
+
+세 가지 모두 예상 status code 가 나오면 (`401` / `404` / `400`)
+auth 모델이 살아 있는 것.
+
+---
+
+## 6. Done 정의 + 정리
+
+골든 패스 (Test #1) + OCR (Test #2) + chat 모달 (Test #3) 가 모두
+검증 신호를 충족하면 **PR #909/#910 의 follow-up "live e2e smoke"
+가 종결**. 이 시점이 양식 엔진을 "UX-complete" 라고 부를 수 있는
+첫 시점.
+
+정리 (CLAUDE.md rule #1 보호):
+
+1. 워크스페이스 Templates 탭에서 `smoke-meeting-notes` (및 OCR 로
+   등록한 항목) 삭제.
+2. 다운로드 받은 `.md` 파일 삭제 (또는 작업물이면 별도 보관).
+3. `git status` 깨끗한지 확인 — workspace 디렉터리는 `.gitignore`
+   로 이미 차단됨.
+
+검증 결과는 단순 1-liner 로 PR #910 의 후속 코멘트 또는
+`docs/handovers/v0.6-template-engine-close-2026-06-13.md` §4 의
+"Not done" 줄에 "smoke OK on `<date>`" 식으로 기록하면 다음
+세션이 staleness 없이 읽을 수 있음.
+
+---
+
+## 7. References
+
+- `docs/design/v0.6-template-formatting-ui.md` — 디자인 메모 (rule #1 spine 포함)
+- `docs/handovers/v0.6-template-engine-close-2026-06-13.md` — feature close handover (§4 "Not done" 줄이 이 가이드가 닫는 항목)
+- `routes/templating.py` — 7 endpoints 사양
+- `core/templating/ingest.py` — 3 입력 모드 + Tesseract 설정
+- `ARCHITECTURE.md` §5.7.14 — 모듈 trust boundary

--- a/docs/handovers/v0.6-template-engine-close-2026-06-13.md
+++ b/docs/handovers/v0.6-template-engine-close-2026-06-13.md
@@ -83,7 +83,9 @@ content onto the template structure and returns a downloadable file
 
 ## 5. Follow-ups / not in scope
 
-- Live e2e smoke (above) — operator-runnable.
+- Live e2e smoke (above) — operator-runnable. Step-by-step in
+  `docs/deployment/v0.6-template-engine-smoke.md` (workspace golden
+  path + Korean OCR + chat modal, ~5–8 min).
 - `git push` surfaced a **Dependabot** alert on the default branch:
   **2 critical + 2 low**. Unrelated to this feature; worth triaging
   next session: https://github.com/Hashevolution/James-RAG-Evol/security/dependabot


### PR DESCRIPTION
## Summary

Adds `docs/deployment/v0.6-template-engine-smoke.md` — an operator runbook for the **live e2e verification** that PR #910 §4 explicitly flagged as **"Not done — no live LLM/UI run this session"** because the 37 unit tests stub the LLM router and Tesseract.

The guide covers the three paths a non-author operator needs to walk through in ~5–8 minutes before claiming the v0.6 template engine "UX-complete":

1. **Workspace golden path** — paste → register → apply → download (md/txt/html)
2. **Korean OCR ingest** — `POST /templates/ingest-image` with `kor+eng` + `--psm 6` (matches `core/templating/ingest.py` + `processors/file_processor.py`)
3. **Chat-page apply modal** — regression check that `templating-chat.js` click delegation doesn't disturb `chat.js` send pipeline (per close handover §2)

Each test ships verification signals + a failure-diagnosis table so the operator can write a single-line result back without coming back to ask. §5 is a 1-minute negative-case curl block (401 unauth / 404 cross-owner / 400 traversal) verifying the `routes/templating.py::_owner_or_401` + path validator contract.

## Cross-link

Close handover §5 ("Live e2e smoke — operator-runnable") now points at this guide so the follow-up has a concrete next step rather than an implicit one. This keeps next session from re-discovering the gap.

## CLAUDE.md compliance

- **Rule #1**: §6 prescribes deleting the smoke templates after the run so no domain-specific content leaks into a `git status` by accident. The guide reminds the operator of this explicitly.
- **Rule #2**: `docs/`-only PR, `core/retrieval` / `core/graph` / `core/reasoning` zero lines touched.
- **Rule #5**: 6.4 KB doc, well under 20 KB.

## Verification

- Guide cross-checked against `routes/templating.py` endpoints + `core/templating/ingest.py` Tesseract config + `frontend/static/templating-chat.js` design contract per close handover §2.
- Negative-case status codes (401 / 404 / 400) match `routes/templating.py::_owner_or_401` + `get_template` + path-id validator behaviour.
- No code touched, so no test impact.

## Out of scope

- Actually running the smoke — that's the operator action this guide describes.
- Any vertical / domain content (Rule #1 unchanged).
- A `live-smoke-OK-on-<date>` line in the close handover — left to the operator to add after they run §1–§5 (per §6 of the guide).

Quality delta: exempt (label: docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)