### PR TITLE
docs(v0.6): entry skeleton 2026-06-14 addendum — 26 PRs + 2 NEW LANDED

### DIFF
--- a/docs/deployment/v0.6-template-engine-smoke.md
+++ b/docs/deployment/v0.6-template-engine-smoke.md
@@ -1,0 +1,218 @@
+# Template Formatting Engine — Live e2e Smoke Guide (v0.6 Track F)
+
+> **Status**: Operator-runbook for the live verification missed in the
+> shipping session of PR #909 + #910. The 37 unit tests stub the LLM
+> and Tesseract, so this guide covers the three paths that need a real
+> browser + real backend before the feature can be claimed
+> UX-complete:
+>
+> 1. Workspace 골든 패스 (paste → register → apply → download)
+> 2. Korean OCR 이미지 등록 → 적용
+> 3. Chat 페이지 apply 모달
+>
+> **Audience**: anyone who has a JAMES instance up locally with the
+> normal LLM backend (Ollama / Claude CLI). About **5–8 minutes**
+> end-to-end.
+>
+> **CLAUDE.md rule #1**: the templates created during this smoke are
+> *workspace user data*, not shipped content. After the smoke, delete
+> them via the workspace tab or `DELETE /templates/{id}` so nothing
+> domain-specific leaks into a git status by accident.
+
+---
+
+## 1. 사전 조건 체크
+
+| 항목 | 확인 |
+|---|---|
+| JAMES 서버 기동 | `python server_llmwiki.py` (또는 평소 기동 스크립트), `/docs` 열어서 swagger 페이지 뜨면 OK |
+| LLM 백엔드 | 워크스페이스에서 평소처럼 채팅이 도는 상태 (Ollama gemma3:4b 등). `format_content` 가 호출 라우터를 그대로 씀 |
+| 로그인 | 브라우저에서 평소처럼 로그인하고 워크스페이스 페이지에 도달. `localStorage.james_token` 채워져 있어야 함 |
+| Tesseract (OCR 경로용) | `tesseract --version` 통과. 한국어 언어팩 (`kor.traineddata`) 설치. `config.py` 의 `TESSERACT_PATH` 가 해당 바이너리 경로를 가리키면 더 안전 |
+
+`config.TESSERACT_PATH` 미설정이어도 PATH 에 있으면 동작. Windows 에서는 보통 `C:\Program Files\Tesseract-OCR\tesseract.exe` 명시가 안전.
+
+---
+
+## 2. Test #1 — Workspace 골든 패스 (~2 분)
+
+**무엇을 검증**: 텍스트 입력 → 등록 → 적용 → 다운로드 한 사이클이
+`routes/templating.py` + `frontend/workspace.html` + `workspace.js`
+조합에서 동작.
+
+### 2.1 등록
+
+1. 워크스페이스 → **Templates** 탭.
+2. 이름: `smoke-meeting-notes` (또는 아무거나).
+3. 양식 본문 paste — 아무 양식이나 한 장:
+
+   ```
+   # 회의 노트
+
+   ## 일시
+   {{datetime}}
+
+   ## 참석자
+   {{attendees}}
+
+   ## 안건
+   {{agenda}}
+
+   ## 결정사항
+   {{decisions}}
+
+   ## 액션
+   {{actions}}
+   ```
+
+4. "등록" 버튼 → 목록에 `smoke-meeting-notes` 가 나타나고
+   `placeholders: 5` (또는 비슷한 spec 요약) 가 보이면 OK.
+
+### 2.2 적용 + 다운로드
+
+1. 목록에서 방금 만든 행 선택.
+2. **raw 내용** 패널에 비구조 텍스트 paste:
+
+   ```
+   3월 14일 오후 2시 토요일. 김지원, 박철수, 이수영 참석.
+   주제는 v0.6 양식 엔진 smoke 진행. 결정: 운영자가 직접
+   브라우저에서 끝까지 돌리기로. 액션: 김지원 가이드 작성,
+   박철수 OCR 한글팩 확인.
+   ```
+
+3. 출력 형식 = `md` 그대로 두고 "적용".
+4. **검증 신호**:
+   - preview 패널에 위 5 섹션이 채워진 markdown 이 나타남.
+   - "다운로드" 클릭 → 브라우저가 `<out_id>.md` 받음.
+   - 내려받은 파일 열어서 회의 시간 / 참석자 / 결정 / 액션이 *raw
+     내용에서 가져온 사실*만 있고 모델이 새 사실을 만들어내지
+     않았는지 확인 (양식 §5 grounding discipline).
+
+### 2.3 실패 시 1차 진단
+
+| 증상 | 원인 가능성 |
+|---|---|
+| 401 alert | JWT 만료 — 로그아웃 후 재로그인 |
+| 403 alert | role 에 `data.view_own` 없음 — `routes/templating.py::_owner_or_401` |
+| preview 비어 있음 | LLM 백엔드 응답 실패 — 서버 로그에서 `format_content` 예외 확인. 502 면 LLM router timeout |
+| 다운로드 404 | apply 응답에서 `out_id` 가 비어 있음 — DB / `core/templating/store.py` write 실패. workspace 디렉터리 권한 확인 |
+| 양식 본문에 들어간 instruction 이 그대로 실행된 듯한 출력 | 회귀 — prompt injection 가드 깨짐, `core/templating/formatter.py` 즉시 확인 + 운영 중단 |
+
+---
+
+## 3. Test #2 — Korean OCR 이미지 등록 (~3 분)
+
+**무엇을 검증**: `POST /templates/ingest-image` 가 한국어가 섞인
+이미지에서 텍스트 추출 → 그대로 `POST /templates/` 등록.
+
+### 3.1 이미지 준비
+
+테스트용 이미지 한 장 — 본인이 직접 작성한 한국어 양식이 가장
+좋음 (실제 문서 사용 금지: 누수 위험). 빠른 방법: 위 §2.1 의
+회의 노트 본문을 메모장 / 워드에 붙여넣고 화면 캡처 →
+`smoke-tpl-ko.png` 로 저장.
+
+크기 12 MB 이하 (`routes/templating.py::_MAX_IMAGE_BYTES`).
+
+### 3.2 업로드
+
+워크스페이스 Templates 탭의 "이미지에서 양식 가져오기" (또는
+동등한 UI 라벨) → 파일 선택 → 업로드.
+
+**검증 신호**:
+- 업로드 후 review 패널에 OCR 추출 텍스트가 나타남.
+- 한국어가 깨지지 않고 (mojibake X) 자모 분리 없이 보이면
+  Tesseract `kor+eng` 가 제대로 잡힌 것.
+- 추출 텍스트를 그대로 "등록" 누르면 §2 와 같은 등록 흐름으로 진입.
+
+### 3.3 실패 시 1차 진단
+
+| 증상 | 원인 가능성 |
+|---|---|
+| 400 "OCR stack unavailable" | `pytesseract` 또는 `Pillow` 미설치. `pip install pytesseract Pillow` |
+| 400 "OCR produced no text" | 이미지 해상도 낮음 / 텍스트가 손글씨 / 배경 잡음. 더 깨끗한 캡처 필요 |
+| 한국어가 영문 OCR 결과로 나옴 | `kor.traineddata` 미설치. Tesseract 설치 경로의 `tessdata/` 확인 |
+| 413 "이미지가 너무 큽니다" | 12 MB 초과 — 캡처 다시 |
+| 502 / 500 + tesseract 경로 에러 | `config.TESSERACT_PATH` 가 가리키는 바이너리가 실제로 없음. Windows 흔한 케이스 |
+
+---
+
+## 4. Test #3 — Chat 페이지 apply 모달 (~2 분)
+
+**무엇을 검증**: `frontend/static/templating-chat.js` 가 chat.js 의
+send 파이프라인을 건드리지 않고 자체 click delegation 만으로
+양식 적용까지 굴린다.
+
+1. 채팅 페이지로 이동 (`index.html`).
+2. 평소처럼 한두 번 채팅을 주고받아 어시스턴트 응답이 화면에 있는
+   상태를 만든다.
+3. 응답 옆 "양식 적용" 버튼 (또는 `data-action="tplc-apply"`
+   엘리먼트) 클릭 → 모달 열림.
+4. 모달의 양식 선택 드롭다운에서 §2 에서 만든
+   `smoke-meeting-notes` 선택 → 적용.
+5. **검증 신호**:
+   - 모달 안에서 preview 가 채워짐.
+   - 다운로드 링크 정상 동작.
+   - **회귀 체크**: 모달을 그냥 닫고 채팅에서 메시지 한 번 더 보내
+     평소처럼 답이 오면 chat.js 송신 파이프라인이 영향받지
+     않았다는 것 (handover §2 의 "둘 다 click 리스너 발화,
+     chat.js 는 모르는 action 무시" 계약이 살아 있음).
+
+회귀 체크가 실패 (모달 사용 이후 채팅 답이 안 옴) → 즉시
+`templating-chat.js` 의 click delegation 이 `event.stopPropagation()`
+같은 걸 호출하지 않는지 확인. 현재 설계상 양쪽 다 발화해야 함.
+
+---
+
+## 5. 부정 케이스 (선택, ~1 분)
+
+빠르게 한 줄씩 — `curl` 로:
+
+```bash
+# 401 — 로그인 X
+curl -i http://localhost:8000/templates/mine/list
+
+# 404 — 남의 자원 (존재 누수 없음). <other_id> = 다른 사용자가
+# 만든 템플릿 id 또는 무작위 ULID
+curl -i -H "Authorization: Bearer <my_jwt>" \
+     http://localhost:8000/templates/<other_id>
+
+# 400 — traversal 시도
+curl -i -H "Authorization: Bearer <my_jwt>" \
+     "http://localhost:8000/templates/..%2Fetc"
+```
+
+세 가지 모두 예상 status code 가 나오면 (`401` / `404` / `400`)
+auth 모델이 살아 있는 것.
+
+---
+
+## 6. Done 정의 + 정리
+
+골든 패스 (Test #1) + OCR (Test #2) + chat 모달 (Test #3) 가 모두
+검증 신호를 충족하면 **PR #909/#910 의 follow-up "live e2e smoke"
+가 종결**. 이 시점이 양식 엔진을 "UX-complete" 라고 부를 수 있는
+첫 시점.
+
+정리 (CLAUDE.md rule #1 보호):
+
+1. 워크스페이스 Templates 탭에서 `smoke-meeting-notes` (및 OCR 로
+   등록한 항목) 삭제.
+2. 다운로드 받은 `.md` 파일 삭제 (또는 작업물이면 별도 보관).
+3. `git status` 깨끗한지 확인 — workspace 디렉터리는 `.gitignore`
+   로 이미 차단됨.
+
+검증 결과는 단순 1-liner 로 PR #910 의 후속 코멘트 또는
+`docs/handovers/v0.6-template-engine-close-2026-06-13.md` §4 의
+"Not done" 줄에 "smoke OK on `<date>`" 식으로 기록하면 다음
+세션이 staleness 없이 읽을 수 있음.
+
+---
+
+## 7. References
+
+- `docs/design/v0.6-template-formatting-ui.md` — 디자인 메모 (rule #1 spine 포함)
+- `docs/handovers/v0.6-template-engine-close-2026-06-13.md` — feature close handover (§4 "Not done" 줄이 이 가이드가 닫는 항목)
+- `routes/templating.py` — 7 endpoints 사양
+- `core/templating/ingest.py` — 3 입력 모드 + Tesseract 설정
+- `ARCHITECTURE.md` §5.7.14 — 모듈 trust boundary

--- a/docs/handovers/v0.6-entry-skeleton-2026-06-13.md
+++ b/docs/handovers/v0.6-entry-skeleton-2026-06-13.md
@@ -12,6 +12,12 @@
 > **Audience**: the next session that reads CLAUDE.md "Where to
 > look next" first row. This skeleton is the bridge between the
 > v0.5 close handover and the eventual v0.6 entry doc.
+>
+> **Last addendum**: §2.7 + §3.1 + §5.1 below (2026-06-14). The
+> 2026-06-13 inventory in §2.1–§2.6 / §3 / §5 is preserved as the
+> baseline; only LANDED markers + a single addendum section have
+> been added. If you are the next session, read top-to-bottom — the
+> baseline numbers still anchor the cycle frame.
 
 ---
 
@@ -147,6 +153,43 @@ interprets by rule rather than post-hoc.
 
 The streak holds.
 
+### 2.7 After-skeleton addendum (2026-06-13 evening + 2026-06-14)
+
+26 more PRs landed between the skeleton write and the 2026-06-14
+session — and 2 OPEN PRs from the 2026-06-14 session that haven't
+self-merged yet. Same four-layer rule #1 protection contract held;
+`core/retrieval` / `core/graph` traversal / `core/reasoning` lines
+changed = **still 0**.
+
+**Eight clusters**, all solo + LOI-independent:
+
+| Cluster | PRs | What |
+|---|---|---|
+| Multi-Phase HTTPS production | #890 / #891 | P1.2 trusted X-Forwarded-* middleware + P1.1 deployment guide |
+| Multi-Phase multi-tenant deployment | #892 / #893 / #894 | P3.1 per-request tenant middleware (signed X-Tenant-Id) + P3.2 per-tenant workspace path resolver + P3.3 deployment guide |
+| Multi-Phase non-developer UX | #895 / #896 / #897 / #898 / #899 | P4.1 5-step onboarding flow + P4.2 knowledge rollback affordance + P4.3 reasoning flow swimlanes + P4.4 glossary + universal tooltips + P4.5 Korean quickstart |
+| Industry-positioning matrix | #887 / #888 / #889 | roadmap + README + CHANGELOG audit → industry comparison matrix → **18-cell verified corrections**. Spawned new memory rule `feedback_external_facing_doc_source_verification_first` (default-negative on certifications, verification log §, lock test, re-verify cadence) |
+| Module-size gate enforcement (Rule #5) | #900 / #901 / #902 / #903 / #904 / #907 / #908 | 7 split refactors closing the 20KB cap on `core/reasoning/reflect.py` / `gemma_client.py` / `lifecycle/replay_graph.py` / `wiki_generator/_ingestion.py` + `_frontmatter.py` / `reasoning/pipeline_synth.py` / `graph_engine.py` |
+| Template-formatting engine (Track F mother-level UI) | #909 / #910 | 7-PR squashed merge — horizontal document-shaping engine (workspace + chat UI + Tesseract OCR ingest) + session-close handover. **Live e2e smoke pending** (OPEN PR #913 from 2026-06-14 supplies the operator runbook) |
+| Dependabot Q2 triage | #911 + 2026-06-14 follow-through | torch CVE-2025-3000 §3 risk-accept + 7-test guardrail. All 4 alerts (13/14 chromadb critical + 17/18 torch low) risk-accepted; 2026-06-14 operator dismiss-as-`not_used` mechanical step prescribed by PR #911 description |
+| **NEW solo-doable items from §5 LANDED** | #905 / #906 | CSP nonce script-flag graduation deployment guide + CLAUDE.md "Where to look next" first-row staleness guard test (see §5.1) |
+
+**2026-06-14 session additions (OPEN)**:
+
+| PR | What |
+|---|---|
+| #912 | `.gitignore` LaTeX build artifacts under `papers/` + preprint zip scope. Closes the 9 untracked LaTeX outputs + 1 zip surfaced in session-open `git status` |
+| #913 | `docs/deployment/v0.6-template-engine-smoke.md` operator runbook — 3-path live e2e smoke (workspace golden path + Korean OCR + chat modal) closing PR #910 §4 "Not done — no live LLM/UI run" line. Cross-linked from close handover §5 |
+
+**Operator-attended (not landed, mechanical only)**:
+
+- GitHub Dependabot UI dismissal of alerts #13 / #14 / #17 / #18
+  via `gh api -X PATCH ... dependabot/alerts/<n> -f
+  state=dismissed -f dismissed_reason=not_used -f
+  dismissed_comment="..."`. All four disposition decisions are
+  baked into the doc + comment block (PR #911), so the API call
+  is the only remaining step.
+
 ---
 
 ## 3. v0.5 close handover §5 work queue — status sweep
@@ -188,6 +231,17 @@ F.2 CR.e), gated on a separate prerequisite (CSP default flip
 needs inline-style migration; link decoration needs T5
 mutation-site wiring), or it's a NEW item not in the close
 handover.
+
+### 3.1 Update 2026-06-14
+
+The §3 table is preserved as-is for cycle anchoring. No queue item
+above has flipped state since the skeleton — both LOI gates and
+all 6 operator-pending lines remain unchanged. The 26 PRs in §2.7
+sit *outside* this table because they're mother-platform hardening
+threads that emerged after the skeleton was written, not entries
+from the close handover §5 work queue. Treat §3 as the close-
+handover-derived backlog (cycle source) and §2.7 as
+opportunistic-but-disciplined hardening (cycle byproduct).
 
 ---
 
@@ -255,6 +309,36 @@ continues:
 
 These are **not** a backlog the next session must clear; they're
 documented so future-self doesn't have to re-discover them.
+
+### 5.1 Update 2026-06-14 — LANDED markers + new candidates
+
+Status of the four §5 items above as of 2026-06-14:
+
+| Item | Status | PR |
+|---|---|---|
+| F.1 `paintLinks` auto-activation | **still READY-but-gated** on T5.A.b mutation-site wiring (external prereq, no change since skeleton) | — |
+| UI #6 partial Option B (top-13 inline-style → utility classes) | **still pending** visual-regression harness landing (external prereq, no change) | — |
+| **CSP nonce script-flag graduation doc** | **LANDED** | **#905** |
+| **v0.6 entry-doc staleness meta-test** | **LANDED** | **#906** |
+
+Two of four NEW solo-doable items shipped within the addendum
+window. The two still-pending items both share the same shape:
+they depend on a separate piece of infrastructure (T5.A.b wiring /
+visual-regression harness) that itself isn't in the §5 candidate
+list. That's accurate — both should stay pending, not be force-
+shipped without the prereq.
+
+**New solo-doable candidates surfaced since the skeleton**:
+
+| Item | Source | Sketch |
+|---|---|---|
+| Operator-runbook for template engine live e2e smoke | PR #910 §4 "Not done" line | LANDED via PR #913 (2026-06-14 session). Workspace golden path + Korean OCR + chat modal. Operator runs the smoke; the doc tells them how |
+| Module-size lock-test extension to wiki/UI surfaces | §2.7 cluster 5 (7 split refactors) | After 7 PR-by-PR splits, a `tests/test_v06_module_size_gate.py` style lock-test that asserts no `core/` file > 20KB could prevent future regression at PR time. Not urgent — the splits were caught manually before merge — but a one-time invariant would close the loop |
+| Industry-comparison doc 6-monthly re-verification automation | PR #889 + memory `feedback_external_facing_doc_source_verification_first` | The verification log §9 of `v0.5-industry-comparison.md` prescribes a re-verify cadence (cycle close / competitor major release / annual). A scheduled cron skill or a CI scheduled-run that re-fetches the 6 systems' canonical docs + flags drift could discharge the cadence semi-mechanically. Higher-stakes than the others — touch only if §6 verification rule is itself well-internalized first |
+| Dependabot dismissal automation note | §2.7 operator-attended box | The `gh api ... --method PATCH` four-call pattern (with comment text matching the risk-assessment doc section) is mechanical enough to live in a one-shot script under `scripts/security/` for future risk-accept rounds. Not urgent; the 2026-06-14 round is being done by hand. Consider only if a third round surfaces with the same shape |
+
+These new candidates follow the same posture as the original four:
+documented for future-self, NOT a forced backlog.
 
 ---
 
@@ -335,6 +419,17 @@ Per v0.5 close handover §8, updated for the current state:
   `james-pack-sdk`)
 - CLAUDE.md rules 1–5 + the v0.5 entry doc's 3 additional rules
 
+**Added 2026-06-14**:
+
+- `docs/deployment/v0.6-csp-nonce-graduation.md` (#905 — §5.1 LANDED)
+- `docs/handovers/v0.6-template-engine-close-2026-06-13.md` (#910 feature close handover; §5 cross-linked to the smoke guide)
+- `docs/deployment/v0.6-template-engine-smoke.md` (#913 operator runbook; closes #910 §4 "Not done" line)
+- `docs/security/dependabot-2026-06-10-risk-assessment.md` (§3 added in #911 — torch CVE-2025-3000 risk-accept)
+- `docs/evaluation/v0.5-industry-comparison.md` §9 verification log (#888 → #889 corrections)
+- `memory/feedback_external_facing_doc_source_verification_first.md` (new memory rule from the #888 → #889 18-cell correction)
+- `tests/test_v06_dependabot_triage_invariants.py` (#911 7-test guardrail asserting zero risky call sites)
+- `tests/test_v06_claude_md_entry_pointer.py` (#906 first-row staleness guard — §5.1 LANDED)
+
 ---
 
 ## 10. Korean summary (한국어 요약)
@@ -367,3 +462,35 @@ Per v0.5 close handover §8, updated for the current state:
   5 rules + v0.5 entry 3 추가 rules 모두 carry-over.
 - **CLAUDE.md "Where to look next"** 첫 행은 이 스켈레톤으로
   업데이트 권장 (별도 PR 또는 이 PR 의 follow-up).
+
+### 10.1 Addendum 한국어 요약 (2026-06-14)
+
+- **스켈레톤 작성 후 26 PR 추가 LANDED** (#886-#911) — 8 클러스터:
+  P1 HTTPS production (2) / P3 multi-tenant (3) / P4 non-developer
+  UX (5) / industry comparison + 18-cell 정정 (3, 새 memory rule
+  `feedback_external_facing_doc_source_verification_first` 박힘) /
+  module-size 20KB gate 강제 split (7) / template-formatting
+  engine + close handover (2) / Dependabot 확장 (1) / **NEW
+  solo-doable §5 LANDED 2건** (#905 CSP graduation doc + #906
+  staleness guard). 측정 0, vertical 0, `core/retrieval` +
+  `core/graph` traversal + `core/reasoning` 0 라인 변경 streak
+  유지.
+- **2026-06-14 세션 OPEN**: #912 `.gitignore` LaTeX 빌드 산출물 +
+  #913 template engine live e2e smoke 운영자 runbook (workspace
+  + Korean OCR + chat modal). 양쪽 self-merge 대기.
+- **Dependabot 4건** (chromadb #13/#14 critical + torch #17/#18
+  low) **risk-accept 결정 완료** (#911 + 가드레일 테스트 7개).
+  CVE 자체는 존재하나 JAMES 사용 방식에서 도달 불가. **GitHub
+  UI dismiss-as-`not_used`** 만 operator 수동 4-call API 호출
+  필요.
+- **§5 새 NEW solo-doable 후보 4건 추가**: module-size lock-test /
+  industry-comparison 6-monthly re-verification / template engine
+  smoke 가이드 (이미 LANDED #913) / Dependabot 자동화 스크립트.
+  모두 "future-self 가 잊지 않게 적어둠" 수준 — 강제 backlog 아님.
+- **§3 close-handover work queue 표 자체는 변경 없음**. §2.7 의
+  26 PR 은 close handover 큐 항목이 아니라 그 위에서 emerge 한
+  hardening 작업. §3 = cycle source / §2.7 = cycle byproduct
+  분리.
+- **다음 세션 진입 절차** (§7) **변경 없음**. 두 fork 모두 여전히
+  operator 결정 대기. 미해결 시 이 스켈레톤 (addendum 포함)이
+  계속 baseline.

--- a/docs/handovers/v0.6-template-engine-close-2026-06-13.md
+++ b/docs/handovers/v0.6-template-engine-close-2026-06-13.md
@@ -83,7 +83,9 @@ content onto the template structure and returns a downloadable file
 
 ## 5. Follow-ups / not in scope
 
-- Live e2e smoke (above) — operator-runnable.
+- Live e2e smoke (above) — operator-runnable. Step-by-step in
+  `docs/deployment/v0.6-template-engine-smoke.md` (workspace golden
+  path + Korean OCR + chat modal, ~5–8 min).
 - `git push` surfaced a **Dependabot** alert on the default branch:
   **2 critical + 2 low**. Unrelated to this feature; worth triaging
   next session: https://github.com/Hashevolution/James-RAG-Evol/security/dependabot


### PR DESCRIPTION
## Summary

Inline addendum to `docs/handovers/v0.6-entry-skeleton-2026-06-13.md` capturing what's happened **since the skeleton was written**, so the next session that reads CLAUDE.md "Where to look next" first row doesn't have to reconstruct it from `git log`.

Three new sections (§2.7 / §3.1 / §5.1) + §9 references + §10.1 Korean summary. The original 2026-06-13 inventory (§2.1–§2.6 / §3 / §5) stays untouched as the cycle baseline.

## Why an addendum, not a rewrite

The skeleton anchors the cycle frame ("v0.5 closed, v0.6 not yet entered, 23 PRs landed since v0.5 close, Dim F gate not cleared"). Rewriting those numbers in place would drift the baseline. Layering the new state as a labelled addendum preserves both the original anchor and the current state on the same page — which is the whole point of a single-page entry skeleton.

## What's in the addendum

- **§2.7 — eight-cluster roll-up of 26 LANDED PRs** (#886–#911) + the 2026-06-14 session's two OPEN PRs (#912 .gitignore + #913 template engine smoke runbook). Each cluster is a coherent multi-phase thread: P1 HTTPS production / P3 multi-tenant / P4 non-developer UX / industry-positioning + 18-cell verified corrections / module-size 20KB gate enforcement (7 splits) / template engine + close handover / Dependabot extension / **NEW §5 LANDED 2건 (#905 + #906)**. The four-layer rule #1 protection contract held + `core/retrieval` + `core/graph` traversal + `core/reasoning` zero-line streak preserved across all 26 PRs.

- **§3.1 — clarifies what didn't change.** The close-handover §5 work queue itself hasn't flipped state (no LOI, all 6 operator-pending items still operator-pending). The 26 addendum PRs are mother-platform hardening that emerged on top of the queue, not entries from it. Names the distinction: §3 = cycle source / §2.7 = cycle byproduct.

- **§5.1 — LANDED markers + new candidates.** Two of the four NEW solo-doable items from skeleton §5 shipped: #905 CSP nonce script-flag graduation deployment guide + #906 staleness guard test. The two still-pending items both depend on external prereqs (T5.A.b wiring / visual-regression harness). Plus four newly-surfaced candidates: module-size lock-test / industry-comparison re-verification cadence automation / template engine smoke runbook (LANDED #913) / Dependabot dismissal automation script.

- **§9 — 8 added references** for the docs / tests landed in the addendum window (CSP graduation guide / template engine close + smoke / Dependabot §3 / industry comparison verification log / new memory rule / dependabot guardrail tests / staleness guard test).

- **§10.1 Korean addendum summary** mirroring §2.7 + §3.1 + §5.1, for the Korean reader.

## Staleness guard test

CLAUDE.md "Where to look next" first row points at `docs/handovers/v0.6-entry-skeleton-2026-06-13.md`, and this PR edits **that same file** rather than creating a new entry doc. So PR #906's `tests/test_v06_claude_md_entry_pointer.py` must still pass — verified 5/5 green locally before commit.

## Out of scope

- Self-merging the two 2026-06-14 OPEN PRs (#912 + #913) — operator decision
- GitHub Dependabot UI dismissal of #13/#14/#17/#18 — operator action via `gh api ... --method PATCH`
- A new entry doc — would only be written when a gate fork resolves (Fork A LOI / Fork B reassess), per §7
- Rule #1 (zero vertical content, unchanged)
- `core/retrieval` / `core/graph` / `core/reasoning` (zero lines touched — Quality Delta Card exempt, label: docs)

Quality delta: exempt (label: docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)