### PR TITLE
feat(v0.6.1): Phase C — core/agent_tools + LLM tool-use loop + agent chat endpoint

### DIFF
--- a/core/agent_tools/__init__.py
+++ b/core/agent_tools/__init__.py
@@ -1,0 +1,52 @@
+"""v0.6.1 Phase C — agent tool registry + dispatcher + LLM tool-use loop.
+
+The pieces here let an LLM (Anthropic Messages API ``tool_use`` or
+Ollama function-calling) emit tool-call requests that JAMES dispatches
+through the existing Phase 5.5 sandbox (`tools/code/sandbox.py`),
+back-channels the results into the LLM loop, and audits every step.
+
+Public surface:
+
+  * :class:`Tool` — frozen dataclass describing one callable.
+  * :func:`register_tool`, :func:`get_tool`, :func:`list_tools` —
+    in-memory registry.
+  * :func:`dispatch` — single entry point used by the agent-chat
+    endpoint AND by anyone calling tools directly (operator scripts,
+    tests). Centralises sandbox + audit + timeout.
+  * :data:`MAX_TOOL_TIMEOUT_SEC` — global cap; individual tools may
+    set a lower per-call timeout.
+
+The 6 built-in tools live in :mod:`core.agent_tools.builtins`. They
+are registered at module import; importing this package surface
+auto-registers them via the builtins module's side effects.
+
+LLM backends live in :mod:`core.agent_tools.backends`.
+
+See ``docs/design/v0.6-agent-tools-user-paths.md`` §2 (G-B / G-C)
+and ``ARCHITECTURE.md`` §5.7.15.
+"""
+from __future__ import annotations
+
+from core.agent_tools.registry import (  # noqa: F401
+    MAX_TOOL_TIMEOUT_SEC,
+    Tool,
+    ToolError,
+    get_tool,
+    list_tools,
+    register_tool,
+)
+from core.agent_tools.dispatcher import dispatch  # noqa: F401
+
+# Auto-register built-in tools at package import time. Side-effect
+# import is intentional (matches `tools/__init__.py` pattern).
+from core.agent_tools import builtins  # noqa: F401
+
+__all__ = [
+    "MAX_TOOL_TIMEOUT_SEC",
+    "Tool",
+    "ToolError",
+    "get_tool",
+    "list_tools",
+    "register_tool",
+    "dispatch",
+]

--- a/core/agent_tools/backends.py
+++ b/core/agent_tools/backends.py
@@ -1,0 +1,271 @@
+"""LLM backends for the agent tool-use loop (v0.6.1 Phase C).
+
+Two backends, runtime-selectable via ``JAMES_AGENT_BACKEND`` env:
+
+  * ``anthropic`` — Anthropic Messages API ``tool_use`` (cloud). Uses
+    ``httpx`` directly; no anthropic SDK dependency. API key from
+    ``ANTHROPIC_API_KEY``. Cloud egress flows through this module's
+    HTTP call — for production deployments, an operator that wants
+    abstraction-layer (§5.7.12) masking should set
+    ``JAMES_FORCE_CLOUD=1`` and add a wrapper at the call site
+    (deferred to Phase E when ``run_shell`` arrives).
+  * ``ollama`` — Ollama ``/api/chat`` with ``tools`` array. Local. The
+    model must support function-calling (mxtral works well; gemma3:4b
+    less reliable). Host from ``OLLAMA_HOST`` (default
+    ``http://localhost:11434``); model from ``JAMES_AGENT_OLLAMA_MODEL``
+    (default ``mxtral:latest``).
+
+Both backends share the ``AgentBackend`` interface
+(``chat_with_tools``) so the agent-chat endpoint can swap without
+caring which one is active.
+"""
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+
+ENV_BACKEND = "JAMES_AGENT_BACKEND"
+ENV_OLLAMA_HOST = "OLLAMA_HOST"
+ENV_OLLAMA_MODEL = "JAMES_AGENT_OLLAMA_MODEL"
+ENV_ANTHROPIC_KEY = "ANTHROPIC_API_KEY"
+ENV_ANTHROPIC_MODEL = "JAMES_AGENT_ANTHROPIC_MODEL"
+
+
+class BackendError(Exception):
+    """LLM backend call failed (HTTP / parse / missing key)."""
+
+
+class AgentBackend(ABC):
+    """Each backend takes a conversation + the JAMES tool registry's
+    schema list and returns:
+
+      ``{"stop_reason": "tool_use"|"end_turn"|"error",
+         "text": "...",                     # for end_turn / error
+         "tool_calls": [                   # for tool_use
+            {"id": "...", "name": "...", "input": {...}}
+         ],
+         "raw": {...}                      # backend-specific echo
+        }``
+
+    The agent-chat endpoint loops: send messages → if ``tool_use``,
+    dispatch each call + append a tool-result message → send again.
+    """
+
+    name: str = "base"
+
+    @abstractmethod
+    def chat_with_tools(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        *,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+    ) -> Dict[str, Any]:
+        ...
+
+
+# ── Anthropic ────────────────────────────────────────────────────
+
+_ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_VERSION = "2023-06-01"
+_DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+
+
+class AnthropicBackend(AgentBackend):
+    name = "anthropic"
+
+    def __init__(self,
+                 api_key: Optional[str] = None,
+                 model: Optional[str] = None,
+                 timeout: float = 60.0):
+        self.api_key = api_key or os.environ.get(ENV_ANTHROPIC_KEY, "").strip()
+        if not self.api_key:
+            raise BackendError(
+                f"{ENV_ANTHROPIC_KEY} env not set; cannot use anthropic backend"
+            )
+        self.model = (model or os.environ.get(ENV_ANTHROPIC_MODEL)
+                      or _DEFAULT_ANTHROPIC_MODEL).strip()
+        self.timeout = timeout
+
+    def chat_with_tools(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        *,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+    ) -> Dict[str, Any]:
+        import httpx
+
+        body: Dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+            "tools": tools,
+        }
+        if system:
+            body["system"] = system
+
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                resp = client.post(_ANTHROPIC_URL, headers=headers,
+                                    content=json.dumps(body))
+        except httpx.HTTPError as e:
+            raise BackendError(f"anthropic http error: {e}")
+        if resp.status_code >= 400:
+            raise BackendError(
+                f"anthropic {resp.status_code}: {resp.text[:300]}")
+        try:
+            data = resp.json()
+        except Exception as e:  # noqa: BLE001
+            raise BackendError(f"anthropic bad json: {e}")
+
+        # Parse Anthropic response shape:
+        #   content: [{type:"text"|"tool_use", ...}]
+        #   stop_reason: "end_turn" | "tool_use" | ...
+        stop_reason = data.get("stop_reason") or "end_turn"
+        text_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
+        for block in data.get("content") or []:
+            btype = block.get("type")
+            if btype == "text":
+                text_parts.append(block.get("text") or "")
+            elif btype == "tool_use":
+                tool_calls.append({
+                    "id": block.get("id"),
+                    "name": block.get("name"),
+                    "input": block.get("input") or {},
+                })
+        return {
+            "stop_reason": stop_reason,
+            "text": "".join(text_parts).strip(),
+            "tool_calls": tool_calls,
+            "raw": data,
+        }
+
+
+# ── Ollama ───────────────────────────────────────────────────────
+
+_DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+_DEFAULT_OLLAMA_MODEL = "mxtral:latest"
+
+
+class OllamaBackend(AgentBackend):
+    name = "ollama"
+
+    def __init__(self,
+                 host: Optional[str] = None,
+                 model: Optional[str] = None,
+                 timeout: float = 120.0):
+        self.host = (host or os.environ.get(ENV_OLLAMA_HOST)
+                     or _DEFAULT_OLLAMA_HOST).rstrip("/")
+        self.model = (model or os.environ.get(ENV_OLLAMA_MODEL)
+                      or _DEFAULT_OLLAMA_MODEL).strip()
+        self.timeout = timeout
+
+    def chat_with_tools(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        *,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+    ) -> Dict[str, Any]:
+        import httpx
+
+        # Ollama expects tools in OpenAI function-call schema:
+        #   {type:"function", function:{name, description, parameters}}
+        ol_tools = [{
+            "type": "function",
+            "function": {
+                "name": t["name"],
+                "description": t.get("description") or "",
+                "parameters": t.get("input_schema") or {"type": "object"},
+            },
+        } for t in tools]
+
+        msgs = list(messages)
+        if system:
+            msgs = [{"role": "system", "content": system}] + msgs
+
+        body = {
+            "model": self.model,
+            "messages": msgs,
+            "tools": ol_tools,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        }
+        url = self.host + "/api/chat"
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                resp = client.post(url, content=json.dumps(body),
+                                    headers={"Content-Type": "application/json"})
+        except httpx.HTTPError as e:
+            raise BackendError(f"ollama http error: {e}")
+        if resp.status_code >= 400:
+            raise BackendError(f"ollama {resp.status_code}: {resp.text[:300]}")
+        try:
+            data = resp.json()
+        except Exception as e:  # noqa: BLE001
+            raise BackendError(f"ollama bad json: {e}")
+
+        msg = data.get("message") or {}
+        text = (msg.get("content") or "").strip()
+        raw_calls = msg.get("tool_calls") or []
+        tool_calls: List[Dict[str, Any]] = []
+        for i, call in enumerate(raw_calls):
+            fn = call.get("function") or {}
+            args = fn.get("arguments")
+            # Ollama may return arguments as a JSON string OR a dict.
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except Exception:
+                    args = {}
+            tool_calls.append({
+                "id": call.get("id") or f"ollama-{i}",
+                "name": fn.get("name"),
+                "input": args or {},
+            })
+        stop_reason = "tool_use" if tool_calls else "end_turn"
+        return {
+            "stop_reason": stop_reason,
+            "text": text,
+            "tool_calls": tool_calls,
+            "raw": data,
+        }
+
+
+# ── Factory ──────────────────────────────────────────────────────
+
+def get_backend(name: Optional[str] = None) -> AgentBackend:
+    """Resolve the active backend from ``name`` (test override) or
+    ``JAMES_AGENT_BACKEND`` env. Defaults to ``ollama`` (local-first
+    is JAMES' identity)."""
+    selected = (name or os.environ.get(ENV_BACKEND) or "ollama").strip().lower()
+    if selected == "anthropic":
+        return AnthropicBackend()
+    if selected == "ollama":
+        return OllamaBackend()
+    raise BackendError(
+        f"unknown backend {selected!r}; expected 'anthropic' or 'ollama'"
+    )
+
+
+def tools_to_schema(tools_list) -> List[Dict[str, Any]]:
+    """Convert ``Tool`` instances into the schema list both backends
+    accept (`{name, description, input_schema}`)."""
+    return [{
+        "name": t.name,
+        "description": t.description,
+        "input_schema": t.input_schema,
+    } for t in tools_list]

--- a/core/agent_tools/builtins.py
+++ b/core/agent_tools/builtins.py
@@ -1,0 +1,325 @@
+"""6 built-in agent tools (v0.6.1 Phase C).
+
+Each tool wraps an existing Phase 5.5 building block when one fits
+(`tools/code/read_file.py`, `tools/code/code_editor.py`) and falls
+back to a direct os/io call otherwise. Every tool calls
+``policy_validate_path`` so the path safety contract is enforced even
+if the dispatcher is bypassed.
+
+Tool surface intentionally mirrors what Claude Code's first-party
+tools expose (list / read / write / edit / glob / grep) so an LLM
+trained on that surface has familiar handles.
+"""
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from typing import Any, Dict, List
+
+from core.agent_tools.registry import Tool, ToolError, register_tool
+
+
+def _validate(path: str, role: str) -> str:
+    """Run the Phase 5.5 sandbox path guard. Raises ``ToolError`` so
+    the dispatcher surfaces an LLM-facing error."""
+    from tools.code.sandbox import validate_path
+    ok, msg = validate_path(path, role=role)
+    if not ok:
+        raise ToolError(f"path rejected: {msg}")
+    return path
+
+
+# ── list_files ──────────────────────────────────────────────────
+
+def _h_list_files(args: Dict[str, Any], role: str) -> List[Dict[str, Any]]:
+    path = args.get("path") or ""
+    if not isinstance(path, str) or not path:
+        raise ToolError("'path' (string) is required")
+    _validate(path, role)
+    if not os.path.isdir(path):
+        raise ToolError(f"not a directory: {path!r}")
+    entries: List[Dict[str, Any]] = []
+    try:
+        for name in sorted(os.listdir(path)):
+            full = os.path.join(path, name)
+            try:
+                is_dir = os.path.isdir(full)
+                size = 0 if is_dir else os.path.getsize(full)
+            except OSError:
+                continue
+            entries.append({"name": name, "is_dir": is_dir, "size": size})
+    except OSError as e:
+        raise ToolError(f"listdir failed: {e}")
+    # Cap so the LLM context doesn't drown on huge dirs.
+    return entries[:500]
+
+
+register_tool(Tool(
+    name="list_files",
+    description=(
+        "List entries (files + subdirs) in a directory the operator "
+        "has allowed. Returns up to 500 entries."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string",
+                     "description": "Absolute path to a directory the agent is allowed to read."},
+        },
+        "required": ["path"],
+    },
+    handler=_h_list_files,
+))
+
+
+# ── read_file ───────────────────────────────────────────────────
+
+def _h_read_file(args: Dict[str, Any], role: str) -> Dict[str, Any]:
+    path = args.get("path") or ""
+    if not isinstance(path, str) or not path:
+        raise ToolError("'path' (string) is required")
+    _validate(path, role)
+    if not os.path.isfile(path):
+        raise ToolError(f"not a file: {path!r}")
+    try:
+        # Mirror the read_file.py tool's 500 KB cap so the LLM never
+        # ingests megabytes of binary unintended.
+        max_bytes = 500 * 1024
+        size = os.path.getsize(path)
+        if size > max_bytes:
+            raise ToolError(f"file too large ({size} bytes > {max_bytes})")
+        with open(path, "rb") as f:
+            data = f.read()
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ToolError("file is not valid UTF-8 text")
+    except OSError as e:
+        raise ToolError(f"read failed: {e}")
+    return {"path": path, "bytes": size, "content": text}
+
+
+register_tool(Tool(
+    name="read_file",
+    description=(
+        "Read a UTF-8 text file from an allowed path. 500 KB cap; "
+        "binary or oversize files surface as an error."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+        },
+        "required": ["path"],
+    },
+    handler=_h_read_file,
+    audit_post_call=False,   # output is the file body — keep audit compact
+))
+
+
+# ── write_file ──────────────────────────────────────────────────
+
+def _h_write_file(args: Dict[str, Any], role: str) -> Dict[str, Any]:
+    path = args.get("path") or ""
+    content = args.get("content")
+    if not isinstance(path, str) or not path:
+        raise ToolError("'path' (string) is required")
+    if not isinstance(content, str):
+        raise ToolError("'content' (string) is required")
+    _validate(path, role)
+    parent = os.path.dirname(path)
+    if parent and not os.path.isdir(parent):
+        raise ToolError(f"parent directory does not exist: {parent!r}")
+    try:
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+    except OSError as e:
+        raise ToolError(f"write failed: {e}")
+    return {"path": path, "bytes": len(content.encode("utf-8"))}
+
+
+register_tool(Tool(
+    name="write_file",
+    description=(
+        "Write (or overwrite) a UTF-8 text file at an allowed path. "
+        "Parent directory must already exist."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "content": {"type": "string"},
+        },
+        "required": ["path", "content"],
+    },
+    handler=_h_write_file,
+))
+
+
+# ── edit_file (substring replace) ───────────────────────────────
+
+def _h_edit_file(args: Dict[str, Any], role: str) -> Dict[str, Any]:
+    path = args.get("path") or ""
+    old = args.get("old_string")
+    new = args.get("new_string")
+    replace_all = bool(args.get("replace_all", False))
+    if not isinstance(path, str) or not path:
+        raise ToolError("'path' (string) is required")
+    if not isinstance(old, str) or not isinstance(new, str):
+        raise ToolError("'old_string' and 'new_string' (strings) are required")
+    if not old:
+        raise ToolError("'old_string' must be non-empty")
+    _validate(path, role)
+    if not os.path.isfile(path):
+        raise ToolError(f"not a file: {path!r}")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        raise ToolError(f"read failed: {e}")
+    count = text.count(old)
+    if count == 0:
+        raise ToolError("old_string not found in file")
+    if count > 1 and not replace_all:
+        raise ToolError(
+            f"old_string is not unique ({count} matches); "
+            "pass replace_all=true or use a more specific snippet"
+        )
+    new_text = text.replace(old, new) if replace_all else text.replace(old, new, 1)
+    try:
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(new_text)
+    except OSError as e:
+        raise ToolError(f"write failed: {e}")
+    return {
+        "path": path,
+        "replaced": count if replace_all else 1,
+        "delta_bytes": len(new_text.encode("utf-8")) - len(text.encode("utf-8")),
+    }
+
+
+register_tool(Tool(
+    name="edit_file",
+    description=(
+        "Replace ``old_string`` with ``new_string`` in a file. By "
+        "default requires the match to be unique; set "
+        "``replace_all: true`` to replace every occurrence."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "old_string": {"type": "string"},
+            "new_string": {"type": "string"},
+            "replace_all": {"type": "boolean"},
+        },
+        "required": ["path", "old_string", "new_string"],
+    },
+    handler=_h_edit_file,
+))
+
+
+# ── glob_files ──────────────────────────────────────────────────
+
+def _h_glob_files(args: Dict[str, Any], role: str) -> List[str]:
+    pattern = args.get("pattern") or ""
+    root = args.get("path") or ""
+    if not isinstance(pattern, str) or not pattern:
+        raise ToolError("'pattern' (string) is required")
+    if not isinstance(root, str) or not root:
+        raise ToolError("'path' (string) is required")
+    _validate(root, role)
+    if not os.path.isdir(root):
+        raise ToolError(f"not a directory: {root!r}")
+    matches: List[str] = []
+    # `pattern` may contain a path component (e.g. "src/**/*.py"). We
+    # treat it as fnmatch against the *relative* path.
+    for dirpath, _dirs, files in os.walk(root):
+        rel_dir = os.path.relpath(dirpath, root)
+        for name in files:
+            rel = name if rel_dir == "." else os.path.join(rel_dir, name)
+            if fnmatch.fnmatch(rel, pattern):
+                matches.append(os.path.join(dirpath, name))
+                if len(matches) >= 500:
+                    return matches
+    return matches
+
+
+register_tool(Tool(
+    name="glob_files",
+    description=(
+        "Find files under ``path`` whose relative path matches "
+        "``pattern`` (fnmatch syntax — ``*.md``, ``src/**/*.py``, …). "
+        "Caps at 500 results."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "pattern": {"type": "string"},
+            "path": {"type": "string"},
+        },
+        "required": ["pattern", "path"],
+    },
+    handler=_h_glob_files,
+))
+
+
+# ── grep_files ──────────────────────────────────────────────────
+
+def _h_grep_files(args: Dict[str, Any], role: str) -> List[Dict[str, Any]]:
+    pattern = args.get("pattern") or ""
+    root = args.get("path") or ""
+    case_insensitive = bool(args.get("case_insensitive", False))
+    if not isinstance(pattern, str) or not pattern:
+        raise ToolError("'pattern' (regex string) is required")
+    if not isinstance(root, str) or not root:
+        raise ToolError("'path' (string) is required")
+    _validate(root, role)
+    if not os.path.isdir(root):
+        raise ToolError(f"not a directory: {root!r}")
+    flags = re.IGNORECASE if case_insensitive else 0
+    try:
+        rgx = re.compile(pattern, flags)
+    except re.error as e:
+        raise ToolError(f"bad regex: {e}")
+    hits: List[Dict[str, Any]] = []
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            full = os.path.join(dirpath, name)
+            try:
+                if os.path.getsize(full) > 1 * 1024 * 1024:
+                    continue   # skip > 1 MB
+                with open(full, "r", encoding="utf-8", errors="replace") as f:
+                    for line_no, line in enumerate(f, start=1):
+                        if rgx.search(line):
+                            hits.append({
+                                "file": full,
+                                "line": line_no,
+                                "text": line.rstrip("\n")[:300],
+                            })
+                            if len(hits) >= 500:
+                                return hits
+            except OSError:
+                continue
+    return hits
+
+
+register_tool(Tool(
+    name="grep_files",
+    description=(
+        "Search for a regex inside text files under ``path``. Returns "
+        "up to 500 ``{file, line, text}`` hits. Files larger than 1 MB "
+        "are skipped."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "pattern": {"type": "string"},
+            "path": {"type": "string"},
+            "case_insensitive": {"type": "boolean"},
+        },
+        "required": ["pattern", "path"],
+    },
+    handler=_h_grep_files,
+))

--- a/core/agent_tools/dispatcher.py
+++ b/core/agent_tools/dispatcher.py
@@ -1,0 +1,130 @@
+"""Tool dispatcher (v0.6.1 Phase C).
+
+Single entry point for every tool call. Wraps the handler with:
+
+  * Tool lookup (404-equivalent → ``is_error: true`` for the LLM loop).
+  * Audit log: one row before the call, one after (success / error /
+    timeout). Both rows include the tool name + role + caller; neither
+    includes the full input/output (kept compact for audit_log
+    ergonomics).
+  * Timeout enforcement via a worker thread + ``join(timeout)``. The
+    underlying Phase 5.5 sandbox already kills subprocess children on
+    its own timeout, so this layer is the fallback for in-process
+    blocking handlers.
+  * Uniform return shape ``{ok, output|error, tool_name, elapsed_ms}``
+    so the LLM loop never branches on exception types.
+
+The dispatcher does **not** enforce the path safety contract — every
+file/edit/grep tool calls ``policy_validate_path`` itself. Defence in
+depth.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict
+
+from core.agent_tools.registry import (
+    MAX_TOOL_TIMEOUT_SEC,
+    ToolError,
+    get_tool,
+)
+
+
+def _audit(role: str, tool_name: str, phase: str, detail: str = "") -> None:
+    """Write one audit row. Failures here MUST NOT break the tool
+    call — the dispatcher is the only audit sink that's allowed to
+    swallow exceptions silently (mirrors `tools/code/sandbox.py`
+    `log_security_event`)."""
+    try:
+        from routes._helpers import _write_audit
+        _write_audit(
+            role,
+            f"agent_tool:{tool_name}",
+            query=f"phase={phase}",
+            answer=(detail or "")[:300],
+        )
+    except Exception:
+        pass
+
+
+def _err(tool_name: str, msg: str, *, elapsed_ms: int = 0) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "tool_name": tool_name,
+        "error": msg,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def _ok(tool_name: str, output: Any, *, elapsed_ms: int) -> Dict[str, Any]:
+    return {
+        "ok": True,
+        "tool_name": tool_name,
+        "output": output,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def dispatch(
+    tool_name: str,
+    args: Dict[str, Any],
+    role: str = "admin",
+) -> Dict[str, Any]:
+    """Look up + run ``tool_name`` with ``args``. Always returns the
+    uniform result dict; never raises (except for bugs in this
+    module)."""
+    tool = get_tool(tool_name)
+    if tool is None:
+        _audit(role, tool_name, phase="lookup_fail")
+        return _err(tool_name, f"unknown tool: {tool_name!r}")
+
+    if not isinstance(args, dict):
+        return _err(tool_name, "args must be a dict")
+
+    if tool.audit_pre_call:
+        _audit(role, tool_name, phase="pre", detail=str(list(args.keys())))
+
+    timeout = max(1, min(int(tool.timeout_sec or MAX_TOOL_TIMEOUT_SEC),
+                         MAX_TOOL_TIMEOUT_SEC))
+    result_holder: Dict[str, Any] = {}
+    start = time.monotonic()
+
+    def _run():
+        try:
+            result_holder["value"] = tool.handler(args, role)
+        except ToolError as e:
+            result_holder["error"] = str(e)
+        except Exception as e:  # noqa: BLE001 — handler boundary
+            result_holder["error"] = f"{type(e).__name__}: {e}"
+
+    th = threading.Thread(target=_run, daemon=True)
+    th.start()
+    th.join(timeout)
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+
+    if th.is_alive():
+        # Thread can't be killed cleanly in Python; the daemon flag
+        # ensures it dies with the process. The caller sees a timeout
+        # error; the handler may continue in the background until it
+        # finishes or the process exits. Real subprocess timeouts are
+        # handled by the sandbox layer one level down (10s default).
+        msg = f"tool timed out after {timeout}s"
+        _audit(role, tool_name, phase="timeout", detail=msg)
+        return _err(tool_name, msg, elapsed_ms=elapsed_ms)
+
+    if "error" in result_holder:
+        msg = result_holder["error"]
+        if tool.audit_post_call:
+            _audit(role, tool_name, phase="error", detail=msg)
+        return _err(tool_name, msg, elapsed_ms=elapsed_ms)
+
+    output = result_holder.get("value")
+    if tool.audit_post_call:
+        # Don't dump the full output into audit — just a size hint.
+        size_hint = (
+            f"{len(output)} chars" if isinstance(output, str)
+            else f"type={type(output).__name__}"
+        )
+        _audit(role, tool_name, phase="ok", detail=size_hint)
+    return _ok(tool_name, output, elapsed_ms=elapsed_ms)

--- a/core/agent_tools/registry.py
+++ b/core/agent_tools/registry.py
@@ -1,0 +1,74 @@
+"""Tool registry (v0.6.1 Phase C).
+
+In-memory only. Built-in tools are registered at import time from
+``core/agent_tools/builtins.py``. Future tools (e.g. the deferred
+Phase E ``run_shell``) register here as well.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+# Global cap. Individual tools MAY pin a lower per-call timeout via
+# ``Tool.timeout_sec``; the dispatcher takes ``min(tool.timeout_sec,
+# MAX_TOOL_TIMEOUT_SEC)``.
+MAX_TOOL_TIMEOUT_SEC = 30
+
+
+class ToolError(Exception):
+    """Raised by tool handlers when input validation or execution
+    fails in a way the caller should surface to the LLM as
+    ``is_error: true`` rather than crashing the chat loop."""
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One callable an LLM may invoke via tool_use / function_call.
+
+    ``input_schema`` follows the JSON-Schema-ish shape Anthropic and
+    Ollama both accept (``{"type": "object", "properties": {...},
+    "required": [...]}``). The dispatcher does NOT enforce schema
+    validation beyond what each handler validates itself — schema is
+    metadata for the LLM, not a runtime guard. Handlers MUST validate
+    their own inputs (path safety etc.).
+    """
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    handler: Callable[[Dict[str, Any], str], Any]   # (args, role) → result
+    timeout_sec: int = MAX_TOOL_TIMEOUT_SEC
+    # When True, the dispatcher writes an audit row BEFORE calling the
+    # handler so a crash inside the handler still leaves a trace.
+    # Default True; tools that produce huge output (e.g. read_file)
+    # may skip the after-row to keep audit_log small.
+    audit_pre_call: bool = True
+    audit_post_call: bool = True
+
+
+_TOOLS: Dict[str, Tool] = {}
+
+
+def register_tool(tool: Tool) -> None:
+    """Add ``tool`` to the registry. Overwrites an existing entry of
+    the same name (last-write-wins; tests rely on this)."""
+    if not isinstance(tool, Tool):
+        raise TypeError("register_tool expects a Tool instance")
+    if not tool.name or "/" in tool.name or "\\" in tool.name:
+        raise ValueError(f"invalid tool name: {tool.name!r}")
+    _TOOLS[tool.name] = tool
+
+
+def get_tool(name: str) -> Optional[Tool]:
+    return _TOOLS.get(name)
+
+
+def list_tools() -> List[Tool]:
+    """Deterministic order — registration order preserved by the
+    underlying dict."""
+    return list(_TOOLS.values())
+
+
+def _clear_for_tests() -> None:
+    """Internal helper for unit tests; not exported."""
+    _TOOLS.clear()

--- a/docs/design/v0.6-agent-tools-user-paths.md
+++ b/docs/design/v0.6-agent-tools-user-paths.md
@@ -88,13 +88,14 @@ UI (otherwise a chat session could implicit-escalate).
 
 ## 5. Phasing
 
-| Phase | Scope | Shipping in this PR? |
+| Phase | Scope | Shipped? |
 |---|---|---|
-| **A** | This memo + ARCHITECTURE §5.7.x trust-zone entry | **YES** |
-| **B** | `JAMES_AGENT_ALLOWED_PATHS` env + `register_user_path()` + admin `GET/POST /admin/agent/allowed-paths` + sandbox.validate_path bypass for registered paths + critical block enforced + tests | **YES** |
-| **C** | LLM tool-calling integration (Anthropic `tool_use` first, Ollama function calling second) + tool registry surfacing existing `tools/code/*` | LOI-independent; defer until operator dogfooding flags this as the next bottleneck |
-| **D** | Chat-side tool-call confirm UI (per-call `Allow / Deny / Always`) + streaming output + cancel button | Defer; depends on Phase C |
-| **E** | `run_shell` tool + stronger `BLOCKED_COMMANDS` + PS / bash dispatch + audit | Defer; highest risk surface, ships only after C/D validated |
+| **A** | This memo + ARCHITECTURE §5.7.15 trust-zone entry | ✅ #918 |
+| **B** | `JAMES_AGENT_ALLOWED_PATHS` env + `register_user_path()` + admin `GET/POST /admin/agent/allowed-paths` + sandbox.validate_path bypass for registered paths + critical block enforced + tests | ✅ #918 |
+| **D-1** | `📂 에이전트 폴더` admin UI page + session-scoped remove | ✅ #919 |
+| **C** | LLM tool-calling: `core/agent_tools/` (registry + dispatcher + 6 built-in tools: `list_files / read_file / write_file / edit_file / glob_files / grep_files`) + backend abstraction (Anthropic + Ollama toggle via `JAMES_AGENT_BACKEND`) + `POST /agent/chat/` tool-use loop (max 5 iterations, admin-only, audit-traced) | ✅ THIS PR |
+| **D-2** | Chat-side per-call confirm card (`Allow / Deny / Always-allow`) + streaming output + cancel button | Defer; PR-3 |
+| **E** | `run_shell` tool + stronger `BLOCKED_COMMANDS` + PS / bash dispatch + audit | Defer; highest risk surface, ships only after D-2 validated |
 
 ## 6. Rule compliance
 

--- a/routes/agent_chat.py
+++ b/routes/agent_chat.py
@@ -1,0 +1,157 @@
+"""Agent chat endpoint (v0.6.1 Phase C).
+
+`POST /agent/chat/` — sends a user message into the LLM tool-use loop:
+
+  1. LLM sees ``messages + tools``.
+  2. If response contains ``tool_use``, dispatch each call via the
+     `core/agent_tools` registry, append the tool-result as a new
+     message, go to (1).
+  3. Else return the final assistant text + the trace of every tool
+     call that fired.
+
+Admin-only for now (Phase D-2 will add per-call confirm UI before
+opening up to non-admin roles). Loop capped at 5 iterations so a
+runaway LLM can't drain the workspace.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from routes._helpers import (
+    _bearer_username,
+    _require_admin,
+    _write_audit,
+    get_role_from_request,
+)
+
+router = APIRouter()
+
+MAX_ITERATIONS = 5
+DEFAULT_MAX_TOKENS = 1024
+
+
+class AgentChatRequest(BaseModel):
+    api_key: str
+    message: str
+    history: Optional[List[Dict[str, Any]]] = None
+    backend: Optional[str] = None     # "anthropic" | "ollama" override
+    max_tokens: Optional[int] = None
+    system: Optional[str] = None
+
+
+@router.post("/agent/chat/", summary="에이전트 챗 (LLM tool-use) [v0.6.1 Phase C]")
+async def agent_chat_route(
+    body: AgentChatRequest,
+    request: Request,
+    role: str = Depends(get_role_from_request),
+):
+    """Run one user-message turn through the LLM tool-use loop."""
+    _require_admin(body.api_key, role)
+    username = _bearer_username(request) or "admin"
+
+    from core.agent_tools import dispatch, list_tools
+    from core.agent_tools.backends import (
+        BackendError,
+        get_backend,
+        tools_to_schema,
+    )
+
+    if not body.message or not body.message.strip():
+        raise HTTPException(status_code=400, detail="message must be non-empty")
+
+    try:
+        backend = get_backend(body.backend)
+    except BackendError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    tools_schema = tools_to_schema(list_tools())
+    max_tokens = max(64, min(int(body.max_tokens or DEFAULT_MAX_TOKENS), 4096))
+    system = body.system or (
+        "You are JAMES, an auditable knowledge platform's agent. You may "
+        "call the listed tools to inspect and modify files in the "
+        "operator-allowed folders. Do not invent file paths; ask the "
+        "user when uncertain. Keep responses concise."
+    )
+
+    # Conversation state. Each backend accepts the Anthropic-style
+    # shape; OllamaBackend internally adapts.
+    messages: List[Dict[str, Any]] = list(body.history or [])
+    messages.append({"role": "user", "content": body.message})
+
+    trace: List[Dict[str, Any]] = []
+    final_text = ""
+    stop_reason = "end_turn"
+    iter_count = 0
+
+    for iter_count in range(1, MAX_ITERATIONS + 1):
+        try:
+            resp = backend.chat_with_tools(
+                messages=messages, tools=tools_schema,
+                system=system, max_tokens=max_tokens,
+            )
+        except BackendError as e:
+            _write_audit(role, "/agent/chat/",
+                         query=f"iter={iter_count}",
+                         answer=f"backend error: {e}")
+            raise HTTPException(status_code=502, detail=str(e))
+
+        stop_reason = resp.get("stop_reason") or "end_turn"
+        final_text = resp.get("text") or final_text
+        calls = resp.get("tool_calls") or []
+
+        if not calls or stop_reason != "tool_use":
+            break
+
+        # Append the assistant message that requested the tool use, so
+        # the next iteration's history is consistent for both backends.
+        assistant_content: List[Dict[str, Any]] = []
+        if final_text:
+            assistant_content.append({"type": "text", "text": final_text})
+        for c in calls:
+            assistant_content.append({
+                "type": "tool_use",
+                "id": c["id"], "name": c["name"], "input": c["input"],
+            })
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        # Run each tool, capture result.
+        tool_result_blocks: List[Dict[str, Any]] = []
+        for c in calls:
+            d = dispatch(c["name"], c["input"], role=role)
+            trace.append({
+                "iter": iter_count,
+                "name": c["name"],
+                "input": c["input"],
+                "ok": d.get("ok"),
+                "error": d.get("error"),
+                "elapsed_ms": d.get("elapsed_ms"),
+            })
+            tool_result_blocks.append({
+                "type": "tool_result",
+                "tool_use_id": c["id"],
+                "is_error": not d.get("ok"),
+                "content": (
+                    d.get("output") if d.get("ok")
+                    else (d.get("error") or "unknown error")
+                ),
+            })
+        messages.append({"role": "user", "content": tool_result_blocks})
+        # Loop continues — backend sees the tool result + can decide
+        # to call more tools or produce the final text.
+
+    _write_audit(role, "/agent/chat/",
+                 query=f"iters={iter_count}",
+                 answer=f"stop={stop_reason} calls={len(trace)}")
+
+    return {
+        "ok": True,
+        "text": final_text,
+        "stop_reason": stop_reason,
+        "iterations": iter_count,
+        "tool_trace": trace,
+        "backend": backend.name,
+        "by": username,
+    }

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -434,6 +434,10 @@ app.include_router(workspace_info_router)
 from routes.agent_paths import router as agent_paths_router
 app.include_router(agent_paths_router)
 
+# v0.6.1 Phase C — agent chat (LLM tool-use loop).
+from routes.agent_chat import router as agent_chat_router
+app.include_router(agent_chat_router)
+
 from routes.multimodal import router as multimodal_router
 from routes.multimodal import ScreenRequest  # noqa: F401  back-compat
 app.include_router(multimodal_router)

--- a/tests/test_v06_agent_tools.py
+++ b/tests/test_v06_agent_tools.py
@@ -1,0 +1,277 @@
+"""v0.6.1 Phase C — agent tool registry / dispatcher / built-ins +
+backend abstraction + agent chat endpoint.
+
+LLM HTTP calls are stubbed; no real Anthropic / Ollama traffic.
+
+Run:
+  python -m unittest tests.test_v06_agent_tools
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _reset_sandbox_state():
+    import tools.code.sandbox as sb
+    sb._USER_REGISTERED_PATHS.clear()
+    sb._USER_PATHS_LOADED = False
+
+
+# ── Registry + dispatcher ─────────────────────────────────────────
+
+class RegistryTests(unittest.TestCase):
+    def test_builtins_registered(self):
+        from core.agent_tools import list_tools, get_tool
+        names = [t.name for t in list_tools()]
+        for expected in ("list_files", "read_file", "write_file",
+                         "edit_file", "glob_files", "grep_files"):
+            self.assertIn(expected, names)
+        self.assertIsNotNone(get_tool("list_files"))
+
+    def test_register_invalid_name_rejected(self):
+        from core.agent_tools.registry import register_tool, Tool
+        with self.assertRaises(ValueError):
+            register_tool(Tool(
+                name="bad/name", description="x",
+                input_schema={"type": "object"}, handler=lambda a, r: None,
+            ))
+
+
+class DispatchUnknownToolTests(unittest.TestCase):
+    def test_unknown_returns_error_dict(self):
+        from core.agent_tools import dispatch
+        r = dispatch("no_such_tool", {}, "admin")
+        self.assertFalse(r["ok"])
+        self.assertIn("unknown tool", r["error"])
+
+    def test_args_must_be_dict(self):
+        from core.agent_tools import dispatch
+        r = dispatch("list_files", "not-a-dict", "admin")
+        self.assertFalse(r["ok"])
+        self.assertIn("dict", r["error"])
+
+
+class BuiltinsRoundTripTests(unittest.TestCase):
+    def setUp(self):
+        _reset_sandbox_state()
+        self._tmp = tempfile.mkdtemp(prefix="james_at_b_")
+        from tools.code.sandbox import register_user_path
+        register_user_path(self._tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        _reset_sandbox_state()
+
+    def test_write_then_read(self):
+        from core.agent_tools import dispatch
+        target = os.path.join(self._tmp, "note.md")
+        w = dispatch("write_file", {"path": target, "content": "hello"}, "admin")
+        self.assertTrue(w["ok"], w)
+        r = dispatch("read_file", {"path": target}, "admin")
+        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["output"]["content"], "hello")
+
+    def test_edit_unique_match(self):
+        from core.agent_tools import dispatch
+        target = os.path.join(self._tmp, "x.md")
+        dispatch("write_file", {"path": target, "content": "alpha beta"}, "admin")
+        e = dispatch("edit_file", {"path": target,
+                                    "old_string": "beta",
+                                    "new_string": "GAMMA"}, "admin")
+        self.assertTrue(e["ok"], e)
+        r = dispatch("read_file", {"path": target}, "admin")
+        self.assertEqual(r["output"]["content"], "alpha GAMMA")
+
+    def test_edit_ambiguous_rejected(self):
+        from core.agent_tools import dispatch
+        target = os.path.join(self._tmp, "x.md")
+        dispatch("write_file",
+                 {"path": target, "content": "x x x"}, "admin")
+        e = dispatch("edit_file",
+                     {"path": target, "old_string": "x", "new_string": "y"},
+                     "admin")
+        self.assertFalse(e["ok"])
+        self.assertIn("not unique", e["error"])
+
+    def test_path_outside_allowed_rejected(self):
+        from core.agent_tools import dispatch
+        # writing to repo workspace (which is allowed by ALLOWED_PATHS)
+        # is fine; writing to system root is not.
+        if os.name == "nt":
+            target = "C:\\Windows\\should_not_write.txt"
+        else:
+            target = "/etc/should_not_write.txt"
+        r = dispatch("write_file", {"path": target, "content": "x"}, "admin")
+        self.assertFalse(r["ok"])
+
+    def test_glob_and_grep(self):
+        from core.agent_tools import dispatch
+        for n in ("a.md", "b.md", "c.txt"):
+            dispatch("write_file",
+                     {"path": os.path.join(self._tmp, n),
+                      "content": "hello world"}, "admin")
+        g = dispatch("glob_files",
+                     {"pattern": "*.md", "path": self._tmp}, "admin")
+        self.assertTrue(g["ok"])
+        self.assertEqual(len(g["output"]), 2)
+        gr = dispatch("grep_files",
+                      {"pattern": "world", "path": self._tmp}, "admin")
+        self.assertTrue(gr["ok"])
+        self.assertEqual(len(gr["output"]), 3)
+
+
+# ── Backend factory ────────────────────────────────────────────────
+
+class BackendFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self._prev_b = os.environ.pop("JAMES_AGENT_BACKEND", None)
+        self._prev_k = os.environ.pop("ANTHROPIC_API_KEY", None)
+
+    def tearDown(self):
+        if self._prev_b is not None:
+            os.environ["JAMES_AGENT_BACKEND"] = self._prev_b
+        if self._prev_k is not None:
+            os.environ["ANTHROPIC_API_KEY"] = self._prev_k
+
+    def test_default_is_ollama(self):
+        from core.agent_tools.backends import get_backend, OllamaBackend
+        b = get_backend()
+        self.assertIsInstance(b, OllamaBackend)
+
+    def test_anthropic_requires_key(self):
+        from core.agent_tools.backends import BackendError, get_backend
+        os.environ["JAMES_AGENT_BACKEND"] = "anthropic"
+        with self.assertRaises(BackendError):
+            get_backend()
+
+    def test_unknown_backend_rejected(self):
+        from core.agent_tools.backends import BackendError, get_backend
+        with self.assertRaises(BackendError):
+            get_backend("madeup")
+
+
+# ── Agent chat endpoint (HTTP, with stubbed backend) ──────────────
+
+class _FakeBackend:
+    name = "fake"
+
+    def __init__(self, *replies):
+        # `replies` are dicts the loop returns one-per-iteration.
+        self._replies = list(replies)
+
+    def chat_with_tools(self, messages, tools, *, system=None, max_tokens=1024):
+        if not self._replies:
+            return {"stop_reason": "end_turn", "text": "(done)", "tool_calls": [], "raw": {}}
+        return self._replies.pop(0)
+
+
+def _make_client(role="admin"):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import routes.agent_chat as ac
+    from routes._helpers import get_role_from_request
+
+    app = FastAPI()
+    app.include_router(ac.router)
+    app.dependency_overrides[get_role_from_request] = lambda: role
+    ac._bearer_username = lambda request: "admin"
+    ac._require_admin = lambda api_key, role: None if role == "admin" else (_ for _ in ()).throw(
+        __import__("fastapi").HTTPException(status_code=403, detail="admin only")
+    )
+    return TestClient(app), ac
+
+
+class AgentChatEndpointTests(unittest.TestCase):
+    def setUp(self):
+        _reset_sandbox_state()
+        self._tmp = tempfile.mkdtemp(prefix="james_ac_")
+        from tools.code.sandbox import register_user_path
+        register_user_path(self._tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        _reset_sandbox_state()
+
+    def test_empty_message_rejected(self):
+        client, _ = _make_client()
+        r = client.post("/agent/chat/",
+                        json={"api_key": "x", "message": "   "})
+        self.assertEqual(r.status_code, 400)
+
+    def test_forbidden_for_non_admin(self):
+        client, _ = _make_client(role="user")
+        r = client.post("/agent/chat/",
+                        json={"api_key": "x", "message": "hi"})
+        self.assertEqual(r.status_code, 403)
+
+    def test_no_tool_use_returns_text(self):
+        client, ac = _make_client()
+        fake = _FakeBackend({"stop_reason": "end_turn",
+                              "text": "hello back", "tool_calls": [], "raw": {}})
+        ac.get_backend = lambda name=None: fake
+        # patch import path the endpoint uses
+        import core.agent_tools.backends as be
+        orig_get = be.get_backend
+        be.get_backend = lambda name=None: fake
+        try:
+            r = client.post("/agent/chat/",
+                            json={"api_key": "x", "message": "hi"})
+        finally:
+            be.get_backend = orig_get
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["stop_reason"], "end_turn")
+        self.assertIn("hello back", body["text"])
+        self.assertEqual(body["tool_trace"], [])
+
+    def test_tool_use_loop_runs_dispatch_then_finishes(self):
+        client, ac = _make_client()
+        # First reply asks for write_file; second is end_turn.
+        target = os.path.join(self._tmp, "agent.md")
+        fake = _FakeBackend(
+            {"stop_reason": "tool_use",
+             "text": "I'll write that file.",
+             "tool_calls": [{
+                 "id": "u1", "name": "write_file",
+                 "input": {"path": target, "content": "hi from agent"},
+             }],
+             "raw": {}},
+            {"stop_reason": "end_turn",
+             "text": "Wrote it.",
+             "tool_calls": [], "raw": {}},
+        )
+        import core.agent_tools.backends as be
+        orig = be.get_backend
+        be.get_backend = lambda name=None: fake
+        try:
+            r = client.post("/agent/chat/",
+                            json={"api_key": "x",
+                                  "message": "write hi from agent to agent.md"})
+        finally:
+            be.get_backend = orig
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["stop_reason"], "end_turn")
+        self.assertEqual(len(body["tool_trace"]), 1)
+        self.assertTrue(body["tool_trace"][0]["ok"])
+        self.assertEqual(body["tool_trace"][0]["name"], "write_file")
+        # And the file actually got written:
+        with open(target, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "hi from agent")
+
+
+class ServerRegistrationTests(unittest.TestCase):
+    def test_agent_chat_route_wired(self):
+        import server_llmwiki
+        paths = {getattr(r, "path", None) for r in server_llmwiki.app.routes}
+        self.assertIn("/agent/chat/", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**PR-2 of the 3-PR series**. Wires the LLM-driven file management dispatcher the operator asked for. After this PR a chat turn into `POST /agent/chat/` can natural-language its way through the **6 file tools** (`list_files / read_file / write_file / edit_file / glob_files / grep_files`) against the operator-allowed folders from #918 / #919. PR-3 will add the chat-side per-call confirm UI + streaming output.

## Architecture summary

```
operator → POST /agent/chat/ {message, history?}
   ↓
LLM tool-use loop (max 5 iter, admin-only)
   ↓
get_backend()         ← JAMES_AGENT_BACKEND={ollama|anthropic}
   • AnthropicBackend (httpx → api.anthropic.com /v1/messages, tool_use)
   • OllamaBackend    (httpx → /api/chat, tools array)
   ↓
LLM emits tool_use block(s)
   ↓
core.agent_tools.dispatch(name, args, role)
   • registry lookup
   • thread + join(timeout)
   • audit pre + post
   ↓
builtins.* handler → validate_path (sandbox v0.6.1) → os/io
   ↓
tool_result message back into the conversation
   ↓
loop or end_turn → final text + tool_trace
```

## What ships

### `core/agent_tools/` (new package)

| Module | Role |
|---|---|
| `registry.py` | `Tool` frozen dataclass + register/get/list. JSON-Schema-ish `input_schema` (Anthropic + Ollama both accept). `MAX_TOOL_TIMEOUT_SEC = 30` |
| `dispatcher.py` | `dispatch(name, args, role)`. Thread + `join(timeout)`. Uniform return shape `{ok, output\|error, tool_name, elapsed_ms}` — LLM loop never branches on exception types. Audit pre + post |
| `builtins.py` | 6 tools registered at import time. `edit_file` uses Claude-Code-style unique-match guard (ambiguous match rejected unless `replace_all: true`) |
| `backends.py` | `AgentBackend` ABC + `AnthropicBackend` (httpx direct, no SDK dep) + `OllamaBackend`. `get_backend(name)` honours `JAMES_AGENT_BACKEND` env (default `ollama` — local-first identity) |

### `routes/agent_chat.py` (new)

- `POST /agent/chat/` — `_require_admin` + audit
- Loop: send → if `tool_use` → dispatch + append result → send again
- `MAX_ITERATIONS = 5` so runaway LLM can't drain the workspace
- Body fields: `message` (required) + optional `history` / `backend` / `max_tokens` / `system`
- Default system instruction reminds LLM to stay within operator-allowed folders + not invent paths
- Wired in `server_llmwiki.py`

### Backend ergonomics

| Env | Default | Note |
|---|---|---|
| `JAMES_AGENT_BACKEND` | `ollama` | `anthropic` switches to cloud |
| `OLLAMA_HOST` | `http://localhost:11434` | |
| `JAMES_AGENT_OLLAMA_MODEL` | `mxtral:latest` | mxtral 47B has reliable function-calling; gemma3:4b less so |
| `ANTHROPIC_API_KEY` | — | required for anthropic backend |
| `JAMES_AGENT_ANTHROPIC_MODEL` | `claude-haiku-4-5-20251001` | cheapest reliable tool_use model |

## Tests — +17, **94/94 v0.6 suite green**

`tests/test_v06_agent_tools.py`:

- RegistryTests (2): all 6 built-ins registered / invalid name rejected
- DispatchUnknownToolTests (2): unknown → error / non-dict args rejected
- BuiltinsRoundTripTests (5): write→read / edit unique / edit ambiguous rejected / path outside allowed rejected (cross-platform) / glob+grep against populated tmp
- BackendFactoryTests (3): default = ollama / anthropic without key → BackendError / unknown name → BackendError
- AgentChatEndpointTests (4): empty 400 / non-admin 403 / no-tool-use returns text / two-iter tool-use loop actually writes file (stubbed `_FakeBackend`)
- ServerRegistrationTests (1): `/agent/chat/` wired

LLM HTTP stubbed end-to-end — no real Anthropic / Ollama traffic in CI.

## Live smoke (confirmed)

```python
register_user_path(tempfile.mkdtemp())
dispatch(\"write_file\", {\"path\": \"<tmp>/a.md\", \"content\": \"# hello\nworld\"}, \"admin\")
# → ok=True
dispatch(\"edit_file\", {\"path\": \"<tmp>/a.md\", \"old_string\": \"world\", \"new_string\": \"JAMES\"}, \"admin\")
# → ok=True (delta_bytes=0)
dispatch(\"read_file\", {\"path\": \"C:\\Windows\\notepad.exe\"}, \"admin\")
# → ok=False, error=\"path rejected: critical system root blocked...\"
```

## Rule compliance

- **Rule #1**: every tool is content-agnostic; allowed paths are operator data. No domain logic in `core/agent_tools/`
- **Rule #2**: `core/retrieval` / `core/graph` traversal / `core/reasoning` **zero lines touched**. `feat` label, QDC exempt
- **Rule #3**: agent chat is **admin-only**. Every tool call audits pre + post. Phase D-2 will add per-call confirm before opening to non-admin
- **Rule #4**: ARCHITECTURE §5.7.15 already covers this trust zone from #918; phasing table updated
- **Rule #5**: largest new file = `builtins.py` 10.7 KB, well under 20 KB cap

## Out of scope (PR-3 / Phase E)

- Chat-side per-call confirm card (Allow / Deny / Always-allow) — PR-3
- Streaming output + cancel button — PR-3
- `run_shell` PowerShell / bash tool — Phase E
- Non-admin agent chat access — PR-3 + per-call confirm prerequisite
- Anthropic abstraction-layer (§5.7.12) routing for cloud egress — deferred to when `run_shell` arrives (memo §6)

Quality delta: exempt (label: feat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)