### PR TITLE
fix(v0.6.1): mobile sidebar overlay — default-collapsed on phones + backdrop + tappable close

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -121,6 +121,12 @@
   <button class="sidebar-open-btn" id="sidebar-open-btn"
           data-action="toggle-sidebar" data-i18n-title="upload.open" title="업로드 열기"
           aria-label="사이드바 열기">▶</button>
+  <!-- v0.6.1 mobile fix (2026-06-15) — backdrop overlay so a phone
+       operator can tap the dimmed area to dismiss the sidebar. Default
+       hidden; index-init.js::toggleSidebar() adds .show only when the
+       sidebar opens on a phone-sized viewport. -->
+  <div id="sidebar-backdrop" data-action="toggle-sidebar"
+       aria-hidden="true"></div>
   <!-- ── 사이드바 (W5: rail + panel split) ── -->
   <aside class="sidebar" id="sidebar">
     <!-- Left rail — mode icons. switchSidebarMode(id) flips both

--- a/frontend/static/index-init.js
+++ b/frontend/static/index-init.js
@@ -23,6 +23,19 @@
 (function () {
   'use strict';
 
+  /* v0.6.1 mobile fix (2026-06-15): on phone-sized viewports the
+   * sidebar is `position:fixed; width:88vw` overlay (mobile.css §
+   * "사이드바"). Default-open used to make the chat surface
+   * inaccessible on first load; the operator caught it on Galaxy
+   * Tailscale tunnel. Default-collapsed on phones, respect operator
+   * choice if they explicitly toggled in a previous session. */
+  function _isPhoneViewport() {
+    try {
+      return window.matchMedia &&
+             window.matchMedia('(max-width: 768px)').matches;
+    } catch (_) { return false; }
+  }
+
   window.addEventListener('DOMContentLoaded', function () {
     if (typeof restoreHistory === 'function') {
       restoreHistory();
@@ -34,6 +47,21 @@
         switchSidebarMode(saved);
       }
     } catch (_) {}
+
+    // v0.6.1 — phone-viewport default-collapsed.
+    var sb = document.getElementById('sidebar');
+    var openBtn = document.getElementById('sidebar-open-btn');
+    if (sb && _isPhoneViewport()) {
+      var pref = '';
+      try { pref = localStorage.getItem('james_sidebar_open_mobile') || ''; }
+      catch (_) {}
+      // Operator hasn't expressed a preference → collapse so the chat
+      // surface is reachable on first paint.
+      if (pref !== 'open') {
+        sb.classList.add('collapsed');
+        if (openBtn) openBtn.classList.add('visible');
+      }
+    }
   });
 
   function toggleSidebar() {
@@ -44,6 +72,17 @@
     var collapsed = sb.classList.toggle('collapsed');
     btn.classList.toggle('visible', collapsed);
     if (tog) tog.textContent = collapsed ? '▶' : '◀';
+
+    // v0.6.1 mobile fix — sync the backdrop overlay and persist the
+    // operator's choice so we don't fight them on the next reload.
+    var bd = document.getElementById('sidebar-backdrop');
+    if (bd) bd.classList.toggle('show', !collapsed && _isPhoneViewport());
+    try {
+      if (_isPhoneViewport()) {
+        localStorage.setItem('james_sidebar_open_mobile',
+                              collapsed ? 'closed' : 'open');
+      }
+    } catch (_) {}
   }
 
   /* W5: sidebar rail mode switcher.

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -342,6 +342,40 @@
     font-size: 18px;
   }
 
+  /* v0.6.1 mobile fix (2026-06-15) — backdrop overlay so tapping outside
+   * the sidebar dismisses it. Default hidden; index-init.js toggles the
+   * .show class. Below the sidebar's z-index (50) and above the chat
+   * surface. */
+  #sidebar-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 49;
+    -webkit-tap-highlight-color: transparent;
+  }
+  #sidebar-backdrop.show { display: block; }
+
+  /* v0.6.1 mobile fix — the close button inside the sidebar header was
+   * the existing .sidebar-toggle (◀). On phones the default size was
+   * too small to find — promote it to 44×44 with an accent border so
+   * the operator can clearly tap it to close. */
+  aside.sidebar .sidebar-toggle {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 10px;
+    font-size: 18px;
+    border-radius: 8px;
+    background: var(--surface-2, #1e293b);
+    border: 1px solid var(--accent, #6cd);
+    color: var(--accent, #6cd);
+    cursor: pointer;
+  }
+  aside.sidebar .sidebar-toggle:active {
+    background: var(--accent, #6cd);
+    color: var(--bg, #0f172a);
+  }
+
   /* 메시지 영역 — 패딩 줄이고 chat 가장자리까지 사용 */
   .messages {
     padding: 16px 12px 12px;


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 (Galaxy + Tailscale tunnel screenshot): chat 페이지 사이드바가 default open + 모바일에서 `position:fixed; width:88vw` overlay → 메인 chat 영역 가림. `◀` 닫기 버튼 작아서 인식 어려움 + backdrop 없어 외부 터치로 닫기 불가.

## 3 fix

1. **모바일 default collapsed** (`index-init.js`)
   - `_isPhoneViewport()` (`matchMedia('(max-width: 768px)')`)
   - DOMContentLoaded 시 phone viewport → `#sidebar` 에 `.collapsed` + `#sidebar-open-btn` 에 `.visible` 추가 → 폰 첫 로드 시 chat 화면 + 떠 있는 `▶` 열기 버튼 보임
   - localStorage `james_sidebar_open_mobile = 'open'` 명시한 경우만 유지 (운영자 의도 존중)
   - desktop viewport 무변경

2. **Backdrop overlay** (`index.html` + `mobile.css`)
   - `<div id="sidebar-backdrop" data-action="toggle-sidebar">` 새 element
   - 폰 viewport 에서 사이드바 열림 시 `.show` 적용, 외부 터치 시 `toggleSidebar`
   - z-index 49 (사이드바 50 바로 아래), `rgba(0,0,0,0.45)` dimming, iOS Safari tap-highlight 끔

3. **닫기 버튼 44×44 + accent** (`mobile.css`)
   - `aside.sidebar .sidebar-toggle` (`◀`) 가 `min-width/min-height: 44px` + accent 색 테두리 + 명시적 padding
   - active 상태에 filled accent 로 invert
   - WCAG 2.5.5 target-size + v0.5 UI #3 패턴

`toggleSidebar()` 가 운영자 선택 (`localStorage.james_sidebar_open_mobile`) 영속 → 재로드 시 운영자와 싸우지 않음.

## Verification (가능 범위)

- `node --check` clean on `index-init.js`
- **119/119 v0.6 unit-test suite green** — regression 없음
- **FastAPI TestClient smoke** (uvicorn / Ollama warm-up 없이): `/workspace/info` → 401 / `/admin/llm-settings/` → 403 / `/agent/chat/` → 403 / `/templates/mine/list` → 401. 모든 auth gate dispatch 정상. BGE-M3 + ChromaDB + 313 entities load on module import without errors
- **시각적 모바일 렌더링 검증은 운영자 측** — dev 환경에 Playwright / Puppeteer 없음. 이 PR 의 fix 는 structural (default-collapsed + backdrop + tappable close); 머지 후 본인이 폰에서 재확인

## 왜 더 일찍 surface 안 했나

v0.5 UI #3 pass (PR #854) 가 모달 7개 모바일 responsive 처리. 사이드바 drawer 는 *모달이 아니라 항상 보이는 surface* 라 그 패스에서 빠졌고, desktop 테스트에서 overlay-blocks-chat 회귀 놓침. Tailscale 통한 dogfooding 으로 catch.

## Rule compliance

- Rule #1: 도메인 콘텐츠 0
- Rule #2: `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. `fix` label, QDC exempt
- Rule #3: role / capability gate 변경 없음
- Rule #5: mobile.css ~14 KB (cap 안)

## 운영자 next step (머지 후)

1. main 받아 자메스 재시작 (or hot reload — `frontend/static/` 만 변경이라 브라우저 새로고침으로 충분)
2. 폰에서 Tailscale URL 접속 → chat 페이지 첫 진입 시 **메인 chat 영역이 보여야 함** + 우측 (또는 좌측) 작은 `▶` 열기 버튼
3. `▶` 탭 → 사이드바 슬라이드 인 + dimmed backdrop 표시
4. 사이드바 외 dimmed 영역 탭 → 닫힘
5. 사이드바 내 `◀` 닫기 버튼 (accent 테두리) 명확히 보임

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)