### PR TITLE
fix(v0.6.1): 4 pages dark-theme unification + i18n DOM-fallback guard

### DIFF
--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -2398,6 +2398,19 @@ function t(key, vars) {
   return text;
 }
 
+/* v0.6.1 (2026-06-15) — lookup without the "fall back to the key
+ * itself" final clause. applyTranslations uses this to decide whether
+ * to leave the DOM's inline fallback content alone (e.g. the Korean
+ * <dd> bodies inside glossary.html, which were getting overwritten
+ * with raw "glossary.def.rag" strings whenever the key wasn't
+ * defined). Returns null when the key is missing in BOTH dictionaries. */
+function _lookupOrNull(key) {
+  var dict = TRANSLATIONS[currentLang] || TRANSLATIONS.en;
+  if (dict[key] != null) return dict[key];
+  if (TRANSLATIONS.en && TRANSLATIONS.en[key] != null) return TRANSLATIONS.en[key];
+  return null;
+}
+
 function setLang(lang) {
   if (!TRANSLATIONS[lang]) return;
   currentLang = lang;
@@ -2432,22 +2445,35 @@ function applyTranslations() {
     var el = els[i];
     var key = el.getAttribute('data-i18n');
     if (key) {
+      // v0.6.1 — skip elements whose key is missing in both dicts;
+      // their inline DOM content is the operator-authored fallback
+      // (Korean glossary <dd> bodies, etc.). Without this guard the
+      // raw key string overwrites the fallback.
+      var translated = _lookupOrNull(key);
+      if (translated == null) continue;
       if (el.hasAttribute('data-i18n-html')) {
-        el.innerHTML = t(key);
+        el.innerHTML = translated;
       } else {
-        el.textContent = t(key);
+        el.textContent = translated;
       }
     }
   }
   var phs = document.querySelectorAll('[data-i18n-placeholder]');
   for (var i = 0; i < phs.length; i++) {
     var key = phs[i].getAttribute('data-i18n-placeholder');
-    if (key) phs[i].placeholder = t(key);
+    if (key) {
+      // v0.6.1 — same DOM-fallback guard.
+      var translated = _lookupOrNull(key);
+      if (translated != null) phs[i].placeholder = translated;
+    }
   }
   var titles = document.querySelectorAll('[data-i18n-title]');
   for (var i = 0; i < titles.length; i++) {
     var key = titles[i].getAttribute('data-i18n-title');
-    if (key) titles[i].title = t(key);
+    if (key) {
+      var translated = _lookupOrNull(key);
+      if (translated != null) titles[i].title = translated;
+    }
   }
   updateLangToggleDisplay();
 }

--- a/frontend/static/onboarding.css
+++ b/frontend/static/onboarding.css
@@ -16,6 +16,21 @@
  * onboarding-specific rules.
  */
 
+/* v0.6.1 mobile dark-theme fix (2026-06-15): the page-level body had
+ * no explicit background-color, so phone browsers (which don't honour
+ * prefers-color-scheme as a default for plain documents) showed white
+ * around the dark cards. tokens.css §"Cyber background texture" warns
+ * "Pages must declare background-color: var(--bg);" — this rule
+ * satisfies that contract for every page that links onboarding.css
+ * (onboarding / glossary / knowledge-rollback / reasoning-flow). */
+body {
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  margin: 0;
+  min-height: 100vh;
+}
+
 .onboarding-main {
   max-width: 760px;
   margin: 32px auto;


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 (Galaxy Tailscale screenshots): **3 페이지 (knowledge-rollback / reasoning-flow / glossary)** 모두 body 가 white + 카드만 dark → hybrid 테마. Glossary 는 추가로 **raw i18n key 문자열** (`glossary.def.rag`) 이 한국어 본문 자리에 표시.

두 회귀 모두 4 Phase-4 페이지가 공유하는 `onboarding.css` + `i18n.js` 의 동작에서 root cause 발견 → 한 자리씩 fix.

## Root causes

1. **`onboarding.css` 에 `body` rule 없음**. `tokens.css:164` 가 명시 "Pages must declare `background-color: var(--bg);` (NOT the `background:` shorthand)". 각 페이지 own css 가 카드에 token 적용, body 에는 안 함 → 폰 브라우저가 카드 주변 흰색
2. **`i18n.js::t(key)` 가 키 없을 때 key 자체를 반환** (line 2394). `applyTranslations` 가 그걸 `textContent`/`innerHTML`/`placeholder`/`title` 로 써서 author 의 inline 한국어 본문 overwrite

## Fixes

### `onboarding.css` (+14 lines)

```css
body {
  background-color: var(--bg);
  color: var(--text);
  font-family: var(--font-body);
  margin: 0;
  min-height: 100vh;
}
```

4 페이지 (`onboarding` / `glossary` / `knowledge-rollback` / `reasoning-flow`) 모두 onboarding.css link → 한 자리에서 다 fix.

### `i18n.js` (+20 lines)

- 새 `_lookupOrNull(key)` helper — 키가 양 dict 에 모두 없으면 `null` 반환 (key string 으로 fall back 안 함)
- `applyTranslations()` 의 3 selector (`[data-i18n]` / `[data-i18n-placeholder]` / `[data-i18n-title]`) 모두 null 일 때 element 건드리지 않음 → author 의 inline fallback 보존
- `t(key)` 자체는 그대로 — 직접 호출 site (chat / agent-chat / etc.) 는 legacy key-as-text fallback 유지 (typo 가 silent 안 되게)

## Verification

- `node --check` clean on `i18n.js`
- **63/63 backend regression** (agent_paths + agent_tools + llm_settings) green
- **시각적 폰 렌더링 검증은 운영자 측** — #924 sidebar fix 와 같은 제약. fix 가 structural (shared stylesheet body fill + shared i18n DOM-fallback guard); 머지 후 본인이 4 페이지 폰에서 재확인

## What this does NOT do (intentional out of scope)

- Author 실제 EN glossary 번역 — `glossary.def.*` 키는 여전히 미정의. EN 사용자는 한국어 inline fallback 그대로 (이전엔 raw key string overwrite 였음). 후속 PR 에서 EN dict 추가 가능
- chat 페이지 sidebar — #924 에서 ship
- 어느 페이지든 onboarding.css 에서 떼어내기 — 공유 stylesheet 가 이번 한-자리 fix 의 핵심

## Rule compliance

- Rule #1: 도메인 콘텐츠 0
- Rule #2: CSS/JS only; `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. `fix` label, QDC exempt
- Rule #5: `onboarding.css` +14 lines, `i18n.js` +20 lines — well under 20KB

## 머지 후 운영자 폰 재확인

1. `/onboarding` / `/glossary` / `/admin/knowledge-rollback` / `/reasoning-flow` 4 페이지 모두 body 가 다크 (`#04060a`) 통일
2. Glossary `<dd>` 안에 한국어 본문 (RAG / Graph-RAG / Entity / Relation) 그대로 표시 — raw key string 사라짐

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)