### PR TITLE
fix(v0.6.1): persist api_key on login — stop re-login prompt on every page navigation

### DIFF
--- a/frontend/static/auth.js
+++ b/frontend/static/auth.js
@@ -65,6 +65,12 @@
       // 자동 동기화되도록 동일 키 사용.
       localStorage.setItem('james_token', token);
       localStorage.setItem('james_role', role);
+      // v0.6.1 (2026-06-15) — persist the api_key the operator typed
+      // so subsequent page navigations don't re-prompt for it.
+      // chat.js / workspace.js / admin.js / agent-chat.js all probe
+      // `localStorage.james_api_key`; before this line the login flow
+      // dropped it, forcing a re-login on every page change.
+      try { localStorage.setItem('james_api_key', apiKey || ''); } catch (_) {}
       // v0.6.1 — refresh the workspace badge after a successful login
       // so the operator sees the correct workspace immediately rather
       // than after a full page reload.

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -931,6 +931,9 @@ function logout() {
   userRole = '';
   localStorage.removeItem('james_token');
   localStorage.removeItem('james_role');
+  // v0.6.1 — also clear the persisted api_key so the next login
+  // isn't auto-completed from the previous user's value.
+  try { localStorage.removeItem('james_api_key'); } catch (_) {}
   updateRoleBadge();
   // [item #1] admin 권한 잃으면 install 버튼 즉시 숨김
   try { updateInstallButton(); } catch (_) {}

--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -39,6 +39,9 @@ function _saveStored(token, role, apiKey) {
 }
 
 function _clearStored() {
+  // v0.6.1 — also drop the persisted api_key (auth.js writes it on
+  // successful login).
+  try { localStorage.removeItem('james_api_key'); } catch (_) {}
   _token = ''; _role = '';
   localStorage.removeItem('james_token');
   localStorage.removeItem('james_role');


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15: chat → workspace → admin → glossary → agent chat 페이지 전환마다 로그인 모달 반복. JWT 만료 (8h) 와 무관.

## Root cause

`auth.js::login()` 가 성공 시 `james_token` + `james_role` 만 저장, **`api_key` 저장 누락**. 모든 페이지 boot logic 이 `localStorage.getItem('james_api_key')` 확인 후 없으면 모달:

- `chat.js:241` DOMContentLoaded check: `if (!localStorage.getItem('james_api_key')) showLogin()`
- `workspace.js:29` `_apiKey = localStorage.getItem('james_api_key')`
- `admin.js:18` `let apiKey = localStorage.getItem('james_api_key')`
- `agent-chat.js` / `workspace-badge.js` / 모든 v0.6.1 admin endpoint helper — 동일 probe

로그인 성공 → JWT 저장 → operator 가 input 에 친 api_key 는 버려짐 → 다음 페이지가 null 보고 모달 → 무한 루프.

## Fix (1줄 + 2 cleanup)

**`auth.js::login()`** — 기존 `setItem` 블록 다음에:

```js
try { localStorage.setItem('james_api_key', apiKey || ''); } catch (_) {}
```

`apiKey` 는 같은 함수 L42 에서 이미 validate 됨.

**Companion `removeItem` 추가** (api_key 가 logout 후 살아남지 않게):
- `chat.js::logout()` — 기존 token/role remove 옆에 추가
- `workspace.js::_clearStored()` — 동일

## 왜 이제야 surface

api_key 의 localStorage contract 는 항상 있었으나 (chat.js / workspace.js 가 v0.6 세션 훨씬 이전부터 읽음), 옛 워크플로우는 *chat 페이지의 prompt() 가 api_key 를 localStorage 저장* 했음. 그 prompt() 를 대체한 login modal 흐름 (auth.js) 이 `setItem` 한 줄 carry-over 안 함. 운영자가 modal 흐름 + 페이지 자주 전환 (workspace badge / agent chat / LLM Routing / glossary 폰 Tailscale) 으로 catch.

## Verification

- `node --check` clean on auth.js / chat.js / workspace.js
- 행동: 첫 로그인 후 chat → workspace → admin → agent chat → glossary 재로그인 없음. logout 시 세 키 atomically 삭제. 다음 로그인 input 빈 칸 (이전 사용자 api_key 안 남음)

## Migration

이번 fix 전에 in-flight 세션인 운영자는 `james_token` 만 있고 `james_api_key` 없음. 새 빌드로 처음 페이지 전환 시 **한 번만** 더 prompt. 다시 로그인하면 그 후부터 영구 persist. 일회성 불편, 별도 마이그레이션 불필요.

## Rule compliance

- Rule #1: 도메인 콘텐츠 0
- Rule #2: JS only; `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. `fix` label, QDC exempt
- Rule #3: role / capability 변경 없음 — api_key 는 항상 required, 이번 PR 은 그저 누락된 persist 추가

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)