### PR TITLE
fix(v0.6.1): admin page lazy auth — stop forcing the login modal on every navigation

### DIFF
--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -293,17 +293,35 @@ function _bindStableInputs() {
 window.addEventListener('DOMContentLoaded', async () => {
   _bindFrontendEvents();
   _bindStableInputs();
-  if (!apiKey) {
-    apiKey = prompt('JAMES API Key:') || '';
-    localStorage.setItem('james_api_key', apiKey);
-  }
-  // [#A8-4] localStorage에서 role 읽음 — chat에서 admin으로 로그인했다면
-  // 자동으로 dashboard 진입. 비-admin role이거나 token 없으면 modal.
-  const storedRole = localStorage.getItem('james_role') || '';
-  if (!token || storedRole !== 'admin') {
+
+  // v0.6.1 (2026-06-15) — operator catch "admin 페이지 돌아올 때마다
+  // 매번 로그인". The original boot had TWO forced auth prompts:
+  //   (1) `prompt('JAMES API Key:')` if apiKey was missing — a
+  //       phone-hostile native dialog left over from before the
+  //       login modal grew an api_key input.
+  //   (2) `if (!token || storedRole !== 'admin') showAdminLoginModal()`
+  //       — a strict client-side gate that fired whenever the
+  //       previously-stored role wasn't literally 'admin' (e.g. an
+  //       empty value during a localStorage hiccup, or the JWT
+  //       expiry window straddling a navigation).
+  //
+  // Both are replaced by lazy auth: if we have a token at all,
+  // optimistically call loadDashboard(); if the server returns
+  // 401 / 403, THEN show the modal. The server is the real
+  // admin-only enforcer (`_require_admin`); the client-side gate
+  // was duplicating it pessimistically. The api_key prompt is gone
+  // — the modal's existing api_key input covers that path now
+  // (parity with the v0.6.1 #928 chat-page persistence fix).
+  if (!token) {
     showAdminLoginModal();
-  } else {
-    loadDashboard();
+    return;
+  }
+  try {
+    await loadDashboard();
+  } catch (_) {
+    // loadDashboard's own _adminGuard handles 401/403 → modal.
+    // The try/catch is just belt-and-suspenders so a non-auth
+    // failure (network blip) doesn't pop the login modal.
   }
 });
 
@@ -753,6 +771,15 @@ async function api(path, method='GET', body=null) {
     alert(t('auth.expired_refresh'));
     location.reload();
     return {};
+  }
+  // v0.6.1 (2026-06-15) — non-admin role tries an admin endpoint →
+  // server returns 403. Don't reload (the chat-side login is still
+  // valid for non-admin pages); just surface the admin login modal so
+  // the operator can re-authenticate as admin without losing their
+  // chat session.
+  if (r.status === 403) {
+    showAdminLoginModal();
+    throw new Error('403');
   }
   if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
   return r.json();


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15: chat 페이지에서 admin 으로 로그인했는데 admin 페이지 갈 때마다 + 다른 페이지 갔다가 admin 돌아올 때마다 modal 뜸. \"내가 어디선가 이것을 강제하는 코딩을 시켰는지 확인\" → **자메스 의 강제 코드 두 자리 발견**.

## Root cause — `admin.js:293-308`

```js
if (!apiKey) {
  apiKey = prompt('JAMES API Key:') || '';        // ← phone-hostile native
  localStorage.setItem('james_api_key', apiKey);
}
const storedRole = localStorage.getItem('james_role') || '';
if (!token || storedRole !== 'admin') {           // ← strict client gate
  showAdminLoginModal();
} else {
  loadDashboard();
}
```

### Forced surface 1 — `prompt('JAMES API Key:')`
Native browser dialog 가 폰 Tailscale tunnel 에서 매우 깨짐. chat 페이지에선 이미 #928 fix 로 제거됨; admin 만 남음.

### Forced surface 2 — `storedRole !== 'admin'`
Strict client-side gate. *literal* `'admin'` 이 아니면 modal — 의도된 동작이지만 edge case 폭발:
- localStorage hiccup during cross-tab navigation
- role 가 `''` 로 half-written
- JWT 만료 윈도우 가 navigation 경계 위에 걸침

Server 가 이미 `_require_admin` 으로 admin-only 검증 — client gate 가 pessimistic 하게 중복.

## Fix — lazy auth + 403 path

1. **prompt() 제거** — modal 의 api_key input 이 그 자리 (chat #928 패턴)
2. **strict role check 제거** — token 있으면 일단 `loadDashboard()` 호출
3. **`api()` 에 403 branch 추가** — non-admin role 이 admin endpoint 부르면 modal 띄움 (chat-side token 은 보존, 운영자 chat 세션 안 잃음)

New boot:
```js
if (!token) { showAdminLoginModal(); return; }
try { await loadDashboard(); }
catch (_) { /* api() already routed 401→reload, 403→modal */ }
```

## 왜 안전한가

admin-only contract 의 **두 enforcer**:
- **Client gate** (이 PR 가 제거하는 줄) — cosmetic only. NOT security
- **Server `_require_admin`** — REAL gate, 모든 admin endpoint 가 403 반환. 이 PR 가 손대지 않음

권한 contract 변경 없음. admin token 있는 운영자 = 즉시 dashboard. non-admin token = server 403 → modal. token 없음 = modal 즉시.

## Verification

- `node --check` clean on admin.js
- 시나리오:
  - admin token + admin role: `/admin` 진입 → prompt 없음, modal 없음, dashboard 즉시 로드
  - non-admin token: loadDashboard 발화 → server 403 → modal
  - 토큰 없음: modal 즉시 (fetch 전)
- 시각 폰 검증은 운영자 측 (#924 / #929 / #930 same constraint)

## Rule compliance

- **Rule #1**: 도메인-agnostic
- **Rule #2**: JS only; `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. `fix` label, QDC exempt
- **Rule #3**: admin-only enforcement preserved (server-side); client gate removed = cosmetic only

## 머지 후 운영자 폰 재확인

```
1. chat 페이지에서 admin 로그인 (#928 fix 로 한 번이면 끝)
2. admin 페이지 진입 → modal 없이 dashboard 바로 로드
3. workspace ↔ admin ↔ glossary ↔ agent chat 자유 전환 — modal 안 뜸
4. JWT 8h 만료 / non-admin role 로 admin endpoint → 그때만 modal
```

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)