### PR TITLE
fix(v0.6.1): sidebar — SEKOS brand + meta/Templates up, + 새 대화 + ADMIN pill stay down

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,13 +80,60 @@
          scrolling, but they sit OUTSIDE the scroll area so the
          sessions list doesn't push them off-screen. -->
 
-    <!-- Sidebar header — close button + brand mark (compact). -->
+    <!-- Sidebar header — close button + brand mark (compact).
+         v0.6.1 (2026-06-15) — brand changed from "JAMES" (codename)
+         to "SEKOS" (Secure Enterprise Knowledge Operating System
+         acronym). The full phrase still surfaces in the welcome
+         hero of the main chat area; the sidebar header gets the
+         short, memorable form. -->
     <div class="sidebar-header">
       <div class="sidebar-title" id="sidebar-title">
-        ▸ <span class="brand" style="font-size:13px">JAMES</span>
+        ▸ <span class="brand" style="font-size:13px">SEKOS</span>
       </div>
       <button class="sidebar-toggle" data-action="toggle-sidebar" data-i18n-title="common.close" title="닫기"
               aria-label="사이드바 닫기">◀</button>
+    </div>
+
+    <!-- v0.6.1 (2026-06-15) — meta row moved UP (operator catch:
+         blue arrows pointed at model chip + workspace badge).
+         Keeps the "what model / what workspace am I in" info right
+         under the brand, before navigation choices. -->
+    <div class="sidebar-section sidebar-meta-row">
+      <button id="model-chip"
+              type="button"
+              class="model-chip"
+              data-action="toggle-model-popover"
+              data-i18n-title="model.chip_title"
+              title="현재 응답에 사용 중인 모델 — 클릭 시 변경"
+              aria-haspopup="listbox"
+              aria-expanded="false">
+        <span class="model-chip-icon" aria-hidden="true">🤖</span>
+        <span class="model-chip-tag" id="model-chip-tag">—</span>
+        <span class="model-chip-caret" aria-hidden="true">▾</span>
+      </button>
+      <button class="nav-btn workspace-badge" id="workspace-badge"
+              type="button"
+              data-i18n-title="workspace.badge_title"
+              title="현재 워크스페이스"
+              aria-label="현재 워크스페이스"
+              style="display:none;font-size:11px">
+        📁 <span id="workspace-name">—</span>
+      </button>
+    </div>
+
+    <!-- v0.6.1 (2026-06-15) — 양식 (Templates) moved UP next to the
+         meta row (operator catch: blue arrow). The remaining
+         primary action (+ 새 대화) stays in the footer where it's
+         reachable with the thumb on a phone. -->
+    <div class="sidebar-section sidebar-actions">
+      <button class="sidebar-action"
+              data-action="tplc-open"
+              data-i18n-title="tplchat.open_title"
+              title="양식 적용"
+              style="flex:1">
+        <span aria-hidden="true">📄</span>
+        <span data-i18n="tplchat.open">양식</span>
+      </button>
     </div>
 
     <!-- TOP FIXED — page nav (Workspace + Admin) — these are
@@ -243,53 +290,12 @@
       </div>
     </div>
 
-    <!-- BOTTOM FIXED FOOTER — Claude.ai parity. Top of the footer
-         carries the primary actions (+ 새 대화 / 양식), then a meta
-         line (model chip + workspace badge), then settings (source +
-         lang), then the profile pill. The 📂 / 🕘 / 🔍 tabs moved
-         to the top of the sidebar so the operator can hit them
-         without scrolling the (potentially long) sessions list. -->
+    <!-- BOTTOM FIXED FOOTER — v0.6.1 (2026-06-15) operator catch
+         (red circles around `+ 새 대화` + ADMIN role pill, red arrow
+         pointing down): keep only the thumb-reach primary action and
+         the profile pill at the bottom. Meta + 양식 moved to the
+         top of the sidebar (above). -->
     <div class="sidebar-section sidebar-footer">
-      <!-- Primary actions row. -->
-      <div class="sidebar-actions">
-        <button class="sidebar-action sidebar-action-primary"
-                data-action="clear-history"
-                data-i18n-title="chat.clear_history"
-                title="새 대화">
-          <span aria-hidden="true">＋</span>
-          <span data-i18n="chat.new_chat">새 대화</span>
-        </button>
-        <button class="sidebar-action"
-                data-action="tplc-open"
-                data-i18n-title="tplchat.open_title"
-                title="양식 적용">
-          <span aria-hidden="true">📄</span>
-          <span data-i18n="tplchat.open">양식</span>
-        </button>
-      </div>
-      <!-- Model chip + workspace badge — meta line. -->
-      <div class="sidebar-meta-row">
-        <button id="model-chip"
-                type="button"
-                class="model-chip"
-                data-action="toggle-model-popover"
-                data-i18n-title="model.chip_title"
-                title="현재 응답에 사용 중인 모델 — 클릭 시 변경"
-                aria-haspopup="listbox"
-                aria-expanded="false">
-          <span class="model-chip-icon" aria-hidden="true">🤖</span>
-          <span class="model-chip-tag" id="model-chip-tag">—</span>
-          <span class="model-chip-caret" aria-hidden="true">▾</span>
-        </button>
-        <button class="nav-btn workspace-badge" id="workspace-badge"
-                type="button"
-                data-i18n-title="workspace.badge_title"
-                title="현재 워크스페이스"
-                aria-label="현재 워크스페이스"
-                style="display:none;font-size:11px">
-          📁 <span id="workspace-name">—</span>
-        </button>
-      </div>
       <!-- Source toggle + lang toggle on one row. -->
       <div class="sidebar-settings-row">
         <div class="source-toggle">
@@ -301,6 +307,14 @@
                 aria-label="언어 전환 / Toggle language"
                 style="font-size:11px;font-weight:700;padding:4px 8px"></button>
       </div>
+      <!-- + 새 대화 — single primary action, large, thumb-friendly. -->
+      <button class="sidebar-action sidebar-action-primary sidebar-action-newchat"
+              data-action="clear-history"
+              data-i18n-title="chat.clear_history"
+              title="새 대화">
+        <span aria-hidden="true">＋</span>
+        <span data-i18n="chat.new_chat">새 대화</span>
+      </button>
       <!-- Role badge — Claude-style profile pill at the very bottom. -->
       <div class="role-badge sidebar-role-pill" id="role-badge"
            data-action="show-login">

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -1193,6 +1193,16 @@ aside.sidebar.collapsed { min-width: 0; }
 }
 .sidebar-action:hover { filter: brightness(1.1); }
 
+/* v0.6.1 (2026-06-15) — the footer-level + 새 대화 button is the
+ * single most-tapped affordance. Make it visibly larger than the
+ * other footer rows so it's hard to miss with a thumb. */
+.sidebar-action-newchat {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 14px;
+  border-radius: 10px;
+}
+
 /* Model chip + workspace badge row. */
 .sidebar-meta-row {
   display: flex;


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 (Tailscale 폰, 마킹 screenshot):

- **파랑 (위로)**: `Templates` 양식 / `🤖 gemma4:e4b` model / `📁 default` workspace badge → 사이드바 위쪽
- **빨강 (아래 유지)**: `+ New chat` button / `ADMIN` role pill → footer 그대로
- **브랜드**: `▸ JAMES` → **`SEKOS`** (Secure Enterprise Knowledge Operating System acronym)

#932 의 reorder 가 model + workspace 를 footer 로 보냈었음. 운영자 의도 = "what context am I in" 신호 (model + workspace) 는 brand 가까이 위에, "who am I" 신호 (role pill) 만 아래.

## 사이드바 layout (top → bottom)

```
▸ SEKOS                              ◀  ← brand (was JAMES)
─────
🤖 gemma4:e4b   📁 default            ← meta MOVED UP
─────
📄 양식                                ← Templates MOVED UP
─────
📦 Workspace      ⚙ Admin             ← page nav
─────
📂 파일 업로드  🕘 내 자료  🔍 검색       ← mode tabs
─────
PREVIOUS CHATS                         ← section label
(sessions list — scrollable, flex:1)

─────────────────────  footer (STAY DOWN)
[PROD][TEST]    KO | EN                ← settings
[＋ 새 대화]                            ← single LARGE primary (thumb-reach)
[● 로그인 / ADMIN]                      ← role pill (Claude profile parity)
```

## Brand

`▸ JAMES` → **`SEKOS`**. Full phrase \"Secure Enterprise Knowledge Operating System\" 은 chat welcome hero 에 그대로. 사이드바 header 만 짧은 acronym.

JAMES = 내부 codename / repo name 유지. SEKOS = user-facing label.

## CSS — `.sidebar-action-newchat`

새 클래스. width 100%, padding 12×14, font 14px, border-radius 10. footer 안 다른 행보다 visibly 큼 — 폰 thumb hit 안전.

## Verification

- `node --check` clean on i18n.js
- **FastAPI TestClient smoke** on `/`:
  - 200 OK
  - `>SEKOS<` present (new brand)
  - `>JAMES<` absent (old brand 사이드바에서 사라짐)
  - `sidebar-action-newchat` class present
  - `href=\"/workspace\"` + `href=\"/admin\"` 둘 다 present
- 시각 폰 검증은 운영자 측

## Rule compliance

- **Rule #1**: brand rename = naming-level, not vertical. SEKOS = 기존 horizontal mother-platform tagline 의 acronym; domain pack identifier 아님
- **Rule #2**: HTML/CSS only; `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. `fix` label, QDC exempt
- **Rule #4**: ARCHITECTURE.md 의 tagline 변경 없음. 브랜드 라벨은 그 tagline 의 surface presentation; trust-zone shift 없음

## 머지 후 운영자 폰 재확인

```
1. 사이드바 최상단 ▸ SEKOS (JAMES 사라짐)
2. 그 아래 🤖 gemma4:e4b + 📁 default 메타
3. 📄 양식 버튼
4. Workspace + Admin / 모드 tabs / 이전 대화 / sessions list
5. 하단 footer: PROD/TEST + KO|EN → + 새 대화 (large primary) → role pill
```

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)