### PR TITLE
fix(v0.6.1): sidebar v2 reorder + ADMIN role pill / login modal prominence

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,10 +94,24 @@
               aria-label="사이드바 닫기">◀</button>
     </div>
 
-    <!-- v0.6.1 (2026-06-15) — meta row moved UP (operator catch:
-         blue arrows pointed at model chip + workspace badge).
-         Keeps the "what model / what workspace am I in" info right
-         under the brand, before navigation choices. -->
+    <!-- v0.6.1 v2 (2026-06-15 PM) — operator catch (red circle + red
+         arrow): + 새 대화 was at the bottom, should be at the top
+         (most-clicked primary action under Claude.ai convention).
+         This is the single LARGE button right under the brand. -->
+    <div class="sidebar-section sidebar-actions">
+      <button class="sidebar-action sidebar-action-primary sidebar-action-newchat"
+              data-action="clear-history"
+              data-i18n-title="chat.clear_history"
+              title="새 대화">
+        <span aria-hidden="true">＋</span>
+        <span data-i18n="chat.new_chat">새 대화</span>
+      </button>
+    </div>
+
+    <!-- v0.6.1 (2026-06-15) — meta row stays under the primary
+         action (operator catch: blue circle around model chip +
+         blue arrow up). "what model / what workspace am I in"
+         info kept near the top, just below + 새 대화. -->
     <div class="sidebar-section sidebar-meta-row">
       <button id="model-chip"
               type="button"
@@ -121,24 +135,9 @@
       </button>
     </div>
 
-    <!-- v0.6.1 (2026-06-15) — 양식 (Templates) moved UP next to the
-         meta row (operator catch: blue arrow). The remaining
-         primary action (+ 새 대화) stays in the footer where it's
-         reachable with the thumb on a phone. -->
-    <div class="sidebar-section sidebar-actions">
-      <button class="sidebar-action"
-              data-action="tplc-open"
-              data-i18n-title="tplchat.open_title"
-              title="양식 적용"
-              style="flex:1">
-        <span aria-hidden="true">📄</span>
-        <span data-i18n="tplchat.open">양식</span>
-      </button>
-    </div>
-
-    <!-- TOP FIXED — page nav (Workspace + Admin) — these are
-         high-frequency destinations, kept at the top of the sidebar
-         like Claude's "채팅 / 프로젝트 / 코드 / 디스패치" links. -->
+    <!-- TOP FIXED — page nav (Workspace + Admin). Mint arrow in the
+         operator's screenshot pointed Workspace upward, so it
+         stays here under meta, ABOVE the 양식 button. -->
     <nav class="sidebar-section sidebar-top-nav" aria-label="페이지 이동">
       <a href="/workspace" class="sidebar-top-link"
          data-i18n-title="workspace.nav_title" title="Workspace">
@@ -151,6 +150,21 @@
         <span data-i18n="sidebar.nav_admin">Admin</span>
       </a>
     </nav>
+
+    <!-- v0.6.1 v2 (2026-06-15 PM) — 양식 (Templates) moved BELOW the
+         Workspace/Admin nav per the screenshot. Templates is a
+         tool, not a destination, so it sits in the secondary
+         action zone right above the mode tabs. -->
+    <div class="sidebar-section sidebar-actions sidebar-actions-secondary">
+      <button class="sidebar-action"
+              data-action="tplc-open"
+              data-i18n-title="tplchat.open_title"
+              title="양식 적용"
+              style="flex:1">
+        <span aria-hidden="true">📄</span>
+        <span data-i18n="tplchat.open">양식</span>
+      </button>
+    </div>
 
     <!-- Mode tabs (upload / recent / search) — kept fixed below the
          page nav. Stay accessible regardless of sessions-list scroll
@@ -290,11 +304,15 @@
       </div>
     </div>
 
-    <!-- BOTTOM FIXED FOOTER — v0.6.1 (2026-06-15) operator catch
-         (red circles around `+ 새 대화` + ADMIN role pill, red arrow
-         pointing down): keep only the thumb-reach primary action and
-         the profile pill at the bottom. Meta + 양식 moved to the
-         top of the sidebar (above). -->
+    <!-- BOTTOM FIXED FOOTER — v0.6.1 v2 (2026-06-15 PM):
+         + 새 대화 moved UP to the top of the sidebar (operator catch
+         from screenshot — red arrow). Footer is now:
+           1) PROD/TEST + KO|EN settings row (compact)
+           2) PROMINENT login/role pill (was a thin chip; now a
+              large, visible badge so the operator can see at a
+              glance whether they're logged in as ADMIN)
+         The session-count-badge bound element stays here so the
+         chat.js updateSessionCountBadge handler keeps working. -->
     <div class="sidebar-section sidebar-footer">
       <!-- Source toggle + lang toggle on one row. -->
       <div class="sidebar-settings-row">
@@ -307,16 +325,11 @@
                 aria-label="언어 전환 / Toggle language"
                 style="font-size:11px;font-weight:700;padding:4px 8px"></button>
       </div>
-      <!-- + 새 대화 — single primary action, large, thumb-friendly. -->
-      <button class="sidebar-action sidebar-action-primary sidebar-action-newchat"
-              data-action="clear-history"
-              data-i18n-title="chat.clear_history"
-              title="새 대화">
-        <span aria-hidden="true">＋</span>
-        <span data-i18n="chat.new_chat">새 대화</span>
-      </button>
-      <!-- Role badge — Claude-style profile pill at the very bottom. -->
-      <div class="role-badge sidebar-role-pill" id="role-badge"
+      <!-- Role badge — PROMINENT version (v0.6.1 v2). When logged out:
+           clear "로그인" call-to-action. When logged in: big role label
+           (ADMIN/USER), bigger green dot, more visible logout button. -->
+      <div class="role-badge sidebar-role-pill role-badge-prominent"
+           id="role-badge"
            data-action="show-login">
         <span class="dot"></span>
         <span class="role-name" id="role-name" data-i18n="auth.login">로그인</span>

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -161,28 +161,35 @@ header {
 }
 .role-badge .logout-btn:hover { color: var(--danger); }
 
-/* ── 로그인 모달 ── */
+/* ── 로그인 모달 ──
+ * v0.6.1 v2 (2026-06-15 PM) — operator catch (login modal 가시성
+ * 부족): 배경 더 짙은 dim 으로 바꿔 modal 내용에 시선 집중, accent
+ * border + ring shadow 로 modal 자체를 brand 색으로 강조. */
 .modal-overlay {
   position: fixed; inset: 0;
-  background: rgba(4,6,10,.35);
+  background: rgba(4,6,10,.72);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   display: flex; align-items: center; justify-content: center;
   z-index: 200;
   animation: fadeIn .15s ease;
 }
 .modal-overlay.hidden { display: none; }
 .modal {
-  background: rgba(7,9,14,.55);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 28px;
-  width: 360px;
+  background: rgba(7,9,14,.92);
+  border: 2px solid var(--accent);
+  border-radius: 14px;
+  padding: 32px;
+  width: 380px;
+  box-shadow: 0 12px 48px rgba(0,0,0,.6),
+              0 0 0 6px rgba(110, 231, 183, .12);
 }
 .modal-title {
-  font-size: 16px; font-weight: 600;
+  font-size: 18px; font-weight: 700;
   font-family: var(--font-ui);
   color: var(--text);
-  margin-bottom: 20px;
-  letter-spacing: 0;
+  margin-bottom: 22px;
+  letter-spacing: .2px;
 }
 .modal-field { margin-bottom: 14px; }
 .modal-field label {
@@ -1284,6 +1291,68 @@ aside.sidebar.collapsed { min-width: 0; }
   text-align: center;
 }
 .sidebar-role-pill:hover { background: var(--bg); }
+
+/* v0.6.1 v2 (2026-06-15 PM) — operator catch: ADMIN role pill 가시성
+ * 부족. 더 큰 글자 / 더 두꺼운 border / 로그인 안 됐을 때는 "로그인"
+ * call-to-action 처럼 accent 색 강조, 로그인 됐을 때는 success border
+ * + green dot 으로 한눈에 admin 상태 인지. */
+.role-badge-prominent {
+  padding: 10px 14px;
+  border-width: 2px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: .3px;
+  transition: border-color .2s, background .2s, box-shadow .2s;
+}
+
+/* Logged-out state — accent border, soft accent background. The pill
+ * IS the login call-to-action, so it should pull the eye. */
+.role-badge-prominent:not(.logged-in) {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+  animation: rolePillPulse 2.4s ease-in-out infinite;
+}
+.role-badge-prominent:not(.logged-in) .dot {
+  width: 9px; height: 9px;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+}
+.role-badge-prominent:not(.logged-in) .role-name {
+  color: var(--accent-fg);
+  font-weight: 700;
+}
+
+/* Logged-in state — success border, green dot, role name in stronger
+ * color. Differentiates ADMIN visually from USER. */
+.role-badge-prominent.logged-in {
+  border-color: var(--success);
+  background: rgba(34, 197, 94, .08);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, .15) inset;
+}
+.role-badge-prominent.logged-in .dot {
+  width: 10px; height: 10px;
+  background: var(--success);
+  box-shadow: 0 0 8px rgba(34, 197, 94, .6);
+}
+.role-badge-prominent.logged-in .role-name {
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: .5px;
+}
+.role-badge-prominent.logged-in .logout-btn {
+  font-size: 14px;
+  color: var(--text-soft);
+  padding: 0 0 0 6px;
+}
+.role-badge-prominent.logged-in .logout-btn:hover {
+  color: var(--danger);
+}
+
+@keyframes rolePillPulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--accent-soft); }
+  50%      { box-shadow: 0 0 0 4px rgba(110, 231, 183, .12); }
+}
 
 /* The single .sidebar-panel host — fills the middle. The 4 panel-modes
  * still rotate via .active. */


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM (Tailscale 폰, 4-색 마킹 screenshot):

- **빨강** (+ New chat) → 위로 (footer → 상단 LARGE primary)
- **파랑** (model chip) → 상단 유지/강조
- **민트** (Workspace) → 위, Templates 위
- **보라** (Admin / mode tabs) → nav 와 함께 cluster

추가 요청: *"현재 로그인 모달과 어드민 계정 로그인 상태 표시는 눈에 띄도록 개선"*

## Sidebar layout v2 (top → bottom)

```
▸ SEKOS                              ◀
─────
[＋  새 대화]                          ← MOVED UP, LARGE primary
─────
🤖 gemma4:e4b   📁 default            ← meta
─────
📦 Workspace      ⚙ Admin             ← page nav
─────
📄 양식                                ← MOVED DOWN below nav
─────
📂 / 🕘 / 🔍 (mode tabs)
─────
PREVIOUS CHATS
(sessions list, flex:1)
─────                                  footer
PROD/TEST    KO | EN
[● 로그인 / ADMIN ✕]                    ← PROMINENT badge
```

## CSS — `.role-badge-prominent`

새 클래스. auth.js 의 `.logged-in` 토글 사용해 두 상태 명확 차별.

**로그아웃 (call-to-action)**:
- 2px accent border + accent-soft 배경
- 13px font-weight 600
- 9px accent dot + glow
- `rolePillPulse` 2.4s 안긴장 ring

**로그인 (ADMIN at a glance)**:
- 2px success green border + rgba(34,197,94,.08) 배경
- 10px green dot + 강한 glow
- inset green ring 으로 depth
- role-name letter-spaced .5px var(--text) 강조
- 14px ✕ 로그아웃 버튼

## CSS — `.modal-overlay` / `.modal`

Login modal prominent:
- overlay `rgba(4,6,10,.72)` (was .35) + `backdrop-filter: blur(4px)` — 뒷배경 dim + blur
- card 2px accent border + 두 겹 shadow (`0 12px 48px ...` + 6px accent halo)
- title 18px / 700

## Verification

- `node --check` clean
- **FastAPI TestClient 8-cell smoke** all True:
  - `>SEKOS<` brand
  - newchat above footer
  - newchat above meta-row
  - meta above nav
  - nav above 양식 (Templates)
  - `role-badge-prominent` class present
  - footer 에 newchat 없음
  - footer 에 prominent role pill 있음

## Rule compliance

- **Rule #1**: 순수 layout / styling. SEKOS / JAMES naming (PR #934) 보존
- **Rule #2**: HTML / CSS only. `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. 26-PR streak

## 머지 후 폰 재확인

- 가장 위: ▸ **SEKOS** + ◀
- **바로 아래 ＋ 새 대화 LARGE 버튼**
- 그 아래 model chip + workspace badge
- Workspace + Admin
- 양식
- 모드 tabs
- 이전 대화 / sessions list
- 하단: PROD/TEST + KO|EN
- **가장 아래 prominent role pill** (admin 일 때 녹색 강조)
- 로그인 modal 클릭 시 → 강한 dim + blur + accent halo 카드

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)