### PR TITLE
fix(v0.6.1): answer-truncation guardrail — NATURAL completeness rule + client heuristic + 계속 button

### DIFF
--- a/core/response_style.py
+++ b/core/response_style.py
@@ -151,6 +151,11 @@ NATURAL_PRESET = StylePreset(
         "- 단순 사실 확인 (예: \"X가 뭐야?\")엔 의도 확인과 다음 작업 제안 "
         "  생략 가능.\n"
         "- 글자수 제약 없음. 내용에 맞는 자연스러운 길이로.\n"
+        "- 답변 완결성 (중요): 시작한 섹션 / 문장 / 리스트 항목은 반드시 "
+        "  끝까지 마무리하세요. 콜론 ':'·하이픈 '-'·번호 '1.' 등으로 끝나는 "
+        "  미완 줄로 답변을 종료하지 마세요. 길어질 것 같으면 미리 핵심을 "
+        "  먼저 적고, 그 다음 자연스러운 마무리 문장 (예: \"이상이 핵심입니다.\" "
+        "  또는 \"필요하면 더 자세히 풀어드릴 수 있어요.\") 으로 닫으세요.\n"
     ),
     rule_text_en=(
         "Answer composition guide:\n"
@@ -177,6 +182,12 @@ NATURAL_PRESET = StylePreset(
         "- For simple fact-checks (\"What is X?\"), intent check and "
         "  next-actions are optional.\n"
         "- No character-count limit. Pick a length that fits.\n"
+        "- Answer completeness (important): finish every section, "
+        "  sentence, and list item you start. Do NOT end the answer "
+        "  on a dangling colon ':', dash '-', or numbered prefix "
+        "  '1.'. If the answer would run long, lead with the core "
+        "  point, then close with a natural wrap (e.g. \"That's the "
+        "  core.\" or \"Happy to expand further if useful.\").\n"
     ),
 )
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -178,6 +178,9 @@ function _bindFrontendEvents() {
       case 'ask-suggestion':
         askSuggestion(parseInt(t.getAttribute('data-index'), 10), t);
         break;
+      // v0.6.1 (2026-06-15 PM) — "continue truncated answer" affordance
+      // surfaced by the truncationHint block in appendJamesMsg.
+      case 'ask-continue':              askContinue(); break;
       // Session-panel rows
       case 'switch-session':            switchSession(t.getAttribute('data-sid')); break;
       case 'rename-session':            renameSession(t.getAttribute('data-sid'), e); break;
@@ -1578,6 +1581,31 @@ function appendJamesMsg(data) {
       </div>`;
   }
 
+  // v0.6.1 (2026-06-15 PM) — answer truncation guardrail. When the
+  // rendered answer looks unfinished, surface an inline hint with a
+  // one-click "계속" affordance. See isLikelyTruncated() at the
+  // bottom of this file.
+  let truncationHint = '';
+  if (isLikelyTruncated(answer)) {
+    truncationHint = `
+      <div role="note" aria-live="polite"
+           style="display:flex;align-items:center;gap:8px;margin-top:8px;
+                  padding:8px 12px;border-radius:8px;
+                  background:rgba(255,183,77,.08);
+                  border:1px solid rgba(255,183,77,.40);
+                  font-size:12px;color:#ffb74d;line-height:1.5">
+        <span aria-hidden="true" style="font-size:14px">⚠️</span>
+        <span style="flex:1">답변이 도중에 끊긴 것 같아요. 이어서 받으려면 아래 버튼을 누르세요.</span>
+        <button data-action="ask-continue"
+                style="background:rgba(255,183,77,.18);
+                       border:1px solid rgba(255,183,77,.60);
+                       border-radius:6px;padding:4px 10px;
+                       color:#ffd180;font-size:12px;cursor:pointer;
+                       font-family:inherit;font-weight:600;
+                       transition:all .15s">계속 ▶</button>
+      </div>`;
+  }
+
   const div = document.createElement('div');
   div.className = 'msg james';
 
@@ -1714,6 +1742,7 @@ function appendJamesMsg(data) {
     <div class="avatar james">🧠</div>
     <div>
       <div class="bubble">${formatAnswerWithParagraphs(cleanAnswer)}${pathsHtml}</div>
+      ${truncationHint}
       ${webBadge}
       ${saveWikiChip}
       ${sensitivityBadge}
@@ -1726,6 +1755,70 @@ function appendJamesMsg(data) {
   `;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
+}
+
+/* v0.6.1 (2026-06-15 PM) — operator catch: "답변이 잘렸다. 끝까지
+ * 잘 나오게 개선." Heuristic answer-truncation detector. The server
+ * already chases done_reason=length internally (core/reasoning/budget
+ * + complete_with_retry), but a model with no native done_reason or
+ * a soft early-stop (gemma4:e4b sometimes halts on a dangling colon
+ * mid-list) bypasses that retry. This adds a client-side belt-and-
+ * braces: when the rendered answer looks unfinished, we surface an
+ * inline "looks cut off — say '계속해줘' to continue" hint so the
+ * operator can recover in one turn without retyping the question.
+ *
+ * NOT a replacement for proper continuation streaming — that's a
+ * separate UX task. This is a low-risk UX guardrail.
+ */
+function askContinue() {
+  /* v0.6.1 (2026-06-15 PM) — fires when the operator taps the
+   * "계속 ▶" button surfaced by isLikelyTruncated(). Drops a
+   * concise continuation prompt into the input box and ships it.
+   * The wording asks the model to RESUME, not RESTART — important
+   * so it doesn't repeat the section it already finished. */
+  const box = document.getElementById('user-input');
+  if (!box) return;
+  box.value = '이전 답변이 도중에 끊겼습니다. 이어서 끝까지 완성해 주세요. (이미 답한 부분은 다시 적지 마세요.)';
+  if (typeof sendMessage === 'function') {
+    sendMessage();
+  }
+}
+
+function isLikelyTruncated(text) {
+  if (!text) return false;
+  const trimmed = String(text).trimEnd();
+  // STRONG cut signals — fire on answers ≥ 20 chars. These are
+  // unambiguous mid-sentence stops the model would never emit as a
+  // natural ending, so length only needs to clear "this isn't just
+  // an exclamation".
+  if (trimmed.length >= 20) {
+    // Dangling terminators: colon / hyphen / bullet / em-dash / star.
+    if (/[:\-*•—]\s*$/.test(trimmed)) return true;
+    // Numbered list item with no body — "4단계:" / "3."
+    if (/(?:^|\n)\s*\d+[.)]\s*$/.test(trimmed)) return true;
+    // Ellipsis (...) / single ellipsis char (…) at end.
+    if (/[…]{1,}$/.test(trimmed)) return true;
+    if (/\.{2,}\s*$/.test(trimmed)) return true;
+    // Open code fence — ``` count odd means we started a block but
+    // never closed it.
+    const fences = (trimmed.match(/```/g) || []).length;
+    if (fences % 2 === 1) return true;
+  }
+  // SOFT cut signals — for answers > 100 chars that DON'T end with a
+  // natural terminator. Korean answers should end with `.`, `!`, `?`
+  // or a terminal jongseong-like ending (`다`, `요`, `용`, `함`,
+  // `움`, `님`, `습니다`, `해요`, …). English answers should end
+  // with `.`, `!`, `?`. 100 char threshold avoids spamming the hint
+  // on short noun-ending factual replies like "샘 뱅크먼-프라이드".
+  if (trimmed.length > 100) {
+    const tail = trimmed.slice(-6);
+    if (!/[.!?。！？]\s*$/.test(tail) &&
+        !/[다요용함움님]\s*$/.test(tail) &&
+        !/(?:습니다|입니다|해요|이에요|예요|있어요|되요|돼요|네요|군요)\s*$/.test(tail)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /* ── item #1-B + #A1: 다음-행동 제안 추출 (다중 포맷 지원) ──


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM (Tailscale 폰): \"답변이 잘렸다. 끝까지 잘 나오게 개선\". 스크린샷의 답이 `데이터 프라이버시:` 라는 dangling colon 으로 종료.

## Root-cause survey (server side)

모든 truncation 후보 자리 점검:
- `pipeline.py:311 answer[:300]` — Memory Loom 저장만, response payload 영향 X
- `gemma_client num_predict=8192` (Korean ~12000자) — cap 아님
- `response_style.py` NATURAL/TERSE preset `max_tokens=8192`
- `engine_synth.py:181 trace_synth_call` style.max_tokens 통과
- `budget.py` adaptive budget OFF default, production 영향 X
- `ollama_local.py` 가 `done_reason=length` 노출 + `complete_with_retry` 가 cap 자동 doubled

가장 가능성 높은 잔여 원인: (a) gemma4:e4b 가 dangling colon 에서 soft early stop, (b) `trace_synth_call` 가 `complete_with_retry` wiring 안 됨 (final synth retry 미발동).

폰 측 서버 로그 없어 root cause 확정 불가 — 두 시나리오 모두 cover 하는 **layered guardrail** 적용.

## 1. NATURAL_PRESET — 답변 완결성 룰 (server-side prompt)

`core/response_style.py` NATURAL_PRESET rule_text 추가 (KO + EN):
- KO: \"시작한 섹션 / 문장 / 리스트 항목은 반드시 끝까지 마무리하세요. 콜론 ':'·하이픈 '-'·번호 '1.' 등으로 끝나는 미완 줄로 답변을 종료하지 마세요\" + 자연 마무리 예시
- EN: \"finish every section, sentence, and list item you start. Do NOT end the answer on a dangling colon ':', dash '-', or numbered prefix '1.'\" + natural wrap suggestions

prompt-side 만 변경. max_tokens / force_two_sections / 다른 dial 모두 동일.

## 2. Client heuristic — visible truncation hint (frontend)

`frontend/static/chat.js`:

### `isLikelyTruncated(text)` 2-tier 감지

| Tier | length | 신호 |
|---|---|---|
| **STRONG** | ≥ 20 | dangling `:` `-` `*` `•` `—` / 번호 list 미완 (`4단계:` / `3.` / `3)`) / ellipsis (`…` `..`) / unclosed code fence (odd ``` count) |
| **SOFT** | > 100 | 자연 terminator 없음: not `. ! ?` + not Korean jongseong (`다요용함움님`) + not Korean 끝 phrase (`습니다 입니다 해요 …`) |

### 14-case unit test (isolated)

9 positives (운영자 cut 케이스 + 하이픈 / 4번째 미완 / 200자 명사 끝 / unclosed code fence 등) + 5 negatives (\"Yes\" / Korean name / 자연 한국어 끝 / 영문 짧은 문장). **14/14 통과**.

### Hint UI

답변 bubble 다음에 amber-tinted note + `계속 ▶` 버튼.

### `askContinue()` 핸들러

입력창에 정확한 continuation prompt 채우고 자동 전송:
> 이전 답변이 도중에 끊겼습니다. 이어서 끝까지 완성해 주세요. (이미 답한 부분은 다시 적지 마세요.)

\"이미 답한 부분은 다시 적지 마세요\" 가 load-bearing — 없으면 gemma 가 전체 다시 시작.

### Click 위임

기존 `t.dataset.action` switch 에 `case 'ask-continue': askContinue(); break;` 추가.

## What this fix does NOT change

- `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**
- 서버 handler 변경 없음. response shape 동일
- 새 endpoint / schema 변경 없음 — 구 client 도 hint 안 보이고 pre-fix UX 유지

## Verification

- `node --check frontend/static/chat.js` clean
- **isolated heuristic 14/14 통과**
- FastAPI TestClient `GET /static/chat.js` 200 + 6-cell content (all True):
  - isLikelyTruncated / askContinue 함수 / 'ask-continue' case / truncationHint var / KO regex literal / 완결성 rule 모두 present

## Out of scope (별도 UX task)

- **server-side `done_reason` exposure** — 응답 payload 에 done_reason 추가. authoritative signal + heuristic 양쪽 사용 가능. 별도 PR
- **streaming continuation** — token-by-token resume. 훨씬 큰 UX surface

## Rule compliance

- **Rule #1**: prompt + client UX. horizontal
- **Rule #2**: `core/response_style.py` = prompt-text module (retrieval / graph / reasoning 아님). 28-PR streak (`core/retrieval` / `core/graph` traversal / `core/reasoning` 0 라인) 유지. `fix` label; QDC exempt (UX guardrail)

## 머지 후 폰 즉시 확인

1. 폰에서 swipe-down 새로고침
2. 답 받았을 때 잘렸으면 amber `⚠️ 답변이 도중에 끊긴 것 같아요 … [계속 ▶]` 표시
3. \"계속 ▶\" 탭 → 자동으로 \"이어서 끝까지 완성해 주세요\" 보내 답 이어 받음

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)