### PR TITLE
fix(v0.6.1): mobile chat readability — Korean eojeol wrap + bigger font + justify + wider bubble

### DIFF
--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -381,12 +381,30 @@
     padding: 16px 12px 12px;
     gap: 14px;
   }
-  .msg { max-width: 100%; }
+  /* v0.6.1 v3 (2026-06-15 PM) — operator catch ("폰 웹에서 줄바꿈이
+   * 이상하다. 글자 크기 조금 더 크게, 대화창 넓히고 끝 정렬"):
+   *   - .msg full-width + smaller gap so the bubble can run wider
+   *   - .bubble bigger font + tighter padding + word-break: keep-all
+   *     so 한국어 어절(eojeol) 단위로 줄바꿈 (was break-word splitting
+   *     "구체적으|로" mid-word)
+   *   - text-align: justify so the right edge lines up cleanly
+   *   - text-justify: inter-character keeps the spacing readable for
+   *     CJK + ASCII mixed text instead of stretching spaces only
+   */
+  .msg { max-width: 100%; gap: 8px; }
   .bubble {
-    padding: 10px 14px;
-    font-size: 14.5px;
+    padding: 12px 14px;
+    font-size: 16px;
     border-radius: 12px;
-    line-height: 1.55;
+    line-height: 1.7;
+    /* CJK 어절-단위 줄바꿈 — 영문 long token 은 overflow-wrap fallback */
+    word-break: keep-all;
+    overflow-wrap: anywhere;
+    /* 양쪽 정렬 — 우측 edge 가 들쭉날쭉 안 되도록 */
+    text-align: justify;
+    text-justify: inter-character;
+    /* avatar 옆 gap 줄여 본문 폭 확보 */
+    max-width: calc(100% - 36px);
   }
   .avatar { width: 28px; height: 28px; font-size: 12px; }
 
@@ -672,7 +690,18 @@
   .welcome-title { font-size: 18px; }
   .welcome-sub { font-size: 12px; }
 
-  .bubble { font-size: 14px; padding: 9px 12px; }
+  /* v0.6.1 v3 (2026-06-15 PM) — keep the 16px font + readability
+   * tweaks even on the narrowest devices (< 480 px). Padding only
+   * shrinks slightly so the bubble still fits, not the text. */
+  .bubble {
+    font-size: 15.5px;
+    padding: 11px 13px;
+    line-height: 1.7;
+    word-break: keep-all;
+    overflow-wrap: anywhere;
+    text-align: justify;
+    text-justify: inter-character;
+  }
 
   /* 어드민 nav-item 더 작게 */
   .nav-item { padding: 6px 10px; font-size: 12px; min-height: 36px; }


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM (Tailscale 폰): \"줄바꿈이 이상하다 → 글자 좀 더 크게 → 대화창 넓혀 → 끝 정렬\". 네 요청 동시 처리.

스크린샷 증상:
- \"구체적으\" + 줄바꿈 + \"로\" — 한국어 어절 중간에서 자름
- 본문 폰트 작음
- bubble 폭 좁음
- 우측 edge 들쭉날쭉

## 변경 (mobile.css `@media (max-width: 768px)` + `(max-width: 480px)`)

### 1. 한국어 어절-단위 줄바꿈

| 이전 | 이후 |
|---|---|
| `word-break: break-word` (chat.css default — 어절 중간 자름) | **`word-break: keep-all`** + `overflow-wrap: anywhere` fallback |

CJK 웹 타이포 표준. 영문 / URL / 긴 mono token 은 anywhere fallback 으로 안전.

### 2. 글자 크기

| viewport | 이전 | 이후 |
|---|---|---|
| < 768px | 14.5px | **16px** (iOS 자동줌 floor, 입력창과 동일) |
| < 480px | 14px | **15.5px** |

line-height 1.55 → **1.7** 양쪽 동일 적용.

### 3. 대화창 폭

- `.msg gap`: 12 → **8 px** (4px gain)
- `.bubble max-width`: `calc(100% - 42px)` → **`calc(100% - 36px)`** (avatar 28 + gap 8 매핑)

총 ~8 px wider. 한국어 한 줄에 1-2 char 더 들어감.

### 4. 끝 정렬

`text-align: justify` + **`text-justify: inter-character`**.

inter-character 가 load-bearing — 없으면 CJK 가 inter-word fallback 으로 떨어져 whitespace river 발생.

## Verification

- `node --check` clean
- **FastAPI TestClient `GET /static/mobile.css`** 200 + 6-cell (all True):
  - `word-break: keep-all`
  - `text-align: justify`
  - `text-justify: inter-character`
  - `font-size: 16px` (wide phone)
  - `font-size: 15.5px` (narrow phone)
  - `overflow-wrap: anywhere`
- 시각 폰 확인 = 운영자 측 swipe-down 새로고침 후

## What it does NOT change

- **Desktop** rendering — 모든 변경 `@media (max-width: 768px)` 안. desktop bubble 14px / break-word / no justify 그대로
- 색 / border / shadow — 시각 identity 유지
- 문단별 복사 button — `padding-right: 26px` reserved 자리 그대로

## Rule compliance

- **Rule #1**: pure CSS mobile @media. horizontal
- **Rule #2**: `frontend/static/mobile.css` only. `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. 29-PR streak. `fix` label; QDC exempt

## 머지 후 폰 즉시 확인

1. swipe-down 새로고침 (cached mobile.css 교체)
2. 한국어 답 = 어절 단위로만 줄바꿈
3. 본문 16px 양쪽 정렬
4. bubble 폭 8px 더 넓음

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)