### PR TITLE
fix(v0.6.1): bubble flex-1 mobile + askContinue input-id fix (operator catch)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1805,10 +1805,20 @@ function askContinue() {
    * "계속 ▶" button surfaced by isLikelyTruncated(). Drops a
    * concise continuation prompt into the input box and ships it.
    * The wording asks the model to RESUME, not RESTART — important
-   * so it doesn't repeat the section it already finished. */
-  const box = document.getElementById('user-input');
+   * so it doesn't repeat the section it already finished.
+   *
+   * v0.6.1 v2 (2026-06-15 PM follow-up) — operator catch: button
+   * silently no-op'd. The textarea in index.html L443 carries
+   * `id="chat-input"`, not `user-input`; sendMessage() at L1242
+   * already uses the right id. This now uses the same id +
+   * dispatches an 'input' event so any keyup/oninput listeners
+   * (auto-resize, send-btn enable) see the new text before
+   * sendMessage() runs.
+   */
+  const box = document.getElementById('chat-input');
   if (!box) return;
   box.value = '이전 답변이 도중에 끊겼습니다. 이어서 끝까지 완성해 주세요. (이미 답한 부분은 다시 적지 마세요.)';
+  box.dispatchEvent(new Event('input', { bubbles: true }));
   if (typeof sendMessage === 'function') {
     sendMessage();
   }

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -392,7 +392,21 @@
    *     CJK + ASCII mixed text instead of stretching spaces only
    */
   .msg { max-width: 100%; gap: 8px; }
+  /* v0.6.1 v4 (2026-06-15 PM follow-up) — operator catch ("선으로
+   * 표시된 곳까지 확장"): on phone, `.msg display:flex` + `.bubble`
+   * without a flex setting meant the bubble only stretched to its
+   * content width, leaving a large ~25 % gap on the right of long
+   * answers (the screenshot shows this directly). Adding
+   *   flex: 1 1 auto;  min-width: 0;
+   * lets the bubble actually consume the remaining row width up to
+   * the existing `max-width`. min-width: 0 keeps long mono tokens
+   * from blowing past the row. text-align: justify also only takes
+   * effect once the bubble is at full width, so this fix unblocks
+   * the v3 justify rule too.
+   */
   .bubble {
+    flex: 1 1 auto;
+    min-width: 0;
     padding: 12px 14px;
     font-size: 16px;
     border-radius: 12px;


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM (Tailscale 폰, cyan rectangle + 계속 ▶ 화살표 screenshot): 두 가지 regression.

### Bug A — bubble 우측 끝까지 안 늘어남

스크린샷 cyan 선이 viewport 우측 끝 표시. 현재 bubble 이 ~25% 짧음.

**Root cause**: `.msg display: flex` 안의 `.bubble` 이 `max-width` 만 정의 — flex item 이 content 크기로 layout. 긴 한국어 답에서 각 줄이 짧으니 content width 작음. v3 의 `text-align: justify` 도 폭 안 채워지면 무효.

**Fix**: `flex: 1 1 auto; min-width: 0` 을 `.bubble` (mobile @media) 에 추가. flex 1 이 row 의 남은 폭 채우고, min-width 0 이 long mono token overflow fallback. justify 도 이제 실제 적용.

### Bug B — \"계속 ▶\" 버튼 무반응

운영자 보고: \"답변 이어서 받기 계속이 작동 안하는 듯\".

**Root cause**: `askContinue()` 가 `getElementById('user-input')` 호출. 실제 textarea id = `chat-input` (index.html L443). element null → guard 가 silently return. sendMessage() 는 올바른 id 사용. PR #937 에서 wrong id 박힘.

**Fix**: id 를 `chat-input` 으로 정정 + `dispatchEvent(new Event('input'))` — 일부 listener (auto-resize / send-btn enable) 가 programmatic value set 에 안 fire 하므로 명시적 event.

## 변경 파일

- `frontend/static/chat.js` — askContinue() id + event dispatch
- `frontend/static/mobile.css` — `.bubble flex: 1 1 auto; min-width: 0`

## Verification

- `node --check chat.js` clean
- **FastAPI TestClient 5-cell smoke** (all True):
  - askContinue uses `chat-input` (no residual `user-input` ref)
  - `new Event('input'` dispatch present
  - mobile.css `flex: 1 1 auto` present
  - mobile.css `min-width: 0` present
  - index.html `id=\"chat-input\"` sanity 매치

## What NOT changed

- Desktop bubble — 둘 다 mobile @media 안
- isLikelyTruncated heuristic — 클릭 핸들러만 fix
- 다른 action 핸들러 — 이미 올바른 id 사용

## Rule compliance

- **Rule #1**: pure UI + DOM-id fix
- **Rule #2**: `chat.js` + `mobile.css` 만. `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. 30-PR streak

## 머지 후 폰 즉시

1. **swipe-down 새로고침**
2. 답 받으면 bubble = viewport 우측 끝까지 (선 표시 자리까지)
3. 답 잘리면 \"계속 ▶\" 클릭 → 입력창에 자동 채워 + 자동 전송 → 답 이어 받음

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)