### PR TITLE
fix(v0.6.1): bubble width v5 fortify — flex 1 1 0 + width:100% + cache-buster

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/glossary.html
+++ b/frontend/glossary.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -8,8 +8,10 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/graph.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
-     rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css">
+     rules win at narrow viewports without !important on every line.
+     v=v5-20260615 cache-bust: forces phones with cached older mobile.css
+     to refetch after the v5 bubble-width fortifications landed. -->
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,8 +8,10 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/chat.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
-     rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css">
+     rules win at narrow viewports without !important on every line.
+     v=v5-20260615 cache-bust: forces phones with cached older mobile.css
+     to refetch after the v5 bubble-width fortifications landed. -->
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/knowledge-rollback.html
+++ b/frontend/knowledge-rollback.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/knowledge-rollback.css">
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -7,7 +7,7 @@
 <title data-i18n="onboarding.page_title">SEKOS — 비개발자 운영자 안내</title>
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/onboarding.css">
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/reasoning-flow.html
+++ b/frontend/reasoning-flow.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/reasoning-flow.css">
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -392,21 +392,32 @@
    *     CJK + ASCII mixed text instead of stretching spaces only
    */
   .msg { max-width: 100%; gap: 8px; }
-  /* v0.6.1 v4 (2026-06-15 PM follow-up) — operator catch ("선으로
-   * 표시된 곳까지 확장"): on phone, `.msg display:flex` + `.bubble`
-   * without a flex setting meant the bubble only stretched to its
-   * content width, leaving a large ~25 % gap on the right of long
-   * answers (the screenshot shows this directly). Adding
-   *   flex: 1 1 auto;  min-width: 0;
-   * lets the bubble actually consume the remaining row width up to
-   * the existing `max-width`. min-width: 0 keeps long mono tokens
-   * from blowing past the row. text-align: justify also only takes
-   * effect once the bubble is at full width, so this fix unblocks
-   * the v3 justify rule too.
+  /* v0.6.1 v5 (2026-06-15 PM follow-up #2) — operator catch
+   * persists: bubble still not reaching the right edge. v4 set
+   * `.bubble flex: 1 1 auto;` but flex-basis: auto means the
+   * starting width is the content's intrinsic size, and the
+   * remaining row distributes from there — long Korean answers
+   * with many short lines still don't pull the bubble to the
+   * right edge in some engines.
+   *
+   * v5 fortifications:
+   *   1) flex: 1 1 0 — basis 0 so the bubble starts at zero
+   *      and absorbs ALL the remaining row width (avatar is
+   *      shrink:0, so it keeps its 28px; the bubble takes
+   *      everything else).
+   *   2) Explicit width: 100% on the .msg.james + .msg.user
+   *      selectors — same specificity (2,0) trumps the base
+   *      `.bubble` (1,0) so any browser cache of an older
+   *      mobile.css still gets overridden by this stronger
+   *      rule once the new file loads.
+   *   3) max-width raised to 100% — the avatar gap is already
+   *      handled by .msg `gap: 8px`, so the bubble doesn't need
+   *      a separate 36 px subtraction on top of that.
    */
   .bubble {
-    flex: 1 1 auto;
+    flex: 1 1 0;
     min-width: 0;
+    width: 100%;
     padding: 12px 14px;
     font-size: 16px;
     border-radius: 12px;
@@ -417,8 +428,18 @@
     /* 양쪽 정렬 — 우측 edge 가 들쭉날쭉 안 되도록 */
     text-align: justify;
     text-justify: inter-character;
-    /* avatar 옆 gap 줄여 본문 폭 확보 */
-    max-width: calc(100% - 36px);
+    max-width: 100%;
+  }
+  /* v5 specificity bump — even when an older cached mobile.css
+   * still defines `.bubble max-width: calc(100% - 36px)`, these
+   * two rules (specificity 2,0 vs 1,0) win once this file does
+   * arrive. */
+  .msg.james .bubble,
+  .msg.user  .bubble {
+    flex: 1 1 0;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
   }
   .avatar { width: 28px; height: 28px; font-size: 12px; }
 
@@ -706,8 +727,15 @@
 
   /* v0.6.1 v3 (2026-06-15 PM) — keep the 16px font + readability
    * tweaks even on the narrowest devices (< 480 px). Padding only
-   * shrinks slightly so the bubble still fits, not the text. */
+   * shrinks slightly so the bubble still fits, not the text.
+   *
+   * v0.6.1 v5 (2026-06-15 PM follow-up #2) — same width
+   * fortification as the < 768 block for narrowest devices. */
   .bubble {
+    flex: 1 1 0;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
     font-size: 15.5px;
     padding: 11px 13px;
     line-height: 1.7;
@@ -715,6 +743,13 @@
     overflow-wrap: anywhere;
     text-align: justify;
     text-justify: inter-character;
+  }
+  .msg.james .bubble,
+  .msg.user  .bubble {
+    flex: 1 1 0;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
   }
 
   /* 어드민 nav-item 더 작게 */

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css">
+<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM (3rd pass): \"선으로 표시된 곳까지 확장이 아직 안됫는데, 확인해봐\". PR #939 의 `flex: 1 1 auto` 만으론 부족.

## Why #939 가 부족했나

1. **flex-basis: auto** = bubble 의 intrinsic content size. 긴 한국어 답 = \"많은 짧은 wrapped line\". basis 가 longest wrapped line 만큼 — grow 가 그 위 remainder 만 distribute. Android Chrome / iOS Safari 에서 우측 gap visible

2. **cached old mobile.css** — 운영자 폰이 stale CSS 사용 중. specificity 동일 (.bubble 1,0) 라 same-priority cascade. 강제 새로 fetch 안 됨

## v5 세 강화

### a) `flex: 1 1 0` (basis 0)

basis 0 = bubble 이 zero 에서 시작 + grow 가 row 의 ALL remaining space 흡수. avatar 는 `flex-shrink: 0` 으로 28px 고정. bubble 이 나머지 전부.

### b) 더 specific selector + 명시 width

```css
.msg.james .bubble,
.msg.user  .bubble {
  flex: 1 1 0;
  min-width: 0;
  width: 100%;
  max-width: 100%;
}
```

specificity 2,0 — cached 옛 `.bubble max-width: calc(100% - 36px)` (1,0) override.

### c) cache-buster `mobile.css?v=v5-20260615`

8 HTML 모두 적용:
- index.html / workspace.html / admin.html / glossary.html / graph.html / onboarding.html / reasoning-flow.html / knowledge-rollback.html

폰 cached old file 무력화. browser 가 새 URL → fresh fetch.

## 변경 파일 (9)

- `frontend/static/mobile.css` — 두 @media block 모두 v5 강화 적용
- `frontend/*.html` × 8 — `mobile.css?v=v5-20260615` cache-buster

## Verification

- `node --check` clean
- **FastAPI TestClient 5-cell smoke** (all True):
  - `GET /` 200 + cache-buster v5 HTML 안에 present
  - `GET /static/mobile.css` 200 + `flex: 1 1 0` present
  - `width: 100%` present
  - `.msg.james .bubble` specific selector present
  - `.msg.user  .bubble` specific selector present

## What this fix does NOT change

- Desktop — 모두 `@media (max-width: 768px)` + `(max-width: 480px)` 안
- 서버 endpoint / handler — cache-buster query string 은 URL 변경, server 는 그대로 disk file serve

## Rule compliance

- **Rule #1**: pure CSS + HTML link tag
- **Rule #2**: mobile.css + 8 HTML link. `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. 31-PR streak. `fix` label; QDC exempt

## 머지 후 폰 즉시

1. swipe-down 새로고침 (HTML 재 fetch → new cache-buster URL → mobile.css fresh fetch)
2. bubble = viewport 우측 끝까지 (cyan 선까지 확장)
3. 줄바꿈 + 글자크기 + justify 모두 동작
4. 계속 ▶ 버튼 (#939 fix) 도 OK

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)