### PR TITLE
fix(v0.6.1): NATURAL preset — short greeting → short reply (drop report tone carry-over)

### DIFF
--- a/core/response_style.py
+++ b/core/response_style.py
@@ -122,6 +122,12 @@ NATURAL_PRESET = StylePreset(
     force_two_sections=False,
     rule_text_ko=(
         "답변 작성 가이드:\n"
+        "- ⭐ 최우선 원칙: 답의 길이/톤은 **사용자의 현재 질문**에 맞추세요. "
+        "이전 대화가 분석 보고서였더라도, 새 질문이 짧은 인사 (\"안녕\", "
+        "\"안녕?\", \"하이\", \"수고\", \"고마워\") 면 한두 문장으로 짧게 "
+        "인사로 응대. \"(잠시 멈추고 ~)\" 같은 메타-내레이션, \"결론부터 "
+        "말씀드리겠습니다\" 같은 보고서 도입부, ## 헤더, 다음 단계 제안 "
+        "전부 생략. 새 질문이 정말 짧은 응대면 답도 짧은 응대.\n"
         "- 자연스러운 한국어 문단으로 답하세요. 'STEP 1', '📚 자료 기반', "
         "'💡 추론' 같은 라벨은 사용하지 마세요.\n"
         "- 다음 흐름을 따르되 강제는 아닙니다 (짧은 질문엔 짧게):\n"
@@ -159,6 +165,14 @@ NATURAL_PRESET = StylePreset(
     ),
     rule_text_en=(
         "Answer composition guide:\n"
+        "- ⭐ Top priority: match the **current** user message's "
+        "length and tone. If the previous turn was a long analysis "
+        "report but the current message is just a greeting (\"hi\", "
+        "\"hello\", \"thanks\", \"ok\"), reply with a short greeting. "
+        "Drop meta-narration (\"(pausing to think) ...\"), report "
+        "openers (\"Let me start with the conclusion\"), ## headers, "
+        "and next-step proposals when the current question is a short "
+        "social reply. Short message gets a short answer.\n"
         "- Natural English prose. No 'STEP 1' headers or "
         "'📚 Data-based' / '💡 Reasoning' labels.\n"
         "- Follow this flow as guidance (short questions get short answers):\n"


### PR DESCRIPTION
## Summary

Operator catch 2026-06-15 PM: \"안녕?\" 한 마디 보냈는데 보고서 톤 그대로 유지된 매우 긴 응답이 돌아옴.

화면 답 시작 — `(잠시 멈추고 자신감 있는 어조로) 좋습니다. 지금까지 논의된 내용은 …` + `결론부터 말씀드리겠습니다` + ## 핵심 결론 / ## 근거 / 다음 단계 전략 제안 ….

## Root cause

이전 turn 이 긴 분석 보고서 → conversation history 에 그 톤이 박힘 → 새 짧은 인사도 같은 톤 유지.

NATURAL preset 의 `rule_text_ko` / `rule_text_en` 가:
- \"분석/추론 질문엔 보고서\" 가이드 turn-global 정의
- **\"현재 메시지의 톤이 이전 turn 의 톤 보다 우선\"** 명시 없음

## Fix

KO + EN rule_text 의 **첫 bullet** 으로 ⭐ 최우선 원칙 prepend:

1. **현재 메시지에 길이/톤 핀**: \"이전 대화가 분석 보고서였더라도, 새 질문이 짧은 인사면 한두 문장으로 짧게\"
2. **실패 phrase 들 명시적 ban**:
   - KO: `(잠시 멈추고 ~)` 메타-내레이션, `결론부터 말씀드리겠습니다` 보고서 도입, `##` 헤더, `다음 단계 제안` 모두 short-greeting branch 에선 생략
   - EN: `(pausing to think) …`, `Let me start with the conclusion`, `##`, next-step proposals 모두 ban
3. **인사 trigger** 단어 명시: `안녕 / 안녕? / 하이 / 수고 / 고마워` (KO), `hi / hello / thanks / ok` (EN)

⭐ 위치 = **첫 bullet** — 이미 있는 \"분석/추론 → 보고서\" 룰보다 cascade 상위에서 win.

## What this fix does NOT change

- prompt 구조 / 템플릿 변경 없음. `rule_text` 문자열 내 추가만
- `max_tokens` / `force_two_sections` 동일 — 진짜 분석 질문은 보고서 톤 그대로
- 새 preset / env flag / endpoint 없음

## Verification

- module reimport clean
- **8-cell rule_text check** (all True):
  - KO: '⭐ 최우선 원칙' + '(잠시 멈추고' ban + '결론부터 말씀드리겠습니다' ban + '안녕' + '고마워' examples
  - EN: 'Top priority' + '(pausing to think)' ban + 'Let me start with the conclusion' ban + 'short greeting' instruction

## Operator complementary action

`+ 새 대화` 버튼 (PR #935) 그대로. 토픽 전환 시 가장 깔끔한 해법. 이 PR 은 \"같은 session 유지하면서 짧은 follow-up\" 케이스 cover.

## Rule compliance

- **Rule #1**: prompt-text 편집. horizontal
- **Rule #2**: `core/response_style.py` = prompt-text module. `core/retrieval` / `core/graph` traversal / `core/reasoning` **0 라인**. 32-PR streak. `fix` label; QDC exempt

## 머지 후 폰

1. swipe-down 새로고침 (HTML 캐시 v=v5 그대로)
2. 짧은 인사 → 짧은 인사 응답 (보고서 톤 carry-over 없음)
3. 진짜 분석 질문 → 보고서 톤 유지

Quality delta: exempt (label: fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)