### PR TITLE
fix(v0.6.1): switchSidebarMode('sessions') early-return + footer 50 badge leak

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,13 +6,13 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v9-20260616 cache-bust: compact session-action modal +
-     emoji→SVG nav icons + working sidebar search input. Pin both
+<!-- v=v10-20260616 cache-bust: switchSidebarMode('sessions') early-
+     return fix + session-count-badge "50" leak fix. Pin both
      stylesheets so a half-cached state can't mismatch. -->
-<link rel="stylesheet" href="/static/chat.css?v=v9-20260616">
+<link rel="stylesheet" href="/static/chat.css?v=v10-20260616">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line. -->
-<link rel="stylesheet" href="/static/mobile.css?v=v9-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v10-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -2821,11 +2821,18 @@ async function loadSessionList() {
     // re-type.
     try { renderSidebarSearch(); } catch (_) {}
 
-    // 배지 업데이트
+    // v0.6.1 v6 (2026-06-16) — operator catch: the bare "50" floating
+    // under the avatar was this badge. The Claude-style reorg moved
+    // the badge from the header into the sidebar footer where it
+    // visually leaked because loadSessionList was overriding the
+    // hidden attribute with style.display='block'. Stop overriding;
+    // the badge stays hidden (it's still in the DOM for callers that
+    // might rebind a visible UI later).
     const badge = document.getElementById('session-count-badge');
     if (badge) {
-      badge.style.display = sessions.length ? 'block' : 'none';
       badge.textContent = sessions.length;
+      // Don't touch badge.hidden / badge.style.display — the HTML
+      // attribute `hidden` keeps it invisible in the footer.
     }
 
     if (!sessions.length) {

--- a/frontend/static/index-init.js
+++ b/frontend/static/index-init.js
@@ -206,16 +206,23 @@
       '.sidebar-rail-item[data-mode], .sidebar-tab[data-mode]'
     );
     var panels = document.querySelectorAll('.sidebar-panel-mode');
-    var matched = false;
+    // v0.6.1 v6 (2026-06-16) — operator catch: tapping 💬 Chat after
+    // switching to 📂 / 🕘 / 🔍 left the sidebar stuck on the previous
+    // mode. Root cause: this loop tracked `matched` on .sidebar-tab,
+    // but there's no tab for 'sessions' — so switchSidebarMode('sessions')
+    // hit `if (!matched) return;` and never toggled the panels. Now we
+    // track existence on the PANELS (the source of truth) and only
+    // early-return when no panel matches the requested mode.
     modeEls.forEach(function (el) {
+      el.classList.toggle('active', el.dataset.mode === modeId);
+    });
+    var matched = false;
+    panels.forEach(function (el) {
       var on = el.dataset.mode === modeId;
       el.classList.toggle('active', on);
       if (on) matched = true;
     });
     if (!matched) return;  // unknown mode → ignore
-    panels.forEach(function (el) {
-      el.classList.toggle('active', el.dataset.mode === modeId);
-    });
     // W8-B: lazy-load the "내 자료" list when switching into recent.
     if (modeId === 'recent' && typeof loadMineSidebar === 'function') {
       loadMineSidebar();


### PR DESCRIPTION
## Summary

운영자 catch 2건 (스크린샷 1장):
1. 💬 Chat 메뉴 탭해도 **이전 대화 목록이 안 나옴** — 사이드바 패널이 직전에 누른 모드 (upload / recent / search) 에 stuck
2. avatar 좌측 아래 **"50"** 숫자가 떠다님

### (1) `switchSidebarMode('sessions')` early-return 버그
- `.sidebar-tab` 에 `data-mode="upload" / "recent" / "search"` 만 있고 **`"sessions"` 탭이 없음** (sessions 는 default panel, 별도 탭 없이 패널만 존재).
- 기존 `switchSidebarMode`:
    ```js
    modeEls.forEach(... matched=true if .sidebar-tab data-mode matches ...);
    if (!matched) return;  // ← 'sessions' 호출 시 여기서 panels 토글 전에 종료
    panels.forEach(...);   // ← 실행 안 됨
    ```
- 결과: 한 번이라도 다른 mode 탭을 누르면 💬 Chat 으로 sessions 패널 복귀가 불가능.
- **Fix**: matched 추적을 PANELS (source of truth) 로 이동. 탭 .active 는 무조건 toggle, early return 은 패널 매치 없을 때만.

### (2) "50" 배지 leak
- `chat.js loadSessionList` 에서 `badge.style.display = sessions.length ? 'block' : 'none'` 가 HTML `hidden` attribute 를 override → footer 에 50 노출.
- Claude-style reorg 가 이 badge 의 visible host 였던 헤더를 제거한 뒤 footer 에 묻혀서 dead element. 표시 의도 없음.
- **Fix**: `textContent` 만 set (미래 callers 가 visible UI rebind 가능), `style.display` / `hidden` 은 절대 안 건드림.

### 캐시
- chat.css + mobile.css `v=v10-20260616` 동시 bump.

## Verification

- 💬 Chat 탭 → `goto-chat-top` → `switchSidebarMode('sessions')` → 패널 매치 → sessions panel `.active`, 다른 panels deactivate → loadSessionList → "PREVIOUS CHATS" 아래에 세션 리스트 표시
- 📂 (upload) / 🕘 (recent) / 🔍 (search) → 각 패널 정상 활성화 + sessions 비활성화
- 알 수 없는 mode 호출 시 panels 매치 없음 → early return (방어 유지)
- "50" 배지: 사라짐. badge.textContent 는 채워지지만 hidden attribute 가 유지되어 화면 미노출
- JS syntax: chat.js / index-init.js parse OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: fix) — interaction regression fix, no measurement axes apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)