### PR TITLE
feat(v0.6.1): English STAGE_META + truncation fix + mobile compact + workspace tooltip

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,13 +6,11 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v10-20260616 cache-bust: switchSidebarMode('sessions') early-
-     return fix + session-count-badge "50" leak fix. Pin both
-     stylesheets so a half-cached state can't mismatch. -->
-<link rel="stylesheet" href="/static/chat.css?v=v10-20260616">
-<!-- mobile-responsive overrides — kept after inline styles so @media
-     rules win at narrow viewports without !important on every line. -->
-<link rel="stylesheet" href="/static/mobile.css?v=v10-20260616">
+<!-- v=v11-20260616 cache-bust: English STAGE_META labels +
+     truncation false-positive fix + mobile conv-actions compaction
+     + workspace badge tooltip self-doc. -->
+<link rel="stylesheet" href="/static/chat.css?v=v11-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v11-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1677,30 +1677,15 @@ function appendJamesMsg(data) {
       </div>`;
   }
 
-  // v0.6.1 (2026-06-15 PM) — answer truncation guardrail. When the
-  // rendered answer looks unfinished, surface an inline hint with a
-  // one-click "계속" affordance. See isLikelyTruncated() at the
-  // bottom of this file.
+  // v0.6.1 (2026-06-15 PM) — answer truncation guardrail. The actual
+  // detector runs AFTER cleanAnswer is extracted (line below) so the
+  // SUGGESTIONS chip block ("(1) X / (2) Y") doesn't trip the SOFT
+  // signal that fires when the tail isn't a sentence terminator.
+  // Operator catch v6 (2026-06-16): the previous order ran the
+  // detector on the raw `answer` which always included the
+  // suggestions tail, producing a false-positive "looks cut off"
+  // hint on perfectly complete answers.
   let truncationHint = '';
-  if (isLikelyTruncated(answer)) {
-    truncationHint = `
-      <div role="note" aria-live="polite"
-           style="display:flex;align-items:center;gap:8px;margin-top:8px;
-                  padding:8px 12px;border-radius:8px;
-                  background:rgba(255,183,77,.08);
-                  border:1px solid rgba(255,183,77,.40);
-                  font-size:12px;color:#ffb74d;line-height:1.5">
-        <span aria-hidden="true" style="font-size:14px">⚠️</span>
-        <span style="flex:1">답변이 도중에 끊긴 것 같아요. 이어서 받으려면 아래 버튼을 누르세요.</span>
-        <button data-action="ask-continue"
-                style="background:rgba(255,183,77,.18);
-                       border:1px solid rgba(255,183,77,.60);
-                       border-radius:6px;padding:4px 10px;
-                       color:#ffd180;font-size:12px;cursor:pointer;
-                       font-family:inherit;font-weight:600;
-                       transition:all .15s">계속 ▶</button>
-      </div>`;
-  }
 
   const div = document.createElement('div');
   div.className = 'msg james';
@@ -1800,6 +1785,28 @@ function appendJamesMsg(data) {
   // chip + 본문에 두 번 보이는 문제 (실사용자 피드백) 해결.
   const { suggestions, cleanAnswer } =
     extractNextActionSuggestions(answer);
+  // Now that the suggestions tail is removed, evaluate truncation
+  // against just the body text. (See truncationHint declaration
+  // above for the operator-catch context.)
+  if (isLikelyTruncated(cleanAnswer)) {
+    truncationHint = `
+      <div role="note" aria-live="polite"
+           style="display:flex;align-items:center;gap:8px;margin-top:8px;
+                  padding:8px 12px;border-radius:8px;
+                  background:rgba(255,183,77,.08);
+                  border:1px solid rgba(255,183,77,.40);
+                  font-size:12px;color:#ffb74d;line-height:1.5">
+        <span aria-hidden="true" style="font-size:14px">⚠</span>
+        <span style="flex:1">답변이 도중에 끊긴 것 같아요. 이어서 받으려면 아래 버튼을 누르세요.</span>
+        <button data-action="ask-continue"
+                style="background:rgba(255,183,77,.18);
+                       border:1px solid rgba(255,183,77,.60);
+                       border-radius:6px;padding:4px 10px;
+                       color:#ffd180;font-size:12px;cursor:pointer;
+                       font-family:inherit;font-weight:600;
+                       transition:all .15s">계속 ▶</button>
+      </div>`;
+  }
   let suggestionsHtml = '';
   if (suggestions.length > 0) {
     // [N-4, 2026-05-13] Cluster header — "✨ 제안" with mint accent so
@@ -2372,10 +2379,15 @@ function appendTyping(traceId) {
       <div id="thinking-${traceId}" class="thinking-stream"
            role="log" aria-live="polite" aria-atomic="false"
            aria-label="Reasoning timeline (retrieve → expand → verify)">
+        <!-- v0.6.1 v6 (2026-06-16) — operator catch: the placeholder
+             label was "JAMES 추론 중" (Korean brand chrome). Replaced
+             with an English DEBUG-style trace word that reads as the
+             first real stage ("Analyzing question") so it's already
+             informative before any stage event has streamed in. -->
         <div class="thinking-placeholder">
           ${brainPulseSvg(true)}
           <span class="thinking-shimmer-text thinking-label thinking-placeholder-text"
-                data-trace="${traceId}">JAMES 추론 중</span>
+                data-trace="${traceId}">Analyzing question…</span>
         </div>
       </div>
     </div>
@@ -2399,34 +2411,44 @@ function appendTyping(traceId) {
   //   verify    — 답변 생성 + 종료 단계 (검증/마무리)
   // 백엔드(server_llmwiki.py · core/reasoning/modes.py)가 실제로
   // 내보내는 stage 와 1:1 대응되며, 빈 phase 컨테이너는 lazy 생성.
+  // v0.6.1 v6 (2026-06-16) — operator catch: labels rewritten to
+  // English debug-style trace words ("Analyzing question",
+  // "Rewriting query", "Searching documents", "Classifying",
+  // "Merging", "Hop blocked", "Generating answer", etc.) so the
+  // operator sees what the engine is ACTUALLY doing, not a generic
+  // "JAMES 추론 중". Icons remain emoji per the operator's own
+  // "시각적 노출 효과" exception clause — they're the small animated
+  // glyphs that read at a glance during the live stream.
   const STAGE_META = {
-    auth:        { icon: '🔐', label: '권한 확인',          color: '#999',    phase: 'retrieve' },
-    risky_coding_blocked: { icon: '🛑', label: '위험 명령 차단', color: '#f06292', phase: 'retrieve' },
-    retrieve:    { icon: '🔍', label: '내부 자료 검색',     color: '#7c6af7', phase: 'retrieve' },
-    rerank:      { icon: '🎯', label: '재정렬',              color: '#7c6af7', phase: 'retrieve' },
-    graph:       { icon: '🕸️', label: '관계 그래프 탐색',   color: '#3da78a', phase: 'expand' },
-    tool:        { icon: '🔧', label: '도구 호출',           color: '#ffb74d', phase: 'expand' },
-    coding_route: { icon: '⌨️', label: '코딩 LLM 라우팅',    color: '#ffb74d', phase: 'expand' },
-    coding_llm_pick: { icon: '⚙️', label: '모델 선택',       color: '#ffb74d', phase: 'expand' },
-    coding_user_pick: { icon: '👤', label: '사용자 모델 선택', color: '#ffb74d', phase: 'expand' },
-    coding_done: { icon: '✓',  label: '코딩 완료',           color: '#4caf7d', phase: 'verify' },
-    coding_llm_error: { icon: '⚠️', label: '코더 LLM 오류',  color: '#f06292', phase: 'verify' },
-    coding_fallback_done: { icon: '↻', label: 'Fallback 완료', color: '#ffb74d', phase: 'verify' },
-    coding_fallback_error: { icon: '⚠️', label: 'Fallback 오류', color: '#f06292', phase: 'verify' },
-    coding_user_pick_done: { icon: '✓', label: '사용자 모델 완료', color: '#4caf7d', phase: 'verify' },
-    coding_user_pick_error: { icon: '⚠️', label: '사용자 모델 오류', color: '#f06292', phase: 'verify' },
-    answer:      { icon: '🤖', label: 'LLM 답변 생성',       color: '#f06292', phase: 'verify' },
-    complete:    { icon: '✅', label: '완료',                color: '#4caf7d', phase: 'verify' },
+    auth:        { icon: '🔐', label: 'Verifying access',        color: '#999',    phase: 'retrieve' },
+    risky_coding_blocked: { icon: '🛑', label: 'Risky command blocked', color: '#f06292', phase: 'retrieve' },
+    rewrite:     { icon: '✏', label: 'Rewriting query',          color: '#7c6af7', phase: 'retrieve' },
+    classify:    { icon: '⌕', label: 'Classifying intent',       color: '#7c6af7', phase: 'retrieve' },
+    retrieve:    { icon: '🔍', label: 'Searching documents',     color: '#7c6af7', phase: 'retrieve' },
+    rerank:      { icon: '🎯', label: 'Re-ranking candidates',   color: '#7c6af7', phase: 'retrieve' },
+    merge:       { icon: '⇆', label: 'Merging evidence',         color: '#7c6af7', phase: 'retrieve' },
+    hop_blocked: { icon: '⊘', label: 'Hop blocked',              color: '#f06292', phase: 'retrieve' },
+    graph:       { icon: '🕸️', label: 'Traversing graph',        color: '#3da78a', phase: 'expand' },
+    expand:      { icon: '⇢', label: 'Expanding context',        color: '#3da78a', phase: 'expand' },
+    tool:        { icon: '🔧', label: 'Calling tool',             color: '#ffb74d', phase: 'expand' },
+    coding_route: { icon: '⌨️', label: 'Routing to coder LLM',    color: '#ffb74d', phase: 'expand' },
+    coding_llm_pick: { icon: '⚙', label: 'Picking model',         color: '#ffb74d', phase: 'expand' },
+    coding_user_pick: { icon: '⌽', label: 'User model override',  color: '#ffb74d', phase: 'expand' },
+    coding_done: { icon: '✓',  label: 'Coder LLM complete',       color: '#4caf7d', phase: 'verify' },
+    coding_llm_error: { icon: '⚠', label: 'Coder LLM error',      color: '#f06292', phase: 'verify' },
+    coding_fallback_done: { icon: '↻', label: 'Fallback complete', color: '#ffb74d', phase: 'verify' },
+    coding_fallback_error: { icon: '⚠', label: 'Fallback error',  color: '#f06292', phase: 'verify' },
+    coding_user_pick_done: { icon: '✓', label: 'User model done', color: '#4caf7d', phase: 'verify' },
+    coding_user_pick_error: { icon: '⚠', label: 'User model error', color: '#f06292', phase: 'verify' },
+    verify:      { icon: '✓', label: 'Verifying claims',         color: '#3da78a', phase: 'verify' },
+    answer:      { icon: '🤖', label: 'Generating answer',        color: '#f06292', phase: 'verify' },
+    complete:    { icon: '✓', label: 'Done',                      color: '#4caf7d', phase: 'verify' },
   };
 
-  // [§4 #3] Phase 단위 메타 — 컨테이너 헤더에 표시. 순서는 timeline
-  // 진행 순서를 강제한다: RETRIEVE → EXPAND → VERIFY. 한 phase 가
-  // 생략되어도(예: graph 사용 안 한 빠른 답변) 다음 phase 가 빈
-  // 자리를 그대로 받는다 — 사용자에겐 진행이 한 칸 점프한 것처럼
-  // 보임. 비어 있는 phase 컨테이너는 절대 만들지 않는다(lazy).
+  // Phase headers — English UPPERCASE debug labels (operator catch).
   const PHASE_META = {
     retrieve: { icon: '🔎', label: 'RETRIEVE', order: 1 },
-    expand:   { icon: '🕸️', label: 'EXPAND',   order: 2 },
+    expand:   { icon: '🕸', label: 'EXPAND',   order: 2 },
     verify:   { icon: '🤖', label: 'VERIFY',   order: 3 },
   };
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -170,13 +170,36 @@
   opacity: 0.7;
 }
 
-/* Active state: spinner 회전 + label shimmer */
+/* Active state — operator catch v0.6.1 v6 (2026-06-16): the previous
+ * pure-rotation felt mechanical and easily blended into the page
+ * background on phones. Now combines a pulse-scale + wiggle so the
+ * icon visibly "breathes" while the stage runs, plus the existing
+ * label shimmer. Reduced motion users still see motion (the spec
+ * asks for *reducing*, not *removing*) but at a slower cadence via
+ * the prefers-reduced-motion block at the file bottom. */
+@keyframes james-icon-active {
+  0%, 100% { transform: scale(1) rotate(-6deg); }
+  25%      { transform: scale(1.18) rotate(0deg); }
+  50%      { transform: scale(1)    rotate(6deg); }
+  75%      { transform: scale(1.18) rotate(0deg); }
+}
 .thinking-line.thinking-active .thinking-icon {
-  animation: james-spin 1.4s linear infinite;
+  animation: james-icon-active 1.0s ease-in-out infinite;
   filter: drop-shadow(0 0 4px var(--stage-color, #7c6af7));
 }
 .thinking-line.thinking-active .thinking-label {
   animation: james-shimmer 1.2s linear infinite;
+}
+/* Placeholder shimmer matches — operator sees "alive" feedback even
+ * during the brief window before the first stage event arrives. */
+.thinking-placeholder-text {
+  animation: james-shimmer 1.2s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .thinking-line.thinking-active .thinking-icon,
+  .thinking-placeholder-text {
+    animation-duration: 2.4s;
+  }
 }
 
 /* Done state: spinner 정지, 색상 흐림 */
@@ -452,14 +475,52 @@
 
   /* 입력 영역 — 모바일은 항상 바닥 + iOS safe-area */
   .input-area, #input-area, footer.input-area {
-    padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0));
-    gap: 6px;
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom, 0));
+    gap: 4px;
   }
   textarea, input[type="text"], #chat-input {
     font-size: 16px;             /* iOS 자동 줌 방지 (≥ 16px) */
     padding: 10px 12px;
     min-height: 44px;
     border-radius: 10px;
+  }
+
+  /* v0.6.1 v6 (2026-06-16) — operator catch: the conv-actions row
+   * (mode picker / recommend / templates / copy-conversation) +
+   * input area felt cluttered on phones. Compact every leaf:
+   *   - row padding 4/16 → 2/10, gap 6 → 4
+   *   - "모델 추천" dashed link (secondary, low-frequency) hidden
+   *     on phones; the operator picks the model via the chip in
+   *     the chat-topbar instead
+   *   - conv-action-chip 글자 크기 11 → 10.5, padding 4/10 → 3/8
+   *   - mode-picker / model-picker select 폰트 11 → 10
+   */
+  .conv-actions {
+    padding: 2px 10px !important;
+    gap: 4px !important;
+  }
+  .conv-actions #mode-picker,
+  .conv-actions #model-picker {
+    font-size: 10px !important;
+    padding: 3px 8px !important;
+  }
+  .conv-actions #mode-recommend-link {
+    display: none !important;
+  }
+  .conv-actions .conv-action-chip {
+    font-size: 10.5px !important;
+    padding: 3px 8px !important;
+  }
+  /* Chat-topbar — same compaction. The bullet + model name + caret
+   * stay; only the spacing tightens. */
+  .chat-topbar {
+    padding: 6px 10px !important;
+    gap: 4px !important;
+  }
+  .chat-topbar .model-chip,
+  .chat-topbar .workspace-badge {
+    font-size: 10.5px !important;
+    padding: 3px 8px !important;
   }
   button, .btn {
     min-height: 36px;

--- a/frontend/static/workspace-badge.js
+++ b/frontend/static/workspace-badge.js
@@ -35,13 +35,25 @@
     var nameEl = document.getElementById('workspace-name');
     if (!nameEl) return;
     nameEl.textContent = info.workspace_name || 'default';
-    // Tooltip = resolved path + entity count for an at-a-glance check.
-    var tooltipBits = [];
-    if (info.workspace_path) tooltipBits.push(info.workspace_path);
+    // v0.6.1 v6 (2026-06-16) — operator catch: the badge said
+    // "default" but the operator (Korean) couldn't tell what the
+    // word meant. Tooltip now self-documents: name on top, then
+    // "기본 workspace" / "사용자 workspace" + path + entities +
+    // tenant flag. Hover-only — visual chrome stays compact.
+    var name = info.workspace_name || 'default';
+    var nameRow = 'Workspace: ' + name
+      + (info.is_default ? ' (기본 / default)' : ' (사용자 선택)');
+    var tooltipBits = [nameRow];
+    if (info.workspace_path) tooltipBits.push('경로: ' + info.workspace_path);
     if (typeof info.entity_count === 'number') {
-      tooltipBits.push('entities: ' + info.entity_count);
+      tooltipBits.push('엔티티: ' + info.entity_count);
     }
-    if (info.per_tenant_enabled) tooltipBits.push('per-tenant');
+    if (info.per_tenant_enabled) tooltipBits.push('per-tenant 격리 활성');
+    if (info.is_default) {
+      tooltipBits.push(
+        '— 별도 workspace 를 만들지 않은 상태입니다. /workspace 페이지에서 분리 가능.'
+      );
+    }
     box.title = tooltipBits.join('\n');
     // Visually distinguish dogfood / non-default so the operator
     // immediately notices they're NOT on the main workspace.


### PR DESCRIPTION
## Summary

운영자 catch 4건 (스크린샷 1장):
1. **모델 라우팅 표시 정확성 + 'default' 의미 설명**
2. **답변 truncation 가드** 가 정상 종결 답변에서도 발화 → 제거
3. **'JAMES 추론 중'** → 영어 stage-name 디버그 라벨 + 작은 아이콘 적극 애니메이션
4. **폰 conv-actions + chat-topbar + input** 깔끔하게 컴팩트

### (1) LLM 라우팅 + 'default' 의미
- `loadActiveModelChip` 가 `/llm/active` 호출 → backend resolver 가 선택한 model 을 chip 에 그대로 표시. 다음 `/query/` 가 실제로 사용할 모델. tooltip 에 source 라벨 (configured / preference / any / session-override) + 경고. **표시 = 실제 사용 모델 동일** 확인.
- workspace badge "**default**" = workspace 이름. 별도 workspace 생성/선택 안 했을 때 backend 기본 workspace 사용. workspace-badge.js tooltip 을 self-doc 화:
    - 1줄: `Workspace: default (기본 / default)`
    - 2줄: `경로: <path>`
    - 3줄: `엔티티: <n>`
    - 4줄: `per-tenant 격리 활성` (해당 시)
    - 5줄: `— 별도 workspace 를 만들지 않은 상태입니다. /workspace 페이지에서 분리 가능.`

### (2) Truncation 가드 false-positive
- `isLikelyTruncated(answer)` 가 **raw answer** 에 적용 → SUGGESTIONS 블록 (`(1) X / (2) Y / (3) Z`) 이 답변 끝에 붙어있어, 본문이 `?` / `다` / `요` 로 정상 종결돼도 마지막 라인 `Z` 가 SOFT signal (length > 100 + 종결어미 없음) 매치 → 매번 hint 발화.
- **Fix**: `extractNextActionSuggestions(answer)` → `cleanAnswer` 추출 후 `isLikelyTruncated(cleanAnswer)` 로 검사. `truncationHint` 변수 선언만 위로 옮기고 실제 평가는 cleanAnswer 가 존재하는 line 으로.

### (3) STAGE_META 영어 디버그 라벨 + 애니메이션
- 한글 라벨 → 영어 debug-style trace 단어:
    - `Verifying access` / `Rewriting query` / `Classifying intent` / `Searching documents` / `Re-ranking candidates` / `Merging evidence` / `Hop blocked` / `Traversing graph` / `Expanding context` / `Calling tool` / `Routing to coder LLM` / `Picking model` / `User model override` / `Coder LLM complete` / `Generating answer` / `Verifying claims` / `Done`
- 신규 stage key: `rewrite` / `classify` / `merge` / `hop_blocked` / `expand` / `verify` — backend 가 emit 시 즉시 표시
- placeholder `JAMES 추론 중` → `Analyzing question…` (이미 첫 진짜 stage 같이 읽힘)
- mobile.css 신규 `@keyframes james-icon-active` (scale 1→1.18 + rotate -6°↔+6° 1.0s ease-in-out) — 기존 단순 회전 대비 시각 강조. `prefers-reduced-motion` 사용자는 2.4s 로 감속
- placeholder text 에도 `james-shimmer` 추가 → 첫 stage 도착 전 alive feedback

### (4) 모바일 chat 영역 컴팩트
- `.conv-actions` padding 4/16 → 2/10, gap 6 → 4
- `#mode-picker` / `#model-picker` font 11 → 10
- `#mode-recommend-link` 폰에서 **hidden** (low-freq, chip 으로 대체)
- `.conv-action-chip` font 12 → 10.5, padding 4/10 → 3/8
- `.chat-topbar` padding 10/16 → 6/10, model-chip / workspace-badge font 11 → 10.5

### 캐시
- `chat.css` + `mobile.css` `v=v11-20260616` 동시 bump.

## Verification

- 모델 chip: hover 시 `현재 응답에 사용 중인 모델 — 클릭 시 변경\n[설정 모델 사용 중]` 와 같이 source 명시
- workspace badge: hover 시 `Workspace: default (기본 / default)` + 경로 + 엔티티 수 + 안내 표시
- 정상 종결 답변 (`?` / `요` / `다` / `.` 끝): truncation hint **미발화**
- 끊긴 답변 (`:` / `-` / `…` / odd code fence / 100+ chars no terminator): hint 정상 발화
- thinking placeholder: `Analyzing question…` 표시 + shimmer
- active stage line: icon 이 1.0s 주기로 wiggle (-6°/+6°) + pulse (1→1.18) + drop-shadow
- 폰 viewport (≤ 768px): conv-actions 한 줄 fit, model chip / workspace badge 작아짐, Recommend 링크 미노출
- JS / CSS syntax: chat.js / workspace-badge.js parse OK

## Out of scope

- backend STAGE_META key 변경 (rewrite / classify / merge / hop_blocked / expand / verify emit) — frontend 는 수신 시 즉시 표시하도록 준비. 실제 backend emit 은 별도 PR.
- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: fix) — UX regression fix + chrome reorg, no measurement axes apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)