### PR TITLE
feat(v0.6.1): feedback chips → monochrome outline SVGs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,11 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v11-20260616 cache-bust: English STAGE_META labels +
-     truncation false-positive fix + mobile conv-actions compaction
-     + workspace badge tooltip self-doc. -->
-<link rel="stylesheet" href="/static/chat.css?v=v11-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v11-20260616">
+<!-- v=v12-20260616 cache-bust: monochrome outline SVG feedback chips
+     (👍 / 👎 / 복사 → Feather-style outline SVGs). -->
+<link rel="stylesheet" href="/static/chat.css?v=v12-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v12-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -1030,14 +1030,20 @@ main { display: flex; flex: 1; overflow: hidden; }
   background: var(--surface-2);
   border: 1px solid var(--border);
   border-radius: 4px;
-  padding: 1px 5px;
+  padding: 3px 4px;
   font-size: 11px;
-  line-height: 1.2;
+  line-height: 1;
   cursor: pointer;
   opacity: 0;
   transition: opacity .15s, color .15s;
   color: var(--muted);
   font-family: inherit;
+  /* v0.6.1 v7 (2026-06-16) — center the inline SVG icon. The button
+   * used to host a text "복사" label; now it carries a small outline
+   * copy glyph that needs flex centering. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .bubble .paragraph:hover .paragraph-copy-btn { opacity: .85; }
 .bubble .paragraph-copy-btn:hover,

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1762,18 +1762,46 @@ function appendJamesMsg(data) {
   const dirIdEsc = dirId ? escHtml(dirId) : '';
   const fbHtml = dirId ? `
     <div class="feedback-btns" style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap">
+      <!-- v0.6.1 v7 (2026-06-16) — operator catch: text-only chips
+           "좋아요 / 별로 / 복사" read fine but the operator wants
+           monochrome OUTLINE icons (no caricature color emoji).
+           Feather/Lucide-style stroked SVGs, currentColor + stroke 2,
+           inherit the chip's text color. title / aria-label keep the
+           hover label + screen-reader name. -->
       <button class="fb-btn" data-action="send-feedback" data-dir-id="${dirIdEsc}" data-signal="explicit_positive"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title="좋아요">좋아요</button>
+               line-height:1;display:inline-flex;align-items:center;justify-content:center;
+               transition:all .15s" title="좋아요" aria-label="좋아요">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round" aria-hidden="true">
+          <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+        </svg>
+      </button>
       <button class="fb-btn" data-action="send-feedback" data-dir-id="${dirIdEsc}" data-signal="explicit_negative"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title="별로예요">별로</button>
+               line-height:1;display:inline-flex;align-items:center;justify-content:center;
+               transition:all .15s" title="별로예요" aria-label="별로예요">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
+        </svg>
+      </button>
       <button class="fb-btn" data-action="copy-answer-text" data-content="${answerEscapedAttr}"
         style="background:none;border:1px solid var(--border);border-radius:6px;
                padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;
-               transition:all .15s" title="이 답변 복사">복사</button>
+               line-height:1;display:inline-flex;align-items:center;justify-content:center;
+               transition:all .15s" title="이 답변 복사" aria-label="이 답변 복사">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+        </svg>
+      </button>
       ${exportButtons}
     </div>` : '';
 
@@ -2687,7 +2715,7 @@ function formatAnswerWithParagraphs(text) {
               data-action="copy-answer-text"
               data-content="${escapedAttr}"
               title="이 문단 복사"
-              aria-label="이 문단 복사">복사</button>
+              aria-label="이 문단 복사"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
     </div>`;
   }).join('');
 }


### PR DESCRIPTION
## Summary

운영자 catch (스크린샷 follow-up): 메시지 끝의 ‘좋아요 / 별로 / 복사’ 텍스트 chip 을 **컬러 없는 단순 outline SVG 이모티콘** 으로 변경해달라.

이전 v5 cycle 에서 컬러 emoji (👍 / 👎 / 📋) → 텍스트 라벨 로 변경했는데, 운영자가 추가로 \"외형은 텍스트보다 작은 모노 outline icon 이 더 깔끔\" 이라고 catch.

### 변경
- **chat.js message feedback chips** (`좋아요` / `별로` / `이 답변 복사`):
    - 텍스트 → **Feather/Lucide-style 14×14 outline SVG** (thumbs-up / thumbs-down / copy)
    - `currentColor` + `stroke 2` (chip 의 텍스트 컬러 그대로 상속, dark/light 자동 대응)
    - `title` + `aria-label` 유지 → screen reader / hover 정상
- **chat.js paragraph copy button**: \"복사\" 텍스트 → 12×12 outline copy SVG
- **chat.css `.paragraph-copy-btn`**: `inline-flex` + center align (SVG 가 중앙 정렬), padding 1/5 → 3/4, line-height 1.2 → 1

### 캐시
- chat.css + mobile.css `v=v12-20260616`

## Verification

- 답변 끝 chip: 3 개 SVG (👍 outline / 👎 outline / copy outline), padding 3/10 안에 14×14 SVG 가 중앙
- 단락 hover (또는 모바일 tap): paragraph 우상단에 작은 copy 아이콘 표시
- 컬러: 단일 `currentColor` (현재 `--muted` 그레이), hover 시 `--accent` 로 변경
- JS syntax: chat.js parse OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: code) — frontend chrome reorg, core/ 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)