### PR TITLE
fix(v0.6.1): + 새 대화 pill stops deleting the current session

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,11 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v12-20260616 cache-bust: monochrome outline SVG feedback chips
-     (👍 / 👎 / 복사 → Feather-style outline SVGs). -->
-<link rel="stylesheet" href="/static/chat.css?v=v12-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v12-20260616">
+<!-- v=v13-20260616 cache-bust: + 새 대화 pill stopped wiping the
+     current session (was wired to clear-history; now dispatches
+     new-session). -->
+<link rel="stylesheet" href="/static/chat.css?v=v13-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v13-20260616">
 </head>
 <body>
 
@@ -447,9 +448,18 @@
           <span class="dot"></span>
           <span class="role-name" id="role-name">?</span>
         </button>
+        <!-- v0.6.1 v8 (2026-06-16) — operator catch: pressing this
+             pill DELETED the current chat from the server (it was
+             wired to clear-history → DELETE /history/?session_id=...).
+             The Claude-style "New chat" pattern starts a fresh
+             session WITHOUT touching prior ones. Now dispatches
+             new-session, which mints a new SID + clears the message
+             pane; previous sessions stay intact in the sidebar list.
+             A separate "Delete current chat" action lives in the
+             session-action-modal for explicit destructive removal. -->
         <button class="sidebar-newchat-pill"
-                data-action="clear-history"
-                data-i18n-title="chat.clear_history"
+                data-action="new-session"
+                data-i18n-title="chat.new_chat"
                 title="새 대화">
           <span aria-hidden="true">＋</span>
           <span data-i18n="chat.new_chat">새 대화</span>

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -866,7 +866,18 @@ function restoreHistory() {
 
 /* ── 대화 초기화 (요약 저장 후 삭제) ── */
 async function clearHistory() {
-  if (!confirm('현재 대화를 초기화할까요?\n대화 내용이 장기 기억으로 요약 저장됩니다.')) return;
+  // v0.6.1 v8 (2026-06-16) — clarified the confirm copy: "초기화"
+  // alone was ambiguous (operator interpreted it as "start fresh",
+  // not "permanently delete"). Spell out that this DELETES the
+  // current session from the server. The sidebar "+ 새 대화" pill
+  // no longer routes here — it dispatches new-session, which keeps
+  // prior sessions intact.
+  if (!confirm(
+    '현재 대화를 [서버에서 삭제] 합니다.\n' +
+    '(대화 내용은 장기 기억으로 요약 저장됩니다.)\n\n' +
+    '계속하시겠습니까?\n' +
+    '※ 기존 세션을 그대로 두고 새 대화만 시작하려면 사이드바의 ＋ 새 대화 버튼을 이용하세요.'
+  )) return;
 
   // 요약 먼저 저장 (장기 기억)
   await summarizeSession();


### PR DESCRIPTION
## Summary

운영자 catch: 사이드바 \"+ 새 대화\" pill 을 누르면 사이드바 리스트에서 직전에 보이던 세션 중 일부가 사라짐.

### Root cause
\"+ 새 대화\" pill 이 `data-action=\"clear-history\"` 로 연결되어 있었고, `clearHistory()` 는:
1. `summarizeSession()` → 장기 기억 저장
2. `localStorage.removeItem(HISTORY_KEY)` → 클라이언트 측 단기 기억 삭제
3. **`fetch DELETE /history/?session_id=<현재 SID>`** ← **서버에서 현재 세션 영구 삭제**
4. `localStorage.removeItem('james_session')`
5. `location.reload()`

즉 \"Claude.ai 의 New chat\" 이 아니라 \"현재 대화 영구 삭제\" 동작. confirm 다이얼로그가 \"초기화 할까요?\" 라는 모호한 표현이라 OK 누른 운영자가 새 세션만 시작하려 했다고 합리적으로 오인 → 현재 세션 소실.

### Fix
- **`frontend/index.html`**: 사이드바 \"+ 새 대화\" pill → **`data-action=\"new-session\"`**. 이미 존재하는 안전한 `newSession()` 함수 (새 SID 발급 + 메시지 패널 비움, 기존 세션 보존). 명시적 destructive 삭제는 session-action-modal 의 \"삭제\" 행으로 그대로 유지.
- **`frontend/static/chat.js`**: `clearHistory()` 의 confirm 문구를 \"[서버에서 삭제]\" 명시 + \"기존 세션 그대로 두고 새 대화만 시작하려면 사이드바 + 새 대화 버튼을 이용하세요\" 안내 추가. 방어적 (다른 call site 에서 여전히 호출 가능 시 대비).

### 캐시
chat.css + mobile.css `v=v13-20260616`

### 회복 불가
이전 wiring 으로 이미 서버에서 DELETE 된 세션은 이 PR 로 복구되지 않습니다. 다음 클릭부터는 안전.

## Verification

- \"+ 새 대화\" pill 클릭 → newSession() 호출 → 새 SID 만 발급 + 메시지 비움 + loadSessionList reload. 기존 세션 모두 사이드바 리스트에 잔존.
- 이전 \"clear-history\" 동작이 필요하면 conversation-menu \"삭제\" 행 사용 (의도가 명시적).
- 만약 외부 call site 가 여전히 `clear-history` 를 호출하면, confirm 문구가 명확하게 \"[서버에서 삭제]\" 라고 경고.
- JS syntax: chat.js parse OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: fix) — destructive-action UX 회귀 fix, no measurement axes apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)