### PR TITLE
feat(v0.6.1): graph node-detail panel — bottom-sheet + markdown render + conf chip

### DIFF
--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -6,12 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<link rel="stylesheet" href="/static/graph.css">
-<!-- mobile-responsive overrides — kept after page styles so @media
-     rules win at narrow viewports without !important on every line.
-     v=v5-20260615 cache-bust: forces phones with cached older mobile.css
-     to refetch after the v5 bubble-width fortifications landed. -->
-<link rel="stylesheet" href="/static/mobile.css?v=v5-20260615">
+<!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
+     + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
+<link rel="stylesheet" href="/static/graph.css?v=v14-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v14-20260616">
 </head>
 <body>
 

--- a/frontend/static/graph.css
+++ b/frontend/static/graph.css
@@ -230,6 +230,73 @@
     border-radius: 6px;
     border: 1px solid var(--border-2);
   }
+  /* v0.6.1 v9 (2026-06-16) — markdown render variant. Drops the
+   * pre-wrap (line breaks come from the <p> / <ul> we generate) so
+   * vertical density matches the desktop neighbor list. */
+  .neighbor-panel .np-summary-body.np-summary-body-md {
+    white-space: normal;
+  }
+  .neighbor-panel .np-section-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--accent-fg);
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    margin: 8px 0 4px;
+  }
+  .neighbor-panel .np-section-title:first-child {
+    margin-top: 0;
+  }
+  .neighbor-panel .np-section-p {
+    margin: 0 0 6px;
+    line-height: 1.55;
+  }
+  .neighbor-panel .np-section-list {
+    list-style: none;
+    margin: 0 0 6px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .neighbor-panel .np-section-list li {
+    padding-left: 12px;
+    position: relative;
+    line-height: 1.5;
+  }
+  .neighbor-panel .np-section-list li::before {
+    content: "·";
+    position: absolute;
+    left: 2px;
+    top: 0;
+    color: var(--muted);
+    font-weight: 700;
+  }
+  /* Confidence intuition chip — replaces "(conf=0.90)" dev token. */
+  .neighbor-panel .np-conf {
+    display: inline-block;
+    font-size: 10.5px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    font-weight: 600;
+    line-height: 1.4;
+    margin-left: 6px;
+    vertical-align: 1px;
+    font-family: var(--font-ui);
+    letter-spacing: 0;
+  }
+  .neighbor-panel .np-conf-high {
+    background: rgba(74, 175, 80, .14);
+    color: #6ed683;
+  }
+  .neighbor-panel .np-conf-med {
+    background: rgba(255, 183, 77, .14);
+    color: #ffc14d;
+  }
+  .neighbor-panel .np-conf-low {
+    background: rgba(240, 98, 146, .14);
+    color: #f06292;
+  }
   .neighbor-panel .np-summary-body.np-empty-body {
     color: var(--muted); font-style: italic;
     background: transparent; border: none; padding: 4px 0;

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -664,6 +664,79 @@
     return String(etype || 'unknown').toUpperCase();
   }
 
+  /* v0.6.1 v9 (2026-06-16) — operator catch: raw markdown
+   * ("## 요약", "## 관계") + dev-style "(conf=0.90)" tokens were
+   * leaking into the entity-summary body. Now we tokenize the body
+   * line-by-line:
+   *   - "## label"  → small section title chip
+   *   - "- text"    → list row (with conf chip rendered inline)
+   *   - other lines → paragraph (with conf chip rendered inline)
+   * Confidence tokens "(conf=0.NN)" turn into a colored intuition
+   * chip: high (≥0.85) green / medium (≥0.6) amber / low pink.
+   */
+  function _renderConfTokens(htmlSafe) {
+    return htmlSafe.replace(
+      /\(conf\s*=\s*([0-9]*\.?[0-9]+)\)/g,
+      function (_m, raw) {
+        var v = parseFloat(raw);
+        if (isNaN(v) || v < 0 || v > 1) return _m;
+        var pct = Math.round(v * 100);
+        var cls, label;
+        if (v >= 0.85) { cls = 'np-conf-high'; label = '높음'; }
+        else if (v >= 0.6) { cls = 'np-conf-med'; label = '보통'; }
+        else { cls = 'np-conf-low'; label = '낮음'; }
+        return '<span class="np-conf ' + cls + '" ' +
+               'title="신뢰도 ' + pct + '% (raw conf=' + raw + ')">' +
+               pct + '% · ' + label +
+               '</span>';
+      },
+    );
+  }
+
+  function _renderEntityBody(text) {
+    var lines = String(text || '').split(/\r?\n/);
+    var parts = [];
+    var inList = false;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var trimmed = line.replace(/\s+$/, '');
+      // skip blank
+      if (!trimmed.length) {
+        if (inList) { parts.push('</ul>'); inList = false; }
+        continue;
+      }
+      // ## 헤딩
+      var mh = /^#{1,4}\s+(.+)$/.exec(trimmed);
+      if (mh) {
+        if (inList) { parts.push('</ul>'); inList = false; }
+        parts.push(
+          '<div class="np-section-title">' +
+          escapeHtml(mh[1]) +
+          '</div>',
+        );
+        continue;
+      }
+      // - 또는 * bullet
+      var mb = /^[\-*]\s+(.+)$/.exec(trimmed);
+      if (mb) {
+        if (!inList) { parts.push('<ul class="np-section-list">'); inList = true; }
+        parts.push(
+          '<li>' + _renderConfTokens(escapeHtml(mb[1])) + '</li>',
+        );
+        continue;
+      }
+      // 일반 문단
+      if (inList) { parts.push('</ul>'); inList = false; }
+      parts.push(
+        '<p class="np-section-p">' +
+        _renderConfTokens(escapeHtml(trimmed)) +
+        '</p>',
+      );
+    }
+    if (inList) parts.push('</ul>');
+    return parts.join('');
+  }
+
   function renderEntitySummary(data) {
     var host = _summaryHostEl();
     if (!host || !data) return;
@@ -671,18 +744,19 @@
     var sens  = data.sensitivity || 'internal';
     var body  = (data.body || '').trim();
 
-    // 본문 발췌 — 너무 길면 첫 ~360자 + 말줄임. body 가 frontmatter 없는
-    // 순수 문서 텍스트라 그대로 잘라도 안전.
     var excerpt;
     if (body.length === 0) {
       excerpt = '<div class="np-summary-body np-empty-body">' +
                 '본문 비어있음 (메타데이터만 존재)</div>';
     } else {
+      // Char budget — keep dialog compact on phones. 360 chars was
+      // the legacy plain-text cap; the markdown render shows similar
+      // density per line so we leave the cap as-is.
       var trimmed = body.length > 360
         ? body.slice(0, 360).trimEnd() + '…'
         : body;
-      excerpt = '<div class="np-summary-body">' +
-                escapeHtml(trimmed) +
+      excerpt = '<div class="np-summary-body np-summary-body-md">' +
+                _renderEntityBody(trimmed) +
                 '</div>';
     }
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -733,13 +733,24 @@
   .main > aside {
     display: none;
   }
+  /* v0.6.1 v9 (2026-06-16) — operator catch: this panel covered ~70%
+   * of the graph viewport. Reframed as a BOTTOM sheet (anchored to
+   * the bottom edge with a max-height ~50vh) so the graph stays
+   * visible above it. The original "left:8 right:8 top:56" wiring
+   * made the panel a top-anchored card that blocked the very node
+   * that was just clicked. Bottom-anchored mirrors Maps / Apple's
+   * detail-sheet pattern. */
   .neighbor-panel {
     right: 8px;
     left: 8px;
-    top: 56px;
+    top: auto;
+    bottom: 12px;
     width: auto;
-    max-height: calc(70% - 56px);
+    max-height: 50vh;
     font-size: 12px;
+    padding: 12px 12px 10px;
+    border-radius: 14px;
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, .45);
   }
   .neighbor-panel .np-close {
     width: 32px;
@@ -752,6 +763,12 @@
   .neighbor-panel .np-item {
     padding: 10px 8px;
     font-size: 13px;
+  }
+  /* Body excerpt — tighter cap so the sheet stays at ~50vh even
+   * with a markdown body. Operator can scroll inside the body if
+   * the document is longer than the budget. */
+  .neighbor-panel .np-summary-body {
+    max-height: 22vh;
   }
   .top-search-drawer {
     width: calc(100% - 16px);


### PR DESCRIPTION
## Summary

운영자 catch (스크린샷 /admin/graph 폰):
1. **노드 클릭 panel 이 화면 ~70% 가림** → 클릭한 노드를 panel 이 덮음
2. **`## 요약` / `## 관계` raw markdown** 본문에 그대로 노출
3. **`(conf=0.90)` 표기**가 직관적이지 않음

### (1) 폰 bottom-sheet 패턴
- `mobile.css` `.neighbor-panel`:
    - **top-anchored → bottom-anchored** (`bottom: 12px; top: auto`)
    - max-height 70% → **50vh**
    - 위쪽 부드러운 shadow + 14 px radius → bottom-sheet 느낌 (Maps / Apple detail-sheet 패턴)
    - body excerpt 22vh cap → 긴 문서여도 sheet 가 ~50vh 유지
- 데스크탑 layout 변경 없음 (top-left anchor 유지)

### (2) 본문 markdown 렌더
- `graph.js _renderEntityBody(text)` 토크나이즈:
    - `## label` → 작은 **section-title chip** (uppercase, accent 컬러)
    - `- text` → list 행 (`::before` bullet)
    - 그 외 → 문단
- `graph.css` `.np-section-title` / `.np-section-p` / `.np-section-list` + `li::before`

### (3) confidence 직관 chip
- `graph.js _renderConfTokens(htmlSafe)`: `(conf=0.NN)` → 컬러 chip
    - ≥0.85 = `90% · 높음` 녹색
    - 0.6-0.84 = `70% · 보통` 노랑
    - <0.6 = `50% · 낮음` 핑크
    - tooltip `신뢰도 90% (raw conf=0.90)` — power user 친화
- `graph.css` `.np-conf` + `.np-conf-high` / `-med` / `-low`

### 캐시
- graph.html 의 graph.css / mobile.css `v=v14-20260616` (chat-page 와 정렬)

## Verification

- 폰 viewport: 노드 클릭 시 panel 이 화면 하단 ~50vh sheet 로 등장, 클릭한 노드 위쪽에 보임
- `## 요약` → 작은 uppercase 라벨 chip
- `(conf=0.90)` → `90% · 높음` 녹색 알약
- `(conf=0.70)` → `70% · 보통` 노랑
- `(conf=0.30)` → `30% · 낮음` 핑크
- bullet `- 핵심임무: Alex Karp (conf=0.90)` → 들여쓰기 + bullet · + conf chip
- tooltip hover → `신뢰도 90% (raw conf=0.90)` raw 값 확인 가능
- graph.js / graph.css / mobile.css / graph.html syntax OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.
- 데스크탑 panel 변경 없음 (모바일 catch 였음). 다음 catch 때 데스크탑도 reorg 가능.
- markdown 렌더는 `##`/`-`/`*` 만 처리 — 인라인 `**bold**`, link, code 등 향후 필요 시 확장.

Quality delta: exempt (label: code) — frontend chrome reorg, core/ 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)