### PR TITLE
feat(v0.6.1): Claude-style answer typography — achromatic hierarchy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v14-20260616 cache-bust: session-action popover (Claude-style)
-     + favorite (즐겨찾기) primitive + favorite-aware sidebar sort. -->
-<link rel="stylesheet" href="/static/chat.css?v=v14-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v14-20260616">
+<!-- v=v15-20260616 cache-bust: Claude-style answer typography
+     (achromatic hierarchy, table + blockquote, line-height 1.7). -->
+<link rel="stylesheet" href="/static/chat.css?v=v15-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v15-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -1099,6 +1099,132 @@ main { display: flex; flex: 1; overflow: hidden; }
 }
 .bubble pre code { background: none; border: none; padding: 0; font-size: 12.5px; }
 
+/* v0.6.1 v10 (2026-06-16) — Claude-style achromatic typography for
+ * james answer body. Hierarchy carried by SIZE + WEIGHT, not color.
+ * All headings inherit the body text color (--text); the only color
+ * differentiators are subtle (--muted) for de-emphasized chrome
+ * (hr, blockquote rule, table border) and the accent only appears
+ * on inline <code> bg + link hover. Reads as "clean B/W document"
+ * matching Claude's answer column. */
+.bubble .md-h1,
+.bubble .md-h2,
+.bubble .md-h3,
+.bubble .md-h4 {
+  color: var(--text);
+  font-family: var(--font-ui);
+  margin: 18px 0 8px;
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+  font-weight: 700;
+}
+.bubble .md-h1:first-child,
+.bubble .md-h2:first-child,
+.bubble .md-h3:first-child,
+.bubble .md-h4:first-child {
+  margin-top: 2px;
+}
+.bubble .md-h1 { font-size: 22px; }
+.bubble .md-h2 { font-size: 18px; }
+.bubble .md-h3 { font-size: 16px; font-weight: 600; }
+.bubble .md-h4 { font-size: 14px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+
+.bubble .md-p {
+  margin: 0 0 12px;
+  line-height: 1.7;
+  color: var(--text);
+}
+.bubble .md-p:last-child { margin-bottom: 0; }
+
+.bubble .md-hr {
+  border: 0;
+  border-top: 1px solid var(--border, #2a2d33);
+  margin: 18px 0;
+}
+
+.bubble .md-quote {
+  margin: 12px 0;
+  padding: 4px 14px;
+  border-left: 3px solid var(--border, #2a2d33);
+  color: var(--text-soft, #cfd2d8);
+  font-style: normal;
+  line-height: 1.65;
+}
+
+.bubble .md-ul,
+.bubble .md-ol {
+  margin: 6px 0 14px;
+  padding-left: 22px;
+  line-height: 1.7;
+}
+.bubble .md-ul { list-style: disc; }
+.bubble .md-ol { list-style: decimal; }
+.bubble .md-li {
+  margin: 0 0 4px;
+  padding-left: 4px;
+}
+.bubble .md-li::marker {
+  color: var(--muted);
+}
+
+/* Inline code — neutral surface so the eye notices a token without
+ * jumping to color. Slightly tighter padding than the legacy chip. */
+.bubble code.md-code,
+.bubble .md-p code,
+.bubble .md-li code,
+.bubble .md-quote code {
+  background: rgba(255, 255, 255, .06);
+  border: 1px solid var(--border-2, #25282f);
+  color: var(--text);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12.5px;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+/* Block code — pre.md-pre */
+.bubble pre.md-pre {
+  background: rgba(0, 0, 0, .35);
+  border: 1px solid var(--border-2, #25282f);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin: 12px 0;
+  overflow-x: auto;
+  line-height: 1.5;
+  font-size: 12.5px;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* GFM table — quiet borders, alternating row tint */
+.bubble .md-table-wrap {
+  margin: 12px 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.bubble .md-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+.bubble .md-table th,
+.bubble .md-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-2, #25282f);
+  text-align: left;
+  vertical-align: top;
+}
+.bubble .md-table th {
+  font-weight: 700;
+  color: var(--text);
+  background: rgba(255, 255, 255, .04);
+}
+.bubble .md-table tr:last-child td {
+  border-bottom: none;
+}
+
+.bubble strong { font-weight: 700; color: var(--text); }
+.bubble em { font-style: italic; }
+
 /* ── [#A4-A] 문단별 복사 버튼 ──
    hover 시 우상단에 작게 노출. 모바일에선 hover가 안 통하므로
    항상 약하게(opacity .35) 보이도록 두고 tap 시 진하게.

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -2739,27 +2739,126 @@ function formatAnswerWithParagraphs(text) {
   }).join('');
 }
 
+/* v0.6.1 v10 (2026-06-16) — Claude-style answer typography.
+ *
+ * Operator catch (screenshot): the assistant body needed Claude.ai-
+ * style "achromatic but cleanly hierarchical" formatting — explicit
+ * line-height, weight/size hierarchy, table + blockquote support,
+ * proper margin between blocks. Previous renderer baked color +
+ * size into inline styles; now structural classes (.md-h1/-h2/-h3,
+ * .md-hr, .md-li, .md-blockquote, .md-table, etc.) take over and
+ * chat.css owns the typography in one place.
+ *
+ * Block tokens (line-anchored) are processed first so they don't
+ * trip the inline-replacement passes:
+ *   ``` ... ```            → <pre><code class="lang-...">
+ *   | h | h |              → <table> (header + body, GFM-style)
+ *   ##/###/####            → <h2>/<h3>/<h4>
+ *   ---                    → <hr>
+ *   > text                 → <blockquote>
+ *   - / * / 1.  text       → <ul>/<ol><li>
+ *
+ * Then inline:
+ *   **bold**, *em*, `code`
+ *
+ * Finally remaining newlines collapse into <p>/<br> so paragraphs
+ * stay distinct (single-line → <br>, double-newline → <p>).
+ */
 function formatAnswer(text) {
+  // ── code fences ────────────────────────────────────────────────
   const codeBlocks = [];
-  text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+  text = String(text || '').replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
     const idx = codeBlocks.length;
-    codeBlocks.push(`<pre><code class="lang-${lang||'text'}">${escHtml(code.trim())}</code></pre>`);
+    codeBlocks.push(
+      `<pre class="md-pre"><code class="lang-${escHtml(lang || 'text')}">${escHtml(code.replace(/\n+$/, ''))}</code></pre>`,
+    );
     return `\x00CODE${idx}\x00`;
   });
+
+  // ── GFM-style table ────────────────────────────────────────────
+  // Detect "| h | h |\n|---|---|\n| r | r |..." blocks. Operate on
+  // raw text so escapeHtml doesn't munge the pipes.
+  const tableBlocks = [];
+  text = text.replace(
+    /(^|\n)(\|[^\n]+\|\n\|[\s:|\-]+\|\n(?:\|[^\n]+\|\n?)+)/g,
+    (_m, lead, block) => {
+      const lines = block.trim().split(/\n/);
+      const split = (row) => row.replace(/^\|/, '').replace(/\|$/, '').split('|').map(s => s.trim());
+      const headers = split(lines[0]);
+      // line 1 = separator (---), skip
+      const bodyRows = lines.slice(2).map(split);
+      const th = headers.map(h => `<th>${escHtml(h)}</th>`).join('');
+      const tr = bodyRows.map(
+        row => '<tr>' + row.map(c => `<td>${_renderInlineMd(escHtml(c))}</td>`).join('') + '</tr>',
+      ).join('');
+      const html = `<div class="md-table-wrap"><table class="md-table"><thead><tr>${th}</tr></thead><tbody>${tr}</tbody></table></div>`;
+      const idx = tableBlocks.length;
+      tableBlocks.push(html);
+      return `${lead}\x00TABLE${idx}\x00`;
+    },
+  );
+
+  // Escape the rest of the text. Code + tables already escaped + held
+  // as sentinels.
   text = escHtml(text);
-  text = text.replace(/^###\s+(.+)$/gm, '<strong style="font-size:13px;color:var(--brand-2)">$1</strong>');
-  text = text.replace(/^##\s+(.+)$/gm,  '<strong style="font-size:14px;color:var(--accent)">$1</strong>');
-  text = text.replace(/^#\s+(.+)$/gm,   '<strong style="font-size:15px;color:var(--accent)">$1</strong>');
-  text = text.replace(/^---+$/gm, '<hr style="border:none;border-top:1px solid var(--border);margin:6px 0">');
-  text = text.replace(/^(\d+\.\s+.+)$/gm, '<span style="display:block;padding-left:8px">$1</span>');
-  text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-  text = text.replace(/\*([^*\n]+)\*/g, '<em>$1</em>');
-  text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
-  text = text.replace(/\n{2,}/g, '<br><br>');
-  text = text.replace(/\n/g, '<br>');
+
+  // ── block-level: headings, hr, blockquote, lists ───────────────
+  text = text.replace(/^####\s+(.+)$/gm, '<h4 class="md-h4">$1</h4>');
+  text = text.replace(/^###\s+(.+)$/gm,  '<h3 class="md-h3">$1</h3>');
+  text = text.replace(/^##\s+(.+)$/gm,   '<h2 class="md-h2">$1</h2>');
+  text = text.replace(/^#\s+(.+)$/gm,    '<h1 class="md-h1">$1</h1>');
+  text = text.replace(/^[-_*]{3,}\s*$/gm, '<hr class="md-hr">');
+  text = text.replace(/^>\s+(.+)$/gm, '<blockquote class="md-quote">$1</blockquote>');
+
+  // ── inline (bold / em / code) ──────────────────────────────────
+  text = _renderInlineMd(text);
+
+  // ── lists: gather consecutive <li> rows under one <ul>/<ol> ────
+  // Convert leading "- " / "* " / "1. " to li markers in a single
+  // pass, then collapse adjacent markers under a list parent.
+  text = text.replace(/^[ \t]*[-*]\s+(.+)$/gm, '<li class="md-li">$1</li>');
+  text = text.replace(/^[ \t]*\d+\.\s+(.+)$/gm, '<li class="md-li md-li-ordered">$1</li>');
+  text = text.replace(
+    /(<li class="md-li md-li-ordered">[\s\S]+?<\/li>)(?=(?:\s*<li class="md-li md-li-ordered">)?)/g,
+    (m) => m,
+  );
+  text = text.replace(/((?:<li class="md-li(?: md-li-ordered)?">[\s\S]+?<\/li>\s*)+)/g, (m) => {
+    if (/md-li-ordered/.test(m)) return `<ol class="md-ol">${m}</ol>`;
+    return `<ul class="md-ul">${m}</ul>`;
+  });
+
+  // ── paragraphs ─────────────────────────────────────────────────
+  // Double-newline → paragraph break; single newline inside a block
+  // becomes <br>. Avoid wrapping a line that's already a block-level
+  // element (heading / hr / blockquote / list / pre / table).
+  const blocks = text.split(/\n{2,}/).map(chunk => {
+    const trimmed = chunk.trim();
+    if (!trimmed) return '';
+    // already a block?
+    if (/^<(h[1-6]|ul|ol|hr|blockquote|pre|div class="md-table-wrap"|\x00TABLE\d+\x00)/.test(trimmed)
+        || /^\x00CODE\d+\x00/.test(trimmed)) {
+      return trimmed.replace(/\n/g, '');
+    }
+    return `<p class="md-p">${trimmed.replace(/\n/g, '<br>')}</p>`;
+  });
+  text = blocks.filter(Boolean).join('');
+
+  // ── restore code + table sentinels ─────────────────────────────
   codeBlocks.forEach((block, idx) => {
     text = text.replace(`\x00CODE${idx}\x00`, block);
   });
+  tableBlocks.forEach((block, idx) => {
+    text = text.replace(`\x00TABLE${idx}\x00`, block);
+  });
+  return text;
+}
+
+// Inline-only render. Splits out so the table-cell pass can reuse
+// it without re-running block-level rules.
+function _renderInlineMd(text) {
+  text = text.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+  text = text.replace(/(^|[^\*])\*([^*\n]+)\*(?!\*)/g, '$1<em>$2</em>');
+  text = text.replace(/`([^`\n]+)`/g, '<code class="md-code">$1</code>');
   return text;
 }
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -869,6 +869,29 @@
   .bubble { line-height: 1.6; }
 }
 
+/* v0.6.1 v10 (2026-06-16) — Claude-style answer typography on phones.
+ * Bump headings a hair so the size step from body→heading is visible
+ * on a small viewport, tighten table padding so wide tables don't
+ * force horizontal scroll on every doc. */
+@media (max-width: 768px) {
+  .bubble .md-h1 { font-size: 20px; }
+  .bubble .md-h2 { font-size: 17px; }
+  .bubble .md-h3 { font-size: 15.5px; }
+  .bubble .md-h4 { font-size: 13px; }
+  .bubble .md-p,
+  .bubble .md-ul,
+  .bubble .md-ol {
+    font-size: 14.5px;
+    line-height: 1.7;
+  }
+  .bubble .md-table { font-size: 12.5px; }
+  .bubble .md-table th,
+  .bubble .md-table td {
+    padding: 6px 8px;
+  }
+  .bubble pre.md-pre { font-size: 12px; padding: 10px 12px; }
+}
+
 /* v0.6.1 v3 (2026-06-15) — Claude-style phone overrides.
  *
  * On phones:


### PR DESCRIPTION
## Summary

운영자 catch (스크린샷 = Claude.ai 답변 페이지): \"답변 양식도 줄간 간격을 두고 글자 크기나 진하기 등을 써서 클로드 답변처럼 무채색이지만 깔끔한 양식으로\".

### 핵심 변경
- **위계는 SIZE + WEIGHT 로** 표현, color 는 무채색 (text / muted / border 만)
- inline style 인스턴스 모두 **구조적 클래스 (`.md-*`)** 로 분리, chat.css 가 typography 단일 source of truth

### Renderer (`chat.js formatAnswer`)
신규 블록 지원:
- `| h | h |` + `|---|---|` + body → **GFM table**
- `> text` → **blockquote**
- `1.` / `- ` / `* ` → 자동 그룹화된 `<ol>` / `<ul>`
- `#`/`##`/`###`/`####` → `h1`/`h2`/`h3`/`h4`
- `---` → `hr`
- 인라인: `**bold**` / `*em*` / \`code\` (연속 `*` hardening)

문단 처리: `\n\n` 단위 chunk → `<p>`, 블록 element 는 wrap 안 함. code + table 은 escapeHtml 전 토크나이즈 → 안전.

`_renderInlineMd()` 분리 → 테이블 셀이 inline 만 재사용.

### Typography (`chat.css`)
| Element | Size | Weight | Note |
|---|---|---|---|
| `.md-h1` | 22 | 700 | line-height 1.35, letter-spacing -0.005em |
| `.md-h2` | 18 | 700 | |
| `.md-h3` | 16 | 600 | |
| `.md-h4` | 14 | 600 | uppercase, muted |
| `.md-p` | inherit | 400 | line-height **1.7**, margin-bottom 12 |
| `.md-ul/-ol` | inherit | — | padding-left 22, marker muted |
| `.md-quote` | inherit | — | 3px 좌측 muted border, no italic |
| `.md-hr` | — | — | 1px muted top border, margin 18 |
| `.md-pre` | 12.5 | — | rgba(0,0,0,.35) bg + horizontal scroll |
| `.md-code` | 12.5 | — | rgba(255,255,255,.06) + 미세 border |
| `.md-table` | 13.5 | — | GFM, alternating row tint via th bg, quiet borders |

모든 element 는 `--text` / `--muted` / `--border` 만 사용 → **무채색**.

### Mobile (`mobile.css`)
- 헤딩 20/17/15.5/13, 본문 14.5 / line-height **1.7**
- 테이블 padding 6/8, pre 12 / 10

### 캐시
- `chat.css` + `mobile.css` `v=v15-20260616`

## Verification

- `## 요약` → 18px 700 무채색 헤딩, 위 margin 18
- `## 관계` 아래 `- 핵심: Alex Karp` → `<ul>` 마커 muted, line-height 1.7
- `| 지표 | 값 |\n|---|---|\n| Q1 | 100 |` → GFM table, alternating th bg
- `> 인용` → 좌측 3px border + soft text
- 인라인 \`code\` → 무채색 chip
- \`\`\`python\n print(\"hi\")\n\`\`\` → md-pre 검정 bg + scroll
- 폰에서 헤딩 한 단계 작게, 본문 14.5
- chat.js / chat.css / mobile.css syntax OK
- inline render smoke: `**bold**` → `<strong>`, `*em*` → `<em>`, \`code\` → `<code class=\"md-code\">`

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.
- 인라인 link `[text](url)` 처리 — 향후 catch 때.
- syntax highlighting (highlight.js / prism) — 향후 catch 때.
- 본문에 streamed mid-render 시 partial markdown 처리 — 향후 catch 때.

Quality delta: exempt (label: code) — frontend chrome reorg, core/ 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)