### PR TITLE
fix(v0.6.1): welcome hero restores on every new chat

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v15-20260616 cache-bust: Claude-style answer typography
-     (achromatic hierarchy, table + blockquote, line-height 1.7). -->
-<link rel="stylesheet" href="/static/chat.css?v=v15-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v15-20260616">
+<!-- v=v16-20260616 cache-bust: welcome hero restores on new chat
+     (hideWelcome toggles display instead of removing the host). -->
+<link rel="stylesheet" href="/static/chat.css?v=v16-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v16-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1476,9 +1476,20 @@ async function sendMessage() {
    메시지 렌더링
 ════════════════════════════════ */
 
+/* v0.6.1 v11 (2026-06-16) — operator catch: pressing "+ 새 대화"
+ * left the chat surface blank instead of restoring the welcome
+ * hero. Root cause: hideWelcome used to REMOVE the element from
+ * the DOM, so newSession() could never re-show it. Now hideWelcome
+ * just toggles display:none; showWelcome restores display:flex.
+ * newSession + sendMessage round-trip across the same element. */
 function hideWelcome() {
   const w = document.getElementById('welcome');
-  if (w) w.remove();
+  if (w) w.style.display = 'none';
+}
+
+function showWelcome() {
+  const w = document.getElementById('welcome');
+  if (w) w.style.display = 'flex';
 }
 
 function appendMsg(role, text) {
@@ -3313,10 +3324,18 @@ function newSession() {
   // 다음 query 가 옛 SID 로 전송되어 backend N-3 게이트가 못 풀림.
   refreshSessionGlobals();
 
-  // 화면 초기화
+  // v0.6.1 v11 (2026-06-16) — operator catch: previously this set
+  // `messages.innerHTML = ''` which also wiped the #welcome host,
+  // so the "Welcome to SEKOS / 무엇이든 물어보세요" hero never
+  // re-appeared on a new chat. Now we only remove message bubbles
+  // (`.msg`) and the loading/typing rows, then explicitly call
+  // showWelcome() so the same hero the operator sees on first
+  // load returns for every new chat.
   const messages = document.getElementById('messages');
-  if (messages) messages.innerHTML = '';
-  document.getElementById('welcome')?.style?.setProperty('display', 'flex');
+  if (messages) {
+    messages.querySelectorAll('.msg, .thinking-stream, .typing').forEach(el => el.remove());
+  }
+  showWelcome();
   toast('새 대화를 시작합니다', 'success');
   // refresh sidebar list so the new session appears at top.
   loadSessionList().catch(() => {});


### PR DESCRIPTION
## Summary

운영자 catch (스크린샷): + 새 대화 누를 때 첫 visitor 가 보는 welcome hero (\"Welcome to SEKOS / 무엇이든 물어보세요 / example chips\") 가 자동 노출되어야 함. 오늘은 빈 화면.

### Root cause
- `hideWelcome()` 가 `w.remove()` 로 `#welcome` element 자체를 DOM 에서 제거. 첫 메시지 보내면 영구 사라짐 → `newSession()` 이 다시 보여주려 해도 element 가 없어서 실패.
- `newSession()` 의 `messages.innerHTML = ''` 도 #welcome 같이 wipe (만약 남아있다면).

### Fix
- **`hideWelcome()`**: `w.remove()` → `w.style.display = 'none'` (호스트 보존)
- 신규 **`showWelcome()`**: `w.style.display = 'flex'` (index.html inline default 와 동일)
- **`newSession()`**: `messages.innerHTML = ''` → `.msg / .thinking-stream / .typing` 만 제거 (#welcome 보존) → `showWelcome()` 명시적 호출

### 캐시
- chat.css + mobile.css `v=v16-20260616` (JS contract 변경에 묶어 cached client refresh)

## Verification

- 첫 visitor / 페이지 첫 로드 → welcome hero 표시 (기존과 동일)
- 메시지 전송 → welcome 숨김 (display:none), 대화 표시
- \"+ 새 대화\" 탭 → 대화 .msg 제거 + welcome 다시 표시 → 첫 visitor 와 동일 view
- 메시지 또 보냄 → welcome 숨김 → 대화 표시 → 다시 + 새 대화 → welcome 표시 (toggle 안정)
- chat.js syntax OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: fix) — UX 회귀 fix, measurement 축 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)