### PR TITLE
feat(v0.6.1): hide per-message avatars on PC too

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v17-20260616 cache-bust: favorite (즐겨찾기) cross-device sync
-     (server-side store, localStorage cache only). -->
-<link rel="stylesheet" href="/static/chat.css?v=v17-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v17-20260616">
+<!-- v=v18-20260616 cache-bust: hide .msg .avatar on PC + mobile
+     (operator catch — Claude-style avatar-less assistant column). -->
+<link rel="stylesheet" href="/static/chat.css?v=v18-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v18-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -1029,6 +1029,14 @@ main { display: flex; flex: 1; overflow: hidden; }
   animation: fadeIn .2s ease;
 }
 .msg.user { margin-left: auto; flex-direction: row-reverse; }
+/* v0.6.1 v13 (2026-06-16) — operator catch: PC web "자메스와 사용자
+ * 아이콘이 없어도 될것같다". Avatars on every row added visual
+ * weight without information value; mobile already hid them. Now
+ * hidden globally so PC matches Claude.ai's avatar-less assistant
+ * column. The .avatar style block stays (operator-tier admin
+ * surfaces may reuse it) but the chat-page .msg .avatar
+ * specifically is display:none. */
+.msg .avatar { display: none !important; }
 .avatar {
   width: 30px; height: 30px;
   border-radius: 6px;
@@ -1051,7 +1059,10 @@ main { display: flex; flex: 1; overflow: hidden; }
   border-radius: 10px;
   font-size: 14px;
   line-height: 1.65;
-  max-width: calc(100% - 42px);
+  /* v13 (2026-06-16) — avatar gone, reclaim the 42 px reserved for
+   * it. user bubble keeps its 80% max via the .msg.user .bubble
+   * override below. */
+  max-width: 100%;
   word-break: break-word;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Summary

운영자 catch (PC 웹 스크린샷): \"pc 웹상 자메스와 사용자 아이콘이 없어도 될것같다. 깔끔하게 구성 개선\".

모바일은 이미 v0.6.1 v3 (Claude-style 평탄화) 에서 `.msg .avatar` 숨김. PC 에서는 여전히 30 px 🧠 / 사용자 아바타가 보였는데, 자메스 bubble border / shadow / left rail 도 제거된 상황에서 avatar 만 시각적 weight 만 주고 정보 가치는 없음.

### 변경
- `chat.css` `.msg .avatar { display: none !important }` — @media gate 제거, 전역 적용
- `.avatar` style block 은 그대로 보존 (admin 등 다른 surface 가 재사용 가능)
- `.bubble { max-width: 100% }` — avatar 자리 42 px 회수
- `.msg.user .bubble` 은 자체 override 로 `min(80%, 640px)` 유지 (사용자 pill 풀폭 방지)

### 캐시
- chat.css + mobile.css `v=v18-20260616`

## Verification

- PC viewport: 자메스 응답 / 사용자 메시지 모두 avatar 없이 본문만
- 자메스 응답: 본문 텍스트가 좌측 정렬, max-width 100% 사용 가능
- 사용자 메시지: 우측 회색 pill, 80% / 640px 캡 유지 (풀폭으로 안 늘어남)
- 모바일: 기존 동작 그대로 유지 (mobile.css 의 같은 룰이 중복되지만 무해)

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: code) — frontend chrome reorg, core/ 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)