### PR TITLE
fix(v0.6.1): switchSession also preserves #welcome host

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,10 @@
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
 <link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v18-20260616 cache-bust: hide .msg .avatar on PC + mobile
-     (operator catch — Claude-style avatar-less assistant column). -->
-<link rel="stylesheet" href="/static/chat.css?v=v18-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v18-20260616">
+<!-- v=v19-20260616 cache-bust: switchSession preserves #welcome host
+     so + 새 대화 can re-show the hero. -->
+<link rel="stylesheet" href="/static/chat.css?v=v19-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v19-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -3277,9 +3277,18 @@ async function switchSession(sessionId) {
   // [N-3 fix] in-memory SESSION_ID / HISTORY_KEY 동기 (newSession 과 동일).
   refreshSessionGlobals();
 
-  // 현재 메시지 초기화 후 해당 세션 히스토리 표시
+  // v0.6.1 v14 (2026-06-16) — operator catch: pressing "+ 새 대화"
+  // showed a blank screen instead of the welcome hero IF the
+  // operator had switched sessions earlier. Root cause: this
+  // function used to do `messages.innerHTML = ''`, which wiped the
+  // #welcome host along with the .msg rows. After that, newSession's
+  // showWelcome() had no element to flip back to display:flex. Now
+  // we remove only the actual conversation rows, leaving #welcome
+  // intact — same pattern as newSession (v11).
   const messages = document.getElementById('messages');
-  if (messages) messages.innerHTML = '';
+  if (messages) {
+    messages.querySelectorAll('.msg, .thinking-stream, .typing').forEach(el => el.remove());
+  }
 
   try {
     const res = await fetch(
@@ -3291,6 +3300,9 @@ async function switchSession(sessionId) {
 
     if (!turns.length) {
       toast('선택한 세션에 대화 기록이 없습니다', 'info');
+      // Empty session — surface the welcome hero so the page is
+      // legible instead of blank below the topbar.
+      showWelcome();
       // refresh sidebar list so the active highlight follows.
       loadSessionList().catch(() => {});
       return;


### PR DESCRIPTION
## Summary

운영자 catch: PR #953 (\"+ 새 대화\" 누를 때 welcome hero 복원) 이후에도, **사이드바에서 다른 세션을 한 번 클릭** 한 뒤 + 새 대화 누르면 hero 가 안 나옴.

### Root cause
PR #953 에서 `newSession()` 만 fix 하고 **`switchSession()` 의 parallel call site 를 빼먹음**.
- `switchSession` 가 `messages.innerHTML = ''` 로 #welcome host 도 함께 wipe
- 그 시점부터 `#welcome` element 가 DOM 에 없음
- 그 뒤 `+ 새 대화` 누르면 `newSession()` 의 `showWelcome()` 가 찾을 element 없음 → no-op
- 빈 화면

### Fix
- `switchSession()` 가 이제 `.msg / .thinking-stream / .typing` 만 제거, `#welcome` 보존 (`newSession` 과 동일 패턴)
- 선택한 세션이 비어있으면 `showWelcome()` 명시 호출 → topbar 아래 빈 화면 안 생김

### 캐시
- chat.css + mobile.css `v=v19-20260616`

## Verification

- 페이지 첫 로드 → welcome 표시
- 메시지 전송 → welcome 숨김, 대화 표시
- + 새 대화 → welcome 복원 (PR #953 fix 유지)
- 사이드바 다른 세션 클릭 → 해당 세션의 turn 들 표시 (welcome 숨김), #welcome 은 DOM 에 보존
- + 새 대화 → **welcome 다시 표시** (이번 fix)
- 사이드바 빈 세션 클릭 → welcome 표시 (이번 fix 추가 이득)
- chat.js syntax OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.

Quality delta: exempt (label: fix) — UX 회귀 fix, measurement 축 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)