### PR TITLE
feat(v0.6.1): serif answer body + larger menu font

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,11 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css">
-<!-- v=v19-20260616 cache-bust: switchSession preserves #welcome host
-     so + 새 대화 can re-show the hero. -->
-<link rel="stylesheet" href="/static/chat.css?v=v19-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v19-20260616">
+<link rel="stylesheet" href="/static/tokens.css?v=v20-20260616">
+<!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
+     글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
+     half-cached state can't mismatch + bring in tokens.css fresh. -->
+<link rel="stylesheet" href="/static/chat.css?v=v20-20260616">
+<link rel="stylesheet" href="/static/mobile.css?v=v20-20260616">
 </head>
 <body>
 

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -313,11 +313,11 @@ header {
   justify-content: space-between;
   gap: 10px;
   width: 100%;
-  padding: 10px 12px;
+  padding: 11px 14px;
   background: transparent;
   border: 0;
   border-radius: 8px;
-  font-size: 14px;
+  font-size: 15px;
   color: var(--text, #e0e0e0);
   cursor: pointer;
   font-family: var(--font-ui);
@@ -1057,8 +1057,12 @@ main { display: flex; flex: 1; overflow: hidden; }
 .bubble {
   padding: 12px 16px;
   border-radius: 10px;
-  font-size: 14px;
-  line-height: 1.65;
+  /* v0.6.1 v15 (2026-06-16) — operator catch: 대화 본문 명조체 +
+   * 글자 크기 ↑ (14 → 16). chrome (사이드바 / 버튼) 은 기존 font-ui
+   * 유지. line-height 1.7 로 한국어 명조 가독성 보강. */
+  font-family: var(--font-serif);
+  font-size: 16px;
+  line-height: 1.75;
   /* v13 (2026-06-16) — avatar gone, reclaim the 42 px reserved for
    * it. user bubble keeps its 80% max via the .msg.user .bubble
    * override below. */
@@ -1117,16 +1121,28 @@ main { display: flex; flex: 1; overflow: hidden; }
  * (hr, blockquote rule, table border) and the accent only appears
  * on inline <code> bg + link hover. Reads as "clean B/W document"
  * matching Claude's answer column. */
+/* v0.6.1 v15 (2026-06-16) — headings inherit the .bubble serif font.
+ * Hierarchy still carried by SIZE + WEIGHT (operator's "기존 글자체도
+ * 활용" applies to chrome / code / meta — the answer body is one
+ * coherent serif block). H4 stays sans uppercase as a label chip. */
 .bubble .md-h1,
 .bubble .md-h2,
-.bubble .md-h3,
-.bubble .md-h4 {
+.bubble .md-h3 {
   color: var(--text);
-  font-family: var(--font-ui);
-  margin: 18px 0 8px;
+  font-family: var(--font-serif);
+  margin: 20px 0 10px;
   line-height: 1.35;
   letter-spacing: -0.005em;
   font-weight: 700;
+}
+.bubble .md-h4 {
+  color: var(--muted);
+  font-family: var(--font-ui);
+  margin: 18px 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
 }
 .bubble .md-h1:first-child,
 .bubble .md-h2:first-child,
@@ -1134,15 +1150,15 @@ main { display: flex; flex: 1; overflow: hidden; }
 .bubble .md-h4:first-child {
   margin-top: 2px;
 }
-.bubble .md-h1 { font-size: 22px; }
-.bubble .md-h2 { font-size: 18px; }
-.bubble .md-h3 { font-size: 16px; font-weight: 600; }
-.bubble .md-h4 { font-size: 14px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+.bubble .md-h1 { font-size: 26px; }
+.bubble .md-h2 { font-size: 22px; }
+.bubble .md-h3 { font-size: 18px; font-weight: 700; }
 
 .bubble .md-p {
-  margin: 0 0 12px;
-  line-height: 1.7;
+  margin: 0 0 14px;
+  line-height: 1.75;
   color: var(--text);
+  font-family: var(--font-serif);
 }
 .bubble .md-p:last-child { margin-bottom: 0; }
 
@@ -1153,19 +1169,21 @@ main { display: flex; flex: 1; overflow: hidden; }
 }
 
 .bubble .md-quote {
-  margin: 12px 0;
+  margin: 14px 0;
   padding: 4px 14px;
   border-left: 3px solid var(--border, #2a2d33);
   color: var(--text-soft, #cfd2d8);
-  font-style: normal;
-  line-height: 1.65;
+  font-family: var(--font-serif);
+  font-style: italic;
+  line-height: 1.7;
 }
 
 .bubble .md-ul,
 .bubble .md-ol {
   margin: 6px 0 14px;
   padding-left: 22px;
-  line-height: 1.7;
+  line-height: 1.75;
+  font-family: var(--font-serif);
 }
 .bubble .md-ul { list-style: disc; }
 .bubble .md-ol { list-style: decimal; }
@@ -1214,8 +1232,9 @@ main { display: flex; flex: 1; overflow: hidden; }
 .bubble .md-table {
   border-collapse: collapse;
   width: 100%;
-  font-size: 13.5px;
-  line-height: 1.5;
+  font-size: 14.5px;
+  line-height: 1.55;
+  font-family: var(--font-serif);
 }
 .bubble .md-table th,
 .bubble .md-table td {
@@ -1740,13 +1759,17 @@ aside.sidebar.collapsed { min-width: 0; }
   align-items: center;
   gap: 12px;
   width: 100%;
-  padding: 10px 12px;
+  padding: 11px 12px;
   background: transparent;
   border: 0;
   border-radius: 8px;
   color: var(--text, #e0e0e0);
   text-decoration: none;
-  font-size: 14px;
+  /* v0.6.1 v15 (2026-06-16) — operator catch: 메뉴 글자 조금 더 크게.
+   * 14 → 15.5 px on desktop (chrome font-ui 유지, 크기만 ↑).
+   * Mobile bump lives in mobile.css. */
+  font-size: 15.5px;
+  font-weight: 500;
   font-family: var(--font-ui);
   line-height: 1.2;
   cursor: pointer;
@@ -2043,7 +2066,7 @@ aside.sidebar { height: 100vh; height: 100dvh; }
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: 14.5px;
   font-weight: 600;
   color: var(--text, #e0e0e0);
 }
@@ -2060,7 +2083,7 @@ aside.sidebar { height: 100vh; height: 100dvh; }
 .session-item-meta {
   display: flex;
   justify-content: space-between;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--muted, #8a8d99);
 }
 .session-item-menu {

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -869,22 +869,22 @@
   .bubble { line-height: 1.6; }
 }
 
-/* v0.6.1 v10 (2026-06-16) — Claude-style answer typography on phones.
- * Bump headings a hair so the size step from body→heading is visible
- * on a small viewport, tighten table padding so wide tables don't
- * force horizontal scroll on every doc. */
+/* v0.6.1 v10/v15 (2026-06-16) — Claude-style serif answer typography
+ * on phones. v15 bumps body up to 15.5 / heading scale increased so
+ * 명조체 가독성 ↑ on small viewport. table + pre stay mono/ui. */
 @media (max-width: 768px) {
-  .bubble .md-h1 { font-size: 20px; }
-  .bubble .md-h2 { font-size: 17px; }
-  .bubble .md-h3 { font-size: 15.5px; }
+  .bubble { font-size: 15.5px; line-height: 1.75; }
+  .bubble .md-h1 { font-size: 22px; }
+  .bubble .md-h2 { font-size: 19px; }
+  .bubble .md-h3 { font-size: 16.5px; }
   .bubble .md-h4 { font-size: 13px; }
   .bubble .md-p,
   .bubble .md-ul,
   .bubble .md-ol {
-    font-size: 14.5px;
-    line-height: 1.7;
+    font-size: 15.5px;
+    line-height: 1.75;
   }
-  .bubble .md-table { font-size: 12.5px; }
+  .bubble .md-table { font-size: 13.5px; }
   .bubble .md-table th,
   .bubble .md-table td {
     padding: 6px 8px;
@@ -913,12 +913,18 @@
     max-width: min(86%, 540px);
   }
   .sidebar-nav-row {
-    padding: 12px 14px;
-    font-size: 15px;
+    padding: 13px 14px;
+    font-size: 16px;
   }
   .sidebar-nav-icon {
     font-size: 18px;
   }
+  /* v0.6.1 v15 (2026-06-16) — 메뉴 글자 ↑ on phone too. session
+   * rows + popover row scale to match. */
+  .session-item-title { font-size: 15px; }
+  .session-item-meta  { font-size: 12px; }
+  .modal-popover-row  { font-size: 16px; padding: 12px 14px; }
+  .sidebar-section-title { font-size: 12px; }
   .chat-topbar {
     padding: 8px 12px;
     gap: 6px;

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -71,9 +71,16 @@
   --shadow-card:  0 1px 0 rgba(255,255,255,.02) inset,
                   0 8px 24px rgba(0,0,0,.18);
 
-  /* ── type ── */
+  /* ── type ──
+   * v0.6.1 v15 (2026-06-16) — operator catch: 대화 본문은 명조체로
+   * 가독성 ↑. UI chrome (사이드바 / 버튼 / 토스트) 은 기존 sans
+   * 유지. 한국어 명조 (Noto Serif KR / Nanum Myeongjo) 를 1순위,
+   * 영어 serif (Source Serif / Georgia) 를 fallback 으로. */
   --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   --font-ui:      'Inter', 'Pretendard', system-ui, -apple-system, sans-serif;
+  --font-serif:   'Noto Serif KR', 'Nanum Myeongjo', 'Source Serif Pro',
+                  'Source Serif 4', Georgia, 'Times New Roman',
+                  'Apple SD Gothic Neo', serif;
 }
 
 /* ── A11y/CSP — small utility classes (v0.5 UI #6) ──


### PR DESCRIPTION
## Summary

운영자 catch:
1. 대화 본문 글자체를 **명조체** 로 (기존 글자체도 활용), 글자 크기 조금 더 크게 → 가시성 ↑. 크기/진하기로 하이라이트 표현.
2. 메뉴 글자도 조금 더 크게 (글자체는 유지).

### (1) 대화 본문 — serif + 크게
- **`tokens.css`** 신규 `--font-serif` 토큰:
    ```
    'Noto Serif KR', 'Nanum Myeongjo', 'Source Serif Pro',
    'Source Serif 4', Georgia, 'Times New Roman',
    'Apple SD Gothic Neo', serif
    ```
    한국어 명조 우선, 영어 serif fallback.
- `chat.css` `.bubble`: font-family `--font-serif`, **size 14 → 16, line-height 1.65 → 1.75**.
- 헤딩 크기:
    - `.md-h1` 22 → **26**
    - `.md-h2` 18 → **22**
    - `.md-h3` 16 → **18**
    - 모두 font-weight 700, serif (h4 만 sans uppercase label)
- `.md-p / .md-ul / .md-ol / .md-quote / .md-table` 모두 serif 상속, line-height 1.75
- **chrome 보존**: code (inline + pre), meta chip, table th 배경, conf chip 등 = 기존 mono / font-ui 유지
- 모바일: `.bubble` body 15.5 / line-height 1.75, 헤딩 22/19/16.5/13

### (2) 사이드바 메뉴 — sans 유지하고 크기만 ↑
- `.sidebar-nav-row` font 14 → **15.5**, padding 10 → 11, weight 500
- `.session-item-title` 13 → **14.5**, `.session-item-meta` 11 → 12
- `.modal-popover-row` 14 → **15**, padding 10/12 → 11/14
- 모바일: sidebar-nav-row **16**, session-item-title **15**, modal-popover-row 16

### 캐시
- tokens.css + chat.css + mobile.css 모두 `v=v20-20260616`

## Verification

- 자메스 응답: 본문 **명조체** (Noto Serif KR / Nanum Myeongjo / fallback), 16 px, line-height 1.75 — 한국어 가독성 ↑
- 헤딩 26/22/18, weight 700 → 위계 명확
- 인용 `> text` → 명조체 italic + 좌측 muted border
- 테이블 → 명조체 14.5 px (cell), th 굵게
- inline `code` / pre block → mono 유지 (코드 가독성)
- conf chip / 별표 / 메타 / 타임스탬프 → font-ui 유지
- 사이드바 메뉴: 채팅/프로젝트/추론 그래프/에이전트/관리자 모두 15.5 → 한 단계 보임
- 폰: 본문 15.5, 메뉴 16 — 큰 폰트 / 가독성 ↑
- chrome (버튼 / 토스트 / 모달 헤더) = font-ui 그대로
- tokens.css / chat.css / mobile.css / index.html syntax OK

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 라인 변경.
- 폰트 파일 self-host — 현재는 system / Google Fonts CDN 의 install 여부에 의존. Noto Serif KR 이 시스템에 없으면 fallback 으로 Nanum Myeongjo → Source Serif → Georgia → serif. 향후 self-hosted `@font-face` 추가 가능.

Quality delta: exempt (label: code) — frontend typography reorg, core/ 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)