### PR TITLE
feat(v0.6.1): meta inventory follow-up (개념/AI/최근 → detail view)

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -112,6 +112,10 @@ class IntentClassifier:
             # 캐논 형식: "wiki 목록", "내부 자료 보여줘"
             r"(wiki|위키|내부\s*자료|보유\s*자료|가지고\s*있는)\s*(목록|리스트|보여)",
             r"(어떤|무슨)\s*(자료|문서|wiki|위키|entity|엔티티).{0,15}(있|가지)",
+            # v0.6.1 v17 (2026-06-16) — "무엇" 토큰도 받아들임. 운영자가
+            # 자연어로 "내부 자료가 무엇이 있나" 처럼 자주 사용.
+            r"(자료|데이터|문서|wiki|entity|knowledge|것).{0,8}(무엇|뭐가|뭐|어떤|무슨).{0,5}(있|가지)",
+            r"(어떤|무슨|무엇|뭐가).{0,5}(자료|문서|데이터|wiki|위키|entity|엔티티).{0,15}(있|가지|보유)",
             r"^(자료|문서|entity|엔티티)\s*(목록|리스트)\s*[?\.!]?$",
             # 캐주얼 한국어: "데이터 뭐 있는지", "문서 뭐가 있어"
             r"(데이터|자료|문서|wiki|위키|entity|엔티티|knowledge)\s*(뭐|무슨|어떤)",
@@ -121,6 +125,25 @@ class IntentClassifier:
             # 캐주얼 한국어: "아는거 뭐 있어", "알고 있는 거 뭐"
             r"(아는|알고\s*있는)\s*(거|것).{0,8}(뭐|무슨|어떤)",
             r"내부\s*에?\s*(무슨|뭐|어떤)\s*(자료|문서|데이터|것|거)",
+            # v0.6.1 v17 (2026-06-16) — meta inventory follow-up.
+            # Operator catch: after the v16 hybrid overview, the natural
+            # follow-up is "개념 자료에는 뭐가 있어?", "조직 리스트",
+            # "AI 관련 자료", "최근 추가된 거" 류. These should land on
+            # meta (not retrieval) so handle_meta can pivot the same
+            # inventory by type / theme / recency. handle_meta inspects
+            # the same query for filter keywords and renders the
+            # appropriate detail view.
+            # type 키워드 + (자료/항목/관련/것/들/리스트/목록 optional) +
+            # (조사/공백 anywhere) + verb (누구·누가 포함)
+            r"(개념|조직|기업|인물|보고서|문서|이벤트|장소|자산|미분류)\s*(자료|항목|관련|것|들|목록|리스트)?\s*\S{0,5}\s*(어떤|뭐|무슨|얼마|몇|있|보여|알려|누구|누가|목록|리스트)",
+            # type 키워드 단독 + 명시 verb (리스트/목록) — "조직 리스트" 류.
+            r"(개념|조직|기업|인물|보고서|문서|이벤트|장소|자산|미분류)\s*(목록|리스트)",
+            # theme + 관련/쪽/는 + 자료/항목/리스트 OR 명시 verb. verb
+            # 그룹은 optional — "AI 관련 자료" 같은 명사구만으로도 meta
+            # 인텐트 인식 (v17 fix).
+            r"(AI|에이아이|머신러닝|블록체인|크립토|crypto|web3|보안|security|연구|논문|연도별|연도|재무|시장|웹\s*자료)\s*(관련|쪽|쪽으로|에|는|을|의)\s*(자료|항목|것|들|목록|리스트|어떤|뭐|무슨|있|보여|알려)",
+            r"(AI|에이아이|머신러닝|블록체인|크립토|crypto|web3|보안|security|연구|논문|연도별|연도|재무|시장|웹\s*자료)\s*(자료|항목|것|들|목록|리스트)\s*(어떤|뭐|무슨|있|보여|알려|\?)?",
+            r"(최근|새로|새로운|새로\s*추가|최신|recent|latest|new)\s*(추가|들어온|올라온)?\s*\S{0,6}\s*(자료|항목|것|것들|문서|entity)?",
             # 영어 — 더 유연하게 (PR #73 패턴은 'what do you' 만 잡음)
             r"(list|show)\s+(all\s+|me\s+)?(your\s+)?(entities|wiki|documents|files|data|knowledge)",
             r"^what\s+(\S+\s+){0,3}do\s+you\s+(have|know)",

--- a/core/reasoning/modes/meta.py
+++ b/core/reasoning/modes/meta.py
@@ -94,6 +94,188 @@ _TYPE_LABELS = {
 }
 
 
+# v0.6.1 v17 (2026-06-16) — query filter taxonomy for meta follow-ups.
+# Operator catch: the v16 hybrid overview produces "분류별: 개념(135),
+# 조직(86), ..."; the natural follow-up is "개념 자료에는 뭐가 있어?".
+# These tables let _parse_meta_filter map a Korean keyword (in the
+# raw query) back to either a specific entity_type or a specific
+# theme bucket so handle_meta can render a focused detail view.
+#
+# Each tuple = (keyword token, raw entity_type / theme label).
+# Order matters: the first hit wins, so more specific terms ("재무
+# 보고서" → "재무 · 시장") should appear before less specific ones
+# ("보고서" → "report") in their respective list.
+_TYPE_FILTER_TOKENS: List[Tuple[str, str]] = [
+    ("인물",       "person"),
+    ("사람",       "person"),
+    ("조직",       "organization"),
+    ("기업",       "company"),
+    ("회사",       "company"),
+    ("개념",       "concept"),
+    ("이벤트",     "event"),
+    ("사건",       "event"),
+    ("장소",       "location"),
+    ("자산",       "asset"),
+    ("문서",       "document"),
+    ("보고서",     "report"),
+    ("미분류",     ""),
+    # English fallback so list/show queries land cleanly.
+    ("person",       "person"),
+    ("organization", "organization"),
+    ("company",      "company"),
+    ("concept",      "concept"),
+    ("event",        "event"),
+    ("location",     "location"),
+    ("asset",        "asset"),
+    ("document",     "document"),
+    ("report",       "report"),
+]
+
+_THEME_FILTER_TOKENS: List[Tuple[str, str]] = [
+    ("연도별",       "연도별 보고서·실적"),
+    ("실적",         "연도별 보고서·실적"),
+    ("연도",         "연도별 보고서·실적"),
+    ("ai",           "AI · 머신러닝"),
+    ("에이아이",     "AI · 머신러닝"),
+    ("머신러닝",     "AI · 머신러닝"),
+    ("llm",          "AI · 머신러닝"),
+    ("블록체인",     "블록체인 · Web3"),
+    ("크립토",       "블록체인 · Web3"),
+    ("crypto",       "블록체인 · Web3"),
+    ("web3",         "블록체인 · Web3"),
+    ("재무",         "재무 · 시장"),
+    ("시장",         "재무 · 시장"),
+    ("매출",         "재무 · 시장"),
+    ("보안",         "보안 · 정책"),
+    ("정책",         "보안 · 정책"),
+    ("security",     "보안 · 정책"),
+    ("연구",         "연구 · 논문"),
+    ("논문",         "연구 · 논문"),
+    ("paper",        "연구 · 논문"),
+    ("웹",           "웹 · 외부 자료"),
+    ("외부",         "웹 · 외부 자료"),
+    ("뉴스",         "웹 · 외부 자료"),
+]
+
+_RECENT_TOKENS = (
+    "최근", "새로", "새로운", "최신", "recent", "latest", "new",
+    "방금", "오늘", "어제",
+)
+
+
+def _parse_meta_filter(query: str) -> Dict[str, str]:
+    """Decide whether the meta query is an OVERVIEW request or a
+    follow-up asking for a specific slice (type / theme / recent).
+
+    Returns: {"kind": "overview"} | {"kind": "type", "raw": <etype>}
+                                  | {"kind": "theme", "label": <theme>}
+                                  | {"kind": "recent"}
+    """
+    q = (query or "").lower().strip()
+    if not q:
+        return {"kind": "overview"}
+    # v0.6.1 v17 (2026-06-16) — theme tokens checked FIRST so a
+    # phrase like "재무 보고서" lands on the "재무 · 시장" theme
+    # rather than the generic "report" type. Both signals are
+    # legitimate; theme is more specific in those compound cases.
+    for token, theme in _THEME_FILTER_TOKENS:
+        if token in q:
+            return {"kind": "theme", "label": theme}
+    # Specific-type request — Korean / English single-word tokens.
+    for token, etype in _TYPE_FILTER_TOKENS:
+        if token in q:
+            return {"kind": "type", "raw": etype}
+    # Recent request.
+    if any(tok in q for tok in _RECENT_TOKENS):
+        return {"kind": "recent"}
+    return {"kind": "overview"}
+
+
+def _render_type_detail(enriched: List[Dict[str, Any]], etype: str) -> str:
+    """Render the full list of entities matching a specific
+    entity_type. Capped at 80 names + "외 N 개" so a giant bucket
+    doesn't blow the answer length.
+    """
+    matching = [
+        e for e in enriched
+        if (e["type"] or "(미분류)") == (etype or "(미분류)")
+    ]
+    label = _TYPE_LABELS.get(etype, etype.title() or "미분류")
+    if not matching:
+        return f"## “{label}” 분류 자료 없음\n\n해당 분류로 등록된 wiki 항목이 없습니다."
+    # Sort: alphabetical for stability across calls.
+    names = sorted([e["name"] for e in matching if e["name"]])
+    out: List[str] = [
+        f"## 분류 ‘{label}’ — 총 {len(matching)}개",
+        "",
+        f"_(전체 보유 자료 중 entity_type = `{etype or '(미분류)'}` 항목)_",
+        "",
+    ]
+    CAP = 80
+    head = names[:CAP]
+    tail = len(names) - len(head)
+    # Bullet list — markdown renders these as the .md-ul on the client.
+    out.extend(f"- {n}" for n in head)
+    if tail > 0:
+        out.append(f"- _(외 {tail}개 더 — 더 좁은 키워드로 다시 질문해 보세요)_")
+    out.append("")
+    out.append(
+        "특정 항목을 자세히 보려면 이름으로 직접 질문하세요. "
+        "예: \"" + head[0] + "에 대해 알려줘\"."
+    )
+    return "\n".join(out)
+
+
+def _render_theme_detail(enriched: List[Dict[str, Any]], theme: str) -> str:
+    matching = [e for e in enriched if _classify_theme(e["name"]) == theme]
+    if not matching:
+        return (
+            f"## 주제 ‘{theme}’ 자료 없음\n\n"
+            "해당 주제 키워드와 매치되는 wiki 항목이 없습니다."
+        )
+    names = sorted([e["name"] for e in matching if e["name"]])
+    out: List[str] = [
+        f"## 주제 ‘{theme}’ — 총 {len(matching)}개",
+        "",
+        "_(이름 패턴 기반 그룹)_",
+        "",
+    ]
+    CAP = 80
+    head = names[:CAP]
+    tail = len(names) - len(head)
+    out.extend(f"- {n}" for n in head)
+    if tail > 0:
+        out.append(f"- _(외 {tail}개 더)_")
+    out.append("")
+    out.append(
+        "특정 항목을 자세히 보려면 이름으로 직접 질문하세요. "
+        "예: \"" + head[0] + "에 대해 알려줘\"."
+    )
+    return "\n".join(out)
+
+
+def _render_recent_detail(enriched: List[Dict[str, Any]], n: int = 30) -> str:
+    recent = sorted(enriched, key=lambda x: x["mtime"], reverse=True)[:n]
+    if not recent:
+        return "## 최근 추가된 자료 없음\n\nwiki 에 아직 등록된 항목이 없습니다."
+    out: List[str] = [
+        f"## 최근 추가된 자료 (top {len(recent)})",
+        "",
+        "_(파일 수정 시각 기준 내림차순)_",
+        "",
+    ]
+    for e in recent:
+        if not e["name"]:
+            continue
+        label = _TYPE_LABELS.get(e["type"], e["type"] or "미분류")
+        out.append(f"- {e['name']} _(타입: {label})_")
+    out.append("")
+    out.append(
+        "특정 항목을 자세히 보려면 이름으로 직접 질문하세요."
+    )
+    return "\n".join(out)
+
+
 # ────────────────────────────────────────────────────────────────────
 # meta — internal-data inventory ("what do you have?")
 # ────────────────────────────────────────────────────────────────────
@@ -159,6 +341,58 @@ def handle_meta(
             for e in enriched:
                 theme = _classify_theme(e["name"]) or "기타"
                 by_theme[theme].append(e["name"])
+
+            # v0.6.1 v17 (2026-06-16) — meta follow-up routing. If
+            # the query carries a type / theme / recent filter, render
+            # the focused detail view instead of the generic overview.
+            # The overview path stays the default for first-shot
+            # queries like "내부 자료가 무엇이 있나".
+            meta_filter = _parse_meta_filter(safe_query)
+            if meta_filter["kind"] == "type":
+                answer = _render_type_detail(enriched, meta_filter["raw"])
+                engine._elapsed(t_meta, "META_inventory")
+                return {
+                    "answer":        answer,
+                    "mode":          "meta",
+                    "graph_paths":   [],
+                    "graph_used":    0,
+                    "sources":       [],
+                    "blocked":       False,
+                    "role_used":     user_role,
+                    "timing_sec":    round(time.time() - t_start, 2),
+                    "unified_score": 1.0,
+                    "loop_count":    0,
+                }
+            if meta_filter["kind"] == "theme":
+                answer = _render_theme_detail(enriched, meta_filter["label"])
+                engine._elapsed(t_meta, "META_inventory")
+                return {
+                    "answer":        answer,
+                    "mode":          "meta",
+                    "graph_paths":   [],
+                    "graph_used":    0,
+                    "sources":       [],
+                    "blocked":       False,
+                    "role_used":     user_role,
+                    "timing_sec":    round(time.time() - t_start, 2),
+                    "unified_score": 1.0,
+                    "loop_count":    0,
+                }
+            if meta_filter["kind"] == "recent":
+                answer = _render_recent_detail(enriched)
+                engine._elapsed(t_meta, "META_inventory")
+                return {
+                    "answer":        answer,
+                    "mode":          "meta",
+                    "graph_paths":   [],
+                    "graph_used":    0,
+                    "sources":       [],
+                    "blocked":       False,
+                    "role_used":     user_role,
+                    "timing_sec":    round(time.time() - t_start, 2),
+                    "unified_score": 1.0,
+                    "loop_count":    0,
+                }
 
             # ── most-recent additions ───────────────────────────
             recent = sorted(


### PR DESCRIPTION
## Summary

운영자 catch: v16 hybrid overview 후 자연스러운 follow-up — \"개념 자료에는 어떤 것들이 있지?\" / \"AI 관련 자료\" / \"최근 추가된 거\" — 가 retrieval 로 흘러가서 hallucinated. **같은 인벤토리를 type / theme / recency 로 pivot** 해서 보여줘야.

### (1) handle_meta — filter-aware routing
- **`core/reasoning/modes/meta.py`**:
    - `_TYPE_FILTER_TOKENS` — Korean + English 토큰 매핑 (인물/조직/concept/person/...)
    - `_THEME_FILTER_TOKENS` — 주제 토큰 매핑 (AI/블록체인/재무/보안/연구/웹/...)
    - `_RECENT_TOKENS` — 최근/새로/최신/recent/latest/new
    - **`_parse_meta_filter(query)`** → `{kind: 'overview' | 'type' | 'theme' | 'recent', ...}`
        - **theme 우선** — \"재무 보고서\" 는 theme=\"재무 · 시장\" (generic type=\"report\" 안 잡힘)
    - **`_render_type_detail`** — 해당 type 의 모든 entity alphabetical full list. Cap 80 + \"외 N개\" + drill-in invite
    - **`_render_theme_detail`** — 같은 shape, `_classify_theme` bucket
    - **`_render_recent_detail`** — mtime top-30 with type label inline
- `handle_meta` 본체에 4-way 분기 (filter kind 별). overview 는 기본 fallback

### (2) intent_classifier — fast-path regex 확장
- **`core/intent_classifier.py`** meta 패턴 추가:
    - `(개념|조직|...) ... (어떤|뭐|있|누구|누가|목록|리스트)`
    - `(개념|조직|...) (목록|리스트)`
    - `(AI|블록체인|...) 관련 (자료|있|어떤)`
    - `(AI|블록체인|...) (자료|항목|목록)`
    - `(최근|새로|최신|recent|latest|new) 추가 ...`
    - `\"내부 자료가 무엇이 있나\"` via new \"무엇/뭐가\" 토큰 (기존 regex 누락)

### Smoke (real 316-entity corpus)
**filter parser**:
```
'개념 자료에는 어떤 것들이 있지?' → {'kind':'type','raw':'concept'}
'조직 리스트'                  → {'kind':'type','raw':'organization'}
'인물 누구누구 있어?'             → {'kind':'type','raw':'person'}
'AI 관련 자료'                → {'kind':'theme','label':'AI · 머신러닝'}
'블록체인 쪽으로 뭐 있어?'         → {'kind':'theme','label':'블록체인 · Web3'}
'최근 추가된 거 뭐 있어'           → {'kind':'recent'}
'재무 보고서 있나?'              → {'kind':'theme','label':'재무 · 시장'}  ← theme-first
'Palantir 관련'              → {'kind':'overview'}
```

**detail render samples**:
- \"개념 자료\" → `## 분류 '개념' — 총 135개` + alphabetical list (cap 80)
- \"인물 누가\" → `## 분류 '인물' — 총 26개` + 26-name list (alex_kantrowitz / alex_karp / ... / 트럼프 / 한용희)
- \"AI 관련\" → `## 주제 'AI · 머신러닝' — 총 4개` (ai_보안 / ai_수요 / ai_칩_시장 / gpt_6_모델_공식_발표)
- \"최근\" → `## 최근 추가된 자료 (top 30)` with `_(타입: ...)_` per row

**intent regex coverage**:
- meta 11/11 ✓ (AI 관련 자료 / 블록체인 관련 자료 / 재무 자료 / 보안 자료 / 인물 누구누구 / 인물 누가 있어? / 조직 리스트 / 개념 자료에는 뭐 있나 / 개념 자료에 어떤 것들이 있지? / 최근 추가 자료 / 내부 자료가 무엇이 있나)
- retrieval 2/2 ✓ (Palantir에 대해 알려줘 / 비트코인이란?) → fast path 안 잡힘 = 정상

## Rule #1 4-layer streak
- 이미 v16 에서 운영자 승인하에 break (option E 결정). 이번 PR 도 같은 영역 (`core/reasoning` + `core/intent_classifier.py`)
- **`core/retrieval` + `core/graph` traversal streak 는 계속 유지** — 두 module 모두 v0.6.1 cycle 0 라인 변경

## Out of scope

- graph-degree top-K (option C) — 후속
- LLM narrative (option D) — fast path 정책 유지
- per-token weighting on filter parse — 단순 first-match-wins 유지

Quality delta: exempt (label: fix) — meta-response UX follow-up, 측정 axis 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)