### PR TITLE
feat(v0.6.1): DiffusionGemma backend spike (opt-in, no quality claim)

### DIFF
--- a/core/reasoning/backends/__init__.py
+++ b/core/reasoning/backends/__init__.py
@@ -332,6 +332,20 @@ def _autoregister() -> None:
         from core.reasoning.backends.claude_code_cli import ClaudeCodeCliBackend
         register_backend("claude_code_cli", ClaudeCodeCliBackend())
 
+    # v0.6.1 v18 (2026-06-16) — DiffusionGemma spike. Off by default
+    # so a stock install never points at a vLLM / llama.cpp-server
+    # endpoint without explicit consent. Honest-framing note: the
+    # backend's value is unmeasured — registering it is an infra
+    # change; promoting it to a default needs the 5-axis Quality
+    # Delta Card per CLAUDE.md rule #2.
+    if os.environ.get("JAMES_ENABLE_DIFFUSIONGEMMA") == "1":
+        from core.reasoning.backends.diffusiongemma_local import (
+            DiffusionGemmaLocalBackend,
+        )
+        register_backend(
+            "diffusiongemma_local", DiffusionGemmaLocalBackend(),
+        )
+
     # Plugin import is last so a plugin can choose to override or
     # extend the built-in registrations. register_backend's
     # idempotent-with-same-instance rule still applies — duplicate

--- a/core/reasoning/backends/diffusiongemma_local.py
+++ b/core/reasoning/backends/diffusiongemma_local.py
@@ -1,0 +1,239 @@
+"""DiffusionGemma backend — OpenAI-compatible HTTP adapter.
+
+Spike — v0.6.1 v18 (2026-06-16).
+
+Target serving stack: **vLLM** (native DiffusionGemma support since
+2026 — `vllm.entrypoints.openai.api_server`) or **llama.cpp-server**
+(Unsloth GGUF). Either exposes `/v1/chat/completions` with the same
+shape as the OpenAI API, so this adapter doesn't care which one is
+running — it just speaks the wire format.
+
+Why an HTTP adapter and not an Ollama tag:
+  - Ollama IS a valid serving path (Unsloth GGUF + ``ollama create``)
+    and would work transparently through the existing ``ollama_local``
+    backend. This adapter exists for the operator who runs vLLM or
+    llama.cpp-server directly, which is the configuration that
+    matches the public DiffusionGemma latency claim (1,100 tok/s,
+    block-parallel denoising). Going through Ollama gives the
+    correctness but not the speed.
+  - It also keeps the diffusion-specific quirks (no Ollama
+    ``done_reason``, model-side block size, denoising schedule)
+    isolated from the byte-identical Ollama path.
+
+Activation (off by default — explicit opt-in):
+
+    JAMES_ENABLE_DIFFUSIONGEMMA=1     # register the backend at boot
+    JAMES_DIFFUSIONGEMMA_URL=http://127.0.0.1:8001
+                                       # vLLM / llama.cpp-server base
+                                       # (without /v1)
+    JAMES_DIFFUSIONGEMMA_MODEL=google/diffusiongemma-26b-a4b-it
+                                       # name the server registered
+
+then routing:
+
+    JAMES_REASONING_BACKEND=diffusiongemma_local
+    # or per-stage:
+    JAMES_BACKEND_SYNTH=diffusiongemma_local
+
+A stock JAMES install with none of those set never reaches this
+adapter — same opt-in pattern as ``claude_code_cli``.
+
+Honest framing — this is a SPIKE. No quality / latency claim is made
+by registering the adapter. The Direction α paired measurement
+harness (``scripts/research/local_vs_cloud_paired.py``) is the
+gatekeeper: run a 5-axis Quality Delta Card against
+``gemma4:e4b`` before promoting this backend to anyone's default.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from core.reasoning.backends import BackendCapability, CompletionResult
+
+
+_DEFAULT_URL = "http://127.0.0.1:8001"
+_DEFAULT_MODEL = "google/diffusiongemma-26b-a4b-it"
+# A pathological prompt should not let the operator turn an LLM call
+# into a denial-of-service. 1 MiB is the same bound the Claude CLI
+# backend applies. Diffusion canvas is fixed-size and short
+# generations are the typical case for JAMES (abstention / citation),
+# so the bound is conservative.
+_MAX_PROMPT_BYTES = 1024 * 1024
+
+
+def _resolve_url() -> str:
+    return (os.environ.get("JAMES_DIFFUSIONGEMMA_URL") or _DEFAULT_URL).rstrip("/")
+
+
+def _resolve_model() -> str:
+    return os.environ.get("JAMES_DIFFUSIONGEMMA_MODEL") or _DEFAULT_MODEL
+
+
+class DiffusionGemmaLocalBackend:
+    """OpenAI-compatible /v1/chat/completions caller.
+
+    Stateless. The shared ``requests.Session`` is constructed lazily
+    on the first call so importing the module never opens a socket;
+    tests inject a fake session via ``self._session = ...``.
+    """
+
+    backend_id = "diffusiongemma_local"
+
+    # D5.B capability declaration. DiffusionGemma is a 26B MoE with
+    # 3.8B active params — sits between "small" (≤4B) and "medium"
+    # (12-27B). Declaring "medium" since the operator-facing
+    # serving cost (VRAM, throughput) matches the medium tier
+    # rather than the small one. ``provider="local"`` because the
+    # adapter hits a localhost URL by default; an operator pointing
+    # ``JAMES_DIFFUSIONGEMMA_URL`` at a remote sovereign endpoint
+    # effectively re-tiers the provider, same as ``ollama_local``.
+    capability = BackendCapability(tier="medium", provider="local")
+
+    def __init__(
+        self,
+        *,
+        url: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        # Constructor-time resolution = snapshot at registry boot.
+        # Tests pass explicit overrides; production reads env.
+        self._url = (url or _resolve_url()).rstrip("/")
+        self._model = model or _resolve_model()
+        self._session: Optional[requests.Session] = None
+
+    # ── Public API ────────────────────────────────────────────────
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_tokens: int = 1024,
+        timeout: float = 60.0,
+        model: Optional[str] = None,
+        use_cache: bool = True,        # accepted, not honored (HTTP layer)
+        temperature: Optional[float] = None,
+        think: Optional[bool] = None,   # accepted, not honored
+        **opts,                         # tolerate future kwargs
+    ) -> CompletionResult:
+        t0 = time.time()
+        url = f"{self._url}/v1/chat/completions"
+        chosen_model = (model or self._model).strip() or _DEFAULT_MODEL
+
+        # Compose chat messages — system+user pair, mirroring the
+        # OpenAI shape. JAMES's existing modes.py / pipeline.py pass
+        # system_prompt to .complete; we surface it as a real role
+        # rather than joining into the user content so the diffusion
+        # canvas can route it to the system slot in its template.
+        messages: List[Dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system[:_MAX_PROMPT_BYTES]})
+        messages.append({"role": "user", "content": (prompt or "")[:_MAX_PROMPT_BYTES]})
+
+        body: Dict[str, Any] = {
+            "model": chosen_model,
+            "messages": messages,
+            "max_tokens": int(max(1, max_tokens)),
+            "stream": False,
+        }
+        if temperature is not None:
+            body["temperature"] = float(temperature)
+
+        try:
+            session = self._get_session()
+        except Exception as e:
+            # session construction is trivial — but guard for the
+            # paranoid case where requests itself is broken.
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"session init failed: {type(e).__name__}: {str(e)[:120]}",
+            )
+
+        # ── HTTP round trip ──
+        try:
+            resp = session.post(
+                url,
+                data=json.dumps(body),
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                timeout=timeout,
+            )
+        except requests.Timeout:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=int((time.time() - t0) * 1000),
+                error="timeout",
+            )
+        except requests.RequestException as e:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=int((time.time() - t0) * 1000),
+                error=f"{type(e).__name__}: {str(e)[:120]}",
+            )
+
+        latency_ms = int((time.time() - t0) * 1000)
+
+        if resp.status_code != 200:
+            # Body might be JSON {"error": {...}} or a vLLM stack
+            # trace. Trim either way so a 5 MB error page doesn't
+            # land in the trace store.
+            body_snippet = (resp.text or "")[:200].strip()
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=latency_ms,
+                error=f"HTTP {resp.status_code}: {body_snippet}",
+            )
+
+        try:
+            data = resp.json()
+        except ValueError as e:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=latency_ms,
+                error=f"non-JSON response: {type(e).__name__}",
+            )
+
+        choices = data.get("choices") if isinstance(data, dict) else None
+        if not isinstance(choices, list) or not choices:
+            return CompletionResult(
+                text="", backend_id=self.backend_id, model=chosen_model,
+                latency_ms=latency_ms,
+                error="response has no choices[]",
+            )
+
+        first = choices[0] if isinstance(choices[0], dict) else {}
+        msg = first.get("message") if isinstance(first.get("message"), dict) else {}
+        text = (msg.get("content") or "") if isinstance(msg, dict) else ""
+        # OpenAI-compatible servers (vLLM / llama.cpp-server) populate
+        # ``finish_reason`` with the same vocabulary ("stop", "length",
+        # …) Ollama's ``done_reason`` uses, so we forward it verbatim.
+        finish_reason = first.get("finish_reason") or ""
+        done_reason = "length" if finish_reason == "length" else ""
+
+        return CompletionResult(
+            text=text or "",
+            backend_id=self.backend_id,
+            model=chosen_model,
+            latency_ms=latency_ms,
+            error="",
+            done_reason=done_reason,
+        )
+
+    # ── Internal helpers ───────────────────────────────────────────
+
+    def _get_session(self) -> requests.Session:
+        # Lazy so importing the module is free of side effects.
+        if self._session is None:
+            self._session = requests.Session()
+        return self._session
+
+
+__all__ = ["DiffusionGemmaLocalBackend"]

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -145,12 +145,44 @@ def _answer_prompt(context: str, question: str) -> str:
 # ─── model calls ──────────────────────────────────────────────────────
 
 
-def call_local(prompt: str, *, model: str, timeout: int = 180) -> str:
-    """Direct Ollama call — not through the JAMES backend registry,
-    because the matrix runner / pipeline isn't booted for measurement.
-    This is the same shape v2 used. num_ctx is explicit (v1 used the
-    Ollama default 2048 and silently truncated 6-7.5k-char articles —
-    see v2 docstring §1)."""
+def call_local(prompt: str, *, model: str, timeout: int = 180,
+               local_backend: str = "ollama") -> str:
+    """Direct local call. The matrix runner / pipeline isn't booted
+    for measurement, so we hit the serving layer directly.
+
+    Two backends supported (CLI flag ``--local-backend``):
+
+      * ``ollama`` (default) — http://127.0.0.1:11434/api/generate.
+        Same byte-identical shape v2 used; num_ctx explicit so the
+        v1 silent truncation bug stays fixed.
+      * ``diffusiongemma_local`` — v0.6.1 v18 (2026-06-16) spike.
+        Goes through the registered backend
+        (``core.reasoning.backends.diffusiongemma_local``) which speaks
+        OpenAI-compatible /v1/chat/completions against vLLM or
+        llama.cpp-server. Lets the operator paired-compare gemma4:e4b
+        vs DiffusionGemma on the same fixture without rewriting the
+        harness. ``model`` becomes the model tag the serving stack
+        announced (e.g. ``google/diffusiongemma-26b-a4b-it``).
+    """
+    if local_backend == "diffusiongemma_local":
+        from core.reasoning.backends.diffusiongemma_local import (
+            DiffusionGemmaLocalBackend,
+        )
+        # URL from env (JAMES_DIFFUSIONGEMMA_URL) is read by the
+        # backend's constructor. Tests stay hermetic; measurement runs
+        # honor whatever the operator pointed the env at.
+        backend = DiffusionGemmaLocalBackend(model=model or None)
+        result = backend.complete(
+            prompt,
+            max_tokens=400,
+            timeout=float(timeout),
+            temperature=0.0,
+        )
+        if result.error and not result.text:
+            raise RuntimeError(f"diffusiongemma backend error: {result.error}")
+        return (result.text or "").strip()
+
+    # default: ollama
     req = urllib.request.Request(
         OLLAMA_URL,
         data=json.dumps({
@@ -282,13 +314,17 @@ def select_queries(n_per_type: int) -> List[dict]:
 def run_one_query(
     query: dict, ctx: str, *,
     local_model: str, run_idx: int, timeout: int,
+    local_backend: str = "ollama",
 ) -> Dict[str, Any]:
     """One paired (local + cloud + judge) trial. Returns a row dict."""
     prompt = _answer_prompt(ctx, query["text"])
     t0 = time.time()
 
     try:
-        la = call_local(prompt, model=local_model, timeout=timeout)
+        la = call_local(
+            prompt, model=local_model, timeout=timeout,
+            local_backend=local_backend,
+        )
         la_err = ""
     except Exception as e:  # noqa: BLE001
         la, la_err = "", f"{type(e).__name__}: {e}"
@@ -446,7 +482,22 @@ def main() -> int:
     ap.add_argument("--n-runs", type=int, default=3,
                     help="paired runs per question (default 3)")
     ap.add_argument("--local-model", default=DEFAULT_LOCAL_MODEL,
-                    help=f"Ollama model tag (default {DEFAULT_LOCAL_MODEL})")
+                    help=f"Ollama / DiffusionGemma model tag (default {DEFAULT_LOCAL_MODEL})")
+    ap.add_argument(
+        "--local-backend",
+        default="ollama",
+        choices=["ollama", "diffusiongemma_local"],
+        help=(
+            "v0.6.1 v18 (2026-06-16) spike — pick which local backend "
+            "drives the LOCAL side of the paired comparison. "
+            "`ollama` (default) hits http://127.0.0.1:11434/api/generate. "
+            "`diffusiongemma_local` hits the JAMES backend adapter "
+            "(/v1/chat/completions on the URL given by "
+            "JAMES_DIFFUSIONGEMMA_URL, default http://127.0.0.1:8001). "
+            "Pair against the existing CLOUD (Claude) path to produce "
+            "the 5-axis Quality Delta Card before promoting the spike."
+        ),
+    )
     ap.add_argument("--timeout", type=int, default=180,
                     help="per-call timeout in seconds")
     ap.add_argument("--output", default="",
@@ -479,6 +530,7 @@ def main() -> int:
             row = run_one_query(
                 q, ctx, local_model=args.local_model,
                 run_idx=run_idx, timeout=args.timeout,
+                local_backend=args.local_backend,
             )
             rows.append(row)
             print(f"local={row['local_verdict'][:4]} "
@@ -519,6 +571,7 @@ def main() -> int:
     out_path.write_text(json.dumps({
         "design": "reasoning-isolated; both models same full gold evidence",
         "local_model": args.local_model,
+        "local_backend": args.local_backend,
         "num_ctx": NUM_CTX,
         "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
         "judge": "claude-cli, blinded A/B per (query, run)",

--- a/tests/test_backend_conformance.py
+++ b/tests/test_backend_conformance.py
@@ -85,6 +85,31 @@ def _instantiate_backend(name: str):
         # Constructor takes an optional cli_path — pass a fake one and
         # patch subprocess.Popen at call sites in the tests below.
         return ClaudeCodeCliBackend(cli_path="/fake/claude")
+    if name == "diffusiongemma_local":
+        # v0.6.1 v18 (2026-06-16) spike. Inject a fake requests.Session
+        # so the suite never reaches a vLLM / llama.cpp-server. The
+        # session returns a Response-like object whose .json() yields
+        # an OpenAI-shaped successful completion.
+        from core.reasoning.backends.diffusiongemma_local import (
+            DiffusionGemmaLocalBackend,
+        )
+        b = DiffusionGemmaLocalBackend(
+            url="http://fake.invalid",
+            model="diffusiongemma-26b-a4b-it-test",
+        )
+        fake_resp = MagicMock()
+        fake_resp.status_code = 200
+        fake_resp.json.return_value = {
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+        }
+        fake_resp.text = '{"choices":[{"message":{"content":"ok"}}]}'
+        fake_session = MagicMock()
+        fake_session.post.return_value = fake_resp
+        b._session = fake_session
+        return b
     raise ValueError(f"no mock harness for backend {name!r}")
 
 
@@ -101,6 +126,8 @@ def _enumerate_reference_backends() -> Iterable[Tuple[str, str]]:
     yield ("ollama_local", "ollama_local")
     if os.environ.get("JAMES_ENABLE_CLAUDE_BACKEND") == "1":
         yield ("claude_code_cli", "claude_code_cli")
+    if os.environ.get("JAMES_ENABLE_DIFFUSIONGEMMA") == "1":
+        yield ("diffusiongemma_local", "diffusiongemma_local")
 
 
 # ─── Conformance assertions ───────────────────────────────────────
@@ -150,6 +177,22 @@ class ReferenceBackendConformanceTests(unittest.TestCase):
             self.assertIsInstance(res2, CompletionResult)
             self.assertNotEqual(res2.error, "")
             self.assertEqual(res2.text, "")
+
+        # diffusiongemma_local — make requests.Session.post raise
+        # (timeout, network down, …).
+        if os.environ.get("JAMES_ENABLE_DIFFUSIONGEMMA") == "1":
+            from core.reasoning.backends.diffusiongemma_local import (
+                DiffusionGemmaLocalBackend,
+            )
+            import requests as _req
+            db = DiffusionGemmaLocalBackend(url="http://fake.invalid")
+            fake_session = MagicMock()
+            fake_session.post.side_effect = _req.Timeout("boom")
+            db._session = fake_session
+            res3 = db.complete("hi", timeout=1.0)
+            self.assertIsInstance(res3, CompletionResult)
+            self.assertNotEqual(res3.error, "")
+            self.assertEqual(res3.text, "")
 
     def test_r2_backend_id_matches_registry_name(self):
         """R2 — backend_id is the registry name. Live registry is


### PR DESCRIPTION
## Summary

운영자 결정 (옵션 A): DiffusionGemma spike 직접 구현. **honest framing 전제**: backend 등록 = infra 변경. promotion 은 별도 PR + 5-axis Quality Delta Card 필수 (CLAUDE.md rule #2).

## 변경

### Adapter — `core/reasoning/backends/diffusiongemma_local.py`
- OpenAI-compat `/v1/chat/completions` (vLLM / llama.cpp-server / Unsloth GGUF 등)
- lazy `requests.Session` — import 시점 socket 없음
- R1: 모든 에러 (timeout / HTTP != 200 / non-JSON / no choices) → `CompletionResult(error=...)`, 절대 raise 안 함
- `finish_reason=\"length\"` → `done_reason=\"length\"` forward → `complete_with_retry` 호환
- capability: `tier=\"medium\"` (26B MoE / 3.8B active, 서빙 비용은 medium 매칭), `provider=\"local\"`
- 1 MiB prompt bound (DoS guard)

### Registry — `core/reasoning/backends/__init__.py`
- `_autoregister` 에 세 번째 opt-in 분기 추가:
    ```python
    if os.environ.get(\"JAMES_ENABLE_DIFFUSIONGEMMA\") == \"1\":
        register diffusiongemma_local
    ```
- `claude_code_cli` 정확히 미러링

### Conformance — `tests/test_backend_conformance.py`
- mock harness: fake `requests.Session` 이 OpenAI-shaped 200 success 반환 → 라이브 vLLM 없음
- `_enumerate_reference_backends` opt-in 분기
- R1 broken-upstream subtest: `requests.Timeout` side_effect → error set / text empty / no raise

**결과**:
| | result |
|---|---|
| `JAMES_ENABLE_DIFFUSIONGEMMA=1` | **11/11 pass** |
| default (off) | **11/11 pass** |

### 측정 하네스 — `scripts/research/local_vs_cloud_paired.py`
- 신규 CLI `--local-backend {ollama, diffusiongemma_local}`
- default `ollama` 유지 → 기존 run 재현 가능
- diffusiongemma 선택 시 `call_local` 이 registered backend 통해 호출 → 동일 fixture 동일 Claude cloud comparator 와 5-axis Delta Card 직접 측정 가능

## 운영자 activation runbook (stock JAMES 에서 off)

```bash
# 1) Serve the model (one of):
python -m vllm.entrypoints.openai.api_server \
    --model google/diffusiongemma-26b-a4b-it
# OR
./llama-server -m diffusiongemma.Q4_K_M.gguf --host 127.0.0.1 --port 8001

# 2) Register
export JAMES_ENABLE_DIFFUSIONGEMMA=1
export JAMES_DIFFUSIONGEMMA_URL=http://127.0.0.1:8001
export JAMES_DIFFUSIONGEMMA_MODEL=google/diffusiongemma-26b-a4b-it

# 3) Route (one of)
export JAMES_REASONING_BACKEND=diffusiongemma_local      # global
export JAMES_BACKEND_SYNTH=diffusiongemma_local          # per-stage

# 4) Paired 측정 — 5-axis Quality Delta Card
python scripts/research/local_vs_cloud_paired.py \
    --local-backend diffusiongemma_local \
    --local-model google/diffusiongemma-26b-a4b-it \
    --n-per-type 3 --n-runs 3
```

## Honest framing — 이 PR 이 **주장하지 않는** 것

- **속도 주장 X**: \"1,100 tok/s / ~4× Gemma\" 는 Google/벤더의 The New Stack 보도. JAMES 가 운영자 하드웨어에서 재측정 후 인용해야.
- **품질 주장 X**: block-parallel denoising 이 fixed canvas 위에서 abstention/grounding 거동을 어떻게 움직이는지 측정 전엔 모름. cycle β RGB finding 의 precedent ([[project_cycle_gamma_phase_b_rgb_baseline]]) 가 직접 관련.
- **Direction α 자동 재오픈 X**: \"local reasoning ceiling\" 가설 ([[project_direction_alpha_local_vs_cloud_quality_thread]]) 은 측정 결과 본 후에만 addendum.

## Rule #1 4-layer protection streak

- `core/reasoning/backends/` = infra (claude_code_cli.py 선례)
- **`core/retrieval` + `core/graph` traversal — 여전히 0 라인 변경, streak 계속**
- `core/reasoning/modes/` — 이번 PR 0 라인 변경 (v16 break 가 여기로 확장 안 됨)
- vertical / LOI gate — 0

## 측정 의무 (default promotion 전 필수)

- 5-axis Quality Delta Card (Path Recall / Graded / Abstention F1 / Token / Latency)
- 양쪽 측정: reasoning-isolated (gold evidence) + full-pipeline (real retrieval) — Direction α v2 vs Stage 4 evidence-leak 교훈 ([[feedback_evidence_grounded_validity_check]])
- n=3 paired minimum ([[feedback_n1_verdict_inflation_n3_caught]])
- 비교 대상: `gemma4:e4b` (현 production small) + `gemma3:12b` (현 medium ceiling) — 한 rung 만 아닌 양쪽

## Memory

`memory/project_diffusiongemma_spike_v18.md` — activation runbook + 측정 의무 + honest-framing 면책 기록. 향후 세션이 \"어댑터 등록 = 가치 입증\" 으로 착각하지 않게.

Quality delta: exempt (label: code) — backend 어댑터 (infra), default 동작 변경 없음, opt-in only. promotion 은 별도 measurement-gated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)