### PR TITLE
fix(v0.6.1): meta regex 'new' substring false-positive (measurement validity)

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -143,7 +143,18 @@ class IntentClassifier:
             # 인텐트 인식 (v17 fix).
             r"(AI|에이아이|머신러닝|블록체인|크립토|crypto|web3|보안|security|연구|논문|연도별|연도|재무|시장|웹\s*자료)\s*(관련|쪽|쪽으로|에|는|을|의)\s*(자료|항목|것|들|목록|리스트|어떤|뭐|무슨|있|보여|알려)",
             r"(AI|에이아이|머신러닝|블록체인|크립토|crypto|web3|보안|security|연구|논문|연도별|연도|재무|시장|웹\s*자료)\s*(자료|항목|것|들|목록|리스트)\s*(어떤|뭐|무슨|있|보여|알려|\?)?",
-            r"(최근|새로|새로운|새로\s*추가|최신|recent|latest|new)\s*(추가|들어온|올라온)?\s*\S{0,6}\s*(자료|항목|것|것들|문서|entity)?",
+            # v0.6.1 v18.1 (2026-06-16) — measurement-validity fix.
+            # The v17 form had `recent|latest|new` with the trailing
+            # noun group OPTIONAL, so bare English `new` / `News` /
+            # `New York` substrings in retrieval queries (MultiHop-RAG
+            # fixture) false-positive matched, polluting paired
+            # measurements that pre-screen intent. Two-pattern split:
+            # Korean tokens stay loose (no English false positives
+            # because Korean characters never appear inside English
+            # words), English tokens REQUIRE an explicit inventory
+            # noun follow-up.
+            r"(최근|새로|새로운|새로\s*추가|최신|방금|어제|오늘)\s*(추가|들어온|올라온|업로드)?\s*\S{0,6}\s*(자료|항목|것|것들|문서|entity)?",
+            r"\b(recent|latest|new)\s+(additions|entries|files|documents|entities|items|uploads|content)\b",
             # v0.6.1 v18 (2026-06-16) — narrative trigger: "요약/정리/
             # 전체적으로/총평". Routes to handle_meta which then
             # detects the narrative keyword and runs the LLM


### PR DESCRIPTION
## Summary

운영자 catch (path A baseline 측정 전 정합성 검증): v17 의 \"recent additions\" meta regex 가 영어 fixture 의 `News` / `New York` / `new` substring 을 false-positive 매치 → MultiHop-RAG fixture **4/9 false positives**.

### Reproduction
paired harness fixture sample (n=3 per answerable type from `eval/multihop_rag_queries.json`):
```
[FP] inference_query  | Which individual is implicated in both inflating the value of a Manhattan apartment …
[FP] comparison_query | Do the TechCrunch article on software companies and the Hacker News article …  ← matched 'News '
[FP] comparison_query | Does 'The New York Times' article attribute the success of the Buffalo Bills' …  ← matched 'New York '
[FP] temporal_query   | Has the advice provided by Sporting News to bettors regarding the evaluation …  ← matched 'News '
```

### Root cause
v17 패턴:
```
r\"(...|recent|latest|new)\s*(추가|들어온|올라온)?\s*\S{0,6}\s*(자료|항목|것|것들|문서|entity)?\"
```
- 두 noun 그룹 모두 optional → 영어 `new` / `News` / `New` 토큰만으로 매치
- 한국어 토큰 (최근/새로/...) 은 영어 단어 안에 안 들어가니 한국어는 무해
- 영어-only 결함

### Fix
Korean-only + English-with-required-noun split:
- **Korean** (loose, 기존 매치 보존):
  ```
  r\"(최근|새로|새로운|새로\s*추가|최신|방금|어제|오늘)\s*(추가|들어온|올라온|업로드)?\s*\S{0,6}\s*(자료|항목|것|것들|문서|entity)?\"
  ```
- **English** (명시적 inventory noun 강제):
  ```
  r\"\b(recent|latest|new)\s+(additions|entries|files|documents|entities|items|uploads|content)\b\"
  ```

### Verification
| Check | Result |
|---|---|
| MultiHop-RAG paired sample (9) | **0/9** FP (was 4/9) |
| Wider sweep (75 answerable) | **0/75** FP |
| Korean meta (10) | 10/10 still match |
| English meta (3) | 3/3 still match (`list all entities` / `show me your wiki` / `recent additions`) |
| Retrieval negatives (5) | 5/5 correctly NOT matched |

### Why critical pre-measurement

upcoming **path A baseline** (`gemma4:e4b` vs `gemma3:27b` vs Claude paired) 가 MultiHop-RAG fixture 통해 LOCAL/CLOUD 답변 path 사용.
- paired harness 자체는 intent_classifier 우회 (`call_local` / `call_cloud_via_abstraction` 직접 호출) → **이 bug 자체는 paired 측정 수학적으로는 무관**
- **그러나** live chat path 에서는 동일 운영자의 \"News\" / \"New York\" 포함 쿼리가 meta 로 routing 되어 inventory dump 반환 → operator-visible regression
- 측정 전 catch = honest move ([[feedback_evidence_grounded_validity_check]])

## Out of scope

- Rule #1 4-layer 보호 contract 유지: vertical 0, `core/retrieval` + `core/graph` traversal 0 라인.
- v16/v17/v18 streak break (`core/reasoning` + `core/intent_classifier`) 이미 진행 중, 이번 PR 도 같은 영역.

Quality delta: exempt (label: fix) — measurement-validity guard, 측정 axis 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)