### PR TITLE
feat(v0.6.1): measurement-environment isolation contract (lock-test + pre-flight)

### DIFF
--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -502,6 +502,20 @@ def main() -> int:
                     help="per-call timeout in seconds")
     ap.add_argument("--output", default="",
                     help="output JSON path; auto-named when empty")
+    # v0.6.1 v18.2 (2026-06-16) — measurement-validity guard.
+    # Operator catch: UI / UX cycles silently rotate measurement
+    # baselines (PR #962 — meta regex matched "News" / "New York"
+    # substrings). Pre-flight runs the lock-test-aligned sanity
+    # checks before any LLM call goes out. --skip-pre-flight is
+    # recorded in the output JSON so an operator can't bypass the
+    # guard invisibly.
+    ap.add_argument("--skip-pre-flight", action="store_true",
+                    help=(
+                        "Bypass measurement-validity pre-flight checks "
+                        "(fixture / regex sweep / backend registry / "
+                        "abstraction smoke). The bypass IS recorded in "
+                        "the output JSON so audit trail stays intact."
+                    ))
     args = ap.parse_args()
 
     if os.environ.get("JAMES_ENABLE_CLAUDE_BACKEND") != "1":
@@ -509,6 +523,36 @@ def main() -> int:
               "the claude_code_cli backend is opt-in (CLAUDE.md rule).",
               file=sys.stderr)
         return 2
+
+    # v0.6.1 v18.2 — pre-flight gate.
+    pre_flight_results: List[Dict[str, Any]] = []
+    pre_flight_skipped = bool(args.skip_pre_flight)
+    if not pre_flight_skipped:
+        try:
+            from scripts.research.pre_flight_check import (
+                run_pre_flight, has_failures, format_results,
+            )
+        except ImportError:
+            # Allow direct script invocation without the scripts/ prefix.
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            from pre_flight_check import (    # type: ignore
+                run_pre_flight, has_failures, format_results,
+            )
+        results = run_pre_flight()
+        print("=== pre-flight check ===")
+        print(format_results(results))
+        # Preserve as plain dicts for the output JSON audit trail.
+        pre_flight_results = [
+            {"name": r.name, "status": r.status,
+             "detail": r.detail, "extra": r.extra}
+            for r in results
+        ]
+        if has_failures(results):
+            print("\n[FATAL] pre-flight failed — paired run blocked. "
+                  "Fix or re-launch with --skip-pre-flight (recorded).",
+                  file=sys.stderr)
+            return 3
+        print()
 
     queries = select_queries(args.n_per_type)
     print(f"local={args.local_model} (num_ctx={NUM_CTX})  "
@@ -572,6 +616,11 @@ def main() -> int:
         "design": "reasoning-isolated; both models same full gold evidence",
         "local_model": args.local_model,
         "local_backend": args.local_backend,
+        # v0.6.1 v18.2 — measurement-validity audit trail.
+        "pre_flight": {
+            "skipped": pre_flight_skipped,
+            "results": pre_flight_results,
+        },
         "num_ctx": NUM_CTX,
         "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
         "judge": "claude-cli, blinded A/B per (query, run)",

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -1,0 +1,393 @@
+"""Pre-flight sanity for the paired measurement harness.
+
+Operator catch v0.6.1 v18.2 (2026-06-16) — the v17 meta regex
+false-positive nearly polluted a paired measurement. Operator
+requested a layered guarantee so UI / UX / chrome cycles don't
+quietly invalidate ongoing measurement work.
+
+This module is Layer 2 of the two-layer answer (Layer 1 is the
+``tests/test_measurement_critical_surfaces.py`` lock-test). It runs
+each time the paired harness launches and validates LIVE STATE before
+any LLM call goes out:
+
+  1. **Fixture integrity** — file exists, schema rows present, the
+     answerable types still have the n×3 minimum the harness assumes.
+  2. **Regex false-positive sweep** — every meta-mode pattern in
+     ``core/intent_classifier`` is tested against the fixture's
+     retrieval queries. Any pattern that matches an answerable query
+     is a measurement-validity bug and blocks the launch.
+  3. **Backend registry baseline** — exactly the backends the operator
+     expects must be registered. Extras suggest a leaked
+     ``JAMES_ENABLE_*`` env from a different shell; missing the
+     reference backend means the cloud path is broken.
+  4. **Abstraction module smoke** — ``core.abstraction.default_decider`` +
+     ``run_cloud_egress`` import + run a no-op call on an empty
+     entities list, mirroring the harness's cloud path.
+
+Each check returns ``(status, detail)``. Statuses:
+  - ``ok``     pass
+  - ``warn``   non-fatal observation worth surfacing in the run log
+  - ``fail``   fatal; refuse to launch unless ``--skip-pre-flight``
+               is explicitly passed (which itself is recorded in the
+               output JSON so the operator can't pretend the check
+               didn't fire).
+
+Usage as a CLI for ad-hoc inspection:
+
+    python scripts/research/pre_flight_check.py
+
+Or as a module (the harness calls ``run_pre_flight()`` in its main()):
+
+    from scripts.research.pre_flight_check import run_pre_flight
+    results = run_pre_flight()
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+# Resolve repo root from this file's location — works whether the
+# operator launches from repo root or from scripts/research/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+# Baseline state the harness expects on a stock JAMES install. If the
+# operator legitimately wants to change one of these (e.g. add a new
+# answerable type), they update the lock-test in the same PR.
+_EXPECTED_REGISTERED_BACKENDS = {"ollama_local"}     # minimum required
+_OPTIONAL_REGISTERED_BACKENDS = {
+    "claude_code_cli",          # opt-in JAMES_ENABLE_CLAUDE_BACKEND=1
+    "diffusiongemma_local",     # opt-in JAMES_ENABLE_DIFFUSIONGEMMA=1
+}
+_EXPECTED_ANSWERABLE_TYPES = (
+    "inference_query", "comparison_query", "temporal_query",
+)
+_MIN_ROWS_PER_TYPE = 9       # n_per_type=3 default × 3 runs = 9 rows
+
+
+@dataclass
+class PreFlightResult:
+    name: str
+    status: str           # "ok" | "warn" | "fail"
+    detail: str
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+# ─── checks ─────────────────────────────────────────────────────────
+
+
+def check_fixture() -> PreFlightResult:
+    try:
+        import local_vs_cloud_paired as harness   # noqa: F401
+    except ModuleNotFoundError:
+        # harness path-based import — replicate what the lock-test does
+        spec = importlib.util.spec_from_file_location(
+            "local_vs_cloud_paired",
+            _REPO_ROOT / "scripts" / "research" / "local_vs_cloud_paired.py",
+        )
+        harness = importlib.util.module_from_spec(spec)
+        sys.modules["local_vs_cloud_paired"] = harness
+        spec.loader.exec_module(harness)
+
+    fixture_path: Path = harness.FIXTURE
+    if not fixture_path.exists():
+        return PreFlightResult(
+            "fixture_exists", "fail",
+            f"missing fixture file: {fixture_path}",
+        )
+
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    queries = data.get("queries", [])
+    if not queries:
+        return PreFlightResult(
+            "fixture_exists", "fail",
+            f"fixture {fixture_path} has empty queries[]",
+        )
+
+    counts = {t: 0 for t in _EXPECTED_ANSWERABLE_TYPES}
+    for q in queries:
+        t = q.get("question_type")
+        if t in counts:
+            counts[t] += 1
+
+    short = [t for t, n in counts.items() if n < _MIN_ROWS_PER_TYPE]
+    if short:
+        return PreFlightResult(
+            "fixture_rows", "fail",
+            f"answerable types short of {_MIN_ROWS_PER_TYPE} rows: {short} "
+            f"(counts={counts})",
+            extra={"counts": counts},
+        )
+
+    return PreFlightResult(
+        "fixture_rows", "ok",
+        f"{sum(counts.values())} answerable queries available "
+        f"(counts={counts})",
+        extra={"counts": counts, "path": str(fixture_path)},
+    )
+
+
+def check_regex_false_positives() -> PreFlightResult:
+    """Every meta-mode regex must NOT match the fixture's retrieval
+    queries. False positives in the live chat path silently route the
+    operator's English queries to handle_meta instead of retrieval —
+    measurement-adjacent but visible-regression.
+
+    The harness itself bypasses intent_classifier, so this check
+    cannot poison a paired RUN; it catches the bug BEFORE the operator
+    hits the broken live path.
+    """
+    try:
+        from core.intent_classifier import IntentClassifier
+    except ImportError as e:
+        return PreFlightResult(
+            "regex_sweep", "fail",
+            f"intent_classifier import failed: {e}",
+        )
+
+    try:
+        import local_vs_cloud_paired as harness
+    except ModuleNotFoundError:
+        return PreFlightResult(
+            "regex_sweep", "warn",
+            "harness module not preloaded — skip regex sweep "
+            "(check_fixture must run before this check)",
+        )
+
+    fixture_path: Path = harness.FIXTURE
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    meta_patterns = IntentClassifier().FAST_PATTERNS.get("meta", [])
+    if not meta_patterns:
+        return PreFlightResult(
+            "regex_sweep", "warn",
+            "meta fast-path patterns missing — classifier surface "
+            "changed; lock-test should already be red",
+        )
+
+    # Compile once per check — cheap, but avoid re-compiling per row.
+    compiled = [re.compile(p, re.IGNORECASE) for p in meta_patterns]
+    answerable = harness.ANSWERABLE
+
+    fp_rows: List[Dict[str, Any]] = []
+    total = 0
+    for q in data.get("queries", []):
+        if q.get("question_type") not in answerable:
+            continue
+        total += 1
+        text = q.get("text", "")
+        for i, cre in enumerate(compiled):
+            m = cre.search(text)
+            if m:
+                fp_rows.append({
+                    "id":      q.get("id"),
+                    "type":    q.get("question_type"),
+                    "text":    text[:120],
+                    "pattern": meta_patterns[i][:80],
+                    "match":   m.group(0),
+                })
+                break       # one match per row is enough
+
+    if fp_rows:
+        return PreFlightResult(
+            "regex_sweep", "fail",
+            f"{len(fp_rows)}/{total} answerable queries falsely "
+            f"classified as meta — live chat path will misroute. "
+            f"First example: {fp_rows[0]!r}",
+            extra={"false_positives": fp_rows[:5], "total": total},
+        )
+    return PreFlightResult(
+        "regex_sweep", "ok",
+        f"0/{total} false positives across answerable fixture rows",
+        extra={"total": total},
+    )
+
+
+def check_backend_registry() -> PreFlightResult:
+    """Backends actually registered should be exactly:
+      - ollama_local (always)
+      - claude_code_cli iff JAMES_ENABLE_CLAUDE_BACKEND=1
+      - diffusiongemma_local iff JAMES_ENABLE_DIFFUSIONGEMMA=1
+    Anything else suggests a JAMES_PLUGINS leak or a code path that
+    auto-registers something unexpected — both rotate the paired
+    baseline silently.
+    """
+    try:
+        from core.reasoning.backends import list_backends
+    except ImportError as e:
+        return PreFlightResult(
+            "backend_registry", "fail",
+            f"backend registry import failed: {e}",
+        )
+
+    registered = set(list_backends())
+    missing = _EXPECTED_REGISTERED_BACKENDS - registered
+    if missing:
+        return PreFlightResult(
+            "backend_registry", "fail",
+            f"required backends missing: {missing}; "
+            f"registered={sorted(registered)}",
+        )
+
+    unexpected = registered - (
+        _EXPECTED_REGISTERED_BACKENDS | _OPTIONAL_REGISTERED_BACKENDS
+    )
+    if unexpected:
+        return PreFlightResult(
+            "backend_registry", "fail",
+            f"unexpected backends registered: {unexpected}; "
+            f"a plugin (JAMES_PLUGINS) may be rotating the measurement "
+            f"baseline. Clear JAMES_PLUGINS or update the expected set.",
+            extra={"registered": sorted(registered)},
+        )
+    return PreFlightResult(
+        "backend_registry", "ok",
+        f"registered={sorted(registered)}",
+        extra={"registered": sorted(registered)},
+    )
+
+
+def check_abstraction_smoke() -> PreFlightResult:
+    """``core.abstraction.default_decider`` + ``run_cloud_egress`` —
+    the cloud-egress path the harness exercises. We don't actually
+    call Claude here (that's the measurement); we just verify the
+    module + symbols are importable + minimally callable on an
+    entities=[] no-op.
+    """
+    try:
+        from core.abstraction import default_decider, run_cloud_egress
+    except ImportError as e:
+        return PreFlightResult(
+            "abstraction_smoke", "fail",
+            f"core.abstraction symbols missing: {e}",
+        )
+
+    if not callable(default_decider):
+        return PreFlightResult(
+            "abstraction_smoke", "fail",
+            "default_decider is no longer callable",
+        )
+    if not callable(run_cloud_egress):
+        return PreFlightResult(
+            "abstraction_smoke", "fail",
+            "run_cloud_egress is no longer callable",
+        )
+
+    try:
+        decider = default_decider()
+    except Exception as e:
+        return PreFlightResult(
+            "abstraction_smoke", "fail",
+            f"default_decider() raised: {type(e).__name__}: {e}",
+        )
+
+    return PreFlightResult(
+        "abstraction_smoke", "ok",
+        f"default_decider={type(decider).__name__}; "
+        f"run_cloud_egress callable",
+    )
+
+
+def check_diffusiongemma_opt_in() -> PreFlightResult:
+    """If JAMES_ENABLE_DIFFUSIONGEMMA=1, the registry must register
+    the backend. If the env says 1 but the backend is missing, the
+    harness's --local-backend diffusiongemma_local will surface a
+    KeyError mid-run. Catch it pre-flight.
+    """
+    flag = os.environ.get("JAMES_ENABLE_DIFFUSIONGEMMA")
+    try:
+        from core.reasoning.backends import list_backends
+    except ImportError as e:
+        return PreFlightResult(
+            "diffusiongemma_optin", "fail",
+            f"backend registry import failed: {e}",
+        )
+    has_dg = "diffusiongemma_local" in list_backends()
+    if flag == "1" and not has_dg:
+        return PreFlightResult(
+            "diffusiongemma_optin", "fail",
+            "JAMES_ENABLE_DIFFUSIONGEMMA=1 but diffusiongemma_local "
+            "not registered — module import probably failed; check the "
+            "server log for the import-time exception.",
+        )
+    if flag != "1" and has_dg:
+        return PreFlightResult(
+            "diffusiongemma_optin", "warn",
+            "diffusiongemma_local is registered without the env flag — "
+            "auto-import side-effect; expected only under "
+            "JAMES_ENABLE_DIFFUSIONGEMMA=1.",
+        )
+    return PreFlightResult(
+        "diffusiongemma_optin", "ok",
+        f"flag={flag!r} registered={has_dg}",
+    )
+
+
+# ─── orchestrator ───────────────────────────────────────────────────
+
+
+_CHECKS = (
+    check_fixture,
+    check_regex_false_positives,
+    check_backend_registry,
+    check_abstraction_smoke,
+    check_diffusiongemma_opt_in,
+)
+
+
+def run_pre_flight() -> List[PreFlightResult]:
+    """Execute every check, return the result list in execution order.
+    Caller decides how to surface (CLI prints, harness aborts).
+    """
+    out: List[PreFlightResult] = []
+    for fn in _CHECKS:
+        try:
+            out.append(fn())
+        except Exception as e:
+            out.append(PreFlightResult(
+                fn.__name__, "fail",
+                f"check raised: {type(e).__name__}: {e}",
+            ))
+    return out
+
+
+def has_failures(results: List[PreFlightResult]) -> bool:
+    return any(r.status == "fail" for r in results)
+
+
+def format_results(results: List[PreFlightResult]) -> str:
+    lines = []
+    for r in results:
+        glyph = {"ok": "✓", "warn": "!", "fail": "✗"}.get(r.status, "?")
+        lines.append(f"  {glyph} [{r.status:4s}] {r.name:24s} — {r.detail}")
+    return "\n".join(lines)
+
+
+# ─── CLI ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    results = run_pre_flight()
+    print("=== paired measurement pre-flight ===")
+    print(format_results(results))
+    failed = has_failures(results)
+    if failed:
+        print("\nRESULT: FAIL — measurement launch blocked. "
+              "Fix the failing checks or pass --skip-pre-flight "
+              "(recorded in output JSON).")
+        return 1
+    warns = [r for r in results if r.status == "warn"]
+    print(f"\nRESULT: PASS ({len(warns)} warning{'s' if len(warns)!=1 else ''})")
+    return 0
+
+
+if __name__ == "__main__":   # pragma: no cover
+    sys.exit(main())

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -1,0 +1,360 @@
+"""Lock test for measurement-critical surfaces.
+
+Operator catch v0.6.1 v18.2 (2026-06-16) — after the v17 meta regex
+false-positive nearly polluted a paired measurement, the operator
+asked: "앞으로 LLM 모델이나 추론 레이어 추가시 측정이 수시로 방해되지
+않도록 격리가 보장되는가?".
+
+This file is half of the two-layer answer (the other half is
+``scripts/research/pre_flight_check.py``):
+
+  Layer 1 — LOCK TEST (this file). Captures the exact set of
+            (module, symbol, value) tuples that ``local_vs_cloud_paired.py``
+            consumes. ANY change to that surface — adding a backend
+            import, renaming a constant, moving a function, changing
+            the fixture path — flips this test red. The PR author then
+            either (a) updates this lock-test alongside the change AND
+            re-runs the paired measurement, or (b) routes the change
+            away from the measurement surface.
+
+  Layer 2 — PRE-FLIGHT CHECK (scripts/research/pre_flight_check.py).
+            Runs each time the paired harness launches. Validates the
+            live state (fixture SHA, regex sweep, backend registry,
+            abstraction module) against the same baseline before any
+            LLM call goes out.
+
+Coverage philosophy: this test is INTENTIONALLY brittle. A green run
+means the measurement surface is byte-stable at the symbol level; a
+red run means the operator MUST inspect the diff before trusting any
+upcoming Quality Delta Card produced by ``local_vs_cloud_paired.py``.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# Symbols paired_local_vs_cloud actually imports. If the harness's
+# import list grows (a new module dependency lands), this set MUST be
+# updated in the SAME PR that introduces the dependency.
+_HARNESS_IMPORTS_REQUIRED = {
+    # stdlib — listed for sanity; their presence is OS-level not
+    # JAMES-level so the lock doesn't actually enforce these
+    ("argparse", None),
+    ("json", None),
+    ("os", None),
+    ("random", None),
+    ("re", None),
+    ("statistics", None),
+    ("sys", None),
+    ("time", None),
+    ("urllib.request", None),
+    # JAMES surface — these MUST stay stable for the paired path
+    # to be valid. The harness imports them on demand inside the
+    # call_cloud_via_abstraction function; we replicate the import
+    # here to assert they resolve.
+    ("core.abstraction", "default_decider"),
+    ("core.abstraction", "run_cloud_egress"),
+    ("core.reasoning.backends.claude_code_cli", "ClaudeCodeCliBackend"),
+    # diffusiongemma branch — opt-in path in call_local. Listed so
+    # removing the file would flip this test red, signaling that the
+    # harness's --local-backend diffusiongemma_local flag silently
+    # broke.
+    ("core.reasoning.backends.diffusiongemma_local", "DiffusionGemmaLocalBackend"),
+}
+
+
+# Symbols + constants the harness exports at module top level.
+# Renaming / moving any of these is a measurement-surface change.
+_HARNESS_TOP_LEVEL_REQUIRED = {
+    "FIXTURE",
+    "RAW",
+    "DEFAULT_LOCAL_MODEL",
+    "OLLAMA_URL",
+    "ANSWERABLE",
+    "MAX_ART_CHARS",
+    "MAX_CTX_CHARS",
+    "NUM_CTX",
+    "CAVEAT_BLOCK",
+    "call_local",
+    "call_cloud_via_abstraction",
+    "judge",
+    "_majority",
+    "select_queries",
+    "run_one_query",
+    "aggregate",
+    "main",
+}
+
+
+# Baseline values the harness uses on every paired run. Changing
+# these silently rotates the comparison's units — e.g. NUM_CTX = 4096
+# would silently truncate evidence between two runs, polluting any
+# Quality Delta Card built across the change. Lock-test catches the
+# rotation BEFORE the next measurement.
+_HARNESS_BASELINE_VALUES = {
+    "DEFAULT_LOCAL_MODEL": "gemma3:4b",
+    "OLLAMA_URL":          "http://127.0.0.1:11434/api/generate",
+    "ANSWERABLE":          ("inference_query", "comparison_query", "temporal_query"),
+    "MAX_ART_CHARS":       7500,
+    "MAX_CTX_CHARS":       16000,
+    "NUM_CTX":             8192,
+}
+
+
+# Modules whose surface the paired harness consumes via abstraction
+# (cloud egress) or backend protocol. Each entry pins the symbol name
+# + whether it's callable. If a refactor renames any of these the
+# harness silently breaks until the maintainer updates the import.
+_DOWNSTREAM_SURFACE = {
+    ("core.abstraction",                                "default_decider", "callable"),
+    ("core.abstraction",                                "run_cloud_egress", "callable"),
+    ("core.reasoning.backends.claude_code_cli",         "ClaudeCodeCliBackend", "class"),
+    ("core.reasoning.backends.diffusiongemma_local",    "DiffusionGemmaLocalBackend", "class"),
+    ("core.reasoning.backends",                         "CompletionResult", "class"),
+    ("core.reasoning.backends",                         "register_backend", "callable"),
+    ("core.reasoning.backends",                         "get_backend", "callable"),
+    ("core.reasoning.backends",                         "list_backends", "callable"),
+}
+
+
+def _import_harness():
+    """Pull the paired harness as a module without running main().
+
+    The harness lives at scripts/research/local_vs_cloud_paired.py.
+    importlib can load it by path so we stay decoupled from any
+    sys.path manipulation main() may want to do at run time.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    harness_path = repo_root / "scripts" / "research" / "local_vs_cloud_paired.py"
+    spec = importlib.util.spec_from_file_location(
+        "local_vs_cloud_paired", harness_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["local_vs_cloud_paired"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class MeasurementSurfaceLockTest(unittest.TestCase):
+    """Every assertion here is a deliberate brittle check. Failures
+    are not "fix the test" prompts — they are "audit your change,
+    re-run the paired baseline, then update this file" prompts.
+    """
+
+    def test_harness_module_loads(self):
+        """The paired harness must load without side effects (no
+        network, no model spinup). This is a smoke for the import
+        itself, before the per-symbol checks below."""
+        mod = _import_harness()
+        self.assertTrue(hasattr(mod, "main"))
+
+    def test_harness_top_level_symbols_present(self):
+        """Every constant + function the paired path depends on must
+        be a module-level attribute. Renaming flips this red."""
+        mod = _import_harness()
+        for sym in _HARNESS_TOP_LEVEL_REQUIRED:
+            with self.subTest(symbol=sym):
+                self.assertTrue(
+                    hasattr(mod, sym),
+                    f"measurement harness lost top-level symbol "
+                    f"{sym!r} — paired path will break silently. "
+                    f"Either restore the symbol or update this "
+                    f"lock-test and re-run the paired baseline.",
+                )
+
+    def test_harness_baseline_values_unchanged(self):
+        """Constants the harness uses across every paired run must
+        match the recorded baseline. Drift = silent unit rotation
+        between two Quality Delta Cards. Catching the drift here
+        forces a deliberate paired re-baseline before promotion."""
+        mod = _import_harness()
+        for name, expected in _HARNESS_BASELINE_VALUES.items():
+            with self.subTest(constant=name):
+                actual = getattr(mod, name, None)
+                self.assertEqual(
+                    actual, expected,
+                    f"measurement baseline drift: {name} changed "
+                    f"from {expected!r} → {actual!r}. Any paired "
+                    f"comparison spanning this change must be "
+                    f"re-baselined. Update the expected value "
+                    f"alongside a fresh n=3 paired run.",
+                )
+
+    def test_downstream_surface_intact(self):
+        """JAMES modules the paired harness depends on (abstraction
+        + backend registry + backend classes) must still expose the
+        symbols by the name + kind the harness uses.
+
+        Failure here means a refactor moved a symbol; either revert
+        the move, give the harness an updated import, or fork the
+        harness behind a feature flag. NEVER edit just the test."""
+        for module_path, symbol, kind in _DOWNSTREAM_SURFACE:
+            with self.subTest(module=module_path, symbol=symbol, kind=kind):
+                try:
+                    mod = importlib.import_module(module_path)
+                except ImportError as e:
+                    self.fail(
+                        f"measurement-critical module {module_path!r} "
+                        f"failed to import: {e}",
+                    )
+                attr = getattr(mod, symbol, None)
+                self.assertIsNotNone(
+                    attr,
+                    f"{module_path}.{symbol} disappeared. Paired "
+                    f"harness's call_cloud_via_abstraction will "
+                    f"raise on the next run.",
+                )
+                if kind == "callable":
+                    self.assertTrue(
+                        callable(attr),
+                        f"{module_path}.{symbol} is no longer callable "
+                        f"(replaced with non-function value)",
+                    )
+                elif kind == "class":
+                    self.assertTrue(
+                        inspect.isclass(attr),
+                        f"{module_path}.{symbol} is no longer a class",
+                    )
+
+    def test_call_local_signature_stable(self):
+        """call_local accepts the exact kwargs run_one_query passes
+        + the new --local-backend dispatch parameter. If the harness's
+        own parameter list changes, the dispatch breaks silently and
+        the paired runs measure unintended values."""
+        mod = _import_harness()
+        sig = inspect.signature(mod.call_local)
+        params = sig.parameters
+        required = {"prompt", "model", "timeout", "local_backend"}
+        missing = required - set(params)
+        self.assertFalse(
+            missing,
+            f"call_local missing measurement-critical kwargs: {missing}. "
+            f"The harness's run_one_query call site will fail with "
+            f"TypeError on the next paired run.",
+        )
+        # local_backend MUST default to "ollama" so a stock paired run
+        # keeps producing measurements against the historical baseline.
+        self.assertEqual(
+            params["local_backend"].default, "ollama",
+            "call_local(local_backend=...) default changed away from "
+            "'ollama'. Existing paired baselines are no longer "
+            "reproducible without --local-backend explicit on the CLI.",
+        )
+
+    def test_judge_signature_stable(self):
+        """judge(question, ctx, ans_a, ans_b, timeout) — Direction α
+        evidence-grounded grader. Argument-order rotation here flips
+        which candidate gets which verdict label. The blind A/B
+        guard upstream cancels the bias, but mis-counting verdicts
+        is still a regression."""
+        mod = _import_harness()
+        sig = inspect.signature(mod.judge)
+        params = list(sig.parameters)
+        expected_prefix = ["question", "evidence", "ans_a", "ans_b"]
+        self.assertEqual(
+            params[:4], expected_prefix,
+            f"judge signature drifted: {params[:4]!r} vs expected "
+            f"{expected_prefix!r}. Verdict labeling changed shape — "
+            f"any paired card produced after this change is "
+            f"non-comparable to prior cards without manual remap.",
+        )
+
+    def test_diffusiongemma_default_off(self):
+        """The DiffusionGemma backend is opt-in. Activation default
+        flip is a measurement-baseline change that needs an explicit
+        Quality Delta Card per CLAUDE.md rule #2. This test makes
+        the flip impossible to land accidentally."""
+        # Snapshot the actual env value before clearing — the test
+        # must not depend on the operator's interactive shell state.
+        prior = os.environ.pop("JAMES_ENABLE_DIFFUSIONGEMMA", None)
+        try:
+            # Re-import the backend registry with the env cleared.
+            # Already-imported registry caches the previous state, so
+            # we inspect the file source directly: it must require the
+            # env literal "1" for registration.
+            import core.reasoning.backends as backends
+            src = Path(backends.__file__).read_text(encoding="utf-8")
+            self.assertIn(
+                'JAMES_ENABLE_DIFFUSIONGEMMA',
+                src,
+                "registry no longer mentions JAMES_ENABLE_DIFFUSIONGEMMA — "
+                "did someone remove the opt-in gate?",
+            )
+            self.assertIn(
+                'JAMES_ENABLE_DIFFUSIONGEMMA") == "1"',
+                src,
+                "DiffusionGemma opt-in gate weakened. The env value "
+                "MUST equal the literal '1' so accidental "
+                "truthy strings (e.g. 'true', 'yes') do not flip the "
+                "default and shift the measurement baseline.",
+            )
+        finally:
+            if prior is not None:
+                os.environ["JAMES_ENABLE_DIFFUSIONGEMMA"] = prior
+
+
+class FixtureLockTest(unittest.TestCase):
+    """The fixture file is the input the harness compares against.
+    A silent edit invalidates every Quality Delta Card produced on
+    either side of the change. We don't pin the entire SHA here —
+    additions to the fixture are legitimate (new questions surface as
+    new measurement runs). Instead we lock the SCHEMA + counts so the
+    paired path keeps reading what it expects.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Force the path-based import so the test class can run alone
+        # (unittest.main without the earlier class running).
+        _import_harness()
+
+    def test_fixture_exists(self):
+        from local_vs_cloud_paired import FIXTURE
+        self.assertTrue(
+            FIXTURE.exists(),
+            f"paired fixture missing: {FIXTURE}. The harness will "
+            f"fail before producing any row.",
+        )
+
+    def test_fixture_has_answerable_rows(self):
+        """Each answerable question_type must have ≥ n_per_type × 3
+        rows so the default run (n_per_type=3) is reproducible."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURE, ANSWERABLE
+        data = _json.loads(FIXTURE.read_text(encoding="utf-8"))
+        queries = data.get("queries", [])
+        for t in ANSWERABLE:
+            with self.subTest(question_type=t):
+                rows = [q for q in queries if q.get("question_type") == t]
+                self.assertGreaterEqual(
+                    len(rows), 9,
+                    f"answerable question_type {t!r} only has "
+                    f"{len(rows)} rows — paired default needs 9.",
+                )
+
+    def test_fixture_query_records_have_required_fields(self):
+        """Every query record must carry id + text + question_type so
+        the harness's select_queries can shape rows."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURE
+        data = _json.loads(FIXTURE.read_text(encoding="utf-8"))
+        for i, q in enumerate(data.get("queries", [])[:50]):
+            with self.subTest(index=i):
+                for field in ("id", "text", "question_type"):
+                    self.assertIn(
+                        field, q,
+                        f"query #{i} missing field {field!r} — "
+                        f"paired harness will fail on this record.",
+                    )
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

운영자 catch (post PR #962): \"앞으로 LLM 모델이나 추론 레이어 추가시 측정이 수시로 방해되지 않도록 별도 환경이 보장되는가?\".

v17 case 에서 명확히 드러난 gap — UI/UX cycle 의 변경이 measurement-critical surface 를 모르게 touch 해도 자동 catch 메커니즘 없었음. 운영자가 직접 sweep 요청 후 fix 가능.

이번 PR 은 **2-layer 격리 contract** 신설. UI/UX 변경이 측정 환경 오염 시 **변경 시점 (Layer 1)** + **측정 launch 시점 (Layer 2)** 두 단계에서 catch.

## Layer 1 — Lock test (`tests/test_measurement_critical_surfaces.py`)

paired harness 가 consume 하는 `(module, symbol, value)` tuple 들을 명시 lock:

- top-level **상수**: `NUM_CTX`, `OLLAMA_URL`, `DEFAULT_LOCAL_MODEL`, `FIXTURE`, `ANSWERABLE`, `MAX_ART_CHARS`, `MAX_CTX_CHARS`, `CAVEAT_BLOCK`
- top-level **함수**: `call_local`, `call_cloud_via_abstraction`, `judge`, `_majority`, `select_queries`, `run_one_query`, `aggregate`, `main`
- **downstream surface**: `core.abstraction.{default_decider, run_cloud_egress}`, `core.reasoning.backends.{claude_code_cli, diffusiongemma_local}`, registry helpers
- **`call_local(local_backend=...)` default = `\"ollama\"`** — paired baseline 재현 보장
- **`judge(question, evidence, ans_a, ans_b, timeout=...)`** verdict 라벨 위치 stable
- **DiffusionGemma opt-in literal `== \"1\"`** (loose truthy 차단)

**10/10 pass**. 변경 시 1+ test red → PR author 가 lock 업데이트 + fresh paired baseline 의무.

## Layer 2 — Pre-flight check (`scripts/research/pre_flight_check.py`)

paired harness 가 launch 전 자동 실행. 5 checks:

| check | 검증 |
|---|---|
| `fixture_rows` | fixture 존재 + answerable type 별 ≥9 rows |
| `regex_sweep` | meta regex 가 fixture retrieval queries 매치하지 않는지 (**v17 \"News\" case 가 launch 시점에 catch**) |
| `backend_registry` | exactly `{ollama_local}` + opt-in `{claude_code_cli, diffusiongemma_local}` per env. extras = `JAMES_PLUGINS` leak |
| `abstraction_smoke` | `default_decider` + `run_cloud_egress` importable + callable |
| `diffusiongemma_optin` | env flag + registry presence consistent |

**5/5 ok** on stock JAMES.

`--skip-pre-flight` opt-out 도 output JSON 에 **기록** — 운영자가 invisible 하게 bypass 못 함.

## Audit trail

Every paired run 의 output JSON:
```json
\"pre_flight\": {
    \"skipped\": false,
    \"results\": [
        {\"name\": \"fixture_rows\", \"status\": \"ok\", \"detail\": \"...\"},
        ...
    ]
}
```

downstream review (Quality Delta Card, joint piece) 가 measurement 환경 sanity 를 별도 로그 안 보고 verify 가능.

## Honest framing — 이 PR 이 **보장하지 않는** 것

- **동적 monkey-patch**: 런타임 함수 패치 catch 안 됨 (static import surface 만 lock)
- **fixture 내 텍스트 drift**: schema + row count 만 lock, 개별 question text 안 pinned (legitimate growth 마찰 회피)
- **2-step PR 협업**: PR #N lock 업데이트 + PR #N+1 surface revert 는 통과. solo dogfood context 에서 비현실적 adversary.

## Rule #1 4-layer protection streak

- 신규 파일만: 1 test + 1 measurement script
- **`core/retrieval` + `core/graph` traversal — 여전히 0 라인 변경, streak 계속**
- `core/reasoning/modes/` + `core/intent_classifier/` + `core/reasoning/backends/` — 이번 PR 0 라인 변경
- vertical / LOI gate — 0

## Runbook — locked surface 변경 시

1. 변경 PR 작성
2. 같은 PR 에서 `_HARNESS_TOP_LEVEL_REQUIRED` / `_HARNESS_BASELINE_VALUES` / `_DOWNSTREAM_SURFACE` 업데이트
3. `python -m unittest tests.test_measurement_critical_surfaces` → pass
4. `python scripts/research/pre_flight_check.py` → pass
5. fresh paired baseline (n=3) — output JSON 의 `pre_flight.results` 가 새 reference
6. PR body 가 memory entry + 새 baseline cite

## Memory entry

`memory/project_measurement_environment_isolation_v18_2.md` — 2-layer contract + locked surface 변경 runbook + trade-off (intentional brittleness vs false-negative risk).

Quality delta: exempt (label: code) — measurement infra. 측정 axis 자체 안 움직이지만, 이후 측정의 무결성을 보호.

🤖 Generated with [Claude Code](https://claude.com/claude-code)