### PR TITLE
fix(v0.6.1): coding regex 'class '/'import ' false-positive + pre-flight expand

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -82,7 +82,20 @@ class IntentClassifier:
         ],
         "coding": [
             r"\b(python|파이썬|javascript|자바스크립트)\b",
-            r"\b(def |class |import |traceback)\b",
+            # v0.6.1 v18.3 (2026-06-16) — measurement-validity fix.
+            # The old form "\b(def |class |import |traceback)\b"
+            # matched English "class " in retrieval queries
+            # (class-action lawsuit / first-class / world-class).
+            # pre-flight retroactive sweep caught this — 7/75
+            # MultiHop-RAG answerable queries falsely classified.
+            # Predates the v0.6.1 cycle (initial release), but the
+            # measurement guard exposes long-running bugs too.
+            # Fix: require code-context follow-up — the next char
+            # after the keyword is `(` / `[` / identifier-friendly,
+            # which English prose doesn't produce after `class `.
+            r"\b(def|class)\s+[A-Za-z_][\w]*\s*[\(:\[]",
+            r"(?:^|\n)\s*(?:from\s+[A-Za-z_][\w.]*\s+)?import\s+[A-Za-z_][\w]*(?:\s*,\s*[A-Za-z_][\w]*)*\s*(?:as\s+[A-Za-z_][\w]*)?\s*(?:#|$|\n)",
+            r"\bTraceback\s+\(most recent call last\)",
             r"(코드 작성|코드 수정|버그 찾아|코드 만들어|스크립트)",
         ],
         "self_evolve": [

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -137,10 +137,20 @@ def check_fixture() -> PreFlightResult:
 
 
 def check_regex_false_positives() -> PreFlightResult:
-    """Every meta-mode regex must NOT match the fixture's retrieval
-    queries. False positives in the live chat path silently route the
-    operator's English queries to handle_meta instead of retrieval —
-    measurement-adjacent but visible-regression.
+    """No fast-path regex (across ALL non-retrieval modes) may match
+    the fixture's retrieval queries. False positives in the live chat
+    path silently route the operator's English queries away from
+    retrieval — measurement-adjacent but visible-regression.
+
+    Modes swept: ``meta``, ``wiki_edit``, ``coding``. ``chat`` is the
+    fallback so its patterns are skipped. ``retrieval`` has no fast
+    patterns — it's the implicit default.
+
+    v18.2 retroactive scan (2026-06-16) found `coding` pattern
+    ``\\b(def |class |import |traceback)\\b`` matching ``class `` in
+    English fixture queries (`class-action`, `first-class`, etc.).
+    Predates the v0.6.1 chrome cycle (initial release) — long-running
+    bug, but now pre-flight catches it before measurement.
 
     The harness itself bypasses intent_classifier, so this check
     cannot poison a paired RUN; it catches the bug BEFORE the operator
@@ -165,16 +175,32 @@ def check_regex_false_positives() -> PreFlightResult:
 
     fixture_path: Path = harness.FIXTURE
     data = json.loads(fixture_path.read_text(encoding="utf-8"))
-    meta_patterns = IntentClassifier().FAST_PATTERNS.get("meta", [])
-    if not meta_patterns:
+    classifier = IntentClassifier()
+
+    # Modes to sweep — every fast-path bucket EXCEPT chat (fallback)
+    # and the implicit retrieval default. If a new mode appears in
+    # FAST_PATTERNS that we want excluded (e.g. a new fallback), add
+    # it to _SWEEP_EXCLUDE.
+    _SWEEP_EXCLUDE = {"chat"}
+    sweep_modes = [
+        m for m in classifier.FAST_PATTERNS
+        if m not in _SWEEP_EXCLUDE
+    ]
+    if not sweep_modes:
         return PreFlightResult(
             "regex_sweep", "warn",
-            "meta fast-path patterns missing — classifier surface "
-            "changed; lock-test should already be red",
+            "no fast-path modes found to sweep — classifier surface "
+            "may have rotated; lock-test should already be red",
         )
 
-    # Compile once per check — cheap, but avoid re-compiling per row.
-    compiled = [re.compile(p, re.IGNORECASE) for p in meta_patterns]
+    # Per-mode compiled patterns.
+    per_mode: Dict[str, List[re.Pattern]] = {}
+    per_mode_raw: Dict[str, List[str]] = {}
+    for mode in sweep_modes:
+        raw = classifier.FAST_PATTERNS.get(mode, [])
+        per_mode[mode] = [re.compile(p, re.IGNORECASE) for p in raw]
+        per_mode_raw[mode] = raw
+
     answerable = harness.ANSWERABLE
 
     fp_rows: List[Dict[str, Any]] = []
@@ -184,30 +210,40 @@ def check_regex_false_positives() -> PreFlightResult:
             continue
         total += 1
         text = q.get("text", "")
-        for i, cre in enumerate(compiled):
-            m = cre.search(text)
-            if m:
-                fp_rows.append({
-                    "id":      q.get("id"),
-                    "type":    q.get("question_type"),
-                    "text":    text[:120],
-                    "pattern": meta_patterns[i][:80],
-                    "match":   m.group(0),
-                })
-                break       # one match per row is enough
+        for mode, compiled in per_mode.items():
+            for i, cre in enumerate(compiled):
+                m = cre.search(text)
+                if m:
+                    fp_rows.append({
+                        "id":      q.get("id"),
+                        "qtype":   q.get("question_type"),
+                        "text":    text[:120],
+                        "mode":    mode,
+                        "pattern": per_mode_raw[mode][i][:80],
+                        "match":   m.group(0),
+                    })
+                    break       # one match per (row, mode) is enough
 
     if fp_rows:
+        by_mode: Dict[str, int] = {}
+        for r in fp_rows:
+            by_mode[r["mode"]] = by_mode.get(r["mode"], 0) + 1
         return PreFlightResult(
             "regex_sweep", "fail",
-            f"{len(fp_rows)}/{total} answerable queries falsely "
-            f"classified as meta — live chat path will misroute. "
-            f"First example: {fp_rows[0]!r}",
-            extra={"false_positives": fp_rows[:5], "total": total},
+            f"{len(fp_rows)} false positives across answerable "
+            f"fixture rows (modes: {by_mode}). Live chat path will "
+            f"misroute. First example: {fp_rows[0]!r}",
+            extra={
+                "false_positives": fp_rows[:5],
+                "total": total,
+                "by_mode": by_mode,
+            },
         )
     return PreFlightResult(
         "regex_sweep", "ok",
-        f"0/{total} false positives across answerable fixture rows",
-        extra={"total": total},
+        f"0/{total} false positives across {len(sweep_modes)} fast-path "
+        f"modes ({sorted(sweep_modes)})",
+        extra={"total": total, "modes_swept": sorted(sweep_modes)},
     )
 
 


### PR DESCRIPTION
## Summary

운영자 catch (retroactive 1단계 scan): 신설된 measurement-isolation guard 로 1단계 PR 들 영향 재검토 중 **`coding` fast-path regex 가 영어 retrieval 쿼리의 `class ` substring 매치** 발견.

## Root cause analysis

`git log` — 패턴 `\b(def |class |import |traceback)\b` 는 **v0.1.0-alpha (initial release) 부터 존재**. v0.6.1 chrome cycle 은 coding bucket 손 안 댐 → **long-running bug**.

그러나 **v18.2 pre-flight `regex_sweep` 가 `meta` 만 scope** → catch 못 함. retroactive scan 으로 sweep 을 모든 non-retrieval mode 로 확장 시:
- **7/75** MultiHop-RAG answerable queries 가 coding 으로 false-classify
- `class ` substring (`class-action`, `first-class`, `world-class`, `class of users` 등) 이 regex `\b(class )` 매치

## Two-part fix

### 1. Coding regex 강화 (code context 강제)
| Token | Old | New |
|---|---|---|
| `def`/`class` | `\b(def |class )\b` | `\b(def|class)\s+[A-Za-z_][\w]*\s*[\(:\[]` (식별자 + `(`/`:`/`[` 강제) |
| `import` | `\b(import )\b` | `(?:^|\n)\s*(?:from\s+...)?import\s+[...]\s*(?:#|$|\n)` (line-start + line-end 강제) |
| `traceback` | `\b(traceback)\b` | `\bTraceback\s+\(most recent call last\)` (Python error 헤더 literal) |

**Verification**:
- POS (9): `def hello(): pass` / `class Foo(object):` / `import json` / `from json import dumps` / `Traceback (most recent call last)` / `python 함수` / `코드 작성` / `import json\n` / `import json # comment` — **9/9 still match**
- NEG (7): `class-action lawsuit` / `import duties on goods` / `first-class flights` / `I attended the class` / `We import goods` / `default class to engage` / `class of users` — **7/7 correctly NOT matched**
- Full fixture sweep: **0/75 FP** (was 7/75)

### 2. Pre-flight `regex_sweep` scope 확장
- meta → **모든 non-retrieval modes** (meta, wiki_edit, coding, self_evolve)
- chat 제외 (fallback bucket)
- 새 mode 가 `FAST_PATTERNS` 에 추가되면 자동 cover (`_SWEEP_EXCLUDE` 에 explicit 등록 안 한 한)

**After fix**:
```
regex_sweep — 0/75 false positives across 4 fast-path modes
              (['coding', 'meta', 'self_evolve', 'wiki_edit'])
```

## Retroactive sweep — 21 PR 매트릭스

| PR range | area | scope | guards |
|---|---|---|---|
| #942-#957 | frontend / Claude reorg | frontend | OK (locked surface 미touch) |
| #954 | favorite cross-device sync | core/memory + routes/history | OK (harness memory 미사용) |
| #958 | meta hybrid grouping | core/reasoning/modes/meta | OK (engine 경유, harness bypass) |
| #959-#960 | meta follow-up + C+D | core/intent + meta | OK (pre-merge resolve) |
| #961 | DiffusionGemma spike | core/reasoning/backends | OK (opt-in, conformance 11/11) |
| #962 | meta regex News FP | core/intent_classifier | OK (pre-PR resolve) |

**21 PR 모두 guards 통과**. retroactive sweep 이 long-running bug 1건 (coding regex, v0.1.0-alpha 부터) 발견 → 이번 PR 에서 fix.

## Honest framing

v18.2 guard 의 lesson: **guard 가 sweep 하는 surface 가 정확해야 함**. meta-only sweep 이었다면 오늘 MultiHop-RAG fixture 위에서 pre-flight green 이 떴겠지만 live chat 의 영어 retrieval 쿼리는 silently regress. 모든 non-retrieval mode 가 정답.

## Out of scope

- per-mode classifier confidence threshold tuning
- LLM-classification fallback 파라미터

## Rule #1 streak
- `core/intent_classifier` + `pre_flight_check.py` 만 touch
- v16 이후 `core/reasoning` + `core/intent_classifier` break 유지
- **`core/retrieval` + `core/graph` traversal — 여전히 0 라인 변경, streak 계속**

Quality delta: exempt (label: fix) — measurement-validity guard fix; bug 는 cycle 이전부터 존재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)