### PR TITLE
feat(v0.6.1): thinking-mode contract — 4-layer guard (measurement + production)

### DIFF
--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -163,6 +163,20 @@ def call_local(prompt: str, *, model: str, timeout: int = 180,
         vs DiffusionGemma on the same fixture without rewriting the
         harness. ``model`` becomes the model tag the serving stack
         announced (e.g. ``google/diffusiongemma-26b-a4b-it``).
+
+    v0.6.1 v18.4 (2026-06-16) — thinking-mode contract. The v18.3
+    Path A baseline launched with gemma4:e4b and produced 27/27 empty
+    LOCAL responses, then auto-classified them as ABSTAINED. Root
+    cause was the d3_e4b_floor_mechanism_thinking_trace memory's
+    finding (PR #602): the e4b model burns ~85% of num_predict on
+    hidden thinking tokens that ``/api/generate`` strips from
+    ``response``. cap=400 left zero room for user-facing answer.
+
+    Fix: when the model is thinking-capable AND the operator's
+    JAMES_GEMMA4_E4B_THINK_OFF=1 flag is set (default in `.env`
+    since PR #609), forward ``think: false`` to the Ollama request.
+    Honor the same contract production code uses — the harness was
+    the last call site bypassing it.
     """
     if local_backend == "diffusiongemma_local":
         from core.reasoning.backends.diffusiongemma_local import (
@@ -182,13 +196,32 @@ def call_local(prompt: str, *, model: str, timeout: int = 180,
             raise RuntimeError(f"diffusiongemma backend error: {result.error}")
         return (result.text or "").strip()
 
-    # default: ollama
+    # default: ollama. v18.4: thinking-aware body.
+    body: Dict[str, Any] = {
+        "model": model, "prompt": prompt, "stream": False,
+        "options": {
+            "num_predict": 400, "temperature": 0.0, "num_ctx": NUM_CTX,
+        },
+    }
+    # Honor production's think_policy contract. is_thinking_capable
+    # gates on the model family; _flag_active reads
+    # JAMES_GEMMA4_E4B_THINK_OFF. When BOTH are true, ``think: false``
+    # joins the Ollama body — matching the gemma_client.py path
+    # production calls already take.
+    try:
+        from core.reasoning.think_policy import (
+            is_thinking_capable, _flag_active,
+        )
+        if is_thinking_capable(model) and _flag_active():
+            body["think"] = False
+    except ImportError:
+        # think_policy module gone (extreme refactor) — fall through
+        # to the legacy direct call. Lock-test catches the loss.
+        pass
+
     req = urllib.request.Request(
         OLLAMA_URL,
-        data=json.dumps({
-            "model": model, "prompt": prompt, "stream": False,
-            "options": {"num_predict": 400, "temperature": 0.0, "num_ctx": NUM_CTX},
-        }).encode(),
+        data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json"},
     )
     r = json.loads(urllib.request.urlopen(req, timeout=timeout).read())

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -370,12 +370,73 @@ def check_diffusiongemma_opt_in() -> PreFlightResult:
 # ─── orchestrator ───────────────────────────────────────────────────
 
 
+def check_thinking_mode_contract() -> PreFlightResult:
+    """v0.6.1 v18.4 (2026-06-16) — operator catch after the Path A
+    baseline produced 27/27 empty responses. The d3_e4b_floor_mechanism
+    memory documented gemma4:e4b's hidden thinking tokens; the v18.3
+    paired harness bypassed the production think_policy contract and
+    measured empty strings as ABSTAINED.
+
+    Two assertions:
+      1. ``core/reasoning/think_policy.py`` is importable + exposes the
+         contract surface (is_thinking_capable, _flag_active). The
+         memory + the PR #602/#609 plumbing must stay reachable from
+         any new call site — the harness is the most recent example.
+      2. If the operator's stock JAMES install has ``gemma4:e4b``
+         available (the production small tier) AND the harness is
+         expected to drive it, the ``JAMES_GEMMA4_E4B_THINK_OFF=1``
+         flag MUST be set. We cannot enumerate installed Ollama
+         models hermetically here, so we surface this as a warning
+         that the operator should resolve before launching against
+         e4b. The warning sits in the output JSON so audit trail
+         records the state at run time.
+    """
+    try:
+        from core.reasoning import think_policy
+    except ImportError as e:
+        return PreFlightResult(
+            "thinking_mode_contract", "fail",
+            f"core.reasoning.think_policy import failed: {e}. "
+            f"Production code (5 stage call sites) + paired harness "
+            f"both depend on this contract. Restore or update the "
+            f"lock-test.",
+        )
+    missing = [
+        sym for sym in ("is_thinking_capable", "_flag_active",
+                        "think_for_stage")
+        if not hasattr(think_policy, sym)
+    ]
+    if missing:
+        return PreFlightResult(
+            "thinking_mode_contract", "fail",
+            f"core.reasoning.think_policy missing symbols: {missing}. "
+            f"call_local + production gemma_client both consume these.",
+        )
+    flag = os.environ.get("JAMES_GEMMA4_E4B_THINK_OFF")
+    if flag != "1":
+        return PreFlightResult(
+            "thinking_mode_contract", "warn",
+            "JAMES_GEMMA4_E4B_THINK_OFF not set to '1'. If the run "
+            "uses gemma4:e4b family the LOCAL responses will be "
+            "empty (hidden thinking tokens absorb num_predict). The "
+            "production .env carries this flag — verify it's loaded "
+            "in the measurement shell.",
+            extra={"env_flag": flag},
+        )
+    return PreFlightResult(
+        "thinking_mode_contract", "ok",
+        "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 "
+        "active (gemma4 family models will receive think:false).",
+    )
+
+
 _CHECKS = (
     check_fixture,
     check_regex_false_positives,
     check_backend_registry,
     check_abstraction_smoke,
     check_diffusiongemma_opt_in,
+    check_thinking_mode_contract,
 )
 
 

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -122,6 +122,13 @@ _DOWNSTREAM_SURFACE = {
     ("core.reasoning.backends",                         "register_backend", "callable"),
     ("core.reasoning.backends",                         "get_backend", "callable"),
     ("core.reasoning.backends",                         "list_backends", "callable"),
+    # v0.6.1 v18.4 — thinking-mode contract. Production code (5 cognitive
+    # stage call sites) + paired harness both honor JAMES_GEMMA4_E4B_THINK_OFF
+    # via these three symbols. Losing any of them resurrects the v18.3
+    # "27/27 empty response" failure mode.
+    ("core.reasoning.think_policy",                     "is_thinking_capable", "callable"),
+    ("core.reasoning.think_policy",                     "_flag_active", "callable"),
+    ("core.reasoning.think_policy",                     "think_for_stage", "callable"),
 }
 
 
@@ -223,6 +230,45 @@ class MeasurementSurfaceLockTest(unittest.TestCase):
                         inspect.isclass(attr),
                         f"{module_path}.{symbol} is no longer a class",
                     )
+
+    def test_call_local_honors_thinking_contract(self):
+        """v0.6.1 v18.4 (2026-06-16) — harness's call_local must
+        consult ``think_policy`` for thinking-capable models. Without
+        this, gemma4:e4b produces 27/27 empty responses (the v18.3
+        Path A baseline failure mode).
+
+        We don't run the actual HTTP call here — instead, we inspect
+        the harness source for the import + the conditional. A refactor
+        that removes the integration trips this test before any
+        operator reaches the empty-response cliff again.
+        """
+        harness_path = (
+            Path(__file__).resolve().parent.parent
+            / "scripts" / "research" / "local_vs_cloud_paired.py"
+        )
+        src = harness_path.read_text(encoding="utf-8")
+        self.assertIn(
+            "from core.reasoning.think_policy",
+            src,
+            "call_local stopped importing think_policy — the harness "
+            "is back on the bypass path that produced 27/27 empty "
+            "responses in v18.3. Restore the import or update the "
+            "lock-test alongside a deliberate measurement-baseline "
+            "change.",
+        )
+        self.assertIn(
+            "is_thinking_capable(model)",
+            src,
+            "call_local stopped gating on is_thinking_capable — the "
+            "harness no longer detects gemma4 family.",
+        )
+        self.assertIn(
+            "\"think\"",
+            src,
+            "call_local stopped forwarding the think field to Ollama. "
+            "gemma4:e4b will absorb num_predict on hidden thinking "
+            "tokens again.",
+        )
 
     def test_call_local_signature_stable(self):
         """call_local accepts the exact kwargs run_one_query passes


### PR DESCRIPTION
## Summary

운영자 catch (post v18.3 Path A 측정 실패): \"gemma4 의 num_predict 400, 이건 think 모드 관련 이미 밝혀진 게 있잖아. **측정 셋업뿐 아니라 자메스 실제 운영에서도 고려되어야 한다. 설계상 안 놓치도록 해야 함**\".

## Bug + prior art

v18.3 Path A baseline → **gemma4:e4b 27/27 LOCAL ABSTAINED**. 응답 raw 검증:
- `response: ''` (빈 문자열)
- `eval_count: 400` (cap 도달), `done_reason: \"length\"`

= memory `d3_e4b_floor_mechanism_thinking_trace` (PR #602) 의 v18.3 surfacing:
- gemma4:e4b 는 **thinking 모델**
- ~85% num_predict 가 hidden thinking tokens (ollama `/api/generate` 의 `response` 에서 strip)
- cap < ~450 → empty response

기존 plumbing (memory `a3_a2_think_mode_track_closure` / PR #609):
- `core/reasoning/think_policy.py` 신설 (is_thinking_capable / _flag_active / think_for_stage)
- 5 production stage (planner / reflect / verify / engine_synth / query_rewriter) + base gemma_client 모두 honor
- `.env` 에 `JAMES_GEMMA4_E4B_THINK_OFF=1` 박힘

**그러나** paired harness 의 `call_local` 가 직접 urllib POST → think field 없음 → ollama default thinking-on → empty response. **harness 가 마지막 bypass site**.

## 4-Layer guard

### 1. paired harness 가 think_policy 통합
- `call_local` 가 `is_thinking_capable(model) and _flag_active()` → `body[\"think\"] = False`
- **Smoke 검증**: 동일 fixture trial 응답 `''` (cap=400 eval=400) → **245자 in 10.5s**

### 2. pre-flight `check_thinking_mode_contract`
- **FAIL** on think_policy import 손상 / 심볼 missing
- **WARN** on `JAMES_GEMMA4_E4B_THINK_OFF != \"1\"` (non-default shell 이 .env 안 load 시 catch)
- 결과 output JSON `pre_flight.results` audit block 에 기록

### 3. lock-test
- `_DOWNSTREAM_SURFACE` 에 `is_thinking_capable + _flag_active + think_for_stage` 등록 → think_policy.py 삭제 시 red
- 신규 `test_call_local_honors_thinking_contract` — harness source 에서 import + `is_thinking_capable(model)` call + `\"think\"` field grep. refactor 가 strip 시 red

### 4. production already covered (이번 PR ripgrep 검증)
- `core/gemma_client/client.py` ✓
- `core/reasoning/engine_synth.py` ✓
- `core/reasoning/planner.py` ✓
- `core/reasoning/reflect/loop.py` ✓
- `core/reasoning/verify.py` ✓
- `core/retrieval/query_rewriter.py` ✓
- **paired harness 가 production stage 밖의 마지막 call site 였음, 이번 PR 로 정합**

## 운영자 UX 함의

v18.4 가드 없으면 운영자가 gemma4:e4b 로 JAMES 사용 + flag 미set 시 chat 응답이 silent 하게 truncate / empty. 5-stage plumbing 이 production 보호, .env flag 가 operator default 보호, **pre-flight WARN 이 non-default shell 이 .env 안 load 시 catch**.

## 설계 룰 (미래 유지보수)

> **ANY 새 LLM call site (cognitive stage / measurement tool / plugin) 가 gemma4:e4b family 사용 시 `think_policy` 통과 의무**. skip 시 empty-response failure mode 재발.
> lock-test + pre-flight 가 omission 을 **다음 측정 launch 전** catch.

## v18.3 Path A baseline 상태 — **INVALID, 재측정 필요**

- `reports/research-runs/v18.3-path-a-baseline/*` 는 failure mode evidence + measurement-guard 동기로 보존
- verdict 인용 금지
- **v18.4 Path A 재측정** 시 patched `call_local` 통과 → honest LOCAL response

## Rule #1 4-layer 보호 streak

- `scripts/research/*` + `tests/*` + `core/reasoning/think_policy.py` surface 만 touch (think_policy 신규 변경 0)
- **`core/retrieval` + `core/graph` traversal — 여전히 0 라인 변경, streak 계속**
- vertical / LOI gate — 0

Quality delta: exempt (label: fix) — measurement-validity guard; v18.3 baseline 은 이 fix 로 invalidated 되지만 guard 자체가 axis 를 안 움직임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)