### PR TITLE
feat(v0.6.1): Phase 2a — chat-mode fixture + paired harness --fixture CLI

### DIFF
--- a/eval/chat_mode_queries.json
+++ b/eval/chat_mode_queries.json
@@ -1,0 +1,229 @@
+{
+  "version": "0.1.0",
+  "description": "Chat-mode measurement fixture — small_talk + factual_chat + open_question + multi_turn. Korean primary (JAMES production use case per user_profile.md). v18.7 Phase 2 prereq.",
+  "source_dataset": "synthesized-jiwon-2026-06-16",
+  "source_license": "CC-BY-4.0 (operator-authored, no third-party content)",
+  "source_citation": "Operator-authored fixture for chat-mode routing decision (v0.6.1 Phase 2 prereq).",
+  "built_at_utc": "2026-06-16T11:00:00Z",
+  "subset": {
+    "small_talk": 5,
+    "factual_chat": 5,
+    "open_question": 5,
+    "multi_turn": 3
+  },
+  "type_distribution": {
+    "small_talk": "Short greeting / wellbeing / casual response. No factual claim. judge-only (lenient bias caveat).",
+    "factual_chat": "General-knowledge factual question. gold_signals applicable.",
+    "open_question": "Creative advice / opinion / open-ended. judge-only (lenient bias caveat).",
+    "multi_turn": "2-turn context carry. First turn given as prior_turns, second turn is the actual probe. judge-only."
+  },
+  "scoring_protocol": {
+    "judge": "Claude CLI, pairwise blinded A/B per (query, run). Same judge protocol as multihop_rag fixture.",
+    "gold_grounded": "Applied to factual_chat only (subset of queries with gold_signals). Other sub-classes report judge-only.",
+    "fairness_caveat": "small_talk / open_question / multi_turn cannot be deterministically graded. Judge bias (per project_judge_reliability_gold_grounded_v18_6: +0.11 to +0.19 over-credit on LOCAL) applies. Reported in Quality Delta Card as 'judge-only' rows."
+  },
+  "queries": [
+    {
+      "id": 1001,
+      "category": "chat-small-talk",
+      "question_type": "small_talk",
+      "text": "안녕하세요. 오늘 기분이 어때요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Short friendly greeting back. No factual claim required.",
+      "gold_signals": []
+    },
+    {
+      "id": 1002,
+      "category": "chat-small-talk",
+      "question_type": "small_talk",
+      "text": "잠깐 쉬어가야겠다. 점심 뭐 먹을까?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Brief casual suggestion or sympathetic acknowledgement.",
+      "gold_signals": []
+    },
+    {
+      "id": 1003,
+      "category": "chat-small-talk",
+      "question_type": "small_talk",
+      "text": "고마워. 도움이 많이 됐어.",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Short polite acknowledgement. Should NOT lecture or summarize prior context unsolicited.",
+      "gold_signals": []
+    },
+    {
+      "id": 1004,
+      "category": "chat-small-talk",
+      "question_type": "small_talk",
+      "text": "오늘 좀 피곤하네. 너는 괜찮아?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Sympathetic + brief check-in style. Avoid clinical / medical claim.",
+      "gold_signals": []
+    },
+    {
+      "id": 1005,
+      "category": "chat-small-talk",
+      "question_type": "small_talk",
+      "text": "Hello, how's it going?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Mirror-language English greeting. Should not switch to Korean unless asked.",
+      "gold_signals": []
+    },
+    {
+      "id": 1011,
+      "category": "chat-factual",
+      "question_type": "factual_chat",
+      "text": "한국의 수도는 어디인가요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Direct factual answer. Korea capital city.",
+      "gold_signals": [
+        {"term": "서울", "aliases": ["Seoul"]}
+      ]
+    },
+    {
+      "id": 1012,
+      "category": "chat-factual",
+      "question_type": "factual_chat",
+      "text": "물의 끓는점은 섭씨 몇 도인가요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Direct factual answer with standard atmospheric pressure caveat optional.",
+      "gold_signals": [
+        {"term": "100", "aliases": ["섭씨 100", "100도", "100°C"]}
+      ]
+    },
+    {
+      "id": 1013,
+      "category": "chat-factual",
+      "question_type": "factual_chat",
+      "text": "지구에서 가장 가까운 항성의 이름은 무엇인가요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Sun / Proxima Centauri (depending on interpretation — both acceptable per gold_signals).",
+      "gold_signals": [
+        {"term": "태양", "aliases": ["the Sun", "Sun", "Proxima Centauri", "프록시마 센타우리"]}
+      ]
+    },
+    {
+      "id": 1014,
+      "category": "chat-factual",
+      "question_type": "factual_chat",
+      "text": "DNA 의 약자를 풀어 쓰면 무엇인가요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Deoxyribonucleic acid / 디옥시리보핵산.",
+      "gold_signals": [
+        {"term": "deoxyribonucleic", "aliases": ["디옥시리보", "디옥시리보핵산"]}
+      ]
+    },
+    {
+      "id": 1015,
+      "category": "chat-factual",
+      "question_type": "factual_chat",
+      "text": "1년은 몇 시간인가요? 대략 계산해 주세요.",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "365 × 24 = 8760 hours (close enough).",
+      "gold_signals": [
+        {"term": "8760", "aliases": ["8,760", "8760시간", "8760 hours"]}
+      ]
+    },
+    {
+      "id": 1021,
+      "category": "chat-open",
+      "question_type": "open_question",
+      "text": "주말에 가족과 시간 보낼 좋은 방법 추천해 주세요.",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Creative open-ended advice. Multiple valid answers. Should NOT hallucinate user's situation.",
+      "gold_signals": []
+    },
+    {
+      "id": 1022,
+      "category": "chat-open",
+      "question_type": "open_question",
+      "text": "스트레스가 많을 때 도움이 되는 방법은 무엇인가요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "General coping suggestions. Should avoid clinical diagnosis claims.",
+      "gold_signals": []
+    },
+    {
+      "id": 1023,
+      "category": "chat-open",
+      "question_type": "open_question",
+      "text": "처음 프로그래밍을 배운다면 어떤 언어부터 시작하는 게 좋을까요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Recommendation with brief reasoning. Python / JS / Scratch all acceptable.",
+      "gold_signals": []
+    },
+    {
+      "id": 1024,
+      "category": "chat-open",
+      "question_type": "open_question",
+      "text": "잠이 잘 안 올 때 무엇을 해보면 좋을까?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "General sleep hygiene advice. Should NOT prescribe medication.",
+      "gold_signals": []
+    },
+    {
+      "id": 1025,
+      "category": "chat-open",
+      "question_type": "open_question",
+      "text": "친구가 갑자기 연락이 뜸해졌어요. 어떻게 하면 좋을까요?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Empathetic relational advice. No clinical claims.",
+      "gold_signals": []
+    },
+    {
+      "id": 1031,
+      "category": "chat-multi-turn",
+      "question_type": "multi_turn",
+      "text": "그것 좀 더 자세히 풀어 설명해 줄래?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Resolve the antecedent 'that' from prior_turns and expand on the photosynthesis explanation.",
+      "prior_turns": [
+        {"role": "user", "text": "광합성이 무엇인지 한 문장으로 설명해 줘."},
+        {"role": "assistant", "text": "광합성은 식물이 햇빛, 물, 이산화탄소를 이용하여 포도당과 산소를 만들어내는 화학 반응입니다."}
+      ],
+      "gold_signals": []
+    },
+    {
+      "id": 1032,
+      "category": "chat-multi-turn",
+      "question_type": "multi_turn",
+      "text": "그 중에서 어떤 게 가장 추천이야?",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Pick one from the prior list (Python / JS / Scratch) and briefly justify. Should NOT introduce new languages.",
+      "prior_turns": [
+        {"role": "user", "text": "처음 프로그래밍을 배운다면 어떤 언어부터 시작하는 게 좋을까?"},
+        {"role": "assistant", "text": "Python, JavaScript, Scratch 세 가지가 자주 추천됩니다. Python 은 문법이 단순하고 데이터 분석·머신러닝까지 확장됩니다. JavaScript 는 웹 작업이 바로 보여서 동기 부여가 좋고요. Scratch 는 시각 블록 방식이라 어린 학습자에게 적합합니다."}
+      ],
+      "gold_signals": []
+    },
+    {
+      "id": 1033,
+      "category": "chat-multi-turn",
+      "question_type": "multi_turn",
+      "text": "방금 정리한 내용 짧게 다시 요약해 줘.",
+      "abstention_truth": "present",
+      "evidence_required": false,
+      "expected_behavior": "Compress the prior assistant turn into 1-2 sentences. Should NOT invent new facts.",
+      "prior_turns": [
+        {"role": "user", "text": "달은 왜 매번 같은 면만 지구를 향하나요?"},
+        {"role": "assistant", "text": "달의 자전 주기와 공전 주기가 약 27.3일로 거의 동일하기 때문입니다. 이를 조석 고정 (tidal locking) 이라고 부르며, 지구의 중력이 오랜 시간에 걸쳐 달의 자전 속도를 늦춰서 결국 동기화되었습니다."}
+      ],
+      "gold_signals": []
+    }
+  ]
+}

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -71,6 +71,22 @@ WS = ROOT / "workspaces" / "hotpot_eval"
 FIXTURE = WS / "eval" / "multihop_rag_queries.json"
 RAW = WS / "raw"
 
+# v0.6.1 v18.7 Phase 2 prereq (2026-06-16) — chat-mode fixture for the
+# routing measurement protocol. Reasoning-isolated multihop_rag fixture
+# can NOT cover chat-mode use cases (no retrieval, no gold_evidence for
+# small_talk / open_question / multi_turn). The chat fixture is
+# operator-authored and scored:
+#   • factual_chat — gold_signals + judge (both axes available)
+#   • small_talk / open_question / multi_turn — judge-only (lenient
+#     bias caveat per project_judge_reliability_gold_grounded_v18_6)
+FIXTURES: Dict[str, Path] = {
+    "multihop": WS / "eval" / "multihop_rag_queries.json",
+    # Chat-mode fixture is operator-authored + tracked (small, no PII,
+    # no third-party license entanglement) — sits under eval/ not under
+    # the gitignored workspaces/ tree the multihop_rag corpus lives in.
+    "chat": ROOT / "eval" / "chat_mode_queries.json",
+}
+
 DEFAULT_LOCAL_MODEL = "gemma3:4b"
 OLLAMA_URL = "http://127.0.0.1:11434/api/generate"
 
@@ -79,7 +95,11 @@ OLLAMA_URL = "http://127.0.0.1:11434/api/generate"
 # excluded — for null queries there is no positive evidence and the
 # scoring would test abstention behavior, not reasoning quality. That
 # is a separate hypothesis (see α-8 abstention work).
-ANSWERABLE = ("inference_query", "comparison_query", "temporal_query")
+ANSWERABLE_BY_FIXTURE: Dict[str, Tuple[str, ...]] = {
+    "multihop": ("inference_query", "comparison_query", "temporal_query"),
+    "chat": ("small_talk", "factual_chat", "open_question", "multi_turn"),
+}
+ANSWERABLE = ANSWERABLE_BY_FIXTURE["multihop"]   # legacy alias
 
 # Evidence size guards (same as v2 — confirmed sufficient by the v2 smoke).
 MAX_ART_CHARS = 7500
@@ -140,6 +160,36 @@ def _answer_prompt(context: str, question: str) -> str:
         "\"I don't know\".\n\n"
         f"Context:\n{context}\n\nQuestion: {question}\n\nAnswer:"
     )
+
+
+def _chat_prompt(query: dict) -> str:
+    """Build a chat-mode prompt — free-form, no evidence injection.
+    prior_turns (multi_turn sub-class) are folded in as conversational
+    context with role labels so both LOCAL and CLOUD see the same
+    prior state. The instruction body keeps the abstention hatch open
+    ("if you don't know, say so") but does NOT require evidence
+    grounding — chat-mode is intentionally general-knowledge / open.
+    """
+    prior = query.get("prior_turns") or []
+    parts: List[str] = []
+    if prior:
+        parts.append("Previous conversation (paired both sides):")
+        for turn in prior:
+            role = turn.get("role", "user")
+            text = turn.get("text", "").strip()
+            parts.append(f"  {role.upper()}: {text}")
+        parts.append("")
+    parts.append(
+        "Respond naturally as a helpful assistant. Mirror the user's "
+        "language (Korean ↔ English). If you genuinely don't know a "
+        "factual answer, say so briefly rather than inventing one. "
+        "Keep the reply appropriately short for chat — do NOT add "
+        "unsolicited disclaimers or restatements."
+    )
+    parts.append("")
+    parts.append(f"User: {query['text']}")
+    parts.append("Assistant:")
+    return "\n".join(parts)
 
 
 # ─── model calls ──────────────────────────────────────────────────────
@@ -348,13 +398,23 @@ def _majority(verdicts: List[str]) -> str:
 # ─── run ──────────────────────────────────────────────────────────────
 
 
-def select_queries(n_per_type: int) -> List[dict]:
-    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+def select_queries(n_per_type: int, fixture_name: str = "multihop") -> List[dict]:
+    """Pick first-N queries per question_type for the given fixture.
+    `multihop` (default) selects the 3 answerable question_types
+    (inference / comparison / temporal) — null_query intentionally
+    excluded. `chat` selects all 4 chat sub-classes (small_talk /
+    factual_chat / open_question / multi_turn)."""
+    path = FIXTURES.get(fixture_name)
+    if path is None or not path.exists():
+        raise FileNotFoundError(
+            f"fixture {fixture_name!r} not found at {path}"
+        )
+    fixture = json.loads(path.read_text(encoding="utf-8"))
     by_type: Dict[str, List[dict]] = {}
     for q in fixture["queries"]:
         by_type.setdefault(q["question_type"], []).append(q)
     selected: List[dict] = []
-    for t in ANSWERABLE:
+    for t in ANSWERABLE_BY_FIXTURE[fixture_name]:
         selected += by_type.get(t, [])[:n_per_type]
     return selected
 
@@ -363,9 +423,15 @@ def run_one_query(
     query: dict, ctx: str, *,
     local_model: str, run_idx: int, timeout: int,
     local_backend: str = "ollama",
+    fixture_name: str = "multihop",
 ) -> Dict[str, Any]:
-    """One paired (local + cloud + judge) trial. Returns a row dict."""
-    prompt = _answer_prompt(ctx, query["text"])
+    """One paired (local + cloud + judge) trial. Returns a row dict.
+    `fixture_name=chat` switches the prompt template to the chat-mode
+    free-form path (prior_turns + no evidence injection)."""
+    if fixture_name == "chat":
+        prompt = _chat_prompt(query)
+    else:
+        prompt = _answer_prompt(ctx, query["text"])
     t0 = time.time()
 
     try:
@@ -520,11 +586,34 @@ CAVEAT_BLOCK = {
         "path is exercised end-to-end (proves §5.7.13 module works against a real "
         "Claude backend) but the abstraction itself is a no-op for this fixture."
     ),
+    "chat_mode_lenient_judge": (
+        "Chat-mode fixture (small_talk / open_question / multi_turn) is "
+        "INTRINSICALLY judge-only. There is no gold ground-truth for free-form "
+        "conversation. Only the factual_chat sub-class carries gold_signals and "
+        "is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-"
+        "0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_"
+        "grounded_v18_6). Report judge_correct AND gold_correct (factual_chat "
+        "subset) separately. Do NOT promote chat-mode-only claims without the "
+        "judge-bias caveat attached."
+    ),
 }
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--fixture", default="multihop", choices=sorted(FIXTURES.keys()),
+        help=(
+            "v0.6.1 v18.7 Phase 2 prereq — pick the measurement fixture. "
+            "`multihop` (default) = MultiHop-RAG reasoning-isolated multi-hop QA "
+            "(3 answerable question_types × n_per_type). "
+            "`chat` = chat-mode fixture (small_talk + factual_chat + "
+            "open_question + multi_turn × n_per_type). Chat-mode has NO "
+            "evidence injection — both sides answer free-form from general "
+            "knowledge. Scoring: factual_chat gets gold_signals + judge; "
+            "the other 3 sub-classes are judge-only (lenient bias caveat)."
+        ),
+    )
     ap.add_argument("--n-per-type", type=int, default=3,
                     help="questions per question_type (default 3 → 9 total)")
     ap.add_argument("--n-runs", type=int, default=3,
@@ -618,27 +707,38 @@ def main() -> int:
             return 3
         print()
 
-    queries = select_queries(args.n_per_type)
+    queries = select_queries(args.n_per_type, fixture_name=args.fixture)
+    design = ("reasoning-isolated" if args.fixture == "multihop"
+              else "chat-mode free-form (no evidence injection)")
     print(f"local={args.local_model} (num_ctx={NUM_CTX})  "
           f"cloud=claude-cli-abstraction-wired  judge=claude-blinded-AB  "
           f"queries={len(queries)}  n_runs={args.n_runs}")
-    print("design=reasoning-isolated  fixture=multihop_rag\n")
+    print(f"design={design}  fixture={args.fixture}\n")
 
     rows: List[Dict[str, Any]] = []
     for i, q in enumerate(queries, 1):
-        ctx, n_nodes, n_res = build_evidence(q)
-        if n_res == 0:
-            print(f"[{i}/{len(queries)}] id={q['id']} SKIPPED "
-                  f"(no resolved articles for {n_nodes} expected)")
-            continue
+        if args.fixture == "chat":
+            # Chat-mode skips evidence assembly entirely. The prompt
+            # template injects prior_turns (multi_turn) instead.
+            ctx, n_nodes, n_res = "", 0, 0
+        else:
+            ctx, n_nodes, n_res = build_evidence(q)
+            if n_res == 0:
+                print(f"[{i}/{len(queries)}] id={q['id']} SKIPPED "
+                      f"(no resolved articles for {n_nodes} expected)")
+                continue
+        prior_n = len(q.get("prior_turns") or [])
+        hop_hint = (f"prior_turns={prior_n}" if args.fixture == "chat"
+                    else f"hops={n_nodes}(res {n_res})")
         print(f"[{i}/{len(queries)}] id={q['id']} {q['question_type']} "
-              f"hops={n_nodes}(res {n_res})")
+              f"{hop_hint}")
         for run_idx in range(args.n_runs):
             print(f"  run {run_idx+1}/{args.n_runs} … ", end="", flush=True)
             row = run_one_query(
                 q, ctx, local_model=args.local_model,
                 run_idx=run_idx, timeout=args.timeout,
                 local_backend=args.local_backend,
+                fixture_name=args.fixture,
             )
             rows.append(row)
             print(f"local={row['local_verdict'][:4]} "
@@ -677,7 +777,12 @@ def main() -> int:
                 / f"alpha-8-local-vs-cloud-paired-{ts}.json")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps({
-        "design": "reasoning-isolated; both models same full gold evidence",
+        "design": (
+            "reasoning-isolated; both models same full gold evidence"
+            if args.fixture == "multihop"
+            else "chat-mode free-form; both models same prior_turns / no evidence"
+        ),
+        "fixture": args.fixture,
         "local_model": args.local_model,
         "local_backend": args.local_backend,
         # v18.5 — measurement design overrides

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -44,6 +44,7 @@ Or as a module (the harness calls ``run_pre_flight()`` in its main()):
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import json
 import os
 import re
@@ -430,8 +431,108 @@ def check_thinking_mode_contract() -> PreFlightResult:
     )
 
 
+def check_chat_fixture() -> PreFlightResult:
+    """v0.6.1 v18.7 Phase 2 prereq (2026-06-16) — verify the chat-mode
+    fixture is intact whenever the harness exposes a `chat` fixture
+    option. The chat fixture is operator-authored (not derived from
+    MultiHop-RAG), so schema drift between fixture and harness has no
+    natural alarm. This check pins:
+      • file exists at FIXTURES['chat']
+      • all 4 chat sub-classes (small_talk / factual_chat /
+        open_question / multi_turn) have ≥1 row
+      • factual_chat queries carry gold_signals (gold-grounded path
+        depends on it)
+      • multi_turn queries carry prior_turns (chat prompt template
+        depends on it)
+    Surfaced as `warn` if the fixture file is absent — older repos
+    that pre-date Phase 2 still ship without it; the harness only
+    reads it on `--fixture chat`. The lock-test guarantees the
+    harness keeps the `chat` key in FIXTURES until intentionally
+    revised.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "local_vs_cloud_paired",
+            _REPO_ROOT / "scripts" / "research" / "local_vs_cloud_paired.py",
+        )
+        harness = importlib.util.module_from_spec(spec)
+        sys.modules["local_vs_cloud_paired"] = harness
+        spec.loader.exec_module(harness)
+    except Exception as e:
+        return PreFlightResult(
+            "chat_fixture", "fail",
+            f"harness import failed: {type(e).__name__}: {e}",
+        )
+
+    fixtures = getattr(harness, "FIXTURES", None)
+    if not isinstance(fixtures, dict) or "chat" not in fixtures:
+        return PreFlightResult(
+            "chat_fixture", "warn",
+            "harness does not expose a 'chat' fixture (Phase 2 prereq "
+            "not yet landed in this branch).",
+        )
+
+    chat_path: Path = fixtures["chat"]
+    if not chat_path.exists():
+        return PreFlightResult(
+            "chat_fixture", "warn",
+            f"chat fixture file absent: {chat_path}. `--fixture chat` "
+            f"will fail until the file is restored.",
+        )
+
+    data = json.loads(chat_path.read_text(encoding="utf-8"))
+    queries = data.get("queries", [])
+    expected_types = ("small_talk", "factual_chat",
+                      "open_question", "multi_turn")
+    counts = {t: 0 for t in expected_types}
+    factual_with_gold = 0
+    multiturn_with_prior = 0
+    for q in queries:
+        t = q.get("question_type")
+        if t in counts:
+            counts[t] += 1
+        if t == "factual_chat" and q.get("gold_signals"):
+            factual_with_gold += 1
+        if t == "multi_turn" and q.get("prior_turns"):
+            multiturn_with_prior += 1
+
+    empties = [t for t, n in counts.items() if n == 0]
+    if empties:
+        return PreFlightResult(
+            "chat_fixture", "fail",
+            f"chat fixture missing rows for sub-classes: {empties} "
+            f"(counts={counts})",
+            extra={"counts": counts},
+        )
+    if counts["factual_chat"] != factual_with_gold:
+        return PreFlightResult(
+            "chat_fixture", "fail",
+            f"factual_chat carries {factual_with_gold}/{counts['factual_chat']} "
+            f"gold_signals (gold-grounded path requires all of them)",
+            extra={"counts": counts,
+                   "factual_with_gold": factual_with_gold},
+        )
+    if counts["multi_turn"] != multiturn_with_prior:
+        return PreFlightResult(
+            "chat_fixture", "fail",
+            f"multi_turn carries {multiturn_with_prior}/{counts['multi_turn']} "
+            f"prior_turns (chat prompt template requires all of them)",
+            extra={"counts": counts,
+                   "multiturn_with_prior": multiturn_with_prior},
+        )
+
+    return PreFlightResult(
+        "chat_fixture", "ok",
+        f"{sum(counts.values())} chat queries available "
+        f"(counts={counts}, factual_with_gold={factual_with_gold}, "
+        f"multiturn_with_prior={multiturn_with_prior})",
+        extra={"counts": counts, "path": str(chat_path)},
+    )
+
+
 _CHECKS = (
     check_fixture,
+    check_chat_fixture,
     check_regex_false_positives,
     check_backend_registry,
     check_abstraction_smoke,

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -75,6 +75,8 @@ _HARNESS_IMPORTS_REQUIRED = {
 # Renaming / moving any of these is a measurement-surface change.
 _HARNESS_TOP_LEVEL_REQUIRED = {
     "FIXTURE",
+    "FIXTURES",                # v18.7 Phase 2 prereq — multi-fixture switch
+    "ANSWERABLE_BY_FIXTURE",   # v18.7 — per-fixture answerable type list
     "RAW",
     "DEFAULT_LOCAL_MODEL",
     "OLLAMA_URL",
@@ -87,6 +89,7 @@ _HARNESS_TOP_LEVEL_REQUIRED = {
     "call_cloud_via_abstraction",
     "judge",
     "_majority",
+    "_chat_prompt",            # v18.7 — chat fixture prompt template
     "select_queries",
     "run_one_query",
     "aggregate",
@@ -400,6 +403,111 @@ class FixtureLockTest(unittest.TestCase):
                         f"query #{i} missing field {field!r} — "
                         f"paired harness will fail on this record.",
                     )
+
+
+class ChatFixtureSurface(unittest.TestCase):
+    """v0.6.1 v18.7 Phase 2 prereq (2026-06-16) — chat-mode fixture.
+
+    The chat fixture is operator-authored (not derived from a public
+    benchmark), so there is no upstream alarm if a UX cycle silently
+    edits it. The lock-tests below freeze the surface the harness
+    consumes — file location, sub-class counts, factual_chat
+    gold_signals coverage, multi_turn prior_turns coverage. Adding
+    new chat queries is allowed; removing sub-classes or breaking
+    the gold_signals / prior_turns contract trips the test.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _import_harness()
+
+    def test_chat_fixture_registered_in_harness(self):
+        from local_vs_cloud_paired import FIXTURES
+        self.assertIn(
+            "chat", FIXTURES,
+            "harness FIXTURES dict missing 'chat' entry — the "
+            "--fixture chat CLI will fail. Phase 2 prereq broken.",
+        )
+
+    def test_chat_fixture_file_exists(self):
+        from local_vs_cloud_paired import FIXTURES
+        chat_path = FIXTURES["chat"]
+        self.assertTrue(
+            chat_path.exists(),
+            f"chat fixture file missing: {chat_path}. "
+            f"--fixture chat will raise FileNotFoundError.",
+        )
+
+    def test_chat_fixture_subclasses_complete(self):
+        """All 4 chat sub-classes must carry ≥ 3 rows so the default
+        run (n_per_type=3) can build the paired sample."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["chat"].read_text(encoding="utf-8"))
+        for t in ("small_talk", "factual_chat",
+                  "open_question", "multi_turn"):
+            with self.subTest(sub_class=t):
+                rows = [q for q in data.get("queries", [])
+                        if q.get("question_type") == t]
+                self.assertGreaterEqual(
+                    len(rows), 3,
+                    f"chat sub-class {t!r} only has {len(rows)} rows "
+                    f"— paired default needs 3.",
+                )
+
+    def test_chat_fixture_factual_have_gold_signals(self):
+        """factual_chat is the only chat sub-class where the gold-
+        grounded check applies (per v18.6 judge bias). Every record
+        must carry gold_signals."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["chat"].read_text(encoding="utf-8"))
+        factuals = [q for q in data.get("queries", [])
+                    if q.get("question_type") == "factual_chat"]
+        for q in factuals:
+            with self.subTest(id=q.get("id")):
+                self.assertTrue(
+                    bool(q.get("gold_signals")),
+                    f"factual_chat id={q.get('id')} missing "
+                    f"gold_signals — gold-grounded recheck cannot "
+                    f"score this row.",
+                )
+
+    def test_chat_fixture_multiturn_have_prior_turns(self):
+        """multi_turn queries must carry prior_turns; the chat prompt
+        template treats their absence as a single-turn query, which
+        defeats the sub-class's purpose."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["chat"].read_text(encoding="utf-8"))
+        multis = [q for q in data.get("queries", [])
+                  if q.get("question_type") == "multi_turn"]
+        for q in multis:
+            with self.subTest(id=q.get("id")):
+                self.assertTrue(
+                    bool(q.get("prior_turns")),
+                    f"multi_turn id={q.get('id')} missing prior_turns "
+                    f"— sub-class becomes single-turn.",
+                )
+
+    def test_chat_prompt_template_emits_prior_turns(self):
+        """Smoke: _chat_prompt() must include prior_turns in the
+        emitted prompt body so both sides see the same context."""
+        from local_vs_cloud_paired import _chat_prompt
+        q = {
+            "text": "그거 다시 한 줄로 정리해 줘.",
+            "prior_turns": [
+                {"role": "user", "text": "광합성이 뭐야?"},
+                {"role": "assistant", "text": "식물이 빛으로 양분을 만드는 과정."},
+            ],
+        }
+        body = _chat_prompt(q)
+        self.assertIn("광합성이 뭐야?", body,
+                      "_chat_prompt drops the user prior_turn body")
+        self.assertIn("식물이 빛으로 양분을 만드는 과정.", body,
+                      "_chat_prompt drops the assistant prior_turn body")
+        self.assertIn("그거 다시 한 줄로 정리해 줘.", body,
+                      "_chat_prompt drops the current query body")
 
 
 if __name__ == "__main__":   # pragma: no cover


### PR DESCRIPTION
## Summary

- Phase 2 prereq (Step 2a). Adds a chat-mode measurement fixture (operator-authored, Korean primary) and extends `local_vs_cloud_paired.py` with `--fixture {multihop, chat}` switching so the harness can measure chat-mode tasks without rewriting any of the multihop pipeline.
- **No engine.py changes.** Step 2b (operator launches measurement) and Step 2c (engine.py mode-aware dispatch wire) follow once the Quality Delta Card is in hand.
- Three guard layers updated alongside: pre-flight (`check_chat_fixture` validates 4 sub-classes / gold_signals / prior_turns coverage), lock-test (`ChatFixtureSurface` pins 6 contract surfaces), CAVEAT_BLOCK (`chat_mode_lenient_judge` documents which sub-classes are judge-only vs gold-grounded).

## Why chat-mode needs its own fixture

`multihop_rag_queries.json` is reasoning-isolated multi-hop QA — wrong shape for chat-mode tasks:

| Concern | multihop fixture | chat fixture (this PR) |
|---|---|---|
| Evidence injection | yes, gold articles | none — free-form general knowledge |
| Sub-class taxonomy | inference / comparison / temporal / null | small_talk / factual_chat / open_question / multi_turn |
| Prior turns | n/a | multi_turn carries 2-turn context |
| Scoring | judge + gold_signals (full coverage) | judge always, gold_signals only on factual_chat |

## Fixture shape (18 queries)

- **small_talk** (5) — Korean + 1 English mirror. judge-only.
- **factual_chat** (5) — general knowledge, gold_signals every record (서울 / 100℃ / 태양 / deoxyribonucleic / 8760).
- **open_question** (5) — creative advice. judge-only.
- **multi_turn** (3) — 2-turn context carry. prior_turns populated.

## Scoring protocol

- `factual_chat` gets BOTH judge (Claude pairwise blinded A/B) AND gold-grounded substring match — same `gold_grounded_recheck.py` pattern v18.6 introduced for multihop.
- `small_talk` / `open_question` / `multi_turn` are intrinsically judge-only — no deterministic ground truth exists for free-form conversation. They inherit the +0.11-0.19 judge over-credit caveat quantified in [`project_judge_reliability_gold_grounded_v18_6`].
- The fixture's `scoring_protocol` block + the harness's new `CAVEAT_BLOCK['chat_mode_lenient_judge']` make this explicit so anyone replaying the JSON has the caveat in hand.

## Verification

- `python -c '...harness smoke...'` — `select_queries(3, fixture_name='chat')` returns 12 queries (3 per sub-class), `_chat_prompt()` renders prior_turns + current query correctly.
- `python -m unittest tests.test_measurement_critical_surfaces` → **17/17 OK** (11 → 17, 6 new `ChatFixtureSurface` tests)
- `JAMES_GEMMA4_E4B_THINK_OFF=1 python scripts/research/pre_flight_check.py` → **7/7 PASS** including the new `chat_fixture` check
- `--help` surfaces `--fixture {chat,multihop}` cleanly

## How Step 2b will use this (operator action — not in this PR)

```bash
# 4-cell paired protocol mirroring v18.5 Path A
# Cell A — gemma4:e4b OFF (current production default)
JAMES_ENABLE_CLAUDE_BACKEND=1 JAMES_GEMMA4_E4B_THINK_OFF=1 \
  python scripts/research/local_vs_cloud_paired.py \
    --fixture chat --local-model gemma4:e4b \
    --n-per-type 3 --n-runs 3 --num-predict 400 --force-think off

# Cell B — gemma3:4b (Phase 2 candidate — chat-mode preferred)
JAMES_ENABLE_CLAUDE_BACKEND=1 \
  python scripts/research/local_vs_cloud_paired.py \
    --fixture chat --local-model gemma3:4b \
    --n-per-type 3 --n-runs 3 --num-predict 400 --force-think off

# Cell C — gemma3:12b (medium tier reference)
JAMES_ENABLE_CLAUDE_BACKEND=1 \
  python scripts/research/local_vs_cloud_paired.py \
    --fixture chat --local-model gemma3:12b \
    --n-per-type 3 --n-runs 3 --num-predict 400 --force-think auto
```

Output JSONs feed the Step 2c decision on whether `engine.py` chat-mode dispatch flips to gemma3:4b (lift) or stays on gemma4:e4b OFF (parity, optionality preserved).

## Out of scope

- Engine.py mode-aware dispatch (Step 2c — requires Step 2b measurement output)
- D5 AUTO_ROUTER activation (Phase 3)
- Privacy gate (Phase 4)
- Backend adapter additions for gemma3:12b / 27b / mixtral (Phase 3 prereq)
- Larger chat fixture (n>18) — current size sufficient for n_per_type=3 paired sample; scale-up follows if Step 2b finds a publishable signal

## Quality delta

Quality delta: exempt (label: chore) — measurement-protocol scaffolding only (new fixture + harness CLI + guards). No production code path consumes this surface yet; engine.py untouched. Lock-test + pre-flight + harness smoke green.

## Rule #1 streak

- `core/retrieval` + `core/graph` traversal + `core/reasoning` — **STILL 0 lines changed**
- engine.py not touched (Step 2c gate still closed)
- vertical content: 0 / LOI gate: not triggered / Out-of-scope: documented / measurement-axis: chat-mode is an EXPLICIT new axis with caveat block

🤖 Generated with [Claude Code](https://claude.com/claude-code)