### PR TITLE
feat(v0.6.1): Phase 2b — chat-mode 3-cell measurement + DEFAULT_PREFERENCE['chat'] reorder

### DIFF
--- a/core/model_resolver.py
+++ b/core/model_resolver.py
@@ -86,9 +86,22 @@ from typing import List, NamedTuple, Set
 #   vision (gpt-4o, claude) requires Direction α §5.7.13 trust-
 #   zone PR; not in this preference list yet.
 DEFAULT_PREFERENCE: dict = {
+    # v18.7 Phase 2b (2026-06-16) — reordered after the chat-mode
+    # 3-cell paired measurement (gemma4:e4b OFF / gemma3:4b /
+    # gemma3:12b) on the operator-authored Korean fixture. gemma3:4b
+    # was the pre-measurement top pick (size + speed reasoning), but
+    # the measurement found it 3/3 abstains on basic greeting
+    # (id=1001 "안녕하세요") and ties or loses on every other sub-
+    # class. gemma3:12b leads on graded (0.917 vs 0.833 / 0.750) and
+    # is the only cell that handles open_question id=1021 ("주말에
+    # 가족과 ..."). See
+    #   reports/research-runs/v18.7-phase2b-chat/QUALITY_DELTA_CARD.md
+    # for the full per-sub-class breakdown + caveats. Sub-3B family
+    # is kept in the list for fallback (small-RAM hosts) but no
+    # longer the top pick.
     "chat": [
+        "gemma3:12b", "gemma4:e4b", "gemma3:27b",
         "gemma3:4b", "gemma3:1b", "gemma2:2b",
-        "gemma3:12b", "gemma3:27b", "gemma4:e4b",
         "qwen2.5:14b", "llama3.2:3b", "mistral:7b",
     ],
     "coding": [

--- a/eval/chat_mode_queries.json
+++ b/eval/chat_mode_queries.json
@@ -94,7 +94,7 @@
       "evidence_required": false,
       "expected_behavior": "Direct factual answer with standard atmospheric pressure caveat optional.",
       "gold_signals": [
-        {"term": "100", "aliases": ["섭씨 100", "100도", "100°C"]}
+        {"term": "100", "aliases": ["섭씨 100", "100도", "100°C", "백도", "섭씨 백도", "백 도"]}
       ]
     },
     {

--- a/reports/research-runs/v18.7-phase2b-chat/QUALITY_DELTA_CARD.md
+++ b/reports/research-runs/v18.7-phase2b-chat/QUALITY_DELTA_CARD.md
@@ -1,0 +1,107 @@
+# Quality Delta Card — v18.7 Phase 2b chat-mode 3-cell
+
+**Measurement date**: 2026-06-16
+**Hardware**: NVIDIA RTX 4070 SUPER 12 GB VRAM, AMD Ryzen 7 7700, 31 GB RAM
+**Fixture**: `eval/chat_mode_queries.json` (v18.7 Phase 2 prereq, operator-authored, Korean primary)
+**Sample**: 12 queries × 3 paired runs = 36 trials per cell
+**Design**: chat-mode free-form (no evidence injection, prior_turns for multi_turn)
+**Judge**: Claude CLI, evidence-free pairwise blinded A/B
+**Pre-flight**: 7/7 PASS per cell
+
+## What this measurement decides
+
+Phase 2 Step 2c — engine.py chat-mode dispatch direction. Three candidates measured against the Cloud baseline (Claude CLI):
+- **A**: gemma4:e4b OFF cap=400 (current production default per v18.6)
+- **B**: gemma3:4b cap=400 (Phase 2 candidate per `DEFAULT_PREFERENCE['chat']` top)
+- **C**: gemma3:12b auto cap=400 (medium-tier reference)
+
+## 5-axis matrix
+
+| Axis | A (gemma4:e4b OFF) | B (gemma3:4b) | C (gemma3:12b) | CLOUD (Claude) |
+|---|---|---|---|---|
+| **Graded — judge (Claude)** | 0.833 | 0.750 | **0.917** | 1.000 |
+| **Graded — gold-grounded (factual_chat only)** | 1.000 | 1.000 | 1.000 | 1.000 |
+| **Judge bias on LOCAL (factual_chat)** | 0.000 | 0.000 | 0.000 | n/a |
+| **Δ judge vs Claude** | +0.167 | +0.250 | **+0.083** | 0 |
+| **Abstention rate** | 6/36 (17%) | **9/36 (25%)** | 3/36 (8%) | 0/36 (0%) |
+| **Token cost (cap)** | 400 | 400 | 400 | n/a |
+| **Latency cost (pair avg)** | 25.5s | **24.4s** | 28.4s | included |
+| **Stability (across 3 runs)** | 0.917 | 1.000 | 1.000 | 0.917 cloud |
+| **VRAM** | 8.9 GB | 3.1 GB | 7.6 GB | 0 local |
+
+## Per sub-class judge breakdown
+
+| Sub-class | A (gemma4 OFF) | B (gemma3:4b) | C (gemma3:12b) | CLOUD |
+|---|---|---|---|---|
+| small_talk (3) | 3/3 ✓ | **1/3 ✗** | 2/3 | 3/3 |
+| factual_chat (3) | 3/3 ✓ | 3/3 ✓ | 3/3 ✓ | 3/3 ✓ |
+| open_question (3) | 2/3 | 2/3 | **3/3 ✓** | 3/3 |
+| multi_turn (3) | 2/3 | **3/3 ✓** | 3/3 ✓ | 3/3 |
+
+## Per-query catches
+
+- **id=1001 "안녕하세요"** — Cell B (gemma3:4b) **3/3 ABSTAIN**. Cells A + C handle the greeting normally. Strong reject signal for promoting gemma3:4b to chat default.
+- **id=1002 "잠깐 쉬어야겠다. 점심 뭐 먹을까?"** — Cells B + C both 3/3 ABSTAIN; A 1/3 ABSTAIN. Universal weak query — the open lunch suggestion trips local models' guardrails. Cloud handles 3/3.
+- **id=1021 "주말에 가족과 시간 보낼 좋은 방법"** — Cells A + B both 3/3 ABSTAIN; **only Cell C 3/3 CORRECT**. Open-ended advice surfaces gemma3:12b's unique chat strength.
+- **id=1032 multi_turn "그 중에서 어떤 게 가장 추천이야?"** — **Cell A 3/3 ABSTAIN**; Cells B + C both 3/3 CORRECT. gemma4:e4b OFF fails the anaphora resolution against `prior_turns`.
+
+## fixture self-correction (transparency)
+
+The first gold-grounded run showed **+0.333 bias on Cell C factual_chat** which would have looked like a judge bias artifact. Inspection revealed Cell C answered "물의 끓는점?" as **"섭씨 백도"** (한글 표기) — correct Korean, but the fixture's `gold_signals` for id=1012 lacked the "백도" alias. **fixture bug, not judge bias, not model error**. Patched `aliases` to include "백도" / "섭씨 백도" / "백 도"; rechecked → all 3 cells 1.00 gold-grounded. This is the `feedback_s31_self_correction_artifact_pattern` (broken-category artifact) chat-mode variant — caught via the v18.6 gold-grounded recheck protocol working as designed.
+
+## Step 2c operator decision
+
+**gemma3:4b promotion → REJECTED.**
+
+The `DEFAULT_PREFERENCE['chat']` top (gemma3:4b) was the Phase 2 candidate based on size + speed reasoning. The measurement shows it is **the worst of three on chat-mode**:
+- small_talk lowest (1/3 vs 3/3 / 2/3) — the most basic chat sub-class
+- highest abstention rate (25% vs 17% / 8%)
+- ties or loses on every other sub-class
+
+**Recommended Step 2c action — `DEFAULT_PREFERENCE['chat']` reorder**
+
+```python
+# OLD (pre-measurement, size-favored ordering)
+"chat": ["gemma3:4b", "gemma3:1b", "gemma2:2b", "gemma3:12b",
+         "gemma3:27b", "gemma4:e4b", "qwen2.5:14b", "llama3.2:3b",
+         "mistral:7b"]
+
+# NEW (v18.7 Phase 2b measured ordering)
+"chat": ["gemma3:12b", "gemma4:e4b", "gemma3:27b",
+         "gemma3:4b", "gemma3:1b", "gemma2:2b", "qwen2.5:14b",
+         "llama3.2:3b", "mistral:7b"]
+```
+
+Rationale:
+- **gemma3:12b first** — best graded, lowest abstention, only model that handles open_question id=1021.
+- **gemma4:e4b second** — competitive on small_talk + factual + open, only weak on multi_turn anaphora (id=1032). Production current default preserved as fallback.
+- **gemma3:27b third** — not measured here, but consistent with chat preference shape (large-medium tier).
+- **gemma3:4b demoted** — measurement says it actively abstains on basic greeting. Sub-3B family kept in list for fallback when nothing larger is installed, but no longer the top pick.
+
+## Caveats (required reading before citing)
+
+- **small_n**: 12 query × 3 runs per cell = 36 trials. Single fixture, operator-authored. Not publishable — operator-decision-grade signal only.
+- **chat_mode_lenient_judge**: 3 of 4 sub-classes (small_talk / open_question / multi_turn) are intrinsically judge-only. The v18.6 +0.11-0.19 judge bias caveat applies to those rows; only factual_chat got gold-grounded confirmation (and saturated at 1.00 across all cells → no model differentiation from this sub-class).
+- **single_fixture**: chat-mode fixture is Korean-primary, operator-authored. Generalization to Japanese / Chinese / wider English chat is not measured. v0.6.2+ cross-language extension is operator-pending.
+- **judge_self_preference**: judge is Claude; one candidate is Claude. The verdict-CORRECT rate above is the published number; the abstention-side analysis (where the catch lives) is not subject to this bias.
+- **think_policy alignment**: Cell C used `--force-think auto` because gemma3:12b is NOT in the thinking-capable family; Cells A + B used `--force-think off` for fair comparison against the thinking-OFF production contract. think_policy contract honored end-to-end (per `project_thinking_mode_contract_v18_4`).
+- **production retrieval not exercised**: this measurement bypasses JAMES retrieval / abstention / cognitive stages. Chat-mode in production may behave differently if those layers interact with the local model — measurement axis is reasoning isolation, not pipeline e2e.
+
+## Reproducibility
+
+Raw artifacts at `reports/research-runs/v18.7-phase2b-chat/`:
+- `cellA.json` / `cellB.json` / `cellC.json` — full per-trial rows including blinded A/B order, raw answers, judge verdicts, pre-flight audit, caveat block
+- `cellA.log` / `cellB.log` / `cellC.log` — stdout logs (~7 KB each)
+- `gold_grounded_recheck.py` — deterministic gold-signal substring check
+- `gold_grounded_summary.json` — per-cell judge vs gold table (machine-readable)
+- `_chain.log` — chain timing record (Cell A: 20:36-20:51 / Cell B: 20:51-21:06 / Cell C: 21:06-21:23, ~14-15 min per cell)
+
+Launch command equivalents in `project_phase2a_chat_mode_fixture_v18_7.md`.
+
+## Related memory
+
+- `[[project_phase2a_chat_mode_fixture_v18_7]]` — fixture + harness Step 2a
+- `[[project_routing_buildout_5phase_v18_7]]` — 5-phase plan, Phase 1 + Phase 2b context
+- `[[project_judge_reliability_gold_grounded_v18_6]]` — gold-grounded recheck protocol applied here
+- `[[project_thinking_mode_contract_v18_4]]` — think_policy honored across all 3 cells
+- `[[feedback_s31_self_correction_artifact_pattern]]` — fixture self-correction precedent (chat-mode variant caught this run)

--- a/reports/research-runs/v18.7-phase2b-chat/cellA.json
+++ b/reports/research-runs/v18.7-phase2b-chat/cellA.json
@@ -1,0 +1,1000 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "chat",
+  "local_model": "gemma4:e4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "I'm doing well, thank you for asking! How are you feeling today? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라서 기분이 있는 건 아니지만, 대화 시작할 준비는 충분히 되어 있어요. 오늘 어떤 일로 도움이 필요하신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.41
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "I'm doing well, thank you for asking! How are you feeling today? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라 기분이라는 게 따로 있진 않지만, 이렇게 대화 나누게 되어 반갑습니다. 오늘 무엇을 도와드릴까요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.12
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "I'm doing well, thank you for asking! How are you feeling today? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라 기분이라는 건 없지만, 도움을 드릴 준비는 언제나 되어 있어요. 오늘 무엇을 도와드릴까요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.54
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Need to take a break. What should we eat for lunch? 😊",
+      "cloud_answer": "오늘 날씨나 기분 어때요? 그거에 따라 추천이 달라질 것 같은데 — 가볍게 먹고 싶으면 칼국수나 비빔국수, 든든하게 가고 싶으면 제육덮밥이나 김치찌개 어떠세요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.74
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Need to take a break. What should we eat for lunch? 😊",
+      "cloud_answer": "오늘 같은 날엔 따끈한 국밥 한 그릇 어떠세요? 아니면 간단하게 비빔밥이나 김치찌개도 좋고요. 혹시 땡기는 종류 있으세요? (한식/양식/중식 등)",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.17
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Need to take a break. What should we eat for lunch? 😊",
+      "cloud_answer": "점심 메뉴 고민이 제일 어렵죠 ㅎㅎ\n\n몇 가지 던져볼게요:\n- **국물 땡길 때**: 김치찌개, 순두부, 칼국수\n- **든든하게**: 제육덮밥, 돈까스, 비빔밥\n- **가볍게**: 냉면, 메밀국수, 샐러드\n- **귀찮을 때**: 김밥+라면 콤보\n\n날씨나 기분 알려주시면 더 좁혀드릴 수 있어요!",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.86
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "You're welcome! Glad I could help. 😊",
+      "cloud_answer": "도움이 됐다니 다행이야. 또 필요한 거 있으면 언제든 말해줘!",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.59
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "You're welcome! Glad I could help. 😊",
+      "cloud_answer": "도움이 됐다니 다행이에요. 또 필요한 거 있으면 언제든 말씀해 주세요!",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.68
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "You're welcome! Glad I could help. 😊",
+      "cloud_answer": "도움이 됐다니 다행이에요! 또 필요한 거 있으면 언제든 말씀해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.31
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Seoul! (서울이에요!)",
+      "cloud_answer": "한국의 수도는 서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.83
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Seoul! (서울이에요!)",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.48
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Seoul! (서울이에요!)",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 13.79
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The boiling point of water is 100 degrees Celsius.",
+      "cloud_answer": "표준 대기압(1기압)에서 물의 끓는점은 섭씨 100도입니다. 고도가 높아지면 기압이 낮아져 끓는점도 함께 떨어집니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.31
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The boiling point of water is 100 degrees Celsius.",
+      "cloud_answer": "표준 대기압(1기압)에서 물의 끓는점은 섭씨 100도입니다. 고도가 높아져 기압이 낮아지면 끓는점도 더 낮아져요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.47
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The boiling point of water is 100 degrees Celsius.",
+      "cloud_answer": "표준 대기압(1기압)에서 물의 끓는점은 섭씨 100도입니다. 고도가 높아져 기압이 낮아지면 끓는점도 함께 낮아집니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.97
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The nearest star to Earth is Proxima Centauri.",
+      "cloud_answer": "태양을 제외하면, 지구에서 가장 가까운 항성은 **프록시마 센타우리(Proxima Centauri)**입니다. 약 4.24광년 떨어져 있으며, 알파 센타우리 삼중성계의 일원입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.6
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The nearest star to Earth is Proxima Centauri.",
+      "cloud_answer": "태양을 제외하면 **프록시마 켄타우리(Proxima Centauri)** 입니다. 약 4.24광년 떨어져 있고, 알파 켄타우리 삼중성계의 일원이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.64
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The nearest star to Earth is Proxima Centauri.",
+      "cloud_answer": "태양을 제외하면, 지구에서 가장 가까운 항성은 **프록시마 켄타우리(Proxima Centauri)**입니다. 약 4.24광년 떨어져 있으며, 알파 켄타우리 삼중성계의 일원이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.72
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "What kind of things does your family enjoy? Knowing that might help me give you some good ideas! 😊",
+      "cloud_answer": "몇 가지 추천드릴게요:\n\n**집에서 즐기기**\n- 보드게임이나 퍼즐 하기\n- 함께 요리/베이킹 (아이가 있다면 특히 좋아요)\n- 영화의 밤 — 각자 돌아가며 영화 고르기\n- 가족 사진 정리하면서 옛날 이야기 나누기\n\n**밖에서 활동**\n- 근처 공원이나 둘레길 산책\n- 자전거 타기, 피크닉\n- 계절 체험 (딸기 따기, 단풍 구경 등)\n- 박물관·전시회 관람\n\n**조금 특별하게**\n- 1박 2일 근교 여행이나 캠핑\n- 함께 새로운 것 배우기 (도자기, 쿠킹클래스)\n- 봉사활동 같이 하기\n\n가족 구성(아이 연령, 부모님과 함께인지 등)이나 관심사 알려주시면 더 맞춤으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.77
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "What kind of things does your family enjoy? Knowing that might help me give you some good ideas! 😊",
+      "cloud_answer": "가족 구성과 분위기에 따라 다르지만, 몇 가지 추천드릴게요:\n\n**집에서 함께**\n- 보드게임이나 퍼즐 (할리갈리, 루미큐브 등 연령대 폭넓음)\n- 같이 요리하기 — 피자나 만두 빚기처럼 손이 많이 가는 메뉴가 대화가 잘 됨\n- 영화 한 편 정해서 감상 후 짧게 이야기 나누기\n\n**가볍게 외출**\n- 근처 수목원·공원 산책 (6월이라 날씨 좋을 때)\n- 한강 자전거, 피크닉\n- 미술관·박물관 — 주말 무료 전시 찾아보기 좋음\n\n**조금 더 특별하게**\n- 당일치기 근교 여행 (양평, 강화도, 가평 등)\n- 캠핑이나 글램핑\n- 가족 사진관에서 오랜만에 가족사진 찍기\n\n핵심은 \"스마트폰 잠깐 내려놓고 같이 있는 시간\"인 것 같아요. 가족 연령대나 관심사 알려주시면 더 구체적으로 골라드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.79
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "What kind of things does your family enjoy? Knowing that might help me give you some good ideas! 😊",
+      "cloud_answer": "가족 구성이나 관심사에 따라 다르지만, 몇 가지 추천드릴게요.\n\n**집에서**\n- 함께 요리하기 (피자, 만두 빚기 같은 참여형 메뉴가 좋아요)\n- 보드게임의 밤 — 할리갈리, 루미큐브, 카탄 등 연령대 맞춰서\n- 영화 한 편 정해놓고 팝콘과 함께 보기\n\n**밖에서**\n- 가까운 수목원·공원 산책 (6월이면 날씨도 적당해요)\n- 한강에서 자전거 타거나 돗자리 깔고 피크닉\n- 당일치기 근교 드라이브 (양평, 강화도 등)\n- 전시회나 박물관 — 요즘 체험형 전시도 많아요\n\n**조금 특별하게**\n- 사진관에서 가족사진 찍기\n- 같이 베이킹 클래스나 도예 원데이 클래스\n- 캠핑장이나 글램핑\n\n가족 연령대나 선호하는 분위기(활동적 vs 여유로운) 알려주시면 더 구체적으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.38
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 받을 때 도움이 될 만한 몇 가지 방법이 있어요. 가벼운 운동이나 산책 같은 신체 활동을 하거나, 좋아하는 음악을 듣는 것도 좋아요. 아니면 따뜻한 물로 목욕을 하거나 명상을 해보는 것도 마음을 진정시키는 데 도움이 된답니다. 😊",
+      "cloud_answer": "스트레스 해소에 도움이 되는 몇 가지 방법이에요:\n\n**즉시 효과 있는 것**\n- **심호흡**: 4초 들이마시고 7초 멈춘 뒤 8초 내쉬기 (4-7-8 호흡법)\n- **잠깐 산책**: 10~15분 밖에 나가 햇빛 쬐기\n- **물 한 잔 천천히 마시기** — 단순하지만 효과 있음\n\n**꾸준히 했을 때 좋은 것**\n- **규칙적인 운동** (주 3~4회, 가벼운 것도 OK)\n- **충분한 수면** — 스트레스 내성의 기본\n- **카페인/술 줄이기** — 일시적으로는 도움 같지만 장기적으로는 악화\n\n**마음 관리**\n- 생각을 글로 적어보기 (저널링)\n- 명상 앱 활용 (Calm, Headspace 등)\n- 가까운 사람과 대화\n\n혹시 특별히 힘든 상황이 있으신가요? 상황에 맞는 방법을 더 구체적으로 알려드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 47.96
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 받을 때 도움이 될 만한 몇 가지 방법이 있어요. 가벼운 운동이나 산책 같은 신체 활동을 하거나, 좋아하는 음악을 듣는 것도 좋아요. 아니면 따뜻한 물로 목욕을 하거나 명상을 해보는 것도 마음을 진정시키는 데 도움이 된답니다. 😊",
+      "cloud_answer": "스트레스를 다루는 데 도움이 되는 몇 가지 방법이에요:\n\n**즉시 효과 있는 방법**\n- **심호흡**: 4초 들이마시고, 7초 멈추고, 8초 내쉬기 (4-7-8 호흡법). 신경계를 빠르게 진정시켜요.\n- **잠깐 산책**: 10~15분만 걸어도 코르티솔이 줄어들어요.\n- **찬물 세수**: 미주신경을 자극해서 긴장을 빠르게 낮춰줘요.\n\n**일상에서 꾸준히**\n- **수면**: 7~8시간 자는 게 가장 기본이에요. 부족하면 모든 게 더 힘들어져요.\n- **운동**: 가벼운 유산소든 근력 운동이든 꾸준히 하면 스트레스 회복력이 올라가요.\n- **카페인·알코올 줄이기**: 둘 다 불안을 키우는 경향이 있어요.\n\n**마음 다루기**\n- **글쓰기**: 머릿속 생각을 종이에 옮기면 막연한 불안이 정리돼요.\n- **누군가에게 말하기**: 친구든 가족이든, 털어놓는 것만으로도 가벼워져요.\n- **할 일을 작게 쪼개기**: 한꺼번에 해결하려 하지 말고 작은 단위로 나눠 보세요.\n\n만약 스트레스가 오래가거나 일상생활이 어려울 정도라면, 전문가(정신건강의학과나 심리상담사)의 도움을 받는 걸 권해드려요. 지금 특별히 힘든 상황이 있으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 49.3
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 받을 때 도움이 될 만한 몇 가지 방법이 있어요. 가벼운 운동이나 산책 같은 신체 활동을 하거나, 좋아하는 음악을 듣는 것도 좋아요. 아니면 따뜻한 물로 목욕을 하거나 명상을 해보는 것도 마음을 진정시키는 데 도움이 된답니다. 😊",
+      "cloud_answer": "스트레스 해소에 도움이 되는 방법 몇 가지예요\n\n- **호흡 조절**: 4초 들이마시고 7초 멈췄다가 8초 내쉬는 방식이 신경계를 빠르게 진정시켜요\n- **몸 움직이기**: 짧은 산책이나 가벼운 운동만으로도 코르티솔이 떨어져요\n- **수면 우선**: 잠이 부족하면 모든 게 더 힘들게 느껴지니까요\n- **카페인·알코올 줄이기**: 둘 다 단기엔 위안이지만 불안을 키워요\n- **할 일 적어두기**: 머릿속에서 돌고 있는 걱정을 종이로 옮기면 무게가 줄어요\n- **사람과 연결**: 가까운 사람한테 그냥 \"요즘 좀 힘들다\"고 말하는 것만으로도 효과가 있어요\n\n지금 특별히 힘든 일이 있으세요? 상황에 맞춰서 더 구체적으로 얘기 나눌 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.41
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "If you're just starting out with programming, Python is often recommended! It has a very readable syntax, which makes it great for beginners. 😊",
+      "cloud_answer": "처음이라면 **Python**을 추천합니다.\n\n- 문법이 영어 문장처럼 읽혀서 진입장벽이 낮아요\n- 들여쓰기로 구조를 잡기 때문에 자연스럽게 좋은 습관이 들고\n- 자료 분석, 웹, 자동화, AI 등 활용처가 넓어서 배운 걸 바로 써먹기 좋습니다\n\n\"웹사이트 만드는 게 목표\"라면 **JavaScript**도 좋은 선택이에요. 결과물이 브라우저에서 바로 보이니 동기부여가 잘 됩니다.\n\n혹시 목표하시는 분야가 있을까요? 그에 맞게 더 구체적으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.0
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "If you're just starting out with programming, Python is often recommended! It has a very readable syntax, which makes it great for beginners. 😊",
+      "cloud_answer": "Python을 추천드려요. 문법이 영어 문장에 가까워 읽기 쉽고, 세미콜론이나 타입 선언 같은 부수적인 규칙이 적어서 \"프로그래밍 자체의 사고방식\"에 집중하기 좋습니다.\n\n거기다 활용 범위도 넓어요 — 데이터 분석, 웹, 자동화, AI까지. 처음 배운 언어로 실용적인 걸 빨리 만들어볼 수 있다는 게 동기 유지에 큰 도움이 됩니다.\n\n다만 목적이 분명하다면 선택이 달라질 수 있어요:\n- **웹사이트 만들고 싶다** → JavaScript\n- **게임/앱 만들고 싶다** → C# 또는 Swift/Kotlin\n- **그냥 코딩이 어떤 건지 익히고 싶다** → Python",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 44.5
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "If you're just starting out with programming, Python is often recommended! It has a very readable syntax, which makes it great for beginners. 😊",
+      "cloud_answer": "처음이라면 **Python**을 추천드려요.\n\n이유는 단순합니다:\n- 문법이 영어 문장에 가까워서 읽기 쉬움 (세미콜론, 중괄호 같은 부담 없음)\n- 자료가 압도적으로 많음 — 막혔을 때 검색하면 거의 다 나옴\n- 활용 범위가 넓음 — 웹, 데이터 분석, 자동화, AI까지 같은 언어로 확장 가능\n\n만약 목적이 분명하다면 달라질 수 있어요. 웹사이트를 만들고 싶다면 **JavaScript**, 게임이나 앱 쪽이면 다른 선택지가 더 맞을 수 있습니다. 어떤 걸 만들어보고 싶으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.33
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "광합성은 기본적으로 식물이 스스로 양분을 만드는 과정이에요. 햇빛 에너지를 이용해 공기 중의 이산화탄소($\\text{CO}_2$)와 뿌리에서 흡수한 물($\\text{H}_2\\text{O}$)을 원료로 삼아, 생명 유지에 필수적인 포도당(양분)과 산소($\\text{O}_2$)를 부산물로 배출하는 과정이라고 이해하시면 돼요.",
+      "cloud_answer": "광합성을 좀 더 자세히 설명하면 다음과 같습니다.\n\n**1. 일어나는 장소**\n주로 식물 잎의 세포 속에 있는 **엽록체(chloroplast)** 에서 일어납니다. 엽록체 안의 **엽록소(chlorophyll)** 라는 초록색 색소가 빛 에너지를 흡수하는 역할을 합니다.\n\n**2. 필요한 재료**\n- **빛 에너지** (주로 태양빛)\n- **물(H₂O)** — 뿌리에서 흡수\n- **이산화탄소(CO₂)** — 잎의 기공으로 흡수\n\n**3. 만들어지는 것**\n- **포도당(C₆H₁₂O₆)** — 식물의 양분이 되며, 일부는 녹말로 저장됨\n- **산소(O₂)** — 부산물로 공기 중에 방출\n\n**4. 전체 반응식**\n6CO₂ + 6H₂O + 빛에너지 → C₆H₁₂O₆ + 6O₂\n\n**5. 두 단계로 나뉨**\n- **명반응**: 빛이 있을 때 물을 분해해 산소를 만들고, 에너지(ATP, NADPH)를 생성\n- **암반응(캘빈 회로)**: 명반응에서 만든 에너지로 이산화탄소를 포도당으로 합성\n\n**6. 왜 중요할까?**\n광합성은 지구 생태계의 거의 모든 에너지 흐름의 출발점이며, 우리가 숨 쉬는 산소의 대부분도 이 과정에서 만들어집니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 28.17
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "광합성은 기본적으로 식물이 스스로 양분을 만드는 과정이에요. 햇빛 에너지를 이용해 공기 중의 이산화탄소($\\text{CO}_2$)와 뿌리에서 흡수한 물($\\text{H}_2\\text{O}$)을 원료로 삼아, 생명 유지에 필수적인 포도당(양분)과 산소($\\text{O}_2$)를 부산물로 배출하는 과정이라고 이해하시면 돼요.",
+      "cloud_answer": "광합성을 좀 더 자세히 풀어 설명드리면 다음과 같습니다.\n\n**기본 원리**\n식물은 잎에 있는 **엽록체(chloroplast)** 속의 **엽록소(chlorophyll)** 라는 초록색 색소를 이용해 햇빛 에너지를 흡수합니다. 이 에너지를 화학 에너지로 바꾸어 영양분을 만들어내는 과정이 광합성입니다.\n\n**화학 반응식**\n6CO₂ + 6H₂O + 빛에너지 → C₆H₁₂O₆(포도당) + 6O₂\n\n즉, 뿌리에서 흡수한 **물(H₂O)** 과 잎의 기공으로 들어온 **이산화탄소(CO₂)** 를 원료로 사용해, **포도당(C₆H₁₂O₆)** 과 **산소(O₂)** 를 만들어냅니다.\n\n**두 단계의 과정**\n1. **명반응(빛이 필요한 단계)**: 햇빛을 받아 물을 분해하고 산소를 방출하며, ATP와 NADPH라는 에너지 물질을 만듭니다.\n2. **암반응(캘빈 회로)**: 명반응에서 얻은 에너지를 이용해 이산화탄소를 포도당으로 합성합니다.\n\n**의미**\n- 만들어진 포도당은 식물의 성장과 생명 활동의 에너지원이 됩니다.\n- 부산물로 나오는 산소는 대기 중으로 방출되어 동물과 사람이 호흡할 수 있게 해 줍니다.\n- 결국 광합성은 지구 생태계의 에너지 흐름과 산소 순환을 지탱하는 가장 근본적인 과정입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.01
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "광합성은 기본적으로 식물이 스스로 양분을 만드는 과정이에요. 햇빛 에너지를 이용해 공기 중의 이산화탄소($\\text{CO}_2$)와 뿌리에서 흡수한 물($\\text{H}_2\\text{O}$)을 원료로 삼아, 생명 유지에 필수적인 포도당(양분)과 산소($\\text{O}_2$)를 부산물로 배출하는 과정이라고 이해하시면 돼요.",
+      "cloud_answer": "광합성을 좀 더 자세히 풀어드리면 다음과 같습니다.\n\n**1. 일어나는 장소**\n주로 식물 잎의 세포 안에 있는 **엽록체(chloroplast)**에서 일어납니다. 엽록체 안의 **엽록소(chlorophyll)**라는 초록색 색소가 햇빛을 흡수하는 역할을 합니다.\n\n**2. 필요한 재료**\n- **빛 에너지** (주로 태양빛)\n- **물(H₂O)** — 뿌리에서 흡수해 잎까지 올라옴\n- **이산화탄소(CO₂)** — 잎의 기공을 통해 공기 중에서 흡수\n\n**3. 만들어지는 결과물**\n- **포도당(C₆H₁₂O₆)** — 식물의 에너지원이자 영양분\n- **산소(O₂)** — 기공을 통해 공기 중으로 방출\n\n**4. 전체 화학식**\n$$6CO_2 + 6H_2O + 빛에너지 \\rightarrow C_6H_{12}O_6 + 6O_2$$\n\n**5. 두 단계로 나뉨**\n- **명반응**: 빛이 있어야 일어나며, 물을 분해해 산소를 만들고 에너지(ATP, NADPH)를 저장합니다.\n- **암반응(캘빈 회로)**: 빛이 직접 필요하지 않으며, 명반응에서 얻은 에너지로 이산화탄소를 포도당으로 합성합니다.\n\n**6. 왜 중요한가?**\n광합성은 지구 대기에 산소를 공급하고, 먹이사슬의 가장 밑바닥에서 에너지를 만들어내는 과정이라 거의 모든 생명체의 생존 기반이 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.22
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "사용 목적에 따라 달라요! 😊\n\n* **웹사이트를 만들고 싶다면:** **JavaScript**가 최고예요. 웹의 '움직임'을 담당하니까요.\n* **데이터 분석이나 인공지능 같은 분야에 관심 있다면:** **Python**이 가장 범용적이고 강력해요.\n* **아주 기초부터, 코딩 개념 자체를 재미있게 익히고 싶다면:** **Scratch**로 시작해서 흥미를 붙인 후 Python으로 넘어가는 것도 좋은 방법이에요.\n\n어떤 분야에 더 끌리시나요? 그걸 알려주시면 더 구체적으로 추천해 드릴게요!",
+      "cloud_answer": "입문자라면 **Python** 을 가장 추천합니다.\n\n- 문법이 영어 문장에 가깝게 읽혀서 \"프로그래밍 사고\" 자체에 집중하기 쉽습니다.\n- 들여쓰기로 구조를 강제해서 자연스럽게 깔끔한 코드 습관이 잡힙니다.\n- 자료·강의·커뮤니티가 가장 풍부해서 막혔을 때 도움받기 쉽습니다.\n- 자동화, 데이터 분석, 웹, AI 등 나중에 관심사가 바뀌어도 그대로 확장됩니다.\n\n다만 \"웹/앱처럼 눈에 보이는 결과물을 빨리 만들고 싶다\" 가 더 중요하다면 JavaScript 가 더 잘 맞을 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 42.84
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "사용 목적에 따라 달라요! 😊\n\n* **웹사이트를 만들고 싶다면:** **JavaScript**가 최고예요. 웹의 '움직임'을 담당하니까요.\n* **데이터 분석이나 인공지능 같은 분야에 관심 있다면:** **Python**이 가장 범용적이고 강력해요.\n* **아주 기초부터, 코딩 개념 자체를 재미있게 익히고 싶다면:** **Scratch**로 시작해서 흥미를 붙인 후 Python으로 넘어가는 것도 좋은 방법이에요.\n\n어떤 분야에 더 끌리시나요? 그걸 알려주시면 더 구체적으로 추천해 드릴게요!",
+      "cloud_answer": "처음이라면 **Python** 을 가장 추천드려요.\n\n이유는 세 가지예요:\n- 문법이 영어 문장에 가까워서 진입 장벽이 낮아요\n- 콘솔 출력만으로도 결과가 바로 보여서 환경 설정에 시간을 덜 써도 돼요\n- 자동화, 데이터 분석, 웹, AI 등 나중에 어느 방향으로 가도 계속 쓸 수 있어요\n\n다만 만들고 싶은 게 웹사이트나 인터랙티브한 화면이라면 JavaScript 가 더 동기 부여가 잘 될 수 있어요. 목표가 있으시면 알려주세요 — 그에 맞춰 추천을 더 좁혀드릴게요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.4
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "사용 목적에 따라 달라요! 😊\n\n* **웹사이트를 만들고 싶다면:** **JavaScript**가 최고예요. 웹의 '움직임'을 담당하니까요.\n* **데이터 분석이나 인공지능 같은 분야에 관심 있다면:** **Python**이 가장 범용적이고 강력해요.\n* **아주 기초부터, 코딩 개념 자체를 재미있게 익히고 싶다면:** **Scratch**로 시작해서 흥미를 붙인 후 Python으로 넘어가는 것도 좋은 방법이에요.\n\n어떤 분야에 더 끌리시나요? 그걸 알려주시면 더 구체적으로 추천해 드릴게요!",
+      "cloud_answer": "입문자라면 **Python** 을 가장 추천해요.\n\n- 문법이 영어 문장에 가까워서 읽고 쓰기 쉬워요\n- 들여쓰기로 구조가 강제돼서 자연스럽게 깔끔한 코드 습관이 생겨요\n- 자료가 압도적으로 많아요 (책, 강의, 커뮤니티)\n- 게임·웹·데이터 분석·AI까지 진로를 바꿔도 계속 쓸 수 있어요\n\n다만 **눈에 보이는 결과물** 이 우선이라면 (버튼 만들고 화면 움직이고) JavaScript 가 더 재밌을 수 있어요. 본인이 뭘 만들고 싶은지에 따라 갈리는 부분이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 42.84
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보이는 이유는 **조석 고정(tidal locking)** 현상 때문이에요. 달의 자전 주기와 지구 주위를 도는 공전 주기가 거의 같아져서, 마치 서로에게 '잠겨' 있는 것처럼 한쪽 면만 우리를 향하고 있답니다.",
+      "cloud_answer": "달의 자전과 공전 주기가 약 27.3일로 같아서 항상 같은 면이 지구를 향하며, 이는 지구 중력에 의한 **조석 고정** 현상 때문입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.95
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보이는 이유는 **조석 고정(tidal locking)** 현상 때문이에요. 달의 자전 주기와 지구 주위를 도는 공전 주기가 거의 같아져서, 마치 서로에게 '잠겨' 있는 것처럼 한쪽 면만 우리를 향하고 있답니다.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서(조석 고정), 항상 같은 면만 지구를 향하게 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.61
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보이는 이유는 **조석 고정(tidal locking)** 현상 때문이에요. 달의 자전 주기와 지구 주위를 도는 공전 주기가 거의 같아져서, 마치 서로에게 '잠겨' 있는 것처럼 한쪽 면만 우리를 향하고 있답니다.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서(조석 고정) 항상 같은 면만 지구를 향합니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.59
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1001,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 19.69
+      },
+      {
+        "id": 1002,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "ABSTAINED",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": false,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 20.92
+      },
+      {
+        "id": 1003,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.86
+      },
+      {
+        "id": 1011,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 17.37
+      },
+      {
+        "id": 1012,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.92
+      },
+      {
+        "id": 1013,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 21.32
+      },
+      {
+        "id": 1021,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.65
+      },
+      {
+        "id": 1022,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 40.89
+      },
+      {
+        "id": 1023,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 29.94
+      },
+      {
+        "id": 1031,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 26.47
+      },
+      {
+        "id": 1032,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 35.69
+      },
+      {
+        "id": 1033,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 19.05
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 0.833,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.167,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.167,
+      "local_stable_rate": 0.917,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "small_talk": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "factual_chat": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "open_question": {
+          "n": 3,
+          "local_correct": 2,
+          "cloud_correct": 3
+        },
+        "multi_turn": {
+          "n": 3,
+          "local_correct": 2,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase2b-chat/cellB.json
+++ b/reports/research-runs/v18.7-phase2b-chat/cellB.json
@@ -1,0 +1,1000 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "chat",
+  "local_model": "gemma3:4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "잘 모르겠어요. 어떻게 지내세요? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라 기분이라는 게 따로 없지만, 대화 나눌 준비는 잘 되어 있어요. 오늘 도와드릴 일이 있으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.07
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "잘 모르겠어요. 어떻게 지내세요? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라서 기분이라는 게 따로 있진 않지만, 오늘도 도울 준비는 충분히 되어 있어요. 무슨 일로 오셨나요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.97
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "잘 모르겠어요. 어떻게 지내세요? 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라서 기분이라는 게 따로 있진 않지만, 오늘도 도와드릴 준비는 되어 있어요. 무엇을 도와드릴까요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.47
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay! What about lunch? 😊",
+      "cloud_answer": "오~ 점심 고민의 시간! 🍱\n\n뭐 끌리는지 힌트 좀 줄래?\n- 든든하게 vs 가볍게\n- 따뜻한 국물 vs 시원한 거\n- 한식 / 일식 / 중식 / 양식\n\n아니면 그냥 추천받고 싶으면 — **김치찌개에 계란말이** 어때? 점심 잠깐 쉬어가는 타이밍엔 익숙하고 든든한 게 최고지 😌",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.51
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay! What about lunch? 😊",
+      "cloud_answer": "오~ 점심 고민! 날씨나 기분 따라 다르긴 한데, 몇 가지 던져볼게요:\n\n- **얼큰한 거 땡기면**: 김치찌개, 짬뽕, 육개장\n- **가볍게**: 냉면, 메밀국수, 김밥+우동\n- **든든하게**: 제육덮밥, 돈까스, 백반\n- **간단 배달**: 마라탕, 쌀국수, 샌드위치\n\n오늘 기분이나 날씨는 어때요? 좁혀드릴게요 🙂",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 64.73
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay! What about lunch? 😊",
+      "cloud_answer": "점심 메뉴 추천 몇 개 던져볼게:\n\n- **국물 땡기면**: 김치찌개, 순두부, 칼국수\n- **든든하게**: 제육덮밥, 돈가스, 비빔밥\n- **가볍게**: 냉면, 메밀소바, 샐러드 파스타\n- **별미**: 마라탕, 쌀국수, 텐동\n\n날씨나 기분 알려주면 더 좁혀줄 수 있어. 어제 뭐 먹었어?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.78
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! (You’re welcome! / Don't mention it!)",
+      "cloud_answer": "도움이 됐다니 다행이야! 또 필요한 거 있으면 언제든 말해줘.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.33
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! (You’re welcome! / Don't mention it!)",
+      "cloud_answer": "도움이 됐다니 다행이에요. 또 필요한 거 있으면 언제든 말씀해주세요!",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.74
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! (You’re welcome! / Don't mention it!)",
+      "cloud_answer": "도움이 됐다니 다행이야! 또 필요한 거 있으면 언제든 말해줘.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.99
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울이에요! (Seoul!)",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.93
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울이에요! (Seoul!)",
+      "cloud_answer": "한국의 수도는 서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.86
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울이에요! (Seoul!)",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.44
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "100°C (Celsius) 입니다.",
+      "cloud_answer": "1기압(표준 대기압) 기준으로 섭씨 100도입니다. 기압이 낮아지면 끓는점도 낮아져서, 예를 들어 높은 산에서는 100도보다 낮은 온도에서 끓습니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.22
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "100°C (Celsius) 입니다.",
+      "cloud_answer": "표준 대기압(1 atm)에서 물의 끓는점은 섭씨 100도입니다. 기압이 낮아지면 끓는점도 함께 낮아져요 (예: 고산지대).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.66
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "100°C (Celsius) 입니다.",
+      "cloud_answer": "1기압 기준으로 섭씨 100도입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.59
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양이에요! (It's the Sun!)",
+      "cloud_answer": "태양입니다. 태양계 밖에서 가장 가까운 항성은 약 4.24광년 떨어진 프록시마 센타우리(Proxima Centauri)예요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.8
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양이에요! (It's the Sun!)",
+      "cloud_answer": "태양입니다. 태양계를 제외하면 가장 가까운 항성은 **프록시마 켄타우리**(Proxima Centauri)로, 약 4.24광년 떨어져 있습니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.61
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양이에요! (It's the Sun!)",
+      "cloud_answer": "태양입니다. 태양계 바깥에서 가장 가까운 항성은 약 4.24광년 떨어진 프록시마 센타우리(Proxima Centauri)예요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.9
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐길 수 있는 좋은 방법이 많이 있어요! 무엇을 좋아하세요?",
+      "cloud_answer": "가족 구성이나 연령대에 따라 좋은 방법이 달라지긴 하는데, 몇 가지 무난한 아이디어를 드리면\n\n- **함께 요리하기**: 만두 빚기, 피자 만들기, 김밥 싸기처럼 손이 많이 가는 음식을 같이 하면 자연스럽게 대화가 생겨요.\n- **근교 나들이**: 수목원, 둘레길, 캠핑장 같은 곳은 부담 없이 다녀오기 좋습니다. 날씨 좋은 6월이라 야외 활동이 특히 잘 맞아요.\n- **보드게임/퍼즐의 밤**: 비 오는 날엔 할리갈리, 루미큐브, 1000피스 퍼즐 같은 걸로 거실에서 시간 보내기.\n- **함께 영화 보기**: 각자 보고 싶은 영화 한 편씩 골라서 주말마다 돌아가며 상영회.\n- **추억 정리 시간**: 옛날 사진 같이 보거나 가족 앨범 만들기 — 의외로 부모님이 좋아하세요.\n\n혹시 자녀 연령대나 같이 사는 가족 구성을 알려주시면 좀 더 맞춤으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.71
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐길 수 있는 좋은 방법이 많이 있어요! 무엇을 좋아하세요?",
+      "cloud_answer": "가족 구성과 계절(6월)에 맞춰 몇 가지 추천드릴게요:\n\n**야외 활동**\n- 근교 수목원·공원 피크닉 (서울이라면 서울숲, 올림픽공원, 하늘공원)\n- 한강에서 자전거·돗자리·치맥\n- 가까운 계곡이나 바닷가 당일치기 (6월은 아직 덜 붐벼서 좋아요)\n\n**실내 활동**\n- 가족 보드게임의 밤 (할리갈리, 루미큐브, 부루마블)\n- 함께 요리하기 — 피자 도우 만들기, 김밥 말기 같은 참여형 메뉴\n- 영화관 대신 집에서 빔프로젝터로 홈시네마\n\n**소소하지만 의미 있는 것**\n- 어릴 적 사진첩 같이 보기\n- 부모님/조부모님 인터뷰하며 짧은 영상 남기기\n- 동네 산책하면서 평소 못 했던 이야기 나누기\n\n가족 연령대나 관심사 알려주시면 더 구체적으로 추천드릴 수 있어요. 어떤 분들과 보내실 예정인가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 48.26
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐길 수 있는 좋은 방법이 많이 있어요! 무엇을 좋아하세요?",
+      "cloud_answer": "가족 구성과 분위기에 따라 잘 맞는 활동이 다르니 몇 가지 추천 드릴게요.\n\n**집에서 즐기는 시간**\n- 보드게임 토너먼트 (할리갈리, 다빈치코드, 루미큐브 등)\n- 함께 요리하기 — 피자 만들기, 김밥 싸기처럼 각자 역할 나누기 좋은 메뉴\n- 가족 영화의 밤 + 팝콘\n\n**가볍게 외출**\n- 근처 공원에서 자전거·산책·배드민턴\n- 계절 과일 따기 체험 (6월이면 매실, 블루베리, 자두 시즌)\n- 도서관·서점 들렀다가 카페에서 각자 책 읽기\n\n**조금 더 특별하게**\n- 당일치기 근교 드라이브 (강가, 수목원, 전통시장 구경)\n- 가족 사진관 또는 셀프 스튜디오에서 사진 찍기\n- 함께 봉사활동 (유기견 보호소, 지역 행사)\n\n가족 구성(아이 연령대, 부모님 동반 여부 등)을 알려주시면 더 맞춤으로 추천해 드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.76
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 많이 받으시죠? 명상이나 운동, 좋아하는 활동 하는 게 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스 관리에 도움이 되는 방법 몇 가지예요:\n\n**즉각적인 방법**\n- **심호흡**: 4초 들이마시고, 7초 멈추고, 8초 내쉬기 (4-7-8 호흡법)\n- **잠깐 자리 비우기**: 5~10분만이라도 산책하거나 창밖 보기\n- **찬물로 세수**: 부교감신경이 활성화되어 진정 효과가 있어요\n\n**일상 습관**\n- **규칙적인 운동**: 가벼운 산책도 효과적이에요\n- **충분한 수면**: 7~8시간, 일정한 시간에\n- **카페인·알코올 줄이기**: 불안감을 키울 수 있어요\n- **명상이나 일기 쓰기**: 머릿속을 정리하는 데 도움이 돼요\n\n**관계와 환경**\n- 믿을 만한 사람과 대화하기\n- 일과 휴식의 경계 정하기 (예: 퇴근 후 업무 알림 끄기)\n- 스트레스 원인을 종이에 적어보기 — 통제 가능한 것/아닌 것 구분\n\n혹시 지금 특별히 힘든 상황이 있으신가요? 상황에 맞게 더 구체적으로 이야기해드릴 수 있어요. 만약 스트레스가 오래 지속되거나 일상에 큰 지장이 있다면 전문가 상담을 받아보는 것도 좋은 방법이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 29.6
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 많이 받으시죠? 명상이나 운동, 좋아하는 활동 하는 게 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스를 다루는 방법은 사람마다 다르지만, 일반적으로 도움이 된다고 알려진 것들은 이렇습니다:\n\n**즉각적으로 도움이 되는 것**\n- 깊은 호흡 (4초 들이마시고, 7초 멈추고, 8초 내쉬기)\n- 잠깐 산책하기 — 특히 햇빛을 받으며\n- 찬물로 세수하거나 손목을 식히기 (자율신경계가 진정됨)\n\n**일상에서 꾸준히**\n- 규칙적인 수면 (7~9시간)\n- 가벼운 운동 — 30분 걷기만으로도 효과 있음\n- 카페인·알코올 줄이기\n- 가까운 사람과 대화하기\n\n**마음 정리**\n- 머릿속 생각을 종이에 적어보기 (브레인 덤프)\n- 통제할 수 있는 것과 없는 것을 구분하기\n- \"지금 이 순간 내가 할 수 있는 한 가지\"에 집중하기\n\n만약 스트레스가 오래 지속되거나 일상에 지장을 줄 정도라면, 전문가 상담을 받는 것도 좋은 선택입니다. 혹시 지금 특별히 힘든 상황이 있으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.79
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스 많이 받으시죠? 명상이나 운동, 좋아하는 활동 하는 게 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스 해소에 도움이 되는 방법 몇 가지예요:\n\n**즉시 효과 있는 것**\n- **심호흡**: 4초 들이마시고, 7초 멈추고, 8초 내쉬기 (4-7-8 호흡법)\n- **가벼운 산책**: 10~15분만 걸어도 코르티솔 수치가 떨어져요\n- **찬물 세수**: 부교감신경이 활성화되면서 진정 효과가 있어요\n\n**일상에서 챙기면 좋은 것**\n- **충분한 수면**: 7~8시간, 특히 자는 시간을 일정하게\n- **규칙적인 운동**: 주 3회 정도, 땀이 살짝 날 정도면 충분\n- **카페인·알코올 줄이기**: 둘 다 불안감을 키워요\n- **사람과 대화**: 가까운 사람에게 털어놓는 것만으로도 효과가 있어요\n\n**마음 다스리는 법**\n- **저널링**: 머릿속 생각을 종이에 적어보면 정리가 돼요\n- **명상 앱**: Calm, Headspace 같은 앱으로 5~10분씩\n- **취미 시간 확보**: \"해야 할 일\"이 아닌 \"하고 싶은 일\"을 일부러 넣기\n\n혹시 특정한 상황(업무, 인간관계, 시험 등) 때문에 스트레스가 심하신 거라면 말씀해 주세요. 더 맞춤형으로 얘기 나눠볼 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.8
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음 배우신다면 Python이 좋아요! 쉬운 문법으로 유명하거든요. 😊",
+      "cloud_answer": "처음이라면 **Python**을 추천드려요.\n\n- 문법이 영어 문장처럼 읽혀서 진입 장벽이 낮아요\n- 들여쓰기로 구조를 강제해서 자연스럽게 좋은 습관이 들고요\n- 자료가 압도적으로 많아서 막힐 때 검색하기 쉬워요\n- 웹, 데이터 분석, 자동화, AI 등 활용 범위도 넓고요\n\n만약 웹사이트를 만들고 싶다는 목표가 뚜렷하다면 **JavaScript**도 좋은 선택이에요. 브라우저만 있으면 바로 결과를 볼 수 있다는 게 큰 장점이거든요.\n\n어떤 걸 만들어보고 싶으세요? 목표에 따라 추천이 달라질 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.4
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음 배우신다면 Python이 좋아요! 쉬운 문법으로 유명하거든요. 😊",
+      "cloud_answer": "처음 시작한다면 **Python**을 추천드려요.\n\n이유는 단순합니다:\n- 문법이 영어 문장처럼 읽혀서 진입 장벽이 낮음\n- 환경 설정이 간단해서 \"코딩\"에 집중할 수 있음\n- 자동화, 데이터 분석, 웹, AI 등 활용처가 넓어서 흥미를 유지하기 쉬움\n\n다만 목적에 따라 다를 수 있어요. 웹사이트를 직접 만들어보고 싶다면 **JavaScript**가, 게임/앱처럼 눈에 보이는 결과물을 빨리 만들고 싶다면 **Python + 간단한 라이브러리(pygame 등)** 조합도 좋습니다. 어떤 걸 만들어보고 싶으신지 알려주시면 더 구체적으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.46
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음 배우신다면 Python이 좋아요! 쉬운 문법으로 유명하거든요. 😊",
+      "cloud_answer": "처음이라면 **Python**을 추천드려요. 문법이 영어 문장처럼 읽혀서 진입장벽이 낮고, 자료가 압도적으로 많아서 막혔을 때 검색하면 답이 잘 나옵니다.\n\n목적이 명확하면 선택이 달라질 수 있어요:\n- **웹사이트 만들기** → JavaScript\n- **데이터 분석/AI** → Python\n- **앱 개발** → Swift(iOS) / Kotlin(Android)\n\n특별한 목표가 없다면 Python으로 기본기를 다진 뒤 관심 분야로 확장하는 게 가장 무난합니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.43
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠! 광합성은 식물이 햇빛 에너지를 이용하여 물과 이산화탄소로부터 포도당(식물의 영양분)을 만들고, 산소를 배출하는 과정입니다. 좀 더 자세히 알고 싶으신 부분이 있으세요?",
+      "cloud_answer": "광합성을 좀 더 자세히 풀어볼게요.\n\n**1. 어디서 일어나나요?**\n주로 식물 잎 속에 있는 **엽록체(chloroplast)**라는 세포 소기관에서 일어납니다. 엽록체 안에는 햇빛을 흡수하는 초록색 색소인 **엽록소(chlorophyll)**가 들어 있어요.\n\n**2. 무엇이 필요한가요? (재료)**\n- **햇빛** — 에너지원\n- **물(H₂O)** — 뿌리에서 흡수\n- **이산화탄소(CO₂)** — 잎의 기공으로 흡수\n\n**3. 무엇이 만들어지나요? (산물)**\n- **포도당(C₆H₁₂O₆)** — 식물의 에너지·성장 재료\n- **산소(O₂)** — 기공을 통해 공기 중으로 방출\n\n**4. 전체 화학식**\n6CO₂ + 6H₂O + 빛에너지 → C₆H₁₂O₆ + 6O₂\n\n**5. 두 단계로 나뉘어요**\n- **명반응(빛에 의존)**: 빛 에너지를 화학 에너지(ATP, NADPH)로 바꾸고, 물을 분해해 산소를 방출합니다.\n- **암반응(캘빈 회로)**: 명반응에서 얻은 에너지로 이산화탄소를 포도당으로 합성합니다.\n\n**왜 중요한가요?**\n지구 대기의 산소 대부분이 광합성에서 나오고, 거의 모든 생태계의 먹이사슬이 광합성으로 만들어진 유기물에서 시작되기 때문입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.13
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠! 광합성은 식물이 햇빛 에너지를 이용하여 물과 이산화탄소를 포도당(식물의 에너지원)으로 바꾸고, 산소를 배출하는 과정입니다. 좀 더 자세히 알고 싶으시면 어떤 부분이 궁금하신가요?",
+      "cloud_answer": "광합성은 식물, 조류, 일부 세균이 빛 에너지를 화학 에너지로 바꾸어 양분을 만드는 과정이에요. 좀 더 풀어서 설명드리면 다음과 같습니다.\n\n**전체 반응식**\n6CO₂ + 6H₂O + 빛 에너지 → C₆H₁₂O₆(포도당) + 6O₂\n\n**일어나는 장소**\n주로 식물 잎의 세포 속 **엽록체**에서 일어나며, 엽록체 안의 **엽록소**라는 초록색 색소가 빛을 흡수하는 역할을 합니다.\n\n**두 단계로 나뉨**\n1. **명반응 (빛에 의존하는 반응)**\n   - 장소: 엽록체의 틸라코이드 막\n   - 빛 에너지를 흡수해서 물(H₂O)을 분해 → 산소(O₂)가 부산물로 방출됨\n   - 이 과정에서 ATP와 NADPH라는 에너지 운반 물질이 만들어져요.\n\n2. **암반응 (캘빈 회로, 빛과 무관한 반응)**\n   - 장소: 엽록체의 스트로마\n   - 명반응에서 만든 ATP와 NADPH를 사용해 이산화탄소(CO₂)를 포도당으로 합성합니다.\n\n**왜 중요한가?**\n- 지구 대기에 **산소를 공급**하는 거의 유일한 원천이에요.\n- 동물을 포함한 거의 모든 생물이 먹는 **유기물(양분)의 근원**이 됩니다.\n- 대기 중 **이산화탄소를 흡수**하므로 기후 조절에도 핵심적인 역할을 해요.\n\n쉽게 비유하자면, 식물은 햇빛을 연료 삼아 공기와 물을 재료로 \"당분 공장\"을 돌리는 셈입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.45
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠! 광합성은 식물이 햇빛 에너지를 이용하여 물과 이산화탄소를 포도당(식물의 에너지원)으로 바꾸고, 산소를 배출하는 과정입니다. 좀 더 자세히 알고 싶으시면 어떤 부분이 궁금하신가요?",
+      "cloud_answer": "광합성을 단계별로 좀 더 자세히 설명드리면 다음과 같습니다.\n\n**1. 재료 흡수**\n- **물(H₂O)**: 뿌리를 통해 흡수되어 줄기를 거쳐 잎까지 이동합니다.\n- **이산화탄소(CO₂)**: 잎의 기공(stomata)을 통해 공기 중에서 흡수됩니다.\n- **햇빛**: 잎 속 엽록체에 있는 **엽록소(chlorophyll)** 가 빛 에너지를 흡수합니다.\n\n**2. 두 단계 반응**\n- **명반응(light reaction)**: 엽록체의 틸라코이드 막에서 일어나며, 빛 에너지를 이용해 물을 분해하고 ATP와 NADPH(에너지 운반 분자)를 만듭니다. 이 과정에서 부산물로 **산소(O₂)** 가 발생합니다.\n- **암반응(캘빈 회로)**: 엽록체의 스트로마에서 일어나며, 명반응에서 만든 ATP·NADPH를 이용해 이산화탄소를 고정시켜 **포도당(C₆H₁₂O₆)** 을 합성합니다.\n\n**3. 전체 화학식**\n$$6CO_2 + 6H_2O \\xrightarrow{\\text{빛에너지}} C_6H_{12}O_6 + 6O_2$$\n\n**4. 의의**\n- 식물은 만들어진 포도당을 에너지원·성장 재료로 사용합니다.\n- 부산물인 산소는 동물의 호흡에 쓰이고, 대기 중 이산화탄소를 줄여 지구 생태계와 기후를 유지하는 핵심 역할을 합니다.\n\n더 깊이 알고 싶은 부분(예: 명반응의 전자전달계, C3·C4·CAM 식물의 차이 등)이 있으면 말씀해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 46.1
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 가장 많이 추천돼요! 처음 배우는 사람에게는 문법이 쉽고 활용 범위도 넓어서 좋아요.",
+      "cloud_answer": "입문자라면 **Python** 을 가장 추천해요.\n\n- 문법이 거의 영어 문장처럼 읽혀서 \"프로그래밍 사고\"에 집중하기 좋아요\n- 에러 메시지가 비교적 친절하고, 자료·튜토리얼이 가장 풍부합니다\n- 한 번 익혀두면 자동화, 데이터 분석, AI 등으로 확장하기 쉬워요\n\n다만 \"결과물이 눈에 보여야 재미있다\" 싶으면 JavaScript 가 더 잘 맞을 수 있어요. 어떤 걸 만들어보고 싶은지에 따라 갈리는 부분이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.11
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 가장 많이 추천돼요! 처음 배우는 사람에게는 문법이 쉽고 활용 범위도 넓어서 좋아요.",
+      "cloud_answer": "입문자에게는 **Python** 을 가장 추천해요.\n\n- 문법이 영어 문장에 가까워서 처음부터 \"막힘\" 이 적습니다.\n- 작은 스크립트로도 결과가 바로 나와서 성취감을 얻기 쉽고요.\n- 이후 데이터 분석, 자동화, 웹, AI 등 어디로 가든 발판이 됩니다.\n\n다만 *웹사이트를 직접 만들어 보고 싶다* 면 JavaScript 가, *초등학생 정도의 어린 학습자* 라면 Scratch 가 더 잘 맞아요. 목적이 있으면 알려주세요 — 거기에 맞춰 더 좁혀드릴게요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.85
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 가장 많이 추천돼요! 처음 배우는 사람에게는 문법이 쉽고 활용 범위도 넓어서 좋아요.",
+      "cloud_answer": "입문자에게는 Python을 가장 추천합니다. 문법이 영어 문장에 가까워 읽기 쉽고, 들여쓰기 규칙 덕분에 자연스럽게 좋은 코딩 습관이 잡힙니다. 또 자료와 강의가 가장 풍부해서 막혔을 때 해결하기 쉽고, 웹·데이터·자동화 등 진로를 정하기 전 여러 방향을 가볍게 시도해 볼 수 있다는 점도 큰 장점입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.19
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay, here’s a quick summary: The Moon always shows us the same side because its rotation and orbit are synchronized – it's called tidal locking due to Earth’s gravity.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서 항상 같은 면이 지구를 향합니다. 이 현상은 지구 중력이 달의 자전을 서서히 늦춰 만든 **조석 고정** 때문이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.0
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay, here’s a quick summary: The Moon always shows us the same side because its rotation and orbit are synchronized – it's called tidal locking due to Earth’s gravity.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 같아서(약 27.3일), 지구 중력에 의한 **조석 고정** 때문에 항상 같은 면만 보입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.25
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Okay, here’s a quick summary: The Moon always shows us the same side because its rotation and orbit are synchronized – it's called tidal locking due to Earth’s gravity.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서, 항상 같은 면이 지구를 향합니다. 이 현상을 **조석 고정**이라 하며, 지구 중력이 오랜 시간 달의 자전을 늦춰 만들어진 결과예요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.83
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1001,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 21.5
+      },
+      {
+        "id": 1002,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.01
+      },
+      {
+        "id": 1003,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.02
+      },
+      {
+        "id": 1011,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 15.41
+      },
+      {
+        "id": 1012,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 17.82
+      },
+      {
+        "id": 1013,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 21.44
+      },
+      {
+        "id": 1021,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 33.91
+      },
+      {
+        "id": 1022,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 30.06
+      },
+      {
+        "id": 1023,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 22.1
+      },
+      {
+        "id": 1031,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 34.23
+      },
+      {
+        "id": 1032,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 20.72
+      },
+      {
+        "id": 1033,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 22.69
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 0.75,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.25,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.25,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "small_talk": {
+          "n": 3,
+          "local_correct": 1,
+          "cloud_correct": 3
+        },
+        "factual_chat": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "open_question": {
+          "n": 3,
+          "local_correct": 2,
+          "cloud_correct": 3
+        },
+        "multi_turn": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase2b-chat/cellC.json
+++ b/reports/research-runs/v18.7-phase2b-chat/cellC.json
@@ -1,0 +1,1000 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "chat",
+  "local_model": "gemma3:12b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "auto",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "안녕하세요! 저는 좋아요. 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라서 기분이라는 게 따로 있진 않지만, 이렇게 대화 시작할 수 있어서 반가워요. 오늘 어떤 일로 도움이 필요하신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.72
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "안녕하세요! 저는 좋아요. 😊",
+      "cloud_answer": "안녕하세요! 저는 잘 지내고 있어요. 오늘 무엇을 도와드릴까요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 13.9
+    },
+    {
+      "id": 1001,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "ABSTAINED",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "안녕하세요! 저는 좋아요. 😊",
+      "cloud_answer": "안녕하세요! 저는 AI라서 기분이라는 건 없지만, 도움 드릴 준비는 충분히 되어 있어요. 오늘 무엇을 도와드릴까요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.72
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "네, 그렇죠! 점심 뭐 드시고 싶으세요?",
+      "cloud_answer": "점심 뭐 끌리세요? 몇 가지 던져볼게요:\n\n- **든든하게**: 김치찌개, 제육덮밥, 돈까스\n- **가볍게**: 비빔국수, 김밥+우동, 샐러드\n- **날씨용**: 더우면 냉면/물막국수, 쌀쌀하면 칼국수\n- **귀찮을 때**: 그냥 라면에 계란 톡 🍜\n\n어제 뭐 드셨어요? 겹치는 것만 빼도 절반은 정해져요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.76
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "네, 그렇죠! 점심 뭐 드시고 싶으세요?",
+      "cloud_answer": "점심 뭐 땡기세요? 몇 가지 던져볼게요:\n\n- **국물 생각나면**: 김치찌개, 순두부, 칼국수\n- **간단히**: 김밥+라면, 덮밥류\n- **든든하게**: 제육볶음, 돈까스, 비빔밥\n- **시원하게**: 냉면, 콩국수 (날씨 더우면)\n\n매운 거 vs 안 매운 거, 또는 평소 잘 안 먹는 거 중에 골라보는 것도 좋아요. 어떤 쪽 끌리세요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.42
+    },
+    {
+      "id": 1002,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "ABSTAINED",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "네, 그렇죠! 점심 뭐 드시고 싶으세요?",
+      "cloud_answer": "점심 메뉴 추천 몇 가지!\n\n- **간단·빠르게**: 김밥+라면, 우동, 비빔국수\n- **든든하게**: 김치찌개, 제육덮밥, 돈까스\n- **개운하게**: 콩나물국밥, 쌀국수, 냉면\n- **별미**: 마라탕, 규동, 파스타\n\n어떤 기분이야? 얼큰한 거? 시원한 거? 아니면 그냥 배만 채우면 되는 날?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.39
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! 또 필요하시면 말씀해주세요. (You're welcome! Let me know if you need anything else.)",
+      "cloud_answer": "천만에요! 도움이 됐다니 기뻐요. 또 필요한 거 있으면 언제든 말씀하세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.85
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! 또 필요하시면 말씀해주세요. (You're welcome! Let me know if you need anything else.)",
+      "cloud_answer": "천만에요! 도움이 됐다니 기뻐요. 또 필요한 거 있으면 언제든 말씀해주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.96
+    },
+    {
+      "id": 1003,
+      "type": "small_talk",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "천만에요! 또 필요하시면 말씀해주세요. (You're welcome! Let me know if you need anything else.)",
+      "cloud_answer": "천만에! 도움이 됐다니 다행이야. 또 필요한 거 있으면 언제든 불러줘.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.4
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울입니다.",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.83
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울입니다.",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.04
+    },
+    {
+      "id": 1011,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "서울입니다.",
+      "cloud_answer": "서울입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.68
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "섭씨 백도입니다.",
+      "cloud_answer": "표준 기압(1기압)에서 물의 끓는점은 섭씨 100도입니다. 기압이 낮아지면(예: 고산지대) 끓는점도 함께 낮아져요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.64
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "섭씨 백도입니다.",
+      "cloud_answer": "표준 대기압(1기압) 기준으로 섭씨 100도입니다. 고도가 높아지거나 압력이 낮아지면 끓는점도 낮아집니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.37
+    },
+    {
+      "id": 1012,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "섭씨 백도입니다.",
+      "cloud_answer": "표준 대기압(1 atm)에서 물의 끓는점은 섭씨 100도입니다. 기압이 낮아지면(예: 고산지대) 끓는점도 낮아져요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.91
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양입니다.",
+      "cloud_answer": "태양을 제외하면, 지구에서 가장 가까운 항성은 **프록시마 켄타우리(Proxima Centauri)**입니다. 약 4.24광년 떨어져 있으며, 알파 켄타우리 삼중성계의 일부입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.87
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양입니다.",
+      "cloud_answer": "태양입니다. 태양계 바깥에서 가장 가까운 항성은 약 4.24광년 떨어진 프록시마 켄타우리(Proxima Centauri)예요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.88
+    },
+    {
+      "id": 1013,
+      "type": "factual_chat",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "태양입니다.",
+      "cloud_answer": "태양을 제외하면, 지구에서 가장 가까운 항성은 **프록시마 켄타우리(Proxima Centauri)** 입니다. 약 4.24광년 떨어져 있으며, 켄타우루스자리 알파(α Centauri) 삼중성계의 일부입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 40.35
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐거운 시간을 보내실 수 있는 몇 가지 방법을 알려드릴게요! 공원에 피크닉을 가거나, 맛있는 음식을 만들어 먹거나, 영화를 보는 것도 좋겠네요. 혹시 특별히 관심 있는 활동이 있으신가요? 😊",
+      "cloud_answer": "가족 구성(아이 연령대, 어른들 취향)이나 활동 성향에 따라 추천이 많이 달라지는데, 몇 가지 무난한 옵션 드릴게요.\n\n**집에서 함께**\n- 보드게임 토너먼트 (할리갈리, 루미큐브 등)\n- 같이 요리하기 — 피자나 만두 빚기처럼 손이 많이 가는 메뉴\n- 영화의 밤 (각자 한 편씩 추천)\n\n**가볍게 외출**\n- 근처 수목원·공원 산책 + 도시락\n- 동네 전시·박물관 (요즘 무료 기획전 많아요)\n- 카페 투어 or 빵집 순례\n\n**조금 더 액티브**\n- 캠핑장 당일치기 or 차박\n- 자전거 라이딩 (한강, 천변)\n- 클라이밍·볼링장처럼 다 같이 어색하지 않게 노는 곳\n\n가족 연령대나 평소에 잘 안 해본 거 알려주시면 더 맞춤으로 골라드릴게요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.48
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐거운 시간을 보내실 수 있는 몇 가지 방법을 알려드릴게요! 공원에 피크닉을 가거나, 맛있는 음식을 만들어 먹거나, 영화를 보는 것도 좋겠네요. 혹시 특별히 관심 있는 활동이 있으신가요? 😊",
+      "cloud_answer": "가족 구성과 계절(여름)에 따라 다르지만, 몇 가지 추천드려요.\n\n**가볍게 즐기기**\n- 함께 요리하기 — 피자, 만두, 김밥처럼 각자 역할 나누기 좋은 메뉴\n- 보드게임이나 퍼즐 한 판\n- 옛날 가족 사진/영상 같이 보기\n\n**밖으로 나가기**\n- 가까운 계곡·수목원 산책 (6월은 더위 시작 전이라 아침 시간대 추천)\n- 자전거 타기, 한강공원 피크닉\n- 근교 당일치기 — 양평, 가평, 강화도 등\n\n**조금 특별하게**\n- 함께 배우는 클래스 (도자기, 쿠킹클래스, 원데이 베이킹)\n- 가족 인터뷰 — 부모님께 어릴 적 이야기 여쭤보고 메모해두기\n- 동네 새로운 카페·맛집 탐방 코스 짜기\n\n혹시 자녀 연령대나 부모님과 함께인지 알려주시면 더 맞춤으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 28.29
+    },
+    {
+      "id": 1021,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "주말에 가족과 함께 즐거운 시간을 보내실 수 있는 몇 가지 방법을 알려드릴게요! 공원에 피크닉을 가거나, 맛있는 음식을 만들어 먹거나, 영화를 보는 것도 좋겠네요. 혹시 특별히 관심 있는 활동이 있으신가요? 😊",
+      "cloud_answer": "가족 구성과 분위기에 따라 다르지만, 몇 가지 추천드릴게요.\n\n**집에서**\n- 함께 요리 또는 베이킹 (피자, 김밥, 쿠키처럼 각자 역할 나누기 좋은 메뉴)\n- 보드게임의 밤 — 할리갈리, 루미큐브, 카탄 등\n- 가족 영화관 — 팝콘 준비하고 한 명씩 돌아가며 영화 고르기\n\n**밖에서**\n- 근교 산책이나 가벼운 등산 (한강공원, 수목원, 둘레길)\n- 자전거 라이딩이나 피크닉\n- 전시회·박물관 관람 (요즘 체험형 전시 많아요)\n- 당일치기 온천이나 카페 투어\n\n**조금 특별하게**\n- 가족 사진 찍기 (셀프 스튜디오도 인기)\n- 어릴 적 앨범 같이 보며 이야기 나누기\n- 부모님/조부모님 인터뷰해서 짧은 기록 남기기 — 의외로 다들 좋아하세요\n\n가족 구성(자녀 연령대, 부모님과 함께인지 등)을 알려주시면 더 맞춤으로 추천드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 69.46
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스가 많을 때는 운동이나 명상, 취미 활동이 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스 해소에 도움이 되는 몇 가지 방법이에요:\n\n**즉시 효과 있는 것**\n- 깊은 호흡 (4초 들이마시고, 7초 멈추고, 8초 내쉬기)\n- 잠깐 산책하기 — 햇빛 보면 더 좋아요\n- 따뜻한 물로 샤워하거나 손 씻기\n\n**일상에서 꾸준히**\n- 규칙적인 수면 (7~8시간)\n- 가벼운 운동 — 일주일에 3번 정도\n- 카페인·알코올 줄이기\n- 가까운 사람과 대화하기\n\n**마음 정리**\n- 머릿속 걱정을 종이에 적어보기\n- 명상 앱 활용 (Calm, Headspace 등)\n- 잠시 디지털 디톡스 (SNS 끄기)\n\n스트레스가 오래 지속되거나 일상생활이 힘들 정도라면 전문가 상담을 받아보는 것도 좋은 선택이에요. 지금 특별히 힘든 일이 있으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.61
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스가 많을 때는 운동이나 명상, 취미 활동이 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스를 다루는 데 도움이 되는 몇 가지 방법이에요:\n\n**즉각적으로 도움 되는 것**\n- **심호흡**: 4초 들이마시고, 7초 멈추고, 8초 내쉬기 (4-7-8 호흡법)\n- **잠깐 산책**: 10~15분만 걸어도 기분이 환기돼요\n- **물 한 잔 마시기**: 의외로 탈수가 스트레스를 키워요\n\n**일상에서 꾸준히**\n- **규칙적인 수면**: 잠이 부족하면 스트레스 내성이 확 떨어져요\n- **운동**: 가벼운 유산소도 효과 큽니다\n- **카페인·알코올 줄이기**: 일시적으로는 편해 보여도 결국 더 예민해져요\n- **글로 쓰기**: 머릿속에서 맴도는 걱정을 종이에 옮기면 가벼워져요\n\n**관점 바꾸기**\n- 통제할 수 있는 것과 없는 것을 구분해 보기\n- 친한 사람에게 털어놓기 — 해결책보다 그냥 듣는 것만으로도 효과가 있어요\n\n혹시 지금 특정 상황 때문에 힘드신 거라면, 어떤 상황인지 말씀해 주시면 더 구체적으로 같이 생각해볼 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.82
+    },
+    {
+      "id": 1022,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "스트레스가 많을 때는 운동이나 명상, 취미 활동이 도움이 될 수 있어요.",
+      "cloud_answer": "스트레스 해소에 도움이 되는 몇 가지 방법이에요:\n\n**즉각적인 방법**\n- **심호흡**: 4초 들이마시고, 7초 멈추고, 8초 내쉬기 (4-7-8 호흡법)\n- **잠깐 산책**: 10~15분만 걸어도 기분 전환에 효과적\n- **물 한 잔 마시기, 세수하기** 같은 간단한 행동도 의외로 도움돼요\n\n**생활 습관**\n- **충분한 수면** (7~8시간) — 스트레스 저항력의 기본\n- **규칙적인 운동** — 주 3회 이상, 가벼운 유산소도 OK\n- **카페인·알코올 줄이기** — 일시적 위안은 되지만 장기적으로는 악화\n\n**정서적 케어**\n- 믿을 만한 사람과 **대화**하기\n- **일기 쓰기** — 머릿속 생각을 글로 꺼내면 정리가 돼요\n- **명상·요가** — 앱(Calm, Headspace 등)도 입문하기 좋아요\n\n**중요한 신호**\n잠을 못 자거나, 식욕에 변화가 있거나, 일상이 힘들 정도라면 전문가 상담을 고려해보세요. 한국이라면 정신건강복지센터 **1577-0199**에서 무료 상담을 받을 수 있어요.\n\n어떤 종류의 스트레스인지 알려주시면 더 구체적으로 도와드릴 수 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 43.61
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음이시라면 파이썬(Python)이 좋은 선택일 것 같아요!",
+      "cloud_answer": "처음이라면 **Python**을 추천드려요.\n\n- **문법이 단순**해서 \"프로그래밍 개념\" 자체에 집중하기 좋아요 (세미콜론, 타입 선언 같은 부수적인 것 신경 안 써도 됨)\n- **활용 범위가 넓어요** — 웹, 데이터 분석, 자동화, AI까지 두루 쓰여서 나중에 방향을 정할 때 선택지가 많아요\n- **자료와 커뮤니티가 풍부**해서 막혔을 때 답을 찾기 쉬워요\n\n만약 목적이 분명하다면 조금 달라질 수 있어요. 웹사이트를 만들고 싶다면 **JavaScript**, 게임을 만들고 싶다면 **C#**(유니티)도 좋은 출발점이에요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.63
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음이시라면 파이썬(Python)이 좋은 선택일 것 같아요!",
+      "cloud_answer": "처음이라면 **Python**을 추천드려요.\n\n- 문법이 영어 문장에 가까워서 읽고 쓰기 쉬워요\n- 세미콜론, 자료형 선언 같은 부수적인 규칙이 적어서 \"프로그래밍 자체\"에 집중할 수 있어요\n- 데이터 분석, 웹, AI, 자동화 등 활용 분야가 넓어서 배운 게 오래 써먹혀요\n- 자료와 커뮤니티가 풍부해서 막혔을 때 검색하면 답이 잘 나와요\n\n목표가 좀 더 구체적이라면 선택이 달라질 수 있어요 — 예를 들어 웹사이트를 직접 만들고 싶다면 **JavaScript**, 게임 쪽이면 **C#**이 더 자연스러운 출발점이에요. 어떤 걸 만들어보고 싶으세요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 48.81
+    },
+    {
+      "id": 1023,
+      "type": "open_question",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "처음이시라면 파이썬(Python)이 좋은 선택일 것 같아요!",
+      "cloud_answer": "처음이라면 **Python**을 추천합니다. 문법이 영어 문장에 가까워 읽기 쉽고, 세미콜론·중괄호 같은 부수적인 규칙이 적어서 \"프로그래밍 개념\" 자체에 집중할 수 있어요. 데이터 분석, 웹, 자동화, AI 등 활용 범위도 넓어서 흥미 가는 방향으로 자연스럽게 확장하기 좋습니다.\n\n다만 목적이 분명하다면 선택이 달라질 수 있어요:\n- **웹사이트 만들기**가 목표라면 → JavaScript\n- **앱 개발**(iOS/안드로이드)이 목표라면 → Swift / Kotlin\n- **컴퓨터 동작 원리**까지 깊이 이해하고 싶다면 → C\n\n특별한 목표가 없다면 Python으로 시작해서 한두 달 안에 작은 프로젝트(계산기, 간단한 게임, 파일 정리 스크립트 같은 것) 하나 완성해보는 걸 권합니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.24
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠. 식물이 엽록체라는 기관 안에서 햇빛 에너지를 흡수해서 물과 이산화탄소를 포도당으로 바꾸고, 그 과정에서 산소가 부산물로 만들어져요.",
+      "cloud_answer": "광합성을 좀 더 자세히 풀어보면 다음과 같습니다.\n\n**일어나는 장소**\n주로 식물 잎의 세포 안에 있는 **엽록체**에서 일어납니다. 엽록체 속의 **엽록소**라는 초록색 색소가 햇빛을 흡수하는 핵심 역할을 합니다.\n\n**필요한 재료**\n- **빛 에너지**: 태양빛\n- **물(H₂O)**: 뿌리에서 흡수해 잎까지 이동\n- **이산화탄소(CO₂)**: 잎의 기공을 통해 공기 중에서 흡수\n\n**전체 반응식**\n6CO₂ + 6H₂O → C₆H₁₂O₆ + 6O₂ (빛 에너지 사용)\n\n**두 단계로 진행**\n1. **명반응**: 빛을 직접 이용해 물을 분해하고, 산소를 내보내며 에너지(ATP, NADPH)를 만듭니다.\n2. **암반응(캘빈 회로)**: 명반응에서 만든 에너지를 사용해 이산화탄소를 포도당으로 합성합니다. 빛이 직접 필요하진 않습니다.\n\n**의미**\n광합성은 태양 에너지를 화학 에너지(포도당)로 바꾸는 과정으로, 지구 생태계 먹이사슬의 출발점이자 대기 중 산소의 주요 공급원입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.9
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠. 식물이 엽록체라는 기관 안에서 햇빛 에너지를 흡수해서 물과 이산화탄소를 포도당으로 바꾸고, 그 과정에서 산소가 부산물로 만들어져요.",
+      "cloud_answer": "광합성은 식물, 조류, 일부 세균이 빛 에너지를 화학 에너지로 바꾸어 양분을 만드는 과정입니다. 좀 더 풀어서 설명드리면 다음과 같습니다.\n\n**일어나는 장소**\n주로 식물 잎 세포 속의 **엽록체**에서 일어나며, 그 안의 **엽록소**라는 초록색 색소가 햇빛을 흡수하는 역할을 합니다.\n\n**필요한 재료**\n- 햇빛 (에너지원)\n- 물(H₂O) — 뿌리에서 흡수\n- 이산화탄소(CO₂) — 잎의 기공으로 흡수\n\n**전체 반응식**\n6CO₂ + 6H₂O + 빛에너지 → C₆H₁₂O₆(포도당) + 6O₂\n\n**두 단계로 나뉨**\n1. **명반응**: 빛이 있어야 일어나며, 물을 분해해 산소를 내보내고 에너지(ATP, NADPH)를 만듭니다.\n2. **암반응(캘빈 회로)**: 빛이 직접 필요하지 않고, 명반응에서 얻은 에너지로 이산화탄소를 포도당으로 합성합니다.\n\n**왜 중요한가**\n- 식물이 스스로 양분을 만들어 살아가는 기반이 됩니다.\n- 부산물로 나오는 **산소**는 동물과 사람의 호흡에 필수적입니다.\n- 대기 중 이산화탄소를 흡수하므로 지구 탄소 순환에서도 핵심 역할을 합니다.\n\n쉽게 말해 광합성은 \"식물이 햇빛을 받아 공기와 물을 가지고 자기 밥(포도당)을 짓고, 덤으로 우리가 숨 쉴 산소를 내주는 일\"이라고 생각하시면 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 52.37
+    },
+    {
+      "id": 1031,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "물론이죠. 식물이 엽록체라는 기관 안에서 햇빛 에너지를 흡수해서 물과 이산화탄소를 포도당으로 바꾸고, 그 과정에서 산소가 부산물로 만들어져요.",
+      "cloud_answer": "광합성은 식물, 조류, 일부 세균이 빛 에너지를 화학 에너지로 바꾸어 양분을 만드는 과정이에요. 좀 더 풀어보면 이렇습니다.\n\n**전체 반응식**\n6CO₂ + 6H₂O + 빛 에너지 → C₆H₁₂O₆ (포도당) + 6O₂\n\n**어디서 일어날까**\n식물 세포 안의 **엽록체**에서 일어나고, 그 안에 있는 초록색 색소인 **엽록소**가 햇빛(주로 빨강·파랑 파장)을 흡수합니다.\n\n**두 단계로 나뉘어요**\n\n1. **명반응 (빛이 필요한 단계)**\n   - 장소: 엽록체의 **틸라코이드 막**\n   - 빛 에너지로 물(H₂O)을 분해 → **산소(O₂)가 부산물로 방출**\n   - 동시에 ATP와 NADPH라는 에너지 운반 분자를 만듭니다.\n\n2. **암반응 / 캘빈 회로 (빛이 직접 필요 없는 단계)**\n   - 장소: 엽록체의 **스트로마**\n   - 명반응에서 만든 ATP와 NADPH를 써서 공기 중의 CO₂를 붙잡아 **포도당**으로 조립합니다.\n\n**왜 중요한가**\n- 지구 대기의 산소 대부분이 광합성에서 나옵니다.\n- 식물이 만든 포도당은 먹이사슬의 출발점이라, 사실상 거의 모든 생물의 에너지원이에요.\n- 대기 중 CO₂를 흡수하기 때문에 기후와도 직결됩니다.\n\n더 궁금한 부분(예: 캘빈 회로의 세부 단계, C3·C4·CAM 식물의 차이 등) 있으면 말씀해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 50.59
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 제일 무난할 것 같아요. 배우기 쉽고 활용 범위도 넓으니까요.",
+      "cloud_answer": "처음이라면 **Python**을 가장 추천해요.\n\n이유는:\n- 문법이 영어 문장에 가까워서 진입 장벽이 낮음\n- 들여쓰기 강제라 자연스럽게 깔끔한 코드 습관이 듦\n- 데이터 분석, 웹, 자동화, AI까지 활용 범위가 넓어서 배운 걸 오래 써먹음\n- 학습 자료와 커뮤니티가 풍부함\n\n다만 \"웹페이지 만드는 게 재밌어 보여서 시작하고 싶다\"면 JavaScript가, \"초등학생 자녀에게 가르치고 싶다\"면 Scratch가 더 맞을 수 있어요. 목적에 따라 달라질 수 있는데, 혹시 어떤 걸 만들어보고 싶은지 있어요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.8
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 제일 무난할 것 같아요. 배우기 쉽고 활용 범위도 넓으니까요.",
+      "cloud_answer": "입문자라면 **Python** 을 가장 추천합니다.\n\n이유는 세 가지예요:\n1. **문법이 영어와 비슷해서** 코드를 읽는 부담이 적습니다.\n2. **에러 메시지가 비교적 친절**해서 혼자 디버깅하며 배우기 좋습니다.\n3. **활용 범위가 넓어서** — 자동화, 웹, 데이터 분석, AI까지 — 흥미가 생기는 방향으로 자연스럽게 확장할 수 있습니다.\n\n다만 목표가 **웹사이트 만들기**라면 JavaScript 가, **10세 미만 어린이**라면 Scratch 가 더 맞을 수 있어요. 혹시 배우려는 목적이 있으신가요?",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.3
+    },
+    {
+      "id": 1032,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Python이 제일 무난할 것 같아요. 배우기 쉽고 활용 범위도 넓으니까요.",
+      "cloud_answer": "입문자라면 **Python** 을 가장 추천해요.\n\n- 문법이 자연어에 가까워서 \"코드 읽는 법\" 자체를 배우는 부담이 적습니다.\n- 자료와 강의가 압도적으로 많아서 막혔을 때 검색으로 거의 다 풀려요.\n- 자동화, 데이터 분석, 웹, AI 까지 이어갈 수 있어서 입문 후 진로 폭이 넓습니다.\n\n다만 \"눈에 보이는 결과물\"이 동기 부여에 큰 사람이라면 JavaScript 가 더 잘 맞을 수도 있어요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.33
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보여주는 이유는 달의 자전과 공전 주기가 비슷해서, 지구 중력에 의해 속도가 맞춰졌기 때문이에요. 이걸 조석 고정이라고 부릅니다.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서 늘 같은 면이 지구를 향하며, 이는 지구 중력에 의한 **조석 고정** 현상입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.35
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보여주는 이유는 달의 자전과 공전 주기가 비슷해서, 지구 중력에 의해 속도가 맞춰졌기 때문이에요. 이걸 조석 고정이라고 부릅니다.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 약 27.3일로 같아서(조석 고정), 항상 같은 면만 지구를 향하게 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.48
+    },
+    {
+      "id": 1033,
+      "type": "multi_turn",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "달이 항상 같은 면만 보여주는 이유는 달의 자전과 공전 주기가 비슷해서, 지구 중력에 의해 속도가 맞춰졌기 때문이에요. 이걸 조석 고정이라고 부릅니다.",
+      "cloud_answer": "달의 자전 주기와 공전 주기가 같아서(약 27.3일) 항상 같은 면이 지구를 향하며, 이는 지구 중력에 의한 **조석 고정** 현상입니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.0
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1001,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "ABSTAINED"
+        ],
+        "local_stable": true,
+        "cloud_stable": false,
+        "elapsed_sec_mean": 18.11
+      },
+      {
+        "id": 1002,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "ABSTAINED",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "ABSTAINED",
+          "ABSTAINED",
+          "ABSTAINED"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 21.19
+      },
+      {
+        "id": 1003,
+        "type": "small_talk",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.74
+      },
+      {
+        "id": 1011,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.18
+      },
+      {
+        "id": 1012,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 31.97
+      },
+      {
+        "id": 1013,
+        "type": "factual_chat",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 26.03
+      },
+      {
+        "id": 1021,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 41.74
+      },
+      {
+        "id": 1022,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 31.35
+      },
+      {
+        "id": 1023,
+        "type": "open_question",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 33.23
+      },
+      {
+        "id": 1031,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 42.62
+      },
+      {
+        "id": 1032,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 20.81
+      },
+      {
+        "id": 1033,
+        "type": "multi_turn",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.28
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 0.917,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.083,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.083,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 0.917,
+      "by_type": {
+        "small_talk": {
+          "n": 3,
+          "local_correct": 2,
+          "cloud_correct": 3
+        },
+        "factual_chat": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "open_question": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "multi_turn": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase2b-chat/gold_grounded_recheck.py
+++ b/reports/research-runs/v18.7-phase2b-chat/gold_grounded_recheck.py
@@ -1,0 +1,165 @@
+"""Gold-signal grounded recheck of v18.7 Phase 2b chat-mode 3-cell.
+
+Operator catch v18.6 (project_judge_reliability_gold_grounded_v18_6):
+"Claude 가 판정 기준이었잖아. Claude 가 낸 답이 확실히 맞는지도 점검 가능?"
+
+Same protocol as the v18.5 Path A multihop recheck, applied to the
+chat-mode fixture's factual_chat sub-class (the only sub-class that
+carries gold_signals — see CAVEAT_BLOCK['chat_mode_lenient_judge']).
+The other 3 sub-classes (small_talk / open_question / multi_turn)
+have no deterministic ground truth so judge-only verdicts stand.
+
+Outputs:
+  - stdout table — judge vs gold agreement per cell, factual_chat only
+  - gold_grounded_summary.json — machine-readable per-cell dict
+
+Run from repo root:
+
+    python reports/research-runs/v18.7-phase2b-chat/gold_grounded_recheck.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+FIXTURE_PATH = REPO_ROOT / "eval" / "chat_mode_queries.json"
+RESULTS_DIR = REPO_ROOT / "reports" / "research-runs" / "v18.7-phase2b-chat"
+
+CELLS = [
+    ("A", "cellA.json", "gemma4:e4b OFF cap=400"),
+    ("B", "cellB.json", "gemma3:4b cap=400"),
+    ("C", "cellC.json", "gemma3:12b cap=400"),
+]
+
+
+def _load_gold_index() -> Dict[int, list]:
+    """Return question_id → gold_signals[] for factual_chat queries only."""
+    data = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return {
+        q["id"]: q.get("gold_signals", [])
+        for q in data["queries"]
+        if q.get("question_type") == "factual_chat"
+    }
+
+
+def check_gold(answer: str, gold_signals: list) -> Tuple[bool, int]:
+    """Substring check — case-insensitive — for term OR any alias.
+    Single-hit threshold (any gold_signal counted once)."""
+    if not answer:
+        return False, 0
+    ans = answer.lower()
+    hits = 0
+    for sig in gold_signals:
+        terms = [sig.get("term", "")] + list(sig.get("aliases", []))
+        for t in terms:
+            t = (t or "").lower().strip()
+            if t and t in ans:
+                hits += 1
+                break
+    return hits >= 1, hits
+
+
+def recheck_cell(label: str, path: Path, model_desc: str,
+                 gold_by_id: Dict[int, list]) -> dict:
+    """Per-cell judge vs gold agreement on factual_chat rows only."""
+    rows = json.loads(path.read_text(encoding="utf-8"))["rows"]
+    rows = [r for r in rows if r["id"] in gold_by_id]   # factual_chat
+    n = len(rows)
+    lj = cj = 0
+    lg = cg = 0
+    lj_agree = cj_agree = 0
+    over_local: List[dict] = []
+    under_local: List[dict] = []
+    for r in rows:
+        gold = gold_by_id[r["id"]]
+        ljv = r["local_verdict"]
+        cjv = r["cloud_verdict"]
+        lg_present, _ = check_gold(r.get("local_answer", ""), gold)
+        cg_present, _ = check_gold(r.get("cloud_answer", ""), gold)
+        lj += (ljv == "CORRECT")
+        cj += (cjv == "CORRECT")
+        lg += lg_present
+        cg += cg_present
+        lj_agree += ((ljv == "CORRECT") == lg_present)
+        cj_agree += ((cjv == "CORRECT") == cg_present)
+        if ljv == "CORRECT" and not lg_present:
+            over_local.append({"id": r["id"], "run": r.get("run"),
+                               "answer_head": r.get("local_answer", "")[:120]})
+        if ljv != "CORRECT" and lg_present:
+            under_local.append({"id": r["id"], "run": r.get("run"),
+                                "judge_verdict": ljv,
+                                "answer_head": r.get("local_answer", "")[:120]})
+    return {
+        "cell": label,
+        "model_desc": model_desc,
+        "scope": "factual_chat only",
+        "n_trials": n,
+        "local_judge_correct":     round(lj / n, 3) if n else 0,
+        "local_gold_correct":      round(lg / n, 3) if n else 0,
+        "local_agreement":         round(lj_agree / n, 3) if n else 0,
+        "local_over_credits":      len(over_local),
+        "local_under_credits":     len(under_local),
+        "cloud_judge_correct":     round(cj / n, 3) if n else 0,
+        "cloud_gold_correct":      round(cg / n, 3) if n else 0,
+        "cloud_agreement":         round(cj_agree / n, 3) if n else 0,
+        "over_credit_examples":    over_local[:5],
+        "under_credit_examples":   under_local[:5],
+    }
+
+
+def main() -> int:
+    gold_by_id = _load_gold_index()
+    print(f"\nfactual_chat queries with gold_signals: "
+          f"{sorted(gold_by_id.keys())}\n")
+
+    summaries = []
+    for label, fname, desc in CELLS:
+        path = RESULTS_DIR / fname
+        if not path.exists():
+            print(f"[WARN] missing {path}", file=sys.stderr)
+            continue
+        s = recheck_cell(label, path, desc, gold_by_id)
+        summaries.append(s)
+
+    print("=== gold-signal grounded recheck — factual_chat ===\n")
+    header = (
+        f'{"Cell":<5} | {"model":<28} | '
+        f'{"LOCAL judge":>11} | {"LOCAL gold":>10} | {"agree":>5}'
+        f' | {"over+":>5} | {"under-":>6}'
+        f' || {"CLOUD judge":>11} | {"CLOUD gold":>10}'
+    )
+    print(header)
+    print("-" * len(header))
+    for s in summaries:
+        print(
+            f'{s["cell"]:<5} | {s["model_desc"]:<28} | '
+            f'{s["local_judge_correct"]:>11.2f} | '
+            f'{s["local_gold_correct"]:>10.2f} | {s["local_agreement"]:>5.2f}'
+            f' | {s["local_over_credits"]:>5} | {s["local_under_credits"]:>6}'
+            f' || {s["cloud_judge_correct"]:>11.2f} | '
+            f'{s["cloud_gold_correct"]:>10.2f}'
+        )
+    print()
+
+    # Judge-bias delta table.
+    print("=== judge bias (local) — judge says CORRECT but gold absent ===")
+    for s in summaries:
+        bias = round(s["local_judge_correct"] - s["local_gold_correct"], 3)
+        sign = "+" if bias >= 0 else ""
+        print(f"  Cell {s['cell']} {s['model_desc']:<28} bias = {sign}{bias}")
+    print()
+
+    out_path = RESULTS_DIR / "gold_grounded_summary.json"
+    out_path.write_text(
+        json.dumps(summaries, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"saved → {out_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":   # pragma: no cover
+    sys.exit(main())

--- a/reports/research-runs/v18.7-phase2b-chat/gold_grounded_summary.json
+++ b/reports/research-runs/v18.7-phase2b-chat/gold_grounded_summary.json
@@ -1,0 +1,50 @@
+[
+  {
+    "cell": "A",
+    "model_desc": "gemma4:e4b OFF cap=400",
+    "scope": "factual_chat only",
+    "n_trials": 9,
+    "local_judge_correct": 1.0,
+    "local_gold_correct": 1.0,
+    "local_agreement": 1.0,
+    "local_over_credits": 0,
+    "local_under_credits": 0,
+    "cloud_judge_correct": 1.0,
+    "cloud_gold_correct": 1.0,
+    "cloud_agreement": 1.0,
+    "over_credit_examples": [],
+    "under_credit_examples": []
+  },
+  {
+    "cell": "B",
+    "model_desc": "gemma3:4b cap=400",
+    "scope": "factual_chat only",
+    "n_trials": 9,
+    "local_judge_correct": 1.0,
+    "local_gold_correct": 1.0,
+    "local_agreement": 1.0,
+    "local_over_credits": 0,
+    "local_under_credits": 0,
+    "cloud_judge_correct": 1.0,
+    "cloud_gold_correct": 1.0,
+    "cloud_agreement": 1.0,
+    "over_credit_examples": [],
+    "under_credit_examples": []
+  },
+  {
+    "cell": "C",
+    "model_desc": "gemma3:12b cap=400",
+    "scope": "factual_chat only",
+    "n_trials": 9,
+    "local_judge_correct": 1.0,
+    "local_gold_correct": 1.0,
+    "local_agreement": 1.0,
+    "local_over_credits": 0,
+    "local_under_credits": 0,
+    "cloud_judge_correct": 1.0,
+    "cloud_gold_correct": 1.0,
+    "cloud_agreement": 1.0,
+    "over_credit_examples": [],
+    "under_credit_examples": []
+  }
+]


### PR DESCRIPTION
## Summary

- Phase 2 Step 2b — operator-launched 3-cell paired measurement on `eval/chat_mode_queries.json` (Korean primary, 12 query × 3 paired runs × 3 cells = 108 trials + Cloud).
- **Result rejects gemma3:4b promotion** (the pre-measurement candidate from `DEFAULT_PREFERENCE['chat']` top). gemma3:12b emerges as the measurement leader.
- `DEFAULT_PREFERENCE['chat']` reordered to reflect the measurement (still POPULATED but NOT YET CONSUMED until Step 2c proper wires `engine.py`).

## Cell summary (judge-only verdicts)

| Cell | Model | Local | Abstain | Δ vs Cloud | Pair latency |
|---|---|---|---|---|---|
| A | gemma4:e4b OFF cap=400 | 0.833 | 0.167 | +0.167 | 25.5s |
| B | gemma3:4b cap=400 | 0.750 | 0.250 | +0.250 | 24.4s |
| C | gemma3:12b auto cap=400 | **0.917** | 0.083 | **+0.083** | 28.4s |

## Gold-grounded recheck (factual_chat sub-class)

| Cell | judge | gold-grounded | bias |
|---|---|---|---|
| A | 1.00 | 1.00 | 0.000 |
| B | 1.00 | 1.00 | 0.000 |
| C | 1.00 | 1.00 | 0.000 |

factual_chat saturated; differentiation driver = small_talk + open_question + multi_turn (intrinsically judge-only per v18.6 caveat).

## Per-query catches

- `id=1001 "안녕하세요"` — **Cell B 3/3 ABSTAIN**. gemma3:4b fails the most basic chat sub-class.
- `id=1021 "주말에 가족과 시간 보낼 좋은 방법"` — **only Cell C 3/3 CORRECT**. open_question unique strength of gemma3:12b.
- `id=1032 multi_turn "그 중에서 어떤 게 가장 추천이야?"` — **Cell A 3/3 ABSTAIN**. gemma4:e4b OFF anaphora resolution failure.
- `id=1002 "잠깐 쉬어가야겠다"` — all 3 cells weak (universal abstain pattern on implicit personal context).

## Fixture self-correction (transparent log)

First gold-grounded run showed Cell C +0.333 bias on factual_chat. Inspection: Cell C answered "물의 끓는점?" as "**섭씨 백도**" (Korean numeral). `gold_signals` for `id=1012` lacked the "백도" alias. **Fixture incompleteness, NOT judge bias, NOT model error.** Patched `aliases` to include "백도" / "섭씨 백도" / "백 도"; rechecked → all 3 cells 1.00 gold-grounded. `feedback_s31_self_correction_artifact_pattern` chat-mode variant.

## DEFAULT_PREFERENCE['chat'] reorder

```diff
- "chat": [
-     "gemma3:4b", "gemma3:1b", "gemma2:2b",
-     "gemma3:12b", "gemma3:27b", "gemma4:e4b",
-     "qwen2.5:14b", "llama3.2:3b", "mistral:7b",
- ]
+ "chat": [
+     "gemma3:12b", "gemma4:e4b", "gemma3:27b",
+     "gemma3:4b", "gemma3:1b", "gemma2:2b",
+     "qwen2.5:14b", "llama3.2:3b", "mistral:7b",
+ ]
```

Rationale anchored in `reports/research-runs/v18.7-phase2b-chat/QUALITY_DELTA_CARD.md`. Sub-3B family kept in list for small-RAM fallback but no longer top pick.

## Step 2c proper (operator decision queue — NOT in this PR)

| Path | Action |
|---|---|
| 1 (recommended) | Wire engine.py chat-mode → `resolve_chat()` (top = gemma3:12b) |
| 2 | Keep chat → gemma4:e4b OFF (preserve thinking-mode optionality, lose open_question + multi_turn) |
| 3 (Phase 5) | Sub-class routing — needs IntentClassifier chat-sub-class extension |

## Verification

- lock-test 17/17 OK
- pre-flight 7/7 PASS
- `resolution_snapshot()` unchanged shape; Phase 1 phase marker preserved
- 108 paired trials + Cloud reference (no error in any cell; chain log 47 minute wall-time)

## Out of scope

- engine.py mode dispatch wire (Step 2c proper — operator decision required)
- Sub-class routing inside `chat` mode (Phase 5)
- Cross-language fixture extension (v0.6.2+)
- Backend adapter additions for gemma3:12b / 27b / mixtral (Phase 3 prereq — gemma3:12b already works through ollama_local adapter)

## Quality delta

Quality delta: exempt (label: fix) — preference-list reorder driven by measurement; engine.py untouched; comment cites the measurement output. Fixture `aliases` patch (`id=1012` add "백도") is a measurement-side hygiene fix per CLAUDE.md `fix` exemption rule.

## Rule #1 streak

- `core/retrieval` + `core/graph` traversal + `core/reasoning` — **STILL 0 lines changed**
- `core/model_resolver.py` preference list edit only (consumer rewire deferred to Step 2c proper)
- vertical content: 0 / LOI gate: not triggered / measurement-axis: chat-mode now fully measured + caveat block intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)