### PR TITLE
feat(v0.6.1): Phase 2c — engine.py chat-mode auto-routes to measured preference (gemma3:12b)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -280,6 +280,33 @@ class ReasoningEngine:
         elif picked_model:
             print(f"[MODEL] mode={mode} using user-selected '{picked_model}'")
 
+        # ── v18.7 Phase 2c — chat-mode consumes the measured preference ──
+        # When the user did NOT pick a model, chat mode auto-routes
+        # through the measured preference list instead of the global
+        # config.GEMMA_MODEL default. The Phase 2b 3-cell paired
+        # measurement (reports/research-runs/v18.7-phase2b-chat/
+        # QUALITY_DELTA_CARD.md) ranked gemma3:12b (0.917) >
+        # gemma4:e4b OFF (0.833) > gemma3:4b (0.750) on the Korean
+        # chat fixture; gemma3:4b 3/3-abstained on a basic greeting.
+        # requested="" makes resolve_for_mode use the preference list
+        # top (not GEMMA_MODEL), so this is the first mode to actually
+        # consume the Phase-1 plumbing. Kill-switch:
+        # JAMES_DISABLE_MODE_AWARE_CHAT=1 reverts to GEMMA_MODEL.
+        # Only `chat` is wired — retrieval/meta/wiki_edit/vision
+        # preference lists are populated but NOT yet measurement-
+        # validated, so they keep the legacy GEMMA_MODEL path.
+        if mode == "chat" and not picked_model:
+            import os
+            if not os.environ.get("JAMES_DISABLE_MODE_AWARE_CHAT"):
+                from core.model_resolver import resolve_for_mode
+                _rm = resolve_for_mode("chat", requested="")
+                if _rm.tag:
+                    picked_model = _rm.tag
+                    print(f"[MODEL] mode=chat auto-routed → '{_rm.tag}' "
+                          f"(source={_rm.source}; Phase 2c measured pref)")
+                    if _rm.warning:
+                        print(f"[MODEL] {_rm.warning}")
+
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":
             return handle_chat(self, safe_query, system_prompt, memory_context, user_role, t_start, response_style=response_style, selected_model=picked_model, hist_ctx=hist_ctx)


### PR DESCRIPTION
## Summary

- Phase 2 Step 2c proper. **First consumption of the model_resolver preference plumbing** (Phase 1) by `engine.py`. When the user did not pick a model, chat-mode auto-routes to the Phase 2b measurement leader (**gemma3:12b**) instead of the global `config.GEMMA_MODEL` default.
- Surgical 27-line addition in `_query_impl`, gated `if mode == "chat" and not picked_model`, with a kill-switch.

## The `resolve_chat()` trap (why this needed `requested=""`)

`resolve_chat()` passes `config.GEMMA_MODEL` as `requested`. `resolve_for_mode` Step 1 returns the requested tag the moment it's installed — so `resolve_chat()` returns `gemma4:e4b` (GEMMA_MODEL) and **never consults the preference list**. To actually reach the measured-best gemma3:12b, engine.py calls `resolve_for_mode("chat", requested="")`: the empty requested skips Step 1, so the preference list top (gemma3:12b, installed) drives.

## The wire

```python
if mode == "chat" and not picked_model:
    import os
    if not os.environ.get("JAMES_DISABLE_MODE_AWARE_CHAT"):
        from core.model_resolver import resolve_for_mode
        _rm = resolve_for_mode("chat", requested="")
        if _rm.tag:
            picked_model = _rm.tag
            print(f"[MODEL] mode=chat auto-routed → '{_rm.tag}' ...")
```

- **chat ONLY.** retrieval / meta / wiki_edit / vision preference lists are populated (Phase 1) but NOT measurement-validated → they keep the legacy GEMMA_MODEL path. Each mode waits for its own measurement (honest-framing rule).
- User picks still win — the secondary picker sets `picked_model` via catalog validation before this branch.
- Kill-switch `JAMES_DISABLE_MODE_AWARE_CHAT=1` reverts to GEMMA_MODEL.

## E2E verification (live)

- `eng.query("안녕하세요. 오늘 기분이 어때요?", mode_override="chat")` → log:
  `[MODEL] mode=chat auto-routed → 'gemma3:12b' (source=preference; Phase 2c measured pref)` — confirmed the real synth call uses gemma3:12b.
- kill-switch ON → no auto-route log (GEMMA_MODEL restored).
- `resolve_chat()` still returns gemma4:e4b (other call sites unaffected — the trap is engine-side only).

## Bench numbers + Quality Delta Card (rule #2 — core/reasoning PR)

- **STEP 7 retrieval**: the chat-mode branch is gated by `if mode == "chat"`. `mode == "retrieval"` never enters it → **structurally guaranteed 0 delta** on the retrieval / graph path. No retrieval/graph/reasoning quality axis is touched.
- **Quality Delta Card** = the Phase 2b chat measurement: `reports/research-runs/v18.7-phase2b-chat/QUALITY_DELTA_CARD.md`. gemma3:12b **0.917** > gemma4:e4b OFF 0.833 > gemma3:4b 0.750 on the Korean chat fixture; gemma3:4b 3/3-abstained on a basic greeting. VRAM: gemma3:12b **7.6 GB < 8.9 GB** gemma4:e4b — no VRAM regression (improvement).

## Out of scope

- retrieval/meta/wiki_edit/vision mode wiring (each gated on its own paired measurement)
- D5 AUTO_ROUTER + backend tier adapters (Phase 3)
- Privacy gate + cost-aware cap (Phase 4)
- Sub-class routing inside chat (Phase 5 — needs IntentClassifier chat-sub-class extension)
- admin routing dashboard (Phase 5)

## Quality delta

Quality delta card cited above — Phase 2b chat measurement is the operator-decision-grade QDC for this change. STEP 7 retrieval delta = 0 (structural no-op for non-chat modes).

## Rule #1 streak

- `core/reasoning/engine.py` changed — **2nd operator-approved reasoning-streak break in v0.6.1** (1st was v16 meta inventory). engine.py 18466 → 20079 bytes (under 20480 gate).
- `core/retrieval` + `core/graph` traversal — **STILL 0 lines changed**.
- vertical content: 0 (routing is domain-agnostic — picks by mode, no domain coupling) / LOI gate: not triggered / measurement-axis: chat-mode measured (Phase 2b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)