### PR TITLE
feat(v0.6.1): Phase 3a — local complexity-tier ladder (plumb-first)

### DIFF
--- a/core/model_resolver.py
+++ b/core/model_resolver.py
@@ -345,6 +345,107 @@ def resolve_vision() -> ResolvedModel:
     return resolve_for_mode("vision", requested="")
 
 
+# ─── v18.7 Phase 3a — local complexity-tier ladder ─────────────────
+# Operator decision 2026-06-16 (Option B): D5 should escalate among
+# LOCAL ollama model sizes by query complexity (4b → 12b → 27b)
+# rather than routing local↔cloud. The existing BackendCapability
+# tier vocabulary (small ≤4B / medium 12-27B / large 70B+ or cloud)
+# does NOT give three local rungs — a 12 GB GPU has no local "large"
+# (70B+). So the local ladder is its own mapping, separate from the
+# backend-tier system: it picks an ollama TAG for a given complexity
+# rung, and a future Phase 3b wire feeds that tag to ollama_local.
+#
+# Rungs (NOT the same as BackendCapability tiers — these are local
+# model-size rungs):
+#   "light"    → gemma3:4b   — narrow scope / CAP_SUBSTITUTION / cheap
+#   "standard" → gemma3:12b  — chat measurement leader (Phase 2b)
+#   "deep"     → gemma3:27b  — broad scope / CAP_HEAVY / verify stage
+#
+# Honest framing: this ladder is DEFINED but NOT YET CONSUMED by the
+# pipeline. gemma3:12b is the only rung with a paired measurement
+# (Phase 2b chat); gemma3:4b lost that measurement and gemma3:27b was
+# not measured. Phase 3b runs a complexity-paired measurement
+# (narrow vs broad query × {4b, 12b, 27b}) BEFORE any escalation is
+# wired into D5 — the α-7 caveat (no activation without measurement)
+# is binding here.
+LOCAL_TIER_LADDER: dict = {
+    "light":    "gemma3:4b",
+    "standard": "gemma3:12b",
+    "deep":     "gemma3:27b",
+}
+
+# Order from cheapest to most capable — used for graceful downgrade
+# when the requested rung's model isn't installed.
+_LADDER_ORDER = ["light", "standard", "deep"]
+
+
+def _local_tier_tag(rung: str) -> str:
+    """Tag for a local complexity rung, honoring env override.
+
+    Env key: JAMES_LOCAL_TIER_<RUNG> (e.g. JAMES_LOCAL_TIER_DEEP).
+    Unknown rung falls back to the 'standard' rung tag.
+    """
+    env_key = f"JAMES_LOCAL_TIER_{rung.upper()}"
+    raw = os.environ.get(env_key, "").strip()
+    if raw:
+        return raw
+    return LOCAL_TIER_LADDER.get(rung, LOCAL_TIER_LADDER["standard"])
+
+
+def resolve_local_tier(rung: str = "standard") -> ResolvedModel:
+    """Resolve an installed ollama tag for a local complexity rung.
+
+    Picks the rung's mapped tag if installed; otherwise downgrades
+    along _LADDER_ORDER (deep → standard → light) to the nearest
+    installed rung, then falls through to resolve_for_mode("chat")
+    as a last resort so this never returns an empty tag when ANY
+    model is installed.
+
+    Never raises. Phase 3a: callers are introspection / probe only —
+    the pipeline does NOT call this yet (Phase 3b wires it after the
+    complexity-paired measurement).
+    """
+    inst = installed_models()
+    chain: List[str] = []
+
+    # Requested rung first.
+    want = _local_tier_tag(rung)
+    chain.append(want)
+    if want in inst:
+        return ResolvedModel(want, "local_tier", chain, "")
+
+    # Downgrade along the ladder from the requested rung downward, then
+    # any remaining rung, to find the nearest installed model.
+    try:
+        start = _LADDER_ORDER.index(rung)
+    except ValueError:
+        start = _LADDER_ORDER.index("standard")
+    candidates = _LADDER_ORDER[start::-1] + _LADDER_ORDER[start + 1:]
+    for r in candidates:
+        tag = _local_tier_tag(r)
+        if tag in chain:
+            continue
+        chain.append(tag)
+        if tag in inst:
+            return ResolvedModel(
+                tag, "local_tier_downgrade", chain,
+                f"requested rung '{rung}' tag '{want}' not installed; "
+                f"using '{tag}' (rung '{r}')",
+            )
+
+    # Last resort — reuse the chat resolver (preference list + any).
+    fallback = resolve_for_mode("chat", requested="")
+    chain.extend(t for t in fallback.fallback_chain if t not in chain)
+    return ResolvedModel(
+        fallback.tag,
+        "local_tier_fallback_chat" if fallback.tag else "none",
+        chain,
+        fallback.warning or (
+            f"no local-tier model installed for rung '{rung}'"
+        ),
+    )
+
+
 def resolution_snapshot() -> dict:
     """Snapshot of current resolution state — for /admin/llm/resolution.
 

--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -69,13 +69,33 @@ wiki_edit   → gemma4:e4b (silent — inferred)   (24.3s)
 self_evolve → gemma4:e4b (silent — inferred)
 ```
 
+## Phase 3a — local complexity-tier ladder (DEFINED, not yet consumed)
+
+Operator decision 2026-06-16 (Option B): D5 escalates among **local
+ollama model sizes** by query complexity, not local↔cloud. The existing
+`BackendCapability` tier vocabulary (small ≤4B / medium 12-27B / large
+70B+ or cloud) gives no third local rung — a 12 GB GPU has no local 70B+.
+So the local ladder is its own mapping in `core/model_resolver.py`,
+separate from the backend-tier system:
+
+| Rung | Model | When (Phase 3b will wire) | Measured? |
+|---|---|---|---|
+| `light` | gemma3:4b | narrow scope / CAP_SUBSTITUTION / cheap | lost Phase 2b chat |
+| `standard` | gemma3:12b | default; chat leader | ✅ Phase 2b |
+| `deep` | gemma3:27b | broad scope / CAP_HEAVY / verify stage | not yet |
+
+- `resolve_local_tier(rung)` — installed-check + downgrade (deep → standard → light) + env override `JAMES_LOCAL_TIER_<RUNG>`.
+- Inspect: `python scripts/research/routing_matrix_probe.py --tier-ladder`
+- **NOT consumed by the pipeline yet.** Phase 3b runs a complexity-paired measurement (narrow vs broad query × {4b, 12b, 27b}) BEFORE wiring escalation into D5 — α-7 caveat (no activation without measurement) is binding.
+
 ## Phase status (5-phase routing build-out)
 
 - ✅ Phase 1 — preference list plumbing (`DEFAULT_PREFERENCE`, PR #969)
 - ✅ Phase 2a/b/c — chat fixture + measurement + engine wire (PR #970/971/972)
-- ⏳ **Phase 3** — D5 AUTO_ROUTER (complexity-tier escalation) + backend
-  tier adapters (gemma3:12b / 27b / mixtral need `BackendCapability`
-  tier declarations)
+- 🔄 **Phase 3** (Option B — local size ladder)
+  - ✅ 3a — `LOCAL_TIER_LADDER` + `resolve_local_tier()` defined (plumb-first)
+  - ⏳ 3b — complexity-paired measurement (narrow/broad × 4b/12b/27b)
+  - ⏳ 3c — wire D5 tier decision → `resolve_local_tier` (after 3b), flip `JAMES_AUTO_ROUTER` only if measured net-positive
 - ⏳ Phase 4 — privacy gate (PII) + cost-aware cap + cloud (Claude) routing
 - ⏳ Phase 5 — sub-class routing inside chat + admin routing dashboard
 

--- a/scripts/research/routing_matrix_probe.py
+++ b/scripts/research/routing_matrix_probe.py
@@ -172,9 +172,32 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--no-llm", action="store_true",
                     help="resolver introspection only (no generation)")
+    ap.add_argument("--tier-ladder", action="store_true",
+                    help="show the v18.7 Phase 3a local complexity-tier "
+                         "ladder (light/standard/deep → ollama tag) and exit")
     ap.add_argument("--user-role", default="admin",
                     help="role to probe under (admin sees all modes)")
     args = ap.parse_args()
+
+    if args.tier_ladder:
+        from core.model_resolver import (
+            LOCAL_TIER_LADDER, resolve_local_tier, installed_models,
+        )
+        inst = installed_models()
+        print("\n=== v18.7 Phase 3a — local complexity-tier ladder ===")
+        print("(DEFINED but NOT YET consumed by the pipeline — Phase 3b "
+              "measures + wires)\n")
+        print(f'{"rung":<10} | {"mapped tag":<14} | {"installed?":<10} | '
+              f'{"resolves to":<16} | source')
+        print("-" * 78)
+        for rung in ("light", "standard", "deep"):
+            mapped = LOCAL_TIER_LADDER[rung]
+            rm = resolve_local_tier(rung)
+            print(f'{rung:<10} | {mapped:<14} | '
+                  f'{"yes" if mapped in inst else "NO":<10} | '
+                  f'{rm.tag:<16} | {rm.source}')
+        print()
+        return 0
 
     print(f"\n=== JAMES routing matrix probe "
           f"({'resolve-only' if args.no_llm else 'live engine'}) ===")


### PR DESCRIPTION
## Summary

Operator decision (Option B): D5 escalates among **local ollama model sizes** (4b → 12b → 27b) by complexity, not local↔cloud. The `BackendCapability` tier vocabulary (small/medium/large=70B+/cloud) gives no third local rung on a 12 GB GPU, so the local ladder is its own mapping in `model_resolver`, separate from the backend-tier system.

## The ladder

| Rung | Model | When (Phase 3b wires) | Measured? |
|---|---|---|---|
| `light` | gemma3:4b | narrow scope / CAP_SUBSTITUTION | lost Phase 2b chat |
| `standard` | gemma3:12b | default; chat leader | ✅ Phase 2b |
| `deep` | gemma3:27b | broad scope / CAP_HEAVY / verify | not yet |

- `resolve_local_tier(rung)` — installed-check + downgrade (deep→standard→light) + env override `JAMES_LOCAL_TIER_<RUNG>` + last-resort `resolve_for_mode("chat")`.
- Inspect: `python scripts/research/routing_matrix_probe.py --tier-ladder`

## Honest framing

- **DEFINED but NOT YET consumed** by the pipeline (same plumb-first cadence as Phase 1).
- Only gemma3:12b has a paired measurement (Phase 2b). gemma3:4b lost it; gemma3:27b unmeasured.
- **Phase 3b** runs a complexity-paired measurement (narrow vs broad query × {4b,12b,27b}) BEFORE wiring escalation. α-7 caveat (no activation without measurement) is binding.

## Why this design (not tiered backends)

Registering `ollama_medium`/`ollama_large` backends would (a) collide with `claude_code_cli` on the "large" tier when cloud is enabled (Phase 4), and (b) trip the pre-flight `backend_registry` guard that pins the registry to `{ollama_local}`. Keeping the ladder in `model_resolver` avoids both and keeps the backend-tier system free for the local↔cloud axis later.

## Verification

- ladder smoke: 3 rungs resolve to installed tags; env override works
- `--tier-ladder` probe table renders
- lock-test 17/17 OK / pre-flight 7/7 PASS (registry guard green — no new backends)

## Out of scope

- Complexity-paired measurement (Phase 3b)
- Wiring D5 tier decision → resolve_local_tier (Phase 3c, after 3b)
- Flipping JAMES_AUTO_ROUTER (gated on 3b net-positive result)

## Quality delta

Quality delta: exempt (label: chore) — pure plumbing, no pipeline consumer, no measurement axis touched. Guards green.

## Rule #1 streak

- `core/model_resolver.py` only / `core/retrieval` + `core/graph` traversal + `core/reasoning` — **0 lines changed**
- JAMES_AUTO_ROUTER stays OFF — no production behavior change
- vertical: 0 / LOI: not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)