### PR TITLE
docs(v0.6.1): Phase 3b tier-ladder measurement — gold-grounded reversal

### DIFF
--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -94,8 +94,8 @@ separate from the backend-tier system:
 - ✅ Phase 2a/b/c — chat fixture + measurement + engine wire (PR #970/971/972)
 - 🔄 **Phase 3** (Option B — local size ladder)
   - ✅ 3a — `LOCAL_TIER_LADDER` + `resolve_local_tier()` defined (plumb-first)
-  - ⏳ 3b — complexity-paired measurement (narrow/broad × 4b/12b/27b)
-  - ⏳ 3c — wire D5 tier decision → `resolve_local_tier` (after 3b), flip `JAMES_AUTO_ROUTER` only if measured net-positive
+  - ✅ 3b — complexity-paired measurement done (4-cell: 4b/gemma4:e4b/12b/27b × multihop). **gold-grounded reversal**: judge-only said escalation pointless, but gold_signals shows 27b=1.000 > 12b=0.889 > 4b=0.852 > gemma4:e4b=0.815. Escalation has a basis (modest +0.111) but costs 2.3× latency + verbose answers. Side finding: gemma4:e4b (current default) is *lowest* on evidence-rich retrieval. See `reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md`.
+  - ⏸️ 3c — wire D5 tier decision → `resolve_local_tier`: **operator trade-off decision** (+0.111 gold-accuracy vs 2.3× latency + verbosity). `JAMES_AUTO_ROUTER` stays OFF until decided. Ladder infra (3a) preserved regardless.
 - ⏳ Phase 4 — privacy gate (PII) + cost-aware cap + cloud (Claude) routing
 - ⏳ Phase 5 — sub-class routing inside chat + admin routing dashboard
 

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md
@@ -1,0 +1,62 @@
+# Quality Delta Card — v18.7 Phase 3b local tier ladder
+
+**Date**: 2026-06-16
+**Hardware**: RTX 4070 SUPER 12 GB, Ryzen 7 7700, 31 GB RAM
+**Fixture**: MultiHop-RAG (reasoning-isolated — gold evidence injected)
+**Sample**: 9 queries × 3 paired runs = 27 trials per cell
+**Question**: does complexity-tier escalation (4b → 12b → 27b) justify wiring D5 to route by query complexity among local models?
+
+## The reversal (why gold-grounded matters)
+
+A judge-only read concluded "escalation is pointless" (4b=12b=gemma4=1.0 > 27b=0.704) and was briefly asserted to the operator. The deterministic `gold_signals` recheck **reversed** it:
+
+| Model | Rung | Judge | **Gold-grounded** | Judge bias | Pair latency |
+|---|---|---|---|---|---|
+| **gemma3:27b** | deep | 0.704 | **1.000** | **−0.296 (under-credit)** | 60.2s |
+| gemma3:12b | standard | 1.000 | 0.889 | +0.111 | 27.5s |
+| gemma3:4b | light | 1.000 | 0.852 | +0.148 | 26.4s |
+| gemma4:e4b | (current default) | 1.000 | 0.815 | +0.185 | 23.2s |
+
+**27b is the only cell at gold-grounded 1.000.** The judge under-credited it by −0.296 because 27b answers verbosely ("Yes, both statements are true according to the provided texts. The New York Times article states...") and the judge tripped on the elaboration — the gold term was present in every case. Same judge-trip class as v18.6.
+
+## Findings
+
+1. **Complexity escalation has a basis** — bigger model = more gold-accurate. The judge-only "pointless" conclusion was an artifact. Not "meaningless".
+2. **But not dramatic** — 27b vs 12b = **+0.111** (modest), and 27b costs **2.3× latency + verbose answers** that confuse the judge (and likely downstream consumers / users).
+3. **Side finding**: the current production default `gemma4:e4b` is the **lowest** of the four on evidence-rich retrieval (gold 0.815) — below even gemma3:4b (0.852). Yet on chat (Phase 2b) gemma4:e4b 0.833 > gemma3:4b 0.750. **Task type flips the model ranking** (open-ended chat vs evidence-rich retrieval) — this is exactly why mode routing (chat≠retrieval) is meaningful.
+
+## Phase 3c decision (operator)
+
+Not "shelve as meaningless" but **"+0.111 accuracy vs (2.3× latency + verbose answers) trade-off"**:
+- Wire D5 complexity escalation only if the modest gold-accuracy gain justifies the latency + verbosity cost.
+- If wired, pair 27b with a response_style that curbs verbosity (also helps downstream + judge agreement).
+- Phase 3a ladder infra (`LOCAL_TIER_LADDER`, `resolve_local_tier`) stays valid regardless.
+
+## Caveats
+
+- **n=9 queries (27 trials)**, single fixture, reasoning-isolated (gold injected = easier than production retrieval). Directional signal, not a publishable claim.
+- **judge-only is unreliable here** — the headline reversal is the lesson: any fixture with `gold_signals` must get a gold-grounded recheck BEFORE concluding (negative OR positive).
+- gold-grounded single-hit threshold (term OR alias present). Does not measure full answer correctness, only gold-term presence.
+- 27b on 12 GB GPU runs with partial offload (60s/pair) — latency is hardware-specific.
+
+## Reproducibility
+
+```bash
+# per cell (multihop, reasoning-isolated)
+JAMES_ENABLE_CLAUDE_BACKEND=1 [JAMES_GEMMA4_E4B_THINK_OFF=1 for gemma4] \
+  python scripts/research/local_vs_cloud_paired.py \
+    --fixture multihop --local-model <model> \
+    --n-per-type 3 --n-runs 3 --num-predict 400 --force-think off \
+    --output reports/research-runs/v18.7-phase3b-tier-ladder/cell_<name>.json
+
+python reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_recheck.py
+```
+
+Raw: `cell_{light_4b,gemma4_e4b,standard_12b,deep_27b}.json` + `gold_grounded_summary.json`.
+
+## Related memory
+
+- `[[project_d5_complexity_routing_negative]]` — the self-corrected conclusion (judge→gold reversal)
+- `[[project_judge_reliability_gold_grounded_v18_6]]` — the rule this measurement re-validated
+- `[[project_graph_rag_reasoning_boundary]]` — companion (reasoning ≈ evidence quality + backbone)
+- `[[project_routing_buildout_5phase_v18_7]]` — 5-phase parent

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/cell_deep_27b.json
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/cell_deep_27b.json
@@ -1,0 +1,779 @@
+{
+  "design": "reasoning-isolated; both models same full gold evidence",
+  "fixture": "multihop",
+  "local_model": "gemma3:27b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of FTX and Alameda Research, is the individual facing seven counts of fraud and conspiracy. Both articles state he is accused of misappropriating customer funds – described as “fraud from the start” and “one of the biggest financial frauds in American history” – to buy real estate, make investments, repay lenders, and even fund political contributions. Prosecutors allege this was done through lies about consumer protection and conflicts of interest.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 86.34
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of FTX and Alameda Research, is the individual facing seven counts of fraud and conspiracy. Both articles state he is accused of misappropriating customer funds – described as “fraud from the start” and “one of the biggest financial frauds in American history” – to buy real estate, make investments, repay lenders, and even fund political contributions. Prosecutors allege this was done with intent, and evidence includes his own statements and communications.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using \"billions of dollars in misappropriated FTX customer deposits\" to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and use more than $100 million of customer funds to make political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.14
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of FTX and Alameda Research, is the individual facing seven counts of fraud and conspiracy. Both articles state he is accused of misappropriating customer funds – described as “fraud from the start” and “one of the biggest financial frauds in American history” – to buy real estate, make investments, repay lenders, and even fund political contributions. Prosecutors allege this was done with intent, and evidence includes his own statements and communications.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.03
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both instances. According to Fortune, he claimed his Trump Tower apartment in Manhattan was valued at $327 million – an amount no New York City apartment has ever reached in a sale. The Age reports that the prosecution argues Trump increased the value of this same penthouse from $200 million to $327 million between 2014 and 2015 “to mask a drop in the value of one of his other properties.”",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 49.1
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both instances. According to the Fortune article, James said Trump claimed his Trump Tower apartment was valued at $327 million – no apartment in New York City has ever sold for close to that amount. The Age article states that between 2014 and 2015, Trump increased the value of the same penthouse apartment to $327 million from $200 million “to mask a drop in the value of one of his other properties.”",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.99
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both instances. According to the Fortune article, James said Trump claimed his Trump Tower apartment was valued at $327 million – no apartment in New York City has ever sold for close to that amount. The Age article states that between 2014 and 2015, Trump increased the value of the same penthouse apartment to $327 million from $200 million “to mask a drop in the value of one of his other properties.”",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 44.9
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune. Both articles report that the board found he was “not consistently candid in his communications,” which is the prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.64
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune. Both articles report that the board found he was “not consistently candid in his communications,” which is the prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.3
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune. Both articles report that the board found he was “not consistently candid in his communications,” which is the prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 31.89
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "ABSTAINED",
+      "local_abstain": false,
+      "cloud_abstain": true,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states Rainforest has secured client commitments representing more than $500 million in processing volume, while the Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021. One relates to payment processing and the other to subscriptions/news readership.",
+      "cloud_answer": "I don't know",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 65.9
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states Rainforest has secured client commitments representing more than $500 million in processing volume, while the Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021. One relates to payment processing and the other to subscriptions/news readership.",
+      "cloud_answer": "No. The TechCrunch article on Rainforest does not report an increase in revenue; it reports client commitments representing more than $500 million in processing, but does not state an actual revenue increase. The Hacker News article on The Epoch Times does report a revenue increase — growing 685% in two years to $122 million in 2021 — but this is attributed to advertising, marketing campaigns, and big-money conservative donors, not specifically described as a subscription model revenue increase.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 63.18
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states Rainforest has secured client commitments representing more than $500 million in processing volume, while the Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021. One relates to payment processing and the other to subscriptions/news readership.",
+      "cloud_answer": "No. Only the Hacker News article on The Epoch Times explicitly reports a revenue increase, stating the nonprofit grew \"its revenue by a staggering 685% in two years, to $122 million in 2021,\" tied to its subscription-driven model (it \"boasts to be the country's fourth-largest newspaper by subscriber count\").\n\nThe TechCrunch article on Rainforest does not report a revenue increase for Rainforest itself. It reports that Rainforest raised an $8.5 million seed round and has secured \"client commitments representing more than $500 million in processing, with much of the volume guaranteed\" — that is processing volume from client commitments, not a reported revenue increase. It also notes software companies want to \"generate more revenue\" by accepting payments, but no actual revenue growth figure is given.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 50.97
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the articles indicate different monetization strategies. The Twitch article details a shift *from* a fixed revenue split (70/30) *to* prioritizing ad revenue and then introducing tiered subscription options like Partner Plus with varying rev shares based on points earned through subscriptions. They are actively working to provide access to higher rev shares over time. \n\nThe Beeper Mini article initially describes a $1.99 per month subscription model, but due to Apple’s actions and instability, they have temporarily made it free and will re-evaluate subscriptions once things stabilize. This is a straightforward paid subscription versus Twitch's more complex tiered system tied to engagement metrics and ad revenue prioritization.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscription revenue splits (a 70/30 split on the first $100,000 for eligible Partner Plus creators, with a points-based system valuing Tier 1, 2, and 3 subs at 1, 2, and 6 points respectively), advertising (with increased rev share, an ad incentive program, and new tools for synchronizing ad breaks with content), community-based support (subscriptions, gifting, cheering), and growing sponsorship opportunities by leveraging Amazon's advertising business.\n\nIn contrast, the Beeper article describes a much simpler subscription-only model: Beeper Mini was originally offered at $1.99 per month for bringing iMessage chats to Android users. Due to the instability caused by Apple's attempts to shut down the service, Beeper decided to make Beeper Mini free for the time being, stating, \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo yes, the strategies differ significantly — Twitch employs a complex, multi-revenue-stream creator monetization model (subs, ads, sponsorships) with tiered rev shares and eligibility criteria, while Beeper's strategy is a straightforward flat-rate consumer subscription that has been temporarily suspended (made free) in response to external disruption from Apple.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 69.5
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the articles indicate different monetization strategies. The Twitch article details a shift *from* a fixed revenue split (70/30) *to* prioritizing ad revenue and then introducing tiered subscription options like Partner Plus with varying rev shares based on points earned through subscriptions. They are actively working to provide access to higher rev shares over time. \n\nThe Beeper Mini article initially describes a $1.99 per month subscription model, but due to Apple’s actions and instability, they have temporarily made it free and will re-evaluate subscriptions once things stabilize. This is a straightforward paid subscription service that was paused due to external factors, while Twitch's strategy involves more complex tiers and revenue sharing adjustments.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscription revenue splits (a 70/30 split on the first $100,000 for Partner Plus creators, with a points-based eligibility system valuing Tier 1, 2, and 3 subs at 1, 2, and 6 points respectively), increased ad revenue share with an ad incentive program, and growing sponsorship opportunities through Amazon advertising — focused on monetizing creators on the platform.\n\nIn contrast, the Beeper Mini article describes a direct consumer subscription model — originally $1.99 per month for Android users to access iMessage features like high-quality photos/videos, tapback reactions, typing indicators, and read receipts. Furthermore, due to the \"chaotic\" situation with Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo the strategies differ: Twitch focuses on creator monetization through revenue splits, ads, and sponsorships, while Beeper Mini uses a flat-rate consumer subscription (currently paused/free due to instability from Apple's interventions).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 68.99
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the articles indicate different monetization strategies. The Twitch article details a shift *from* a fixed revenue split (70/30) *to* prioritizing ad revenue and then introducing tiered subscription options like Partner Plus with varying rev shares based on points earned through subscriptions. They are actively working to provide access to higher rev shares over time. \n\nThe Beeper Mini article initially describes a $1.99 per month subscription model, but due to Apple’s actions and instability, they have temporarily made it free and will re-evaluate subscriptions once things stabilize. This is a straightforward paid subscription service that was paused due to external factors, while Twitch's strategy involves more complex tiers and revenue sharing adjustments.",
+      "cloud_answer": "Yes. The TechCrunch article on Twitch describes a monetization strategy centered on multiple revenue streams for creators: subscription revenue splits (including the Partner Plus program offering a 70/30 split on the first $100,000 for eligible creators based on a points-based system), advertising revenue (with an increased rev share and an ad incentive program), community-based viewer support through subscriptions, gifting, and cheering, and growing sponsorship/branded partnership opportunities leveraging Amazon advertising.\n\nIn contrast, the TechCrunch article on Beeper Mini describes a much simpler subscription strategy: a single flat $1.99 per month subscription fee for access to iMessage features on Android. Moreover, due to the instability caused by Apple's attempts to shut the app down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo the strategies differ significantly: Twitch focuses on a multi-pronged creator monetization model (subs with tiered revenue splits, ads, sponsorships) within a community-based platform, while Beeper Mini relies on a straightforward flat-rate consumer subscription—currently paused and offered for free amid its conflict with Apple.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 66.21
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are true according to the provided texts. \n\nThe New York Times article states that Jordan Poyer “was the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,” indicating his significant contribution to the Bills’ defense.\n\nThe Sporting News article says, \"The Ravens' offense is just fine…but he still can't afford to make big mistakes... The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.” This clearly indicates that the Ravens’ defense requires improvement.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 52.21
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are true according to the provided texts. \n\nThe New York Times article states that Jordan Poyer “was the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,” indicating his significant contribution to the Bills’ defense.\n\nThe Sporting News article says, \"The Ravens' offense is just fine…but he still can't afford to make big mistakes... The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.” This clearly indicates that the Ravens’ defense requires improvement.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 46.6
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are true according to the provided texts. \n\nThe New York Times article states that Jordan Poyer “was the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,” indicating his significant contribution to the Bills’ defense.\n\nThe Sporting News article says, \"The Ravens' offense is just fine…but he still can't afford to make big mistakes... The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.” This clearly indicates that the Ravens’ defense requires improvement.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 47.47
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, after Dave Clark was ousted as CEO of Flexport and made comments on social media (reported Oct 7th), Ryan Petersen took back the CEO title and began cutting costs, including layoffs (reported Oct 30th). This indicates a change in leadership and strategy at Flexport following the initial reporting on Clark’s departure. Additionally, the October 30th article details potential acquisition plans – acquiring Convoy's technology – which was not mentioned in the earlier report.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 41.95
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, after Dave Clark was ousted as CEO of Flexport and made comments about the company on social media (reported October 7th), Ryan Petersen took back the CEO title and began cutting costs, including layoffs (reported October 30th). This indicates a change in leadership and strategy at Flexport following the initial reporting on Clark’s departure. Additionally, the later article details potential acquisition plans involving Convoy, suggesting further shifts within the company beyond just personnel changes.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 35.69
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, after Dave Clark was ousted as CEO of Flexport and made comments about the company on social media (reported October 7th), Ryan Petersen took back the CEO title and began cutting costs, including layoffs (reported October 30th). This indicates a change in leadership and strategy at Flexport following the initial reporting on Clark’s departure. Additionally, the later article details potential acquisition plans involving Convoy, suggesting further shifts within the company beyond just personnel changes.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 35.78
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Both articles portray Google as having a negative influence on the digital ecosystem, though in different ways. The Verge article (November 1, 2023) focuses on how SEO manipulation, facilitated by Google’s algorithm, degrades search results and prioritizes profit over authentic information. It suggests Google's objectivity is corrupting access to truth.\n\nThe TechCrunch article (December 15, 2023) details a class action antitrust lawsuit alleging that Google *directly* “siphons off” content, readers, and ad revenue from news publishers through anticompetitive behavior. This represents an escalation in the portrayal of Google’s negative influence – moving beyond algorithmic issues to direct legal accusations of monopolistic practices harming businesses. \n\nTherefore, there *was* a change: the later report details more concrete and legally defined harm caused by Google than the earlier one, which focused on broader concerns about search quality and manipulation.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 70.8
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "INCORRECT",
+      "cloud_verdict": "INCORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Both articles portray Google as having a negative influence on the digital ecosystem, but with different focuses. The Verge article (November 1, 2023) details how SEO practices, influenced by Google’s algorithm, have degraded search results and created a “search-optimized hellhole.” It focuses on *how* information is presented through search.\n\nThe TechCrunch article (December 15, 2023) describes a class action lawsuit alleging that Google actively *takes* content, readers, and ad revenue from news publishers through anticompetitive behavior – focusing on the economic impact of Google’s actions on news organizations. \n\nTherefore, there was a change in portrayal: The earlier article focused on the quality of search results as being negatively impacted by SEO practices leveraging Google's algorithm, while the later article focuses on direct financial harm to publishers due to alleged anticompetitive behavior by Google itself. Both agree on negative influence but highlight different aspects and mechanisms.",
+      "cloud_answer": "",
+      "local_error": "",
+      "cloud_error": "RuntimeError: cloud backend error: exit code 1",
+      "judge_error": "skipped: candidate error",
+      "elapsed_sec": 68.07
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Both articles portray Google as having a negative influence on the digital ecosystem, but with different focuses. The Verge article (November 1, 2023) details how SEO practices, influenced by Google’s algorithm, have degraded search results and created a “search-optimized hellhole.” It focuses on *how* information is presented through search.\n\nThe TechCrunch article (December 15, 2023) describes a class action lawsuit alleging that Google actively *takes* content, readers, and ad revenue from news publishers through anticompetitive behavior – focusing on the economic impact of Google’s actions on news organizations. \n\nTherefore, there was a change in portrayal: The earlier article focused on the quality of search results as being negatively impacted by SEO practices leveraging Google's algorithm, while the later article focuses on direct financial harm to publishers due to alleged anticompetitive behavior by Google itself. Both agree on negative influence but highlight different aspects and mechanisms.",
+      "cloud_answer": "No, there was a change in portrayal. The Verge article from November 1, 2023 portrays Google's influence largely through the lens of SEO practitioners exploiting/manipulating Google Search, with Google described as an \"all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that some blame for \"corrupting our access to the truth,\" while focusing on how SEO professionals degrade the quality of search results. The later TechCrunch article from December 15, 2023 shifts the portrayal to depict Google as the active antagonist itself, accused of \"anticompetitive behavior\" that \"siphons off\" news publishers' content, readers, and ad revenue, with AI's harms to publishers' bottom line specifically cited, framing Google as violating the Sherman Act and other antitrust laws.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 102.6
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the advice provided by Sporting News to bettors regarding the evaluation of betting opportunities and offers involved reading requirements, going with the favored team, and focusing on hype. Here's how those elements appear across the provided articles:\n\n* **Reading Requirements:** Multiple articles emphasize *reading the requirements* for any available promotions and offers before accepting them (December 18th article). They also stress ensuring you’re using only *legal online sportsbooks* and advise against offshore options, implying due diligence is needed.\n* **Going with the Favored Team:** The December 18th article specifically suggests going with the favored Eagles when betting on the MNF game to increase chances of winning a FanDuel bonus bet.\n* **Focusing on Hype:** The September 28th article directly discusses leaning into the \"hype\" surrounding Travis Kelce and Taylor Swift, acknowledging it as a profitable storyline that FanDuel is capitalizing on with prop bets. This demonstrates an awareness of how media attention/public interest influences betting opportunities.",
+      "cloud_answer": "Yes. Based on the provided context:\n\n- **Reading requirements**: In the October 4, 2023 article on NBA Rookie of the Year odds, Sporting News advises: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the December 18, 2023 article on Eagles vs. Seahawks Monday Night Football, Sporting News advises: \"Since you need your moneyline bet to win to claim the $150 in bonus bets, if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The September 28, 2023 article on Chiefs-Jets Week 4 leans into the Travis Kelce and Taylor Swift celebrity storyline, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 89.13
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the advice provided by Sporting News to bettors regarding the evaluation of betting opportunities and offers involved reading requirements, going with the favored team, and focusing on hype. Here's how those elements appear across the provided articles:\n\n* **Reading Requirements:** Multiple articles emphasize *reading the requirements* for any available promotions and offers before accepting them (December 18th article). They also stress ensuring you’re using only *legal online sportsbooks* and advise against illegal offshore options (December 18th article).\n* **Going with the Favored Team:** The December 18th article, when discussing a FanDuel promotion tied to Taylor Swift and Travis Kelce, suggests if wagering on the Chiefs-Jets game, bettors might want to “go with the favored Eagles” to increase their chances of winning the associated bonus bet. Similarly, in the September 28th article, it is suggested that if you are wagering on tonight’s MNF game (Eagles vs Seahawks), you should probably go with the favored Eagles.\n* **Focusing on Hype:** The September 28th article *explicitly* discusses leaning into a profitable storyline – the hype surrounding Travis Kelce and Taylor Swift – as a marketing tactic by FanDuel, acknowledging the attention it's receiving.",
+      "cloud_answer": "Yes. Based on the provided context:\n\n- **Reading requirements**: In the October 4, 2023 article on NBA Rookie of the Year odds, Sporting News states: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the December 18, 2023 article on Eagles vs. Seahawks MNF bonuses, Sporting News advises: \"Since you need your moneyline bet to win to claim the $150 in bonus bets, if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The September 28, 2023 article on FanDuel 'Prop Stars' Picks leans into the Travis Kelce and Taylor Swift hype, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 125.69
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the advice provided by Sporting News to bettors regarding the evaluation of betting opportunities and offers involved reading requirements, going with the favored team, and focusing on hype. Here's how those elements appear across the provided articles:\n\n* **Reading Requirements:** Multiple articles emphasize *reading the requirements* for any available promotions and offers before accepting them (December 18th article). They also stress ensuring you’re using only *legal online sportsbooks* and advise against illegal offshore options (December 18th article).\n* **Going with the Favored Team:** The December 18th article, when discussing a FanDuel promotion tied to Taylor Swift and Travis Kelce, suggests if wagering on the Chiefs-Jets game, bettors might want to “go with the favored Eagles” to increase their chances of winning the associated bonus bet. Similarly, in the September 28th article, it is suggested that if you are wagering on tonight’s MNF game (Eagles vs Seahawks), you should probably go with the favored Eagles.\n* **Focusing on Hype:** The September 28th article *explicitly* discusses leaning into a profitable storyline – the hype surrounding Travis Kelce and Taylor Swift – as a marketing tactic by FanDuel, acknowledging the attention it's receiving.",
+      "cloud_answer": "Yes. Based on the context:\n\n- **Reading requirements**: The October 4, 2023 article advises, \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: The December 18, 2023 article states, \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The September 28, 2023 article highlights leaning into the Travis Kelce and Taylor Swift storyline, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 102.96
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1,
+        "type": "inference_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 58.84
+      },
+      {
+        "id": 2,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 46.66
+      },
+      {
+        "id": 3,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 34.94
+      },
+      {
+        "id": 26,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "ABSTAINED",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": false,
+        "elapsed_sec_mean": 60.02
+      },
+      {
+        "id": 27,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 68.23
+      },
+      {
+        "id": 28,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "INCORRECT",
+        "cloud_majority": "INCORRECT",
+        "local_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "INCORRECT"
+        ],
+        "cloud_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "INCORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 48.76
+      },
+      {
+        "id": 76,
+        "type": "temporal_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "INCORRECT",
+        "cloud_majority": "INCORRECT",
+        "local_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "INCORRECT"
+        ],
+        "cloud_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "INCORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.81
+      },
+      {
+        "id": 77,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "INCORRECT",
+        "cloud_majority": "INCORRECT",
+        "local_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "INCORRECT",
+          "INCORRECT",
+          "CORRECT"
+        ],
+        "local_stable": false,
+        "cloud_stable": false,
+        "elapsed_sec_mean": 80.49
+      },
+      {
+        "id": 78,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 105.93
+      }
+    ],
+    "summary": {
+      "n_questions": 9,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 0.667,
+      "cloud_correct_rate": 0.667,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 0.889,
+      "cloud_stable_rate": 0.778,
+      "by_type": {
+        "inference_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "comparison_query": {
+          "n": 3,
+          "local_correct": 2,
+          "cloud_correct": 2
+        },
+        "temporal_query": {
+          "n": 3,
+          "local_correct": 1,
+          "cloud_correct": 1
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/cell_gemma4_e4b.json
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/cell_gemma4_e4b.json
@@ -1,0 +1,779 @@
+{
+  "design": "reasoning-isolated; both models same full gold evidence",
+  "fixture": "multihop",
+  "local_model": "gemma4:e4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried is the individual associated with the cryptocurrency industry facing a criminal trial on fraud and conspiracy charges, according to reports from The Verge and TechCrunch. Prosecutors allege he committed fraud for personal gain.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.33
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried is the individual associated with the cryptocurrency industry facing a criminal trial on fraud and conspiracy charges, according to reports from The Verge and TechCrunch. Prosecutors allege he committed fraud for personal gain.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy), as reported by both The Verge and TechCrunch. Prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and use more than $100 million of customer funds to make political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.57
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried is the individual associated with the cryptocurrency industry facing a criminal trial on fraud and conspiracy charges, according to reports from The Verge and TechCrunch. Prosecutors allege he committed fraud for personal gain.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions. The SEC alleges FTX was a fraud \"from the start,\" with John J. Ray III describing Bankman-Fried's conduct as \"really just old-fashioned embezzlement.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.47
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both inflating the value of his Manhattan penthouse at Trump Tower—which was valued at $327 million according to allegations from James and noted as an amount no apartment in New York City has ever sold for close to—and is accused by Judge Arthur Engoron, writing in a September ruling, that increasing the value of this apartment between 2014 and 2015 was \"to mask a drop in the value of one of his other properties.\"",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.51
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both inflating the value of his Manhattan penthouse at Trump Tower—which was valued at $327 million according to allegations from James and noted as an amount no apartment in New York City has ever sold for close to—and is accused by Judge Arthur Engoron, writing in a September ruling, that increasing the value of this apartment between 2014 and 2015 was \"to mask a drop in the value of one of his other properties.\"",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.39
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump is implicated in both inflating the value of his Manhattan penthouse at Trump Tower—which was valued at $327 million according to allegations from James and noted as an amount no apartment in New York City has ever sold for close to—and is accused by Judge Arthur Engoron, writing in a September ruling, that increasing the value of this apartment between 2014 and 2015 was \"to mask a drop in the value of one of his other properties.\"",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.72
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and he is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 43.99
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and he is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.34
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and he is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.77
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article mentions that Rainforest secured client commitments representing more than $500 million in processing, with much of the volume guaranteed. The Hacker News article states that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "No. The Epoch Times article reports a revenue increase — revenue grew \"by a staggering 685% in two years, to $122 million in 2021\" — but this growth is attributed to \"aggressive online and real-world marketing campaigns and big-money conservative donors,\" not specifically to a subscription model (although subscriber count is mentioned).\n\nThe TechCrunch article does not report a revenue increase for Rainforest. It reports that Rainforest secured \"client commitments representing more than $500 million in processing, with much of the volume guaranteed\" — this is payment processing volume from clients, not Rainforest's own revenue growth. The article also notes Rainforest raised an $8.5 million seed round, but that is funding, not revenue.\n\nSo only the Epoch Times article reports an actual revenue increase, and it is not specifically tied to a subscription model in the context provided.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.87
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article mentions that Rainforest secured client commitments representing more than $500 million in processing, with much of the volume guaranteed. The Hacker News article states that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "Yes, both articles report revenue increases tied to their respective models.\n\n- **TechCrunch (Rainforest / payments):** The article notes that software companies want to \"accept payments and generate more revenue from being able to do so,\" and that Rainforest, founded in 2022, has \"seen impressive growth in a short period of time, securing client commitments representing more than $500 million in processing, with much of the volume guaranteed.\" It also reports an $8.5 million seed round led by Accel.\n\n- **NBC News/Hacker News (The Epoch Times / subscriptions):** The article states that The Epoch Times, which \"boasts to be the country's fourth-largest newspaper by subscriber count,\" grew \"its revenue by a staggering 685% in two years, to $122 million in 2021, according to the group's most recent tax records,\" funded through \"aggressive online and real-world marketing campaigns and big-money conservative donors.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.65
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article mentions that Rainforest secured client commitments representing more than $500 million in processing, with much of the volume guaranteed. The Hacker News article states that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "No, only the Hacker News article on The Epoch Times explicitly reports a revenue increase. It states The Epoch Times grew \"its revenue by a staggering 685% in two years, to $122 million in 2021,\" driven by subscriptions, aggressive marketing, and big-money conservative donors.\n\nThe TechCrunch article on Rainforest does not report a specific revenue increase tied to a payments model. It mentions that software companies want to \"generate more revenue from being able to\" accept payments, and that Rainforest has secured \"client commitments representing more than $500 million in processing\" — but processing volume commitments are not the same as a reported revenue increase. The article also notes Rainforest's $8.5 million seed round led by Accel, but again that is funding, not revenue growth.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 28.19
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article on Twitch discusses that Mike Minton stated that \"the combination of making it easier to run, increasing the rev share and then recently in the keynote, we talked about two new features to allow moderators to know when an ad break is coming, and adjust the ad break around the content\" was part of improving the ad experience. Regarding monetization strategies generally, Twitch's Chief Monetization Officer mentioned that \"the third piece, which is where we’re behind, is sponsorships,\" and they are now focused on growing sponsorship opportunities for streamers.\n\nThe TechCrunch article on Beeper Mini states that it has decided to make Beeper Mini free for the time being due to the unstable nature of its status, with the plan to \"look at turning on subscriptions again\" once things stabilize.",
+      "cloud_answer": "Yes. The Twitch article describes a platform-based monetization strategy built around multiple revenue streams for creators: subscription revenue splits (a 70/30 split on the first $100,000 for Partner Plus-eligible streamers, with eligibility based on a points-based system valuing Tier 1, 2, and 3 subs at 1, 2, and 6 points), prioritizing ad revenue (with an increased rev share and an ad incentive program), viewer support through subscriptions, gifting, and cheering, and growing sponsorship/branded partnership opportunities leveraging Amazon's advertising business.\n\nIn contrast, the Beeper Mini article describes a simple direct-to-consumer subscription strategy: a single $1.99 per month subscription fee charged to users for access to iMessage on Android. Moreover, due to the instability caused by Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, planning to \"look at turning on subscriptions again\" once things stabilize.\n\nSo the strategies differ significantly — Twitch focuses on a multi-pronged creator monetization model (subs with revenue splits, ads, and sponsorships) on a community-based livestreaming platform, while Beeper Mini relies on a straightforward user-paid subscription model that is currently paused in favor of free access.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 29.32
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article on Twitch discusses that Mike Minton stated that \"the combination of making it easier to run, increasing the rev share and then recently in the keynote, we talked about two new features to allow moderators to know when an ad break is coming, and adjust the ad break around the content\" was part of improving the ad experience. Regarding monetization strategies generally, Twitch's Chief Monetization Officer mentioned that \"the third piece, which is where we’re behind, is sponsorships,\" and they are now focused on growing sponsorship opportunities for streamers.\n\nThe TechCrunch article on Beeper Mini states that it has decided to make Beeper Mini free for the time being due to the unstable nature of its status, with the plan to \"look at turning on subscriptions again\" once things stabilize.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscription revenue splits (a 70/30 split on the first $100,000 for Partner Plus creators, with a points-based eligibility system valuing Tier 1, 2, and 3 subs at 1, 2, and 6 points), prioritizing ad revenue (with an increased rev share and an ad incentive program), and growing sponsorship opportunities by leveraging Amazon advertising to connect streamers with brands.\n\nIn contrast, the Beeper Mini article describes a single subscription-based monetization model — originally $1.99 per month for access to iMessage features on Android — which Beeper decided to suspend, making Beeper Mini free for the time being due to the \"chaotic\" situation following Apple's attempt to shut it down, with plans to \"look at turning on subscriptions again\" once things stabilize.\n\nSo the strategies differ significantly: Twitch is pursuing a diversified creator-monetization approach (subs, ads, sponsorships) with revenue shared with streamers, while Beeper Mini relies on a simple flat-rate consumer subscription that has been temporarily paused.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.92
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch article on Twitch discusses that Mike Minton stated that \"the combination of making it easier to run, increasing the rev share and then recently in the keynote, we talked about two new features to allow moderators to know when an ad break is coming, and adjust the ad break around the content\" was part of improving the ad experience. Regarding monetization strategies generally, Twitch's Chief Monetization Officer mentioned that \"the third piece, which is where we’re behind, is sponsorships,\" and they are now focused on growing sponsorship opportunities for streamers.\n\nThe TechCrunch article on Beeper Mini states that it has decided to make Beeper Mini free for the time being due to the unstable nature of its status, with the plan to \"look at turning on subscriptions again\" once things stabilize.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscription revenue splits (a 70/30 split on the first $100,000 for eligible Partner Plus creators, with a points-based system valuing Tier 1, 2, and 3 subs at 1, 2, and 6 points), advertising revenue (with increased rev share and an ad incentive program), viewer-driven support through subscriptions, gifting, and cheering, and growing sponsorship opportunities leveraging Amazon advertising for branded partnerships.\n\nIn contrast, the Beeper article indicates that Beeper Mini was originally a paid subscription service at $1.99 per month, but due to the instability caused by Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo the strategies differ significantly: Twitch is actively expanding and refining a complex creator-revenue-sharing monetization model across subs, ads, and sponsorships, while Beeper has paused its subscription monetization entirely and made its app free in response to external disruption.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.03
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, \"The New York Times\" article mentions that Jordan Poyer is a new safety for the Buffalo Bills and details his career achievements. The \"Sporting News\" article states that \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week\" for the Baltimore Ravens.",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,\" a Bills captain for the fourth time, a Pro Bowl safety, and an All-Pro. The Sporting News article states about the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.75
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, \"The New York Times\" article mentions that Jordan Poyer is a new safety for the Buffalo Bills and details his career achievements. The \"Sporting News\" article states that \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week\" for the Baltimore Ravens.",
+      "cloud_answer": "Yes. The New York Times article highlights Jordan Poyer's contributions to the Bills, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,\" a Bills captain for the fourth time, a Pro Bowl safety, and an All-Pro, indicating his significant role on the defense. The Sporting News article states about the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.47
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, \"The New York Times\" article mentions that Jordan Poyer is a new safety for the Buffalo Bills and details his career achievements. The \"Sporting News\" article states that \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week\" for the Baltimore Ravens.",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Bills, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame, a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before.\" The Sporting News article states about the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.68
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch report from October 7, 2023, mentioned that Dave Clark called recent reporting on Flexport \"deeply concerning\" in a post on social media site X. The subsequent article on October 30, 2023, noted that Flexport founder Ryan Petersen took back the CEO title and had been criticizing former CEO Dave Clark of overspending, specifically around hiring and expanding too quickly.",
+      "cloud_answer": "Yes. The October 7, 2023 report focused on Dave Clark, the ousted former CEO, firing back at Flexport's founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport (valued at $8 billion).\n\nThe October 30, 2023 report shifted to actions by founder Ryan Petersen, who had taken back the CEO title after his hand-picked successor (Clark) was pushed out. Petersen was focused on getting the company's financial house in order, criticized Clark for overspending on hiring and rapid expansion, and spent the prior month cutting costs, including laying off about 20% of workers (around 600 people). Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, the shuttered digital freight startup — a potential move that raised questions about whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the nature changed from a public dispute/defense by the ousted CEO to the returning founder-CEO's cost-cutting actions and a potential acquisition that seemingly contradicted that frugality stance.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.33
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch report from October 7, 2023, mentioned that Dave Clark called recent reporting on Flexport \"deeply concerning\" in a post on social media site X. The subsequent article on October 30, 2023, noted that Flexport founder Ryan Petersen took back the CEO title and had criticized former CEO Dave Clark of overspending, specifically around hiring and expanding too quickly, while also spending the past month cutting costs, including laying off about 20% of its workers.",
+      "cloud_answer": "Yes. The October 7, 2023 report focused on Dave Clark, the ousted former CEO, firing back at Flexport's founder and board after a CNBC report about his last days at the company, calling the reporting \"deeply concerning.\" By the October 30, 2023 article, the nature of events had shifted to Ryan Petersen — who had taken back the CEO title after his hand-picked successor (Clark) was pushed out — actively running the company: criticizing Clark for overspending (particularly on hiring and expanding too quickly), cutting costs, laying off about 20% of workers (roughly 600 people), and pursuing a potential acquisition of Convoy's technology to restore its trucking services. So the reporting moved from Clark's public pushback against the company and board to Petersen's concrete operational actions (cost-cutting, layoffs, and a potential acquisition) as the reinstated CEO.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.22
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The TechCrunch report from October 7, 2023, mentioned that Dave Clark called recent reporting on Flexport \"deeply concerning\" in a post on social media site X. The subsequent article on October 30, 2023, noted that Flexport founder Ryan Petersen took back the CEO title and had criticized former CEO Dave Clark of overspending, specifically around hiring and expanding too quickly, while also spending the past month cutting costs, including laying off about 20% of its workers.",
+      "cloud_answer": "Yes. The October 7, 2023 report focused on Dave Clark, the ousted former CEO, firing back at Flexport's founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport.\n\nThe October 30, 2023 article reported a shift in nature: founder Ryan Petersen had taken back the CEO title after his hand-picked successor (Clark) was pushed out, and was taking concrete actions — criticizing Clark for overspending (specifically on hiring and expanding too quickly), cutting costs, and laying off about 20% of workers (about 600 people). Additionally, Flexport was in talks to acquire the technology of Convoy, a shuttered digital freight startup, which would involve restoring Convoy's trucking services and spending money — raising the question of whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the events shifted from a public war of words between the ousted CEO and the company (Oct 7) to the returning founder-CEO's operational restructuring actions and a potential acquisition that seemed to contradict his cost-cutting message (Oct 30).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.14
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge published on November 1, 2023, discussed that some people blame SEO experts for making online life feel like a \"search-optimized hellhole,\" suggesting that the practice seemed to have destroyed the illusion that the internet was ever about anything other than selling stuff. In contrast, the TechCrunch article from December 15, 2023, reported on a class action lawsuit accusing Google and Alphabet of anticompetitive behavior for \"siphoning off\" news publishers’ content, their readers, and ad revenue through anticompetitive means.",
+      "cloud_answer": "Based on the context, there was a change in portrayal. The Verge article from November 1, 2023 portrays Google's influence on the digital ecosystem primarily through the lens of search quality degradation — describing Google Search results as \"absolutely unusable,\" \"garbage,\" and \"a nightmare,\" with some blaming Google itself as \"an all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that is \"corrupting our access to the truth,\" while others blame SEO practitioners for turning online life into a \"search-optimized hellhole.\"\n\nThe TechCrunch article from December 15, 2023 shifts the portrayal to focus on Google's alleged anticompetitive behavior harming news publishers specifically, framing Google and Alphabet as violators of U.S. antitrust law (the Sherman Act) that \"siphons off\" news publishers' content, readers, and ad revenue through anticompetitive means, with AI's harms to publishers' bottom line specifically cited.\n\nSo the portrayal shifted from a focus on search result quality and SEO-driven degradation of information access to a focus on antitrust violations and AI-driven harm to news publishers' business models.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.64
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge published on November 1, 2023, mentioned that some people blame \"the people I wanted to see in Florida, the ones who engage in the mysterious art of search engine optimization, or SEO,\" while others blame Google itself for corrupting access to truth. In contrast, the TechCrunch article from December 15, 2023, reported a class action lawsuit accusing Google and Alphabet of anticompetitive behavior by \"siphoning off\" news publishers’ content, readers, and ad revenue through anticompetitive means.",
+      "cloud_answer": "No, there was a change in portrayal. The Verge article (November 1, 2023) focuses on how Google's influence on the internet's appearance is shaped by SEO practitioners exploiting/manipulating Google's algorithm to clog search results with low-quality, ad-driven content, with some users blaming Google itself as an \"all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share\" that is \"corrupting our access to the truth.\"\n\nThe later TechCrunch article (December 15, 2023) portrays Google differently — as the direct subject of a class action antitrust lawsuit accusing Google and Alphabet of \"anticompetitive behavior in violation of U.S. antitrust law, the Sherman Act, and others.\" It frames Google as actively harming news publishers by \"siphon[ing] off\" their content, readers, and ad revenue through anticompetitive means, with specific reference to AI's harms to publishers' bottom line.\n\nSo the portrayal shifted from Google as a search platform being gamed/manipulated by SEO actors (with Google as a somewhat passive or complicit giant) to Google as an active anticompetitive aggressor directly harming publishers, particularly through AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.11
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge published on November 1, 2023, mentioned that some people blame \"the people I wanted to see in Florida, the ones who engage in the mysterious art of search engine optimization, or SEO,\" while others blame Google itself for corrupting access to truth. In contrast, the TechCrunch article from December 15, 2023, reported a class action lawsuit accusing Google and Alphabet of anticompetitive behavior by \"siphoning off\" news publishers’ content, readers, and ad revenue through anticompetitive means.",
+      "cloud_answer": "No, there was a change in the portrayal. The Verge article from November 1, 2023 portrays Google's influence on the digital ecosystem in terms of the quality and authenticity of search results, describing how SEO practitioners exploit Google's algorithms to make search results feel \"absolutely unusable,\" \"garbage,\" and \"a nightmare,\" with content that \"doesn't feel authentic\" — framing Google's influence as being corrupted/manipulated by SEO professionals (though noting some blame Google itself as an \"all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share\").\n\nThe later TechCrunch article from December 15, 2023 portrays Google's influence differently — as the direct subject of anticompetitive behavior and antitrust violations. It describes Google (and parent company Alphabet) as actively engaging in anticompetitive conduct that \"siphons off\" news publishers' content, readers, and ad revenue, violating the Sherman Act and harming publishers' bottom lines, with specific citation of AI's harms.\n\nSo the portrayal shifted from Google as a platform whose search ecosystem is being degraded/manipulated by third-party SEO actors (with users frustrated at result quality), to Google itself as the active antitrust violator directly harming news publishers through its own anticompetitive practices and AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.55
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors included reading the requirements for any available promotions before accepting them, and in one instance, it suggested that if wagering on tonight's MNF game, users would probably want to go with the favored Eagles. The reports published covered dates up to December 18, 2023, but there is no mention of focusing on hype between September 28, 2023, and December 18, 2023.",
+      "cloud_answer": "Yes. Based on the context:\n\n- **Reading requirements**: The October 4, 2023 article (NBA ROTY odds) advises, \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: The December 18, 2023 article (Eagles vs. Seahawks MNF) advises, \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The September 28, 2023 article (FanDuel 'Prop Stars' Picks) references companies like FanDuel leaning into the profitable Travis Kelce/Taylor Swift storyline hype.\n\nAll three pieces of advice appear in reports published between September 28, 2023, and December 18, 2023.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.41
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors included reading the requirements for any available promotions before accepting them, and in one instance, it suggested that if wagering on tonight's MNF game, users would probably want to go with the favored Eagles. The reports published cover dates up to December 18, 2023, which is after September 28, 2023.",
+      "cloud_answer": "Yes. According to the Sporting News articles in the provided context:\n\n1. **Reading requirements** — In the October 4, 2023 NBA Rookie of the Year article: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n2. **Going with the favored Eagles** — In the December 18, 2023 Monday Night Football article: \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n3. **Focusing on hype** — In the September 28, 2023 FanDuel 'Prop Stars' article, Sporting News notes that \"despite the fatigue from many... companies like FanDuel just can't help but lean into a profitable storyline,\" referencing the Travis Kelce and Taylor Swift hype.\n\nAll three pieces of advice/coverage appear in Sporting News reports published between September 28, 2023, and December 18, 2023.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.21
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors included reading the requirements for any available promotions before accepting them, and in one instance, it suggested that if wagering on tonight's MNF game, users would probably want to go with the favored Eagles. The reports published cover dates up to December 18, 2023, which is after September 28, 2023.",
+      "cloud_answer": "Yes. Based on the context:\n\n- **Reading requirements**: In the October 4, 2023 article on NBA Rookie of the Year odds, Sporting News states: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the December 18, 2023 article on Eagles vs. Seahawks MNF bonuses, Sporting News advises: \"Since you need your moneyline bet to win to claim the $150 in bonus bets, if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: In the September 28, 2023 article on FanDuel 'Prop Stars' Picks, Sporting News leans into the Travis Kelce and Taylor Swift storyline, noting that \"despite the fatigue from many... companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.92
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1,
+        "type": "inference_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.12
+      },
+      {
+        "id": 2,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 22.54
+      },
+      {
+        "id": 3,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.37
+      },
+      {
+        "id": 26,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 26.9
+      },
+      {
+        "id": 27,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.76
+      },
+      {
+        "id": 28,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 20.63
+      },
+      {
+        "id": 76,
+        "type": "temporal_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.56
+      },
+      {
+        "id": 77,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 22.1
+      },
+      {
+        "id": 78,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 18.85
+      }
+    ],
+    "summary": {
+      "n_questions": 9,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "inference_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "comparison_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "temporal_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/cell_light_4b.json
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/cell_light_4b.json
@@ -1,0 +1,779 @@
+{
+  "design": "reasoning-isolated; both models same full gold evidence",
+  "fixture": "multihop",
+  "local_model": "gemma3:4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.26
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including allegedly using \"billions of dollars in misappropriated FTX customer deposits\" to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and use more than $100 million of customer funds to make political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.57
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including allegedly using \"billions of dollars in misappropriated FTX customer deposits\" to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.73
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump. The article details how Trump inflated the value of his Fifth Avenue penthouse to $327 million and used that adjustment to mask a drop in the value of Mar-a-Lago.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.43
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump. The article details how Trump inflated the value of his Fifth Avenue penthouse to $327 million and used that adjustment to mask a drop in the value of Mar-a-Lago.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.65
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Donald Trump. The article details how Trump inflated the value of his Fifth Avenue penthouse to $327 million and used that adjustment to mask a drop in the value of Mar-a-Lago.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.95
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.62
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.9
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Altman is the figure associated with generative AI technology whose departure from OpenAI was considered shocking according to Fortune, and is also the subject of a prevailing theory suggesting a lack of full truthfulness with the board as reported by TechCrunch.",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.37
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report a significant increase in revenue. The TechCrunch article states that Rainforest has seen impressive growth with more than $500 million in processing commitments guaranteed, and The Epoch Times reports a staggering 685% increase in revenue to $122 million in 2021.",
+      "cloud_answer": "No. The Hacker News article on The Epoch Times explicitly reports a revenue increase — growth of 685% in two years to $122 million in 2021 — tied to its subscription/nonprofit model. The TechCrunch article on Rainforest does not report an actual revenue increase; it reports client commitments representing more than $500 million in processing volume (not revenue), and only describes the general aim of helping software companies \"generate more revenue\" by accepting payments.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.49
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report a significant increase in revenue. The TechCrunch article states that Rainforest has seen impressive growth with more than $500 million in processing commitments guaranteed, and The Epoch Times reports a staggering 685% increase in revenue to $122 million in 2021.",
+      "cloud_answer": "No, only partially. The Epoch Times article specifically reports a revenue increase, stating the nonprofit grew \"its revenue by a staggering 685% in two years, to $122 million in 2021,\" tied to its subscription/donation model (becoming \"the country's fourth-largest newspaper by subscriber count\") and ad-buying campaigns.\n\nThe TechCrunch article on Rainforest does not report an actual revenue increase from a payment model. It mentions that software companies want to \"accept payments and generate more revenue\" as a motivation, and notes that Rainforest has secured \"client commitments representing more than $500 million in processing\" — but that figure is processing volume commitments, not a reported revenue increase.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 29.59
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report a significant increase in revenue. The TechCrunch article states that Rainforest has seen impressive growth with more than $500 million in processing commitments guaranteed, and The Epoch Times reports a staggering 685% increase in revenue to $122 million in 2021.",
+      "cloud_answer": "No. The TechCrunch article does not report a revenue increase tied to payment models for Rainforest; it only states that Rainforest has secured \"client commitments representing more than $500 million in processing, with much of the volume guaranteed\" — that is processing volume, not revenue growth.\n\nThe Epoch Times article does report a revenue increase — \"growing its revenue by a staggering 685% in two years, to $122 million in 2021\" — but the context attributes this growth to a combination of advertising spending (e.g., directing \"millions of dollars in advertising toward supporting President Donald Trump's campaign\"), \"aggressive online and real-world marketing campaigns and big-money conservative donors,\" and subscriber growth (claiming to be \"the country's fourth-largest newspaper by subscriber count\"), not specifically to a subscription model alone.\n\nSo only the Epoch Times article reports a revenue increase, and it is not exclusively tied to subscriptions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.14
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the TechCrunch articles present significantly different monetization strategies. The Twitch article details a complex system of tiered subscriptions with point-based eligibility for the Partner Plus program, aiming to incentivize deeper community support and reward higher subscription tiers. It focuses on leveraging Amazon’s advertising revenue alongside increased rev shares for streamers. Conversely, the Beeper Mini article describes a straightforward monthly subscription model ($1.99) designed to provide access to iMessage functionality between iOS and Android devices.",
+      "cloud_answer": "Yes. The Twitch article describes a platform-driven monetization strategy centered on subscription revenue splits with creators (a 70/30 split on the first $100,000 for Partner Plus-eligible streamers), a points-based eligibility system across Tier 1, 2, and 3 subs, increased ad revenue share, an ad incentive program, and growing sponsorship opportunities through Amazon advertising to support creators.\n\nIn contrast, the Beeper Mini article describes a direct consumer subscription strategy: Beeper Mini was offered to Android users for $1.99 per month to access iMessage features (high-quality photos and videos, tapback reactions, typing indicators, read receipts, and more). Due to the instability caused by Apple's attempts to shut it down, Beeper made the app free for the time being, stating, \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo the strategies differ: Twitch focuses on splitting subscription, ad, and sponsorship revenue with creators on its platform, while Beeper's plan centers on charging end users a flat monthly subscription fee for app access (currently paused/free during instability).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 42.02
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the TechCrunch articles present significantly different monetization strategies. The Twitch article details a complex system of tiered subscriptions with point-based eligibility for higher revenue shares, aiming to incentivize deeper community support and focusing on advertising and sponsorships alongside subscription income. The Beeper Mini article, conversely, outlines a straightforward monthly subscription model ($1.99) designed to provide access to iMessage functionality between iOS and Android devices.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscriptions (with a 70/30 revenue split on the first $100,000 for Partner Plus creators, qualified via a points-based system where Tier 1, 2, and 3 subs earn 1, 2, and 6 points respectively), advertising (with increased rev share and an ad incentive program, plus new features letting moderators adjust ad breaks around content), and sponsorships (leveraging Amazon advertising to set up influencer deals programmatically). The focus is on revenue sharing with creators across multiple income streams.\n\nIn contrast, the Beeper article describes a much simpler, direct consumer subscription model: Beeper Mini was originally priced at $1.99 per month for Android users to access iMessage features. However, due to the instability caused by Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, planning to \"look at turning on subscriptions again\" once things stabilize.\n\nSo the strategies differ significantly: Twitch is refining a complex creator-revenue-sharing ecosystem (subs, ads, sponsorships) on a platform, while Beeper is using a straightforward flat-fee consumer subscription that it has temporarily suspended in favor of free access due to external disruption from Apple.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.95
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, the TechCrunch articles present significantly different monetization strategies. The Twitch article details a complex system of tiered subscriptions with point-based eligibility for higher revenue shares, aiming to incentivize deeper community support and focusing on advertising and sponsorships alongside subscription income. The Beeper Mini article, conversely, outlines a straightforward monthly subscription model ($1.99) designed to provide access to iMessage functionality between iOS and Android devices.",
+      "cloud_answer": "Yes. The Twitch article describes a complex, multi-pronged monetization strategy centered on subscription revenue splits (a 70/30 split on the first $100,000 for eligible Partner Plus creators), a points-based eligibility system (Tier 1, 2, and 3 subs earning 1, 2, and 6 points respectively), increased ad revenue share with an ad incentive program, and growing sponsorship opportunities through Amazon advertising — all aimed at creators monetizing their content on the platform.\n\nIn contrast, the Beeper Mini article describes a much simpler, direct-to-consumer subscription strategy: Beeper Mini was originally offered at $1.99 per month to Android users for iMessage access. Due to the instability caused by Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\"\n\nSo the strategies differ significantly: Twitch's is a creator-monetization platform model with revenue splits, ads, and sponsorships, while Beeper's is a straightforward paid consumer app subscription (temporarily suspended due to Apple's interference).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.38
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes. The \"The New York Times\" article explicitly attributes the Bills’ defensive success to Jordan Poyer’s transformation and sobriety, highlighting his unique approach and impact. Conversely, the “Sporting News” article identifies the Ravens' defense as a key area needing improvement ahead of their upcoming game against the Bengals.",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Buffalo Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,\" a Bills captain for the fourth time, a Pro Bowl safety the previous year, and an All-Pro the year before that. The Sporting News article states about the Baltimore Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 28.6
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes. The \"The New York Times\" article explicitly attributes the Bills’ defensive success to Jordan Poyer and his transformation through ayahuasca, highlighting his unique approach and impact on the team. Conversely, the “Sporting News” article identifies the Ravens' defense as a key area needing improvement before their upcoming game against the Bengals.",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame, a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before.\" The Sporting News article states regarding the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.36
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes. The \"The New York Times\" article explicitly attributes the Bills’ defensive success to Jordan Poyer and his transformation through ayahuasca, highlighting his unique approach and impact on the team. Conversely, the “Sporting News” article identifies the Ravens' defense as a key area needing improvement before their upcoming game against the Bengals.",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Buffalo Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame, a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before.\" The Sporting News article suggests the Baltimore Ravens' defense needs to improve before facing the Bengals, stating \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 49.1
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the nature of the events reported. The initial report (October 7th) detailed Dave Clark’s angry response to Flexport’s CEO being ousted and his accusations against the company's board. Subsequently, Ryan Petersen (Flexport’s new CEO) took action by implementing cost-cutting measures, including layoffs, in an attempt to stabilize the company financially. This shift from a reactive, combative situation to a proactive, corrective one marked a change in the narrative surrounding Flexport’s troubles.",
+      "cloud_answer": "Yes. The October 7, 2023 report focused on Dave Clark, the former Amazon executive ousted as CEO of Flexport just a year into the job, firing back at the founder and board, calling recent reporting on the logistics company \"deeply concerning\" in a lengthy post on social media site X, following a CNBC report about his last days at Flexport.\n\nThe October 30, 2023 report shifted to Ryan Petersen's actions after retaking the CEO title from his hand-picked successor. Petersen's focus was on getting the company's financial house back in order, criticizing Clark for overspending on hiring and expansion. Petersen spent the month cutting costs, including laying off about 20% of workers (about 600 people). Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, a digital freight startup that had shuttered — a move that, if completed, would restore Convoy's trucking services for customers and partners and would cost money, raising the question of whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the nature changed from a public dispute/defense by the ousted CEO (Clark) to the returning CEO (Petersen) taking concrete operational actions: cost-cutting, layoffs, and a potential acquisition.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 48.02
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the nature of the events reported. The initial report (October 7th) detailed Dave Clark’s angry response to Flexport’s CEO being ousted and his accusations against the company's board. Subsequently, Ryan Petersen (Flexport’s new CEO) took action by implementing cost-cutting measures, including layoffs, and re-evaluating how the company communicated with regulators. This shift demonstrated a clear change in leadership and a focus on financial stability following Clark’s criticisms and the previous instability at Flexport.",
+      "cloud_answer": "Yes. The October 7, 2023 report focused on Dave Clark, the ousted former CEO, firing back at Flexport's founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport.\n\nBy the October 30, 2023 report, the nature of events had shifted to actions taken by Ryan Petersen, who had taken back the CEO title after his hand-picked successor (Dave Clark) was pushed out. Petersen was focused on getting the company's financial house back in order, criticized Clark for overspending (specifically around hiring and expanding too quickly), and spent the past month cutting costs, including laying off about 20% of its workers (about 600 people). Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, a digital freight startup that had shuttered — a potential deal that raised questions about whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the reporting shifted from Clark's public pushback against Flexport's leadership to Petersen's cost-cutting actions as returning CEO and a potential acquisition that seemed to contradict his frugality message.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.11
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the nature of the events reported. The initial report (October 7th) detailed Dave Clark’s angry response to Flexport’s CEO being ousted and his accusations against the company's board. Subsequently, Ryan Petersen (Flexport’s new CEO) took action by implementing cost-cutting measures, including layoffs, and re-evaluating how the company communicated with regulators. This shift demonstrated a clear change in leadership and a focus on financial stability following Clark’s criticisms and the previous instability at Flexport.",
+      "cloud_answer": "Yes. The October 7, 2023 report concerned Dave Clark, the ousted former CEO of Flexport, firing back at the company's founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport.\n\nThe October 30, 2023 report concerned Ryan Petersen, who had taken back the CEO title after his hand-picked successor (Clark) was pushed out. Petersen's actions focused on getting the company's financial house back in order, criticizing Clark for overspending on hiring and expanding too quickly, and cutting costs — including laying off about 20% of workers (about 600 people). Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, a digital freight startup that had shuttered, with plans to restore Convoy's trucking services — a move that would cost money and potentially contradict Petersen's stated frugality.\n\nSo the nature of the events shifted from a public dispute/defense by the ousted former CEO (Clark) about reporting on his tenure, to operational and strategic actions by the returning CEO (Petersen) — cost-cutting, layoffs, and a potential acquisition of Convoy's technology.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 23.55
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the portrayal of Google’s influence. The Verge article highlighted how SEO experts were manipulating search results to create “search-optimized hellholes” and exploiting user impulses for profit. The TechCrunch article focuses on an antitrust lawsuit alleging Google's anticompetitive behavior regarding AI and its impact on news publishers’ revenue, suggesting a shift from individual manipulation of search results to broader concerns about Google’s market dominance and harm to the media industry.",
+      "cloud_answer": "No, there was a change in the portrayal. The Verge report from November 1, 2023 focuses on how Google Search results have become a \"search-optimized hellhole\" degraded by SEO practitioners who exploit the algorithm, with some users blaming Google itself as an \"all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that is \"corrupting our access to the truth.\" The portrayal centers on Google's influence being undermined or manipulated by SEO professionals degrading content quality.\n\nThe later TechCrunch report from December 15, 2023 shifts the portrayal to Google as an active anticompetitive actor directly harming news publishers. It describes a class action antitrust lawsuit filed by Helena World Chronicle accusing Google and Alphabet of violating the Sherman Act and other antitrust laws, alleging Google \"siphons off\" news publishers' content, readers, and ad revenue through anticompetitive means, and specifically cites AI's harms to publishers' bottom line.\n\nSo the portrayal shifted from Google as a search platform whose results are being degraded/manipulated by third-party SEO actors, to Google itself being accused of anticompetitive conduct and directly harming publishers (including via AI).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.9
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the portrayal of Google’s influence. The Verge article highlighted how SEO experts were manipulating search results to create “search-optimized hellholes” and exploiting user impulses for profit. The TechCrunch article focuses on an antitrust lawsuit alleging Google's actions are harming news publishers by siphoning off their content, readers, and ad revenue through anticompetitive means related to AI. While both articles address Google’s influence, the Verge emphasizes a more direct manipulation of search results for commercial gain, whereas the TechCrunch article frames it as an antitrust issue impacting the broader media landscape.",
+      "cloud_answer": "Based on the context, there was a change in portrayal. The Verge article from November 1, 2023 portrays Google's influence on the digital ecosystem primarily through the lens of search engine optimization (SEO) — describing how Google Search results have become \"absolutely unusable,\" \"garbage,\" and \"a nightmare,\" with blame directed at both Google itself (as \"an all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that may be \"corrupting our access to the truth\") and at SEO practitioners who manipulate Google's algorithm to clog the internet with low-quality, ad-driven content.\n\nThe later TechCrunch article from December 15, 2023 portrays Google's influence differently — through the lens of antitrust violations harming news publishers. It describes a class action lawsuit accusing Google and Alphabet of \"anticompetitive behavior in violation of U.S. antitrust law, the Sherman Act, and others,\" with the publisher Helena World Chronicle arguing that Google \"siphons off\" news publishers' content, readers, and ad revenue through anticompetitive means, and specifically citing AI's harms to publishers' bottom line.\n\nSo the portrayal shifted from Google's role in degrading search result quality (alongside SEO practitioners) to Google being accused of actively harming news publishers' businesses through anticompetitive practices and AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.39
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, there was a significant change in the portrayal of Google’s influence. The Verge article highlighted how SEO experts were manipulating search results to create “search-optimized hellholes” and exploiting user impulses for profit. The TechCrunch article focuses on an antitrust lawsuit alleging Google's actions are harming news publishers by siphoning off their content, readers, and ad revenue through anticompetitive means related to AI. While both articles address Google’s influence, the Verge emphasizes a more direct manipulation of search results for commercial gain, whereas the TechCrunch article frames it as an antitrust issue impacting the broader media landscape.",
+      "cloud_answer": "Based on the context, there was a change in portrayal between the two reports.\n\nThe Verge article from November 1, 2023 portrays Google's influence on the digital ecosystem primarily through the lens of search quality degradation, focusing on how SEO practitioners exploit and manipulate Google's algorithms to make search results feel \"absolutely unusable,\" \"garbage,\" and \"a nightmare.\" It frames the issue around SEO professionals \"ruining the internet\" by gaming the system, though it notes some blame Google itself as \"an all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that is \"corrupting our access to the truth.\"\n\nThe TechCrunch article from December 15, 2023 shifts the portrayal toward Google's direct anticompetitive behavior harming news publishers. It describes Google as engaging in conduct that violates U.S. antitrust law (the Sherman Act), with the publisher Helena World Chronicle arguing that Google \"siphons off\" news publishers' content, readers, and ad revenue through anticompetitive means, and specifically cites AI's harms to publishers' bottom line.\n\nSo the portrayal shifted from Google as the platform whose search results are being degraded by third-party SEO manipulators (with Google as a somewhat passive or complicit giant) to Google as an active anticompetitive actor directly harming content creators through its practices, including AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.15
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Based solely on the provided context, here’s a breakdown of the answer:\n\nThe article focuses heavily on promoting FanDuel sportsbook bonus offers for NFL games, particularly the Eagles vs. Seahawks matchup. It encourages readers to use specific promo codes (TSNCO, SPORTSPICK, SPORTSRIV, NEWS1000) and links to sign up for accounts and claim welcome bonuses. The article also highlights trends like Travis Kelce and Taylor Swift-inspired props, suggesting a focus on hype and celebrity connections to drive engagement.\n\nThe advice given is:\n\n*   **Read requirements:** Before accepting any promotions, be aware of the restrictions.\n*   **Focus on hyped games:** The article actively promotes betting on popular matchups (like Eagles vs. Seahawks) due to the increased interest and promotional offers associated with them.",
+      "cloud_answer": "Yes. Between those dates, Sporting News advised bettors to read the requirements for any available promotions and offers before accepting them (NBA Rookie of the Year Odds, published 2023-10-04), and to go with the favored Eagles if wagering on the MNF moneyline (Eagles vs. Seahawks, published 2023-12-18). However, the provided context does not include advice from Sporting News about focusing on hype during this period.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 44.26
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Based solely on the provided context, here’s a breakdown of the answer:\n\nThe article discusses FanDuel offering bonus codes for NFL games, specifically the Eagles vs. Seahawks matchup. It highlights various offers like $1,000 first bets, bonus bets, and promotions tied to Travis Kelce and Taylor Swift. The article advises readers to use these promo codes and links to sign up for new accounts and claim bonuses.\n\nThe context also mentions that the best way to bet on NBA Rookie of the Year is to read requirements before accepting offers, focus on hyped teams like the Eagles, and consider the timing of bets (earlier bets have less data). However, this information is not directly related to the FanDuel promo codes or the Chiefs-Jets game.",
+      "cloud_answer": "Yes. Based on the context:\n\n- **Reading requirements**: In the October 4, 2023 NBA Rookie of the Year article, Sporting News advises: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the December 18, 2023 Eagles vs. Seahawks article, Sporting News advises: \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: In the September 28, 2023 FanDuel 'Prop Stars' article, Sporting News highlights leaning into the Travis Kelce/Taylor Swift storyline, noting \"companies like FanDuel just can't help but lean into a profitable storyline.\"\n\nAll three pieces of advice appear in reports published between September 28, 2023, and December 18, 2023.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 21.65
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Based solely on the provided context, here’s a breakdown of the answer:\n\nThe article discusses FanDuel offering bonus codes for NFL games, specifically the Eagles vs. Seahawks matchup. It highlights various offers like $1,000 first bets, bonus bets, and promotions tied to Travis Kelce and Taylor Swift. The article advises readers to use these promo codes and links to sign up for new accounts and claim bonuses.\n\nThe context also mentions that the best way to bet on NBA Rookie of the Year is to read requirements before accepting offers, focus on hyped teams like the Eagles, and consider the timing of bets (earlier bets have less data). However, this information is not directly related to the FanDuel promo codes or the Chiefs-Jets game.",
+      "cloud_answer": "Yes. Within the context provided between September 28, 2023, and December 18, 2023:\n\n- **Reading requirements**: In the NBA Rookie of the Year Odds article (published October 4, 2023), Sporting News advises, \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the Eagles vs. Seahawks MNF article (published December 18, 2023), Sporting News states, \"Since you need your moneyline bet to win to claim the $150 in bonus bets, if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The FanDuel 'Prop Stars' article (published September 28, 2023) reflects leaning into the hype around the Travis Kelce and Taylor Swift storyline, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 39.61
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1,
+        "type": "inference_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 18.85
+      },
+      {
+        "id": 2,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.68
+      },
+      {
+        "id": 3,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.96
+      },
+      {
+        "id": 26,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.74
+      },
+      {
+        "id": 27,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 29.78
+      },
+      {
+        "id": 28,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 31.69
+      },
+      {
+        "id": 76,
+        "type": "temporal_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 30.89
+      },
+      {
+        "id": 77,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.48
+      },
+      {
+        "id": 78,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 35.17
+      }
+    ],
+    "summary": {
+      "n_questions": 9,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "inference_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "comparison_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "temporal_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/cell_standard_12b.json
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/cell_standard_12b.json
@@ -1,0 +1,779 @@
+{
+  "design": "reasoning-isolated; both models same full gold evidence",
+  "fixture": "multihop",
+  "local_model": "gemma3:12b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "off",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of failed cryptocurrency exchange FTX, is on trial for seven counts of wire fraud and conspiracy. He is accused of using \"billions of dollars in misappropriated FTX customer deposits\" to help buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, and repay Alameda’s lenders; prosecutors also allege he used over $100 million of customer funds for political contributions. Prosecutors argue that Bankman-Fried lied about consumer protection and made false statements regarding FTX's handling of conflicts of interest and customer assets.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on fraud and conspiracy charges. He faces seven counts of criminal charges — two counts of wire fraud and five counts of conspiracy — and is accused by prosecutors of misappropriating billions of dollars in FTX customer deposits for personal gain, including buying more than $200 million of real estate for himself, making billions of dollars of investments for his own interest, repaying Alameda's lenders, and using more than $100 million of customer funds to make political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.44
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of failed cryptocurrency exchange FTX, is on trial for seven counts of wire fraud and conspiracy. He is accused of using \"billions of dollars in misappropriated FTX customer deposits\" to help buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, and repay Alameda’s lenders; prosecutors also allege he used over $100 million of customer funds for political contributions. Prosecutors argue that Bankman-Fried lied about consumer protection and made false statements regarding FTX's segregation of customer assets.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). According to prosecutors, he is accused of misappropriating billions of dollars in FTX customer deposits for personal gain, including using the funds to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.77
+    },
+    {
+      "id": 1,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Sam Bankman-Fried, the founder of failed cryptocurrency exchange FTX, is on trial for seven counts of wire fraud and conspiracy. He is accused of using \"billions of dollars in misappropriated FTX customer deposits\" to help buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, and repay Alameda’s lenders; prosecutors also allege he used over $100 million of customer funds for political contributions. Prosecutors argue that Bankman-Fried lied about consumer protection and made false statements regarding FTX's segregation of customer assets.",
+      "cloud_answer": "Sam Bankman-Fried, the founder of FTX and co-founder of Alameda Research, is the individual associated with the cryptocurrency industry facing a criminal trial on seven counts of fraud and conspiracy charges (two counts of wire fraud and five counts of conspiracy). As reported by both The Verge and TechCrunch, prosecutors accuse him of committing fraud for personal gain, including using billions of dollars in misappropriated FTX customer deposits to buy more than $200 million of real estate for himself, make billions of dollars of investments for his own interest, repay Alameda's lenders, and make more than $100 million in political contributions.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 43.27
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, Donald Trump is implicated in both inflating the value of his Manhattan penthouse apartment to nearly three times its actual size and valuing it at $327 million—a figure no New York City apartment has ever sold for—as stated in 'Fortune'. Additionally, 'The Age' reports that between 2014 and 2015, Trump increased the value of the apartment to mask a drop in the value of one of his other properties.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.5
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, Donald Trump is implicated in both inflating the value of his Manhattan penthouse apartment to nearly three times its actual size and valuing it at $327 million—a figure no New York City apartment has ever sold for—as stated in 'Fortune'. Additionally, 'The Age' reports that between 2014 and 2015, Trump increased the value of the apartment to mask a drop in the value of one of his other properties.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.37
+    },
+    {
+      "id": 2,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to the provided context, Donald Trump is implicated in both inflating the value of his Manhattan penthouse apartment to nearly three times its actual size and valuing it at $327 million—a figure no New York City apartment has ever sold for—as stated in 'Fortune'. Additionally, 'The Age' reports that between 2014 and 2015, Trump increased the value of the apartment to mask a drop in the value of one of his other properties.",
+      "cloud_answer": "Donald Trump",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.43
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to both Fortune and TechCrunch, Sam Altman, who was the CEO of OpenAI, is the figure associated with generative AI technology whose departure from OpenAI was considered shocking. Both sources state that the board's reasoning for his firing involved him \"not consistently candid in his communications\" (Fortune) and a theory suggests he may have circumvented the board in a major deal by not being fully truthful (TechCrunch).",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.18
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to both Fortune and TechCrunch, Sam Altman, who was the CEO of OpenAI, is the figure associated with generative AI technology whose departure from OpenAI was considered shocking. Both sources state that the board's reasoning for his firing involved him \"not consistently candid in his communications\" (Fortune) and a theory suggests he may have circumvented the board in a major deal by not being fully truthful (TechCrunch).",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.83
+    },
+    {
+      "id": 3,
+      "type": "inference_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "According to both Fortune and TechCrunch, Sam Altman, who was the CEO of OpenAI, is the figure associated with generative AI technology whose departure from OpenAI was considered shocking. Both sources state that the board's reasoning for his firing involved him \"not consistently candid in his communications\" (Fortune) and a theory suggests he may have circumvented the board in a major deal by not being fully truthful (TechCrunch).",
+      "cloud_answer": "Sam Altman",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.17
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "ABSTAINED",
+      "local_abstain": false,
+      "cloud_abstain": true,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states that Rainforest has seen \"impressive growth\" securing client commitments representing more than $500 million in processing volume. The Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "I don't know",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.26
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states that Rainforest has seen \"impressive growth\" securing client commitments representing more than $500 million in processing volume. The Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "Partially. The Hacker News article on The Epoch Times explicitly reports a revenue increase tied to its subscription/nonprofit model: revenue grew \"by a staggering 685% in two years, to $122 million in 2021,\" and it boasts being \"the country's fourth-largest newspaper by subscriber count.\"\n\nThe TechCrunch article on Rainforest does not report a specific revenue increase for software companies from payment models. It mentions that software companies want to \"accept payments and generate more revenue from being able to do so,\" and that Rainforest itself has secured \"client commitments representing more than $500 million in processing\" — but that figure is processing volume, not a reported revenue increase. So only The Epoch Times article reports an actual revenue increase; the TechCrunch article describes a revenue-generation motivation and processing-volume commitments rather than a reported revenue rise.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.28
+    },
+    {
+      "id": 26,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both articles report increases in revenue. The TechCrunch article states that Rainforest has seen \"impressive growth\" securing client commitments representing more than $500 million in processing volume. The Hacker News article reports that The Epoch Times grew its revenue by a staggering 685% in two years, to $122 million in 2021.",
+      "cloud_answer": "No. The TechCrunch article reports that Rainforest secured client commitments representing more than $500 million in processing, but this is processing volume, not revenue from a payment model. The Hacker News article reports that The Epoch Times grew its revenue by 685% in two years, to $122 million in 2021, but the context attributes this growth to advertising, marketing campaigns, and big-money conservative donors rather than specifically to a subscription model.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.54
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The Twitch article indicates a focus on diversifying monetization strategies beyond just subscriptions and ads, specifically mentioning growing sponsorship opportunities for streamers. They aim to provide three options – subscriptions, ads, and sponsorships – based on the streamer’s size, location, experience, and content type. In contrast, Beeper Mini initially planned a subscription model ($1.99/month) but made it free temporarily due to instability after Apple's intervention, highlighting a reliance on that single revenue stream which was then disrupted.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscription revenue splits (with a 70/30 split on the first $100,000 for Partner Plus creators, qualified via a points-based system on Tier 1, 2, and 3 subs), ad revenue with an increased rev share and ad incentive program, and growing sponsorship opportunities — leveraging Amazon advertising to connect creators with brands. The strategy is built around enabling creators to earn through subscriptions, gifting, cheering, ads, and branded partnerships on an ongoing platform basis.\n\nIn contrast, the Beeper Mini article describes a much simpler subscription monetization plan: a flat $1.99 per month subscription for Android users to access iMessage features. However, due to the instability caused by Apple's attempts to shut the app down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\" There is no mention of ad revenue, revenue splits with third parties, sponsorships, or tiered subscription points — it is a direct consumer subscription model that has been temporarily suspended.\n\nSo yes, the two articles indicate substantially different monetization strategies: Twitch's is a creator-economy platform model with multiple revenue streams and revenue sharing, while Beeper Mini's is a straightforward paid-app subscription (currently paused and offered free).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 47.78
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The Twitch article indicates a focus on tiered subscription points and ad revenue incentives to benefit creators, with potential for higher rev shares over time. The goal is to support creators where livestreaming is a meaningful part of their work. In contrast, the Beeper Mini article initially planned a $1.99 monthly subscription fee but made it free due to instability after Apple shut down its services and challenged Apple's security concerns by offering an open-source audit.",
+      "cloud_answer": "Yes. The Twitch article describes a multi-pronged monetization strategy centered on subscriptions (with a tiered revenue split — 70/30 on the first $100,000 for Partner Plus creators, qualified via a points-based system where Tier 1, 2, and 3 subs earn 1, 2, and 6 points), advertising (with an increased rev share, an ad incentive program, and new features letting moderators adjust ad breaks around content), and growing sponsorship/branded partnership opportunities by leveraging Amazon advertising to connect advertisers with streamers programmatically.\n\nIn contrast, the Beeper article indicates that Beeper Mini, which had been offered at $1.99 per month, was made free for the time being due to the \"chaotic\" situation following Apple's attempt to shut it down, with the company saying \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\" Beeper's approach is a single flat-rate subscription for the app itself, temporarily suspended, rather than Twitch's diversified creator-monetization model spanning subs, ads, and sponsorships.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 66.56
+    },
+    {
+      "id": 27,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The Twitch article indicates a focus on tiered subscription points and ad revenue incentives to benefit creators, with potential for higher rev shares over time. The goal is to support creators where livestreaming is a meaningful part of their work. In contrast, the Beeper Mini article initially planned a $1.99 monthly subscription fee but made it free due to instability after Apple shut down its services and challenged Apple's security concerns by offering an open-source audit.",
+      "cloud_answer": "Yes. The TechCrunch article on Twitch's subscription revenue split policy indicates a monetization strategy focused on multiple revenue streams for creators: subscriptions (with a tiered Partner Plus program offering a 70/30 revenue split on the first $100,000 for eligible streamers based on a points-based system), advertising (with an increased rev share and ad incentive program, plus features to synchronize ad breaks with content), and sponsorships (leveraging Amazon's advertising business to grow branded partnership opportunities). Twitch's strategy is about diversifying monetization options for creators on its platform.\n\nIn contrast, the TechCrunch article on Beeper Mini indicates a different monetization strategy: Beeper Mini was originally planned as a paid subscription service at $1.99 per month for Android users to access iMessage features. However, due to the chaotic situation caused by Apple's attempts to shut it down, Beeper decided to make Beeper Mini free for the time being, stating \"As soon as things stabilize (we hope they will), we'll look at turning on subscriptions again.\" Beeper's strategy is a direct consumer subscription model for a single service.\n\nSo yes, the two monetization strategies are different: Twitch focuses on a multi-pronged creator monetization ecosystem (subs, ads, sponsorships) with revenue splits, while Beeper Mini uses a straightforward direct-to-consumer monthly subscription fee (temporarily suspended in favor of free access).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.47
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are accurate according to the provided context.\n\nThe \"New York Times\" article attributes the success of the Buffalo Bills’ defense to Jordan Poyer, describing him as a versatile player who contributes significantly despite playing various positions. The article states he is “a hybrid linebacker in a three-safety dime package” and has played multiple defensive roles.\n\nThe \"Sporting News\" article suggests that the Baltimore Ravens' defense needs to improve before their game against the Cincinnati Bengals, stating they \"need to pick up the pieces.\"",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame, a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before.\"\n\nThe Sporting News article suggests the Baltimore Ravens' defense needs to improve before their game against the Cincinnati Bengals, stating: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 29.09
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are accurate according to the provided context.\n\nThe \"New York Times\" article attributes the success of the Buffalo Bills’ defense to Jordan Poyer, describing him as a versatile player who contributes significantly despite playing various positions. The article states he is “a hybrid linebacker in a three-safety dime package” and has played multiple defensive roles.\n\nThe \"Sporting News\" article suggests that the Baltimore Ravens' defense needs to improve before their game against the Cincinnati Bengals, stating they \"need to pick up the pieces.\"",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer by noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame,\" a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before. The Sporting News article states about the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 39.4
+    },
+    {
+      "id": 28,
+      "type": "comparison_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "Yes, both statements are accurate according to the provided context.\n\nThe \"New York Times\" article attributes the success of the Buffalo Bills’ defense to Jordan Poyer, describing him as a versatile player who contributes significantly despite playing various positions. The article states he is “a hybrid linebacker in a three-safety dime package” and has played multiple defensive roles.\n\nThe \"Sporting News\" article suggests that the Baltimore Ravens' defense needs to improve before their game against the Cincinnati Bengals, stating they \"need to pick up the pieces.\"",
+      "cloud_answer": "Yes. The New York Times article attributes success to Jordan Poyer's contributions to the Bills' defense, noting he is \"the only player in the NFL to have 500 or more tackles, 20 or more interceptions and 10 or more sacks in that time frame, a Bills captain for the fourth time, an Ed Block Courage Award winner in 2017, a Pro Bowl safety last year and an All-Pro the year before.\" The Sporting News article states about the Ravens: \"The defense needs to pick up the pieces, too, stat, ahead of facing the Bengals on a short week.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.17
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "After Dave Clark’s initial comments on Flexport (reported October 7, 2023), Ryan Petersen took back the CEO title and began focusing on financial frugality, including cost-cutting measures like layoffs. Subsequently (October 30, 2023), it was reported that Flexport is in talks to acquire Convoy’s technology, which raised eyebrows given Petersen's recent emphasis on financial restraint and criticism of previous overspending at the company.",
+      "cloud_answer": "Yes. The October 7, 2023 report described Dave Clark, the former Flexport CEO who had been ousted just a year into the job, firing back at the company's founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport.\n\nThe October 30, 2023 report described a shift in focus to Ryan Petersen, who had taken back the CEO title after his hand-picked successor (Clark) was pushed out. Petersen's actions centered on getting the company's financial house back in order, criticizing Clark for overspending on hiring and expansion, and spending the past month cutting costs, including laying off about 20% of workers (about 600 people). Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, a digital freight startup that had shuttered — a potential deal that raised questions about whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the nature of the events changed from a public dispute and turmoil between the ousted CEO (Clark) and Flexport's leadership, to the returning CEO (Petersen) taking concrete operational actions — cost-cutting, layoffs, and a potential acquisition — to restructure the company.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.12
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 2,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "After Dave Clark’s initial comments on Flexport (reported October 7, 2023), Ryan Petersen took back the CEO title and began focusing on financial frugality, including cost-cutting measures like layoffs. Subsequently (October 30, 2023), it was reported that Flexport is in talks to acquire Convoy’s technology, which raised eyebrows given Petersen's recent emphasis on financial restraint and criticism of previous overspending at Flexport.",
+      "cloud_answer": "Yes. The October 7, 2023 report described turmoil at Flexport, with ousted former CEO Dave Clark firing back at the founder and board on social media site X, calling recent reporting on the logistics company \"deeply concerning,\" following a CNBC report about his last days at Flexport (then valued at $8 billion).\n\nBy the October 30, 2023 report, the nature of the events had shifted from public conflict to operational and financial restructuring under returning CEO Ryan Petersen. Petersen had taken back the CEO title after his hand-picked successor (Clark) was pushed out, and his focus was on getting the company's financial house back in order. He criticized Clark for overspending—specifically around hiring and expanding too quickly—and spent the past month cutting costs, including laying off about 20% of its workers, or about 600 people. Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, a shuttered digital freight startup, which raised the question of whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the events changed from a public dispute over Clark's ouster to Petersen's cost-cutting measures and a potential acquisition move.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.14
+    },
+    {
+      "id": 76,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 2,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "After Dave Clark’s initial comments on Flexport (reported October 7, 2023), Ryan Petersen took back the CEO title and began focusing on financial frugality, including cost-cutting measures like layoffs. Subsequently (October 30, 2023), it was reported that Flexport is in talks to acquire Convoy’s technology, which raised eyebrows given Petersen's recent emphasis on financial restraint and criticism of previous overspending at Flexport.",
+      "cloud_answer": "Yes. The October 7, 2023 report covered Dave Clark, the former Amazon executive ousted as CEO of Flexport just a year into the job, firing back at the founder and board, calling recent reporting on the logistics company \"deeply concerning\" in a lengthy post on X following a CNBC report about his last days at Flexport.\n\nThe October 30, 2023 article reported a shift in focus to Ryan Petersen, Flexport's founder, who had taken back the CEO title after his hand-picked successor was pushed out. Petersen's actions centered on getting the company's financial house back in order, criticizing former CEO Dave Clark for overspending (specifically around hiring and expanding too quickly), and cutting costs — including laying off about 20% of workers, or about 600 people. Additionally, Flexport was reported to be in talks to acquire the technology of Convoy, the digital freight startup that had shuttered, which would potentially cost money and raised the question of whether Petersen's \"reign of financial frugality\" was already over.\n\nSo the nature changed from Clark publicly defending himself against reporting about his ouster, to Petersen actively restructuring the company financially while simultaneously considering a potentially costly acquisition.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 22.27
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge (November 1, 2023) portrays Google as having an influence on the digital ecosystem through SEO practices that degrade the quality of search results. It blames both Google and those who engage in search engine optimization (SEO). The report from TechCrunch (December 15, 2023) details a class action lawsuit against Google alleging anticompetitive behavior related to news publishers' content, readers, and ad revenue, as well as citing AI’s harms.",
+      "cloud_answer": "No, there was a change in the portrayal. The Verge article from November 1, 2023 focuses on how Google's influence on the internet's appearance is shaped by SEO practitioners who manipulate Google's algorithm to rank higher in search results, portraying Google as a powerful search platform (with 90 percent market share) whose results are being degraded by third-party SEO professionals turning online life into a \"search-optimized hellhole.\" Some blame Google itself as \"an all-powerful, all-seeing, trillion-dollar corporation... corrupting our access to the truth,\" but the article's primary framing is about SEO practitioners exploiting the system.\n\nIn contrast, the later TechCrunch article from December 15, 2023 portrays Google itself as the direct antagonist engaging in anticompetitive behavior that violates U.S. antitrust law (the Sherman Act). It describes Google as \"siphon[ing] off\" news publishers' content, readers, and ad revenue through anticompetitive means, and specifically cites AI's harms to publishers' bottom line. This shifts the portrayal from Google as a platform being gamed by others to Google as an active perpetrator directly harming news publishers' businesses through its own conduct, including AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.78
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge (November 1, 2023) portrays Google as having an influence on the digital ecosystem through search engine optimization (SEO), where SEO experts manipulate algorithms to appear high in search results and generate advertising revenue. This practice is described as degrading the quality of online information and creating a \"search-optimized hellhole.\"\n\nThe article from TechCrunch (December 15, 2023) portrays Google's influence as anticompetitive behavior that “siphons off” news publishers’ content, their readers and ad revenue through anticompetitive means. The lawsuit alleges Google is violating antitrust laws.\n\nTherefore, there was a change in the portrayal of Google's influence; The Verge focused on SEO manipulation impacting information quality while TechCrunch highlights alleged anticompetitive practices harming news publishers financially.",
+      "cloud_answer": "Based on the provided context, there was a change in the portrayal of Google's influence on the digital ecosystem between the two reports.\n\nThe Verge article from November 1, 2023 portrays Google's influence in terms of search quality degradation, describing how people are unhappy with Google Search results, calling them \"absolutely unusable,\" \"garbage,\" and \"a nightmare.\" It focuses on how SEO practices have made googling feel like content is \"suspiciously\" written to promote products, with some blaming Google itself as \"an all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share for online search\" that is \"corrupting our access to the truth.\"\n\nThe TechCrunch article from December 15, 2023 portrays Google's influence differently — through the lens of antitrust law and direct harm to news publishers' businesses. It describes Google as engaging in \"anticompetitive behavior in violation of U.S. antitrust law, the Sherman Act, and others,\" with the lawsuit arguing that Google \"siphons off\" news publishers' content, their readers, and ad revenue through anticompetitive means, and specifically cites AI's harms to publishers' bottom line.\n\nSo the portrayal shifted from a cultural/quality critique of Google's search dominance degrading internet content, to a legal/economic critique framing Google as an anticompetitive actor causing concrete financial harm to publishers, including through AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 27.04
+    },
+    {
+      "id": 77,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The article from The Verge (November 1, 2023) portrays Google as having an influence on the digital ecosystem through search engine optimization (SEO), where SEO experts manipulate algorithms to appear high in search results and generate advertising revenue. This practice is described as degrading the quality of online information and creating a \"search-optimized hellhole.\"\n\nThe article from TechCrunch (December 15, 2023) portrays Google's influence as anticompetitive behavior that “siphons off” news publishers’ content, their readers and ad revenue through anticompetitive means. The lawsuit alleges Google is violating antitrust laws.\n\nTherefore, there was a change in the portrayal of Google's influence; The Verge focused on SEO manipulation impacting information quality while TechCrunch highlights alleged anticompetitive practices harming news publishers financially.",
+      "cloud_answer": "No, there was a change in portrayal. The Verge article (November 1, 2023) frames Google's influence on the digital ecosystem primarily through the lens of Search quality degradation, describing how SEO practitioners exploit Google's algorithms to fill results with \"garbage,\" \"unusable,\" and inauthentic content — turning the internet into a \"search-optimized hellhole.\" Blame is shared between Google itself (as an \"all-powerful, all-seeing, trillion-dollar corporation with a 90 percent market share\") and the SEO professionals who manipulate it.\n\nThe later TechCrunch article (December 15, 2023) shifts the portrayal to one of direct anticompetitive harm. It describes Google as engaging in \"anticompetitive behavior in violation of U.S. antitrust law, the Sherman Act, and others,\" with the Helena World Chronicle class action arguing that Google \"siphons off\" news publishers' content, readers, and ad revenue — explicitly citing AI's harms to publishers' bottom line.\n\nSo the portrayal evolved from Google being depicted as the corrupted/manipulated gatekeeper of search quality, to Google being depicted as an active antitrust violator directly extracting value (content, readers, ad revenue) from news publishers via AI.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.03
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 0,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors involved reading the requirements for any available promotions and offers before accepting them. Additionally, they suggested wagering on the favored Eagles when considering bets for the Monday Night Football game. Finally, they acknowledged that companies like FanDuel were capitalizing on hype surrounding Travis Kelce and Taylor Swift to create betting opportunities.",
+      "cloud_answer": "Yes. According to the provided context:\n\n- **Reading requirements**: The October 4, 2023 article advises, \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: The December 18, 2023 article states, \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: The September 28, 2023 article highlights leaning into the Travis Kelce and Taylor Swift storyline, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.45
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 1,
+      "hops": 3,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors involved reading the requirements for any available promotions and offers before accepting them. Additionally, they suggested going with the favored Eagles when betting on Monday Night Football. Finally, they acknowledged that companies like FanDuel leaned into hype surrounding Travis Kelce and Taylor Swift for promotional purposes.",
+      "cloud_answer": "Yes. According to the context:\n\n- **Reading requirements**: In the NBA Rookie of the Year Odds article (published October 4, 2023), Sporting News urges bettors to \"read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n- **Going with the favored Eagles**: In the Monday Night Football Eagles vs. Seahawks article (published December 18, 2023), Sporting News advises that \"if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n- **Focusing on hype**: In the FanDuel 'Prop Stars' Picks article (published September 28, 2023), Sporting News highlights leaning into the profitable storyline/hype around the Travis Kelce and Taylor Swift celebrity couple, noting that \"companies like FanDuel just can't help but lean into a profitable storyline.\"\n\nAll three pieces of advice were provided by Sporting News between September 28, 2023, and December 18, 2023.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.6
+    },
+    {
+      "id": 78,
+      "type": "temporal_query",
+      "run": 2,
+      "hops": 3,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "The advice provided by Sporting News to bettors involved reading the requirements for any available promotions and offers before accepting them. Additionally, they suggested going with the favored Eagles when betting on Monday Night Football. Finally, they acknowledged that companies like FanDuel leaned into hype surrounding Travis Kelce and Taylor Swift for promotional purposes.",
+      "cloud_answer": "Yes. Across the articles published between September 28, 2023, and December 18, 2023, Sporting News advised bettors to:\n\n1. **Read the requirements** — In the October 4, 2023 article on NBA Rookie of the Year odds, Sporting News stated: \"We urge you to read the requirements for any available promotions and offers before accepting them so you're aware of any restrictions before betting.\"\n\n2. **Go with the favored Eagles** — In the December 18, 2023 article on Eagles vs. Seahawks Monday Night Football, Sporting News advised: \"Since you need your moneyline bet to win to claim the $150 in bonus bets, if you're wagering on tonight's MNF game, you'll probably want to go with the favored Eagles.\"\n\n3. **Focusing on hype** — In the September 28, 2023 article, Sporting News noted that companies like FanDuel \"just can't help but lean into a profitable storyline\" regarding the Travis Kelce and Taylor Swift hype, framing prop bets around that celebrity storyline.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 40.31
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 1,
+        "type": "inference_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 29.83
+      },
+      {
+        "id": 2,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 19.43
+      },
+      {
+        "id": 3,
+        "type": "inference_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.39
+      },
+      {
+        "id": 26,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "ABSTAINED",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": false,
+        "elapsed_sec_mean": 25.36
+      },
+      {
+        "id": 27,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 46.94
+      },
+      {
+        "id": 28,
+        "type": "comparison_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 29.55
+      },
+      {
+        "id": 76,
+        "type": "temporal_query",
+        "hops": 2,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.84
+      },
+      {
+        "id": 77,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 27.28
+      },
+      {
+        "id": 78,
+        "type": "temporal_query",
+        "hops": 3,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 26.45
+      }
+    ],
+    "summary": {
+      "n_questions": 9,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 0.889,
+      "by_type": {
+        "inference_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "comparison_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "temporal_query": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_recheck.py
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_recheck.py
@@ -1,0 +1,95 @@
+"""Gold-signal grounded recheck — v18.7 Phase 3b local tier ladder.
+
+4-cell multihop measurement (gemma3:4b / gemma4:e4b / gemma3:12b /
+gemma3:27b), reasoning-isolated (gold evidence injected). The judge
+(Claude) verdict alone said 4b=12b=gemma4=1.0 > 27b=0.704, which would
+have (and briefly did) concluded "complexity escalation is pointless".
+The deterministic gold_signals recheck below REVERSED that: 27b is the
+only cell at gold-grounded 1.000, and the judge UNDER-credited it by
+-0.296 because 27b answers verbosely and the judge tripped on the
+elaboration. This is the v18.6 judge-reliability rule catching a
+premature judge-only conclusion (project_d5_complexity_routing_negative
+self-correction).
+
+Run from repo root:
+    python reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_recheck.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+FIXTURE_PATH = REPO_ROOT / "workspaces" / "hotpot_eval" / "eval" / "multihop_rag_queries.json"
+RESULTS_DIR = REPO_ROOT / "reports" / "research-runs" / "v18.7-phase3b-tier-ladder"
+
+CELLS = [
+    ("gemma3:4b",  "cell_light_4b.json",     "light"),
+    ("gemma4:e4b", "cell_gemma4_e4b.json",   "(current default)"),
+    ("gemma3:12b", "cell_standard_12b.json", "standard"),
+    ("gemma3:27b", "cell_deep_27b.json",     "deep"),
+]
+
+
+def _gold_index() -> Dict[int, list]:
+    fx = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return {q["id"]: q.get("gold_signals", []) for q in fx["queries"]}
+
+
+def check_gold(answer: str, sigs: list) -> bool:
+    a = (answer or "").lower()
+    for s in sigs:
+        terms = [s.get("term", "")] + list(s.get("aliases", []))
+        if any(t and t.lower().strip() in a for t in terms):
+            return True
+    return False
+
+
+def recheck(model: str, fname: str, rung: str,
+            gold: Dict[int, list]) -> dict:
+    path = RESULTS_DIR / fname
+    rows = json.loads(path.read_text(encoding="utf-8"))["rows"]
+    rows = [r for r in rows if gold.get(r["id"])]
+    n = len(rows)
+    j = sum(1 for r in rows if r["local_verdict"] == "CORRECT")
+    g = sum(1 for r in rows if check_gold(r.get("local_answer", ""), gold[r["id"]]))
+    elaps = [r["elapsed_sec"] for r in rows]
+    return {
+        "model": model, "rung": rung, "n": n,
+        "judge_correct": round(j / n, 3) if n else 0,
+        "gold_correct": round(g / n, 3) if n else 0,
+        "judge_bias": round((j - g) / n, 3) if n else 0,
+        "pair_latency_sec": round(sum(elaps) / len(elaps), 1) if elaps else 0,
+    }
+
+
+def main() -> int:
+    gold = _gold_index()
+    out = [recheck(m, f, r, gold) for m, f, r in CELLS
+           if (RESULTS_DIR / f).exists()]
+
+    print("\n=== v18.7 Phase 3b gold-grounded recheck (multihop, n=27/cell) ===\n")
+    hdr = (f'{"model":<12} | {"rung":<18} | {"judge":>6} | '
+           f'{"gold":>6} | {"bias":>7} | {"pair s":>7}')
+    print(hdr)
+    print("-" * len(hdr))
+    for s in sorted(out, key=lambda x: -x["gold_correct"]):
+        print(f'{s["model"]:<12} | {s["rung"]:<18} | '
+              f'{s["judge_correct"]:>6.3f} | {s["gold_correct"]:>6.3f} | '
+              f'{s["judge_bias"]:>+7.3f} | {s["pair_latency_sec"]:>7.1f}')
+    print()
+    print("KEY: gold-grounded REVERSES the judge-only ranking. 27b is the")
+    print("only cell at gold 1.000 (judge under-credited it -0.296 due to")
+    print("verbose answers). Escalation has a basis but it is modest")
+    print("(+0.111 over 12b) and costs 2.3x latency + verbosity.")
+
+    (RESULTS_DIR / "gold_grounded_summary.json").write_text(
+        json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nsaved → {(RESULTS_DIR / 'gold_grounded_summary.json').relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_summary.json
+++ b/reports/research-runs/v18.7-phase3b-tier-ladder/gold_grounded_summary.json
@@ -1,0 +1,38 @@
+[
+  {
+    "model": "gemma3:4b",
+    "rung": "light",
+    "n": 27,
+    "judge_correct": 1.0,
+    "gold_correct": 0.852,
+    "judge_bias": 0.148,
+    "pair_latency_sec": 26.4
+  },
+  {
+    "model": "gemma4:e4b",
+    "rung": "(current default)",
+    "n": 27,
+    "judge_correct": 1.0,
+    "gold_correct": 0.815,
+    "judge_bias": 0.185,
+    "pair_latency_sec": 23.2
+  },
+  {
+    "model": "gemma3:12b",
+    "rung": "standard",
+    "n": 27,
+    "judge_correct": 1.0,
+    "gold_correct": 0.889,
+    "judge_bias": 0.111,
+    "pair_latency_sec": 27.5
+  },
+  {
+    "model": "gemma3:27b",
+    "rung": "deep",
+    "n": 27,
+    "judge_correct": 0.704,
+    "gold_correct": 1.0,
+    "judge_bias": -0.296,
+    "pair_latency_sec": 60.2
+  }
+]


### PR DESCRIPTION
## Summary

4-cell complexity-paired measurement (gemma3:4b / gemma4:e4b / gemma3:12b / gemma3:27b × multihop, reasoning-isolated, n=27/cell vs cloud) to test whether the Phase 3a local tier ladder is justified.

**Headline — gold-grounded reversal**: a judge-only read said complexity escalation was pointless (4b=12b=gemma4=1.0 > 27b=0.704). The deterministic `gold_signals` recheck **reversed** it:

| model | judge | **gold-grounded** | bias |
|---|---|---|---|
| **gemma3:27b** | 0.704 | **1.000** | **−0.296 (under-credit)** |
| gemma3:12b | 1.000 | 0.889 | +0.111 |
| gemma3:4b | 1.000 | 0.852 | +0.148 |
| gemma4:e4b | 1.000 | 0.815 | +0.185 |

27b is the only cell at gold 1.000 — the judge under-credited it because 27b answers verbosely and tripped the judge (gold term present every time). Same judge-trip class as v18.6.

## Findings

1. Complexity escalation **has a basis** (bigger = more gold-accurate). The judge-only "pointless" verdict was an artifact.
2. But **modest** (+0.111 over 12b) and costs **2.3× latency + verbose answers**.
3. **Side finding**: current default `gemma4:e4b` is the *lowest* on evidence-rich retrieval (0.815) — yet beat 4b on chat (Phase 2b). Task type flips the ranking → mode routing is meaningful.

## Phase 3c (operator trade-off)

Not "shelve as meaningless" but **+0.111 gold-accuracy vs 2.3× latency + verbosity**. `JAMES_AUTO_ROUTER` stays OFF until decided. Phase 3a ladder infra preserved regardless. If wired, pair 27b with a verbosity-curbing response_style.

## Meta lesson (re-validated)

judge-only conclusions (negative OR positive) are unsafe; any fixture with `gold_signals` requires a gold-grounded recheck **before** concluding. This PR documents a live self-correction where the judge-only conclusion was briefly asserted then reversed.

## Quality delta

Quality delta: exempt (label: docs) — measurement artifacts + reference doc. No core/ change.

## Rule #1 streak

`core/retrieval` + `core/graph` traversal + `core/reasoning` — 0 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)