### PR TITLE
feat(v0.6.1): Phase 3c — retrieval mode wired to measured preference (gemma3:12b)

### DIFF
--- a/core/model_resolver.py
+++ b/core/model_resolver.py
@@ -114,8 +114,20 @@ DEFAULT_PREFERENCE: dict = {
     # v18_5]] §γ) hooks them into intent-aware dispatch alongside the
     # chat-mode measurement protocol. Until then, every mode resolves
     # to the same legacy GEMMA_MODEL — same behavior as pre-v18.7.
+    # v18.7 Phase 3c (2026-06-16) — reordered after the tier-ladder
+    # gold-grounded measurement (reports/research-runs/
+    # v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md). On evidence-rich
+    # multihop the gold-grounded ranking was 27b(1.0) > 12b(0.889) >
+    # 4b(0.852) > gemma4:e4b(0.815). gemma4:e4b (the global GEMMA_MODEL
+    # default) is the WEAKEST on evidence-rich retrieval, so it is
+    # demoted. gemma3:12b leads on value (0.889, fast, non-verbose);
+    # gemma3:27b is most accurate (1.0) but 2.3x slower + verbose, so it
+    # sits second (used when 12b is absent, or for a future
+    # verify-stage-only deep escalation). full complexity escalation is
+    # NOT auto-wired — the gain over 12b (+0.111) does not justify the
+    # latency + verbosity for a default path.
     "retrieval": [
-        "gemma4:e4b", "gemma3:12b", "gemma3:27b",
+        "gemma3:12b", "gemma3:27b", "gemma4:e4b",
         "mixtral:8x7b", "qwen2.5:14b", "llama3.1:8b",
     ],
     "meta": [

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -280,30 +280,34 @@ class ReasoningEngine:
         elif picked_model:
             print(f"[MODEL] mode={mode} using user-selected '{picked_model}'")
 
-        # ── v18.7 Phase 2c — chat-mode consumes the measured preference ──
-        # When the user did NOT pick a model, chat mode auto-routes
+        # ── v18.7 Phase 2c/3c — measured-preference mode routing ──
+        # When the user did NOT pick a model, these modes auto-route
         # through the measured preference list instead of the global
-        # config.GEMMA_MODEL default. The Phase 2b 3-cell paired
-        # measurement (reports/research-runs/v18.7-phase2b-chat/
-        # QUALITY_DELTA_CARD.md) ranked gemma3:12b (0.917) >
-        # gemma4:e4b OFF (0.833) > gemma3:4b (0.750) on the Korean
-        # chat fixture; gemma3:4b 3/3-abstained on a basic greeting.
-        # requested="" makes resolve_for_mode use the preference list
-        # top (not GEMMA_MODEL), so this is the first mode to actually
-        # consume the Phase-1 plumbing. Kill-switch:
-        # JAMES_DISABLE_MODE_AWARE_CHAT=1 reverts to GEMMA_MODEL.
-        # Only `chat` is wired — retrieval/meta/wiki_edit/vision
-        # preference lists are populated but NOT yet measurement-
-        # validated, so they keep the legacy GEMMA_MODEL path.
-        if mode == "chat" and not picked_model:
+        # config.GEMMA_MODEL default. requested="" makes
+        # resolve_for_mode use the preference-list top (not
+        # GEMMA_MODEL), so these are the modes that actually consume
+        # the Phase-1 plumbing.
+        #   • chat (Phase 2b, v18.7-phase2b-chat QDC): gemma3:12b
+        #     (0.917) > gemma4:e4b (0.833) > gemma3:4b (0.750) on the
+        #     Korean chat fixture.
+        #   • retrieval (Phase 3b, v18.7-phase3b-tier-ladder QDC):
+        #     gold-grounded 27b(1.0) > 12b(0.889) > 4b(0.852) >
+        #     gemma4:e4b(0.815). The default GEMMA_MODEL (gemma4:e4b)
+        #     is WEAKEST on evidence-rich retrieval; preference top is
+        #     gemma3:12b (best value; 27b is more accurate but 2.3x
+        #     slower + verbose, so not the default).
+        # Kill-switch: JAMES_DISABLE_MODE_AWARE_ROUTING=1 reverts both
+        # to GEMMA_MODEL. meta/wiki_edit/vision/self_evolve stay on the
+        # legacy path (not yet measurement-validated per mode).
+        if mode in ("chat", "retrieval") and not picked_model:
             import os
-            if not os.environ.get("JAMES_DISABLE_MODE_AWARE_CHAT"):
+            if not os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
                 from core.model_resolver import resolve_for_mode
-                _rm = resolve_for_mode("chat", requested="")
+                _rm = resolve_for_mode(mode, requested="")
                 if _rm.tag:
                     picked_model = _rm.tag
-                    print(f"[MODEL] mode=chat auto-routed → '{_rm.tag}' "
-                          f"(source={_rm.source}; Phase 2c measured pref)")
+                    print(f"[MODEL] mode={mode} auto-routed → '{_rm.tag}' "
+                          f"(source={_rm.source}; measured pref)")
                     if _rm.warning:
                         print(f"[MODEL] {_rm.warning}")
 

--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -19,7 +19,7 @@
 | Mode | Trigger (IntentClassifier) | Model | Resolution path | Observability | Status |
 |---|---|---|---|---|---|
 | **chat** | 일상 대화·인사 | **gemma3:12b** | engine.py `resolve_for_mode("chat", requested="")` → preference top | `[MODEL] mode=chat auto-routed → gemma3:12b` ✅ observed | **measurement-backed (Phase 2c)** |
-| **retrieval** | 지식 검색·정보 조회 | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent (no log on happy path) | legacy (unmeasured) |
+| **retrieval** | 지식 검색·정보 조회 | **gemma3:12b** | engine.py `resolve_for_mode("retrieval", requested="")` → preference top | `[MODEL] mode=retrieval auto-routed → gemma3:12b` ✅ observed | **measurement-backed (Phase 3c)** |
 | **meta** | 내부자료 인벤토리 | none (no LLM) | fast-path inventory generation | `(fast-path)` ✅ confirmed | n/a |
 | **coding** | 코드 작성·버그 | qwen2.5-coder:32b | `llm.router(task_type="coding")` | `[coding_route]` / router log ✅ | dedicated router |
 | **wiki_edit** | 지식 수정·삭제 (admin) | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent | legacy (unmeasured) |
@@ -29,9 +29,9 @@
 ## Resolution priority (3-tier)
 
 ```
-1. user secondary-picker selection   → catalog-validated tag wins (every mode)
-2. chat + no pick                     → gemma3:12b (Phase 2c; kill-switch JAMES_DISABLE_MODE_AWARE_CHAT=1)
-3. other mode + no pick               → legacy GEMMA_MODEL (gemma4:e4b), or coding=qwen-coder:32b
+1. user secondary-picker selection      → catalog-validated tag wins (every mode)
+2. chat/retrieval + no pick              → gemma3:12b (Phase 2c/3c; kill-switch JAMES_DISABLE_MODE_AWARE_ROUTING=1)
+3. other mode + no pick                  → legacy GEMMA_MODEL (gemma4:e4b), or coding=qwen-coder:32b
 ```
 
 ## The `resolve_chat()` trap (important)
@@ -95,7 +95,7 @@ separate from the backend-tier system:
 - 🔄 **Phase 3** (Option B — local size ladder)
   - ✅ 3a — `LOCAL_TIER_LADDER` + `resolve_local_tier()` defined (plumb-first)
   - ✅ 3b — complexity-paired measurement done (4-cell: 4b/gemma4:e4b/12b/27b × multihop). **gold-grounded reversal**: judge-only said escalation pointless, but gold_signals shows 27b=1.000 > 12b=0.889 > 4b=0.852 > gemma4:e4b=0.815. Escalation has a basis (modest +0.111) but costs 2.3× latency + verbose answers. Side finding: gemma4:e4b (current default) is *lowest* on evidence-rich retrieval. See `reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md`.
-  - ⏸️ 3c — wire D5 tier decision → `resolve_local_tier`: **operator trade-off decision** (+0.111 gold-accuracy vs 2.3× latency + verbosity). `JAMES_AUTO_ROUTER` stays OFF until decided. Ladder infra (3a) preserved regardless.
+  - ✅ 3c — **retrieval mode wired** to `resolve_for_mode("retrieval", "")` → gemma3:12b (the measured-best *default*; gemma4:e4b demoted as weakest on evidence-rich retrieval). Done via the same engine.py mode-routing block as chat (kill-switch generalized to `JAMES_DISABLE_MODE_AWARE_ROUTING`). **Full 27b complexity escalation NOT auto-wired** — the +0.111 gold-accuracy gain over 12b doesn't justify 2.3× latency + verbose answers for a default path. `LOCAL_TIER_LADDER` infra (3a) preserved for a future verify-stage-only deep escalation with verbosity-curbing response_style. `JAMES_AUTO_ROUTER` stays OFF.
 - ⏳ Phase 4 — privacy gate (PII) + cost-aware cap + cloud (Claude) routing
 - ⏳ Phase 5 — sub-class routing inside chat + admin routing dashboard
 

--- a/scripts/research/routing_matrix_probe.py
+++ b/scripts/research/routing_matrix_probe.py
@@ -143,13 +143,14 @@ def probe_mode_resolve_only(mode: str) -> Dict[str, object]:
     from core.model_resolver import resolve_for_mode, resolve_chat
 
     note = ""
-    if mode == "chat":
-        if os.environ.get("JAMES_DISABLE_MODE_AWARE_CHAT"):
+    if mode in ("chat", "retrieval"):
+        if os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
             rm = resolve_chat()
             note = "kill-switch ON → resolve_chat()/GEMMA_MODEL"
         else:
-            rm = resolve_for_mode("chat", requested="")
-            note = "Phase 2c auto-route (preference top)"
+            rm = resolve_for_mode(mode, requested="")
+            phase = "Phase 2c" if mode == "chat" else "Phase 3c"
+            note = f"{phase} auto-route (measured preference top)"
         model = rm.tag
     elif mode == "coding":
         try:
@@ -161,7 +162,7 @@ def probe_mode_resolve_only(mode: str) -> Dict[str, object]:
     elif mode == "meta":
         model = "(fast-path — no LLM)"
         note = "inventory generated without LLM"
-    else:  # retrieval / wiki_edit / self_evolve
+    else:  # wiki_edit / self_evolve (retrieval now handled above)
         rm = resolve_chat()
         model = rm.tag
         note = "legacy: call_gemma(model=None) → resolve_chat() → GEMMA_MODEL"


### PR DESCRIPTION
## Summary

Phase 3c, wired in the form the measurement most strongly supports. Retrieval mode now auto-routes to **gemma3:12b** instead of the global `GEMMA_MODEL` (gemma4:e4b) — which the Phase 3b gold-grounded measurement found **weakest on evidence-rich retrieval** (0.815, below even gemma3:4b).

## Wired

- `DEFAULT_PREFERENCE['retrieval']` reordered: `gemma3:12b → gemma3:27b → gemma4:e4b → ...` (gemma4:e4b demoted from first). 12b = best value (0.889, fast, non-verbose); 27b = most accurate (1.000) but 2.3× slower + verbose → second.
- `engine.py` mode-routing block extended `chat` → `(chat, retrieval)`. Kill-switch generalized `JAMES_DISABLE_MODE_AWARE_CHAT` → **`JAMES_DISABLE_MODE_AWARE_ROUTING`**.
- probe + routing-matrix doc updated.

## NOT wired (honest bound)

Full 27b complexity escalation — the **+0.111** gold-accuracy gain over 12b does not justify **2.3× latency + verbose answers** for a default path. `LOCAL_TIER_LADDER` infra (Phase 3a) preserved for a future verify-stage-only deep escalation paired with a verbosity-curbing response_style. `JAMES_AUTO_ROUTER` stays OFF.

## E2E verification (live)

- retrieval → `[MODEL] mode=retrieval auto-routed → 'gemma3:12b' (source=preference; measured pref)`
- chat still → gemma3:12b
- `JAMES_DISABLE_MODE_AWARE_ROUTING=1` → 0 auto-route lines (both revert to GEMMA_MODEL)

## Bench + Quality Delta Card (rule #2)

Quality Delta Card = Phase 3b gold-grounded (`reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md`): gemma3:12b 0.889 > gemma4:e4b 0.815 on evidence-rich multihop. VRAM 7.6 GB < 8.9 GB — no regression. STEP 7 retrieval logic unchanged; this swaps which model the synth step calls.

## Rule #1 streak

- `core/reasoning/engine.py` + `core/model_resolver.py` (mode-routing only)
- `core/retrieval` + `core/graph` traversal — **0 lines changed**
- engine.py 20296 B < 20480 gate. lock-test 17/17, pre-flight 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)