### PR TITLE
docs(repro): benchmarks/ reproducibility package — one-command RAB/LRB repro + honest framing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Reproducibility Program overview
+    url: https://github.com/Hashevolution/James-RAG-Evol/blob/main/benchmarks/REPRODUCTION_PROGRAM.md
+    about: How reproduction reports are triaged (confirmed / variant / failed).
+  - name: Benchmark Challenge
+    url: https://github.com/Hashevolution/James-RAG-Evol/blob/main/benchmarks/CHALLENGE.md
+    about: Try to beat JAMES under identical datasets / models / constraints.

--- a/.github/ISSUE_TEMPLATE/reproduction-report.yml
+++ b/.github/ISSUE_TEMPLATE/reproduction-report.yml
@@ -1,0 +1,77 @@
+name: "Reproduction report"
+description: "Report the result of running benchmarks/run_all.sh on your hardware (match OR mismatch — both welcome)."
+title: "[repro] <one-line summary of your result>"
+labels: ["reproduction"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for independently reproducing JAMES's benchmarks!
+        See `benchmarks/REPRODUCTION_PROGRAM.md` for context. Negative and
+        variant results are as valuable as confirmations.
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Which tier did you run?
+      options:
+        - "core (default — RAB + LRB, deterministic)"
+        - "core + --full (LRB S3 publication-scale)"
+        - "core + --with-llm (RAGAS)"
+        - "all tiers"
+    validations:
+      required: true
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Self-assessed outcome
+      description: "See REPRODUCTION_PROGRAM.md for definitions."
+      options:
+        - "confirmed (core-tier numbers matched / LLM-tier inside band)"
+        - "variant (LLM-tier outside band, or env difference explains a delta)"
+        - "failed (core-tier numbers differ)"
+        - "not sure — please help me classify"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 24.04 / macOS 15.1 / Windows 11"
+    validations:
+      required: true
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware (CPU / RAM / GPU)
+      placeholder: "e.g. Apple M3 Pro / 36 GB / (no discrete GPU)"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version + requirements file used
+      placeholder: "e.g. 3.11.9, requirements_pinned.txt"
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: "LLM model version (only if you ran --with-llm / --full james)"
+      placeholder: "e.g. ollama gemma4:e4b (digest abc123)"
+    validations:
+      required: false
+  - type: textarea
+    id: output
+    attributes:
+      label: Benchmark output
+      description: "Paste the RAB + LRB tables (and RAGAS if run). Raw stdout is fine."
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: "Deviations, install friction, surprises."
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -143,25 +143,39 @@ Two benchmarks released as a sibling pair, both pre-registered before measuremen
 
 ### Reproduce in 60 seconds
 
+**One command** (wraps everything below; deterministic core tier, no GPU/Ollama, ~2 min):
+
 ```bash
 git clone https://github.com/Hashevolution/James-RAG-Evol.git
 cd James-RAG-Evol
 python -m pip install -r requirements.txt
+bash benchmarks/run_all.sh        # see benchmarks/README.md for --full / --with-llm
+```
 
+<details>
+<summary>Or run each benchmark by hand</summary>
+
+```bash
 # RAB scenario-S1 (deterministic; no LLM call; ~5 seconds)
 python scripts/research/rab_run.py --sut reference     # AC/RF/PC = 1.000/1.000/1.000
 python scripts/research/rab_run.py --sut baseline0     # AC/RF/PC = 0.275/0.000/0.000
 python scripts/research/rab_run.py --sut james         # AC/RF/PC = 1.000/1.000/1.000
 
 # LRB Phase B (S2 time-travel) token-mode (deterministic; no LLM; ~30 seconds)
+# Scenario fixtures are gitignored — build them first (deterministic, no LLM):
+python scripts/research/build_lrb_scenario_s1.py
+python scripts/research/build_lrb_scenario_s2.py
 PYTHONPATH=. python scripts/research/lrb_run_phase_b.py --scenarios S1,S2
+#   → S2 R@1: Vanilla 0.225 < Naive 0.538 < JAMES 0.688 (JAMES − Naive gap +0.15)
 
 # LRB S3 publication-scale (1000 docs / 5.6k events / 1000 queries; ~3 minutes)
 python scripts/research/build_lrb_scenario_s3.py --scale publication
 python scripts/research/lrb_run_s3.py --scale publication
 ```
 
-Every `result.json` + `bench.jsonl` artifact in `reports/external/lrb/` and `reports/rab/` is SHA-pinned against the scenario fixture; **byte-identical re-runs are the verification protocol**.
+</details>
+
+Every `result.json` + `bench.jsonl` artifact in `reports/external/lrb/` and `reports/rab/` is SHA-pinned against the scenario fixture; **byte-identical re-runs are the verification protocol**. Full reproducibility disclosure + the community reproduction program live in [`benchmarks/`](benchmarks/README.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1327,6 +1327,45 @@ external developers can publish their own packs.
 - Vertical Products (separate business decision per domain after v1.0)
 - Federation across multiple JAMES instances (Beyond v1.0 section)
 
+### Scalability — vector compression tier (trigger-gated, NOT version-scheduled)
+
+**Entry trigger** (none of which is currently met): a real deployed
+corpus whose float32 vector index exceeds available RAM — concretely
+**> ~1M documents** at the default 384-dim, or a pilot that measures a
+vector-store memory bottleneck. Until a trigger fires this stays a note,
+not work: at 384-dim even 1M docs ≈ 1.5 GB fits the reference 32 GB
+machine, so adopting compression now would be optimization against an
+**unproven premise** (cf. the cloud-tier S6/S7 shelving lesson).
+
+**Priority ladder when the trigger fires** — ranked by
+*(memory saved × recall kept) ÷ replay/audit cost*, not memory alone,
+because byte-identical replay (RAB / `reconstruct_graph_at(t)`) is the
+crown-jewel constraint:
+
+- [ ] **1. Int8 scalar quantization** (~4×) — *replay-safe*: a fixed,
+      audit-logged scale makes it deterministic; backend-agnostic
+      (quantize at the embedding level before ChromaDB). First and
+      lowest-risk. Entry PR must paste a 5-axis Quality Delta Card
+      (rule #2) — the "Recall within 1%" claim is re-measured on JAMES's
+      own QVT/LRB queries, not imported from the literature.
+- [ ] **2. Dimensionality reduction** — requires a **model swap** (the
+      default `paraphrase-multilingual-MiniLM-L12-v2` is multilingual
+      and **not** Matryoshka, so head-truncation is unsafe). Forces full
+      re-ingestion + **KO/EN bilingual re-validation** (bilingual
+      regression has bitten before — see `feedback_d2_v2_softener_bilingual_regression`).
+      Separate measurement cycle.
+- [ ] **3. FAISS IVFPQ** (~10–100×) — strongest memory win but the
+      **trained codebook is a replay liability**: historical replays must
+      pin their era's codebook. Also a **backend change** (ChromaDB →
+      FAISS = trust-boundary / `docs/ARCHITECTURE.md` PR, rule #4).
+      Architecture decision precedes any build.
+- [ ] **4. Binary + rescoring** — only at very large scale; keeps float32
+      for rescore (so the "32×" is index-only), and rescore ordering must
+      be made deterministic for audit reproducibility.
+
+Rule #1 is not implicated (horizontal infra, not a domain feature) — this
+is a *priority/trigger* question, not a permission one.
+
 ---
 
 ## Beyond v1.0 — Speculative

--- a/benchmarks/CHALLENGE.md
+++ b/benchmarks/CHALLENGE.md
@@ -1,0 +1,50 @@
+# Benchmark Challenge (Phase 7)
+
+> Status: **draft** — open for discussion. This defines a fair-comparison
+> challenge so improvement claims compete under identical constraints instead
+> of in isolation.
+
+JAMES publishes deterministic benchmarks (RAB, LRB) with committed fixtures
+and scorers. If you think another system does better, **show it under the same
+constraints** and send a PR.
+
+## The challenge
+
+Beat JAMES on a published benchmark **without changing the measurement**.
+
+### Constraints (must all hold)
+
+- **Same datasets** — the committed fixtures in `eval/rab/scenarios/` and
+  `eval/external/lrb/`. No re-sampling, no relabeling.
+- **Same scorer** — `eval/rab/scorer.py` (AC/RF/PC) and the LRB token-mode
+  scorer. The scorer is the contract; don't modify it.
+- **Same models / context limits** — if your system uses an LLM, use the
+  disclosed model class (`gemma4:e4b`) and `num_ctx=2048`, or disclose the
+  exact substitution so it can be reproduced.
+- **Same evaluation procedure** — run via `benchmarks/run_all.sh` (or add a
+  sibling adapter that the existing runner can call).
+
+### How to submit
+
+1. Add your system as a new SUT adapter next to the existing ones
+   (`eval/rab/adapters/`, `eval/external/lrb/adapters/`).
+2. Run `bash benchmarks/run_all.sh` and paste the table in your PR.
+3. Open a PR. For any PR touching `core/{retrieval,graph,reasoning}`, paste
+   the bench numbers + Quality Delta Card per the repository's
+   `.github/PULL_REQUEST_TEMPLATE.md` (project rule #2).
+
+## What "winning" means here (honest framing)
+
+RAB's headline is the **gap structure**, not a single score — its SPEC §6.5
+disclaims a "JAMES-wins" reading. So a meaningful challenge result is one of:
+
+- A system that **closes the audit gap** (e.g. a default-logging stack that
+  reaches AC/RF/PC > baseline-0's 0.275/0/0 without an audit-native runtime), or
+- A system that **beats JAMES on LRB R@1** while preserving temporal validity
+  semantics, or
+- A demonstration that one of the benchmarks is **gameable** — i.e. a trivial
+  SUT scores high without the capability the metric intends to measure. That is
+  a contribution to the *benchmark*, and we want to hear it.
+
+The aim is a benchmark **competition around JAMES**, with every claim pinned to
+a reproducible command — not isolated leaderboard assertions.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,118 @@
+# JAMES Benchmarks — Reproducibility Package
+
+This directory is the **single entry point** for independently reproducing
+PROJECT JAMES's published benchmark numbers. It does not introduce new
+measurements; it wraps the committed, pre-registered runners
+(`scripts/research/rab_run.py`, `scripts/research/lrb_run_phase_b.py`,
+`eval/ragas/run_ragas.py`) behind one command and discloses the exact
+environment they were captured in.
+
+> **What is reproducible here, stated honestly.**
+> The headline reproducible numbers are **RAB** (audit-log replayability)
+> and **LRB** (temporal/lifecycle retrieval). Both are scored by
+> **deterministic scorers with no LLM in the path**, so they are
+> byte-identical across machines. They are *not* a generic "Graph-RAG
+> beats vector RAG on reasoning" claim — on open multi-hop reasoning
+> (MuSiQue/MultiHop-RAG) the project's own measured result is a
+> **null/parity** finding, documented in
+> `docs/handovers/v0.4-track-c-musique-improvement-loop-FINAL-2026-06-12.md`.
+> RAB's SPEC §6.5 explicitly disclaims a "JAMES-wins" framing; the
+> contribution is the *benchmark and the gap structure*, not a leaderboard win.
+
+---
+
+## Reproduce the benchmark results in under 15 minutes
+
+**Prerequisites:** Python ≥ 3.11, `git`, and a bash shell. No GPU, no
+Ollama, and no network are needed for the deterministic core tier.
+
+```bash
+git clone https://github.com/Hashevolution/James-RAG-Evol.git
+cd James-RAG-Evol
+python -m pip install -r requirements.txt
+
+bash benchmarks/run_all.sh
+```
+
+That's the whole core path. It runs:
+
+1. **RAB v0.1.1** — 3 systems-under-test (reference / baseline0 / james) on
+   scenario S1. Deterministic, no LLM, ~5 s each.
+2. **LRB Phase B** — S1 + S2 time-travel retrieval, token-mode. Deterministic,
+   no LLM, ~30 s.
+
+Total wall time for the core tier is **1–2 minutes** on a laptop.
+
+### Optional tiers
+
+```bash
+bash benchmarks/run_all.sh --full       # + LRB S3 publication-scale (1000 docs), ~3-6 min, still no LLM
+bash benchmarks/run_all.sh --with-llm   # + RAGAS suite — needs Ollama (gemma4:e4b) + server, ~90 min, band-checked
+```
+
+---
+
+## Expected output
+
+The core tier must print these numbers (deterministic — any deviation is a
+real finding worth an issue):
+
+### RAB v0.1.1 — scenario S1 (AC / RF / PC)
+
+| SUT | Audit Completeness | Replay Fidelity | Provenance Coverage |
+|---|---|---|---|
+| `reference` | 1.000 | 1.000 | 1.000 |
+| `baseline0` (vanilla default logging) | **0.275** | **0.000** | **0.000** |
+| `james` (audit-native) | 1.000 | 1.000 | 1.000 |
+
+The point is the **gap** between an audit-native runtime and a default-logging
+one — the three metrics operationalise EU AI Act Articles 10 / 12 / 19
+(in force 2026-08-02).
+
+### LRB Phase B — S2 time-travel (R@1, V / N / J)
+
+The S2 gap table must show `R@1` strictly ordered **Vanilla < Naive < JAMES**,
+with the JAMES − Naive gap above +0.10. Publication-scale (`--full`) R@1
+reference values:
+
+| SUT | R@1 (S3 publication, 1000 docs) |
+|---|---|
+| Vanilla (append-only) | 0.502 |
+| Naive-supersede | 0.721 |
+| **JAMES (validity-window)** | **0.845** |
+
+Honest framing (locked in the preprint): the **pattern + gap are
+scale-robust**; the **absolute magnitudes are scenario-sensitive**.
+
+### RAGAS (`--with-llm` only)
+
+Band-checked, not point-identical. A run landing inside the committed
+tolerance bands (`eval/ragas/baseline.json`: judge ±0.15, embedding ±0.10) is
+a confirmed reproduction. `context_precision`/`context_recall` should be
+≈ 1.0; `answer_relevancy` should land in **[0.649, 0.757]**.
+
+---
+
+## Files in this package
+
+| File | Purpose |
+|---|---|
+| `run_all.sh` | One-command orchestrator (core / `--full` / `--with-llm`) |
+| `config.yaml` | Disclosure: what is scored, reference numbers, environment fingerprint |
+| `seeds.txt` | Random-seed / determinism posture |
+| `REPRODUCIBILITY.md` | Full deterministic-evaluation disclosure (Phase 2) |
+| `REPRODUCTION_PROGRAM.md` | How to submit an independent reproduction (Phase 3) |
+| `CHALLENGE.md` | Benchmark challenge — beat JAMES under identical constraints (Phase 7) |
+
+## What this package deliberately does NOT claim
+
+- It does **not** ship HotpotQA / LongFact subsets. The project does not
+  currently have validated, JAMES-specific gains on those, and inventing a
+  "James wins" table for them would violate the project's honest-framing rule.
+  Adding new external benchmarks is scoped as a **separate future measurement
+  cycle**, not a packaging task.
+- It does **not** claim RAGAS as a headline. RAGAS here is a 3-row sibling
+  cross-check with judge-variance bands; see
+  `docs/evaluation/v0.5-evaluation-coverage-mapping.md` for the full mapping
+  of standard RAG metrics to what the project measures (and deliberately
+  doesn't).

--- a/benchmarks/REPRODUCIBILITY.md
+++ b/benchmarks/REPRODUCIBILITY.md
@@ -1,0 +1,108 @@
+# Deterministic Evaluation Disclosure (Phase 2)
+
+> Purpose: eliminate ambiguity about how the published numbers were produced,
+> so different evaluators obtain substantially identical results. This is the
+> full disclosure that `benchmarks/config.yaml` summarises.
+
+## 1. Exact software / model versions
+
+| Component | Value | Source of truth |
+|---|---|---|
+| Python | ≥ 3.11 | `pyproject.toml` |
+| Dependencies | `requirements.txt` (loose) / `requirements_pinned.txt` (frozen v0.4.3) | repo root |
+| Reasoning LLM | `gemma4:e4b` (Ollama) | `config.py`, `eval/ragas/baseline.json` fingerprint |
+| Coding-mode LLM | `qwen2.5-coder:32b` | `config.py` |
+| Embedding model | `paraphrase-multilingual-MiniLM-L12-v2` (sentence-transformers) | `config.py` |
+| Ollama endpoint | `http://localhost:11434` | `core/gemma_client/config.py` |
+| Vector store | ChromaDB (embedded, persistent) | `core/vector_store.py` |
+| Sparse retriever | `rank-bm25 ≥ 0.2.2` | `requirements.txt` |
+| LLM decode temperature | `0.0` (greedy) | inference call sites |
+
+**Important:** the LLM/embedding models above are **only** needed for the
+LLM tier (`--with-llm`, and `--full` if you opt into the JAMES-engine RAB
+mode). The **deterministic core tier needs none of them.**
+
+## 2. Prompt templates, hyperparameters
+
+Core retrieval/graph hyperparameters (HANDOVER.md §2 "핵심 LLM 설정"):
+
+```
+MAX_DEPTH=4              # Graph DFS depth cap
+DFS_SCORE_THRESHOLD=0.05
+DEPTH_DECAY=0.7
+num_ctx=2048
+temperature=0
+Hybrid weights: Vector 0.60 / BM25 0.20 / keyword 0.20
+```
+
+Prompt templates live with the engine (`core/reasoning/`) and are exercised
+only in the LLM tier. The deterministic benches do not call them.
+
+## 3. Determinism tiers (read this before filing a variance report)
+
+| Tier | Benchmarks | LLM? | Reproducibility |
+|---|---|---|---|
+| **Core** | RAB (all SUTs, no `--engine`); LRB Phase B + S3 token-mode | No | **Byte-identical** across machines. Pure functions over committed JSON fixtures. Runners print `fixture_sha` / `log_sha` so you can confirm you scored identical bytes. |
+| **LLM** | RAGAS; LRB-S3 with `--engine james`; RAB `--engine` | Yes (Ollama) | **Band-based.** Local inference is not fully deterministic even at temp 0. Judge metrics reported as bands, not points. |
+
+A result that differs in the **core tier** is a genuine finding — please open
+an issue (it likely means a fixture or scorer changed). A result that differs
+in the **LLM tier** but lands inside the documented band is a normal,
+**confirmed** reproduction.
+
+## 4. LLM-tier prerequisites (`--with-llm` / `--full james`)
+
+```bash
+# 1. Install + start Ollama (https://ollama.com), then:
+ollama pull gemma4:e4b
+ollama serve            # must be listening on :11434
+
+# 2. (RAGAS path) start the JAMES server in another shell:
+python server_llmwiki.py    # serves :8000
+
+# 3. Run the LLM tier:
+bash benchmarks/run_all.sh --with-llm
+```
+
+## 5. Random seeds
+
+See `benchmarks/seeds.txt`. Summary: the core tier has **no RNG** (nothing to
+seed); the LLM tier uses `temperature=0` plus numpy/sklearn seed 42 in test
+fixtures, and reports bands for judge metrics.
+
+## 6. Hardware specification (reference capture)
+
+The committed reference numbers were captured on:
+
+```
+OS:        Windows 11 Home 10.0.26200
+CPU:       AMD Ryzen 7 7700 (8-core)
+RAM:       32 GB
+GPU:       NVIDIA GeForce RTX 4070 SUPER (12 GB VRAM)
+```
+
+Hardware affects **wall-clock time only**, never the core-tier metric values.
+RAGAS `elapsed_*` fields are informational and explicitly **not** gated by
+`--check`.
+
+## 7. Dataset subsets used
+
+| Benchmark | Fixture (committed) | Size |
+|---|---|---|
+| RAB | `eval/rab/scenarios/s1_lifecycle_small.json`, `s2_lifecycle_large.json` | frozen v0.1.1 |
+| LRB | `eval/external/lrb/` scenarios S1/S2/S3 (S3 built by `build_lrb_scenario_s3.py`) | S3 publication = 1000 docs / ~5.6k events / 1000 queries |
+| RAGAS | `eval/ragas/fixture_v0.2.json` | 3 rows (small by design — sibling cross-check, not headline) |
+
+All scored fixtures are committed to git. There is **no hidden
+preprocessing**: the core-tier runners read the committed JSON directly.
+Datasets that require a download (MuSiQue / 2Wiki / RGB / ALCE for the
+*separate* external-benchmark cycle) are **out of scope** for this package and
+are not part of the reproduction core.
+
+## 8. Success criterion
+
+> Different users obtain substantially identical results.
+
+- **Core tier:** identical to the digit shown in `benchmarks/README.md`
+  "Expected output". Any deviation → issue.
+- **LLM tier:** inside the bands in `eval/ragas/baseline.json`.

--- a/benchmarks/REPRODUCTION_PROGRAM.md
+++ b/benchmarks/REPRODUCTION_PROGRAM.md
@@ -1,0 +1,53 @@
+# JAMES Reproducibility Program (Phase 3)
+
+We want independent validation of the published RAB / LRB numbers. If you run
+`benchmarks/run_all.sh` on your own hardware, please tell us what you got —
+**whether it matched or not.** Negative and variant reproductions are as
+valuable as confirmations; the project's entire evaluation history is built on
+honest null results.
+
+## How to submit a reproduction
+
+1. Run the core tier (and optionally `--full` / `--with-llm`):
+   ```bash
+   bash benchmarks/run_all.sh
+   ```
+2. Open a GitHub issue using the **"Reproduction report"** template
+   (`.github/ISSUE_TEMPLATE/reproduction-report.yml`). Include:
+   - Operating system
+   - Hardware configuration (CPU / RAM / GPU)
+   - Python version + whether you used `requirements.txt` or `requirements_pinned.txt`
+   - Model version (only if you ran the LLM tier)
+   - The benchmark output (paste the RAB + LRB tables)
+   - Which tier(s) you ran
+
+## How we triage (labels)
+
+| Label | Meaning |
+|---|---|
+| `reproduction-confirmed` | Core-tier numbers byte-identical to `benchmarks/README.md`; LLM-tier inside bands |
+| `reproduction-variant` | Core-tier identical, LLM-tier outside band, OR a documented environment difference explains a delta |
+| `reproduction-failed` | Core-tier numbers differ — a real discrepancy we need to investigate |
+
+A `reproduction-failed` on the **core tier** is treated as a potential bug in
+a fixture or scorer and gets priority — the core tier is supposed to be
+byte-identical, so a mismatch means something genuinely diverged.
+
+## Public tracking
+
+Confirmed/variant/failed reproductions are tracked openly via the labels above
+(`is:issue label:reproduction-confirmed` etc.). The goal is **3–5 independent
+reproductions** on hardware other than the reference RTX 4070 SUPER machine.
+
+> **Operator note (not auto-created by this doc):** the three labels above
+> must be created once in the repo settings (Issues → Labels), and the issue
+> template enabled. This file + the template are committed; label creation and
+> the "call for reproductions" announcement are manual operator steps — see
+> `docs/external/announcement-drafts.md`.
+
+## Scope
+
+This program covers the **deterministic RAB + LRB core** (and the band-checked
+RAGAS sibling). It does **not** solicit reproductions of generic "Graph-RAG
+reasoning gains" — the project does not claim those; see
+`benchmarks/README.md` "What this package deliberately does NOT claim".

--- a/benchmarks/config.yaml
+++ b/benchmarks/config.yaml
@@ -1,0 +1,76 @@
+# benchmarks/config.yaml
+# ---------------------------------------------------------------------------
+# Single source of truth for the reproduction environment. Every value here
+# is a DISCLOSURE, not a knob the harness reads at runtime — the committed
+# runners are self-contained. This file exists so an external evaluator can
+# confirm (a) which artifacts are scored, (b) under which model/embedding/
+# hardware the reference numbers were captured, and (c) what is deterministic
+# vs. LLM-judge band-based.
+#
+# Fingerprint values mirror the committed baselines
+# (eval/ragas/baseline.json, eval/rab/SPEC-v0.1.md runner_env).
+version: "repro-v1"
+project_version: "v0.6.1"
+captured_against_doi: "10.5281/zenodo.20652679"   # v0.4.4 data archive
+
+# --- What gets scored -------------------------------------------------------
+benchmarks:
+  rab:
+    name: "RAB v0.1.1 — Replayable-Audit Benchmark"
+    deterministic: true            # no LLM in the scored path
+    scorer: "eval/rab/scorer.py"   # AC / RF / PC, deterministic
+    spec: "eval/rab/SPEC-v0.1.md"
+    fixtures:
+      - "eval/rab/scenarios/s1_lifecycle_small.json"
+      - "eval/rab/scenarios/s2_lifecycle_large.json"
+    suts: [reference, baseline0, baseline1, james]
+    headline: "4-SUT gap structure (Art. 10/12/19), NOT a JAMES-wins claim"
+    reference_numbers:               # scenario S1
+      reference: {AC: 1.000, RF: 1.000, PC: 1.000}
+      baseline0: {AC: 0.275, RF: 0.000, PC: 0.000}
+      james:     {AC: 1.000, RF: 1.000, PC: 1.000}
+
+  lrb:
+    name: "LRB v0.2.x — Lifecycle Retrieval Benchmark"
+    deterministic: true            # token-mode retrieval scoring, no LLM
+    fixtures_dir: "eval/external/lrb/"
+    scenarios: [S1, S2, S3]
+    suts: [vanilla, naive_supersede, james]   # V / N / J
+    headline: "R@1 V < N < J on S2; JAMES - Naive gap > +0.10 throughout"
+    reference_numbers:               # S3 publication-scale R@1
+      s3_publication_r_at_1: {vanilla: 0.502, naive: 0.721, james: 0.845}
+    framing: |
+      Pattern + gap are scale-robust (strong); absolute magnitudes are
+      scenario-sensitive (moderate). See papers/lrb-preprint/main.pdf §5.
+
+  ragas:
+    name: "RAGAS suite (sibling, LLM-judge)"
+    deterministic: false           # faithfulness/answer_relevancy are judged
+    requires_ollama: true
+    fixture: "eval/ragas/fixture_v0.2.json"   # 3 rows — small by design
+    baseline: "eval/ragas/baseline.json"
+    note: |
+      LLM-judge metrics are BAND-checked, not point-identical. This is a
+      reproducibility caveat, not a defect — see invariants in baseline.json.
+      RAGAS is a secondary cross-check; the headline reproducible numbers are
+      RAB + LRB. Coverage mapping: docs/evaluation/v0.5-evaluation-coverage-mapping.md
+
+# --- Reference environment (fingerprint) ------------------------------------
+environment:
+  os: "Windows 11 Home 10.0.26200"
+  cpu: "AMD Ryzen 7 7700 8-Core"
+  ram_gb: 32
+  gpu: "NVIDIA GeForce RTX 4070 SUPER (12 GB VRAM)"
+  python: ">=3.11"
+  ollama_model: "gemma4:e4b"        # only needed for --with-llm / --full james
+  coding_model: "qwen2.5-coder:32b"
+  embedding_model: "paraphrase-multilingual-MiniLM-L12-v2"
+  ollama_endpoint: "http://localhost:11434"
+  llm_temperature: 0.0
+  requirements: "requirements.txt   (pinned freeze: requirements_pinned.txt)"
+
+# --- Determinism posture ----------------------------------------------------
+determinism:
+  core_tier: "byte-identical across machines (RAB + LRB token-mode; no LLM)"
+  llm_tier: "band-based (RAGAS / LRB-S3 james-engine) — Ollama is nondeterministic"
+  seeds_file: "benchmarks/seeds.txt"

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# benchmarks/run_all.sh — single-command reproduction entry point.
+#
+# Goal: a fresh clone reproduces the project's PUBLISHED, DETERMINISTIC
+# benchmark numbers (RAB v0.1.1 + LRB v0.2.x) in well under 15 minutes,
+# with no LLM call and no hidden preprocessing.
+#
+#   git clone https://github.com/Hashevolution/James-RAG-Evol.git
+#   cd James-RAG-Evol
+#   python -m pip install -r requirements.txt
+#   bash benchmarks/run_all.sh
+#
+# Tiers (honest split — see benchmarks/REPRODUCIBILITY.md §3):
+#   (default)     CORE — RAB (3 SUTs) + LRB Phase B. Deterministic, no LLM,
+#                 byte-identical across machines. ~1-2 min.
+#   --full        CORE + LRB S3 publication-scale (1000 docs, deterministic
+#                 retrieval scoring, no LLM). ~3-6 min.
+#   --with-llm    CORE + RAGAS suite. Requires a running Ollama + the server.
+#                 LLM-judge metrics are BAND-checked, not point-identical
+#                 (see eval/ragas/baseline.json tolerance). Adds ~90 min.
+#
+# This script only ORCHESTRATES the committed runners; it adds no new
+# measurement logic. Every command it calls is documented in README.md
+# "Reproduce in 60 seconds".
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WITH_LLM=0
+FULL=0
+for arg in "$@"; do
+  case "$arg" in
+    --with-llm) WITH_LLM=1 ;;
+    --full)     FULL=1 ;;
+    -h|--help)
+      sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+PY="${PYTHON:-python}"
+
+hr()   { printf '%.0s=' {1..70}; printf '\n'; }
+note() { printf '\n>>> %s\n' "$1"; }
+
+note "JAMES reproduction harness — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "repo: $REPO_ROOT"
+echo "python: $($PY --version 2>&1)"
+echo "git sha: $(git rev-parse --short HEAD 2>/dev/null || echo 'n/a')"
+echo "tiers: core$([ $FULL -eq 1 ] && echo ' +full')$([ $WITH_LLM -eq 1 ] && echo ' +with-llm')"
+
+# ---------------------------------------------------------------------------
+hr; note "RAB v0.1.1 — Replayable-Audit Benchmark (scenario S1, deterministic)"
+echo "Expected gap structure (NOT a JAMES-wins claim — see SPEC §6.5):"
+echo "  reference  AC/RF/PC = 1.000 / 1.000 / 1.000"
+echo "  baseline0  AC/RF/PC = 0.275 / 0.000 / 0.000   (vanilla default logging)"
+echo "  james      AC/RF/PC = 1.000 / 1.000 / 1.000   (audit-native)"
+echo
+for sut in reference baseline0 james; do
+  $PY scripts/research/rab_run.py --sut "$sut"
+  echo
+done
+
+# ---------------------------------------------------------------------------
+hr; note "LRB Phase B — Lifecycle Retrieval Benchmark (S1+S2 time-travel, token-mode)"
+echo "Expected: R@1 V < N < J on S2, JAMES - Naive gap > +0.10 (deterministic)."
+echo "Building scenario fixtures (gitignored — regenerated deterministically)..."
+$PY scripts/research/build_lrb_scenario_s1.py
+$PY scripts/research/build_lrb_scenario_s2.py
+echo
+PYTHONPATH=. $PY scripts/research/lrb_run_phase_b.py --scenarios S1,S2
+
+# ---------------------------------------------------------------------------
+if [ $FULL -eq 1 ]; then
+  hr; note "LRB S3 — publication-scale (1000 docs / ~5.6k events / 1000 queries)"
+  $PY scripts/research/build_lrb_scenario_s3.py --scale publication
+  $PY scripts/research/lrb_run_s3.py --scale publication
+fi
+
+# ---------------------------------------------------------------------------
+if [ $WITH_LLM -eq 1 ]; then
+  hr; note "RAGAS suite (LLM-judge; band-checked, not point-identical)"
+  echo "Requires Ollama running (model: gemma4:e4b) + JAMES server. See"
+  echo "benchmarks/REPRODUCIBILITY.md §4 for the LLM prerequisites."
+  $PY eval/ragas/run_ragas.py --check
+fi
+
+# ---------------------------------------------------------------------------
+hr; note "DONE."
+echo "Compare your output against benchmarks/README.md '#expected-output'."
+echo "Reproduced something different? Open a reproduction-report issue —"
+echo "see benchmarks/REPRODUCTION_PROGRAM.md."

--- a/benchmarks/seeds.txt
+++ b/benchmarks/seeds.txt
@@ -1,0 +1,24 @@
+# benchmarks/seeds.txt — random-seed posture for reproduction.
+#
+# Read this together with benchmarks/REPRODUCIBILITY.md §3 (determinism tiers).
+#
+# CORE TIER (RAB + LRB token-mode) — no RNG, no LLM.
+#   These benchmarks are deterministic BY CONSTRUCTION: the scored path is
+#   pure functions over committed JSON fixtures (event-log replay for RAB,
+#   token-overlap retrieval scoring for LRB). There is no seed to set because
+#   there is no sampling. Same fixture SHA in -> byte-identical AC/RF/PC and
+#   R@k out. The runners print fixture_sha / log_sha so you can confirm you
+#   scored the same bytes we did.
+#
+# LLM TIER (RAGAS, LRB-S3 --engine james) — Ollama in the path.
+#   Ollama / local model inference is NOT fully deterministic even at
+#   temperature 0 (attention kernels, batching). We therefore report BANDS,
+#   not points, for judge-based metrics. The relevant seeds/knobs:
+NUMPY_SEED=42          # unit-test fixtures (tests/conftest.py)
+SKLEARN_SEED=42        # any sklearn split in test fixtures
+LLM_TEMPERATURE=0.0    # greedy decode requested from Ollama
+# Note: LLM_TEMPERATURE=0 reduces but does not remove run-to-run variance.
+# RAGAS tolerance bands (eval/ragas/baseline.json): judge_metric_abs=0.15,
+# embedding_metric_abs=0.10. A reproduction landing inside the band is a
+# CONFIRMED reproduction; outside the band on a judge metric is a VARIANT,
+# not a failure — flag it in your reproduction-report issue.

--- a/core/agent_tools/registry.py
+++ b/core/agent_tools/registry.py
@@ -6,7 +6,7 @@ Phase E ``run_shell``) register here as well.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
 # Global cap. Individual tools MAY pin a lower per-call timeout via

--- a/core/security/forwarded.py
+++ b/core/security/forwarded.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Final, List, Optional, Sequence, Tuple, Union
+from typing import Final, List, Optional, Tuple, Union
 
 
 JAMES_TRUSTED_PROXIES_ENV:        Final[str] = "JAMES_TRUSTED_PROXIES"

--- a/docs/design/v0.6-circle-modal-ask-edit.md
+++ b/docs/design/v0.6-circle-modal-ask-edit.md
@@ -52,6 +52,33 @@ The circle→region→claim mapping (§6) is the single hard primitive **both**
 intents share. Build **Ask first** so this mapping is validated under a
 read-only path before any write touches it.
 
+### 2.1 Region-selection interaction (resolved 2026-06-19)
+
+The mouse-drawn region is a **gesture to pick content**, not a pixel
+selection. What it resolves to depends on the target:
+
+- **Document targets (T1/T2/T3 text)** → the drawn shape resolves to a
+  **text span**, never raw pixels. Pipeline: drawn shape → hit-test the
+  underlying word boxes → snap to sentence (D2). A wobbly hand-drawn
+  circle therefore selects *the sentence(s) it overlaps*, not the curve's
+  pixels — which is why D2 locks the unit to **sentence** (partial-sentence
+  regeneration degrades quality).
+- **Image target (Phase 2)** → the drawn shape is used **literally as a
+  pixel inpaint mask** (inside = edit / outside = preserve, with edge
+  feathering). Pixel precision matters here; out of mother scope.
+
+**Two gesture modes, one resolver** (both feed the same overlap→snap step):
+
+| Mode | Mechanics | Use |
+|---|---|---|
+| **Drag box/ellipse** (default) | `mousedown→move→up` = one bbox; intersect with word boxes | fast, precise, lowest effort |
+| **Free-hand lasso** (toggle) | capture `pointermove` points → closed polygon → per-word point-in-polygon | natural "동그라미" feel |
+
+Hit-testing: DOM text via `Range` + `getClientRects()` per text node vs the
+shape; PDF text via PDF.js `getTextContent()` item positions vs the shape's
+bbox. Both then sentence-snap (§6). Pixel precision is **not** required for
+document targets because the output is always a text range.
+
 ## 3. Target × Intent matrix
 
 | Target | Ask (READ) | Edit (WRITE) |
@@ -223,6 +250,7 @@ arXiv timeline untouched (steps 1–2 even help it).
 | D6 | T2 "save as knowledge" boundary | **Explicit promote → CR** in UI (rule #3-locked) |
 | D7 | Ask scope in Phase 1 | **Tier 1 + Tier 2 both** (sequence T1→T2 within phase) |
 | D8 | Edit-mode first slice | **Modes (a)+(b) together**; mode (b) gated by approval-forced + ABAC filter |
+| D9 | Region-selection gesture | **Drag box/ellipse default + free-hand lasso toggle**; document = resolves to text span (overlap→sentence-snap), image = literal pixel mask (§2.1) |
 
 ## 10. Out of scope (this memo)
 

--- a/docs/design/v0.6-circle-modal-ask-edit.md
+++ b/docs/design/v0.6-circle-modal-ask-edit.md
@@ -97,7 +97,10 @@ doc/chunk + offset requires a claim↔chunk attribution step over the
 persisted `graph_paths` (audit SQLite) + the retrieved set
 (`/admin/trace/{trace_id}`, `/admin/audit/recent-traces`). Not
 from-scratch (the trace is persisted), but a distinct piece of work.
-**Phase-1 scope decision needed** (§9, D7): Tier 1 only, or Tier 1+2.
+**DECIDED (2026-06-19): Tier 1 + Tier 2 are both in Phase 1** — sequence
+Tier 1 (groundedness) before Tier 2 (chunk+offset attribution) within the
+phase. Tier 2 must keep the same honesty rule: if no chunk crosses the
+attribution threshold, surface `REASONED`, never a forced citation.
 
 ### 4.3 Conversational follow-up
 
@@ -192,26 +195,34 @@ for the write paths.
 
 1. **Ask Tier 1** (groundedness verdict) — read-only, reuses verify +
    abstention, validates region→claim mapping, advances RAB PC narrative.
-2. **T1 Edit via CR** (mode a, then mode b with approval-forced + ABAC filter).
-3. **T2 artifact edit** + promote-to-knowledge boundary.
-4. **Ask Tier 2** (specific-chunk attribution).
-5. **PDF suggestion-only** Ask/Edit.
+2. **Ask Tier 2** (specific-chunk + offset attribution) — in Phase 1 per
+   D7; same honesty rule (no forced citation).
+3. **T1 Edit via CR** — modes **(a) and (b) ship together** per the edit-mode
+   decision. Mode (b) full-rewrite carries two **hard prerequisites** that
+   gate its merge: approval-forced (rule #3, via CR `approval_evidence`) +
+   ABAC context filter before prompt injection (§5.1). Mode (a) has the
+   same approver gate via CR but a smaller diff.
+4. **T2 artifact edit** + promote-to-knowledge boundary.
+5. **PDF suggestion-only** Ask/Edit (in-place layout-preserving replacement
+   is a later roadmap goal per D1 — separate scope).
 6. *(Phase 2, separate)* image — see §10.
 
-Each step is independently shippable and keeps the RAB arXiv timeline
-untouched (step 1 even helps it).
+Ask precedes Edit (read-only validates the shared region→claim primitive
+before any write). Each step is independently shippable and keeps the RAB
+arXiv timeline untouched (steps 1–2 even help it).
 
-## 9. Open decisions (operator)
+## 9. Decisions (resolved 2026-06-19 unless noted)
 
-| # | Decision | Recommended default |
+| # | Decision | Resolution |
 |---|---|---|
-| D1 | PDF in-place text replacement? | **Suggestion-only** (layout risk) |
-| D2 | Boundary-snap default unit | **Sentence** (token/paragraph optional) |
-| D3 | Mode (b) confirm/approve | **Forced** (rule #3 — not optional) |
+| D1 | PDF in-place text replacement? | **Suggestion-only for Phase 1; in-place (layout-preserving) = later roadmap goal**, separate scope |
+| D2 | Boundary-snap default unit | **Sentence** (token/paragraph selectable) |
+| D3 | Mode (b) confirm/approve | **Forced** (rule #3 — rule-locked, not optional) |
 | D4 | Image backend | **Deferred** (Phase 2 out of mother) |
 | D5 | Image location | **Demo site + post-v1.0** |
-| D6 | T2 "save as knowledge" boundary | **Explicit promote → CR** in UI |
-| D7 | Ask scope in Phase 1 | **Tier 1 only** first; Tier 2 as step 4 |
+| D6 | T2 "save as knowledge" boundary | **Explicit promote → CR** in UI (rule #3-locked) |
+| D7 | Ask scope in Phase 1 | **Tier 1 + Tier 2 both** (sequence T1→T2 within phase) |
+| D8 | Edit-mode first slice | **Modes (a)+(b) together**; mode (b) gated by approval-forced + ABAC filter |
 
 ## 10. Out of scope (this memo)
 
@@ -222,7 +233,8 @@ untouched (step 1 even helps it).
   the 4080 is 16GB; the project reference machine is **RTX 4070 SUPER
   12GB**. Re-pin the VRAM budget to the real machine when Phase 2 is
   scoped.)
-- **PDF in-place replacement** (D1 = suggestion-only).
+- **PDF in-place replacement** — out of Phase 1 (D1: suggestion-only now;
+  layout-preserving in-place kept as a later roadmap goal, separate scope).
 - Any measurement / implementation — this is design-only.
 
 ## 11. References (verified symbols)

--- a/docs/design/v0.6-circle-modal-ask-edit.md
+++ b/docs/design/v0.6-circle-modal-ask-edit.md
@@ -1,0 +1,239 @@
+# Design Memo — "Circle → Modal → Ask / Edit" (v0.6)
+
+> **Status: DESIGN ONLY (pre-implementation).** No code, no measurement
+> yet. This memo is the suitability-corrected redesign of the
+> 2026-06-16 handover ("동그라미 → 모달 → 편집"). It folds in two
+> operator additions (2026-06-19): (1) template-generated documents are
+> editable too, (2) the circled region also supports a conversational
+> **provenance/grounding inquiry** ("근거가 뭐야?"), not only editing.
+>
+> **Why this supersedes the original handover's mechanics:** the
+> handover proposed a new direct-write `/api/edit` path. JAMES already
+> ships the primitive that makes "edit-with-audit" actually *replayable*
+> — the **Change Request** (`core/change_request_merge.py` +
+> `core.security.approval_evidence`). Routing knowledge edits through CR
+> is the difference between "an editor that logs" and JAMES's
+> differentiator. See §5.
+
+---
+
+## 0. One line
+
+A circled region on a rendered document opens a modal with **two
+intents**: **Ask** (read-only: "is this from a source or inferred?") and
+**Edit** (write). Write semantics depend on *what* was circled:
+knowledge document → Change Request (approval-gated, replayable);
+template-output document → artifact edit (lighter); RAG answer → transient.
+
+## 1. Confirmed decisions (frozen — operator-set)
+
+- Region targets: PDF canvas (coordinate) **and** RAG-rendered text (DOM) — both.
+- Edit modes: (a) region-only regenerate-and-replace, (b) instruction-driven full-context rewrite — both.
+- Edit targets: document **and** image.
+- Build order: **document first**, image later.
+- Image engine: **local only** (no external SaaS — security-philosophy).
+- **(2026-06-19)** Phase 1 also edits **template-generated documents** (workspace 양식 outputs), for usability.
+- **(2026-06-19)** The region also supports a **conversational provenance/grounding inquiry**.
+
+## 2. Shared primitive — one selection surface, two intents
+
+```
+[rendered doc/answer]
+   ↓ draw circle/rect (canvas overlay)
+[region bbox]
+   ↓ region → claim/text-span mapping  (§6 boundary-snap)
+[selected claim + surrounding context]
+   ↓ MODAL
+   ├── Ask  → provenance/grounding answer (READ)   §4
+   └── Edit → region mutation (WRITE)              §5
+```
+
+The circle→region→claim mapping (§6) is the single hard primitive **both**
+intents share. Build **Ask first** so this mapping is validated under a
+read-only path before any write touches it.
+
+## 3. Target × Intent matrix
+
+| Target | Ask (READ) | Edit (WRITE) |
+|---|---|---|
+| **T1 Knowledge doc** (wiki entity / ingested source) | verify + trace read | **Change Request** — approval-gated, replayable (§5.1) |
+| **T2 Template-output doc** (`routes/templating.py` reshaped file) | same | **Artifact edit** — re-render + re-download, audit-logged, *no approval gate*; "save as knowledge" → promotes to CR (§5.2) |
+| **T3 RAG answer render** (ephemeral) | same — highest value | transient, or "save as knowledge?" → CR |
+
+Ask works on all three targets. Write semantics differ because **T1
+mutates knowledge state (replay-relevant); T2 mutates a downloadable
+artifact (not knowledge); T3 mutates nothing persistent.**
+
+## 4. Ask — provenance / grounding inquiry (build first)
+
+User circles a sentence, asks "근거가 뭐야?" / "이거 추론이야?". JAMES
+answers from **already-computed** signals.
+
+### 4.1 Tier 1 — groundedness classification (near-wiring; do first)
+
+`core/reasoning/verify.py::Verifier.verify()` already returns
+`VerifyResult { is_grounded: bool, unsupported_claims: List[str], ... }`
+by asking the backend whether each claim is supported by the retrieved
+context (`{"grounded": true|false, "unsupported": [...]}`). Plus the
+abstention softener (`core/reasoning/pipeline_synth/softener.py`).
+
+→ A circled claim resolves to one of three **honest** verdicts:
+
+| Verdict | Source signal | Modal says |
+|---|---|---|
+| `SOURCE-GROUNDED` | claim ∉ `unsupported_claims`, `is_grounded` | "자료 지지 — 출처 보기" → §4.2 |
+| `REASONED` | claim ∈ `unsupported_claims` | "직접 근거 없음, 추론 산물" (NOT a fabricated citation) |
+| `ABSTAINED` | abstention trigger fired | "근거 불충분으로 단정 회피" |
+
+**Honesty is structural**: the modal never invents a source — if verify
+says unsupported, it says so. This is the abstention/honest-framing
+discipline applied to UX.
+
+### 4.2 Tier 2 — specific-chunk attribution (real gap; do later)
+
+verify checks support against `[Internal Data]` *as a whole*, not against
+a specific chunk. Mapping a `SOURCE-GROUNDED` claim to **which** source
+doc/chunk + offset requires a claim↔chunk attribution step over the
+persisted `graph_paths` (audit SQLite) + the retrieved set
+(`/admin/trace/{trace_id}`, `/admin/audit/recent-traces`). Not
+from-scratch (the trace is persisted), but a distinct piece of work.
+**Phase-1 scope decision needed** (§9, D7): Tier 1 only, or Tier 1+2.
+
+### 4.3 Conversational follow-up
+
+After the verdict, follow-ups ("어느 stage에서 나왔어?", "왜 이걸 골랐어?")
+read the reasoning trace (`graph_paths`, trace files) — a scoped,
+read-only Q&A over existing audit data. Reuses the chat synth path with
+the trace as context; no new write surface.
+
+### 4.4 Priority alignment (important)
+
+Ask is the **user-facing surface of RAB's Provenance Coverage (PC)**. It
+*complements* the RAB arXiv track (EU AI Act Art. 10/12/19, 2026-08-02),
+not competes with it — which makes it the most defensible first slice
+even under the arXiv-priority constraint.
+
+## 5. Edit — write semantics by target
+
+### 5.1 T1 knowledge doc → Change Request (NOT a new endpoint)
+
+Route through the existing primitive:
+
+- Build a **region-scoped CR** (the diff = the circled span's
+  before/after), then `core/change_request_merge.py` apply with
+  `approval_evidence` — `core.security.approval_evidence.require_approval_evidence()`
+  enforces a human approver.
+- Result: the edit is (a) **replayable** via `reconstruct_graph_at(t)`,
+  (b) **approver-logged** (rule #3), (c) **audit-native by construction**
+  (not bolted-on), (d) **rollback-able** via the existing
+  `frontend/static/knowledge-rollback.js` + `time-travel.js` surfaces.
+- Mode (a) region-only and mode (b) full-rewrite are both *CR payloads*;
+  mode (b) just has a larger diff scope.
+
+**Mode (b) is approval-forced** (resolves handover open item): an LLM
+mutating knowledge without an approver in the audit log is "a bug, not a
+feature" (rule #3). CR apply gives this for free.
+
+**Mode (b) ABAC context-leakage** (handover's correct catch): the
+full-rewrite context must pass `core/policy_engine.py` ABAC filtering
+*before* injection, so fields the user can't see never enter the rewrite
+prompt. Reuse the existing retrieval-time policy filter.
+
+### 5.2 T2 template-output doc → artifact edit (lighter)
+
+Template outputs (`routes/templating.py`, owner-scoped, "ships zero
+templates" per rule #1) are **downloadable artifacts, not graph state**:
+
+- Edit path = regenerate the circled region (mode a) or reshape (mode b)
+  → re-render → re-download. **Audit-logged** (who/region/instruction/
+  mode) for consistency, but **no approval gate / no knowledge replay**
+  (nothing in the knowledge state changed).
+- **Explicit boundary**: a "이 수정본을 정식 지식으로 저장" action
+  *promotes* the artifact into knowledge → at that moment it becomes a
+  **CR** (§5.1) with the approval gate. The UI must make this transition
+  explicit, not implicit.
+- **rule #1**: the edit feature stays domain-agnostic — it shapes
+  user-provided templates, ships no domain templates.
+
+### 5.3 T3 RAG answer render → transient
+
+Editing an ephemeral answer has no persistence/audit meaning; offer
+"save as knowledge?" → CR, otherwise discard.
+
+## 6. Boundary-snap rule (region → claim) — the shared hard problem
+
+The handover's real difficulty. Spec:
+
+- Default: include every token whose bbox intersects the circle; extend
+  both ends to the nearest **sentence** boundary (partial-sentence
+  regeneration degrades quality).
+- Granularity is a user setting: token / **sentence (default)** / paragraph.
+- DOM path (RAG-rendered): `Range` + `getClientRects()` → text offsets.
+- PDF path: PDF.js `getTextContent()` transform → text items overlapping
+  the bbox. **PDF write-back is out of scope** — PDF returns
+  *suggestions only* (separate panel/comment), no in-place layout-breaking
+  replacement.
+
+Validating this mapping under the read-only **Ask** path first de-risks it
+for the write paths.
+
+## 7. Discipline gates (must-pass)
+
+| Gate | Requirement |
+|---|---|
+| **rule #1** | Horizontal UX, no domain content. T2 edit stays template-agnostic. Not blocked, but watched. |
+| **rule #2** | Any `core/reasoning`/synth change → STEP7 bench + 5-axis Quality Delta Card. |
+| **rule #3** | T1 + promoted-T2 edits = human approver in audit log. Mode (b) approval-forced. |
+| **No-untested-feature** | Edit + Ask paths need eval-harness regression coverage before merge. |
+| **Output filter** | Gemma edit/answer output passes the existing injection/output filter before reaching the user. |
+| **Honest provenance** | Ask never fabricates a citation; `REASONED`/`ABSTAINED` verdicts are surfaced as-is. |
+
+## 8. Build order
+
+1. **Ask Tier 1** (groundedness verdict) — read-only, reuses verify +
+   abstention, validates region→claim mapping, advances RAB PC narrative.
+2. **T1 Edit via CR** (mode a, then mode b with approval-forced + ABAC filter).
+3. **T2 artifact edit** + promote-to-knowledge boundary.
+4. **Ask Tier 2** (specific-chunk attribution).
+5. **PDF suggestion-only** Ask/Edit.
+6. *(Phase 2, separate)* image — see §10.
+
+Each step is independently shippable and keeps the RAB arXiv timeline
+untouched (step 1 even helps it).
+
+## 9. Open decisions (operator)
+
+| # | Decision | Recommended default |
+|---|---|---|
+| D1 | PDF in-place text replacement? | **Suggestion-only** (layout risk) |
+| D2 | Boundary-snap default unit | **Sentence** (token/paragraph optional) |
+| D3 | Mode (b) confirm/approve | **Forced** (rule #3 — not optional) |
+| D4 | Image backend | **Deferred** (Phase 2 out of mother) |
+| D5 | Image location | **Demo site + post-v1.0** |
+| D6 | T2 "save as knowledge" boundary | **Explicit promote → CR** in UI |
+| D7 | Ask scope in Phase 1 | **Tier 1 only** first; Tier 2 as step 4 |
+
+## 10. Out of scope (this memo)
+
+- **Phase 2 image editing** (SDXL/diffusers/ComfyUI): 100% greenfield +
+  multi-GB model + VRAM swap + new content-safety policy surface + outside
+  "secure local RAG" core → **mother-excluded**, demo-site/post-v1.0
+  candidate. (Note: the handover's "RTX 4080 12GB" is a factual error —
+  the 4080 is 16GB; the project reference machine is **RTX 4070 SUPER
+  12GB**. Re-pin the VRAM budget to the real machine when Phase 2 is
+  scoped.)
+- **PDF in-place replacement** (D1 = suggestion-only).
+- Any measurement / implementation — this is design-only.
+
+## 11. References (verified symbols)
+
+- `core/reasoning/verify.py` — `Verifier.verify()` → `VerifyResult{is_grounded, unsupported_claims}`
+- `core/reasoning/pipeline_synth/softener.py` — abstention triggers
+- `core/change_request_merge.py` — CR apply + `approval_evidence`
+- `core/security/approval_evidence.py` — `require_approval_evidence()` / `ApprovalEvidence`
+- `core/policy_engine.py` — ABAC/RBAC filter (mode-b context gating)
+- `routes/admin.py` / `server_llmwiki.py` — `/admin/trace/{trace_id}`, `/admin/audit/recent-traces`, `/admin/graph/{snapshot,diff-vs-now,last-change}`
+- `routes/templating.py` — template reshape (T2 target), owner-scoped, rule #1
+- `frontend/static/{knowledge-rollback,time-travel}.js`, `frontend/workspace.html` 양식 tab
+- `reconstruct_graph_at(t)` (v0.4.2 T5) — replay primitive CR edits inherit
+- CLAUDE.md rules #1/#2/#3; `docs/design/v0.6-template-formatting-ui.md`

--- a/docs/external/announcement-drafts.md
+++ b/docs/external/announcement-drafts.md
@@ -1,0 +1,82 @@
+# External Announcement Drafts (Phase 5) — NOT POSTED
+
+> **These are drafts for operator review. Nothing here has been or should be
+> auto-posted.** External-facing claims are gated on measurement evidence
+> (v0.5 entry rule) and the honest-framing rule. The framing below is
+> deliberately *adversarial-invite*, not *gains-marketing* — we ask people to
+> break the benchmarks, not to admire a leaderboard win.
+>
+> Why the framing differs from the original handover: the handover suggested
+> "Can anyone reproduce these Graph-RAG gains?". The project has **not**
+> established generic Graph-RAG reasoning gains (MuSiQue/MultiHop-RAG measured
+> null/parity), and RAB's SPEC §6.5 disclaims a JAMES-wins reading. Posting a
+> "gains" claim would resurrect an overclaim the project spent multiple cycles
+> retracting. The honest ask is about **reproducible audit/lifecycle
+> benchmarks**, not reasoning superiority.
+
+---
+
+## r/LocalLLaMA (draft)
+
+**Title:** Two deterministic RAG benchmarks you can reproduce in ~2 minutes (no GPU): audit-replayability + temporal retrieval
+
+**Body:**
+We've been building a local-first Graph-RAG engine and got tired of
+unreproducible benchmark claims, so we shipped two **deterministic-scorer**
+benchmarks (no LLM in the scored path) with committed fixtures:
+
+- **RAB** — scores whether a RAG/agent system's audit log can be *replayed*
+  (3 metrics mapped to EU AI Act Art. 10/12/19).
+- **LRB** — scores *temporal* retrieval (does the system retrieve what was
+  valid at query-time?).
+
+```
+git clone … && cd James-RAG-Evol
+pip install -r requirements.txt
+bash benchmarks/run_all.sh        # ~2 min, no GPU, no Ollama
+```
+
+Honest scope: this is **not** a "we beat vector RAG on reasoning" post. On
+open multi-hop our own measured result is null/parity, and we say so. The ask
+is narrower and more useful: **can you reproduce the deterministic numbers, or
+break the benchmarks?** Variant/failed reproductions welcome.
+
+---
+
+## r/MachineLearning (draft)
+
+**Title:** [P] Pre-registered, deterministic-scorer RAG benchmarks (RAB: audit-replay; LRB: temporal retrieval) — reproduction + adversarial reports wanted
+
+**Body:**
+Two sibling benchmarks, both pre-registered before measurement, both scored by
+deterministic functions over committed JSON (no LLM judge in the headline
+path), both with baseline-vs-system gap tables. Preprints + SPEC + fixtures +
+one-command runner all committed.
+
+We're explicitly inviting **adversarial scrutiny**: a trivial system that
+games either metric is a contribution to the benchmark. Honest-framing note:
+the RAB headline is the *gap structure*, not a JAMES-wins leaderboard; LRB's
+pattern/gap are scale-robust while absolute magnitudes are scenario-sensitive.
+Repro path: `benchmarks/README.md`.
+
+---
+
+## Hacker News (draft)
+
+**Title:** Show HN: Reproduce our RAG audit + temporal-retrieval benchmarks in 2 minutes (no GPU)
+
+**Body:**
+Deterministic-scorer benchmarks with committed fixtures and a one-command
+runner. Not a reasoning-superiority claim — on open multi-hop we measured
+null/parity and document it. We want reproductions and benchmark-breaking
+attempts. `bash benchmarks/run_all.sh`.
+
+---
+
+## Pre-post checklist (operator)
+
+- [ ] Core tier re-run green on a non-reference machine (Linux/macOS) before posting
+- [ ] Repro labels created (`reproduction-confirmed` / `-variant` / `-failed`)
+- [ ] Issue template enabled (`.github/ISSUE_TEMPLATE/reproduction-report.yml`)
+- [ ] Links resolve (preprint PDFs, SPEC, `benchmarks/README.md`)
+- [ ] No "gains"/"beats"/"SOTA" language re-introduced in the final post

--- a/docs/reports/reproducibility-report-v1-SKELETON.md
+++ b/docs/reports/reproducibility-report-v1-SKELETON.md
@@ -1,0 +1,101 @@
+# JAMES-RAG-Evol Reproducibility Report v1 — SKELETON
+
+> **Status: SKELETON / NOT FOR RELEASE.** This is the scaffold for a citable
+> reproducibility report. It binds together the two existing preprints
+> (RAB, LRB) under a single "can anyone reproduce this?" narrative. Sections
+> marked _[fill]_ pull from committed artifacts; the honest-framing verdicts
+> are pre-locked so a future author cannot quietly upgrade them.
+>
+> Zenodo DOI minting and arXiv submission are **operator actions** — this
+> skeleton does not self-publish.
+
+## 0. Framing lock (read first)
+
+This report's claims are bounded by the project's measured reality:
+
+- **What we claim is reproducible:** RAB (audit-log replayability) and LRB
+  (temporal/lifecycle retrieval), both deterministic-scorer-only.
+- **What we do NOT claim:** generic Graph-RAG reasoning gains. On open
+  multi-hop (MuSiQue/MultiHop-RAG) the measured result is null/parity
+  (`docs/handovers/v0.4-track-c-musique-improvement-loop-FINAL-2026-06-12.md`).
+- **RAB headline = gap structure, not a JAMES-wins leaderboard** (SPEC §6.5).
+- **LRB headline = scale-robust pattern + gap (strong); absolute magnitudes
+  scenario-sensitive (moderate)** (preprint §5).
+
+Any draft that strengthens these beyond the evidence violates the repository's
+honest-framing rule and must be rejected in review.
+
+## 1. Motivation
+
+_[fill]_ Why replayable, audit-native Graph-RAG matters: EU AI Act Articles
+10/12/19 (in force 2026-08-02) presuppose an audit instrument that did not
+exist; RAB is that instrument. Cross-reference `papers/rab-preprint/main.pdf`
+§1 and README "Why this exists".
+
+## 2. Architecture (high level)
+
+_[fill]_ 6-stage pipeline (security → routing → hybrid retrieval → graph →
+reasoning → output filter) + Layer-4 lifecycle store + `reconstruct_graph_at(t)`.
+Reuse README "Architecture" + `docs/ARCHITECTURE.md`. One paragraph + the
+existing mermaid diagram; this report is about *evidence*, not design.
+
+## 3. Experimental setup (complete reproducibility spec)
+
+_[fill — mostly transclude]_ Pull verbatim from `benchmarks/REPRODUCIBILITY.md`:
+software/model versions, hyperparameters, determinism tiers, hardware
+fingerprint, dataset subsets, seeds. State the one-command path
+(`bash benchmarks/run_all.sh`).
+
+## 4. Benchmarks
+
+### 4.1 RAB v0.1.1 — Replayable-Audit Benchmark
+_[fill]_ AC / RF / PC definitions; 4-SUT design; mapping to Art. 10/12/19.
+Source: `eval/rab/SPEC-v0.1.md`, `papers/rab-preprint/main.pdf`.
+
+### 4.2 LRB v0.2.x — Lifecycle Retrieval Benchmark
+_[fill]_ Temporal validity scoring; S1/S2/S3; V/N/J SUTs; 7 deterministic axes.
+Source: `papers/lrb-preprint/main.pdf`.
+
+### 4.3 RAGAS (sibling cross-check)
+_[fill]_ 3-row fixture; band semantics; explicitly secondary. Source:
+`eval/ragas/`, `docs/evaluation/v0.5-evaluation-coverage-mapping.md`.
+
+### 4.4 (Out of scope) HotpotQA / LongFact / MuSiQue
+_[fill]_ State plainly: not part of v1 reproducibility claims. MuSiQue measured
+null/parity; HotpotQA/LongFact not integrated. Deferred to a future
+measurement cycle, not packaged as wins.
+
+## 5. Results (baseline vs JAMES)
+
+_[fill — transclude the committed tables]_
+
+| Benchmark | Baseline | JAMES | Reproduce |
+|---|---|---|---|
+| RAB S1 (AC/RF/PC) | baseline0 = 0.275/0.000/0.000 | 1.000/1.000/1.000 | `rab_run.py --sut {baseline0,james}` |
+| LRB S3 R@1 | Vanilla 0.502 / Naive 0.721 | **0.845** | `lrb_run_s3.py --scale publication` |
+| RAGAS answer_relevancy | band [0.649, 0.757] | band [0.649, 0.757] | `run_ragas.py --check` |
+
+## 6. Failure cases & limitations
+
+_[fill]_ Be generous here — it is the credibility centre of gravity:
+- MuSiQue/MultiHop-RAG null/parity (no JAMES-specific reasoning lift).
+- Graph build is O(N²) (lifted into RAB as the RF-cost axis).
+- LLM-tier nondeterminism → bands, not points.
+- RAGAS fixture is 3 rows (small).
+
+## 7. Threats to validity
+
+_[fill]_ Single reference machine; Ollama nondeterminism; deterministic
+scorers could be gameable (invite challenge — see `benchmarks/CHALLENGE.md`);
+fixtures authored by the project (mitigated by committing them + deterministic
+scoring + the reproduction program).
+
+## 8. Reproduction instructions
+
+_[fill]_ Transclude `benchmarks/README.md` "Reproduce ... under 15 minutes".
+
+## 9. Archival
+
+_[operator]_ Mint Zenodo DOI for this report; cross-link to the v0.4.4 data
+archive DOI `10.5281/zenodo.20652679` and the two preprints. Maintain
+release-to-report traceability (Phase 6).

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -729,7 +729,6 @@ async def admin_audit_recent_traces(
     """
     _require_feature(api_key, role, "admin.metrics")
 
-    from pathlib import Path as _Path
     from datetime import datetime as _dt
     from core.observability import _trace_root
 

--- a/routes/workspace_info.py
+++ b/routes/workspace_info.py
@@ -31,7 +31,7 @@ not yet loaded it returns 0 rather than initialising it.
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -51,7 +51,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 
 # Resolve repo root from this file's location — works whether the

--- a/scripts/research/routing_matrix_probe.py
+++ b/scripts/research/routing_matrix_probe.py
@@ -41,7 +41,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -30,7 +30,6 @@ upcoming Quality Delta Card produced by ``local_vs_cloud_paired.py``.
 """
 from __future__ import annotations
 
-import hashlib
 import importlib
 import inspect
 import os

--- a/tests/test_v05_admin_diff_vs_now.py
+++ b/tests/test_v05_admin_diff_vs_now.py
@@ -30,7 +30,6 @@ import sqlite3
 import sys
 import tempfile
 import unittest
-from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_v05_admin_trace_replay.py
+++ b/tests/test_v05_admin_trace_replay.py
@@ -143,7 +143,6 @@ class TraceReplayRoundTripTests(TraceReplayBaseTests):
         day = "2026-06-01"
         # 5 stages, one every 10 minutes starting 00:00 UTC. The
         # cutoff tests use a midpoint between stage 2 and stage 3.
-        base = "2026-06-01T00:00:00+00:00"
         stages = []
         for i, (stage, offset_min) in enumerate([
             ("auth",     0),

--- a/tests/test_v06_agent_paths.py
+++ b/tests/test_v06_agent_paths.py
@@ -157,7 +157,6 @@ def _make_client(role="admin"):
     app.dependency_overrides[get_role_from_request] = lambda: role
     ap._bearer_username = lambda request: "admin"
     # Stub the api_key + admin gate so the test doesn't need a real key.
-    import routes._helpers as h
     ap._require_admin = lambda api_key, role: None if role == "admin" else (_ for _ in ()).throw(
         __import__("fastapi").HTTPException(status_code=403, detail="admin only")
     )

--- a/tests/test_v06_g2c_oidc_async_tenant.py
+++ b/tests/test_v06_g2c_oidc_async_tenant.py
@@ -43,7 +43,6 @@ import asyncio
 import os
 import sys
 import unittest
-from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/test_v06_glossary.py
+++ b/tests/test_v06_glossary.py
@@ -23,7 +23,6 @@ Run:
 from __future__ import annotations
 
 import os
-import re
 import sys
 import unittest
 from pathlib import Path

--- a/tests/test_v06_graph_rag_step2_driver.py
+++ b/tests/test_v06_graph_rag_step2_driver.py
@@ -23,12 +23,10 @@ Run:
 """
 from __future__ import annotations
 
-import io
 import os
 import subprocess
 import sys
 import unittest
-from contextlib import redirect_stdout
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_v06_knowledge_rollback.py
+++ b/tests/test_v06_knowledge_rollback.py
@@ -316,7 +316,7 @@ class HtmlStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not HTML.exists():
-            raise unittest.SkipTest(f"knowledge-rollback.html missing")
+            raise unittest.SkipTest("knowledge-rollback.html missing")
         cls.body = HTML.read_text(encoding="utf-8")
 
     def test_two_flow_section_titles(self):
@@ -349,7 +349,7 @@ class JsStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not JS.exists():
-            raise unittest.SkipTest(f"knowledge-rollback.js missing")
+            raise unittest.SkipTest("knowledge-rollback.js missing")
         cls.body = JS.read_text(encoding="utf-8")
 
     def test_exposes_global(self):

--- a/tests/test_v06_reasoning_flow.py
+++ b/tests/test_v06_reasoning_flow.py
@@ -202,7 +202,7 @@ class HtmlStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not HTML.exists():
-            raise unittest.SkipTest(f"reasoning-flow.html missing")
+            raise unittest.SkipTest("reasoning-flow.html missing")
         cls.body = HTML.read_text(encoding="utf-8")
 
     def test_three_swimlanes_present(self):

--- a/tests/test_v06_reflect_module_size.py
+++ b/tests/test_v06_reflect_module_size.py
@@ -69,7 +69,7 @@ class PublicImportSurfaceTests(unittest.TestCase):
 
     def test_canonical_public_imports(self):
         # Public API as called by pipeline_synth.py + research scripts.
-        from core.reasoning.reflect import (
+        from core.reasoning.reflect import (  # noqa: F401 — importability contract
             ReflectionLoop, get_reflection_loop, DEFAULT_BACKEND_ID,
         )
         self.assertTrue(callable(get_reflection_loop))
@@ -89,7 +89,7 @@ class PublicImportSurfaceTests(unittest.TestCase):
         )
 
     def test_canonical_prompt_constants(self):
-        from core.reasoning.reflect import (
+        from core.reasoning.reflect import (  # noqa: F401 — importability contract
             CRITIQUE_PROMPT_EN,
             CRITIQUE_PROMPT_KO,
             REVISE_PROMPT_EN,


### PR DESCRIPTION
## Summary

Adds a dedicated `benchmarks/` reproducibility package so any external evaluator can reproduce the project's **published, deterministic** benchmark numbers from a fresh clone in under 15 minutes — the "External Reproducibility & Credibility Upgrade" handover.

It wraps the already-committed, pre-registered runners (`rab_run.py`, `lrb_run_phase_b.py`, `run_ragas.py`) behind a single `bash benchmarks/run_all.sh`. **No new measurement logic; zero `core/` changes.**

**Suitability-review note (why the framing differs from the literal handover):** the handover suggested reproducing "Graph-RAG **gains**" on HotpotQA / LongFact. The project has *not* established generic Graph-RAG reasoning gains — MuSiQue / MultiHop-RAG measured **null/parity**, and RAB SPEC §6.5 explicitly disclaims a "JAMES-wins" reading. So this package reproduces the project's **actually-measured** claims (RAB audit-replay gap structure + LRB temporal pattern) and states plainly what it does *not* claim. New external-benchmark integration (HotpotQA/LongFact) is deferred to a separate measurement cycle per operator decision.

### Contents
| Phase | File(s) |
|---|---|
| P1 one-command + 15-min repro | `benchmarks/{run_all.sh,config.yaml,seeds.txt,README.md}` |
| P2 deterministic disclosure | `benchmarks/REPRODUCIBILITY.md` (determinism tiers, fingerprint, seeds) |
| P3 community program | `benchmarks/REPRODUCTION_PROGRAM.md` + `.github/ISSUE_TEMPLATE/{reproduction-report.yml,config.yml}` |
| P4 report skeleton | `docs/reports/reproducibility-report-v1-SKELETON.md` (framing-locked) |
| P5 announcement drafts | `docs/external/announcement-drafts.md` (**NOT posted** — operator review) |
| P7 challenge | `benchmarks/CHALLENGE.md` (fair-comparison under identical constraints) |
| README fix | `README.md` "Reproduce in 60 seconds" — add missing LRB fixture-build step + one-command path |
| ROADMAP addendum | `ROADMAP.md` v1.0.0 — trigger-gated **vector-compression scalability tier** (Int8 → dim-reduction → IVFPQ → binary), ranked by replay/audit cost; not current work (premise unproven) |

> Note: the ROADMAP addendum (`17b38dc`) is a small, separate-topic doc note co-located here only because of the session branch constraint. It documents the *decision not to build* vector compression yet (gated on a real RAM-exceeding corpus), consistent with the project's premise-before-infra discipline.

## Verification

Core tier run end-to-end from a **fresh-clone simulation** (LRB fixtures deleted then rebuilt), exit 0:

```
RAB S1 : reference 1.000/1.000/1.000 · baseline0 0.275/0.000/0.000 · james 1.000/1.000/1.000
LRB S2 : R@1  Vanilla 0.225 < Naive 0.538 < JAMES 0.688   (JAMES − Naive gap +0.15 > +0.10)
```

Both match the documented reference numbers byte-for-byte. The README quick-block previously failed on a fresh clone (`FileNotFoundError` — gitignored LRB fixtures were never built); this PR adds the `build_lrb_scenario_s1/s2` step both in `run_all.sh` and the README.

Quality delta: exempt (label: `docs`) — no `core/{retrieval,graph,reasoning}` lines touched; this is packaging + documentation over existing runners.

## Out of scope
- **HotpotQA / LongFact integration** — net-new measurement; deferred to a separate cycle (operator decision). Building a "James wins" table for unmeasured benchmarks would violate the honest-framing rule.
- **Vector compression implementation** — trigger-gated (see ROADMAP addendum); not built until a real corpus exceeds RAM.
- **Zenodo DOI minting (P4), Reddit/HN posting (P5), Papers with Code (P6)** — operator/external actions; drafts + skeletons are provided, nothing is auto-published.
- **Docker/compose** — excluded this round (Ollama containerization friction); deterministic core needs no GPU/Ollama anyway.
- **Repro labels creation + issue-template enablement** — one-time repo-settings step (operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)