### PR TITLE
feat(v0.6.1): Phase 4 — privacy gate + monthly cost cap primitives (plumb-first)

### DIFF
--- a/core/model_resolver.py
+++ b/core/model_resolver.py
@@ -497,8 +497,11 @@ def resolution_snapshot() -> dict:
                      "wiki_edit", "vision")
     }
     out["ttl_s"] = _CACHE_TTL_S
-    # v18.7 — Phase 1 marker. Tells any consumer (admin page, future
-    # Phase 2 PR, debugging session) that the lists are populated but
-    # engine.py hasn't been rewired yet.
-    out["phase"] = "phase1_preference_only"
+    # Routing build-out phase marker + Phase-4 introspection live in
+    # core/routing.snapshot() (rule-#5 size discipline).
+    try:
+        from core.routing import snapshot as _rs
+        out.update(_rs())
+    except Exception as exc:
+        out["routing_snapshot_error"] = f"{type(exc).__name__}: {exc}"
     return out

--- a/core/routing/__init__.py
+++ b/core/routing/__init__.py
@@ -1,0 +1,97 @@
+"""v0.6.1 Phase 4 — Privacy + Cost Cap primitives (plumb-first).
+
+Phase 4 of the 5-Phase routing build-out. See
+``docs/design/v0.6.1-phase4-privacy-cost-cap.md`` for the design
+memo and ``docs/reference/routing-matrix.md`` for the phase ladder.
+
+Public API (frozen per design memo §3):
+
+  from core.routing import (
+      # privacy gate
+      PrivacyCheck, detect_pii, check_query_privacy,
+      # cost cap
+      CostStatus, CostBudget, default_budget, check_cap,
+  )
+
+**Plumb-first contract**: these primitives are populated, not yet
+consumed. ``engine.py``, ``call_gemma``, and ``resolve_for_mode``
+are unchanged in Phase 4. The Phase 5 wire (cloud egress decision)
+will call ``check_query_privacy`` + ``check_cap`` before any
+``run_cloud_egress`` call.
+
+Layering vs §5.7.12 / §5.7.13:
+  - §5.7.12 / §5.7.13 = per-entity mask / pass / keep-local INSIDE
+    a cloud call (already shipped in ``core/abstraction/``).
+  - Phase 4 = per-query pre-check that the cloud call can happen
+    at all (privacy gate + cost cap).
+  These are orthogonal axes. A query can pass Phase 4 and still
+  have its individual entities masked by §5.7.12, or fail Phase 4
+  (PII / over-cap) and never reach §5.7.12.
+"""
+from __future__ import annotations
+
+import os
+
+from core.routing.privacy import (
+    PrivacyCheck,
+    check_query_privacy,
+    detect_pii,
+)
+from core.routing.cost_cap import (
+    CostBudget,
+    CostStatus,
+    check_cap,
+    default_budget,
+)
+
+
+def snapshot() -> dict:
+    """Routing-side introspection for ``/admin/llm/resolution``.
+
+    Returns the routing build-out phase marker plus the Phase 4
+    sub-keys (``privacy`` + ``cost_cap``). ``model_resolver.
+    resolution_snapshot()`` merges this dict in. Lives here so the
+    resolver stays under the rule-#5 20 KB ceiling and so the
+    Phase 5 wire extends this single helper rather than editing
+    the resolver again.
+    """
+    out: dict = {
+        "phase": "phase4_privacy_cost_cap_primitives",
+    }
+    try:
+        budget = default_budget()
+        cost = budget.status()
+        out["cost_cap"] = {
+            "cap_usd":      cost.cap_usd,
+            "used_usd_est": cost.used_usd_est,
+            "used_tokens":  cost.used_tokens,
+            "month":        cost.month,
+            "under_cap":    cost.under_cap,
+            "tally_path":   budget.path,
+        }
+    except Exception as exc:  # never break the resolver snapshot
+        out["cost_cap"] = {"error": f"{type(exc).__name__}: {exc}"}
+    out["privacy"] = {
+        "force_local_env": os.environ.get(
+            "JAMES_PRIVACY_FORCE_LOCAL", "",
+        ).strip() == "1",
+        "extra_patterns_configured": bool(
+            os.environ.get("JAMES_PRIVACY_PII_PATTERNS_EXTRA", "").strip(),
+        ),
+    }
+    return out
+
+
+__all__ = [
+    # privacy
+    "PrivacyCheck",
+    "detect_pii",
+    "check_query_privacy",
+    # cost
+    "CostStatus",
+    "CostBudget",
+    "default_budget",
+    "check_cap",
+    # introspection
+    "snapshot",
+]

--- a/core/routing/cost_cap.py
+++ b/core/routing/cost_cap.py
@@ -1,0 +1,241 @@
+"""v0.6.1 Phase 4 — Cost-aware monthly cap (plumb-first).
+
+Single-host monthly token tally backed by an atomic-write JSON
+file. Phase 5 will call ``check_cap`` before any cloud egress;
+this module is callable but has no consumer yet.
+
+Env contract (lazy, resolved at call time for test isolation):
+  JAMES_COST_CAP_MONTHLY_USD : USD ceiling for the current month.
+                                 0.0 (default) = no cap.
+  JAMES_COST_CAP_FILE        : tally file path. Default:
+                                 ``$JAMES_WORKSPACE/.james_cost.json``
+                                 fallback to ``./.james_cost.json``.
+
+Concurrency: last-writer-wins on the tally file. Acceptable for
+the v0.6.1 single-host operator model. Multi-host coordination is
+a v0.6.2+ concern.
+
+File schema (forward-compatible — extra keys allowed):
+  {
+    "month": "2026-06",
+    "tokens": 12345,
+    "usd_est": 0.0738,
+    "schema": 1
+  }
+
+On month rollover or schema-version mismatch, the reader returns
+a fresh tally without overwriting the file — the writer rolls
+over on the next ``record`` call.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import List, NamedTuple, Optional
+
+
+_SCHEMA_VERSION = 1
+_DEFAULT_FILE = ".james_cost.json"
+
+
+class CostStatus(NamedTuple):
+    """Outcome of ``check_cap``.
+
+    under_cap   : True iff the projected total (used + estimate)
+                  stays under cap_usd. Also True when cap_usd == 0.0
+                  (the no-cap branch).
+    used_tokens : tokens recorded for the current month.
+    used_usd_est: USD estimate for the current month.
+    cap_usd     : the cap value in effect (0.0 = no cap).
+    month       : YYYY-MM the tally is bound to.
+    reasons     : list of human strings explaining the verdict
+                  ("over_cap", "no_cap", "fresh_tally", ...).
+    """
+    under_cap:    bool
+    used_tokens:  int
+    used_usd_est: float
+    cap_usd:      float
+    month:        str
+    reasons:      List[str]
+
+
+def _current_month() -> str:
+    """Return YYYY-MM in UTC. Centralised so tests can monkey-patch."""
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+def _resolve_path(explicit: Optional[str] = None) -> str:
+    """Resolve the tally file path with env + workspace fallback."""
+    if explicit:
+        return explicit
+    raw = os.environ.get("JAMES_COST_CAP_FILE", "").strip()
+    if raw:
+        return raw
+    ws = os.environ.get("JAMES_WORKSPACE", "").strip()
+    if ws and os.path.isdir(ws):
+        return os.path.join(ws, _DEFAULT_FILE)
+    return _DEFAULT_FILE
+
+
+def _resolve_cap_env() -> float:
+    """Read JAMES_COST_CAP_MONTHLY_USD at call time."""
+    raw = os.environ.get("JAMES_COST_CAP_MONTHLY_USD", "").strip()
+    if not raw:
+        return 0.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        print(
+            f"[routing.cost_cap] JAMES_COST_CAP_MONTHLY_USD={raw!r} "
+            "not a number; treating as no-cap (0.0)"
+        )
+        return 0.0
+
+
+class CostBudget:
+    """Atomic JSON-file monthly tally.
+
+    Construct directly for tests + scripts; call ``default_budget()``
+    in production to honor env defaults.
+    """
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        cap_usd: float = 0.0,
+    ) -> None:
+        self.path = _resolve_path(path)
+        self.cap_usd = max(0.0, float(cap_usd))
+
+    # ─── load / save ──────────────────────────────────────────────
+    def _load(self) -> dict:
+        """Read the tally file. Missing / malformed → fresh tally
+        (the reader does NOT rewrite; the writer rolls over)."""
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except FileNotFoundError:
+            return {"month": _current_month(), "tokens": 0,
+                    "usd_est": 0.0, "schema": _SCHEMA_VERSION}
+        except (OSError, ValueError) as exc:
+            print(
+                f"[routing.cost_cap] tally file unreadable "
+                f"({self.path}): {exc}; using fresh tally"
+            )
+            return {"month": _current_month(), "tokens": 0,
+                    "usd_est": 0.0, "schema": _SCHEMA_VERSION}
+
+        # Schema-version mismatch → fresh tally (forward-compat).
+        if data.get("schema") != _SCHEMA_VERSION:
+            return {"month": _current_month(), "tokens": 0,
+                    "usd_est": 0.0, "schema": _SCHEMA_VERSION}
+
+        # Month rollover → fresh tally.
+        if data.get("month") != _current_month():
+            return {"month": _current_month(), "tokens": 0,
+                    "usd_est": 0.0, "schema": _SCHEMA_VERSION}
+
+        # Normalise numeric fields.
+        data["tokens"] = int(data.get("tokens", 0) or 0)
+        data["usd_est"] = float(data.get("usd_est", 0.0) or 0.0)
+        return data
+
+    def _save(self, data: dict) -> None:
+        """Atomic write: tmp + os.replace."""
+        directory = os.path.dirname(self.path) or "."
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError:
+            pass
+        tmp = f"{self.path}.tmp.{os.getpid()}.{int(time.time() * 1000)}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+        os.replace(tmp, self.path)
+
+    # ─── operations ───────────────────────────────────────────────
+    def record(self, tokens: int, usd_est: float = 0.0) -> None:
+        """Add tokens + USD estimate to the current month's tally."""
+        data = self._load()
+        data["tokens"] = int(data["tokens"]) + max(0, int(tokens))
+        data["usd_est"] = float(data["usd_est"]) + max(0.0, float(usd_est))
+        self._save(data)
+
+    def status(self) -> CostStatus:
+        """Snapshot the current tally + cap state."""
+        data = self._load()
+        reasons: List[str] = []
+        cap = self.cap_usd
+        if cap <= 0.0:
+            reasons.append("no_cap")
+            under = True
+        else:
+            under = data["usd_est"] < cap
+            reasons.append("under_cap" if under else "over_cap")
+        return CostStatus(
+            under_cap=under,
+            used_tokens=int(data["tokens"]),
+            used_usd_est=float(data["usd_est"]),
+            cap_usd=cap,
+            month=str(data["month"]),
+            reasons=reasons,
+        )
+
+
+def default_budget() -> CostBudget:
+    """Construct a CostBudget honoring the env defaults."""
+    return CostBudget(path=None, cap_usd=_resolve_cap_env())
+
+
+def check_cap(
+    tokens_estimate: int,
+    *,
+    budget: Optional[CostBudget] = None,
+    usd_estimate: float = 0.0,
+) -> CostStatus:
+    """Pre-flight cap check.
+
+    Returns ``under_cap=False`` iff cap_usd > 0.0 AND the projected
+    total (existing usd_est + ``usd_estimate``) would exceed it.
+
+    ``tokens_estimate`` is currently informational (rolled into
+    the CostStatus' projected math when ``usd_estimate`` is 0.0 by
+    assuming a 0.0 USD-per-token rate — i.e. only the explicit
+    ``usd_estimate`` counts). Phase 5 will add a token-rate table
+    so the caller can pass tokens alone.
+    """
+    if budget is None:
+        budget = default_budget()
+    base = budget.status()
+    cap = base.cap_usd
+    if cap <= 0.0:
+        # No cap configured → always under.
+        return base
+    projected = base.used_usd_est + max(0.0, float(usd_estimate))
+    under = projected < cap
+    reasons = list(base.reasons)
+    if under and "over_cap" in reasons:
+        reasons.remove("over_cap")
+        reasons.append("under_cap")
+    elif (not under) and "under_cap" in reasons:
+        reasons.remove("under_cap")
+        reasons.append("over_cap")
+    if tokens_estimate:
+        reasons.append(f"tokens_estimate={int(tokens_estimate)}")
+    return CostStatus(
+        under_cap=under,
+        used_tokens=base.used_tokens,
+        used_usd_est=base.used_usd_est,
+        cap_usd=cap,
+        month=base.month,
+        reasons=reasons,
+    )
+
+
+__all__ = [
+    "CostStatus",
+    "CostBudget",
+    "default_budget",
+    "check_cap",
+]

--- a/core/routing/privacy.py
+++ b/core/routing/privacy.py
@@ -1,0 +1,189 @@
+"""v0.6.1 Phase 4 — Privacy gate (query-level PII pre-check).
+
+Detects structured PII patterns in raw query text *before* any
+cloud egress decision. Orthogonal to §5.7.12's per-entity mask
+(that pass operates inside the cloud call; this one decides
+whether the cloud call can happen at all).
+
+Plumb-first: this module is callable but has no consumer yet.
+Phase 5 will wire ``check_query_privacy`` into the cloud egress
+branch.
+
+Env contract (lazy, resolved at call time for test isolation):
+  JAMES_PRIVACY_FORCE_LOCAL=1
+    When set, ``check_query_privacy`` returns ``force_local=True``
+    on any pattern match. When unset, matches are reported via
+    ``PrivacyCheck.reasons`` for operator observation but do NOT
+    block — the default-OFF posture lets operators monitor false-
+    positive rates before flipping the switch.
+  JAMES_PRIVACY_PII_PATTERNS_EXTRA=name1:regex1,name2:regex2
+    Operator-extensible patterns appended to the shipped set.
+    Invalid regex is logged + skipped; never raises.
+
+Redacted-span policy: matches are returned with first/last 2 chars
+of the value preserved and the middle replaced by ``…``. The raw
+PII never leaves ``detect_pii`` — even ``PrivacyCheck.matched`` is
+safe to log or to surface in the operator dashboard.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import List, NamedTuple, Pattern, Tuple
+
+
+class PrivacyCheck(NamedTuple):
+    """Outcome of a query-level privacy pre-check.
+
+    force_local : if True, the caller MUST NOT egress this query.
+                  Only True when JAMES_PRIVACY_FORCE_LOCAL=1 AND
+                  at least one pattern matched.
+    reasons     : list of pattern names that matched
+                  (e.g. ["korean_rrn", "email"]).
+    matched     : list of (pattern_name, redacted_span) — redacted
+                  spans are safe to log; never contains raw PII.
+    """
+    force_local: bool
+    reasons:     List[str]
+    matched:     List[Tuple[str, str]]
+
+
+# ─── Shipped patterns ──────────────────────────────────────────────
+# Keep these intentionally conservative — false-positives turn into
+# refused cloud calls. Operators extend via the env knob.
+
+# Korean Resident Registration Number: 6 digits, hyphen, 7 digits.
+# Surrounded by word-boundaries to avoid catching plain phone-like
+# digit strings.
+_RRN_RE: Pattern[str] = re.compile(r"\b\d{6}-\d{7}\b")
+
+# Korean mobile: 010-XXXX-XXXX (also tolerates +82 10-XXXX-XXXX and
+# spaced separators).
+_PHONE_KR_RE: Pattern[str] = re.compile(
+    r"(?:\+?82[- ]?1[016789]|0?1[016789])[- ]?\d{3,4}[- ]?\d{4}"
+)
+
+# RFC-5322-simplified email. Good enough for "is there an address
+# in this query?" — not for validation of arbitrary user input.
+_EMAIL_RE: Pattern[str] = re.compile(
+    r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"
+)
+
+# Payment card: 13–19 digits, optionally separated by space or hyphen
+# in groups of four. We do NOT Luhn-validate at this layer — the
+# regex catches the shape; the user-intent layer can choose to drop
+# false-positives. Boundary chars stop matches inside long ID
+# strings.
+_CARD_RE: Pattern[str] = re.compile(
+    r"(?<!\d)(?:\d[ -]?){13,19}(?!\d)"
+)
+
+
+_BUILTIN: List[Tuple[str, Pattern[str]]] = [
+    ("korean_rrn", _RRN_RE),
+    ("phone_kr",   _PHONE_KR_RE),
+    ("email",      _EMAIL_RE),
+    ("card_number", _CARD_RE),
+]
+
+
+def _extra_patterns() -> List[Tuple[str, Pattern[str]]]:
+    """Parse JAMES_PRIVACY_PII_PATTERNS_EXTRA at call time.
+
+    Format: ``name1:regex1,name2:regex2``. Invalid entries are
+    logged + skipped, never raise. Resolved lazily so tests can
+    swap env between calls.
+    """
+    raw = os.environ.get("JAMES_PRIVACY_PII_PATTERNS_EXTRA", "").strip()
+    if not raw:
+        return []
+    out: List[Tuple[str, Pattern[str]]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry or ":" not in entry:
+            continue
+        name, _, pattern = entry.partition(":")
+        name = name.strip()
+        pattern = pattern.strip()
+        if not name or not pattern:
+            continue
+        try:
+            out.append((name, re.compile(pattern)))
+        except re.error as exc:
+            print(
+                f"[routing.privacy] extra pattern '{name}' "
+                f"invalid regex, skipped: {exc}"
+            )
+    return out
+
+
+def _redact(value: str) -> str:
+    """Return a span-safe placeholder for a matched PII value.
+
+    Preserves first/last 2 chars (so the operator can spot which
+    record matched) and collapses the middle with ``…``. Values of
+    4 chars or fewer collapse to a single ``…``.
+    """
+    v = value.strip()
+    if len(v) <= 4:
+        return "…"
+    return f"{v[:2]}…{v[-2:]}"
+
+
+def detect_pii(text: str) -> List[Tuple[str, str]]:
+    """Return matched (pattern_name, redacted_span) pairs.
+
+    Each pattern contributes at most one entry per match. The raw
+    matched span is never returned; ``_redact`` collapses it before
+    return so the caller can log freely.
+
+    Returns ``[]`` for empty / non-str input.
+    """
+    if not text or not isinstance(text, str):
+        return []
+    out: List[Tuple[str, str]] = []
+    for name, pat in (*_BUILTIN, *_extra_patterns()):
+        for m in pat.finditer(text):
+            out.append((name, _redact(m.group(0))))
+    return out
+
+
+def check_query_privacy(
+    text: str,
+    *,
+    force_local_flag: bool | None = None,
+) -> PrivacyCheck:
+    """Query-level PII pre-check (Phase 4 plumb-first).
+
+    Args:
+      text: raw query string.
+      force_local_flag: override env. ``None`` = read
+        ``JAMES_PRIVACY_FORCE_LOCAL`` at call time.
+
+    Returns ``PrivacyCheck``. ``force_local=True`` iff both:
+      - the flag (env or explicit) is True, AND
+      - at least one pattern matched.
+
+    Report-only mode (flag OFF): ``force_local=False`` even when
+    patterns match. ``reasons`` + ``matched`` still populated so
+    operators can monitor false-positive rates before flipping
+    the flag ON.
+    """
+    matched = detect_pii(text)
+    if force_local_flag is None:
+        force_local_flag = (
+            os.environ.get("JAMES_PRIVACY_FORCE_LOCAL", "").strip() == "1"
+        )
+    reasons = sorted({name for name, _ in matched})
+    return PrivacyCheck(
+        force_local=bool(force_local_flag) and bool(matched),
+        reasons=reasons,
+        matched=matched,
+    )
+
+
+__all__ = [
+    "PrivacyCheck",
+    "detect_pii",
+    "check_query_privacy",
+]

--- a/docs/design/v0.6.1-phase4-privacy-cost-cap.md
+++ b/docs/design/v0.6.1-phase4-privacy-cost-cap.md
@@ -1,0 +1,283 @@
+# v0.6.1 Phase 4 — Privacy Gate + Cost-aware Cap (plumb-first)
+
+> **Status**: design-stage, plumb-first. Phase 4 of the
+> 5-Phase routing build-out
+> ([[project_routing_buildout_5phase_v18_7]]). This memo lands
+> with PR #978-+1 alongside `core/routing/{privacy,cost_cap}.py`.
+> Phase 5 will wire these into the cloud egress decision and the
+> resolver's preference selection.
+>
+> **Plumb-first contract**: the primitives in this PR are
+> *populated, not yet consumed*. Default behaviour is byte-
+> identical to v0.6.1 Phase 3c. `engine.py`, `call_gemma`, and
+> `resolve_for_mode` are NOT changed. The only behavioural
+> surface is `resolution_snapshot()['phase']` flipping to
+> `phase4_privacy_cost_cap_primitives` and two new sub-keys
+> (`privacy`, `cost_cap`) for operator introspection.
+
+---
+
+## 1. Why Phase 4 exists
+
+Phase 1–3 measured the *local* routing axis end-to-end:
+
+- Phase 1 — `DEFAULT_PREFERENCE` per mode (plumb-first; PR #969)
+- Phase 2 — chat-mode 3-cell paired measurement + `engine.py`
+  wire to `gemma3:12b` (PR #970/971/972)
+- Phase 3 — retrieval-mode complexity-tier ladder + `engine.py`
+  wire to `gemma3:12b` (PR #974/976/977)
+
+The next step on the 5-Phase roadmap is the cloud egress
+decision. §5.7.12 already pins the trust contract (entity-level
+mask / pass / keep-local), and `core/abstraction/` already
+enforces it inside `run_cloud_egress`. What §5.7.12 deliberately
+does NOT cover is two orthogonal axes that any cloud egress
+decision still has to clear:
+
+1. **Privacy gate (query-level)** — even with the per-entity
+   mask, a query whose *text* contains structured PII (Korean
+   RRN, phone, email, card number) should not egress at all.
+   The abstraction layer protects against KG-tagged entities;
+   raw query text is outside its scope. Phase 4 fills that gap.
+2. **Cost-aware cap (operator budget)** — even a privacy-safe
+   query may exceed a monthly cloud budget. Today the operator
+   has no in-process counter; cost protection is "watch the
+   billing dashboard." Phase 4 adds a file-based monthly tally
+   + a configurable cap.
+
+A third, smaller item — exposing the cloud backend as a
+preference option — is **deferred to Phase 5**. Cloud-as-option
+needs the consumer side (`resolve_for_mode` + `engine.py`) to
+understand the new "cloud / local" axis on the preference list,
+and that wire is the Phase 5 measurement question. This PR
+keeps the cloud surface exactly as §5.7.12 + the existing
+`JAMES_FORCE_CLOUD` env flag describes.
+
+---
+
+## 2. Non-goals (this PR)
+
+- Wiring Phase 4 primitives into the cloud egress path. (Phase 5.)
+- Changing the §5.7.12 trust zone or the §5.7.13 abstraction
+  module API. (Phase 4 layers *above* §5.7.12, not inside.)
+- Adding a PII classifier-ML model. The detector is regex-only
+  for v0.6.1; operator-extensible patterns are an env knob.
+- Cross-process or persisted-DB cost tally. The tally is a
+  single JSON file written atomically — fits the v0.6.1
+  single-host operator model. Multi-host coordination is a
+  v0.6.2+ concern.
+- Quality measurement. There is no quality delta to measure
+  for a plumb-first primitive that has no consumer. CLAUDE.md
+  rule #2 exemption: label `code` (no `core/retrieval`,
+  `core/graph` traversal, or `core/reasoning` lines touched).
+
+---
+
+## 3. Public API (frozen for Phase 4)
+
+```python
+from core.routing import (
+    # privacy gate
+    PrivacyCheck, detect_pii, check_query_privacy,
+    # cost cap
+    CostStatus, CostBudget, default_budget, check_cap,
+)
+```
+
+### 3.1 Privacy gate
+
+```python
+class PrivacyCheck(NamedTuple):
+    force_local: bool            # if True, caller MUST NOT egress
+    reasons:     list[str]       # ["korean_rrn", "email", ...]
+    matched:     list[tuple[str, str]]  # (pattern_name, redacted_span)
+
+def detect_pii(text: str) -> list[tuple[str, str]]:
+    """Return matched (pattern_name, redacted_span) pairs."""
+
+def check_query_privacy(
+    text: str,
+    *,
+    force_local_flag: bool | None = None,  # None → env
+) -> PrivacyCheck:
+    """Query-level PII pre-check. force_local=True iff
+    JAMES_PRIVACY_FORCE_LOCAL=1 AND at least one pattern matches.
+
+    Operators can extend patterns via
+      JAMES_PRIVACY_PII_PATTERNS_EXTRA=name1:regex1,name2:regex2
+    """
+```
+
+Patterns shipped by default:
+
+| Name | Regex sketch | Why |
+|---|---|---|
+| `korean_rrn` | 6 digits + `-` + 7 digits (`\d{6}-\d{7}`) | Korean Resident Registration Number |
+| `phone_kr` | `010-\d{4}-\d{4}` (also `+82` form) | Korean mobile |
+| `email` | RFC 5322 simplified | universal PII |
+| `card_number` | 4×4-digit Luhn-shaped | payment card |
+
+**Important**: the detector returns a **redacted span** (first/last
+2 chars + `…`), not the raw match. The PrivacyCheck struct
+never carries the raw PII so logging it is safe.
+
+### 3.2 Cost-aware cap
+
+```python
+class CostStatus(NamedTuple):
+    under_cap:        bool
+    used_tokens:      int      # this month, all backends counted
+    used_usd_est:     float    # rough estimate
+    cap_usd:          float    # 0.0 = no cap
+    month:            str      # "2026-06"
+    reasons:          list[str]
+
+class CostBudget:
+    """Atomic JSON-file monthly tally. Default file:
+    `.james_cost.json` in JAMES_WORKSPACE (or cwd as fallback)."""
+
+    def __init__(self, path: str | None = None,
+                 cap_usd: float = 0.0): ...
+    def record(self, tokens: int, usd_est: float = 0.0) -> None: ...
+    def status(self) -> CostStatus: ...
+
+def default_budget() -> CostBudget:
+    """Reads JAMES_COST_CAP_MONTHLY_USD + JAMES_COST_CAP_FILE."""
+
+def check_cap(
+    tokens_estimate: int,
+    *,
+    budget: CostBudget | None = None,
+) -> CostStatus:
+    """Pre-flight cap check. under_cap=False stops the egress."""
+```
+
+Atomic write protocol: write `<file>.tmp`, `os.replace` to `<file>`.
+The file format is forward-compatible (extra keys allowed) so a
+future v0.6.2 can add per-backend tallies without breaking
+the Phase 4 reader.
+
+### 3.3 Env contract
+
+| Env | Default | Effect |
+|---|---|---|
+| `JAMES_PRIVACY_FORCE_LOCAL` | unset (OFF) | When `1`, `check_query_privacy` returns `force_local=True` on any pattern match. When unset, returns matched patterns for *reporting* but `force_local=False` (no behaviour change). |
+| `JAMES_PRIVACY_PII_PATTERNS_EXTRA` | unset | Comma-separated `name:regex` pairs. Validated at import-time; bad regex logged + skipped, never raises. |
+| `JAMES_COST_CAP_MONTHLY_USD` | `0.0` | USD ceiling for the current month. `0.0` = no cap. |
+| `JAMES_COST_CAP_FILE` | `.james_cost.json` in `JAMES_WORKSPACE` (fallback: cwd) | Tally file path. Operator can point at a shared volume across processes if they accept the last-writer-wins semantics. |
+
+All four env reads are **lazy** (resolved at function-call time,
+not import-time) so test isolation works.
+
+---
+
+## 4. Where the consumer lives (Phase 5, not this PR)
+
+The intended Phase 5 consumer site:
+
+```python
+# scripts/research/local_vs_cloud_paired.py + the eventual
+# router cloud branch in core/reasoning (Phase 5)
+
+from core.routing import check_query_privacy, check_cap
+
+priv = check_query_privacy(query_text)
+if priv.force_local:
+    return run_local(...)              # privacy gate
+
+cost = check_cap(tokens_estimate)
+if not cost.under_cap:
+    return run_local(...)              # cost cap
+
+# §5.7.12 trust zone still applies on entity level
+return run_cloud_egress(...)
+```
+
+Phase 5 measurement is: "does the cloud egress decision survive
+the privacy gate + cost cap in production traffic?" That requires
+a real cloud workload trace, which is operator-pending (skeleton
+§3 row "Track E v0.2.3b cross-model runner").
+
+Until Phase 5 wires the consumer, the primitives are inspectable
+via `resolution_snapshot()['privacy']` + `['cost_cap']` and
+via `scripts/research/routing_matrix_probe.py --phase4` (no live
+LLM needed — it's pure introspection).
+
+---
+
+## 5. Test plan
+
+1. **Unit tests for `detect_pii`** — every shipped pattern hits +
+   misses on canonical samples. Redacted span never contains the
+   full raw value.
+2. **Unit tests for `check_query_privacy`** — env flag ON/OFF
+   matrix × pattern-match yes/no. `force_local` only flips when
+   both ON AND match.
+3. **Unit tests for `CostBudget`** — atomic write (tmp+replace),
+   month rollover detected, malformed file → fresh tally
+   (logged), 0.0 cap → always under_cap.
+4. **Unit tests for `check_cap`** — over/under boundary, missing
+   file fresh, cap=0.0 short-circuits.
+5. **Lock-test extension** — `tests/test_measurement_critical_
+   surfaces.py` gets a `RoutingPhase4Surface` class asserting the
+   import surface stays stable (PrivacyCheck / CostStatus
+   namedtuples + 4 public callables) so future routing PRs catch
+   accidental renames before merge.
+6. **Pre-flight check extension** — `scripts/research/pre_flight_
+   check.py` gets `check_phase4_primitives_import()` so the
+   measurement harness fails fast if the routing primitives
+   regress.
+
+No live LLM call required for any of these.
+
+---
+
+## 6. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| PII regex false-positive blocks legitimate queries | `JAMES_PRIVACY_FORCE_LOCAL` is OFF by default. When OFF, the gate *reports* matches via `PrivacyCheck.reasons` but does not block. Operators turn it ON only after observing the report. |
+| Cost tally file corruption | Atomic write + on-read fallback to fresh tally with a logged warning. Worst case: one month of cost data is lost; the cap still functions for the rest of the month. |
+| Operator confuses Phase 4 with §5.7.12 | This memo + the routing-matrix doc make the layering explicit: §5.7.12 = per-entity mask inside the cloud call; Phase 4 = per-query pre-check that the cloud call can happen at all. |
+| Plumb-first dead code rots | `resolution_snapshot()['phase']` marker + lock-test + Phase 5 entry in [[project_routing_buildout_5phase_v18_7]] all point at the consumer site. If Phase 5 is abandoned, this memo's §4 becomes the removal checklist. |
+
+---
+
+## 7. Module size + rule discipline
+
+- `core/routing/__init__.py` — re-export only (well under 5 KB).
+- `core/routing/privacy.py` — single-file detector + check
+  (~6 KB target).
+- `core/routing/cost_cap.py` — single-file budget + check
+  (~5 KB target).
+- `tests/test_routing_phase4.py` — combined unit tests
+  (~8 KB target).
+
+All four well under the rule #5 20 KB ceiling.
+
+**Rule check**:
+- Rule #1 (no domain features): ✅ pure infrastructure
+- Rule #2 (bench numbers + Quality Delta Card): ✅ exempt
+  (`code` label — no `core/retrieval` / `core/graph` traversal /
+  `core/reasoning` lines touched; the PR introduces primitives,
+  there is no consumer to measure)
+- Rule #3 (self-evolution opt-in): n/a
+- Rule #4 (architecture changes): ✅ no §5.7.x change — Phase 4
+  layers above the existing §5.7.12 / §5.7.13 contract; ARCHITECTURE
+  doc update follows Phase 5 wire, not this primitive PR
+- Rule #5 (module size): ✅ all new files well under 20 KB
+
+---
+
+## 8. References
+
+- [[project_routing_buildout_5phase_v18_7]] — 5-Phase build-out
+  status (this PR advances Phase 1–3 ✅ to Phase 4 plumb-first)
+- §5.7.12 / §5.7.13 — cloud egress trust zone + abstraction
+  module (the layer Phase 4 sits above)
+- `core/abstraction/_policy.py` — per-entity decision (orthogonal
+  to Phase 4's per-query check)
+- `core/model_resolver.py` — Phase 1 plumbing this PR extends
+  the snapshot of
+- `docs/reference/routing-matrix.md` — updated to mark Phase 4
+  as plumb-first + reference this memo

--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -96,8 +96,43 @@ separate from the backend-tier system:
   - ✅ 3a — `LOCAL_TIER_LADDER` + `resolve_local_tier()` defined (plumb-first)
   - ✅ 3b — complexity-paired measurement done (4-cell: 4b/gemma4:e4b/12b/27b × multihop). **gold-grounded reversal**: judge-only said escalation pointless, but gold_signals shows 27b=1.000 > 12b=0.889 > 4b=0.852 > gemma4:e4b=0.815. Escalation has a basis (modest +0.111) but costs 2.3× latency + verbose answers. Side finding: gemma4:e4b (current default) is *lowest* on evidence-rich retrieval. See `reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md`.
   - ✅ 3c — **retrieval mode wired** to `resolve_for_mode("retrieval", "")` → gemma3:12b (the measured-best *default*; gemma4:e4b demoted as weakest on evidence-rich retrieval). Done via the same engine.py mode-routing block as chat (kill-switch generalized to `JAMES_DISABLE_MODE_AWARE_ROUTING`). **Full 27b complexity escalation NOT auto-wired** — the +0.111 gold-accuracy gain over 12b doesn't justify 2.3× latency + verbose answers for a default path. `LOCAL_TIER_LADDER` infra (3a) preserved for a future verify-stage-only deep escalation with verbosity-curbing response_style. `JAMES_AUTO_ROUTER` stays OFF.
-- ⏳ Phase 4 — privacy gate (PII) + cost-aware cap + cloud (Claude) routing
-- ⏳ Phase 5 — sub-class routing inside chat + admin routing dashboard
+- 🔄 **Phase 4** — privacy gate (PII) + cost-aware cap
+  - ✅ 4a — `core/routing/` primitives shipped **plumb-first** (PR
+    #978-+1): `PrivacyCheck` / `detect_pii` / `check_query_privacy`
+    + `CostStatus` / `CostBudget` / `default_budget` / `check_cap`.
+    Default behaviour byte-identical to Phase 3c — `engine.py`,
+    `call_gemma`, `resolve_for_mode` unchanged. `resolution_snapshot()`
+    advances to `phase4_privacy_cost_cap_primitives` and exposes
+    `privacy` + `cost_cap` sub-keys for operator introspection.
+    Surface locked by `RoutingPhase4Surface` lock-test + the
+    `routing_phase4_primitives` pre-flight check. Design memo:
+    `docs/design/v0.6.1-phase4-privacy-cost-cap.md`.
+  - ⏳ 4b — cloud egress consumer wire. Defers to Phase 5 because
+    the Phase-5 cloud-as-preference question and the privacy + cost
+    consumer share the same site (`scripts/research/local_vs_cloud_
+    paired.py` + the eventual router cloud branch). Plumb-first
+    primitives ready to drop into that wire.
+- ⏳ Phase 5 — cloud as preference option + sub-class routing inside chat + admin routing dashboard
+
+**Phase 4 env contract** (all default OFF / no-cap):
+
+| Env | Default | Effect |
+|---|---|---|
+| `JAMES_PRIVACY_FORCE_LOCAL` | unset (OFF) | When `1`, the gate blocks egress on any PII pattern match. When unset, matches are reported but not blocking. |
+| `JAMES_PRIVACY_PII_PATTERNS_EXTRA` | unset | Comma-separated `name:regex` pairs — operator-extensible patterns. Invalid regex logged + skipped, never raises. |
+| `JAMES_COST_CAP_MONTHLY_USD` | `0.0` | USD ceiling for the current month. `0.0` = no cap. |
+| `JAMES_COST_CAP_FILE` | `$JAMES_WORKSPACE/.james_cost.json` (cwd fallback) | Tally file path. |
+
+Layering vs §5.7.12 / §5.7.13:
+
+- §5.7.12 / §5.7.13 — per-entity mask / pass / keep-local INSIDE a
+  cloud call (already shipped in `core/abstraction/`).
+- Phase 4 — per-query pre-check that the cloud call can happen at
+  all (privacy gate + cost cap).
+
+These are orthogonal. A query can pass Phase 4 and still have its
+entities masked by §5.7.12; or fail Phase 4 (PII / over-cap) and
+never reach §5.7.12.
 
 Related memory: `project_routing_buildout_5phase_v18_7`,
 `project_phase2c_engine_chat_wire_v18_7`,

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -530,6 +530,66 @@ def check_chat_fixture() -> PreFlightResult:
     )
 
 
+def check_routing_phase4_primitives() -> PreFlightResult:
+    """v0.6.1 Phase 4 — verify ``core/routing`` plumb-first primitives
+    are importable and expose the locked surface.
+
+    Phase 4 is plumb-first: no consumer exists yet, but the Phase 5
+    cloud egress wire (and the eventual Phase 5 paired measurement
+    over the cloud branch) will call ``check_query_privacy`` +
+    ``check_cap`` before any ``run_cloud_egress`` invocation. This
+    check guards the import path so a regression in the routing
+    primitives is caught BEFORE a paired run goes out with a half-
+    wired cloud branch.
+
+    Symbol set mirrors ``RoutingPhase4Surface`` in
+    ``tests/test_measurement_critical_surfaces.py``.
+    """
+    required = (
+        "PrivacyCheck", "detect_pii", "check_query_privacy",
+        "CostStatus", "CostBudget", "default_budget", "check_cap",
+    )
+    try:
+        import core.routing as routing_pkg
+    except Exception as exc:
+        return PreFlightResult(
+            "routing_phase4_primitives",
+            "fail",
+            f"core.routing import failed: {type(exc).__name__}: {exc}",
+        )
+    missing = [s for s in required if not hasattr(routing_pkg, s)]
+    if missing:
+        return PreFlightResult(
+            "routing_phase4_primitives",
+            "fail",
+            f"core.routing missing Phase 4 symbols: {missing}",
+        )
+    # Smoke: detect_pii('') must not raise and the empty-cap branch
+    # must short-circuit. Both are surface invariants Phase 5 leans on.
+    try:
+        routing_pkg.detect_pii("")
+        budget = routing_pkg.CostBudget(cap_usd=0.0)
+        status = routing_pkg.check_cap(0, budget=budget)
+    except Exception as exc:
+        return PreFlightResult(
+            "routing_phase4_primitives",
+            "fail",
+            f"smoke failed: {type(exc).__name__}: {exc}",
+        )
+    if not status.under_cap:
+        return PreFlightResult(
+            "routing_phase4_primitives",
+            "fail",
+            "check_cap(cap=0.0) did not short-circuit to under_cap=True",
+        )
+    return PreFlightResult(
+        "routing_phase4_primitives",
+        "ok",
+        f"surface stable ({len(required)} symbols); plumb-first "
+        f"(no consumer yet — Phase 5 wires)",
+    )
+
+
 _CHECKS = (
     check_fixture,
     check_chat_fixture,
@@ -538,6 +598,7 @@ _CHECKS = (
     check_abstraction_smoke,
     check_diffusiongemma_opt_in,
     check_thinking_mode_contract,
+    check_routing_phase4_primitives,
 )
 
 

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -510,5 +510,80 @@ class ChatFixtureSurface(unittest.TestCase):
                       "_chat_prompt drops the current query body")
 
 
+class RoutingPhase4Surface(unittest.TestCase):
+    """v0.6.1 v18.7 Phase 4 (2026-06-20) — privacy + cost cap primitives.
+
+    Phase 4 ships ``core/routing/`` as plumb-first: populated, not
+    yet consumed by ``engine.py`` or the cloud egress branch. The
+    lock-tests below freeze the public surface (4 callables + 3
+    namedtuple shapes) so a future Phase 5 wire — or any other PR
+    that re-touches routing primitives — catches accidental renames
+    and tuple-field changes before merge. The Phase 5 consumer site
+    in `local_vs_cloud_paired.py` will rely on the exact symbols
+    locked here.
+    """
+
+    def test_core_routing_public_surface(self):
+        """``core.routing.__all__`` must export the 7 Phase-4
+        public symbols. Adding new ones is allowed; renaming or
+        removing any of these breaks the Phase 5 wire."""
+        import core.routing as routing_pkg
+        required = {
+            "PrivacyCheck",
+            "detect_pii",
+            "check_query_privacy",
+            "CostStatus",
+            "CostBudget",
+            "default_budget",
+            "check_cap",
+        }
+        missing = required - set(getattr(routing_pkg, "__all__", []))
+        self.assertFalse(
+            missing,
+            f"core.routing.__all__ missing Phase 4 symbols: {missing}",
+        )
+        for sym in required:
+            with self.subTest(symbol=sym):
+                self.assertTrue(
+                    hasattr(routing_pkg, sym),
+                    f"core.routing.{sym} not importable",
+                )
+
+    def test_privacy_check_namedtuple_shape(self):
+        from core.routing import PrivacyCheck
+        self.assertEqual(
+            PrivacyCheck._fields,
+            ("force_local", "reasons", "matched"),
+            "PrivacyCheck tuple shape changed — Phase 5 consumer "
+            "unpacks (force_local, reasons, matched) positionally",
+        )
+
+    def test_cost_status_namedtuple_shape(self):
+        from core.routing import CostStatus
+        self.assertEqual(
+            CostStatus._fields,
+            ("under_cap", "used_tokens", "used_usd_est",
+             "cap_usd", "month", "reasons"),
+            "CostStatus tuple shape changed — Phase 5 consumer "
+            "depends on the 6-field layout",
+        )
+
+    def test_detect_pii_callable_no_raise_on_empty(self):
+        """Surface invariant: detect_pii('') must not raise — the
+        Phase 5 consumer may call it on an empty intent slot."""
+        from core.routing import detect_pii
+        self.assertEqual(detect_pii(""), [])
+
+    def test_check_cap_no_cap_short_circuit(self):
+        """Surface invariant: check_cap with cap_usd=0 always
+        returns under_cap=True. Phase 5 must be able to treat the
+        no-cap branch as a pass-through."""
+        from core.routing import CostBudget, check_cap
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as d:
+            b = CostBudget(os.path.join(d, ".cost.json"), cap_usd=0.0)
+            self.assertTrue(check_cap(0, budget=b).under_cap)
+
+
 if __name__ == "__main__":   # pragma: no cover
     unittest.main()

--- a/tests/test_routing_phase4.py
+++ b/tests/test_routing_phase4.py
@@ -1,0 +1,298 @@
+"""v0.6.1 Phase 4 — privacy gate + cost cap unit tests.
+
+Covers the design memo §5 test plan items 1-4. Surface lock-tests
+live in ``test_measurement_critical_surfaces.py`` (item 5); pre-
+flight wiring lives in ``scripts/research/pre_flight_check.py``
+(item 6).
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest import mock
+
+from core.routing import (
+    CostBudget,
+    CostStatus,
+    PrivacyCheck,
+    check_cap,
+    check_query_privacy,
+    default_budget,
+    detect_pii,
+)
+from core.routing.cost_cap import _SCHEMA_VERSION, _current_month
+
+
+# ───────────────────────── privacy ───────────────────────────────
+
+
+class DetectPiiTests(unittest.TestCase):
+    """Pattern hits + misses + redaction safety (memo §5.1)."""
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(detect_pii(""), [])
+        self.assertEqual(detect_pii(None), [])  # type: ignore[arg-type]
+        self.assertEqual(detect_pii(123), [])   # type: ignore[arg-type]
+
+    def test_korean_rrn_match(self):
+        out = detect_pii("주민번호 900101-1234567 입니다")
+        names = [n for n, _ in out]
+        self.assertIn("korean_rrn", names)
+        # redacted span never carries the raw value
+        for name, redacted in out:
+            if name == "korean_rrn":
+                self.assertNotIn("1234567", redacted)
+                self.assertNotIn("900101-1234567", redacted)
+                self.assertIn("…", redacted)
+
+    def test_phone_kr_match(self):
+        out = detect_pii("연락처는 010-1234-5678 입니다")
+        names = [n for n, _ in out]
+        self.assertIn("phone_kr", names)
+
+    def test_email_match(self):
+        out = detect_pii("contact: alice.bob@example.com")
+        names = [n for n, _ in out]
+        self.assertIn("email", names)
+        for name, redacted in out:
+            if name == "email":
+                self.assertNotIn("alice.bob@example.com", redacted)
+
+    def test_card_number_match(self):
+        out = detect_pii("카드번호 4111-1111-1111-1111 확인")
+        names = [n for n, _ in out]
+        self.assertIn("card_number", names)
+
+    def test_clean_text_no_match(self):
+        self.assertEqual(detect_pii("오늘 날씨 어때?"), [])
+        self.assertEqual(
+            detect_pii("Find the latest research papers."), []
+        )
+
+    def test_multiple_patterns_same_text(self):
+        out = detect_pii(
+            "이름 김철수 이메일 kim@a.co 전화 010-1111-2222"
+        )
+        names = {n for n, _ in out}
+        self.assertIn("email", names)
+        self.assertIn("phone_kr", names)
+
+
+class CheckQueryPrivacyTests(unittest.TestCase):
+    """force_local matrix (memo §5.2)."""
+
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in (
+                "JAMES_PRIVACY_FORCE_LOCAL",
+                "JAMES_PRIVACY_PII_PATTERNS_EXTRA",
+            )
+            if k in os.environ
+        }
+
+    def tearDown(self):
+        for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                  "JAMES_PRIVACY_PII_PATTERNS_EXTRA"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+
+    def test_flag_off_match_does_not_block(self):
+        os.environ.pop("JAMES_PRIVACY_FORCE_LOCAL", None)
+        out = check_query_privacy("주민번호 900101-1234567")
+        self.assertIsInstance(out, PrivacyCheck)
+        self.assertFalse(out.force_local)
+        self.assertIn("korean_rrn", out.reasons)
+
+    def test_flag_on_match_blocks(self):
+        os.environ["JAMES_PRIVACY_FORCE_LOCAL"] = "1"
+        out = check_query_privacy("주민번호 900101-1234567")
+        self.assertTrue(out.force_local)
+        self.assertIn("korean_rrn", out.reasons)
+
+    def test_flag_on_no_match_does_not_block(self):
+        os.environ["JAMES_PRIVACY_FORCE_LOCAL"] = "1"
+        out = check_query_privacy("오늘 날씨 어때")
+        self.assertFalse(out.force_local)
+        self.assertEqual(out.reasons, [])
+
+    def test_explicit_flag_overrides_env(self):
+        os.environ.pop("JAMES_PRIVACY_FORCE_LOCAL", None)
+        out = check_query_privacy(
+            "이메일 a@b.co", force_local_flag=True,
+        )
+        self.assertTrue(out.force_local)
+
+    def test_extra_pattern_env_extends(self):
+        os.environ["JAMES_PRIVACY_FORCE_LOCAL"] = "1"
+        os.environ["JAMES_PRIVACY_PII_PATTERNS_EXTRA"] = (
+            r"secret_token:SK-[A-Z0-9]{8}"
+        )
+        out = check_query_privacy("api key SK-ABCD1234 here")
+        self.assertTrue(out.force_local)
+        self.assertIn("secret_token", out.reasons)
+
+    def test_invalid_extra_pattern_skipped(self):
+        os.environ["JAMES_PRIVACY_PII_PATTERNS_EXTRA"] = (
+            r"bad:[unclosed"
+        )
+        # Must not raise.
+        out = check_query_privacy("alice@example.com")
+        self.assertIn("email", out.reasons)
+
+
+# ───────────────────────── cost cap ──────────────────────────────
+
+
+class CostBudgetTests(unittest.TestCase):
+    """Atomic write + rollover + fresh-on-error (memo §5.3)."""
+
+    def setUp(self):
+        self.tmpdir = self._mktmp()
+        self.path = os.path.join(self.tmpdir, ".james_cost.json")
+
+    def tearDown(self):
+        for p in (self.path, self.path + ".tmp"):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+        for f in os.listdir(self.tmpdir):
+            try:
+                os.remove(os.path.join(self.tmpdir, f))
+            except OSError:
+                pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _mktmp() -> str:
+        import tempfile
+        return tempfile.mkdtemp(prefix="james_cost_test_")
+
+    def test_fresh_status_no_cap(self):
+        b = CostBudget(self.path, cap_usd=0.0)
+        s = b.status()
+        self.assertTrue(s.under_cap)
+        self.assertEqual(s.used_tokens, 0)
+        self.assertEqual(s.used_usd_est, 0.0)
+        self.assertIn("no_cap", s.reasons)
+
+    def test_record_persists_atomic(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        b.record(tokens=1000, usd_est=0.5)
+        with open(self.path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        self.assertEqual(data["tokens"], 1000)
+        self.assertAlmostEqual(data["usd_est"], 0.5)
+        self.assertEqual(data["schema"], _SCHEMA_VERSION)
+        self.assertEqual(data["month"], _current_month())
+
+    def test_record_accumulates(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        b.record(100, 0.1)
+        b.record(200, 0.2)
+        s = b.status()
+        self.assertEqual(s.used_tokens, 300)
+        self.assertAlmostEqual(s.used_usd_est, 0.3)
+
+    def test_month_rollover_resets(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(
+                {"month": "1999-01", "tokens": 999,
+                 "usd_est": 99.9, "schema": _SCHEMA_VERSION},
+                fh,
+            )
+        s = b.status()
+        self.assertEqual(s.used_tokens, 0)
+        self.assertEqual(s.used_usd_est, 0.0)
+        self.assertEqual(s.month, _current_month())
+
+    def test_schema_mismatch_resets(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(
+                {"month": _current_month(), "tokens": 999,
+                 "usd_est": 99.9, "schema": 999},
+                fh,
+            )
+        s = b.status()
+        self.assertEqual(s.used_tokens, 0)
+
+    def test_malformed_file_fresh_tally(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            fh.write("{ this is not json")
+        s = b.status()
+        self.assertEqual(s.used_tokens, 0)
+
+
+class CheckCapTests(unittest.TestCase):
+    """Boundary + env (memo §5.4)."""
+
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in (
+                "JAMES_COST_CAP_MONTHLY_USD",
+                "JAMES_COST_CAP_FILE",
+            )
+            if k in os.environ
+        }
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix="james_cap_test_")
+        self.path = os.path.join(self.tmpdir, ".james_cost.json")
+
+    def tearDown(self):
+        for k in ("JAMES_COST_CAP_MONTHLY_USD",
+                  "JAMES_COST_CAP_FILE"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+        try:
+            os.remove(self.path)
+        except OSError:
+            pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    def test_no_cap_always_under(self):
+        b = CostBudget(self.path, cap_usd=0.0)
+        s = check_cap(1_000_000, budget=b, usd_estimate=999.0)
+        self.assertTrue(s.under_cap)
+
+    def test_under_cap_projection(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        b.record(0, 5.0)
+        s = check_cap(100, budget=b, usd_estimate=4.0)
+        self.assertTrue(s.under_cap)
+
+    def test_over_cap_projection(self):
+        b = CostBudget(self.path, cap_usd=10.0)
+        b.record(0, 5.0)
+        s = check_cap(100, budget=b, usd_estimate=6.0)
+        self.assertFalse(s.under_cap)
+        self.assertIn("over_cap", s.reasons)
+
+    def test_default_budget_reads_env(self):
+        os.environ["JAMES_COST_CAP_FILE"] = self.path
+        os.environ["JAMES_COST_CAP_MONTHLY_USD"] = "12.50"
+        b = default_budget()
+        self.assertEqual(b.path, self.path)
+        self.assertAlmostEqual(b.cap_usd, 12.5)
+
+    def test_default_budget_bad_cap_falls_to_zero(self):
+        os.environ["JAMES_COST_CAP_MONTHLY_USD"] = "not-a-number"
+        b = default_budget()
+        self.assertEqual(b.cap_usd, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 4 of the 5-Phase routing build-out. Ships two **plumb-first** primitives in a new `core/routing/` package, layered orthogonally above §5.7.12 / §5.7.13:

- **Privacy gate** (`core/routing/privacy.py`) — query-level PII pre-check. 4 shipped regex patterns (`korean_rrn`, `phone_kr`, `email`, `card_number`) + env-extensible. `check_query_privacy()` returns `PrivacyCheck(force_local, reasons, matched)` with redacted spans. `force_local=True` only when `JAMES_PRIVACY_FORCE_LOCAL=1` AND a match exists; default OFF is report-only so operators monitor FP rates first.
- **Cost cap** (`core/routing/cost_cap.py`) — atomic-write monthly JSON tally + `CostBudget` class + `check_cap()`. Env: `JAMES_COST_CAP_MONTHLY_USD` (default `0.0` = no-cap) + `JAMES_COST_CAP_FILE`. Month rollover, schema mismatch, malformed file all degrade to fresh tally without overwriting.

**Plumb-first contract**: `engine.py`, `call_gemma`, `resolve_for_mode`, and `core/abstraction/` are unchanged. `resolution_snapshot()` merges a new `core/routing.snapshot()` helper that advances `phase` to `phase4_privacy_cost_cap_primitives` and exposes `privacy` + `cost_cap` sub-keys for `/admin/llm/resolution`. Phase 5 will wire the consumer (cloud egress decision in `local_vs_cloud_paired.py` + the eventual router cloud branch).

**Layering vs §5.7.12 / §5.7.13** — orthogonal. §5.7.x = per-entity mask *inside* a cloud call (`core/abstraction/`). Phase 4 = per-query pre-check that the cloud call can happen *at all*. A query can pass Phase 4 and still have entities masked by §5.7.x, or fail Phase 4 (PII / over-cap) and never reach §5.7.x.

## Verification

- `python -m unittest tests.test_routing_phase4` — **24/24 ✓** (8 PII patterns + 6 PrivacyCheck matrix + 6 CostBudget atomic + 4 check_cap boundary)
- `python -m unittest tests.test_measurement_critical_surfaces` — **46/46 ✓** (includes new `RoutingPhase4Surface` 5-test lock — 7 public symbols + 2 namedtuple shapes + 2 surface invariants)
- `python scripts/research/pre_flight_check.py` — **PASS 0 warnings** with new `routing_phase4_primitives` check (8th check)
- Module sizes (rule #5): all new files well under 20 KB. `core/model_resolver.py` staged blob = 20,335 bytes (was 20,251) — phase marker + introspection moved into `core/routing.snapshot()` so the resolver doesn't grow toward the ceiling.

**Streak (rule #1/#2)**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `code`) — no `core/retrieval`, `core/graph` traversal, or `core/reasoning` lines touched; PR introduces plumb-first primitives with no consumer to measure.

**Pre-existing failures noted (NOT this PR)**: `tests/test_model_resolver.py` already has 3 failures + 2 errors on `main` since Phase 2b reorder of `DEFAULT_PREFERENCE['chat']` (PR #971). Surfaced for a future cleanup PR; not in Phase 4 scope.

## Out of scope

- Wiring Phase 4 primitives into the cloud egress path (Phase 5)
- §5.7.12 / §5.7.13 trust-zone or abstraction-module API changes
- PII ML classifier (regex-only; operator-extensible env)
- Cross-process / DB-backed cost tally (single-host file model fits v0.6.1; multi-host is v0.6.2+)
- Quality measurement (no consumer = nothing to measure)
- Vertical content per CLAUDE.md rule #1 (blocked until v1.0 / LOI)

## Test plan

- [x] `tests/test_routing_phase4.py` 24/24 green
- [x] `tests/test_measurement_critical_surfaces.py` 46/46 green (incl. 5 new `RoutingPhase4Surface` lock-tests)
- [x] `scripts/research/pre_flight_check.py` 8/8 ok
- [x] Module sizes verified under rule #5 ceiling (resolver blob 20,335 < 20,480)
- [x] Phase marker visible at `/admin/llm/resolution` (manual smoke via `core.model_resolver.resolution_snapshot()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)