### PR TITLE
fix(v0.6.1): refresh stale resolver + coding-model regex tests (5 failures cleared)

### DIFF
--- a/tests/test_coding_mode.py
+++ b/tests/test_coding_mode.py
@@ -55,12 +55,18 @@ class ConfigCodingModelTests(unittest.TestCase):
         # config.CODING_MODEL must be importable.
         import config
         # Re-read the source to catch the hard-coded default literal.
+        # v0.6.1 introduced a ``_llm_setting(...)`` wrapper for DB-first
+        # resolution; the wrapper takes the historical env name and
+        # default in the same positions, so we accept either the raw
+        # ``os.environ.get(...)`` form or the wrapper form, as long as
+        # both the env key and the documented default literal are
+        # present on the CODING_MODEL line.
         src = (Path(__file__).resolve().parent.parent / "config.py").read_text(encoding="utf-8")
         self.assertRegex(
             src,
-            r'CODING_MODEL\s*=\s*os\.environ\.get\(\s*["\']JAMES_CODING_MODEL["\']\s*,\s*["\']qwen2\.5-coder:32b["\']',
-            "config.CODING_MODEL must read JAMES_CODING_MODEL env with "
-            "qwen2.5-coder:32b as the documented fallback default",
+            r'CODING_MODEL\s*=\s*[^\n]*["\']JAMES_CODING_MODEL["\'][^\n]*["\']qwen2\.5-coder:32b["\']',
+            "config.CODING_MODEL must reference JAMES_CODING_MODEL env "
+            "with qwen2.5-coder:32b as the documented fallback default",
         )
         self.assertTrue(hasattr(config, "CODING_MODEL"),
                         "config module must export CODING_MODEL attribute")

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -53,12 +53,13 @@ class ResolveChainTests(unittest.TestCase):
         self.assertIn("gemma3:4b", r.warning)
 
     def test_preference_first_match_wins(self):
-        # If gemma3:4b and gemma3:12b both installed, gemma3:4b should
-        # win (higher in default preference list).
+        # v18.7 Phase 2b reorder (PR #971): chat preference top is
+        # gemma3:12b after the paired measurement. With both 4b + 12b
+        # installed, the resolver picks 12b.
         with mock.patch.object(self.mr, "installed_models",
                                return_value={"gemma3:12b", "gemma3:4b"}):
             r = self.mr.resolve_for_mode("chat", requested="")
-        self.assertEqual(r.tag, "gemma3:4b")
+        self.assertEqual(r.tag, "gemma3:12b")
         self.assertEqual(r.source, "preference")
 
     def test_no_preference_match_falls_to_any(self):
@@ -72,13 +73,15 @@ class ResolveChainTests(unittest.TestCase):
         self.assertIn("last resort", r.warning)
 
     def test_nothing_installed_returns_none_with_install_command(self):
+        # v18.7 Phase 2b reorder (PR #971): the install suggestion is
+        # the head of the preference list, now gemma3:12b.
         with mock.patch.object(self.mr, "installed_models", return_value=set()):
             r = self.mr.resolve_for_mode("chat", requested="gemma3:4b")
         self.assertEqual(r.tag, "")
         self.assertEqual(r.source, "none")
         self.assertIn("ollama pull", r.warning)
         # Suggestion should be the head of the preference list.
-        self.assertIn("gemma3:4b", r.warning)
+        self.assertIn("gemma3:12b", r.warning)
 
     def test_fallback_chain_records_attempts(self):
         # The chain must include at least the requested + every
@@ -200,13 +203,17 @@ class SnapshotTests(unittest.TestCase):
 
 class GemmaClientIntegrationTests(unittest.TestCase):
     """Source-level: gemma_client.call_gemma must call resolve_chat()
-    when model=None. This is the actual production wiring point."""
+    when model=None. This is the actual production wiring point.
+
+    v0.6 package split: ``core.gemma_client`` is now a façade package;
+    the actual ``call_gemma`` source lives in ``core.gemma_client.client``.
+    """
 
     @classmethod
     def setUpClass(cls):
         import inspect
-        from core import gemma_client
-        cls.src = inspect.getsource(gemma_client)
+        from core.gemma_client import client as gemma_client_client
+        cls.src = inspect.getsource(gemma_client_client)
 
     def test_call_gemma_imports_resolver(self):
         self.assertIn("from core.model_resolver import resolve_chat", self.src,


### PR DESCRIPTION
## Summary

Clears 5 pre-existing failures on main since the v0.6.1 Phase 2b chat reorder (PR #971) and the v0.6 gemma_client package split — all measurement-infra hygiene, no behavior change.

- **test_preference_first_match_wins** / **test_nothing_installed_returns_none_with_install_command**: chat preference top is now `gemma3:12b` (was `gemma3:4b`); assertions and install-suggestion expectation follow the measured ranking.
- **GemmaClientIntegrationTests** (3 tests): `core.gemma_client` is now a façade package; the `call_gemma` source lives in `core.gemma_client.client`. Source inspection switched to the client module.
- **test_config_exposes_coding_model**: `config.py`'s `CODING_MODEL` line now flows through the `_llm_setting` wrapper (v0.6.1 DB-first resolution). Regex loosened to require the env name + default literal on the same line, accepting both the raw `os.environ.get` form and the wrapper form.

## Verification

```
python -m unittest tests.test_model_resolver tests.test_coding_mode \
    tests.test_config_env_loading
Ran 30 tests in 8.888s — OK
```

**Streak**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `fix` — measurement-side oracle correction; the very thing being corrected is what would be measured against).

## Out of scope

- Wrapper-form tightening of the regex (the loosened form is correct; the wrapper is the live API)
- Untouched test files that may still be brittle (one-PR-one-fix)
- Vertical content per CLAUDE.md rule #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)