### PR TITLE
feat(v0.6.1): Phase 5a — Phase 4 gate wired into cloud egress site

### DIFF
--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -96,23 +96,36 @@ separate from the backend-tier system:
   - ✅ 3a — `LOCAL_TIER_LADDER` + `resolve_local_tier()` defined (plumb-first)
   - ✅ 3b — complexity-paired measurement done (4-cell: 4b/gemma4:e4b/12b/27b × multihop). **gold-grounded reversal**: judge-only said escalation pointless, but gold_signals shows 27b=1.000 > 12b=0.889 > 4b=0.852 > gemma4:e4b=0.815. Escalation has a basis (modest +0.111) but costs 2.3× latency + verbose answers. Side finding: gemma4:e4b (current default) is *lowest* on evidence-rich retrieval. See `reports/research-runs/v18.7-phase3b-tier-ladder/QUALITY_DELTA_CARD.md`.
   - ✅ 3c — **retrieval mode wired** to `resolve_for_mode("retrieval", "")` → gemma3:12b (the measured-best *default*; gemma4:e4b demoted as weakest on evidence-rich retrieval). Done via the same engine.py mode-routing block as chat (kill-switch generalized to `JAMES_DISABLE_MODE_AWARE_ROUTING`). **Full 27b complexity escalation NOT auto-wired** — the +0.111 gold-accuracy gain over 12b doesn't justify 2.3× latency + verbose answers for a default path. `LOCAL_TIER_LADDER` infra (3a) preserved for a future verify-stage-only deep escalation with verbosity-curbing response_style. `JAMES_AUTO_ROUTER` stays OFF.
-- 🔄 **Phase 4** — privacy gate (PII) + cost-aware cap
-  - ✅ 4a — `core/routing/` primitives shipped **plumb-first** (PR
-    #978-+1): `PrivacyCheck` / `detect_pii` / `check_query_privacy`
-    + `CostStatus` / `CostBudget` / `default_budget` / `check_cap`.
-    Default behaviour byte-identical to Phase 3c — `engine.py`,
-    `call_gemma`, `resolve_for_mode` unchanged. `resolution_snapshot()`
-    advances to `phase4_privacy_cost_cap_primitives` and exposes
-    `privacy` + `cost_cap` sub-keys for operator introspection.
-    Surface locked by `RoutingPhase4Surface` lock-test + the
-    `routing_phase4_primitives` pre-flight check. Design memo:
-    `docs/design/v0.6.1-phase4-privacy-cost-cap.md`.
-  - ⏳ 4b — cloud egress consumer wire. Defers to Phase 5 because
-    the Phase-5 cloud-as-preference question and the privacy + cost
-    consumer share the same site (`scripts/research/local_vs_cloud_
-    paired.py` + the eventual router cloud branch). Plumb-first
-    primitives ready to drop into that wire.
-- ⏳ Phase 5 — cloud as preference option + sub-class routing inside chat + admin routing dashboard
+- ✅ **Phase 4** — privacy gate (PII) + cost-aware cap (plumb-first
+  primitives shipped in PR #980, design memo
+  `docs/design/v0.6.1-phase4-privacy-cost-cap.md`).
+  - ✅ 4a — `core/routing/` primitives: `PrivacyCheck` /
+    `detect_pii` / `check_query_privacy` + `CostStatus` /
+    `CostBudget` / `default_budget` / `check_cap`. Default
+    behaviour byte-identical (force_local OFF, cap=0.0).
+    `resolution_snapshot()` advances to
+    `phase4_privacy_cost_cap_primitives` and exposes `privacy` +
+    `cost_cap` sub-keys for operator introspection. Surface locked
+    by `RoutingPhase4Surface` lock-test + `routing_phase4_primitives`
+    pre-flight check.
+- 🔄 **Phase 5** — cloud egress consumer wire + cloud-as-preference + sub-class routing inside chat + admin routing dashboard
+  - ✅ 5a — **gate wired into the cloud egress site**
+    (`scripts/research/local_vs_cloud_paired.call_cloud_via_
+    abstraction`). Gate calls `check_query_privacy(prompt)` +
+    `check_cap(tokens_estimate, usd_estimate)` BEFORE `run_cloud_
+    egress`. Trips raise `RuntimeError("cloud refused by privacy
+    gate: ...")` / `RuntimeError("cloud refused by cost cap: ...")`
+    which the caller's cloud-error catch records. Source-level
+    invariants locked by `WireSourceInvariantTests` in
+    `tests/test_phase5a_cloud_gate.py` (5 source-pattern checks +
+    3 behaviour tests with mocked egress). Default behaviour
+    byte-identical: gate is a pure no-op until the operator flips
+    `JAMES_PRIVACY_FORCE_LOCAL=1` or sets
+    `JAMES_COST_CAP_MONTHLY_USD>0`.
+  - ⏳ 5b — production router cloud branch wire (same gate, applied
+    inside the eventual `engine.py` cloud route — gated on Phase
+    5 cloud-as-preference measurement).
+  - ⏳ 5c — cloud as preference option + sub-class routing inside chat + admin routing dashboard.
 
 **Phase 4 env contract** (all default OFF / no-cap):
 

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -293,16 +293,54 @@ def call_local(prompt: str, *, model: str, timeout: int = 180,
     return (r.get("response") or "").strip()
 
 
-def call_cloud_via_abstraction(prompt: str, *, timeout: int = 180) -> str:
+def call_cloud_via_abstraction(
+    prompt: str,
+    *,
+    timeout: int = 180,
+    tokens_estimate: int = 0,
+    usd_estimate: float = 0.0,
+) -> str:
     """Cloud call via `core.abstraction.run_cloud_egress` against the
     `ClaudeCodeCliBackend`. The fixture's gold-evidence has no PII so
     `entities=[]` makes the abstraction a no-op — but the full call
     chain (build_map → mask_text → backend.complete → unmask_text →
     emit_egress_event) is exercised end-to-end.
 
+    v0.6.1 Phase 5a — Phase 4 routing primitives are consulted *before*
+    egress:
+
+      1. ``check_query_privacy(prompt)`` — refuses the call if
+         ``JAMES_PRIVACY_FORCE_LOCAL=1`` AND a PII pattern matches.
+      2. ``check_cap(tokens_estimate, usd_estimate)`` — refuses the
+         call if the projected USD total would exceed
+         ``JAMES_COST_CAP_MONTHLY_USD`` (0.0 = no cap, default).
+
+    Default behaviour is byte-identical: both env knobs default OFF /
+    no-cap, so the gate is a pure no-op until an operator opts in.
+    Gate trips raise ``RuntimeError`` with the cause; the caller's
+    cloud-error catch records ``[cloud refused: ...]`` and the row
+    falls through to whatever non-cloud column the cell represents.
+
     Returns the raw text answer (errors propagate up so the per-run row
     records `[cloud error: ...]` in the caller's catch).
     """
+    # v0.6.1 Phase 5a — privacy + cost gate. Both default OFF / no-cap
+    # → no-op unless the operator flips the env.
+    from core.routing import check_cap, check_query_privacy
+
+    priv = check_query_privacy(prompt)
+    if priv.force_local:
+        raise RuntimeError(
+            f"cloud refused by privacy gate: {priv.reasons}"
+        )
+    cost = check_cap(tokens_estimate, usd_estimate=usd_estimate)
+    if not cost.under_cap:
+        raise RuntimeError(
+            f"cloud refused by cost cap: "
+            f"used_usd={cost.used_usd_est:.4f}/{cost.cap_usd:.4f} "
+            f"(month={cost.month})"
+        )
+
     # Local imports — avoid loading the core stack at module import time
     # so `--help` / linting doesn't require the full env.
     from core.abstraction import default_decider, run_cloud_egress

--- a/tests/test_phase5a_cloud_gate.py
+++ b/tests/test_phase5a_cloud_gate.py
@@ -1,0 +1,171 @@
+"""v0.6.1 Phase 5a — Phase 4 gate wired into the cloud egress site.
+
+Verifies the live wire in
+``scripts/research/local_vs_cloud_paired.call_cloud_via_abstraction``:
+
+1. With default env (force_local OFF + no cap), the gate is a pure
+   no-op — the function reaches the cloud backend call as before.
+2. ``JAMES_PRIVACY_FORCE_LOCAL=1`` + PII in prompt → RuntimeError
+   "cloud refused by privacy gate".
+3. ``JAMES_COST_CAP_MONTHLY_USD`` exceeded → RuntimeError
+   "cloud refused by cost cap".
+4. Source-level: the function MUST import ``check_query_privacy`` +
+   ``check_cap`` from ``core.routing`` and refuse on a positive
+   outcome. The source check guards the wire site against accidental
+   removal in a future cleanup.
+
+Cloud is never actually called in any of these tests — the gate
+refuses before the abstraction module is even imported.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parent.parent / "scripts" / "research"),
+)
+
+
+def _fresh_harness():
+    """Re-import the harness so env changes between tests are
+    picked up (the routing primitives resolve env at call time, but
+    re-import keeps the test boundary clean)."""
+    if "local_vs_cloud_paired" in sys.modules:
+        return importlib.reload(sys.modules["local_vs_cloud_paired"])
+    return importlib.import_module("local_vs_cloud_paired")
+
+
+class PrivacyGateRefusalTests(unittest.TestCase):
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                      "JAMES_COST_CAP_MONTHLY_USD")
+            if k in os.environ
+        }
+
+    def tearDown(self):
+        for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                  "JAMES_COST_CAP_MONTHLY_USD"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+
+    def test_privacy_gate_blocks_when_flag_on_and_pii_present(self):
+        os.environ["JAMES_PRIVACY_FORCE_LOCAL"] = "1"
+        harness = _fresh_harness()
+        with self.assertRaises(RuntimeError) as ctx:
+            harness.call_cloud_via_abstraction(
+                prompt="주민번호 900101-1234567 의 의미",
+            )
+        self.assertIn("privacy gate", str(ctx.exception))
+
+    def test_privacy_gate_silent_when_flag_off(self):
+        # With the flag OFF (default), the gate must reach the
+        # downstream egress call without raising. We mock
+        # ``run_cloud_egress`` so the test is hermetic — no real
+        # cloud backend reachable from CI.
+        os.environ.pop("JAMES_PRIVACY_FORCE_LOCAL", None)
+        harness = _fresh_harness()
+        from unittest import mock
+
+        class _Result:
+            text = "answer"
+            error = ""
+
+        fake_egress = mock.MagicMock(return_value=(_Result(), []))
+        # Patch the symbol on the abstraction module so the harness's
+        # local import (``from core.abstraction import ...``) picks
+        # the mock up.
+        with mock.patch(
+            "core.abstraction.run_cloud_egress",
+            fake_egress,
+        ):
+            out = harness.call_cloud_via_abstraction(
+                prompt="주민번호 900101-1234567 의 의미",
+            )
+        self.assertEqual(out, "answer")
+        fake_egress.assert_called_once()
+
+
+class CostCapRefusalTests(unittest.TestCase):
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in ("JAMES_COST_CAP_MONTHLY_USD",
+                      "JAMES_COST_CAP_FILE")
+            if k in os.environ
+        }
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix="phase5a_cap_")
+        self.tally = os.path.join(self.tmpdir, ".james_cost.json")
+        os.environ["JAMES_COST_CAP_FILE"] = self.tally
+
+    def tearDown(self):
+        for k in ("JAMES_COST_CAP_MONTHLY_USD",
+                  "JAMES_COST_CAP_FILE"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+        for f in os.listdir(self.tmpdir):
+            try:
+                os.remove(os.path.join(self.tmpdir, f))
+            except OSError:
+                pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    def test_cost_cap_blocks_when_projection_exceeds(self):
+        os.environ["JAMES_COST_CAP_MONTHLY_USD"] = "1.0"
+        harness = _fresh_harness()
+        # usd_estimate forces the cap projection to fail.
+        with self.assertRaises(RuntimeError) as ctx:
+            harness.call_cloud_via_abstraction(
+                prompt="benign question",
+                tokens_estimate=100,
+                usd_estimate=5.0,
+            )
+        self.assertIn("cost cap", str(ctx.exception))
+
+
+class WireSourceInvariantTests(unittest.TestCase):
+    """The Phase 5a wire MUST stay at the call site. A future cleanup
+    PR that accidentally removes the gate is caught here."""
+
+    @classmethod
+    def setUpClass(cls):
+        harness = _fresh_harness()
+        cls.src = inspect.getsource(harness.call_cloud_via_abstraction)
+
+    def test_imports_routing_primitives(self):
+        self.assertIn("from core.routing import", self.src,
+                      "Phase 5a wire missing: routing import dropped")
+
+    def test_calls_check_query_privacy(self):
+        self.assertIn("check_query_privacy(", self.src,
+                      "Phase 5a wire missing: privacy gate dropped")
+
+    def test_calls_check_cap(self):
+        self.assertIn("check_cap(", self.src,
+                      "Phase 5a wire missing: cost cap dropped")
+
+    def test_refuses_on_force_local(self):
+        self.assertIn("force_local", self.src,
+                      "Phase 5a wire missing: force_local refusal")
+
+    def test_refuses_on_over_cap(self):
+        self.assertIn("under_cap", self.src,
+                      "Phase 5a wire missing: under_cap refusal")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Wires the **plumb-first** Phase 4 primitives (PR #980) into the cloud egress consumer site. Default behaviour byte-identical: gate is a pure no-op until the operator opts in.

**Site**: `scripts/research/local_vs_cloud_paired.call_cloud_via_abstraction` — the only production-relevant cloud egress site in JAMES today (the paired harness is the live measurement infrastructure; production router doesn't yet have a cloud branch).

**Gate** (BEFORE any `run_cloud_egress` call):

1. `check_query_privacy(prompt)` — refuses egress if `JAMES_PRIVACY_FORCE_LOCAL=1` AND a PII pattern matches.
2. `check_cap(tokens_estimate, usd_estimate)` — refuses egress if the projected USD total would exceed `JAMES_COST_CAP_MONTHLY_USD` (`0.0` = no cap, default).

Trips raise `RuntimeError` with the cause; the harness's cloud-error catch records `[cloud refused: ...]` exactly like a backend error.

**Why caller-side**: §5.7.13 contract says PolicyEngine MUST gate egress BEFORE `build_map` runs. Phase 5b will add defense-in-depth inside `run_cloud_egress` + extend the same gate to the eventual production router cloud branch.

## Verification

```
python -m unittest tests.test_phase5a_cloud_gate
Ran 8 tests in 4.717s — OK
```

- 2 privacy gate (refuse with flag ON, silent with flag OFF, mocked egress for hermetic CI)
- 1 cost cap (refuse on over-cap projection)
- 5 source-level invariants (`WireSourceInvariantTests`): import + `check_query_privacy(` + `check_cap(` + `force_local` + `under_cap` all required to stay at the call site

**Streak (rule #1/#2)**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `code`) — measurement harness wire; gate is byte-identical no-op by default. Phase 5b wire will be measured (real cloud workload trace).

## Out of scope

- Defense-in-depth gate inside `core/abstraction/_runner.run_cloud_egress` (Phase 5b)
- Production router cloud branch wire (Phase 5b)
- Token-rate table for the caller-passes-tokens-alone cost path (Phase 5b)
- Quality measurement of the gate (no live cloud workload yet)
- Vertical content per CLAUDE.md rule #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)