### PR TITLE
test(v0.6.1): module-size invariant gate (rule #5) — forward + anti-creep

### DIFF
--- a/tests/test_v06_module_size_gate.py
+++ b/tests/test_v06_module_size_gate.py
@@ -1,0 +1,163 @@
+"""v0.6.1 — CLAUDE.md rule #5 module-size invariant test.
+
+Rule #5: no file in ``core/`` exceeds 20 KB (20,480 bytes,
+LF-normalized).
+
+This test is the safety net behind the seven split refactors that
+landed in PR #900-#908 (v0.5 cycle close addendum) — without it, a
+future PR can push a single file back over 20 KB and reviewers
+have to catch it by hand at PR time.
+
+Two protections:
+
+1. **Forward-only enforcement** — every ``core/**/*.py`` file MUST
+   stay under the 20 KB ceiling, EXCEPT for an explicit grandfather
+   list of files that were already over-cap when this test landed.
+   The grandfather list documents the split-debt TODO so future-self
+   doesn't lose sight of it.
+
+2. **Anti-grandfather creep** — every grandfathered file must STILL
+   be over the ceiling for the entry to remain valid. If a file falls
+   back under the ceiling (good — somebody split it), the entry MUST
+   be removed in the same PR. This stops the list growing silently
+   or holding stale entries that mask a real regression.
+
+Run: ``python -m unittest tests.test_v06_module_size_gate``
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+
+
+CAP_BYTES = 20 * 1024  # 20 KB = 20,480 bytes per CLAUDE.md rule #5
+CORE_DIR = Path(__file__).resolve().parent.parent / "core"
+
+
+# ─── Grandfather list ──────────────────────────────────────────────
+# Files in ``core/`` that were already over the 20 KB cap when this
+# test landed (2026-06-20). Each entry is split-debt: a future PR
+# should split the file into smaller modules and remove the entry.
+#
+# Format: { relative_path: brief_split_plan }. The path is relative
+# to the ``core/`` directory and uses POSIX separators for stability
+# across Windows + Linux CI.
+GRANDFATHERED: dict = {
+    "reasoning/modes/meta.py": (
+        "31.6 KB — handle_meta has grown four sub-modes "
+        "(inventory / theme / entity_type / recent) plus the LLM-"
+        "narrative variant. Split candidate: ``modes/meta/_inventory."
+        "py`` (fast-path) + ``modes/meta/_narrative.py`` (LLM-narr) "
+        "+ ``modes/meta/__init__.py`` (dispatch facade)."
+    ),
+}
+
+
+def _normalized_size(path: Path) -> int:
+    """Return the file size after CRLF → LF normalization.
+
+    Matches the size git stores in its blob for repos with
+    ``core.autocrlf=true`` on Windows — the byte count rule #5
+    actually constrains on disk.
+    """
+    with open(path, "rb") as fh:
+        return len(fh.read().replace(b"\r\n", b"\n"))
+
+
+def _all_core_python_files() -> list[Path]:
+    """Walk ``core/`` and return every ``*.py`` file.
+
+    ``__pycache__`` directories are skipped (Python writes byte-code
+    there and the size has no operator meaning).
+    """
+    out: list[Path] = []
+    for root, dirs, files in os.walk(CORE_DIR):
+        # Prune byte-code dir in-place so os.walk doesn't descend.
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for name in files:
+            if name.endswith(".py"):
+                out.append(Path(root) / name)
+    return out
+
+
+def _rel(path: Path) -> str:
+    """Path relative to core/ as POSIX (stable across OSes)."""
+    return path.relative_to(CORE_DIR).as_posix()
+
+
+class ModuleSizeGateTests(unittest.TestCase):
+    """Rule #5 enforcement (forward-only) + grandfather anti-creep."""
+
+    def test_no_new_oversize_files(self):
+        """Every ``core/**/*.py`` not on the grandfather list MUST
+        stay under the 20 KB ceiling."""
+        violations: list[str] = []
+        for path in _all_core_python_files():
+            rel = _rel(path)
+            if rel in GRANDFATHERED:
+                continue
+            size = _normalized_size(path)
+            if size > CAP_BYTES:
+                violations.append(
+                    f"  {rel}: {size:,} bytes (over cap by "
+                    f"{size - CAP_BYTES:,} bytes)"
+                )
+        if violations:
+            self.fail(
+                "CLAUDE.md rule #5 violation — "
+                f"{len(violations)} file(s) over 20 KB:\n"
+                + "\n".join(violations)
+                + "\n\nEither split the file into smaller modules "
+                "(see e.g. core/abstraction/ for the pattern), or "
+                "if the file genuinely cannot be split right now, "
+                "add it to GRANDFATHERED in this test file with a "
+                "brief split plan."
+            )
+
+    def test_grandfather_entries_still_oversize(self):
+        """Every entry in ``GRANDFATHERED`` must STILL be over the
+        cap. If a file fell back under, the entry is stale (somebody
+        already split it) and MUST be removed in the same PR."""
+        stale: list[str] = []
+        for rel in GRANDFATHERED:
+            path = CORE_DIR / rel
+            if not path.exists():
+                stale.append(
+                    f"  {rel}: grandfather entry exists but file "
+                    f"is missing — entry stale, remove."
+                )
+                continue
+            size = _normalized_size(path)
+            if size <= CAP_BYTES:
+                stale.append(
+                    f"  {rel}: now {size:,} bytes ≤ 20,480 bytes — "
+                    f"file is split-clean, remove grandfather entry."
+                )
+        if stale:
+            self.fail(
+                "Stale grandfather entries — "
+                f"{len(stale)} entry/entries refer to files that no "
+                "longer violate the cap:\n"
+                + "\n".join(stale)
+                + "\n\nRemove the stale entry/entries from "
+                "GRANDFATHERED so the test starts enforcing the cap "
+                "for that file again."
+            )
+
+    def test_grandfather_paths_exist(self):
+        """Every grandfather entry MUST point at a real file.
+        Catches typos in path strings at gate-add time."""
+        missing = [
+            rel for rel in GRANDFATHERED
+            if not (CORE_DIR / rel).exists()
+        ]
+        if missing:
+            self.fail(
+                "Grandfather entries point at missing files:\n  "
+                + "\n  ".join(missing)
+            )
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Skeleton §5.1 NEW solo-doable item. Closes the *module-size lock-test extension* candidate surfaced after the 7 split refactors in the v0.5 close addendum (PR #900-#908).

Three assertions in `tests/test_v06_module_size_gate.py`:

1. **`test_no_new_oversize_files`** — every `core/**/*.py` NOT on the grandfather list MUST stay under 20 KB (CLAUDE.md rule #5).
2. **`test_grandfather_entries_still_oversize`** — every grandfather entry MUST STILL be over the cap. If somebody splits a file under, the entry MUST come out in the same PR (anti-creep).
3. **`test_grandfather_paths_exist`** — typo guard at gate-add time.

Sizing uses CRLF → LF normalization so the test matches the LF-normalized byte count git stores in its blob (the count rule #5 actually constrains on disk across Windows + Linux CI).

**Grandfather list** (split-debt TODO): 1 entry —
- `core/reasoning/modes/meta.py` (31.6 KB) — `handle_meta`'s four sub-modes plus the LLM-narrative variant. Split candidate documented inline.

`intent_classifier.py` was suspected oversize from a raw byte count but the LF-normalized size is 20,382 < 20,480 (under cap) — not grandfathered.

## Verification

```
python -m unittest tests.test_v06_module_size_gate
Ran 3 tests in 0.023s — OK
```

**Streak**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `chore` — tests-only invariant, no production code touched).

## Out of scope

- Actually splitting `core/reasoning/modes/meta.py` (separate refactor PR)
- Extending the cap to `routes/` or `frontend/` (rule #5 only constrains `core/`)
- Per-file size budgets / per-package targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)