### PR TITLE
feat(v0.6.1): Phase wiki_edit-a — fixture + harness path (Phase 2a/3a pattern)

### DIFF
--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -22,7 +22,7 @@
 | **retrieval** | 지식 검색·정보 조회 | **gemma3:12b** | engine.py `resolve_for_mode("retrieval", requested="")` → preference top | `[MODEL] mode=retrieval auto-routed → gemma3:12b` ✅ observed | **measurement-backed (Phase 3c)** |
 | **meta** | 내부자료 인벤토리 | none (no LLM) | fast-path inventory generation | `(fast-path)` ✅ confirmed | n/a |
 | **coding** | 코드 작성·버그 | qwen2.5-coder:32b | `llm.router(task_type="coding")` | `[coding_route]` / router log ✅ | dedicated router |
-| **wiki_edit** | 지식 수정·삭제 (admin) | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent | legacy (unmeasured) |
+| **wiki_edit** | 지식 수정·삭제 (admin) | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent | legacy (Phase wiki_edit-a fixture ✅; measurement + wire pending) |
 | **self_evolve** | 자메스 자기개선 (admin) | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent | legacy (unmeasured) |
 | vision | (FUTURE — not routed) | llava:13b | `call_gemma_vision` direct | n/a | inactive |
 
@@ -108,6 +108,24 @@ separate from the backend-tier system:
     `cost_cap` sub-keys for operator introspection. Surface locked
     by `RoutingPhase4Surface` lock-test + `routing_phase4_primitives`
     pre-flight check.
+- 🔄 **Phase wiki_edit** (parallel to Phase 5)
+  - ✅ wiki_edit-a — fixture + harness path (PR `feat/v0.6.1-wiki-edit-mode-fixture`):
+    `eval/wiki_edit_mode_queries.json` (4 sub-classes × 3: factual_edit
+    / format_edit / summarize / reword; factual_edit + summarize carry
+    `gold_signals` for gold-grounded recheck) +
+    `local_vs_cloud_paired._wiki_edit_prompt` (folds `original_doc` +
+    edit instruction into the prompt body) + `FIXTURES["wiki_edit"]`
+    + `ANSWERABLE_BY_FIXTURE["wiki_edit"]` + pre-flight
+    `check_wiki_edit_fixture` (9th check) + lock-test
+    `WikiEditFixtureSurface` (6 invariants). Default behaviour
+    unchanged; only the `--fixture wiki_edit` CLI is now available.
+  - ⏳ wiki_edit-b — paired measurement (operator launches; same
+    3-cell pattern as Phase 2b chat: gemma4:e4b OFF / gemma3:12b /
+    gemma3:27b paired against the Korean fixture). Cell choice for
+    wiki_edit is informed by the Phase 3b finding (gemma3:27b leads
+    on evidence-rich tasks but 2.3× slower + verbose).
+  - ⏳ wiki_edit-c — engine wire + `DEFAULT_PREFERENCE['wiki_edit']`
+    reorder (post-measurement).
 - 🔄 **Phase 5** — cloud egress consumer wire + cloud-as-preference + sub-class routing inside chat + admin routing dashboard
   - ✅ 5a — **gate wired into the cloud egress site**
     (`scripts/research/local_vs_cloud_paired.call_cloud_via_

--- a/eval/wiki_edit_mode_queries.json
+++ b/eval/wiki_edit_mode_queries.json
@@ -1,0 +1,159 @@
+{
+  "version": "0.1.0",
+  "description": "wiki_edit mode measurement fixture — factual_edit + format_edit + summarize + reword. Korean primary (JAMES production use case per user_profile.md). v18.7 Phase wiki_edit-a prereq.",
+  "source_dataset": "synthesized-jiwon-2026-06-20",
+  "source_license": "CC-BY-4.0 (operator-authored, no third-party content)",
+  "source_citation": "Operator-authored fixture for wiki_edit-mode routing decision (v0.6.1 Phase wiki_edit-a prereq).",
+  "built_at_utc": "2026-06-20T00:00:00Z",
+  "subset": {
+    "factual_edit": 3,
+    "format_edit":  3,
+    "summarize":    3,
+    "reword":       3
+  },
+  "type_distribution": {
+    "factual_edit": "Specific fact substitution / correction inside the original_doc. gold_signals = expected substring after edit (deterministic).",
+    "format_edit":  "Apply markdown structure (heading / bullet / table). judge-only — formatting variability is acceptable.",
+    "summarize":    "Compress the original_doc to ~30% length while preserving key facts. gold_signals = key facts that must remain.",
+    "reword":       "Paraphrase the original_doc without changing facts. judge-only — many valid rewordings."
+  },
+  "scoring_protocol": {
+    "judge": "Claude CLI, pairwise blinded A/B per (query, run). Same judge protocol as multihop_rag + chat fixtures.",
+    "gold_grounded": "Applied to factual_edit + summarize (subset of queries with gold_signals). format_edit + reword report judge-only.",
+    "fairness_caveat": "format_edit / reword cannot be deterministically graded; many valid outputs. Judge bias (per project_judge_reliability_gold_grounded_v18_6: +0.11 to +0.19 over-credit on LOCAL) applies. Reported in Quality Delta Card as 'judge-only' rows."
+  },
+  "queries": [
+    {
+      "id": 3001,
+      "category": "wiki-edit-factual",
+      "question_type": "factual_edit",
+      "text": "본문의 '2023년' 부분을 '2024년' 으로 정정해 주세요. 다른 내용은 그대로 두세요.",
+      "original_doc": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2023년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Edited document with the single year change applied; all other content preserved verbatim.",
+      "gold_signals": ["2024년", "김 교수 연구팀은", "광합성 효소"]
+    },
+    {
+      "id": 3002,
+      "category": "wiki-edit-factual",
+      "question_type": "factual_edit",
+      "text": "두 번째 문장의 수치 '15%' 를 '20%' 로 바꿔 주세요.",
+      "original_doc": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 15% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "abstention_variant": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Replace '15%' with '20%' on the second sentence; the rest verbatim.",
+      "gold_signals": ["20%", "2030년까지 30%", "재생에너지"]
+    },
+    {
+      "id": 3003,
+      "category": "wiki-edit-factual",
+      "question_type": "factual_edit",
+      "text": "본문에서 'Python 3.10' 을 'Python 3.12' 로 정정해 주세요.",
+      "original_doc": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.10 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Replace 'Python 3.10' with 'Python 3.12'; preserve FastAPI/PostgreSQL/Redis lines verbatim.",
+      "gold_signals": ["Python 3.12", "FastAPI 0.110", "PostgreSQL 16", "Redis 7"]
+    },
+    {
+      "id": 3011,
+      "category": "wiki-edit-format",
+      "question_type": "format_edit",
+      "text": "본문을 마크다운 bullet list 로 정리해 주세요. 각 항목은 '- ' 로 시작해야 합니다.",
+      "original_doc": "[Wiki] 보안 체크리스트\nHTTPS 만 허용한다. CSP nonce 를 적용한다. API key 는 환경변수에 둔다. 로그에는 PII 를 남기지 않는다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Four bullet items, each starting with '- '. Contents preserve every original claim.",
+      "gold_signals": []
+    },
+    {
+      "id": 3012,
+      "category": "wiki-edit-format",
+      "question_type": "format_edit",
+      "text": "본문을 '## 개요' / '## 주의사항' 두 섹션 마크다운으로 나눠 주세요.",
+      "original_doc": "[Wiki] 파일 업로드 API\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Two H2 sections labeled '## 개요' and '## 주의사항'; original sentences distributed appropriately.",
+      "gold_signals": []
+    },
+    {
+      "id": 3013,
+      "category": "wiki-edit-format",
+      "question_type": "format_edit",
+      "text": "본문의 비교 내용을 마크다운 표 (header: 항목, 옵션 A, 옵션 B) 로 만들어 주세요.",
+      "original_doc": "[Wiki] 캐시 옵션 비교\n메모리 캐시는 빠르고 휘발성이 있다. 디스크 캐시는 느리지만 영속성이 있다. 메모리 캐시는 무료고 디스크 캐시는 SSD 비용이 든다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Markdown table with header row '| 항목 | 옵션 A | 옵션 B |' and at least 2 data rows comparing the two options.",
+      "gold_signals": []
+    },
+    {
+      "id": 3021,
+      "category": "wiki-edit-summarize",
+      "question_type": "summarize",
+      "text": "본문을 핵심만 남기고 한 문단으로 요약해 주세요. 수치는 보존해 주세요.",
+      "original_doc": "[Wiki] 분기 성과 보고\n2026년 1분기 매출은 120억 원으로 전년 대비 18% 성장했다. 영업이익률은 9.5% 로 작년 동기의 7.2% 대비 개선됐다. 신규 가입자는 4만 5천 명이었고, 이 중 70% 가 기존 채널을 통해 유입됐다. 마케팅 비용은 8억 원으로 매출의 6.7% 수준이었다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "One short paragraph (≈30% length) preserving the four numeric facts.",
+      "gold_signals": ["120억", "18%", "9.5%", "4만 5천"]
+    },
+    {
+      "id": 3022,
+      "category": "wiki-edit-summarize",
+      "question_type": "summarize",
+      "text": "본문을 3 줄 이내로 요약해 주세요. 핵심 결정만 남겨 주세요.",
+      "original_doc": "[Wiki] 2026 라이선싱 결정\n팀은 코어 모듈을 Apache-2.0 으로 유지하기로 결정했다. 새로 추가되는 plug-in SDK 는 MIT 로 공개한다. 단, 제3자 fixture 와 외부 벤치마크 결과는 원저작권을 그대로 보존하며 CITATION.md 에 출처를 명시한다. 상업적 호스팅 서비스는 별도 BSL 조항을 검토 중이다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "≤3 lines covering core=Apache-2.0, SDK=MIT, third-party preserves original license.",
+      "gold_signals": ["Apache-2.0", "MIT", "CITATION"]
+    },
+    {
+      "id": 3023,
+      "category": "wiki-edit-summarize",
+      "question_type": "summarize",
+      "text": "본문을 한 줄로 요약해 주세요.",
+      "original_doc": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지로 plumb-first 하게 도입했다. PII 검출 정규식 4종 + env-extensible, 그리고 atomic JSON 월별 token tally 가 핵심이다. 기본값은 모두 OFF / no-cap 이라 byte-identical 무동작이고, Phase 5 가 cloud egress 시 consumer 로 wire 한다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Single sentence covering Phase 4 = privacy gate + cost cap (plumb-first, default no-op).",
+      "gold_signals": ["Phase 4", "privacy", "cost cap"]
+    },
+    {
+      "id": 3031,
+      "category": "wiki-edit-reword",
+      "question_type": "reword",
+      "text": "본문을 사내 비기술자 독자에게 친근한 어투로 다시 써 주세요. 사실은 바꾸지 마세요.",
+      "original_doc": "[Wiki] 인증 토큰 회전\n인증 토큰은 24시간마다 회전되며 회전 시점에는 모든 활성 세션이 재인증을 요구받는다. 회전 실패 시 시스템은 fallback 모드로 진입한다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Friendlier prose; facts (24h rotation, re-auth, fallback on failure) preserved.",
+      "gold_signals": []
+    },
+    {
+      "id": 3032,
+      "category": "wiki-edit-reword",
+      "question_type": "reword",
+      "text": "본문을 좀 더 간결하고 단정한 사내 문서 톤으로 다시 써 주세요.",
+      "original_doc": "[Wiki] 코드 리뷰 가이드\n사실 코드 리뷰는 좀 부담스러울 수 있어요. 그래도 우리가 함께 더 좋은 결과를 만들려면, 일단 한 번씩은 동료의 PR 을 차분히 봐 주세요. 그리고 너무 큰 PR 은 가급적 피해 주시면 좋겠어요.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "Concise, formal tone; preserves three facts (reviews encouraged / PR review expected / avoid large PRs).",
+      "gold_signals": []
+    },
+    {
+      "id": 3033,
+      "category": "wiki-edit-reword",
+      "question_type": "reword",
+      "text": "본문을 영어로 번역해 주세요. 의미는 충실히 보존해 주세요.",
+      "original_doc": "[Wiki] 백업 정책\n데이터는 매일 자정 백업되며 7일치를 보관한다. 월말 백업은 별도로 1년간 보관한다.",
+      "abstention_truth": "absent",
+      "evidence_required": true,
+      "expected_behavior": "English translation that preserves the daily-midnight cadence, 7-day retention, and the 1-year month-end retention.",
+      "gold_signals": []
+    }
+  ]
+}

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -85,6 +85,12 @@ FIXTURES: Dict[str, Path] = {
     # no third-party license entanglement) — sits under eval/ not under
     # the gitignored workspaces/ tree the multihop_rag corpus lives in.
     "chat": ROOT / "eval" / "chat_mode_queries.json",
+    # v18.7 Phase wiki_edit-a (2026-06-20) — operator-authored fixture
+    # for wiki_edit mode routing. Same eval/ location + tracked, same
+    # rationale as the chat fixture. Each query carries an
+    # ``original_doc`` block that `_wiki_edit_prompt` folds in as the
+    # edit target.
+    "wiki_edit": ROOT / "eval" / "wiki_edit_mode_queries.json",
 }
 
 DEFAULT_LOCAL_MODEL = "gemma3:4b"
@@ -98,6 +104,7 @@ OLLAMA_URL = "http://127.0.0.1:11434/api/generate"
 ANSWERABLE_BY_FIXTURE: Dict[str, Tuple[str, ...]] = {
     "multihop": ("inference_query", "comparison_query", "temporal_query"),
     "chat": ("small_talk", "factual_chat", "open_question", "multi_turn"),
+    "wiki_edit": ("factual_edit", "format_edit", "summarize", "reword"),
 }
 ANSWERABLE = ANSWERABLE_BY_FIXTURE["multihop"]   # legacy alias
 
@@ -160,6 +167,36 @@ def _answer_prompt(context: str, question: str) -> str:
         "\"I don't know\".\n\n"
         f"Context:\n{context}\n\nQuestion: {question}\n\nAnswer:"
     )
+
+
+def _wiki_edit_prompt(query: dict) -> str:
+    """Build a wiki_edit-mode prompt — the original document is folded
+    in as the edit target, then the edit instruction is appended.
+
+    Unlike `_answer_prompt` (which forbids non-evidence content) and
+    `_chat_prompt` (which has no evidence at all), the wiki_edit path
+    REQUIRES the model to rewrite the original_doc per the instruction.
+    The instruction body still keeps a narrow abstention hatch ("if
+    the instruction cannot be applied, say so") but the expected
+    behaviour is a rewritten document, not a refusal.
+    """
+    doc = (query.get("original_doc") or "").strip()
+    parts: List[str] = [
+        "You are editing an existing internal-wiki document. Apply the "
+        "edit instruction to the document below, preserving everything "
+        "the instruction does not change. Mirror the user's language "
+        "(Korean ↔ English). If the instruction genuinely cannot be "
+        "applied to the document as written, reply with exactly: "
+        "\"INSTRUCTION_NOT_APPLICABLE\".",
+        "",
+        "Original document:",
+        doc,
+        "",
+        f"Edit instruction: {query['text']}",
+        "",
+        "Edited document:",
+    ]
+    return "\n".join(parts)
 
 
 def _chat_prompt(query: dict) -> str:
@@ -464,10 +501,17 @@ def run_one_query(
     fixture_name: str = "multihop",
 ) -> Dict[str, Any]:
     """One paired (local + cloud + judge) trial. Returns a row dict.
-    `fixture_name=chat` switches the prompt template to the chat-mode
-    free-form path (prior_turns + no evidence injection)."""
+
+    Prompt template per fixture:
+      - ``multihop`` (default): evidence-grounded answer (``_answer_prompt``).
+      - ``chat``:               free-form chat (``_chat_prompt``).
+      - ``wiki_edit``:          edit the embedded ``original_doc``
+                                (``_wiki_edit_prompt``).
+    """
     if fixture_name == "chat":
         prompt = _chat_prompt(query)
+    elif fixture_name == "wiki_edit":
+        prompt = _wiki_edit_prompt(query)
     else:
         prompt = _answer_prompt(ctx, query["text"])
     t0 = time.time()
@@ -759,6 +803,19 @@ def main() -> int:
             # Chat-mode skips evidence assembly entirely. The prompt
             # template injects prior_turns (multi_turn) instead.
             ctx, n_nodes, n_res = "", 0, 0
+        elif args.fixture == "wiki_edit":
+            # wiki_edit folds the embedded original_doc into the prompt
+            # template; no external evidence assembly is needed. The
+            # n_nodes/n_res signals are reused to surface "doc length"
+            # for log readability.
+            doc = q.get("original_doc") or ""
+            ctx = ""
+            n_nodes = 1
+            n_res = 1 if doc.strip() else 0
+            if n_res == 0:
+                print(f"[{i}/{len(queries)}] id={q['id']} SKIPPED "
+                      f"(no original_doc in record)")
+                continue
         else:
             ctx, n_nodes, n_res = build_evidence(q)
             if n_res == 0:
@@ -766,8 +823,12 @@ def main() -> int:
                       f"(no resolved articles for {n_nodes} expected)")
                 continue
         prior_n = len(q.get("prior_turns") or [])
-        hop_hint = (f"prior_turns={prior_n}" if args.fixture == "chat"
-                    else f"hops={n_nodes}(res {n_res})")
+        if args.fixture == "chat":
+            hop_hint = f"prior_turns={prior_n}"
+        elif args.fixture == "wiki_edit":
+            hop_hint = f"doc_chars={len(q.get('original_doc') or '')}"
+        else:
+            hop_hint = f"hops={n_nodes}(res {n_res})"
         print(f"[{i}/{len(queries)}] id={q['id']} {q['question_type']} "
               f"{hop_hint}")
         for run_idx in range(args.n_runs):

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -590,9 +590,99 @@ def check_routing_phase4_primitives() -> PreFlightResult:
     )
 
 
+def check_wiki_edit_fixture() -> PreFlightResult:
+    """v0.6.1 Phase wiki_edit-a (2026-06-20) — wiki_edit-mode fixture.
+
+    Mirrors ``check_chat_fixture``. Asserts:
+      - fixture registered in ``harness.FIXTURES['wiki_edit']``
+      - file exists + parses
+      - 4 sub-classes each have ≥3 rows (paired ``n_per_type=3`` default)
+      - ``factual_edit`` + ``summarize`` rows carry ``gold_signals``
+        (gold-grounded recheck per
+        ``project_judge_reliability_gold_grounded_v18_6``)
+      - every row carries a non-empty ``original_doc`` (the prompt
+        template needs it; missing docs would silently degrade to an
+        empty edit target).
+    """
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from local_vs_cloud_paired import (
+            ANSWERABLE_BY_FIXTURE, FIXTURES,
+        )
+    except Exception as exc:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"harness import failed: {type(exc).__name__}: {exc}",
+        )
+    path = FIXTURES.get("wiki_edit")
+    if path is None:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            "FIXTURES['wiki_edit'] not registered",
+        )
+    if not path.exists():
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"fixture file missing: {path}",
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"fixture unreadable: {type(exc).__name__}: {exc}",
+        )
+    rows = data.get("queries", [])
+    counts: dict = {}
+    for q in rows:
+        counts[q.get("question_type", "?")] = (
+            counts.get(q.get("question_type", "?"), 0) + 1
+        )
+    expected = ANSWERABLE_BY_FIXTURE.get("wiki_edit", ())
+    for t in expected:
+        if counts.get(t, 0) < 3:
+            return PreFlightResult(
+                "wiki_edit_fixture", "fail",
+                f"sub-class {t!r} has only {counts.get(t, 0)} rows; "
+                "paired default needs 3",
+            )
+    factual_with_gold = sum(
+        1 for q in rows
+        if q.get("question_type") == "factual_edit" and q.get("gold_signals")
+    )
+    summarize_with_gold = sum(
+        1 for q in rows
+        if q.get("question_type") == "summarize" and q.get("gold_signals")
+    )
+    if factual_with_gold < 3:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"factual_edit rows with gold_signals: {factual_with_gold} < 3",
+        )
+    if summarize_with_gold < 3:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"summarize rows with gold_signals: {summarize_with_gold} < 3",
+        )
+    missing_docs = [q.get("id") for q in rows
+                    if not (q.get("original_doc") or "").strip()]
+    if missing_docs:
+        return PreFlightResult(
+            "wiki_edit_fixture", "fail",
+            f"rows missing original_doc: {missing_docs}",
+        )
+    return PreFlightResult(
+        "wiki_edit_fixture", "ok",
+        f"{len(rows)} wiki_edit queries available "
+        f"(counts={counts}, factual_with_gold={factual_with_gold}, "
+        f"summarize_with_gold={summarize_with_gold})",
+    )
+
+
 _CHECKS = (
     check_fixture,
     check_chat_fixture,
+    check_wiki_edit_fixture,
     check_regex_false_positives,
     check_backend_registry,
     check_abstraction_smoke,

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -509,6 +509,107 @@ class ChatFixtureSurface(unittest.TestCase):
                       "_chat_prompt drops the current query body")
 
 
+class WikiEditFixtureSurface(unittest.TestCase):
+    """v0.6.1 v18.7 Phase wiki_edit-a prereq (2026-06-20) — wiki_edit-mode
+    fixture. Mirrors ``ChatFixtureSurface``.
+
+    The wiki_edit fixture is operator-authored (not derived from a
+    public benchmark), so there is no upstream alarm if a UX cycle
+    silently edits it. The lock-tests below freeze the surface the
+    harness consumes — file location, sub-class counts, factual_edit
+    gold_signals coverage, every-row-has-original_doc contract, and
+    that ``_wiki_edit_prompt`` actually folds the doc + instruction
+    into the prompt body.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _import_harness()
+
+    def test_wiki_edit_fixture_registered_in_harness(self):
+        from local_vs_cloud_paired import FIXTURES
+        self.assertIn(
+            "wiki_edit", FIXTURES,
+            "harness FIXTURES dict missing 'wiki_edit' entry — the "
+            "--fixture wiki_edit CLI will fail. Phase wiki_edit-a "
+            "prereq broken.",
+        )
+
+    def test_wiki_edit_fixture_file_exists(self):
+        from local_vs_cloud_paired import FIXTURES
+        path = FIXTURES["wiki_edit"]
+        self.assertTrue(
+            path.exists(),
+            f"wiki_edit fixture file missing: {path}. "
+            f"--fixture wiki_edit will raise FileNotFoundError.",
+        )
+
+    def test_wiki_edit_fixture_subclasses_complete(self):
+        """All 4 wiki_edit sub-classes must carry ≥ 3 rows so the
+        default run (n_per_type=3) can build the paired sample."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["wiki_edit"].read_text(encoding="utf-8"))
+        for t in ("factual_edit", "format_edit", "summarize", "reword"):
+            with self.subTest(sub_class=t):
+                rows = [q for q in data.get("queries", [])
+                        if q.get("question_type") == t]
+                self.assertGreaterEqual(
+                    len(rows), 3,
+                    f"wiki_edit sub-class {t!r} only has {len(rows)} "
+                    f"rows — paired default needs 3.",
+                )
+
+    def test_wiki_edit_factual_have_gold_signals(self):
+        """factual_edit is the deterministic sub-class — every row
+        must carry gold_signals so gold-grounded recheck applies."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["wiki_edit"].read_text(encoding="utf-8"))
+        factuals = [q for q in data.get("queries", [])
+                    if q.get("question_type") == "factual_edit"]
+        for q in factuals:
+            with self.subTest(id=q.get("id")):
+                self.assertTrue(
+                    bool(q.get("gold_signals")),
+                    f"factual_edit id={q.get('id')} missing "
+                    f"gold_signals — gold-grounded recheck cannot "
+                    f"score this row.",
+                )
+
+    def test_wiki_edit_every_row_has_original_doc(self):
+        """Every wiki_edit row MUST carry a non-empty original_doc;
+        the prompt template needs it as the edit target."""
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["wiki_edit"].read_text(encoding="utf-8"))
+        for q in data.get("queries", []):
+            with self.subTest(id=q.get("id")):
+                doc = (q.get("original_doc") or "").strip()
+                self.assertTrue(
+                    bool(doc),
+                    f"wiki_edit id={q.get('id')} missing original_doc "
+                    f"— prompt would have an empty edit target.",
+                )
+
+    def test_wiki_edit_prompt_template_emits_doc(self):
+        """Smoke: ``_wiki_edit_prompt()`` must include the original_doc
+        body AND the edit instruction so both sides see the same edit
+        task."""
+        from local_vs_cloud_paired import _wiki_edit_prompt
+        q = {
+            "text": "본문의 '2023년' 부분을 '2024년' 으로 정정해 주세요.",
+            "original_doc": "[Wiki] 광합성 연구\n2023년 발견.",
+        }
+        body = _wiki_edit_prompt(q)
+        self.assertIn("[Wiki] 광합성 연구", body,
+                      "_wiki_edit_prompt drops the original_doc body")
+        self.assertIn("2023년 발견.", body,
+                      "_wiki_edit_prompt drops the original_doc body")
+        self.assertIn("'2024년' 으로 정정", body,
+                      "_wiki_edit_prompt drops the edit instruction")
+
+
 class RoutingPhase4Surface(unittest.TestCase):
     """v0.6.1 v18.7 Phase 4 (2026-06-20) — privacy + cost cap primitives.
 


### PR DESCRIPTION
## Summary

Phase wiki_edit-a of the routing build-out — parallel to Phase 5 (cloud egress). Same **plumb-first** pattern as Phase 2a (chat) / Phase 3a (tier ladder): fixture + harness CLI ship now; paired measurement (-b) + engine wire (-c) follow as operator-launched steps.

### Fixture

`eval/wiki_edit_mode_queries.json` — 12 operator-authored Korean queries, 4 sub-classes × 3 rows each:

| Sub-class | Rows | Scoring |
|---|---|---|
| `factual_edit` | 3 | gold_signals (deterministic) |
| `format_edit` | 3 | judge-only (markdown variability OK) |
| `summarize` | 3 | gold_signals (key-fact retention) |
| `reword` | 3 | judge-only (many valid paraphrases) |

`scoring_protocol.fairness_caveat` documents the v18.6 lenient-bias caveat inline; gold-grounded recheck applies only to `factual_edit` + `summarize`.

### Harness

`scripts/research/local_vs_cloud_paired.py`:

- `FIXTURES["wiki_edit"]` + `ANSWERABLE_BY_FIXTURE["wiki_edit"]`
- `_wiki_edit_prompt(query)` — folds `original_doc` + edit instruction into the prompt body; mirrors `_chat_prompt` structurally
- main-loop handles `--fixture wiki_edit` (skip external evidence assembly; surface `doc_chars=` in the per-query log line)

### 4-layer guard

- **Lock-test** `WikiEditFixtureSurface` (6 cases): registered in harness, file exists, sub-class counts ≥ 3, factual_edit gold_signals present, every row carries `original_doc`, prompt template emits doc + instruction.
- **Pre-flight** `check_wiki_edit_fixture` — 9th check; mirrors the lock-test.

## Verification

```
python -m unittest tests.test_measurement_critical_surfaces
Ran 28 tests in 4.944s — OK

python scripts/research/pre_flight_check.py
RESULT: PASS (0 warnings) — 9/9 checks ok
  ✓ wiki_edit_fixture — 12 wiki_edit queries available
    (counts={'factual_edit': 3, 'format_edit': 3, 'summarize': 3, 'reword': 3},
     factual_with_gold=3, summarize_with_gold=3)
```

**Streak**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `code`) — measurement infra, no core/{retrieval,graph,reasoning} touched. Quality measurement happens in Phase wiki_edit-b.

## Operator launch (Phase wiki_edit-b)

```
python scripts/research/local_vs_cloud_paired.py \
  --fixture wiki_edit --n-per-type 3 --n-runs 3 \
  --local-model gemma4:e4b --local-backend ollama
```

Suggested cells (mirror Phase 2b chat):
- **Cell A**: `gemma4:e4b` OFF (current default)
- **Cell B**: `gemma3:12b` (Phase 2b/3b winner on prior fixtures)
- **Cell C**: `gemma3:27b` (Phase 3b accuracy leader; 2.3× slower + verbose — interesting axis for edit tasks where verbosity is bad)

## Phase wiki_edit-c (post-measurement)

Same shape as Phase 2c/3c — extend engine.py's mode-routing branch:

```python
if mode in ("chat", "retrieval", "wiki_edit") and not picked_model:
    resolve_for_mode(mode, requested="")
```

`JAMES_DISABLE_MODE_AWARE_ROUTING` kill-switch stays generalized.

## Out of scope

- Phase wiki_edit-b paired measurement run (operator launches)
- Phase wiki_edit-c engine wire + DEFAULT_PREFERENCE reorder (post-measurement)
- Real wiki document corpus (operator-authored synthesized fixture is intentional — same rationale as the chat fixture)
- Circle-modal-ask-edit UX (separate design memo `docs/design/v0.6-circle-modal-ask-edit.md`, pre-implementation)
- Vertical content per CLAUDE.md rule #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)