### PR TITLE
feat(v0.6.1): Phase 5b — defense-in-depth gate in run_cloud_egress

### DIFF
--- a/core/abstraction/_runner.py
+++ b/core/abstraction/_runner.py
@@ -81,13 +81,81 @@ def run_cloud_egress(
         the response (left verbatim in `text`), surfaced separately so
         the caller can decide treatment (UI annotation, refuse-show, …).
 
-    On a refused egress (keep-local name in prompt), returns an error
-    `CompletionResult` with `error="refused: keep_local in prompt: …"`
-    and an empty `flagged` list. The cloud backend is NOT called.
+    On a refused egress (keep-local name in prompt, or v0.6.1 Phase 5b
+    privacy-gate / cost-cap trip), returns an error `CompletionResult`
+    with `error="refused: …"` and an empty `flagged` list. The cloud
+    backend is NOT called.
     On a backend-side error (timeout, network, CLI not found), the
     backend's error `CompletionResult` is returned as-is with the
     unmask step skipped (no answer to unmask).
+
+    Phase 5b defense-in-depth (v0.6.1 v18.7, 2026-06-20):
+    Even though §5.7.13 caller obligation #1 puts PolicyEngine gating
+    on the caller side (and Phase 5a wired the gate at
+    `local_vs_cloud_paired.call_cloud_via_abstraction`), the runner
+    re-checks `core.routing.check_query_privacy(prompt+system)` +
+    `check_cap(max_tokens)` here so that any future caller that
+    bypasses the §5.7.13 §1 obligation still cannot egress under
+    `JAMES_PRIVACY_FORCE_LOCAL=1` / over-cap. Default OFF / no-cap =
+    pure no-op; byte-identical to pre-5b.
     """
+    # ── Phase 5b — privacy + cost defense-in-depth ──────────────────
+    # Caller-side gate (§5.7.13 §1) is the contract; this layer is
+    # belt-and-suspenders for future callers (production router cloud
+    # branch, third-party plug-ins) that may forget the contract.
+    try:
+        from core.routing import check_cap, check_query_privacy
+    except Exception:  # pragma: no cover — surface stability is locked
+        # Surface lock-test catches missing imports; if it ever
+        # somehow disappears at runtime, fall through to the legacy
+        # behaviour rather than break the cloud path.
+        check_cap = None  # type: ignore[assignment]
+        check_query_privacy = None  # type: ignore[assignment]
+
+    if check_query_privacy is not None:
+        priv = check_query_privacy((prompt or "") + "\n" + (system or ""))
+        if priv.force_local:
+            amap_for_audit = build_map((), lambda e: Decision.PASS)
+            emit_egress_event(
+                stage, prompt, backend.backend_id, amap_for_audit,
+                reason=f"refused_privacy_gate:{','.join(priv.reasons)}",
+            )
+            return (
+                CompletionResult(
+                    text="",
+                    backend_id=backend.backend_id,
+                    error=(
+                        "refused: privacy gate (reasons="
+                        f"{priv.reasons})"
+                    ),
+                ),
+                [],
+            )
+
+    if check_cap is not None:
+        cost = check_cap(tokens_estimate=max_tokens)
+        if not cost.under_cap:
+            amap_for_audit = build_map((), lambda e: Decision.PASS)
+            emit_egress_event(
+                stage, prompt, backend.backend_id, amap_for_audit,
+                reason=(
+                    f"refused_cost_cap:"
+                    f"used={cost.used_usd_est:.4f}/{cost.cap_usd:.4f}"
+                ),
+            )
+            return (
+                CompletionResult(
+                    text="",
+                    backend_id=backend.backend_id,
+                    error=(
+                        "refused: cost cap "
+                        f"(used_usd={cost.used_usd_est:.4f}/"
+                        f"{cost.cap_usd:.4f} month={cost.month})"
+                    ),
+                ),
+                [],
+            )
+
     amap = build_map(entities, decider)
 
     # §5.7.13 caller obligation #4 (runner-side defense-in-depth):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -990,6 +990,15 @@ invoking the module)
   treatment) and are **never** stripped from the response without
   operator review.
 
+> **v0.6.1 Phase 5b note (2026-06-20)** — runner-side `run_cloud_egress`
+> additionally re-checks `core.routing.check_query_privacy(prompt+system)`
+> + `check_cap(max_tokens)` before `build_map`. This is *defense-in-depth*
+> only: caller-side gating per §5.7.13 §1 above is still the contract, and
+> with the env defaults (`JAMES_PRIVACY_FORCE_LOCAL` unset,
+> `JAMES_COST_CAP_MONTHLY_USD=0.0`) the runner re-check is a byte-identical
+> no-op. The note is recorded here so a future contract reader sees both
+> layers and does not mistake the runner check for a contract relaxation.
+
 **Non-goals (what this module deliberately does NOT do)**
 
 - **Does not classify sensitivity.** That is a property of the entity

--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -140,9 +140,18 @@ separate from the backend-tier system:
     byte-identical: gate is a pure no-op until the operator flips
     `JAMES_PRIVACY_FORCE_LOCAL=1` or sets
     `JAMES_COST_CAP_MONTHLY_USD>0`.
-  - ⏳ 5b — production router cloud branch wire (same gate, applied
-    inside the eventual `engine.py` cloud route — gated on Phase
-    5 cloud-as-preference measurement).
+  - ✅ 5b (defense-in-depth) — gate also runs **inside**
+    `core/abstraction/_runner.run_cloud_egress`. Any future caller
+    that bypasses the §5.7.13 §1 caller-side obligation is still
+    refused under `JAMES_PRIVACY_FORCE_LOCAL=1` / over-cap. Refusal
+    returns `CompletionResult(error="refused: privacy gate" / "cost
+    cap")` and emits a `refused_privacy_gate` / `refused_cost_cap`
+    audit reason. Default OFF / no-cap = byte-identical no-op.
+    Source-level + behaviour invariants locked by
+    `tests/test_phase5b_abstraction_gate.py` (8 cases).
+  - ⏳ 5b' — production router cloud branch wire (the eventual
+    `engine.py` cloud route still needs to be built; gated on the
+    Phase 5 cloud-as-preference measurement).
   - ⏳ 5c — cloud as preference option + sub-class routing inside chat + admin routing dashboard.
 
 **Phase 4 env contract** (all default OFF / no-cap):

--- a/tests/test_phase5b_abstraction_gate.py
+++ b/tests/test_phase5b_abstraction_gate.py
@@ -1,0 +1,211 @@
+"""v0.6.1 Phase 5b — defense-in-depth gate inside run_cloud_egress.
+
+§5.7.13 caller obligation #1 puts PolicyEngine gating on the caller
+side. Phase 5a wired the gate at
+`local_vs_cloud_paired.call_cloud_via_abstraction`. Phase 5b adds a
+runner-side re-check so a future caller that bypasses the §5.7.13 §1
+obligation still cannot egress when the operator has opted in.
+
+Verified:
+
+1. Default OFF / no-cap → byte-identical to pre-5b (backend is
+   called as before; the gate is a pure no-op).
+2. `JAMES_PRIVACY_FORCE_LOCAL=1` + PII in prompt → backend NOT
+   called; returned CompletionResult.error starts with
+   "refused: privacy gate".
+3. `JAMES_COST_CAP_MONTHLY_USD` exceeded → backend NOT called;
+   CompletionResult.error starts with "refused: cost cap".
+4. Source-level: the imports + the two gate branches MUST stay
+   present at the top of run_cloud_egress so a future cleanup that
+   accidentally removes them is caught at PR time.
+
+All behaviour tests use a stub backend so no real cloud is reached.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from core.abstraction import run_cloud_egress
+from core.abstraction._policy import default_decider
+from core.reasoning.backends import CompletionResult
+
+
+class _StubBackend:
+    """Minimal backend that records whether it was called.
+
+    Mirrors the `Backend` protocol just enough for `run_cloud_egress`
+    (a `backend_id` attribute + a `complete(...)` method returning a
+    `CompletionResult`).
+    """
+
+    backend_id = "stub_cloud"
+
+    def __init__(self):
+        self.calls = 0
+
+    def complete(self, masked_prompt, **_):
+        self.calls += 1
+        return CompletionResult(
+            text="ok",
+            backend_id=self.backend_id,
+        )
+
+
+class GatePassThroughTests(unittest.TestCase):
+    """Default env → byte-identical no-op (backend is called)."""
+
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                      "JAMES_COST_CAP_MONTHLY_USD")
+            if k in os.environ
+        }
+
+    def tearDown(self):
+        for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                  "JAMES_COST_CAP_MONTHLY_USD"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+
+    def test_default_passes_through_to_backend(self):
+        be = _StubBackend()
+        result, flagged = run_cloud_egress(
+            backend=be, prompt="benign question with no PII",
+            entities=[], decider=default_decider(),
+        )
+        self.assertEqual(be.calls, 1, "backend must be called when "
+                         "gate is OFF")
+        self.assertEqual(result.error, "")
+        self.assertEqual(flagged, [])
+
+
+class PrivacyGateRefusalTests(unittest.TestCase):
+    """Runner-side privacy gate trips on PII when the env flag is ON."""
+
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                      "JAMES_COST_CAP_MONTHLY_USD")
+            if k in os.environ
+        }
+
+    def tearDown(self):
+        for k in ("JAMES_PRIVACY_FORCE_LOCAL",
+                  "JAMES_COST_CAP_MONTHLY_USD"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+
+    def test_privacy_refusal_skips_backend(self):
+        os.environ["JAMES_PRIVACY_FORCE_LOCAL"] = "1"
+        be = _StubBackend()
+        result, flagged = run_cloud_egress(
+            backend=be,
+            prompt="주민번호 900101-1234567 의 의미",
+            entities=[], decider=default_decider(),
+        )
+        self.assertEqual(be.calls, 0,
+                         "privacy refusal must not call the backend")
+        self.assertTrue(result.error.startswith("refused: privacy gate"),
+                        f"error did not match: {result.error!r}")
+        self.assertEqual(flagged, [])
+
+    def test_privacy_off_with_pii_still_calls_backend(self):
+        """Flag OFF (default) — PII present but gate does not block."""
+        os.environ.pop("JAMES_PRIVACY_FORCE_LOCAL", None)
+        be = _StubBackend()
+        result, _ = run_cloud_egress(
+            backend=be,
+            prompt="주민번호 900101-1234567 의 의미",
+            entities=[], decider=default_decider(),
+        )
+        self.assertEqual(be.calls, 1)
+        self.assertEqual(result.error, "")
+
+
+class CostCapRefusalTests(unittest.TestCase):
+    """Runner-side cost cap trips when the projection exceeds."""
+
+    def setUp(self):
+        self._env = {
+            k: os.environ.pop(k)
+            for k in ("JAMES_COST_CAP_MONTHLY_USD",
+                      "JAMES_COST_CAP_FILE")
+            if k in os.environ
+        }
+        self.tmpdir = tempfile.mkdtemp(prefix="phase5b_cap_")
+        os.environ["JAMES_COST_CAP_FILE"] = os.path.join(
+            self.tmpdir, ".james_cost.json"
+        )
+
+    def tearDown(self):
+        for k in ("JAMES_COST_CAP_MONTHLY_USD",
+                  "JAMES_COST_CAP_FILE"):
+            os.environ.pop(k, None)
+        for k, v in self._env.items():
+            os.environ[k] = v
+        for f in os.listdir(self.tmpdir):
+            try:
+                os.remove(os.path.join(self.tmpdir, f))
+            except OSError:
+                pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    def test_cost_cap_with_prefilled_tally_blocks(self):
+        """Pre-fill the tally over the cap, then run egress —
+        check_cap snapshots the existing usd_est >= cap and refuses."""
+        from core.routing import CostBudget
+        budget = CostBudget(
+            os.environ["JAMES_COST_CAP_FILE"], cap_usd=1.0,
+        )
+        budget.record(tokens=0, usd_est=2.0)  # over-cap pre-load
+        os.environ["JAMES_COST_CAP_MONTHLY_USD"] = "1.0"
+        be = _StubBackend()
+        result, _ = run_cloud_egress(
+            backend=be, prompt="benign question",
+            entities=[], decider=default_decider(),
+        )
+        self.assertEqual(be.calls, 0,
+                         "cost-cap refusal must not call the backend")
+        self.assertTrue(result.error.startswith("refused: cost cap"),
+                        f"error did not match: {result.error!r}")
+
+
+class WireSourceInvariantTests(unittest.TestCase):
+    """Source-level: the Phase 5b gate MUST stay at the runner entry.
+    A future cleanup that drops the imports or the two branches is
+    caught here."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = inspect.getsource(run_cloud_egress)
+
+    def test_imports_check_query_privacy(self):
+        self.assertIn("check_query_privacy", self.src,
+                      "Phase 5b wire missing: privacy gate import")
+
+    def test_imports_check_cap(self):
+        self.assertIn("check_cap", self.src,
+                      "Phase 5b wire missing: cost cap import")
+
+    def test_emits_refused_privacy_audit_reason(self):
+        self.assertIn("refused_privacy_gate", self.src,
+                      "Phase 5b wire missing: privacy audit reason")
+
+    def test_emits_refused_cost_cap_audit_reason(self):
+        self.assertIn("refused_cost_cap", self.src,
+                      "Phase 5b wire missing: cost-cap audit reason")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a runner-side re-check of the Phase 4 routing primitives inside `core/abstraction/_runner.run_cloud_egress`.

§5.7.13 §1 caller-side gating remains the contract (PolicyEngine MUST gate egress BEFORE `build_map` runs). Phase 5a wired the gate at `local_vs_cloud_paired.call_cloud_via_abstraction` (measurement infra). Phase 5b is **belt-and-suspenders** for future callers (production router cloud branch, third-party plug-ins) that may forget the contract.

Two gates run BEFORE `build_map`:

1. **`check_query_privacy(prompt + system)`** — refuses if `JAMES_PRIVACY_FORCE_LOCAL=1` AND a PII pattern matches.
2. **`check_cap(max_tokens)`** — refuses if the projected USD total would exceed `JAMES_COST_CAP_MONTHLY_USD`.

Refusal returns `CompletionResult(error="refused: privacy gate" / "cost cap")` with an empty `flagged` list and emits a `refused_privacy_gate:<reasons>` / `refused_cost_cap:<used/cap>` audit row — same schema as the existing keep-local refusal.

**Default behaviour byte-identical pre-5b**: env defaults (`JAMES_PRIVACY_FORCE_LOCAL` unset, `JAMES_COST_CAP_MONTHLY_USD=0.0`) → both gates are pure no-ops, backend is called as before.

**ARCHITECTURE.md §5.7.13** gets a short defense-in-depth note next to caller obligation #1 so a future contract reader sees both layers and does not mistake the runner check for a contract relaxation.

## Verification

```
python -m unittest tests.test_phase5b_abstraction_gate
Ran 8 tests in 0.077s — OK
```

- 1 pass-through default (backend IS called, no refusal)
- 2 privacy gate (refusal blocks backend with flag ON; flag OFF + PII still calls backend)
- 1 cost cap (pre-filled tally over cap blocks backend)
- 4 source-level invariants: imports + audit-reason strings MUST stay in the runner source

**Streak (rule #1/#2)**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed.

**Quality delta**: exempt (label: `code`) — defense-in-depth layer; no quality-affecting code path changes when env defaults are in effect.

## Out of scope

- Phase 5b' production router cloud branch wire (the eventual `engine.py` cloud route still needs to be built; gated on the Phase 5 cloud-as-preference measurement)
- Token-rate table for the caller-passes-tokens-alone cost path
- Vertical content per CLAUDE.md rule #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)