### PR TITLE
docs(v0.6.1): Phase wiki_edit-b 3-cell paired measurement — results + QDC

### DIFF
--- a/reports/research-runs/v18.7-phase-wikiedit-b/QUALITY_DELTA_CARD.md
+++ b/reports/research-runs/v18.7-phase-wikiedit-b/QUALITY_DELTA_CARD.md
@@ -1,0 +1,129 @@
+# Quality Delta Card — Phase wiki_edit-b (3-cell paired measurement, COMPLETE)
+
+> **Cycle**: v0.6.1 v18.7 Phase wiki_edit-b
+> **Date**: 2026-06-20
+> **Fixture**: `eval/wiki_edit_mode_queries.json` (12 Korean queries, 4 sub-classes × 3 rows)
+> **Design**: 3 cells × 12 queries × 3 paired runs = 36 paired-rows per cell, 108 LOCAL + 108 CLOUD + 108 judge calls total
+> **Judge**: Claude CLI (`claude_code_cli`), pairwise blinded A/B
+> **Cloud anchor**: Claude (same backend as judge — self-preference caveat applies)
+
+---
+
+## Cells
+
+| Cell | Local model | Think | num_predict | Why this cell |
+|---|---|---|---|---|
+| **A** | `gemma4:e4b` | OFF (`JAMES_GEMMA4_E4B_THINK_OFF=1`) | 400 | Current production default (config.GEMMA_MODEL) |
+| **B** | `gemma3:12b` | (n/a — non-gemma4) | 400 | Phase 2b/3b winner on prior fixtures (chat / retrieval) |
+| **C** | `gemma3:27b` | (n/a — non-gemma4) | 400 | Phase 3b accuracy leader; verbose; 2.3× slower → axis of interest |
+
+---
+
+## Results
+
+### Judge-graded (Claude pairwise A/B; gold-grounded recheck where applicable)
+
+| Sub-class | Cell A judge L \| C | A gold L \| C | Cell B judge L \| C | B gold L \| C | Cell C judge L \| C | C gold L \| C |
+|---|---|---|---|---|---|---|
+| `factual_edit`   (gold) | 1.000 \| 1.000 | 1.000 \| 1.000 | 1.000 \| 1.000 | 1.000 \| 1.000 | 1.000 \| 1.000 | 1.000 \| 1.000 |
+| `format_edit`    (judge-only) | 1.000 \| 1.000 | — | 1.000 \| 1.000 | — | 1.000 \| 1.000 | — |
+| `summarize`      (gold) | 1.000 \| 1.000 | **0.667** \| 1.000 | 1.000 \| 1.000 | **1.000** \| 1.000 | 1.000 \| 1.000 | **0.333** \| 1.000 |
+| `reword`         (judge-only) | 1.000 \| 1.000 | — | 1.000 \| 1.000 | — | 1.000 \| 1.000 | — |
+
+**Headline**: judge column hides every gap (all 1.000). Gold-grounded `summarize` recheck reveals a **clean ranking**:
+
+> **gemma3:12b (1.000) > gemma4:e4b OFF (0.667) > gemma3:27b (0.333)**
+
+This **inverts the Phase 3b retrieval ranking** (27b > 12b > 4b > gemma4:e4b on evidence-rich multi-hop), see §"Cross-task ranking reversal" below.
+
+### Latency + answer length
+
+| Cell | mean latency | median | max | mean `summarize` ans_chars | mean `format_edit` ans_chars |
+|---|---|---|---|---|---|
+| A — gemma4:e4b OFF | 35.1 s | 18.4 s | 129.8 s | 188 | 117 |
+| B — gemma3:12b     | **23.2 s** | 17.8 s |  58.0 s | 211 | 102 |
+| C — gemma3:27b     | 37.2 s | 35.1 s |  54.2 s | **365** | **224** |
+
+Cell B is the fastest. Cell C's `summarize` answers are **94% longer** than Cell B's — confirming the 27b verbose tendency from Phase 3b on a task where verbosity actively hurts (key facts buried under extra prose).
+
+---
+
+## Cross-task ranking reversal (⭐ finding)
+
+Two paired measurements, same models, different tasks:
+
+| Task (cycle) | gemma3:12b gold | gemma3:27b gold | gemma4:e4b gold |
+|---|---|---|---|
+| **Retrieval** (Phase 3b: evidence-rich multi-hop QA) | 0.889 | **1.000** | 0.815 |
+| **Wiki edit** (Phase wiki_edit-b: summarize sub-class) | **1.000** | 0.333 | 0.667 |
+
+**Interpretation**: 27b's verbose tendency is amplifying. On evidence-rich retrieval (where the question wants every relevant fact in the answer), verbosity helps — 27b includes more correct facts, gold-grounded score climbs. On `summarize` (where the question wants a compressed extract), verbosity inverts the score — extra prose displaces / dilutes the key facts the gold_signals expect, and the model's answer ends up failing the deterministic match even though the underlying knowledge is correct.
+
+This is a layer-intent alignment lesson: **task verb (summarize vs explain) flips which model wins**. The ladder pattern from Phase 3b ("27b for accuracy-critical retrieval; 12b for default") is task-conditional, not absolute.
+
+---
+
+## Verdict
+
+`gemma3:12b` is the wiki_edit winner on every axis. Promote to top of `DEFAULT_PREFERENCE['wiki_edit']`. **`gemma3:27b` is demoted**, not promoted — its 27b → verbose → summarize-fail chain is the reverse of what one would predict from the Phase 3b retrieval ladder.
+
+Recommended reorder:
+
+```python
+"wiki_edit": [
+    "gemma3:12b",   # Phase wiki_edit-b winner: 1.000 gold all axes, fastest (mean 23.2 s)
+    "gemma4:e4b",   # OFF: summarize gold 0.667; lighter alternative
+    "gemma3:27b",   # demoted: verbose → summarize gold 0.333 (facts buried)
+    "mixtral:8x7b", "qwen2.5:14b",  # legacy tail unchanged
+],
+```
+
+Phase wiki_edit-c lands this reorder + extends `engine.py`'s mode-routing branch to include `wiki_edit` in the `resolve_for_mode(mode, requested="")` set.
+
+---
+
+## Caveats
+
+- **`small_n`**: 12 queries × 3 runs = 36 paired rows. The gold-grounded gap (1.000 vs 0.667 vs 0.333) is large enough to clear noise, but a publishable claim needs cross-corpus validation.
+- **Judge self-preference**: judge is Claude; cloud is Claude. The `cloud_verdict=CORRECT` 100% is consistent with v18.6 lenient bias (+0.11 to +0.19 over-credit). Gold-grounded recheck is the verdict source for `factual_edit` + `summarize`.
+- **`judge-only` sub-classes** (`format_edit` + `reword`): no gold ground-truth. Judge results read 1.000 across the board; should NOT be cited as quality parity without an additional axis.
+- **`fixture_fitness`**: operator-authored fixture (no upstream alarm if a UX cycle silently edits it). `WikiEditFixtureSurface` lock-test + `check_wiki_edit_fixture` pre-flight keep the surface stable.
+- **`local_backend`**: Ollama HTTP only; DiffusionGemma spike opt-in (`JAMES_ENABLE_DIFFUSIONGEMMA=1`) was not part of these cells.
+- **`single-host measurement`**: n=3 paired runs per query; per-row verdict is the majority. Cross-host / cross-machine replay is a future Phase wiki_edit-d concern.
+- **`task-conditional ladder`**: the cross-task reversal (Phase 3b retrieval vs Phase wiki_edit-b summarize) means a single global ranking doesn't exist. The per-mode `DEFAULT_PREFERENCE` IS the right abstraction; the operator-pending Phase 5 dashboard should surface BOTH measurement results so the operator sees the task-conditional gap.
+
+---
+
+## Pareto axes (5-axis QDC convention)
+
+| Axis | Cell A (current default) | Cell B (proposed top) | Cell C | Δ (B − A) |
+|---|---|---|---|---|
+| Path coverage     | n/a (no retrieval; doc embedded in prompt) | n/a | n/a | 0 |
+| Graded answer (gold mean across factual_edit + summarize) | (1.0 + 0.667) / 2 = **0.833** | (1.0 + 1.0) / 2 = **1.000** | (1.0 + 0.333) / 2 = **0.667** | **+0.167** (vs A) |
+| Abstention F1     | n/a (no `null_query` rows) | n/a | n/a | 0 |
+| Token cost (mean ans_chars across 4 sub-classes) | (119+117+188+134)/4 ≈ **139** | (120+102+211+121)/4 ≈ **139** | (119+224+365+131)/4 ≈ **210** | ≈ 0 (vs A); +51% (vs C) |
+| Latency cost (mean s) | 35.1 | **23.2** | 37.2 | **−11.9 s** (vs A) |
+
+**Pareto verdict** — Cell B dominates Cell A on graded answer AND latency, ties on token cost. Cell C loses on graded answer, ties on latency, loses on token cost.
+
+---
+
+## Layer-intent matrix entry
+
+`wiki_edit` is a **synthesis** layer (no retrieval / no graph traversal). Per `mechanism_layer_intent_axis_alignment`, the layer's design-intent axes:
+
+- **fact preservation** (deterministic): gold_signals key-fact match — `wiki_edit`'s reason-to-exist
+- **format fidelity** (judge): markdown / structural compliance
+- **brevity** (latency + answer length): edit should NOT amplify token count
+
+**Cell B wins on all three.** **Cell C fails on fact preservation + brevity** (verbose → facts buried, longer answers). The matrix-aligned scorecard says: **promote B, demote C**.
+
+---
+
+## References
+
+- Fixture: `eval/wiki_edit_mode_queries.json`
+- Raw rows: `reports/research-runs/v18.7-phase-wikiedit-b/cell{A,B,C}_*.json` (3 × 1.0 MB)
+- Memory: `project_phase_wiki_edit_a_fixture_v18_7` (the -a fixture + harness PR)
+- Memory: `project_judge_reliability_gold_grounded_v18_6` (judge bias caveat)
+- Memory: `project_d5_complexity_routing_negative_v18_7` (Phase 3b 27b verbose finding — wiki_edit-b confirms + extends)

--- a/reports/research-runs/v18.7-phase-wikiedit-b/cellA_gemma4_off.json
+++ b/reports/research-runs/v18.7-phase-wikiedit-b/cellA_gemma4_off.json
@@ -1,0 +1,1012 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "wiki_edit",
+  "local_model": "gemma4:e4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "auto",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "wiki_edit_fixture",
+        "status": "ok",
+        "detail": "12 wiki_edit queries available (counts={'factual_edit': 3, 'format_edit': 3, 'summarize': 3, 'reword': 3}, factual_with_gold=3, summarize_with_gold=3)",
+        "extra": {}
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      },
+      {
+        "name": "routing_phase4_primitives",
+        "status": "ok",
+        "detail": "surface stable (7 symbols); plumb-first (no consumer yet — Phase 5 wires)",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 95.86
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 67.04
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.29
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.68
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 66.9
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.2
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.37
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.02
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.34
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 129.75
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.15
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.3
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다.\n\n## 주의사항\n스캔 실패 시 422 를 반환한다.",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 127.21
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다.\n\n## 주의사항\n스캔 실패 시 422 를 반환한다.",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.66
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다.\n\n## 주의사항\n스캔 실패 시 422 를 반환한다.",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.13
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 캐시 옵션 비교\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n|---|---|---|\n| 속도/특성 | 빠르고 휘발성이 있다. | 느리지만 영속성이 있다. |\n| 비용 | 무료고 | SSD 비용이 든다. |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 57.8
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 캐시 옵션 비교\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n|---|---|---|\n| 속도/특성 | 빠르고 휘발성이 있다. | 느리지만 영속성이 있다. |\n| 비용 | 무료고 | SSD 비용이 든다. |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.45
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 캐시 옵션 비교\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n|---|---|---|\n| 속도/특성 | 빠르고 휘발성이 있다. | 느리지만 영속성이 있다. |\n| 비용 | 무료고 | SSD 비용이 든다. |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.28
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 분기 성과 보고\n2026년 1분기는 매출 120억 원(전년 대비 18% 성장)을 기록했으며, 영업이익률은 9.5%(작년 동기 7.2%)로 개선되었다. 신규 가입자는 4만 5천 명 중 70%가 기존 채널에서 유입되었고, 마케팅 비용은 8억 원(매출의 6.7%) 수준이었다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.14
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 분기 성과 보고\n2026년 1분기는 매출 120억 원(전년 대비 18% 성장)을 기록했으며, 영업이익률은 9.5%(작년 동기 7.2%)로 개선되었다. 신규 가입자는 4만 5천 명 중 70%가 기존 채널에서 유입되었고, 마케팅 비용은 8억 원(매출의 6.7%) 수준이었다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출은 120억 원(전년 대비 +18%), 영업이익률은 9.5%(작년 동기 7.2%)였다. 신규 가입자 4만 5천 명 중 70%는 기존 채널에서 유입됐으며, 마케팅 비용은 8억 원(매출의 6.7%)이었다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.48
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 분기 성과 보고\n2026년 1분기는 매출 120억 원(전년 대비 18% 성장)을 기록했으며, 영업이익률은 9.5%(작년 동기 7.2%)로 개선되었다. 신규 가입자는 4만 5천 명 중 70%가 기존 채널에서 유입되었고, 마케팅 비용은 8억 원(매출의 6.7%) 수준이었다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%)로 개선됐다. 신규 가입자 4만 5천 명 중 70%가 기존 채널 유입이며, 마케팅 비용은 8억 원(매출의 6.7%)이었다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.13
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK는 MIT로 공개한다. 제3자 fixture와 외부 벤치마크 결과는 원저작권을 유지하며 출처를 명시한다. 상업적 호스팅 서비스는 별도 BSL 조항을 검토 중이다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture 및 외부 벤치마크 결과는 원저작권을 보존하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.41
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK는 MIT로 공개한다. 제3자 fixture와 외부 벤치마크 결과는 원저작권을 유지하며 출처를 명시한다. 상업적 호스팅 서비스는 별도 BSL 조항을 검토 중이다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture 와 외부 벤치마크 결과는 원저작권을 보존하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.59
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK는 MIT로 공개한다. 제3자 fixture와 외부 벤치마크 결과는 원저작권을 유지하며 출처를 명시한다. 상업적 호스팅 서비스는 별도 BSL 조항을 검토 중이다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture 와 외부 벤치마크는 원저작권 유지·CITATION.md 출처 명시.\n상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.3
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4는 privacy gate와 monthly cost cap을 core/routing/패키지로 plumb-first 도입했으며, PII 검출 정규식 4종 + env-extensible 및 atomic JSON 월별 token tally가 핵심이며 기본값은 모두 OFF/no-cap으로 byte-identical 무동작이고 Phase 5에서 cloud egress 시 consumer로 wire한다.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 에 plumb-first 로 도입했고 (PII 정규식 4종 + atomic JSON token tally, 기본 OFF/no-cap 으로 byte-identical 무동작), Phase 5 가 cloud egress 시 wire 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.31
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4는 privacy gate와 monthly cost cap을 core/routing/패키지로 plumb-first 도입했으며, PII 검출 정규식 4종 + env-extensible 및 atomic JSON 월별 token tally가 핵심이며 기본값은 모두 OFF/no-cap으로 byte-identical 무동작이고 Phase 5에서 cloud egress 시 consumer로 wire한다.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate (PII 검출 정규식 4종 + env-extensible) 와 monthly cost cap (atomic JSON token tally) 을 core/routing/ 패키지로 plumb-first 도입했으며, 기본값 OFF/no-cap 으로 byte-identical 무동작이고 Phase 5 에서 cloud egress consumer 로 wire 된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.72
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4는 privacy gate와 monthly cost cap을 core/routing/패키지로 plumb-first 도입했으며, PII 검출 정규식 4종 + env-extensible 및 atomic JSON 월별 token tally가 핵심이며 기본값은 모두 OFF/no-cap으로 byte-identical 무동작이고 Phase 5에서 cloud egress 시 consumer로 wire한다.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate(PII 정규식 4종 + env 확장)와 atomic JSON 월별 token tally 기반 cost cap 을 core/routing/ 에 plumb-first 로 도입했으며, 기본값 OFF/no-cap 으로 byte-identical 무동작이고 Phase 5 에서 cloud egress consumer 로 wire 된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.03
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰이라는 건요, 24시간마다 주기적으로 바뀌어요. 이 '바뀌는 시점'에는 현재 사용 중인 모든 기기(세션)에서 다시 한번 로그인을 하셔야 해요. 만약 이 과정이 원활하게 진행되지 않으면, 시스템은 안전한 비상 모드(fallback 모드)로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희 인증 토큰은 하루(24시간)에 한 번씩 새 것으로 바뀌어요. 토큰이 바뀌는 순간에는 그때까지 로그인되어 있던 모든 사용자에게 다시 한 번 로그인을 부탁드리게 됩니다. 만약 토큰 교체 과정에서 문제가 생기면, 시스템은 자동으로 fallback 모드(예비 동작 모드)로 전환돼요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.01
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰이라는 건요, 24시간마다 주기적으로 바뀌어요. 이 '바뀌는 시점'에는 현재 사용 중인 모든 기기(세션)에서 다시 한번 로그인을 하셔야 해요. 만약 이 과정이 원활하게 진행되지 않으면, 시스템은 안전한 비상 모드(fallback 모드)로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n보안을 위해 인증 토큰은 24시간마다 새것으로 바뀝니다. 토큰이 바뀌는 순간, 사용 중이던 모든 세션은 다시 한 번 로그인(재인증)을 해주셔야 해요. 만약 토큰 교체 과정에서 문제가 생기면, 시스템이 자동으로 대체(fallback) 모드로 전환됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 40.56
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰이라는 건요, 24시간마다 주기적으로 바뀌어요. 이 '바뀌는 시점'에는 현재 사용 중인 모든 기기(세션)에서 다시 한번 로그인을 하셔야 해요. 만약 이 과정이 원활하게 진행되지 않으면, 시스템은 안전한 비상 모드(fallback 모드)로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n우리가 쓰는 인증 토큰은 24시간마다 한 번씩 새것으로 바뀌어요. 이때 로그인되어 있던 모든 화면에서는 다시 한 번 로그인을 해 주셔야 해요. 혹시 토큰을 바꾸는 과정에서 문제가 생기면, 시스템이 자동으로 fallback 모드(예비 모드)로 넘어가게 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.85
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있지만, 더 나은 결과물을 만들기 위해 동료의 PR을 검토해 주시기 바랍니다. 또한, 가능한 한 큰 규모의 PR은 지양해 주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 위한 협업 과정입니다. 동료의 PR을 한 번씩 차분히 검토해 주세요. PR은 가급적 작은 단위로 올려 주시기 바랍니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.83
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있지만, 더 나은 결과물을 만들기 위해 동료의 PR을 검토해 주시기 바랍니다. 또한, 가능한 한 큰 규모의 PR은 지양해 주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n더 나은 결과물을 위해 동료의 PR을 꼼꼼히 검토해 주세요. PR은 가급적 작은 단위로 올려 주시기 바랍니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 20.35
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있지만, 더 나은 결과물을 만들기 위해 동료의 PR을 검토해 주시기 바랍니다. 또한, 가능한 한 큰 규모의 PR은 지양해 주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n더 나은 결과물을 위해 동료의 PR을 꼼꼼히 리뷰해 주세요. 가능하면 PR 단위를 작게 유지해 주시기 바랍니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.73
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. Monthly backups are kept separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up every day at midnight, and 7 days' worth is retained. End-of-month backups are kept separately for one year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 56.02
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. Monthly backups are kept separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up every day at midnight, and 7 days' worth is retained. The end-of-month backup is stored separately for one year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.97
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. Monthly backups are kept separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight, and 7 days' worth is retained. End-of-month backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.2
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 3001,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 67.06
+      },
+      {
+        "id": 3002,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 32.59
+      },
+      {
+        "id": 3003,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.58
+      },
+      {
+        "id": 3011,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 60.4
+      },
+      {
+        "id": 3012,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 60.33
+      },
+      {
+        "id": 3013,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.51
+      },
+      {
+        "id": 3021,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 24.58
+      },
+      {
+        "id": 3022,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.1
+      },
+      {
+        "id": 3023,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.69
+      },
+      {
+        "id": 3031,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.81
+      },
+      {
+        "id": 3032,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 17.97
+      },
+      {
+        "id": 3033,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 36.06
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "factual_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "format_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "summarize": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "reword": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase-wikiedit-b/cellB_gemma3_12b.json
+++ b/reports/research-runs/v18.7-phase-wikiedit-b/cellB_gemma3_12b.json
@@ -1,0 +1,1012 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "wiki_edit",
+  "local_model": "gemma3:12b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "auto",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "wiki_edit_fixture",
+        "status": "ok",
+        "detail": "12 wiki_edit queries available (counts={'factual_edit': 3, 'format_edit': 3, 'summarize': 3, 'reword': 3}, factual_with_gold=3, summarize_with_gold=3)",
+        "extra": {}
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      },
+      {
+        "name": "routing_phase4_primitives",
+        "status": "ok",
+        "detail": "surface stable (7 symbols); plumb-first (no consumer yet — Phase 5 wires)",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.83
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.64
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.45
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 **20%** 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.15
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 **20%** 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 57.96
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 **20%** 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.76
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.78
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.17
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.55
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.58
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.02
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.94
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.\n\n## 주의사항",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.99
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.\n\n## 주의사항",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.1
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다. 업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.\n\n## 주의사항",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.68
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n|---|---|---|\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.96
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n|---|---|---|\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 39.12
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n|---|---|---|\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.57
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "2026년 1분기 매출액 120억 원(전년 대비 18% 성장), 영업이익률 9.5%(작년 동기 대비 개선), 신규 가입자 4만 5천 명(70%가 기존 채널 유입), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.45
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "2026년 1분기 매출액 120억 원(전년 대비 18% 성장), 영업이익률 9.5%(작년 동기 대비 개선), 신규 가입자 4만 5천 명(70%가 기존 채널 유입), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.05
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "2026년 1분기 매출액 120억 원(전년 대비 18% 성장), 영업이익률 9.5%(작년 동기 대비 개선), 신규 가입자 4만 5천 명(70%가 기존 채널 유입), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.91
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "코어 모듈은 Apache-2.0 라이선스를 유지한다.\n새로운 플러그인 SDK는 MIT 라이선스로 공개된다.\n제3자 fixture 및 외부 벤치마크 결과는 원저작권을 존중하며 CITATION.md에 출처를 명시한다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture·외부 벤치마크는 원저작권 유지 및 CITATION.md 출처 명시.\n상업적 호스팅 서비스용 BSL 조항은 검토 중.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 29.47
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "코어 모듈은 Apache-2.0 라이선스를 유지한다.\n새로운 플러그인 SDK는 MIT 라이선스로 공개된다.\n제3자 fixture 및 외부 벤치마크 결과는 원저작권을 존중하며 CITATION.md에 출처를 명시한다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다. 제3자 fixture 와 외부 벤치마크 결과는 원저작권을 보존하고 CITATION.md 에 출처를 명시한다. 상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.11
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "코어 모듈은 Apache-2.0 라이선스를 유지한다.\n새로운 플러그인 SDK는 MIT 라이선스로 공개된다.\n제3자 fixture 및 외부 벤치마크 결과는 원저작권을 존중하며 CITATION.md에 출처를 명시한다.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture·외부 벤치마크는 원저작권을 보존하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스용 BSL 조항은 별도 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.65
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지로 plumb-first 하게 도입했다. PII 검출 정규식 4종 + env-extensible, 그리고 atomic JSON 월별 token tally 가 핵심이다. 기본값은 모두 OFF / no-cap 이라 byte-identical 무동작이고, Phase 5 가 cloud egress 시 consumer 로 wire 한다.\n\n**요약: Phase 4는 privacy gate 및 월별 비용 제한 기능을 도입했으며, PII 검출 정규식과 atomic JSON 월별 토큰 집계를 핵심으로 하며, 기본적으로 비활성화되어 있습니다.**",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지에 plumb-first 도입했고 (PII 정규식 4종 + env 확장, atomic JSON 월별 token tally), 기본값 OFF/no-cap 으로 byte-identical 무동작이며 Phase 5 가 cloud egress 시 wire 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.78
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지로 plumb-first 하게 도입했다. PII 검출 정규식 4종 + env-extensible, 그리고 atomic JSON 월별 token tally 가 핵심이다. 기본값은 모두 OFF / no-cap 이라 byte-identical 무동작이고, Phase 5 가 cloud egress 시 consumer 로 wire 한다.\n\n**요약: Phase 4는 privacy gate 및 월별 비용 제한 기능을 도입했으며, PII 검출 정규식과 atomic JSON 월별 토큰 집계를 핵심으로 하며, 기본적으로 비활성화되어 있습니다.**",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate (PII 정규식 4종 + env-extensible) 와 atomic JSON 월별 token tally 기반 monthly cost cap 을 core/routing/ 패키지에 plumb-first 로 도입했으며, 기본값 OFF / no-cap 으로 byte-identical 무동작이고 Phase 5 에서 cloud egress consumer 에 wire 된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.52
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지로 plumb-first 하게 도입했다. PII 검출 정규식 4종 + env-extensible, 그리고 atomic JSON 월별 token tally 가 핵심이다. 기본값은 모두 OFF / no-cap 이라 byte-identical 무동작이고, Phase 5 가 cloud egress 시 consumer 로 wire 한다.\n\n**요약: Phase 4는 privacy gate 및 월별 비용 제한 기능을 도입했으며, PII 검출 정규식과 atomic JSON 월별 토큰 집계를 핵심으로 하며, 기본적으로 비활성화되어 있습니다.**",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4는 privacy gate(PII 정규식 4종 + env-extensible)와 monthly cost cap(atomic JSON token tally)을 core/routing/ 패키지에 plumb-first로 도입했으며, 기본값이 모두 OFF/no-cap이라 byte-identical 무동작이고 Phase 5에서 cloud egress 시 consumer로 wire한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.21
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 교체 주기\n\n인증 토큰은 매일 한 번, 24시간마다 바뀌어요. 이 토큰이 바뀔 때마다 현재 사용 중인 모든 세션은 다시 로그인해야 합니다. 만약 토큰 교체가 실패하면, 시스템은 임시적인 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희 시스템은 보안을 위해 인증 토큰을 24시간마다 새것으로 바꿔드려요. 이 시점이 되면 현재 사용 중이신 모든 세션에서 다시 한 번 로그인을 부탁드리게 됩니다. 혹시 토큰 교체가 잘 안 될 경우에는 시스템이 자동으로 fallback 모드로 전환되니 안심하셔도 괜찮아요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.27
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 교체 주기\n\n인증 토큰은 매일 한 번, 24시간마다 바뀌어요. 이 토큰이 바뀔 때마다 현재 사용 중인 모든 세션은 다시 로그인해야 합니다. 만약 토큰 교체가 실패하면, 시스템은 임시적인 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n우리가 사용하는 인증 토큰은 하루(24시간)에 한 번씩 새것으로 바뀌어요. 토큰이 바뀌는 순간에는 그동안 켜져 있던 모든 세션에서 다시 한 번 로그인(재인증)을 해주셔야 해요. 혹시라도 토큰 교체가 제대로 되지 않으면, 시스템이 비상 운영 상태(fallback 모드)로 전환된답니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.73
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 교체 주기\n\n인증 토큰은 매일 한 번, 24시간마다 바뀌어요. 이 토큰이 바뀔 때마다 현재 사용 중인 모든 세션은 다시 로그인해야 합니다. 만약 토큰 교체가 실패하면, 시스템은 임시적인 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희 시스템의 인증 토큰은 24시간마다 한 번씩 새것으로 바뀌어요. 이때 사용 중이던 모든 세션은 다시 로그인해 주셔야 한답니다. 혹시라도 토큰 교체가 잘 되지 않으면, 시스템이 자동으로 fallback 모드로 전환되니 안심하셔도 돼요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.15
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 안내\n\n코드 리뷰는 부담스러울 수 있습니다. 하지만 함께 더 나은 결과를 위해, 동료의 PR을 꼼꼼히 검토해주시고, 큰 PR은 가능한 피해주세요.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 만들기 위한 협업 과정입니다. 동료의 PR을 한 번씩 차분히 검토해 주시고, PR 단위는 가능한 한 작게 유지해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.33
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 안내\n\n코드 리뷰는 부담스러울 수 있습니다. 하지만 함께 더 나은 결과를 위해, 동료의 PR을 꼼꼼히 검토해주시고, 큰 PR은 가능한 피해주세요.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 만들기 위한 필수 과정입니다. 동료의 PR을 차분히 검토해 주세요. 또한 지나치게 큰 PR은 가급적 지양해 주시기 바랍니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 16.57
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 안내\n\n코드 리뷰는 부담스러울 수 있습니다. 하지만 함께 더 나은 결과를 위해, 동료의 PR을 꼼꼼히 검토해주시고, 큰 PR은 가능한 피해주세요.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n더 나은 결과물을 위해 동료의 PR을 차분히 검토해 주세요. PR 규모는 가급적 작게 유지해 주시기 바랍니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 17.16
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight, and 7 days' worth is retained. End-of-month backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 15.02
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight and retained for 7 days. End-of-month backups are retained separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.22
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight and retained for 7 days. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight, and 7 days' worth is retained. End-of-month backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 19.7
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 3001,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 18.64
+      },
+      {
+        "id": 3002,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.29
+      },
+      {
+        "id": 3003,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.17
+      },
+      {
+        "id": 3011,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.18
+      },
+      {
+        "id": 3012,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.26
+      },
+      {
+        "id": 3013,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 31.88
+      },
+      {
+        "id": 3021,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.47
+      },
+      {
+        "id": 3022,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 21.08
+      },
+      {
+        "id": 3023,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 17.84
+      },
+      {
+        "id": 3031,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 19.05
+      },
+      {
+        "id": 3032,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 23.69
+      },
+      {
+        "id": 3033,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 16.31
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "factual_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "format_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "summarize": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "reword": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase-wikiedit-b/cellC_gemma3_27b.json
+++ b/reports/research-runs/v18.7-phase-wikiedit-b/cellC_gemma3_27b.json
@@ -1,0 +1,1012 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "wiki_edit",
+  "local_model": "gemma3:27b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "auto",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "wiki_edit_fixture",
+        "status": "ok",
+        "detail": "12 wiki_edit queries available (counts={'factual_edit': 3, 'format_edit': 3, 'summarize': 3, 'reword': 3}, factual_with_gold=3, summarize_with_gold=3)",
+        "extra": {}
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      },
+      {
+        "name": "routing_phase4_primitives",
+        "status": "ok",
+        "detail": "surface stable (7 symbols); plumb-first (no consumer yet — Phase 5 wires)",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 3,
+  "n_runs": 3,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 47.22
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.39
+    },
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 53.73
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.01
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 34.91
+    },
+    {
+      "id": 3002,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "cloud_answer": "[Wiki] 재생에너지 현황\n2025년 한국의 재생에너지 발전 비중은 꾸준히 증가하고 있다. 작년 기준 전체 발전량의 20% 가 재생에너지에서 나왔다. 정부는 2030년까지 30% 달성을 목표로 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 34.22
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 34.82
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.48
+    },
+    {
+      "id": 3003,
+      "type": "factual_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "cloud_answer": "[Wiki] 백엔드 스택 v0.5\n현재 서버는 Python 3.12 위에서 FastAPI 0.110 을 사용한다. PostgreSQL 16 + Redis 7 조합으로 데이터 계층을 구성했고, 캐시 무효화는 pub/sub 으로 처리한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 38.35
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Security Checklist\n- Only allow HTTPS.\n- Apply CSP nonce.\n- Place API keys in environment variables.\n- Do not leave PII in logs.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.87
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Security Checklist\n- Only allow HTTPS.\n- Apply CSP nonce.\n- Place API keys in environment variables.\n- Do not leave PII in logs.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.94
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Security Checklist\n- Only allow HTTPS.\n- Apply CSP nonce.\n- Place API keys in environment variables.\n- Do not leave PII in logs.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 24.65
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] File Upload API\n\n## Overview\nThe upload endpoint only accepts multipart/form-data. The file size must be less than or equal to 100MB. Virus scanning is enforced upon upload. If the scan fails, a 422 will be returned.\n\n## Precautions",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 33.67
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] File Upload API\n\n## Overview\nThe upload endpoint only accepts multipart/form-data. The file size must be less than or equal to 100MB. Virus scanning is enforced upon upload. If the scan fails, a 422 will be returned.\n\n## Precautions",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 34.17
+    },
+    {
+      "id": 3012,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] File Upload API\n\n## Overview\nThe upload endpoint only accepts multipart/form-data. The file size must be less than or equal to 100MB. Virus scanning is enforced upon upload. If the scan fails, a 422 will be returned.\n\n## Precautions",
+      "cloud_answer": "[Wiki] 파일 업로드 API\n\n## 개요\n업로드 엔드포인트는 multipart/form-data 만 받는다. 파일 크기는 100MB 이하여야 한다.\n\n## 주의사항\n업로드 시 바이러스 스캔이 강제된다. 스캔 실패 시 422 를 반환한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 54.2
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Cache Option Comparison\nMemory caches are fast and volatile. Disk caches are slow but persistent. Memory caches are free while disk caches cost SSD money.\n\n| Item | Option A | Option B |\n|---|---|---|\n| Speed | Fast | Slow |\n| Persistence | Volatile | Persistent |\n| Cost | Free | SSD Cost |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.91
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Cache Option Comparison\nMemory caches are fast and volatile. Disk caches are slow but persistent. Memory caches are free while disk caches cost SSD money.\n\n| Item | Option A | Option B |\n|---|---|---|\n| Speed | Fast | Slow |\n| Persistence | Volatile | Persistent |\n| Cost | Free | SSD Cost |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 메모리 캐시 | 디스크 캐시 |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 40.09
+    },
+    {
+      "id": 3013,
+      "type": "format_edit",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Cache Option Comparison\nMemory caches are fast and volatile. Disk caches are slow but persistent. Memory caches are free while disk caches cost SSD money.\n\n| Item | Option A | Option B |\n|---|---|---|\n| Speed | Fast | Slow |\n| Persistence | Volatile | Persistent |\n| Cost | Free | SSD Cost |",
+      "cloud_answer": "[Wiki] 캐시 옵션 비교\n\n| 항목 | 옵션 A (메모리 캐시) | 옵션 B (디스크 캐시) |\n| --- | --- | --- |\n| 속도 | 빠름 | 느림 |\n| 영속성 | 휘발성 | 영속성 있음 |\n| 비용 | 무료 | SSD 비용 발생 |",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 36.9
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Quarterly Performance Report\nFirst quarter sales in 2026 were KRW 12 billion, an 18% increase year-over-year. Operating profit margin improved to 9.5%, compared to 7.2% for the same period last year. New subscribers totaled 45,000, with 70% coming through existing channels. Marketing costs were KRW 800 million, representing 6.7% of sales.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.93
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Quarterly Performance Report\nFirst quarter sales in 2026 were KRW 12 billion, an 18% increase year-over-year. Operating profit margin improved to 9.5%, compared to 7.2% for the same period last year. New subscribers totaled 45,000, with 70% coming through existing channels. Marketing costs were KRW 800 million, representing 6.7% of sales.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 45.47
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Quarterly Performance Report\nFirst quarter sales in 2026 were KRW 12 billion, an 18% increase year-over-year. Operating profit margin improved to 9.5%, compared to 7.2% for the same period last year. New subscribers totaled 45,000, with 70% coming through existing channels. Marketing costs were KRW 800 million, representing 6.7% of sales.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(70% 기존 채널 유입), 마케팅 비용 8억 원(매출의 6.7%)을 기록했다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 48.04
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 Licensing Decision\n\nThe team decided to keep the core module under Apache-2.0. The newly added plug-in SDK will be released under MIT. Commercial hosting services are undergoing separate BSL clause review.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture 및 외부 벤치마크는 원저작권을 유지하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.82
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 Licensing Decision\n\nThe team decided to keep the core module under Apache-2.0. The newly added plug-in SDK will be released under MIT. Commercial hosting services are undergoing separate BSL clause review.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture 및 외부 벤치마크는 원저작권을 유지하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스에는 별도 BSL 조항 적용을 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 33.27
+    },
+    {
+      "id": 3022,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 2026 Licensing Decision\n\nThe team decided to keep the core module under Apache-2.0. The newly added plug-in SDK will be released under MIT. Commercial hosting services are undergoing separate BSL clause review.",
+      "cloud_answer": "[Wiki] 2026 라이선싱 결정\n코어 모듈은 Apache-2.0, 신규 plug-in SDK 는 MIT 로 공개한다.\n제3자 fixture·외부 벤치마크는 원저작권을 보존하고 CITATION.md 에 출처를 명시한다.\n상업적 호스팅 서비스용 BSL 조항은 검토 중이다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 30.9
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 introduced privacy gate and monthly cost cap plumb-first into the core/routing/ package, utilizing 4 PII detection regexes + env-extensibility, and atomic JSON monthly token tally as key components. All defaults are OFF / no-cap for byte-identical no-op behavior, with Phase 5 wiring it as a consumer during cloud egress.\n\n**Summary:** Phase 4 implemented privacy and cost controls in routing with extensible detection and tracking, defaulting to off, for use in later phases' cloud egress.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 에 plumb-first 로 도입했고 (PII 정규식 4종 + env 확장, atomic JSON 월별 tally), 기본값 OFF/no-cap 으로 byte-identical 무동작이며 Phase 5 에서 cloud egress consumer 로 wire 된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 50.09
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 introduced privacy gate and monthly cost cap plumb-first into the core/routing/ package, utilizing 4 PII detection regexes + env-extensibility, and atomic JSON monthly token tally as key components. All defaults are OFF / no-cap for byte-identical no-op behavior, with Phase 5 wiring it as a consumer during cloud egress.\n\n**Summary:** Phase 4 implemented privacy and cost controls in routing with extensible detection and tracking, defaulting to off, for use in later phases' cloud egress.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 패키지로 plumb-first 도입했고 (PII regex 4종 + env-extensible, atomic JSON 월별 token tally), 기본값이 모두 OFF / no-cap 이라 byte-identical 무동작이며 Phase 5 가 cloud egress 시 consumer 로 wire 한다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 49.71
+    },
+    {
+      "id": 3023,
+      "type": "summarize",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 introduced privacy gate and monthly cost cap plumb-first into the core/routing/ package, utilizing 4 PII detection regexes + env-extensibility, and atomic JSON monthly token tally as key components. All defaults are OFF / no-cap for byte-identical no-op behavior, with Phase 5 wiring it as a consumer during cloud egress.\n\n**Summary:** Phase 4 implemented privacy and cost controls in routing with extensible detection and tracking, defaulting to off, for use in later phases' cloud egress.",
+      "cloud_answer": "[Wiki] Phase 4 routing primitives\nPhase 4 는 privacy gate 와 monthly cost cap 을 core/routing/ 에 plumb-first 로 도입했고, 기본 OFF/no-cap 으로 무동작이며 Phase 5 에서 cloud egress consumer 와 wire 된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 49.7
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰은 24시간마다 자동으로 바뀌는데요, 바뀔 때마다 현재 로그인된 모든 사용자는 다시 한번 로그인을 해야 합니다. 혹시 변경이 제대로 안 되면 시스템은 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n보안을 위해 인증 토큰은 24시간마다 한 번씩 새 것으로 바뀌어요. 이때 로그인되어 있던 분들은 모두 다시 로그인을 해주셔야 해요. 혹시 토큰 교체가 제대로 되지 않으면, 시스템이 자동으로 fallback 모드로 전환되니 걱정하지 않으셔도 됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.51
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰은 24시간마다 자동으로 바뀌는데요, 바뀔 때마다 현재 로그인된 모든 사용자는 다시 한번 로그인을 해야 합니다. 혹시 변경이 제대로 안 되면 시스템은 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희가 사용하는 인증 토큰은 24시간마다 한 번씩 새것으로 바뀌어요. 이때 현재 사용 중인 모든 세션은 다시 한 번 로그인(재인증)을 해주셔야 해요. 만약 토큰 교체가 잘 안 되면, 시스템은 임시로 안전하게 작동하는 fallback 모드로 전환됩니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.14
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰은 24시간마다 자동으로 바뀌는데요, 바뀔 때마다 현재 로그인된 모든 사용자는 다시 한번 로그인을 해야 합니다. 혹시 변경이 제대로 안 되면 시스템은 안전 모드로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희 시스템의 인증 토큰은 하루(24시간)에 한 번씩 새것으로 바뀌어요. 이렇게 토큰이 바뀌는 순간에는 그때까지 로그인되어 있던 모든 분들이 다시 한 번 로그인을 해주셔야 해요. 혹시라도 이 교체 과정이 잘 안 되는 경우에는 시스템이 자동으로 'fallback(예비)' 모드로 전환된답니다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 39.06
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있습니다. 하지만 팀의 코드 품질 향상을 위해 동료의 PR을 꼼꼼히 검토 부탁드립니다. 변경 사항이 큰 PR은 가능한 분할하여 제출해주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 만들기 위한 협업 과정입니다. 동료의 PR을 차분히 검토해 주시고, 가능하면 PR 단위를 너무 크지 않게 유지해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 35.07
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있습니다. 하지만 팀의 코드 품질 향상을 위해 동료의 PR을 꼼꼼히 검토 부탁드립니다. 변경 사항이 큰 PR은 가능한 분할하여 제출해주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 만들기 위한 협업 과정입니다. 동료의 PR을 차분히 검토해 주시고, PR 규모는 가급적 작게 유지해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 32.6
+    },
+    {
+      "id": 3032,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 부담스러울 수 있습니다. 하지만 팀의 코드 품질 향상을 위해 동료의 PR을 꼼꼼히 검토 부탁드립니다. 변경 사항이 큰 PR은 가능한 분할하여 제출해주시면 감사하겠습니다.",
+      "cloud_answer": "[Wiki] 코드 리뷰 가이드\n코드 리뷰는 더 나은 결과물을 만들기 위한 협업의 한 과정입니다. 동료의 PR을 차분히 검토해 주시고, 가능한 한 PR 크기는 작게 유지해 주세요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 31.8
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight, and a 7-day retention period is maintained. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight and retained for 7 days. End-of-month backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.71
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 1,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight, and a 7-day retention period is maintained. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight, and 7 days' worth is retained. End-of-month backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 26.23
+    },
+    {
+      "id": 3033,
+      "type": "reword",
+      "run": 2,
+      "hops": 0,
+      "a_is_local": false,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] Backup Policy\nData is backed up daily at midnight, and a 7-day retention period is maintained. End-of-month backups are stored separately for one year.",
+      "cloud_answer": "[Wiki] 백업 정책\nData is backed up daily at midnight, and 7 days' worth is retained. Month-end backups are stored separately for 1 year.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 25.76
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 3001,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 45.78
+      },
+      {
+        "id": 3002,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 34.71
+      },
+      {
+        "id": 3003,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 36.88
+      },
+      {
+        "id": 3011,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 27.15
+      },
+      {
+        "id": 3012,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 40.68
+      },
+      {
+        "id": 3013,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.97
+      },
+      {
+        "id": 3021,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 46.48
+      },
+      {
+        "id": 3022,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 31.66
+      },
+      {
+        "id": 3023,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 49.83
+      },
+      {
+        "id": 3031,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 36.57
+      },
+      {
+        "id": 3032,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 33.16
+      },
+      {
+        "id": 3033,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 3,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT",
+          "CORRECT",
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 25.9
+      }
+    ],
+    "summary": {
+      "n_questions": 12,
+      "n_runs_per_question": 3,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "factual_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "format_edit": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "summarize": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        },
+        "reword": {
+          "n": 3,
+          "local_correct": 3,
+          "cloud_correct": 3
+        }
+      }
+    }
+  }
+}

--- a/reports/research-runs/v18.7-phase-wikiedit-b/smoke_cellA.json
+++ b/reports/research-runs/v18.7-phase-wikiedit-b/smoke_cellA.json
@@ -1,0 +1,284 @@
+{
+  "design": "chat-mode free-form; both models same prior_turns / no evidence",
+  "fixture": "wiki_edit",
+  "local_model": "gemma4:e4b",
+  "local_backend": "ollama",
+  "num_predict": 400,
+  "force_think": "auto",
+  "pre_flight": {
+    "skipped": false,
+    "results": [
+      {
+        "name": "fixture_rows",
+        "status": "ok",
+        "detail": "75 answerable queries available (counts={'inference_query': 25, 'comparison_query': 25, 'temporal_query': 25})",
+        "extra": {
+          "counts": {
+            "inference_query": 25,
+            "comparison_query": 25,
+            "temporal_query": 25
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\workspaces\\hotpot_eval\\eval\\multihop_rag_queries.json"
+        }
+      },
+      {
+        "name": "chat_fixture",
+        "status": "ok",
+        "detail": "18 chat queries available (counts={'small_talk': 5, 'factual_chat': 5, 'open_question': 5, 'multi_turn': 3}, factual_with_gold=5, multiturn_with_prior=3)",
+        "extra": {
+          "counts": {
+            "small_talk": 5,
+            "factual_chat": 5,
+            "open_question": 5,
+            "multi_turn": 3
+          },
+          "path": "C:\\Project\\James-RAG-Evol-v010\\eval\\chat_mode_queries.json"
+        }
+      },
+      {
+        "name": "wiki_edit_fixture",
+        "status": "ok",
+        "detail": "12 wiki_edit queries available (counts={'factual_edit': 3, 'format_edit': 3, 'summarize': 3, 'reword': 3}, factual_with_gold=3, summarize_with_gold=3)",
+        "extra": {}
+      },
+      {
+        "name": "regex_sweep",
+        "status": "ok",
+        "detail": "0/75 false positives across 4 fast-path modes (['coding', 'meta', 'self_evolve', 'wiki_edit'])",
+        "extra": {
+          "total": 75,
+          "modes_swept": [
+            "coding",
+            "meta",
+            "self_evolve",
+            "wiki_edit"
+          ]
+        }
+      },
+      {
+        "name": "backend_registry",
+        "status": "ok",
+        "detail": "registered=['claude_code_cli', 'ollama_local']",
+        "extra": {
+          "registered": [
+            "claude_code_cli",
+            "ollama_local"
+          ]
+        }
+      },
+      {
+        "name": "abstraction_smoke",
+        "status": "ok",
+        "detail": "default_decider=function; run_cloud_egress callable",
+        "extra": {}
+      },
+      {
+        "name": "diffusiongemma_optin",
+        "status": "ok",
+        "detail": "flag=None registered=False",
+        "extra": {}
+      },
+      {
+        "name": "thinking_mode_contract",
+        "status": "ok",
+        "detail": "think_policy surface intact; JAMES_GEMMA4_E4B_THINK_OFF=1 active (gemma4 family models will receive think:false).",
+        "extra": {}
+      },
+      {
+        "name": "routing_phase4_primitives",
+        "status": "ok",
+        "detail": "surface stable (7 symbols); plumb-first (no consumer yet — Phase 5 wires)",
+        "extra": {}
+      }
+    ]
+  },
+  "num_ctx": 8192,
+  "cloud_backend": "claude_code_cli (via core.abstraction.run_cloud_egress)",
+  "judge": "claude-cli, blinded A/B per (query, run)",
+  "n_per_type": 1,
+  "n_runs": 1,
+  "caveat": {
+    "judge_self_preference": "judge is Claude; one candidate is Claude — self-preference is possible. Mitigated by blinding A/B + evidence-grounded grading + per-question raw dump. Treat the auto-score as a SIGNAL; confirm against raw answers.",
+    "gold_evidence_not_pipeline": "Reasoning-isolated design: both models get the same full gold evidence. Does NOT measure the full retrieval pipeline. A production Pareto claim needs a separate full-pipeline run (with JAMES retrieval + abstention) before any operator-facing conclusion.",
+    "small_n": "Sample is the first answerable N per question_type from MultiHop-RAG. Not representative. The verdict here is a §4.1 closure SIGNAL, not a publishable claim. n=3 paired (per feedback_n1_verdict_inflation_n3_caught) but n_questions is still small.",
+    "lenient_judge": "ABSTAINED + INCORRECT are scored separately, but two contradictory CORRECT answers can both land CORRECT (judge grades each independently). Per α-8 closure: paired Δ near 0 + collapse to noise band on n=3 has been observed (n=1 inflation pattern).",
+    "local_model_caveat": "Default local-model is gemma3:4b. Does NOT equate to gemma4 e4b (production tier, has the α-cycle thinking-trace floor on multihop). Re-run with --local-model gemma4:e4b to compare against the production tier.",
+    "abstraction_no_op": "Cloud path goes through core.abstraction.run_cloud_egress, but the gold-evidence fixture has no PII so entities=[] → mask is empty. The call path is exercised end-to-end (proves §5.7.13 module works against a real Claude backend) but the abstraction itself is a no-op for this fixture.",
+    "chat_mode_lenient_judge": "Chat-mode fixture (small_talk / open_question / multi_turn) is INTRINSICALLY judge-only. There is no gold ground-truth for free-form conversation. Only the factual_chat sub-class carries gold_signals and is gold-grounded checkable. The other 3 sub-classes inherit the +0.11-0.19 lenient bias quantified in v18.6 (project_judge_reliability_gold_grounded_v18_6). Report judge_correct AND gold_correct (factual_chat subset) separately. Do NOT promote chat-mode-only claims without the judge-bias caveat attached."
+  },
+  "rows": [
+    {
+      "id": 3001,
+      "type": "factual_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "cloud_answer": "[Wiki] 광합성 연구\n광합성은 식물이 빛 에너지를 화학 에너지로 전환하는 과정이다. 김 교수 연구팀은 2024년 새로운 광합성 효소를 발견했다. 이 발견은 농업 분야에 큰 영향을 줄 것으로 기대된다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 70.97
+    },
+    {
+      "id": 3011,
+      "type": "format_edit",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "cloud_answer": "[Wiki] 보안 체크리스트\n- HTTPS 만 허용한다.\n- CSP nonce 를 적용한다.\n- API key 는 환경변수에 둔다.\n- 로그에는 PII 를 남기지 않는다.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 14.68
+    },
+    {
+      "id": 3021,
+      "type": "summarize",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 분기 성과 보고\n2026년 1분기는 매출 120억 원(전년 대비 18% 성장)을 기록했으며, 영업이익률은 9.5%(작년 동기 7.2%)로 개선되었다. 신규 가입자는 4만 5천 명 중 70%가 기존 채널에서 유입되었고, 마케팅 비용은 8억 원(매출의 6.7%) 수준이었다.",
+      "cloud_answer": "[Wiki] 분기 성과 보고\n2026년 1분기 매출 120억 원(전년 대비 +18%), 영업이익률 9.5%(전년 동기 7.2%), 신규 가입자 4만 5천 명(기존 채널 유입 70%), 마케팅 비용 8억 원(매출의 6.7%).",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 37.19
+    },
+    {
+      "id": 3031,
+      "type": "reword",
+      "run": 0,
+      "hops": 0,
+      "a_is_local": true,
+      "local_verdict": "CORRECT",
+      "cloud_verdict": "CORRECT",
+      "local_abstain": false,
+      "cloud_abstain": false,
+      "local_answer": "[Wiki] 인증 토큰 회전\n인증 토큰이라는 건요, 24시간마다 주기적으로 바뀌어요. 이 '바뀌는 시점'에는 현재 사용 중인 모든 기기(세션)에서 다시 한번 로그인을 하셔야 해요. 만약 이 과정이 원활하게 진행되지 않으면, 시스템은 안전한 비상 모드(fallback 모드)로 전환됩니다.",
+      "cloud_answer": "[Wiki] 인증 토큰 회전\n저희 시스템의 인증 토큰은 하루에 한 번, 24시간마다 새것으로 바뀌어요. 이렇게 토큰이 바뀌는 순간에는 그때 접속해 계신 모든 분들이 다시 한 번 로그인을 해주셔야 한답니다. 혹시라도 토큰 교체 과정에서 문제가 생기면, 시스템은 자동으로 fallback 모드로 전환되어 안전하게 운영을 이어가요.",
+      "local_error": "",
+      "cloud_error": "",
+      "judge_error": "",
+      "elapsed_sec": 18.73
+    }
+  ],
+  "aggregate": {
+    "per_question": [
+      {
+        "id": 3001,
+        "type": "factual_edit",
+        "hops": 0,
+        "n_runs": 1,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 70.97
+      },
+      {
+        "id": 3011,
+        "type": "format_edit",
+        "hops": 0,
+        "n_runs": 1,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 14.68
+      },
+      {
+        "id": 3021,
+        "type": "summarize",
+        "hops": 0,
+        "n_runs": 1,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 37.19
+      },
+      {
+        "id": 3031,
+        "type": "reword",
+        "hops": 0,
+        "n_runs": 1,
+        "local_majority": "CORRECT",
+        "cloud_majority": "CORRECT",
+        "local_verdicts": [
+          "CORRECT"
+        ],
+        "cloud_verdicts": [
+          "CORRECT"
+        ],
+        "local_stable": true,
+        "cloud_stable": true,
+        "elapsed_sec_mean": 18.73
+      }
+    ],
+    "summary": {
+      "n_questions": 4,
+      "n_runs_per_question": 1,
+      "local_correct_rate": 1.0,
+      "cloud_correct_rate": 1.0,
+      "local_abstain_rate": 0.0,
+      "cloud_abstain_rate": 0.0,
+      "delta_correct_cloud_minus_local": 0.0,
+      "local_stable_rate": 1.0,
+      "cloud_stable_rate": 1.0,
+      "by_type": {
+        "factual_edit": {
+          "n": 1,
+          "local_correct": 1,
+          "cloud_correct": 1
+        },
+        "format_edit": {
+          "n": 1,
+          "local_correct": 1,
+          "cloud_correct": 1
+        },
+        "summarize": {
+          "n": 1,
+          "local_correct": 1,
+          "cloud_correct": 1
+        },
+        "reword": {
+          "n": 1,
+          "local_correct": 1,
+          "cloud_correct": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

108 LOCAL + 108 CLOUD + 108 judge LLM calls (3 cells × 12 queries × 3 paired runs) on the Phase wiki_edit-a fixture.

**Cells**:
- A — `gemma4:e4b` OFF (`JAMES_GEMMA4_E4B_THINK_OFF=1`, cap=400) — current default
- B — `gemma3:12b` (cap=400) — Phase 2b/3b winner on prior fixtures
- C — `gemma3:27b` (cap=400) — Phase 3b accuracy leader; verbose; 2.3× slower

### Gold-grounded headline (summarize sub-class)

> **gemma3:12b (1.000) > gemma4:e4b OFF (0.667) > gemma3:27b (0.333)**

The judge column hides every gap (all 1.000). Gold-grounded recheck — applied to `factual_edit` + `summarize` per their `gold_signals` — surfaces the actual ranking.

### ⭐ Cross-task ranking reversal

| Task | gemma3:12b gold | gemma3:27b gold | gemma4:e4b gold |
|---|---|---|---|
| **Retrieval** (Phase 3b: evidence-rich multi-hop) | 0.889 | **1.000** | 0.815 |
| **Wiki edit** (Phase wiki_edit-b: summarize) | **1.000** | 0.333 | 0.667 |

27b's verbose tendency helps on retrieval (more facts included → more gold matches) but **hurts on summarize** (extra prose displaces key facts → gold_signals fail). **Task verb (summarize vs explain) flips which model wins**. The per-mode `DEFAULT_PREFERENCE` IS the right abstraction; a single global ranking does not exist.

### Latency + verbosity

| Cell | mean latency | summarize ans_chars | format ans_chars |
|---|---|---|---|
| A | 35.1 s | 188 | 117 |
| B | **23.2 s** | 211 | 102 |
| C | 37.2 s | **365** (+73% vs B) | **224** (+120% vs B) |

## Verification

`reports/research-runs/v18.7-phase-wikiedit-b/`:
- `cellA_gemma4_off.json` (38 rows)
- `cellB_gemma3_12b.json`
- `cellC_gemma3_27b.json`
- `smoke_cellA.json` (n=1×1 wire verification — 4/4 CORRECT, 142 s)
- `QUALITY_DELTA_CARD.md` (5-axis Pareto + cross-task reversal section)

**Pareto verdict (5-axis)**:
- Cell B Pareto-dominates Cell A on graded answer + latency; ties on token cost.
- Cell C loses on graded answer + token cost; ties on latency.
- **Promote B. Demote C.**

**Streak (rule #1/#2)**: `core/retrieval` + `core/graph` traversal + `core/reasoning` all 0 lines changed (results-only PR).

**Quality delta**: exempt (label: `docs`) — measurement results + analysis; engine wire is the follow-up Phase wiki_edit-c PR.

## Phase wiki_edit-c (follow-up)

Reorder `DEFAULT_PREFERENCE['wiki_edit']` per the 3-cell ranking + extend `engine.py`'s mode-routing branch from `("chat", "retrieval")` to `("chat", "retrieval", "wiki_edit")`. `JAMES_DISABLE_MODE_AWARE_ROUTING` kill-switch stays generalized.

## Caveats

- `small_n` = 12 × 3 runs per cell. Gap is large enough to clear noise; cross-corpus validation pending.
- Judge self-preference (cloud=Claude=judge); gold-grounded recheck is the verdict source for `factual_edit` + `summarize`.
- Judge-only sub-classes (`format_edit` + `reword`): no gold ground-truth; 1.000 across all cells should NOT be cited as parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)