### PR TITLE
feat(v0.6.1): vision mode — handler + engine wire + chat image-attach (실사용)

### DIFF
--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -34,6 +34,8 @@ ACTIVE_MODES = {
     "coding",
     "wiki_edit",
     "self_evolve",   # [P7] 자기 인식/진화 활성화
+    "vision",        # [v18.7] 이미지→텍스트 (handle_vision); image_path
+                     # 첨부 또는 명시 override 로만 진입 (텍스트 라우터 X).
 }
 
 # 미래 확장 예정 모드 (현재는 fallback 처리)
@@ -45,8 +47,8 @@ FUTURE_MODES = {
 # role별 허용 모드
 ROLE_ALLOWED = {
     "admin":    ACTIVE_MODES | FUTURE_MODES,
-    "manager":  {"chat", "retrieval", "meta", "coding"},
-    "employee": {"chat", "retrieval", "meta", "coding"},
+    "manager":  {"chat", "retrieval", "meta", "coding", "vision"},
+    "employee": {"chat", "retrieval", "meta", "coding", "vision"},
     # external sees meta too — listing entity *names* leaks no
     # ABAC-protected content (the read still goes through retrieval +
     # role filter). The list itself is the kind of inventory question

--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -28,6 +28,7 @@ from core.reasoning.modes import (
     handle_wiki_edit,
     handle_self_evolve,
     handle_coding,
+    handle_vision,
 )
 
 TIMING_TARGET_SEC = 30.0
@@ -230,7 +231,7 @@ class ReasoningEngine:
         # role-allowed 체크는 그대로 적용해서 권한 우회 방지.
         from core.intent_classifier import ROLE_ALLOWED
         VALID_OVERRIDES = {"chat", "retrieval", "meta", "coding",
-                           "wiki_edit", "self_evolve"}
+                           "wiki_edit", "self_evolve", "vision"}
         override = (mode_override or "").strip().lower()
         if override and override in VALID_OVERRIDES:
             allowed = ROLE_ALLOWED.get(user_role, {"chat", "retrieval"})
@@ -269,6 +270,15 @@ class ReasoningEngine:
                   f"retrieval pipeline)")
             mode = "retrieval"
 
+        # ── Image attached → vision mode (v18.7 vision-wire) ─────
+        # An image_path in kwargs forces vision regardless of what the
+        # text router produced — the query is *about* the image. Gated
+        # by ROLE_ALLOWED so external (chat-only) can't reach it.
+        if kwargs.get("image_path") and "vision" in ROLE_ALLOWED.get(
+                user_role, {"chat", "retrieval"}):
+            print(f"[ROUTER] image attached → mode=vision (was {mode!r})")
+            mode = "vision"
+
         # ── [#A2 phase 2] selected_model validation ────────────
         # The user's secondary-picker choice arrives untrusted. Reject
         # anything not in the catalog for the resolved mode — silent
@@ -280,25 +290,15 @@ class ReasoningEngine:
         elif picked_model:
             print(f"[MODEL] mode={mode} using user-selected '{picked_model}'")
 
-        # ── v18.7 Phase 2c/3c — measured-preference mode routing ──
-        # When the user did NOT pick a model, these modes auto-route
-        # through the measured preference list instead of the global
-        # config.GEMMA_MODEL default. requested="" makes
-        # resolve_for_mode use the preference-list top (not
-        # GEMMA_MODEL), so these are the modes that actually consume
-        # the Phase-1 plumbing.
-        #   • chat (Phase 2b, v18.7-phase2b-chat QDC): gemma3:12b
-        #     (0.917) > gemma4:e4b (0.833) > gemma3:4b (0.750) on the
-        #     Korean chat fixture.
-        #   • retrieval (Phase 3b, v18.7-phase3b-tier-ladder QDC):
-        #     gold-grounded 27b(1.0) > 12b(0.889) > 4b(0.852) >
-        #     gemma4:e4b(0.815). The default GEMMA_MODEL (gemma4:e4b)
-        #     is WEAKEST on evidence-rich retrieval; preference top is
-        #     gemma3:12b (best value; 27b is more accurate but 2.3x
-        #     slower + verbose, so not the default).
-        # Kill-switch: JAMES_DISABLE_MODE_AWARE_ROUTING=1 reverts both
-        # to GEMMA_MODEL. meta/wiki_edit/vision/self_evolve stay on the
-        # legacy path (not yet measurement-validated per mode).
+        # ── v18.7 Phase 2c/3c/wiki_edit-c — measured-preference routing ──
+        # When the user did NOT pick a model, these modes auto-route via
+        # resolve_for_mode(mode, requested="") to the preference-list top
+        # (requested="" bypasses config.GEMMA_MODEL). All three are
+        # measurement-backed → gemma3:12b; see docs/reference/
+        # routing-matrix.md for the per-mode QDC + ranking. Kill-switch
+        # JAMES_DISABLE_MODE_AWARE_ROUTING=1 reverts all to GEMMA_MODEL.
+        # meta/self_evolve stay legacy; vision resolves its own
+        # single-candidate model inside handle_vision (no text catalog).
         if mode in ("chat", "retrieval", "wiki_edit") and not picked_model:
             import os
             if not os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
@@ -322,6 +322,8 @@ class ReasoningEngine:
             return handle_self_evolve(self, safe_query, system_prompt, user_role, t_start, selected_model=picked_model)
         if mode == "coding":
             return handle_coding(self, safe_query, system_prompt, user_role, t_start, selected_model=picked_model)
+        if mode == "vision":
+            return handle_vision(self, safe_query, kwargs.get("image_path", ""), user_role, t_start, selected_model=picked_model)
 
         # ── PR-O5 (cycle 12) — internal RAG feature gate ──────────
         # external (= guest / 비로그인) 는 일상 챗만 허용. internal

--- a/core/reasoning/modes/__init__.py
+++ b/core/reasoning/modes/__init__.py
@@ -38,6 +38,7 @@ from .meta         import handle_meta
 from .wiki_edit    import handle_wiki_edit
 from .self_evolve  import handle_self_evolve
 from .coding       import handle_coding
+from .vision       import handle_vision
 
 # Shared constants (originally module-level in the monolith). Kept in
 # ``_common`` so any future handler can re-use them — re-exported here
@@ -55,6 +56,7 @@ __all__ = [
     "handle_wiki_edit",
     "handle_self_evolve",
     "handle_coding",
+    "handle_vision",
     "CONTINUITY_DIRECTIVE_KO",
     "CONTINUITY_DIRECTIVE_EN",
 ]

--- a/core/reasoning/modes/vision.py
+++ b/core/reasoning/modes/vision.py
@@ -1,0 +1,190 @@
+"""``handle_vision`` — image → text analysis via the local vision model.
+
+The reasoning-engine peer to ``handle_chat`` / ``handle_meta`` /
+``handle_wiki_edit`` for the ``vision`` mode. It is the dispatch + routing
+shell, NOT a re-implementation of the vision pipeline — the actual
+EXIF + llava work stays in ``tools.multimodal.image_analyzer.analyze_image``.
+
+Why this differs from the text modes
+------------------------------------
+chat / retrieval / wiki_edit each went through an a/b/c quality
+measurement (3-cell paired) because they have several candidate text
+models. Vision has a SINGLE local candidate (llava), so there is no
+marginal ranking to measure — a 3-cell QDC is moot. The "routing" work
+here is therefore *resolution robustness*, not model selection:
+
+  - pick the vision model through ``resolve_for_mode("vision")`` so it is
+    installed-checked with a graceful fallback + operator warning, instead
+    of a blind ``config.MULTIMODAL_MODEL`` reference (which, as of v18.7,
+    is not even defined in config.py → silently hardcoded to ``llava:13b``
+    with no install check); and
+  - honour the shared ``JAMES_DISABLE_MODE_AWARE_ROUTING`` kill-switch so
+    one env var reverts ALL mode-aware routing (chat / retrieval /
+    wiki_edit / vision) to the legacy path.
+
+Trust (#44)
+-----------
+Vision output is ``source="vision"`` ``trust="low"`` — model hallucination
+plus prompt-injection text baked into an image can flow through an
+OCR-like path. ``handle_vision`` RETURNS the analysis to the user but
+never feeds it back into a downstream synth prompt, so no quarantine gate
+is needed on this path; the ``trust`` marker is carried in
+``vision_meta`` for any caller that later does compose it.
+
+Plumb-first (v0.6.1 v18.7 vision-handler)
+-----------------------------------------
+This handler is exported + unit-tested but ``engine.py`` does NOT dispatch
+to ``mode == "vision"`` yet, and images do not yet flow through the
+``/query`` path (they arrive via the dedicated ``/analyze/image/`` REST
+route). Behaviour is byte-identical until the follow-up vision-wire PR
+adds the engine dispatch + ``VALID_OVERRIDES`` entry + image plumbing.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Tuple
+
+
+def _resolve_vision_model(selected_model: str) -> Tuple[str, str, str]:
+    """Return ``(tag, source, warning)`` for the vision model.
+
+    Priority:
+      1. explicit user pick (``selected_model``) — trusted by the caller.
+      2. ``JAMES_DISABLE_MODE_AWARE_ROUTING`` set → legacy config default
+         (``MULTIMODAL_MODEL`` if defined, else ``llava:13b``) with NO
+         install check — same kill-switch semantics as the text modes.
+      3. ``resolve_for_mode("vision")`` → preference list (currently a
+         single entry, ``llava:13b``) with install-check + graceful
+         fallback + warning.
+
+    ``tag`` is empty only when nothing at all is installed in Ollama, in
+    which case the handler surfaces a friendly install hint.
+    """
+    sel = (selected_model or "").strip()
+    if sel:
+        return sel, "requested", ""
+
+    if os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
+        try:
+            from config import MULTIMODAL_MODEL  # type: ignore
+            legacy = (MULTIMODAL_MODEL or "").strip() or "llava:13b"
+        except Exception:
+            legacy = "llava:13b"
+        return legacy, "legacy_killswitch", ""
+
+    try:
+        from core.model_resolver import resolve_for_mode
+        rm = resolve_for_mode("vision", requested="")
+        return rm.tag, rm.source, rm.warning
+    except Exception:
+        # Resolver unreachable (e.g. Ollama down at import) → assume the
+        # canonical local vision tag; the downstream llava client does its
+        # own is_available() check and degrades to EXIF-only.
+        return "llava:13b", "fallback", ""
+
+
+def handle_vision(
+    engine,
+    safe_query: str,
+    image_path: str,
+    user_role: str,
+    t_start: float,
+    selected_model: str = "",
+) -> Dict[str, Any]:
+    """Analyse ``image_path`` and return the standard reasoning-engine row.
+
+    ``safe_query`` is the (optional) user text accompanying the image —
+    "이 사진 어디야?" etc. When empty, the analyzer's default structured
+    prompt is used.
+    """
+    t_vision = time.time()
+
+    def _row(answer: str, *, blocked: bool = False, **extra) -> Dict[str, Any]:
+        row: Dict[str, Any] = {
+            "answer":        answer,
+            "mode":          "vision",
+            "graph_paths":   [],
+            "graph_used":    0,
+            "sources":       [image_path] if image_path else [],
+            "blocked":       blocked,
+            "role_used":     user_role,
+            "timing_sec":    round(time.time() - t_start, 2),
+            "unified_score": 1.0,
+            "loop_count":    0,
+        }
+        row.update(extra)
+        return row
+
+    # No image attached → friendly guidance. Keeps the (future) engine
+    # dispatch safe even when the /query path routes mode="vision" without
+    # an image payload.
+    if not (image_path or "").strip():
+        return _row(
+            "이미지가 첨부되지 않았습니다. 분석할 이미지를 첨부한 뒤 다시 질문해 주세요."
+        )
+
+    model_tag, source, warning = _resolve_vision_model(selected_model)
+    if not model_tag:
+        return _row(
+            "비전 모델이 설치되어 있지 않습니다. "
+            "먼저 `ollama pull llava:13b` 를 실행해 주세요."
+        )
+    if warning:
+        print(f"[VISION] {warning}")
+    print(f"[VISION] model={model_tag} (source={source}) image={image_path}")
+
+    answer = ""
+    vision_meta: Dict[str, Any] = {}
+    try:
+        from tools.multimodal.image_analyzer import analyze_image
+
+        result = analyze_image(image_path, role=user_role, model=model_tag)
+
+        if result.get("error"):
+            return _row(f"❌ 이미지 분석 실패: {result['error']}")
+
+        description = (result.get("description") or "").strip()
+        location    = (result.get("location") or "").strip()
+        date        = (result.get("date") or "").strip()
+        persons     = result.get("persons") or []
+        tags        = result.get("tags") or []
+
+        lines = []
+        if description:
+            lines.append(description)
+        meta_bits = []
+        if date:
+            meta_bits.append(f"날짜: {date}")
+        if location:
+            meta_bits.append(f"장소: {location}")
+        if persons:
+            meta_bits.append("인물: " + ", ".join(str(p) for p in persons))
+        if tags:
+            meta_bits.append("태그: " + ", ".join(str(t) for t in tags))
+        if meta_bits:
+            if lines:
+                lines.append("")
+            lines.extend(f"- {b}" for b in meta_bits)
+        answer = "\n".join(lines).strip() or (
+            "이미지에서 분석 가능한 정보를 찾지 못했습니다."
+        )
+
+        vision_meta = {
+            "model":    model_tag,
+            "source":   "vision",   # #44 trust classification
+            "trust":    "low",
+            "date":     date,
+            "location": location,
+            "persons":  persons,
+            "tags":     tags,
+        }
+    except Exception as e:
+        engine._log("vision", e, user_role)
+        answer = f"❌ 이미지 분석 중 오류: {e}"
+
+    engine._elapsed(t_vision, "VISION")
+    return _row(answer, vision_meta=vision_meta)
+
+
+__all__ = ["handle_vision"]

--- a/docs/reference/routing-matrix.md
+++ b/docs/reference/routing-matrix.md
@@ -24,7 +24,7 @@
 | **coding** | 코드 작성·버그 | qwen2.5-coder:32b | `llm.router(task_type="coding")` | `[coding_route]` / router log ✅ | dedicated router |
 | **wiki_edit** | 지식 수정·삭제 (admin) | **gemma3:12b** | engine.py `resolve_for_mode("wiki_edit", requested="")` → preference top | `[MODEL] mode=wiki_edit auto-routed → gemma3:12b` ✅ observed | **measurement-backed (Phase wiki_edit-c)** |
 | **self_evolve** | 자메스 자기개선 (admin) | gemma4:e4b | `call_gemma(model=None)` → `resolve_chat()` → GEMMA_MODEL | silent | legacy (unmeasured) |
-| vision | (FUTURE — not routed) | llava:13b | `call_gemma_vision` direct | n/a | inactive |
+| vision | 이미지 → 텍스트 분석 (image_path 첨부) | **llava:13b** | engine `image_path→vision` override → `handle_vision` → `resolve_for_mode("vision")` (install-check + graceful fallback) | `[ROUTER] image attached → mode=vision` + `[VISION] model=llava:13b (source=preference)` | **active** (handler + engine dispatch + `/query` image_path + 챗 첨부 UI/`POST /vision/upload/`). single local candidate → no a/b/c QDC, routing = resolution-robustness only |
 
 ## Resolution priority (3-tier)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -620,7 +620,32 @@
       <div id="chat-attachment-row"
            style="display:none;flex-wrap:wrap;gap:6px;padding:6px 16px;
                   border-bottom:1px solid var(--border-2);"></div>
+      <!-- v18.7 vision-wire — 단일 이미지 첨부 미리보기. 첨부 시 표시,
+           전송/제거 시 숨김. (코퍼스 인제스트용 chat-attachment-row 와
+           별개 — 이건 비전 모드 1회성 첨부.) -->
+      <div id="vision-preview"
+           style="display:none;align-items:center;gap:8px;padding:6px 16px;
+                  border-bottom:1px solid var(--border-2);font-size:13px;">
+        <span id="vision-preview-name" style="color:var(--text-2);"></span>
+        <button id="vision-clear-btn" data-action="clear-vision-image"
+                aria-label="이미지 첨부 제거"
+                style="background:none;border:none;color:var(--text-3);
+                       cursor:pointer;padding:2px 6px;">제거</button>
+      </div>
+      <input type="file" id="vision-file-input" accept="image/*"
+             style="display:none" aria-hidden="true">
       <div class="input-wrap">
+        <button class="attach-btn" id="attach-btn" data-action="attach-image"
+                aria-label="이미지 첨부"
+                style="background:none;border:none;cursor:pointer;
+                       padding:0 8px;color:var(--text-3);display:flex;
+                       align-items:center;">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+          </svg>
+        </button>
         <textarea id="chat-input" placeholder="Type a message (Shift+Enter for new line)"
                   data-i18n-placeholder="chat.placeholder" rows="1"></textarea>
         <button class="send-btn" id="send-btn" data-action="send-message"

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -175,6 +175,13 @@ function _bindFrontendEvents() {
       case 'copy-conversation':         copyConversation(); break;
       // Send + login
       case 'send-message':              sendMessage(); break;
+      // v18.7 vision-wire — image attach
+      case 'attach-image': {
+        const vfi = document.getElementById('vision-file-input');
+        if (vfi) vfi.click();
+        break;
+      }
+      case 'clear-vision-image':        clearVisionImage(); break;
       case 'toggle-api-key-visibility': toggleApiKeyVisibility(); break;
       case 'close-login':               closeLogin(); break;
       case 'do-login':                  doLogin(); break;
@@ -276,6 +283,9 @@ function _bindStableInputs() {
   if (mp)  mp.addEventListener('change', () => onModePickerChange());
   const mdp = document.getElementById('model-picker');
   if (mdp) mdp.addEventListener('change', () => onModelPickerChange());
+  // v18.7 vision-wire — image file selection → upload → preview.
+  const vfi = document.getElementById('vision-file-input');
+  if (vfi) vfi.addEventListener('change', (e) => handleVisionFileChange(e));
   // Modal-overlay click-outside → close. Each overlay's existing
   // close*Outside fn already checks ``e.target === overlay`` so we
   // forward the event unchanged.
@@ -1323,10 +1333,73 @@ let lastUserQuestion = '';
 // askWithForceWeb이 set, sendMessage가 read+clear (단발성).
 let _forceWebOnce = false;
 
+// v18.7 vision-wire — 첨부된 이미지의 server-side 경로 + 표시 이름.
+// handleVisionFileChange가 업로드 성공 시 set, sendMessage가 read +
+// 단발성 clear (force_web과 동일 1회용 패턴). null = 텍스트 전용 질의.
+let _pendingVisionImage = null;
+
+/* 이미지 선택 → /vision/upload/ 즉시 업로드 → 경로 확보 + 미리보기.
+   업로드를 선택 시점에 끝내두면 전송 시점엔 image_path가 이미 준비됨. */
+async function handleVisionFileChange(e) {
+  const f = e.target && e.target.files && e.target.files[0];
+  if (!f) return;
+  // 같은 파일 재선택도 change가 다시 뜨도록 input 초기화.
+  e.target.value = '';
+
+  const nameEl = document.getElementById('vision-preview-name');
+  const row    = document.getElementById('vision-preview');
+  if (nameEl) nameEl.textContent = `업로드 중… ${f.name}`;
+  if (row)    row.style.display = 'flex';
+
+  try {
+    const fd = new FormData();
+    fd.append('file', f);
+    fd.append('api_key', getApiKey());
+    const headers = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;  // multipart: Content-Type 미설정
+    const r = await fetch(`${API}/vision/upload/`, {
+      method: 'POST', headers, body: fd,
+    });
+    if (!r.ok) {
+      const err = await r.json().catch(() => ({}));
+      throw new Error(err.detail || r.statusText);
+    }
+    const data = await r.json();
+    _pendingVisionImage = { path: data.image_path, name: data.filename || f.name };
+    renderVisionPreview();
+  } catch (err) {
+    _pendingVisionImage = null;
+    clearVisionImage();
+    toast(`이미지 업로드 실패: ${err.message || err}`, 'error');
+  }
+}
+
+function renderVisionPreview() {
+  const row    = document.getElementById('vision-preview');
+  const nameEl = document.getElementById('vision-preview-name');
+  if (!_pendingVisionImage) { if (row) row.style.display = 'none'; return; }
+  if (nameEl) nameEl.textContent = `첨부: ${_pendingVisionImage.name}`;
+  if (row)    row.style.display = 'flex';
+}
+
+function clearVisionImage() {
+  _pendingVisionImage = null;
+  const row = document.getElementById('vision-preview');
+  if (row) row.style.display = 'none';
+  const vfi = document.getElementById('vision-file-input');
+  if (vfi) vfi.value = '';
+}
+
 async function sendMessage() {
   const input = document.getElementById('chat-input');
   const text  = input.value.trim();
-  if (!text) return;
+  // 이미지가 첨부돼 있으면 텍스트 없이도 전송 허용 (analyzer 기본 프롬프트).
+  if (!text && !_pendingVisionImage) return;
+
+  // 단발성 vision 첨부 capture + clear (force_web과 동일 패턴).
+  const visImg = _pendingVisionImage;
+  _pendingVisionImage = null;
+  clearVisionImage();
 
   // item #4: 다음 답변이 다운로드 버튼을 보일지 결정
   pendingReportRequest = REPORT_REQUEST_KEYWORDS.test(text);
@@ -1338,8 +1411,13 @@ async function sendMessage() {
   _forceWebOnce = false;
 
   hideWelcome();
-  appendMsg('user', text);
-  saveToLocal('user', text);
+  // 이미지 첨부 시 사용자 bubble에 표시 (텍스트 없으면 분석 요청만).
+  const userBubble = visImg
+    ? (text ? `${text}\n[첨부 이미지: ${visImg.name}]`
+            : `[이미지 분석 요청: ${visImg.name}]`)
+    : text;
+  appendMsg('user', userBubble);
+  saveToLocal('user', userBubble);
   input.value = '';
   input.style.height = 'auto';
 
@@ -1404,6 +1482,9 @@ async function sendMessage() {
         // [#A2 phase 2] secondary picker로 고른 LLM tag. 서버 catalog
         // 검증 후 mode handler의 call_gemma(model=...)로 전달.
         selected_model:   selectedModel || '',
+        // v18.7 vision-wire — 첨부 이미지의 server-side 경로. 서버가
+        // _safe_image_path(UPLOAD_DIR 격리) 재검증 후 vision 모드 라우팅.
+        image_path:       visImg ? visImg.path : '',
       }),
       signal: AC ? AC.signal : undefined,
     });

--- a/llm/providers/llava_client.py
+++ b/llm/providers/llava_client.py
@@ -19,14 +19,18 @@ from llm.base import BaseLLM
 class LlavaClient(BaseLLM):
     name = "llava"
 
-    def __init__(self):
+    def __init__(self, model: str = ""):
         try:
             from config import MULTIMODAL_MODEL, OLLAMA_API_URL
-            self.model   = MULTIMODAL_MODEL   # llava:13b
-            self.api_url = OLLAMA_API_URL
+            default_model = MULTIMODAL_MODEL   # llava:13b
+            self.api_url  = OLLAMA_API_URL
         except ImportError:
-            self.model   = "llava:13b"
-            self.api_url = "http://127.0.0.1:11434/api/generate"
+            default_model = "llava:13b"
+            self.api_url  = "http://127.0.0.1:11434/api/generate"
+        # An explicit (resolved) tag wins — e.g. handle_vision passes the
+        # ``resolve_for_mode("vision")`` result. Empty keeps the legacy
+        # config/hardcoded default so existing callers are byte-identical.
+        self.model = (model or "").strip() or default_model
 
     def generate(self, messages: list, **kwargs) -> str:
         """텍스트 전용 — 이미지 없을 때 fallback"""

--- a/routes/multimodal.py
+++ b/routes/multimodal.py
@@ -117,6 +117,58 @@ async def analyze_video(
         try: os.remove(tmp_path)
         except Exception: pass
 
+@router.post("/vision/upload/", summary="비전 이미지 업로드 (챗 첨부) [v18.7]")
+async def vision_upload(
+    file:    UploadFile = File(...),
+    api_key: str = Form(...),
+    role:    str = Depends(get_role_from_request),
+):
+    """챗 비전 첨부용 경량 업로드.
+
+    이미지를 UPLOAD_DIR 에 저장하고 server-side 경로만 반환한다 —
+    분석/인제스트 없음 (그건 handle_vision 가 POST /query/ 흐름에서
+    수행). 반환된 image_path 를 클라이언트가 다음 /query/ 요청에 실어
+    보내면, 서버가 _safe_image_path 로 UPLOAD_DIR 격리를 재검증한 뒤
+    vision 모드로 라우팅한다. (클라이언트가 경로를 변조해도 격리
+    재검증에서 걸러진다.)
+    """
+    verify_api_key(api_key)
+
+    # ROLE_ALLOWED 와 동일 정책 — external(일상챗 전용) 차단.
+    from core.intent_classifier import ROLE_ALLOWED
+    if "vision" not in ROLE_ALLOWED.get(role, set()):
+        raise HTTPException(status_code=403, detail="비전 분석 권한이 없습니다.")
+
+    suffix  = os.path.splitext(file.filename or "")[1].lower()
+    allowed = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+    if suffix not in allowed:
+        raise HTTPException(status_code=400,
+                            detail=f"지원 형식: {sorted(allowed)}")
+
+    data = await file.read()
+    try:
+        from config import MAX_UPLOAD_BYTES
+        cap = MAX_UPLOAD_BYTES
+    except Exception:
+        cap = 20 * 1024 * 1024
+    if len(data) > cap:
+        raise HTTPException(status_code=413,
+                            detail="이미지가 너무 큽니다.")
+
+    import uuid
+    name = f"chatvis_{int(time.time())}_{uuid.uuid4().hex[:8]}{suffix}"
+    dest = os.path.join(UPLOAD_DIR, name)
+    with open(dest, "wb") as f:
+        f.write(data)
+
+    _write_audit(role, "/vision/upload/", query=(file.filename or "")[:80],
+                 answer=f"saved {name} ({len(data)} bytes)")
+    return {
+        "image_path": os.path.abspath(dest),
+        "filename":   file.filename or name,
+        "bytes":      len(data),
+    }
+
 @router.post("/screen/analyze/", summary="화면 분석 [P7-SCR-1]")
 async def screen_analyze(
     data: ScreenRequest,

--- a/routes/query.py
+++ b/routes/query.py
@@ -27,6 +27,27 @@ class _LazySingleton:
 rag_engine = _LazySingleton(get_rag_engine)
 router = APIRouter()
 
+
+def _safe_image_path(raw: str) -> str:
+    """Return ``raw`` only if it resolves to an existing file INSIDE
+    UPLOAD_DIR; else "". Blocks path-traversal / arbitrary-file-read via
+    a client-supplied ``image_path`` (the client can only reference files
+    it legitimately uploaded through /analyze/image/).
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return ""
+    try:
+        import os
+        from config import UPLOAD_DIR
+        base = os.path.realpath(UPLOAD_DIR)
+        target = os.path.realpath(raw)
+        if os.path.commonpath([base, target]) != base:
+            return ""           # outside UPLOAD_DIR → reject
+        return target if os.path.isfile(target) else ""
+    except Exception:
+        return ""
+
 # ─── Pydantic ───
 
 class QueryRequest(BaseModel):
@@ -70,6 +91,13 @@ class QueryRequest(BaseModel):
     # silently falls back to the mode default (security: client cannot
     # request arbitrary Ollama tags).
     selected_model:   str  = ""
+    # [v18.7 vision-wire] Server-side path of a previously-uploaded image
+    # (e.g. the temp file written by POST /analyze/image/). When set and
+    # the path resolves INSIDE UPLOAD_DIR (path-traversal guard) and the
+    # role is vision-allowed, the engine routes this turn to vision mode
+    # (handle_vision → local llava). A path outside UPLOAD_DIR, or a
+    # non-existent file, is silently dropped — the query proceeds as text.
+    image_path:       str  = ""
 
 class QueryResponse(BaseModel):
     question:       str
@@ -157,6 +185,7 @@ async def query(
         mode_override    = data.mode_override,     # item #6: chat 페이지 모드 picker
         force_web_search = data.force_web_search,  # [#A8-6] explicit web exploration
         selected_model   = data.selected_model,    # [#A2 phase 2] user-picked LLM tag
+        image_path       = _safe_image_path(data.image_path),  # vision-wire
     )
     elapsed = time.time() - t_start
 

--- a/tests/test_v06_module_size_gate.py
+++ b/tests/test_v06_module_size_gate.py
@@ -47,8 +47,27 @@ GRANDFATHERED: dict = {
     # v0.6.1 v18.7 (2026-06-20) — meta.py split into the meta/
     # package (PR `refactor/v0.6.1-meta-mode-split`); the entry
     # was removed in the same PR per the anti-creep rule.
-    # No grandfather entries currently — every core/**/*.py is at
-    # or under the rule #5 ceiling.
+    #
+    # ── Pre-existing split-debt surfaced 2026-06-21 ──────────────
+    # Both files crept over the 20 KB cap AFTER the gate (#983) landed
+    # — model_resolver.py via the Phase 3a/3c/wiki_edit-c routing
+    # build-out, intent_classifier.py via #987 + the vision mode
+    # registration. They were already RED before the vision-wire PR
+    # discovered them; grandfathered here (operator decision) so the
+    # gate is GREEN, with the actual splits deferred to the
+    # ``fix/v0.6.1-test-suite-sweep`` branch.
+    "model_resolver.py": (
+        "extract the Phase-3a LOCAL_TIER_LADDER + resolve_local_tier "
+        "+ resolution_snapshot block (~3 KB) into a sibling "
+        "core/model_resolver_tiers.py, leaving the per-mode preference "
+        "resolution in the main module."
+    ),
+    "intent_classifier.py": (
+        "extract the mode taxonomy (ACTIVE_MODES / FUTURE_MODES / "
+        "ROLE_ALLOWED) + the classify_fast pattern tables into a "
+        "core/intent/ package (e.g. intent/_modes.py + "
+        "intent/_patterns.py) like the meta/ split."
+    ),
 }
 
 

--- a/tests/test_vision_mode.py
+++ b/tests/test_vision_mode.py
@@ -1,0 +1,177 @@
+"""vision mode — handle_vision dispatch shell + resolution robustness.
+
+Coverage:
+  - handle_vision returns the standard reasoning-engine row dict
+    (mode='vision', graph_paths=[], short-circuits before retrieval).
+  - No image attached → friendly guidance, not an error/crash.
+  - Model resolution priority: explicit pick > kill-switch legacy >
+    resolve_for_mode("vision"); empty resolved tag → install hint.
+  - Successful analysis surfaces the description + meta bits and tags the
+    output trust='low' (#44).
+  - analyze_image error is normalised into a user-facing message.
+  - Source-level: handler exported from core.reasoning.modes; the reused
+    image pipeline (analyze_image / LlavaClient) accepts the threaded
+    ``model`` tag with a byte-identical default.
+
+Run:
+  python -m unittest tests.test_vision_mode
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _FakeEngine:
+    """Minimal stand-in exposing the helpers handle_vision uses."""
+
+    def __init__(self):
+        self.logged = []
+        self.elapsed = []
+
+    def _log(self, where, exc, role):
+        self.logged.append((where, str(exc), role))
+
+    def _elapsed(self, t0, label):
+        self.elapsed.append(label)
+
+
+def _call(query="이 사진 설명해줘", image_path="/tmp/x.png", role="admin",
+          selected_model=""):
+    from core.reasoning.modes.vision import handle_vision
+    import time
+    eng = _FakeEngine()
+    row = handle_vision(eng, query, image_path, role, time.time(),
+                        selected_model=selected_model)
+    return eng, row
+
+
+class RowShapeTests(unittest.TestCase):
+    def test_no_image_returns_friendly_guidance(self):
+        _, row = _call(image_path="")
+        self.assertEqual(row["mode"], "vision")
+        self.assertFalse(row["blocked"])
+        self.assertEqual(row["sources"], [])
+        self.assertIn("이미지", row["answer"])
+
+    def test_row_has_standard_keys(self):
+        with mock.patch(
+            "tools.multimodal.image_analyzer.analyze_image",
+            return_value={"description": "고양이 사진", "tags": ["cat"]},
+        ), mock.patch.dict(os.environ,
+                            {"JAMES_DISABLE_MODE_AWARE_ROUTING": "1"}):
+            _, row = _call()
+        for k in ("answer", "mode", "graph_paths", "graph_used", "sources",
+                  "blocked", "role_used", "timing_sec", "unified_score",
+                  "loop_count"):
+            self.assertIn(k, row)
+        self.assertEqual(row["mode"], "vision")
+        self.assertEqual(row["graph_paths"], [])
+        self.assertEqual(row["sources"], ["/tmp/x.png"])
+
+
+class ResolutionTests(unittest.TestCase):
+    def test_explicit_pick_wins(self):
+        from core.reasoning.modes.vision import _resolve_vision_model
+        tag, source, _ = _resolve_vision_model("llava:34b")
+        self.assertEqual(tag, "llava:34b")
+        self.assertEqual(source, "requested")
+
+    def test_killswitch_uses_legacy_default(self):
+        from core.reasoning.modes.vision import _resolve_vision_model
+        with mock.patch.dict(os.environ,
+                             {"JAMES_DISABLE_MODE_AWARE_ROUTING": "1"}):
+            tag, source, _ = _resolve_vision_model("")
+        self.assertEqual(tag, "llava:13b")
+        self.assertEqual(source, "legacy_killswitch")
+
+    def test_resolver_consulted_when_no_killswitch(self):
+        from core.reasoning.modes import vision as vmod
+        fake = mock.Mock()
+        fake.tag, fake.source, fake.warning = "llava:13b", "preference", ""
+        env = {k: v for k, v in os.environ.items()
+               if k != "JAMES_DISABLE_MODE_AWARE_ROUTING"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch("core.model_resolver.resolve_for_mode",
+                           return_value=fake) as rfm:
+            tag, source, _ = vmod._resolve_vision_model("")
+        rfm.assert_called_once_with("vision", requested="")
+        self.assertEqual((tag, source), ("llava:13b", "preference"))
+
+    def test_no_vision_model_installed_returns_install_hint(self):
+        from core.reasoning.modes import vision as vmod
+        fake = mock.Mock()
+        fake.tag, fake.source, fake.warning = "", "none", "nothing installed"
+        env = {k: v for k, v in os.environ.items()
+               if k != "JAMES_DISABLE_MODE_AWARE_ROUTING"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch("core.model_resolver.resolve_for_mode",
+                           return_value=fake):
+            _, row = _call()
+        self.assertIn("ollama pull llava", row["answer"])
+
+
+class AnalysisTests(unittest.TestCase):
+    def test_success_surfaces_description_and_trust_low(self):
+        payload = {
+            "description": "해변에서 노을을 보는 사람",
+            "location": "부산", "date": "2024-01-15",
+            "persons": ["미상"], "tags": ["beach", "sunset"],
+        }
+        with mock.patch("tools.multimodal.image_analyzer.analyze_image",
+                        return_value=payload), \
+                mock.patch.dict(os.environ,
+                                {"JAMES_DISABLE_MODE_AWARE_ROUTING": "1"}):
+            _, row = _call()
+        self.assertIn("해변", row["answer"])
+        self.assertIn("부산", row["answer"])
+        self.assertEqual(row["vision_meta"]["trust"], "low")
+        self.assertEqual(row["vision_meta"]["source"], "vision")
+        self.assertEqual(row["vision_meta"]["model"], "llava:13b")
+
+    def test_analyze_error_normalised(self):
+        with mock.patch("tools.multimodal.image_analyzer.analyze_image",
+                        return_value={"error": "파일 없음"}), \
+                mock.patch.dict(os.environ,
+                                {"JAMES_DISABLE_MODE_AWARE_ROUTING": "1"}):
+            _, row = _call()
+        self.assertIn("실패", row["answer"])
+        self.assertEqual(row["mode"], "vision")
+
+    def test_model_tag_threaded_to_analyze_image(self):
+        with mock.patch("tools.multimodal.image_analyzer.analyze_image",
+                        return_value={"description": "x"}) as ai, \
+                mock.patch.dict(os.environ,
+                                {"JAMES_DISABLE_MODE_AWARE_ROUTING": "1"}):
+            _call(selected_model="llava:34b")
+        # explicit pick flows through to the analyzer
+        _, kwargs = ai.call_args
+        self.assertEqual(kwargs.get("model"), "llava:34b")
+
+
+class SourceLevelTests(unittest.TestCase):
+    def test_handler_exported_from_modes_package(self):
+        import core.reasoning.modes as md
+        self.assertTrue(hasattr(md, "handle_vision"))
+        self.assertIn("handle_vision", md.__all__)
+
+    def test_analyze_image_accepts_model_param(self):
+        from tools.multimodal.image_analyzer import analyze_image
+        sig = inspect.signature(analyze_image)
+        self.assertIn("model", sig.parameters)
+        self.assertEqual(sig.parameters["model"].default, "")
+
+    def test_llava_client_accepts_model_param(self):
+        from llm.providers.llava_client import LlavaClient
+        sig = inspect.signature(LlavaClient.__init__)
+        self.assertIn("model", sig.parameters)
+        self.assertEqual(sig.parameters["model"].default, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vision_upload_wire.py
+++ b/tests/test_vision_upload_wire.py
@@ -1,0 +1,199 @@
+"""vision-wire end-to-end plumbing — /vision/upload/ route + chat UI.
+
+Completes the "실사용 가능" arm: a chat user attaches an image, the
+client uploads it to /vision/upload/ (lightweight save → server path),
+then the next /query/ carries image_path → engine routes to vision.
+
+This guards the WIRE at source level (the project's pattern for route +
+frontend plumbing, cf. tests/test_chat_mode_picker.py) so the chain
+can't silently break:
+
+  backend:  POST /vision/upload/ exists, role-gated (ROLE_ALLOWED vision,
+            external blocked), ext-validated, returns image_path under
+            UPLOAD_DIR.
+  frontend: index.html has the attach button + hidden file input +
+            preview; chat.js uploads on select, forwards image_path in
+            /query/, and treats the attachment as single-use.
+
+Functional containment of the returned path is covered by
+tests/test_vision_wire.py::SafeImagePathTests.
+
+Run:
+  python -m unittest tests.test_vision_upload_wire
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import config  # noqa: E402,F401 — load .env before routes.* → core.auth import
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class BackendUploadRouteTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from tests._server_split_helpers import combined_server_source
+        cls.src = combined_server_source()
+
+    def test_route_registered(self):
+        self.assertIn('"/vision/upload/"', self.src,
+                      "POST /vision/upload/ must be registered")
+
+    def test_role_gated_against_role_allowed(self):
+        # Must consult ROLE_ALLOWED so external (chat-only) is blocked.
+        idx = self.src.index('"/vision/upload/"')
+        body = self.src[idx:idx + 1600]
+        self.assertIn("ROLE_ALLOWED", body)
+        self.assertRegex(body, r'"vision"\s+not\s+in\s+ROLE_ALLOWED',
+                         "upload must 403 when role lacks vision")
+        self.assertIn("403", body)
+
+    def test_extension_allowlist(self):
+        idx = self.src.index('"/vision/upload/"')
+        body = self.src[idx:idx + 1600]
+        for ext in (".jpg", ".png", ".webp"):
+            self.assertIn(ext, body, f"{ext} must be in the allowlist")
+
+    def test_returns_image_path(self):
+        idx = self.src.index('"/vision/upload/"')
+        body = self.src[idx:idx + 1600]
+        self.assertIn("image_path", body,
+                      "upload response must carry image_path for /query/")
+        self.assertIn("UPLOAD_DIR", body)
+
+    def test_size_cap_enforced(self):
+        idx = self.src.index('"/vision/upload/"')
+        body = self.src[idx:idx + 1600]
+        self.assertIn("413", body, "oversize upload must be rejected (413)")
+
+
+class BackendUploadFunctionalTests(unittest.TestCase):
+    """Exercise vision_upload() directly (no full app boot): it must
+    save under UPLOAD_DIR, return a containment-valid path, gate role,
+    and reject bad extensions."""
+
+    def _upload_file(self, name: str, data: bytes):
+        import io
+        from starlette.datastructures import UploadFile, Headers
+        # Construct across Starlette versions: filename + file are stable.
+        try:
+            return UploadFile(filename=name, file=io.BytesIO(data),
+                              headers=Headers({}))
+        except TypeError:
+            return UploadFile(filename=name, file=io.BytesIO(data))
+
+    def setUp(self):
+        from unittest import mock
+        import routes.multimodal as mm
+        # verify_api_key hits the key store; stub it for the unit.
+        self._patch = mock.patch.object(mm, "verify_api_key", lambda k: None)
+        self._patch.start()
+        self.mm = mm
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_happy_path_saves_and_returns_contained_path(self):
+        import asyncio
+        from routes.query import _safe_image_path
+        uf = self._upload_file("photo.png", b"\x89PNG\r\n\x1a\n" + b"x" * 32)
+        res = asyncio.run(self.mm.vision_upload(
+            file=uf, api_key="k", role="admin"))
+        path = res["image_path"]
+        try:
+            self.assertTrue(os.path.isfile(path))
+            # The very guard /query/ uses must accept this path.
+            self.assertEqual(os.path.realpath(_safe_image_path(path)),
+                             os.path.realpath(path))
+        finally:
+            if os.path.isfile(path):
+                os.remove(path)
+
+    def test_external_role_forbidden(self):
+        import asyncio
+        from fastapi import HTTPException
+        uf = self._upload_file("photo.png", b"\x89PNG\r\n")
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(self.mm.vision_upload(
+                file=uf, api_key="k", role="external"))
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_bad_extension_rejected(self):
+        import asyncio
+        from fastapi import HTTPException
+        uf = self._upload_file("evil.txt", b"not an image")
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(self.mm.vision_upload(
+                file=uf, api_key="k", role="admin"))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class FrontendIndexHtmlTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    def test_attach_button_present(self):
+        self.assertIn('data-action="attach-image"', self.html)
+
+    def test_file_input_present(self):
+        self.assertIn('id="vision-file-input"', self.html)
+        self.assertIn('accept="image/*"', self.html)
+
+    def test_preview_and_clear_present(self):
+        self.assertIn('id="vision-preview"', self.html)
+        self.assertIn('data-action="clear-vision-image"', self.html)
+
+    def test_no_emoji_icon(self):
+        # Operator catch (2026-06-16): chat page uses SVG/text, no emoji.
+        # The attach button must use an inline <svg>, not an emoji glyph.
+        idx = self.html.index('data-action="attach-image"')
+        btn = self.html[idx:idx + 600]
+        self.assertIn("<svg", btn, "attach button must use an SVG icon")
+
+
+class FrontendChatJsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.js = (ROOT / "frontend" / "static" / "chat.js").read_text(encoding="utf-8")
+
+    def test_upload_handler_posts_to_vision_upload(self):
+        self.assertIn("handleVisionFileChange", self.js)
+        self.assertIn("/vision/upload/", self.js)
+        self.assertIn("FormData", self.js)
+
+    def test_query_body_forwards_image_path(self):
+        idx = self.js.index("`${API}/query/`")
+        body = self.js[idx:idx + 1500]
+        self.assertRegex(body, r"image_path:\s*visImg",
+                         "/query/ body must forward the attached image_path")
+
+    def test_attachment_is_single_use(self):
+        # Captured + cleared each send (force_web-style), so a stale image
+        # can't ride along on the next text-only turn.
+        self.assertIn("_pendingVisionImage = null", self.js)
+        self.assertIn("clearVisionImage", self.js)
+
+    def test_empty_text_allowed_with_image(self):
+        self.assertRegex(
+            self.js, r"if\s*\(!text\s*&&\s*!_pendingVisionImage\)\s*return;",
+            "an image-only turn (no text) must still send")
+
+    def test_multipart_omits_json_content_type(self):
+        # The upload fetch must NOT set Content-Type: application/json
+        # (browser sets the multipart boundary). Guard: the upload block
+        # builds a bare headers obj, not getAuthHeaders().
+        idx = self.js.index("handleVisionFileChange")
+        block = self.js[idx:idx + 1200]
+        self.assertNotIn("getAuthHeaders()", block,
+                         "multipart upload must not reuse the JSON headers")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vision_wire.py
+++ b/tests/test_vision_wire.py
@@ -1,0 +1,141 @@
+"""vision-wire — engine dispatch + /query image plumbing for vision mode.
+
+Builds on the plumb-first vision handler (tests/test_vision_mode.py):
+this guards the WIRE that makes an attached image route through the
+unified mode dispatch to handle_vision.
+
+Coverage:
+  - engine: image_path in kwargs forces mode="vision" (analogous to the
+    force_web_search→retrieval override); the override runs AFTER mode
+    resolution and BEFORE dispatch; "vision" dispatch branch + import +
+    VALID_OVERRIDES entry are present.
+  - intent_classifier: "vision" is an ACTIVE_MODE; admin/manager/employee
+    are vision-allowed, external is NOT (chat-only policy).
+  - route: _safe_image_path enforces UPLOAD_DIR containment (path-
+    traversal guard) and existence; QueryRequest carries image_path.
+
+Run:
+  python -m unittest tests.test_vision_wire
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Load .env (populates JAMES_JWT_SECRET) BEFORE any test imports
+# routes.query → core.auth, which raises at import time if the secret
+# is unset. Without this, SafeImagePathTests is order-dependent in a
+# multi-module unittest run.
+import config  # noqa: E402,F401
+
+
+class EngineWireTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import core.reasoning.engine as eng
+        cls.src = inspect.getsource(eng)
+
+    def test_image_override_block_present(self):
+        m = re.search(
+            r'if\s+kwargs\.get\(\s*[\'"]image_path[\'"]\s*\).*?mode\s*=\s*[\'"]vision[\'"]',
+            self.src, re.DOTALL,
+        )
+        self.assertIsNotNone(
+            m, "engine must force mode='vision' when image_path is attached")
+
+    def test_override_after_router_before_dispatch(self):
+        router_idx = self.src.index("QueryRouter().route(")
+        img_idx = self.src.index('kwargs.get("image_path")')
+        dispatch_idx = self.src.index('if mode == "vision":')
+        self.assertLess(router_idx, img_idx,
+                        "image override must run AFTER QueryRouter")
+        self.assertLess(img_idx, dispatch_idx,
+                        "image override must run BEFORE mode dispatch")
+
+    def test_vision_dispatch_branch_present(self):
+        self.assertIn('if mode == "vision":', self.src)
+        self.assertIn("return handle_vision(", self.src)
+
+    def test_handle_vision_imported(self):
+        self.assertIn("handle_vision", self.src)
+
+    def test_vision_in_valid_overrides(self):
+        # The VALID_OVERRIDES set literal must include "vision" so an
+        # explicit client mode_override="vision" is recognised.
+        m = re.search(r"VALID_OVERRIDES\s*=\s*\{(.+?)\}", self.src, re.DOTALL)
+        self.assertIsNotNone(m)
+        self.assertIn('"vision"', m.group(1))
+
+    def test_role_gate_on_image_override(self):
+        # The override must consult ROLE_ALLOWED so external can't reach
+        # vision via an attached image.
+        idx = self.src.index('kwargs.get("image_path")')
+        window = self.src[idx:idx + 250]
+        self.assertIn("ROLE_ALLOWED", window)
+
+
+class IntentTaxonomyTests(unittest.TestCase):
+    def test_vision_is_active_mode(self):
+        from core.intent_classifier import ACTIVE_MODES
+        self.assertIn("vision", ACTIVE_MODES)
+
+    def test_role_allowed_matrix(self):
+        from core.intent_classifier import ROLE_ALLOWED
+        self.assertIn("vision", ROLE_ALLOWED["admin"])
+        self.assertIn("vision", ROLE_ALLOWED["manager"])
+        self.assertIn("vision", ROLE_ALLOWED["employee"])
+        self.assertNotIn("vision", ROLE_ALLOWED["external"],
+                         "external is chat-only — must NOT reach vision")
+
+
+class SafeImagePathTests(unittest.TestCase):
+    def setUp(self):
+        from config import UPLOAD_DIR
+        self.upload_dir = UPLOAD_DIR
+        os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+    def test_empty_returns_empty(self):
+        from routes.query import _safe_image_path
+        self.assertEqual(_safe_image_path(""), "")
+        self.assertEqual(_safe_image_path("   "), "")
+
+    def test_outside_upload_dir_rejected(self):
+        from routes.query import _safe_image_path
+        # __file__ exists but lives in tests/, not UPLOAD_DIR
+        self.assertEqual(_safe_image_path(__file__), "")
+
+    def test_traversal_attempt_rejected(self):
+        from routes.query import _safe_image_path
+        evil = os.path.join(self.upload_dir, "..", "..", "config.py")
+        self.assertEqual(_safe_image_path(evil), "")
+
+    def test_nonexistent_inside_upload_dir_rejected(self):
+        from routes.query import _safe_image_path
+        ghost = os.path.join(self.upload_dir, "does_not_exist_zzz.png")
+        self.assertEqual(_safe_image_path(ghost), "")
+
+    def test_valid_file_inside_upload_dir_accepted(self):
+        from routes.query import _safe_image_path
+        p = os.path.join(self.upload_dir, "_vision_wire_test.png")
+        with open(p, "wb") as f:
+            f.write(b"\x89PNG\r\n")
+        try:
+            got = _safe_image_path(p)
+            self.assertEqual(os.path.realpath(got), os.path.realpath(p))
+        finally:
+            os.remove(p)
+
+    def test_query_request_has_image_path_field(self):
+        from routes.query import QueryRequest
+        f = QueryRequest.model_fields
+        self.assertIn("image_path", f)
+        self.assertEqual(f["image_path"].default, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/multimodal/image_analyzer.py
+++ b/tools/multimodal/image_analyzer.py
@@ -120,9 +120,14 @@ def _ensure_llava_loaded() -> bool:
 
 # ─── 메인 분석 함수 ──────────────────────────────────────────
 
-def analyze_image(image_path: str, role: str = "admin") -> dict:
+def analyze_image(image_path: str, role: str = "admin", model: str = "") -> dict:
     """
     이미지 종합 분석.
+
+    ``model`` (optional): explicit Ollama vision tag to use, e.g. the
+    ``resolve_for_mode("vision")`` result threaded by ``handle_vision``.
+    Empty → the LlavaClient legacy default (config ``MULTIMODAL_MODEL`` or
+    hardcoded ``llava:13b``), so existing callers stay byte-identical.
 
     Returns:
         {
@@ -168,7 +173,7 @@ def analyze_image(image_path: str, role: str = "admin") -> dict:
     _ensure_llava_loaded()
     try:
         from llm.providers.llava_client import LlavaClient
-        client = LlavaClient()
+        client = LlavaClient(model=model)
 
         if not client.is_available():
             print("[IMAGE] llava 미설치 → EXIF 결과만 반환")


### PR DESCRIPTION
## Summary

Completes the **vision arm** of the v0.6.1 5-phase routing build-out and makes it **end-to-end usable** in the chat page. An operator attaches an image → it routes through the unified mode dispatch → local **llava** analysis → answer.

Three logical commits:
1. **handler (plumb-first)** — `handle_vision`, the reasoning-engine peer to `handle_chat`/`handle_meta`/`handle_wiki_edit`. Dispatch/routing shell reusing the existing `image_analyzer`/`LlavaClient` pipeline. Model picked via `resolve_for_mode("vision")` (install-check + graceful fallback + `JAMES_DISABLE_MODE_AWARE_ROUTING` kill-switch) instead of the blind `config.MULTIMODAL_MODEL` reference (which was **never defined** → silently hardcoded `llava:13b`, no install check).
2. **wire** — engine `image_path→vision` override (after router, before dispatch; ROLE_ALLOWED-gated) + dispatch branch; `vision` registered in `ACTIVE_MODES`/`VALID_OVERRIDES` (external excluded — chat-only); `QueryRequest.image_path` + `_safe_image_path()` UPLOAD_DIR-containment guard.
3. **UI (실사용)** — `POST /vision/upload/` lightweight chat-attach upload (role-gated, ext-allowlist, size-cap) + chat composer attach button (inline **SVG**, not emoji) + single-use attachment plumbing in `chat.js`.

### Why no Quality Delta Card
**Quality delta: exempt.** Vision has a **single local candidate (llava)** → no marginal model ranking to measure (3-cell a/b/c QDC is moot). Image→text is orthogonal to the text-QA QVT axes. STEP 7 retrieval **Δ=0** — the vision dispatch is unreachable on text queries (structural no-op). The routing work here is *resolution robustness*, not model selection.

### Rule #5 (module size)
Surfaced a **pre-existing** RED module-size gate: `model_resolver.py` (21,042 B) + `intent_classifier.py` crept over the 20 KB cap after the gate (#983) landed — RED **before** any vision change (stash-confirmed). Per operator decision, **grandfathered** with split-plans; actual splits deferred to `fix/v0.6.1-test-suite-sweep`. New/edited files stay under cap (engine.py 20,040 B, vision.py 7,495 B LF-normalized).

## Verification

- **76 tests green**: `test_vision_mode` (12) + `test_vision_wire` (14) + `test_vision_upload_wire` (17, incl. functional `vision_upload()` direct calls: happy-path saves + containment-valid, external→403, bad-ext→400) + module-size gate + adjacent regression (`test_force_web_overrides_mode`, `test_meta_mode`, `test_multimodal_trusted`).
- `chat.js` passes `node --check`.
- `core/retrieval` + `core/graph` traversal: **0 lines** (streak preserved).
- Security: `_safe_image_path` re-validates UPLOAD_DIR containment server-side (client-supplied path is tamper-safe); vision gated against `ROLE_ALLOWED` (external blocked) at both `/vision/upload/` and the engine override.
- ⚠️ **Not** live-clicked in a browser — needs a running server + `ollama pull llava:13b`. Verified via functional + source-level tests.

## Out of scope

- Cloud vision (gpt-4o/claude) — needs Direction α §5.7.13 trust-zone (local llava only here).
- `UPLOAD_DIR` `chatvis_*` files are not auto-pruned (operator cleanup, same as other UPLOAD_DIR temps).
- The two grandfathered file splits + the pre-existing brittle `test_chat_mode_picker` window tests → `fix/v0.6.1-test-suite-sweep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)