### PR TITLE
feat(v0.6.1): workspace 추론 편집 — load → select → instruct → apply

### DIFF
--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -779,6 +779,122 @@ async function _crPost(path, body) {
   return r.json();
 }
 
+/* ── v18.7 추론 편집 모달 ──────────────────────────────────────
+   문서 불러오기 → 본문 드래그 선택 → 자연어 지시 → LLM 초안 →
+   검토/수정 → 적용. base_hash 자동(운영자 SHA 손계산 불필요), 적용
+   시 충돌 검사(409)로 동시편집 방지. 챗 wiki_edit 와 동일
+   read_entity/update_entity 재사용 (백업+감사+벡터 동기화). */
+let _weBaseHash = '';
+
+function openWikiEdit() {
+  if (!_isAdmin()) { toast('admin 전용 기능입니다.', 'error'); return; }
+  _weBaseHash = '';
+  const msg = document.getElementById('we-msg'); if (msg) msg.textContent = '';
+  const nm = document.getElementById('we-name'); if (nm) nm.value = '';
+  const body = document.getElementById('we-body'); if (body) body.textContent = '';
+  const ins = document.getElementById('we-instruction'); if (ins) ins.value = '';
+  const draft = document.getElementById('we-draft'); if (draft) draft.value = '';
+  document.getElementById('we-body-wrap').style.display = 'none';
+  document.getElementById('we-instruction-wrap').style.display = 'none';
+  document.getElementById('we-draft-wrap').style.display = 'none';
+  document.getElementById('we-apply-btn').style.display = 'none';
+  const m = document.getElementById('wiki-edit-modal');
+  if (m) m.classList.remove('hidden');
+}
+
+function closeWikiEdit() {
+  const m = document.getElementById('wiki-edit-modal');
+  if (m) m.classList.add('hidden');
+}
+
+async function wikiEditLoad() {
+  const name = document.getElementById('we-name').value.trim();
+  const msg = document.getElementById('we-msg');
+  msg.textContent = '';
+  if (!name) { msg.textContent = '❌ ENTITY 이름을 입력하세요.'; return; }
+  try {
+    const data = await _apiFetch(
+      `/admin/wiki/edit/source?name=${encodeURIComponent(name)}`);
+    if (!data.found) {
+      msg.textContent = `❌ ${data.message || '문서를 찾을 수 없습니다.'}`;
+      return;
+    }
+    document.getElementById('we-body').textContent = data.body || '';
+    _weBaseHash = data.base_hash || '';
+    document.getElementById('we-body-wrap').style.display = '';
+    document.getElementById('we-instruction-wrap').style.display = '';
+    document.getElementById('we-draft-wrap').style.display = 'none';
+    document.getElementById('we-apply-btn').style.display = 'none';
+    msg.textContent = `✅ 불러옴 (${(data.body || '').length}자)`;
+  } catch (e) { msg.textContent = `❌ ${e.message}`; }
+}
+
+function _weCaptureSelection() {
+  // 본문(#we-body) 안에서 드래그된 텍스트만 선택으로 인정.
+  try {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return '';
+    const body = document.getElementById('we-body');
+    if (body && sel.anchorNode && body.contains(sel.anchorNode)) {
+      return sel.toString();
+    }
+  } catch (_) {}
+  return '';
+}
+
+async function wikiEditDraft() {
+  const name = document.getElementById('we-name').value.trim();
+  const instruction = document.getElementById('we-instruction').value.trim();
+  const msg = document.getElementById('we-msg');
+  msg.textContent = '';
+  if (!name) { msg.textContent = '❌ 먼저 문서를 불러오세요.'; return; }
+  if (!instruction) { msg.textContent = '❌ 편집 지시를 입력하세요.'; return; }
+  const selected = _weCaptureSelection();
+  const btn = document.getElementById('we-draft-btn');
+  if (btn) { btn.disabled = true; btn.textContent = '초안 생성 중…'; }
+  try {
+    const data = await _crPost('/admin/wiki/edit/draft', {
+      name, instruction, selected_text: selected,
+    });
+    document.getElementById('we-draft').value = data.draft_body || '';
+    document.getElementById('we-model').textContent = `model: ${data.model || ''}`;
+    _weBaseHash = data.base_hash || _weBaseHash;
+    document.getElementById('we-draft-wrap').style.display = '';
+    document.getElementById('we-apply-btn').style.display = '';
+    msg.textContent = selected
+      ? `✅ 초안 생성 (선택 ${selected.length}자 중심)`
+      : '✅ 초안 생성 (문서 전체 대상)';
+  } catch (e) {
+    msg.textContent = `❌ ${e.message}`;
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '초안 생성'; }
+  }
+}
+
+async function wikiEditApply() {
+  const name = document.getElementById('we-name').value.trim();
+  const newBody = document.getElementById('we-draft').value;
+  const msg = document.getElementById('we-msg');
+  msg.textContent = '';
+  if (!newBody.trim()) { msg.textContent = '❌ 적용할 본문이 비었습니다.'; return; }
+  if (!confirm(`'${name}' 문서에 편집을 적용합니다. 계속할까요?\n(변경 전 자동 백업됩니다)`)) return;
+  const btn = document.getElementById('we-apply-btn');
+  if (btn) { btn.disabled = true; btn.textContent = '적용 중…'; }
+  try {
+    await _crPost('/admin/wiki/edit/apply', {
+      name, new_body: newBody, base_hash: _weBaseHash,
+    });
+    toast(`✅ 적용 완료: ${name}`, 'success');
+    closeWikiEdit();
+    if (_currentTab === 'data') reloadData();
+  } catch (e) {
+    // 409 = 불러온 뒤 누군가 수정 → 충돌. 메시지로 재로드 유도.
+    msg.textContent = `❌ ${e.message}`;
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '적용'; }
+  }
+}
+
 /* ── [v0.6 template-formatting engine] Templates tab ──
  *
  * Backend contract (routes/templating.py):
@@ -1167,6 +1283,12 @@ function _bindFrontendEvents() {
       case 'cr-submit-approve':  submitCrApprove(); break;
       case 'cr-submit-reject':   submitCrReject(); break;
       case 'cr-submit-comment':  submitCrComment(); break;
+      // v18.7 — 추론 편집 모달
+      case 'wiki-edit-open':     openWikiEdit(); break;
+      case 'wiki-edit-close':    closeWikiEdit(); break;
+      case 'wiki-edit-load':     wikiEditLoad(); break;
+      case 'wiki-edit-draft':    wikiEditDraft(); break;
+      case 'wiki-edit-apply':    wikiEditApply(); break;
       /* ── [v0.6 template-formatting engine] actions ── */
       case 'tpl-reload':         reloadTemplates(); break;
       case 'tpl-create':         createTemplate(); break;

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -230,6 +230,10 @@
                 id="cr-propose-toggle"
                 style="margin-left:auto"
                 data-i18n="workspace.cr_new">+ 새 제안</button>
+        <!-- v18.7 — 추론 편집 모달 런처 (admin). 문서 불러오기 →
+             드래그 선택 → 자연어 지시 → 초안 → 적용. base_hash 자동. -->
+        <button class="header-btn" data-action="wiki-edit-open"
+                id="wiki-edit-launch">추론 편집</button>
         <button class="header-btn" data-action="cr-reload"
                 data-i18n="workspace.refresh">새로고침</button>
       </div>
@@ -626,6 +630,59 @@
     </div>
     <div class="modal-link">
       <a href="#" data-action="open-forgot" data-i18n="auth.forgot_password">비밀번호를 잊으셨나요?</a>
+    </div>
+  </div>
+</div>
+
+<!-- v18.7 — 추론 편집 모달. 문서 불러오기 → 본문에서 드래그 선택 →
+     자연어 지시 → LLM 초안 → 검토/수정 → 적용 (base_hash 충돌 검사). -->
+<div class="modal-overlay hidden" id="wiki-edit-modal"
+     role="dialog" aria-modal="true" aria-labelledby="wiki-edit-title">
+  <div class="modal" style="max-width:880px;width:92vw">
+    <div class="modal-title" id="wiki-edit-title">▸ 추론 편집</div>
+    <div class="hint">엔티티를 불러와 본문에서 수정할 부분을 드래그 선택한 뒤,
+      자연어 지시로 편집 초안을 만들고 검토·수정 후 적용합니다.
+      (선택을 비워두면 문서 전체가 대상)</div>
+
+    <div class="modal-field" style="display:flex;gap:8px;align-items:flex-end">
+      <div style="flex:1">
+        <label>ENTITY 이름</label>
+        <input type="text" id="we-name" placeholder="예: 비트코인" spellcheck="false">
+      </div>
+      <button class="modal-btn" data-action="wiki-edit-load">불러오기</button>
+    </div>
+    <div class="modal-error" id="we-msg"></div>
+
+    <div class="modal-field" id="we-body-wrap" style="display:none">
+      <label>현재 본문 <span style="color:var(--muted)">(수정할 부분을 드래그 선택)</span></label>
+      <div id="we-body"
+           style="white-space:pre-wrap;max-height:240px;overflow:auto;
+                  background:var(--bg);border:1px solid var(--border);
+                  border-radius:6px;padding:10px;font-size:13px;
+                  font-family:var(--font-mono)"></div>
+    </div>
+
+    <div class="modal-field" id="we-instruction-wrap" style="display:none">
+      <label>편집 지시 (자연어)</label>
+      <textarea id="we-instruction" rows="2"
+                placeholder="예: 2024년 실적 문단을 최신 수치로 갱신하고 군더더기 문장은 제거해줘"></textarea>
+      <div class="modal-actions" style="margin-top:8px">
+        <button class="modal-btn primary" data-action="wiki-edit-draft"
+                id="we-draft-btn">초안 생성</button>
+      </div>
+    </div>
+
+    <div class="modal-field" id="we-draft-wrap" style="display:none">
+      <label>편집 초안 <span style="color:var(--muted)">(적용 전 직접 수정 가능)</span>
+        · <span id="we-model" style="font-family:var(--font-mono);color:var(--muted)"></span></label>
+      <textarea id="we-draft" rows="10"
+                style="font-family:var(--font-mono);font-size:13px"></textarea>
+    </div>
+
+    <div class="modal-actions">
+      <button class="modal-btn cancel" data-action="wiki-edit-close">닫기</button>
+      <button class="modal-btn primary" data-action="wiki-edit-apply"
+              id="we-apply-btn" style="display:none">적용</button>
     </div>
   </div>
 </div>

--- a/routes/wiki_edit_ui.py
+++ b/routes/wiki_edit_ui.py
@@ -1,0 +1,199 @@
+"""Workspace document-edit endpoints — load / draft / apply (v18.7).
+
+Powers the workspace "추론 편집" modal: load a wiki entity's body onto
+the screen, optionally mouse-select a region, give James a natural-
+language instruction, preview the LLM-drafted new body, then apply.
+
+Three admin-gated endpoints (all reuse the SAME audited primitives the
+chat ``wiki_edit`` mode uses — ``read_entity`` / ``update_entity`` from
+``tools/wiki/wiki_editor.py`` — so backup + audit log + vector/index
+resync happen exactly as before):
+
+  GET  /admin/wiki/edit/source?name=<entity>
+        → {name, found, body, base_hash}
+        Unblocks the base_hash gap the CR propose form has: the client
+        no longer has to compute a SHA by hand.
+
+  POST /admin/wiki/edit/draft  {name, instruction, selected_text?}
+        → {name, current_body, draft_body, base_hash, model}
+        Dry-run: reads the entity, asks the measured wiki_edit model
+        (resolve_for_mode("wiki_edit") → gemma3:12b) to apply the
+        instruction (optionally focused on the selected region), and
+        returns the proposed new body WITHOUT writing.
+
+  POST /admin/wiki/edit/apply  {name, new_body, base_hash}
+        → {applied, new_hash}
+        Optimistic-lock: re-reads the entity, recomputes the hash, and
+        rejects (409) if it shifted since the draft was made (someone
+        else edited in between). Otherwise writes via update_entity.
+
+``base_hash`` is the SHA-256 of the entity's read_text() content; both
+source and apply compute it the same way (over read_entity output) so
+the conflict check is consistent.
+"""
+from __future__ import annotations
+
+import hashlib
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from routes._helpers import (
+    _require_feature,
+    _write_audit,
+    get_role_from_request,
+)
+
+router = APIRouter()
+
+
+# ─── Pydantic ───
+class _DraftRequest(BaseModel):
+    api_key:       str
+    name:          str
+    instruction:   str
+    selected_text: str = ""
+
+
+class _ApplyRequest(BaseModel):
+    api_key:   str
+    name:      str
+    new_body:  str
+    base_hash: str
+
+
+# ─── Helpers ───
+def _entity_hash(text: str) -> str:
+    """SHA-256 of the entity body text. Consistent across source/apply
+    (both hash read_entity() output) so the optimistic-lock conflict
+    check is reliable."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def _draft_prompt(current: str, instruction: str, selected_text: str) -> str:
+    """Build the wiki_edit-style edit prompt. When a selection is given,
+    the model is told to focus there while keeping the whole document
+    consistent."""
+    sel = (selected_text or "").strip()
+    focus = (
+        f"\n[선택한 부분]\n{sel}\n"
+        "특히 이 부분을 중심으로 수정하되, 문서 전체의 일관성을 유지하라.\n"
+        if sel else ""
+    )
+    return (
+        "아래 wiki 문서를 다음 지시에 맞게 수정하라.\n"
+        f"지시: {instruction}\n"
+        f"{focus}"
+        f"\n[현재 내용]\n{current}\n\n"
+        "수정된 전체 내용만 출력하라 (frontmatter 포함, 설명 없이):"
+    )
+
+
+# ─── Endpoints ───
+@router.get("/admin/wiki/edit/source",
+            summary="문서 편집 — 현재 본문 + base_hash 로드 [v18.7]")
+async def edit_source(
+    name:    str,
+    api_key: str,
+    role:    str = Depends(get_role_from_request),
+):
+    """Return the entity body + its base_hash so the workspace can
+    display it and later submit a conflict-checked edit."""
+    _require_feature(api_key, role, "admin.data")
+
+    from tools.wiki.wiki_editor import read_entity
+    ok, content, msg = read_entity(name)
+    if not ok:
+        return {"name": name, "found": False, "body": "", "base_hash": "",
+                "message": msg}
+    return {
+        "name":      name,
+        "found":     True,
+        "body":      content,
+        "base_hash": _entity_hash(content),
+    }
+
+
+@router.post("/admin/wiki/edit/draft",
+             summary="문서 편집 — 추론 지시로 초안 생성 (미적용) [v18.7]")
+async def edit_draft(
+    data: _DraftRequest,
+    role: str = Depends(get_role_from_request),
+):
+    """Dry-run edit: LLM drafts the new body from the instruction; no
+    write. Uses the measured wiki_edit model preference."""
+    _require_feature(data.api_key, role, "admin.data")
+    if not (data.instruction or "").strip():
+        raise HTTPException(status_code=400, detail="지시(instruction)가 비었습니다.")
+
+    from tools.wiki.wiki_editor import read_entity
+    ok, current, msg = read_entity(data.name)
+    if not ok:
+        raise HTTPException(status_code=404, detail=msg)
+
+    # Measured wiki_edit preference (Phase wiki_edit-c → gemma3:12b).
+    model = ""
+    try:
+        from core.model_resolver import resolve_for_mode
+        model = resolve_for_mode("wiki_edit", requested="").tag or ""
+    except Exception:
+        model = ""
+
+    from core.reasoning.trace_helpers import trace_synth_call
+    draft = trace_synth_call(
+        _draft_prompt(current, data.instruction, data.selected_text),
+        applied_rule="reasoning.synth.wiki_edit_ui_draft",
+        user_role=role,
+        timeout=90,
+        use_cache=False,
+        model=model or None,
+    ) or ""
+    draft = draft.strip()
+    if not draft:
+        raise HTTPException(status_code=502, detail="초안 생성 실패 (빈 응답)")
+
+    return {
+        "name":         data.name,
+        "current_body": current,
+        "draft_body":   draft,
+        "base_hash":    _entity_hash(current),
+        "model":        model or "(default)",
+    }
+
+
+@router.post("/admin/wiki/edit/apply",
+             summary="문서 편집 — 초안 적용 (충돌 검사) [v18.7]")
+async def edit_apply(
+    data: _ApplyRequest,
+    role: str = Depends(get_role_from_request),
+):
+    """Apply the (possibly hand-tweaked) new body. Optimistic-lock: the
+    entity must still hash to base_hash, else 409 (someone edited in
+    between). Reuses update_entity → backup + audit + vector resync."""
+    _require_feature(data.api_key, role, "admin.data")
+    if not (data.new_body or "").strip():
+        raise HTTPException(status_code=400, detail="새 본문이 비었습니다.")
+
+    from tools.wiki.wiki_editor import read_entity, update_entity
+    ok, current, msg = read_entity(data.name)
+    if not ok:
+        raise HTTPException(status_code=404, detail=msg)
+
+    if _entity_hash(current) != (data.base_hash or ""):
+        raise HTTPException(
+            status_code=409,
+            detail="문서가 불러온 이후 변경되었습니다. 다시 불러와 편집하세요.",
+        )
+
+    applied, apply_msg = update_entity(data.name, data.new_body, role)
+    if not applied:
+        raise HTTPException(status_code=400, detail=apply_msg)
+
+    _write_audit(role, "/admin/wiki/edit/apply", query=data.name[:80],
+                 answer=apply_msg[:80])
+    return {
+        "applied":  True,
+        "name":     data.name,
+        "new_hash": _entity_hash(data.new_body),
+        "message":  apply_msg,
+    }

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -454,6 +454,10 @@ app.include_router(ops_router)
 from routes.templating import router as templating_router
 app.include_router(templating_router)
 
+# [v18.7 vision/wiki-edit cycle] workspace 추론-편집 모달 endpoints.
+from routes.wiki_edit_ui import router as wiki_edit_ui_router
+app.include_router(wiki_edit_ui_router)
+
 
 
 @app.on_event("startup")

--- a/tests/test_wiki_edit_ui.py
+++ b/tests/test_wiki_edit_ui.py
@@ -1,0 +1,207 @@
+"""workspace 추론-편집 — load/draft/apply endpoints + modal wiring.
+
+Backend functional (no app boot — endpoints called directly with the
+audited primitives mocked): exercises the real source/draft/apply logic
+including the optimistic-lock 409 conflict check that prevents two
+operators from clobbering each other.
+
+Frontend source-level: launcher + modal markup + chat.js-style wiring
+(the project pattern for UI plumbing).
+
+Run:
+  python -m unittest tests.test_wiki_edit_ui
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import config  # noqa: E402,F401 — load .env before routes.* → core.auth
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class HelperTests(unittest.TestCase):
+    def test_entity_hash_deterministic_and_distinct(self):
+        from routes.wiki_edit_ui import _entity_hash
+        self.assertEqual(_entity_hash("abc"), _entity_hash("abc"))
+        self.assertNotEqual(_entity_hash("abc"), _entity_hash("abd"))
+        self.assertEqual(len(_entity_hash("x")), 64)
+
+    def test_draft_prompt_includes_instruction_and_selection(self):
+        from routes.wiki_edit_ui import _draft_prompt
+        p = _draft_prompt("CUR", "지시문", "선택부분")
+        for needle in ("CUR", "지시문", "선택부분", "수정된 전체"):
+            self.assertIn(needle, p)
+
+    def test_draft_prompt_omits_focus_without_selection(self):
+        from routes.wiki_edit_ui import _draft_prompt
+        self.assertNotIn("선택한 부분", _draft_prompt("CUR", "지시문", ""))
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        import routes.wiki_edit_ui as m
+        self.m = m
+        self._patches = [
+            mock.patch.object(m, "_require_feature", lambda *a, **k: None),
+            mock.patch.object(m, "_write_audit", lambda *a, **k: None),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+
+class SourceTests(_Base):
+    def test_found_returns_body_and_hash(self):
+        from routes.wiki_edit_ui import _entity_hash
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(True, "본문내용", "ok")):
+            res = asyncio.run(self.m.edit_source(
+                name="비트코인", api_key="k", role="admin"))
+        self.assertTrue(res["found"])
+        self.assertEqual(res["body"], "본문내용")
+        self.assertEqual(res["base_hash"], _entity_hash("본문내용"))
+
+    def test_not_found(self):
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(False, "", "없음")):
+            res = asyncio.run(self.m.edit_source(
+                name="x", api_key="k", role="admin"))
+        self.assertFalse(res["found"])
+        self.assertEqual(res["base_hash"], "")
+
+
+class DraftTests(_Base):
+    def _req(self, **kw):
+        from routes.wiki_edit_ui import _DraftRequest
+        base = dict(api_key="k", name="비트코인", instruction="갱신해줘",
+                    selected_text="")
+        base.update(kw)
+        return _DraftRequest(**base)
+
+    def test_happy_path(self):
+        from routes.wiki_edit_ui import _entity_hash
+        fake = mock.Mock(); fake.tag = "gemma3:12b"
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(True, "CUR", "")), \
+             mock.patch("core.model_resolver.resolve_for_mode",
+                        return_value=fake), \
+             mock.patch("core.reasoning.trace_helpers.trace_synth_call",
+                        return_value="NEW BODY"):
+            res = asyncio.run(self.m.edit_draft(self._req(), role="admin"))
+        self.assertEqual(res["draft_body"], "NEW BODY")
+        self.assertEqual(res["base_hash"], _entity_hash("CUR"))
+        self.assertEqual(res["model"], "gemma3:12b")
+
+    def test_empty_instruction_400(self):
+        from fastapi import HTTPException
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(self.m.edit_draft(self._req(instruction="  "),
+                                          role="admin"))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_entity_missing_404(self):
+        from fastapi import HTTPException
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(False, "", "없음")):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(self.m.edit_draft(self._req(), role="admin"))
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_empty_llm_response_502(self):
+        from fastapi import HTTPException
+        fake = mock.Mock(); fake.tag = "gemma3:12b"
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(True, "CUR", "")), \
+             mock.patch("core.model_resolver.resolve_for_mode",
+                        return_value=fake), \
+             mock.patch("core.reasoning.trace_helpers.trace_synth_call",
+                        return_value="   "):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(self.m.edit_draft(self._req(), role="admin"))
+        self.assertEqual(ctx.exception.status_code, 502)
+
+
+class ApplyTests(_Base):
+    def _req(self, **kw):
+        from routes.wiki_edit_ui import _ApplyRequest, _entity_hash
+        base = dict(api_key="k", name="비트코인", new_body="새 본문",
+                    base_hash=_entity_hash("CUR"))
+        base.update(kw)
+        return _ApplyRequest(**base)
+
+    def test_happy_path_applies(self):
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(True, "CUR", "")), \
+             mock.patch("tools.wiki.wiki_editor.update_entity",
+                        return_value=(True, "✅ 수정 완료")) as upd:
+            res = asyncio.run(self.m.edit_apply(self._req(), role="admin"))
+        self.assertTrue(res["applied"])
+        upd.assert_called_once()
+
+    def test_conflict_409_when_hash_shifted(self):
+        from fastapi import HTTPException
+        # current is "CHANGED" but the request's base_hash is for "CUR".
+        with mock.patch("tools.wiki.wiki_editor.read_entity",
+                        return_value=(True, "CHANGED", "")), \
+             mock.patch("tools.wiki.wiki_editor.update_entity") as upd:
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(self.m.edit_apply(self._req(), role="admin"))
+        self.assertEqual(ctx.exception.status_code, 409)
+        upd.assert_not_called()   # must NOT write on conflict
+
+    def test_empty_body_400(self):
+        from fastapi import HTTPException
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(self.m.edit_apply(self._req(new_body="  "),
+                                          role="admin"))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class FrontendWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (ROOT / "frontend" / "workspace.html").read_text(encoding="utf-8")
+        cls.js = (ROOT / "frontend" / "static" / "workspace.js").read_text(encoding="utf-8")
+
+    def test_launcher_and_modal_present(self):
+        self.assertIn('data-action="wiki-edit-open"', self.html)
+        self.assertIn('id="wiki-edit-modal"', self.html)
+        for el in ("we-name", "we-body", "we-instruction", "we-draft",
+                   "we-apply-btn"):
+            self.assertIn(f'id="{el}"', self.html)
+
+    def test_actions_wired(self):
+        for act in ("wiki-edit-open", "wiki-edit-load", "wiki-edit-draft",
+                    "wiki-edit-apply", "wiki-edit-close"):
+            self.assertIn(f"case '{act}'", self.js)
+
+    def test_draft_posts_to_endpoint_with_selection(self):
+        idx = self.js.index("async function wikiEditDraft")
+        body = self.js[idx:idx + 900]
+        self.assertIn("/admin/wiki/edit/draft", body)
+        self.assertIn("selected_text", body)
+        self.assertIn("_weCaptureSelection", self.js)
+
+    def test_apply_passes_base_hash(self):
+        idx = self.js.index("async function wikiEditApply")
+        body = self.js[idx:idx + 800]
+        self.assertIn("/admin/wiki/edit/apply", body)
+        self.assertIn("base_hash", body)
+
+    def test_admin_gated_launcher(self):
+        idx = self.js.index("function openWikiEdit")
+        self.assertIn("_isAdmin()", self.js[idx:idx + 200])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the operator-described document-editing workflow in the **workspace**: load a wiki document onto the screen, **mouse-select** a part, open a **modal**, give James a **natural-language instruction**, preview the LLM draft, and **apply** — closing the gap reported earlier (the workspace CR flow existed at the API level but was UI-unusable because `base_hash` had to be hand-computed).

**Flow**: workspace CR tab → **추론 편집** launcher → modal → enter entity name → 불러오기 (body shown, selectable, base_hash auto-loaded) → drag-select a region → instruction → 초안 생성 (LLM, no write) → review/edit draft → 적용 (confirm + backup + 409 conflict check).

### Backend — `routes/wiki_edit_ui.py` (3 admin-gated endpoints)
- `GET /admin/wiki/edit/source` → `{body, base_hash}` (auto base_hash — closes the manual-SHA gap).
- `POST /admin/wiki/edit/draft` → LLM drafts a new body from the instruction (focused on the selected region if any); **no write**. Uses the measured `resolve_for_mode("wiki_edit")` → gemma3:12b.
- `POST /admin/wiki/edit/apply` → **optimistic-lock**: re-reads + recomputes hash, **409** if shifted since draft (concurrent-edit guard), else writes via `update_entity`.

Reuses the **same audited primitives** as the chat `wiki_edit` mode (`read_entity` / `update_entity`) → backup + audit log + vector/index resync unchanged.

### Frontend
Workspace launcher + modal + load/draft/apply/selection-capture wiring (admin-gated, inline-styled = CSP-safe, no css/cache-buster touch).

### Why no Quality Delta Card
`core/` is **untouched** (no `core/retrieval` / `core/graph` / `core/reasoning` change) — the LLM call goes through the existing `trace_synth_call` from a route. Rule #2 N/A.

## Verification

- **17 tests** (`tests/test_wiki_edit_ui.py`): functional source/draft/apply called directly with the audited primitives mocked — incl. the **409 conflict guard** (asserts `update_entity` is NOT called on a hash shift), 400/404/502 guards, helper hashing/prompt — plus source-level frontend wiring (launcher/modal/actions/selection/base_hash/admin-gate).
- `server_llmwiki` imports with the 3 routes registered; 45-test adjacent regression (`test_change_request_endpoints`, `test_meta_mode`) green; `workspace.js` passes `node --check`.
- `core/retrieval` + `core/graph` traversal + `core/reasoning`: **0 lines**.
- ⚠️ **Not** live-tested with a running LLM — draft calls real gemma3:12b but tests mock it. Needs a running server + ollama to verify edit quality.

## Out of scope

- The mouse selection is passed to the LLM as **focus context** (the model regenerates the full body), **not** a surgical span-replace.
- Apply is **direct** (backup + audit), not a CR review-queue submission — same immediate-edit model as the chat `wiki_edit` mode.
- New UI text is Korean-only (no English i18n toggle).
- An entity *picker* (vs. typing the name) — future polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)