### PR TITLE
feat(v0.6.1): Phase meta-a — meta-mode fixture + harness (plumb-first)

### DIFF
--- a/eval/meta_mode_queries.json
+++ b/eval/meta_mode_queries.json
@@ -1,0 +1,126 @@
+{
+  "_meta": {
+    "purpose": "meta-mode (inventory LLM-narrative) paired-measurement fixture (v18.7 Phase meta-a). Operator-authored, synthetic distribution snapshots — no real corpus state, no PII. Mirrors handle_meta's option-D narrative path (core/reasoning/modes/meta/_render.py::_render_llm_narrative): given a corpus distribution, the model must summarize strengths/gaps + recommend, citing numbers EXACTLY.",
+    "scoring": "gold_signals = the exact counts that MUST appear verbatim in the narrative (numeric fidelity is the deterministic axis). Strength/gap/recommendation quality is judge-only (lenient-bias caveat per project_judge_reliability_gold_grounded_v18_6). Sub-classes vary corpus scale (small/medium/large).",
+    "status": "POPULATED, NOT CONSUMED — engine.py + _render.py unchanged. Phase meta-b (operator 3-cell launch) measures gemma4:e4b / gemma3:12b / gemma3:27b; Phase meta-c reorders DEFAULT_PREFERENCE['meta'] + wires _render_llm_narrative's call_gemma to resolve_for_mode('meta')."
+  },
+  "queries": [
+    {
+      "id": "meta_1001",
+      "question_type": "small_corpus",
+      "text": "보유 자료 전체를 요약해줘",
+      "distribution": {
+        "total": 42,
+        "by_type": [["개념", 18], ["조직", 12], ["인물", 8], ["보고서", 4]],
+        "by_theme": [["AI", 15], ["보안", 10], ["크립토", 7]],
+        "hubs": [["PALANTIR", 9], ["OPENAI", 6]],
+        "recent": ["ANTHROPIC", "MISTRAL", "LLAMA"]
+      },
+      "gold_signals": ["42", "18", "15"]
+    },
+    {
+      "id": "meta_1002",
+      "question_type": "small_corpus",
+      "text": "내부 자료 총평 정리해줘",
+      "distribution": {
+        "total": 31,
+        "by_type": [["인물", 14], ["조직", 9], ["개념", 8]],
+        "by_theme": [["금융", 12], ["연구", 11], ["시장", 8]],
+        "hubs": [["BLACKROCK", 7]],
+        "recent": ["VANGUARD", "FIDELITY"]
+      },
+      "gold_signals": ["31", "14", "12"]
+    },
+    {
+      "id": "meta_1003",
+      "question_type": "small_corpus",
+      "text": "자료 전체 싹 다 요약",
+      "distribution": {
+        "total": 27,
+        "by_type": [["보고서", 15], ["개념", 7], ["이벤트", 5]],
+        "by_theme": [["블록체인", 13], ["규제", 9], ["보안", 5]],
+        "hubs": [["BITCOIN", 11], ["ETHEREUM", 8]],
+        "recent": ["SOLANA"]
+      },
+      "gold_signals": ["27", "15", "13"]
+    },
+    {
+      "id": "meta_1011",
+      "question_type": "medium_corpus",
+      "text": "보유 자료 요약해줘",
+      "distribution": {
+        "total": 313,
+        "by_type": [["개념", 120], ["조직", 85], ["인물", 60], ["보고서", 48]],
+        "by_theme": [["AI", 90], ["크립토", 70], ["보안", 50]],
+        "hubs": [["PALANTIR", 27], ["BITCOIN", 22], ["NVIDIA", 18]],
+        "recent": ["OPENAI", "ANTHROPIC", "MISTRAL"]
+      },
+      "gold_signals": ["313", "120", "90", "27"]
+    },
+    {
+      "id": "meta_1012",
+      "question_type": "medium_corpus",
+      "text": "내부 자료 전체적으로 정리해줘",
+      "distribution": {
+        "total": 268,
+        "by_type": [["조직", 110], ["인물", 78], ["개념", 50], ["장소", 30]],
+        "by_theme": [["시장", 95], ["재무", 80], ["연구", 55]],
+        "hubs": [["BLACKROCK", 31], ["VANGUARD", 24]],
+        "recent": ["FIDELITY", "STATESTREET"]
+      },
+      "gold_signals": ["268", "110", "95", "31"]
+    },
+    {
+      "id": "meta_1013",
+      "question_type": "medium_corpus",
+      "text": "wiki 자료 총괄 요약",
+      "distribution": {
+        "total": 199,
+        "by_type": [["개념", 80], ["보고서", 64], ["이벤트", 35], ["인물", 20]],
+        "by_theme": [["보안", 75], ["규제", 60], ["AI", 40]],
+        "hubs": [["MITRE", 19], ["NIST", 16]],
+        "recent": ["CISA", "ENISA"]
+      },
+      "gold_signals": ["199", "80", "75", "19"]
+    },
+    {
+      "id": "meta_1021",
+      "question_type": "large_corpus",
+      "text": "보유 자료 전체 요약해줘",
+      "distribution": {
+        "total": 1240,
+        "by_type": [["개념", 430], ["조직", 360], ["인물", 250], ["보고서", 120], ["이벤트", 80]],
+        "by_theme": [["AI", 380], ["크립토", 300], ["금융", 280], ["보안", 180], ["규제", 100]],
+        "hubs": [["PALANTIR", 88], ["BITCOIN", 71], ["OPENAI", 64], ["NVIDIA", 55]],
+        "recent": ["ANTHROPIC", "MISTRAL", "COHERE", "DEEPSEEK", "QWEN"]
+      },
+      "gold_signals": ["1240", "430", "380", "88"]
+    },
+    {
+      "id": "meta_1022",
+      "question_type": "large_corpus",
+      "text": "내부 자료 싹 다 정리해줘",
+      "distribution": {
+        "total": 980,
+        "by_type": [["조직", 340], ["인물", 300], ["개념", 200], ["장소", 90], ["자산", 50]],
+        "by_theme": [["시장", 320], ["재무", 260], ["연구", 240], ["규제", 160]],
+        "hubs": [["BLACKROCK", 77], ["VANGUARD", 62], ["FIDELITY", 49]],
+        "recent": ["STATESTREET", "PIMCO", "CITADEL"]
+      },
+      "gold_signals": ["980", "340", "320", "77"]
+    },
+    {
+      "id": "meta_1023",
+      "question_type": "large_corpus",
+      "text": "전체 자료 총평 요약",
+      "distribution": {
+        "total": 1530,
+        "by_type": [["보고서", 520], ["개념", 410], ["조직", 300], ["인물", 200], ["이벤트", 100]],
+        "by_theme": [["보안", 450], ["규제", 400], ["AI", 380], ["블록체인", 300]],
+        "hubs": [["MITRE", 95], ["NIST", 80], ["CISA", 66]],
+        "recent": ["ENISA", "BSI", "ANSSI"]
+      },
+      "gold_signals": ["1530", "520", "450", "95"]
+    }
+  ]
+}

--- a/scripts/research/local_vs_cloud_paired.py
+++ b/scripts/research/local_vs_cloud_paired.py
@@ -91,6 +91,11 @@ FIXTURES: Dict[str, Path] = {
     # ``original_doc`` block that `_wiki_edit_prompt` folds in as the
     # edit target.
     "wiki_edit": ROOT / "eval" / "wiki_edit_mode_queries.json",
+    # v18.7 Phase meta-a (2026-06-21) — operator-authored synthetic
+    # distribution snapshots for meta-mode (inventory LLM-narrative).
+    # `_meta_prompt` mirrors handle_meta's option-D prompt; gold_signals
+    # are the counts that must be cited verbatim.
+    "meta": ROOT / "eval" / "meta_mode_queries.json",
 }
 
 DEFAULT_LOCAL_MODEL = "gemma3:4b"
@@ -105,6 +110,7 @@ ANSWERABLE_BY_FIXTURE: Dict[str, Tuple[str, ...]] = {
     "multihop": ("inference_query", "comparison_query", "temporal_query"),
     "chat": ("small_talk", "factual_chat", "open_question", "multi_turn"),
     "wiki_edit": ("factual_edit", "format_edit", "summarize", "reword"),
+    "meta": ("small_corpus", "medium_corpus", "large_corpus"),
 }
 ANSWERABLE = ANSWERABLE_BY_FIXTURE["multihop"]   # legacy alias
 
@@ -197,6 +203,37 @@ def _wiki_edit_prompt(query: dict) -> str:
         "Edited document:",
     ]
     return "\n".join(parts)
+
+
+def _meta_prompt(query: dict) -> str:
+    """Build a meta-mode (inventory narrative) prompt — byte-identical to
+    handle_meta's option-D prompt (core/reasoning/modes/meta/_render.py::
+    _render_llm_narrative), fed from the fixture's synthetic distribution
+    instead of a live corpus scan. The model must summarize strengths /
+    gaps + one recommendation, citing the counts EXACTLY.
+    """
+    d = query.get("distribution") or {}
+    total = d.get("total", 0)
+    type_summary = ", ".join(f"{t} {n}개" for t, n in d.get("by_type", []))
+    theme_summary = ", ".join(f"{t} {n}개" for t, n in d.get("by_theme", []))
+    hub_summary = ", ".join(
+        f"{name} ({c}연결)" for name, c in d.get("hubs", [])
+    )
+    recent_summary = ", ".join(d.get("recent", []))
+    return (
+        "아래는 한 RAG 시스템이 보유한 wiki 자료의 분포 요약입니다.\n"
+        "이 정보를 바탕으로 한국어로 2~3문단의 자연어 요약을 작성해 주세요.\n"
+        "- 어떤 주제·분야에 강점이 있는지\n"
+        "- 빈약하거나 빠진 영역이 있는지\n"
+        "- 운영자가 다음에 어떤 자료를 추가하면 좋을지 한 줄 추천\n"
+        "숫자는 정확히 인용하고, 추측은 하지 마세요.\n\n"
+        f"[총 자료 수] {total}개\n"
+        f"[분류별] {type_summary}\n"
+        f"[주제별] {theme_summary}\n"
+        f"[핵심 hub] {hub_summary or '연결 데이터 없음'}\n"
+        f"[최근 추가] {recent_summary}\n\n"
+        "요약:"
+    )
 
 
 def _chat_prompt(query: dict) -> str:
@@ -512,6 +549,8 @@ def run_one_query(
         prompt = _chat_prompt(query)
     elif fixture_name == "wiki_edit":
         prompt = _wiki_edit_prompt(query)
+    elif fixture_name == "meta":
+        prompt = _meta_prompt(query)
     else:
         prompt = _answer_prompt(ctx, query["text"])
     t0 = time.time()
@@ -816,6 +855,17 @@ def main() -> int:
                 print(f"[{i}/{len(queries)}] id={q['id']} SKIPPED "
                       f"(no original_doc in record)")
                 continue
+        elif args.fixture == "meta":
+            # meta folds the synthetic distribution into the prompt
+            # template; no external evidence assembly. n_res guards
+            # against an empty distribution record.
+            ctx = ""
+            n_nodes = 1
+            n_res = 1 if (q.get("distribution") or {}).get("total") else 0
+            if n_res == 0:
+                print(f"[{i}/{len(queries)}] id={q['id']} SKIPPED "
+                      f"(no distribution in record)")
+                continue
         else:
             ctx, n_nodes, n_res = build_evidence(q)
             if n_res == 0:
@@ -827,6 +877,8 @@ def main() -> int:
             hop_hint = f"prior_turns={prior_n}"
         elif args.fixture == "wiki_edit":
             hop_hint = f"doc_chars={len(q.get('original_doc') or '')}"
+        elif args.fixture == "meta":
+            hop_hint = f"total={(q.get('distribution') or {}).get('total', 0)}"
         else:
             hop_hint = f"hops={n_nodes}(res {n_res})"
         print(f"[{i}/{len(queries)}] id={q['id']} {q['question_type']} "

--- a/scripts/research/pre_flight_check.py
+++ b/scripts/research/pre_flight_check.py
@@ -679,10 +679,69 @@ def check_wiki_edit_fixture() -> PreFlightResult:
     )
 
 
+def check_meta_fixture() -> PreFlightResult:
+    """v0.6.1 Phase meta-a (2026-06-21) — meta-mode (inventory narrative)
+    fixture. Mirrors ``check_wiki_edit_fixture``. Asserts:
+      - fixture registered in ``FIXTURES['meta']`` + file parses
+      - 3 sub-classes (small/medium/large_corpus) each have ≥3 rows
+      - every row carries ``gold_signals`` (numeric fidelity is the
+        deterministic axis) + a ``distribution`` with a non-zero total
+        (the prompt template needs it; an empty distribution would
+        silently degrade the narrative prompt).
+    """
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from local_vs_cloud_paired import ANSWERABLE_BY_FIXTURE, FIXTURES
+    except Exception as exc:
+        return PreFlightResult(
+            "meta_fixture", "fail",
+            f"harness import failed: {type(exc).__name__}: {exc}",
+        )
+    path = FIXTURES.get("meta")
+    if path is None:
+        return PreFlightResult("meta_fixture", "fail",
+                               "FIXTURES['meta'] not registered")
+    if not path.exists():
+        return PreFlightResult("meta_fixture", "fail",
+                               f"fixture file missing: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return PreFlightResult("meta_fixture", "fail",
+                               f"fixture unreadable: {type(exc).__name__}: {exc}")
+    rows = data.get("queries", [])
+    counts: dict = {}
+    for q in rows:
+        counts[q.get("question_type", "?")] = (
+            counts.get(q.get("question_type", "?"), 0) + 1
+        )
+    for t in ANSWERABLE_BY_FIXTURE.get("meta", ()):
+        if counts.get(t, 0) < 3:
+            return PreFlightResult(
+                "meta_fixture", "fail",
+                f"sub-class {t!r} has only {counts.get(t, 0)} rows; "
+                "paired default needs 3",
+            )
+    no_gold = [q.get("id") for q in rows if not q.get("gold_signals")]
+    if no_gold:
+        return PreFlightResult("meta_fixture", "fail",
+                               f"rows missing gold_signals: {no_gold}")
+    no_dist = [q.get("id") for q in rows
+               if not (q.get("distribution") or {}).get("total")]
+    if no_dist:
+        return PreFlightResult("meta_fixture", "fail",
+                               f"rows missing distribution.total: {no_dist}")
+    return PreFlightResult(
+        "meta_fixture", "ok",
+        f"{len(rows)} meta queries available (counts={counts})",
+    )
+
+
 _CHECKS = (
     check_fixture,
     check_chat_fixture,
     check_wiki_edit_fixture,
+    check_meta_fixture,
     check_regex_false_positives,
     check_backend_registry,
     check_abstraction_smoke,

--- a/tests/test_measurement_critical_surfaces.py
+++ b/tests/test_measurement_critical_surfaces.py
@@ -610,6 +610,77 @@ class WikiEditFixtureSurface(unittest.TestCase):
                       "_wiki_edit_prompt drops the edit instruction")
 
 
+class MetaFixtureSurface(unittest.TestCase):
+    """v0.6.1 v18.7 Phase meta-a prereq (2026-06-21) — meta-mode
+    (inventory narrative) fixture. Mirrors ``WikiEditFixtureSurface``.
+
+    Operator-authored synthetic distributions, so a UX cycle could
+    silently break it with no upstream alarm. Lock the surface the
+    harness consumes — registration, sub-class counts, gold_signals +
+    distribution coverage, and that ``_meta_prompt`` mirrors
+    handle_meta's narrative prompt (counts folded in + exact-citation
+    directive)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _import_harness()
+
+    def test_meta_fixture_registered(self):
+        from local_vs_cloud_paired import FIXTURES
+        self.assertIn("meta", FIXTURES,
+                      "harness FIXTURES dict missing 'meta' — "
+                      "--fixture meta CLI will fail.")
+
+    def test_meta_fixture_file_exists(self):
+        from local_vs_cloud_paired import FIXTURES
+        self.assertTrue(FIXTURES["meta"].exists(),
+                        f"meta fixture missing: {FIXTURES['meta']}")
+
+    def test_meta_subclasses_complete(self):
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["meta"].read_text(encoding="utf-8"))
+        for t in ("small_corpus", "medium_corpus", "large_corpus"):
+            with self.subTest(sub_class=t):
+                rows = [q for q in data.get("queries", [])
+                        if q.get("question_type") == t]
+                self.assertGreaterEqual(
+                    len(rows), 3,
+                    f"meta sub-class {t!r} only has {len(rows)} rows.")
+
+    def test_meta_every_row_has_gold_and_distribution(self):
+        import json as _json
+        from local_vs_cloud_paired import FIXTURES
+        data = _json.loads(FIXTURES["meta"].read_text(encoding="utf-8"))
+        for q in data.get("queries", []):
+            with self.subTest(id=q.get("id")):
+                self.assertTrue(bool(q.get("gold_signals")),
+                                f"meta id={q.get('id')} missing gold_signals")
+                self.assertTrue(
+                    bool((q.get("distribution") or {}).get("total")),
+                    f"meta id={q.get('id')} missing distribution.total")
+
+    def test_meta_prompt_template_emits_counts_and_directive(self):
+        """``_meta_prompt`` must fold the distribution counts in AND
+        carry the exact-citation directive (mirrors the production
+        _render_llm_narrative prompt)."""
+        from local_vs_cloud_paired import _meta_prompt
+        q = {
+            "distribution": {
+                "total": 313,
+                "by_type": [["개념", 120]],
+                "by_theme": [["AI", 90]],
+                "hubs": [["PALANTIR", 27]],
+                "recent": ["OPENAI"],
+            },
+        }
+        body = _meta_prompt(q)
+        self.assertIn("313", body, "_meta_prompt drops the total count")
+        self.assertIn("개념 120개", body, "_meta_prompt drops the type summary")
+        self.assertIn("숫자는 정확히 인용", body,
+                      "_meta_prompt drops the exact-citation directive")
+
+
 class RoutingPhase4Surface(unittest.TestCase):
     """v0.6.1 v18.7 Phase 4 (2026-06-20) — privacy + cost cap primitives.
 


### PR DESCRIPTION
## Summary

Completes the **5-phase routing roadmap's last unmeasured mode** measurement infrastructure. chat / retrieval / wiki_edit / vision are done; coding has its own router; **meta** was the remaining one. Same plumb-first pattern as Phase wiki_edit-a / chat-2a.

The meta narrative path (`handle_meta` option-D → `_render_llm_narrative`) summarizes a corpus distribution and is told to **cite numbers exactly**. The fixture captures that as synthetic distribution snapshots + numeric `gold_signals`.

- `eval/meta_mode_queries.json` — 9 synthetic snapshots, 3 sub-classes × 3 (small/medium/large_corpus), each with `gold_signals` (counts that must appear verbatim) + a `distribution`. No real corpus state, no PII.
- `local_vs_cloud_paired.py` — `FIXTURES['meta']`, `ANSWERABLE_BY_FIXTURE`, `_meta_prompt` (**byte-identical** to the production `_render_llm_narrative` prompt, fed from the fixture), dispatch + evidence-skip branches.
- `pre_flight_check.py` — `check_meta_fixture` (10th check).
- `tests/test_measurement_critical_surfaces.py` — `MetaFixtureSurface` (5 lock-tests).

## Verification

- **33 lock-tests** green (incl. 5 new `MetaFixtureSurface`); `check_meta_fixture` → `ok` (9 queries, 3×3); harness loads `--fixture meta` and `_meta_prompt` mirrors the render prompt.
- **POPULATED, NOT CONSUMED** — `engine.py` + `_render.py` unchanged; only the `--fixture meta` CLI is added. Default behaviour byte-identical.
- `core/retrieval` + `core/graph` traversal + `core/reasoning`: **0 lines**.

## Out of scope (operator-gated, per discipline)

- **Phase meta-b** — operator 3-cell live launch (gemma4:e4b / gemma3:12b / gemma3:27b). The meta narrative is a *summarize* task, so the cross-task reversal predicts gemma3:12b — but that must be **measured**, not transferred from wiki_edit-b (the project's no-cross-fixture-transfer rule).
- **Phase meta-c** — reorder `DEFAULT_PREFERENCE['meta']` + wire `_render_llm_narrative`'s `call_gemma` to `resolve_for_mode('meta')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)