### PR TITLE
fix(v0.6.1): alce_smoke utf-8 stdout + D-alce research-tier NLI smoke

### DIFF
--- a/reports/external/alce/asqa-smoke-20260621T154253Z.result.json
+++ b/reports/external/alce/asqa-smoke-20260621T154253Z.result.json
@@ -1,0 +1,235 @@
+{
+  "benchmark": "alce-asqa",
+  "loader": "alce-asqa",
+  "producer": "alce-closed-corpus",
+  "split": "dev",
+  "n_queries": 20,
+  "n_rows": 20,
+  "n_errors": 0,
+  "elapsed_s": 75.988,
+  "started_at": "2026-06-21T15:41:37.755391+00:00",
+  "axes": [
+    {
+      "name": "citation_precision",
+      "score": 0.6239,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.3333,
+        "alce-asqa-7089015503030534342": 0.8333,
+        "alce-asqa-8793099883447006698": 0.4286,
+        "alce-asqa--881464876144297194": 0.25,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.5,
+        "alce-asqa--3322598412088356524": 0.1429,
+        "alce-asqa--4633355453516911545": 0.8333,
+        "alce-asqa--7464414779466400769": 0.3333,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 1.0,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.6667,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.2,
+        "alce-asqa--6617858863213285972": 0.4286,
+        "alce-asqa--7031499911070053371": 0.2,
+        "alce-asqa--2419910984507145175": 0.75,
+        "alce-asqa-3228155858422343609": 0.6667
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    },
+    {
+      "name": "citation_recall",
+      "score": 0.7344,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.5,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 0.6667,
+        "alce-asqa--881464876144297194": 0.3333,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.75,
+        "alce-asqa--3322598412088356524": 0.3333,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.3333,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 1.0,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.5,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.3333,
+        "alce-asqa--6617858863213285972": 0.75,
+        "alce-asqa--7031499911070053371": 0.3333,
+        "alce-asqa--2419910984507145175": 1.0,
+        "alce-asqa-3228155858422343609": 0.5
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    }
+  ],
+  "rows": [
+    {
+      "id": "alce-asqa--7013890438520559398",
+      "answer": "The search results provide varying information regarding the highest number of goals scored in world football [1][2][5]. According to FIFA, Pelé's 1,281 goals are recognized as the highest total achieved by a professional footballer [1]. However, the Soccer Statistic Foundation (rssf) only recognizes 767 goals for Pelé, placing him third behind Josef Bican with 805 and Romario with 772 [1]. The RSSSF estimates that Josef Bican scored at least 805 goals in all competitive matches, which would make him the most prolific scorer of all time [5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7089015503030534342",
+      "answer": "The song \"The Sound of Silence,\" which was initially titled \"The Sounds of Silence,\" is by the American music duo Simon & Garfunkel [1][3]. Paul Simon wrote the song over several months spanning 1963 and 1964 [1][3]. The acoustic version of the song appeared on the album *Wednesday Morning, 3 A.M.* [2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-8793099883447006698",
+      "answer": "The first Apple iPhone was officially announced on January 9, 2007 [1][2][4]. Following its announcement at the Macworld convention, the initial version of the iPhone became publicly available on June 29, 2007, in select markets [2][3][5]. This first-generation model featured quad-band GSM cellular connectivity with support for GPRS and EDGE data transfer [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--881464876144297194",
+      "answer": "The identical twin British actors James Andrew Eric Phelps and Oliver Martyn John Phelps are best known for portraying Fred and George Weasley in the *Harry Potter* film series [1][4]. The twins were cast as Fred and George Weasley after auditioning for the film *Harry Potter and the Philosopher's Stone* when they were 14 years old, despite having no prior acting experience [3]. James and Oliver Phelps went on to play their characters in all subsequent installments of the series [3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1650309494326541834",
+      "answer": "Virginia has 34 state parks [1][2]. These parks are managed by the Department of Conservation and Recreation and the Department of Forestry [1][2]. Additionally, Virginia maintains 17 state forests [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-2378678654868379935",
+      "answer": "The search results provide information about performers at different years' Champions League finals, but they do not specify who performed at the 2018 men's UEFA Champions League Final [1][2][3]. However, the 2018 UEFA Champions League Final was played at the NSC Olimpiyskiy Stadium in Kiev, Ukraine, on May 26, 2018, featuring a match between Liverpool and Real Madrid [4]. For the 2016 final, American singer Alicia Keys performed during the opening ceremony, and Italian tenor Andrea Bocelli sang the UEFA Champions League Anthem [1]. In contrast, for the 2018 UEFA Women's Champions League Final, Lipa performed at the opening ceremony, joined by Jamaican rapper Sean Paul [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--3322598412088356524",
+      "answer": "The provided search results do not contain information specifying who killed a man in \"Thelma and Louise\" [1][2][3][4][5]. However, one document mentions that the killer at the scene of Lindsay's death was revealed to be Richard Thompson, whose real name is Marcus Andrews, a medical technician working for Rhyme [4]. This same individual later killed both Thelma and police Captain Howard Cheney [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--4633355453516911545",
+      "answer": "Charlie Day portrays Charlie Kelly, a fictional character on the FX series *It's Always Sunny in Philadelphia* [1][2]. This character is also known as Charles Rutherford Kelly [1][2]. Charlie Kelly is depicted as an easily excitable man-child who has been co-owner at Paddy's and is a childhood friend to Mac and Dennis [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7464414779466400769",
+      "answer": "The provided search results indicate that the Lakers have won a total of 16 NBA championships [1][2]. Specifically, the sources mention the Lakers winning titles in 2008 and 2010 [1][2]. Furthermore, one source notes that the two teams with the most championships are the Celtics with 17 and the Lakers with 16 [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1562758409663917015",
+      "answer": "The Congress party (INC) holds majority support in several Indian states, including Punjab, Chhattisgarh, Rajasthan, and Madhya Pradesh [2]. In Karnataka and Puducherry, the party shares power with an alliance partner, Janata Dal (Secular) and Dravida [2]. India is described as a federal union consisting of 29 states and 7 union territories [1][4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7813254335895169912",
+      "answer": "The search results mention two different actresses who played the role of Fruma Sarah in *Fiddler on the Roof*. In 1971, Ruth Madoc portrayed Fruma Sarah in the film adaptation of the musical [1]. More recently, an actress played the role of Fruma Sarah during the 2015-2016 Broadway Revival of *Fiddler on the Roof* [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-732619765350082410",
+      "answer": "Toronto hosted the MLB All-Star Game in 1991 [1]. Specifically, the 62nd Major League Baseball All-Star Game took place on July 9, 1991, at SkyDome, which is the home stadium for the Toronto Blue Jays of the American League [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-6962706727076805207",
+      "answer": "Law enforcement agencies utilize specialized vehicles known as bait cars, which can also be called decoy cars, hot cars, or trap cars [1][3]. These cars are designed to capture thieves who steal items from automobiles or car thieves generally [1][3]. The vehicles are equipped with audio and video surveillance technology, allowing them to be remotely monitored and controlled [1][2][3].\n\nWhen set up to catch thieves, these bait cars may include GPS tracking [1][3]. Furthermore, a \"kill switch\" might be installed, enabling police to remotely lock all doors or disable the engine to prevent escape [1][3]. If the car is intended to catch thieves stealing items from it, it might be disabled so that it cannot be started and will contain specially prepared \"bait property\" [2]. In some scenarios, officers are immediately alerted if the car is stolen, allowing them to monitor it and send commands such as locking doors or disabling the engine [2]. These bait cars can also function as part of a honey trap sting operation, which lures criminals into exposing themselves [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3127369420834732535",
+      "answer": "The American reality television series *Jersey Shore* ran on MTV from December 3, 2009, until December 20, 2012 [1][2]. One source notes that MTV renewed the series for a fourth and final season on April 24, 2014 [5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--8056895208806271453",
+      "answer": "The plane crash storyline appeared in multiple seasons of *Grey's Anatomy* [2][3]. Specifically, a plane crash was featured in \"Flight,\" which is the twenty-fourth and final episode of the eighth season [4]. Additionally, the eleventh season included an episode titled \"One Flight Down\" that featured a plane crash in Seattle, bringing back memories of the tragic plane crash from season 8, where Mark Sloan and Lexie Grey died [2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-4131723857510142703",
+      "answer": "The provided search results do not state the current number of branches for the Oriental Bank of Commerce [1][3]. However, one document mentions that after acquiring Global Trust Bank (GTB) on August 14, 2004, which brought with it 103 branches, OBC's total branch count increased to 1092 as of March 31, 2010 [1]. Furthermore, another document notes that Oriental Bank Corporation was a bank in India during the 19th century and expanded by opening branches [4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--6617858863213285972",
+      "answer": "The Rams relocated from Los Angeles to St. Louis in 1995 [2][3]. Specifically, owner Georgia Frontiere announced the move on January 15, 1995 [5]. This move followed a period when the NFL had not had a team in St. Louis since the Cardinals moved there in 1960 and subsequently departed for Arizona in 1988 [1][2][3]. The Rams played their first game at their St. Louis stadium, the Edward Jones Dome, on October 22, 1996 [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7031499911070053371",
+      "answer": "The search results provide several dates related to the Voortrekkers movement, but they do not specify a single arrival date for them in South Africa [1][2][3]. The film *De Voortrekkers* depicts the Boers' Great Trek occurring toward the end of the 1830s [3]. Furthermore, the commemoration of Jan van Riebeeck's arrival in Table Bay in 1652 was held by the Voortrekkers at a festival in Cape Town in 1952 [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--2419910984507145175",
+      "answer": "Heath Ledger portrayed the character of Patrick in the film *10 Things I Hate About You* [3][4]. In the story, Cameron attempts to convince the bad boy Patrick to help him get around his father's strict dating rules regarding Bianca Stratford [4]. The character Patrick reflects the outlandish behavior of Petruchio from Shakespeare's work [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3228155858422343609",
+      "answer": "The provided search results describe \"Windows Live Movie Maker\" as a video editing software from Microsoft [1][2]. While one document mentions that an updated version of the software was available through the \"Windows Live Essentials suite\" [5], it does not explicitly state whether the software itself was free to use.",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    }
+  ],
+  "honest_tier": "research-tier: smoke n=20 with NLI adapter (roberta-mnli). STRONGER than string-containment fallback, but NOT ALCE-official-grade (T5-XXL TRUE NLI Mixture, GPU-only, remains deferred). Useful for cross-checking the fallback result and for paper methods cross-verifier robustness claims. Pre-reg: docs/research/cycle-gamma-c3-alce-smoke-preregistration-2026-06-11.md + docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md (verifier provenance).",
+  "verifier_grade": "research-tier-roberta-mnli",
+  "fixture_sha": "d72737ce7d46629d3504fc508f29ec0c270e0ddd5cff3fad69625d2c0e4be35b",
+  "n_docs_per_query": 5
+}

--- a/scripts/research/alce_smoke_run.py
+++ b/scripts/research/alce_smoke_run.py
@@ -33,6 +33,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
 
+# Windows consoles default to cp949 (KR locale); the axis `notes` carry an
+# em-dash (—) that crashes the final print AFTER the result JSON is already
+# written. Force utf-8 so the run completes cleanly (mirrors
+# local_vs_cloud_paired.py).
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
 from eval.external.alce_loader import ALCELoader
 from eval.external.alce_nli_adapter import (ALCE_ADAPTER_NAMES,
                                             get_alce_adapter)


### PR DESCRIPTION
## Summary

Two things, one cause — a live D-alce run surfaced a Windows-console bug:

1. **Fix** — `alce_smoke_run.py` crashed on Windows (cp949 console) at the **final** print of the axis `notes` (em-dash `—`), AFTER the result JSON was already written. The measurement was unaffected but the run exited non-zero and recall/paths never printed. Force `sys.stdout.reconfigure(encoding="utf-8")` (mirrors `local_vs_cloud_paired.py`).

2. **Result** — the D-alce research-tier NLI smoke this produced, upgrading the cycle γ ALCE promise from infrastructure-only string-containment to a real NLI checkpoint (RoBERTa-large-MNLI, CPU, fully local — no API/Claude/GPU):

   | axis | research-tier (RoBERTa-MNLI) | prior fallback (StringContainment, 2026-06-11) |
   |---|---|---|
   | citation_precision | **0.6239** | 0.8168 |
   | citation_recall | **0.7344** | 0.9067 |

   n=20, 0 errors, 76s. **The real NLI is stricter → the lenient fallback inflated citation quality by ~0.18–0.20.** Still NOT ALCE-official-grade (T5-XXL TRUE NLI Mixture is GPU-only, `is_alce_grade=False`), but a genuine research-tier upgrade of the 4-bench promise's ALCE leg.

## Verification

- Re-ran `--n 2` post-fix → completes cleanly (recall + notes + paths + elapsed all print, exit 0).
- All NLI deps were already present (transformers 5.7, torch 2.11, `roberta-large-mnli` + `DeBERTa-v3-anli` cached) — the run needed no download.

## Out of scope

- No `core/` touch — measurement tooling + report artifact only.
- ALCE-official T5-XXL NLI grade remains deferred (GPU-only).
- `bench.jsonl` (per-row generations) is `.gitignore`d; only the aggregate `result.json` is committed (matching the prior smoke artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)