### PR TITLE
docs(v0.6.1): LRB v0.2.3b 3-model LLM-grounded smoke — results

### DIFF
--- a/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "james",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 447.654,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 1.0,
+      "R@10": 1.0,
+      "P@5": 0.2,
+      "P@10": 0.1,
+      "latency_s_mean": 4.476502,
+      "token_cost_mean": 360.565,
+      "temporal_accuracy": 1.0,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.98,
+        "P@1": 0.98,
+        "temporal_accuracy_strict_top1": 0.98
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.552744,
+        "token_cost_mean": 409.3167,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.432175,
+        "token_cost_mean": 343.2269,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.563382,
+        "token_cost_mean": 380.35,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T16:26:18.269465+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "naive-supersede",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 447.4354,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.78,
+      "R@10": 0.78,
+      "P@5": 0.156,
+      "P@10": 0.078,
+      "latency_s_mean": 4.474319,
+      "token_cost_mean": 348.84,
+      "temporal_accuracy": 0.78,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.76,
+        "P@1": 0.76,
+        "temporal_accuracy_strict_top1": 0.76
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.2,
+        "R@10": 0.2,
+        "P@5": 0.04,
+        "P@10": 0.02,
+        "temporal_accuracy": 0.2,
+        "latency_s_mean": 4.513006,
+        "token_cost_mean": 357.0333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.436704,
+        "token_cost_mean": 343.2269,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "latency_s_mean": 4.567551,
+        "token_cost_mean": 360.9375,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.428571,
+        "R@10": 0.428571,
+        "P@5": 0.085714,
+        "P@10": 0.042857,
+        "temporal_accuracy": 0.428571,
+        "R@1": 0.428571
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.833333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 0.25,
+        "R@10": 0.25,
+        "P@5": 0.05,
+        "P@10": 0.025,
+        "temporal_accuracy": 0.25,
+        "R@1": 0.25
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T16:18:50.610958+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma3-12b-llm-grounded-20260621T154706Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "vanilla",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 456.481,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.99,
+      "R@10": 0.99,
+      "P@5": 0.198,
+      "P@10": 0.099,
+      "latency_s_mean": 4.564773,
+      "token_cost_mean": 359.475,
+      "temporal_accuracy": 0.99,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.62,
+        "P@1": 0.62,
+        "temporal_accuracy_strict_top1": 0.62
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.552128,
+        "token_cost_mean": 361.8333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.558801,
+        "token_cost_mean": 356.8269,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.95,
+        "R@10": 0.95,
+        "P@5": 0.19,
+        "P@10": 0.095,
+        "temporal_accuracy": 0.95,
+        "latency_s_mean": 4.593668,
+        "token_cost_mean": 366.3125,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.142857
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.666667
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.416667
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.571429
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.125
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T16:11:23.171141+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "james",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 329.5696,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.99,
+      "R@10": 0.99,
+      "P@5": 0.198,
+      "P@10": 0.099,
+      "latency_s_mean": 3.295657,
+      "token_cost_mean": 347.3075,
+      "temporal_accuracy": 0.99,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.95,
+        "P@1": 0.95,
+        "temporal_accuracy_strict_top1": 0.95
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.437982,
+        "token_cost_mean": 408.1333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.222545,
+        "token_cost_mean": 323.5154,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.95,
+        "R@10": 0.95,
+        "P@5": 0.19,
+        "P@10": 0.095,
+        "temporal_accuracy": 0.95,
+        "latency_s_mean": 3.426527,
+        "token_cost_mean": 379.0125,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.666667
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.875
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T16:03:46.685829+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 337.3634,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.79,
+      "R@10": 0.8,
+      "P@5": 0.158,
+      "P@10": 0.08,
+      "latency_s_mean": 3.373595,
+      "token_cost_mean": 331.61,
+      "temporal_accuracy": 0.8,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.74,
+        "P@1": 0.74,
+        "temporal_accuracy_strict_top1": 0.74
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.2,
+        "R@10": 0.2,
+        "P@5": 0.04,
+        "P@10": 0.02,
+        "temporal_accuracy": 0.2,
+        "latency_s_mean": 3.38051,
+        "token_cost_mean": 341.4,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.362267,
+        "token_cost_mean": 323.5154,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.55,
+        "R@10": 0.6,
+        "P@5": 0.11,
+        "P@10": 0.06,
+        "temporal_accuracy": 0.6,
+        "latency_s_mean": 3.405227,
+        "token_cost_mean": 350.575,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.428571,
+        "R@10": 0.428571,
+        "P@5": 0.085714,
+        "P@10": 0.042857,
+        "temporal_accuracy": 0.428571,
+        "R@1": 0.285714
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.666667,
+        "R@10": 0.833333,
+        "P@5": 0.133333,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T15:58:17.111868+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260621T154706Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 333.6764,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.97,
+      "R@10": 0.97,
+      "P@5": 0.194,
+      "P@10": 0.097,
+      "latency_s_mean": 3.336725,
+      "token_cost_mean": 332.7225,
+      "temporal_accuracy": 0.97,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.51,
+        "P@1": 0.51,
+        "temporal_accuracy_strict_top1": 0.51
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.933333,
+        "R@10": 0.933333,
+        "P@5": 0.186667,
+        "P@10": 0.093333,
+        "temporal_accuracy": 0.933333,
+        "latency_s_mean": 3.43235,
+        "token_cost_mean": 341.4333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.276546,
+        "token_cost_mean": 323.1077,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.9,
+        "R@10": 0.9,
+        "P@5": 0.18,
+        "P@10": 0.09,
+        "temporal_accuracy": 0.9,
+        "latency_s_mean": 3.460587,
+        "token_cost_mean": 357.4375,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.142857
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.166667
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.857143,
+        "R@10": 0.857143,
+        "P@5": 0.171429,
+        "P@10": 0.085714,
+        "temporal_accuracy": 0.857143,
+        "R@1": 0.857143
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.375
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.866667
+      }
+    }
+  },
+  "started_at": "2026-06-21T15:52:39.743948+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "james",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 1678.4207,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.98,
+      "R@10": 1.0,
+      "P@5": 0.196,
+      "P@10": 0.1,
+      "latency_s_mean": 16.784168,
+      "token_cost_mean": 342.2825,
+      "temporal_accuracy": 1.0,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.85,
+        "P@1": 0.85,
+        "temporal_accuracy_strict_top1": 0.85
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.866667,
+        "R@10": 1.0,
+        "P@5": 0.173333,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 17.321099,
+        "token_cost_mean": 398.0667,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 16.535794,
+        "token_cost_mean": 324.4308,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 17.188685,
+        "token_cost_mean": 358.4625,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.714286,
+        "R@10": 1.0,
+        "P@5": 0.142857,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.285714
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.5
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.75
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T17:50:32.860993+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "naive-supersede",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 1686.8163,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.8,
+      "R@10": 0.8,
+      "P@5": 0.16,
+      "P@10": 0.08,
+      "latency_s_mean": 16.868122,
+      "token_cost_mean": 331.7075,
+      "temporal_accuracy": 0.8,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.71,
+        "P@1": 0.71,
+        "temporal_accuracy_strict_top1": 0.71
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.2,
+        "R@10": 0.2,
+        "P@5": 0.04,
+        "P@10": 0.02,
+        "temporal_accuracy": 0.2,
+        "latency_s_mean": 17.323176,
+        "token_cost_mean": 338.75,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 16.674894,
+        "token_cost_mean": 324.4308,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.6,
+        "R@10": 0.6,
+        "P@5": 0.12,
+        "P@10": 0.06,
+        "temporal_accuracy": 0.6,
+        "latency_s_mean": 17.15482,
+        "token_cost_mean": 350.075,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.428571,
+        "R@10": 0.428571,
+        "P@5": 0.085714,
+        "P@10": 0.042857,
+        "temporal_accuracy": 0.428571,
+        "R@1": 0.285714
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.166667
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T17:22:34.425806+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-mixtral-8x7b-llm-grounded-20260621T154706Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "vanilla",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 1689.3211,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.98,
+      "R@10": 0.99,
+      "P@5": 0.196,
+      "P@10": 0.099,
+      "latency_s_mean": 16.893173,
+      "token_cost_mean": 339.3425,
+      "temporal_accuracy": 0.99,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.53,
+        "P@1": 0.53,
+        "temporal_accuracy_strict_top1": 0.53
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.933333,
+        "R@10": 1.0,
+        "P@5": 0.186667,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 17.385336,
+        "token_cost_mean": 353.4333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 16.681747,
+        "token_cost_mean": 329.1808,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.95,
+        "R@10": 0.95,
+        "P@5": 0.19,
+        "P@10": 0.095,
+        "temporal_accuracy": 0.95,
+        "latency_s_mean": 17.211185,
+        "token_cost_mean": 361.8,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.285714
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.166667
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.75
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.857143,
+        "R@10": 1.0,
+        "P@5": 0.171429,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.714286
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.5
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.5
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-21T16:54:27.595236+00:00"
+}

--- a/reports/research-runs/lrb-v023b-3model-llm-grounded-smoke-20260621.md
+++ b/reports/research-runs/lrb-v023b-3model-llm-grounded-smoke-20260621.md
@@ -1,0 +1,60 @@
+# LRB v0.2.3b — 3-model LLM-grounded smoke results (2026-06-21)
+
+Runner: `scripts/research/lrb_run_v023b_s3_cross_model.py
+--scale smoke --modes llm-grounded --models gemma4:e4b,gemma3:12b,mixtral:8x7b`
+Prereg: `docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md`
+
+Scale: S3 **smoke** (scenario_S3_smoke.json — 100 queries / 282 events).
+3 SUTs × 3 local reranker models × 1 mode (llm-grounded). The 4th prereg
+leg (`claude-haiku-4-5`) is excluded here — it needs the cloud backend
+(`JAMES_ENABLE_CLAUDE_BACKEND` + Max-plan CLI). Wall-clock ≈ 2 h
+(mixtral cells ≈ 28 min each; gemma4 ≈ 5.5 min).
+
+## Gap-table (R@1 = correct *current* fact retrieved at rank 1)
+
+| reranker model | vanilla | naive-supersede | **james** | V<N<J | **J−N gap** |
+|---|---|---|---|---|---|
+| gemma4:e4b   | 0.51 | 0.74 | **0.95** | ✅ | **+0.21** |
+| gemma3:12b   | 0.62 | 0.76 | **0.98** | ✅ | **+0.22** |
+| mixtral:8x7b | 0.53 | 0.71 | **0.85** | ✅ | **+0.14** |
+| *(ref) token-mode* | *0.51* | *0.73* | *0.93* | *✅* | *+0.20* |
+
+Temporal accuracy (time-travel correctness): james 0.99–1.00 across all
+3 models; naive-supersede **0.78–0.80**; vanilla 0.97–0.99.
+
+## Findings
+
+1. **V<N<J holds 3/3 under LLM reranking.** The +0.20 J−N gap seen in
+   the deterministic token-mode reproduces at +0.14–+0.22 with a real
+   LLM reranker. → JAMES's advantage lives in the SUT's retrieval /
+   supersede mechanism, **not** the reranker — rebuts the "token-overlap
+   scoring artifact" objection.
+
+2. **Bigger backbone does NOT widen the gap** (mixtral 47B has the
+   *smallest* gap +0.14 and lowest james R@1 0.85; gemma3:12b the
+   largest +0.22 / 0.98). → JAMES's lift is structural
+   (validity-window), not a function of model capability — consistent
+   with it being a mother-platform layer contribution.
+
+3. **The two-axis story.** vanilla keeps all history → stale facts win
+   rank-1 (low R@1, high temp_acc); naive-supersede deletes superseded
+   facts → current fact rank-1 improves but **time-travel breaks**
+   (temp_acc drops to ~0.79); **james marks a validity-window (no
+   delete)** → wins BOTH axes (R@1 0.85–0.98 AND temp_acc 0.99–1.00).
+   This is the replayable-audit differentiator.
+
+## Honest caveats
+
+- **smoke scale (100 q)**, not publication (1000). The v0.2.3 token-mode
+  publication run already showed R@1 V<N<J preserved 4/4 scale points;
+  the LLM-grounded *publication* run is the strong claim and is NOT done
+  here (≈ 10× wall-clock, ~1 day with mixtral).
+- 3-local-model only; the `claude-haiku-4-5` cross-leg is pending the
+  cloud backend.
+- Per-cell `result.json` committed; per-row `bench.jsonl` is gitignored.
+
+## One-line
+JAMES's validity-window advantage (J−N ≈ +0.20) reproduces across **3
+distinct LLM rerankers** AND across **token-mode ↔ LLM-grounded**, and is
+**independent of backbone size** — strengthening that it is a structural
+mechanism, not a model or scorer artifact.


### PR DESCRIPTION
## Summary

Runs and documents the **LRB v0.2.3b cross-model** measurement (a Track E operator-pending item — found fully runnable: gemma4:e4b / gemma3:12b / mixtral:8x7b all installed in Ollama). 3 SUTs × 3 local rerankers × llm-grounded, S3 smoke (100 queries, ~2 h). The 4th prereg leg (`claude-haiku-4-5`) is excluded — needs the cloud backend.

### Gap-table (R@1 = correct *current* fact at rank 1)
| reranker | vanilla | naive-supersede | **james** | V<N<J | J−N gap |
|---|---|---|---|---|---|
| gemma4:e4b | 0.51 | 0.74 | **0.95** | ✅ | +0.21 |
| gemma3:12b | 0.62 | 0.76 | **0.98** | ✅ | +0.22 |
| mixtral:8x7b | 0.53 | 0.71 | **0.85** | ✅ | +0.14 |
| *(ref) token-mode* | *0.51* | *0.73* | *0.93* | *✅* | *+0.20* |

### Findings
1. **V<N<J holds 3/3 under real LLM reranking** — the +0.20 gap reproduces (+0.14–+0.22), so it is **not a token-overlap scoring artifact**.
2. **Bigger backbone does not widen it** (mixtral 47B has the *smallest* gap) → JAMES's lift is **structural (validity-window)**, not capability-driven.
3. **Two-axis story**: james wins R@1 **and** temporal_acc (0.99–1.00); naive-supersede trades time-travel away (temp_acc ~0.79); vanilla keeps stale facts (low R@1). The replayable-audit differentiator.

## Verification
- 9/9 cells completed, exit 0. Per-cell `result.json` committed (9 files); full analysis in `reports/research-runs/lrb-v023b-3model-llm-grounded-smoke-20260621.md`.

## Out of scope
- **smoke (100q)**, not publication (1000q ≈ 1 day with mixtral) — the strong claim. Token-mode publication already showed V<N<J preserved 4/4 scale points.
- claude-haiku cross-leg pending cloud backend. `bench.jsonl` gitignored. No `core/` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)