### PR TITLE
feat(v0.6.1): de-emoji graph + glossary page chrome → SVG/text

### DIFF
--- a/frontend/glossary.html
+++ b/frontend/glossary.html
@@ -30,7 +30,7 @@
             title="현재 워크스페이스"
             aria-label="현재 워크스페이스"
             style="display:none;font-size:11px">
-      📁 <span id="workspace-name">—</span>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px;margin-right:3px"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg><span id="workspace-name">—</span>
     </button>
     <button class="nav-btn" data-lang-toggle data-action="toggle-lang"
             title="Language / 언어"
@@ -325,7 +325,7 @@
   </div>
 
   <p class="glossary-footer-note" data-i18n="glossary.footer_note">
-    💡 다른 페이지에서 <span class="glossary-term-demo">점선 밑줄</span> 이
+    다른 페이지에서 <span class="glossary-term-demo">점선 밑줄</span> 이
     그어진 단어 위에 마우스를 올리면 같은 설명이 툴팁으로 나타납니다.
   </p>
 </main>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -33,7 +33,7 @@
             title="현재 워크스페이스"
             aria-label="현재 워크스페이스"
             style="display:none;font-size:11px">
-      📁 <span id="workspace-name">—</span>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px;margin-right:3px"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg><span id="workspace-name">—</span>
     </button>
     <button class="nav-btn" data-lang-toggle data-action="toggle-lang" title="Language / 언어"
             aria-label="언어 전환 / Toggle language"
@@ -207,7 +207,7 @@
                      border:1px solid var(--border);border-radius:7px;
                      color:var(--text-soft);font-size:12px;cursor:pointer;
                      font-family:var(--font-mono);letter-spacing:.4px">
-        🔒 Edit mode: OFF
+        Edit mode: OFF
       </button>
       <div id="graph-edit-hint" class="stat"
            style="margin-top:8px;line-height:1.6;font-size:11px;display:none">
@@ -230,7 +230,7 @@
     <div class="tsd-toggle" id="tsd-toggle" data-action="toggle-search-drawer"
          title="엔티티 검색 (Esc로 닫기)"
          data-i18n-title="graph.search_toggle_title">
-      <span data-i18n="graph.search_toggle_label">🔎 검색 ▾</span>
+      <span data-i18n="graph.search_toggle_label">검색 ▾</span>
     </div>
     <div class="top-search-drawer" id="search-drawer">
       <div class="tsd-body">

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -535,7 +535,7 @@
     panel.innerHTML =
       '<button class="np-close" data-action="close-neighbor" ' +
       'title="닫기">×</button>' +
-      '<div class="np-title">🔗 ' + escapeHtml(centerNode.name || '?') + '</div>' +
+      '<div class="np-title">' + escapeHtml(centerNode.name || '?') + '</div>' +
       '<div class="np-meta">' + neighbors.length + '개 직접 연결' +
       (neighbors.length > 50 ? ' (50개까지 표시)' : '') + '</div>' +
       '<div class="np-list">' + rowsHtml + '</div>';
@@ -804,7 +804,7 @@
       setTimeout(function () { input.focus(); }, 80);
     }
     var toggle = document.getElementById('tsd-toggle');
-    if (toggle) toggle.textContent = '🔎 검색 ▴';
+    if (toggle) toggle.textContent = '검색 ▴';
   }
 
   window.hideSearchDrawer = function () {
@@ -812,7 +812,7 @@
     if (!drawer) return;
     drawer.classList.remove('tsd-open');
     var toggle = document.getElementById('tsd-toggle');
-    if (toggle) toggle.textContent = '🔎 검색 ▾';
+    if (toggle) toggle.textContent = '검색 ▾';
   };
 
   // Render the list rows for query `q` (case-insensitive substring).

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -161,7 +161,7 @@
                 'style="background:transparent;border:1px solid var(--border);' +
                        'color:var(--text-soft);width:24px;height:22px;' +
                        'border-radius:4px;cursor:pointer;font-size:11px;line-height:1">' +
-          '✏️' +
+          '수정' +
         '</button>' +
         '<button type="button" data-action="del-src" data-idx="' + idx + '" ' +
                 'title="Delete this source" ' +
@@ -469,7 +469,7 @@
 
     if (editEnabled) {
       editEnabled = false;
-      btn.textContent = '🔒 Edit mode: OFF';
+      btn.textContent = 'Edit mode: OFF';
       if (hint) hint.style.display = 'none';
       return;
     }
@@ -491,7 +491,7 @@
       }
     }
     editEnabled = true;
-    btn.textContent = '🔓 Edit mode: ON';
+    btn.textContent = 'Edit mode: ON';
     if (hint) hint.style.display = 'block';
   }
 

--- a/frontend/static/graph_node_editor.js
+++ b/frontend/static/graph_node_editor.js
@@ -80,7 +80,7 @@
     var btn = document.createElement('button');
     btn.type = 'button';
     btn.id = 'np-summary-edit-btn';
-    btn.textContent = '✏️ ' + _t('graph.node.edit.button', '노드 편집');
+    btn.textContent = _t('graph.node.edit.button', '노드 편집');
     btn.setAttribute('style',
       'margin-top:10px;width:100%;padding:8px 10px;' +
       'background:var(--surface-2);border:1px solid var(--border);' +


### PR DESCRIPTION
## Summary
PR **2 of the de-emoji series** (after workspace #998). Chrome-only, operator-confirmed scope.

**Removed (pictographic chrome → SVG/text):** 📁 badge (folder SVG), 💡 glossary tip, 🔗 graph panel title, 🔎 search toggle (html + js ▴/▾), 🔒/🔓 edit-mode button (html + graph_editor.js), ✏️ node-edit + row-edit buttons.

**Kept** (consistent with chrome-only rule): ⚠ truncation warning (functional status, like ✅/❌), ✕ close/delete glyph (standard UI affordance), ✏/✕ in code comments (not user-facing).

## Verification
- graph.js / graph_editor.js / graph_node_editor.js `node --check` OK; graph.html + glossary.html `<svg>` balanced 1/1; pictographic emoji 0 remaining.
- No `core/` touch. ⚠ Not visually click-tested (no visual-regression harness yet).

## Series status
Done: workspace (#998), graph, glossary. **Remaining: admin page (~243 glyphs — largest) + residual chat-page string emoji + other i18n keys + misc js (upload/reasoning-flow/time-travel-trace/templating-chat).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)