### PR TITLE
feat(v0.6.1): intro front door — PR-intro-2 (route switch + link migration)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -37,7 +37,7 @@
             aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <!-- v0.6 Phase 4 P4.1 — operator onboarding entry point -->
-    <a href="/onboarding" class="nav-btn"
+    <a href="/#tour" class="nav-btn"
        data-i18n="admin.onboarding_link"
        title="Operator guide / 운영자 안내"
        style="font-size:12px">운영자 안내</a>
@@ -52,11 +52,11 @@
        title="Reasoning flow / 추론 흐름"
        style="font-size:12px">추론 흐름</a>
     <!-- v0.6 Phase 4 P4.4 — glossary entry point -->
-    <a href="/glossary" class="nav-btn"
+    <a href="/#glossary" class="nav-btn"
        data-i18n="admin.glossary_link"
        title="Glossary / 용어 설명"
        style="font-size:12px">용어 설명</a>
-    <a href="/" class="nav-btn" data-i18n="admin.chat_link">← 챗으로</a>
+    <a href="/chat" class="nav-btn" data-i18n="admin.chat_link">← 챗으로</a>
   </div>
 </header>
 
@@ -901,7 +901,7 @@
       <div style="margin-top:14px;padding:12px;background:var(--surface-2);
            border:1px solid var(--border);border-radius:8px;font-size:12px;
            color:var(--muted);line-height:1.6">
-        새 파일 업로드는 <a href="/" style="color:var(--accent-fg);
+        새 파일 업로드는 <a href="/chat" style="color:var(--accent-fg);
            text-decoration:none">Chat 페이지</a>에서 진행됩니다.
         업로드 직후 이 트리에 반영되며, 자세한 내역은
         <a href="#" data-action="show-page" data-page="uploads"

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -39,7 +39,7 @@
             aria-label="언어 전환 / Toggle language"
             style="font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <a href="/admin" class="nav-btn">← <span data-i18n="graph.back_admin">Admin</span></a>
-    <a href="/" class="nav-btn">← <span data-i18n="graph.back_chat">Chat</span></a>
+    <a href="/chat" class="nav-btn">← <span data-i18n="graph.back_chat">Chat</span></a>
   </div>
 </header>
 

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -32,7 +32,7 @@
                    border:1px solid var(--border);border-radius:6px;
                    padding:5px 10px;cursor:pointer;color:var(--text-soft)"></button>
     <!-- PR-intro-1: chat still served at / ; PR-intro-2 flips this to /chat -->
-    <a href="/" class="nav-btn" data-i18n="intro.skip_to_chat">챗 시작 →</a>
+    <a href="/chat" class="nav-btn" data-i18n="intro.skip_to_chat">챗 시작 →</a>
   </div>
 </header>
 
@@ -49,7 +49,7 @@
     </p>
     <div class="intro-hero-cta">
       <!-- PR-intro-1: chat = / ; PR-intro-2 → /chat -->
-      <a href="/" class="intro-cta intro-cta-primary" data-i18n="intro.cta_chat">챗 시작</a>
+      <a href="/chat" class="intro-cta intro-cta-primary" data-i18n="intro.cta_chat">챗 시작</a>
       <a href="/workspace" class="intro-cta" data-i18n="intro.cta_workspace">워크스페이스</a>
       <a href="/admin" class="intro-cta" data-i18n="intro.cta_admin">관리자</a>
     </div>

--- a/frontend/static/glossary.js
+++ b/frontend/static/glossary.js
@@ -97,8 +97,7 @@
       '<span class="tooltip-term">' + escapeHtml(term.replace(/-/g, ' ')) +
       '</span>' +
       '<span>' + escapeHtml(def) + '</span>' +
-      '<a class="tooltip-link" href="/glossary#' +
-      encodeURIComponent(term) + '">전체 용어집 →</a>';
+      '<a class="tooltip-link" href="/#glossary">전체 용어집 →</a>';
     // Position next to the trigger.
     var rect = trigger.getBoundingClientRect();
     var top = rect.bottom + window.scrollY + 6;

--- a/frontend/static/intro.js
+++ b/frontend/static/intro.js
@@ -20,20 +20,29 @@
   'use strict';
 
   var SEEN_KEY = 'james_intro_seen';
-  // PR-intro-2 will serve chat here; until then chat is still at "/".
-  var CHAT_PATH = '/chat';
+  var CHAT_PATH = '/chat';  // chat app (PR-intro-2 moved it off "/")
 
   function seen() {
-    try { return localStorage.getItem(SEEN_KEY) === '1'; } catch (_) { return false; }
+    try {
+      return localStorage.getItem(SEEN_KEY) === '1'
+        // honour the legacy onboarding flag so users who finished the old
+        // /onboarding flow are recognised without re-seeing the intro.
+        || localStorage.getItem('james_onboarding_completed') === '1';
+    } catch (_) { return false; }
   }
   function markSeen() {
     try { localStorage.setItem(SEEN_KEY, '1'); } catch (_) {}
   }
 
   // ── 2. front-door auto-skip (only when this IS the front door) ──
-  // At "/intro" (isolated-review route) pathname !== "/", so this is a
-  // no-op; it activates automatically once the page is served at "/".
-  if (window.location.pathname === '/' && seen()) {
+  // When served at "/", a returning visitor is bounced to /chat — UNLESS
+  // they arrived with an explicit section hash (#tour / #glossary /
+  // #intro), e.g. the /onboarding→/#tour and /glossary→/#glossary 301s,
+  // or the admin "안내 / 용어집" links. Those must SHOW the section, not
+  // skip. At the legacy /intro route (pathname !== "/") this is a no-op.
+  var _h = (window.location.hash || '').replace('#', '');
+  if (window.location.pathname === '/' && seen()
+      && _h !== 'tour' && _h !== 'glossary' && _h !== 'intro') {
     window.location.replace(CHAT_PATH);
     return;
   }

--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -148,7 +148,7 @@ function openForgot() {
   closeLogin();
   // Simple punt: navigate to the chat page where the existing
   // forgot-password modal lives. Returning here is the user's choice.
-  window.location.href = '/';
+  window.location.href = '/chat';
 }
 
 /* ── data tab — main feature ── */

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -44,7 +44,7 @@
     <button class="header-btn" data-lang-toggle data-action="toggle-lang"
             aria-label="언어 전환 / Toggle language"
             style="font-weight:700"></button>
-    <a href="/" class="header-btn" style="text-decoration:none" data-i18n="workspace.back_chat">챗</a>
+    <a href="/chat" class="header-btn" style="text-decoration:none" data-i18n="workspace.back_chat">챗</a>
     <button class="header-btn" id="login-btn"
             data-action="show-login" data-i18n="auth.login">로그인</button>
     <button class="header-btn" id="logout-btn"

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -21,7 +21,7 @@ import sqlite3
 import time
 from collections import defaultdict
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, HTMLResponse, FileResponse
+from fastapi.responses import JSONResponse, HTMLResponse, FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from config import BASE_DIR, UPLOAD_DIR, WIKI_DIR, CHROMA_DIR
@@ -232,6 +232,19 @@ async def security_headers_middleware(request: Request, call_next):
 
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def serve_index():
+    """v0.6.1 PR-intro-2 — `/` is now the public intro front door.
+    Daily chat moved to /chat. intro.js auto-skips returning visitors
+    (localStorage james_intro_seen) straight to /chat, so daily entry is
+    frictionless. See docs/design/v0.6.1-intro-page-restructure.md."""
+    page = os.path.join(FRONTEND_DIR, "intro.html")
+    if os.path.exists(page):
+        return FileResponse(page)
+    return HTMLResponse("<h1>SEKOS</h1><p>frontend/intro.html 없음</p>")
+
+
+@app.get("/chat", response_class=HTMLResponse, include_in_schema=False)
+async def serve_chat():
+    """v0.6.1 PR-intro-2 — the chat app (was served at `/`)."""
     index = os.path.join(FRONTEND_DIR, "index.html")
     if os.path.exists(index):
         return FileResponse(index)
@@ -279,10 +292,8 @@ async def serve_glossary():
     (`/static/glossary.js`) that other pages load to auto-attach
     hover tooltips on elements with `data-glossary="<term-slug>"`.
     """
-    page = os.path.join(FRONTEND_DIR, "glossary.html")
-    if os.path.exists(page):
-        return FileResponse(page)
-    return HTMLResponse("<h1>Glossary</h1><p>frontend/glossary.html 없음</p>")
+    # v0.6.1 PR-intro-2 — glossary folded into the intro front door.
+    return RedirectResponse(url="/#glossary", status_code=301)
 
 
 @app.get("/admin/reasoning-flow", response_class=HTMLResponse, include_in_schema=False)
@@ -332,10 +343,8 @@ async def serve_onboarding():
     downstream pages it points at (`/admin`, `/admin/graph`) gate
     on JWT.
     """
-    page = os.path.join(FRONTEND_DIR, "onboarding.html")
-    if os.path.exists(page):
-        return FileResponse(page)
-    return HTMLResponse("<h1>Onboarding</h1><p>frontend/onboarding.html 없음</p>")
+    # v0.6.1 PR-intro-2 — onboarding folded into the intro front door.
+    return RedirectResponse(url="/#tour", status_code=301)
 
 
 @app.get("/workspace", response_class=HTMLResponse, include_in_schema=False)


### PR DESCRIPTION
## Summary
Promotes the intro page (built in #1004) to the **front door**.

**Routing** (`server_llmwiki.py`): `/`→intro.html · `/chat`→index.html (chat, NEW) · `/onboarding`→**301** `/#tour` · `/glossary`→**301** `/#glossary` · `/intro` kept as alias.

**Chat-link migration** (`/`→`/chat`): admin.html (←챗으로 + upload hint), graph.html, workspace.html, workspace.js, intro.html CTAs. admin nav `/onboarding`→`/#tour`, `/glossary`→`/#glossary` (direct; 301s remain for bookmarks). glossary.js tooltip href → `/#glossary`.

**intro.js auto-skip hardened**: at `/`, returning visitor → /chat ONLY when no section hash — so the 301s + admin anchors SHOW the section instead of bouncing. `seen()` also honours legacy `james_onboarding_completed`.

## Verification
- intro/glossary/workspace `.js` `node --check` OK; routes `/`,`/chat`,`/intro`,`/onboarding`,`/glossary` registered; no residual chat `href="/"` in migrated files; `test_chat_mode_picker` green; server imports OK. No `core/` touch.
- ⚠ Not visually click-tested. **Operator: `/` should now show intro (first visit) / bounce to `/chat` (returning); `/chat` = chat; old `/onboarding`,`/glossary` 301 to intro sections.**

## Next
PR-intro-3: delete now-dead `onboarding.html` + `glossary.html` (their CSS/JS stay — intro reuses them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)