### PR TITLE
fix(v0.6.1): align onboarding/glossary tests to intro front-door routing

### DIFF
--- a/tests/test_v06_glossary.py
+++ b/tests/test_v06_glossary.py
@@ -202,7 +202,9 @@ class ServerAndEntryPointTests(unittest.TestCase):
 
     def test_admin_html_link_to_glossary(self):
         body = ADMIN_HTML.read_text(encoding="utf-8")
-        self.assertIn('href="/glossary"', body)
+        # v0.6.1 PR-intro-2 — glossary folded into the intro front door;
+        # the admin link now points at the glossary section anchor.
+        self.assertIn('href="/#glossary"', body)
         self.assertIn('admin.glossary_link', body)
 
 

--- a/tests/test_v06_onboarding_flow.py
+++ b/tests/test_v06_onboarding_flow.py
@@ -203,8 +203,10 @@ class I18nKeysPresenceTests(unittest.TestCase):
 class AdminEntryPointTests(unittest.TestCase):
     def test_admin_html_links_to_onboarding(self):
         body = ADMIN_HTML.read_text(encoding="utf-8")
-        self.assertIn('href="/onboarding"', body,
-                      "admin.html header must link to /onboarding")
+        # v0.6.1 PR-intro-2 — onboarding folded into the intro front door;
+        # the admin link now points at the tour section anchor (/#tour).
+        self.assertIn('href="/#tour"', body,
+                      "admin.html header must link to the intro tour (/#tour)")
         self.assertIn('admin.onboarding_link', body,
                       "admin.html must use the i18n key for the link label")
 
@@ -214,7 +216,9 @@ class ServerRouteTests(unittest.TestCase):
         body = SERVER.read_text(encoding="utf-8")
         self.assertIn('@app.get("/onboarding"', body)
         self.assertIn("async def serve_onboarding", body)
-        self.assertIn("onboarding.html", body)
+        # v0.6.1 PR-intro-2 — /onboarding now 301-redirects into the intro
+        # front door (the 5-step tour content moved to intro.html#tour).
+        self.assertIn("/#tour", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
PR-intro-2 (#1005) changed admin links + the `/onboarding`,`/glossary` routes; **3 source-level assertions** in the v0.6 onboarding/glossary suites still expected the old shape and went RED on main. Realigns them:

- `test_v06_onboarding_flow`: admin link `/onboarding`→`/#tour`; route test now asserts the 301 target `/#tour` (was the `onboarding.html` FileResponse string).
- `test_v06_glossary`: admin link `/glossary`→`/#glossary`.

`@app.get("/onboarding"` / `"/glossary"` decorators + `serve_*` fn names unchanged (still registered, now redirecting).

## Out of scope (deferred)
Deleting the now-unreachable `onboarding.html` / `glossary.html` + retargeting their content tests to `intro.html` — held until the operator visually confirms `/intro` (the 301s make the old files harmless dead weight meanwhile).

## Verification
47 tests green (onboarding + glossary + chat-mode-picker). frontend/test only, `core/` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)