### PR TITLE
feat(v0.6.1): reasoning-graph hub — PR-graph-1 (tabs + embed)

### DIFF
--- a/docs/design/v0.6.1-graph-hub-consolidation.md
+++ b/docs/design/v0.6.1-graph-hub-consolidation.md
@@ -1,0 +1,102 @@
+# v0.6.1 — Reasoning-graph hub consolidation (design memo)
+
+> Status: **DESIGN (not built)**. Operator decision 2026-06-22:
+> **Option A** — fold `/admin/reasoning-flow` + `/admin/knowledge-rollback`
+> into `/admin/graph` as tabs; design-first.
+
+## 1. Goal & fit
+
+Three admin audit/explainability surfaces, related but distinct:
+
+| page | backend | relationship to graph |
+|---|---|---|
+| `/admin/graph` | `/admin/graph/snapshot` (+ Time-Travel panel) | the 3D knowledge-state graph |
+| `/admin/knowledge-rollback` | `/admin/graph/last-change`, **`/admin/graph/diff-vs-now`**, `log-rollback-intent` | **uses graph time-travel primitives** — the "undo/restore action" face of the graph (STRONG fit) |
+| `/admin/reasoning-flow` | `/admin/audit/recent-traces`, `/admin/trace/{id}` | a *different data axis* — one reasoning RUN's steps (RETRIEVE/EXPAND/VERIFY), not graph nodes (WEAKER fit, but same audit family) |
+
+Consolidate into a **"추론 그래프 = reasoning & audit hub"** at `/admin/graph`
+with tabs. Backend unchanged.
+
+**Key constraint discovered:** the graph page's **Time-Travel panel drives
+the live 3D view** (reconstruct-at-T → graph re-renders). It is a graph
+*control*, so it STAYS in the graph tab — it is NOT merged into the
+rollback tab. Tabs are therefore:
+
+```
+/admin/graph
+ ├─ [그래프]     3D graph + ALL current panels incl. Time-Travel (default)
+ ├─ [추론 흐름]  reasoning-flow trace view (embedded)
+ └─ [롤백]       knowledge-rollback undo/restore (embedded)
+```
+
+## 2. Tab + lazy/resize design
+
+- All three drivers wire on `DOMContentLoaded` today (graph.js → initGraph
+  auto-runs the 3D; reasoning-flow.js / knowledge-rollback.js `wire()`
+  only *bind handlers* + fetch on demand — cheap). So all can co-load;
+  the heavy 3D belongs to the DEFAULT tab, so no eager cost on the others.
+- **3D resize gotcha**: a 3d-force-graph inside a `display:none` container
+  has 0×0 size. When the user returns to the 그래프 tab, the new
+  `graph-tabs.js` must trigger the graph's resize/refit. Approach: keep
+  the graph tab visible by default; on switch-to-graph, dispatch a
+  `window.resize` (3d-force-graph listens) or call the graph's exposed
+  resize. Verify graph.js exposes one (else add a tiny hook).
+- New `graph-tabs.js`: tab bar + `#graph`/`#flow`/`#rollback` hash sync
+  (so the /admin/reasoning-flow→#flow and /admin/knowledge-rollback→
+  #rollback 301s land on the right tab), + the resize trigger.
+
+## 3. Routes — before → after
+
+| URL | After |
+|---|---|
+| `/admin/graph` | tab hub (graph default) — same route |
+| `/admin/reasoning-flow` | **301 → /admin/graph#flow** |
+| `/admin/knowledge-rollback` | **301 → /admin/graph#rollback** |
+
+`server_llmwiki.py`: turn serve_reasoning_flow + serve_knowledge_rollback
+into `RedirectResponse(..., 301)` (same as the intro /onboarding,/glossary
+pattern).
+
+## 4. CSS / scripts on graph.html
+- **Add imports**: `reasoning-flow.css`, `knowledge-rollback.css` (the
+  embedded tab markup uses their classes — keep both files).
+- **Add scripts**: `reasoning-flow.js`, `knowledge-rollback.js` +
+  `graph-tabs.js`.
+- KEEP: glossary.js (already loaded), time-travel*.js, graph_editor*.
+
+## 5. Migration checklist (build PRs)
+- **admin sidebar links** (admin.html:45, :50): `/admin/knowledge-rollback`
+  → `/admin/graph#rollback`; `/admin/reasoning-flow` → `/admin/graph#flow`.
+- **test retarget**: `test_v06_glossary.py` CrossPageWiringTests asserts
+  REASONING_HTML + ROLLBACK_HTML load glossary.js — once those files are
+  deleted, point those two assertions at graph.html (which loads
+  glossary.js) or drop them. No dedicated reasoning-flow/rollback UI test
+  suites exist (only backend test_evolution_rollback + graph-viz tests,
+  both unaffected).
+- **i18n**: graph.* / flow.* / rollback.* keys all exist + reused; add a
+  few `graph.hub.tab_*` keys (그래프 / 추론 흐름 / 롤백).
+
+## 6. Risks & mitigations
+- **3D resize on tab show** (§2) — the one real technical risk; mitigated
+  by a resize trigger in graph-tabs.js + manual verify.
+- **Heavier single page** — three.js + force-graph already load on
+  /admin/graph; reasoning-flow/rollback add only light JS. Acceptable.
+- **No visual-regression harness** — build PRs verify node-check +
+  tag-balance + route registration; operator dogfoods the tabs.
+- **Bookmarks to old URLs** — 301s preserve them.
+
+## 7. Phased build (on approval)
+1. **PR-graph-1**: add tab bar + embed reasoning-flow + knowledge-rollback
+   markup into graph.html as `#flow` / `#rollback` tab panels + import
+   their CSS + load their JS + `graph-tabs.js` (hash sync + 3D resize).
+   The graph tab stays default → existing graph behaviour unchanged;
+   review the new tabs in place. Old standalone routes still serve (for
+   isolated comparison).
+2. **PR-graph-2**: route 301s + admin sidebar link migration + glossary
+   cross-wiring test retarget.
+3. **PR-graph-3**: delete `reasoning-flow.html` + `knowledge-rollback.html`
+   (content now in graph.html; their CSS/JS stay — graph reuses them).
+
+Rule #1/#5 unaffected (frontend only, `core/` 0 lines). No measurement axis.
+Mirrors the intro consolidation (#1004–#1007) pattern.
+```

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -9,6 +9,11 @@
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">
+<!-- v0.6.1 graph-hub: 추론 흐름 + 롤백 tabs embedded here; reuse their CSS
+     (onboarding.css supplies .onb-btn used by both). -->
+<link rel="stylesheet" href="/static/onboarding.css">
+<link rel="stylesheet" href="/static/reasoning-flow.css">
+<link rel="stylesheet" href="/static/knowledge-rollback.css">
 <link rel="stylesheet" href="/static/mobile.css?v=v14-20260616">
 </head>
 <body>
@@ -43,7 +48,21 @@
   </div>
 </header>
 
-<main id="main" class="main">
+<!-- v0.6.1 graph-hub tab bar — graph (default) / 추론 흐름 / 롤백.
+     reasoning-flow + knowledge-rollback folded in as tabs; the graph
+     Time-Travel panel stays in the graph tab (it drives the 3D view).
+     graph-tabs.js syncs #flow/#rollback hash (anything else, incl the
+     time-travel #t=, stays on the graph tab). -->
+<nav class="graph-hub-tabs" role="tablist" aria-label="Reasoning & audit">
+  <button class="graph-hub-tab graph-hub-tab-active" data-graph-tab-btn="graph"
+          role="tab" data-i18n="graph.hub.tab_graph">그래프</button>
+  <button class="graph-hub-tab" data-graph-tab-btn="flow"
+          role="tab" data-i18n="graph.hub.tab_flow">추론 흐름</button>
+  <button class="graph-hub-tab" data-graph-tab-btn="rollback"
+          role="tab" data-i18n="graph.hub.tab_rollback">롤백</button>
+</nav>
+
+<main id="main" class="main" data-graph-tab="graph">
   <aside>
     <!-- v0.5 Track F.1 TT.a — Time-Travel timestamp picker.
          Surfaces the G3 corpus_reconstruct_view_at primitive (PR #849)
@@ -250,6 +269,90 @@
     <div class="neighbor-panel" id="neighbor-panel"></div>
   </div>
 </main>
+
+<!-- ══ Tab: 추론 흐름 (reasoning-flow, embedded; driven by reasoning-flow.js) ══ -->
+<section class="flow-main" data-graph-tab="flow" hidden>
+  <h1 class="flow-h1" data-i18n="flow.title">추론 흐름 보기</h1>
+  <p class="flow-intro" data-i18n="flow.intro">질문 하나가 시스템 안에서 어떻게 흘러갔는지 단계별 시각화로 보여드립니다. 어떤 자료를 찾았고, 어떤 그래프를 거쳤고, 어떻게 답을 만들었는지 — 한눈에 추적할 수 있습니다.</p>
+  <section class="flow-selector" role="region" aria-labelledby="flow-selector-title">
+    <h2 id="flow-selector-title" data-i18n="flow.selector.title">추적할 질문 선택</h2>
+    <div class="selector-row">
+      <label for="flow-trace-input" class="field-label" data-i18n="flow.selector.label">trace_id 직접 입력</label>
+      <input id="flow-trace-input" type="text" autocomplete="off" spellcheck="false" placeholder="예: 0193a8f5..." aria-label="Trace ID" class="flow-input">
+      <button id="flow-load-btn" type="button" class="onb-btn onb-btn-primary" data-i18n="flow.selector.load">불러오기</button>
+    </div>
+    <div class="recent-list-wrapper">
+      <label class="field-label" data-i18n="flow.selector.recent_label">최근 질문 목록 (오늘)</label>
+      <button id="flow-refresh-btn" type="button" class="onb-btn" style="font-size:11px;padding:6px 12px;min-height:32px" data-i18n="flow.selector.refresh">↻ 새로 고침</button>
+      <div id="flow-recent-list" class="recent-list" aria-live="polite">
+        <div class="empty-state" data-i18n="flow.selector.empty">최근 질문이 없습니다. trace_id 를 직접 입력해 보세요.</div>
+      </div>
+    </div>
+  </section>
+  <section class="flow-viz-section" id="flow-viz-section" role="region" aria-labelledby="flow-viz-title" hidden>
+    <h2 id="flow-viz-title" data-i18n="flow.viz.title">추론 흐름</h2>
+    <div id="flow-summary" class="flow-summary"></div>
+    <div class="flow-swimlanes" id="flow-swimlanes">
+      <div class="swimlane" data-phase="retrieve">
+        <div class="swimlane-header"><span class="phase-label" data-i18n="flow.phase.retrieve">RETRIEVE</span><span class="phase-sub" data-i18n="flow.phase.retrieve_sub">자료 찾기</span></div>
+        <div class="swimlane-body" id="phase-retrieve"></div>
+      </div>
+      <div class="swimlane" data-phase="expand">
+        <div class="swimlane-header"><span class="phase-label" data-i18n="flow.phase.expand">EXPAND</span><span class="phase-sub" data-i18n="flow.phase.expand_sub">관계 탐색</span></div>
+        <div class="swimlane-body" id="phase-expand"></div>
+      </div>
+      <div class="swimlane" data-phase="verify">
+        <div class="swimlane-header"><span class="phase-label" data-i18n="flow.phase.verify">VERIFY</span><span class="phase-sub" data-i18n="flow.phase.verify_sub">답변 생성</span></div>
+        <div class="swimlane-body" id="phase-verify"></div>
+      </div>
+    </div>
+    <p class="flow-hint" data-i18n="flow.viz.hint">각 카드를 클릭하면 상세 정보를 볼 수 있습니다.</p>
+  </section>
+  <section class="flow-detail" id="flow-detail-panel" role="region" aria-labelledby="flow-detail-title" aria-live="polite" hidden>
+    <h2 id="flow-detail-title" data-i18n="flow.detail.title">단계 상세</h2>
+    <div id="flow-detail-content"></div>
+  </section>
+  <div id="flow-error" class="flow-error" hidden role="alert"></div>
+  <p class="flow-footer-note" data-i18n="flow.footer_note">이 시각화는 감사 로그에 기록된 추론 단계를 그대로 보여줍니다. 위조 불가능한 forensic evidence 로 활용할 수 있습니다.</p>
+</section>
+
+<!-- ══ Tab: 롤백 (knowledge-rollback, embedded; driven by knowledge-rollback.js) ══ -->
+<section class="onboarding-main" data-graph-tab="rollback" hidden>
+  <h1 class="rollback-h1" data-i18n="rollback.title">지식 롤백</h1>
+  <p class="rollback-intro" data-i18n="rollback.intro">실수로 잘못된 변경이 들어갔거나, 과거 시점의 상태로 돌려놓고 싶을 때 사용합니다. 두 가지 동작이 있습니다.</p>
+  <section class="rollback-flow" role="region" aria-labelledby="undo-last-title">
+    <div class="flow-icon" aria-hidden="true">↶</div>
+    <h2 id="undo-last-title" data-i18n="rollback.undo_last.title">최근 변경 되돌리기</h2>
+    <p class="flow-desc" data-i18n="rollback.undo_last.desc">가장 최근에 시스템에 들어간 변경을 되돌립니다. 어떤 변경이었는지 먼저 보여드린 뒤, 확인하시면 진행합니다.</p>
+    <button id="rollback-undo-last-btn" type="button" class="onb-btn onb-btn-primary" data-i18n="rollback.undo_last.button">↶ 최근 변경 되돌리기</button>
+    <div id="rollback-undo-last-preview" class="flow-preview" hidden aria-live="polite"></div>
+  </section>
+  <section class="rollback-flow" role="region" aria-labelledby="restore-to-title">
+    <div class="flow-icon" aria-hidden="true">⏰</div>
+    <h2 id="restore-to-title" data-i18n="rollback.restore_to.title">특정 시점으로 복원</h2>
+    <p class="flow-desc" data-i18n="rollback.restore_to.desc">지난 시점 (예: 어제 오후 3시) 의 상태로 시스템을 되돌립니다. 복원 전에 "그때 vs 지금" 차이를 보여드립니다.</p>
+    <div class="flow-controls">
+      <label for="rollback-restore-time" class="field-label" data-i18n="rollback.restore_to.pick">돌아갈 시점</label>
+      <input id="rollback-restore-time" type="datetime-local" aria-label="복원할 시점" class="rollback-input">
+      <button id="rollback-restore-preview-btn" type="button" class="onb-btn" data-i18n="rollback.restore_to.preview_button">미리보기</button>
+    </div>
+    <div id="rollback-restore-preview" class="flow-preview" hidden aria-live="polite"></div>
+  </section>
+  <div id="rollback-confirm-modal" class="rollback-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="rollback-confirm-title" hidden>
+    <div class="rollback-modal-card">
+      <h2 id="rollback-confirm-title" data-i18n="rollback.confirm.title">롤백 확인</h2>
+      <div id="rollback-confirm-summary" class="confirm-summary"></div>
+      <label for="rollback-note" data-i18n="rollback.confirm.note_label" style="display:block;margin:14px 0 6px;font-size:12px;color:var(--text-soft);font-family:var(--font-mono)">왜 되돌리시나요? (감사 기록에 남습니다)</label>
+      <textarea id="rollback-note" rows="3" placeholder="예: 어제 14시에 잘못된 휴가 정책 문서가 업로드됨" data-i18n-placeholder="rollback.confirm.note_placeholder" class="rollback-textarea"></textarea>
+      <div class="rollback-modal-buttons">
+        <button id="rollback-cancel-btn" type="button" class="onb-btn" data-i18n="rollback.confirm.cancel">취소</button>
+        <button id="rollback-confirm-btn" type="button" class="onb-btn onb-btn-primary" data-i18n="rollback.confirm.proceed">확인 — 진행</button>
+      </div>
+    </div>
+  </div>
+  <div id="rollback-result-panel" class="rollback-result" hidden role="status" aria-live="polite"></div>
+  <p class="rollback-footer-note" data-i18n="rollback.footer_note">모든 롤백 의도는 감사 로그에 기록됩니다. 누가 언제 무엇을 되돌리려 했는지 모두 추적 가능합니다.</p>
+</section>
 
 <!-- Admin login modal — same flow as admin.html -->
 <div class="modal-overlay" id="login-modal"
@@ -532,5 +635,10 @@
 <!-- v0.6.1 — workspace badge in header (reasoning graph is workspace-
      scoped, see ARCHITECTURE / per-workspace data layout). -->
 <script src="/static/workspace-badge.js"></script>
+<!-- v0.6.1 graph-hub: 추론 흐름 + 롤백 tab drivers (wire on load; fetch on
+     demand) + tab switcher (hash sync + 3D resize on return to graph). -->
+<script src="/static/reasoning-flow.js"></script>
+<script src="/static/knowledge-rollback.js"></script>
+<script src="/static/graph-tabs.js"></script>
 </body>
 </html>

--- a/frontend/static/graph-tabs.js
+++ b/frontend/static/graph-tabs.js
@@ -1,0 +1,73 @@
+/* graph-tabs.js — reasoning-graph hub tabs (v0.6.1).
+ *
+ * Folds /admin/reasoning-flow (#flow) and /admin/knowledge-rollback
+ * (#rollback) into /admin/graph as tabs. The graph tab is default and
+ * keeps its Time-Travel panel (which drives the live 3D view).
+ *
+ * Hash policy — the graph's Time-Travel deep-link uses `#t=<ISO>`, so we
+ * must NOT clobber it: only `#flow` / `#rollback` select the other tabs;
+ * ANY other hash (incl. `#t=...` or empty) resolves to the graph tab.
+ *
+ * 3D resize — a 3d-force-graph inside a `display:none` container renders
+ * at 0×0. When the user returns to the graph tab we dispatch a window
+ * resize so the force-graph re-fits its container.
+ */
+(function () {
+  'use strict';
+
+  var TABS = ['graph', 'flow', 'rollback'];
+
+  function tabFromHash() {
+    var h = window.location.hash || '';
+    if (h.indexOf('#flow') === 0) return 'flow';
+    if (h.indexOf('#rollback') === 0) return 'rollback';
+    return 'graph';  // includes '', '#', and the time-travel '#t=...'
+  }
+
+  function show(name) {
+    if (TABS.indexOf(name) === -1) name = 'graph';
+    document.querySelectorAll('[data-graph-tab]').forEach(function (panel) {
+      var on = panel.getAttribute('data-graph-tab') === name;
+      if (on) panel.removeAttribute('hidden');
+      else panel.setAttribute('hidden', '');
+    });
+    document.querySelectorAll('[data-graph-tab-btn]').forEach(function (btn) {
+      btn.classList.toggle('graph-hub-tab-active',
+        btn.getAttribute('data-graph-tab-btn') === name);
+    });
+    // Returning to the graph: the 3D canvas was display:none → re-fit it.
+    if (name === 'graph') {
+      try { window.dispatchEvent(new Event('resize')); } catch (_) {}
+    }
+  }
+
+  function selectTab(name) {
+    // Update the hash without disturbing the time-travel '#t=' deep-link:
+    // graph tab clears only a tab-hash; flow/rollback set their own.
+    var cur = window.location.hash || '';
+    if (name === 'flow' || name === 'rollback') {
+      if (history.replaceState) history.replaceState(null, '', '#' + name);
+      else window.location.hash = name;
+    } else if (cur.indexOf('#flow') === 0 || cur.indexOf('#rollback') === 0) {
+      if (history.replaceState) history.replaceState(null, '', window.location.pathname + window.location.search);
+      else window.location.hash = '';
+    }
+    show(name);
+  }
+
+  function bind() {
+    document.querySelectorAll('[data-graph-tab-btn]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        selectTab(btn.getAttribute('data-graph-tab-btn'));
+      });
+    });
+    window.addEventListener('hashchange', function () { show(tabFromHash()); });
+    show(tabFromHash());
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind);
+  } else {
+    bind();
+  }
+})();

--- a/frontend/static/graph.css
+++ b/frontend/static/graph.css
@@ -438,3 +438,41 @@
      mobile.css's graph section — see PR mobile-css-extension. The
      original 720px / 480px breakpoints were promoted to the project-
      standard 768px / 480px so all four pages share one boundary. */
+
+/* v0.6.1 graph-hub tab bar — graph / 추론 흐름 / 롤백 (graph-tabs.js).
+   Sits between the header and the tab panels. The graph tab is the 3D
+   view (default); flow/rollback are scrollable content panels. */
+.graph-hub-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.graph-hub-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 9px 15px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-ui, sans-serif);
+  cursor: pointer;
+  transition: color .15s, border-color .15s;
+}
+.graph-hub-tab:hover { color: var(--text-soft); }
+.graph-hub-tab-active {
+  color: var(--accent-fg);
+  border-bottom-color: var(--accent);
+}
+/* flow / rollback panels: constrained reading width, scrollable. */
+section[data-graph-tab="flow"],
+section[data-graph-tab="rollback"] {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 20px 56px;
+}
+[data-graph-tab][hidden] { display: none !important; }

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -1185,6 +1185,9 @@ const TRANSLATIONS = {
 
     /* ── Reasoning Graph (v0.2 Axis 3 Observability) ── */
     'graph.title':               'Reasoning Graph',
+    'graph.hub.tab_graph':       'Graph',
+    'graph.hub.tab_flow':        'Reasoning flow',
+    'graph.hub.tab_rollback':    'Rollback',
     'graph.back_admin':          'Admin',
     'graph.back_chat':           'Chat',
     'graph.filter.source':       'Source',
@@ -2410,6 +2413,9 @@ const TRANSLATIONS = {
 
     /* ── 추론 그래프 (v0.2 Axis 3 옵저버빌리티) ── */
     'graph.title':               '추론 그래프',
+    'graph.hub.tab_graph':       '그래프',
+    'graph.hub.tab_flow':        '추론 흐름',
+    'graph.hub.tab_rollback':    '롤백',
     'graph.back_admin':          '관리자',
     'graph.back_chat':           '챗',
     'graph.filter.source':       '소스',


### PR DESCRIPTION
## Summary
Folds `/admin/reasoning-flow` + `/admin/knowledge-rollback` into `/admin/graph` as tabs (operator **Option A**). Design: `docs/design/v0.6.1-graph-hub-consolidation.md`.

This PR adds the tabs + embeds both surfaces **in place**; the graph tab is default so existing graph behaviour is unchanged, and the old standalone routes still serve (review side-by-side). Route 301s + link migration + test retarget = PR-graph-2; delete old HTML = PR-graph-3.

- **graph.html**: tab bar [그래프 | 추론 흐름 | 롤백]; existing `<main>` (3D graph + Time-Travel) → default `graph` tab; reasoning-flow + knowledge-rollback `<main>` embedded verbatim as `#flow`/`#rollback` (same ids → driven by existing reasoning-flow.js / knowledge-rollback.js). Imports their CSS; loads their JS + graph-tabs.js.
- **graph-tabs.js** (NEW): tab switching + hash sync. **Avoids clobbering the Time-Travel `#t=<ISO>` deep-link** — only `#flow`/`#rollback` pick other tabs; anything else (incl `#t=`) = graph. On return to graph, dispatches window resize so the 3d-force-graph (0×0 while hidden) re-fits.
- **graph.css**: tab-bar + panel styles. **i18n.js**: `graph.hub.tab_*` (ko+en).

**Design note**: the Time-Travel panel STAYS in the graph tab (it drives the 3D view) — not merged into rollback.

## Verification
- graph-tabs.js / i18n.js `node --check` OK; graph.html balanced (main 1/1, section 7/7, div 98/98); no duplicate ids; 6 hub i18n keys. No `core/` touch.
- ⚠ Not visually click-tested — **operator: open `/admin/graph`, switch tabs; verify the 3D graph re-fits when returning to the 그래프 tab.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)