### PR TITLE
feat(v0.6.1): reasoning-graph hub — PR-graph-2 (route 301s + link migration)

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -42,12 +42,12 @@
        title="Operator guide / 운영자 안내"
        style="font-size:12px">운영자 안내</a>
     <!-- v0.6 Phase 4 P4.2 — knowledge rollback affordance entry point -->
-    <a href="/admin/knowledge-rollback" class="nav-btn"
+    <a href="/admin/graph#rollback" class="nav-btn"
        data-i18n="admin.rollback_link"
        title="Knowledge rollback / 지식 롤백"
        style="font-size:12px">↶ 지식 롤백</a>
     <!-- v0.6 Phase 4 P4.3 — reasoning flow visualization entry point -->
-    <a href="/admin/reasoning-flow" class="nav-btn"
+    <a href="/admin/graph#flow" class="nav-btn"
        data-i18n="admin.flow_link"
        title="Reasoning flow / 추론 흐름"
        style="font-size:12px">추론 흐름</a>

--- a/server_llmwiki.py
+++ b/server_llmwiki.py
@@ -305,12 +305,8 @@ async def serve_reasoning_flow():
     primitive + the new `/admin/audit/recent-traces` listing endpoint.
     HTML is public; backend endpoints admin-gate.
     """
-    page = os.path.join(FRONTEND_DIR, "reasoning-flow.html")
-    if os.path.exists(page):
-        return FileResponse(page)
-    return HTMLResponse(
-        "<h1>Reasoning flow</h1><p>frontend/reasoning-flow.html 없음</p>"
-    )
+    # v0.6.1 graph-hub — reasoning flow folded into the graph hub tab.
+    return RedirectResponse(url="/admin/graph#flow", status_code=301)
 
 
 @app.get("/admin/knowledge-rollback", response_class=HTMLResponse, include_in_schema=False)
@@ -322,12 +318,8 @@ async def serve_knowledge_rollback():
     it calls (`/admin/graph/last-change`, `/admin/graph/diff-vs-now`,
     `/admin/graph/log-rollback-intent`) all admin-gate.
     """
-    page = os.path.join(FRONTEND_DIR, "knowledge-rollback.html")
-    if os.path.exists(page):
-        return FileResponse(page)
-    return HTMLResponse(
-        "<h1>Knowledge Rollback</h1><p>frontend/knowledge-rollback.html 없음</p>"
-    )
+    # v0.6.1 graph-hub — knowledge rollback folded into the graph hub tab.
+    return RedirectResponse(url="/admin/graph#rollback", status_code=301)
 
 
 @app.get("/onboarding", response_class=HTMLResponse, include_in_schema=False)

--- a/tests/test_v06_knowledge_rollback.py
+++ b/tests/test_v06_knowledge_rollback.py
@@ -395,7 +395,7 @@ class I18nKeysTests(unittest.TestCase):
 class AdminEntryPointTests(unittest.TestCase):
     def test_admin_html_links_to_rollback(self):
         body = ADMIN_HTML.read_text(encoding="utf-8")
-        self.assertIn('href="/admin/knowledge-rollback"', body)
+        self.assertIn('href="/admin/graph#rollback"', body)  # v0.6.1 graph-hub
         self.assertIn('admin.rollback_link', body)
 
 

--- a/tests/test_v06_reasoning_flow.py
+++ b/tests/test_v06_reasoning_flow.py
@@ -297,7 +297,7 @@ class I18nKeysTests(unittest.TestCase):
 class EntryPointTests(unittest.TestCase):
     def test_admin_html_link(self):
         body = ADMIN_HTML.read_text(encoding="utf-8")
-        self.assertIn('href="/admin/reasoning-flow"', body)
+        self.assertIn('href="/admin/graph#flow"', body)  # v0.6.1 graph-hub
         self.assertIn('admin.flow_link', body)
 
     def test_server_route_registered(self):


### PR DESCRIPTION
## Summary
Promotes the graph hub tabs (#1008) to canonical.

- **server**: `/admin/reasoning-flow`→**301** `/admin/graph#flow`; `/admin/knowledge-rollback`→**301** `/admin/graph#rollback` (decorators + serve_* fn names stay, now redirecting).
- **admin.html**: the two sidebar nav links → hub tab anchors.
- **tests**: reasoning_flow / knowledge_rollback admin-link assertions realigned to `/admin/graph#flow`/`#rollback` (route-decorator + serve_* assertions stay green).

Old `reasoning-flow.html` / `knowledge-rollback.html` still present (unreachable via 301) — deleted in PR-graph-3 with content-test retarget.

## Verification
Server imports OK; **53 tests green** (reasoning_flow + knowledge_rollback + glossary). frontend + route + test only, `core/` 0.
⚠ Not visually click-tested — operator: `/admin/reasoning-flow` + `/admin/knowledge-rollback` should 301 into the graph hub tabs; admin sidebar links land on the right tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)