### PR TITLE
fix(v0.6.1): graph-hub PR-3 test retarget (deletions landed without them)

### DIFF
--- a/tests/test_v06_glossary.py
+++ b/tests/test_v06_glossary.py
@@ -40,8 +40,10 @@ I18N       = REPO_ROOT / "frontend" / "static" / "i18n.js"
 ADMIN_HTML = REPO_ROOT / "frontend" / "admin.html"
 GRAPH_HTML = REPO_ROOT / "frontend" / "graph.html"
 INTRO_HTML = REPO_ROOT / "frontend" / "intro.html"
-REASONING_HTML  = REPO_ROOT / "frontend" / "reasoning-flow.html"
-ROLLBACK_HTML   = REPO_ROOT / "frontend" / "knowledge-rollback.html"
+# v0.6.1 graph-hub: reasoning-flow + knowledge-rollback folded into
+# graph.html (#flow / #rollback tabs) — glossary.js is loaded there.
+REASONING_HTML  = REPO_ROOT / "frontend" / "graph.html"
+ROLLBACK_HTML   = REPO_ROOT / "frontend" / "graph.html"
 SERVER     = REPO_ROOT / "server_llmwiki.py"
 
 

--- a/tests/test_v06_knowledge_rollback.py
+++ b/tests/test_v06_knowledge_rollback.py
@@ -47,7 +47,8 @@ ensure_utf8_console()
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-HTML = REPO_ROOT / "frontend" / "knowledge-rollback.html"
+# v0.6.1 graph-hub: knowledge-rollback folded into graph.html (#rollback tab).
+HTML = REPO_ROOT / "frontend" / "graph.html"
 JS   = REPO_ROOT / "frontend" / "static" / "knowledge-rollback.js"
 CSS  = REPO_ROOT / "frontend" / "static" / "knowledge-rollback.css"
 I18N = REPO_ROOT / "frontend" / "static" / "i18n.js"
@@ -316,8 +317,15 @@ class HtmlStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not HTML.exists():
-            raise unittest.SkipTest("knowledge-rollback.html missing")
+            raise unittest.SkipTest("graph.html (#rollback tab) missing")
         cls.body = HTML.read_text(encoding="utf-8")
+        # v0.6.1 graph-hub: rollback surface is now the #rollback tab
+        # section in graph.html. Slice it for section-scoped checks
+        # (jargon / region count / dialog) — the rest of the hub page is
+        # out of scope.
+        _s = cls.body.find('data-graph-tab="rollback"')
+        _e = cls.body.find('<!-- Admin login modal')
+        cls.rollback = cls.body[_s:_e] if (_s != -1 and _e != -1) else cls.body
 
     def test_two_flow_section_titles(self):
         for label in ("undo-last-title", "restore-to-title"):
@@ -335,14 +343,15 @@ class HtmlStructureTests(unittest.TestCase):
     def test_no_technical_jargon(self):
         for term in ("trace_id", "audit_log", "reconstruct_graph_at",
                      "tenant_id", "JWT", "T7 supersede"):
-            self.assertNotIn(term, self.body,
+            self.assertNotIn(term, self.rollback,
                              f"technical jargon leaked: {term!r}")
 
     def test_a11y_skip_link_and_roles(self):
         self.assertIn('class="skip-link"', self.body)
-        self.assertEqual(self.body.count('role="region"'), 2)
-        self.assertIn('role="dialog"', self.body)
-        self.assertIn('aria-modal="true"', self.body)
+        # 2 regions within the #rollback tab section (undo / restore).
+        self.assertEqual(self.rollback.count('role="region"'), 2)
+        self.assertIn('role="dialog"', self.rollback)
+        self.assertIn('aria-modal="true"', self.rollback)
 
 
 class JsStructureTests(unittest.TestCase):

--- a/tests/test_v06_reasoning_flow.py
+++ b/tests/test_v06_reasoning_flow.py
@@ -48,7 +48,8 @@ ensure_utf8_console()
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-HTML       = REPO_ROOT / "frontend" / "reasoning-flow.html"
+# v0.6.1 graph-hub: reasoning-flow folded into graph.html (#flow tab).
+HTML       = REPO_ROOT / "frontend" / "graph.html"
 JS         = REPO_ROOT / "frontend" / "static" / "reasoning-flow.js"
 CSS        = REPO_ROOT / "frontend" / "static" / "reasoning-flow.css"
 I18N       = REPO_ROOT / "frontend" / "static" / "i18n.js"
@@ -202,8 +203,15 @@ class HtmlStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not HTML.exists():
-            raise unittest.SkipTest("reasoning-flow.html missing")
+            raise unittest.SkipTest("graph.html (#flow tab) missing")
         cls.body = HTML.read_text(encoding="utf-8")
+        # v0.6.1 graph-hub: the reasoning-flow surface is now the #flow
+        # tab section embedded in graph.html. Slice it for the
+        # section-scoped checks (jargon / region count) — the rest of the
+        # hub page (graph tab, rollback tab, modals) is out of scope.
+        _s = cls.body.find('data-graph-tab="flow"')
+        _e = cls.body.find('data-graph-tab="rollback"')
+        cls.flow = cls.body[_s:_e] if (_s != -1 and _e != -1) else cls.body
 
     def test_three_swimlanes_present(self):
         for phase_id in ("phase-retrieve", "phase-expand", "phase-verify"):
@@ -223,13 +231,14 @@ class HtmlStructureTests(unittest.TestCase):
         for term in ("trace_id 가 위조", "audit_log table",
                      "reconstruct_graph_at", "T7 supersede chain",
                      "JWT"):
-            self.assertNotIn(term, self.body,
+            self.assertNotIn(term, self.flow,
                              f"technical jargon leaked: {term!r}")
 
     def test_a11y_skip_link_and_roles(self):
         self.assertIn('class="skip-link"', self.body)
-        self.assertEqual(self.body.count('role="region"'), 3)
-        self.assertIn('aria-live="polite"', self.body)
+        # 3 regions within the #flow tab section (selector / viz / detail).
+        self.assertEqual(self.flow.count('role="region"'), 3)
+        self.assertIn('aria-live="polite"', self.flow)
 
 
 class JsStructureTests(unittest.TestCase):


### PR DESCRIPTION
PR-graph-3 (#1010) merged the file deletions but a `git rm` + `git add <deleted-path>` abort dropped the accompanying test retargets, leaving the suites pointing at deleted files (main RED). This lands the retargets: HTML var → graph.html; jargon + role-region counts + dialog scoped to the #flow / #rollback tab-section slices; glossary REASONING/ROLLBACK_HTML → graph.html. **53 tests green**, test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)