### PR TITLE
chore(v0.6.1): refresh driver docstrings after page consolidation

### DIFF
--- a/frontend/static/knowledge-rollback.js
+++ b/frontend/static/knowledge-rollback.js
@@ -1,6 +1,6 @@
 /* PROJECT JAMES — knowledge rollback affordance (Phase 4 P4.2).
  *
- * Drives `frontend/knowledge-rollback.html`. Two flows:
+ * Drives the rollback tab embedded in /admin/graph (#rollback). Two flows:
  *
  *   A. Undo recent change
  *      1. fetch GET /admin/graph/last-change

--- a/frontend/static/onboarding.js
+++ b/frontend/static/onboarding.js
@@ -1,6 +1,6 @@
 /* PROJECT JAMES — operator onboarding flow (Phase 4 P4.1).
  *
- * Drives the 5-step `frontend/onboarding.html` page:
+ * Drives the 5-step tour embedded in the intro front door (#tour);
  *
  *   1. Welcome
  *   2. Search

--- a/frontend/static/reasoning-flow.js
+++ b/frontend/static/reasoning-flow.js
@@ -1,6 +1,6 @@
 /* PROJECT JAMES — reasoning flow visualization (Phase 4 P4.3).
  *
- * Drives `frontend/reasoning-flow.html`. Three responsibilities:
+ * Drives the reasoning-flow tab embedded in /admin/graph (#flow). Three responsibilities:
  *
  *   1. List recent traces (GET /admin/audit/recent-traces)
  *   2. Load a specific trace (GET /admin/trace/{trace_id})


### PR DESCRIPTION
Comment-only. onboarding.js / reasoning-flow.js / knowledge-rollback.js now drive embedded tab content (intro #tour, graph #flow/#rollback), not deleted standalone pages — docstrings updated to match. The deleted pages' page_title i18n keys are KEPT (pinned by v0.6 key-presence contract tests, harmless). No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)