### PR TITLE
feat(v0.6.1): answer → reasoning-trace deep-link (gap ①)

### DIFF
--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1980,6 +1980,20 @@ function appendJamesMsg(data) {
       </div>`;
   }
 
+  // v0.6.1 — link this answer to its reasoning trace. Closes the
+  // answer→trace→replay loop: opens the graph hub on the #flow tab and
+  // auto-loads this trace via ?trace=. Admin-only (the trace viewer is
+  // admin-gated — a non-admin would just hit the login modal).
+  const traceLink = (data.trace_id && userRole === 'admin') ? `
+      <a class="trace-link" href="/admin/graph?trace=${encodeURIComponent(data.trace_id)}#flow"
+         target="_blank" rel="noopener"
+         title="이 답변의 추론 과정 보기"
+         style="display:inline-flex;align-items:center;gap:4px;margin-top:6px;
+                font-size:11px;color:var(--muted);text-decoration:none">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span data-i18n="chat.view_reasoning">추론 과정 보기</span>
+      </a>` : '';
+
   div.innerHTML = `
     <div class="avatar james"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="3"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="2" x2="9" y2="4"/><line x1="15" y1="2" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="22"/><line x1="15" y1="20" x2="15" y2="22"/></svg></div>
     <div>
@@ -1990,6 +2004,7 @@ function appendJamesMsg(data) {
       ${sensitivityBadge}
       ${confidenceBadge}
       ${metaHtml}
+      ${traceLink}
       ${forceWebChip}
       ${suggestionsHtml}
       ${fbHtml}

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -122,6 +122,7 @@ const TRANSLATIONS = {
     'common.last':           'Last',
 
     'chat.title':            'Secure Enterprise Knowledge Operating System — Security Reasoning Engine',
+    'chat.view_reasoning':   'View reasoning',
     'chat.placeholder':      'Type a message (Shift+Enter for new line)',
     'chat.example1':         'What is economics?',
     'chat.example2':         'Find documents about John Smith',
@@ -1353,6 +1354,7 @@ const TRANSLATIONS = {
     'common.last':           '마지막',
 
     'chat.title':            'Secure Enterprise Knowledge Operating System — 보안 추론 엔진',
+    'chat.view_reasoning':   '추론 과정 보기',
     'chat.placeholder':      '메시지를 입력하세요 (Shift+Enter: 줄바꿈)',
     'chat.example1':         '경제학이란 무엇인가?',
     'chat.example2':         '김철수 관련 자료 찾아줘',

--- a/frontend/static/reasoning-flow.js
+++ b/frontend/static/reasoning-flow.js
@@ -420,6 +420,12 @@
       refreshBtn.addEventListener('click', loadRecentTraces);
     }
     loadRecentTraces();
+    // v0.6.1 — deep-link from a chat answer: /admin/graph?trace=<id>#flow
+    // (graph-tabs lands on #flow; we auto-load the trace here).
+    try {
+      var deepTrace = new URLSearchParams(window.location.search).get('trace');
+      if (deepTrace && deepTrace.trim()) loadTrace(deepTrace.trim());
+    } catch (e) {}
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Closes the answer→trace→replay loop (gap ① of the linkage check).

- **chat.js**: each admin answer carries a **"추론 과정 보기 / View reasoning"** link → `/admin/graph?trace=<trace_id>#flow` (new tab), using `data.trace_id` from the /query response. SVG icon (de-emoji).
- **reasoning-flow.js**: reads `?trace=<id>` on load → auto-loads it into the swimlane viewer.
- **i18n**: chat.view_reasoning (ko/en).

node --check OK. frontend only, core/ 0. Gaps ② (search) + ③ (flow↔graph cross-link) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)