### PR TITLE
feat(v0.6.1): entity-edit lifecycle cascade — Phase 1 (invalidate stale relations)

### DIFF
--- a/core/cascade/__init__.py
+++ b/core/cascade/__init__.py
@@ -46,6 +46,7 @@ from ._modify import (
     diff_triples,
     load_extraction_sidecar,
 )
+from ._modify_entity import cascade_modify_entity
 
 
 __all__ = [
@@ -59,6 +60,8 @@ __all__ = [
     "cascade_modify_doc",
     "diff_triples",
     "load_extraction_sidecar",
+    # entity-edit cascade (Phase 1: invalidate stale relations)
+    "cascade_modify_entity",
     # helpers (kept exported for tests / scripts that import them directly)
     "strip_uuid_prefix",
     "_read_frontmatter",

--- a/core/cascade/_modify_entity.py
+++ b/core/cascade/_modify_entity.py
@@ -1,0 +1,157 @@
+"""``core.cascade._modify_entity`` — entity-edit lifecycle cascade
+(Phase 1: invalidate stale relations).
+
+When a wiki entity is edited and saved, the graph (= the entity's
+frontmatter ``relations:`` arrays — there is no separate graph store)
+must not keep asserting relations the new text no longer supports.
+``update_entity`` previously re-embedded the vector chunks only, leaving
+the graph relations stale → graph reasoning could cite a relation the
+edited text dropped.
+
+This module re-extracts relations from the edited prose, diffs them
+against the entity's current frontmatter relations, and **invalidates**
+(preserves, never hard-deletes — replay audit) any relation the new text
+no longer supports, emitting a lifecycle event per invalidation.
+
+Phase 1 scope = the *dangerous* direction (graph asserting a dropped
+relation). Newly-implied relations (a missing edge — the safe direction)
+are reported in the summary but materialising them as graph edges needs
+ingestion's relation builder (target resolution / confidence / source
+stamping) and is deferred to Phase 2.
+
+Design: docs/design/v0.6.1-entity-edit-cascade.md.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from ._helpers import _read_frontmatter, _write_frontmatter
+
+
+def _triple_key(source: str, label: str, target: str):
+    return (
+        (source or "").strip().lower(),
+        (label or "관련").strip().lower(),
+        (target or "").strip().lower(),
+    )
+
+
+def _emit_invalidate(entity_name: str, rel: Dict[str, Any],
+                     ts: str, user_role: str) -> None:
+    try:
+        from core.lifecycle.replay_audit import (
+            EVT_CASCADE_INVALIDATE, emit_lifecycle_event,
+        )
+        emit_lifecycle_event(
+            EVT_CASCADE_INVALIDATE,
+            {
+                "reason":  "entity_edit",
+                "entity":  entity_name,
+                "edge_id": rel.get("id") or "",
+                "target":  rel.get("target"),
+                "label":   rel.get("label"),
+                "ts":      ts,
+            },
+            user_role=user_role,
+        )
+    except Exception:
+        # lifecycle logging is best-effort; never break the edit.
+        pass
+
+
+def cascade_modify_entity(entity_path, entity_name: str, *,
+                          wiki_generator, user_role: str = "admin") -> Dict[str, Any]:
+    """Phase 1 entity-edit cascade. Best-effort: returns a summary dict
+    and never raises (the caller's save must survive a cascade failure).
+
+    Returns: {
+      ok:             bool,    # the cascade ran (extraction succeeded)
+      extracted:      bool,
+      invalidated:    [{target, label, edge_id}],
+      added_detected: [{target, label}],   # reported only (Phase 2 adds)
+      skipped_reason: str,
+    }
+    """
+    summary: Dict[str, Any] = {
+        "ok": False, "extracted": False,
+        "invalidated": [], "added_detected": [], "skipped_reason": "",
+    }
+    if os.environ.get("JAMES_DISABLE_EDIT_CASCADE") == "1":
+        summary["skipped_reason"] = "disabled"
+        return summary
+    try:
+        path = Path(entity_path)
+        parsed = _read_frontmatter(path)
+        if not parsed:
+            summary["skipped_reason"] = "no_frontmatter"
+            return summary
+        fm, body = parsed
+        relations = fm.get("relations") or []
+
+        # Re-extract relations from the edited prose (best-effort).
+        try:
+            new_ext = wiki_generator._llm_extract_document_entities(
+                entity_name, body, {}) or {}
+        except Exception as e:  # noqa: BLE001
+            summary["skipped_reason"] = f"extract_failed: {e}"
+            return summary
+        summary["extracted"] = True
+
+        new_rels = new_ext.get("relations", []) or []
+        new_keys = {
+            _triple_key(r.get("source"), r.get("label"), r.get("target"))
+            for r in new_rels if isinstance(r, dict)
+        }
+        name_l = (entity_name or "").strip().lower()
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # ── invalidate stale edges (the dangerous direction) ──
+        changed = False
+        for rel in relations:
+            if not isinstance(rel, dict):
+                continue
+            status = rel.get("status") or {}
+            if status.get("active") is False:
+                continue  # already inactive
+            key = _triple_key(entity_name, rel.get("label"), rel.get("target"))
+            if key not in new_keys:
+                rel.setdefault("status", {})
+                rel["status"]["active"] = False
+                rel["status"]["invalidated_at"] = ts
+                rel["mutation_type"] = "invalidated"
+                changed = True
+                summary["invalidated"].append({
+                    "target":  rel.get("target"),
+                    "label":   rel.get("label"),
+                    "edge_id": rel.get("id") or "",
+                })
+                _emit_invalidate(entity_name, rel, ts, user_role)
+
+        # ── report newly-implied edges (the safe direction; Phase 2 adds) ──
+        cur_keys = {
+            _triple_key(entity_name, r.get("label"), r.get("target"))
+            for r in relations if isinstance(r, dict)
+        }
+        for r in new_rels:
+            if not isinstance(r, dict):
+                continue
+            if (r.get("source") or "").strip().lower() != name_l:
+                continue
+            if _triple_key(r.get("source"), r.get("label"), r.get("target")) not in cur_keys:
+                summary["added_detected"].append({
+                    "target": r.get("target"), "label": r.get("label"),
+                })
+
+        if changed:
+            _write_frontmatter(path, fm, body)  # this IS the graph update
+        summary["ok"] = True
+        return summary
+    except Exception as e:  # noqa: BLE001
+        summary["skipped_reason"] = f"error: {e}"
+        return summary
+
+
+__all__ = ["cascade_modify_entity"]

--- a/docs/design/v0.6.1-entity-edit-cascade.md
+++ b/docs/design/v0.6.1-entity-edit-cascade.md
@@ -1,0 +1,86 @@
+# v0.6.1 — Entity-edit lifecycle cascade
+
+> Status: DESIGN + build (Phase 1). Operator decision 2026-06-22: when a
+> wiki entity is edited and saved, fire a cascade so the graph /
+> relationships stay consistent with the new content (reasoning
+> consistency). "위키 편집에 케스케이드 발동 (완전 해결)".
+
+## Problem
+Editing a wiki entity went through `tools/wiki/wiki_editor.update_entity`
+→ `_resync_vector` (re-embed) + `_refresh_index` (entity_id index) only.
+The entity's **frontmatter `relations:` were untouched**, so graph
+reasoning could keep citing relations the edited text no longer supports.
+Meanwhile the upload-file path (`PUT /admin/files` → `cascade_modify_doc`)
+*does* cascade. Wiki-entity edits bypassed the cascade entirely.
+
+## Key structural fact (from the cascade map)
+**The graph IS the entity frontmatter `relations:` arrays** — there is no
+separate persisted graph store; edges are read on-demand from each
+entity's frontmatter. So **updating an entity's frontmatter relations is
+the graph update** — no graph-traversal/rebuild code is touched.
+
+## Building blocks (all exist)
+- `llm_extract_document_entities(filename, content, metadata)` →
+  `{entities, relations:[{source,target,label,confidence}]}`.
+- `diff_triples(old_ext, new_ext)` → added/removed/kept triples
+  (identity = (source,label,target), case-insensitive).
+- relation entry shape carries `status{active,superseded_by,...}` +
+  `mutation_type` + `id` + `sources[]` + `validity`.
+- `emit_lifecycle_event(EVT_CASCADE_INVALIDATE, payload, user_role)` +
+  `supersede_edge(old,new,ts)` — preserve, never hard-delete (replay
+  audit).
+- `_read_frontmatter(path)` / `_write_frontmatter(path, fm, body)`.
+
+## Design — `core/cascade/_modify_entity.py::cascade_modify_entity`
+Called from `update_entity` AFTER the file is written (best-effort).
+
+```
+cascade_modify_entity(entity_path, entity_name, *, wiki_generator,
+                      user_role="admin") -> summary dict
+```
+1. `_read_frontmatter(entity_path)` → (fm, body). Current relations =
+   `fm["relations"]` (this entity's outgoing edges).
+2. `new_ext = wiki_generator._llm_extract_document_entities(name, body, {})`
+   — re-extract from the edited prose (best-effort; on failure return
+   `{ok:False, skipped:True}` and the save still succeeds).
+3. Build `old_ext` from fm relations (source = entity_name) →
+   `diff = diff_triples(old_ext, new_ext)`.
+4. **Phase 1 — invalidate stale edges (the dangerous case):** for each
+   `removed_triple` (a frontmatter relation no longer supported by the
+   new text), mark the matching fm relation `status.active=False`,
+   `mutation_type="invalidated"`, `status.invalidated_at=<ts>` (kept in
+   the list — preserved, not deleted) and `emit_lifecycle_event(
+   EVT_CASCADE_INVALIDATE, {entity, edge_id, triple})`.
+5. `_write_frontmatter(entity_path, fm, body)` — this IS the graph update.
+6. Return `{ok, invalidated:[...], added_detected:[...], extracted}`.
+   `added_detected` (new triples with source==entity, not yet in the
+   graph) are reported + lifecycle-noted but **not auto-added in Phase 1**
+   (see below).
+
+## Phasing
+- **Phase 1 (this PR)** — invalidate stale relations + report added.
+  This closes the *dangerous* inconsistency (graph asserting a relation
+  the text dropped). Added-but-missing edges are the *safe* direction
+  (a missing edge, not a wrong one) and are only reported.
+- **Phase 2 (follow-up)** — actually materialise added relations as graph
+  edges, which requires ingestion's relation builder (target resolution
+  via `resolve_pending_relations`, confidence noisy-OR, `sources[]`
+  stamping with an EDIT role). Deferred so Phase 1 ships the safety-
+  critical half correctly.
+
+## Wiring / safety
+- `update_entity` calls it after `_resync_vector`/`_refresh_index`,
+  wrapped in try/except so a cascade failure never breaks the save.
+- Env kill-switch `JAMES_DISABLE_EDIT_CASCADE=1` (default ON).
+- Applies to ALL entity edits (chat wiki_edit + workspace 원본자료 편집) —
+  one chokepoint = consistent.
+- The apply endpoint returns the cascade summary so the UI can show
+  "관계 N개 무효화 / M개 추가 감지".
+
+## Rule #2 note
+Touches `core/cascade` + `core/lifecycle` (write path), **not**
+`core/retrieval` / `core/graph` traversal / `core/reasoning`. STEP 7
+retrieval Δ = 0 (write-path correctness, not a retrieval knob). No 5-axis
+QDC axis applies — this is lifecycle correctness (exempt, like a `fix`).
+The graph-traversal/reasoning 0-line streak is preserved (the "graph" is
+frontmatter data, edited via _write_frontmatter).

--- a/tests/test_entity_edit_cascade.py
+++ b/tests/test_entity_edit_cascade.py
@@ -1,0 +1,124 @@
+"""Entity-edit lifecycle cascade (Phase 1) — invalidate stale relations.
+
+When a wiki entity's content is edited so a relation it asserted is no
+longer supported, cascade_modify_entity must mark that frontmatter
+relation inactive (preserved, not deleted) so graph reasoning stops
+citing it — while leaving still-supported relations active.
+
+Design: docs/design/v0.6.1-entity-edit-cascade.md.
+Run: python -m unittest tests.test_entity_edit_cascade
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.cascade import cascade_modify_entity
+from core.cascade._helpers import _read_frontmatter
+
+
+ENTITY_MD = """---
+name: Alpha
+type: concept
+relations:
+  - target: Beta
+    label: 관련
+  - target: Gamma
+    label: 포함
+---
+Alpha is related to Beta. (the Gamma link has been removed from this text)
+"""
+
+
+class _StubGen:
+    """Stub wiki_generator: returns a fixed extraction. Only Alpha→Beta
+    survives; Alpha→Gamma is gone."""
+    def __init__(self, relations, raise_on_call=False):
+        self._relations = relations
+        self._raise = raise_on_call
+
+    def _llm_extract_document_entities(self, name, body, meta):
+        if self._raise:
+            raise RuntimeError("extractor down")
+        return {"entities": [], "relations": self._relations}
+
+
+def _write(tmp: Path, text: str) -> Path:
+    p = tmp / "Alpha.md"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class CascadeInvalidateTests(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_EDIT_CASCADE", None)
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def test_stale_relation_invalidated_supported_kept(self):
+        path = _write(self.tmp, ENTITY_MD)
+        gen = _StubGen([{"source": "Alpha", "target": "Beta", "label": "관련"}])
+        out = cascade_modify_entity(path, "Alpha", wiki_generator=gen)
+        self.assertTrue(out["ok"])
+        self.assertTrue(out["extracted"])
+        # Gamma/포함 dropped → invalidated; Beta/관련 kept.
+        inv_targets = {r["target"] for r in out["invalidated"]}
+        self.assertIn("Gamma", inv_targets)
+        self.assertNotIn("Beta", inv_targets)
+        # frontmatter reflects it: Gamma inactive, Beta active.
+        fm, _body = _read_frontmatter(path)
+        rels = {r["target"]: r for r in fm["relations"]}
+        self.assertFalse(rels["Gamma"]["status"]["active"])
+        self.assertEqual(rels["Gamma"]["mutation_type"], "invalidated")
+        self.assertNotEqual(rels["Beta"].get("status", {}).get("active"), False)
+
+    def test_added_relation_detected_not_materialised(self):
+        path = _write(self.tmp, ENTITY_MD)
+        # new text now also asserts Alpha→Delta (not in frontmatter)
+        gen = _StubGen([
+            {"source": "Alpha", "target": "Beta", "label": "관련"},
+            {"source": "Alpha", "target": "Gamma", "label": "포함"},
+            {"source": "Alpha", "target": "Delta", "label": "관련"},
+        ])
+        out = cascade_modify_entity(path, "Alpha", wiki_generator=gen)
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["invalidated"], [])  # all kept
+        added = {r["target"] for r in out["added_detected"]}
+        self.assertIn("Delta", added)
+        # Phase 1 does NOT add it to the frontmatter graph.
+        fm, _ = _read_frontmatter(path)
+        self.assertNotIn("Delta", {r["target"] for r in fm["relations"]})
+
+    def test_extractor_failure_is_safe_noop(self):
+        path = _write(self.tmp, ENTITY_MD)
+        before = path.read_text(encoding="utf-8")
+        gen = _StubGen([], raise_on_call=True)
+        out = cascade_modify_entity(path, "Alpha", wiki_generator=gen)
+        self.assertFalse(out["ok"])
+        self.assertIn("extract_failed", out["skipped_reason"])
+        self.assertEqual(path.read_text(encoding="utf-8"), before)  # untouched
+
+    def test_kill_switch_skips(self):
+        os.environ["JAMES_DISABLE_EDIT_CASCADE"] = "1"
+        try:
+            path = _write(self.tmp, ENTITY_MD)
+            before = path.read_text(encoding="utf-8")
+            gen = _StubGen([{"source": "Alpha", "target": "Beta", "label": "관련"}])
+            out = cascade_modify_entity(path, "Alpha", wiki_generator=gen)
+            self.assertFalse(out["ok"])
+            self.assertEqual(out["skipped_reason"], "disabled")
+            self.assertEqual(path.read_text(encoding="utf-8"), before)
+        finally:
+            os.environ.pop("JAMES_DISABLE_EDIT_CASCADE", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/wiki/wiki_editor.py
+++ b/tools/wiki/wiki_editor.py
@@ -134,6 +134,37 @@ def _refresh_index():
         print(f"[WIKI_EDIT] entity_id_index 갱신 실패: {e}")
 
 
+def _cascade_edit(path, name: str, user_role: str = "admin"):
+    """v0.6.1 — entity-edit lifecycle cascade. Re-extract relations from
+    the edited content and invalidate graph relations it no longer
+    supports (keeps reasoning consistent). Best-effort: never breaks the
+    save. Returns the cascade summary dict or None.
+    See docs/design/v0.6.1-entity-edit-cascade.md."""
+    try:
+        try:
+            from core.graph_rag_engine import RAGEngine
+        except ModuleNotFoundError:
+            try:
+                from graph_rag_engine import RAGEngine
+            except ModuleNotFoundError:
+                import sys
+                sys.path.insert(0, str(BASE_DIR))
+                from core.graph_rag_engine import RAGEngine
+        from core.cascade import cascade_modify_entity
+        engine = RAGEngine(default_role="admin")
+        wg = getattr(engine, "wiki_generator", None)
+        if wg is None:
+            return None
+        summary = cascade_modify_entity(path, name, wiki_generator=wg,
+                                        user_role=user_role)
+        inv = len(summary.get("invalidated", [])) if summary else 0
+        print(f"[WIKI_EDIT] edit cascade: {inv} relation(s) invalidated")
+        return summary
+    except Exception as e:
+        print(f"[WIKI_EDIT] edit cascade 실패: {e}")
+        return None
+
+
 # ─────────────────────────────────────────────
 # 핵심 탐색
 # ─────────────────────────────────────────────
@@ -213,8 +244,15 @@ def update_entity(name: str, new_content: str,
     _audit("UPDATE", str(path.name), f"chars {len(old_content)}→{len(new_content)}", user_role)
     _resync_vector(path.name, new_content)
     _refresh_index()
+    # v0.6.1 — lifecycle cascade: keep the graph consistent with the edit.
+    casc = _cascade_edit(path, name, user_role)
 
-    return True, f"✅ '{name}' 수정 완료 (백업: {backup.name})"
+    msg = f"✅ '{name}' 수정 완료 (백업: {backup.name})"
+    if casc and casc.get("invalidated"):
+        msg += f" · 관계 {len(casc['invalidated'])}개 무효화"
+    if casc and casc.get("added_detected"):
+        msg += f" · 신규 관계 {len(casc['added_detected'])}개 감지"
+    return True, msg
 
 
 def append_to_entity(name: str, append_text: str,


### PR DESCRIPTION
## Summary
Closes the consistency gap found in the workspace audit: editing a wiki entity left its frontmatter `relations:` (which **are** the graph — no separate store) stale, so graph reasoning could cite a relation the edited text dropped. The upload path cascaded; the entity-edit path didn't. This wires the cascade.

Design: `docs/design/v0.6.1-entity-edit-cascade.md`.

- **core/cascade/_modify_entity.py** (NEW) `cascade_modify_entity`: re-extract relations from edited prose → `diff_triples` vs current frontmatter → **invalidate** (status.active=False, mutation_type="invalidated" — preserved, not deleted; `EVT_CASCADE_INVALIDATE` emitted) any relation the new text no longer supports. Writing frontmatter = the graph update. Added edges (safe direction) reported only → Phase 2. Best-effort + `JAMES_DISABLE_EDIT_CASCADE` kill-switch.
- **tools/wiki/wiki_editor.update_entity**: `_cascade_edit` after resync (failure-safe); message reports "관계 N개 무효화 / M개 감지" → surfaced to UI. Applies to chat + workspace edits (one chokepoint).
- **core/cascade/__init__.py**: export.

## Phasing
**Phase 1 (this)** = invalidate stale relations (the *dangerous* direction — graph asserting a dropped relation). **Phase 2** = materialise newly-implied edges (needs ingestion's target-resolution/confidence/source builder).

## Rule #2
Touches `core/cascade` + `core/lifecycle` (write path), **not** `core/retrieval` / `core/graph` traversal / `core/reasoning` (0 lines — streak preserved). STEP 7 retrieval Δ=0 (write-path correctness) — no 5-axis QDC axis applies (lifecycle correctness, exempt like `fix`).

## Verification
17 tests green (phase_d_modify_cascade + 4 new: invalidate / add-detect / extractor-failure-noop / kill-switch). imports OK; files <20KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)