### PR TITLE
feat(v0.6.1): entity-edit cascade — Phase 2 (materialise newly-implied edges)

### DIFF
--- a/core/cascade/_modify_entity.py
+++ b/core/cascade/_modify_entity.py
@@ -13,11 +13,11 @@ against the entity's current frontmatter relations, and **invalidates**
 (preserves, never hard-deletes — replay audit) any relation the new text
 no longer supports, emitting a lifecycle event per invalidation.
 
-Phase 1 scope = the *dangerous* direction (graph asserting a dropped
-relation). Newly-implied relations (a missing edge — the safe direction)
-are reported in the summary but materialising them as graph edges needs
-ingestion's relation builder (target resolution / confidence / source
-stamping) and is deferred to Phase 2.
+Phase 1 = invalidate the *dangerous* direction (graph asserting a dropped
+relation). Phase 2 = materialise newly-implied edges (the safe direction)
+as MANUAL-sourced relations with target_id UNRESOLVED, then back-fill via
+``resolve_pending_relations`` — so the edited text's new relations become
+real graph edges, not just a report.
 
 Design: docs/design/v0.6.1-entity-edit-cascade.md.
 """
@@ -70,14 +70,14 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
     Returns: {
       ok:             bool,    # the cascade ran (extraction succeeded)
       extracted:      bool,
-      invalidated:    [{target, label, edge_id}],
-      added_detected: [{target, label}],   # reported only (Phase 2 adds)
+      invalidated:    [{target, label, edge_id}],   # stale edges deactivated
+      added:          [{target, label}],            # new MANUAL edges added
       skipped_reason: str,
     }
     """
     summary: Dict[str, Any] = {
         "ok": False, "extracted": False,
-        "invalidated": [], "added_detected": [], "skipped_reason": "",
+        "invalidated": [], "added": [], "skipped_reason": "",
     }
     if os.environ.get("JAMES_DISABLE_EDIT_CASCADE") == "1":
         summary["skipped_reason"] = "disabled"
@@ -130,7 +130,11 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
                 })
                 _emit_invalidate(entity_name, rel, ts, user_role)
 
-        # ── report newly-implied edges (the safe direction; Phase 2 adds) ──
+        # ── Phase 2: materialise newly-implied edges (the safe direction) ──
+        # New outgoing relations the edited text now asserts but the graph
+        # lacks. Added as MANUAL-sourced edges (so a future doc cascade
+        # preserves them) with target_id UNRESOLVED → resolved after write.
+        from core.relations_schema import MANUAL_SOURCE_ROLE
         cur_keys = {
             _triple_key(entity_name, r.get("label"), r.get("target"))
             for r in relations if isinstance(r, dict)
@@ -140,13 +144,41 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
                 continue
             if (r.get("source") or "").strip().lower() != name_l:
                 continue
-            if _triple_key(r.get("source"), r.get("label"), r.get("target")) not in cur_keys:
-                summary["added_detected"].append({
-                    "target": r.get("target"), "label": r.get("label"),
-                })
+            tgt = (r.get("target") or "").strip()
+            label = (r.get("label") or "관련").strip()[:20]
+            if not tgt:
+                continue
+            key = _triple_key(entity_name, label, tgt)
+            if key in cur_keys:
+                continue
+            try:
+                conf = float(r.get("confidence", 0.7))
+            except (TypeError, ValueError):
+                conf = 0.7
+            conf = max(0.0, min(1.0, conf))
+            relations.append({
+                "target":     tgt,
+                "target_id":  "UNRESOLVED",
+                "label":      label,
+                "confidence": conf,
+                "sources":    [{"doc_id": entity_name, "weight": conf,
+                                "role": MANUAL_SOURCE_ROLE, "ts": ts}],
+                "status":        {"active": True},
+                "mutation_type": "active",
+            })
+            cur_keys.add(key)
+            changed = True
+            summary["added"].append({"target": tgt, "label": label})
 
         if changed:
+            fm["relations"] = relations
             _write_frontmatter(path, fm, body)  # this IS the graph update
+            # back-fill target_id for the freshly-added edges (best-effort).
+            if summary["added"]:
+                try:
+                    wiki_generator.resolve_pending_relations()
+                except Exception:
+                    pass
         summary["ok"] = True
         return summary
     except Exception as e:  # noqa: BLE001

--- a/docs/design/v0.6.1-entity-edit-cascade.md
+++ b/docs/design/v0.6.1-entity-edit-cascade.md
@@ -58,15 +58,22 @@ cascade_modify_entity(entity_path, entity_name, *, wiki_generator,
    (see below).
 
 ## Phasing
-- **Phase 1 (this PR)** — invalidate stale relations + report added.
-  This closes the *dangerous* inconsistency (graph asserting a relation
-  the text dropped). Added-but-missing edges are the *safe* direction
-  (a missing edge, not a wrong one) and are only reported.
-- **Phase 2 (follow-up)** — actually materialise added relations as graph
-  edges, which requires ingestion's relation builder (target resolution
-  via `resolve_pending_relations`, confidence noisy-OR, `sources[]`
-  stamping with an EDIT role). Deferred so Phase 1 ships the safety-
-  critical half correctly.
+- **Phase 1 (done)** — invalidate stale relations (the *dangerous*
+  direction: graph asserting a relation the text dropped).
+- **Phase 2 (done)** — materialise newly-implied edges (the *safe*
+  direction): added as MANUAL-sourced relations (`role="manual"` so a
+  later doc cascade preserves them) with `target_id="UNRESOLVED"`, then
+  `wiki_generator.resolve_pending_relations()` back-fills the target_id
+  from the entity index. Both directions now keep the graph consistent
+  with the edited text.
+
+### Still out of scope (future)
+- **Inverse / inbound edges**: the cascade only touches THIS entity's
+  outgoing relations. Inbound edges on OTHER entities, and T6 causality
+  propagation to facts derived from a changed relation, are not swept
+  here (that is the doc-level cascade / T6 territory).
+- `llm_extract_document_entities` truncates content to 2000 chars — a
+  very long entity body is only partially re-extracted.
 
 ## Wiring / safety
 - `update_entity` calls it after `_resync_vector`/`_refresh_index`,

--- a/tests/test_entity_edit_cascade.py
+++ b/tests/test_entity_edit_cascade.py
@@ -47,6 +47,10 @@ class _StubGen:
             raise RuntimeError("extractor down")
         return {"entities": [], "relations": self._relations}
 
+    def resolve_pending_relations(self):
+        # Phase 2 back-fill sweep — no-op in the unit test (no entity index).
+        return 0
+
 
 def _write(tmp: Path, text: str) -> Path:
     p = tmp / "Alpha.md"
@@ -80,7 +84,7 @@ class CascadeInvalidateTests(unittest.TestCase):
         self.assertEqual(rels["Gamma"]["mutation_type"], "invalidated")
         self.assertNotEqual(rels["Beta"].get("status", {}).get("active"), False)
 
-    def test_added_relation_detected_not_materialised(self):
+    def test_added_relation_materialised(self):
         path = _write(self.tmp, ENTITY_MD)
         # new text now also asserts Alpha→Delta (not in frontmatter)
         gen = _StubGen([
@@ -91,11 +95,14 @@ class CascadeInvalidateTests(unittest.TestCase):
         out = cascade_modify_entity(path, "Alpha", wiki_generator=gen)
         self.assertTrue(out["ok"])
         self.assertEqual(out["invalidated"], [])  # all kept
-        added = {r["target"] for r in out["added_detected"]}
+        added = {r["target"] for r in out["added"]}
         self.assertIn("Delta", added)
-        # Phase 1 does NOT add it to the frontmatter graph.
+        # Phase 2 DOES add it to the frontmatter graph as a MANUAL edge.
         fm, _ = _read_frontmatter(path)
-        self.assertNotIn("Delta", {r["target"] for r in fm["relations"]})
+        delta = {r["target"]: r for r in fm["relations"]}.get("Delta")
+        self.assertIsNotNone(delta)
+        self.assertEqual(delta["status"]["active"], True)
+        self.assertEqual(delta["sources"][0]["role"], "manual")
 
     def test_extractor_failure_is_safe_noop(self):
         path = _write(self.tmp, ENTITY_MD)

--- a/tools/wiki/wiki_editor.py
+++ b/tools/wiki/wiki_editor.py
@@ -250,8 +250,8 @@ def update_entity(name: str, new_content: str,
     msg = f"✅ '{name}' 수정 완료 (백업: {backup.name})"
     if casc and casc.get("invalidated"):
         msg += f" · 관계 {len(casc['invalidated'])}개 무효화"
-    if casc and casc.get("added_detected"):
-        msg += f" · 신규 관계 {len(casc['added_detected'])}개 감지"
+    if casc and casc.get("added"):
+        msg += f" · 신규 관계 {len(casc['added'])}개 추가"
     return True, msg
 
 


### PR DESCRIPTION
## Summary
Completes the entity-edit cascade. Phase 1 (#1018) invalidated stale relations (dangerous direction); **Phase 2 adds the safe direction** — relations the edited text now asserts but the graph lacks become real edges.

- **core/cascade/_modify_entity.py**: after the invalidate pass, new outgoing triples are appended to frontmatter `relations:` as **MANUAL** edges (`role="manual"` → preserved by future doc cascade) with `target_id="UNRESOLVED"` + status active; then `resolve_pending_relations()` back-fills target_id. summary `added_detected`→`added` (materialised).
- **wiki_editor**: edit message "신규 관계 N개 추가".
- **test**: now asserts the added edge IS in the frontmatter (active, manual).

## Now consistent both ways
edit drops a relation → invalidated (preserved, audit); edit asserts a new relation → added as a manual edge. Graph stays consistent with the edited text.

## Out of scope (design-noted)
Inverse/inbound edges on other entities + T6 causality propagation (doc-level cascade); 2000-char extraction truncation.

## Rule #2
core/cascade write path only — `core/retrieval`/`core/graph` traversal/`core/reasoning` 0 lines (streak preserved). STEP 7 Δ=0, lifecycle correctness (exempt like fix).

## Verification
17 tests green (4 entity_edit_cascade + 13 phase_d); import OK; module <20KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)