### PR TITLE
feat(v0.6.1): cascade reasoning-consistency probe — measures the live-traversal gap

### DIFF
--- a/eval/cascade_consistency_fixture.json
+++ b/eval/cascade_consistency_fixture.json
@@ -1,0 +1,53 @@
+{
+  "_doc": "Cascade reasoning-consistency probe fixture. Each scenario is one entity whose frontmatter relations mix ACTIVE edges (must still be traversed) with edges the lifecycle has deactivated (invalidated/superseded/expired — must NOT be traversed once the edit/lifecycle ran). All confidences are >= CONFIDENCE_THRESHOLD (0.6) so the EXISTING confidence filter does not mask the question: does live traversal honor status? See docs/design/v0.6.1-entity-edit-cascade.md + scripts/research/cascade_consistency_probe.py.",
+  "scenarios": [
+    {
+      "name": "edit_dropped_relation",
+      "entity": {
+        "name": "Alpha", "entity_type": "concept",
+        "relations": [
+          {"target": "Beta",  "label": "관련", "confidence": 0.90, "status": {"active": true},  "mutation_type": "active"},
+          {"target": "Gamma", "label": "포함", "confidence": 0.90, "status": {"active": false, "invalidated_at": "2026-06-22T00:00:00Z"}, "mutation_type": "invalidated"}
+        ]
+      },
+      "should_appear": ["Beta"],
+      "should_not_appear": ["Gamma"]
+    },
+    {
+      "name": "superseded_relation",
+      "entity": {
+        "name": "Delta", "entity_type": "concept",
+        "relations": [
+          {"target": "Epsilon", "label": "관련", "confidence": 0.95, "status": {"active": true}, "mutation_type": "active"},
+          {"target": "Zeta",    "label": "관련", "confidence": 0.95, "status": {"active": false, "superseded_by": "e_concept_deadbeef00"}, "mutation_type": "superseded"}
+        ]
+      },
+      "should_appear": ["Epsilon"],
+      "should_not_appear": ["Zeta"]
+    },
+    {
+      "name": "expired_relation",
+      "entity": {
+        "name": "Theta", "entity_type": "concept",
+        "relations": [
+          {"target": "Iota",  "label": "관련", "confidence": 0.80, "status": {"active": true}, "mutation_type": "active"},
+          {"target": "Kappa", "label": "관련", "confidence": 0.80, "status": {"active": false}, "mutation_type": "expired"}
+        ]
+      },
+      "should_appear": ["Iota"],
+      "should_not_appear": ["Kappa"]
+    },
+    {
+      "name": "all_active_control",
+      "entity": {
+        "name": "Lambda", "entity_type": "concept",
+        "relations": [
+          {"target": "Mu", "label": "관련", "confidence": 0.90, "status": {"active": true}, "mutation_type": "active"},
+          {"target": "Nu", "label": "포함", "confidence": 0.90, "status": {"active": true}, "mutation_type": "active"}
+        ]
+      },
+      "should_appear": ["Mu", "Nu"],
+      "should_not_appear": []
+    }
+  ]
+}

--- a/reports/research-runs/cascade-consistency-probe.json
+++ b/reports/research-runs/cascade-consistency-probe.json
@@ -1,0 +1,71 @@
+{
+  "fixture": "eval\\cascade_consistency_fixture.json",
+  "scenarios": 4,
+  "metrics": {
+    "current": {
+      "invalidated_leakage": 3,
+      "active_dropped": 0,
+      "consistent_scenarios": "1/4",
+      "active_retention": 1.0
+    },
+    "filtered_fix": {
+      "invalidated_leakage": 0,
+      "active_dropped": 0,
+      "consistent_scenarios": "4/4",
+      "active_retention": 1.0
+    }
+  },
+  "rows": [
+    {
+      "scenario": "edit_dropped_relation",
+      "current": {
+        "leaked": [
+          "Gamma"
+        ],
+        "dropped_active": []
+      },
+      "filtered": {
+        "leaked": [],
+        "dropped_active": []
+      }
+    },
+    {
+      "scenario": "superseded_relation",
+      "current": {
+        "leaked": [
+          "Zeta"
+        ],
+        "dropped_active": []
+      },
+      "filtered": {
+        "leaked": [],
+        "dropped_active": []
+      }
+    },
+    {
+      "scenario": "expired_relation",
+      "current": {
+        "leaked": [
+          "Kappa"
+        ],
+        "dropped_active": []
+      },
+      "filtered": {
+        "leaked": [],
+        "dropped_active": []
+      }
+    },
+    {
+      "scenario": "all_active_control",
+      "current": {
+        "leaked": [],
+        "dropped_active": []
+      },
+      "filtered": {
+        "leaked": [],
+        "dropped_active": []
+      }
+    }
+  ],
+  "verdict": "CURRENT live traversal LEAKS lifecycle-deactivated relations (status ignored); the status-aware filter removes the leak with full active-relation retention."
+}

--- a/scripts/research/cascade_consistency_probe.py
+++ b/scripts/research/cascade_consistency_probe.py
@@ -1,0 +1,170 @@
+"""Cascade reasoning-consistency probe (deterministic, no LLM/server).
+
+Question (from the 2026-06-22 measurement check): does the entity-edit
+cascade (and the broader T1/T7 lifecycle) actually keep LIVE graph
+reasoning consistent? The cascade sets a dropped relation's
+``status.active=False`` — but does live traversal HONOR that, or keep
+traversing it?
+
+This probe calls the REAL live-context builder
+(``GraphEngine.build_graph_context_str`` — the function that hands graph
+relations to the LLM) on fixture entities that mix active edges with
+lifecycle-deactivated edges (invalidated / superseded / expired), all
+above CONFIDENCE_THRESHOLD so the existing confidence filter can't mask
+the question. It then models the candidate fix (a status-aware filter)
+by pre-filtering the entity's relations, and measures both arms:
+
+  - leakage   = a should-NOT-appear (deactivated) target that still
+                appears in the context  → the inconsistency.
+  - retention = a should-appear (active) target that appears
+                (Path-Recall analog) → the fix must not drop these.
+
+Paired arms:
+  CURRENT  — relations passed as-is (today's behavior).
+  FILTERED — relations pre-filtered by status (the proposed fix).
+
+Run: python scripts/research/cascade_consistency_probe.py
+Exit 0 always (a measurement, not a gate). Writes a JSON report next to
+the fixture under reports/research-runs/.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURE = ROOT / "eval" / "cascade_consistency_fixture.json"
+
+
+def _is_active(rel: dict) -> bool:
+    """The candidate status-aware predicate the live traversal currently
+    lacks: an edge is live only if it is not lifecycle-deactivated."""
+    st = rel.get("status") or {}
+    if st.get("active") is False:
+        return False
+    if rel.get("mutation_type") in ("invalidated", "superseded", "expired"):
+        return False
+    return True
+
+
+def _context_for(eng, entity: dict) -> str:
+    # exercise the REAL live-context builder (confidence-only filter today)
+    return eng.build_graph_context_str([entity], [], 0.0)
+
+
+def _present(targets, ctx: str):
+    return {t: (t in ctx) for t in targets}
+
+
+def main() -> int:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    from core.graph_engine.engine import GraphEngine
+    # build_graph_context_str only needs get_rel_type (staticmethod) +
+    # module helpers — skip __init__ (no WikiGenerator/vector store).
+    eng = object.__new__(GraphEngine)
+
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    scenarios = data["scenarios"]
+
+    rows = []
+    cur_leaks = cur_drops = filt_leaks = filt_drops = 0
+    tot_bad = tot_good = 0
+    cur_consistent = filt_consistent = 0
+
+    for sc in scenarios:
+        ent = sc["entity"]
+        good = sc.get("should_appear", [])
+        bad = sc.get("should_not_appear", [])
+        tot_good += len(good)
+        tot_bad += len(bad)
+
+        # CURRENT arm — relations as-is.
+        cur_ctx = _context_for(eng, ent)
+        cur_bad = _present(bad, cur_ctx)
+        cur_good = _present(good, cur_ctx)
+
+        # FILTERED arm — status-aware pre-filter (the proposed fix).
+        filt_ent = dict(ent)
+        filt_ent["relations"] = [r for r in ent.get("relations", []) if _is_active(r)]
+        filt_ctx = _context_for(eng, filt_ent)
+        filt_bad = _present(bad, filt_ctx)
+        filt_good = _present(good, filt_ctx)
+
+        c_leak = sum(1 for v in cur_bad.values() if v)
+        c_drop = sum(1 for v in cur_good.values() if not v)
+        f_leak = sum(1 for v in filt_bad.values() if v)
+        f_drop = sum(1 for v in filt_good.values() if not v)
+        cur_leaks += c_leak; cur_drops += c_drop
+        filt_leaks += f_leak; filt_drops += f_drop
+        if c_leak == 0 and c_drop == 0:
+            cur_consistent += 1
+        if f_leak == 0 and f_drop == 0:
+            filt_consistent += 1
+
+        rows.append({
+            "scenario": sc["name"],
+            "current":  {"leaked": [k for k, v in cur_bad.items() if v],
+                         "dropped_active": [k for k, v in cur_good.items() if not v]},
+            "filtered": {"leaked": [k for k, v in filt_bad.items() if v],
+                         "dropped_active": [k for k, v in filt_good.items() if not v]},
+        })
+
+    n = len(scenarios)
+    report = {
+        "fixture": str(FIXTURE.relative_to(ROOT)),
+        "scenarios": n,
+        "metrics": {
+            "current": {
+                "invalidated_leakage": cur_leaks,
+                "active_dropped": cur_drops,
+                "consistent_scenarios": f"{cur_consistent}/{n}",
+                "active_retention": round((tot_good - cur_drops) / tot_good, 3) if tot_good else None,
+            },
+            "filtered_fix": {
+                "invalidated_leakage": filt_leaks,
+                "active_dropped": filt_drops,
+                "consistent_scenarios": f"{filt_consistent}/{n}",
+                "active_retention": round((tot_good - filt_drops) / tot_good, 3) if tot_good else None,
+            },
+        },
+        "rows": rows,
+        "verdict": (
+            "CURRENT live traversal LEAKS lifecycle-deactivated relations "
+            "(status ignored); the status-aware filter removes the leak with "
+            "full active-relation retention."
+            if cur_leaks > 0 and filt_leaks == 0 and filt_drops == 0
+            else "see metrics"
+        ),
+    }
+
+    out_dir = ROOT / "reports" / "research-runs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "cascade-consistency-probe.json"
+    out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(f"[cascade-probe] scenarios={n}  fixture={report['fixture']}")
+    print(f"  CURRENT  : invalidated_leakage={cur_leaks}  active_dropped={cur_drops}  "
+          f"consistent={cur_consistent}/{n}  active_retention="
+          f"{report['metrics']['current']['active_retention']}")
+    print(f"  FILTERED : invalidated_leakage={filt_leaks}  active_dropped={filt_drops}  "
+          f"consistent={filt_consistent}/{n}  active_retention="
+          f"{report['metrics']['filtered_fix']['active_retention']}")
+    for r in rows:
+        if r["current"]["leaked"] or r["current"]["dropped_active"]:
+            print(f"    · {r['scenario']}: CURRENT leaked={r['current']['leaked']} "
+                  f"dropped={r['current']['dropped_active']}")
+    print(f"  verdict: {report['verdict']}")
+    print(f"  report → {out_path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cascade_consistency_probe.py
+++ b/tests/test_cascade_consistency_probe.py
@@ -1,0 +1,50 @@
+"""Lock-test for the cascade reasoning-consistency probe.
+
+Pins the measurement finding's *stable* half: the status-aware filter
+(the proposed traversal fix) removes ALL leakage of lifecycle-deactivated
+relations with FULL active-relation retention. The CURRENT-arm leakage
+(today's traversal ignores status) is recorded by the probe but not
+hard-asserted here — once a real traversal status-filter lands, the
+CURRENT arm will stop leaking, and that is the intended outcome, not a
+test break.
+
+Run: python -m unittest tests.test_cascade_consistency_probe
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class CascadeProbeTests(unittest.TestCase):
+    def test_probe_runs_and_filter_is_clean(self):
+        from scripts.research import cascade_consistency_probe as probe
+        rc = probe.main()
+        self.assertEqual(rc, 0)
+        report = ROOT / "reports" / "research-runs" / "cascade-consistency-probe.json"
+        self.assertTrue(report.exists())
+        data = json.loads(report.read_text(encoding="utf-8"))
+        filt = data["metrics"]["filtered_fix"]
+        # the proposed status-aware filter: zero leakage, no active loss.
+        self.assertEqual(filt["invalidated_leakage"], 0)
+        self.assertEqual(filt["active_dropped"], 0)
+        self.assertEqual(filt["active_retention"], 1.0)
+
+    def test_filter_predicate_excludes_deactivated(self):
+        from scripts.research.cascade_consistency_probe import _is_active
+        self.assertTrue(_is_active({"status": {"active": True}, "mutation_type": "active"}))
+        self.assertFalse(_is_active({"status": {"active": False}, "mutation_type": "invalidated"}))
+        self.assertFalse(_is_active({"mutation_type": "superseded"}))
+        self.assertFalse(_is_active({"mutation_type": "expired"}))
+        self.assertTrue(_is_active({}))  # untagged legacy edge = active
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
"먼저 측정" before touching traversal. A **deterministic** probe (no LLM/server) that calls the REAL live-context builder (`GraphEngine.build_graph_context_str`) on fixture entities mixing active edges with lifecycle-deactivated ones (invalidated/superseded/expired, all ≥ CONFIDENCE_THRESHOLD), comparing **CURRENT** (as-is) vs **FILTERED** (candidate status-aware filter = proposed fix).

## Result (4 scenarios)
| arm | invalidated_leakage | active_retention | consistent |
|---|---|---|---|
| **CURRENT** | **3/3** | 1.0 | 1/4 |
| **FILTERED** | **0** | 1.0 | 4/4 |

→ **Empirically confirms live graph traversal IGNORES lifecycle status** — every deactivated relation leaks into the LLM context. So the entity-edit cascade (#1018/#1019) **and the broader T1/T7 lifecycle are COSMETIC at the live-query layer**; status is honored only in the `reconstruct_*_at` (time-travel) path. The status-aware filter removes the leak with **zero active-relation loss** (Path-Recall analog 1.0) → Pareto-positive; the evidence the eventual traversal change (core/graph, Rule #2) needs.

## Files
fixture (4 scenarios) + probe + JSON report + lock-test (pins the stable filter arm + `_is_active`).

## Scope
Measurement only — probe READS via `build_graph_context_str`; `core/retrieval`/`core/graph` traversal/`core/reasoning` **0 lines** (streak intact). No QDC axis (this IS the measurement).

## Next (operator decision)
The measurement clears the way for **Option A** (add the status filter to live traversal) with QDC — now backed by this evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)