### PR TITLE
feat(v0.6.1): live traversal honors lifecycle status (Option A — measurement-backed)

### DIFF
--- a/core/graph_engine/constants.py
+++ b/core/graph_engine/constants.py
@@ -6,11 +6,42 @@ byte-identical to the pre-split file; only the location moved.
 """
 from __future__ import annotations
 
+import os
+
 
 CONFIDENCE_THRESHOLD = 0.6
 MAX_DEPTH            = 4
 DFS_SCORE_THRESHOLD  = 0.05
 DEPTH_DECAY          = 0.7
+
+# Relation mutation_types that mean the edge is NOT part of the current
+# graph state (deactivated by the cascade / T1 expiration / T7 supersede).
+_DEAD_MUTATION_TYPES = ("invalidated", "superseded", "expired")
+
+
+def relation_is_live(rel: dict) -> bool:
+    """v0.6.1 — current-state live traversal must honor lifecycle status.
+
+    Measurement (cascade_consistency_probe, PR #1020) showed live graph
+    traversal filtered relations by confidence ONLY, so cascade-/T1-/T7-
+    deactivated edges leaked into the LLM context (status was honored only
+    in the reconstruct_*_at time-travel path). This predicate restores
+    consistency: an edge is live unless ``status.active is False`` or its
+    ``mutation_type`` is invalidated/superseded/expired.
+
+    Kill-switch ``JAMES_DISABLE_STATUS_FILTER=1`` → legacy (leaky)
+    behavior, for A/B measurement. Untagged legacy edges (no status /
+    mutation_type) are treated as live.
+    """
+    if os.environ.get("JAMES_DISABLE_STATUS_FILTER") == "1":
+        return True
+    if not isinstance(rel, dict):
+        return False
+    if (rel.get("status") or {}).get("active") is False:
+        return False
+    if rel.get("mutation_type") in _DEAD_MUTATION_TYPES:
+        return False
+    return True
 
 
 __all__ = [
@@ -18,4 +49,5 @@ __all__ = [
     "MAX_DEPTH",
     "DFS_SCORE_THRESHOLD",
     "DEPTH_DECAY",
+    "relation_is_live",
 ]

--- a/core/graph_engine/engine.py
+++ b/core/graph_engine/engine.py
@@ -34,6 +34,7 @@ from core.graph_engine.constants import (
     DEPTH_DECAY,
     DFS_SCORE_THRESHOLD,
     MAX_DEPTH,
+    relation_is_live,
 )
 from core.graph_engine.doc_hop_rule import _doc_outgoing_hop_valid
 
@@ -305,6 +306,8 @@ class GraphEngine:
             for rel in relations:
                 if not isinstance(rel, dict):
                     continue
+                if not relation_is_live(rel):   # v0.6.1 — honor lifecycle status
+                    continue
                 if float(rel.get("confidence", 0)) < CONFIDENCE_THRESHOLD:
                     continue
 
@@ -420,7 +423,8 @@ class GraphEngine:
 
             rels = [
                 r for r in e.get("relations", [])
-                if isinstance(r, dict) and float(r.get("confidence", 0)) >= CONFIDENCE_THRESHOLD
+                if isinstance(r, dict) and relation_is_live(r)
+                and float(r.get("confidence", 0)) >= CONFIDENCE_THRESHOLD
             ][:3]
             if rels:
                 rel_strs = []

--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -1,0 +1,70 @@
+# v0.6.1 — Measurement / Fix Loop (entry 2026-06-22)
+
+> Autonomous loop handover. The operator asked to run a 6–7h+
+> measurement-or-fix loop. This doc is the resumable work-queue + entry
+> contract so the loop survives context compaction.
+
+## Where we are
+This session shipped #998–#1020 (UI consolidation → trace linkage →
+workspace source-docs → entity-edit cascade → **cascade consistency
+measurement**). The headline finding that drives this loop:
+
+**🔴 The lifecycle is COSMETIC at the live-query layer.** The
+`cascade_consistency_probe` (#1020, deterministic) proved live graph
+traversal (`expand_dynamic` + `build_graph_context_str` + `load_entity`)
+filters relations ONLY by confidence — it **ignores `status.active` /
+`mutation_type`**. So invalidated/superseded/expired relations leak into
+the LLM context (3/3 in the fixture). `status` is honored only in the
+`reconstruct_*_at` (time-travel) path. The status-aware filter removes
+the leak with **0 active-relation loss** (Path-Recall analog 1.0).
+Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
+
+## Loop work-queue (priority order)
+1. **Option A — live-traversal status filter (THE measurement-backed fix).**
+   Add a `_relation_is_live(rel)` gate (status.active != False AND
+   mutation_type not in {invalidated,superseded,expired}) to
+   `expand_dynamic` (~L305) + `build_graph_context_str` (~L422). Default
+   ON; env kill-switch `JAMES_DISABLE_STATUS_FILTER=1`.
+   - Measure: re-run `cascade_consistency_probe` (CURRENT arm should now
+     read 0 leakage too) + STEP7 bench (`scripts/bench.py --suite=step7
+     --mode=retrieval`) for latency/paths/answer_len delta.
+   - **Rule #2**: core/graph change → 5-axis Quality Delta Card vs
+     `eval/qvt/baseline_<sha>.json`. The probe (#1020) + the QVT run are
+     the evidence. The graded/abstention axes need the LLM judge (server)
+     — if unavailable in-loop, run the deterministic axes + mark graded
+     operator-gated.
+   - Test: a regression test that live traversal excludes a deactivated
+     relation.
+2. **Live entity-edit cascade dogfood** (LLM-in-loop, unproven): server
+   up → edit a real entity that drops/adds a relation → confirm the
+   cascade invalidates/adds + (with Option A) the live query stops/starts
+   using it end-to-end.
+3. **5-axis QVT regression** for Option A on the standard fixture (if not
+   covered by step 1).
+4. **Broader measurement backlog** (only if NLI/models available):
+   re-confirm D-alce / v0.2.3b / HR numbers haven't drifted.
+
+## Entry contract / rules (must hold every iteration)
+- Branch per PR `feat|fix|chore/v0.6.1-<topic>`; PR into main; squash-merge
+  after green; sync main. Never commit to main directly (a `git rm` +
+  `git add <deleted-path>` abort bit us twice — use `git add -A`).
+- core/ files < 20KB (rule #5). Mother-platform only, no domain features.
+- **Option A breaks the core/graph-traversal 0-line streak** — that is
+  the one operator-approved, measurement-gated exception (this loop).
+  Every other PR keeps core/retrieval+reasoning untouched unless measured.
+- Each iteration = one scoped, verified, committed PR. Re-run the probe /
+  tests as the gate. Log honest negatives (a fix that regresses an axis
+  is reverted, not reframed).
+- Windows: `PYTHONIOENCODING=utf-8` for scripts; visual harness +
+  consistency probe are deterministic (no server) and safe to re-run.
+
+## Tooling
+- `python scripts/research/cascade_consistency_probe.py` — deterministic
+  consistency measurement (no server/LLM).
+- `python scripts/visual_regression.py` — UI render check (needs server).
+- `python scripts/bench.py --suite=step7 --mode=retrieval` — STEP7.
+- Server: `python server_llmwiki.py` (healthz at :8000/healthz).
+
+## Status log (append per iteration)
+- 2026-06-22 entry: finding measured (#1020). Loop starting at item 1
+  (Option A).

--- a/tests/test_graph_status_filter.py
+++ b/tests/test_graph_status_filter.py
@@ -1,0 +1,76 @@
+"""Live-traversal lifecycle-status filter (v0.6.1, Option A).
+
+Pins that current-state graph traversal honors lifecycle status: a
+relation deactivated by the cascade / T1 / T7 must NOT appear in the live
+LLM context, while active relations are retained. Backed by the
+measurement in scripts/research/cascade_consistency_probe.py (#1020).
+
+Run: python -m unittest tests.test_graph_status_filter
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.graph_engine.constants import relation_is_live
+from core.graph_engine.engine import GraphEngine
+
+
+class RelationIsLiveTests(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+    def test_active_is_live(self):
+        self.assertTrue(relation_is_live({"status": {"active": True}, "mutation_type": "active"}))
+
+    def test_untagged_legacy_is_live(self):
+        self.assertTrue(relation_is_live({"target": "X", "label": "관련"}))
+
+    def test_deactivated_not_live(self):
+        self.assertFalse(relation_is_live({"status": {"active": False}}))
+        self.assertFalse(relation_is_live({"mutation_type": "invalidated"}))
+        self.assertFalse(relation_is_live({"mutation_type": "superseded"}))
+        self.assertFalse(relation_is_live({"mutation_type": "expired"}))
+
+    def test_kill_switch_restores_legacy(self):
+        os.environ["JAMES_DISABLE_STATUS_FILTER"] = "1"
+        try:
+            self.assertTrue(relation_is_live({"mutation_type": "invalidated"}))
+        finally:
+            os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+
+class LiveContextExcludesDeadEdgeTests(unittest.TestCase):
+    """The REAL live-context builder must drop a deactivated edge."""
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+        self.eng = object.__new__(GraphEngine)  # build_graph_context_str needs no __init__
+        self.entity = {
+            "name": "Alpha", "entity_type": "concept",
+            "relations": [
+                {"target": "Beta",  "label": "관련", "confidence": 0.9,
+                 "status": {"active": True}, "mutation_type": "active"},
+                {"target": "Gamma", "label": "포함", "confidence": 0.9,
+                 "status": {"active": False}, "mutation_type": "invalidated"},
+            ],
+        }
+
+    def test_dead_edge_excluded_active_kept(self):
+        ctx = self.eng.build_graph_context_str([self.entity], [], 0.0)
+        self.assertIn("Beta", ctx)       # active retained
+        self.assertNotIn("Gamma", ctx)   # invalidated excluded
+
+    def test_kill_switch_leaks_again(self):
+        os.environ["JAMES_DISABLE_STATUS_FILTER"] = "1"
+        try:
+            ctx = self.eng.build_graph_context_str([self.entity], [], 0.0)
+            self.assertIn("Gamma", ctx)  # legacy behavior: leaks
+        finally:
+            os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Makes current-state graph traversal honor lifecycle status, so the entity-edit cascade (#1018/#1019) + the T1/T7 lifecycle become **real at the live-query layer** (the probe #1020 proved they were cosmetic there).

- **constants.py** `relation_is_live(rel)`: live unless `status.active is False` or `mutation_type ∈ {invalidated,superseded,expired}`. Kill-switch `JAMES_DISABLE_STATUS_FILTER=1`. Untagged legacy edges = live.
- **engine.py**: gate at the two live-output sites — `expand_dynamic` loop + `build_graph_context_str` comprehension.

## Measurement (Rule #2)
- **Probe A/B** (real `build_graph_context_str`): kill-switch ON = **3/3 leakage** (legacy) → default = **0 leakage**, active_retention **1.0**, consistent 4/4. Pareto-positive.
- **STEP7 / 5-axis on current data: structural Δ=0** — current KG = 316 files / ~879 relations / **0 deactivated markers** → `relation_is_live` True for every edge → filter is a no-op on existing retrieval. It only changes traversal once edges get deactivated (= the consistency it restores).
- **158 tests green** (116 graph + 42 cascade/status/probe); no regression. engine.py 19,169B (<20KB).

Operator-approved, measurement-gated break of the core/graph-traversal 0-line streak (the loop's sanctioned exception). Includes the measurement/fix-loop handover doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)