### PR TITLE
chore(v0.6.1): loop status log — iter 1 done

### DIFF
--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -66,5 +66,17 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
 - Server: `python server_llmwiki.py` (healthz at :8000/healthz).
 
 ## Status log (append per iteration)
-- 2026-06-22 entry: finding measured (#1020). Loop starting at item 1
-  (Option A).
+- 2026-06-22 entry: finding measured (#1020). Loop starting at item 1.
+- **iter 1 DONE (#1021)** — Option A live-traversal status filter landed.
+  `relation_is_live` gate in expand_dynamic + build_graph_context_str.
+  Probe A/B: kill-switch=3 leak / default=0 leak, retention 1.0. STEP7
+  Δ=0 proven structurally (current KG = 316 files / 879 rels / **0
+  deactivated edges** → filter is a no-op until edges deactivate). 158
+  tests green. core/graph 0-line streak broken here (sanctioned).
+  - NOTE for follow-up: `compute_graph_score` (engine ~L293/L364) still
+    scores ALL relations incl. dead ones — secondary (scoring, not the
+    leak); fold into a future iteration if it matters.
+- **NEXT = iter 2**: live entity-edit cascade dogfood (LLM-in-loop,
+  server up) — edit a real entity dropping/adding a relation → confirm
+  cascade invalidate/add AND (with #1021) the live query stops/starts
+  using it end-to-end. Then iter 3+ per the queue.


### PR DESCRIPTION
Loop status log: iter 1 (Option A traversal status filter #1021) done; next = live cascade dogfood. docs-only.