### PR TITLE
feat(v0.6.1): graph score excludes lifecycle-dead relations (loop iter 2)

### DIFF
--- a/core/ontology.py
+++ b/core/ontology.py
@@ -155,11 +155,20 @@ def is_sensitive_relation(rel_type: str) -> bool:
     return bool(RELATION_TYPES.get(normalize_relation(rel_type), {}).get("sensitive", False))
 
 def compute_graph_score(relations: List[Dict], depth: int = 1) -> float:
-    """score = Σ(weight × confidence) / depth"""
+    """score = Σ(weight × confidence) / depth
+
+    v0.6.1 — exclude lifecycle-deactivated edges (cascade / T1 / T7) so a
+    relation the cascade invalidated no longer inflates the graph score
+    that drives DFS halting + entity ranking (companion to the live-output
+    filter in expand_dynamic / build_graph_context_str, PR #1021).
+    Lazy import keeps core.ontology free of a graph_engine import cycle.
+    """
     if not relations or depth < 1: return 0.0
+    from core.graph_engine.constants import relation_is_live
     total = 0.0
     for rel in relations:
         if not isinstance(rel, dict): continue
+        if not relation_is_live(rel): continue
         raw = rel.get("type") or rel.get("label") or "RELATED_TO"
         if is_sensitive_relation(raw): continue
         total += get_relation_weight(raw) * float(rel.get("confidence", 0.0))

--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -76,7 +76,21 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
   - NOTE for follow-up: `compute_graph_score` (engine ~L293/L364) still
     scores ALL relations incl. dead ones — secondary (scoring, not the
     leak); fold into a future iteration if it matters.
-- **NEXT = iter 2**: live entity-edit cascade dogfood (LLM-in-loop,
-  server up) — edit a real entity dropping/adding a relation → confirm
-  cascade invalidate/add AND (with #1021) the live query stops/starts
-  using it end-to-end. Then iter 3+ per the queue.
+- **iter 2 DONE (#NNNN)** — `compute_graph_score` (core/ontology.py) now
+  excludes lifecycle-dead edges via `relation_is_live` (lazy import, no
+  cycle). Dead edges no longer inflate the score that drives DFS halting
+  + ranking. Verified: score(active)==score(active+dead); kill-switch
+  restores counting. ontology.py 19,289B. STEP7 Δ=0 structural (KG still
+  0 deactivated edges). 42 tests green.
+  - Decision: the **live LLM cascade dogfood** (named as iter2) is
+    operator-gated — it mutates the real KG + vector store and the
+    mixtral re-extraction is non-deterministic, so it is NOT a clean
+    autonomous-PR deliverable. Operator manual-verify: edit an entity in
+    the workspace 원본자료 편집, watch "관계 N개 무효화/추가", then query
+    and confirm the dropped relation is gone from the answer's graph path.
+- **NEXT = iter 3**: validity-window awareness — `relation_is_live` honors
+  status.active + mutation_type but NOT `validity.to < now` (a relation
+  whose validity expired but hasn't been swept to mutation_type=expired
+  could still leak). Check whether an expiration sweep already covers it;
+  if a gap exists, extend the predicate (clock-aware). Else iter 3 = next
+  measurement item.

--- a/tests/test_graph_status_filter.py
+++ b/tests/test_graph_status_filter.py
@@ -72,5 +72,31 @@ class LiveContextExcludesDeadEdgeTests(unittest.TestCase):
             os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
 
 
+class GraphScoreExcludesDeadTests(unittest.TestCase):
+    """v0.6.1 iter2 — a deactivated edge must not inflate compute_graph_score
+    (which drives DFS halting + ranking)."""
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+    def test_dead_relation_excluded_from_score(self):
+        from core.ontology import compute_graph_score
+        active = {"target": "B", "label": "관련", "confidence": 0.9, "status": {"active": True}}
+        dead = {"target": "C", "label": "관련", "confidence": 0.9,
+                "status": {"active": False}, "mutation_type": "invalidated"}
+        self.assertEqual(compute_graph_score([active]), compute_graph_score([active, dead]))
+
+    def test_kill_switch_counts_dead(self):
+        from core.ontology import compute_graph_score
+        active = {"target": "B", "label": "관련", "confidence": 0.9, "status": {"active": True}}
+        dead = {"target": "C", "label": "관련", "confidence": 0.9,
+                "status": {"active": False}, "mutation_type": "invalidated"}
+        os.environ["JAMES_DISABLE_STATUS_FILTER"] = "1"
+        try:
+            self.assertGreater(compute_graph_score([active, dead]),
+                               compute_graph_score([active]))
+        finally:
+            os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Companion to #1021. `compute_graph_score` counted ALL relations (sensitive-filtered only), so lifecycle-deactivated edges still inflated the score driving DFS halting + ranking. Now skips `not relation_is_live(rel)` (lazy import, no cycle). Verified score([active])==score([active,dead]); kill-switch restores legacy. STEP7 Δ=0 structural (KG has 0 deactivated edges). 42 tests green; ontology.py 19,289B. Live LLM dogfood judged operator-gated (KG-mutating/non-deterministic).