### PR TITLE
feat(v0.6.1): live traversal honors T1 validity window (loop iter 3)

### DIFF
--- a/core/graph_engine/constants.py
+++ b/core/graph_engine/constants.py
@@ -7,6 +7,7 @@ byte-identical to the pre-split file; only the location moved.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 
 
 CONFIDENCE_THRESHOLD = 0.6
@@ -19,19 +20,47 @@ DEPTH_DECAY          = 0.7
 _DEAD_MUTATION_TYPES = ("invalidated", "superseded", "expired")
 
 
-def relation_is_live(rel: dict) -> bool:
+def _now_utc():
+    try:
+        from core.lifecycle.clock import now
+        return now()
+    except Exception:
+        return datetime.now(timezone.utc)
+
+
+def _parse_ts(s):
+    """ISO-8601 → tz-aware datetime, or None if empty/unparseable (treated
+    as 'no constraint' so a bad timestamp never breaks traversal)."""
+    if not s or not isinstance(s, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def relation_is_live(rel: dict, *, at=None) -> bool:
     """v0.6.1 — current-state live traversal must honor lifecycle status.
 
     Measurement (cascade_consistency_probe, PR #1020) showed live graph
     traversal filtered relations by confidence ONLY, so cascade-/T1-/T7-
     deactivated edges leaked into the LLM context (status was honored only
     in the reconstruct_*_at time-travel path). This predicate restores
-    consistency: an edge is live unless ``status.active is False`` or its
-    ``mutation_type`` is invalidated/superseded/expired.
+    consistency. An edge is NOT live if:
+      - ``status.active is False``; or
+      - ``mutation_type`` ∈ {invalidated, superseded, expired}; or
+      - it has a T1 ``validity`` window and the clock is outside it
+        (``validity.to < now`` expired, or ``validity.from > now`` not yet
+        valid). This catches time-expired edges the batch expiration sweep
+        (run_expiration_cascade — NOT per-query) has not yet marked.
 
+    ``at`` overrides the comparison clock (tests / explicit current time).
     Kill-switch ``JAMES_DISABLE_STATUS_FILTER=1`` → legacy (leaky)
-    behavior, for A/B measurement. Untagged legacy edges (no status /
-    mutation_type) are treated as live.
+    behavior. Untagged legacy edges (no status / mutation_type / validity)
+    are live.
     """
     if os.environ.get("JAMES_DISABLE_STATUS_FILTER") == "1":
         return True
@@ -41,6 +70,19 @@ def relation_is_live(rel: dict) -> bool:
         return False
     if rel.get("mutation_type") in _DEAD_MUTATION_TYPES:
         return False
+    val = rel.get("validity")
+    if isinstance(val, dict) and (val.get("to") or val.get("from")):
+        cur = at or _now_utc()
+        to_ = _parse_ts(val.get("to"))
+        frm = _parse_ts(val.get("from"))
+        try:
+            if to_ is not None and to_ < cur:
+                return False
+            if frm is not None and frm > cur:
+                return False
+        except TypeError:
+            # naive/aware mismatch — be permissive, never break traversal.
+            return True
     return True
 
 

--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -88,9 +88,18 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
     autonomous-PR deliverable. Operator manual-verify: edit an entity in
     the workspace 원본자료 편집, watch "관계 N개 무효화/추가", then query
     and confirm the dropped relation is gone from the answer's graph path.
-- **NEXT = iter 3**: validity-window awareness — `relation_is_live` honors
-  status.active + mutation_type but NOT `validity.to < now` (a relation
-  whose validity expired but hasn't been swept to mutation_type=expired
-  could still leak). Check whether an expiration sweep already covers it;
-  if a gap exists, extend the predicate (clock-aware). Else iter 3 = next
-  measurement item.
+- **iter 3 DONE (#NNNN)** — `relation_is_live` now honors the T1 validity
+  window. Confirmed gap: `expiration_cascade` is a BATCH sweep
+  (run_expiration_cascade only — not per-query), and no live path checked
+  `validity.to`. The predicate now excludes `validity.to < now` (expired)
+  and `validity.from > now` (not-yet-valid), clock-aware (`at` override
+  for tests), robust parse (bad ts → permissive, never breaks traversal).
+  STEP7 Δ=0 structural (KG has 0 non-null validity.to). 103 graph tests
+  green; constants.py 3,388B.
+- **NEXT = iter 4**: (correctness) verify the live status/validity filter
+  does NOT pollute the reconstruct_*_at (time-travel) path — those build
+  a historical snapshot and must NOT apply "now"-based filtering. Confirm
+  reconstruct does not route through expand_dynamic / build_graph_context_str
+  / compute_graph_score; if it does, guard it. Then write a short
+  consolidation results doc for the iter1-3 lifecycle-consistency arc.
+  After that, pivot to the broader measurement backlog or close the arc.

--- a/tests/test_graph_status_filter.py
+++ b/tests/test_graph_status_filter.py
@@ -72,6 +72,56 @@ class LiveContextExcludesDeadEdgeTests(unittest.TestCase):
             os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
 
 
+class ValidityWindowTests(unittest.TestCase):
+    """v0.6.1 iter3 — relation_is_live honors the T1 validity window for
+    current-state queries (the expiration sweep is batch, not per-query,
+    so a time-expired-but-unswept edge would otherwise leak)."""
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+        from datetime import datetime, timezone
+        self.at = datetime(2026, 6, 22, tzinfo=timezone.utc)
+
+    def _rel(self, frm=None, to=None):
+        r = {"target": "X", "label": "관련", "confidence": 0.9,
+             "status": {"active": True}, "mutation_type": "active"}
+        if frm or to:
+            r["validity"] = {"from": frm, "to": to}
+        return r
+
+    def test_expired_to_in_past_not_live(self):
+        self.assertFalse(relation_is_live(
+            self._rel(to="2020-01-01T00:00:00Z"), at=self.at))
+
+    def test_not_yet_valid_from_in_future_not_live(self):
+        self.assertFalse(relation_is_live(
+            self._rel(frm="2099-01-01T00:00:00Z"), at=self.at))
+
+    def test_within_window_is_live(self):
+        self.assertTrue(relation_is_live(
+            self._rel(frm="2020-01-01T00:00:00Z", to="2099-01-01T00:00:00Z"),
+            at=self.at))
+
+    def test_no_validity_is_live(self):
+        self.assertTrue(relation_is_live(self._rel(), at=self.at))
+
+    def test_unparseable_validity_is_permissive(self):
+        self.assertTrue(relation_is_live(self._rel(to="not-a-date"), at=self.at))
+
+    def test_context_excludes_time_expired_edge(self):
+        # real build_graph_context_str, real now: a 2020 to-date is expired.
+        eng = object.__new__(GraphEngine)
+        ent = {"name": "Omicron", "entity_type": "concept", "relations": [
+            {"target": "Pi", "label": "관련", "confidence": 0.9,
+             "status": {"active": True}, "mutation_type": "active"},
+            {"target": "Rho", "label": "관련", "confidence": 0.9,
+             "status": {"active": True}, "mutation_type": "active",
+             "validity": {"from": "2019-01-01T00:00:00Z", "to": "2020-01-01T00:00:00Z"}},
+        ]}
+        ctx = eng.build_graph_context_str([ent], [], 0.0)
+        self.assertIn("Pi", ctx)
+        self.assertNotIn("Rho", ctx)
+
+
 class GraphScoreExcludesDeadTests(unittest.TestCase):
     """v0.6.1 iter2 — a deactivated edge must not inflate compute_graph_score
     (which drives DFS halting + ranking)."""


### PR DESCRIPTION
Confirmed gap: `expiration_cascade` is a BATCH sweep (never per-query), and no live path checked `validity.to`. A time-expired-but-unswept edge leaked into live traversal. `relation_is_live` now also excludes edges outside their T1 validity window (`validity.to < now` / `validity.from > now`), clock-aware (`at` override), robust parse (never breaks traversal). STEP7 Δ=0 structural (KG 0 non-null validity.to). 103 graph tests green; constants.py 3,388B. Completes the live-consistency triad: traversal output (#1021) + score (#1023) + validity (this).