### PR TITLE
feat(v0.6.1): pin time-travel isolation + close live-consistency arc (loop iter 4)

### DIFF
--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -96,10 +96,19 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
   for tests), robust parse (bad ts → permissive, never breaks traversal).
   STEP7 Δ=0 structural (KG has 0 non-null validity.to). 103 graph tests
   green; constants.py 3,388B.
-- **NEXT = iter 4**: (correctness) verify the live status/validity filter
-  does NOT pollute the reconstruct_*_at (time-travel) path — those build
-  a historical snapshot and must NOT apply "now"-based filtering. Confirm
-  reconstruct does not route through expand_dynamic / build_graph_context_str
-  / compute_graph_score; if it does, guard it. Then write a short
-  consolidation results doc for the iter1-3 lifecycle-consistency arc.
-  After that, pivot to the broader measurement backlog or close the arc.
+- **iter 4 DONE (#NNNN)** — time-travel isolation VERIFIED + pinned.
+  `reconstruct_graph_at` is pure event-replay (LOCK 4, audit_log only);
+  source audit confirmed `core/lifecycle/**` references none of the live
+  now-based fns (relation_is_live / expand_dynamic / build_graph_context_str
+  / compute_graph_score) → the live filter does NOT pollute historical
+  snapshots. Pinned by `tests/test_reconstruct_isolation.py` (2 tests).
+  Consolidation report: `reports/research-runs/lifecycle-live-consistency-
+  arc-20260622.md`. **The lifecycle live-consistency arc (iter1-4) is
+  CLOSED** — traversal + score + validity honor lifecycle; time-travel
+  stays isolated; no live-data regression (structural Δ=0).
+- **NEXT = iter 5**: pivot to the broader measurement backlog — re-confirm
+  D-alce / v0.2.3b cross-model / HR numbers haven't drifted (NLI cached;
+  see memory `project_d_alce_research_tier_nli_2026_06_21`). Pick the
+  cheapest deterministic check first; LLM/NLI-heavy runs are fine if the
+  models are local. If the backlog is not cheaply re-runnable, log that
+  honestly and close the loop.

--- a/reports/research-runs/lifecycle-live-consistency-arc-20260622.md
+++ b/reports/research-runs/lifecycle-live-consistency-arc-20260622.md
@@ -1,0 +1,59 @@
+# Lifecycle live-consistency arc — results (2026-06-22)
+
+Measurement/fix loop, iter 1–4. Triggered by the operator question
+"does editing a document fire a cascade that keeps reasoning consistent?"
+and the follow-up "측정 관련".
+
+## The finding (measured, not assumed)
+`scripts/research/cascade_consistency_probe.py` (deterministic, calls the
+REAL `GraphEngine.build_graph_context_str`) showed the **live graph query
+path ignored lifecycle status entirely** — it filtered relations by
+`confidence` only. So cascade-/T1-/T7-deactivated relations
+(invalidated / superseded / expired) leaked into the LLM context.
+Lifecycle status was honored ONLY in the `reconstruct_*_at` time-travel
+path. ⇒ the entity-edit cascade (#1018/#1019) and the broader lifecycle
+were **cosmetic at the live-query layer**.
+
+Probe (4 scenarios), pre-fix vs the status-aware filter:
+
+| arm | invalidated leakage | active retention | consistent |
+|---|---|---|---|
+| CURRENT (legacy) | 3/3 | 1.0 | 1/4 |
+| FILTERED (fix) | 0 | 1.0 | 4/4 |
+
+The fix removes the leak with **zero active-relation loss** (Pareto).
+
+## The fixes (live-consistency triad)
+| PR | change | site |
+|---|---|---|
+| #1021 | `relation_is_live(rel)` gate — exclude `status.active==False` / `mutation_type∈{invalidated,superseded,expired}` | `expand_dynamic` + `build_graph_context_str` |
+| #1023 | dead edges no longer inflate the graph score (DFS halting / ranking) | `compute_graph_score` |
+| #1024 | honor the T1 **validity window** (`validity.to<now` / `validity.from>now`) — catches time-expired edges the BATCH `expiration_cascade` sweep hasn't marked yet | `relation_is_live` (clock-aware) |
+
+All gated by `JAMES_DISABLE_STATUS_FILTER=1` (A/B + rollback).
+
+## No-regression evidence (Rule #2)
+- **STEP7 / 5-axis Δ = 0, structural**: the current KG has **0 deactivated
+  edges and 0 non-null `validity.to`** (316 files / ~879 relations), so
+  `relation_is_live` is True for every existing edge → the filter is a
+  **no-op on current data**. It only changes traversal once edges get
+  deactivated/expired — which is exactly the consistency it restores.
+- ~160 graph/cascade tests green across the arc; core/graph files < 20 KB.
+
+## Time-travel isolation (iter 4, verified)
+`reconstruct_graph_at` is a **pure event-replay** (LOCK 4 — reads only the
+audit_log, not the wiki / graph engine). Source audit confirmed
+`core/lifecycle/**` references none of the live now-based functions, so
+the live filter does NOT pollute historical snapshots (a
+historically-valid-then-expired edge is still present at its past `t`).
+Pinned by `tests/test_reconstruct_isolation.py`.
+
+## Honest scope / remaining
+- **Live LLM cascade dogfood** = operator-gated (mutates real KG + vector
+  store; mixtral re-extraction non-deterministic) — not an autonomous PR.
+  Manual check: edit an entity → "관계 N개 무효화/추가" → query → the
+  dropped relation is gone from the answer's graph path.
+- **Inbound / T6 causality** propagation (other entities' edges into a
+  changed fact) is doc-level / T6 cascade territory — out of this arc.
+- `compute_graph_score` is now the only score path filtered; if other
+  ranking surfaces read raw relations, audit them in a future arc.

--- a/tests/test_reconstruct_isolation.py
+++ b/tests/test_reconstruct_isolation.py
@@ -1,0 +1,60 @@
+"""LOCK: time-travel reconstruct stays isolated from the live filter.
+
+The v0.6.1 live-consistency triad (#1021/#1023/#1024) made the *current-
+state* query path honor lifecycle status + validity via a now-based
+filter (`relation_is_live`) in `expand_dynamic` / `build_graph_context_str`
+/ `compute_graph_score`. The `reconstruct_*_at` time-travel path must NOT
+use any of those — it is a pure event-replay (LOCK 4) that projects a
+*historical* snapshot, where a now-expired edge may still be valid. If
+reconstruct routed through the now-based filter, a historically-valid-
+then-expired edge would be wrongly dropped from a past snapshot.
+
+iter4 of the measurement/fix loop verified (by source absence) that
+core/lifecycle/* references none of those live functions. This test pins
+that isolation so a future refactor can't silently break time-travel.
+
+Run: python -m unittest tests.test_reconstruct_isolation
+"""
+from __future__ import annotations
+
+import glob
+import os
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# The live, now-based functions reconstruct must never call.
+_LIVE_FNS = (
+    "relation_is_live",
+    "expand_dynamic",
+    "build_graph_context_str",
+    "compute_graph_score",
+)
+
+
+class ReconstructIsolationTests(unittest.TestCase):
+    def test_lifecycle_replay_does_not_use_live_now_filter(self):
+        offenders = []
+        for f in glob.glob(str(ROOT / "core" / "lifecycle" / "**" / "*.py"),
+                           recursive=True):
+            src = Path(f).read_text(encoding="utf-8")
+            for fn in _LIVE_FNS:
+                if fn in src:
+                    offenders.append((os.path.relpath(f, ROOT), fn))
+        self.assertEqual(
+            offenders, [],
+            "reconstruct/time-travel must stay isolated from the live "
+            f"now-based filter, found: {offenders}")
+
+    def test_reconstruct_is_pure_event_replay(self):
+        # The primitive must not import the graph engine (its pure-replay
+        # contract reads only the audit_log).
+        src = (ROOT / "core" / "lifecycle" / "replay_graph" /
+               "primitives.py").read_text(encoding="utf-8")
+        self.assertNotIn("graph_engine", src)
+        self.assertIn("reconstruct_graph_at", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
iter4 (correctness): verified the live now-based filter (#1021/#1023/#1024) does NOT pollute reconstruct_*_at. `reconstruct_graph_at` is pure event-replay (LOCK 4); source audit confirmed core/lifecycle/** references none of the live fns → historical snapshots intact. Pinned by test_reconstruct_isolation.py (2 tests). Consolidation report added. **Arc CLOSED**: traversal+score+validity honor lifecycle; time-travel isolated; structural Δ=0. test+docs only, core/ 0.