### PR TITLE
feat(v0.6.1): current-state graph snapshot honors lifecycle status (loop iter 5)

### DIFF
--- a/core/graph_snapshot.py
+++ b/core/graph_snapshot.py
@@ -155,6 +155,12 @@ def build_snapshot(
         kept_ids.add(eid)
 
     # ── Pass 2: walk relations, drop sensitive types, count degree. ──
+    # v0.6.1 — the /admin/graph/snapshot is the CURRENT-state view (no time
+    # param; time-travel uses reconstruct_graph_at separately) and the edge
+    # payload carries no status field, so a lifecycle-dead edge would render
+    # indistinguishable from a live one. Exclude dead edges for consistency
+    # with the live query path (#1021); kill-switch JAMES_DISABLE_STATUS_FILTER.
+    from core.graph_engine.constants import relation_is_live
     edges: List[Dict[str, Any]] = []
     degree: Dict[str, int] = {nid: 0 for nid in kept_ids}
     for eid, fm in raw_entities.items():
@@ -162,6 +168,8 @@ def build_snapshot(
             continue
         for rel in fm.get("relations", []) or []:
             if not isinstance(rel, dict):
+                continue
+            if not relation_is_live(rel):
                 continue
             target_id = rel.get("target_id") or ""
             if not target_id or target_id == "UNRESOLVED":

--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -106,9 +106,21 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
   arc-20260622.md`. **The lifecycle live-consistency arc (iter1-4) is
   CLOSED** — traversal + score + validity honor lifecycle; time-travel
   stays isolated; no live-data regression (structural Δ=0).
-- **NEXT = iter 5**: pivot to the broader measurement backlog — re-confirm
-  D-alce / v0.2.3b cross-model / HR numbers haven't drifted (NLI cached;
-  see memory `project_d_alce_research_tier_nli_2026_06_21`). Pick the
-  cheapest deterministic check first; LLM/NLI-heavy runs are fine if the
-  models are local. If the backlog is not cheaply re-runnable, log that
-  honestly and close the loop.
+- **iter 5 DONE (#NNNN)** — audited all relation-reading surfaces; the
+  current-state 3D graph snapshot (`/admin/graph/snapshot`, build_snapshot)
+  also leaked dead edges (its edge payload has no status field → a dead
+  edge renders as live). Added the `relation_is_live` gate there too. The
+  other relation-readers (graph_editor / cascade / lifecycle sweep) are
+  write/maintenance paths that MUST see all edges — correctly left alone.
+  So the live-consistency coverage is now: LLM context (#1021) + graph
+  score (#1023) + validity (#1024) + 3D viz (this). STEP7/viz Δ=0
+  structural (KG 0 deactivated edges). 32 tests green; graph_snapshot.py
+  10,001B.
+- **NEXT = iter 6**: (a) final check for any REMAINING user-facing relation
+  output surface (neighbor panel / node-detail / citation) that lists
+  edges without honoring status; fix if found, else pin "clean". (b) Then
+  assess the LLM-heavy backlog (D-alce/v0.2.3b/HR) — these are hours-long
+  generative runs, NOT cheap drift checks, and nothing changed that would
+  drift them (filters are no-ops on current data). Per the loop rule, if
+  no cheap deterministic fix/measurement item remains, **wind down the
+  loop honestly** (final summary, no further wakeup) and report.

--- a/tests/test_graph_status_filter.py
+++ b/tests/test_graph_status_filter.py
@@ -148,5 +148,52 @@ class GraphScoreExcludesDeadTests(unittest.TestCase):
             os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
 
 
+class _SnapStubGen:
+    """Stub WikiGenerator for build_snapshot: entity_id_index +
+    _read_frontmatter over in-memory frontmatter dicts."""
+    def __init__(self, fms, entity_path):
+        self._fms = fms
+        self.entity_id_index = {k: k for k in fms}
+        self.entity_path = entity_path
+        self.entity_types = ["concept"]
+
+    def refresh_entity_map(self):
+        pass
+
+    def _read_frontmatter(self, path):
+        return self._fms.get(str(path))
+
+
+class GraphSnapshotExcludesDeadTests(unittest.TestCase):
+    """v0.6.1 iter5 — the current-state /admin/graph/snapshot (3D viz) must
+    not render lifecycle-dead edges as if they were live (its edge payload
+    has no status field, so a dead edge is indistinguishable)."""
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_STATUS_FILTER", None)
+
+    def test_snapshot_drops_dead_edge_keeps_live(self):
+        import tempfile
+        from core.graph_snapshot import build_snapshot, invalidate_cache
+        A, B, C = "e_concept_aaaaaaaa01", "e_concept_bbbbbbbb02", "e_concept_cccccccc03"
+        fms = {
+            A: {"name": "A", "entity_type": "concept", "relations": [
+                {"target": "B", "target_id": B, "label": "관련", "type": "RELATED_TO",
+                 "confidence": 0.9, "status": {"active": True}, "mutation_type": "active"},
+                {"target": "C", "target_id": C, "label": "관련", "type": "RELATED_TO",
+                 "confidence": 0.9, "status": {"active": False}, "mutation_type": "invalidated"},
+            ]},
+            B: {"name": "B", "entity_type": "concept"},
+            C: {"name": "C", "entity_type": "concept"},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            gen = _SnapStubGen(fms, __import__("pathlib").Path(td))
+            invalidate_cache()
+            snap = build_snapshot(gen)
+            targets = {e.get("t") for e in snap.get("edges", [])}
+            self.assertIn(B, targets)       # live edge kept
+            self.assertNotIn(C, targets)    # dead edge dropped
+            invalidate_cache()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Surface audit found one more leak: the current-state 3D graph snapshot (`/admin/graph/snapshot` → build_snapshot) didn't honor lifecycle status, and its edge payload has no status field → a dead edge rendered as live. Added `relation_is_live` gate (lazy import, kill-switch). Other relation-readers (graph_editor/cascade/lifecycle sweep) MUST see all edges — left untouched. Live-consistency now complete: LLM context (#1021) + score (#1023) + validity (#1024) + 3D viz (this). Δ=0 structural. 32 tests green; graph_snapshot.py 10,001B.