### PR TITLE
chore(v0.6.1): loop iter 6 — surface audit clean, arc + loop closed

### DIFF
--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -116,11 +116,45 @@ Memory: `project_entity_edit_cascade_v0_6_1` (🔴🔴 MEASUREMENT FINDING).
   score (#1023) + validity (#1024) + 3D viz (this). STEP7/viz Δ=0
   structural (KG 0 deactivated edges). 32 tests green; graph_snapshot.py
   10,001B.
-- **NEXT = iter 6**: (a) final check for any REMAINING user-facing relation
-  output surface (neighbor panel / node-detail / citation) that lists
-  edges without honoring status; fix if found, else pin "clean". (b) Then
-  assess the LLM-heavy backlog (D-alce/v0.2.3b/HR) — these are hours-long
-  generative runs, NOT cheap drift checks, and nothing changed that would
-  drift them (filters are no-ops on current data). Per the loop rule, if
-  no cheap deterministic fix/measurement item remains, **wind down the
-  loop honestly** (final summary, no further wakeup) and report.
+- **iter 6 DONE — audit clean, loop wound down.** Audited the remaining
+  relation surfaces: `/admin/entities/{id}` + `/admin/graph/relation`
+  return the FULL relation dicts (status/mutation_type/validity included)
+  + full frontmatter → the inspector CAN distinguish dead from live, so
+  these are legitimate detail/audit views, NOT leaks (contrast: the 3D
+  snapshot #1026 stripped status into a thin edge payload → that WAS a
+  leak, now fixed). `relation_count` (admin entity list) counts all incl.
+  dead — a minor inspection stat, not a reasoning input; left as-is.
+  → **No further deterministic consistency bug.** Honest negative for the
+  "more surfaces leak" hypothesis: the 4 fixed surfaces (LLM context /
+  score / validity / 3D viz) were the complete set; detail endpoints are
+  correctly full-view.
+  - (b) LLM-heavy backlog (D-alce / v0.2.3b / HR): hours-long generative
+    runs, NOT cheap drift checks, and this loop's changes are no-ops on
+    current data → no drift expected. Skipped per the loop rule (not a
+    cheap measurement); operator can re-run if a model/data change later
+    warrants it.
+
+## FINAL SUMMARY — loop closed 2026-06-23
+**Arc: lifecycle live-consistency.** Trigger: operator asked whether
+editing a document keeps reasoning consistent; the probe (#1020) measured
+that live traversal IGNORED lifecycle status (cosmetic — only time-travel
+honored it). Fixed across every user-facing surface, measurement-gated.
+
+PRs: #1020 probe (deterministic measurement) · #1021 traversal status
+filter · #1022 log · #1023 graph-score · #1024 T1 validity-window · #1025
+time-travel isolation verify+pin + arc report · #1026 3D snapshot filter.
+
+Evidence: probe A/B kill-switch=3 leak / default=0, active retention 1.0
+(Pareto). STEP7/viz Δ=0 **structural** (current KG: 0 deactivated edges,
+0 non-null validity.to → filter is a no-op on existing data; it only acts
+once edges deactivate). ~68 deterministic tests green; all core/ < 20 KB;
+single env kill-switch `JAMES_DISABLE_STATUS_FILTER`.
+
+Remaining (NOT done, by design):
+- **Live LLM cascade dogfood** — operator-gated (mutates real KG/vector
+  store, mixtral non-deterministic). Manual verify steps in the iter2 log.
+- **Inbound / T6 causality** propagation — doc-level cascade territory.
+- **LLM-heavy measurement backlog** (D-alce/v0.2.3b/HR) — re-run only on a
+  model/data change.
+Consolidated report: `reports/research-runs/lifecycle-live-consistency-
+arc-20260622.md`. **No further wakeup scheduled.**


### PR DESCRIPTION
iter6: remaining relation surfaces (/admin/entities/{id}, /admin/graph/relation) return FULL relation dicts + frontmatter (status included) → legitimate detail/audit views, NOT leaks. No further deterministic consistency bug (honest negative). LLM-heavy backlog skipped (hours-long, no drift expected). Final loop summary in handover. Arc closed: #1020-#1026. ~68 tests green. docs-only.