### PR TITLE
chore(v0.6.1): backlog re-measure — D-alce drift (sampling variance)

### DIFF
--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -157,4 +157,26 @@ Remaining (NOT done, by design):
 - **LLM-heavy measurement backlog** (D-alce/v0.2.3b/HR) — re-run only on a
   model/data change.
 Consolidated report: `reports/research-runs/lifecycle-live-consistency-
-arc-20260622.md`. **No further wakeup scheduled.**
+arc-20260622.md`.
+
+## RE-OPENED 2026-06-23 — operator chose option 1: re-measure LLM backlog
+Loop resumed to explicitly re-run the LLM-heavy backlog vs the 2026-06-21
+baselines (drift check). Note: this session's status filter is in the
+LIVE query path the `james` SUT may use, so the LRB re-runs (HR / v0.2.3b)
+double as "did the filter move the supersede-sensitive numbers?" — D-alce
+is citation-only (untouched).
+
+- **iter-D DONE — D-alce re-run** (`alce_smoke_run.py --verifier
+  roberta-mnli --device cpu --model gemma4:e4b --n 20`):
+  precision **0.5849** / recall **0.6825** vs baseline 0.6239 / 0.7344
+  (Δ −0.039 / −0.052). The ALCE/citation path is untouched by this
+  session, and n=20 with no generation seed → this is **gemma4 sampling
+  variance, not code drift**. (Self-corrected a false "gemma4:e4b missing"
+  alarm — it was a list-truncation artifact; the model is present and was
+  used.) Result: `reports/external/alce/asqa-smoke-20260622T*.result.json`.
+- **iter-H IN PROGRESS — HR N=100 × 3 SUT × cross-NLI** (background;
+  `lrb_v024_hr_smoke.py --n 100 --sut all --model gemma4:e4b --verifiers
+  roberta,deberta`). Baseline: vanilla 0.492/0.400 · naive 0.425/0.364 ·
+  james 0.436/0.358. Log: `reports/research-runs/_hr_rerun_20260623.log`.
+- **iter-V PENDING — v0.2.3b 3-model** (`lrb_run_v023b_s3_cross_model.py`)
+  vs J−N +0.20 / temporal_acc 0.99-1.00. Heaviest (hours) — run after HR.


### PR DESCRIPTION
Operator opted to re-run the LLM backlog vs 2026-06-21 baselines. iter-D: D-alce precision 0.5849/recall 0.6825 vs 0.6239/0.7344 (Δ −0.039/−0.052) = gemma4 sampling variance (n=20, ALCE path untouched by this session). HR N=100 in progress; v0.2.3b pending. docs-only.