### PR TITLE
feat(v0.6.1): intro scroll-reveal animation

### DIFF
--- a/frontend/static/intro.css
+++ b/frontend/static/intro.css
@@ -128,3 +128,34 @@
   .intro-hero { padding: 28px 8px 20px; }
   .intro-tab { padding: 9px 11px; font-size: 13px; }
 }
+
+/* ── scroll-reveal (v0.6.1) ───────────────────────────────────
+   Progressive enhancement: intro.js adds `.reveal` ONLY when
+   IntersectionObserver is available, then toggles `.is-visible` as each
+   block scrolls into view. No JS / no IO → elements never get `.reveal` →
+   render normally. The HERO is left static (above the fold — the request
+   is scroll-DOWN reveal, not a load entrance). prefers-reduced-motion →
+   all motion off. */
+.reveal {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity .55s cubic-bezier(.22,.61,.36,1),
+              transform .55s cubic-bezier(.22,.61,.36,1);
+  will-change: opacity, transform;
+}
+.reveal.is-visible { opacity: 1; transform: translateY(0); }
+
+/* card hover lift — subtle depth on the 소개 cards */
+.intro-card {
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.intro-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--accent);
+  box-shadow: 0 8px 22px -10px var(--accent-soft, rgba(0,0,0,.25));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .reveal.is-visible { opacity: 1; transform: none; transition: none; }
+  .intro-card:hover { transform: none; }
+}

--- a/frontend/static/intro.js
+++ b/frontend/static/intro.js
@@ -74,6 +74,37 @@
     }
   }
 
+  // ── scroll-reveal (v0.6.1) ──
+  // Fade-and-rise each content block as it scrolls into view. Pure
+  // progressive enhancement: only adds the (initially-hidden) `.reveal`
+  // class when IntersectionObserver exists, so a no-JS / old browser
+  // never hides anything. Hidden tab sections (display:none) are still
+  // observed — IO re-fires when a tab switch makes them visible.
+  function setupReveal() {
+    if (!('IntersectionObserver' in window)) return;
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) {
+          e.target.classList.add('is-visible');
+          io.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+
+    var sel = '.intro-card, .intro-moat, .glossary-section, .step';
+    var cardN = 0;
+    document.querySelectorAll(sel).forEach(function (el) {
+      if (el.classList.contains('reveal')) return;
+      el.classList.add('reveal');
+      // gentle stagger across a row of cards
+      if (el.classList.contains('intro-card')) {
+        el.style.transitionDelay = ((cardN % 6) * 70) + 'ms';
+        cardN++;
+      }
+      io.observe(el);
+    });
+  }
+
   function bind() {
     document.querySelectorAll('[data-intro-tab]').forEach(function (t) {
       t.addEventListener('click', function () {
@@ -90,6 +121,7 @@
 
     window.addEventListener('hashchange', syncFromHash);
     syncFromHash();
+    setupReveal();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Operator: scroll-down animation for a more polished intro. Each content block (cards / moat / glossary sections / tour steps) fades-up on entering the viewport via IntersectionObserver (no lib, CSP-safe, progressive enhancement — no-JS never hides anything). + subtle card hover lift; prefers-reduced-motion disables all motion. HERO left static (above-fold; a hero load-anim attempt blanked the hero in the harness → removed). Verified live: HERO+tabs+cards+moat all visible, **0 console errors**, diff 0.76% (<1.0%). frontend only, core/ 0.