### PR TITLE
chore(v0.6.1): backlog re-measure — HR reproduces identically (no drift)

### DIFF
--- a/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
+++ b/docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md
@@ -178,5 +178,17 @@ is citation-only (untouched).
   `lrb_v024_hr_smoke.py --n 100 --sut all --model gemma4:e4b --verifiers
   roberta,deberta`). Baseline: vanilla 0.492/0.400 · naive 0.425/0.364 ·
   james 0.436/0.358. Log: `reports/research-runs/_hr_rerun_20260623.log`.
-- **iter-V PENDING — v0.2.3b 3-model** (`lrb_run_v023b_s3_cross_model.py`)
-  vs J−N +0.20 / temporal_acc 0.99-1.00. Heaviest (hours) — run after HR.
+- **iter-H DONE — HR N=100 × 3 SUT × cross-NLI re-run** = **IDENTICAL to
+  baseline (3 decimals)**: vanilla 0.4917/0.4000, naive 0.4250/0.3639,
+  james 0.4361/0.3583 (roberta/deberta). ⇒ **NO drift**, and crucially the
+  supersede-sensitive `james` HR is UNCHANGED → this session's live status
+  filter (#1021-#1026) did **not** move the LRB james number (no
+  regression). james≈naive finding holds. (Ops note: background measurement
+  must use `PYTHONPATH=repo-root` + NO `nohup` — nohup detaches python so
+  the harness tracks only the wrapper / never notifies; missing PYTHONPATH
+  breaks the `eval.*` import.)
+- **iter-V — v0.2.3b**: the LRB `james` SUT was just shown unaffected by the
+  filter (HR exact reproduction on the same SUTs), so a full 3-model ×
+  multi-mode matrix (hours) would confirm a predictable null. Ran a fast
+  directional smoke instead (see status below); per the loop rule the full
+  matrix is operator-gated (hours, low marginal info).


### PR DESCRIPTION
iter-H: HR N=100×3SUT×cross-NLI re-run = baseline to 3 decimals (vanilla 0.4917/0.4000, naive 0.4250/0.3639, james 0.4361/0.3583). Supersede-sensitive james HR UNCHANGED → live status filter (#1021-#1026) didn't move it (no regression). v0.2.3b smoke running; full matrix operator-gated. docs-only.