### PR TITLE
chore(v0.6.1): backlog re-measure raw result JSONs

### DIFF
--- a/reports/external/alce/asqa-smoke-20260622T184346Z.result.json
+++ b/reports/external/alce/asqa-smoke-20260622T184346Z.result.json
@@ -1,0 +1,235 @@
+{
+  "benchmark": "alce-asqa",
+  "loader": "alce-asqa",
+  "producer": "alce-closed-corpus",
+  "split": "dev",
+  "n_queries": 20,
+  "n_rows": 20,
+  "n_errors": 0,
+  "elapsed_s": 72.594,
+  "started_at": "2026-06-22T18:42:34.322081+00:00",
+  "axes": [
+    {
+      "name": "citation_precision",
+      "score": 0.5849,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.6,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 0.3333,
+        "alce-asqa--881464876144297194": 0.5,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.0,
+        "alce-asqa--3322598412088356524": 0.1667,
+        "alce-asqa--4633355453516911545": 0.8,
+        "alce-asqa--7464414779466400769": 0.2857,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 0.5,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.4,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.2,
+        "alce-asqa--6617858863213285972": 0.3333,
+        "alce-asqa--7031499911070053371": 0.0,
+        "alce-asqa--2419910984507145175": 0.6,
+        "alce-asqa-3228155858422343609": 0.6
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    },
+    {
+      "name": "citation_recall",
+      "score": 0.6825,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.75,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 0.5,
+        "alce-asqa--881464876144297194": 0.6667,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.0,
+        "alce-asqa--3322598412088356524": 0.5,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.25,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 0.5,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.5,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.3333,
+        "alce-asqa--6617858863213285972": 0.5,
+        "alce-asqa--7031499911070053371": 0.0,
+        "alce-asqa--2419910984507145175": 1.0,
+        "alce-asqa-3228155858422343609": 0.6667
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    }
+  ],
+  "rows": [
+    {
+      "id": "alce-asqa--7013890438520559398",
+      "answer": "The search results provide varying information regarding the highest number of goals scored in world football [1][2]. For instance, Pelé's 1281 goals are acknowledged by FIFA as the highest total for a professional footballer, though the Soccer Statistic Foundation (rssf) only recognizes 767 goals, placing him third behind Josef Bican and Romario [1]. Conversely, the Rec.Sport.Soccer Statistics Foundation (RSSSF) estimates that Josef Bican scored at least 805 goals in all competitive matches, which would make him the most prolific scorer of all time [5]. Additionally, Godfrey Chitalu's record is mentioned, with the Football Association of Zambia claiming he scored 116 goals during the 1972 calendar year and 107 during the 1972 season, though FIFA stated they would not ratify such records for domestic competitions [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7089015503030534342",
+      "answer": "The song \"The Sound of Silence,\" which was originally titled \"The Sounds of Silence,\" is by the American music duo Simon & Garfunkel [1][3]. Paul Simon wrote the song over several months spanning 1963 and 1964 [1][3]. The acoustic version of the song appeared on the album *Wednesday Morning, 3 A.M.* [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-8793099883447006698",
+      "answer": "The first Apple iPhone was officially announced on January 9, 2007 [1][2][4]. Following its announcement at the Macworld convention, the initial version of the iPhone became publicly available on June 29, 2007, in select markets [2][3][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--881464876144297194",
+      "answer": "The identical twin British actors James and Oliver Phelps are best known for portraying Fred and George Weasley in the *Harry Potter* film series [1][4]. The twins were cast as Fred and George Weasley after auditioning when they were 14 years old, despite having no prior acting experience [3]. Specifically, the Phelps brothers played Fred and George respectively throughout the films [5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1650309494326541834",
+      "answer": "Virginia has 34 state parks [1][2]. These state parks, along with 17 state forests, are managed by the Department of Conservation and Recreation and the Department of Forestry [1][2]. Historically, Virginia's initial six state parks were established in June 1936 [3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-2378678654868379935",
+      "answer": "The provided search results detail performers for different years' Champions League finals, but they specifically mention performances for the 2016 and 2017 finals [1][3]. For the 2018 UEFA Champions League Final, which took place at the NSC Olimpiyskiy Stadium in Kiev, Ukraine on May 26, 2018, no specific performers are listed in the search results [4]. However, other years featured notable performances; for instance, Alicia Keys performed at the opening ceremony before the 2016 final, and Andrea Bocelli sang the UEFA Champions League Anthem that year [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--3322598412088356524",
+      "answer": "The provided search results do not contain information specifying who killed a man in *Thelma & Louise* [1][2][3][4][5]. However, one document mentions that the killer at the scene of Lindsay's death was Richard Thompson, whose real name is Marcus Andrews, and this individual killed both Thelma and police Captain Howard Cheney [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--4633355453516911545",
+      "answer": "Charlie Day portrays Charlie Kelly, a fictional character on the FX series *It's Always Sunny in Philadelphia* [1][2]. This character is co-owner of Paddy's and a childhood friend to Mac and Dennis [1][2]. The sitcom follows \"The Gang,\" which includes Charlie, as they are depicted as debauched friends who operate an Irish bar in South Philadelphia [3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7464414779466400769",
+      "answer": "The provided search results offer varying information regarding the total number of times the Lakers have won the finals, but they do mention specific instances of victories [1][2]. For example, one source notes that the two teams (Lakers and Celtics) have a combined 67 championships, with the Lakers having won 16 titles [1][2]. Another document states that the Lakers' 2010 championship win secured their 16th NBA title overall [4]. Furthermore, another account mentions the Lakers winning in 2010 after defeating the Celtics in a series where they rallied from a 3–2 deficit to win in seven games [4][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1562758409663917015",
+      "answer": "The Congress party (INC) holds majority support in several Indian states, including Punjab, Chhattisgarh, Rajasthan, and Madhya Pradesh [2]. Furthermore, in Karnataka and Puducherry, the party shares power with its alliance partner, Janata Dal (Secular) and Dravida [2]. India is described as a federal union that comprises 29 states and 7 union territories [1][4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7813254335895169912",
+      "answer": "The provided search results mention different individuals associated with the role of Fruma Sarah in *Fiddler on the Roof*. In 1971, Ruth Madoc portrayed Fruma Sarah in the film adaptation of the musical [1]. Separately, another actress played the role of Fruma Sarah during the 2015-2016 Broadway Revival of *Fiddler on the Roof* [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-732619765350082410",
+      "answer": "Toronto hosted the MLB All-Star Game in 1991 [1]. Specifically, the 62nd Major League Baseball All-Star Game took place on July 9, 1991, at SkyDome, which was the home stadium for the Toronto Blue Jays of the American League [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-6962706727076805207",
+      "answer": "Law enforcement agencies utilize specialized vehicles known as bait cars, which can also be called decoy cars, hot cars, or trap cars [1][3]. These cars are designed to capture thieves who steal items from automobiles or car thieves generally [1][3]. The vehicles are equipped with audio and video surveillance technology that allows them to be remotely monitored and controlled [1][2][3].\n\nWhen set up to catch thieves, these bait cars may include GPS tracking [1][3]. Furthermore, a \"kill switch\" might be installed, enabling police to remotely lock all doors and disable the engine to prevent escape [1][3]. In some instances, the car may be disabled so that it cannot be started, and specially prepared \"bait property\" is included [2]. If the bait car is stolen, officers are immediately alerted and can control the vehicle by sending commands such as honking the horn, locking doors, or disabling the engine [2]. These operations can also function as part of a honey trap sting operation to encourage criminals to expose themselves [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3127369420834732535",
+      "answer": "The American reality television series *Jersey Shore* ran on MTV from December 3, 2009, until December 20, 2012 [1][2]. While one source notes that MTV renewed the series for a fourth and final season on April 24, 2014 [5], another document states that the show ran through December 20, 2012 [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--8056895208806271453",
+      "answer": "A plane crash storyline appeared in multiple seasons of *Grey's Anatomy*. Specifically, a plane crash was featured in \"Flight,\" which is the twenty-fourth and final episode of the eighth season [4]. Another instance involving a plane crash occurred in the eleventh season with the episode titled \"One Flight Down\" [2][3]. This later event brought patients to Grey Sloan Memorial and revisited memories of the tragic plane crash from season 8, which had resulted in the deaths of Mark Sloan and Lexie Grey [2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-4131723857510142703",
+      "answer": "The provided search results do not state the current number of branches for the Oriental Bank of Commerce [1][3]. However, one document mentions that after acquiring Global Trust Bank (GTB) on August 14, 2004, which brought 103 branches, OBC's total branch count increased to 1092 as of March 31, 2010 [1]. Additionally, another source notes that the Oriental Bank Corporation was a bank in India during the 19th century and expanded with opening branches [4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--6617858863213285972",
+      "answer": "The Rams relocated from Los Angeles to St. Louis in 1995 [2][3]. Specifically, owner Georgia Frontiere announced the move on January 15, 1995 [5]. This move occurred after the team played in the Greater Los Angeles Area for nearly 50 years [5]. The Rams played as the St. Louis Rams from 1995 through the 2015 seasons [2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7031499911070053371",
+      "answer": "The provided search results detail various milestones for the Voortrekkers organization but do not specify a single date for their arrival in South Africa [1][2][3]. However, one source mentions that a 1916 film depicts the Boers' Great Trek occurring toward the end of the 1830s [3]. Furthermore, another document notes that the commemoration of Jan van Riebeeck’s arrival in Table Bay in 1652 took place at a festival in Cape Town in 1952 [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--2419910984507145175",
+      "answer": "Heath Ledger portrayed the character of Patrick in the film *10 Things I Hate About You* [3][4]. In the story, Cameron attempts to convince Patrick to help him get around his father's strict dating rules regarding Bianca Stratford [4]. The character Patrick is depicted as a \"bad boy\" [4], and his name references the home of his relative character Petruchio [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3228155858422343609",
+      "answer": "The provided search results describe Microsoft's video editing software, which at times was known as Windows Live Movie Maker [1][2]. For instance, a standalone product called \"Windows Live Movie Maker 2009\" was released through the Windows Live Essentials suite on August 19, 2009 [4]. While some versions were part of suites like Windows Essentials [1][2], the search results do not explicitly state whether Microsoft Live Movie Maker was entirely free to use.",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    }
+  ],
+  "honest_tier": "research-tier: smoke n=20 with NLI adapter (roberta-mnli). STRONGER than string-containment fallback, but NOT ALCE-official-grade (T5-XXL TRUE NLI Mixture, GPU-only, remains deferred). Useful for cross-checking the fallback result and for paper methods cross-verifier robustness claims. Pre-reg: docs/research/cycle-gamma-c3-alce-smoke-preregistration-2026-06-11.md + docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md (verifier provenance).",
+  "verifier_grade": "research-tier-roberta-mnli",
+  "fixture_sha": "d72737ce7d46629d3504fc508f29ec0c270e0ddd5cff3fad69625d2c0e4be35b",
+  "n_docs_per_query": 5
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T193006Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T193006Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 336.7516,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.79,
+      "R@10": 0.8,
+      "P@5": 0.158,
+      "P@10": 0.08,
+      "latency_s_mean": 3.367474,
+      "token_cost_mean": 331.61,
+      "temporal_accuracy": 0.8,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.74,
+        "P@1": 0.74,
+        "temporal_accuracy_strict_top1": 0.74
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.2,
+        "R@10": 0.2,
+        "P@5": 0.04,
+        "P@10": 0.02,
+        "temporal_accuracy": 0.2,
+        "latency_s_mean": 3.384006,
+        "token_cost_mean": 341.4,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.350078,
+        "token_cost_mean": 323.5154,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.55,
+        "R@10": 0.6,
+        "P@5": 0.11,
+        "P@10": 0.06,
+        "temporal_accuracy": 0.6,
+        "latency_s_mean": 3.411611,
+        "token_cost_mean": 350.575,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.428571,
+        "R@10": 0.428571,
+        "P@5": 0.085714,
+        "P@10": 0.042857,
+        "temporal_accuracy": 0.428571,
+        "R@1": 0.285714
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.666667,
+        "R@10": 0.833333,
+        "P@5": 0.133333,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-22T19:41:28.201125+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T193006Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T193006Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 345.3366,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.97,
+      "R@10": 0.97,
+      "P@5": 0.194,
+      "P@10": 0.097,
+      "latency_s_mean": 3.453325,
+      "token_cost_mean": 332.7225,
+      "temporal_accuracy": 0.97,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.51,
+        "P@1": 0.51,
+        "temporal_accuracy_strict_top1": 0.51
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.933333,
+        "R@10": 0.933333,
+        "P@5": 0.186667,
+        "P@10": 0.093333,
+        "temporal_accuracy": 0.933333,
+        "latency_s_mean": 3.434195,
+        "token_cost_mean": 341.4333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.46829,
+        "token_cost_mean": 323.1077,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.9,
+        "R@10": 0.9,
+        "P@5": 0.18,
+        "P@10": 0.09,
+        "temporal_accuracy": 0.9,
+        "latency_s_mean": 3.419035,
+        "token_cost_mean": 357.4375,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.142857
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.166667
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.857143,
+        "R@10": 0.857143,
+        "P@5": 0.171429,
+        "P@10": 0.085714,
+        "temporal_accuracy": 0.857143,
+        "R@1": 0.857143
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.375
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.866667
+      }
+    }
+  },
+  "started_at": "2026-06-22T19:35:51.445202+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "james",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 328.978,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.99,
+      "R@10": 0.99,
+      "P@5": 0.198,
+      "P@10": 0.099,
+      "latency_s_mean": 3.289739,
+      "token_cost_mean": 347.3075,
+      "temporal_accuracy": 0.99,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.95,
+        "P@1": 0.95,
+        "temporal_accuracy_strict_top1": 0.95
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.433467,
+        "token_cost_mean": 408.1333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.2208,
+        "token_cost_mean": 323.5154,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.95,
+        "R@10": 0.95,
+        "P@5": 0.19,
+        "P@10": 0.095,
+        "temporal_accuracy": 0.95,
+        "latency_s_mean": 3.405997,
+        "token_cost_mean": 379.0125,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.666667
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.875
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-22T20:02:57.516218+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 337.1009,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.79,
+      "R@10": 0.8,
+      "P@5": 0.158,
+      "P@10": 0.08,
+      "latency_s_mean": 3.370967,
+      "token_cost_mean": 331.61,
+      "temporal_accuracy": 0.8,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.74,
+        "P@1": 0.74,
+        "temporal_accuracy_strict_top1": 0.74
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.2,
+        "R@10": 0.2,
+        "P@5": 0.04,
+        "P@10": 0.02,
+        "temporal_accuracy": 0.2,
+        "latency_s_mean": 3.380258,
+        "token_cost_mean": 341.4,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.350079,
+        "token_cost_mean": 323.5154,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.55,
+        "R@10": 0.6,
+        "P@5": 0.11,
+        "P@10": 0.06,
+        "temporal_accuracy": 0.6,
+        "latency_s_mean": 3.431884,
+        "token_cost_mean": 350.575,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.833333
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.428571,
+        "R@10": 0.428571,
+        "P@5": 0.085714,
+        "P@10": 0.042857,
+        "temporal_accuracy": 0.428571,
+        "R@1": 0.285714
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.666667,
+        "R@10": 0.833333,
+        "P@5": 0.133333,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-06-22T19:57:28.534225+00:00"
+}

--- a/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-smoke-gemma4-e4b-llm-grounded-20260622T194611Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-smoke",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "smoke",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 100,
+  "elapsed_s": 339.4933,
+  "fixture_sha": "1f221bb130d24bae882cecc3f856aa10a16aa3ca96bdfc78caf5479cdc83a950",
+  "honest_tier": "v0.2.3b S3-smoke cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.97,
+      "R@10": 0.97,
+      "P@5": 0.194,
+      "P@10": 0.097,
+      "latency_s_mean": 3.394894,
+      "token_cost_mean": 332.7225,
+      "temporal_accuracy": 0.97,
+      "n": 100,
+      "exploratory": {
+        "R@1": 0.51,
+        "P@1": 0.51,
+        "temporal_accuracy_strict_top1": 0.51
+      }
+    },
+    "per_timestamp": {
+      "qt=24/vt=0": {
+        "R@5": 0.933333,
+        "R@10": 0.933333,
+        "P@5": 0.186667,
+        "P@10": 0.093333,
+        "temporal_accuracy": 0.933333,
+        "latency_s_mean": 3.439477,
+        "token_cost_mean": 341.4333,
+        "n": 15
+      },
+      "qt=24/vt=24": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.375741,
+        "token_cost_mean": 323.1077,
+        "n": 65
+      },
+      "qt=24/vt=8": {
+        "R@5": 0.9,
+        "R@10": 0.9,
+        "P@5": 0.18,
+        "P@10": 0.09,
+        "temporal_accuracy": 0.9,
+        "latency_s_mean": 3.423708,
+        "token_cost_mean": 357.4375,
+        "n": 20
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 14,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.142857
+      },
+      "current-director": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 12,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.166667
+      },
+      "historical-early-contract": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 7,
+        "R@5": 0.857143,
+        "R@10": 0.857143,
+        "P@5": 0.171429,
+        "P@10": 0.085714,
+        "temporal_accuracy": 0.857143,
+        "R@1": 0.857143
+      },
+      "historical-mid-director": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.333333
+      },
+      "historical-mid-policy": {
+        "n": 8,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.375
+      },
+      "historical-mid-project-lead": {
+        "n": 6,
+        "R@5": 0.833333,
+        "R@10": 0.833333,
+        "P@5": 0.166667,
+        "P@10": 0.083333,
+        "temporal_accuracy": 0.833333,
+        "R@1": 0.5
+      },
+      "never-stale-budget": {
+        "n": 15,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.866667
+      }
+    }
+  },
+  "started_at": "2026-06-22T19:51:51.429104+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.james-gemma4-e4b-deberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.james-gemma4-e4b-deberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "james",
+  "model": "gemma4:e4b",
+  "nli_verifier": "deberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.358333,
+    "n_queries": 60,
+    "n_claims_total": 85,
+    "n_entailed": 29,
+    "n_neutral": 12,
+    "n_contradicted": 44,
+    "n_empty_answers": 0,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "DebertaV3NliVerifier",
+    "elapsed_s": 511.4848
+  },
+  "started_at": "2026-06-22T19:26:58.299794+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.james-gemma4-e4b-roberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.james-gemma4-e4b-roberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "james",
+  "model": "gemma4:e4b",
+  "nli_verifier": "roberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.436111,
+    "n_queries": 60,
+    "n_claims_total": 85,
+    "n_entailed": 40,
+    "n_neutral": 8,
+    "n_contradicted": 37,
+    "n_empty_answers": 0,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "RobertaMnliVerifier",
+    "elapsed_s": 28.2
+  },
+  "started_at": "2026-06-22T19:03:05.058786+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.naive-supersede-gemma4-e4b-deberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.naive-supersede-gemma4-e4b-deberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "nli_verifier": "deberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.363889,
+    "n_queries": 60,
+    "n_claims_total": 86,
+    "n_entailed": 30,
+    "n_neutral": 12,
+    "n_contradicted": 44,
+    "n_empty_answers": 0,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "DebertaV3NliVerifier",
+    "elapsed_s": 482.106
+  },
+  "started_at": "2026-06-22T19:18:26.802641+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.naive-supersede-gemma4-e4b-roberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.naive-supersede-gemma4-e4b-roberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "nli_verifier": "roberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.425,
+    "n_queries": 60,
+    "n_claims_total": 86,
+    "n_entailed": 39,
+    "n_neutral": 8,
+    "n_contradicted": 39,
+    "n_empty_answers": 0,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "RobertaMnliVerifier",
+    "elapsed_s": 28.3821
+  },
+  "started_at": "2026-06-22T19:02:36.856022+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.vanilla-gemma4-e4b-deberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.vanilla-gemma4-e4b-deberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "nli_verifier": "deberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.4,
+    "n_queries": 60,
+    "n_claims_total": 75,
+    "n_entailed": 24,
+    "n_neutral": 14,
+    "n_contradicted": 37,
+    "n_empty_answers": 8,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "DebertaV3NliVerifier",
+    "elapsed_s": 439.6327
+  },
+  "started_at": "2026-06-22T19:10:24.694236+00:00"
+}

--- a/reports/external/lrb/v024-hr-smoke-20260622T184938Z.vanilla-gemma4-e4b-roberta.result.json
+++ b/reports/external/lrb/v024-hr-smoke-20260622T184938Z.vanilla-gemma4-e4b-roberta.result.json
@@ -1,0 +1,23 @@
+{
+  "benchmark": "lrb-v024-hr-smoke",
+  "scenario": "S1",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "nli_verifier": "roberta",
+  "n_queries": 100,
+  "t_week": 12,
+  "honest_tier": "v0.2.4 HR smoke (n=<=20). Validates end-to-end pipeline (answer gen + claim extract + NLI). NOT publication. Cross-NLI agreement check requires running both verifiers.",
+  "axes": {
+    "HR_mean": 0.491667,
+    "n_queries": 60,
+    "n_claims_total": 75,
+    "n_entailed": 35,
+    "n_neutral": 3,
+    "n_contradicted": 37,
+    "n_empty_answers": 8,
+    "context_truncated_count": 0,
+    "nli_verifier_id": "RobertaMnliVerifier",
+    "elapsed_s": 31.5249
+  },
+  "started_at": "2026-06-22T19:02:08.471793+00:00"
+}


### PR DESCRIPTION
Raw artifacts behind the LLM-backlog re-measurement (#1028/#1030/#1031) — same tracked category as the existing 65 lrb result JSONs. D-alce 184346Z + HR 184938Z ×6 + v0.2.3b 194611Z ×3 (complete) + 193006Z ×2 (timed-out partial, honest record). Verdict: no regression. data-only.