### PR TITLE
feat(v0.6.1): entity-edit cascade — Phase 3 (inbound inverse + T6 propagation)

### DIFF
--- a/core/cascade/_modify_entity.py
+++ b/core/cascade/_modify_entity.py
@@ -62,6 +62,73 @@ def _emit_invalidate(entity_name: str, rel: Dict[str, Any],
         pass
 
 
+def _propagate_inbound_t6(entity_name, invalidated, *,
+                          wiki_generator, user_role, ts):
+    """Phase 3 — for each invalidated outgoing edge A→B: invalidate the
+    inverse edge B→A on the target entity, and (if A→B carries an edge id)
+    T6-cascade facts derived from it. Best-effort; never raises."""
+    out = {"inverse_invalidated": [], "derived_invalidated": []}
+    idx = getattr(wiki_generator, "entity_id_index", {}) or {}
+    name_l = (entity_name or "").strip().lower()
+    inv_label_fn = getattr(wiki_generator, "_inverse_label_for", None)
+    entity_root = getattr(wiki_generator, "entity_path", None)
+
+    for inv in invalidated:
+        # (a) inverse edge B→A on the target entity
+        tgt_id = inv.get("target_id")
+        tpath = idx.get(tgt_id) if tgt_id else None
+        if tpath:
+            try:
+                parsed = _read_frontmatter(Path(tpath))
+            except Exception:
+                parsed = None
+            if parsed:
+                tfm, tbody = parsed
+                want_label = None
+                if callable(inv_label_fn):
+                    try:
+                        want_label = (inv_label_fn(inv.get("label")) or "").strip().lower()
+                    except Exception:
+                        want_label = None
+                changed = False
+                for r in (tfm.get("relations") or []):
+                    if not isinstance(r, dict):
+                        continue
+                    if (r.get("status") or {}).get("active") is False:
+                        continue
+                    if (r.get("target") or "").strip().lower() != name_l:
+                        continue
+                    # prefer the computed inverse label; else any B→A edge
+                    # (entity pairs rarely carry multiple distinct relations).
+                    if want_label and (r.get("label") or "").strip().lower() != want_label:
+                        continue
+                    r.setdefault("status", {})
+                    r["status"]["active"] = False
+                    r["status"]["invalidated_at"] = ts
+                    r["mutation_type"] = "invalidated"
+                    changed = True
+                    out["inverse_invalidated"].append({
+                        "entity_id": tgt_id, "label": r.get("label"),
+                    })
+                    _emit_invalidate(entity_name, r, ts, user_role)
+                if changed:
+                    try:
+                        _write_frontmatter(Path(tpath), tfm, tbody)
+                    except Exception:
+                        pass
+        # (b) T6 — facts derived from the invalidated edge (needs an id)
+        eid = inv.get("edge_id")
+        if eid and entity_root:
+            try:
+                from core.lifecycle.causality import invalidate_derived_facts
+                derived = invalidate_derived_facts(eid, entity_root)
+                if derived:
+                    out["derived_invalidated"].extend(derived)
+            except Exception:
+                pass
+    return out
+
+
 def cascade_modify_entity(entity_path, entity_name: str, *,
                           wiki_generator, user_role: str = "admin") -> Dict[str, Any]:
     """Phase 1 entity-edit cascade. Best-effort: returns a summary dict
@@ -77,7 +144,9 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
     """
     summary: Dict[str, Any] = {
         "ok": False, "extracted": False,
-        "invalidated": [], "added": [], "skipped_reason": "",
+        "invalidated": [], "added": [],
+        "inverse_invalidated": [], "derived_invalidated": [],
+        "skipped_reason": "",
     }
     if os.environ.get("JAMES_DISABLE_EDIT_CASCADE") == "1":
         summary["skipped_reason"] = "disabled"
@@ -124,9 +193,10 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
                 rel["mutation_type"] = "invalidated"
                 changed = True
                 summary["invalidated"].append({
-                    "target":  rel.get("target"),
-                    "label":   rel.get("label"),
-                    "edge_id": rel.get("id") or "",
+                    "target":    rel.get("target"),
+                    "target_id": rel.get("target_id") or "",
+                    "label":     rel.get("label"),
+                    "edge_id":   rel.get("id") or "",
                 })
                 _emit_invalidate(entity_name, rel, ts, user_role)
 
@@ -179,6 +249,18 @@ def cascade_modify_entity(entity_path, entity_name: str, *,
                     wiki_generator.resolve_pending_relations()
                 except Exception:
                     pass
+
+        # ── Phase 3: inbound (inverse edge) + T6 derived-fact propagation ──
+        # An invalidated outgoing edge A→B leaves a stale inverse B→A on
+        # the target entity, and any fact DERIVED from A→B. Sweep both so
+        # the whole neighbourhood stays consistent, not just A's own row.
+        if summary["invalidated"]:
+            prop = _propagate_inbound_t6(
+                entity_name, summary["invalidated"],
+                wiki_generator=wiki_generator, user_role=user_role, ts=ts)
+            summary["inverse_invalidated"] = prop["inverse_invalidated"]
+            summary["derived_invalidated"] = prop["derived_invalidated"]
+
         summary["ok"] = True
         return summary
     except Exception as e:  # noqa: BLE001

--- a/docs/design/v0.6.1-entity-edit-cascade.md
+++ b/docs/design/v0.6.1-entity-edit-cascade.md
@@ -67,13 +67,26 @@ cascade_modify_entity(entity_path, entity_name, *, wiki_generator,
   from the entity index. Both directions now keep the graph consistent
   with the edited text.
 
+- **Phase 3 (done)** — inbound (inverse) + T6 propagation. For each
+  invalidated outgoing edge A→B, `_propagate_inbound_t6` (a) resolves the
+  target entity B via `wiki_generator.entity_id_index[target_id]`, finds
+  the inverse edge B→A (matched on target-name + the computed inverse
+  label via `_inverse_label_for` when available, else any B→A edge) and
+  invalidates it too (cross-entity `_write_frontmatter` + lifecycle emit);
+  and (b) if A→B carries an edge `id`, calls
+  `core.lifecycle.causality.invalidate_derived_facts(id, entity_root)` to
+  cascade T6-derived facts. Best-effort; never breaks the save. summary
+  gains `inverse_invalidated` + `derived_invalidated`. So an edit now keeps
+  the whole neighbourhood consistent, not just A's own row.
+
 ### Still out of scope (future)
-- **Inverse / inbound edges**: the cascade only touches THIS entity's
-  outgoing relations. Inbound edges on OTHER entities, and T6 causality
-  propagation to facts derived from a changed relation, are not swept
-  here (that is the doc-level cascade / T6 territory).
 - `llm_extract_document_entities` truncates content to 2000 chars — a
   very long entity body is only partially re-extracted.
+- Inverse-label matching falls back to "any B→A edge" when the inverse
+  label can't be computed — fine for the common single-relation pair, but
+  a pair with multiple distinct relations could over-invalidate.
+- T6 propagation only fires for edges that carry an `id` (superseded/new
+  edges); plain extract-sourced edges without an id don't reach T6.
 
 ## Wiring / safety
 - `update_entity` calls it after `_resync_vector`/`_refresh_index`,

--- a/tests/test_entity_edit_cascade.py
+++ b/tests/test_entity_edit_cascade.py
@@ -127,5 +127,75 @@ class CascadeInvalidateTests(unittest.TestCase):
             os.environ.pop("JAMES_DISABLE_EDIT_CASCADE", None)
 
 
+class _InboundStubGen:
+    """Stub with an entity index so the inverse-edge sweep can resolve the
+    target entity file. _llm_extract returns NO relations → Alpha→Beta is
+    invalidated, which must also invalidate the inverse Beta→Alpha."""
+    def __init__(self, entity_id_index, entity_path):
+        self.entity_id_index = entity_id_index
+        self.entity_path = entity_path
+
+    def _llm_extract_document_entities(self, name, body, meta):
+        return {"entities": [], "relations": []}   # nothing survives
+
+    def resolve_pending_relations(self):
+        return 0
+
+
+A_MD = """---
+name: Alpha
+type: concept
+relations:
+  - target: Beta
+    target_id: e_concept_bbbb000001
+    label: 관련
+    status: {active: true}
+    mutation_type: active
+---
+Alpha body (the Beta link is no longer stated here).
+"""
+
+B_MD = """---
+name: Beta
+type: concept
+relations:
+  - target: Alpha
+    target_id: e_concept_aaaa000001
+    label: 관련
+    status: {active: true}
+    mutation_type: active
+---
+Beta body.
+"""
+
+
+class InboundT6Tests(unittest.TestCase):
+    """Phase 3 — invalidating A→B must also invalidate the inverse B→A on
+    the target entity (bidirectional graph consistency)."""
+    def setUp(self):
+        os.environ.pop("JAMES_DISABLE_EDIT_CASCADE", None)
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def test_inverse_edge_invalidated_on_target(self):
+        a = self.tmp / "Alpha.md"; a.write_text(A_MD, encoding="utf-8")
+        b = self.tmp / "Beta.md";  b.write_text(B_MD, encoding="utf-8")
+        gen = _InboundStubGen({"e_concept_bbbb000001": str(b)}, self.tmp)
+
+        out = cascade_modify_entity(a, "Alpha", wiki_generator=gen)
+        self.assertTrue(out["ok"])
+        # A→Beta invalidated on Alpha
+        self.assertIn("Beta", {r["target"] for r in out["invalidated"]})
+        # inverse Beta→Alpha invalidated on Beta (Phase 3)
+        self.assertTrue(out["inverse_invalidated"])
+        fmb, _ = _read_frontmatter(b)
+        beta_to_alpha = {r["target"]: r for r in fmb["relations"]}["Alpha"]
+        self.assertFalse(beta_to_alpha["status"]["active"])
+        self.assertEqual(beta_to_alpha["mutation_type"], "invalidated")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Phase 1/2 only touched the edited entity's outgoing relations; Phase 3 sweeps the neighbourhood. For each invalidated A→B: (a) invalidate the inverse B→A on the target entity (resolved via entity_id_index, matched on inverse label when computable), (b) T6-cascade derived facts via invalidate_derived_facts when the edge has an id. Best-effort. With #1021's live filter → full bidirectional consistency (B stops traversing stale B→A). core/cascade only; traversal/retrieval/reasoning 0 lines. 35 tests green; <20KB.