### PR TITLE
feat(v0.6.1): surface edit-cascade result in 추론편집 modal

### DIFF
--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -961,10 +961,12 @@ async function wikiEditApply() {
   const btn = document.getElementById('we-apply-btn');
   if (btn) { btn.disabled = true; btn.textContent = '적용 중…'; }
   try {
-    await _crPost('/admin/wiki/edit/apply', {
+    const res = await _crPost('/admin/wiki/edit/apply', {
       name, new_body: newBody, base_hash: _weBaseHash,
     });
-    toast(`✅ 적용 완료: ${name}`, 'success');
+    // v0.6.1 — surface the cascade result (관계 무효화/추가/역방향/파생)
+    // returned by update_entity so the operator sees what the edit did.
+    toast((res && res.message) ? res.message : `✅ 적용 완료: ${name}`, 'success');
     closeWikiEdit();
     if (_currentTab === 'data') reloadData();
   } catch (e) {

--- a/tools/wiki/wiki_editor.py
+++ b/tools/wiki/wiki_editor.py
@@ -252,6 +252,10 @@ def update_entity(name: str, new_content: str,
         msg += f" · 관계 {len(casc['invalidated'])}개 무효화"
     if casc and casc.get("added"):
         msg += f" · 신규 관계 {len(casc['added'])}개 추가"
+    if casc and casc.get("inverse_invalidated"):
+        msg += f" · 역방향 {len(casc['inverse_invalidated'])}개"
+    if casc and casc.get("derived_invalidated"):
+        msg += f" · 파생 {len(casc['derived_invalidated'])}개"
     return True, msg
 
 


### PR DESCRIPTION
The cascade returns 관계 무효화/추가/역방향/파생; the apply endpoint passes it as `message`; but the modal showed only a generic toast. Now: update_entity message adds the Phase 3 counts (역방향/파생), and wikiEditApply toasts the response `message`. Closes the cascade feedback loop (#1018/#1019/#1033). frontend+tools, core/ 0. 5 cascade tests green.