### PR TITLE
fix(v0.6.1): agent uses registered folders + recover text-emitted tool calls

### DIFF
--- a/routes/agent_chat.py
+++ b/routes/agent_chat.py
@@ -15,7 +15,8 @@ runaway LLM can't drain the workspace.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import json
+from typing import Any, Dict, List, Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -31,6 +32,44 @@ router = APIRouter()
 
 MAX_ITERATIONS = 5
 DEFAULT_MAX_TOKENS = 1024
+
+
+def _extract_text_tool_call(text: str, tool_names: Set[str]) -> Optional[Dict[str, Any]]:
+    """Recover a tool call that a model emitted as plain JSON *text*
+    instead of a structured tool_call.
+
+    Some local models (e.g. ``qwen2.5-coder`` via Ollama) narrate the
+    call — ``{"name": "list_files", "arguments": {...}}`` — in the
+    message content rather than using the native tool-calling channel, so
+    ``tool_calls`` comes back empty and nothing dispatches. This scans the
+    text for a JSON object whose ``name`` is one of the known tools and
+    whose args live under ``arguments`` / ``parameters`` / ``input``.
+    Returns a normalised ``{id, name, input}`` or ``None``.
+    """
+    if not text:
+        return None
+    dec = json.JSONDecoder()
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] != "{":
+            i += 1
+            continue
+        try:
+            obj, end = dec.raw_decode(text, i)
+        except ValueError:
+            i += 1
+            continue
+        i = end
+        if isinstance(obj, dict):
+            name = obj.get("name")
+            args = obj.get("arguments")
+            if args is None:
+                args = obj.get("parameters")
+            if args is None:
+                args = obj.get("input")
+            if name in tool_names and isinstance(args, dict):
+                return {"id": "text-fallback", "name": name, "input": args}
+    return None
 
 
 class AgentChatRequest(BaseModel):
@@ -78,12 +117,32 @@ async def agent_chat_route(
         t for t in list_tools() if t.name != "run_shell" or _shell_on
     ]
     tools_schema = tools_to_schema(visible_tools)
+    _tool_names: Set[str] = {t.name for t in visible_tools}
     max_tokens = max(64, min(int(body.max_tokens or DEFAULT_MAX_TOKENS), 4096))
+
+    # The model can't guess which folders it is allowed to touch — tell it
+    # the registered absolute paths explicitly, so it uses a real path
+    # (e.g. C:\Project\foo) instead of a placeholder like
+    # "<provide-absolute-path>".
+    try:
+        from tools.code.sandbox import get_user_registered_paths
+        _allowed = get_user_registered_paths()
+    except Exception:
+        _allowed = []
+    _folders_line = (
+        " The operator has allowed these absolute folders — use one of "
+        "these EXACT paths for the 'path'/'cwd' argument, never a "
+        "placeholder: " + "; ".join(_allowed) + "."
+        if _allowed else
+        " No folders are registered yet — tell the operator to register a "
+        "folder on this page before you can read or edit files."
+    )
     system = body.system or (
         "You are JAMES, an auditable knowledge platform's agent. You may "
         "call the listed tools to inspect and modify files in the "
-        "operator-allowed folders. Do not invent file paths; ask the "
-        "user when uncertain. Keep responses concise."
+        "operator-allowed folders. Do not invent file paths; use the "
+        "allowed folders below. Keep responses concise."
+        + _folders_line
         + (
             " You also have run_shell: it runs a shell command in an "
             "operator-allowed folder (pass an absolute 'cwd' inside an "
@@ -119,6 +178,16 @@ async def agent_chat_route(
         stop_reason = resp.get("stop_reason") or "end_turn"
         final_text = resp.get("text") or final_text
         calls = resp.get("tool_calls") or []
+
+        # Fallback: a model that narrated a tool call as JSON text (no
+        # native tool_call) — recover + dispatch it so the file op still
+        # runs, and don't echo the raw JSON to the user.
+        if not calls:
+            fb = _extract_text_tool_call(resp.get("text") or "", _tool_names)
+            if fb:
+                calls = [fb]
+                stop_reason = "tool_use"
+                final_text = ""
 
         if not calls or stop_reason != "tool_use":
             break

--- a/tests/test_v06_agent_tools.py
+++ b/tests/test_v06_agent_tools.py
@@ -8,6 +8,7 @@ Run:
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sys
@@ -135,12 +136,16 @@ class BackendFactoryTests(unittest.TestCase):
         self._prev_c = os.environ.pop("JAMES_AGENT_ALLOW_CLOUD", None)
 
     def tearDown(self):
-        if self._prev_b is not None:
-            os.environ["JAMES_AGENT_BACKEND"] = self._prev_b
-        if self._prev_k is not None:
-            os.environ["ANTHROPIC_API_KEY"] = self._prev_k
-        if self._prev_c is not None:
-            os.environ["JAMES_AGENT_ALLOW_CLOUD"] = self._prev_c
+        # Restore the prior value, OR remove the var entirely if it
+        # wasn't set before — otherwise an env we added (e.g.
+        # JAMES_AGENT_BACKEND=anthropic) leaks into later test classes.
+        for var, prev in (("JAMES_AGENT_BACKEND", self._prev_b),
+                          ("ANTHROPIC_API_KEY", self._prev_k),
+                          ("JAMES_AGENT_ALLOW_CLOUD", self._prev_c)):
+            if prev is not None:
+                os.environ[var] = prev
+            else:
+                os.environ.pop(var, None)
 
     def test_default_is_ollama(self):
         from core.agent_tools.backends import get_backend, OllamaBackend
@@ -281,6 +286,97 @@ class AgentChatEndpointTests(unittest.TestCase):
         # And the file actually got written:
         with open(target, encoding="utf-8") as f:
             self.assertEqual(f.read(), "hi from agent")
+
+
+class TextToolCallFallbackTests(unittest.TestCase):
+    """A model that narrates a tool call as JSON text (no native
+    tool_call) must still be recovered + dispatched."""
+
+    def test_extract_arguments_key(self):
+        from routes.agent_chat import _extract_text_tool_call
+        txt = 'Sure: ' + json.dumps(
+            {"name": "list_files", "arguments": {"path": "C:\\x"}})
+        fb = _extract_text_tool_call(txt, {"list_files"})
+        self.assertEqual(fb["name"], "list_files")
+        self.assertEqual(fb["input"]["path"], "C:\\x")
+
+    def test_extract_parameters_and_input_keys(self):
+        from routes.agent_chat import _extract_text_tool_call
+        a = _extract_text_tool_call(
+            json.dumps({"name": "read_file", "parameters": {"path": "a"}}),
+            {"read_file"})
+        self.assertEqual(a["input"]["path"], "a")
+        b = _extract_text_tool_call(
+            json.dumps({"name": "read_file", "input": {"path": "b"}}),
+            {"read_file"})
+        self.assertEqual(b["input"]["path"], "b")
+
+    def test_extract_unknown_name_is_none(self):
+        from routes.agent_chat import _extract_text_tool_call
+        self.assertIsNone(_extract_text_tool_call(
+            json.dumps({"name": "nope", "arguments": {}}), {"list_files"}))
+
+    def test_extract_plain_text_is_none(self):
+        from routes.agent_chat import _extract_text_tool_call
+        self.assertIsNone(_extract_text_tool_call("just a normal answer", {"list_files"}))
+
+
+class TextFallbackEndpointTests(unittest.TestCase):
+    def setUp(self):
+        _reset_sandbox_state()
+        self._tmp = tempfile.mkdtemp(prefix="james_fb_")
+        from tools.code.sandbox import register_user_path
+        register_user_path(self._tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        _reset_sandbox_state()
+
+    def test_text_tool_call_is_dispatched(self):
+        client, ac = _make_client()
+        narrated = json.dumps(
+            {"name": "list_files", "arguments": {"path": self._tmp}})
+        fake = _FakeBackend(
+            {"stop_reason": "end_turn", "text": narrated,
+             "tool_calls": [], "raw": {}},
+            {"stop_reason": "end_turn", "text": "Here are the files.",
+             "tool_calls": [], "raw": {}},
+        )
+        import core.agent_tools.backends as be
+        orig = be.get_backend
+        be.get_backend = lambda name=None, model=None: fake
+        try:
+            r = client.post("/agent/chat/",
+                            json={"api_key": "x", "message": "list files"})
+        finally:
+            be.get_backend = orig
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(len(body["tool_trace"]), 1)
+        self.assertEqual(body["tool_trace"][0]["name"], "list_files")
+        self.assertTrue(body["tool_trace"][0]["ok"], body["tool_trace"])
+
+    def test_system_prompt_lists_allowed_folders(self):
+        client, ac = _make_client()
+
+        class _Cap:
+            name = "cap"
+            def __init__(self): self.system = None
+            def chat_with_tools(self, messages, tools, *, system=None, max_tokens=1024):
+                self.system = system
+                return {"stop_reason": "end_turn", "text": "ok",
+                        "tool_calls": [], "raw": {}}
+
+        cap = _Cap()
+        import core.agent_tools.backends as be
+        orig = be.get_backend
+        be.get_backend = lambda name=None, model=None: cap
+        try:
+            client.post("/agent/chat/", json={"api_key": "x", "message": "hi"})
+        finally:
+            be.get_backend = orig
+        self.assertIsNotNone(cap.system)
+        self.assertIn(self._tmp, cap.system)
 
 
 class ServerRegistrationTests(unittest.TestCase):

--- a/tests/test_v06_agent_ux.py
+++ b/tests/test_v06_agent_ux.py
@@ -91,11 +91,16 @@ class LLMSettingsTests(unittest.TestCase):
         self._orig = llm._list_installed_ollama_models
         llm._list_installed_ollama_models = lambda: {"mxtral:latest", "gemma3:12b"}
         os.environ["JAMES_SETTINGS_USE_DB"] = "0"   # env/default, no DB writes
+        # Defensive: ensure no leaked agent-backend env from another test
+        # class makes ls.get("agent_backend") resolve to non-default.
+        self._prev_be = os.environ.pop("JAMES_AGENT_BACKEND", None)
 
     def tearDown(self):
         import routes.llm as llm
         llm._list_installed_ollama_models = self._orig
         os.environ.pop("JAMES_SETTINGS_USE_DB", None)
+        if self._prev_be is not None:
+            os.environ["JAMES_AGENT_BACKEND"] = self._prev_be
 
     def test_get_returns_models_and_defaults(self):
         c = _make_client()


### PR DESCRIPTION
## Summary
Operator dogfooding (mobile) caught two reasons the agent appeared not to work after registering a folder — the folder **was** registered (`C:\Project\aduino` showed in the list), but:

1. **The agent never knew the allowed folder paths.** The system prompt said "do not invent file paths" but never listed them, so the model emitted a placeholder `{"path": "<provide-absolute-path>"}`. **Fix:** inject the registered absolute paths (`get_user_registered_paths`) into the system prompt — *"use one of these EXACT paths…"*. When none are registered, the prompt tells the model to ask the operator to register one.

2. **`qwen2.5-coder:32b` narrated the tool call as plain JSON text** instead of using Ollama's native `tool_calls` channel → `tool_calls` empty → nothing dispatched → raw JSON shown to the user. **Fix:** `_extract_text_tool_call()` recovers a tool call from the assistant text (JSON object whose `name` is a known tool, args under `arguments`/`parameters`/`input`); the loop dispatches it and no longer echoes the raw JSON. (`mxtral:latest`, the default, does native tool calls and is still recommended for multi-step.)

Also fixes a pre-existing **test-isolation leak**: `BackendFactoryTests.tearDown` didn't remove `JAMES_AGENT_BACKEND` when it wasn't set before, leaking `"anthropic"` into later test classes.

## Verification
- New tests: `TextToolCallFallbackTests` (parse arguments/parameters/input, unknown-name → None, plain text → None) + `TextFallbackEndpointTests` (text tool call dispatched; system prompt lists allowed folders).
- Full agent suite (tools + shell + ux + paths) = 74 green; `test_measurement_critical_surfaces` = 33 green.

## Out of scope
- Models that emit malformed/partial JSON still won't dispatch; for reliable multi-step, use a native-tool model (mxtral:latest default).

Quality delta: exempt (label: fix) — wiring/measurement-side correction; `core/retrieval` + `core/graph` traversal + `core/reasoning` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq