### PR TITLE
fix(v0.6.1): chat sidebar 에이전트 link → /admin#agent

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -128,7 +128,7 @@
            - 채팅  → current page (active by default)
            - 프로젝트 → /workspace
            - 추론 그래프 → /admin/graph
-           - 에이전트 → /admin#agent-chat
+           - 에이전트 → /admin#agent
            - 관리자 → /admin -->
     <!-- v0.6.1 v5 (2026-06-16) — operator catch: emoji icons (
          ) lowered the professional concept. Replaced with
@@ -182,7 +182,7 @@
         </span>
         <span class="sidebar-nav-label" data-i18n="sidebar.nav_graph">추론 그래프</span>
       </a>
-      <a href="/admin#agent-chat" class="sidebar-nav-row"
+      <a href="/admin#agent" class="sidebar-nav-row"
          data-i18n-title="sidebar.nav_agent_title"
          title="에이전트 챗 (자연어 도구 호출)">
         <span class="sidebar-nav-icon" aria-hidden="true">

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -323,11 +323,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     // The try/catch is just belt-and-suspenders so a non-auth
     // failure (network blip) doesn't pop the login modal.
   }
-  // v0.6.1 (2026-06-15) — chat-sidebar deep links (#agent-chat / #agent-
-  // folders / #...) jump straight to a page without going through the
-  // dashboard. The chat sidebar's "에이전트" / "추론 그래프" entries
-  // rely on this. Only fires for known page ids so a stray hash can't
-  // null-deref into a missing element.
+  // v0.6.1 — chat-sidebar deep links (#agent / #graph / #...) jump
+  // straight to a page without going through the dashboard. The chat
+  // sidebar's "에이전트" / "추론 그래프" entries rely on this. Only fires
+  // for known page ids so a stray hash can't null-deref into a missing
+  // element.
   _maybeApplyHashRoute();
 });
 


### PR DESCRIPTION
## Summary
The chat sidebar's **에이전트** entry linked to `/admin#agent-chat`, but the agent-folders + agent-chat pages were merged into one `page-agent` (#1040). The stale hash matched no `page-<id>`, so `_maybeApplyHashRoute` no-op'd and the user landed on the admin **dashboard** instead of the agent page.

Fix: point the link at `#agent` (which has both `page-agent` and the `data-page="agent"` nav-item) so it deep-links straight to the unified agent page. Updated the nav comment + the stale admin.js comment.

## Verification
- `page-agent` + `data-page="agent"` nav-item confirmed present; no remaining `page-agent-chat`/`page-agent-folders` ids.
- `node --check` clean.

Quality delta: exempt (label: fix) — frontend link only; core untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq