### PR TITLE
fix(v0.6.1): "그래프에서 이 추론 보기" reliably shows the trace trail

### DIFF
--- a/frontend/static/reasoning-flow.js
+++ b/frontend/static/reasoning-flow.js
@@ -436,7 +436,16 @@
         var ttApply = $('time-travel-trace-apply');
         if (ttInput) ttInput.value = _currentTraceId;
         if (window.JAMES_GraphTabs) window.JAMES_GraphTabs.select('graph');
-        if (ttApply) ttApply.click();
+        // Defer the trail fetch until the graph tab is actually visible
+        // and laid out — otherwise the trail panel is created inside a
+        // still-hidden .stage and the user (esp. on mobile) sees nothing
+        // happen. Double rAF lets the tab-switch paint first.
+        var fire = function () { if (ttApply) ttApply.click(); };
+        if (window.requestAnimationFrame) {
+          requestAnimationFrame(function () { requestAnimationFrame(fire); });
+        } else {
+          setTimeout(fire, 60);
+        }
       });
     }
     // v0.6.1 (gap ②) — debounced question search over recent traces.

--- a/frontend/static/time-travel-trace.js
+++ b/frontend/static/time-travel-trace.js
@@ -108,6 +108,18 @@
     if (panel) panel.style.display = 'none';
   }
 
+  // Make the panel noticeable when it (re)appears — scroll it into the
+  // viewport and briefly flash its border. Without this the small
+  // top-right overlay is easy to miss, esp. on phones (the "그래프에서
+  // 이 추론 보기" button felt like it did nothing).
+  function revealPanel(panel) {
+    if (!panel) return;
+    try { panel.scrollIntoView({ block: 'nearest' }); } catch (_) {}
+    var base = '0 2px 10px rgba(0,0,0,.4)';
+    panel.style.boxShadow = '0 0 0 2px var(--accent-fg,#6cf), ' + base;
+    setTimeout(function () { panel.style.boxShadow = base; }, 1200);
+  }
+
   function renderHeader(stateText) {
     return '<div style="font-weight:600;color:var(--accent-fg);' +
            'margin-bottom:6px;letter-spacing:.4px">' +
@@ -126,6 +138,7 @@
       escapeHtml(t('graph.timetravel.trace.loading', 'Loading trail…')) +
       ' (' + escapeHtml(traceId) + ')'
     );
+    revealPanel(panel);
   }
 
   function renderError(detail, traceId) {
@@ -139,6 +152,7 @@
       escapeHtml(t('graph.timetravel.trace.error', 'Trail unavailable')) +
       safeDetail + traceFrag + '</span>'
     );
+    revealPanel(panel);
   }
 
   function renderEmpty() {
@@ -249,6 +263,7 @@
     }
 
     panel.innerHTML = header + toFlowBtn + phaseHtml;
+    revealPanel(panel);
 
     var toFlow = document.getElementById('trace-to-flow-btn');
     if (toFlow) {


### PR DESCRIPTION
## Summary
Clicking **"그래프에서 이 추론 보기 →"** on the reasoning-flow view navigated to the graph tab but appeared to do nothing afterwards.

What the button actually does: switch to the graph tab + fill the Time-Travel trace input + click "Show trail", which renders the trace's 3-phase reasoning trail (RETRIEVE→EXPAND→VERIFY) in a small top-right overlay. Two reasons it felt dead:
1. The trail fetch fired immediately after the tab switch, so the panel was created inside a still-hidden `.stage` (race) — not painted / easy to miss.
2. The overlay is a small corner panel on the 3D canvas — on phones it's easy to not notice it appear.

**Fixes (frontend only):**
- `reasoning-flow.js`: defer the trail trigger with a double `requestAnimationFrame` so the graph tab is visible/laid-out before the panel renders.
- `time-travel-trace.js`: `revealPanel()` scrolls the trail panel into view + briefly flashes its border whenever it (re)appears (loading/trail/error), so the result is obvious.

## Known gap (NOT this PR)
The trace path is **not highlighted on the 3D graph canvas** itself — `graph.js` has no trace consumer, and `trace-replay` returns only audit stages (no node ids). Highlighting the traversed nodes/edges on the 3D graph is a separate feature (needs a trace→nodes endpoint + graph.js highlight).

## Verification
- `node --check` clean; trace-replay endpoint unchanged → backend trace-replay tests **24 green**.

Quality delta: exempt (label: fix) — frontend UX; core untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq