### PR TITLE
fix(v0.6.1): graph canvas black after tab-switch / trace highlight (mobile)

### DIFF
--- a/frontend/static/graph-tabs.js
+++ b/frontend/static/graph-tabs.js
@@ -35,9 +35,21 @@
       btn.classList.toggle('graph-hub-tab-active',
         btn.getAttribute('data-graph-tab-btn') === name);
     });
-    // Returning to the graph: the 3D canvas was display:none → re-fit it.
+    // Returning to the graph: the 3D canvas was display:none (0×0) → it
+    // must be re-fit BEFORE any camera op, else it renders black. Force a
+    // reflow so clientWidth/Height are real, dispatch resize now, and
+    // again on the next frame (mobile layout can lag a frame).
     if (name === 'graph') {
-      try { window.dispatchEvent(new Event('resize')); } catch (_) {}
+      try {
+        var gc = document.getElementById('graph-canvas');
+        if (gc) { void gc.offsetHeight; }   // force synchronous reflow
+        window.dispatchEvent(new Event('resize'));
+        if (window.requestAnimationFrame) {
+          requestAnimationFrame(function () {
+            try { window.dispatchEvent(new Event('resize')); } catch (_) {}
+          });
+        }
+      } catch (_) {}
     }
   }
 

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -1390,14 +1390,33 @@
       stepMs += STEP_GAP / 2;
     });
     setTimeout(function () { startPulseLoop(loopEdges); }, stepMs + 400);
-    // Fly the camera to fit just the highlighted trace nodes.
-    try {
-      if (graph.zoomToFit) {
-        graph.zoomToFit(700, 90, function (nn) {
+    // Fly the camera to fit just the highlighted trace nodes — but
+    // DEFER + GUARD: when arriving via a tab switch the canvas may still
+    // be 0×0 (just un-hidden) and the force layout may not have settled.
+    // Zooming then flies the camera into empty space → black screen.
+    // So: wait a beat, re-fit the canvas size, and only zoom if the
+    // canvas has real size AND the matched nodes have real positions.
+    var doFit = function () {
+      try {
+        if (!graph || !graph.zoomToFit) return;
+        var el = document.getElementById('graph-canvas');
+        if (!el || el.clientWidth < 2 || el.clientHeight < 2) return;
+        graph.width(el.clientWidth).height(el.clientHeight);
+        var spread = matched.some(function (n) {
+          return isFinite(n.x) && isFinite(n.y) &&
+                 (Math.abs(n.x) + Math.abs(n.y) + Math.abs(n.z || 0)) > 1;
+        });
+        if (!spread) return;   // positions not settled — leave camera as-is
+        graph.zoomToFit(800, 70, function (nn) {
           return activePathNodes.has(nn.id);
         });
-      }
-    } catch (_) {}
+      } catch (_) {}
+    };
+    if (window.requestAnimationFrame) {
+      requestAnimationFrame(function () { setTimeout(doFit, 250); });
+    } else {
+      setTimeout(doFit, 300);
+    }
     return matched.length;
   }
 


### PR DESCRIPTION
## Summary
On phone, "그래프에서 이 추론 보기" → the trail panel correctly shows **"그래프에 4개 노드 강조됨"** (highlight logic works) and N=513/E=863 (data loaded), but the 3D canvas was fully **BLACK**. Not slow — broken render.

Two compounding causes:
1. Arriving via the tab switch, the graph canvas was `display:none` → 0×0; `graph-tabs.js` dispatched a single resize, but mobile layout lags a frame so the canvas could stay 0-size.
2. `highlightTraceNodes()` called `graph.zoomToFit()` **immediately** — on a 0×0 canvas and before the force layout settled, flying the camera to a degenerate/empty box → black screen.

**Fixes (frontend only):**
- `graph-tabs.js`: on returning to the graph tab, force a synchronous reflow (read `offsetHeight`) before dispatching `resize`, then dispatch `resize` again on the next animation frame (catches mobile layout lag).
- `graph.js` `highlightTraceNodes()`: **defer** `zoomToFit` (rAF + 250ms) and **guard** it — re-fit the canvas to its real `clientWidth/Height`, and only zoom if the canvas has real size AND the matched nodes have settled finite positions. Otherwise skip the camera move (the halo/edge/pulse highlight is still applied, so the nodes light up in the normal full-graph view).

Net: the graph renders on tab-switch and the trace nodes light up; the camera gently fits them once ready, never into the void.

## Answer to "slow or broken?"
**Broken render, not slow** — the highlight matched 4 nodes instantly; the camera/canvas was the problem.

## Verification
- `node --check` clean (graph.js / graph-tabs.js / time-travel-trace.js).

Quality delta: exempt (label: fix) — frontend render/UX; core untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq