### PR TITLE
fix(v0.6.1): reasoning-flow / rollback tabs scroll on mobile

### DIFF
--- a/frontend/static/graph.css
+++ b/frontend/static/graph.css
@@ -463,9 +463,18 @@
   color: var(--accent-fg);
   border-bottom-color: var(--accent);
 }
-/* flow / rollback panels: constrained reading width, scrollable. */
+/* flow / rollback panels: constrained reading width, scrollable.
+   They are flex siblings of the (overflow:hidden) body, so they must
+   claim the remaining height and scroll INTERNALLY — otherwise tall
+   content (the stage list) is clipped and the page won't scroll on
+   mobile. */
 section[data-graph-tab="flow"],
 section[data-graph-tab="rollback"] {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
   max-width: 960px;
   margin: 0 auto;
   padding: 24px 20px 56px;


### PR DESCRIPTION
## Summary
The Reasoning-flow tab (and Rollback) wouldn't scroll — tall content (the stage list) was clipped.

**Cause:** `graph.html`'s `body` is a flex column with `overflow:hidden` (needed so the graph tab's 3D canvas fills the screen). The flow/rollback `<section>` panels are flex siblings of body but had no flex/overflow, so they sized to content and got clipped with nowhere to scroll.

**Fix:** `section[data-graph-tab="flow"|"rollback"]` now `flex:1 1 auto; min-height:0; overflow-y:auto` (+ `-webkit-overflow-scrolling:touch`) so each claims the remaining viewport height below the header/tabs and scrolls internally. Kept the centered `max-width:960px` reading column. The graph tab (`#main`) is unchanged (full-height, no scroll).

CSS only; no JS/core change.

Quality delta: exempt (label: fix) — frontend layout; core untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq