### PR TITLE
fix(v0.6.1): trace search + applying a different trace to the graph

### DIFF
--- a/core/reasoning/pipeline_loops.py
+++ b/core/reasoning/pipeline_loops.py
@@ -241,6 +241,10 @@ def run_loop_0_retrieve(
     top_doc = docs[0] if docs else {}
     log_stage(
         "retrieve",
+        # The user question text (capped) so the reasoning-flow tab can
+        # search traces by question. Observability-only; nothing reads it
+        # back into the answer path.
+        query=(safe_query or "")[:200],
         top_k=len(docs),
         avg_vec_score=round(avg_score, 4),
         top_vector_score=round(top_doc.get("score", 0.0), 4),

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -1364,7 +1364,11 @@
      a trace's graph stage matched. Returns the count actually found in
      the current snapshot (ids not in the snapshot are skipped). ── */
   function highlightTraceNodes(nodeIds) {
-    if (!graph || !nodeIds || !nodeIds.length) return 0;
+    if (!graph) return 0;
+    // Switching to a trace with NO graph nodes must still clear the
+    // PREVIOUS trace's highlight — otherwise the old halos/edges stay lit
+    // while the panel shows the new trace.
+    if (!nodeIds || !nodeIds.length) { clearTraceHighlight(); return 0; }
     clearActivePath(/*skipRefresh*/true);
     var matched = [];
     for (var i = 0; i < nodeIds.length; i++) {

--- a/frontend/static/reasoning-flow.js
+++ b/frontend/static/reasoning-flow.js
@@ -432,15 +432,23 @@
     if (toGraphBtn) {
       toGraphBtn.addEventListener('click', function () {
         if (!_currentTraceId) return;
-        var ttInput = $('time-travel-trace-input');
-        var ttApply = $('time-travel-trace-apply');
-        if (ttInput) ttInput.value = _currentTraceId;
+        var tid = _currentTraceId;            // capture — survives any later change
         if (window.JAMES_GraphTabs) window.JAMES_GraphTabs.select('graph');
-        // Defer the trail fetch until the graph tab is actually visible
-        // and laid out — otherwise the trail panel is created inside a
-        // still-hidden .stage and the user (esp. on mobile) sees nothing
-        // happen. Double rAF lets the tab-switch paint first.
-        var fire = function () { if (ttApply) ttApply.click(); };
+        // Defer the trail fetch until the graph tab is visible + laid out
+        // (the panel/canvas were just un-hidden). Pass the trace_id
+        // DIRECTLY to showTrace so it never depends on reading the input
+        // element at the right moment (the prior input+click path raced
+        // the tab switch and sometimes fetched nothing).
+        var fire = function () {
+          if (window.JAMES_TimeTravelTrace && window.JAMES_TimeTravelTrace.showTrace) {
+            window.JAMES_TimeTravelTrace.showTrace(tid);
+          } else {
+            var ttInput = $('time-travel-trace-input');
+            var ttApply = $('time-travel-trace-apply');
+            if (ttInput) ttInput.value = tid;
+            if (ttApply) ttApply.click();
+          }
+        };
         if (window.requestAnimationFrame) {
           requestAnimationFrame(function () { requestAnimationFrame(fire); });
         } else {

--- a/frontend/static/time-travel-trace.js
+++ b/frontend/static/time-travel-trace.js
@@ -383,6 +383,18 @@
     fetchTrail(traceId, currentCutoffIso);
   }
 
+  // Direct API for cross-module callers (the flow→graph button). Takes the
+  // trace_id explicitly so it doesn't depend on the input element being
+  // present/populated at call time (avoids a tab-switch race), and still
+  // syncs the visible input for display.
+  function showTrace(traceId) {
+    traceId = (traceId || '').trim();
+    if (!traceId) return;
+    var input = $('time-travel-trace-input');
+    if (input) input.value = traceId;
+    fetchTrail(traceId, currentCutoffIso);
+  }
+
   function onCutoffSet(ev) {
     var iso = (ev && ev.detail && ev.detail.iso) || '';
     currentCutoffIso = iso;
@@ -430,6 +442,7 @@
   // Expose for tests + downstream code.
   window.JAMES_TimeTravelTrace = {
     show: onShowTrail,
+    showTrace: showTrace,
     hide: hidePanel,
     fetchTrail: fetchTrail,
     renderTrail: renderTrail,


### PR DESCRIPTION
## Summary
Comprehensive re-check of the trace chain surfaced **3 real bugs**:

1. **Search never matched.** The user question text was logged in **no** stage (auth logs `role`; coding_route logs `query_len`), so `/admin/audit/recent-traces` always saw an empty `question` and the question filter dropped everything. **Fix:** the retrieve stage now logs `query=<text>[:200]` (observability-only; answer path unchanged). Search works for traces created from now on — pre-existing traces have no question/nodes and can't be back-filled.

2. **Switching to a trace with no graph nodes left the previous trace's highlight lit** — `highlightTraceNodes()` early-returned on empty ids without clearing. **Fix:** on empty ids it now `clearTraceHighlight()` first.

3. **The flow→graph button raced the tab switch:** it set the input value then clicked Apply, but `onShowTrail` read the input back and could see it empty mid-switch → fetched nothing. **Fix:** new `JAMES_TimeTravelTrace.showTrace(traceId)` takes the id **directly**; the button calls it (captured id, no DOM-read race). Old path kept as fallback.

## Operator note
Search + graph-apply work for **new** traces (run a query after this lands). Older traces predate the `query` / `matched_entity_ids` logging, so they won't be searchable or highlightable — that's inherent (logs can't be back-filled), and the panel says so for graph nodes.

## Verification
- `node --check` clean (graph.js / time-travel-trace.js / reasoning-flow.js); `core.reasoning.pipeline_loops` import clean.
- trace-replay + observability **behavior** tests = 37 green.
- ⚠ Pre-existing unrelated RED: `test_observability.test_pipeline_emits_three_core_stages` (stale source-grep for the `answer` stage, which lives in `pipeline_synth.py`) — RED on `main` too, untouched here.

Quality delta: exempt — observability-only field in `core/reasoning` (no answer-path change); retrieval/graph traversal untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq