### PR TITLE
docs(v0.6.1): document JAMES_GEMMA_MAX_PROMPT_CHARS for full-length reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,20 @@ TAVILY_API_KEY=tvly-your-tavily-key-here
 # Tool 접근/수정 차단할 파일들 (쉼표 구분)
 JAMES_PROTECTED_FILES=core/security_layer.py,core/auth.py,config.py
 
+# ── LLM 프롬프트 길이 캡 (선택, 단 리포트/장문 생성엔 사실상 필수) ──
+# Gemma 클라이언트는 모든 프롬프트를 이 글자 수로 잘라냅니다. 코드
+# 기본값은 4000자(측정 재현성 byte-identical 유지용)지만, 리포트 작성
+# 시 컨텍스트+지시문이 함께 4000자로 잘려 보고서가 짧게/불완전하게
+# 나옵니다(synth 프롬프트 7760 → 4000 절단 사례). 운영 환경에서는 synth
+# 컨텍스트 예산(JAMES_SYNTH_CONTEXT_CHARS, 기본 8000) + 페르소나/메모리/
+# 지시문 여유를 덮도록 16000 이상 권장. (gemma3:12b 등 컨텍스트 윈도우
+# 충분.)
+JAMES_GEMMA_MAX_PROMPT_CHARS=16000
+
+# synth 단계 검색 컨텍스트 글자 수 상한 (기본 8000). 위 프롬프트 캡보다
+# 작아야 의미 있음.
+# JAMES_SYNTH_CONTEXT_CHARS=8000
+
 # ── Tesseract OCR 경로 (Windows만 해당) ───────────────────────
 # 기본 경로와 다르면 명시
 # TESSERACT_PATH=C:\Program Files\Tesseract-OCR\tesseract.exe


### PR DESCRIPTION
## Summary
Operator's debug trace showed report generation truncated — `[GEMMA] 프롬프트 7760자 → 4000자 축약`. The Gemma client caps **every** prompt at 4000 chars (`core/gemma_client/config.py::_DEFAULT_MAX_PROMPT_LEN`). The default is deliberately 4000 in code for measurement byte-identity, but it silently chops the report's context + instructions and undermines the 8000-char `JAMES_SYNTH_CONTEXT_CHARS` budget → short/incomplete answers.

Remedy = the existing env knob. Documented in `.env.example` (set to 16000) so production feeds full prompts to large models (gemma3:12b etc.); the code default stays 4000 for measurement reproducibility.

No code change — `.env.example` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq