### PR TITLE
feat(v0.6.1): drive the continue banner off a real server truncation signal

### DIFF
--- a/core/reasoning/pipeline.py
+++ b/core/reasoning/pipeline.py
@@ -43,6 +43,16 @@ from core.reasoning.pipeline_synth import generate_answer
 from core.security_layer import filter_answer_by_role
 
 
+def _answer_was_truncated() -> bool:
+    """True if the final answer generation hit the output-token cap
+    (backend reported done_reason=="length"). Best-effort."""
+    try:
+        from core.reasoning.trace_helpers import get_answer_done_reason
+        return get_answer_done_reason() == "length"
+    except Exception:
+        return False
+
+
 def run_retrieval_pipeline(
     engine,
     safe_query: str,
@@ -54,6 +64,14 @@ def run_retrieval_pipeline(
     force_web_search: bool = False,   # [#A8-6] 사용자가 chip 클릭 시 True
     selected_model: str = "",         # [#A2 phase 2] catalog-validated user pick
 ) -> Dict[str, Any]:
+    # v0.6.1 — clear the answer truncation signal at the start so a prior
+    # query's value can't leak into this one (the answer-producing
+    # generations set it during this run).
+    try:
+        from core.reasoning.trace_helpers import reset_answer_done_reason
+        reset_answer_done_reason()
+    except Exception:
+        pass
     # ── STEP 0.5a: entity anchor expansion (F9.3) ───────
     # Opt-in via JAMES_ENABLE_ENTITY_ANCHOR=1 (default OFF). Helper
     # at core/reasoning/pipeline_query_expansion.py — extracted to
@@ -356,6 +374,10 @@ def run_retrieval_pipeline(
         # data via `loop_state["docs"]` if they hold the engine.
         "retrieved_contexts": [d.get("text", "") for d in loop_state["docs"]],
         "blocked":       False,
+        # v0.6.1 — True when the final answer's generation hit the output
+        # token cap (backend done_reason=="length"). Drives the UI's
+        # "continue" banner accurately (vs the old blind heuristic).
+        "truncated":     _answer_was_truncated(),
         "timing_sec":    round(total, 2),
         "unified_score": round(unified_score if "unified_score" in dir() else 0.0, 3),
         "loop_count":    min(MAX_LOOP + 1, 3),

--- a/core/reasoning/reflect/loop.py
+++ b/core/reasoning/reflect/loop.py
@@ -326,6 +326,15 @@ class ReflectionLoop:
         text = getattr(result, "text", "") or ""
         err = getattr(result, "error", "") or ""
 
+        # The revised pass produces the FINAL displayed answer — record its
+        # truncation signal so the pipeline's `truncated` flag is accurate.
+        if applied_rule.endswith("revised") and not err:
+            try:
+                from core.reasoning.trace_helpers import set_answer_done_reason
+                set_answer_done_reason(getattr(result, "done_reason", "") or "")
+            except Exception:
+                pass
+
         self._emit(
             applied_rule=applied_rule,
             prompt=prompt,

--- a/core/reasoning/trace_helpers.py
+++ b/core/reasoning/trace_helpers.py
@@ -65,6 +65,30 @@ from core.reasoning.trace_schema import (
 )
 
 
+# v0.6.1 — last answer-stage truncation signal. The backend reports
+# ``done_reason="length"`` when the model hit the output-token cap; the
+# answer-PRODUCING generations (synth here + reflect.revised) record it so
+# the pipeline can surface an accurate `truncated` flag to the UI's
+# "continue" banner (replacing the blind client-side heuristic). Reset at
+# pipeline start. Single-process local-first app: a module global is
+# adequate (not request-isolated under concurrent load — acceptable).
+_ANSWER_DONE_REASON = ""
+
+
+def set_answer_done_reason(reason) -> None:
+    global _ANSWER_DONE_REASON
+    _ANSWER_DONE_REASON = reason or ""
+
+
+def get_answer_done_reason() -> str:
+    return _ANSWER_DONE_REASON
+
+
+def reset_answer_done_reason() -> None:
+    global _ANSWER_DONE_REASON
+    _ANSWER_DONE_REASON = ""
+
+
 # Sentinel string used in error rows to mark a backend-reported failure
 # (the backend returned text matching RouterWrapper's known error strings
 # rather than a clean response). Mirrors the OllamaLocalBackend convention
@@ -296,6 +320,11 @@ def trace_synth_call(
     err = result.error or ""
     if not err and _is_router_error(text_str):
         err = "backend reported error string"
+
+    # Record the truncation signal for this answer-producing generation
+    # (synth / web_fallback / retry). reflect.revised overwrites it later
+    # if reflection runs; the pipeline reads the final value.
+    set_answer_done_reason(getattr(result, "done_reason", "") or "")
 
     emit_trace_step(
         TraceStep(

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1924,10 +1924,18 @@ function appendJamesMsg(data) {
   // chip + 본문에 두 번 보이는 문제 (실사용자 피드백) 해결.
   const { suggestions, cleanAnswer } =
     extractNextActionSuggestions(answer);
-  // Now that the suggestions tail is removed, evaluate truncation
-  // against just the body text. (See truncationHint declaration
-  // above for the operator-catch context.)
-  if (isLikelyTruncated(cleanAnswer)) {
+  // v0.6.1 — prefer the SERVER truncation signal (data.truncated, set
+  // when the final answer's generation hit the output-token cap). It's
+  // authoritative, so when present we trust it and skip the blind
+  // client heuristic (which false-positived on answers that merely end
+  // without punctuation). Only paths that don't carry the flag (e.g. the
+  // streaming preview) fall back to isLikelyTruncated().
+  var _hasServerTrunc =
+    data && Object.prototype.hasOwnProperty.call(data, 'truncated');
+  var _showTrunc = _hasServerTrunc
+    ? (data.truncated === true)
+    : isLikelyTruncated(cleanAnswer);
+  if (_showTrunc) {
     truncationHint = `
       <div role="note" aria-live="polite"
            style="display:flex;align-items:center;gap:8px;margin-top:8px;

--- a/routes/query.py
+++ b/routes/query.py
@@ -279,6 +279,9 @@ async def query(
         "web_sources":   result.get("web_sources", []),
         # [#A8-7] chat-side 위키 저장 chip용 proposal id
         "pending_save_proposal_id": result.get("pending_save_proposal_id", ""),
+        # v0.6.1 — accurate truncation signal (final answer hit the output
+        # token cap). The chat UI shows its "continue" banner on this.
+        "truncated":     bool(result.get("truncated", False)),
     }
     # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
     # fed the LLM are surfaced only when (a) caller opted in via


### PR DESCRIPTION
## Summary
The chat "답변이 도중에 끊긴 것 같아요 [계속]" banner fired on a **blind client heuristic** (any answer ending without `.` / `다` / `요`), so it false-positived on complete answers. Operator chose: make it accurate.

Now it's driven by an **authoritative server flag**: the backend already computes `done_reason=="length"` (model hit the output-token cap); we record it from the answer-producing generations and surface it as `truncated` in the `/query` response.

**Plumb (metadata only — answer text / retrieval / ranking byte-identical):**
- `trace_helpers.py`: module holder + set/get/reset; synth path records `done_reason` after each `backend.complete`.
- `reflect/loop.py`: the `reflect.revised` pass (the final answer when reflection runs) records its `done_reason`, overriding synth's.
- `pipeline.py`: reset at pipeline start; result dict gains `truncated` = (final `done_reason == "length"`).
- `routes/query.py`: response gains `truncated`.
- `chat.js`: `appendJamesMsg` prefers `data.truncated` when present (authoritative → no false positives); only flag-less paths (streaming preview) fall back to the old heuristic.

→ The banner now appears **only when the answer truly hit the token cap**, not on normal answers. (Genuine soft early-stops by small models are better solved by a bigger model / the prompt-cap fix, not a blind banner.)

## Verification
- `node --check` clean; reasoning/query imports clean; helper roundtrip ok.
- trace-replay + observability **behavior** tests = 37 green; measurement lock-tests = 33 green.
- ⚠ Pre-existing unrelated RED: `test_observability.test_pipeline_emits_three_core_stages` (stale grep for the `answer` stage, now in `pipeline_synth.py`) — RED on `main` too.

Quality delta: exempt — metadata/observability plumbing in `core/reasoning` (no answer-path change); retrieval/graph traversal untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq