### PR TITLE
fix(v0.6.1): chat header shows the ACTUAL routed model (+ fix stripped truncated)

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -104,11 +104,19 @@ class ReasoningEngine:
         thin wrapper so the cleanup invariant is impossible to skip.
         """
         try:
-            return self._query_impl(
+            result = self._query_impl(
                 user_query, user_role, source_type, session_id,
                 response_style, mode_override, selected_model,
                 **kwargs,
             )
+            # v0.6.1 — surface the model that ACTUALLY answered (auto-routed
+            # per mode) so the chat header reflects reality, not the picker
+            # default. _last_routed_model is set in _query_impl after the
+            # routing decision; empty for modes that resolve downstream
+            # (meta/vision) → UI keeps its current chip.
+            if isinstance(result, dict) and not result.get("model_used"):
+                result["model_used"] = getattr(self, "_last_routed_model", "") or ""
+            return result
         finally:
             # PR-10b — release the turn's scratch and clear the
             # session ContextVar so the next request in this
@@ -152,6 +160,9 @@ class ReasoningEngine:
         """
         # [P7-FIX] kwargs에 session_id 주입 (내부 메서드들이 참조)
         kwargs["session_id"] = session_id
+        # v0.6.1 — clear the per-query routed-model marker so a prior
+        # query's model can't leak into this one's reported model_used.
+        self._last_routed_model = ""
         if user_role is None:
             user_role = self.default_role
 
@@ -310,6 +321,20 @@ class ReasoningEngine:
                           f"(source={_rm.source}; measured pref)")
                     if _rm.warning:
                         print(f"[MODEL] {_rm.warning}")
+
+        # v0.6.1 — remember the model actually chosen for this query so
+        # query() can report it. picked_model holds the user pick OR the
+        # auto-routed tag; fall back to the legacy default for the LLM
+        # modes when neither applied, so the header is right in the common
+        # cases (coding resolves CODING_MODEL downstream; meta uses no LLM).
+        _eff_model = picked_model
+        if not _eff_model and mode in ("chat", "retrieval", "wiki_edit"):
+            try:
+                from config import GEMMA_MODEL as _GM
+                _eff_model = _GM
+            except Exception:
+                _eff_model = ""
+        self._last_routed_model = _eff_model or ""
 
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -1591,6 +1591,18 @@ function appendJamesMsg(data) {
   const answer   = data.answer     || '응답 없음';
   const mode     = data.mode       || '';
   const paths    = data.graph_paths || [];
+
+  // v0.6.1 — sync the header model chip with the model that ACTUALLY
+  // answered (auto-routed per mode), not the picker default. Only when
+  // the server reported one (empty for meta/vision → keep current chip).
+  if (data.model_used) {
+    const _tagEl = document.getElementById('model-chip-tag');
+    if (_tagEl) {
+      _tagEl.textContent = data.model_used;
+      const _chip = document.getElementById('model-chip');
+      if (_chip) _chip.setAttribute('data-source', 'used');
+    }
+  }
   const timing   = data.timing_sec != null ? `${data.timing_sec}s` : '';
   const dirId    = data.direction_id ||
     (data.answer ? btoa(encodeURIComponent(

--- a/routes/query.py
+++ b/routes/query.py
@@ -123,6 +123,13 @@ class QueryResponse(BaseModel):
     # [#A8-7] chat-side "📥 위키 저장" chip이 approve API에 보낼 proposal id.
     # 빈 문자열이면 chip 숨김. web_used=true일 때만 채워진다.
     pending_save_proposal_id: str = ""
+    # v0.6.1 — final answer hit the output-token cap (drives the UI
+    # "continue" banner). NOTE: response_model strips keys absent here, so
+    # this MUST be declared for the dict value to reach the client.
+    truncated:      bool  = False
+    # v0.6.1 — the LLM model that ACTUALLY produced the answer (auto-routed
+    # per mode), so the chat header reflects reality, not the picker default.
+    model_used:     str   = ""
 
 # ─── Endpoints ───
 
@@ -282,6 +289,8 @@ async def query(
         # v0.6.1 — accurate truncation signal (final answer hit the output
         # token cap). The chat UI shows its "continue" banner on this.
         "truncated":     bool(result.get("truncated", False)),
+        # v0.6.1 — model that actually answered (auto-routed per mode).
+        "model_used":    result.get("model_used", ""),
     }
     # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
     # fed the LLM are surfaced only when (a) caller opted in via


### PR DESCRIPTION
## Summary
The chat header model chip showed the **picker default** (`gemma4:e4b` from `/llm/active`), not the model that actually answered. A debug trace showed the answer was auto-routed to `gemma3:12b` (retrieval mode), but the header still said `gemma4:e4b`.

**Root cause:** the chosen model (`engine.py` `picked_model`) was computed + logged but never returned to the client.

**Also found (important):** `routes/query.py` uses `response_model=QueryResponse`, which **strips any response-dict key not declared on the model**. So the `truncated` field added in #1060 was being **silently dropped** before reaching the client (the continue banner kept falling back to the heuristic). Declaring it here actually activates #1060.

**Changes (metadata only — answer/retrieval/ranking byte-identical):**
- `engine.py`: record `self._last_routed_model` after the routing decision (user pick / auto-route / legacy default for chat·retrieval·wiki_edit); reset per query; `query()` injects `result["model_used"]`.
- `routes/query.py`: `QueryResponse` gains **`model_used`** AND **`truncated`** (both stripped without a field); response populates `model_used`.
- `chat.js`: `appendJamesMsg` updates `#model-chip-tag` to `data.model_used` when present (empty for meta/vision → chip unchanged).

## Verification
- `node --check` clean; `QueryResponse` exposes `model_used` + `truncated`; server import clean.
- query / model-resolver / style + measurement lock-tests = 53 + 33 green.

Quality delta: exempt — metadata reporting in `core/reasoning` (no answer-path change); retrieval/graph traversal untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaBmTRkGhNqztxsZFHpRZq