### PR TITLE
fix(v0.6.1): compact mobile upload chips + tap-to-expand per-file folder

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,8 +9,8 @@
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
-<link rel="stylesheet" href="/static/chat.css?v=v20-20260616">
-<link rel="stylesheet" href="/static/mobile.css?v=v20-20260616">
+<link rel="stylesheet" href="/static/chat.css?v=v22-20260625-upload">
+<link rel="stylesheet" href="/static/mobile.css?v=v22-20260625-upload">
 </head>
 <body>
 

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -851,6 +851,18 @@ main { display: flex; flex: 1; overflow: hidden; }
 }
 .folder-input::placeholder { color: var(--muted); opacity: .8; }
 
+/* Folder toggle button — only used on phones, where the per-file folder
+   input is collapsed into a compact chip (mobile.css reveals it). Hidden
+   on desktop, where the folder row is always visible. */
+.folder-toggle {
+  display: none;
+  background: none; border: none; color: var(--muted);
+  cursor: pointer; padding: 2px 4px; border-radius: 4px;
+  flex-shrink: 0; line-height: 0;
+}
+.folder-toggle:hover { color: var(--accent-fg); }
+.file-item.show-folder .folder-toggle { color: var(--accent-fg); }
+
 /* ── 진행 표시 (Issue #14) ── */
 .file-progress-row {
   display: flex; align-items: center; gap: 6px;

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -250,6 +250,7 @@ function _bindFrontendEvents() {
       // upload.js mini-thumbnails
       case 'chat-attach-click':         _chatAttachClick(); break;
       case 'remove-or-cancel':          removeOrCancel(t.getAttribute('data-item-id')); break;
+      case 'toggle-folder':             toggleFolderRow(t.getAttribute('data-item-id')); break;
     }
   });
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -527,6 +527,21 @@
     min-width: 36px;
   }
 
+  /* ── 업로드 파일 — 폰 컴팩트 칩 (operator 폰 dogfooding catch
+   *    2026-06-25) ──
+   *  데스크톱 사이드바의 키 큰 파일 카드(아이콘+이름+크기+상태+✕ 위에
+   *  파일별 "저장 폴더" 텍스트 입력란까지)가 좁은 폰 하단을 잠식했다.
+   *  폰에선 칩 = file-item-top 한 줄(아이콘+이름+상태+폴더+✕)만 노출하고
+   *  파일별 폴더 입력란은 기본 숨김 → 폴더 버튼 탭하면 그 파일만 펼친다.
+   *  (.file-item 은 column 레이아웃이라 row 로 바꾸지 않고, 아래 행들을
+   *   숨겨 한 줄만 남기는 방식.) */
+  .file-list { padding: 6px 12px 10px; }
+  .file-item { padding: 7px 9px; margin-bottom: 5px; }
+  .file-item .file-size { display: none; }          /* 칩 좁게 — 크기 생략 */
+  .folder-toggle { display: inline-flex; align-items: center; }
+  .file-folder-row { display: none; }               /* 기본 숨김 */
+  .file-item.show-folder .file-folder-row { display: flex; }
+
   /* 답변 옆 buttons (👍 👎 📥) — 가로 스크롤 가능하게 */
   .feedback-btns {
     flex-wrap: wrap;

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -398,6 +398,19 @@ function removeOrCancel(id) {
 // Backwards-compat alias for any inline onclick that still calls removeFile
 function removeFile(id) { removeOrCancel(id); }
 
+/* Mobile: per-file "저장 폴더" input is hidden by default (the chip is a
+   compact thumbnail+name+✕). The folder button toggles it open for the
+   one file. No-op visual on desktop where the folder row is always shown. */
+function toggleFolderRow(id) {
+  const el = document.getElementById(`file-${id}`);
+  if (!el) return;
+  const opened = el.classList.toggle('show-folder');
+  if (opened) {
+    const inp = document.getElementById(`folder-${id}`);
+    if (inp) inp.focus();
+  }
+}
+
 /* ── 업로드 버튼 상태 ── */
 function updateUploadBtn() {
   const pending = uploadQueue.filter(i => i.status === 'ready').length;
@@ -438,6 +451,7 @@ function renderFileItem(item) {
         <div class="file-size">${formatSize(item.file.size)}</div>
       </div>
       <span class="file-status status-ready" id="status-${item.id}">대기</span>
+      <button class="folder-toggle" data-action="toggle-folder" data-item-id="${escHtml(item.id)}" aria-label="저장 폴더 설정" title="저장 폴더"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg></button>
       <button class="remove-btn" id="action-${item.id}" data-action="remove-or-cancel" data-item-id="${escHtml(item.id)}" title="제거">✕</button>
     </div>
     <div class="file-progress-row" id="progress-${item.id}" style="display:none;">


### PR DESCRIPTION
## Summary
Operator phone dogfooding catch — attaching files on a phone rendered the desktop sidebar's **tall file cards** (icon + name + size + status + ✕, plus a per-file `저장 폴더` text input row each), crowding the narrow mobile bottom area (2 files already pushed the composer).

On mobile (`@media ≤768px`) each file is now a **compact single-line chip** (~52px) and the per-file folder input is **hidden by default**; a new folder-toggle button (SVG, hidden on desktop) reveals that one file's folder input on tap. Desktop unchanged.

- `upload.js`: folder-toggle button + `toggleFolderRow()`
- `chat.js`: `toggle-folder` delegation case (CSP-safe, no inline onclick)
- `chat.css`: `.folder-toggle` hidden on desktop + base styling
- `mobile.css`: compact `.file-item` + `.file-folder-row` hidden by default, `.show-folder` reveals it; `.file-size` hidden on chips
- `index.html`: chat.css/mobile.css cache-bust → `v22-20260625-upload`

## Verification
Playwright @ 390px viewport with 2 files attached: **2 chips @ 52px each**, folder rows `display:none` by default → only the tapped chip flips to `flex`, **no JS errors**. `node --check` on edited JS OK. Full visual confirmation best done by operator on a real phone (the harness/headless run hit the unauthenticated login modal).

## Out of scope
- Broader mobile upload-panel chrome (dropzone + Choose Folder + Take Photo + common-save-instruction stack above the chips) — separate, larger.
- The dead `#chat-attachment-row` mini-preview (never wired in chat.js).

## Quality delta
Quality delta: exempt (label: fix) — mobile CSS/JS chrome only; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)