### PR TITLE
feat(v0.6.1): composer paperclip → multi-file corpus upload (Claude-style)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -608,9 +608,19 @@
       </div>
       <input class="d-none" type="file" id="vision-file-input" accept="image/*"
              aria-hidden="true">
+      <!-- v0.6.1 — composer multi-file corpus attach. The paperclip now
+           opens THIS (multiple, all corpus types) and the picked files are
+           ingested into the knowledge base (reusing the proven /upload/
+           pipeline) + shown as compact chips in #chat-attachment-row.
+           (#vision-file-input above is kept for single-image vision Q&A,
+            currently not wired to the paperclip — operator chose corpus
+            upload semantics for the composer.) -->
+      <input class="d-none" type="file" id="composer-file-input" multiple
+             accept="image/*,audio/*,video/*,.pdf,.txt,.md,.json,.docx,.xlsx,.pptx,.hwp,.hwpx"
+             aria-hidden="true">
       <div class="input-wrap">
-        <button class="attach-btn u-6ab03333" id="attach-btn" data-action="attach-image"
-                aria-label="이미지 첨부"
+        <button class="attach-btn u-6ab03333" id="attach-btn" data-action="composer-attach"
+                aria-label="파일 첨부 (지식베이스 업로드)"
                >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
                stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -630,8 +640,8 @@
 <script src="/static/i18n.js"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
-<script src="/static/chat.js"></script>
-<script src="/static/upload.js"></script>
+<script src="/static/chat.js?v=v22-20260625-upload"></script>
+<script src="/static/upload.js?v=v22-20260625-upload"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 UI #4 — inline <script> block extracted to /static/index-init.js
      so the chat page's CSP can drop script-src 'unsafe-inline'. No

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -251,6 +251,12 @@ function _bindFrontendEvents() {
       case 'chat-attach-click':         _chatAttachClick(); break;
       case 'remove-or-cancel':          removeOrCancel(t.getAttribute('data-item-id')); break;
       case 'toggle-folder':             toggleFolderRow(t.getAttribute('data-item-id')); break;
+      case 'composer-attach': {
+        // Composer paperclip → multi-file corpus upload (knowledge base).
+        const ci = document.getElementById('composer-file-input');
+        if (ci) ci.click();
+        break;
+      }
     }
   });
 

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -28,6 +28,24 @@ if (_folderInput) {
     e.target.value = '';
   });
 }
+// v0.6.1 — 챗 컴포저 클립(📎) → 다중 파일 코퍼스 업로드. 사이드바
+// dropzone 과 달리 "올리면 바로 업로드" — 첨부 즉시 인제스트(검증된
+// /upload/ 파이프라인 재사용) + #chat-attachment-row 칩으로 표시. 사이드바
+// 의 수동 "업로드 및 분석" 버튼 흐름(파일별 폴더 지정)은 그대로 유지.
+const _composerInput = document.getElementById('composer-file-input');
+if (_composerInput) {
+  _composerInput.addEventListener('change', async e => {
+    const files = Array.from(e.target.files).map(_captureRelPath);
+    e.target.value = '';
+    if (!files.length) return;
+    addFiles(files);                 // 큐 + 컴포저 칩(renderChatAttachmentRow)
+    try { await uploadFiles(); }     // 즉시 코퍼스 인제스트
+    catch (err) {
+      if (typeof toast === 'function') toast(`업로드 실패: ${err && err.message || err}`, 'error');
+    }
+    if (typeof renderChatAttachmentRow === 'function') renderChatAttachmentRow();
+  });
+}
 // v0.6 — 모바일 카메라 직접 진입용 input (capture="environment"). 폰에선
 // 후면 카메라가 즉시 열리고 1장 캡처 후 큐에 add. PC 에선 일반 파일 피커.
 const _cameraInput = document.getElementById('camera-input');


### PR DESCRIPTION
## Summary
Operator phone catch — the chat composer paperclip opened the **single, image-only vision picker** (`/vision/upload/`, ephemeral per-question analysis), **not a corpus upload**. Users expected "attach in chat = upload to the knowledge base" and wanted multiple files like Claude.

The paperclip now opens a **multi-file, all-corpus-types picker** (`#composer-file-input`); picked files are **ingested into the knowledge base** via the proven `/upload/` pipeline (254 prior successful uploads), shown as compact chips in the existing `#chat-attachment-row` (thumbnail + status + ✕). **Attach = auto-ingest** (no extra button); on success `uploadFiles()` posts a "파일 업로드 완료" summary into the chat and clears the chips. The sidebar dropzone's manual flow (per-file folder targeting) is unchanged. Vision single-image code is preserved (dormant, re-wireable) per the operator's corpus-upload choice.

> Note: `/upload/` is admin-only — a non-admin who attaches gets the login prompt (expected). Auth/role unchanged.

## Verification
- **Pipeline works** (the "does upload actually work?" check): audit log shows **254** successful `/upload/` + **6** `/vision/upload/`; `uploads/` holds **55** ingested files with `.extraction.json` sidecars.
- **New wiring** (Playwright @ 390px): paperclip `data-action=composer-attach`; 2 files → `uploadQueue=2` + `#chat-attachment-row` `display:flex` with **2 chips** + **2 `POST /upload/` fired**; no JS errors. (Live successful ingest needs the operator's admin session — 403 otherwise, by design.)
- `node --check` on edited JS OK.

## Out of scope
- Ephemeral per-message context (Claude's model) + multi-image vision — would need new backend; operator chose corpus-ingest semantics.
- De-emoji of the chip status glyphs (↑/✅/❌) — pre-existing.

## Quality delta
Quality delta: exempt (label: feat) — composer wiring (HTML/JS) reusing the existing `/upload/` pipeline; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)