### PR TITLE
fix(v0.6.1): stack chat attachment row above the input (was pushing input off-screen)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
-<link rel="stylesheet" href="/static/chat.css?v=v22-20260625-upload">
+<link rel="stylesheet" href="/static/chat.css?v=v23-20260625-inputcol">
 <link rel="stylesheet" href="/static/mobile.css?v=v22-20260625-upload">
 </head>
 <body>

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -1336,8 +1336,14 @@ main { display: flex; flex: 1; overflow: hidden; }
   padding: 16px 24px 20px;
   background: var(--bg);
   display: flex;
+  /* Stack vertically so the attachment rows (#chat-attachment-row /
+     #vision-preview, both full-width "border-bottom" rows) sit ABOVE the
+     input — Claude-style — instead of beside it. A horizontal row pushed
+     the input + send button off-screen on phones once an attachment chip
+     appeared (operator catch 2026-06-25). */
+  flex-direction: column;
   gap: 10px;
-  align-items: flex-end;
+  align-items: stretch;
 }
 .input-wrap {
   flex: 1;


### PR DESCRIPTION
## Summary
Operator phone catch — attaching a file pushed the **input + send button off the right edge** of the phone screen. The attachment indicator (`#vision-preview` "첨부: …" / `#chat-attachment-row` chips) sat **beside** the input instead of above it.

Root cause: `.input-area` was `display:flex` in the default **row** direction, so the attachment rows (full-width, `border-bottom` — designed to stack above) became horizontal siblings of `.input-wrap`. Fix: `.input-area` → `flex-direction: column; align-items: stretch`, so attachments stack **above** the input (Claude-style) and the input + send stay full-width and on-screen. The send button lives inside `.input-wrap`, so it is preserved.

## Verification
Playwright @ 390px: `flex-direction=column`; `#vision-preview` y=726 sits **above** `.input-wrap` y=779; `.send-btn` right=**375 ≤ 390** (previously off-screen). When no attachment is present the layout is unchanged (single input row).

## Out of scope
- Desktop is also column now (attachment above input) — when no attachment it is identical; with one it is the same Claude-style improvement.

## Quality delta
Quality delta: exempt (label: fix) — one CSS rule (`.input-area`); `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)