### PR TITLE
fix(v0.6.1): vision extraction must use llava, not the text model (no-entities bug)

### DIFF
--- a/config.py
+++ b/config.py
@@ -195,6 +195,13 @@ GEMMA_MODEL    = _llm_setting("default_model", "JAMES_LLM_MODEL", "gemma4:e4b")
 # (e.g. gemma4:e4b) if the 32B coder is too heavy for their tunnel
 # / reverse proxy timeout.
 CODING_MODEL   = _llm_setting("coding_model", "JAMES_CODING_MODEL", "qwen2.5-coder:32b")
+# Vision / multimodal model. Used for image text-extraction + captioning
+# during corpus ingest (processors/file_processor.extract_image →
+# GemmaClient.call_gemma_vision) and the chat vision mode. MUST be a
+# vision-capable model: sending images to a text-only model (the old bug —
+# call_gemma_vision used GEMMA_MODEL) makes the LLM reply "no image
+# attached", so uploaded images yielded no real text → no entities.
+MULTIMODAL_MODEL = _llm_setting("multimodal_model", "JAMES_MULTIMODAL_MODEL", "llava:13b")
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
 # [Track 1 PR-C, 2026-05-19] LLM_TEMPERATURE — default sampling

--- a/core/gemma_client/client.py
+++ b/core/gemma_client/client.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 import requests
 
-from config import GEMMA_MODEL, OLLAMA_API_URL
+from config import GEMMA_MODEL, MULTIMODAL_MODEL, OLLAMA_API_URL
 from core.gemma_client.config import _resolve_max_prompt_len
 from core.gemma_client.errors import (
     is_cacheable_response,
@@ -344,7 +344,11 @@ class GemmaClient:
             resp = requests.post(
                 OLLAMA_API_URL,
                 json={
-                    "model":  GEMMA_MODEL,
+                    # MUST be a vision-capable model. GEMMA_MODEL (text)
+                    # ignored the image → "no image attached" replies, so
+                    # uploaded images produced no entities. See
+                    # config.MULTIMODAL_MODEL.
+                    "model":  MULTIMODAL_MODEL,
                     "prompt": prompt,
                     "images": [image_b64],
                     "stream": False,

--- a/tests/test_vision_model_routing.py
+++ b/tests/test_vision_model_routing.py
@@ -1,0 +1,77 @@
+"""v0.6.1 — vision call must use the multimodal model, not the text model.
+
+Regression guard for the bug where `GemmaClient.call_gemma_vision`
+posted images to `GEMMA_MODEL` (a text-only model, e.g. gemma4:e4b),
+which ignored the image and replied "no image attached" — so every
+uploaded image yielded no real text → no entities/relations in the KG.
+The fix routes the call to `config.MULTIMODAL_MODEL` (llava:13b default).
+
+Covers:
+  * `config.MULTIMODAL_MODEL` exists and defaults to a vision model.
+  * `call_gemma_vision` posts with `model == MULTIMODAL_MODEL` (NOT
+    `GEMMA_MODEL`) and carries the base64 image in `images`.
+
+Run:
+  python -m unittest tests.test_vision_model_routing
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class VisionModelRouting(unittest.TestCase):
+    def test_multimodal_model_configured_and_vision_capable(self):
+        import config
+        self.assertTrue(hasattr(config, "MULTIMODAL_MODEL"),
+                        "config.MULTIMODAL_MODEL missing")
+        self.assertTrue(config.MULTIMODAL_MODEL.strip(),
+                        "MULTIMODAL_MODEL is empty")
+        # text-only models must NOT be the multimodal default
+        self.assertNotEqual(config.MULTIMODAL_MODEL, config.GEMMA_MODEL,
+                            "MULTIMODAL_MODEL must differ from the text GEMMA_MODEL")
+
+    def test_call_gemma_vision_uses_multimodal_model(self):
+        import config
+        from core.gemma_client.client import GemmaClient
+
+        # a real (tiny) file so the `open(image_path, 'rb')` read succeeds
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tf:
+            tf.write(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+            img_path = tf.name
+
+        captured = {}
+
+        class _Resp:
+            def raise_for_status(self): pass
+            def json(self): return {"response": "보이는 것: 한국어 문서"}
+
+        def _fake_post(url, json=None, timeout=None, **kw):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+        try:
+            with mock.patch("core.gemma_client.client.requests.post",
+                            side_effect=_fake_post):
+                GemmaClient().call_gemma_vision("이 이미지 설명", img_path)
+        finally:
+            os.unlink(img_path)
+
+        self.assertIn("json", captured, "requests.post was not called")
+        payload = captured["json"]
+        self.assertEqual(payload.get("model"), config.MULTIMODAL_MODEL,
+                         "vision call must use MULTIMODAL_MODEL")
+        self.assertNotEqual(payload.get("model"), config.GEMMA_MODEL,
+                            "vision call must NOT use the text GEMMA_MODEL (the bug)")
+        self.assertTrue(payload.get("images"),
+                        "vision call must carry the base64 image in 'images'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Root cause of **"uploaded images formed no entities/relations"**: the corpus-ingest image path (`file_processor.extract_image` → `RouterWrapper` → `GemmaClient.call_gemma_vision`) posted the image to **`GEMMA_MODEL`** (`gemma4:e4b` — a **text** model), which ignored the image and replied "이미지가 첨부되어 있지 않습니다 / no image attached". That refusal became the extracted "content", so entity extraction had nothing real to work with — the `extraction.json` sidecars showed `relations: []` and only a trivial date / filename-document entity.

> The sidebar "indexed" badge only means *processed + vector-stored*, not *knowledge extracted* — which is why it looked fine but the graph was empty for images.

**Fix**: route the vision call to a multimodal model — add `config.MULTIMODAL_MODEL` (default `llava:13b`) and use it in `call_gemma_vision` instead of `GEMMA_MODEL`.

## Verification
Live, on the actual uploaded photo, via the **same** path (`RouterWrapper("vision").call_gemma_vision`):
- **before**: `"이미지가 필요합니다"` (model saw no image)
- **after**: a real ~600-char description ("a document with Korean text, a notice/info sheet about regulations…") → entity extraction now has genuine content.

Only caller is the upload path (`file_processor`). `tests/test_vision_model_routing.py` (2) green; `test_measurement_critical_surfaces` 33/33 green.

## Out of scope / note
- Already-uploaded images do **not** reprocess automatically — re-upload to extract entities with the fixed model.
- Photo quality still matters (a blurry photo yields a description, not exact OCR text); clearer document images extract real text → richer entities.

## Quality delta
Quality delta: exempt (label: fix) — `config.py` + `core/gemma_client` vision client; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)