### PR TITLE
fix(v0.6.1): image OCR — vision→OCR routing, drop harmful binarization, gate OCR noise

### DIFF
--- a/processors/file_processor.py
+++ b/processors/file_processor.py
@@ -22,6 +22,7 @@ PROJECT JAMES - File Processor Module
          후속 phase 가 단일 quarantine chokepoint 로 통일 예정.
 """
 import os
+import re
 import cv2
 import numpy as np
 from PIL import Image
@@ -32,6 +33,17 @@ from pdf2image import convert_from_path
 from config import POPPLER_PATH, TESSERACT_PATH
 from core.policy_engine import TrustedContent
 from utils.metadata import MetadataGenerator
+
+# Minimum per-word OCR confidence (Tesseract 0-100 scale; EasyOCR's 0-1
+# scale is compared against this/100). Words below this are dropped — the
+# key defence against OCR "noise" (a blurry photo can otherwise emit tens
+# of thousands of low-confidence garbage tokens that would pollute the KG).
+_OCR_MIN_CONF = 55
+
+# Sentinel the vision model emits when it cannot read any text. Lets us
+# distinguish "no transcription" from real text WITHOUT a fragile
+# length/keyword heuristic, so the OCR fallback fires correctly.
+_NO_TEXT = "<NO_TEXT>"
 
 
 class FileProcessor:
@@ -118,33 +130,110 @@ class FileProcessor:
         )
 
     def _preprocess_image(self, img):
-        w, h  = img.size
-        img   = img.resize((w * 2, h * 2), Image.LANCZOS)
-        img_np = np.array(img.convert("L"))
-        binary = cv2.adaptiveThreshold(img_np, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
-                                        cv2.THRESH_BINARY, 11, 2)
-        return Image.fromarray(binary)
+        # NO hard binarization. Adaptive thresholding targets clean,
+        # evenly-lit scans; on PHOTOS it freezes lighting gradients + JPEG
+        # noise into black/white speckle that Tesseract reads as thousands
+        # of phantom characters (measured on a blurry doc photo: this path
+        # produced 296k garbage chars vs ~2k on the plain grayscale image —
+        # a 136× amplification). Modern Tesseract-LSTM normalises internally
+        # and reads grayscale better, so hand it grayscale and let it work.
+        # A 2× upscale still helps small text, but only when the image is
+        # small — upscaling an already-large photo just multiplies the noise.
+        w, h = img.size
+        if max(w, h) < 2000:
+            img = img.resize((w * 2, h * 2), Image.LANCZOS)
+        return img.convert("L")
 
     def _extract_with_tesseract(self, img):
+        # Confidence-filtered: keep only words Tesseract is reasonably sure
+        # about. A blurry / textless photo otherwise yields huge runs of
+        # low-confidence gibberish (observed: 296k garbage chars) that would
+        # be ingested as fake "text". image_to_data gives per-word conf.
         pytesseract.pytesseract.tesseract_cmd = TESSERACT_PATH
         processed = self._preprocess_image(img)
-        return pytesseract.image_to_string(processed, lang="kor+eng", config="--psm 6")
+        try:
+            data = pytesseract.image_to_data(
+                processed, lang="kor+eng", config="--psm 6",
+                output_type=pytesseract.Output.DICT,
+            )
+        except Exception as e:
+            print(f"[DEBUG] Tesseract 오류: {e}")
+            return ""
+        words = []
+        for w, c in zip(data.get("text", []), data.get("conf", [])):
+            try:
+                conf = float(c)
+            except (TypeError, ValueError):
+                conf = -1.0
+            if conf >= _OCR_MIN_CONF and w.strip():
+                words.append(w.strip())
+        return " ".join(words)
 
     def _extract_with_easyocr(self, filepath):
         reader = self.get_easyocr_reader()
         if not reader:
             return ""
-        results = reader.readtext(filepath, detail=0, paragraph=True)
-        return "\n".join(results)
+        try:
+            # detail=1 → (bbox, text, confidence); EasyOCR conf is 0-1.
+            results = reader.readtext(filepath, detail=1, paragraph=False)
+        except Exception as e:
+            print(f"[DEBUG] EasyOCR 오류: {e}")
+            return ""
+        kept = [
+            t for (_b, t, conf) in results
+            if conf >= (_OCR_MIN_CONF / 100.0) and t and t.strip()
+        ]
+        return "\n".join(kept)
+
+    @staticmethod
+    def _looks_like_text(text: str) -> bool:
+        """True iff ``text`` reads as real extracted text, not OCR noise.
+
+        Three guards (confidence filtering already drops most low-conf
+        noise upstream; this is the final gate before the KG):
+
+          1. ≥10 word-characters total (reject near-empty).
+          2. ≥50% of non-space chars are Hangul / Latin / digit (rejects
+             block-char / symbol soup like EasyOCR's ▒█).
+          3. NOT fragmented: a real document OCR yields multi-character
+             "words", whereas an unreadable photo yields a stream of
+             isolated 1-char tokens + symbols ("y | ® Fo 이 고 il Ki ...").
+             Require ≥40% of whitespace tokens to be real words (≥2 word-
+             chars) AND at least 5 such words.
+        """
+        t = (text or "").strip()
+        valid = len(re.findall(r"[가-힣A-Za-z0-9]", t))
+        if valid < 10:
+            return False
+        nonspace = len(re.sub(r"\s", "", t)) or 1
+        if (valid / nonspace) < 0.5:
+            return False
+        tokens = t.split()
+        if not tokens:
+            return False
+        words = [w for w in tokens
+                 if len(re.findall(r"[가-힣A-Za-z0-9]", w)) >= 2]
+        return (len(words) / len(tokens)) >= 0.4 and len(words) >= 5
 
     def _extract_with_vision_tiling(self, filepath):
+        # Verbatim-transcription prompt with a hard sentinel: the model
+        # must emit `<NO_TEXT>: <short description>` when it cannot read
+        # any text, instead of a verbose "the image is too blurry…"
+        # paragraph. The old prompt's apology (> 10 chars) defeated the
+        # length-based OCR fallback, so blurry document photos extracted
+        # nothing AND never reached OCR.
         try:
             filename = os.path.basename(filepath)
             res = self.gemma_client.call_gemma_vision(
-                "이 이미지의 모든 텍스트를 마크다운으로 추출해. 표가 있다면 형식을 유지해.",
-                filepath
+                "이 이미지에 보이는 모든 텍스트를 그대로(verbatim) 마크다운으로 옮겨 적어. "
+                "표가 있으면 표 형식을 유지해. 설명·사과·번역·추측은 절대 하지 마. "
+                "읽을 수 있는 텍스트가 전혀 없거나 흐려서 못 읽으면, 다른 말 없이 정확히 "
+                f"`{_NO_TEXT}: ` 뒤에 이 이미지가 무엇인지 8단어 이내로만 적어 "
+                f"(예: `{_NO_TEXT}: 흐릿한 한국어 공지 문서 사진`).",
+                filepath,
             )
-            if res.count('|') >= 3:
+            res = res or ""
+            if _NO_TEXT not in res and res.count('|') >= 3:
                 res = f"\n\n> **[ORIGINAL_IMAGE_REFERENCE_REQUIRED: {filename}]**\n" + res
             return res
         except Exception as e:
@@ -153,20 +242,41 @@ class FileProcessor:
 
     def extract_image(self, filepath) -> TrustedContent:
         # 이미지에서 추출된 모든 텍스트는 low-trust (적대적 픽셀 가능).
-        # vision tiling 성공 시 source="vision", OCR fallback 시 source="ocr".
-        text   = self._extract_with_vision_tiling(filepath)
-        source = "vision"
-        if len(text) < 10:
-            text   = self._extract_with_easyocr(filepath)
+        #
+        # Flow (v0.6.1): vision transcription → if it emitted <NO_TEXT> (or
+        # the result isn't real text) fall through to confidence-gated OCR
+        # (Tesseract → EasyOCR). OCR output passes only `_looks_like_text`,
+        # so garbage from an unreadable photo is discarded rather than
+        # ingested. When nothing is readable we keep an honest, NON-garbage
+        # marker (+ the model's short hint) so a document entity still has
+        # minimal context without fabricated text.
+        vtext   = self._extract_with_vision_tiling(filepath)
+        no_text = _NO_TEXT in vtext
+
+        desc = ""
+        if no_text:
+            m = re.search(rf"{re.escape(_NO_TEXT)}\s*:?\s*([^\n]*)", vtext)
+            desc = (m.group(1).strip() if m else "")[:120]
+
+        text, source = "", "vision"
+        if not no_text and self._looks_like_text(vtext):
+            text, source = vtext.strip(), "vision"
+        else:
+            # vision could not transcribe → confidence-gated OCR fallback
             source = "ocr"
-        if len(text) < 10:
-            text   = self._extract_with_tesseract(Image.open(filepath))
-            source = "ocr"
-        return TrustedContent(
-            text=f"[이미지 분석 결과]\n{text}",
-            source=source,
-            trust="low",
-        )
+            otext = self._extract_with_tesseract(Image.open(filepath))
+            if not self._looks_like_text(otext):
+                otext = self._extract_with_easyocr(filepath)
+            text = otext.strip() if self._looks_like_text(otext) else ""
+
+        if text:
+            body = f"[이미지 텍스트]\n{text}"
+        else:
+            # Nothing readable by vision OR OCR — do NOT ingest noise.
+            body   = f"[이미지 분석] {desc or '텍스트를 추출할 수 없는 이미지'}"
+            source = "vision"
+
+        return TrustedContent(text=body, source=source, trust="low")
 
     def extract_audio(self, filepath) -> TrustedContent:
         model = self.get_whisper_model()

--- a/tests/test_image_extraction_ocr_fallback.py
+++ b/tests/test_image_extraction_ocr_fallback.py
@@ -1,0 +1,103 @@
+"""v0.6.1 — image extraction: vision→OCR fallback + noise gate.
+
+Guards the fix for "uploaded images formed no entities, and a naive OCR
+fallback would dump garbage into the KG":
+
+  * The old `len(text) < 10` gate could not tell a real transcription
+    from the vision model's verbose "too blurry to read" apology, so the
+    OCR fallback never fired. Now the vision prompt emits a `<NO_TEXT>`
+    sentinel and `extract_image` routes to OCR on it.
+  * OCR output is confidence-filtered (`_OCR_MIN_CONF`) and must pass
+    `_looks_like_text`, so a blurry/textless photo (observed: 296k
+    garbage chars) is discarded — `extract_image` then keeps an honest,
+    NON-garbage marker instead of fabricated text.
+
+These tests mock the vision + OCR calls (no model / Tesseract needed) so
+they run fast and deterministically.
+
+Run:
+  python -m unittest tests.test_image_extraction_ocr_fallback
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _make_processor():
+    """FileProcessor without running its heavy __init__ (vision client,
+    metadata gen). We only exercise the pure extraction logic."""
+    from processors.file_processor import FileProcessor
+    fp = FileProcessor.__new__(FileProcessor)
+    return fp
+
+
+class LooksLikeText(unittest.TestCase):
+    def setUp(self):
+        self.fp = _make_processor()
+
+    def test_real_text_passes(self):
+        self.assertTrue(self.fp._looks_like_text(
+            "미국 증권거래위원회(SEC)가 비트코인 spot ETF 11종을 일괄 승인했다."))
+        self.assertTrue(self.fp._looks_like_text(
+            "The quarterly report shows revenue of 12 million dollars."))
+
+    def test_noise_and_empty_fail(self):
+        self.assertFalse(self.fp._looks_like_text(""))
+        self.assertFalse(self.fp._looks_like_text("안녕"))           # too short
+        self.assertFalse(self.fp._looks_like_text("▒█▒█ ░░ █▒ ▓▓"))  # block noise
+        self.assertFalse(self.fp._looks_like_text("!@#$ %^&* ()[] {}|\\"))
+        # fragmented single-char garbage — the real confidence-passed
+        # Tesseract output on an unreadable photo (de-binarized path). Has
+        # many valid Hangul/digit chars but no real words → must be rejected.
+        self.assertFalse(self.fp._looks_like_text(
+            "y | ® Fo 160 > 이 고 il Ki 10, K | 1< | = RO | = 7) Oo 더 38 "
+            "= 해 a As <| ~ = ie Hot = ms @ = Mel 기 고 야 OH 20 = oF 여 시 주"))
+
+
+class ExtractImageFlow(unittest.TestCase):
+    def setUp(self):
+        self.fp = _make_processor()
+
+    def test_vision_transcription_used_directly(self):
+        good = "제목: 2026 1분기 보고서\n매출 120억원, 영업이익 30억원."
+        with mock.patch.object(self.fp, "_extract_with_vision_tiling", return_value=good), \
+             mock.patch.object(self.fp, "_extract_with_tesseract") as tess, \
+             mock.patch.object(self.fp, "_extract_with_easyocr") as easy:
+            tc = self.fp.extract_image("x.jpg")
+        self.assertIn("2026 1분기 보고서", tc.text)
+        self.assertEqual(tc.source, "vision")
+        tess.assert_not_called()   # no need to fall through to OCR
+        easy.assert_not_called()
+
+    def test_no_text_sentinel_falls_through_to_ocr(self):
+        sentinel = "<NO_TEXT>: 흐릿한 한국어 공지 문서 사진"
+        ocr_good = "공지사항\n2026년 6월 25일 전 직원 교육 일정 안내드립니다."
+        with mock.patch.object(self.fp, "_extract_with_vision_tiling", return_value=sentinel), \
+             mock.patch.object(self.fp, "_extract_with_tesseract", return_value=ocr_good), \
+             mock.patch("processors.file_processor.Image.open", return_value=object()):
+            tc = self.fp.extract_image("x.jpg")
+        self.assertIn("교육 일정", tc.text)
+        self.assertEqual(tc.source, "ocr")
+
+    def test_garbage_ocr_discarded_no_fabricated_text(self):
+        # vision says no-text; OCR returns confidence-passed-but-still-noise
+        # block chars → _looks_like_text rejects → honest marker, NO garbage.
+        sentinel = "<NO_TEXT>: 흐릿한 문서 사진"
+        garbage = "▒█▒█ ░░░ █▒▓ ▒░█▓ ░▒█"
+        with mock.patch.object(self.fp, "_extract_with_vision_tiling", return_value=sentinel), \
+             mock.patch.object(self.fp, "_extract_with_tesseract", return_value=garbage), \
+             mock.patch.object(self.fp, "_extract_with_easyocr", return_value=garbage), \
+             mock.patch("processors.file_processor.Image.open", return_value=object()):
+            tc = self.fp.extract_image("x.jpg")
+        self.assertNotIn("▒", tc.text)            # no garbage ingested
+        self.assertIn("흐릿한 문서 사진", tc.text)  # honest hint kept
+        self.assertNotIn("이미지 텍스트", tc.text)  # not labelled as real text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Builds on the vision-model fix (#1067). Three remaining problems in image text extraction:

1. **Routing** — the `len(text) < 10` gate could not distinguish a real transcription from llava's verbose "too blurry to read" apology (>10 chars), so the OCR fallback never fired. Vision now emits a `<NO_TEXT>: <hint>` **sentinel**; `extract_image` routes to OCR on it.

2. **Harmful binarization** (operator advice ✅, empirically validated) — `_preprocess_image` hard-binarized (adaptive Gaussian threshold) + 2× upscale. That targets clean scans; on photos it freezes lighting gradients + JPEG noise into speckle. **Measured: 296,213 garbage chars vs ~2k on plain grayscale — a 136× amplification.** Removed binarization → hand Tesseract-LSTM grayscale; upscale only small (<2000px) images. Scanned-PDF Otsu path is separate and untouched.

3. **OCR noise → KG** — OCR is now **confidence-filtered** (per-word conf ≥ 55) AND must pass `_looks_like_text` (valid-char ratio + a **fragmentation guard** that rejects isolated-1-char-token streams like `y | ® Fo 이 고 il Ki …` that a degraded photo emits even at high confidence). Unreadable images keep an honest `[이미지 분석] <hint>` marker — no fabricated text in the graph.

**Net**: readable document images extract real text → entities; genuinely unreadable photos extract nothing (correct) instead of dumping garbage.

## Verification
- Live on the actual blurry photo: binarized path = 296k garbage; de-binarized + conf-filter = 126 conf-passed tokens that are still fragmented garbage → `_looks_like_text` rejects → honest marker, **0 garbage to KG**.
- `_looks_like_text`: real Korean/English/notice → pass; block noise / fragmented garbage / 2-word / empty → reject.
- `tests/test_image_extraction_ocr_fallback.py` 5/5; `test_measurement_critical_surfaces` 33/33.

## Out of scope / follow-up
- **Operator advice #1 — PaddleOCR as the #1 engine**: sound upgrade (better on photos/CJK), deferred — heavy dep (PaddlePaddle), needs Windows install + real-image test. Order would be Paddle → EasyOCR → Tesseract.
- Genuinely low-res/blurry photos still won't extract (no engine recovers absent pixels).

## Quality delta
Quality delta: exempt (label: fix) — `processors/file_processor` ingest path; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)