### PR TITLE
feat(v0.6.1): EasyOCR-first fallback + image-OCR upgrade path (PaddleOCR blocked on Py3.14)

### DIFF
--- a/docs/deployment/v0.6.1-image-ocr-upgrade.md
+++ b/docs/deployment/v0.6.1-image-ocr-upgrade.md
@@ -1,0 +1,66 @@
+# v0.6.1 — Image OCR quality: engine strategy + upgrade path
+
+Image uploads extract text via `processors/file_processor.extract_image`:
+
+```
+1. Vision model (config.MULTIMODAL_MODEL) — transcribe text, or emit
+   `<NO_TEXT>: <hint>` when it can't read any.
+2. On <NO_TEXT> / non-text → OCR fallback:  EasyOCR (neural) → Tesseract.
+3. Every OCR result is confidence-filtered + must pass `_looks_like_text`
+   (valid-char ratio + fragmentation guard). Garbage is discarded — an
+   unreadable photo yields an honest "[이미지 분석] <hint>" marker, never
+   fabricated text in the knowledge graph.
+```
+
+## Why not PaddleOCR (the obvious "best photo OCR")
+
+PaddleOCR is genuinely the strongest local photo/CJK OCR, and was the
+first choice. **It is not installable in this environment**: the runtime
+is **Python 3.14**, and `paddlepaddle` ships **no wheel for 3.14**
+(`pip install paddlepaddle` → *No matching distribution found*).
+PaddlePaddle support typically lags to 3.12/3.13.
+
+To use PaddleOCR you would need one of:
+- a **separate Python 3.11/3.12 venv** running PaddleOCR as a subprocess
+  / local microservice that `extract_image` shells out to, or
+- pin the whole app to Python ≤ 3.13.
+
+Both are larger efforts; revisit if photo-OCR volume justifies it.
+
+## The higher-leverage upgrade: a stronger vision model (no code change)
+
+`llava:13b` (the default `MULTIMODAL_MODEL`) is an older model and weak at
+OCR. Modern vision models read documents far better. Because the vision
+model is config-driven, **swapping it needs zero code change** — pull a
+better model and point `MULTIMODAL_MODEL` at it:
+
+```bash
+ollama pull qwen2.5vl:7b          # excellent OCR; or minicpm-v, llama3.2-vision
+# then one of:
+setx JAMES_MULTIMODAL_MODEL qwen2.5vl:7b      # env (Windows)
+# or set llm_setting "multimodal_model" = "qwen2.5vl:7b" in the admin UI
+```
+
+Restart the server; `call_gemma_vision` (ollama `/api/generate` with
+`images=[…]`) works identically for any ollama vision model. Verify by
+re-uploading a document image and checking the extraction sidecar
+(`uploads/<uuid>_<name>.extraction.json`) has real entities.
+
+Recommended candidates (ollama), best-first for document OCR:
+`qwen2.5vl:7b` → `minicpm-v` → `llama3.2-vision:11b` → (current) `llava:13b`.
+
+## Hard limit
+
+No engine recovers text that isn't in the pixels. A genuinely low-res /
+blurry / oblique phone photo (every local engine — llava, EasyOCR,
+Tesseract — failed on one such image during this work) will still extract
+nothing; the noise gate then correctly keeps it out of the KG rather than
+inventing text. For best results, upload sharp, front-on scans or
+screenshots.
+
+## Related
+
+- `#1067` — vision call must use a multimodal model (was the text model).
+- `#1068` — vision→OCR routing, removed harmful binarization (measured
+  136× garbage amplification), OCR noise gate.
+- `config.MULTIMODAL_MODEL` / `JAMES_MULTIMODAL_MODEL` — the swap seam.

--- a/processors/file_processor.py
+++ b/processors/file_processor.py
@@ -262,11 +262,15 @@ class FileProcessor:
         if not no_text and self._looks_like_text(vtext):
             text, source = vtext.strip(), "vision"
         else:
-            # vision could not transcribe → confidence-gated OCR fallback
+            # vision could not transcribe → confidence-gated OCR fallback.
+            # EasyOCR (neural) goes first — it reads real-world / Korean
+            # photos markedly better than Tesseract; Tesseract is the
+            # cheaper last resort. (PaddleOCR would be a stronger #1 still,
+            # but has no wheel for this Python — see the upgrade note.)
             source = "ocr"
-            otext = self._extract_with_tesseract(Image.open(filepath))
+            otext = self._extract_with_easyocr(filepath)
             if not self._looks_like_text(otext):
-                otext = self._extract_with_easyocr(filepath)
+                otext = self._extract_with_tesseract(Image.open(filepath))
             text = otext.strip() if self._looks_like_text(otext) else ""
 
         if text:

--- a/tests/test_image_extraction_ocr_fallback.py
+++ b/tests/test_image_extraction_ocr_fallback.py
@@ -75,14 +75,18 @@ class ExtractImageFlow(unittest.TestCase):
         easy.assert_not_called()
 
     def test_no_text_sentinel_falls_through_to_ocr(self):
+        # EasyOCR (the neural #1 fallback) returns good text → Tesseract
+        # is not even reached.
         sentinel = "<NO_TEXT>: 흐릿한 한국어 공지 문서 사진"
         ocr_good = "공지사항\n2026년 6월 25일 전 직원 교육 일정 안내드립니다."
         with mock.patch.object(self.fp, "_extract_with_vision_tiling", return_value=sentinel), \
-             mock.patch.object(self.fp, "_extract_with_tesseract", return_value=ocr_good), \
+             mock.patch.object(self.fp, "_extract_with_easyocr", return_value=ocr_good), \
+             mock.patch.object(self.fp, "_extract_with_tesseract") as tess, \
              mock.patch("processors.file_processor.Image.open", return_value=object()):
             tc = self.fp.extract_image("x.jpg")
         self.assertIn("교육 일정", tc.text)
         self.assertEqual(tc.source, "ocr")
+        tess.assert_not_called()   # EasyOCR succeeded first
 
     def test_garbage_ocr_discarded_no_fabricated_text(self):
         # vision says no-text; OCR returns confidence-passed-but-still-noise


### PR DESCRIPTION
## Summary
Operator asked to make **PaddleOCR the #1 OCR engine**. It is **not installable here**: runtime is **Python 3.14** and `paddlepaddle` ships **no wheel for 3.14** (`pip install paddlepaddle` → *No matching distribution found*; Paddle lags to 3.12/3.13).

Two achievable improvements instead:

1. **Code** — reorder the OCR fallback to **EasyOCR (neural) before Tesseract**. EasyOCR reads real-world / Korean photos markedly better; Tesseract stays as the cheap last resort.

2. **Doc (higher-leverage, zero-code)** — `llava:13b` is weak at OCR. Since the vision model is config-driven (`config.MULTIMODAL_MODEL`, added in #1067), the operator can `ollama pull qwen2.5vl:7b` and set `JAMES_MULTIMODAL_MODEL` with **no code change** for far better document reading. `docs/deployment/v0.6.1-image-ocr-upgrade.md` captures the engine strategy, the PaddleOCR blocker + workarounds (separate Py3.11/3.12 microservice), and the recommended model swap (`qwen2.5vl:7b` → `minicpm-v` → `llama3.2-vision` → llava).

## Verification
- `tests/test_image_extraction_ocr_fallback.py` 5/5 (updated mock order: EasyOCR first; Tesseract not reached when EasyOCR succeeds).
- syntax OK.

## Out of scope
- Installing PaddleOCR (needs a separate Python ≤3.13 runtime — a larger effort, revisit if photo-OCR volume justifies it).
- Pulling the better vision model (operator action — ~3-9 GB download).

## Quality delta
Quality delta: exempt (label: feat) — `processors/file_processor` OCR ordering + a deployment doc; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)