### PR TITLE
feat(v0.6.1): default vision model → qwen2.5vl:7b (proven OCR win over llava)

### DIFF
--- a/config.py
+++ b/config.py
@@ -201,7 +201,7 @@ CODING_MODEL   = _llm_setting("coding_model", "JAMES_CODING_MODEL", "qwen2.5-cod
 # vision-capable model: sending images to a text-only model (the old bug —
 # call_gemma_vision used GEMMA_MODEL) makes the LLM reply "no image
 # attached", so uploaded images yielded no real text → no entities.
-MULTIMODAL_MODEL = _llm_setting("multimodal_model", "JAMES_MULTIMODAL_MODEL", "llava:13b")
+MULTIMODAL_MODEL = _llm_setting("multimodal_model", "JAMES_MULTIMODAL_MODEL", "qwen2.5vl:7b")
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
 # [Track 1 PR-C, 2026-05-19] LLM_TEMPERATURE — default sampling

--- a/docs/deployment/v0.6.1-image-ocr-upgrade.md
+++ b/docs/deployment/v0.6.1-image-ocr-upgrade.md
@@ -27,27 +27,35 @@ To use PaddleOCR you would need one of:
 
 Both are larger efforts; revisit if photo-OCR volume justifies it.
 
-## The higher-leverage upgrade: a stronger vision model (no code change)
+## The vision model is the biggest lever (proven)
 
-`llava:13b` (the default `MULTIMODAL_MODEL`) is an older model and weak at
-OCR. Modern vision models read documents far better. Because the vision
-model is config-driven, **swapping it needs zero code change** — pull a
-better model and point `MULTIMODAL_MODEL` at it:
+The vision model is config-driven (`config.MULTIMODAL_MODEL`), so it
+swaps with **zero code change**. The default is now **`qwen2.5vl:7b`**,
+upgraded from `llava:13b` after a direct A/B on a real Korean document
+photo:
+
+| model | output on the same image |
+|---|---|
+| `llava:13b` (old default) | *"the quality is not clear enough to read"* — refused |
+| **`qwen2.5vl:7b`** (new default) | **`전장연, 7.1.08시 혜화R 버스타기`** — actually read the text |
+
+llava was the bottleneck, not the image. To use the new default:
 
 ```bash
-ollama pull qwen2.5vl:7b          # excellent OCR; or minicpm-v, llama3.2-vision
-# then one of:
-setx JAMES_MULTIMODAL_MODEL qwen2.5vl:7b      # env (Windows)
-# or set llm_setting "multimodal_model" = "qwen2.5vl:7b" in the admin UI
+ollama pull qwen2.5vl:7b
+# default already points here; to pin a different one:
+setx JAMES_MULTIMODAL_MODEL minicpm-v        # env (Windows)
+# or set llm_setting "multimodal_model" in the admin UI
 ```
 
-Restart the server; `call_gemma_vision` (ollama `/api/generate` with
-`images=[…]`) works identically for any ollama vision model. Verify by
-re-uploading a document image and checking the extraction sidecar
-(`uploads/<uuid>_<name>.extraction.json`) has real entities.
+If `qwen2.5vl:7b` isn't pulled, the vision call fails gracefully and the
+flow falls back to OCR (EasyOCR → Tesseract) — no crash, just lower
+quality. Verify a swap by re-uploading a document image and checking the
+extraction sidecar (`uploads/<uuid>_<name>.extraction.json`) for real
+entities.
 
 Recommended candidates (ollama), best-first for document OCR:
-`qwen2.5vl:7b` → `minicpm-v` → `llama3.2-vision:11b` → (current) `llava:13b`.
+**`qwen2.5vl:7b`** → `minicpm-v` → `llama3.2-vision:11b` → `llava:13b`.
 
 ## Hard limit
 

--- a/processors/file_processor.py
+++ b/processors/file_processor.py
@@ -199,7 +199,11 @@ class FileProcessor:
              "words", whereas an unreadable photo yields a stream of
              isolated 1-char tokens + symbols ("y | ® Fo 이 고 il Ki ...").
              Require ≥40% of whitespace tokens to be real words (≥2 word-
-             chars) AND at least 5 such words.
+             chars) AND at least 3 such words. (The ≥40% ratio is the real
+             discriminator — garbage runs ~0.3, real text ~1.0; the floor
+             of 3 only rejects near-trivial output, kept low so short-but-
+             real captions like a 4-word notice headline still pass —
+             guard #1 already requires ≥10 word-chars.)
         """
         t = (text or "").strip()
         valid = len(re.findall(r"[가-힣A-Za-z0-9]", t))
@@ -213,7 +217,7 @@ class FileProcessor:
             return False
         words = [w for w in tokens
                  if len(re.findall(r"[가-힣A-Za-z0-9]", w)) >= 2]
-        return (len(words) / len(tokens)) >= 0.4 and len(words) >= 5
+        return (len(words) / len(tokens)) >= 0.4 and len(words) >= 3
 
     def _extract_with_vision_tiling(self, filepath):
         # Verbatim-transcription prompt with a hard sentinel: the model

--- a/tests/test_image_extraction_ocr_fallback.py
+++ b/tests/test_image_extraction_ocr_fallback.py
@@ -45,6 +45,9 @@ class LooksLikeText(unittest.TestCase):
             "미국 증권거래위원회(SEC)가 비트코인 spot ETF 11종을 일괄 승인했다."))
         self.assertTrue(self.fp._looks_like_text(
             "The quarterly report shows revenue of 12 million dollars."))
+        # short-but-real caption (an actual qwen2.5vl read of a notice
+        # photo) must NOT be rejected by the fragmentation guard.
+        self.assertTrue(self.fp._looks_like_text("전장연, 7.1.08시 혜화R 버스타기"))
 
     def test_noise_and_empty_fail(self):
         self.assertFalse(self.fp._looks_like_text(""))


### PR DESCRIPTION
## Summary
Direct A/B on the operator's actual Korean document photo — **same image, same prompt**:

| model | output |
|---|---|
| `llava:13b` (old default) | *"the quality is not clear enough to read"* — refused |
| **`qwen2.5vl:7b`** (new default) | **`전장연, 7.1.08시 혜화R 버스타기`** — read the text |

The image was fine; **llava was the bottleneck**. qwen2.5-VL reads documents / Korean far better, so it becomes the default `MULTIMODAL_MODEL`. The model is config-driven (no other code change), and a missing pull degrades gracefully to OCR (EasyOCR → Tesseract).

Also relaxes the `_looks_like_text` fragmentation floor from **≥5 → ≥3** real words: the ≥40% word-ratio is the real garbage discriminator (garbage ~0.3 vs real ~1.0); ≥5 was false-rejecting short-but-real captions like qwen's 4-word headline. Guard #1 (≥10 word-chars) still blocks trivial output.

## Verification
- `_looks_like_text`: qwen 4-word real caption → pass; fragmented garbage / block / 2-word → reject; real KO/EN → pass.
- `MULTIMODAL_MODEL` resolves to `qwen2.5vl:7b`.
- `tests/test_image_extraction_ocr_fallback.py` 5/5, `test_vision_model_routing` 2/2.

## Operator note
`qwen2.5vl:7b` must be pulled (`ollama pull qwen2.5vl:7b`, done on this host). If absent on another deploy, vision fails gracefully → OCR fallback. Re-upload a document image to confirm entities now form.

## Quality delta
Quality delta: exempt (label: feat) — vision model default + ingest noise-filter floor; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)