### PR TITLE
fix(v0.6.1): do not ingest the vision error string as image text

### DIFF
--- a/processors/file_processor.py
+++ b/processors/file_processor.py
@@ -237,6 +237,16 @@ class FileProcessor:
                 filepath,
             )
             res = res or ""
+            # GemmaClient.call_gemma_vision SWALLOWS HTTP/timeout errors and
+            # returns a "[Gemma Vision 오류] …" STRING (e.g. a transient 400
+            # while the model cold-loads after a restart). That string has
+            # real words, so _looks_like_text would accept it and the error
+            # message would be ingested as the image's text + spawn a bogus
+            # "Gemma Vision" entity. Treat any such error string as a failed
+            # transcription → "" so extract_image falls through to OCR.
+            if res.lstrip().startswith("[Gemma Vision 오류]"):
+                print(f"[DEBUG] Vision 호출 실패(에러 문자열) → OCR fallback: {res[:80]}")
+                return ""
             if _NO_TEXT not in res and res.count('|') >= 3:
                 res = f"\n\n> **[ORIGINAL_IMAGE_REFERENCE_REQUIRED: {filename}]**\n" + res
             return res

--- a/tests/test_image_extraction_ocr_fallback.py
+++ b/tests/test_image_extraction_ocr_fallback.py
@@ -91,6 +91,17 @@ class ExtractImageFlow(unittest.TestCase):
         self.assertEqual(tc.source, "ocr")
         tess.assert_not_called()   # EasyOCR succeeded first
 
+    def test_vision_error_string_not_treated_as_text(self):
+        # call_gemma_vision swallows a transient 400 (model cold-load) into
+        # a "[Gemma Vision 오류] …" string. It has real words but must NOT
+        # be transcription — _extract_with_vision_tiling returns "" so the
+        # flow falls to OCR instead of ingesting the error message.
+        self.fp.gemma_client = mock.Mock()
+        self.fp.gemma_client.call_gemma_vision.return_value = (
+            "[Gemma Vision 오류] 400 Client Error: Bad Request for url: "
+            "http://127.0.0.1:11434/api/generate")
+        self.assertEqual(self.fp._extract_with_vision_tiling("x.jpg"), "")
+
     def test_garbage_ocr_discarded_no_fabricated_text(self):
         # vision says no-text; OCR returns confidence-passed-but-still-noise
         # block chars → _looks_like_text rejects → honest marker, NO garbage.


### PR DESCRIPTION
## Summary
Debug from a real upload right after the qwen2.5vl swap: extraction logged `129자, source=vision` but the metadata exposed it as an **error** — `keywords ["Gemma","Vision","오류","Client Error","Bad Request"]`, `summary "이미지 파일에서 Gemma Vision 오류 메시지를 추출함"`.

**Root cause**: the vision call hit a **transient HTTP 400** (qwen2.5vl:7b cold-loading into ollama right after the server restart). `GemmaClient.call_gemma_vision` swallows errors into a `[Gemma Vision 오류] …` **string**; that string has real words, so `_looks_like_text` accepted it → the error message was ingested as the image text + spawned a bogus `Gemma Vision` entity.

**Fix**: `_extract_with_vision_tiling` returns `""` when the vision call yields a `[Gemma Vision 오류]` error string → `extract_image` falls through to OCR (or the honest marker) instead of ingesting the error.

The **model swap is fine** — re-running the exact server path once warm reads the image correctly: `전장연, 7.1.~7.2. 08시 혜화R 버스타기 …`. The 400 was cold-start only.

## Verification
- `tests/test_image_extraction_ocr_fallback.py` 6/6 (+ error-string → "" case).
- Live: `RouterWrapper("vision").call_gemma_vision` on the image → real text (44 chars).

## Quality delta
Quality delta: exempt (label: fix) — `processors/file_processor` vision error handling; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)