### PR TITLE
fix(v0.6.1): raise vision num_ctx — high-res images overflowed 4096 ctx → 400

### DIFF
--- a/config.py
+++ b/config.py
@@ -202,6 +202,16 @@ CODING_MODEL   = _llm_setting("coding_model", "JAMES_CODING_MODEL", "qwen2.5-cod
 # call_gemma_vision used GEMMA_MODEL) makes the LLM reply "no image
 # attached", so uploaded images yielded no real text → no entities.
 MULTIMODAL_MODEL = _llm_setting("multimodal_model", "JAMES_MULTIMODAL_MODEL", "qwen2.5vl:7b")
+# Context window for the vision call. A high-res photo (e.g. a 12 MP phone
+# shot of a document) becomes thousands of vision tokens; with the default
+# ollama context (4096) the image + prompt overflow → HTTP 400
+# `exceed_context_size_error` and NO text is read. 8192 fits a 12 MP image
+# + the extraction prompt with headroom; operators with larger photos can
+# raise it (more VRAM) via JAMES_VISION_NUM_CTX.
+try:
+    VISION_NUM_CTX = int(os.environ.get("JAMES_VISION_NUM_CTX", "8192"))
+except ValueError:
+    VISION_NUM_CTX = 8192
 OLLAMA_API_URL = os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434/api/generate")
 
 # [Track 1 PR-C, 2026-05-19] LLM_TEMPERATURE — default sampling

--- a/core/gemma_client/client.py
+++ b/core/gemma_client/client.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 import requests
 
-from config import GEMMA_MODEL, MULTIMODAL_MODEL, OLLAMA_API_URL
+from config import GEMMA_MODEL, MULTIMODAL_MODEL, OLLAMA_API_URL, VISION_NUM_CTX
 from core.gemma_client.config import _resolve_max_prompt_len
 from core.gemma_client.errors import (
     is_cacheable_response,
@@ -352,6 +352,10 @@ class GemmaClient:
                     "prompt": prompt,
                     "images": [image_b64],
                     "stream": False,
+                    # A high-res image's vision tokens + the prompt overflow
+                    # the default 4096 context → HTTP 400 and zero text read.
+                    # See config.VISION_NUM_CTX.
+                    "options": {"num_ctx": VISION_NUM_CTX},
                 },
                 timeout=timeout,
             )


### PR DESCRIPTION
## Summary
The qwen2.5vl swap read the test image **standalone** but **400d in the server**. Captured ollamas raw response:

> `"request (4165 tokens) exceeds the available context size (4096 tokens), try increasing it"` — `n_prompt_tokens=4165, n_ctx=4096`

A 12 MP phone photo becomes thousands of vision tokens; with the (verbose) extraction prompt it overflows ollamas **default 4096** context → HTTP 400, zero text. The standalone repro happened to use a SHORT prompt that fit under 4096 — which is why it passed and the server didnt.

**Fix**: send `options.num_ctx` on the vision call (`config.VISION_NUM_CTX`, default **8192**, env `JAMES_VISION_NUM_CTX`).

## Verification
End-to-end via the real extraction path (`_extract_with_vision_tiling`, full prompt, num_ctx=8192): the same image now returns the **full document as a markdown table** — `<전장연 7.1~7.2 1박2일 전체 일정>` with dates, times, head-counts (휠체어 수), and locations. `looks_like_text=True`. Real entities will form on the next upload.
- `test_vision_model_routing` + `test_image_extraction_ocr_fallback` 8/8.

## Operator note
Larger photos (e.g. 48 MP) may still exceed 8192 → raise `JAMES_VISION_NUM_CTX` (more VRAM). Until then the error-string guard (#1071) keeps a failed call out of the KG.

## Quality delta
Quality delta: exempt (label: fix) — vision request context size; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)