### PR TITLE
feat(v0.6.1): heartbeat-stream /query/ + /upload/ (survive mobile/Tailscale tunnel drops)

### DIFF
--- a/core/http_heartbeat.py
+++ b/core/http_heartbeat.py
@@ -1,0 +1,86 @@
+"""Keep long HTTP responses alive over flaky mobile / Tailscale tunnels.
+
+A request that holds an *idle* connection while the server does 30–90 s of
+work (a full RAG query, an image ingest with vision OCR) gets dropped by a
+mobile network or a Tailscale re-handshake — the browser surfaces it as
+``Failed to fetch`` and the (server-side already-finished) result is lost.
+The same blocking call inside an ``async def`` handler also pins the event
+loop, so ``/trace/poll`` can't serve live reasoning stages during the
+request.
+
+``stream_json_with_heartbeat`` fixes both:
+
+  * runs the blocking ``work()`` in a worker thread (frees the event loop →
+    ``/trace/poll`` streams stages live), and
+  * emits JSON-insignificant whitespace every few seconds while it runs, so
+    bytes keep flowing and the tunnel stays up.
+
+The heartbeat is leading whitespace; ``Response.json()`` / ``JSON.parse``
+ignore it, so clients need **no change** — they still ``await r.json()``.
+
+``contextvars`` (e.g. ``core.observability.current_trace_id``) propagate
+into the worker thread because ``anyio.to_thread.run_sync`` copies the
+current context — so trace correlation is preserved.
+
+Usage — do the fast, status-bearing validation (auth, 400/413/403) BEFORE
+calling this (the streamed response is always HTTP 200); put only the slow
+work in ``work``::
+
+    return await stream_json_with_heartbeat(_do_the_slow_work)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable
+
+import anyio
+from fastapi.responses import StreamingResponse
+
+# Default gap between heartbeats. Comfortably under the idle-eviction
+# windows seen on mobile carriers / Tailscale (~30–60 s) while staying
+# cheap (one byte).
+_HEARTBEAT_INTERVAL_SEC = 12.0
+
+# Leading whitespace — ignored by any JSON parser, so the client reads the
+# concatenated body as plain JSON.
+_HEARTBEAT = b" "
+
+
+async def stream_json_with_heartbeat(
+    work: Callable[[], Any],
+    *,
+    interval: float = _HEARTBEAT_INTERVAL_SEC,
+) -> StreamingResponse:
+    """Stream ``json.dumps(work())`` while keeping the connection alive.
+
+    ``work`` is a blocking, no-arg callable returning a JSON-serialisable
+    object. It runs in a worker thread. On exception the error is streamed
+    in the body (``{"answer": "", "error": ...}``) rather than tearing the
+    connection — the HTTP status is already ``200`` once streaming starts,
+    and the client's empty-answer handling still applies.
+    """
+    async def gen():
+        task = asyncio.ensure_future(anyio.to_thread.run_sync(work))
+        while not task.done():
+            done, _ = await asyncio.wait({task}, timeout=interval)
+            if not done:
+                yield _HEARTBEAT
+        try:
+            result = task.result()
+            yield json.dumps(result, ensure_ascii=False).encode("utf-8")
+        except Exception as e:  # noqa: BLE001 — surface, don't tear the socket
+            yield json.dumps(
+                {"answer": "", "error": str(e)[:500]},
+                ensure_ascii=False,
+            ).encode("utf-8")
+
+    # no-store: the whitespace-prefixed body must never be cached.
+    return StreamingResponse(
+        gen(),
+        media_type="application/json",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+__all__ = ("stream_json_with_heartbeat",)

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 from typing import Optional
 
 from config import MAX_UPLOAD_BYTES, UPLOAD_DIR
+from core.http_heartbeat import stream_json_with_heartbeat
 from core.api_keys import (
     issue_api_key as _api_key_issue,
     list_api_keys as _api_key_list,
@@ -258,210 +259,217 @@ async def upload(
         print(f"[UPLOAD] data_artifacts register skipped: {_e}")
         artifact_id = None
 
-    try:
-        # #44 phase 4-B: process_file 가 TrustedContent 반환.
-        # #44 phase 4-C: ingestion 검역은 PolicyEngine 단일 chokepoint
-        # (`default_engine.sanitize_for_ingestion`) 로 라우팅. 기존
-        # `sanitize_document_content` 는 backwards-compat shim 으로 유지되며
-        # 동일한 코드 경로(extract_data_only + log_attack) 를 사용한다.
-        tc = file_processor.process_file(filepath, file.filename)
-        print(f"[UPLOAD] provenance source={tc.source} trust={tc.trust} "
-              f"file={file.filename}")
-
-        # [P4-SRV-5] Instruction Isolation — PolicyEngine ingestion gate
-        raw_content, _sanitize_decision = default_engine.sanitize_for_ingestion(
-            tc, source=file.filename,
-        )
-
-        meta   = file_processor.generate_file_metadata(raw_content)
-        from utils.tokenizer import split_chunks
-        chunks = split_chunks(raw_content)
-
-        # [P7-FIX] 업로드는 서버 내부 작업
-        # Memory Trust는 사용자 쿼리 신뢰도 검증용 — 업로드에 적용 불필요
-        # api_key 검증(verify_api_key) 통과 = 신뢰된 요청으로 처리
-
-        rag_engine.vector_store.add_documents_with_meta(
-            texts=chunks, source=file.filename,
-            metadata={
-                "sensitivity": meta.get("sensitivity", "internal"),
-                "owner":       meta.get("owner", "system"),
-                "category":    meta.get("category", "기타"),
-                "source_type": "prod",
-            },
-        )
-        # [W8-C 2026-05-11] capture entity_ids so we can write
-        # wiki_links rows after the entity files are on disk. The
-        # process_document_for_entities return type was unused before;
-        # we now consume it to make the artifact ↔ entity relation
-        # queryable from /admin/artifacts/<id> + the workspace UI.
-        created_entity_ids: list = []
-        # Phase D — extraction sidecar 경로. 물리 파일 옆에 `<uuid>_<file>
-        # .extraction.json` 으로 저장 → 재업로드 시 modify cascade 가 이
-        # 파일을 읽어 old/new triple diff 를 한다.
-        extraction_sidecar = os.path.join(
-            UPLOAD_DIR, unique_name + ".extraction.json",
-        )
+    # Run the slow ingest (vision OCR / entity extraction, ~30-60s) in a
+    # worker thread + heartbeat the connection so a mobile/Tailscale tunnel
+    # does not drop the upload mid-process (which left the composer chip
+    # stuck even though the server finished). Validation/size/auth errors
+    # already raised above with proper status before streaming starts.
+    def _work():
         try:
-            created_entity_ids = list(
-                rag_engine.wiki_generator.process_document_for_entities(
-                    file.filename, raw_content, [],
-                    user_role="admin",
-                    metadata=meta,
-                    extraction_sidecar_path=extraction_sidecar,
-                ) or []
+            # #44 phase 4-B: process_file 가 TrustedContent 반환.
+            # #44 phase 4-C: ingestion 검역은 PolicyEngine 단일 chokepoint
+            # (`default_engine.sanitize_for_ingestion`) 로 라우팅. 기존
+            # `sanitize_document_content` 는 backwards-compat shim 으로 유지되며
+            # 동일한 코드 경로(extract_data_only + log_attack) 를 사용한다.
+            tc = file_processor.process_file(filepath, file.filename)
+            print(f"[UPLOAD] provenance source={tc.source} trust={tc.trust} "
+                  f"file={file.filename}")
+
+            # [P4-SRV-5] Instruction Isolation — PolicyEngine ingestion gate
+            raw_content, _sanitize_decision = default_engine.sanitize_for_ingestion(
+                tc, source=file.filename,
             )
-        except TypeError:
-            # 구버전 시그니처 fallback (metadata/user_role 미지원)
+
+            meta   = file_processor.generate_file_metadata(raw_content)
+            from utils.tokenizer import split_chunks
+            chunks = split_chunks(raw_content)
+
+            # [P7-FIX] 업로드는 서버 내부 작업
+            # Memory Trust는 사용자 쿼리 신뢰도 검증용 — 업로드에 적용 불필요
+            # api_key 검증(verify_api_key) 통과 = 신뢰된 요청으로 처리
+
+            rag_engine.vector_store.add_documents_with_meta(
+                texts=chunks, source=file.filename,
+                metadata={
+                    "sensitivity": meta.get("sensitivity", "internal"),
+                    "owner":       meta.get("owner", "system"),
+                    "category":    meta.get("category", "기타"),
+                    "source_type": "prod",
+                },
+            )
+            # [W8-C 2026-05-11] capture entity_ids so we can write
+            # wiki_links rows after the entity files are on disk. The
+            # process_document_for_entities return type was unused before;
+            # we now consume it to make the artifact ↔ entity relation
+            # queryable from /admin/artifacts/<id> + the workspace UI.
+            created_entity_ids: list = []
+            # Phase D — extraction sidecar 경로. 물리 파일 옆에 `<uuid>_<file>
+            # .extraction.json` 으로 저장 → 재업로드 시 modify cascade 가 이
+            # 파일을 읽어 old/new triple diff 를 한다.
+            extraction_sidecar = os.path.join(
+                UPLOAD_DIR, unique_name + ".extraction.json",
+            )
             try:
                 created_entity_ids = list(
                     rag_engine.wiki_generator.process_document_for_entities(
-                        file.filename, raw_content, []
+                        file.filename, raw_content, [],
+                        user_role="admin",
+                        metadata=meta,
+                        extraction_sidecar_path=extraction_sidecar,
                     ) or []
                 )
+            except TypeError:
+                # 구버전 시그니처 fallback (metadata/user_role 미지원)
+                try:
+                    created_entity_ids = list(
+                        rag_engine.wiki_generator.process_document_for_entities(
+                            file.filename, raw_content, []
+                        ) or []
+                    )
+                except AttributeError:
+                    pass
             except AttributeError:
+                # process_document_for_entities 없음 → 문서 entity 직접 생성
+                try:
+                    doc_entity = {
+                        "name":        os.path.splitext(file.filename)[0],
+                        "type":        "document",
+                        "relations":   [],
+                        "attributes": {
+                            "summary":   meta.get("summary", ""),
+                            "category":  meta.get("category", "기타"),
+                            "keywords":  ", ".join(meta.get("keywords", [])),
+                        },
+                        "sensitivity": meta.get("sensitivity", "internal"),
+                        "source_type": "prod",
+                    }
+                    created_path = rag_engine.wiki_generator.create_entity_file(
+                        doc_entity, file.filename, []
+                    )
+                    # create_entity_file returns the .md file path.
+                    # The entity_id matches the stem (no extension).
+                    if created_path:
+                        from pathlib import Path as _PathW8C
+                        created_entity_ids.append(_PathW8C(created_path).stem)
+                except Exception as wiki_err:
+                    print(f"[UPLOAD] wiki entity 생성 skip: {wiki_err}")
+            except Exception as e:
+                print(f"[UPLOAD] entity 처리 skip: {e}")
+
+            # [W8-C 2026-05-11] write wiki_links rows. Best-effort — a
+            # failure here does NOT roll back the upload (the bytes are on
+            # disk and the vector store / wiki .md files exist). It only
+            # means the artifact ↔ entity relation isn't queryable for
+            # this upload; subsequent uploads continue to track.
+            if artifact_id and created_entity_ids:
+                try:
+                    from core.data_artifacts import link_entity
+                    for eid in created_entity_ids:
+                        if eid:
+                            link_entity(artifact_id, eid)
+                    print(f"[UPLOAD] linked {len(created_entity_ids)} entities "
+                          f"to artifact {artifact_id}")
+                except Exception as _e:
+                    print(f"[UPLOAD] link_entity skipped: {_e}")
+
+            # ── [P7] Media Store — 이미지/영상/오디오 날짜별 폴더 보관 ──
+            MEDIA_EXTS = {
+                ".jpg",".jpeg",".png",".gif",".webp",".bmp",".tiff",
+                ".mp4",".avi",".mov",".mkv",".webm",
+                ".mp3",".wav",".m4a",".aac",".flac",
+            }
+            fname_lower = file.filename.lower()
+            if any(fname_lower.endswith(ext) for ext in MEDIA_EXTS):
+                try:
+                    from tools.multimodal.media_store import (
+                        store_media, store_with_instruction, MEDIA_BASE
+                    )
+                    # 절대 경로로 변환 (상대 경로 오류 방지)
+                    abs_filepath = os.path.abspath(filepath)
+                    print(f"[UPLOAD] 미디어 저장 시작: {abs_filepath}")
+                    print(f"[UPLOAD] MEDIA_BASE: {os.path.abspath(MEDIA_BASE)}")
+
+                    analysis = {
+                        "path":        abs_filepath,
+                        "type":        "media_image" if any(
+                            fname_lower.endswith(e)
+                            for e in [".jpg",".jpeg",".png",".gif",".webp",".bmp"]
+                        ) else "media_video",
+                        "date":        "",
+                        "location":    "",
+                        "persons":     [],
+                        "tags":        meta.get("keywords", []),
+                        "description": meta.get("summary", ""),
+                        "analyzed_at": __import__("datetime").datetime.now().isoformat(),
+                    }
+                    if instruction.strip():
+                        store_result = store_with_instruction(
+                            src_path    = abs_filepath,
+                            instruction = instruction,
+                            analysis    = analysis,
+                            source_type = source_type,
+                            move        = False,
+                        )
+                    else:
+                        store_result = store_media(
+                            src_path    = abs_filepath,
+                            analysis    = analysis,
+                            source_type = source_type,
+                            move        = False,
+                        )
+
+                    if store_result.get("success"):
+                        # store_with_instruction → "stored_path"
+                        # store_media → "original_path"
+                        stored = (store_result.get("stored_path")
+                                  or store_result.get("original_path",""))
+                        print(f"[UPLOAD] ✅ 미디어 보관 완료: {stored}")
+                    else:
+                        err = store_result.get("error","알 수 없는 오류")
+                        print(f"[UPLOAD] ❌ 미디어 보관 실패: {err}")
+                except Exception as media_err:
+                    import traceback
+                    print(f"[UPLOAD] media_store skip: {media_err}")
+                    print(traceback.format_exc())
+
+            try:
+                for f_name in os.listdir(UPLOAD_DIR):
+                    if f_name.endswith("_" + file.filename) and f_name != unique_name:
+                        os.remove(os.path.join(UPLOAD_DIR, f_name))
+            except Exception:
                 pass
-        except AttributeError:
-            # process_document_for_entities 없음 → 문서 entity 직접 생성
-            try:
-                doc_entity = {
-                    "name":        os.path.splitext(file.filename)[0],
-                    "type":        "document",
-                    "relations":   [],
-                    "attributes": {
-                        "summary":   meta.get("summary", ""),
-                        "category":  meta.get("category", "기타"),
-                        "keywords":  ", ".join(meta.get("keywords", [])),
-                    },
-                    "sensitivity": meta.get("sensitivity", "internal"),
-                    "source_type": "prod",
-                }
-                created_path = rag_engine.wiki_generator.create_entity_file(
-                    doc_entity, file.filename, []
-                )
-                # create_entity_file returns the .md file path.
-                # The entity_id matches the stem (no extension).
-                if created_path:
-                    from pathlib import Path as _PathW8C
-                    created_entity_ids.append(_PathW8C(created_path).stem)
-            except Exception as wiki_err:
-                print(f"[UPLOAD] wiki entity 생성 skip: {wiki_err}")
+
+            # [W7-A] mark indexed only after vector + entity steps succeeded.
+            if artifact_id:
+                try:
+                    _da_update_status(artifact_id, "indexed")
+                except Exception as _e:
+                    print(f"[UPLOAD] status update skipped: {_e}")
+
+            result_data = {
+                "status":      "ok",
+                "filename":    unique_name,
+                "category":    meta.get("category","기타"),
+                "summary":     meta.get("summary",""),
+                "keywords":    meta.get("keywords",[]),
+                "sensitivity": meta.get("sensitivity","internal"),
+                "artifact_id": artifact_id,   # [W7-A]
+            }
+            _write_audit(role, "/upload/", query=file.filename, ip_address=ip)
+            return result_data
+        except HTTPException:
+            # [W7-A] HTTPException propagation — surface but mark failed
+            # so the operator can find it via /admin/artifacts/list.
+            if artifact_id:
+                try: _da_update_status(artifact_id, "failed")
+                except Exception: pass
+            raise
         except Exception as e:
-            print(f"[UPLOAD] entity 처리 skip: {e}")
-
-        # [W8-C 2026-05-11] write wiki_links rows. Best-effort — a
-        # failure here does NOT roll back the upload (the bytes are on
-        # disk and the vector store / wiki .md files exist). It only
-        # means the artifact ↔ entity relation isn't queryable for
-        # this upload; subsequent uploads continue to track.
-        if artifact_id and created_entity_ids:
-            try:
-                from core.data_artifacts import link_entity
-                for eid in created_entity_ids:
-                    if eid:
-                        link_entity(artifact_id, eid)
-                print(f"[UPLOAD] linked {len(created_entity_ids)} entities "
-                      f"to artifact {artifact_id}")
-            except Exception as _e:
-                print(f"[UPLOAD] link_entity skipped: {_e}")
-
-        # ── [P7] Media Store — 이미지/영상/오디오 날짜별 폴더 보관 ──
-        MEDIA_EXTS = {
-            ".jpg",".jpeg",".png",".gif",".webp",".bmp",".tiff",
-            ".mp4",".avi",".mov",".mkv",".webm",
-            ".mp3",".wav",".m4a",".aac",".flac",
-        }
-        fname_lower = file.filename.lower()
-        if any(fname_lower.endswith(ext) for ext in MEDIA_EXTS):
-            try:
-                from tools.multimodal.media_store import (
-                    store_media, store_with_instruction, MEDIA_BASE
-                )
-                # 절대 경로로 변환 (상대 경로 오류 방지)
-                abs_filepath = os.path.abspath(filepath)
-                print(f"[UPLOAD] 미디어 저장 시작: {abs_filepath}")
-                print(f"[UPLOAD] MEDIA_BASE: {os.path.abspath(MEDIA_BASE)}")
-
-                analysis = {
-                    "path":        abs_filepath,
-                    "type":        "media_image" if any(
-                        fname_lower.endswith(e)
-                        for e in [".jpg",".jpeg",".png",".gif",".webp",".bmp"]
-                    ) else "media_video",
-                    "date":        "",
-                    "location":    "",
-                    "persons":     [],
-                    "tags":        meta.get("keywords", []),
-                    "description": meta.get("summary", ""),
-                    "analyzed_at": __import__("datetime").datetime.now().isoformat(),
-                }
-                if instruction.strip():
-                    store_result = store_with_instruction(
-                        src_path    = abs_filepath,
-                        instruction = instruction,
-                        analysis    = analysis,
-                        source_type = source_type,
-                        move        = False,
-                    )
-                else:
-                    store_result = store_media(
-                        src_path    = abs_filepath,
-                        analysis    = analysis,
-                        source_type = source_type,
-                        move        = False,
-                    )
-
-                if store_result.get("success"):
-                    # store_with_instruction → "stored_path"
-                    # store_media → "original_path"
-                    stored = (store_result.get("stored_path")
-                              or store_result.get("original_path",""))
-                    print(f"[UPLOAD] ✅ 미디어 보관 완료: {stored}")
-                else:
-                    err = store_result.get("error","알 수 없는 오류")
-                    print(f"[UPLOAD] ❌ 미디어 보관 실패: {err}")
-            except Exception as media_err:
-                import traceback
-                print(f"[UPLOAD] media_store skip: {media_err}")
-                print(traceback.format_exc())
-
-        try:
-            for f_name in os.listdir(UPLOAD_DIR):
-                if f_name.endswith("_" + file.filename) and f_name != unique_name:
-                    os.remove(os.path.join(UPLOAD_DIR, f_name))
-        except Exception:
-            pass
-
-        # [W7-A] mark indexed only after vector + entity steps succeeded.
-        if artifact_id:
-            try:
-                _da_update_status(artifact_id, "indexed")
-            except Exception as _e:
-                print(f"[UPLOAD] status update skipped: {_e}")
-
-        result_data = {
-            "status":      "ok",
-            "filename":    unique_name,
-            "category":    meta.get("category","기타"),
-            "summary":     meta.get("summary",""),
-            "keywords":    meta.get("keywords",[]),
-            "sensitivity": meta.get("sensitivity","internal"),
-            "artifact_id": artifact_id,   # [W7-A]
-        }
-        _write_audit(role, "/upload/", query=file.filename, ip_address=ip)
-        return result_data
-    except HTTPException:
-        # [W7-A] HTTPException propagation — surface but mark failed
-        # so the operator can find it via /admin/artifacts/list.
-        if artifact_id:
-            try: _da_update_status(artifact_id, "failed")
-            except Exception: pass
-        raise
-    except Exception as e:
-        if artifact_id:
-            try: _da_update_status(artifact_id, "failed")
-            except Exception: pass
-        raise HTTPException(status_code=500, detail=f"분석 실패: {e}")
+            if artifact_id:
+                try: _da_update_status(artifact_id, "failed")
+                except Exception: pass
+            raise HTTPException(status_code=500, detail=f"분석 실패: {e}")
+    return await stream_json_with_heartbeat(_work)
 
 @router.get("/admin/users", summary="사용자 목록 (W4 P2-A: real implementation)")
 async def admin_users(

--- a/routes/query.py
+++ b/routes/query.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from core.feedback_engine import FeedbackEngine
+from core.http_heartbeat import stream_json_with_heartbeat
 from routes._deps import get_rag_engine
 from routes._helpers import (
     _require_feature,
@@ -182,120 +183,127 @@ async def query(
     log_stage("auth", role=role, allowed=True, session_id=session_id,
               question_len=len(question), include_contexts=data.include_contexts)
 
-    t_start = time.time()
-    result  = rag_engine.query(
-        user_query       = question,
-        user_role        = role,
-        session_id       = session_id,
-        session_language = data.session_language,  # [STEP2-A] 세션 언어
-        response_style   = data.response_style,    # brief/standard/detailed
-        mode_override    = data.mode_override,     # item #6: chat 페이지 모드 picker
-        force_web_search = data.force_web_search,  # [#A8-6] explicit web exploration
-        selected_model   = data.selected_model,    # [#A2 phase 2] user-picked LLM tag
-        image_path       = _safe_image_path(data.image_path),  # vision-wire
-    )
-    elapsed = time.time() - t_start
+    # Run the blocking ~30-90s reasoning pipeline in a worker thread and
+    # heartbeat the connection: mobile/Tailscale tunnels drop an idle
+    # request ("Failed to fetch"), and threading frees the event loop so
+    # /trace/poll streams reasoning stages live. current_trace_id
+    # (ContextVar) propagates into the thread via anyio.to_thread.
+    def _work():
+        t_start = time.time()
+        result  = rag_engine.query(
+            user_query       = question,
+            user_role        = role,
+            session_id       = session_id,
+            session_language = data.session_language,  # [STEP2-A] 세션 언어
+            response_style   = data.response_style,    # brief/standard/detailed
+            mode_override    = data.mode_override,     # item #6: chat 페이지 모드 picker
+            force_web_search = data.force_web_search,  # [#A8-6] explicit web exploration
+            selected_model   = data.selected_model,    # [#A2 phase 2] user-picked LLM tag
+            image_path       = _safe_image_path(data.image_path),  # vision-wire
+        )
+        elapsed = time.time() - t_start
 
-    log_stage("complete", elapsed_ms=int(elapsed * 1000),
-              blocked=bool(result.get("blocked", False)),
-              answer_len=len(result.get("answer", "") or ""),
-              graph_paths=len(result.get("graph_paths") or []),
-              mode=result.get("mode", ""))
+        log_stage("complete", elapsed_ms=int(elapsed * 1000),
+                  blocked=bool(result.get("blocked", False)),
+                  answer_len=len(result.get("answer", "") or ""),
+                  graph_paths=len(result.get("graph_paths") or []),
+                  mode=result.get("mode", ""))
 
-    answer = result.get("answer", "")
+        answer = result.get("answer", "")
 
-    # [P4-SRV-2] 감사 로그
-    _write_audit(
-        user_role      = role,
-        endpoint       = "/query/",
-        query          = question,
-        answer         = answer,
-        graph_paths    = result.get("graph_paths", []),
-        blocked        = result.get("blocked", False),
-        security_event = "blocked" if result.get("blocked") else "",
-        elapsed_sec    = elapsed,
-        ip_address     = ip,
-    )
+        # [P4-SRV-2] 감사 로그
+        _write_audit(
+            user_role      = role,
+            endpoint       = "/query/",
+            query          = question,
+            answer         = answer,
+            graph_paths    = result.get("graph_paths", []),
+            blocked        = result.get("blocked", False),
+            security_event = "blocked" if result.get("blocked") else "",
+            elapsed_sec    = elapsed,
+            ip_address     = ip,
+        )
 
-    # [P7] 대화 히스토리 자동 저장
-    if not result.get("blocked") and answer:
+        # [P7] 대화 히스토리 자동 저장
+        if not result.get("blocked") and answer:
+            try:
+                from core.memory import MemoryStore
+                MemoryStore().save_turn(
+                    session_id = session_id,
+                    question   = question,
+                    answer     = answer,
+                    mode       = result.get("mode", ""),
+                )
+            except Exception as e:
+                print(f"[HISTORY] 저장 실패: {e}")
+
+        # [P7-EVO] 자기진화 관찰 — 개선 신호 자동 수집
+        if not result.get("blocked"):
+            try:
+                from tools.self.evo_analyzer import observe_and_signal
+                signal = observe_and_signal(question, {
+                    **result,
+                    "unified_score": result.get("unified_score", 1.0),
+                })
+                if signal:
+                    print(f"[EVO] 신호 감지: {signal['type']} "
+                          f"score={signal.get('score','-'):.3f}")
+            except Exception:
+                pass
+
+        # [P7-EVO-B] 중요도 측정 — LOOM 연동
+        if not result.get("blocked"):
+            try:
+                from tools.self.importance_scorer import score_query
+                imp = score_query(
+                    question,
+                    unified_score = result.get("unified_score", 1.0),
+                    answer        = result.get("answer", ""),
+                )
+                if imp["propose_wiki"]:
+                    print(f"[EVO-B] wiki 보강 제안 대상: '{question[:40]}'")
+            except Exception:
+                pass
+
+        # [P8-EVAL-1] 성능 지표 기록
         try:
-            from core.memory import MemoryStore
-            MemoryStore().save_turn(
-                session_id = session_id,
-                question   = question,
-                answer     = answer,
-                mode       = result.get("mode", ""),
-            )
-        except Exception as e:
-            print(f"[HISTORY] 저장 실패: {e}")
-
-    # [P7-EVO] 자기진화 관찰 — 개선 신호 자동 수집
-    if not result.get("blocked"):
-        try:
-            from tools.self.evo_analyzer import observe_and_signal
-            signal = observe_and_signal(question, {
-                **result,
-                "unified_score": result.get("unified_score", 1.0),
-            })
-            if signal:
-                print(f"[EVO] 신호 감지: {signal['type']} "
-                      f"score={signal.get('score','-'):.3f}")
+            from tools.self.performance_evaluator import record_query
+            record_query(question, result, elapsed)
         except Exception:
             pass
 
-    # [P7-EVO-B] 중요도 측정 — LOOM 연동
-    if not result.get("blocked"):
-        try:
-            from tools.self.importance_scorer import score_query
-            imp = score_query(
-                question,
-                unified_score = result.get("unified_score", 1.0),
-                answer        = result.get("answer", ""),
-            )
-            if imp["propose_wiki"]:
-                print(f"[EVO-B] wiki 보강 제안 대상: '{question[:40]}'")
-        except Exception:
-            pass
-
-    # [P8-EVAL-1] 성능 지표 기록
-    try:
-        from tools.self.performance_evaluator import record_query
-        record_query(question, result, elapsed)
-    except Exception:
-        pass
-
-    response = {
-        "question":      question,
-        "answer":        answer,
-        "sources":       result.get("sources", []),
-        "blocked":       result.get("blocked", False),
-        "role_used":     role,
-        "graph_paths":   result.get("graph_paths", []),
-        "timing_sec":    round(elapsed, 2),
-        "mode":          result.get("mode", ""),
-        "session_id":    session_id,
-        "unified_score": round(result.get("unified_score", 0.0), 3),  # [3-B] 신뢰도
-        "direction_id":  FeedbackEngine.make_direction_id(
-            result.get("mode",""), question
-        ) if not result.get("blocked") else "",
-        # [#47 phase 1] correlate response to per-stage trace file.
-        "trace_id":      trace_id,
-        # [#A6-2] 웹 검색 사용됨 배지 + 출처 URL (자료 부족 fallback 시).
-        "web_used":      bool(result.get("web_used", False)),
-        "web_sources":   result.get("web_sources", []),
-        # [#A8-7] chat-side 위키 저장 chip용 proposal id
-        "pending_save_proposal_id": result.get("pending_save_proposal_id", ""),
-        # v0.6.1 — accurate truncation signal (final answer hit the output
-        # token cap). The chat UI shows its "continue" banner on this.
-        "truncated":     bool(result.get("truncated", False)),
-        # v0.6.1 — model that actually answered (auto-routed per mode).
-        "model_used":    result.get("model_used", ""),
-    }
-    # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
-    # fed the LLM are surfaced only when (a) caller opted in via
-    # `include_contexts=true` AND (b) resolved role is "admin". Other
-    # roles see the same response shape as before.
-    if data.include_contexts and role == "admin":
-        response["retrieved_contexts"] = result.get("retrieved_contexts", [])
-    return response
+        response = {
+            "question":      question,
+            "answer":        answer,
+            "sources":       result.get("sources", []),
+            "blocked":       result.get("blocked", False),
+            "role_used":     role,
+            "graph_paths":   result.get("graph_paths", []),
+            "timing_sec":    round(elapsed, 2),
+            "mode":          result.get("mode", ""),
+            "session_id":    session_id,
+            "unified_score": round(result.get("unified_score", 0.0), 3),  # [3-B] 신뢰도
+            "direction_id":  FeedbackEngine.make_direction_id(
+                result.get("mode",""), question
+            ) if not result.get("blocked") else "",
+            # [#47 phase 1] correlate response to per-stage trace file.
+            "trace_id":      trace_id,
+            # [#A6-2] 웹 검색 사용됨 배지 + 출처 URL (자료 부족 fallback 시).
+            "web_used":      bool(result.get("web_used", False)),
+            "web_sources":   result.get("web_sources", []),
+            # [#A8-7] chat-side 위키 저장 chip용 proposal id
+            "pending_save_proposal_id": result.get("pending_save_proposal_id", ""),
+            # v0.6.1 — accurate truncation signal (final answer hit the output
+            # token cap). The chat UI shows its "continue" banner on this.
+            "truncated":     bool(result.get("truncated", False)),
+            # v0.6.1 — model that actually answered (auto-routed per mode).
+            "model_used":    result.get("model_used", ""),
+        }
+        # [#65 phase 3] admin-only RAGAS evaluation hook. The chunk texts that
+        # fed the LLM are surfaced only when (a) caller opted in via
+        # `include_contexts=true` AND (b) resolved role is "admin". Other
+        # roles see the same response shape as before.
+        if data.include_contexts and role == "admin":
+            response["retrieved_contexts"] = result.get("retrieved_contexts", [])
+        return response
+    return await stream_json_with_heartbeat(_work)

--- a/tests/test_http_heartbeat.py
+++ b/tests/test_http_heartbeat.py
@@ -1,0 +1,98 @@
+"""v0.6.1 — stream_json_with_heartbeat keeps long responses alive.
+
+Long /query/ and /upload/ requests over a mobile / Tailscale tunnel were
+dropped while the server worked (idle connection → "Failed to fetch", and
+the composer chip stuck because the upload XHR errored even though the
+server finished). The fix runs the blocking work in a worker thread and
+streams JSON-insignificant whitespace until it's done.
+
+Covers:
+  * whitespace heartbeats are streamed while slow work runs, then the
+    final JSON — and the concatenated body parses (clients use r.json(),
+    which ignores leading whitespace).
+  * an exception in work is surfaced in the body (NOT a torn connection).
+  * a contextvar set before the call propagates into the worker thread
+    (so core.observability.current_trace_id keeps trace correlation).
+
+Run:
+  python -m unittest tests.test_http_heartbeat
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import unittest
+from contextvars import ContextVar
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.http_heartbeat import stream_json_with_heartbeat
+
+
+async def _drain(resp):
+    out = []
+    async for c in resp.body_iterator:
+        out.append(c if isinstance(c, (bytes, bytearray)) else c.encode("utf-8"))
+    return b"".join(out), out
+
+
+class HeartbeatStream(unittest.TestCase):
+    def test_heartbeats_then_parseable_json(self):
+        def slow():
+            time.sleep(0.5)
+            return {"answer": "ok", "mode": "retrieval"}
+
+        async def run():
+            resp = await stream_json_with_heartbeat(slow, interval=0.1)
+            return await _drain(resp)
+
+        body, chunks = asyncio.run(run())
+        # at least a couple of whitespace heartbeats during the 0.5s work
+        hb = sum(1 for c in chunks if c.strip() == b"")
+        self.assertGreaterEqual(hb, 2)
+        self.assertTrue(body.lstrip().startswith(b"{"))
+        # client-equivalent parse (leading whitespace ignored)
+        self.assertEqual(json.loads(body)["answer"], "ok")
+
+    def test_exception_surfaced_in_body_not_torn(self):
+        def boom():
+            raise ValueError("model load failed")
+
+        async def run():
+            resp = await stream_json_with_heartbeat(boom, interval=0.1)
+            return await _drain(resp)
+
+        body, _ = asyncio.run(run())
+        parsed = json.loads(body)
+        self.assertEqual(parsed["answer"], "")
+        self.assertIn("model load failed", parsed["error"])
+
+    def test_fast_work_no_required_heartbeat(self):
+        async def run():
+            resp = await stream_json_with_heartbeat(lambda: {"answer": "x"}, interval=5.0)
+            return await _drain(resp)
+
+        body, _ = asyncio.run(run())
+        self.assertEqual(json.loads(body)["answer"], "x")
+
+    def test_contextvar_propagates_into_worker_thread(self):
+        cv: ContextVar[str] = ContextVar("cv", default="")
+
+        def work():
+            # must see the value set in the calling (async) context
+            return {"seen": cv.get()}
+
+        async def run():
+            cv.set("trace-123")
+            resp = await stream_json_with_heartbeat(work, interval=0.1)
+            return await _drain(resp)
+
+        body, _ = asyncio.run(run())
+        self.assertEqual(json.loads(body)["seen"], "trace-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Operator (phone over Tailscale): a long query returned **"Failed to fetch"** before the answer, and the composer upload **chip stayed stuck** even though the server finished (entities formed). Shared root cause: a request that holds an **idle** connection for 30–90s (full RAG query / image ingest with vision OCR) is evicted by the mobile network or a Tailscale re-handshake. The blocking call inside the `async` handler also pinned the event loop, so `/trace/poll` couldn't stream reasoning stages live.

**Fix**: `core/http_heartbeat.stream_json_with_heartbeat` runs the blocking work in a **worker thread** (frees the loop → `/trace/poll` streams stages live) and emits **JSON-insignificant whitespace** every ~12s while it runs, so bytes keep flowing and the tunnel stays up. The heartbeat is leading whitespace, which `r.json()` / `JSON.parse` ignore → **no client change**. `current_trace_id` (ContextVar) propagates into the thread via `anyio.to_thread`, preserving trace correlation.

## Bonus
Threading the blocking pipeline also fixes the **"reasoning not reflecting live"** symptom — the event loop is now free to serve `/trace/poll` during the request.

## Verification
- `tests/test_http_heartbeat.py` 4/4: stream+parse, error-in-body, fast-path, **contextvar propagation**.
- `routes.query` / `routes.auth` import OK; slow blocks wrapped, validation (400/413/403) still raises proper status before streaming.
- `test_measurement_critical_surfaces` 33/33.
- **Live end-to-end pending on the operator's server** (real query/upload over the tunnel) — the helper + propagation are unit-tested; the route wraps are structural.

## Trade-off
A rare slow-path error (after streaming starts, status already 200) now surfaces in the body (`{"answer":"","error":...}`) instead of a 5xx; the file is still saved + marked `failed` server-side. Validation errors are unaffected (raised before streaming).

## Quality delta
Quality delta: exempt (label: feat) — transport-robustness wrapper on two routes + a new `core/http_heartbeat` util; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)