### PR TITLE
feat(v0.6.1): real "detailed" answer style — reproduce source detail, not a summary

### DIFF
--- a/core/answer_style_classifier.py
+++ b/core/answer_style_classifier.py
@@ -76,6 +76,25 @@ class AnswerStyleClassifier:
     #   - "compare X and Y" / "analyze X" / "evaluate X" / why / how
     #   - "비교/분석/평가/왜/어떻게/원인/방법"
     #   - "report on X" / "summarize X" / "보고서/요약/정리"
+    # ── Fast patterns — explicit "give me the full detail" requests ──
+    # Match → "detailed" (DETAILED_PRESET: reproduce the source content
+    # in full — tables/numbers/items — instead of summarising). Checked
+    # BEFORE terse/natural so "상세히 알려줘" / "원문 그대로" wins even if
+    # the query also looks short. Operator catch 2026-06-26: an ingested
+    # document's detail (a schedule table) was only ever summarised back.
+    FAST_DETAILED_PATTERNS = [
+        r"상세\s*(히|하게|한|하면|내용|정보|일정|하게요)",
+        r"자세\s*(히|하게|한|하게요)",
+        r"구체적(으로|인)",
+        r"낱낱이|빠짐없이|하나도\s*빠짐없|모든\s*(내용|항목|정보|일정)",
+        r"전체\s*(내용|일정|목록|표|텍스트|원문)",
+        r"원문|원본|있는\s*그대로|그대로\s*(보여|알려|적어|읽어)",
+        r"풀어서\s*(설명|알려|적어|보여)",
+        r"\b(in\s+detail|full\s+detail|verbatim|word[\s\-]for[\s\-]word|"
+        r"every\s+detail|full\s+text|the\s+(full|complete|entire)\s+"
+        r"(list|table|schedule|content|text|details))\b",
+    ]
+
     FAST_TERSE_PATTERNS = [
         # ── EN Wh-fact question (single-line answer expected) ──
         # "Who is the CEO?" / "What is X?" — directly Wh + copula
@@ -193,6 +212,12 @@ terse / natural"""
         q = query.strip()
         if not q:
             return "natural"
+
+        # DETAILED 패턴 최우선 — "상세히/원문/전체 내용" 명시 요청은
+        # 요약이 아니라 원문 재현을 원하는 것.
+        for pat in self.FAST_DETAILED_PATTERNS:
+            if re.search(pat, q, re.IGNORECASE):
+                return "detailed"
 
         # NOT_TERSE 패턴 먼저 — 분석/비교/보고서 explicit 우선
         for pat in self.FAST_NOT_TERSE_PATTERNS:

--- a/core/response_style.py
+++ b/core/response_style.py
@@ -317,16 +317,63 @@ TERSE_PRESET = StylePreset(
 )
 
 
+# Detailed / verbatim preset (2026-06-26) — for explicit "상세히 / 자세히
+# / 원문 / 전체 내용" requests. Unlike NATURAL (which condenses into a
+# readable answer), this tells the model to REPRODUCE the relevant source
+# content in full so an ingested document's tables / numbers / items
+# survive instead of collapsing into a one-line summary. It is a
+# format/verbosity variant (same 8192 cap + injectors as NATURAL), NOT a
+# v1-style token-cut preset.
+DETAILED_PRESET = StylePreset(
+    name="detailed",
+    max_tokens=8192,
+    force_two_sections=False,
+    rule_text_ko=(
+        "답변 작성 가이드 (상세/원문 모드):\n"
+        "- 사용자가 **상세한 내용 / 원문 그대로**를 요청했습니다. 내부 "
+        "자료의 관련 부분을 **요약하지 말고 빠짐없이 그대로 재현**하세요.\n"
+        "- 표가 있으면 **표 형식 그대로, 모든 행**을 옮기세요. 숫자·날짜·"
+        "시간·인원·장소·항목·금액을 **하나도 생략하지 말고** 보존.\n"
+        "- 압축·일반화·\"등\"으로 뭉뚱그리기 금지. 자료에 있는 구체 항목을 "
+        "전부 나열하세요.\n"
+        "- 자연스러운 한국어로 구조화하되 ('STEP 1', 📚/💡 라벨 금지) "
+        "내용의 완전성을 최우선으로.\n"
+        "- 컨텍스트에 [관련 자료 목록]이 있으면 첫 줄에 참고 파일을 명시.\n"
+        "- 자료에 없는 내용은 지어내지 말고 \"제공된 자료에는 없습니다\"라고 "
+        "명시하세요.\n"
+        "- 완결성: 시작한 표·문장·항목은 끝까지 마무리. 미완 줄로 끝내지 "
+        "마세요.\n"
+    ),
+    rule_text_en=(
+        "Answer guide (detailed / verbatim mode):\n"
+        "- The user asked for the FULL detail / the source as-is. "
+        "REPRODUCE the relevant internal-source content in full — do NOT "
+        "summarise.\n"
+        "- Keep tables as tables (every row). Preserve every number, date, "
+        "time, count, place, item, and amount — omit nothing.\n"
+        "- No compressing, generalising, or \"etc.\". List every concrete "
+        "item present in the source.\n"
+        "- Structure as natural prose (no 'STEP 1' or 📚/💡 labels) but "
+        "completeness comes first.\n"
+        "- If the context has a [Source Files] list, name the files first.\n"
+        "- Do not invent content not in the source; say so if it is absent.\n"
+        "- Completeness: finish every table, sentence, and item you start.\n"
+    ),
+)
+
+
 # Style id → preset registry. default (unmatched / empty) → NATURAL.
 _STYLE_REGISTRY = {
     "terse": TERSE_PRESET,
     "natural": NATURAL_PRESET,
-    # brief / standard / detailed keep resolving to NATURAL (v2 decision:
-    # the v1 token-cutting presets were rejected by user feedback; we
-    # do NOT resurrect token-cut behavior, only style/format variants).
+    # brief / standard keep resolving to NATURAL (v2 decision: the v1
+    # token-cutting presets were rejected by user feedback). "detailed"
+    # now resolves to the real DETAILED_PRESET (2026-06-26) — a
+    # format/verbosity variant that reproduces source detail, NOT a
+    # token-cut preset.
     "brief": NATURAL_PRESET,
     "standard": NATURAL_PRESET,
-    "detailed": NATURAL_PRESET,
+    "detailed": DETAILED_PRESET,
 }
 
 

--- a/tests/test_answer_style_classifier.py
+++ b/tests/test_answer_style_classifier.py
@@ -28,6 +28,21 @@ class FastPatternTerseTests(unittest.TestCase):
         from core.answer_style_classifier import AnswerStyleClassifier
         self.cls = AnswerStyleClassifier()
 
+    def test_detail_requests_classify_detailed(self):
+        # 2026-06-26 — explicit "give me the full detail" requests must
+        # win over terse/natural so DETAILED_PRESET reproduces source
+        # content (e.g. an ingested schedule table) instead of summarising.
+        for q in [
+            "전장연 일정 상세히 알려줘",
+            "이 자료 원문 그대로 보여줘",
+            "7월 1일 전체 일정 알려줘",
+            "구체적으로 설명해",
+            "tell me in detail",
+            "show me the full table",
+        ]:
+            self.assertEqual(self.cls.classify_fast(q), "detailed",
+                             f"detail request {q!r} → detailed")
+
     def test_en_wh_fact_question(self):
         for q in [
             "Who is the CEO of TechCorp?",

--- a/tests/test_response_style.py
+++ b/tests/test_response_style.py
@@ -46,24 +46,38 @@ class NaturalFlowResolverTests(unittest.TestCase):
         os.environ.pop("JAMES_RESPONSE_STYLE", None)
         self.assertIs(resolve_style(), NATURAL_PRESET)
 
-    def test_all_legacy_ids_resolve_to_natural(self):
+    def test_brief_standard_resolve_to_natural(self):
+        # brief / standard still collapse to NATURAL (v1 token-cut presets
+        # not resurrected). "detailed" is now a real preset — see
+        # test_detailed_resolves_to_detailed_preset.
         from core.response_style import resolve_style, NATURAL_PRESET
-        for legacy in ("brief", "standard", "detailed",
-                       "BRIEF", "Standard", "  detailed  "):
+        for legacy in ("brief", "standard", "BRIEF", "Standard"):
             self.assertIs(resolve_style(legacy), NATURAL_PRESET,
                           f"legacy id {legacy!r} must resolve to NATURAL")
+
+    def test_detailed_resolves_to_detailed_preset(self):
+        # 2026-06-26: "detailed" now resolves to the real DETAILED_PRESET
+        # (reproduce source detail) instead of NATURAL.
+        from core.response_style import (
+            resolve_style, DETAILED_PRESET, NATURAL_PRESET,
+        )
+        for v in ("detailed", "DETAILED", "  detailed  "):
+            self.assertIs(resolve_style(v), DETAILED_PRESET,
+                          f"{v!r} must resolve to DETAILED_PRESET")
+        self.assertIsNot(DETAILED_PRESET, NATURAL_PRESET)
+        self.assertEqual(DETAILED_PRESET.name, "detailed")
 
     def test_unknown_values_resolve_to_natural(self):
         from core.response_style import resolve_style, NATURAL_PRESET
         for val in ("verbose", "nonsense", "", "  "):
             self.assertIs(resolve_style(val), NATURAL_PRESET)
 
-    def test_env_var_does_not_change_outcome_in_v2(self):
+    def test_env_var_brief_and_unknown_still_natural(self):
         from core.response_style import resolve_style, NATURAL_PRESET
-        for val in ("brief", "detailed", "anything"):
+        for val in ("brief", "standard", "anything"):
             os.environ["JAMES_RESPONSE_STYLE"] = val
             self.assertIs(resolve_style(), NATURAL_PRESET,
-                          f"env={val!r} must still return NATURAL in v2")
+                          f"env={val!r} must still return NATURAL")
 
     def test_natural_preset_properties(self):
         from core.response_style import NATURAL_PRESET
@@ -215,10 +229,12 @@ class StyleOverrideTests(unittest.TestCase):
         # explicit terse wins over env natural
         self.assertIs(self.rs.resolve_style("terse"), self.rs.TERSE_PRESET)
 
-    def test_v1_presets_still_natural(self):
-        # brief/standard/detailed NOT resurrected (no token-cut) → NATURAL
-        for s in ("brief", "standard", "detailed"):
+    def test_brief_standard_still_natural(self):
+        # brief/standard NOT resurrected (no token-cut) → NATURAL.
+        # "detailed" is a real preset now (2026-06-26).
+        for s in ("brief", "standard"):
             self.assertIs(self.rs.resolve_style(s), self.rs.NATURAL_PRESET)
+        self.assertIs(self.rs.resolve_style("detailed"), self.rs.DETAILED_PRESET)
 
     def test_unknown_falls_back_to_natural(self):
         self.assertIs(self.rs.resolve_style("nonsense-style"), self.rs.NATURAL_PRESET)


### PR DESCRIPTION
## Summary
After an image's full text was ingested, asking about it **in detail** only ever got a one-line **summary** back.

**Root cause**: the document's full content (a schedule table) is stored + retrieved fine, but `response_style="detailed"` **collapsed to NATURAL** (the v2 redesign mapped brief/standard/detailed→NATURAL), so no style told the synth LLM to **reproduce** the source instead of condensing it. The chat UI also never sends `response_style` — the engine auto-classifies it, and the classifier only emitted terse/natural.

**Fix** (no chat.js change — keyword-driven, automatic):
- `answer_style_classifier`: `FAST_DETAILED_PATTERNS` checked first — a query asking for full detail (`상세히/자세히/구체적으로/낱낱이/전체 내용/원문/그대로` · `in detail/verbatim/full table`…) → `"detailed"`.
- `response_style`: add a real **DETAILED_PRESET** (rule_text: reproduce the relevant source verbatim — keep tables/rows, every number/date/count/place; do not summarise) and map `detailed` → it. `brief/standard` still → NATURAL; empty/unknown → NATURAL (**byte-identical, no regression**).

## Verification (e2e)
`전장연 7월 1일~2일 전체 일정 상세히 알려줘` → `[STYLE] …→ detailed (fast)` → the answer is now the **FULL schedule table** (7 rows: times, 인원/휠체어 counts, 서울지방조달청/잠수교/한국재정정보원…), vs the prior one-line summary.
- `test_response_style` 27/27 (updated: brief/standard→natural kept, detailed→DETAILED_PRESET), `test_answer_style_classifier` 17/17 (+detail-request test), `test_measurement_critical_surfaces` 33/33.

## How to use
Just phrase the question with a detail cue — "상세히", "전체 내용", "원문 그대로", "구체적으로", "in detail". No UI toggle needed.

## Quality delta
Quality delta: exempt (label: feat) — response-style/format layer (verbosity), opt-in, default path byte-identical; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)