### PR TITLE
fix(v0.6.1): more aggressive heartbeat (immediate + 5s) for flaky mobile tunnels

### DIFF
--- a/core/http_heartbeat.py
+++ b/core/http_heartbeat.py
@@ -37,10 +37,11 @@ from typing import Any, Callable
 import anyio
 from fastapi.responses import StreamingResponse
 
-# Default gap between heartbeats. Comfortably under the idle-eviction
-# windows seen on mobile carriers / Tailscale (~30–60 s) while staying
-# cheap (one byte).
-_HEARTBEAT_INTERVAL_SEC = 12.0
+# Default gap between heartbeats. Kept short (5 s) so even an aggressive
+# mobile-carrier / Tailscale idle-eviction window can't open between
+# beats. The first beat is emitted IMMEDIATELY (see gen()) so there is no
+# initial idle gap between the headers and the first body byte.
+_HEARTBEAT_INTERVAL_SEC = 5.0
 
 # Leading whitespace — ignored by any JSON parser, so the client reads the
 # concatenated body as plain JSON.
@@ -62,6 +63,9 @@ async def stream_json_with_heartbeat(
     """
     async def gen():
         task = asyncio.ensure_future(anyio.to_thread.run_sync(work))
+        # Emit one byte immediately so the body starts flowing the moment
+        # the headers go out — no initial idle gap for the tunnel to drop.
+        yield _HEARTBEAT
         while not task.done():
             done, _ = await asyncio.wait({task}, timeout=interval)
             if not done:


### PR DESCRIPTION
## Summary
#1073 streams correctly (verified locally: `/query/` **TTFB 0.005s**, total 14.7s, `Cache-Control: no-store`, `chunked`), but a phone over a Tailscale/mobile tunnel still hit **"Failed to fetch"** on a long (~135s detailed) query. The 12s interval — and the 12s gap between headers and the first body byte — can exceed an aggressive idle-eviction window.

**Fix**: emit one heartbeat byte **immediately** (no initial idle gap) + beat every **5s** (was 12s). Still JSON-insignificant whitespace → no client change.

## Note
Diagnosis confirmed the server runs #1073 (streaming + no-store header). The remaining failure is tunnel-side idle eviction; this tightens the keepalive. If long queries still drop, the durable fix is delivering the answer via `/trace/poll` (returns fast, no long-held request) — larger, deferred. Operators can also halve query time now with `JAMES_DISABLE_COGNITIVE_STAGES=1` (skips planner/reflect/verify — ~60s of a 135s query).

## Quality delta
Quality delta: exempt (label: fix) — transport keepalive timing; `core/retrieval` + `core/graph` traversal + `core/reasoning` 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)