### PR TITLE
docs(v0.6.1): session close handover 2026-06-26 (#1062-#1075)

### DIFF
--- a/docs/handovers/v0.6.1-session-close-2026-06-26.md
+++ b/docs/handovers/v0.6.1-session-close-2026-06-26.md
@@ -1,0 +1,127 @@
+# v0.6.1 — Session close / next-session entry (2026-06-26)
+
+> 🟢 READ FIRST. Long session (PRs **#1062–#1075**). main = `a4bb5d6`,
+> tree clean. Two operator-side items remain open (see §4). Theme:
+> CSP HTML migration + a full **image-upload → entities → detailed Q&A**
+> chain repair, driven by live phone dogfooding.
+
+## 1. What shipped (themes)
+
+### CSP `style-src` (HTML surface)
+- **#1062** — migrated all **596 inline `style="..."`** attrs across the
+  5 served pages into CSS classes (`scripts/migrate_inline_styles.py`:
+  103 atoms + 184 verbatim `.u-<hash>` components in `tokens.css`).
+  `.d-none` (no `!important`) + 9 `classList.remove('d-none')` show-site
+  fixes. **CSP NOT flipped to enforce** — JS-injected inline styles
+  (~493: innerHTML + cssText) remain; `unsafe-inline` stays. Guard:
+  `tests/test_v06_csp_inline_style_migration.py`.
+- **#1063** — refreshed the stale `admin` visual-regression baseline
+  (predated the #1040 agent-nav merge).
+
+### Mobile upload UX
+- **#1064** — mobile upload chips compacted; per-file folder input hidden
+  by default + tap-to-expand (`.d-none` toggle).
+- **#1065** — composer paperclip 📎 → **multi-file corpus upload** (was
+  single-image vision). Auto-ingest via the proven `/upload/` pipeline +
+  `#chat-attachment-row` chips. Vision single-image path preserved but
+  dormant.
+- **#1066** — `.input-area` row → **column** so the attachment row sits
+  ABOVE the input (was pushing input+send off-screen on phones).
+
+### Image ingest / vision pipeline (the big arc — image was a CLEAR doc all along)
+Four stacked bottlenecks, each found + fixed live:
+- **#1067** — `call_gemma_vision` sent images to **`GEMMA_MODEL` (text)**
+  → "no image attached". Added `config.MULTIMODAL_MODEL`, routed to it.
+- **#1068** — vision→OCR routing via `<NO_TEXT>` sentinel; **removed
+  harmful adaptive-threshold binarization** (measured **296k garbage vs
+  ~2k grayscale = 136×**); OCR confidence-gate + `_looks_like_text`
+  (valid-ratio + fragmentation guard) so unreadable photos yield an
+  honest marker, never KG garbage.
+- **#1069** — EasyOCR-first fallback; **PaddleOCR BLOCKED** (Python 3.14,
+  no `paddlepaddle` wheel) → documented; upgrade path doc.
+- **#1070** — default `MULTIMODAL_MODEL` `llava:13b` → **`qwen2.5vl:7b`**
+  (A/B proven: llava "too blurry to read" vs qwen read the text). Pulled
+  on this host. Relaxed `_looks_like_text` word-floor 5→3 (was rejecting
+  short real captions).
+- **#1071** — `[Gemma Vision 오류]` error string no longer ingested as
+  text (transient cold-load 400 → OCR fallback).
+- **#1072** — **vision `num_ctx` 4096 → 8192** (`config.VISION_NUM_CTX`).
+  A 12 MP photo's vision tokens + prompt = 4165 > 4096 → HTTP 400. THIS
+  was the final "no text" cause. Verified e2e: full schedule table read.
+
+**Result**: re-upload now creates real entities (전장연(org),
+서울지방조달청(org) + relations). The full table is stored as 5 chunks +
+retrievable. See `memory/project_chat_upload_paths_v0_6_1.md`.
+
+### Long-request robustness + detailed answers
+- **#1073** — `core/http_heartbeat.stream_json_with_heartbeat`: runs the
+  blocking work in a worker thread (frees the loop → `/trace/poll`
+  streams stages live) + streams JSON-insignificant whitespace so a
+  mobile/Tailscale tunnel doesn't drop the idle connection. Applied to
+  **`/query/`** and **`/upload/`**. No client change (`r.json()` ignores
+  leading whitespace). ContextVar (trace_id) propagates into the thread.
+- **#1075** — heartbeat made aggressive: **immediate first byte + 5s**
+  interval (was 12s). Verified #1073 streams (TTFB 0.005s, Cache-Control
+  no-store, chunked).
+- **#1074** — real **"detailed" answer style**. `response_style="detailed"`
+  used to collapse to NATURAL; chat UI never sends it. Now: the style
+  classifier maps detail cues (상세히/자세히/구체적으로/전체 내용/원문/
+  그대로 · in detail/verbatim/full table) → `"detailed"` → new
+  **DETAILED_PRESET** (reproduce source verbatim: tables/rows/numbers, no
+  summary). Verified: "상세히" query returns the full 7-row table vs a
+  one-line summary. brief/standard/empty → NATURAL (no regression).
+
+## 2. Invariants held
+- `core/retrieval` + `core/graph` **traversal** + `core/reasoning` =
+  **0 lines** all session. New core utils: `core/http_heartbeat.py`,
+  `config.MULTIMODAL_MODEL` / `VISION_NUM_CTX`, `DETAILED_PRESET`,
+  classifier `FAST_DETAILED_PATTERNS` (response-style/vision layers, not
+  the protected three). No vertical/domain code. core/ files < 20 KB.
+- Every PR: branch → squash-merge → sync. No direct-to-main.
+
+## 3. ⚠️ Environment caution (my mistake this session)
+I launched test servers with `run_in_background` repeatedly; they
+orphaned in session 0 and co-bound `:8000`, stealing the operator's
+requests nondeterministically (and `taskkill //IM python.exe` cleanup
+killed the operator's server). **Next session: do NOT background-launch
+the server.** To test, attach to the operator's running server (curl
+localhost) or run a single foreground check. If `:8000` has >1 listener,
+that's orphan pollution → operator kills session-0 python or reboots.
+`Get-NetTCPConnection -LocalPort 8000 -State Listen | Select OwningProcess`
+should show exactly one PID.
+
+## 4. OPEN — operator-side, test on the live phone
+1. **Long-query "Failed to fetch" over the mobile tunnel** (the live
+   debug stages don't show because the dropped query connection aborts
+   the chat + its `/trace/poll` polling). #1073+#1075 tighten keepalive;
+   server confirmed running #1073. Pending operator test after:
+   `git pull` + **`JAMES_DISABLE_COGNITIVE_STAGES=1`** (halves a ~135s
+   detailed query to ~70s — the biggest drop-avoidance lever; skips
+   planner/reflect/verify) + restart. **If it still drops** → the durable
+   fix is delivering the answer via `/trace/poll` (query returns fast, no
+   long-held request) — a query/trace + chat.js change, NOT yet done.
+2. **Detailed-mode dogfood** — confirm "상세히/전체/원문" questions now
+   return the full document content on the phone.
+
+## 5. Other open / deferred
+- CSP enforce: still blocked on the ~493 JS-injected inline styles
+  (innerHTML templates + cssText; some dynamic → CSSOM refactor).
+- PaddleOCR as #1 OCR engine: blocked on Python 3.14 (needs a separate
+  Py≤3.13 microservice). qwen2.5vl is the better, working lever instead.
+- EasyOCR `cv2 !ssize.empty()` on 12 MP files (secondary; vision succeeds
+  first so OCR isn't reached for readable images).
+- Vision single-image chat mode is dormant (paperclip now = corpus
+  upload) — re-add as a separate affordance if both are wanted.
+- v0.6 entry decision (Fork A LOI / Fork B reassess) — still the biggest
+  strategic lever, untouched this session.
+
+## 6. Operator quick-refs
+- Better vision model (zero code): `ollama pull qwen2.5vl:7b` + default
+  already points there; override via `JAMES_MULTIMODAL_MODEL`. Doc:
+  `docs/deployment/v0.6.1-image-ocr-upgrade.md`.
+- Faster queries: `JAMES_DISABLE_COGNITIVE_STAGES=1`.
+- Larger photos overflow 8192 ctx → raise `JAMES_VISION_NUM_CTX`.
+- Detailed answers: phrase with 상세히/전체/원문/구체적으로/in detail.
+- Re-run the inline-style migration: `python scripts/migrate_inline_styles.py --apply`.
+- Memories updated: `project_chat_upload_paths_v0_6_1`,
+  `project_csp_style_src_html_migration_v0_6_1`.


### PR DESCRIPTION
Session close handover. Image-upload→entities→detailed-Q&A chain repaired across #1067-#1074 (vision model routing, num_ctx, OCR quality, detailed style) + CSP HTML migration (#1062) + heartbeat streaming (#1073/#1075). Two operator-side items open. core/retrieval+graph+reasoning 0 lines all session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)