### PR TITLE
refactor(v0.6.2): lift the engine mode/model routing block to engine_routing.py

### DIFF
--- a/core/reasoning/engine.py
+++ b/core/reasoning/engine.py
@@ -235,106 +235,19 @@ class ReasoningEngine:
             self, safe_query, user_role, kwargs, response_style=response_style,
         )
 
-        # ── Query Router (STEP 0.5a) ─────────────────────────
-        # pre_check 통과 후에만 진입. 보안 순서 유지.
-        # item #6: mode_override가 있으면 router 건너뛰고 그 모드 사용
-        # (클라이언트가 챗 페이지 dropdown으로 명시한 경우). 단,
-        # role-allowed 체크는 그대로 적용해서 권한 우회 방지.
-        from core.intent_classifier import ROLE_ALLOWED
-        VALID_OVERRIDES = {"chat", "retrieval", "meta", "coding",
-                           "wiki_edit", "self_evolve", "vision"}
-        override = (mode_override or "").strip().lower()
-        if override and override in VALID_OVERRIDES:
-            allowed = ROLE_ALLOWED.get(user_role, {"chat", "retrieval"})
-            if override in allowed:
-                mode = override
-                print(f"[ROUTER] mode={mode} (client override) | query='{safe_query[:40]}'")
-            else:
-                # 권한 없는 모드 override → router 정상 사용
-                print(f"[ROUTER] override {override!r} 권한 없음 (role={user_role}) → 자동 라우팅")
-                override = ""
-
-        if not override or override not in VALID_OVERRIDES:
-            try:
-                from core.query_router import QueryRouter
-                mode = QueryRouter().route(safe_query, user_role=user_role)
-                print(f"[ROUTER] mode={mode} | query='{safe_query[:40]}'")
-            except Exception as e:
-                self._log("query_router", e, user_role)
-                mode = "retrieval"   # fallback → 기존 Loop
-
-        # ── [Bug fix, 2026-05-09] force_web_search forces retrieval ──
-        # The chip click sends force_web_search=True. Only the retrieval
-        # pipeline (run_retrieval_pipeline) honors this flag — chat /
-        # meta / wiki_edit / etc. silently drop it, which surfaces as:
-        # user clicks the "🌐 웹으로 더 조사" chip → server takes the
-        # chat path again → memory_context (prior turns including the
-        # last inference-only answer) is mixed back into the prompt →
-        # new answer looks identical to the previous → user concludes
-        # "the search must be based on James's earlier answer".
-        #
-        # Reality: no web search ran. Force-route to retrieval so the
-        # web search actually fires with the original user question.
-        if kwargs.get("force_web_search") and mode != "retrieval":
-            print(f"[ROUTER] force_web_search=True overrides mode "
-                  f"{mode!r} → retrieval (web search needs the "
-                  f"retrieval pipeline)")
-            mode = "retrieval"
-
-        # ── Image attached → vision mode (v18.7 vision-wire) ─────
-        # An image_path in kwargs forces vision regardless of what the
-        # text router produced — the query is *about* the image. Gated
-        # by ROLE_ALLOWED so external (chat-only) can't reach it.
-        if kwargs.get("image_path") and "vision" in ROLE_ALLOWED.get(
-                user_role, {"chat", "retrieval"}):
-            print(f"[ROUTER] image attached → mode=vision (was {mode!r})")
-            mode = "vision"
-
-        # ── [#A2 phase 2] selected_model validation ────────────
-        # The user's secondary-picker choice arrives untrusted. Reject
-        # anything not in the catalog for the resolved mode — silent
-        # fallback to mode default, never echo arbitrary tags to Ollama.
-        from core.model_catalog import resolve_model
-        picked_model = resolve_model(mode, (selected_model or "").strip()) or ""
-        if selected_model and not picked_model:
-            print(f"[MODEL] '{selected_model}' rejected for mode={mode} → mode default")
-        elif picked_model:
-            print(f"[MODEL] mode={mode} using user-selected '{picked_model}'")
-
-        # ── v18.7 Phase 2c/3c/wiki_edit-c — measured-preference routing ──
-        # When the user did NOT pick a model, these modes auto-route via
-        # resolve_for_mode(mode, requested="") to the preference-list top
-        # (requested="" bypasses config.GEMMA_MODEL). All three are
-        # measurement-backed → gemma3:12b; see docs/reference/
-        # routing-matrix.md for the per-mode QDC + ranking. Kill-switch
-        # JAMES_DISABLE_MODE_AWARE_ROUTING=1 reverts all to GEMMA_MODEL.
-        # meta/self_evolve stay legacy; vision resolves its own
-        # single-candidate model inside handle_vision (no text catalog).
-        if mode in ("chat", "retrieval", "wiki_edit") and not picked_model:
-            import os
-            if not os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
-                from core.model_resolver import resolve_for_mode
-                _rm = resolve_for_mode(mode, requested="")
-                if _rm.tag:
-                    picked_model = _rm.tag
-                    print(f"[MODEL] mode={mode} auto-routed → '{_rm.tag}' "
-                          f"(source={_rm.source}; measured pref)")
-                    if _rm.warning:
-                        print(f"[MODEL] {_rm.warning}")
-
-        # v0.6.1 — remember the model actually chosen for this query so
-        # query() can report it. picked_model holds the user pick OR the
-        # auto-routed tag; fall back to the legacy default for the LLM
-        # modes when neither applied, so the header is right in the common
-        # cases (coding resolves CODING_MODEL downstream; meta uses no LLM).
-        _eff_model = picked_model
-        if not _eff_model and mode in ("chat", "retrieval", "wiki_edit"):
-            try:
-                from config import GEMMA_MODEL as _GM
-                _eff_model = _GM
-            except Exception:
-                _eff_model = ""
-        self._last_routed_model = _eff_model or ""
+        # ── Mode + model routing (delegated) ─────────────────
+        # The STEP 0.5a query-router block, the force_web_search /
+        # attached-image overrides, the [#A2 phase 2] selected_model
+        # catalog validation, and the v18.7 measured-preference
+        # auto-routing moved to core/reasoning/engine_routing.py for
+        # the rule #5 module-size split (2026-07-01). Behaviour is
+        # byte-identical; the helper also sets
+        # ``self._last_routed_model`` for the v0.6.1 model_used report.
+        from core.reasoning.engine_routing import resolve_mode_and_model
+        mode, picked_model = resolve_mode_and_model(
+            self, safe_query, user_role, mode_override, selected_model,
+            kwargs,
+        )
 
         # ── Mode dispatch (#29 phase 2: extracted to core/reasoning/modes.py) ──
         if mode == "chat":

--- a/core/reasoning/engine_routing.py
+++ b/core/reasoning/engine_routing.py
@@ -1,0 +1,147 @@
+"""Mode + model routing for ``ReasoningEngine._query_impl``.
+
+Extracted from ``core/reasoning/engine.py`` by the 2026-07-01
+module-size split (CLAUDE.md rule #5 — engine.py crossed the 20 KB
+cap when the v0.6.1 model_used reporting landed) and landed on
+main 2026-09-07. Behaviour is byte-identical to the pre-split
+file; only the location moved.
+
+The function owns the four routing decisions that sat between
+``build_memory_context`` and the mode dispatch:
+
+  1. Query-mode resolution — client ``mode_override`` (role-gated) or
+     ``QueryRouter`` auto-routing, with the ``force_web_search`` and
+     attached-image overrides.
+  2. ``selected_model`` validation — the user's picker choice is
+     untrusted; anything not in the catalog for the resolved mode is
+     rejected (silent fallback to mode default).
+  3. Measured-preference auto-routing (v18.7 Phase 2c/3c/wiki_edit-c)
+     for chat / retrieval / wiki_edit when no explicit pick was made.
+  4. ``engine._last_routed_model`` bookkeeping so ``query()`` can report
+     the model that actually answered (v0.6.1).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+
+def resolve_mode_and_model(
+    engine,
+    safe_query: str,
+    user_role: str,
+    mode_override: str,
+    selected_model: str,
+    kwargs: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Resolve (mode, picked_model) for this query.
+
+    ``engine`` is the calling ``ReasoningEngine`` — used for ``_log``
+    and the ``_last_routed_model`` marker. ``kwargs`` is the query's
+    kwargs dict (read-only here: ``force_web_search`` / ``image_path``).
+    """
+    # ── Query Router (STEP 0.5a) ─────────────────────────
+    # pre_check 통과 후에만 진입. 보안 순서 유지.
+    # item #6: mode_override가 있으면 router 건너뛰고 그 모드 사용
+    # (클라이언트가 챗 페이지 dropdown으로 명시한 경우). 단,
+    # role-allowed 체크는 그대로 적용해서 권한 우회 방지.
+    from core.intent_classifier import ROLE_ALLOWED
+    VALID_OVERRIDES = {"chat", "retrieval", "meta", "coding",
+                       "wiki_edit", "self_evolve", "vision"}
+    mode = ""
+    override = (mode_override or "").strip().lower()
+    if override and override in VALID_OVERRIDES:
+        allowed = ROLE_ALLOWED.get(user_role, {"chat", "retrieval"})
+        if override in allowed:
+            mode = override
+            print(f"[ROUTER] mode={mode} (client override) | query='{safe_query[:40]}'")
+        else:
+            # 권한 없는 모드 override → router 정상 사용
+            print(f"[ROUTER] override {override!r} 권한 없음 (role={user_role}) → 자동 라우팅")
+            override = ""
+
+    if not override or override not in VALID_OVERRIDES:
+        try:
+            from core.query_router import QueryRouter
+            mode = QueryRouter().route(safe_query, user_role=user_role)
+            print(f"[ROUTER] mode={mode} | query='{safe_query[:40]}'")
+        except Exception as e:
+            engine._log("query_router", e, user_role)
+            mode = "retrieval"   # fallback → 기존 Loop
+
+    # ── [Bug fix, 2026-05-09] force_web_search forces retrieval ──
+    # The chip click sends force_web_search=True. Only the retrieval
+    # pipeline (run_retrieval_pipeline) honors this flag — chat /
+    # meta / wiki_edit / etc. silently drop it, which surfaces as:
+    # user clicks the "🌐 웹으로 더 조사" chip → server takes the
+    # chat path again → memory_context (prior turns including the
+    # last inference-only answer) is mixed back into the prompt →
+    # new answer looks identical to the previous → user concludes
+    # "the search must be based on James's earlier answer".
+    #
+    # Reality: no web search ran. Force-route to retrieval so the
+    # web search actually fires with the original user question.
+    if kwargs.get("force_web_search") and mode != "retrieval":
+        print(f"[ROUTER] force_web_search=True overrides mode "
+              f"{mode!r} → retrieval (web search needs the "
+              f"retrieval pipeline)")
+        mode = "retrieval"
+
+    # ── Image attached → vision mode (v18.7 vision-wire) ─────
+    # An image_path in kwargs forces vision regardless of what the
+    # text router produced — the query is *about* the image. Gated
+    # by ROLE_ALLOWED so external (chat-only) can't reach it.
+    if kwargs.get("image_path") and "vision" in ROLE_ALLOWED.get(
+            user_role, {"chat", "retrieval"}):
+        print(f"[ROUTER] image attached → mode=vision (was {mode!r})")
+        mode = "vision"
+
+    # ── [#A2 phase 2] selected_model validation ────────────
+    # The user's secondary-picker choice arrives untrusted. Reject
+    # anything not in the catalog for the resolved mode — silent
+    # fallback to mode default, never echo arbitrary tags to Ollama.
+    from core.model_catalog import resolve_model
+    picked_model = resolve_model(mode, (selected_model or "").strip()) or ""
+    if selected_model and not picked_model:
+        print(f"[MODEL] '{selected_model}' rejected for mode={mode} → mode default")
+    elif picked_model:
+        print(f"[MODEL] mode={mode} using user-selected '{picked_model}'")
+
+    # ── v18.7 Phase 2c/3c/wiki_edit-c — measured-preference routing ──
+    # When the user did NOT pick a model, these modes auto-route via
+    # resolve_for_mode(mode, requested="") to the preference-list top
+    # (requested="" bypasses config.GEMMA_MODEL). All three are
+    # measurement-backed → gemma3:12b; see docs/reference/
+    # routing-matrix.md for the per-mode QDC + ranking. Kill-switch
+    # JAMES_DISABLE_MODE_AWARE_ROUTING=1 reverts all to GEMMA_MODEL.
+    # meta/self_evolve stay legacy; vision resolves its own
+    # single-candidate model inside handle_vision (no text catalog).
+    if mode in ("chat", "retrieval", "wiki_edit") and not picked_model:
+        import os
+        if not os.environ.get("JAMES_DISABLE_MODE_AWARE_ROUTING"):
+            from core.model_resolver import resolve_for_mode
+            _rm = resolve_for_mode(mode, requested="")
+            if _rm.tag:
+                picked_model = _rm.tag
+                print(f"[MODEL] mode={mode} auto-routed → '{_rm.tag}' "
+                      f"(source={_rm.source}; measured pref)")
+                if _rm.warning:
+                    print(f"[MODEL] {_rm.warning}")
+
+    # v0.6.1 — remember the model actually chosen for this query so
+    # query() can report it. picked_model holds the user pick OR the
+    # auto-routed tag; fall back to the legacy default for the LLM
+    # modes when neither applied, so the header is right in the common
+    # cases (coding resolves CODING_MODEL downstream; meta uses no LLM).
+    _eff_model = picked_model
+    if not _eff_model and mode in ("chat", "retrieval", "wiki_edit"):
+        try:
+            from config import GEMMA_MODEL as _GM
+            _eff_model = _GM
+        except Exception:
+            _eff_model = ""
+    engine._last_routed_model = _eff_model or ""
+
+    return mode, picked_model
+
+
+__all__ = ["resolve_mode_and_model"]

--- a/reports/research-runs/engine-routing-split-step7-20260908.md
+++ b/reports/research-runs/engine-routing-split-step7-20260908.md
@@ -1,0 +1,71 @@
+# STEP 7 bench — engine_routing.py split (rule #2 gate for PR #1083)
+
+**Date**: 2026-09-08
+**Change under test**: `core/reasoning/engine.py` mode/model routing block
+lifted to `core/reasoning/engine_routing.py` (rule #5 split-debt from #1080)
+**Arms**: `3fafd8f` (main) vs `549ffd1` (branch)
+**Harness**: `python scripts/bench.py --suite=step7 --mode=retrieval`,
+20 queries, RAG path confirmed (auto-minted admin bearer, `graph_paths > 0`)
+
+## 1. Why three runs, not two
+
+The first A/B pair showed the branch **+323.2s (+20.3%)** slower. A verbatim
+code move cannot cost 20% on a path whose queries each spend 60–200s in a
+local LLM, and the repo's own variance study
+(`step7-bench-variance-analysis-2026-05-29.md` §3) puts same-code 3-run CV at
+**3.4%** — so the result was either a real regression or the A arm was an
+outlier. A second run of **main** (A2) settles it.
+
+## 2. Results
+
+| run | sha | total | path recall |
+|---|---|---:|---|
+| A1 main | `3fafd8f` | 1594.6s | 0.818 (9/11) |
+| A2 main | `3fafd8f` | 1818.9s | 0.833 (10/12) |
+| B branch | `549ffd1` | 1917.8s | 0.833 (10/12) |
+
+| comparison | Δ total | median per-query \|Δ\| | queries slower |
+|---|---:|---:|---:|
+| **A2 − A1** (identical code) | **+224.3s (+14.1%)** | **14.9s** | 15/20 |
+| **B − A2** (the change) | **+98.9s (+5.4%)** | **7.6s** | 13/20 |
+
+**The change's delta is smaller than the same-code delta on both measures.**
+A1 was the outlier: it was the first run of the session, its q1 hit the 120s
+timeout cap, and the spillover put q2 at 210.1s — the largest single value
+anywhere in the three runs (q2 came in at 111.6s and 146.1s afterwards).
+
+- **Path recall**: A2 and B are **identical** (0.833, 10/12). A1's 0.818 (9/11)
+  differs only because the timed-out q1 was not scored — the denominator, not
+  the retrieval.
+- **Status flips**: q1 only, `timeout → ok → ok`. §3 of the variance study
+  already classifies 120s-cap flips as boundary noise, not regression.
+- **Blocked queries** (q11, q12 security): 0.0s in all three runs.
+
+## 3. Structural verification (stronger than the timing)
+
+The timing evidence is statistical; the change itself is provable. Of the
+**100 lines removed** from `engine.py`:
+
+- **98 reappear character-for-character** in `engine_routing.py` (indentation
+  aside — a method body became a function body)
+- **2 are the mechanical `self.` → `engine.` rename** required by the
+  parameter: `self._log("query_router", …)` and
+  `self._last_routed_model = _eff_model or ""`
+
+`engine.py` gains 13 lines: a comment and the delegation call. No behavioural
+edit exists to measure.
+
+## 4. Axes not measured
+
+Graded Answer, Abstention F1 and Token Cost need the QVT oracle applied to
+answer text, which `scripts/bench.py` does not retain. Capturing them means
+`qvt_capture_baseline.py` on both arms (~70 min each), and the only baseline
+on disk is `eval/qvt/baseline_2a31b20.json` from 2026-05 — four months of
+intervening change would be attributed to this PR. Recorded as a known gap
+rather than papered over with a stale reference.
+
+## 5. Verdict
+
+**Bench-neutral.** The measured delta sits inside the same-code noise band,
+path recall is identical against the comparable run, and the code is a proven
+verbatim move. No evidence of regression on the axes this harness reports.

--- a/tests/_pipeline_src.py
+++ b/tests/_pipeline_src.py
@@ -90,14 +90,21 @@ def pipeline_source() -> str:
 
 
 def engine_source() -> str:
-    """Concatenated source of the three modules that together implement
+    """Concatenated source of the four modules that together implement
     ``ReasoningEngine.query``. Use instead of
     ``inspect.getsource(engine)`` when the symbol you're grepping for
-    may live in the memory-context block or the canonical RAG synth.
+    may live in the memory-context block, the mode/model routing block
+    (split out 2026-07-01), or the canonical RAG synth.
     """
-    from core.reasoning import engine, engine_memory, engine_synth
+    from core.reasoning import (
+        engine,
+        engine_memory,
+        engine_routing,
+        engine_synth,
+    )
     return "\n".join(
-        module_source(m) for m in (engine, engine_memory, engine_synth))
+        module_source(m)
+        for m in (engine, engine_memory, engine_routing, engine_synth))
 
 
 # Back-compat alias for the private name this started out as.

--- a/tests/test_a2_phase2_selected_model.py
+++ b/tests/test_a2_phase2_selected_model.py
@@ -128,8 +128,13 @@ class EngineWiringTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         import core.reasoning.engine as eng
+        import core.reasoning.engine_routing as eng_routing
         cls.eng = eng
-        cls.src = inspect.getsource(eng)
+        # The mode/model routing block (incl. resolve_model validation)
+        # moved to engine_routing.py in the 2026-07-01 rule #5 split —
+        # concatenate both so the structural greps keep seeing the
+        # whole query path.
+        cls.src = inspect.getsource(eng) + "\n" + inspect.getsource(eng_routing)
 
     def test_query_signature_has_selected_model(self):
         m = re.search(

--- a/tests/test_chat_mode_picker.py
+++ b/tests/test_chat_mode_picker.py
@@ -49,7 +49,12 @@ class BackendModeOverrideTests(unittest.TestCase):
         from tests._server_split_helpers import combined_server_source
         cls.srv_src = combined_server_source()
         import core.reasoning.engine as eng
-        cls.eng_src = inspect.getsource(eng)
+        import core.reasoning.engine_routing as eng_routing
+        # The override-validation block moved to engine_routing.py in
+        # the 2026-07-01 rule #5 split — concatenate so the body scan
+        # below can find it in resolve_mode_and_model.
+        cls.eng_src = (inspect.getsource(eng) + "\n"
+                       + inspect.getsource(eng_routing))
 
     def test_query_request_field(self):
         m = re.search(
@@ -87,7 +92,10 @@ class BackendModeOverrideTests(unittest.TestCase):
         # try/finally wrapper that delegates to ``_query_impl`` where
         # the override validation actually lives. Scan whichever
         # method's body holds the override logic.
-        for fn_name in ("_query_impl", "query"):
+        # resolve_mode_and_model (engine_routing.py) holds the override
+        # logic since the 2026-07-01 split; older names kept for
+        # documentation of the scan's history.
+        for fn_name in ("resolve_mode_and_model", "_query_impl", "query"):
             try:
                 idx = self.eng_src.index(f"def {fn_name}(")
             except ValueError:

--- a/tests/test_force_web_overrides_mode.py
+++ b/tests/test_force_web_overrides_mode.py
@@ -48,8 +48,15 @@ class EngineModeOverrideTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # The routing block (incl. the force_web override) moved to
+        # engine_routing.py in the 2026-07-01 rule #5 split. Concatenate
+        # routing BEFORE engine so the ordering assertions below keep
+        # their meaning: routing (router → force_web override) runs
+        # before the dispatch (`if mode == "chat":`) that stays in
+        # engine._query_impl.
         import core.reasoning.engine as eng
-        cls.src = inspect.getsource(eng)
+        import core.reasoning.engine_routing as eng_routing
+        cls.src = inspect.getsource(eng_routing) + "\n" + inspect.getsource(eng)
 
     def test_force_web_override_block_present(self):
         # Look for the explicit override snippet: when force_web_search

--- a/tests/test_v06_module_size_gate.py
+++ b/tests/test_v06_module_size_gate.py
@@ -65,24 +65,11 @@ GRANDFATHERED: dict = {
     #   all three presets fingerprint the same field-for-field against
     #   the pre-split module, and resolve_style agrees on 8 inputs.
     #
-    "reasoning/engine.py": (
-        "21,464 bytes, 984 over. NOT split here on purpose: engine.py "
-        "is core/reasoning, so CLAUDE.md rule #2 requires STEP 7 bench "
-        "numbers and a Quality Delta Card on any PR touching it — and "
-        "bench.py needs a live server plus Ollama, neither of which "
-        "exists in a session container. Splitting it blind would ship "
-        "an unmeasured change to the hottest path in the system.\n"
-        "Split plan, for an operator who can run the bench: the file "
-        "is query() plus its helpers. The memory-context assembly "
-        "already left for engine_memory.py and the canonical RAG synth "
-        "for engine_synth.py, so the remaining seam is the mode "
-        "dispatch block — lift it to core/reasoning/engine_dispatch.py "
-        "the way pipeline_synth was lifted, keeping engine.query() as "
-        "the entry point. Expect ~3-4 KB to move, which clears the cap "
-        "with room. tests/_pipeline_src.py::engine_source already "
-        "concatenates the engine companions, and _module_source walks "
-        "a package, so the structural tests absorb either shape."
-    ),
+    # core/reasoning/engine.py — DE-GRANDFATHERED 2026-09-07. The
+    # mode/model routing block moved to engine_routing.py (the seam
+    # this entry named), taking engine.py from 21,464 to 16,733
+    # bytes. engine_source() concatenates the companion, so the
+    # structural greps still see the whole query path.
 }
 
 

--- a/tests/test_vision_wire.py
+++ b/tests/test_vision_wire.py
@@ -37,8 +37,14 @@ import config  # noqa: E402,F401
 class EngineWireTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # The routing block (incl. the image_path → vision override)
+        # moved to engine_routing.py in the 2026-07-01 rule #5 split.
+        # Concatenate routing BEFORE engine so the ordering assertions
+        # (override after router, before the dispatch that stays in
+        # engine._query_impl) keep their meaning.
         import core.reasoning.engine as eng
-        cls.src = inspect.getsource(eng)
+        import core.reasoning.engine_routing as eng_routing
+        cls.src = inspect.getsource(eng_routing) + "\n" + inspect.getsource(eng)
 
     def test_image_override_block_present(self):
         m = re.search(


### PR DESCRIPTION
## Summary

Pays down the rule #5 split-debt that #1080 recorded and deliberately left unpaid.

`core/reasoning/engine.py` stood at **21,464 bytes — 984 over** CLAUDE.md rule #5's 20 KB ceiling, carried as the sole entry in `tests/test_v06_module_size_gate.py::GRANDFATHERED`. That entry named the seam *and* the reason it was not cut:

> engine.py is `core/reasoning`, so CLAUDE.md rule #2 requires STEP 7 bench numbers and a Quality Delta Card on any PR touching it — and bench.py needs a live server plus Ollama, neither of which exists in a session container. Splitting it blind would ship an unmeasured change to the hottest path in the system.

The split itself was already written on 2026-07-01 on `claude/sekos-design-structure-review-k56bmn` and never landed — that branch has sat unmerged for two months.

This lifts the four routing decisions that sat between `build_memory_context` and the mode dispatch into `core/reasoning/engine_routing.resolve_mode_and_model`:

1. mode resolution — client `mode_override` (role-gated) or `QueryRouter` auto-routing, with the `force_web_search` and attached-image overrides
2. `selected_model` validation — the picker choice is untrusted; anything not in the catalog for the resolved mode is rejected
3. measured-preference auto-routing (v18.7 Phase 2c / 3c / wiki_edit-c)
4. `_last_routed_model` bookkeeping so `query()` can report the model that actually answered

The code moved verbatim; `_query_impl` calls it where the block used to sit.

| file | before | after |
|---|---:|---:|
| `core/reasoning/engine.py` | 21,464 | **16,733** |
| `core/reasoning/engine_routing.py` | — | 7,316 |

**`GRANDFATHERED` is now empty** — rule #5 is enforced with no exceptions for the first time since the vision-wire PR.

### What was taken, and what was left

From the 2026-07-01 branch, **only the engine half**. Its `core/response_style.py` half is dropped: #1080 performed that same split independently on 2026-08-26, down to the same `core/response_style_presets.py` filename, and the two versions differ by ~15 lines of docstring. Its two test-repair commits are dropped for the same reason — #1079/#1080 repaired those files more generally, and re-applying the older fixes would undo that.

Structural-grep tests **follow the seam rather than loosen**: `engine_source()` concatenates the new companion, and the four suites that grep the query path by source text (`test_a2_phase2_selected_model`, `test_chat_mode_picker`, `test_force_web_overrides_mode`, `test_vision_wire`) read both modules.

## Verification

- `pytest tests/` on this branch → **11 failed, 5278 passed, 1268 subtests passed**
- `pytest tests/` on `main` (`3fafd8f`) → **11 failed, 5278 passed, 1267 subtests passed**
- **The failure set is identical, item for item.** All 11 are pre-existing local-environment artifacts (FastAPI `include_router(prefix=)` behaviour, `.env`-dependent model/embedding-path pins, frontend-contract greps); CI's own baseline on `3fafd8f` is 1 failure. This branch introduces none and fixes none. The one extra subtest is the new module entering the backend-helper grep.
- `pytest tests/test_v06_module_size_gate.py` → 3 passed with the grandfather list empty
- `ruff check --select F` (the enforced gate) → clean

## Quality Delta

`Quality delta: measured` — STEP 7, `--suite=step7 --mode=retrieval`, RAG path
confirmed (`graph_paths > 0` throughout). Full write-up:
[`reports/research-runs/engine-routing-split-step7-20260908.md`](reports/research-runs/engine-routing-split-step7-20260908.md).

**Three runs, not two.** The first A/B pair read the branch **+20.3%** slower.
A verbatim code move cannot cost 20% on a path spending 60–200s per query in a
local LLM, and `step7-bench-variance-analysis-2026-05-29.md` §3 puts same-code
3-run CV at **3.4%** — so either it was a regression or the A arm was an
outlier. A repeat run of `main` decides it.

| run | sha | total | path recall |
|---|---|---:|---|
| A1 main | `3fafd8f` | 1594.6s | 0.818 (9/11) |
| A2 main | `3fafd8f` | 1818.9s | 0.833 (10/12) |
| B branch | `549ffd1` | 1917.8s | 0.833 (10/12) |

| comparison | Δ total | median per-query \|Δ\| | slower on |
|---|---:|---:|---:|
| **A2 − A1** — *identical code* | +224.3s (**+14.1%**) | **14.9s** | 15/20 |
| **B − A2** — *the change* | +98.9s (**+5.4%**) | **7.6s** | 13/20 |

**The change's delta is smaller than the same-code delta on both measures.**
A1 was the outlier — first run of the session, q1 hit the 120s cap, and the
spillover put q2 at 210.1s, the largest single value across all three runs
(111.6s and 146.1s on the later ones).

| axis | main | branch | verdict |
|---|---|---|---|
| **Path Recall** | 0.833 (10/12) | 0.833 (10/12) | **identical** vs the comparable run |
| **Latency Cost** | see table | see table | **inside same-code noise** |
| graph_paths | non-zero throughout | non-zero throughout | RAG path confirmed both arms |
| Graded Answer | — | — | **not measured**, see below |
| Abstention F1 | — | — | **not measured**, see below |
| Token Cost | — | — | **not measured**, see below |

A1's 0.818 (9/11) differs from the other two only in the denominator: the
timed-out q1 was not scored. Status flips are confined to q1 at the 120s cap —
which §3 of the variance study already classifies as boundary noise.

### Structural verification — stronger than the timing

The timing argument is statistical; the change itself is provable. Of the
**100 lines removed** from `engine.py`, **98 reappear character-for-character**
in `engine_routing.py` (indentation aside — a method body became a function
body), and the remaining **2 are the mechanical `self.` → `engine.` rename**
the parameter requires (`self._log("query_router", …)` and
`self._last_routed_model = _eff_model or ""`). `engine.py` gains 13 lines: a
comment and the delegation call. There is no behavioural edit to measure.

### The three unmeasured axes — operator call

Graded Answer, Abstention F1 and Token Cost need the QVT oracle applied to
answer *text*, which `bench.py` does not retain. Measuring them means
`qvt_capture_baseline.py` on both arms (~70 min each, ~2.5 h total), and the
only baseline on disk is `eval/qvt/baseline_2a31b20.json` from **2026-05** —
comparing a September branch against it would attribute four months of
intervening change to this PR. Stated as a gap rather than closed with a stale
reference. Say the word if the full capture should run before merge.

## Out of scope

- The other two salvageable pieces of the 2026-07-01 branch, each its own PR: **local-LLM defaults** (`keep_alive` is absent from `main` entirely — 0 occurrences in `core/gemma_client/` — plus the prompt-cap double-truncation and vision drift fixes), and the **`live_eval` real-use evaluation loop** (cherry-picks clean).
- The 11 standing local failures and the 1 standing CI failure (LRB S2, adjudicated in #1082).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
