### PR TITLE
feat(v0.6.2): real-use evaluation loop — live traffic → report → bench suite

### DIFF
--- a/docs/evaluation/v0.6.1-live-use-evaluation.md
+++ b/docs/evaluation/v0.6.1-live-use-evaluation.md
@@ -1,0 +1,90 @@
+# v0.6.1 — 실사용(Real-Use) 평가 루프
+
+> 2026-07-01 SEKOS 설계·구조 리뷰에서 식별된 갭을 닫는 문서.
+> 하니스: `scripts/live_eval.py` · 테스트: `tests/test_live_eval.py`
+
+## 1. 배경 — 갭이 무엇이었나
+
+JAMES 의 평가 체계는 두 층으로 갈라져 있었다:
+
+| 층 | 존재 여부 | 구성물 |
+|---|---|---|
+| **벤치마크 평가** (고정 fixture + 오라클) | ✅ 성숙 | STEP7 회귀 (`scripts/bench.py`) · QVT 5-axis · RAB · RAGAS · 외부 벤치 (ALCE/MuSiQue/RGB/LRB) |
+| **실사용 수집** (라이브 트래픽 캡처) | ✅ 성숙 | `james_audit.db` audit_log (질의/답변/지연/차단) · `workspace/feedback_shadow.jsonl` (👍/👎) · `reports/trace/` per-trace JSONL · `workspace/eval_log.jsonl` (self-grade) |
+| **실사용 → 평가 연결층** | ❌ **부재** | (이 문서가 도입) |
+
+즉 운영자가 폰으로 dogfooding 하며 만든 진짜 질의·진짜 실패는 어디에도
+평가 자산으로 환류되지 않았다. 벤치 fixture 는 전부 수작업 저작이었다.
+
+## 2. 루프 구조
+
+```
+      (운영 서버, 이미 존재)
+ /query/ ──► james_audit.db ──┐
+ chat.js 👍/👎 ──► feedback_shadow.jsonl ──┤
+                              ▼
+              ① python scripts/live_eval.py report
+                 실사용 품질 리포트 (볼륨·차단율·무응답율·
+                 LLM 오류율·지연 p50/p90/p99·피드백 요약·
+                 부정 피드백 질의 목록·최다 지연 질의)
+                              ▼
+              ② python scripts/live_eval.py promote
+                 부정 피드백 질의 → eval/regression/
+                 live_queries_queries.json (bench.py 포맷)
+                              ▼
+              ③ python scripts/bench.py --suite=live_queries
+                 어제의 실제 실패를 오늘의 빌드에 리플레이
+                              ▼
+              ④ (선택) 운영자가 entry 에 gold_signals /
+                 expected_path 를 보강 → 정식 회귀 게이트로 승격
+```
+
+## 3. 사용법
+
+```bash
+# 최근 7일 실사용 리포트 (기본값)
+python scripts/live_eval.py report
+
+# 30일 창 + 대시보드용 JSON 저장
+python scripts/live_eval.py report --days 30 --json reports/live-eval/2026-07.json
+
+# 부정 피드백 질의를 승격 (미리보기)
+python scripts/live_eval.py promote --dry-run
+
+# 승격 실행 → eval/regression/live_queries_queries.json
+python scripts/live_eval.py promote
+
+# 피드백 없는 질의도 창에서 샘플 (코퍼스 구축 세션용)
+python scripts/live_eval.py promote --all --limit 20
+
+# 리플레이 (라이브 서버 + JAMES_API_KEY 필요)
+python scripts/bench.py --suite=live_queries
+```
+
+두 서브커맨드 모두 **오프라인** — 라이브 LLM 불필요, 이미 캡처된
+데이터만 읽는다. `promote` 가 쓰는 파일은 eval fixture 하나뿐이다.
+
+## 4. 설계 결정
+
+- **조인 키 = 질의 80자 접두사.** `FeedbackEngine.accumulate` 는
+  `query[:80]` 을 기록하고 audit_log 는 `query[:500]` 을 기록한다.
+  md5 `direction_id` (mode+query 해시) 는 역산이 불가능하므로 조인에
+  쓰지 않는다.
+- **승격은 merge-safe.** 기존 entry 는 질의 텍스트로 매칭해 그대로
+  두고 (id 안정, 운영자가 나중에 추가한 `gold_signals` /
+  `expected_path` 보존), 같은 질의 재승격은 no-op.
+- **분류 마커는 런타임 taxonomy 를 미러링.** 오류 =
+  `[Gemma 오류]` 계열 (`core/gemma_client/errors.ERROR_PREFIXES`),
+  무응답 = "자료에 없음" 계열 (`engine_synth` NO_INFO 정규화) +
+  `insufficient information` (terse preset).
+- **승격 직후의 entry 는 '리플레이 가능' 수준.** gold_signals 가
+  없으므로 정답 채점은 안 되지만 차단/오류/지연 회귀는 즉시 잡힌다.
+  정답 채점까지 원하면 운영자가 entry 를 보강한다 (§2 ④).
+
+## 5. 다음 단계 후보 (미구현, 강제 아님)
+
+- `/admin/dashboard` 에 report JSON 시각화 섹션 (피드백 추이 그래프)
+- trace JSONL 조인 → stage 별 지연 분해를 리포트에 포함
+- `promote` 시 해당 질의의 당시 답변을 `notes` 로 첨부 (회귀 판단 참고)
+- 세션 단위 (multi-turn) 리플레이 — `memory.save_turn` 의 session_id
+  를 사용

--- a/scripts/live_eval.py
+++ b/scripts/live_eval.py
@@ -1,0 +1,451 @@
+"""live_eval — 실사용(real-use) 트래픽 → 평가 루프 하니스.
+
+Why this exists (v0.6.1 design review, 2026-07-01)
+--------------------------------------------------
+JAMES already *captures* everything a real-use evaluation needs —
+`james_audit.db` (every query/answer/latency/block),
+`workspace/feedback_shadow.jsonl` (thumbs-up / thumbs-down signals from chat.js), and the
+per-trace JSONL under `reports/trace/`. What was missing is the
+connective tissue: nothing read that live traffic back OUT into an
+evaluation artefact. Benchmarks (STEP7 / QVT / RAB / LRB) all run on
+hand-authored fixtures; the operator's actual phone-dogfood queries
+never became regression material.
+
+This harness closes the loop with two subcommands:
+
+  report   Join audit_log × feedback_shadow over a time window and
+           print a real-use quality report (volume, block rate,
+           LLM-error rate, abstention rate, latency percentiles,
+           feedback summary, worst queries). Optional JSON output for
+           dashboards / tracking over time.
+
+  promote  Select real queries (default: those that received negative
+           feedback) into ``eval/regression/live_queries.json`` — the
+           same suite format ``scripts/bench.py`` already consumes, so
+
+               python scripts/bench.py --suite=live_queries
+
+           replays yesterday's real failures against today's build.
+           Promotion is merge-safe: existing entries keep their ids and
+           any operator-added ``gold_signals`` / ``expected_path``
+           enrichment; re-promoting the same query text is a no-op.
+
+Both subcommands are read-only with respect to production state
+(promote writes only the eval fixture). No live LLM needed — this is
+offline analysis of already-captured traffic, so it runs anywhere the
+repo + the data files exist.
+
+Usage:
+  python scripts/live_eval.py report [--days 7] [--db PATH] [--json OUT]
+  python scripts/live_eval.py promote [--days 7] [--all] [--limit 20]
+                                      [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+DEFAULT_DB = ROOT / "james_audit.db"
+DEFAULT_SHADOW = ROOT / "workspace" / "feedback_shadow.jsonl"
+DEFAULT_SUITE = ROOT / "eval" / "regression" / "live_queries_queries.json"
+
+# Answer-text markers, mirroring the taxonomy the runtime itself uses:
+#   errors — core/gemma_client/errors.ERROR_PREFIXES family
+#   abstention — engine_synth NO_INFO family ("자료에 없음" normalisation)
+ERROR_MARKERS = ("[Gemma 오류]", "[Gemma 응답 없음]", "[Gemma Vision 오류]")
+ABSTENTION_MARKERS = (
+    "자료에 없",
+    "자료에는 없",
+    "자료에는 직접 언급이 없",
+    "insufficient information",
+)
+
+# Negative / positive signal names from core/feedback_engine.FEEDBACK_SIGNALS.
+NEGATIVE_SIGNALS = {"explicit_negative", "implicit_negative", "correction",
+                    "objection"}
+POSITIVE_SIGNALS = {"explicit_positive", "implicit_positive"}
+
+
+# ─── Data loading ──────────────────────────────────────────────────
+
+def load_audit_rows(db_path: Path, since: datetime,
+                    endpoint_prefix: str = "/query") -> List[Dict]:
+    """Read audit_log rows for user-facing query endpoints since ``since``.
+
+    Returns plain dicts (no sqlite3.Row leakage) so callers/tests can
+    build fixtures easily. Missing DB → empty list (a fresh install has
+    no traffic yet; the report should say so, not crash).
+    """
+    if not Path(db_path).exists():
+        return []
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """SELECT timestamp, user_role, endpoint, query, answer,
+                      graph_paths, blocked, security_event, elapsed_sec
+               FROM audit_log
+               WHERE endpoint LIKE ? AND timestamp >= ?
+               ORDER BY timestamp ASC""",
+            (endpoint_prefix + "%", since.isoformat()),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def load_feedback_entries(shadow_path: Path, since: datetime) -> List[Dict]:
+    """Read feedback_shadow.jsonl entries since ``since``.
+
+    Tolerates missing file and malformed lines (append-only JSONL
+    written by a live server can have a torn final line).
+    """
+    p = Path(shadow_path)
+    if not p.exists():
+        return []
+    out: List[Dict] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = entry.get("time", "")
+        if ts and ts >= since.isoformat():
+            out.append(entry)
+    return out
+
+
+# ─── Metrics ───────────────────────────────────────────────────────
+
+def _percentile(sorted_vals: List[float], q: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    idx = min(int(len(sorted_vals) * q), len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def _classify_answer(answer: str) -> str:
+    a = answer or ""
+    if any(m in a for m in ERROR_MARKERS):
+        return "error"
+    if any(m in a for m in ABSTENTION_MARKERS):
+        return "abstention"
+    return "answered"
+
+
+def build_report(rows: List[Dict], feedback: List[Dict],
+                 window_days: int) -> Dict:
+    """Compute the real-use quality report as a plain dict.
+
+    Feedback ↔ query join: feedback entries carry ``query[:80]`` (see
+    FeedbackEngine.accumulate); audit rows carry ``query[:500]``. Join
+    on the 80-char prefix — deterministic and independent of the md5
+    direction_id (which hashes mode+query and can't be inverted).
+    """
+    total = len(rows)
+    blocked = sum(1 for r in rows if r.get("blocked"))
+    latencies = sorted(
+        float(r.get("elapsed_sec") or 0.0)
+        for r in rows if not r.get("blocked")
+    )
+    kinds = {"answered": 0, "abstention": 0, "error": 0}
+    for r in rows:
+        if not r.get("blocked"):
+            kinds[_classify_answer(r.get("answer") or "")] += 1
+
+    # Feedback summary + negative-feedback query texts.
+    sig_counts: Dict[str, int] = {}
+    neg_queries: Dict[str, int] = {}
+    pos_count = neg_count = 0
+    for e in feedback:
+        sig = e.get("signal", "")
+        sig_counts[sig] = sig_counts.get(sig, 0) + 1
+        if sig in NEGATIVE_SIGNALS:
+            neg_count += 1
+            q = (e.get("query") or "").strip()
+            if q:
+                neg_queries[q] = neg_queries.get(q, 0) + 1
+        elif sig in POSITIVE_SIGNALS:
+            pos_count += 1
+
+    # Slowest non-blocked queries (top 5).
+    slowest = sorted(
+        (r for r in rows if not r.get("blocked")),
+        key=lambda r: float(r.get("elapsed_sec") or 0.0),
+        reverse=True,
+    )[:5]
+
+    answered_total = max(1, total - blocked)
+    return {
+        "window_days": window_days,
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "total_queries": total,
+        "blocked": blocked,
+        "block_rate": round(blocked / total, 3) if total else 0.0,
+        "answered": kinds["answered"],
+        "abstention": kinds["abstention"],
+        "abstention_rate": round(kinds["abstention"] / answered_total, 3),
+        "llm_errors": kinds["error"],
+        "llm_error_rate": round(kinds["error"] / answered_total, 3),
+        "latency": {
+            "p50": round(_percentile(latencies, 0.50), 2),
+            "p90": round(_percentile(latencies, 0.90), 2),
+            "p99": round(_percentile(latencies, 0.99), 2),
+            "max": round(latencies[-1], 2) if latencies else 0.0,
+        },
+        "feedback": {
+            "total": len(feedback),
+            "positive": pos_count,
+            "negative": neg_count,
+            "by_signal": sig_counts,
+        },
+        "negative_feedback_queries": [
+            {"query": q, "count": c}
+            for q, c in sorted(neg_queries.items(), key=lambda kv: -kv[1])
+        ],
+        "slowest_queries": [
+            {"query": (r.get("query") or "")[:80],
+             "elapsed_sec": round(float(r.get("elapsed_sec") or 0.0), 1),
+             "timestamp": r.get("timestamp", "")}
+            for r in slowest
+        ],
+    }
+
+
+def format_report_md(rep: Dict) -> str:
+    """Render the report dict as operator-readable markdown."""
+    fb = rep["feedback"]
+    lines = [
+        f"# 실사용 평가 리포트 (최근 {rep['window_days']}일)",
+        "",
+        f"- 생성: {rep['generated_at']}",
+        f"- 총 질의: **{rep['total_queries']}** "
+        f"(차단 {rep['blocked']}, 차단율 {rep['block_rate']:.1%})",
+        f"- 정상 답변: {rep['answered']} · "
+        f"무응답(자료 없음): {rep['abstention']} "
+        f"({rep['abstention_rate']:.1%}) · "
+        f"LLM 오류: {rep['llm_errors']} ({rep['llm_error_rate']:.1%})",
+        f"- 지연 (비차단): p50 {rep['latency']['p50']}s / "
+        f"p90 {rep['latency']['p90']}s / p99 {rep['latency']['p99']}s / "
+        f"max {rep['latency']['max']}s",
+        f"- 피드백: 총 {fb['total']} (긍정 {fb['positive']} / 부정 {fb['negative']})",
+        "",
+    ]
+    if rep["negative_feedback_queries"]:
+        lines.append("## 부정 피드백 질의 (promote 후보)")
+        for item in rep["negative_feedback_queries"]:
+            lines.append(f"- ({item['count']}×) {item['query']}")
+        lines.append("")
+    if rep["slowest_queries"]:
+        lines.append("## 최다 지연 질의 (top 5)")
+        for item in rep["slowest_queries"]:
+            lines.append(
+                f"- {item['elapsed_sec']}s — {item['query']}")
+        lines.append("")
+    lines.append(
+        "다음 단계: `python scripts/live_eval.py promote` 로 부정 피드백 "
+        "질의를 `eval/regression/live_queries_queries.json` 에 승격 → "
+        "`python scripts/bench.py --suite=live_queries` 로 리플레이.")
+    return "\n".join(lines)
+
+
+
+# ─── Promotion ─────────────────────────────────────────────────────
+
+def _empty_suite() -> Dict:
+    return {
+        "version": "live-v1",
+        "description": (
+            "Real-use regression suite — queries promoted from live "
+            "traffic by scripts/live_eval.py. Each entry records why it "
+            "was promoted (negative feedback / operator pick). Operators "
+            "may enrich entries with gold_signals / expected_path over "
+            "time; promotion NEVER overwrites existing enrichment. "
+            "Replay: python scripts/bench.py --suite=live_queries"
+        ),
+        "endpoint": {"url": "/query/", "method": "POST", "timeout": 120},
+        "queries": [],
+    }
+
+
+def load_suite(path: Path) -> Dict:
+    if Path(path).exists():
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    return _empty_suite()
+
+
+def promote_queries(suite: Dict, candidates: List[Dict]) -> Dict:
+    """Merge candidate queries into the suite (idempotent).
+
+    ``candidates``: [{"text": ..., "reason": ..., "first_seen": ...}].
+    Existing entries are matched by exact query text and left
+    untouched (ids stable, operator enrichment preserved).
+    """
+    existing_texts = {q.get("text", "") for q in suite.get("queries", [])}
+    next_id = 1 + max(
+        (int(q.get("id", 0)) for q in suite.get("queries", [])), default=0,
+    )
+    added = 0
+    for cand in candidates:
+        text = (cand.get("text") or "").strip()
+        if not text or text in existing_texts:
+            continue
+        suite["queries"].append({
+            "id": next_id,
+            "category": "live",
+            "text": text,
+            "promoted": {
+                "reason": cand.get("reason", "operator"),
+                "first_seen": cand.get("first_seen", ""),
+                "promoted_at": datetime.now().isoformat(timespec="seconds"),
+            },
+        })
+        existing_texts.add(text)
+        next_id += 1
+        added += 1
+    suite["_last_promotion_added"] = added
+    return suite
+
+
+def collect_candidates(rows: List[Dict], feedback: List[Dict],
+                       include_all: bool = False,
+                       limit: int = 20) -> List[Dict]:
+    """Pick promotion candidates from the window's traffic.
+
+    Default: queries with negative feedback (join on the 80-char query
+    prefix, same rule as build_report). ``include_all`` adds every
+    distinct non-blocked query in the window (rate-limited by
+    ``limit``, newest first) for corpus-building sessions.
+    """
+    # audit rows by 80-char prefix → full text + first_seen
+    by_prefix: Dict[str, Dict] = {}
+    for r in rows:
+        if r.get("blocked"):
+            continue
+        q = (r.get("query") or "").strip()
+        if not q:
+            continue
+        key = q[:80]
+        if key not in by_prefix:
+            by_prefix[key] = {"text": q, "first_seen": r.get("timestamp", "")}
+
+    out: List[Dict] = []
+    seen = set()
+    for e in feedback:
+        if e.get("signal") not in NEGATIVE_SIGNALS:
+            continue
+        key = (e.get("query") or "").strip()[:80]
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        hit = by_prefix.get(key, {"text": key, "first_seen": e.get("time", "")})
+        out.append({**hit, "reason": "negative_feedback"})
+
+    if include_all:
+        for key, hit in sorted(by_prefix.items(),
+                               key=lambda kv: kv[1]["first_seen"],
+                               reverse=True):
+            if key in seen:
+                continue
+            if len(out) >= limit:
+                break
+            seen.add(key)
+            out.append({**hit, "reason": "window_sample"})
+    return out
+
+
+# ─── CLI ───────────────────────────────────────────────────────────
+
+def main(argv: Optional[List[str]] = None) -> int:
+    # The report is Markdown with Korean text; a Windows console
+    # defaults to cp949 and raises UnicodeEncodeError on anything
+    # outside it. Caught by a live run against james_audit.db that
+    # the synthetic-fixture tests could not see, since they call
+    # format_report_md() directly rather than printing it.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):  # pragma: no cover
+            pass
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--days", type=int, default=7,
+                        help="lookback window in days (default 7)")
+    common.add_argument("--db", default=str(DEFAULT_DB),
+                        help="james_audit.db path")
+    common.add_argument("--shadow", default=str(DEFAULT_SHADOW),
+                        help="feedback_shadow.jsonl path")
+
+    p_rep = sub.add_parser("report", parents=[common],
+                           help="real-use quality report")
+    p_rep.add_argument("--json", dest="json_out", default="",
+                       help="also write the raw report dict to this path")
+
+    p_pro = sub.add_parser("promote", parents=[common],
+                           help="promote live queries into the bench suite")
+    p_pro.add_argument("--suite", default=str(DEFAULT_SUITE),
+                       help="target suite JSON (bench.py format)")
+    p_pro.add_argument("--all", action="store_true",
+                       help="also sample non-feedback queries from the window")
+    p_pro.add_argument("--limit", type=int, default=20,
+                       help="max sampled queries with --all (default 20)")
+    p_pro.add_argument("--dry-run", action="store_true",
+                       help="print candidates without writing the suite")
+
+    args = ap.parse_args(argv)
+    since = datetime.now() - timedelta(days=args.days)
+    rows = load_audit_rows(Path(args.db), since)
+    feedback = load_feedback_entries(Path(args.shadow), since)
+
+    if args.cmd == "report":
+        rep = build_report(rows, feedback, args.days)
+        print(format_report_md(rep))
+        if args.json_out:
+            out = Path(args.json_out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(rep, ensure_ascii=False, indent=2),
+                           encoding="utf-8")
+            print(f"\n[live_eval] JSON → {out}")
+        return 0
+
+    # promote
+    candidates = collect_candidates(rows, feedback,
+                                    include_all=args.all, limit=args.limit)
+    if not candidates:
+        print("[live_eval] promote 후보 없음 (창 내 부정 피드백 질의 0건)")
+        return 0
+    if args.dry_run:
+        for c in candidates:
+            print(f"- [{c['reason']}] {c['text'][:100]}")
+        print(f"[live_eval] dry-run — {len(candidates)}건 (미기록)")
+        return 0
+    suite_path = Path(args.suite)
+    suite = load_suite(suite_path)
+    suite = promote_queries(suite, candidates)
+    added = suite.pop("_last_promotion_added", 0)
+    suite_path.parent.mkdir(parents=True, exist_ok=True)
+    suite_path.write_text(
+        json.dumps(suite, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[live_eval] {added}건 신규 승격 (총 {len(suite['queries'])}건) "
+          f"→ {suite_path}")
+    print("[live_eval] 리플레이: python scripts/bench.py --suite=live_queries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_eval.py
+++ b/tests/test_live_eval.py
@@ -1,0 +1,234 @@
+"""Real-use evaluation harness (scripts/live_eval.py) — v0.6.1.
+
+Covers the capture→report→promote loop against synthetic fixtures:
+  * audit_log rows in a temp sqlite DB (same schema as
+    server_llmwiki._init_audit_db)
+  * feedback_shadow.jsonl entries (same fields FeedbackEngine.accumulate
+    writes)
+  * promotion into the bench.py-compatible suite JSON, including the
+    merge-safety guarantees (stable ids, no overwrite of operator
+    enrichment, idempotent re-promotion).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.live_eval import (  # noqa: E402
+    build_report,
+    collect_candidates,
+    format_report_md,
+    load_audit_rows,
+    load_feedback_entries,
+    load_suite,
+    promote_queries,
+)
+
+
+def _make_audit_db(path: Path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.execute("""
+        CREATE TABLE audit_log (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp    TEXT    NOT NULL,
+            user_role    TEXT    NOT NULL,
+            endpoint     TEXT    NOT NULL,
+            query        TEXT,
+            answer       TEXT,
+            graph_paths  TEXT,
+            blocked      INTEGER   DEFAULT 0,
+            security_event TEXT,
+            elapsed_sec  REAL,
+            ip_address   TEXT
+        )
+    """)
+    conn.executemany(
+        """INSERT INTO audit_log
+           (timestamp, user_role, endpoint, query, answer, graph_paths,
+            blocked, security_event, elapsed_sec, ip_address)
+           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _now(offset_min: int = 0) -> str:
+    return (datetime.now() + timedelta(minutes=offset_min)).isoformat()
+
+
+class LoadersTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_missing_db_and_shadow_return_empty(self):
+        since = datetime.now() - timedelta(days=7)
+        self.assertEqual(load_audit_rows(self.dir / "nope.db", since), [])
+        self.assertEqual(
+            load_feedback_entries(self.dir / "nope.jsonl", since), [])
+
+    def test_audit_rows_filtered_by_endpoint_and_time(self):
+        db = self.dir / "a.db"
+        old = (datetime.now() - timedelta(days=30)).isoformat()
+        _make_audit_db(db, [
+            (_now(), "admin", "/query/", "질문1", "답1", "[]", 0, "", 3.2, ""),
+            (_now(), "admin", "/login/", "", "", "[]", 0, "", 0.1, ""),
+            (old, "admin", "/query/", "옛질문", "답", "[]", 0, "", 1.0, ""),
+        ])
+        since = datetime.now() - timedelta(days=7)
+        rows = load_audit_rows(db, since)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["query"], "질문1")
+
+    def test_feedback_tolerates_torn_line(self):
+        p = self.dir / "s.jsonl"
+        good = {"direction_id": "d1", "signal": "explicit_negative",
+                "delta": -1.0, "score": -1.0, "query": "질문1",
+                "time": _now()}
+        p.write_text(json.dumps(good, ensure_ascii=False) +
+                     "\n{torn-line", encoding="utf-8")
+        since = datetime.now() - timedelta(days=1)
+        entries = load_feedback_entries(p, since)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["signal"], "explicit_negative")
+
+
+class ReportTests(unittest.TestCase):
+    def _rows(self):
+        return [
+            {"timestamp": _now(), "endpoint": "/query/", "query": "q-ok",
+             "answer": "정상 답변입니다", "blocked": 0, "elapsed_sec": 2.0},
+            {"timestamp": _now(), "endpoint": "/query/", "query": "q-abst",
+             "answer": "제공된 자료에는 없습니다", "blocked": 0,
+             "elapsed_sec": 4.0},
+            {"timestamp": _now(), "endpoint": "/query/", "query": "q-err",
+             "answer": "[Gemma 오류] 응답 시간 초과 (120s)", "blocked": 0,
+             "elapsed_sec": 120.0},
+            {"timestamp": _now(), "endpoint": "/query/", "query": "q-block",
+             "answer": "차단", "blocked": 1, "elapsed_sec": 0.0},
+        ]
+
+    def _feedback(self):
+        return [
+            {"signal": "explicit_negative", "query": "q-err", "time": _now()},
+            {"signal": "explicit_positive", "query": "q-ok", "time": _now()},
+        ]
+
+    def test_counts_and_rates(self):
+        rep = build_report(self._rows(), self._feedback(), window_days=7)
+        self.assertEqual(rep["total_queries"], 4)
+        self.assertEqual(rep["blocked"], 1)
+        self.assertEqual(rep["answered"], 1)
+        self.assertEqual(rep["abstention"], 1)
+        self.assertEqual(rep["llm_errors"], 1)
+        self.assertEqual(rep["feedback"]["negative"], 1)
+        self.assertEqual(rep["feedback"]["positive"], 1)
+        self.assertEqual(
+            rep["negative_feedback_queries"][0]["query"], "q-err")
+
+    def test_latency_percentiles_exclude_blocked(self):
+        rep = build_report(self._rows(), [], window_days=7)
+        self.assertEqual(rep["latency"]["max"], 120.0)
+        self.assertGreaterEqual(rep["latency"]["p50"], 2.0)
+
+    def test_markdown_renders_key_sections(self):
+        rep = build_report(self._rows(), self._feedback(), window_days=7)
+        md = format_report_md(rep)
+        self.assertIn("실사용 평가 리포트", md)
+        self.assertIn("부정 피드백 질의", md)
+        self.assertIn("q-err", md)
+        self.assertIn("bench.py --suite=live_queries", md)
+
+    def test_empty_window_does_not_crash(self):
+        rep = build_report([], [], window_days=7)
+        self.assertEqual(rep["total_queries"], 0)
+        self.assertIn("실사용 평가 리포트", format_report_md(rep))
+
+
+class PromotionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.suite_path = Path(self.tmp.name) / "live_queries_queries.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _rows(self):
+        return [
+            {"timestamp": _now(), "endpoint": "/query/",
+             "query": "실패한 질문입니다", "answer": "…", "blocked": 0,
+             "elapsed_sec": 5.0},
+            {"timestamp": _now(), "endpoint": "/query/",
+             "query": "잘 된 질문", "answer": "…", "blocked": 0,
+             "elapsed_sec": 1.0},
+        ]
+
+    def _neg_feedback(self):
+        return [{"signal": "explicit_negative",
+                 "query": "실패한 질문입니다", "time": _now()}]
+
+    def test_candidates_default_negative_only(self):
+        cands = collect_candidates(self._rows(), self._neg_feedback())
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["reason"], "negative_feedback")
+        self.assertEqual(cands[0]["text"], "실패한 질문입니다")
+
+    def test_candidates_all_samples_window(self):
+        cands = collect_candidates(self._rows(), self._neg_feedback(),
+                                   include_all=True, limit=10)
+        texts = {c["text"] for c in cands}
+        self.assertIn("잘 된 질문", texts)
+        self.assertEqual(len(cands), 2)  # dedup vs feedback candidate
+
+    def test_promote_creates_bench_compatible_suite(self):
+        suite = load_suite(self.suite_path)
+        suite = promote_queries(
+            suite, collect_candidates(self._rows(), self._neg_feedback()))
+        # bench.py contract: endpoint block + queries[].id / .text
+        self.assertEqual(suite["endpoint"]["url"], "/query/")
+        self.assertEqual(len(suite["queries"]), 1)
+        q = suite["queries"][0]
+        self.assertEqual(q["id"], 1)
+        self.assertEqual(q["text"], "실패한 질문입니다")
+        self.assertEqual(q["promoted"]["reason"], "negative_feedback")
+
+    def test_promotion_idempotent_and_preserves_enrichment(self):
+        suite = load_suite(self.suite_path)
+        cands = collect_candidates(self._rows(), self._neg_feedback())
+        suite = promote_queries(suite, cands)
+        # Operator later enriches the entry:
+        suite["queries"][0]["gold_signals"] = [{"term": "정답",
+                                                "aliases": []}]
+        # Re-promoting the same query must not duplicate or overwrite.
+        suite = promote_queries(suite, cands)
+        suite.pop("_last_promotion_added", None)
+        self.assertEqual(len(suite["queries"]), 1)
+        self.assertEqual(suite["queries"][0]["gold_signals"][0]["term"],
+                         "정답")
+
+    def test_ids_stay_stable_across_promotions(self):
+        suite = load_suite(self.suite_path)
+        suite = promote_queries(
+            suite, [{"text": "첫 질문", "reason": "operator",
+                     "first_seen": _now()}])
+        suite = promote_queries(
+            suite, [{"text": "둘째 질문", "reason": "operator",
+                     "first_seen": _now()}])
+        ids = [q["id"] for q in suite["queries"]]
+        self.assertEqual(ids, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`scripts/live_eval.py` closes the gap between the capture layer JAMES already has — `james_audit.db`, `feedback_shadow.jsonl`, trace JSONL — and the benchmark layer, which until now held **hand-authored fixtures only**. Real traffic could be recorded but never fed back into the eval harness.

- **`report`** — joins `audit_log` × feedback over a time window: volume, block rate, abstention rate, LLM-error rate, latency p50/p90/p99, feedback summary, negative-feedback queries, slowest queries. Markdown to stdout, optional JSON for tracking over time.
- **`promote`** — turns negative-feedback (or `--all` sampled) real queries into `eval/regression/live_queries_queries.json` in `bench.py` suite format, so `bench.py --suite=live_queries` replays yesterday's real failures against today's build. Merge-safe: stable ids, operator `gold_signals` enrichment is never overwritten, re-promotion is idempotent.

Both commands are **offline** — no live LLM.

Written 2026-07-01 on `claude/sekos-design-structure-review-k56bmn` and never landed.

## Two fixes were needed before it could ship

**1. `import os` unused.** It would have failed the F-class ruff gate that #1078 restored *after* this code was written.

**2. A live run died on the real database.** `report --days 1` against `james_audit.db` raised `UnicodeEncodeError: 'cp949' codec can't encode character '\U0001f44d'` — the report carried 👍 / 👎 / 🐢, and a Windows console is cp949.

The unit tests could not catch this: they call `format_report_md()` and assert on the **returned string**, never printing it. So the crash lived exactly one layer above where the fixtures reach — the same shape as `feedback_measurement_smoke_caught_wiring_bugs`.

Fixed twice over: the emoji are now text labels (`긍정` / `부정`, plain headings), matching the de-emoji convention already applied to non-chat surfaces, and `main()` forces UTF-8 on stdout/stderr so redirected Korean output survives regardless of console codepage.

## Verification

Against the **real database**, not fixtures alone:

```
$ python scripts/live_eval.py report --days 1
# 실사용 평가 리포트 (최근 1일)
- 총 질의: 59 (차단 6, 차단율 10.2%)
- 정상 답변: 53 · 무응답(자료 없음): 0 (0.0%) · LLM 오류: 0 (0.0%)
- 지연 (비차단): p50 88.37s / p90 123.24s / p99 146.09s / max 146.09s
```

That window is tonight's three STEP 7 bench runs from #1083 — 59 queries, and the 10.2% block rate is exactly the security fixtures (2 per run × 3). The numbers are independently checkable against the bench output in that PR.

```
$ python scripts/live_eval.py promote --days 1 --all --limit 3 --dry-run
- [window_sample] RAG가 무엇인가?
- [window_sample] RAG 기법을 사용하는 코딩 도구 3 개를 알려줘
- [window_sample] Which company issues IBIT and FBTC bitcoin ETFs?
[live_eval] dry-run — 3건 (미기록)
```

`git status eval/` clean afterwards — dry-run wrote nothing.

- `pytest tests/test_live_eval.py` → 12 passed
- `ruff check --select F` → clean
- No `core/` file touched; `scripts/live_eval.py` is 18 KB and is not under the rule #5 `core/` gate.

## Quality Delta

`Quality delta: exempt (label: code)` — evaluation-side harness; the PR *is* measurement machinery, so measuring it against itself is circular. No `core/` changes.

## Out of scope

- The 2026-07-01 branch's design-review document. It is a snapshot of the codebase as of 2026-07-01 and two months of change (#1077–#1084) have landed since; publishing it unchecked would re-create exactly the documentation drift #1081 fixed. Worth a pass to re-verify its findings against current `main` before it lands, if at all.
- `response_style` split + test-repair commits from the same branch — superseded, see #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
