### PR TITLE
docs(v0.6.2): re-verify the 2026-07-01 SEKOS design review against current main

### DIFF
--- a/docs/reviews/v0.6.2-sekos-design-structure-review.md
+++ b/docs/reviews/v0.6.2-sekos-design-structure-review.md
@@ -1,0 +1,261 @@
+# SEKOS 설계·구조 리뷰 — 2026-07-01 원본, 2026-09-08 재검증
+
+> 원본은 2026-07-01 에 `claude/sekos-design-structure-review-k56bmn`
+> 에서 작성됐고 머지되지 않은 채 두 달을 보냈다. 그 사이 #1077–#1085
+> 가 랜딩되면서 원본 수치와 진단 상당수가 낡았다.
+>
+> 이 문서는 원본의 **모든 주장을 현재 main 기준으로 다시 실측한**
+> 판본이다. 낡은 셀은 고쳤고, 뒤집힌 진단은 뒤집힌 채로 적었으며,
+> 그대로 유효한 것은 유효하다고 표시했다. 재검증 로그는 §8.
+>
+> **기준일**: 2026-09-08, main = `1c6e4b2` (PR #1085 이후)
+> **원본 기준일**: 2026-07-01, main = `e37042d` (PR #1076 이후)
+
+---
+
+## 1. 요약
+
+아키텍처 규율에 대한 원본의 평가는 유지된다 — 보호 3층 0-라인 변경
+계약, rule #1 4-layer 수직화 방지, 문서-주도 운영. **`core/` 안의
+수직 도메인 오염은 재검증에서도 0건**이다 (legal/food/retail/travel/
+finance 전수 grep → 전부 산문·주석·pack id 예시, 실제 결합 없음).
+
+원본이 지적한 4건 중 **3건은 이 사이에 해결됐다**:
+
+1. **이중 절단 (해결)** — 프롬프트 캡 4000 → 16000, PR #1084.
+2. **rule #5 게이트 RED (해결)** — `response_style` 분할은 #1080 이,
+   `engine.py` 분할은 #1083 이 각각 처리. **GRANDFATHERED 딕셔너리는
+   현재 비어 있다** = rule #5 예외 0건.
+3. **실사용 평가 연결층 부재 (해결)** — `scripts/live_eval.py`,
+   PR #1085.
+
+**4번은 해결이 아니라 진단이 뒤집혔다.** 원본은 "main 에서 117건
+실패, 대부분 order-dependence, 격리 실행 시 전부 통과"로 봤다.
+현재 실측은 다르다 — 전체 스위트 로컬 **11건 실패, 그리고 그 11건은
+격리 실행에서도 똑같이 실패한다** (§3.3). 순서 문제가 아니다.
+진짜 문제는 그 아래 있었다: **CI 가 57개 테스트 파일을 `--ignore`
+하고 있고, 그 안에 902개의 통과 테스트와 8건의 적색이 들어 있다.**
+
+---
+
+## 2. 원본 브랜치 처리 결과
+
+원본 7 커밋 중 3 계열만 살렸다. 나머지는 그 사이 main 이 독립적으로
+같은 일을 했기 때문이다.
+
+| 원본 커밋 | 처리 | 근거 |
+|---|---|---|
+| `c5eb780` 로컬 LLM 기본값 (이중 절단 / keep_alive / vision drift) | **랜딩 #1084** | 세 건 모두 main 에서 여전히 유효한 문제였음을 랜딩 전 확인 |
+| `4262aed` rule #5 분할 (response_style + engine routing) | **절반만 랜딩 #1083** | `response_style` 절반은 #1080 이 2026-08-26 에 같은 파일명으로 독립 수행 (두 판본 차이 ~15줄, 전부 docstring). engine 절반만 남아 있었다 |
+| `3eaef5b` live_eval 루프 | **랜딩 #1085** | 클린 cherry-pick. 단 실DB 스모크에서 cp949 크래시 + F401 발견 → 수정 후 랜딩 |
+| `94d2ade` 구조-grep 테스트 3건 | **랜딩 #1083** | engine 분할과 짝 |
+| `8c6f3cd` post-split 경로 + 백엔드 격리 복구 | **폐기** | #1079/#1080 이 더 일반적으로 해결 (`module_source()` 헬퍼). 재적용하면 되돌리는 셈 |
+| `6a50839` stale pin 10건 복구 | **폐기** | 동상 |
+| `ae7309c` 이 리뷰 문서 | **이 문서로 대체** | 재검증본 |
+
+원본 §2 의 "전체 스위트 136 failed → ~30건 복구" 수치는 `e37042d`
+시점 값이라 지금은 재현되지 않는다. 현재 값은 §3.3.
+
+---
+
+## 3. 구조 리뷰 — 재실측
+
+### 3.1 크기/응집 (유효, 수치 갱신)
+
+원본 진단 그대로 유효하다. 두 달 동안 전부 **더 커졌다**.
+
+| 대상 | 2026-07-01 | 2026-09-08 | Δ |
+|---|---:|---:|---:|
+| `frontend/static/admin.js` | 193,730B | **198,262B** | +2.3% |
+| `frontend/static/i18n.js` | 169,707B | **172,388B** | +1.6% |
+| `frontend/static/chat.js` | 162,236B | **166,906B** | +2.9% |
+| `routes/admin.py` | 108,989B | **111,865B** | +2.6% |
+| `server_llmwiki.py` | 38,980B | **40,105B** | +2.9% |
+
+`routes/admin.py` 는 2,876줄 / 54 endpoint 로 원본과 동일하다 (증가분은
+줄 수가 아니라 줄 길이). `core/` 20KB 게이트의 5배이고 `routes/` 는
+게이트 미적용 — 원본의 도메인별 분할 권장은 유효하다.
+
+### 3.2 계층 위반 / 결합 (전부 유효, 변동 없음)
+
+재검증에서 **네 건 모두 원본 그대로**다.
+
+- **`core/agent_tools/dispatcher.py:40` → `routes._helpers._write_audit`**:
+  줄 번호까지 동일. core 가 HTTP 층을 역참조하는 유일 지점이고,
+  `core/audit_bridge.py` 는 이미 존재한다 — 내리는 방향이 맞다.
+- **모델 선택 책임 8개 모듈 분산**: `llm/{router,selection}` +
+  `core/{model_resolver,model_resolver_tiers,model_catalog,llm_catalog,
+  llm_settings}` + `routes/llm_settings` — 8개 전부 여전히 존재.
+  `docs/design/v0.6-llm-routing-unification.md` 의 Phase 진행이 정답.
+- **`core/security/` vs `core/security_layer/`**: 두 형제 패키지 유지.
+- **"engine" 4형제**: `graph_rag_engine.py` / `graph_engine/` /
+  `retrieval_engine.py` / `reasoning/engine.py` 유지. #1083 이
+  `reasoning/engine_routing.py` 를 더했으므로 명명 지도 필요성은
+  오히려 커졌다.
+
+### 3.3 테스트 위생 — **진단이 뒤집혔다**
+
+원본: *"전체 스위트 117건 실패, ~40-100건이 order-dependent, 격리
+실행 시 전부 통과."* → **현재 실측으로 성립하지 않는다.**
+
+| 측정 | 결과 |
+|---|---|
+| 전체 스위트, 로컬 (`pytest tests/`) | **11 failed / 5,298 passed** |
+| 같은 11건을 모듈 단위로 격리 실행 | **11건 그대로 실패** |
+| CI (`main`, run 34163805508) | **1 failed / 4,392 passed** |
+
+즉 order-dependence 가설은 현재 실패 집합을 설명하지 못한다. 격리해도
+같은 결과다. 대신 재검증에서 **더 큰 것이 나왔다**:
+
+> **CI 는 57개 테스트 파일을 `--ignore` 한다.**
+> 그 57개를 로컬에서 돌리면 **902 passed / 8 failed**.
+> 오늘 로컬에서 실패하는 8개 모듈 중 **6개가 이 무시 목록 안에 있다.**
+
+무시 목록에 있으면 CI 가 구조적으로 볼 수 없다. 그래서 그중 하나는
+**main 에서 실제로 stale 한 채 조용히 남아 있다**:
+
+- `tests/test_default_llm_model.py` 는 `config.py` 에서
+  `GEMMA_MODEL = os.environ.get("JAMES_LLM_MODEL", ...)` 패턴을 grep
+  하는데, 현재 config.py 는
+  `GEMMA_MODEL = _llm_setting("default_model", "JAMES_LLM_MODEL", "gemma4:e4b")`
+  (config.py:192) 다. 패턴이 안 맞아 환경과 무관하게 실패한다. 이
+  파일은 CI 무시 목록에 있어 게이트가 잡지 못한다.
+
+나머지는 로컬 환경 의존이다 — 이 호스트의 `.env` 12개 override 가
+`test_embedding_model_abstraction` 의 "env 미설정 시 legacy minilm
+경로" 단언을 깨고 (`chroma_db_bge_m3` vs `chroma_db`), FastAPI 버전
+차이가 `test_app_routes_helper` 를 깬다. **근본 수선은 순서 격리가
+아니라 env 격리**(테스트가 ambient env 대신 monkeypatch 된 env 를
+읽게 하는 것)와 **무시 목록 축소**다.
+
+### 3.4 잔재 (일부 해결, 수치 갱신)
+
+- 루트의 `james_*_test.py` — 원본 "8개" → **현재 6개**. `tests/` 밖
+  고아 스크립트라는 진단은 유효.
+- **"테스트가 커밋된 리포트를 변조" — 해결됨.** #1080 이
+  `reports/research-runs/cascade-consistency-probe.json` 하드코드를
+  고쳤다. 오늘 밤 전체 스위트를 네 차례 돌린 뒤에도 `git status
+  reports/` 는 클린이다. 재검증으로 확인.
+- **수직 도메인 오염 — 0건 재확인** (§1).
+
+---
+
+## 4. 로컬 AI 리뷰 — 항목별 재검증
+
+### 4.1 해결됨 (PR #1084)
+
+이중 절단 (`JAMES_GEMMA_MAX_PROMPT_CHARS` 4000 → 16000, 캡 ≥ 1.5×
+synth 컨텍스트 불변식 테스트 포함) / `JAMES_OLLAMA_KEEP_ALIVE`
+(기본 30m, `"0"`/`"off"` 로 해제) / vision drift (`DEFAULT_PREFERENCE
+["vision"]` + `llm_catalog` 가 qwen2.5vl:7b 선두).
+
+### 4.2 열려 있는 것 — 재검증 결과
+
+| # | 발견 | 재검증 (2026-09-08) |
+|---|---|---|
+| 1 | `ollama_local` 백엔드 `tier="small"` 하드코드 | **유효, 변동 없음** — `core/reasoning/backends/ollama_local.py:33` 줄 번호까지 동일. 27B 를 띄워도 D5 라우터에겐 small |
+| 2 | `num_ctx=8192` 고정 | **절반 해결** — 이제 `JAMES_NUM_CTX` env 로 조절 가능 (기본 8192, `client.py:289`). 그러나 **모델별 자동 사이징은 여전히 없다**: `llm_catalog` 의 `context_window` 필드 = **0건** |
+| 3 | 토큰 스트리밍 부재 (`stream:False`) | **유효** — `client.py:250`(텍스트) / `:362`(비전) 양쪽 `"stream": False`. #1073 heartbeat 는 keepalive 이지 체감 지연 단축이 아니라는 원본 지적 그대로 |
+| 4 | 응답 캐시가 >2000자 프롬프트에서 비활성 → RAG 질의 히트율 ~0 | **유효** — `client.py:209` `if len(prompt) > 2000` |
+| 5 | planner→synth→reflect→verify 순차 왕복 | **유효** — `JAMES_DISABLE_COGNITIVE_STAGES` 레버는 `planner.py` / `reflect/loop.py` 에 살아 있음 |
+| 6 | 리랭커 기본이 영어 전용 | **유효** — `core/retrieval/rerank.py:33` `DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"` |
+| 7 | `mixtral:8x7b` 가 preference 엔 있는데 catalog 엔 없음 | **유효** — `model_resolver.py:131,150` 에 있고 `llm_catalog.py` 엔 0건. 다만 원본이 "README 오기"로 부른 `mxtral` 표기는 **오기가 아니라 저장소 전반의 약칭**(CLAUDE.md·메모리·README 일관)이다. 실제 불일치는 *추천기 ↔ 카탈로그* 쪽 하나뿐 |
+
+### 4.3 운영자 즉시 레버 (갱신)
+
+```bash
+# (1)(2) 는 이제 기본값이다 — .env 에 적을 필요 없음 (PR #1084)
+#   JAMES_GEMMA_MAX_PROMPT_CHARS=16000
+#   JAMES_OLLAMA_KEEP_ALIVE=30m
+
+# 긴 질의 체감 단축 (135s→70s 실측, handover 2026-06-26)
+JAMES_DISABLE_COGNITIVE_STAGES=1
+
+# 한국어 리랭킹 품질 (기본은 여전히 영어 전용)
+JAMES_RERANKER_MODEL=BAAI/bge-reranker-base
+
+# 컨텍스트窓 (이제 env 로 조절 가능 — §4.2-2)
+JAMES_NUM_CTX=16384
+JAMES_VISION_NUM_CTX=12288
+```
+
+모델 선택은 원본 그대로 유효: 채팅/검색/위키 = **gemma3:12b**
+(v18.7 측정), vision = **qwen2.5vl:7b** (#1070 A/B).
+
+---
+
+## 5. 실사용 평가 — 랜딩 완료
+
+`scripts/live_eval.py` 는 PR #1085 로 main 에 있다. 랜딩 시 실DB
+스모크에서 원본이 못 본 결함 하나가 나왔다: 리포트에 이모지가 있어
+Windows cp949 콘솔에서 `UnicodeEncodeError` 로 죽었다. 단위 테스트는
+`format_report_md()` 반환값만 검사하고 출력을 거치지 않아 못 잡는
+자리였다. 텍스트 라벨 + stdout UTF-8 강제로 수정 후 랜딩.
+
+§5.3 의 다음 단계(admin 대시보드 시각화 / trace 조인 stage 지연 분해 /
+세션 리플레이 / self-grade ↔ 피드백 상관)는 전부 미구현 그대로다.
+
+---
+
+## 6. 우선순위 — 개정
+
+원본의 P1 #2("order-dependent 테스트 근절")는 전제가 틀렸으므로
+내용을 바꿔 대체한다.
+
+1. **P1 — CI 무시 목록 축소** (§3.3). 57개 파일 / 902 테스트가
+   게이트 밖에 있고 그중 8건이 적색이며, 최소 1건(`test_default_llm_model`)
+   은 그래서 stale 한 채 남았다. 무시 목록을 한 번에 없앨 수는 없지만,
+   *왜 무시되는지* 사유를 파일별로 붙이고 (env 의존 / 느림 / 외부
+   바인딩) env 의존분부터 monkeypatch 격리로 되살리는 것이 순서다.
+   솔로 가능, 보호층 무관.
+2. **P1 — `routes/admin.py` 분할** (111,865B / 2,876줄 / 54 endpoint).
+   게이트 확장(`routes/` 완화 캡)과 함께. 솔로 가능.
+3. **P2 — 토큰 스트리밍** (§4.2-3). 모바일 드롭 근본 해소 + 체감
+   지연. 파급이 크므로 별도 사이클.
+4. **P2 — LLM 라우팅 통합** (§3.2). 설계 memo 의 Phase 진행.
+5. **P3 — `context_window` 필드 + 모델별 num_ctx 자동 사이징**
+   (§4.2-2), 캐시 정책 재설계 (§4.2-4). 측정 동반.
+6. **운영 — live_eval 루프 가동**: 폰 dogfooding 후 `report` →
+   `promote` → `bench --suite=live_queries` 를 주간 루틴으로.
+
+---
+
+## 7. 한국어 요약
+
+2026-07-01 리뷰를 두 달 뒤 현재 main 기준으로 전수 재검증했다.
+원본이 지적한 4건 중 이중 절단·rule #5 게이트·실사용 평가 연결층
+**3건은 그 사이 해결됐고**(#1083/#1084/#1085), 네 번째는 해결이
+아니라 **진단이 뒤집혔다**. "117건 실패, order-dependence" 는 현재
+성립하지 않는다 — 로컬 11건이고 격리해도 그대로 실패한다. 대신 더
+큰 것이 나왔다: **CI 가 57개 파일(902 테스트)을 무시하고 있고, 그
+안에 8건의 적색과 최소 1건의 stale 테스트가 숨어 있다.** 구조
+쪽 발견(admin.py·프론트 모놀리스·계층 역참조·모델 선택 8분산)은
+전부 유효하며 파일들은 두 달간 2-3% 더 커졌다. 로컬 AI 미해결 7건
+중 6건 유효, 1건(num_ctx)은 env 조절까지만 절반 해결. 최우선은
+CI 무시 목록 축소 — 게이트가 못 보는 902 테스트가 있는 한 다른
+게이트 수치도 신호 가치가 제한된다.
+
+---
+
+## 8. 재검증 로그
+
+원본의 모든 셀을 아래 방법으로 다시 실측했다. 일반 지식이나 원본
+문장을 근거로 쓴 셀은 없다.
+
+| 대상 | 방법 | 결과 |
+|---|---|---|
+| §3.1 파일 크기 5건 | `os.path.getsize` 실측 | 전부 증가, 표 갱신 |
+| `routes/admin.py` 줄/endpoint | `wc -l` + `@router.` 카운트 | 2,876 / 54 — 원본과 동일 |
+| §3.2 dispatcher → routes 역참조 | `grep -n` | `:40` 줄 번호까지 동일 |
+| §3.2 모델선택 8모듈 | 8개 경로 존재 확인 | 8/8 존재 |
+| §3.2 security 형제 / engine 4형제 | `ls -d` | 전부 존재 |
+| §3.3 전체 스위트 | `pytest tests/` on `1c6e4b2` | 11 failed / 5,298 passed |
+| §3.3 격리 실행 | 8개 모듈 개별 `pytest` | 11건 그대로 실패 → order 가설 반증 |
+| §3.3 CI 무시 목록 | `.github/workflows/test.yml` 파싱 | 57 파일 |
+| §3.3 무시 목록 실행 | 57 파일 일괄 `pytest` | 902 passed / 8 failed |
+| §3.3 stale 테스트 | 실패 메시지 → `config.py:192` 대조 | 패턴 불일치 확인 |
+| §3.4 루트 고아 스크립트 | `ls james_*_test.py` | 8 → 6 |
+| §3.4 리포트 변조 | #1080 diff + 4회 실행 후 `git status reports/` | 클린 — 해결 확인 |
+| §4.2 7개 항목 | 각 파일 `grep -n` (줄 번호 포함) | 6건 유효 / 1건 절반 해결 |
+| §1 수직 오염 | `core/` 전수 grep + 히트 육안 확인 | 0건 (전부 산문·주석) |
+| §2 원본 커밋 처리 | `git cherry` + 파일 내용 대조 | 3 랜딩 / 2 폐기 / 1 절반 / 1 대체 |


### PR DESCRIPTION
## Summary

The SEKOS design & structure review was written on `claude/sekos-design-structure-review-k56bmn` on **2026-07-01** and never merged. Publishing it as-is would have re-created exactly the documentation drift #1081 just finished fixing — #1077 through #1085 landed in between.

So every cell was **re-measured against current `main` (`1c6e4b2`)** rather than carried over. §8 of the document records the method used for each one; no cell rests on the original's wording or on general knowledge.

## What changed against the original

### Three of the four headline findings are now closed

| original finding | status |
|---|---|
| Prompt-cap double truncation (4000 vs 8000 synth context) | **closed** — #1084 |
| rule #5 module-size gate RED on main | **closed** — #1080 took `response_style`, #1083 took `engine.py`. `GRANDFATHERED` is now **empty** |
| No live-traffic → evaluation link | **closed** — #1085 |

### The fourth did not close — it inverted

The original read: *"117 failures on main, mostly order-dependence, all green in isolation."*

Re-measured:

| measurement | result |
|---|---|
| `pytest tests/` locally on `1c6e4b2` | **11 failed / 5,298 passed** |
| the same 11, run module-by-module in isolation | **all 11 still fail** |
| CI on `main` (run 34163805508) | 1 failed / 4,392 passed |

Order-dependence does not explain the current failure set — isolating them changes nothing. What the re-check *did* surface is bigger:

> **CI carries `--ignore` for 57 test files.** Running that set locally gives **902 passed / 8 failed**. Six of the eight modules failing locally sit inside that list.

And because they are invisible to the gate, at least one is **genuinely stale on `main`**: `tests/test_default_llm_model.py` greps `config.py` for `GEMMA_MODEL = os.environ.get("JAMES_LLM_MODEL", ...)`, but that line became `GEMMA_MODEL = _llm_setting("default_model", "JAMES_LLM_MODEL", "gemma4:e4b")` at `config.py:192`. It fails regardless of environment and nothing catches it.

The rest are environment-driven — this host's `.env` (12 overrides) breaks `test_embedding_model_abstraction`'s "unset env resolves legacy minilm paths" assertion (`chroma_db_bge_m3` vs `chroma_db`), and a FastAPI version difference breaks `test_app_routes_helper`. The fix is **env isolation and a shorter ignore list**, not order isolation — so **P1 is rewritten accordingly**.

### Two corrections against the original's own claims

- Root orphan scripts: the original said **8** `james_*_test.py`; there are **6**.
- The original called README's `mxtral 47B` a typo. It is not — it is the repo-wide shorthand, consistent across CLAUDE.md, memory and both READMEs. The real mismatch in that item is **recommender vs catalog**: `mixtral:8x7b` appears in `model_resolver.py:131,150` and **0 times** in `llm_catalog.py`.

### What still holds

All of §3.2 verified unchanged, down to the line number — `core/agent_tools/dispatcher.py:40` still reaches back into `routes._helpers._write_audit` while `core/audit_bridge.py` already exists; the 8 model-selection modules are all still there; both `core/security/` and `core/security_layer/` remain; the four "engine" siblings remain (and #1083 added a fifth name, so the case for a naming map got stronger).

The size findings hold and **every one of those files grew 2–3%** in the two months (`admin.js` 193,730 → 198,262B, `routes/admin.py` 108,989 → 111,865B, and so on).

Of the seven open local-AI items, **six verified unchanged** (including `ollama_local.py:33`'s `tier="small"` hardcode, at the same line number) and **one is half closed**: `num_ctx` is tunable via `JAMES_NUM_CTX` now, but per-model sizing is still absent — `context_window` appears **0 times** in `llm_catalog.py`.

`core/` vertical-domain contamination re-checked at **0** — every `legal|food|retail|travel|finance` hit is prose, a comment, or a pack-id example.

## Verification

- `pytest tests/test_v06_claude_md_entry_pointer.py` → 6 passed (the doc-pointer recency invariant #1081 added is unaffected)
- No test pins a `docs/reviews/` path
- Docs-only change; no `core/` file touched

## Quality Delta

`Quality delta: exempt (label: docs)` — no `core/` change.

## Out of scope

- Acting on any of the findings. This PR records the re-verified state; §6 lists the revised priorities (P1 is now the CI ignore list, then `routes/admin.py`).
- The original 2026-07-01 file is not added — this supersedes it, and the branch it came from is now drained (see the disposition table in §2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
