### PR TITLE
docs(v0.6.2): correct the review's P1 — the CI ignore list is planned debt

### DIFF
--- a/docs/reviews/v0.6.2-sekos-design-structure-review.md
+++ b/docs/reviews/v0.6.2-sekos-design-structure-review.md
@@ -204,10 +204,23 @@ Windows cp949 콘솔에서 `UnicodeEncodeError` 로 죽었다. 단위 테스트�
 
 1. **P1 — CI 무시 목록 축소** (§3.3). 57개 파일 / 902 테스트가
    게이트 밖에 있고 그중 8건이 적색이며, 최소 1건(`test_default_llm_model`)
-   은 그래서 stale 한 채 남았다. 무시 목록을 한 번에 없앨 수는 없지만,
-   *왜 무시되는지* 사유를 파일별로 붙이고 (env 의존 / 느림 / 외부
-   바인딩) env 의존분부터 monkeypatch 격리로 되살리는 것이 순서다.
-   솔로 가능, 보호층 무관.
+   은 그래서 stale 한 채 남았다.
+
+   **정정 (2026-09-08)**: 이 목록은 사유 없이 방치된 것이 아니다.
+   `.github/workflows/test.yml` 은 두 개의 그룹 주석("LLM / Ollama
+   service-bound (no CI Ollama service yet)" · "Admin / endpoint tests
+   needing DB or server setup")과 명시적 iteration plan 을 달고 있고,
+   그 plan 은 *"목록에서 한 줄을 지우는 것 자체가 성공 신호"* 라고
+   적어 두었다. 즉 계획된 부채다.
+
+   따라서 P1 은 "사유를 붙이는 것"이 아니라 **그 plan 을 실제로
+   집행하는 것**이다. 순서: (a) 적색 8건부터 — 특히 `test_default_llm_model`
+   은 CI 의존성과 무관하게 그냥 stale 하므로 지금 고치고 목록에서
+   빼면 된다. (b) 두 그룹 중 "DB or server setup" 쪽은 Ollama 를
+   기다릴 필요가 없다 — TestClient app-factory / DB fixture 격리로
+   되살릴 수 있고, plan 이 이미 그 방법을 지목하고 있다. (c) 남은
+   Ollama service-bound 분은 CI 에 Ollama 서비스 컨테이너가 생길
+   때까지 유지. 솔로 가능, 보호층 무관.
 2. **P1 — `routes/admin.py` 분할** (111,865B / 2,876줄 / 54 endpoint).
    게이트 확장(`routes/` 완화 캡)과 함께. 솔로 가능.
 3. **P2 — 토큰 스트리밍** (§4.2-3). 모바일 드롭 근본 해소 + 체감
@@ -233,7 +246,9 @@ Windows cp949 콘솔에서 `UnicodeEncodeError` 로 죽었다. 단위 테스트�
 전부 유효하며 파일들은 두 달간 2-3% 더 커졌다. 로컬 AI 미해결 7건
 중 6건 유효, 1건(num_ctx)은 env 조절까지만 절반 해결. 최우선은
 CI 무시 목록 축소 — 게이트가 못 보는 902 테스트가 있는 한 다른
-게이트 수치도 신호 가치가 제한된다.
+게이트 수치도 신호 가치가 제한된다. 다만 그 목록은 계획된
+부채다 — workflow 가 그룹 사유와 해소 계획을 이미 달고 있으므로,
+할 일은 계획을 세우는 것이 아니라 집행하는 것이다 (§6-1).
 
 ---
 
@@ -251,7 +266,7 @@ CI 무시 목록 축소 — 게이트가 못 보는 902 테스트가 있는 한 
 | §3.2 security 형제 / engine 4형제 | `ls -d` | 전부 존재 |
 | §3.3 전체 스위트 | `pytest tests/` on `1c6e4b2` | 11 failed / 5,298 passed |
 | §3.3 격리 실행 | 8개 모듈 개별 `pytest` | 11건 그대로 실패 → order 가설 반증 |
-| §3.3 CI 무시 목록 | `.github/workflows/test.yml` 파싱 | 57 파일 |
+| §3.3 CI 무시 목록 | `.github/workflows/test.yml` 파싱 | 57 파일, 2개 그룹 주석 + iteration plan 존재 |
 | §3.3 무시 목록 실행 | 57 파일 일괄 `pytest` | 902 passed / 8 failed |
 | §3.3 stale 테스트 | 실패 메시지 → `config.py:192` 대조 | 패턴 불일치 확인 |
 | §3.4 루트 고아 스크립트 | `ls james_*_test.py` | 8 → 6 |


### PR DESCRIPTION
## Summary

#1086 landed a P1 that reads as though the 57-file CI ignore list sits there without stated reasons (*"사유를 파일별로 붙이고"*). **It does not.** `.github/workflows/test.yml` carries two group comments — `LLM / Ollama service-bound (no CI Ollama service yet)` and `Admin / endpoint tests needing DB or server setup` — plus an iteration plan naming the exit condition, which states that *removing an entry from the list is itself the success signal*.

I missed those when writing the review, and the miss changes what the task is.

## What the P1 becomes

Not "document the list" but **execute the plan already written on it**, in this order:

1. **The 8 red ones first.** `test_default_llm_model` is stale for reasons unrelated to any CI dependency — it greps a `config.py` pattern that no longer exists — so it can be fixed and un-ignored today.
2. **The DB/server group next.** It does not need an Ollama service container, and the plan already names the remedy (TestClient app-factory, DB fixture cleanup).
3. **The Ollama-bound remainder stays** until CI grows that service.

## What is unchanged

The finding itself: **902 tests and 8 failures sit outside the gate**, and one stale test hid there. Only the characterisation of *why* — and therefore the shape of the work — is corrected. §3.3 measurements stand as published.

## Verification

- `gh` / workflow re-read at `068c4a5`; group comments at `test.yml:55` and `:74`, iteration plan at `:115`
- Docs-only; no `core/` change

## Quality Delta

`Quality delta: exempt (label: docs)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)