### PR TITLE
fix(v0.6.2): repair the LRB-S2 token collision and re-run the fixture

### DIFF
--- a/reports/research-runs/lrb-s2-collision-repair-20260908.md
+++ b/reports/research-runs/lrb-s2-collision-repair-20260908.md
@@ -1,0 +1,109 @@
+# LRB-S2 — collision repaired, fixture re-run
+
+**Date**: 2026-09-08
+**Decision executed**: #1 of
+[`lrb-s2-fixture-nonreproduction-20260819.md`](lrb-s2-fixture-nonreproduction-20260819.md)
+§7 — *repair the collision*, chosen by the operator.
+**Scope**: `scripts/research/build_lrb_scenario_s2.py` and the S2 assertion
+in `tests/test_lrb_v021_cross_model.py`. **S3 is untouched** — it reproduces
+its published figure exactly
+([`lrb-s3-collision-check-20260903.md`](lrb-s3-collision-check-20260903.md)),
+and changing shared naming would have broken that.
+
+---
+
+## 1. The repair
+
+Policy titles were `Policy {i}: Operating Standard`. The historical-policy
+query template injects a bare time offset:
+
+```
+What was the text of Policy 1: Operating Standard 16 weeks ago?
+```
+
+so the token `16` entered the query and matched `co-pol-016`'s title as
+strongly as the gold policy's own number matched its own — on top of the
+three content words every policy title shares. Departments and projects
+never had the problem because their titles are word-based.
+
+Policies now match that: `Policy One: …` … `Policy Forty: …`. The ordinal
+is still unique per policy and still a single token, so the gold keeps a
+distinguishing term — it is simply no longer a term the query's time
+expression can produce by accident.
+
+## 2. Effect on the colliding cell
+
+`historical-mid-policy`, n = 4, top-1:
+
+| query | gold | before | after |
+|---|---|---|---|
+| lrb-s2-q057 | co-pol-001.v2 | co-pol-016 ✗ | co-pol-001.v2 ✓ |
+| lrb-s2-q058 | co-pol-005.v2 | co-pol-016 ✗ | co-pol-005.v2 ✓ |
+| lrb-s2-q059 | co-pol-010 | co-pol-010 ✓ | co-pol-010 ✓ |
+| lrb-s2-q060 | co-pol-015 | co-pol-015 ✓ | co-pol-015 ✓ |
+
+The cell goes from 2/4 to **4/4** on this machine.
+
+## 3. Re-run — token mode, k=10, all three SUTs
+
+| SUT | published | repaired | Δ |
+|---|---:|---:|---:|
+| Vanilla RAG | 0.225 | **0.2500** | +0.025 |
+| Naive supersede | 0.5375 | **0.5875** | +0.050 |
+| JAMES validity | 0.7125 | **0.7625** | +0.050 |
+
+Other axes on the repaired fixture: JAMES R@5 0.9500 / R@10 1.0000 /
+P@5 0.1900 / P@10 0.1000 / temporal_accuracy 1.0000.
+
+**The artifact suppressed all three SUTs, so the claims survive it.**
+V < N < J still holds, and **J − N is 0.175 on both fixtures** — identical
+to four decimals. J − V widens from 0.4875 to 0.5125. The "gap > +0.10"
+headline is unaffected.
+
+Fixture sha256 `2c1b210c…`, identical across two clean rebuilds here.
+
+## 4. What the investigation turned up on the way
+
+The 2026-08-19 report recorded the committed builder producing sha
+`1ddfb6c0…` and the published run using `9f40d2e0…`, and concluded the
+repository could not rebuild the published fixture.
+
+**On this machine the committed builder produces `9f40d2e0…` — the
+published fixture — byte for byte**, and scores exactly 0.7125. The
+June-dated copy already on disk is byte-identical to that fresh rebuild.
+
+So the same builder, unchanged in git since 2026-06-12, yields different
+artifacts in different environments. The consequence is visible in the
+colliding cell: it loses **2 of 4** here and **4 of 4** on CI, which is
+where the −0.025 came from. The collision is real in both places; only how
+many of the four ties break toward the distractor differs.
+
+This is not diagnosed further here — the repair removes the tie entirely,
+so the environment sensitivity it exposed goes with it. But it is recorded
+because it bears on §7 decision #3 (commit the fixtures): a builder that is
+deterministic *within* an environment and not *across* one is exactly the
+failure mode that pinning SHAs in-repo would have caught in June rather
+than in August.
+
+## 5. What this does not settle
+
+The published figure is now superseded, not reproduced. **0.7125 embedded
+the artifact** — 2 of those 4 queries were already failing in the published
+run, which is why the report called it "weaker form" there.
+
+Decision #2 is therefore live and is **not taken here**: the old figures
+still stand in
+
+- `papers/lrb-preprint/README.md`
+- `.zenodo.json`
+- `docs/release_notes_v0.4.4.md`
+- `CLAUDE.md` and the v0.4 LRB handovers
+
+Re-baselining a preprint or a minted DOI record is an operator decision, so
+none of those files is edited. `tests/test_lrb_v021_cross_model.py` now
+pins the repaired numbers with that divergence stated in the test itself:
+green there means the repository reproduces itself, not that it reproduces
+the paper.
+
+Decision #3 (commit the fixtures) and #4 (check S3) are unchanged — #4 was
+already closed on 2026-09-03.

--- a/reports/research-runs/lrb-s2-fixture-nonreproduction-20260819.md
+++ b/reports/research-runs/lrb-s2-fixture-nonreproduction-20260819.md
@@ -136,5 +136,18 @@ committed.
    diverge from a published run again.
 4. **Check S3** for the same collision before the ladder is cited further.
 
+> **Update 2026-09-08 — decision #1 taken, see
+> [`lrb-s2-collision-repair-20260908.md`](lrb-s2-collision-repair-20260908.md).**
+> Policy titles are spelled out, the colliding cell goes 2/4 → 4/4, and the
+> re-run gives V/N/J = 0.2500 / 0.5875 / 0.7625. All three rose, so V < N < J
+> holds and J − N stays 0.175 to four decimals. Two corrections to this
+> report: the committed builder reproduces `9f40d2e0…` — the *published*
+> fixture — on a Windows host and scores 0.7125 there, so the artifact is
+> environment-dependent rather than a lost generator; and the cell loses
+> 2 of 4 here against 4 of 4 on CI, which is where the −0.025 came from.
+> Decisions #2 (preprint) and #3 (commit the fixtures) remain open; #3 is
+> now better motivated, since a builder deterministic within an environment
+> but not across one is what SHA pinning would have caught.
+
 Until one is chosen, `test_token_mode_s2_reproduces_phase_b_baseline`
 stays red on purpose: it is reporting a true non-reproduction.

--- a/scripts/research/build_lrb_scenario_s2.py
+++ b/scripts/research/build_lrb_scenario_s2.py
@@ -136,7 +136,40 @@ assert len(CONTRACTS) == 40
 
 BUDGETS = [(f"co-bud-{i:03d}", f"FY26 Operating Budget {i}", dep[0])
            for i, dep in enumerate(DEPARTMENTS, start=1)]
-POLICIES = [(f"co-pol-{i:03d}", f"Policy {i}: Operating Standard",
+# Policy titles are spelled out rather than numbered.
+#
+# They used to read "Policy 16: Operating Standard", and the
+# historical-policy query template injects a bare time offset — "What
+# was the text of Policy 1: Operating Standard 16 weeks ago?". That put
+# the token `16` in the query, which then matched co-pol-016's title as
+# strongly as the gold policy's own number matched its title, on top of
+# the three content words every policy title shares. The distractor won
+# the resulting tie, so the cell measured a numeric-token collision
+# rather than time-travel retrieval.
+#
+# Departments and projects never had the problem because their titles
+# are word-based; policies now match that. The spelled-out ordinal is
+# still unique per policy and still one token, so the gold keeps its
+# distinguishing term — it simply is no longer a term the query's time
+# expression can produce by accident.
+#
+# See reports/research-runs/lrb-s2-fixture-nonreproduction-20260819.md
+# for the original diagnosis and lrb-s2-collision-repair-20260908.md
+# for the repair and its measured effect.
+_ORDINAL_WORDS = (
+    "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight",
+    "Nine", "Ten", "Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen",
+    "Sixteen", "Seventeen", "Eighteen", "Nineteen", "Twenty",
+    "TwentyOne", "TwentyTwo", "TwentyThree", "TwentyFour", "TwentyFive",
+    "TwentySix", "TwentySeven", "TwentyEight", "TwentyNine", "Thirty",
+    "ThirtyOne", "ThirtyTwo", "ThirtyThree", "ThirtyFour", "ThirtyFive",
+    "ThirtySix", "ThirtySeven", "ThirtyEight", "ThirtyNine", "Forty",
+)
+assert len(_ORDINAL_WORDS) == 40
+assert len(set(_ORDINAL_WORDS)) == 40
+
+POLICIES = [(f"co-pol-{i:03d}",
+             f"Policy {_ORDINAL_WORDS[i - 1]}: Operating Standard",
              DEPARTMENTS[(i - 1) % len(DEPARTMENTS)][0])
             for i in range(1, 41)]
 APPOINTMENTS = [(f"co-app-{i:03d}", f"Appointment Record {i}",

--- a/tests/test_lrb_v021_cross_model.py
+++ b/tests/test_lrb_v021_cross_model.py
@@ -186,15 +186,37 @@ def test_token_mode_s1_reproduces_phase_b_baseline():
                     - expected_r1) < 1e-5
 
 
-def test_token_mode_s2_reproduces_phase_b_baseline():
+def test_token_mode_s2_matches_the_repaired_fixture():
+    """Token-mode R@1 for the three SUTs on the collision-repaired S2.
+
+    These are NOT the published Phase B figures, and the difference is
+    deliberate. The published run (0.225 / 0.5375 / 0.7125) was measured
+    on a fixture whose historical-mid-policy queries injected a bare
+    time offset — "…Policy 1: Operating Standard 16 weeks ago?" — that
+    matched co-pol-016's numbered title, so the cell scored a numeric
+    token collision instead of time-travel retrieval. Diagnosed in
+    reports/research-runs/lrb-s2-fixture-nonreproduction-20260819.md,
+    repaired 2026-09-08 by spelling policy titles out; the numbers below
+    are the re-run that repair requires.
+
+    The artifact suppressed all three SUTs, so the ordering claim and
+    the headline gap survive it: V < N < J still holds and J − N is
+    0.175 on both fixtures, unchanged to four decimals.
+
+    Until the preprint is re-baselined or footnoted — decision #2 in
+    that report, an operator call — papers/lrb-preprint/README.md,
+    .zenodo.json and the v0.4.4 release notes still carry the old
+    figures. Green here means the repository reproduces itself, not
+    that it reproduces the paper.
+    """
     from scripts.research.lrb_run_v021_cross_model import (
         run_sut_cross_model)
     sc = load_scenario(FIXTURE_S2)
     sha = fixture_sha(FIXTURE_S2)
     for cls, expected_r1 in [
-        (VanillaRagAdapter, 0.225),
-        (NaiveSupersedeAdapter, 0.5375),
-        (JamesValidityAdapter, 0.7125),
+        (VanillaRagAdapter, 0.2500),      # published 0.225
+        (NaiveSupersedeAdapter, 0.5875),  # published 0.5375
+        (JamesValidityAdapter, 0.7625),   # published 0.7125
     ]:
         r = run_sut_cross_model(cls, sc, sha, sut_name="t",
                                 mode="token", model="token-baseline",


### PR DESCRIPTION
## Summary

Executes **decision #1** of [`lrb-s2-fixture-nonreproduction-20260819.md`](reports/research-runs/lrb-s2-fixture-nonreproduction-20260819.md) §7 — *repair the collision* — as chosen by the operator. Full write-up: [`lrb-s2-collision-repair-20260908.md`](reports/research-runs/lrb-s2-collision-repair-20260908.md).

## The repair

Policy titles were `Policy {i}: Operating Standard`, and the historical-policy query template injects a bare time offset:

```
What was the text of Policy 1: Operating Standard 16 weeks ago?
```

The token `16` entered the query and matched **co-pol-016**'s title as strongly as the gold policy's own number matched its own — on top of the three content words every policy title shares. Departments and projects never collided because their titles are word-based.

Policies now match that: `Policy One:` … `Policy Forty:`. The ordinal stays unique and single-token, so the gold keeps a distinguishing term — it simply stops being a term the time expression can produce by accident.

## Effect

`historical-mid-policy` top-1 goes **2/4 → 4/4**:

| query | gold | before | after |
|---|---|---|---|
| q057 | co-pol-001.v2 | co-pol-016 ✗ | co-pol-001.v2 ✓ |
| q058 | co-pol-005.v2 | co-pol-016 ✗ | co-pol-005.v2 ✓ |
| q059 | co-pol-010 | ✓ | ✓ |
| q060 | co-pol-015 | ✓ | ✓ |

Re-run, token mode, k=10:

| SUT | published | repaired | Δ |
|---|---:|---:|---:|
| Vanilla RAG | 0.225 | **0.2500** | +0.025 |
| Naive supersede | 0.5375 | **0.5875** | +0.050 |
| JAMES validity | 0.7125 | **0.7625** | +0.050 |

**All three rose, so the claims survive the artifact.** V < N < J holds, and **J − N is 0.175 on both fixtures — identical to four decimals**. J − V widens 0.4875 → 0.5125. The "gap > +0.10" headline is unaffected. Fixture sha256 `2c1b210c…`, stable across two clean rebuilds.

**S3 is deliberately untouched** — it reproduces its published figure exactly ([`lrb-s3-collision-check-20260903.md`](reports/research-runs/lrb-s3-collision-check-20260903.md)), and changing shared naming would have broken that.

## Found while measuring — recorded, not chased

The August report had the committed builder producing sha `1ddfb6c0…` against the published run's `9f40d2e0…`, and concluded the repository could not rebuild the published fixture.

**On this machine the committed builder produces `9f40d2e0…` — the published fixture, byte for byte — and scores exactly 0.7125.** The June-dated copy on disk is byte-identical to a fresh rebuild.

So the same builder, unchanged in git since 2026-06-12, yields different artifacts in different environments. It shows up in the colliding cell, which loses **2 of 4 here and 4 of 4 on CI** — that difference is the whole of the −0.025. The collision is real in both places; only how many ties break toward the distractor differs.

Not diagnosed further, because the repair removes the tie and the sensitivity with it. But it is recorded, because it strengthens **decision #3** (commit the fixtures): a builder deterministic *within* an environment and not *across* one is exactly what pinning SHAs in-repo would have caught in June rather than in August.

## What this deliberately does not do

The published figure is **superseded, not reproduced** — 0.7125 embedded the artifact, with 2 of those 4 queries already failing in the published run.

**Decision #2 is not taken here.** These files keep the old numbers untouched:

- `papers/lrb-preprint/README.md`
- `.zenodo.json`
- `docs/release_notes_v0.4.4.md`
- `CLAUDE.md` and the v0.4 LRB handovers

Re-baselining a preprint or a minted DOI record is an operator decision. The test pins the repaired numbers and states the divergence in its own docstring, and is renamed off `..._reproduces_phase_b_baseline` accordingly — **green there means the repository reproduces itself, not that it reproduces the paper.**

## Verification

- `pytest tests/test_lrb_v021_cross_model.py` → 18 passed
- Full local suite → the 11 pre-existing failures only (this branch is off `main`; #1088 clears them)
- `ruff check --select F` → clean
- Fixture rebuilt twice from clean → identical sha256

## Quality Delta

`Quality delta: exempt (label: fix)` — benchmark-fixture correction; the thing being corrected is what a delta card would measure against. No `core/` source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
