### PR TITLE
fix(v0.6.2): EasyOCR lost every Korean-named upload — decode with PIL, not cv2

### DIFF
--- a/processors/file_processor.py
+++ b/processors/file_processor.py
@@ -25,7 +25,7 @@ import os
 import re
 import cv2
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 import pytesseract
 import whisper
 from pdf2image import convert_from_path
@@ -169,13 +169,44 @@ class FileProcessor:
                 words.append(w.strip())
         return " ".join(words)
 
+    # EasyOCR decodes a *path* with cv2.imread, which cannot open a
+    # non-ASCII filename on Windows: it returns None, and EasyOCR then
+    # trips on the empty array ("!ssize.empty()" on older builds,
+    # "'NoneType' object has no attribute 'shape'" on 1.7.2). Every
+    # Korean-named upload therefore lost its OCR pass silently.
+    #
+    # Reproduced 2026-09-08: the same 12 MP photo reads fine as
+    # photo_12mp.jpg and fails as 사진_12메가.jpg, so the trigger is the
+    # filename, not the megapixels the 2026-06-26 note attributed it to.
+    #
+    # PIL opens unicode paths, so decode here and hand EasyOCR the array.
+    # The size bound is separate insurance: EasyOCR's detector scales by
+    # the long edge, and a phone photo's 4000 px carries no more legible
+    # text than 2600 while costing several times the memory.
+    _EASYOCR_MAX_EDGE = 2600
+
     def _extract_with_easyocr(self, filepath):
         reader = self.get_easyocr_reader()
         if not reader:
             return ""
         try:
+            with Image.open(filepath) as im:
+                im = ImageOps.exif_transpose(im).convert("RGB")
+                longest = max(im.size)
+                if longest > self._EASYOCR_MAX_EDGE:
+                    scale = self._EASYOCR_MAX_EDGE / longest
+                    im = im.resize(
+                        (max(1, int(im.width * scale)),
+                         max(1, int(im.height * scale))),
+                        Image.LANCZOS,
+                    )
+                array = np.array(im)
+        except Exception as e:
+            print(f"[DEBUG] EasyOCR 이미지 로드 실패: {e}")
+            return ""
+        try:
             # detail=1 → (bbox, text, confidence); EasyOCR conf is 0-1.
-            results = reader.readtext(filepath, detail=1, paragraph=False)
+            results = reader.readtext(array, detail=1, paragraph=False)
         except Exception as e:
             print(f"[DEBUG] EasyOCR 오류: {e}")
             return ""

--- a/tests/test_easyocr_unicode_path.py
+++ b/tests/test_easyocr_unicode_path.py
@@ -1,0 +1,121 @@
+"""EasyOCR must not lose a Korean-named upload.
+
+`reader.readtext(path)` makes EasyOCR decode the file with `cv2.imread`,
+which cannot open a non-ASCII filename on Windows — it returns None, and
+EasyOCR trips on the empty array ("!ssize.empty()" on older builds,
+"'NoneType' object has no attribute 'shape'" on 1.7.2). The OCR pass was
+silently lost for every Korean-named file.
+
+Reproduced 2026-09-08: the same 12 MP photo reads fine as
+`photo_12mp.jpg` and fails as `사진_12메가.jpg`, so the trigger is the
+filename, not the megapixels the 2026-06-26 note attributed it to.
+
+These tests use a stub reader, so they run without the EasyOCR models
+(~100 MB) and without a GPU. What they pin is the contract that fixes it:
+the extractor decodes the image itself and hands EasyOCR an array.
+
+Run:
+    python -m unittest tests.test_easyocr_unicode_path
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _StubReader:
+    """Records what it was handed instead of running a model."""
+
+    def __init__(self):
+        self.received = None
+
+    def readtext(self, image, detail=1, paragraph=False):
+        self.received = image
+        return [([[0, 0], [1, 0], [1, 1], [0, 1]], "OPERATING STANDARD", 0.99)]
+
+
+def _write_image(directory: Path, name: str, size=(400, 300)) -> Path:
+    from PIL import Image
+
+    p = directory / name
+    Image.new("RGB", size, (245, 245, 240)).save(p, quality=90)
+    return p
+
+
+class EasyOcrUnicodePathTests(unittest.TestCase):
+    def setUp(self):
+        from processors.file_processor import FileProcessor
+
+        # __init__ builds a RouterWrapper and a MetadataGenerator; neither
+        # is used by the extractor under test.
+        self.fp = FileProcessor.__new__(FileProcessor)
+        self.reader = _StubReader()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _extract(self, path):
+        with patch.object(type(self.fp), "get_easyocr_reader",
+                          lambda _self: self.reader):
+            return self.fp._extract_with_easyocr(str(path))
+
+    def test_korean_filename_still_reaches_the_reader(self):
+        import numpy as np
+
+        p = _write_image(self.tmp, "사진_12메가.jpg")
+        text = self._extract(p)
+        self.assertIsInstance(
+            self.reader.received, np.ndarray,
+            "EasyOCR must be handed a decoded array, not a path — a path "
+            "sends it through cv2.imread, which returns None for a "
+            "non-ASCII filename on Windows")
+        self.assertIn("OPERATING STANDARD", text)
+
+    def test_ascii_and_korean_filenames_agree(self):
+        a = _write_image(self.tmp, "photo.jpg")
+        k = _write_image(self.tmp, "사진.jpg")
+        self.assertEqual(self._extract(a), self._extract(k),
+                         "the filename must not change the OCR result")
+
+    def test_oversized_image_is_bounded(self):
+        from processors.file_processor import FileProcessor
+
+        cap = FileProcessor._EASYOCR_MAX_EDGE
+        p = _write_image(self.tmp, "big.jpg", size=(cap * 2, cap))
+        self._extract(p)
+        h, w = self.reader.received.shape[:2]
+        self.assertEqual(max(w, h), cap,
+                         f"long edge must be capped at {cap}px before the "
+                         f"detector sees it")
+        self.assertAlmostEqual(w / h, 2.0, places=1,
+                               msg="aspect ratio must be preserved")
+
+    def test_small_image_is_not_upscaled(self):
+        p = _write_image(self.tmp, "small.jpg", size=(400, 300))
+        self._extract(p)
+        h, w = self.reader.received.shape[:2]
+        self.assertEqual((w, h), (400, 300),
+                         "an image already under the cap must pass through "
+                         "untouched — upscaling only multiplies photo noise")
+
+    def test_unreadable_file_returns_empty_not_raises(self):
+        p = self.tmp / "not-an-image.jpg"
+        p.write_bytes(b"this is not a JPEG")
+        self.assertEqual(self._extract(p), "",
+                         "a corrupt upload must degrade to no-OCR, not "
+                         "propagate an exception into the ingest path")
+        self.assertIsNone(self.reader.received,
+                          "the reader must not be called at all when the "
+                          "image cannot be decoded")
+
+
+if __name__ == "__main__":   # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 3.4. The 2026-06-26 handover recorded *"EasyOCR `cv2 !ssize.empty()` on 12 MP files"* and attributed it to size. **It is the filename.**

`reader.readtext(path)` makes EasyOCR decode the file with `cv2.imread`, which cannot open a non-ASCII path on Windows — it returns `None`, and EasyOCR then trips on the empty array (`!ssize.empty()` on older builds, `'NoneType' object has no attribute 'shape'` on the installed 1.7.2). The `except` branch swallowed it and returned `""`, so **every Korean-named upload silently lost its OCR pass.**

## Reproduced before changing anything

Same synthetic 12 MP photo, two names:

```
photo_12mp.jpg    cv2.imread -> (3000, 4000, 3)     easyocr -> OK
사진_12메가.jpg    cv2.imread -> None (FAILS)        easyocr -> AttributeError
```

Megapixels were never the trigger; ASCII 12 MP was fine all along.

## The fix

The extractor opens the image itself with PIL — which handles unicode paths — applies EXIF orientation, and hands EasyOCR a numpy array, so cv2 never sees the path. After the fix both filenames return identical text through the **real** reader:

```
ascii path   -> 30 chars: 'OPERATING\nSTANDARD\nPOLICY 2026'
korean path  -> 30 chars: 'OPERATING\nSTANDARD\nPOLICY 2026'
```

A **long-edge cap of 2600 px** rides along as separate insurance. The note's size worry is not baseless even though it was not the cause: EasyOCR's detector scales by the long edge, and a 4000 px phone photo carries no more legible text than 2600 while costing several times the memory. Images already under the cap pass through untouched — upscaling only multiplies photo noise, the same reasoning `_preprocess_image` already documents.

## Verification

`tests/test_easyocr_unicode_path.py` pins the contract with a **stub reader**, so it runs without the ~100 MB EasyOCR models and without a GPU:

- the reader receives an `ndarray`, not a path
- ASCII and Korean filenames produce identical output
- an oversized image is capped at the long edge with aspect preserved
- an image under the cap is passed through untouched
- a corrupt file degrades to no-OCR **without the reader being called at all**

**Confirmed to be a real guard, not decoration: 4 of the 5 fail against `main`**, 5 pass with the fix.

- full local suite → **5,312 passed**, zero failures
- `ruff check --select F` → clean

## Out of scope

- The other half of the 3.4 line — *"비전 단일이미지 모드 재노출 여부 결정"* — is a product decision about re-exposing single-image vision mode, not a defect, and belongs to the operator.
- Phase 3.1 (mobile long-query drop). Its durable fix is written in the roadmap as conditional — *"if it still drops"* after an operator test that has not happened yet. Building it now would build on an unverified premise.

## Quality Delta

`Quality delta: exempt (label: fix)` — ingestion-side defect repair; no `core/retrieval`, `core/graph` traversal or `core/reasoning` lines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
