### PR TITLE
fix(v0.6.2): a timed-out setUpClass leaked mock patches into an unrelated test file

### DIFF
--- a/tests/test_entity_name_markdown_strip.py
+++ b/tests/test_entity_name_markdown_strip.py
@@ -63,6 +63,21 @@ class _MarkdownStripBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Every undo is registered with addClassCleanup the moment the
+        # thing it undoes exists, rather than in tearDownClass.
+        #
+        # tearDownClass does not run when setUpClass raises, and this
+        # setUpClass CAN raise: the docstring above describes the leak,
+        # and it has now cost three CI runs (2026-09-07/08) where a
+        # pytest-timeout=30s expiry landed mid-setup, left the patches
+        # started, and made test_native_done_reason import a MagicMock —
+        # "Expected 'call_router_meta' to be called once. Called 0 times."
+        # The two always failed together because they are one failure.
+        #
+        # unittest calls doClassCleanups even when setUpClass raises, so
+        # cleanups registered as we go unwind whatever was already
+        # started. The timeout still fails this class — it should — but
+        # it stops taking an unrelated file down with it.
         cls.tmp = tempfile.mkdtemp()
         cls._patchers = [
             patch("config.WIKI_DIR", cls.tmp),
@@ -75,18 +90,18 @@ class _MarkdownStripBase(unittest.TestCase):
         ]
         for p in cls._patchers:
             p.start()
+            cls.addClassCleanup(p.stop)
         import core.wiki_generator as wg_mod
-        cls._orig_wiki_dir = wg_mod.WIKI_DIR
+        orig_wiki_dir = wg_mod.WIKI_DIR
+        cls._orig_wiki_dir = orig_wiki_dir
+
+        def _restore_wiki_dir():
+            wg_mod.WIKI_DIR = orig_wiki_dir
+
+        cls.addClassCleanup(_restore_wiki_dir)
         wg_mod.WIKI_DIR = cls.tmp
         from core.wiki_generator import WikiGenerator
         cls.wg = WikiGenerator(source_type="test")
-
-    @classmethod
-    def tearDownClass(cls):
-        for p in cls._patchers:
-            p.stop()
-        import core.wiki_generator as wg_mod
-        wg_mod.WIKI_DIR = cls._orig_wiki_dir
 
     def _read_fm(self, path: Path):
         raw = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

The CI flake that has appeared **three times in two days** (#1082, #1085, #1090), always as the same pair:

- five `EntityNameMarkdownStripTests` errors — `Timeout (>30.0s) from pytest-timeout` **at setup**
- `test_native_done_reason` — `Expected 'call_router_meta' to be called once. Called 0 times.`

**They are one failure, not two.** The test file's own docstring already described the mechanism: `setUpClass` starts four patches and stops them in `tearDownClass`, but **tearDownClass does not run when setUpClass raises**. A timeout landing mid-setup leaves `llm.router.RouterWrapper` replaced by a `MagicMock` for the rest of the session, and the next file that imports it fails for reasons that have nothing to do with it.

I twice wrote this off as two independent flakes and re-ran the job. Third time is enough.

## The fix

Each undo is registered with `addClassCleanup` at the moment the thing it undoes exists. `unittest` calls `doClassCleanups` even when `setUpClass` raises, so whatever was already started unwinds.

The timeout still fails this class — it should, it is a real slow-setup problem. It just stops taking an unrelated file down with it.

## Verification

Simulated the interruption rather than waiting for CI to flake again — run the real `setUpClass`, raise the way a timeout does, then inspect module state:

| | identity restored | after |
|---|---|---|
| `main` | **False** | `<MagicMock name='RouterWrapper' id='…'>` |
| this PR | **True** | `<class 'llm.router.RouterWrapper'>` |

Plus `pytest tests/test_entity_name_markdown_strip.py tests/test_native_done_reason.py` → 17 passed, and `ruff --select F` clean.

## Out of scope

The **underlying slowness**. This makes the failure local; it does not make setup fast. The class still does ~seconds of patch resolution and lazy-import warm-up against a 30s budget on a cold runner, which is why it tips over at all.

## Quality Delta

`Quality delta: exempt (label: fix)` — test-side isolation repair; no `core/` source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)