### PR TITLE
fix(v0.6.2): the 30s timeout was a model download, not a slow import

### DIFF
--- a/tests/test_entity_name_markdown_strip.py
+++ b/tests/test_entity_name_markdown_strip.py
@@ -85,12 +85,35 @@ class _MarkdownStripBase(unittest.TestCase):
         # So the unwind is explicit and catches BaseException, which
         # does not depend on any runner's catch semantics.
         cls.tmp = tempfile.mkdtemp()
+        _INIT_STATE = "core.wiki_generator._frontmatter.init_state"
         cls._patchers = [
             patch("config.WIKI_DIR", cls.tmp),
             patch(
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site, not the definition site.
+            #
+            # init_state.py binds both names at module import
+            # ("from core.vector_store import VectorStore"), so patching
+            # core.vector_store.VectorStore leaves init_state's own
+            # reference pointing at the real class — and WikiGenerator()
+            # builds a real VectorStore, which calls _load_model(), which
+            # downloads BAAI/bge-m3 from HuggingFace and writes the
+            # shards to disk. That is the 30s timeout: not a slow import,
+            # a model download.
+            #
+            # It never showed locally because the model is already cached
+            # on the operator machine; CI has no cache, so it fetched
+            # ~GBs inside a 30s budget on every run. The stack trace on
+            # run 34189813550 names it exactly:
+            #   WikiGenerator -> VectorStore() -> _load_model()
+            #   -> model.save(LOCAL_MODEL_PATH) -> Writing model shards
+            #
+            # The definition-site patches stay too: harmless, and they
+            # cover any path that resolves the attribute at call time.
+            patch(f"{_INIT_STATE}.VectorStore"),
+            patch(f"{_INIT_STATE}.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]


### PR DESCRIPTION
## Summary

The five `EntityNameMarkdownStripTests` timeouts survived both #1092 and #1093, because both addressed the **blast radius** and not the **cause**. CI's stack trace on run 34189813550 names it outright:

```
setUpClass -> WikiGenerator(source_type="test")
  -> init_state.__init__ -> VectorStore()
    -> _load_model() -> model.save(LOCAL_MODEL_PATH)
      -> "Writing model shards"
```

`setUpClass` patches `core.vector_store.VectorStore`. But `core/wiki_generator/_frontmatter/init_state.py` binds the name **at module import** (`from core.vector_store import VectorStore`), so its own reference still points at the real class. The mock never applied, `WikiGenerator()` built a real `VectorStore`, and that **downloaded BAAI/bge-m3 from HuggingFace and wrote the shards to disk** — inside a 30 second budget, on every run.

## Why it took this long to see

It never reproduces locally: the model is already cached on the operator machine, so the same line costs milliseconds here and gigabytes of network there. Local setup measures **0.02s**.

That is also why three earlier sessions of conftest pre-imports (#582, #592, #593, #595) never fixed it — and why `tests/conftest.py` carries a long docstring about warming heavy imports. **They were warming imports for a step whose cost is a network fetch.**

## The fix

Patch at the **use site** as well as the definition site. Verified the real class is never constructed:

```
init_state.VectorStore during the class: MagicMock
wg.vector_store:                         MagicMock
real VectorStore.__init__ calls:         0
```

The definition-site patches stay — harmless, and they still cover any path that resolves the attribute at call time.

#1093's `BaseException` unwind remains worth having: it bounds what a timeout can damage. **This removes the timeout itself.**

## Verification

- `tests/test_entity_name_markdown_strip.py` + `tests/test_native_done_reason.py` → 17 passed
- spy on `VectorStore.__init__` → **0 calls** during the class
- full local suite → **5,312 passed**, zero failures
- `ruff --select F` → clean

## Out of scope

The same latent shape elsewhere. Any other test patching `core.vector_store.VectorStore` while the code under test imported it by name is exposed to the same thing; this PR fixes the one module CI proved. A sweep is worth doing, separately, with evidence rather than a grep-and-hope.

## Quality Delta

`Quality delta: exempt (label: fix)` — test-side repair; no `core/` source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)