### PR TITLE
feat(v0.6.2): Phase 3.3 pilot — measure what CSP actually blocks, migrate upload.js

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
-<link rel="stylesheet" href="/static/chat.css?v=v23-20260625-inputcol">
+<link rel="stylesheet" href="/static/chat.css?v=v24-20260908-csp-upload">
 <link rel="stylesheet" href="/static/mobile.css?v=v22-20260625-upload">
 </head>
 <body>
@@ -641,7 +641,7 @@
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
 <script src="/static/chat.js?v=v22-20260625-upload"></script>
-<script src="/static/upload.js?v=v22-20260625-upload"></script>
+<script src="/static/upload.js?v=v24-20260908-csp-upload"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 UI #4 — inline <script> block extracted to /static/index-init.js
      so the chat page's CSP can drop script-src 'unsafe-inline'. No

--- a/frontend/static/chat.css
+++ b/frontend/static/chat.css
@@ -2111,5 +2111,75 @@ aside.sidebar { height: 100vh; height: 100dvh; }
   color: var(--text, #e0e0e0);
   background: var(--surface, #1e293b);
 }
-</content>
-</invoke>
+/* ─────────────────────────────────────────────────────────────
+   CSP style-src migration — upload.js
+   ─────────────────────────────────────────────────────────────
+   These replace `style="…"` attributes that upload.js used to write
+   into innerHTML. Measured 2026-09-08 against an enforce-mode server:
+   a style ATTRIBUTE arriving through innerHTML or setAttribute is
+   blocked once 'unsafe-inline' leaves style-src, while CSSOM writes
+   (el.style.x = …, cssText, setProperty) are not governed by CSP at
+   all. So only the attribute form needs a class; the dynamic values
+   upload.js sets programmatically stay as they are.
+   ───────────────────────────────────────────────────────────── */
+
+/* Drag-and-drop overlay card */
+.upload-drop-card {
+  background: var(--surface, #14161a);
+  padding: 24px 32px;
+  border-radius: 16px;
+  border: 1px solid var(--border, #25282f);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, .5);
+  text-align: center;
+  pointer-events: none;
+}
+.upload-drop-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text, #fff);
+}
+.upload-drop-hint {
+  font-size: 12px;
+  color: var(--muted, #888);
+  margin-top: 6px;
+}
+
+/* Composer attachment chips */
+.chat-attach-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 4px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--text-soft);
+  max-width: 200px;
+  font-family: var(--font-ui);
+}
+.chat-attach-thumb {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  border-radius: 5px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.chat-attach-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 5px;
+}
+.chat-attach-icon { font-size: 18px; }
+.chat-attach-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-attach-status { flex-shrink: 0; }

--- a/frontend/static/upload.js
+++ b/frontend/static/upload.js
@@ -179,15 +179,12 @@ dropZone.addEventListener('drop', async e => {
       transition:opacity .15s ease;
     `;
     overlay.innerHTML = `
-      <div style="background:var(--surface,#14161a); padding:24px 32px;
-                  border-radius:16px; border:1px solid var(--border,#25282f);
-                  box-shadow:0 12px 40px rgba(0,0,0,.5); text-align:center;
-                  pointer-events:none">
-        <div style="margin-bottom:8px"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></div>
-        <div style="font-size:16px; font-weight:600; color:var(--text,#fff)">
+      <div class="upload-drop-card">
+        <div class="mb-8"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></div>
+        <div class="upload-drop-title">
           여기에 놓으면 업로드 큐에 추가됩니다
         </div>
-        <div style="font-size:12px; color:var(--muted,#888); margin-top:6px">
+        <div class="upload-drop-hint">
           이미지 / PDF / Word / 텍스트 파일 지원
         </div>
       </div>
@@ -325,8 +322,8 @@ function renderChatAttachmentRow() {
     const isImg  = /^image\//.test(it.file.type || '');
     const thumb  = isImg && _thumbDataCache.has(it.id)
       ? `<img src="${_thumbDataCache.get(it.id)}" alt=""
-              style="width:100%;height:100%;object-fit:cover;border-radius:5px">`
-      : `<span style="font-size:18px">${
+              class="chat-attach-thumb-img">`
+      : `<span class="chat-attach-icon">${
           (typeof getFileIcon === 'function') ? getFileIcon(it.file.name) : 'DOC'
         }</span>`;
     const status = it.status === 'upload' ? '↑'
@@ -340,17 +337,12 @@ function renderChatAttachmentRow() {
     return `
       <div data-action="chat-attach-click"
            title="${it.file.name.replace(/"/g, '&quot;')}"
-           style="display:flex;align-items:center;gap:6px;padding:4px 8px 4px 4px;
-                  background:var(--surface-2);border:1px solid var(--border);
-                  border-radius:8px;cursor:pointer;font-size:11px;color:var(--text-soft);
-                  max-width:200px;font-family:var(--font-ui)">
-        <span style="width:24px;height:24px;display:flex;align-items:center;
-                     justify-content:center;background:var(--bg);border-radius:5px;
-                     overflow:hidden;flex-shrink:0">${thumb}</span>
-        <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
+           class="chat-attach-chip">
+        <span class="chat-attach-thumb">${thumb}</span>
+        <span class="chat-attach-name">
           ${name}
         </span>
-        ${status ? `<span style="flex-shrink:0">${status}</span>` : ''}
+        ${status ? `<span class="chat-attach-status">${status}</span>` : ''}
       </div>`;
   }).join('');
 }
@@ -472,7 +464,7 @@ function renderFileItem(item) {
       <button class="folder-toggle" data-action="toggle-folder" data-item-id="${escHtml(item.id)}" aria-label="저장 폴더 설정" title="저장 폴더"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg></button>
       <button class="remove-btn" id="action-${item.id}" data-action="remove-or-cancel" data-item-id="${escHtml(item.id)}" title="제거">✕</button>
     </div>
-    <div class="file-progress-row" id="progress-${item.id}" style="display:none;">
+    <div class="file-progress-row d-none" id="progress-${item.id}">
       <div class="file-progress-bar"><div class="file-progress-fill" id="progress-fill-${item.id}"></div></div>
       <span class="file-progress-pct" id="progress-pct-${item.id}">0%</span>
     </div>
@@ -511,7 +503,11 @@ function setStatus(id, status, label) {
   }
   // Per-file progress bar visible only during upload.
   const prog = document.getElementById(`progress-${id}`);
-  if (prog) prog.style.display = (status === 'upload') ? '' : 'none';
+  // Class toggle, not style.display: the row now starts hidden via the
+  // .d-none class (CSP blocks the style attribute it used to carry), and
+  // style.display = '' would clear the inline value and fall straight
+  // back to .d-none — leaving the bar permanently invisible.
+  if (prog) prog.classList.toggle('d-none', status !== 'upload');
   // W6: keep the chat-input mini-thumbnail status indicator in sync
   // (⬆️ / ✅ / ❌).
   if (typeof renderChatAttachmentRow === 'function') {


### PR DESCRIPTION
## Summary

The roadmap sizes Phase 3.3 as *"JS 주입 인라인 스타일 ~493개"*, and I repeated a similar figure (684) before checking. **Both are wrong**, and the difference decides how big this phase is.

## What CSP actually blocks — measured, not assumed

Ran an enforce-mode server on a scratch port (`:8011`) so the operator's `:8000` stayed untouched, then probed each way of applying a style in the live page:

| how the style is applied | applied? | governed by CSP? |
|---|---|---|
| `el.style.color = …` | ✅ | **no** |
| `el.style.cssText = …` | ✅ | **no** |
| `el.style.setProperty(…)` | ✅ | **no** |
| `innerHTML` containing `style="…"` | ❌ **blocked** | yes |
| `setAttribute('style', …)` | ❌ **blocked** | yes |

**CSP does not govern CSSOM.** So the work surface is the **479 template-string `style="` occurrences only** — the 195 `.style.*` assignments and 10 `cssText` writes are already safe and need no migration.

That also gives the recipe for the rest: a dynamic value keeps being set programmatically after its static styling moves to a class. Both halves stay CSP-clean.

| | count |
|---|---:|
| believed work items (roadmap / my own restatement) | 493 / 684 |
| **actual work surface** | **479** |
| already CSP-safe, no action | **205** |

## The pilot — upload.js, 11 → 0

Uses the atomic / component class convention #1062 established in `tokens.css`. Two of the eleven needed more than a swap:

**1. The progress row would have been permanently invisible.** It started hidden via `style="display:none"` and was revealed with `prog.style.display = ''`. Move the attribute to `.d-none` and that empty string clears the inline value and falls straight back to the class — the bar never appears again. It now toggles the class.

**2. Appending to chat.css silently did nothing for the first rule.** The file ends with two stray lines — `</content>` and `</invoke>` — present on `main`, and in no other file in the repo. A CSS parser recovering from them consumes up to the next `{`, swallowing whichever rule follows. Harmless while nothing followed it; a trap for exactly this kind of append. Removed.

Caught because the verification below reported 8/9 rather than 9/9 — a screenshot would not have seen it, since the drop overlay and attachment chips only render mid-drag.

## Verification

- **computed-style comparison in the live page**, class version against the original inline version, 25 properties each → **9 of 9 identical**
- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**
- cache busters bumped (chat.css, upload.js) per the mobile-cache convention

## Out of scope

- The remaining **468 occurrences across 18 files** — `admin.js` (235) and `chat.js` (52) dominate. Each is its own PR with the same verification.
- **The enforce flip itself.** It comes last, once the count reaches zero; flipping now breaks the UI, which is what `csp_nonce.py` already warns about.
- `csp_nonce.py`'s docstring still says *"409 inline style attributes remain across the 4 HTML pages"*. #1062 took the HTML count to **0**; the remaining ones are all JS-injected. Worth correcting when the next slice lands.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
