### PR TITLE
fix(v0.6.2): sweep the use-site VectorStore patch across the remaining five files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,9 +109,23 @@ import server_llmwiki  # noqa: F401 — pulls all routes/ + heavy startup deps
 # at session start. Side-effects are recoverable; we only need caches
 # primed for create_entity_file's first call to stay under 30s on cold
 # CI runners.
+#
+# 2026-09-08 — the warm-up itself must not build a real VectorStore.
+# WikiGenerator.__init__ constructs one, and VectorStore._load_model()
+# downloads BAAI/bge-m3 from HuggingFace and writes the shards to disk
+# when the model is not already cached. That is invisible on a developer
+# machine and a multi-GB fetch on a CI runner — paid here at session
+# start, and paid again by every test whose own patch missed the use
+# site (see #1094 and the sweep alongside this change). The mixin
+# __init__ chain still runs; only the embedding model is mocked out.
+from unittest.mock import patch as _patch
+
+_INIT_STATE = "core.wiki_generator._frontmatter.init_state"
 try:
     from core.wiki_generator import WikiGenerator
-    WikiGenerator(source_type="test")
+    with _patch(f"{_INIT_STATE}.VectorStore"), \
+            _patch(f"{_INIT_STATE}.RouterWrapper"):
+        WikiGenerator(source_type="test")
 except Exception:
     # Instantiation side-effects (filesystem, network, config) are not
     # required to succeed — the goal is just to trigger any lazy

--- a/tests/test_attributes_summary_cleanup.py
+++ b/tests/test_attributes_summary_cleanup.py
@@ -68,6 +68,15 @@ class _Base(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]

--- a/tests/test_event_ingest_emit.py
+++ b/tests/test_event_ingest_emit.py
@@ -71,6 +71,15 @@ class _EventIngestBase(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]

--- a/tests/test_phase_b_ingestion_sources.py
+++ b/tests/test_phase_b_ingestion_sources.py
@@ -138,6 +138,15 @@ class CreateEntityFileSourcesPropagationTests(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]
@@ -242,6 +251,15 @@ class ProcessDocumentSourcesIntegrationTests(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]
@@ -387,6 +405,15 @@ class CrossDocSourceAggregationTests(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]

--- a/tests/test_phase_d_modify_cascade.py
+++ b/tests/test_phase_d_modify_cascade.py
@@ -185,6 +185,15 @@ class CascadeModifyDocIntegrationTests(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]

--- a/tests/test_wiki_summary_body_sync.py
+++ b/tests/test_wiki_summary_body_sync.py
@@ -47,6 +47,15 @@ class _WikiSummaryBodyBase(unittest.TestCase):
                 "core.memory.verify_before_write",
                 return_value=(True, "ok", 0.99),
             ),
+            # Patch at the USE site too. init_state.py binds both
+            # names at module import ("from core.vector_store import
+            # VectorStore"), so patching only the definition site
+            # leaves WikiGenerator building a REAL VectorStore —
+            # which calls _load_model() and downloads BAAI/bge-m3
+            # from HuggingFace. Invisible locally (the model is
+            # cached) and a >30s pytest-timeout on CI. See #1094.
+            patch("core.wiki_generator._frontmatter.init_state.VectorStore"),
+            patch("core.wiki_generator._frontmatter.init_state.RouterWrapper"),
             patch("core.vector_store.VectorStore"),
             patch("llm.router.RouterWrapper"),
         ]


### PR DESCRIPTION
## Summary

#1094 fixed one file and said the sweep was **out of scope until there was evidence rather than a grep**. CI produced the evidence on the very next run: `test_event_ingest_emit` hit the same `>30s` pytest-timeout, for the same reason.

`setUpClass` patches `core.vector_store.VectorStore`, but `core/wiki_generator/_frontmatter/init_state.py` binds the name at module import — so `WikiGenerator()` built a **real** `VectorStore`, and `_load_model()` downloaded BAAI/bge-m3 from HuggingFace inside a 30 second budget.

## The sweep

The five remaining files the conftest docstring already listed as sharing this fixture:

| file | sites |
|---|---:|
| `test_attributes_summary_cleanup` | 1 |
| `test_event_ingest_emit` | 1 |
| `test_phase_b_ingestion_sources` | **3** |
| `test_phase_d_modify_cascade` | 1 |
| `test_wiki_summary_body_sync` | 1 |

All now patch the use site alongside the definition site.

## Verification

Spied on `VectorStore.__init__` while running all six files (including the one #1094 already fixed):

```
tests run: 50   failures: 0   errors: 0
real VectorStore.__init__ calls: 0
```

Full local suite → **5,312 passed**.

## conftest's warm-up had it too

It instantiates `WikiGenerator` at session start, which built a real `VectorStore` as well. It now mocks the embedding model while still running the mixin `__init__` chain it exists to prime.

**Session-start constructions: 3 → 2.**

## The remaining 2 — leftovers, stated not hidden

They come from `import server_llmwiki` standing up the production engine (`graph_rag_engine → engine → init_state / retrieval_engine`). Removing them means either not warming the server module, or making `VectorStore`'s model load lazy — a `core/` change that would need rule #2 bench numbers.

They cost session-start wall time on a cold runner. They are **not** inside any per-test timeout, so they are not what was failing.

## Quality Delta

`Quality delta: exempt (label: fix)` — test-side repair; no `core/` source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
