### PR TITLE
feat(v0.6.2): Phase 3.3 batch — 115 more inline styles across 12 JS files

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/tokens.css?v=v26-20260908-csp-batch">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->
@@ -1320,7 +1320,7 @@
   </main>
 </div>
 
-<script src="/static/i18n.js"></script>
+<script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
 <script src="/static/admin.js"></script>
@@ -1330,10 +1330,10 @@
 <!-- v0.6.1 Phase D-2 — agent chat panel (loaded by admin.js
      showPage() loader map). Self-contained; talks directly to
      POST /agent/chat/. -->
-<script src="/static/agent-chat.js"></script>
+<script src="/static/agent-chat.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.5 Track F.2 CR.a — Change Review list page (UI shell). Loads
      after admin.js so the SPA page-toggle wiring is already in place. -->
-<script src="/static/change-requests.js"></script>
+<script src="/static/change-requests.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script. -->
 <script src="/static/glossary.js"></script>
 

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/tokens.css?v=v26-20260908-csp-batch">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">
@@ -516,10 +516,10 @@
   </div>
 </div>
 
-<script src="/static/i18n.js"></script>
+<script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
-<script src="/static/graph.js"></script>
-<script src="/static/graph_editor.js"></script>
+<script src="/static/graph.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/graph_editor.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/graph_node_editor.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 Track F.1 TT.a — Time-Travel picker UI shell (event-dispatch
@@ -532,19 +532,19 @@
      /graph stage. Edge colour-decoration is gated on a join key
      (link.edge_id) that arrives with later T5 mutation-site wiring —
      until then the overlay is summary-only. -->
-<script src="/static/time-travel-renderer.js"></script>
+<script src="/static/time-travel-renderer.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.5 Track F.1 TT.c — Reasoning trail replay. Renders one
      trace_id's stages in the same 3-phase format chat.js uses
      (RETRIEVE → EXPAND → VERIFY), filtered to the active time-travel
      cutoff. Loads after the picker (TT.a) + corpus renderer (TT.b)
      so the cutoff event has already wired the panel state. -->
-<script src="/static/time-travel-trace.js"></script>
+<script src="/static/time-travel-trace.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.5 Track F.1 TT.d — Now-vs-T diff view. Renders a side-by-side
      modal comparing the audit-replay snapshot at the picker's T
      against the live audit-replay snapshot at "now". Loads last so
      it can hook the picker button + the `james:timetravel:*`
      events the prior shells dispatch. -->
-<script src="/static/time-travel-diff.js"></script>
+<script src="/static/time-travel-diff.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script.
      Scans the page for elements with `data-glossary="<term>"` and
      attaches hover/focus tooltips with plain-Korean definitions. -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/tokens.css?v=v26-20260908-csp-batch">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
@@ -637,7 +637,7 @@
   </section>
 </main>
 
-<script src="/static/i18n.js"></script>
+<script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
 <script src="/static/chat.js?v=v25-20260908-csp-chatjs"></script>
@@ -652,7 +652,7 @@
 <!-- v0.6 template-formatting engine — chat-side apply panel. Self-
      contained (own auth read + own click delegation); does NOT touch
      chat.js's send pipeline. -->
-<script src="/static/templating-chat.js"></script>
+<script src="/static/templating-chat.js?v=v26-20260908-csp-batch"></script>
 <!-- v0.6.1 — workspace badge in header. Self-contained boot fetch. -->
 <script src="/static/workspace-badge.js"></script>
 

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/tokens.css?v=v26-20260908-csp-batch">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">
@@ -248,7 +248,7 @@
 
 </main>
 
-<script src="/static/i18n.js"></script>
+<script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/intro.js"></script>
 <!-- onboarding step nav drives the #tour section -->

--- a/frontend/static/agent-chat.js
+++ b/frontend/static/agent-chat.js
@@ -174,7 +174,7 @@
     const box = _log();
     if (box) {
       box.innerHTML =
-        `<div style="color:var(--muted);font-size:12px">${
+        `<div class="c-muted fs-12">${
           _esc(_t('agentchat.empty', '(아직 대화 없음 — 아래에 메시지를 입력하세요)'))
         }</div>`;
     }
@@ -206,7 +206,7 @@
 
   function _renderUserBubble(text) {
     _appendNode(`
-      <div style="align-self:flex-end;max-width:80%;background:var(--accent,#3b82f6);color:var(--on-accent,#fff);padding:8px 12px;border-radius:12px 12px 4px 12px;font-size:13px;white-space:pre-wrap;word-break:break-word">
+      <div class="u-d03fd082">
         ${_esc(text)}
       </div>
     `);
@@ -215,7 +215,7 @@
   function _renderAssistantBubble(text) {
     if (!text) return;
     _appendNode(`
-      <div style="align-self:flex-start;max-width:80%;background:var(--surface-2,#1e293b);color:var(--text);padding:8px 12px;border-radius:12px 12px 12px 4px;font-size:13px;white-space:pre-wrap;word-break:break-word">
+      <div class="u-cfa36ab5">
         ${_esc(text)}
       </div>
     `);
@@ -223,7 +223,7 @@
 
   function _renderErrorBubble(msg) {
     _appendNode(`
-      <div style="align-self:flex-start;max-width:90%;background:#5b1e1e;color:#fcc;padding:8px 12px;border-radius:8px;font-size:12px;font-family:var(--font-mono)">
+      <div class="u-f101c803">
         ❌ ${_esc(msg)}
       </div>
     `);
@@ -240,16 +240,16 @@
     const isShell = call.name === 'run_shell';
     const border = isShell ? '#a16207' : 'var(--border,#334155)';
     const shellTag = isShell
-      ? ` <span style="color:#fc8" title="${_esc(_t('agentchat.shell_tag_title', '셸 명령 실행 — 운영자 허용 폴더 안에서만'))}">⚠ shell</span>`
+      ? ` <span class="u-6b219d48" title="${_esc(_t('agentchat.shell_tag_title', '셸 명령 실행 — 운영자 허용 폴더 안에서만'))}">⚠ shell</span>`
       : '';
     _appendNode(`
       <div style="align-self:flex-start;max-width:92%;background:var(--bg,#0f172a);border:1px solid ${border};border-radius:8px;padding:8px 12px;font-family:var(--font-mono);font-size:11px;color:var(--text)">
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px">
+        <div class="d-flex justify-between items-center mb-4">
           <span><strong>${okIcon} ${_esc(call.name)}</strong>${shellTag}
-                <span style="color:var(--muted);margin-left:6px">iter ${call.iter || ''}</span></span>
-          <span style="color:var(--muted)">${call.elapsed_ms != null ? call.elapsed_ms + ' ms' : ''}</span>
+                <span class="c-muted ml-6">iter ${call.iter || ''}</span></span>
+          <span class="c-muted">${call.elapsed_ms != null ? call.elapsed_ms + ' ms' : ''}</span>
         </div>
-        <div style="color:var(--muted);word-break:break-all;margin-bottom:2px">args: ${_esc(argsJson)}</div>
+        <div class="u-1ad59c6e">args: ${_esc(argsJson)}</div>
         <div style="color:${call.ok ? 'var(--muted)' : '#fcc'};word-break:break-all">${detail}</div>
       </div>
     `);
@@ -288,7 +288,7 @@
     box.innerHTML = '';
     if (!_history.length) {
       box.innerHTML =
-        `<div style="color:var(--muted);font-size:12px">${
+        `<div class="c-muted fs-12">${
           _esc(_t('agentchat.empty', '(아직 대화 없음 — 아래에 메시지를 입력하세요)'))
         }</div>`;
       return;
@@ -304,7 +304,7 @@
     const box = document.getElementById('agent-session-list');
     if (!box) return;
     if (!_sessions.length) {
-      box.innerHTML = `<div style="color:var(--muted);font-size:11px">${
+      box.innerHTML = `<div class="c-muted fs-11">${
         _esc(_t('agentsess.empty', '세션 없음 — + 새 대화'))}</div>`;
       return;
     }
@@ -315,7 +315,7 @@
         padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;
         background:${active ? 'var(--accent,#3b82f6)' : 'var(--bg)'};
         color:${active ? '#fff' : 'var(--text)'};border:1px solid var(--border)">
-        <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${_esc(s.title)}</span>
+        <span class="u-7afdde9c">${_esc(s.title)}</span>
         <button data-action="agent-session-del" data-sid="${_esc(s.id)}"
           title="${_esc(_t('agentsess.del', '삭제'))}"
           style="border:0;background:transparent;color:${active ? '#fff' : 'var(--muted)'};
@@ -541,7 +541,7 @@
       _renderBrowse(d);
     } catch (e) {
       const l = document.getElementById('agent-browse-list');
-      if (l) l.innerHTML = `<div style="color:#f88;font-size:12px;padding:6px">${_esc(e.message || e)}</div>`;
+      if (l) l.innerHTML = `<div class="u-72af977b">${_esc(e.message || e)}</div>`;
     }
   }
   function _renderBrowse(d) {
@@ -553,22 +553,19 @@
     if (!list) return;
     let html = '';
     if (d.parent !== null && d.current) {
-      html += `<div data-action="agent-browse-nav" data-path="${_esc(d.parent)}"
-        style="padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;
-        font-family:var(--font-mono);background:var(--bg);border:1px solid var(--border)">⬑ ${
+      html += `<div class="u-bbdb0a17" data-action="agent-browse-nav" data-path="${_esc(d.parent)}"
+       >⬑ ${
         _esc(_t('agent.browse_up', '상위 폴더'))}</div>`;
     }
     const entries = d.entries || [];
     if (!entries.length && d.current) {
-      html += `<div style="color:var(--muted);font-size:12px;padding:6px">${
+      html += `<div class="u-59298278">${
         _esc(_t('agent.browse_empty', '(하위 폴더 없음)'))}</div>`;
     }
-    html += entries.map(en => `<div data-action="agent-browse-nav" data-path="${_esc(en.path)}"
-      style="display:flex;justify-content:space-between;align-items:center;padding:6px 8px;
-      border-radius:6px;cursor:pointer;font-size:12px;font-family:var(--font-mono);
-      background:var(--bg);border:1px solid var(--border)">
-      <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">📁 ${_esc(en.name)}</span>
-      ${en.registerable ? '' : `<span style="color:#f88;font-size:10px" title="${_esc(_t('agent.browse_blocked', '등록 불가'))}">⛔</span>`}
+    html += entries.map(en => `<div class="u-b7e2de6c" data-action="agent-browse-nav" data-path="${_esc(en.path)}"
+     >
+      <span class="u-7afdde9c">📁 ${_esc(en.name)}</span>
+      ${en.registerable ? '' : `<span class="u-f10d923e" title="${_esc(_t('agent.browse_blocked', '등록 불가'))}">⛔</span>`}
     </div>`).join('');
     list.innerHTML = html;
   }

--- a/frontend/static/change-requests.js
+++ b/frontend/static/change-requests.js
@@ -122,21 +122,21 @@
     var targetText = cr.target_type + '/' + cr.target_id;
     return [
       '<tr data-cr-id="' + escHtml(cr.cr_id) + '">',
-      '<td class="muted-12" style="font-family:var(--font-mono)">',
+      '<td class="muted-12 font-mono">',
       escHtml(cr.cr_id),
       '</td>',
       '<td>' + escHtml(cr.title) + '</td>',
-      '<td class="muted-12" style="font-family:var(--font-mono)">',
+      '<td class="muted-12 font-mono">',
       escHtml(targetText),
       '</td>',
       '<td class="muted-12">' + escHtml(cr.proposer) + '</td>',
       '<td class="muted-12">' + escHtml(ageText) + '</td>',
       '<td>' + statusBadge(cr.status) + '</td>',
       '<td>',
-      '<button class="btn btn-primary"',
+      '<button class="btn btn-primary u-caa31bf0"',
       ' data-action="cr-view" data-cr-id="' + escHtml(cr.cr_id) + '"',
       ' aria-label="View CR ' + escHtml(cr.cr_id) + '"',
-      ' style="padding:5px 12px;font-size:11px">View</button>',
+      '>View</button>',
       '</td>',
       '</tr>'
     ].join('');
@@ -180,8 +180,8 @@
     if (!body) return;
     if (!items.length) {
       body.innerHTML =
-        '<tr><td colspan="7" class="muted-12"' +
-        ' style="text-align:center;padding:18px">' +
+        '<tr><td colspan="7" class="muted-12 u-2057e1f6"' +
+        '>' +
         'No change requests match this filter.</td></tr>';
     } else {
       body.innerHTML = items.map(renderRow).join('');
@@ -289,7 +289,7 @@
   function _renderMetaRow(label, value) {
     return (
       '<div class="muted-12">' + escHtml(label) + '</div>' +
-      '<div style="color:var(--text);word-break:break-all">' +
+      '<div class="c-text wb-all">' +
       escHtml(value) + '</div>'
     );
   }
@@ -435,7 +435,7 @@
     slot.innerHTML = [
       '<div style="display:flex;align-items:center;gap:10px;',
       'flex-wrap:wrap;font-family:var(--font-mono);font-size:11px">',
-      '<span class="muted-12" style="font-family:var(--font-mono)">',
+      '<span class="muted-12 font-mono">',
       'Contradiction classifier:',
       '</span>',
       '<span style="' + badgeStyle + 'padding:3px 10px;',
@@ -512,7 +512,7 @@
     // CR is not open → show terminal state, no actions.
     if (cr.status !== 'open') {
       slot.innerHTML = (
-        '<span class="muted-12" style="font-family:var(--font-mono)">' +
+        '<span class="muted-12 font-mono">' +
         'CR is ' + escHtml(cr.status) + ' — no actions available.' +
         '</span>'
       );

--- a/frontend/static/graph.js
+++ b/frontend/static/graph.js
@@ -357,7 +357,7 @@
           '<div><strong>' + (meta.node_count || 0) + '</strong> nodes</div>' +
           '<div><strong>' + (meta.edge_count || 0) + '</strong> edges</div>' +
           '<div>source: ' + (meta.source_type || source) + '</div>' +
-          (meta.truncated ? '<div style="color:var(--warn)">⚠ truncated to ' + meta.edge_hard_cap + ' edges</div>' : '');
+          (meta.truncated ? '<div class="u-f95e7372">⚠ truncated to ' + meta.edge_hard_cap + ' edges</div>' : '');
       }
       setOverlayCounts(meta);
       setStatus('');

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -111,7 +111,7 @@
     $('edge-edit-conf').textContent = (edge.conf != null) ? String(edge.conf) : '—';
     $('edge-edit-error').textContent = '';
     $('edge-edit-sources').innerHTML =
-      '<div style="color:var(--muted);font-family:var(--font-mono);font-size:11px">Loading sources...</div>';
+      '<div class="c-muted font-mono fs-11">Loading sources...</div>';
     modal.classList.add('show');
     refreshSources();
   }
@@ -147,15 +147,15 @@
   // module-scope tracks which row is currently in edit mode.
   function renderSourceRow(s, idx) {
     if (idx === editingIdx) return renderSourceEditRow(s, idx);
-    var doc = s.doc_id ? String(s.doc_id) : '<span style="color:var(--muted)">(none)</span>';
+    var doc = s.doc_id ? String(s.doc_id) : '<span class="c-muted">(none)</span>';
     var w   = (typeof s.weight === 'number') ? s.weight.toFixed(2) : '?';
     var ts  = s.ts ? String(s.ts).slice(0, 19) : '';
     var meta = '';
-    if (s.author) meta += '<div style="color:var(--muted);font-size:10px">author: ' + escapeHtml(s.author) + '</div>';
-    if (s.note)   meta += '<div style="color:var(--muted);font-size:10px;margin-top:2px">note: ' + escapeHtml(s.note) + '</div>';
+    if (s.author) meta += '<div class="c-muted fs-10">author: ' + escapeHtml(s.author) + '</div>';
+    if (s.note)   meta += '<div class="u-67e7f9a2">note: ' + escapeHtml(s.note) + '</div>';
     // Per-row actions: ✏️ (edit weight/note) and ✕ (delete this source only).
     var actions = '' +
-      '<div style="display:flex;flex-direction:column;gap:4px;align-items:flex-end">' +
+      '<div class="d-flex flex-col gap-4 items-end">' +
         '<button type="button" data-action="edit-src" data-idx="' + idx + '" ' +
                 'title="Edit this source" ' +
                 'style="background:transparent;border:1px solid var(--border);' +
@@ -174,11 +174,11 @@
     return '' +
       '<div data-src-idx="' + idx + '" style="display:flex;align-items:flex-start;' +
          'gap:8px;padding:6px 0;border-bottom:1px solid var(--border)">' +
-        '<div style="flex:1;min-width:0">' +
-          '<div style="display:flex;gap:6px;align-items:center;font-family:var(--font-mono);font-size:11px">' +
+        '<div class="u-89bd09bd">' +
+          '<div class="d-flex gap-6 items-center font-mono fs-11">' +
             roleBadge(s.role || '?') +
-            '<span style="color:var(--text-soft)">w=' + w + '</span>' +
-            (ts ? '<span style="color:var(--muted);font-size:10px">' + ts + '</span>' : '') +
+            '<span class="c-text-soft">w=' + w + '</span>' +
+            (ts ? '<span class="c-muted fs-10">' + ts + '</span>' : '') +
           '</div>' +
           '<div style="margin-top:2px;color:var(--text-soft);font-family:var(--font-mono);' +
                 'font-size:10px;word-break:break-all">' + doc + '</div>' +
@@ -201,25 +201,25 @@
         '<div style="display:flex;gap:6px;align-items:center;font-family:var(--font-mono);' +
               'font-size:11px;margin-bottom:6px">' +
           roleBadge(s.role || '?') +
-          '<span style="color:var(--muted);font-size:10px">editing #' + idx + '</span>' +
+          '<span class="c-muted fs-10">editing #' + idx + '</span>' +
         '</div>' +
-        '<div style="display:flex;gap:6px;align-items:center;margin-bottom:4px">' +
-          '<label style="color:var(--muted);font-size:10px;font-family:var(--font-mono);width:50px">weight</label>' +
+        '<div class="d-flex gap-6 items-center mb-4">' +
+          '<label class="u-81e3f213">weight</label>' +
           '<input type="number" min="0" max="1" step="0.05" value="' + w + '" ' +
                  'data-edit-weight="' + idx + '" ' +
                  'style="flex:1;background:var(--bg);border:1px solid var(--border);' +
                         'color:var(--text);padding:3px 6px;border-radius:4px;' +
                         'font-family:var(--font-mono);font-size:11px">' +
         '</div>' +
-        '<div style="display:flex;gap:6px;align-items:center;margin-bottom:6px">' +
-          '<label style="color:var(--muted);font-size:10px;font-family:var(--font-mono);width:50px">note</label>' +
+        '<div class="d-flex gap-6 items-center mb-6">' +
+          '<label class="u-81e3f213">note</label>' +
           '<input type="text" value="' + escapeHtml(note) + '" ' +
                  'data-edit-note="' + idx + '" placeholder="(optional)" ' +
                  'style="flex:1;background:var(--bg);border:1px solid var(--border);' +
                         'color:var(--text);padding:3px 6px;border-radius:4px;' +
                         'font-family:var(--font-mono);font-size:11px">' +
         '</div>' +
-        '<div style="display:flex;gap:6px;justify-content:flex-end">' +
+        '<div class="d-flex gap-6 justify-end">' +
           '<button type="button" data-action="cancel-edit-src" data-idx="' + idx + '" ' +
                   'style="background:transparent;border:1px solid var(--border);' +
                          'color:var(--text-soft);padding:3px 10px;border-radius:4px;' +
@@ -249,7 +249,7 @@
       var r = await fetch(url, { headers: authHeaders() });
       if (!r.ok) {
         var j = await r.json().catch(function () { return {}; });
-        box.innerHTML = '<div style="color:var(--danger);font-size:11px">' +
+        box.innerHTML = '<div class="c-danger fs-11">' +
                         escapeHtml(j.detail || ('error ' + r.status)) + '</div>';
         return;
       }
@@ -258,7 +258,7 @@
       var srcs = rel.sources || [];
       currentSources = srcs.slice();   // [Stage E.1] cache for per-row mutations
       if (!srcs.length) {
-        box.innerHTML = '<div style="color:var(--muted);font-size:11px">No sources (legacy or unmigrated relation).</div>';
+        box.innerHTML = '<div class="c-muted fs-11">No sources (legacy or unmigrated relation).</div>';
         editingIdx = -1;
         return;
       }
@@ -270,7 +270,7 @@
         $('edge-edit-conf').textContent = String(rel.confidence);
       }
     } catch (e) {
-      box.innerHTML = '<div style="color:var(--danger);font-size:11px">' +
+      box.innerHTML = '<div class="c-danger fs-11">' +
                       escapeHtml(String(e)) + '</div>';
     }
   }

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -2628,7 +2628,7 @@ function updateLangToggleDisplay() {
     var koActive = currentLang === 'ko';
     btns[i].innerHTML =
       '<span style="opacity:' + (koActive ? 1 : 0.4) + ';font-weight:' + (koActive ? 700 : 400) + '">KO</span>' +
-      '<span style="opacity:0.5;margin:0 4px">|</span>' +
+      '<span class="u-160ef599">|</span>' +
       '<span style="opacity:' + (!koActive ? 1 : 0.4) + ';font-weight:' + (!koActive ? 700 : 400) + '">EN</span>';
   }
 }

--- a/frontend/static/templating-chat.js
+++ b/frontend/static/templating-chat.js
@@ -150,7 +150,7 @@
               'border:1px solid var(--border);border-radius:10px;color:var(--muted)">' +
               _esc(p) + '</span>';
           }).join('')
-        : '<span style="color:var(--muted);font-size:11px">' +
+        : '<span class="c-muted fs-11">' +
             _esc(_tt('tplchat.no_placeholders', 'No placeholders — free-form template.')) +
           '</span>';
     } catch (e) {

--- a/frontend/static/time-travel-diff.js
+++ b/frontend/static/time-travel-diff.js
@@ -121,7 +121,7 @@
       escapeHtml(t('graph.timetravel.diff.title',
                    'State diff: T → NOW')) +
       '</div>' +
-      '<div style="color:var(--muted)">' +
+      '<div class="c-muted">' +
       escapeHtml(t('graph.timetravel.diff.loading',
                    'Computing diff…')) +
       '</div>'
@@ -137,14 +137,14 @@
       escapeHtml(t('graph.timetravel.diff.title',
                    'State diff: T → NOW')) +
       '</div>' +
-      '<div style="color:var(--danger,#e06)">' +
+      '<div class="u-6812cd91">' +
       escapeHtml(t('graph.timetravel.diff.error', 'Diff unavailable')) +
       safeDetail + '</div>' + closeButtonHtml()
     );
   }
 
   function closeButtonHtml() {
-    return '<div style="margin-top:14px;text-align:right">' +
+    return '<div class="u-4552a90f">' +
            '<button type="button" data-action="diff-close" ' +
            'aria-label="Close diff modal" ' +
            'style="padding:7px 14px;background:var(--surface-2);' +
@@ -179,18 +179,18 @@
       var id = ids[i];
       rows += '<li style="display:flex;align-items:center;' +
               'padding:3px 0;border-bottom:1px dashed rgba(255,255,255,.05)">' +
-              '<span style="flex:1;word-break:break-all">' +
+              '<span class="flex-1 wb-all">' +
               escapeHtml(id) + '</span>' +
               (opts.evidence === false ? '' : evidenceLinkHtml(id)) +
               '</li>';
     }
-    return '<div style="margin-top:10px">' +
+    return '<div class="mt-10">' +
            '<div style="font-weight:600;color:var(--accent-fg);' +
            'font-size:10px;letter-spacing:1px;margin-bottom:4px">' +
            escapeHtml(label) +
            ' <span style="color:var(--muted);font-weight:400;' +
            'letter-spacing:0">(' + ids.length + ')</span></div>' +
-           '<ul style="list-style:none;padding:0;margin:0">' +
+           '<ul class="u-82ef8585">' +
            rows + '</ul></div>';
   }
 
@@ -208,29 +208,29 @@
       var at_now = (c.at_now || []).join(' → ') || '∅';
       rows += '<li style="padding:4px 0;border-bottom:1px dashed ' +
               'rgba(255,255,255,.05)">' +
-              '<div style="display:flex;align-items:center">' +
+              '<div class="d-flex items-center">' +
               '<span style="flex:1;font-weight:600;color:var(--text);' +
               'word-break:break-all">' + escapeHtml(head) + '</span>' +
               evidenceLinkHtml(head) + '</div>' +
-              '<div style="margin-top:2px;color:var(--muted);font-size:10px">' +
+              '<div class="u-1a5d6bb4">' +
               'T: ' + escapeHtml(at_t) + '</div>' +
-              '<div style="color:var(--muted);font-size:10px">' +
+              '<div class="c-muted fs-10">' +
               'NOW: ' + escapeHtml(at_now) + '</div></li>';
     }
-    return '<div style="margin-top:10px">' +
+    return '<div class="mt-10">' +
            '<div style="font-weight:600;color:var(--accent-fg);' +
            'font-size:10px;letter-spacing:1px;margin-bottom:4px">' +
            escapeHtml(label) +
            ' <span style="color:var(--muted);font-weight:400;' +
            'letter-spacing:0">(' + keys.length + ')</span></div>' +
-           '<ul style="list-style:none;padding:0;margin:0">' +
+           '<ul class="u-82ef8585">' +
            rows + '</ul></div>';
   }
 
   function summaryRow(leftLabel, leftVal, rightVal) {
     return '<div style="display:flex;gap:12px;padding:4px 0;' +
            'border-bottom:1px dashed rgba(255,255,255,.05)">' +
-           '<span style="flex:1;color:var(--muted)">' +
+           '<span class="flex-1 c-muted">' +
            escapeHtml(leftLabel) + '</span>' +
            '<span style="flex:0 0 80px;text-align:right;color:var(--text);' +
            'font-weight:600">' + escapeHtml(String(leftVal)) + '</span>' +
@@ -262,7 +262,7 @@
       '<div id="' + MODAL_ID + '-title" style="font-weight:700;' +
       'color:var(--accent-fg);letter-spacing:.4px;margin-bottom:4px">' +
       escapeHtml(title) + '</div>' +
-      '<div style="color:var(--muted);font-size:10px;margin-bottom:10px">' +
+      '<div class="c-muted fs-10 mb-10">' +
       'T: ' + escapeHtml(body.t) + ' • NOW: ' + escapeHtml(body.now) +
       '</div>';
 
@@ -270,7 +270,7 @@
     var summary =
       '<div style="display:flex;gap:12px;padding:4px 0;' +
       'border-bottom:1px solid var(--border)">' +
-      '<span style="flex:1"></span>' +
+      '<span class="flex-1"></span>' +
       '<span style="flex:0 0 80px;text-align:right;font-weight:600;' +
       'color:var(--accent-fg);font-size:10px;letter-spacing:1px">' +
       escapeHtml(thenLabel) + '</span>' +

--- a/frontend/static/time-travel-renderer.js
+++ b/frontend/static/time-travel-renderer.js
@@ -84,7 +84,7 @@
       'margin-bottom:6px;letter-spacing:.4px">' +
       escapeHtml(t('graph.timetravel.replay.title', 'Replay state')) +
       '</div>' +
-      '<div style="color:var(--muted)">' +
+      '<div class="c-muted">' +
       escapeHtml(t('graph.timetravel.replay.loading', 'Loading replay…')) +
       '</div>';
   }
@@ -99,7 +99,7 @@
       'margin-bottom:6px;letter-spacing:.4px">' +
       escapeHtml(t('graph.timetravel.replay.title', 'Replay state')) +
       '</div>' +
-      '<div style="color:var(--danger,#e06)">' +
+      '<div class="u-6812cd91">' +
       escapeHtml(t('graph.timetravel.replay.error',
                    'Replay unavailable')) + safeDetail +
       '</div>';
@@ -167,7 +167,7 @@
     return '<div style="display:flex;justify-content:space-between;' +
            'gap:8px">' +
            '<span>' + escapeHtml(label) + '</span>' +
-           '<span style="color:var(--text);font-weight:600">' +
+           '<span class="c-text fw-600">' +
            escapeHtml(String(value)) + '</span></div>';
   }
 

--- a/frontend/static/time-travel-trace.js
+++ b/frontend/static/time-travel-trace.js
@@ -129,7 +129,7 @@
            escapeHtml(t('graph.timetravel.trace.title',
                         'Reasoning trail')) +
            '</div>' +
-           '<div style="color:var(--muted);margin-bottom:6px">' +
+           '<div class="c-muted mb-6">' +
            stateText + '</div>';
   }
 
@@ -151,7 +151,7 @@
     var safeDetail = detail ? ' — ' + escapeHtml(detail) : '';
     var traceFrag = traceId ? ' (' + escapeHtml(traceId) + ')' : '';
     panel.innerHTML = renderHeader(
-      '<span style="color:var(--danger,#e06)">' +
+      '<span class="u-6812cd91">' +
       escapeHtml(t('graph.timetravel.trace.error', 'Trail unavailable')) +
       safeDetail + traceFrag + '</span>'
     );
@@ -198,10 +198,10 @@
     var label = entry.meta.label || entry.stage || '';
     return '<div style="display:flex;gap:6px;padding:3px 0;' +
            'border-bottom:1px dashed rgba(255,255,255,.05)">' +
-           '<span style="flex:0 0 16px">' + escapeHtml(icon) + '</span>' +
-           '<span style="flex:1;color:var(--text)">' +
+           '<span class="u-fe407230">' + escapeHtml(icon) + '</span>' +
+           '<span class="flex-1 c-text">' +
            escapeHtml(label) + '</span>' +
-           '<span style="color:var(--muted);font-size:10px">' +
+           '<span class="c-muted fs-10">' +
            escapeHtml(tsLabel) + '</span></div>';
   }
 
@@ -213,7 +213,7 @@
     for (var i = 0; i < entries.length; i++) {
       rows += renderStageRow(entries[i]);
     }
-    return '<div style="margin-top:8px">' +
+    return '<div class="mt-8">' +
            '<div style="font-weight:600;color:var(--accent-fg);' +
            'font-size:10px;letter-spacing:1px;margin-bottom:3px">' +
            escapeHtml(label) +
@@ -242,12 +242,12 @@
       '<div style="color:var(--muted);font-size:10px;' +
       'margin-bottom:6px;word-break:break-all">' +
       escapeHtml(traceId) + '</div>' +
-      '<div style="color:var(--muted);font-size:10px;margin-bottom:3px">' +
+      '<div class="u-85503ffb">' +
       escapeHtml(replayedLabel) +
-      '<span style="color:var(--text);font-weight:600">' +
+      '<span class="c-text fw-600">' +
       escapeHtml(String(replayed)) + '</span>' +
       escapeHtml(ofLabel) +
-      '<span style="color:var(--text)">' +
+      '<span class="c-text">' +
       escapeHtml(String(total)) + '</span></div>';
 
     // v0.6.1 (gap ③) — jump to the swimlane flow view of this same trace.

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -395,8 +395,12 @@ body::before {
  * (verbatim relocations of one-off inline styles). Enables
  * CSP style-src without 'unsafe-inline' for the HTML surface. */
 /* atoms */
-.c-accent-fg{color:var(--accent-fg)}
+.c-danger{color:var(--danger)}
 .c-muted{color:var(--muted)}
+.c-text{color:var(--text)}
+.c-text-soft{color:var(--text-soft)}
+.cursor-pointer{cursor:pointer}
+.d-block{display:block}
 .d-flex{display:flex}
 .flex-1{flex:1}
 .flex-col{flex-direction:column}
@@ -405,41 +409,60 @@ body::before {
 .fs-10{font-size:10px}
 .fs-11{font-size:11px}
 .fs-12{font-size:12px}
-.fs-14{font-size:14px}
+.fw-600{font-weight:600}
+.gap-4{gap:4px}
 .gap-6{gap:6px}
+.gap-8{gap:8px}
 .items-center{align-items:center}
-.lh-15{line-height:1.5}
-.minw-220{min-width:220px}
-.ml-auto{margin-left:auto}
+.items-end{align-items:flex-end}
+.justify-between{justify-content:space-between}
+.justify-end{justify-content:flex-end}
+.mb-10{margin-bottom:10px}
+.mb-4{margin-bottom:4px}
+.mb-6{margin-bottom:6px}
+.mb-8{margin-bottom:8px}
+.ml-6{margin-left:6px}
 .mt-10{margin-top:10px}
-.mt-6{margin-top:6px}
 .mt-8{margin-top:8px}
-.no-underline{text-decoration:none}
-.p-16{padding:16px}
 .text-center{text-align:center}
+.wb-all{word-break:break-all}
 /* components (verbatim one-off styles) */
-.u-02736ec7{display:flex;justify-content:space-between;margin-top:3px}
-.u-03db33f2{color:var(--muted,#888);font-size:12px;text-align:center;padding:20px}
-.u-172b0816{display:flex;align-items:center;gap:8px;margin-top:8px;padding:8px 12px;border-radius:8px;background:rgba(255,183,77,.08);border:1px solid rgba(255,183,77,.40);font-size:12px;color:#ffb74d;line-height:1.5}
-.u-1d1dc4d1{margin-top:3px}
-.u-2e05dbe3{cursor:pointer;font-size:11px;color:#4fc3f7;font-weight:600;user-select:none;display:inline-block;background:rgba(79,195,247,.10);padding:3px 9px;border-radius:6px;border:1px solid rgba(79,195,247,.30)}
-.u-2e56c4a1{cursor:pointer;font-size:11px;color:var(--muted);font-family:var(--font-mono);user-select:none;padding:2px 0}
-.u-356897e8{color:var(--danger);font-size:11px;padding:8px;text-align:center}
-.u-3736917b{color:#4caf7d;font-weight:600;margin-right:6px}
-.u-4278e205{font-size:13px;color:var(--text);white-space:pre-line;line-height:1.55;margin-bottom:18px}
-.u-4c8aa240{display:inline-flex;align-items:center;gap:6px;margin-top:6px;padding:4px 10px;border-radius:6px;background:rgba(239,68,68,.10);border:1px solid rgba(239,68,68,.45);font-size:11px;color:#fca5a5;font-family:var(--font-mono);letter-spacing:.3px}
-.u-5efeca4c{color:var(--accent);font-weight:600;margin-right:6px}
-.u-60d69e07{color:var(--muted);font-size:11px;padding:8px;text-align:center}
-.u-800ac3bf{margin:6px 0 0 18px;padding:0;font-family:var(--font-ui)}
-.u-81f9b541{background:none;border:1px solid var(--border);border-radius:6px;padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:all .15s}
-.u-8bc9917b{text-align:left;background:var(--surface-2);border:1px solid var(--accent-soft, rgba(107,231,208,.30));border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:13px;transition:all .15s;width:100%;font-family:inherit}
-.u-9699b833{display:inline-flex;align-items:center;gap:4px;margin-top:6px;font-size:11px;color:var(--muted);text-decoration:none}
-.u-9ee96dc4{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--accent);font-weight:700;letter-spacing:.4px;text-transform:uppercase}
-.u-a14e60e1{flex:1;max-width:80px;background:var(--bg);border-radius:3px;height:4px;overflow:hidden}
-.u-ae4f0321{color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.u-b87e02c4{text-align:left;background:rgba(76,175,125,.10);border:1px solid rgba(76,175,125,.45);border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:12px;width:100%;font-family:inherit;transition:all .15s}
-.u-ce16bc45{padding:8px 10px;border-bottom:1px solid var(--border-2);font-size:11px}
-.u-e87f4f41{background:rgba(255,183,77,.18);border:1px solid rgba(255,183,77,.60);border-radius:6px;padding:4px 10px;color:#ffd180;font-size:12px;cursor:pointer;font-family:inherit;font-weight:600;transition:all .15s}
+.u-0aece2c5{font-size:12px;margin-top:3px}
+.u-0b0be5ab{padding:8px;font-size:10px;color:var(--muted)}
+.u-14449c57{padding:4px 10px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer;font-size:11px}
+.u-160ef599{opacity:0.5;margin:0 4px}
+.u-1a5d6bb4{margin-top:2px;color:var(--muted);font-size:10px}
+.u-1ad59c6e{color:var(--muted);word-break:break-all;margin-bottom:2px}
+.u-2057e1f6{text-align:center;padding:18px}
+.u-42ac55af{padding:14px;font-size:12px;color:#e66}
+.u-4552a90f{margin-top:14px;text-align:right}
+.u-59298278{color:var(--muted);font-size:12px;padding:6px}
+.u-67e7f9a2{color:var(--muted);font-size:10px;margin-top:2px}
+.u-6812cd91{color:var(--danger,#e06)}
+.u-6b219d48{color:#fc8}
+.u-6fd9cc46{padding:14px;font-size:12px;color:var(--muted)}
+.u-72af977b{color:#f88;font-size:12px;padding:6px}
+.u-79f6fd5b{font-weight:600;font-size:13px;flex:1;min-width:0;word-break:break-all}
+.u-7afdde9c{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.u-81e3f213{color:var(--muted);font-size:10px;font-family:var(--font-mono);width:50px}
+.u-82ef8585{list-style:none;padding:0;margin:0}
+.u-85503ffb{color:var(--muted);font-size:10px;margin-bottom:3px}
+.u-89bd09bd{flex:1;min-width:0}
+.u-91d91dbb{background:var(--bg);border:1px solid var(--border-2);border-radius:6px;padding:8px 10px}
+.u-9b09d1c6{white-space:pre-wrap;word-break:break-word;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:12px;font-size:12px;max-height:60vh;overflow:auto}
+.u-a2f72b9b{display:flex;justify-content:space-between;align-items:center;background:var(--bg);border:1px solid var(--border-2);border-radius:6px;padding:6px 10px}
+.u-ad422ade{padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer}
+.u-b7092eba{padding:4px 10px;background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;cursor:pointer;font-size:11px}
+.u-b7e2de6c{display:flex;justify-content:space-between;align-items:center;padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;font-family:var(--font-mono);background:var(--bg);border:1px solid var(--border)}
+.u-bbdb0a17{padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;font-family:var(--font-mono);background:var(--bg);border:1px solid var(--border)}
+.u-caa31bf0{padding:5px 12px;font-size:11px}
+.u-cfa36ab5{align-self:flex-start;max-width:80%;background:var(--surface-2,#1e293b);color:var(--text);padding:8px 12px;border-radius:12px 12px 12px 4px;font-size:13px;white-space:pre-wrap;word-break:break-word}
+.u-d03fd082{align-self:flex-end;max-width:80%;background:var(--accent,#3b82f6);color:var(--on-accent,#fff);padding:8px 12px;border-radius:12px 12px 4px 12px;font-size:13px;white-space:pre-wrap;word-break:break-word}
+.u-de82cac5{font-size:11px;color:#8cf;margin-bottom:6px}
+.u-f101c803{align-self:flex-start;max-width:90%;background:#5b1e1e;color:#fcc;padding:8px 12px;border-radius:8px;font-size:12px;font-family:var(--font-mono)}
+.u-f10d923e{color:#f88;font-size:10px}
+.u-f95e7372{color:var(--warn)}
+.u-fe407230{flex:0 0 16px}
 /* carried forward from earlier runs */
 .accent-accent{accent-color:var(--accent)}
 .bd-1{border:1px solid var(--border)}
@@ -451,59 +474,51 @@ body::before {
 .br-7{border-radius:7px}
 .br-8{border-radius:8px}
 .c-accent{color:var(--accent)}
-.c-danger{color:var(--danger)}
-.c-text{color:var(--text)}
+.c-accent-fg{color:var(--accent-fg)}
 .c-text-2{color:var(--text-2)}
-.c-text-soft{color:var(--text-soft)}
-.cursor-pointer{cursor:pointer}
-.d-block{display:block}
 .d-inline-block{display:inline-block}
 .d-none{display:none}
 .font-ui{font-family:var(--font-ui)}
 .fs-13{font-size:13px}
+.fs-14{font-size:14px}
 .fs-15{font-size:15px}
 .fs-16{font-size:16px}
 .fs-inherit{font-size:inherit}
 .fw-400{font-weight:400}
-.fw-600{font-weight:600}
 .fw-700{font-weight:700}
 .gap-10{gap:10px}
 .gap-14{gap:14px}
-.gap-4{gap:4px}
-.gap-8{gap:8px}
-.items-end{align-items:flex-end}
 .items-start{align-items:flex-start}
-.justify-between{justify-content:space-between}
 .justify-center{justify-content:center}
-.justify-end{justify-content:flex-end}
+.lh-15{line-height:1.5}
 .lh-16{line-height:1.6}
 .ls-05{letter-spacing:.5px}
 .ls-1{letter-spacing:1px}
 .m-0{margin:0}
-.mb-10{margin-bottom:10px}
 .mb-12{margin-bottom:12px}
 .mb-14{margin-bottom:14px}
 .mb-16{margin-bottom:16px}
 .mb-20{margin-bottom:20px}
-.mb-4{margin-bottom:4px}
-.mb-6{margin-bottom:6px}
-.mb-8{margin-bottom:8px}
+.minw-220{min-width:220px}
 .minw-260{min-width:260px}
 .ml-10{margin-left:10px}
 .ml-12{margin-left:12px}
-.ml-6{margin-left:6px}
 .ml-8{margin-left:8px}
+.ml-auto{margin-left:auto}
 .mr-3{margin-right:3px}
 .mr-4{margin-right:4px}
 .mt-12{margin-top:12px}
 .mt-16{margin-top:16px}
 .mt-20{margin-top:20px}
 .mt-4{margin-top:4px}
+.mt-6{margin-top:6px}
+.no-underline{text-decoration:none}
 .outline-none{outline:none}
 .ovy-auto{overflow-y:auto}
 .p-10{padding:10px}
 .p-10-14{padding:10px 14px}
 .p-12-20{padding:12px 20px}
+.p-16{padding:16px}
 .p-16-0{padding:16px 0}
 .p-16-20{padding:16px 20px}
 .p-20{padding:20px}
@@ -519,8 +534,10 @@ body::before {
 .resize-v{resize:vertical}
 .self-center{align-self:center}
 .self-start{align-self:start}
+.u-02736ec7{display:flex;justify-content:space-between;margin-top:3px}
 .u-02b336d7{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;border-bottom:1px solid var(--border);padding-bottom:8px}
 .u-039f2f43{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:8px 10px;color:var(--text);font-size:13px;outline:none;box-sizing:border-box}
+.u-03db33f2{color:var(--muted,#888);font-size:12px;text-align:center;padding:20px}
 .u-051f894b{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:11px;max-height:280px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-family:var(--font-mono)}
 .u-062d4a88{margin-top:24px}
 .u-065d769b{display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:9999;align-items:flex-start;justify-content:center;overflow-y:auto;padding:40px 16px}
@@ -533,6 +550,7 @@ body::before {
 .u-1417170d{display:block;margin:14px 0 6px;font-size:12px;color:var(--text-soft);font-family:var(--font-mono)}
 .u-15397f03{flex:2;padding:10px;background:#1e5a7a;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer}
 .u-160ee922{flex:1;min-width:200px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px}
+.u-172b0816{display:flex;align-items:center;gap:8px;margin-top:8px;padding:8px 12px;border-radius:8px;background:rgba(255,183,77,.08);border:1px solid rgba(255,183,77,.40);font-size:12px;color:#ffb74d;line-height:1.5}
 .u-18ba313a{font-family:var(--font-mono);font-size:11px;color:var(--muted);line-height:1.8}
 .u-198baae3{padding:4px 10px;font-size:11px}
 .u-19bff323{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:18px}
@@ -540,8 +558,8 @@ body::before {
 .u-1aab2bbb{flex:1;padding:9px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer}
 .u-1addcfff{max-width:880px;width:92vw}
 .u-1d182703{background:var(--t-document)}
+.u-1d1dc4d1{margin-top:3px}
 .u-1f02e31d{font-family:var(--font-mono);font-size:12px;white-space:pre-wrap;color:var(--text);max-height:400px;overflow-y:auto}
-.u-2057e1f6{text-align:center;padding:18px}
 .u-2079cee6{font-size:12px;color:var(--muted-2);font-family:var(--font-mono);letter-spacing:.5px;display:inline-block;margin-top:6px;padding:2px 10px;border:1px solid var(--border-2);border-radius:4px}
 .u-212754e8{display:flex;gap:10px;margin-top:18px}
 .u-2430bfe7{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--muted);font-size:14px;padding:4px 6px}
@@ -552,11 +570,15 @@ body::before {
 .u-2abd191f{white-space:pre-wrap;font-family:var(--font-mono);font-size:12px;background:var(--bg);padding:12px;border-radius:4px;max-height:50vh;overflow-y:auto}
 .u-2ac71257{padding:9px 16px;background:var(--accent);color:var(--on-accent);border:0;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600}
 .u-2ad1dbdc{flex:1;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
+.u-2e05dbe3{cursor:pointer;font-size:11px;color:#4fc3f7;font-weight:600;user-select:none;display:inline-block;background:rgba(79,195,247,.10);padding:3px 9px;border-radius:6px;border:1px solid rgba(79,195,247,.30)}
+.u-2e56c4a1{cursor:pointer;font-size:11px;color:var(--muted);font-family:var(--font-mono);user-select:none;padding:2px 0}
 .u-2ff2369d{background:var(--bg);border:1px solid var(--border);border-left:3px solid var(--danger);border-radius:6px;padding:10px 12px;font-size:11px;line-height:1.5;color:var(--text-soft);max-height:360px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:0}
 .u-31c2f318{padding:8px 14px;background:#1e7a3e;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px}
 .u-31db86e6{display:flex;flex-direction:column;gap:4px;max-height:55vh;overflow:auto}
 .u-34f48e04{flex:2;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
+.u-356897e8{color:var(--danger);font-size:11px;padding:8px;text-align:center}
 .u-3726dd17{display:none;margin-top:14px;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px}
+.u-3736917b{color:#4caf7d;font-weight:600;margin-right:6px}
 .u-38643f9d{font-size:11px;color:var(--muted);font-family:var(--font-mono);min-height:14px}
 .u-38f9e152{align-items:flex-start;padding-bottom:0}
 .u-390dd707{display:grid;grid-template-columns:auto 1fr;gap:10px 12px;align-items:start}
@@ -572,6 +594,7 @@ body::before {
 .u-3f0ee34f{margin-top:14px;padding:12px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;font-size:12px;color:var(--muted);line-height:1.6}
 .u-3fc63d02{flex:1;padding:10px;background:var(--accent);border:none;border-radius:7px;color:var(--on-accent);font-size:12px;font-weight:600;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px}
 .u-415f6c14{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:4px 10px;border-radius:6px;font-size:12px}
+.u-4278e205{font-size:13px;color:var(--text);white-space:pre-line;line-height:1.55;margin-bottom:18px}
 .u-427e46c1{padding:10px 12px;font-size:11px;color:var(--muted);border-bottom:1px solid var(--border-2);display:flex;justify-content:space-between;align-items:center}
 .u-431df820{font-size:36px;font-weight:900;letter-spacing:-1px}
 .u-43ff79ff{line-height:1.7}
@@ -582,6 +605,7 @@ body::before {
 .u-4b28c85b{display:flex;flex-direction:column;gap:6px;min-height:24px;margin-top:6px;font-family:var(--font-mono);font-size:12px}
 .u-4bf6e6cb{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:320}
 .u-4c2e6fd3{background:transparent;border:0;color:var(--muted);cursor:pointer;font-size:20px}
+.u-4c8aa240{display:inline-flex;align-items:center;gap:6px;margin-top:6px;padding:4px 10px;border-radius:6px;background:rgba(239,68,68,.10);border:1px solid rgba(239,68,68,.45);font-size:11px;color:#fca5a5;font-family:var(--font-mono);letter-spacing:.3px}
 .u-4e41ca5e{margin-bottom:20px;padding:20px;background:var(--surface);border:1px solid var(--border);border-radius:12px;text-align:center}
 .u-4e6a0b38{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:4px 10px;border-radius:6px;font-size:11px;cursor:pointer}
 .u-4ee85ded{max-height:200px;overflow:auto;background:var(--bg);border:1px solid var(--border-2);border-radius:6px;padding:10px;font-size:12px;white-space:pre-wrap;word-break:break-word}
@@ -595,8 +619,10 @@ body::before {
 .u-5dad51e1{flex:1;min-width:160px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px}
 .u-5dcc4888{display:none;background:var(--accent-soft);border:1px solid var(--accent);color:var(--accent-fg);padding:4px 10px;border-radius:6px;font-size:11px;cursor:pointer;font-family:var(--font-ui)}
 .u-5ddb24b1{font-size:12px;color:var(--danger);min-height:18px;margin-bottom:10px;font-family:var(--font-mono)}
+.u-5efeca4c{color:var(--accent);font-weight:600;margin-right:6px}
 .u-5f31f7a4{margin-left:6px;padding:1px 8px;border-radius:4px;font-size:11px;background:var(--accent-soft);color:var(--accent-fg)}
 .u-5f42ab00{display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,.55);align-items:center;justify-content:center}
+.u-60d69e07{color:var(--muted);font-size:11px;padding:8px;text-align:center}
 .u-6342850d{display:flex;justify-content:space-between;font-size:10px;color:var(--muted);width:100%;position:absolute;margin-top:24px;pointer-events:none}
 .u-671ed45d{margin-top:14px;text-align:center;font-size:12px}
 .u-698d0f45{padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer}
@@ -611,13 +637,15 @@ body::before {
 .u-78cb8b59{color:#4caf7d;font-size:11px}
 .u-79c3e149{flex:1;min-width:240px;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px;font-family:var(--font-mono)}
 .u-7ff27f7b{max-width:560px;width:92vw}
+.u-800ac3bf{margin:6px 0 0 18px;padding:0;font-family:var(--font-ui)}
+.u-81f9b541{background:none;border:1px solid var(--border);border-radius:6px;padding:3px 10px;cursor:pointer;color:var(--muted);font-size:12px;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:all .15s}
 .u-84be825a{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 14px;font-size:12px;line-height:1.5;color:var(--text-soft);margin-bottom:18px;white-space:pre-wrap;min-height:36px}
 .u-85181f38{padding:36px;width:560px;max-width:92vw;max-height:88vh;overflow-y:auto}
 .u-87f8977c{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:12px;margin-bottom:12px;font-family:var(--font-mono);font-size:12px;word-break:break-all;color:var(--text)}
 .u-8869ee63{display:grid;grid-template-columns:auto 1fr;column-gap:12px;row-gap:6px;margin-bottom:18px;font-size:12px;font-family:var(--font-mono)}
-.u-89bd09bd{flex:1;min-width:0}
 .u-89fcfdab{font-size:11px;padding:6px 12px;min-height:32px;margin-bottom:8px}
 .u-8a63b251{padding-right:40px}
+.u-8bc9917b{text-align:left;background:var(--surface-2);border:1px solid var(--accent-soft, rgba(107,231,208,.30));border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:13px;transition:all .15s;width:100%;font-family:inherit}
 .u-8f3a65ea{padding:36px;width:340px}
 .u-903cf72f{display:none;color:#1e7a3e;font-size:12px;margin-bottom:8px}
 .u-912cc26a{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--muted);font-size:14px;padding:2px 4px}
@@ -628,6 +656,7 @@ body::before {
 .u-93b290df{flex-basis:100%;font-size:12px;color:var(--muted);font-family:var(--font-mono);min-height:16px}
 .u-942a8980{display:flex;gap:8px;justify-content:flex-end;margin-top:14px;flex-wrap:wrap;align-items:center}
 .u-94756a6c{flex:1;min-width:200px;padding:8px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:13px}
+.u-9699b833{display:inline-flex;align-items:center;gap:4px;margin-top:6px;font-size:11px;color:var(--muted);text-decoration:none}
 .u-96de41ff{display:flex;flex-wrap:wrap;gap:4px;margin:-4px 0 12px}
 .u-974eb5eb{padding:12px 0;display:flex;justify-content:flex-end}
 .u-978fde3d{padding:6px 14px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text-soft);cursor:pointer;font-size:12px}
@@ -637,8 +666,10 @@ body::before {
 .u-9d5c9183{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin-bottom:20px}
 .u-9d72653d{flex:1;min-width:160px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
 .u-9e9e719b{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:8px}
+.u-9ee96dc4{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--accent);font-weight:700;letter-spacing:.4px;text-transform:uppercase}
 .u-9ff490e0{background:var(--t-event)}
 .u-a0830e29{max-width:520px;width:92%;max-height:85vh;overflow-y:auto}
+.u-a14e60e1{flex:1;max-width:80px;background:var(--bg);border-radius:3px;height:4px;overflow:hidden}
 .u-a345ace1{display:none;background:var(--surface-2);border:1px solid var(--accent);border-radius:8px;padding:12px;margin-bottom:14px;font-size:12px}
 .u-a4ecb3a2{background:var(--surface);border:1px solid var(--border);border-radius:10px;width:min(620px,92vw);max-height:82vh;display:flex;flex-direction:column;padding:16px;gap:10px}
 .u-a737cc80{font-size:11px;color:var(--muted);min-height:14px;margin-bottom:4px;font-family:var(--font-mono)}
@@ -646,6 +677,7 @@ body::before {
 .u-aa69727c{padding:12px 16px;background:var(--surface);border:1px solid var(--border);border-radius:8px;display:flex;flex-direction:column;gap:10px}
 .u-ab7defe6{white-space:pre-wrap;max-height:240px;overflow:auto;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:13px;font-family:var(--font-mono)}
 .u-abd6d905{flex:1;min-width:320px;display:flex;flex-direction:column;gap:12px}
+.u-ae4f0321{color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .u-af524a3f{font-size:11px;color:var(--muted);font-family:var(--font-mono);word-break:break-all;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:6px}
 .u-b083d1b4{background:var(--bg);border:1px solid var(--border);border-left:3px solid var(--success);border-radius:6px;padding:10px 12px;font-size:11px;line-height:1.5;color:var(--text-soft);max-height:360px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:0}
 .u-b193c0d0{display:flex;gap:8px;align-items:center;margin:10px 0;flex-wrap:wrap}
@@ -654,6 +686,7 @@ body::before {
 .u-b507437c{margin-top:8px;font-size:12px;color:var(--muted);line-height:1.55}
 .u-b6b4121e{display:grid;grid-template-columns:auto 1fr auto;gap:8px;align-items:end}
 .u-b6bc178b{flex:2;padding:10px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer}
+.u-b87e02c4{text-align:left;background:rgba(76,175,125,.10);border:1px solid rgba(76,175,125,.45);border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:12px;width:100%;font-family:inherit;transition:all .15s}
 .u-b8867a16{font-size:12px;font-family:var(--font-mono);color:var(--muted);min-height:20px;margin-top:8px;padding:8px;background:var(--bg);border-radius:6px;display:none}
 .u-ba3f4872{flex:1;overflow:auto;display:flex;flex-direction:column;gap:3px;min-height:200px;max-height:50vh}
 .u-bcdf512f{margin-top:14px;display:flex;gap:10px;justify-content:center}
@@ -668,6 +701,7 @@ body::before {
 .u-c6e02b13{display:grid;grid-template-columns:auto 1fr;gap:10px 12px;align-items:center}
 .u-c7f59426{margin:0 12px;padding:8px;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;color:var(--text-soft);font-size:12px;cursor:pointer;font-family:var(--font-ui)}
 .u-caeb6867{display:flex;align-items:center;gap:10px;min-width:220px}
+.u-ce16bc45{padding:8px 10px;border-bottom:1px solid var(--border-2);font-size:11px}
 .u-d4099956{font-size:11px;color:var(--muted);margin-bottom:18px;line-height:1.5}
 .u-d40e04fd{background:var(--t-person)}
 .u-d755eb62{display:none;position:fixed;top:8px;left:8px;z-index:60;width:44px;height:44px;border:1px solid var(--border);background:var(--surface);color:var(--text);border-radius:8px;font-size:20px;cursor:pointer}
@@ -688,6 +722,7 @@ body::before {
 .u-e56abdee{width:100%;padding:11px;background:var(--danger);border:none;border-radius:8px;color:#fff;font-size:14px;font-weight:600;cursor:pointer}
 .u-e6f429e1{padding:14px 18px;margin-bottom:20px;background:var(--surface);border:1px solid var(--border);border-radius:8px}
 .u-e74ffa36{display:flex;gap:24px;flex-wrap:wrap;font-family:var(--font-mono);font-size:13px}
+.u-e87f4f41{background:rgba(255,183,77,.18);border:1px solid rgba(255,183,77,.60);border-radius:6px;padding:4px 10px;color:#ffd180;font-size:12px;cursor:pointer;font-family:inherit;font-weight:600;transition:all .15s}
 .u-e8a4793a{flex:1;min-width:180px;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px}
 .u-e8dc057b{background:var(--bg);height:6px;border-radius:3px;overflow:hidden}
 .u-ec943564{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:28px;width:520px;max-width:92vw;box-shadow:0 24px 80px rgba(0,0,0,.7)}

--- a/frontend/static/workspace.js
+++ b/frontend/static/workspace.js
@@ -287,14 +287,14 @@ async function reloadData() {
       const uploaderCell = adminPath
         ? `<td class="mono">${_esc(it.uploaded_by || '-')}</td>`
         : '';
-      return `<tr data-action="open-detail" data-artifact-id="${_esc(it.artifact_id)}" style="cursor:pointer">
+      return `<tr class="cursor-pointer" data-action="open-detail" data-artifact-id="${_esc(it.artifact_id)}">
         <td>${_esc(it.origin_name || '')}
-            <span style="color:var(--muted);font-size:10px;display:block;font-family:var(--font-mono)">${_fmtBytes(it.origin_size)}</span>
+            <span class="c-muted fs-10 d-block font-mono">${_fmtBytes(it.origin_size)}</span>
         </td>
         ${uploaderCell}
         <td class="mono">${_fmtTs(it.uploaded_at)}</td>
         <td><span class="status-badge status-${status}">${status}</span></td>
-        <td class="mono" style="text-align:center">${it.entity_count || 0}</td>
+        <td class="mono text-center">${it.entity_count || 0}</td>
       </tr>`;
     }).join('');
   } catch (e) {
@@ -315,7 +315,7 @@ async function openDetail(artifactId) {
     document.getElementById('d-status').textContent   = it.status || '-';
     const ents = document.getElementById('d-entities');
     if (!it.entities || !it.entities.length) {
-      ents.innerHTML = `<span style="color:var(--muted);font-size:11px">${t('workspace.no_entities')}</span>`;
+      ents.innerHTML = `<span class="c-muted fs-11">${t('workspace.no_entities')}</span>`;
     } else {
       ents.innerHTML = it.entities.map(e =>
         `<span class="chip">${_esc(e)}</span>`).join('');
@@ -351,27 +351,27 @@ async function srcSearch() {
   const qel = document.getElementById('src-q');
   const q = (qel && qel.value) || '';
   if (!q.trim()) {
-    list.innerHTML = `<div style="padding:14px;font-size:12px;color:var(--muted)">${t('workspace.src_hint')}</div>`;
+    list.innerHTML = `<div class="u-6fd9cc46">${t('workspace.src_hint')}</div>`;
     return;
   }
-  list.innerHTML = `<div style="padding:14px;font-size:12px;color:var(--muted)">…</div>`;
+  list.innerHTML = `<div class="u-6fd9cc46">…</div>`;
   try {
     const root = _srcRoot();
     const data = await _apiFetch(
       `/admin/files/search?q=${encodeURIComponent(q.trim())}&root=${encodeURIComponent(root)}`);
     const rows = data.matches || [];
     if (!rows.length) {
-      list.innerHTML = `<div style="padding:14px;font-size:12px;color:var(--muted)">${t('workspace.src_no_match')}</div>`;
+      list.innerHTML = `<div class="u-6fd9cc46">${t('workspace.src_no_match')}</div>`;
       return;
     }
     list.innerHTML = rows.map(r =>
-      `<div data-action="src-open" data-path="${_esc(r.path)}" style="padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer">
-         <div style="font-size:12px;color:var(--text);word-break:break-all">${_esc(r.name)}</div>
-         <div style="font-size:10px;color:var(--muted)">${_esc(r.path)} · ${_fmtBytes(r.size)}</div>
+      `<div class="u-ad422ade" data-action="src-open" data-path="${_esc(r.path)}">
+         <div class="fs-12 c-text wb-all">${_esc(r.name)}</div>
+         <div class="fs-10 c-muted">${_esc(r.path)} · ${_fmtBytes(r.size)}</div>
        </div>`).join('')
-      + (data.truncated ? `<div style="padding:8px;font-size:10px;color:var(--muted)">${t('workspace.src_truncated')}</div>` : '');
+      + (data.truncated ? `<div class="u-0b0be5ab">${t('workspace.src_truncated')}</div>` : '');
   } catch (e) {
-    list.innerHTML = `<div style="padding:14px;font-size:12px;color:#e66">${_esc(e.message)}</div>`;
+    list.innerHTML = `<div class="u-42ac55af">${_esc(e.message)}</div>`;
   }
 }
 async function srcOpen(path) {
@@ -381,35 +381,35 @@ async function srcOpen(path) {
   const editable = (root === 'wiki' && /\.md$/i.test(path));
   const dlUrl = `${API}/admin/files/download?root=${encodeURIComponent(root)}&path=${encodeURIComponent(path)}&api_key=${encodeURIComponent(_apiKey || '')}`;
   const head =
-    `<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
-       <div style="font-weight:600;font-size:13px;flex:1;min-width:0;word-break:break-all">${_esc(path)}</div>
+    `<div class="d-flex gap-8 items-center mb-8 flex-wrap">
+       <div class="u-79f6fd5b">${_esc(path)}</div>
        ${editable ? `<button class="modal-btn primary" data-action="src-edit" data-path="${_esc(path)}">${t('workspace.src_edit')}</button>` : ''}
        <a class="modal-btn" href="${dlUrl}" target="_blank" rel="noopener">${t('workspace.src_download')}</a>
      </div>`;
-  view.innerHTML = `<div style="padding:14px;font-size:12px;color:var(--muted)">…</div>`;
+  view.innerHTML = `<div class="u-6fd9cc46">…</div>`;
   try {
     const data = await _apiFetch(
       `/admin/files/view?root=${encodeURIComponent(root)}&path=${encodeURIComponent(path)}`);
     // Extracted (PDF/Office) content is read-only text pulled from the
     // binary; flag it so the user knows it's not the raw file.
     const note = data.extracted
-      ? `<div style="font-size:11px;color:#8cf;margin-bottom:6px">📄 ${t('workspace.src_extracted')}</div>`
+      ? `<div class="u-de82cac5">📄 ${t('workspace.src_extracted')}</div>`
       : '';
     // Uploaded originals aren't editable here — editing is for 위키 .md
     // entities. Point the user there so they can reach the edit step.
     const editHint = (!editable && root !== 'wiki')
-      ? `<div style="font-size:11px;color:var(--muted);margin-top:8px">${t('workspace.src_edit_hint')}</div>`
+      ? `<div class="fs-11 c-muted mt-8">${t('workspace.src_edit_hint')}</div>`
       : '';
     view.innerHTML = head + note +
-      `<pre style="white-space:pre-wrap;word-break:break-word;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:12px;font-size:12px;max-height:60vh;overflow:auto">${_esc(data.content)}</pre>`
+      `<pre class="u-9b09d1c6">${_esc(data.content)}</pre>`
       + editHint;
   } catch (e) {
     // 415 (binary, no text) / 413 (too big) → view unavailable, download works.
     const editHint = (root !== 'wiki')
-      ? `<div style="font-size:11px;color:var(--muted);margin-top:8px">${t('workspace.src_edit_hint')}</div>`
+      ? `<div class="fs-11 c-muted mt-8">${t('workspace.src_edit_hint')}</div>`
       : '';
     view.innerHTML = head +
-      `<div style="padding:14px;font-size:12px;color:var(--muted)">${_esc(e.message)}<br>${t('workspace.src_download_only')}</div>`
+      `<div class="u-6fd9cc46">${_esc(e.message)}<br>${t('workspace.src_download_only')}</div>`
       + editHint;
   }
 }
@@ -522,15 +522,15 @@ async function reloadJobs() {
       const ownerCell = adminPath
         ? `<td class="mono">${_esc(j.owner || '-')}</td>` : '';
       const resultCell = j.output_path
-        ? `<span class="mono" style="font-size:10px;color:var(--muted)">${_esc(j.output_path.split('/').pop())}</span>`
-        : '<span style="color:var(--muted)">—</span>';
+        ? `<span class="mono fs-10 c-muted">${_esc(j.output_path.split('/').pop())}</span>`
+        : '<span class="c-muted">—</span>';
       const dlBtn = (j.status === 'done' && j.output_path)
-        ? `<button data-action="download-job" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
-                   style="padding:4px 10px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer;font-size:11px">다운로드</button>`
+        ? `<button class="u-14449c57" data-action="download-job" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
+                  >다운로드</button>`
         : (j.status === 'failed'
-            ? `<button data-action="show-job-error" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
-                       style="padding:4px 10px;background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;cursor:pointer;font-size:11px">에러 보기</button>`
-            : '<span style="color:var(--muted)">—</span>');
+            ? `<button class="u-b7092eba" data-action="show-job-error" data-job-id="${_esc(j.job_id)}" data-admin="${adminPath ? 'true' : 'false'}"
+                      >에러 보기</button>`
+            : '<span class="c-muted">—</span>');
       return `<tr>
         <td class="mono">${_esc(j.job_type)}</td>
         <td class="mono">${_fmtTs(j.created_at)}</td>
@@ -638,10 +638,10 @@ async function reloadCrs() {
     body.innerHTML = items.map(cr => {
       const statusBadge =
         `<span class="status-badge status-${cr.status}">${cr.status}</span>`;
-      return `<tr style="cursor:pointer" data-action="cr-open" data-cr-id="${_esc(cr.cr_id)}">
+      return `<tr class="cursor-pointer" data-action="cr-open" data-cr-id="${_esc(cr.cr_id)}">
         <td>${statusBadge}</td>
-        <td class="mono" style="font-size:11px">${_esc(cr.target_type)}<br>
-            <span style="color:var(--muted);font-size:10px">${_esc(cr.target_id)}</span></td>
+        <td class="mono fs-11">${_esc(cr.target_type)}<br>
+            <span class="c-muted fs-10">${_esc(cr.target_id)}</span></td>
         <td>${_esc(cr.title)}</td>
         <td class="mono">${_esc(cr.proposer)}</td>
         <td class="mono">${_fmtTs(cr.created_at)}</td>
@@ -710,17 +710,15 @@ function _renderCrDetail(cr, reviews) {
   const reviewsEl = document.getElementById('cr-detail-reviews');
   if (!reviews.length) {
     reviewsEl.innerHTML =
-      `<div class="empty" style="font-size:11px">${t('workspace.cr_no_reviews')}</div>`;
+      `<div class="empty fs-11">${t('workspace.cr_no_reviews')}</div>`;
   } else {
     reviewsEl.innerHTML = reviews.map(rv => `
-      <div style="background:var(--bg);border:1px solid var(--border-2);
-                  border-radius:6px;padding:8px 10px">
-        <div style="font-size:11px;color:var(--muted);font-family:var(--font-mono);
-                    display:flex;justify-content:space-between">
+      <div class="u-91d91dbb">
+        <div class="fs-11 c-muted font-mono d-flex justify-between">
           <span>${_esc(rv.reviewer)} · ${_esc(rv.decision)}</span>
           <span>${_fmtTs(rv.created_at)}</span>
         </div>
-        <div style="font-size:12px;margin-top:3px">${_esc(rv.body) || ''}</div>
+        <div class="u-0aece2c5">${_esc(rv.body) || ''}</div>
       </div>
     `).join('');
   }
@@ -1036,14 +1034,14 @@ async function reloadTemplates() {
       return;
     }
     body.innerHTML = items.map(it => `
-      <tr style="cursor:pointer" data-action="tpl-open"
+      <tr class="cursor-pointer" data-action="tpl-open"
           data-tpl-id="${_esc(it.id)}" data-tpl-name="${_esc(it.name)}">
         <td>${_esc(it.name)}</td>
-        <td class="mono" style="font-size:11px">${_esc(it.mode || 'text')}</td>
+        <td class="mono fs-11">${_esc(it.mode || 'text')}</td>
         <td class="mono">${_fmtTs(_tsToSec(it.created_at))}</td>
         <td>
-          <button data-action="tpl-delete" data-tpl-id="${_esc(it.id)}"
-                  style="padding:4px 10px;background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;cursor:pointer;font-size:11px"
+          <button class="u-b7092eba" data-action="tpl-delete" data-tpl-id="${_esc(it.id)}"
+                 
                   >${t('common.delete')}</button>
         </td>
       </tr>`).join('');
@@ -1201,33 +1199,31 @@ async function openTemplate(tplId, tplName) {
   document.getElementById('tpl-result').style.display = 'none';
   document.getElementById('tpl-apply-content').value = '';
   const ph = document.getElementById('tpl-apply-placeholders');
-  ph.innerHTML = `<span style="color:var(--muted);font-size:11px">${t('common.loading')}</span>`;
+  ph.innerHTML = `<span class="c-muted fs-11">${t('common.loading')}</span>`;
   try {
     const data = await _apiFetch(`/templates/${encodeURIComponent(tplId)}`);
     const placeholders = (data.spec && data.spec.placeholders) || [];
     ph.innerHTML = placeholders.length
       ? placeholders.map(p => `<span class="chip">${_esc(p)}</span>`).join('')
-      : `<span style="color:var(--muted);font-size:11px">${t('workspace.tpl_no_placeholders')}</span>`;
+      : `<span class="c-muted fs-11">${t('workspace.tpl_no_placeholders')}</span>`;
     _renderTplOutputs(data.outputs || []);
   } catch (e) {
-    ph.innerHTML = `<span style="color:var(--muted);font-size:11px">${_esc(e.message)}</span>`;
+    ph.innerHTML = `<span class="c-muted fs-11">${_esc(e.message)}</span>`;
   }
 }
 
 function _renderTplOutputs(outputs) {
   const el = document.getElementById('tpl-apply-outputs');
   if (!outputs.length) {
-    el.innerHTML = `<span style="color:var(--muted);font-size:11px">${t('workspace.tpl_no_outputs')}</span>`;
+    el.innerHTML = `<span class="c-muted fs-11">${t('workspace.tpl_no_outputs')}</span>`;
     return;
   }
   el.innerHTML = outputs.map(o => `
-    <div style="display:flex;justify-content:space-between;align-items:center;
-                background:var(--bg);border:1px solid var(--border-2);
-                border-radius:6px;padding:6px 10px">
-      <span class="mono" style="font-size:11px">${_esc(o.filename)}
-        <span style="color:var(--muted)">· ${_fmtBytes(o.size)}</span></span>
-      <button data-action="tpl-download-out" data-out-id="${_esc(o.out_id)}"
-              style="padding:4px 10px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer;font-size:11px"
+    <div class="u-a2f72b9b">
+      <span class="mono fs-11">${_esc(o.filename)}
+        <span class="c-muted">· ${_fmtBytes(o.size)}</span></span>
+      <button class="u-14449c57" data-action="tpl-download-out" data-out-id="${_esc(o.out_id)}"
+             
               >${t('workspace.tpl_download')}</button>
     </div>`).join('');
 }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/tokens.css?v=v26-20260908-csp-batch">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->
@@ -708,9 +708,9 @@
 <div class="toast" id="toast" role="status" aria-live="polite"
      aria-atomic="true"></div>
 
-<script src="/static/i18n.js"></script>
+<script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
-<script src="/static/workspace.js"></script>
+<script src="/static/workspace.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.6.1 — workspace badge in header. -->
 <script src="/static/workspace-badge.js"></script>

--- a/scripts/migrate_inline_styles.py
+++ b/scripts/migrate_inline_styles.py
@@ -225,6 +225,23 @@ assert len(ATOM_DECL) == len(ATOMS), "duplicate atom class name detected"
 # hand-converted or explicitly deferred.
 JS_FILES = [
     FRONTEND / "static" / "chat.js",
+    # 2026-09-08 batch — the mid-size files. admin.js (235 sites)
+    # is deliberately left for its own pass: it is bigger than all
+    # of these together and deserves a diff a reviewer can read.
+    FRONTEND / "static" / "workspace.js",
+    FRONTEND / "static" / "time-travel-diff.js",
+    FRONTEND / "static" / "graph_editor.js",
+    FRONTEND / "static" / "agent-chat.js",
+    FRONTEND / "static" / "time-travel-trace.js",
+    FRONTEND / "static" / "change-requests.js",
+    FRONTEND / "static" / "time-travel-renderer.js",
+    FRONTEND / "static" / "upload.js",
+    FRONTEND / "static" / "templating-chat.js",
+    FRONTEND / "static" / "i18n.js",
+    FRONTEND / "static" / "graph.js",
+    FRONTEND / "static" / "reasoning-flow.js",
+    FRONTEND / "static" / "a11y-modal.js",
+    FRONTEND / "static" / "glossary.js",
 ]
 
 


### PR DESCRIPTION
## Summary

Runs the tool #1097 extended over the mid-size JS files. **`admin.js` is deliberately excluded** — at 235 sites it is larger than all of these together and deserves a diff a reviewer can actually read.

| file | migrated | deferred (dynamic) |
|---|---:|---:|
| `workspace.js` | **43** | 0 |
| `graph_editor.js` | 18 | 4 |
| `agent-chat.js` | 18 | 4 |
| `time-travel-diff.js` | 14 | 18 |
| `time-travel-trace.js` | 9 | 7 |
| `change-requests.js` | 7 | 10 |
| `time-travel-renderer.js` | 3 | 7 |
| `graph.js` / `templating-chat.js` / `i18n.js` | 1 each | 3 |
| **total** | **115** | **64** |

The 64 deferred are `${...}` values — counted rather than converted, so the remaining work stays visible.

31 atoms + 36 verbatim classes. The block stayed **additive** (the #1097 fix): **319 → 354 rules, 0 lost**.

## Verification

Same method as the earlier slices, and through the **markup path on both sides** so attribute selectors see what they would really see: each converted value rendered as its class against the original inline declaration, compared across *every* computed property.

> **72 unique pairs — 72 identical, 0 mismatches.**

- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**
- `ruff --select F` → clean
- cache busters bumped for all 11 touched assets across the 5 pages

## Phase 3.3 progress

| | sites |
|---|---:|
| start of phase | 479 |
| #1095 `upload.js` | −11 |
| #1097 `chat.js` | −42 |
| this PR | **−115** |
| **remaining** | **311** |

Of the 311: `admin.js` **235**, plus **66 dynamic** spread across eight files, plus 10 in `chat.js`.

## Out of scope

- **`admin.js`** — next, on its own.
- **The dynamic sites.** Each needs class-for-static plus CSSOM-for-dynamic by hand; the tool counts them but will not guess.
- **The enforce flip.** Last, once the count reaches zero.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
