### PR TITLE
feat(v0.6.2): convert the last two tool-invisible style attributes in admin.js

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1323,7 +1323,7 @@
 <script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
-<script src="/static/admin.js?v=v27-20260908-csp-admin"></script>
+<script src="/static/admin.js?v=v28-20260908-csp-fragments"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.6.1 — workspace badge in header. -->
 <script src="/static/workspace-badge.js"></script>

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -1688,7 +1688,7 @@ async function loadLongTerm() {
       // present in the API response (memory/store.py:492).
       const sid = s.session_id || '';
       const attrs = sid
-        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml((s.topic || '').slice(0, 40))}" style="cursor:pointer"`
+        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml((s.topic || '').slice(0, 40))}" class="cursor-pointer"`
         : '';
       const hint   = sid ? '' : ' <em class="c-muted fs-10">(no session_id)</em>';
       return `
@@ -1716,12 +1716,12 @@ async function loadSessions() {
       // (액션 버튼은 그대로 두고 행 일부만 클릭 가능하게 — 실수로
       // summarize&delete 버튼 누르는 사고 방지)
       const expandable = sid
-        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml(sid.slice(0,20))}" style="cursor:pointer"`
+        ? `data-action="open-session-turns" data-sid="${escapeHtml(sid)}" data-title="${escapeHtml(sid.slice(0,20))}"`
         : '';
       return `
         <tr>
-          <td class="mono fs-10" ${expandable}>${escapeHtml(sid.slice(0,20)) || '-'}</td>
-          <td class="mono" ${expandable}>${s.turn_count ?? 0} turns</td>
+          <td class="mono fs-10${sid ? ' cursor-pointer' : ''}" ${expandable}>${escapeHtml(sid.slice(0,20)) || '-'}</td>
+          <td class="mono${sid ? ' cursor-pointer' : ''}" ${expandable}>${s.turn_count ?? 0} turns</td>
           <td class="mono">${s.started?.slice(0,16) || '-'}</td>
           <td class="mono">${s.last?.slice(0,16) || '-'}</td>
           <td>


### PR DESCRIPTION
## Summary

These are attribute **fragments**, not tags: a template string builds `data-action=… style="cursor:pointer"` and it gets interpolated into a tag defined elsewhere. `_TAG_RE` only matches complete opening tags, so the tool never saw them — they were the only remaining *static* sites in the whole JS surface.

The two need different treatment, which is exactly why the tool is right not to guess:

| site | lands in | conversion |
|---|---|---|
| `admin.js:1691` | `<tr ${attrs}>` — no class of its own | attribute simply becomes `class="cursor-pointer"` |
| `admin.js:1719` | `<td class="mono fs-10" ${expandable}>` — **already has a class** | class moves onto the host cells, gated on the same `sid` that gates the fragment |

A naive swap on the second would have produced a duplicate `class=` attribute. The parser keeps the first and ignores the second, so the cursor would have silently vanished — no error, no visual diff at desktop width.

## Verification

- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**
- `admin.js` cache buster bumped

## Phase 3.3 status

**This closes everything the migration tool can reach.**

| | sites |
|---|---:|
| start of phase | 479 |
| migrated across #1095 / #1097 / #1098 / #1099 / this | **−381** |
| **remaining** | **98** |

All 98 are hand work:

- **35 dynamic** — `${…}` interpolation. Some are fixed variant sets (3-value chips → modifier classes); others are genuinely computed (`width:${pct}%` → class + CSSOM).
- **62 concatenated** — the attribute is split across a JS string join, so the value only exists at runtime.
- 1 is inside a comment.

## Out of scope

- Those 98. They are a different kind of work from what the tool does, and worth their own pass.
- **The enforce flip.** Last, once the count reaches zero.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
