### PR TITLE
feat(v0.6.2): resolve literal string concatenation — 38 more sites, 89 → 51

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v27-20260908-csp-admin">
+<link rel="stylesheet" href="/static/tokens.css?v=v30-20260908-csp-concat">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v27-20260908-csp-admin">
+<link rel="stylesheet" href="/static/tokens.css?v=v30-20260908-csp-concat">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">
@@ -519,7 +519,7 @@
 <script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/graph.js?v=v26-20260908-csp-batch"></script>
-<script src="/static/graph_editor.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/graph_editor.js?v=v30-20260908-csp-concat"></script>
 <script src="/static/graph_node_editor.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 Track F.1 TT.a — Time-Travel picker UI shell (event-dispatch
@@ -532,19 +532,19 @@
      /graph stage. Edge colour-decoration is gated on a join key
      (link.edge_id) that arrives with later T5 mutation-site wiring —
      until then the overlay is summary-only. -->
-<script src="/static/time-travel-renderer.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/time-travel-renderer.js?v=v30-20260908-csp-concat"></script>
 <!-- v0.5 Track F.1 TT.c — Reasoning trail replay. Renders one
      trace_id's stages in the same 3-phase format chat.js uses
      (RETRIEVE → EXPAND → VERIFY), filtered to the active time-travel
      cutoff. Loads after the picker (TT.a) + corpus renderer (TT.b)
      so the cutoff event has already wired the panel state. -->
-<script src="/static/time-travel-trace.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/time-travel-trace.js?v=v30-20260908-csp-concat"></script>
 <!-- v0.5 Track F.1 TT.d — Now-vs-T diff view. Renders a side-by-side
      modal comparing the audit-replay snapshot at the picker's T
      against the live audit-replay snapshot at "now". Loads last so
      it can hook the picker button + the `james:timetravel:*`
      events the prior shells dispatch. -->
-<script src="/static/time-travel-diff.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/time-travel-diff.js?v=v30-20260908-csp-concat"></script>
 <!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script.
      Scans the page for elements with `data-glossary="<term>"` and
      attaches hover/focus tooltips with plain-Korean definitions. -->
@@ -554,7 +554,7 @@
 <script src="/static/workspace-badge.js"></script>
 <!-- v0.6.1 graph-hub: 추론 흐름 + 롤백 tab drivers (wire on load; fetch on
      demand) + tab switcher (hash sync + 3D resize on return to graph). -->
-<script src="/static/reasoning-flow.js"></script>
+<script src="/static/reasoning-flow.js?v=v30-20260908-csp-concat"></script>
 <script src="/static/knowledge-rollback.js"></script>
 <script src="/static/graph-tabs.js"></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v27-20260908-csp-admin">
+<link rel="stylesheet" href="/static/tokens.css?v=v30-20260908-csp-concat">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
@@ -640,7 +640,7 @@
 <script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
-<script src="/static/chat.js?v=v29-20260908-csp-chat-dyn"></script>
+<script src="/static/chat.js?v=v30-20260908-csp-concat"></script>
 <script src="/static/upload.js?v=v24-20260908-csp-upload"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 UI #4 — inline <script> block extracted to /static/index-init.js
@@ -652,7 +652,7 @@
 <!-- v0.6 template-formatting engine — chat-side apply panel. Self-
      contained (own auth read + own click delegation); does NOT touch
      chat.js's send pipeline. -->
-<script src="/static/templating-chat.js?v=v26-20260908-csp-batch"></script>
+<script src="/static/templating-chat.js?v=v30-20260908-csp-concat"></script>
 <!-- v0.6.1 — workspace badge in header. Self-contained boot fetch. -->
 <script src="/static/workspace-badge.js"></script>
 

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v27-20260908-csp-admin">
+<link rel="stylesheet" href="/static/tokens.css?v=v30-20260908-csp-concat">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">

--- a/frontend/static/chat.js
+++ b/frontend/static/chat.js
@@ -351,8 +351,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const listEl = document.getElementById('session-list');
       if (listEl) {
         listEl.innerHTML =
-          '<div style="color:var(--muted,#888);font-size:12px;'
-          + 'text-align:center;padding:20px">'
+          '<div class="fs-12 text-center p-20 u-6695ffc3">'
           + (t('chat.session_login_hint')
              || '로그인 후 이전 대화가 표시됩니다')
           + '</div>';

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -172,16 +172,14 @@
         '</button>' +
       '</div>';
     return '' +
-      '<div data-src-idx="' + idx + '" style="display:flex;align-items:flex-start;' +
-         'gap:8px;padding:6px 0;border-bottom:1px solid var(--border)">' +
+      '<div class="d-flex items-start gap-8 u-0765bc70" data-src-idx="' + idx + '">' +
         '<div class="u-89bd09bd">' +
           '<div class="d-flex gap-6 items-center font-mono fs-11">' +
             roleBadge(s.role || '?') +
             '<span class="c-text-soft">w=' + w + '</span>' +
             (ts ? '<span class="c-muted fs-10">' + ts + '</span>' : '') +
           '</div>' +
-          '<div style="margin-top:2px;color:var(--text-soft);font-family:var(--font-mono);' +
-                'font-size:10px;word-break:break-all">' + doc + '</div>' +
+          '<div class="c-text-soft font-mono fs-10 wb-all u-f005b881">' + doc + '</div>' +
           meta +
         '</div>' +
         actions +
@@ -198,8 +196,7 @@
       '<div data-src-idx="' + idx + '" data-edit="1" ' +
            'style="padding:6px 0;border-bottom:1px solid var(--border);' +
                   'background:rgba(99,102,241,.05)">' +
-        '<div style="display:flex;gap:6px;align-items:center;font-family:var(--font-mono);' +
-              'font-size:11px;margin-bottom:6px">' +
+        '<div class="d-flex gap-6 items-center font-mono fs-11 mb-6">' +
           roleBadge(s.role || '?') +
           '<span class="c-muted fs-10">editing #' + idx + '</span>' +
         '</div>' +

--- a/frontend/static/reasoning-flow.js
+++ b/frontend/static/reasoning-flow.js
@@ -245,8 +245,7 @@
       summary.innerHTML =
         '<dl>' +
         '<dt>' + escapeHtml(t('flow.summary.trace_id', 'Trace ID')) +
-        '</dt><dd style="font-family:var(--font-mono);font-size:11px;' +
-        'word-break:break-all">' + escapeHtml(body.trace_id || '?') +
+        '</dt><dd class="font-mono fs-11 wb-all">' + escapeHtml(body.trace_id || '?') +
         '</dd>' +
         '<dt>' + escapeHtml(t('flow.summary.day', '날짜')) +
         '</dt><dd>' + escapeHtml(body.day || '?') + '</dd>' +

--- a/frontend/static/templating-chat.js
+++ b/frontend/static/templating-chat.js
@@ -146,8 +146,7 @@
       var phs = (data.spec && data.spec.placeholders) || [];
       ph.innerHTML = phs.length
         ? phs.map(function (p) {
-            return '<span class="chip" style="font-size:11px;padding:2px 8px;' +
-              'border:1px solid var(--border);border-radius:10px;color:var(--muted)">' +
+            return '<span class="chip fs-11 bd-1 c-muted u-519c6b2e">' +
               _esc(p) + '</span>';
           }).join('')
         : '<span class="c-muted fs-11">' +

--- a/frontend/static/time-travel-diff.js
+++ b/frontend/static/time-travel-diff.js
@@ -116,8 +116,7 @@
   function renderLoading() {
     showModal();
     setBody(
-      '<div id="' + MODAL_ID + '-title" style="font-weight:700;' +
-      'color:var(--accent-fg);letter-spacing:.4px;margin-bottom:8px">' +
+      '<div class="fw-700 c-accent-fg mb-8 u-bedf52b8" id="' + MODAL_ID + '-title">' +
       escapeHtml(t('graph.timetravel.diff.title',
                    'State diff: T → NOW')) +
       '</div>' +
@@ -132,8 +131,7 @@
     showModal();
     var safeDetail = detail ? ' — ' + escapeHtml(detail) : '';
     setBody(
-      '<div id="' + MODAL_ID + '-title" style="font-weight:700;' +
-      'color:var(--accent-fg);letter-spacing:.4px;margin-bottom:8px">' +
+      '<div class="fw-700 c-accent-fg mb-8 u-bedf52b8" id="' + MODAL_ID + '-title">' +
       escapeHtml(t('graph.timetravel.diff.title',
                    'State diff: T → NOW')) +
       '</div>' +
@@ -177,19 +175,16 @@
     var rows = '';
     for (var i = 0; i < ids.length; i++) {
       var id = ids[i];
-      rows += '<li style="display:flex;align-items:center;' +
-              'padding:3px 0;border-bottom:1px dashed rgba(255,255,255,.05)">' +
+      rows += '<li class="d-flex items-center u-5c9e3ed5">' +
               '<span class="flex-1 wb-all">' +
               escapeHtml(id) + '</span>' +
               (opts.evidence === false ? '' : evidenceLinkHtml(id)) +
               '</li>';
     }
     return '<div class="mt-10">' +
-           '<div style="font-weight:600;color:var(--accent-fg);' +
-           'font-size:10px;letter-spacing:1px;margin-bottom:4px">' +
+           '<div class="fw-600 c-accent-fg fs-10 ls-1 mb-4">' +
            escapeHtml(label) +
-           ' <span style="color:var(--muted);font-weight:400;' +
-           'letter-spacing:0">(' + ids.length + ')</span></div>' +
+           ' <span class="c-muted fw-400 ls-0">(' + ids.length + ')</span></div>' +
            '<ul class="u-82ef8585">' +
            rows + '</ul></div>';
   }
@@ -206,11 +201,9 @@
       var c = chainsObj[head];
       var at_t = (c.at_t || []).join(' → ') || '∅';
       var at_now = (c.at_now || []).join(' → ') || '∅';
-      rows += '<li style="padding:4px 0;border-bottom:1px dashed ' +
-              'rgba(255,255,255,.05)">' +
+      rows += '<li class="u-c2bfc000">' +
               '<div class="d-flex items-center">' +
-              '<span style="flex:1;font-weight:600;color:var(--text);' +
-              'word-break:break-all">' + escapeHtml(head) + '</span>' +
+              '<span class="flex-1 fw-600 c-text wb-all">' + escapeHtml(head) + '</span>' +
               evidenceLinkHtml(head) + '</div>' +
               '<div class="u-1a5d6bb4">' +
               'T: ' + escapeHtml(at_t) + '</div>' +
@@ -218,24 +211,19 @@
               'NOW: ' + escapeHtml(at_now) + '</div></li>';
     }
     return '<div class="mt-10">' +
-           '<div style="font-weight:600;color:var(--accent-fg);' +
-           'font-size:10px;letter-spacing:1px;margin-bottom:4px">' +
+           '<div class="fw-600 c-accent-fg fs-10 ls-1 mb-4">' +
            escapeHtml(label) +
-           ' <span style="color:var(--muted);font-weight:400;' +
-           'letter-spacing:0">(' + keys.length + ')</span></div>' +
+           ' <span class="c-muted fw-400 ls-0">(' + keys.length + ')</span></div>' +
            '<ul class="u-82ef8585">' +
            rows + '</ul></div>';
   }
 
   function summaryRow(leftLabel, leftVal, rightVal) {
-    return '<div style="display:flex;gap:12px;padding:4px 0;' +
-           'border-bottom:1px dashed rgba(255,255,255,.05)">' +
+    return '<div class="d-flex u-1507212a">' +
            '<span class="flex-1 c-muted">' +
            escapeHtml(leftLabel) + '</span>' +
-           '<span style="flex:0 0 80px;text-align:right;color:var(--text);' +
-           'font-weight:600">' + escapeHtml(String(leftVal)) + '</span>' +
-           '<span style="flex:0 0 80px;text-align:right;color:var(--text);' +
-           'font-weight:600">' + escapeHtml(String(rightVal)) + '</span>' +
+           '<span class="c-text fw-600 u-56876cf6">' + escapeHtml(String(leftVal)) + '</span>' +
+           '<span class="c-text fw-600 u-56876cf6">' + escapeHtml(String(rightVal)) + '</span>' +
            '</div>';
   }
 
@@ -259,8 +247,7 @@
                        'No changes between T and NOW.');
 
     var header =
-      '<div id="' + MODAL_ID + '-title" style="font-weight:700;' +
-      'color:var(--accent-fg);letter-spacing:.4px;margin-bottom:4px">' +
+      '<div class="fw-700 c-accent-fg mb-4 u-bedf52b8" id="' + MODAL_ID + '-title">' +
       escapeHtml(title) + '</div>' +
       '<div class="c-muted fs-10 mb-10">' +
       'T: ' + escapeHtml(body.t) + ' • NOW: ' + escapeHtml(body.now) +
@@ -268,14 +255,11 @@
 
     // Header row of the summary table (T | NOW).
     var summary =
-      '<div style="display:flex;gap:12px;padding:4px 0;' +
-      'border-bottom:1px solid var(--border)">' +
+      '<div class="d-flex u-9d1b88d9">' +
       '<span class="flex-1"></span>' +
-      '<span style="flex:0 0 80px;text-align:right;font-weight:600;' +
-      'color:var(--accent-fg);font-size:10px;letter-spacing:1px">' +
+      '<span class="fw-600 c-accent-fg fs-10 ls-1 u-56876cf6">' +
       escapeHtml(thenLabel) + '</span>' +
-      '<span style="flex:0 0 80px;text-align:right;font-weight:600;' +
-      'color:var(--accent-fg);font-size:10px;letter-spacing:1px">' +
+      '<span class="fw-600 c-accent-fg fs-10 ls-1 u-56876cf6">' +
       escapeHtml(nowLabel) + '</span></div>' +
       summaryRow(eventsT, body.event_count_at_t, body.event_count_at_now);
 
@@ -303,14 +287,12 @@
       listSection(packsRemovedLabel, packsRemoved, { evidence: false });
 
     if (!anyDiff) {
-      sections = '<div style="margin-top:14px;color:var(--muted);' +
-                 'font-style:italic">' + escapeHtml(emptyLabel) +
+      sections = '<div class="c-muted u-3c4d5870">' + escapeHtml(emptyLabel) +
                  '</div>';
     }
 
     if (body.truncated) {
-      sections += '<div style="margin-top:8px;color:var(--muted);' +
-                  'font-size:10px">(' +
+      sections += '<div class="mt-8 c-muted fs-10">(' +
                   escapeHtml('capped at limit — partial view') + ')</div>';
     }
 

--- a/frontend/static/time-travel-renderer.js
+++ b/frontend/static/time-travel-renderer.js
@@ -80,8 +80,7 @@
     if (!panel) return;
     panel.style.display = 'block';
     panel.innerHTML =
-      '<div style="font-weight:600;color:var(--accent-fg);' +
-      'margin-bottom:6px;letter-spacing:.4px">' +
+      '<div class="fw-600 c-accent-fg mb-6 u-bedf52b8">' +
       escapeHtml(t('graph.timetravel.replay.title', 'Replay state')) +
       '</div>' +
       '<div class="c-muted">' +
@@ -95,8 +94,7 @@
     panel.style.display = 'block';
     var safeDetail = detail ? ' — ' + escapeHtml(detail) : '';
     panel.innerHTML =
-      '<div style="font-weight:600;color:var(--accent-fg);' +
-      'margin-bottom:6px;letter-spacing:.4px">' +
+      '<div class="fw-600 c-accent-fg mb-6 u-bedf52b8">' +
       escapeHtml(t('graph.timetravel.replay.title', 'Replay state')) +
       '</div>' +
       '<div class="u-6812cd91">' +
@@ -141,31 +139,26 @@
     rows += rowHtml(chainsLabel, chainCount);
     if (packs.length > 0) {
       rows += rowHtml(packsLabel, packs.length);
-      rows += '<div style="margin:4px 0 0 8px;color:var(--muted);' +
-              'font-size:10px;word-break:break-all">' +
+      rows += '<div class="c-muted fs-10 wb-all u-57ae8689">' +
               escapeHtml(packs.join(', ')) + '</div>';
     }
 
     var body = rows;
     if (snap.event_count === 0) {
-      body += '<div style="margin-top:8px;color:var(--muted);' +
-              'font-style:italic">' + escapeHtml(emptyLabel) + '</div>';
+      body += '<div class="mt-8 c-muted u-4ddbd91c">' + escapeHtml(emptyLabel) + '</div>';
     }
     if (snap.truncated) {
-      body += '<div style="margin-top:6px;color:var(--muted);' +
-              'font-size:10px">' + escapeHtml(truncatedLabel) + '</div>';
+      body += '<div class="mt-6 c-muted fs-10">' + escapeHtml(truncatedLabel) + '</div>';
     }
 
     panel.innerHTML =
-      '<div style="font-weight:600;color:var(--accent-fg);' +
-      'margin-bottom:6px;letter-spacing:.4px">' +
+      '<div class="fw-600 c-accent-fg mb-6 u-bedf52b8">' +
       escapeHtml(t('graph.timetravel.replay.title', 'Replay state')) +
       '</div>' + body;
   }
 
   function rowHtml(label, value) {
-    return '<div style="display:flex;justify-content:space-between;' +
-           'gap:8px">' +
+    return '<div class="d-flex justify-between gap-8">' +
            '<span>' + escapeHtml(label) + '</span>' +
            '<span class="c-text fw-600">' +
            escapeHtml(String(value)) + '</span></div>';

--- a/frontend/static/time-travel-trace.js
+++ b/frontend/static/time-travel-trace.js
@@ -124,8 +124,7 @@
   }
 
   function renderHeader(stateText) {
-    return '<div style="font-weight:600;color:var(--accent-fg);' +
-           'margin-bottom:6px;letter-spacing:.4px">' +
+    return '<div class="fw-600 c-accent-fg mb-6 u-bedf52b8">' +
            escapeHtml(t('graph.timetravel.trace.title',
                         'Reasoning trail')) +
            '</div>' +
@@ -196,8 +195,7 @@
     }
     var icon = entry.meta.icon || '·';
     var label = entry.meta.label || entry.stage || '';
-    return '<div style="display:flex;gap:6px;padding:3px 0;' +
-           'border-bottom:1px dashed rgba(255,255,255,.05)">' +
+    return '<div class="d-flex gap-6 u-5c9e3ed5">' +
            '<span class="u-fe407230">' + escapeHtml(icon) + '</span>' +
            '<span class="flex-1 c-text">' +
            escapeHtml(label) + '</span>' +
@@ -214,11 +212,9 @@
       rows += renderStageRow(entries[i]);
     }
     return '<div class="mt-8">' +
-           '<div style="font-weight:600;color:var(--accent-fg);' +
-           'font-size:10px;letter-spacing:1px;margin-bottom:3px">' +
+           '<div class="fw-600 c-accent-fg fs-10 ls-1 u-bf903b75">' +
            escapeHtml(label) +
-           ' <span style="color:var(--muted);font-weight:400;' +
-           'letter-spacing:0">(' + entries.length + ')</span></div>' +
+           ' <span class="c-muted fw-400 ls-0">(' + entries.length + ')</span></div>' +
            rows + '</div>';
   }
 
@@ -235,12 +231,10 @@
     var ofLabel = t('graph.timetravel.trace.of', ' of ');
 
     var header =
-      '<div style="font-weight:600;color:var(--accent-fg);' +
-      'margin-bottom:6px;letter-spacing:.4px">' +
+      '<div class="fw-600 c-accent-fg mb-6 u-bedf52b8">' +
       escapeHtml(t('graph.timetravel.trace.title', 'Reasoning trail')) +
       '</div>' +
-      '<div style="color:var(--muted);font-size:10px;' +
-      'margin-bottom:6px;word-break:break-all">' +
+      '<div class="c-muted fs-10 mb-6 wb-all">' +
       escapeHtml(traceId) + '</div>' +
       '<div class="u-85503ffb">' +
       escapeHtml(replayedLabel) +
@@ -297,8 +291,7 @@
                  '그래프에 %n개 노드 강조됨').replace('%n', String(lit));
     }
     panel.insertAdjacentHTML('afterbegin',
-      '<div style="font-size:10px;color:var(--accent-fg,#6cf);' +
-      'margin-bottom:4px">● ' + escapeHtml(hlNote) + '</div>');
+      '<div class="fs-10 mb-4 u-e8895f24">● ' + escapeHtml(hlNote) + '</div>');
 
     revealPanel(panel);
 

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -395,9 +395,54 @@ body::before {
  * (verbatim relocations of one-off inline styles). Enables
  * CSP style-src without 'unsafe-inline' for the HTML surface. */
 /* atoms */
+.bd-1{border:1px solid var(--border)}
+.c-accent-fg{color:var(--accent-fg)}
+.c-muted{color:var(--muted)}
+.c-text{color:var(--text)}
+.c-text-soft{color:var(--text-soft)}
+.d-flex{display:flex}
+.flex-1{flex:1}
+.font-mono{font-family:var(--font-mono)}
+.fs-10{font-size:10px}
+.fs-11{font-size:11px}
+.fs-12{font-size:12px}
+.fw-400{font-weight:400}
+.fw-600{font-weight:600}
+.fw-700{font-weight:700}
+.gap-6{gap:6px}
+.gap-8{gap:8px}
+.items-center{align-items:center}
+.items-start{align-items:flex-start}
+.justify-between{justify-content:space-between}
+.ls-0{letter-spacing:0}
+.ls-1{letter-spacing:1px}
+.mb-4{margin-bottom:4px}
+.mb-6{margin-bottom:6px}
+.mb-8{margin-bottom:8px}
+.mt-6{margin-top:6px}
+.mt-8{margin-top:8px}
+.p-20{padding:20px}
+.text-center{text-align:center}
+.wb-all{word-break:break-all}
+/* components (verbatim one-off styles) */
+.u-0765bc70{padding:6px 0;border-bottom:1px solid var(--border)}
+.u-1507212a{gap:12px;padding:4px 0;border-bottom:1px dashed rgba(255,255,255,.05)}
+.u-3c4d5870{margin-top:14px;font-style:italic}
+.u-4ddbd91c{font-style:italic}
+.u-519c6b2e{padding:2px 8px;border-radius:10px}
+.u-56876cf6{flex:0 0 80px;text-align:right}
+.u-57ae8689{margin:4px 0 0 8px}
+.u-5c9e3ed5{padding:3px 0;border-bottom:1px dashed rgba(255,255,255,.05)}
+.u-6695ffc3{color:var(--muted,#888)}
+.u-9d1b88d9{gap:12px;padding:4px 0;border-bottom:1px solid var(--border)}
+.u-bedf52b8{letter-spacing:.4px}
+.u-bf903b75{margin-bottom:3px}
+.u-c2bfc000{padding:4px 0;border-bottom:1px dashed rgba(255,255,255,.05)}
+.u-e8895f24{color:var(--accent-fg,#6cf)}
+.u-f005b881{margin-top:2px}
+/* carried forward from earlier runs */
 .accent-accent{accent-color:var(--accent)}
 .bd-0{border:0}
-.bd-1{border:1px solid var(--border)}
 .bd-none{border:none}
 .bg-accent{background:var(--accent)}
 .bg-bg{background:var(--bg)}
@@ -405,187 +450,74 @@ body::before {
 .bg-surface-2{background:var(--surface-2)}
 .bg-transparent{background:transparent}
 .br-6{border-radius:6px}
+.br-7{border-radius:7px}
 .br-8{border-radius:8px}
 .c-accent{color:var(--accent)}
-.c-accent-fg{color:var(--accent-fg)}
 .c-danger{color:var(--danger)}
-.c-muted{color:var(--muted)}
 .c-on-accent{color:var(--on-accent)}
-.c-text{color:var(--text)}
+.c-text-2{color:var(--text-2)}
 .cursor-pointer{cursor:pointer}
-.d-flex{display:flex}
+.d-block{display:block}
 .d-grid{display:grid}
 .d-inline-block{display:inline-block}
-.flex-1{flex:1}
+.d-none{display:none}
 .flex-col{flex-direction:column}
 .flex-wrap{flex-wrap:wrap}
-.font-mono{font-family:var(--font-mono)}
-.fs-10{font-size:10px}
-.fs-11{font-size:11px}
-.fs-12{font-size:12px}
+.font-ui{font-family:var(--font-ui)}
 .fs-13{font-size:13px}
+.fs-14{font-size:14px}
 .fs-15{font-size:15px}
-.fw-400{font-weight:400}
-.fw-600{font-weight:600}
-.fw-700{font-weight:700}
+.fs-16{font-size:16px}
+.fs-inherit{font-size:inherit}
 .gap-10{gap:10px}
 .gap-14{gap:14px}
 .gap-4{gap:4px}
-.gap-6{gap:6px}
-.gap-8{gap:8px}
-.items-center{align-items:center}
 .items-end{align-items:flex-end}
-.justify-between{justify-content:space-between}
+.justify-center{justify-content:center}
+.justify-end{justify-content:flex-end}
 .lh-15{line-height:1.5}
 .lh-16{line-height:1.6}
-.ls-1{letter-spacing:1px}
+.ls-05{letter-spacing:.5px}
 .m-0{margin:0}
 .mb-10{margin-bottom:10px}
+.mb-12{margin-bottom:12px}
 .mb-14{margin-bottom:14px}
-.mb-4{margin-bottom:4px}
-.mb-6{margin-bottom:6px}
-.mb-8{margin-bottom:8px}
+.mb-16{margin-bottom:16px}
+.mb-20{margin-bottom:20px}
 .minw-200{min-width:200px}
+.minw-220{min-width:220px}
 .minw-260{min-width:260px}
 .minw-280{min-width:280px}
+.ml-10{margin-left:10px}
+.ml-12{margin-left:12px}
 .ml-6{margin-left:6px}
 .ml-8{margin-left:8px}
+.ml-auto{margin-left:auto}
+.mr-3{margin-right:3px}
 .mr-4{margin-right:4px}
+.mt-10{margin-top:10px}
+.mt-12{margin-top:12px}
 .mt-16{margin-top:16px}
-.mt-6{margin-top:6px}
-.mt-8{margin-top:8px}
+.mt-20{margin-top:20px}
+.mt-4{margin-top:4px}
+.no-underline{text-decoration:none}
+.outline-none{outline:none}
 .ov-auto{overflow:auto}
 .ov-hidden{overflow:hidden}
 .ovy-auto{overflow-y:auto}
 .p-10{padding:10px}
 .p-10-14{padding:10px 14px}
-.p-16{padding:16px}
-.p-20{padding:20px}
-.p-3-10{padding:3px 10px}
-.p-6-10{padding:6px 10px}
-.p-8-10{padding:8px 10px}
-.p-8-20{padding:8px 20px}
-.text-center{text-align:center}
-.va-middle{vertical-align:middle}
-.w-full{width:100%}
-.wb-all{word-break:break-all}
-.wb-word{word-break:break-word}
-.ws-pre-wrap{white-space:pre-wrap}
-/* components (verbatim one-off styles) */
-.u-0765bc70{padding:6px 0;border-bottom:1px solid var(--border)}
-.u-07bf82f0{margin:2px 0;padding:3px 6px 3px 18px;border-left:1px dashed var(--border-2)}
-.u-0c8f2ccd{color:#f88}
-.u-0f6e6c09{margin-top:1px}
-.u-0ff31430{padding:4px 10px;background:#7a1e1e;color:#fff;border-radius:4px}
-.u-12da9e4d{width:14px;height:14px}
-.u-1b1ea0a5{text-transform:uppercase;letter-spacing:.3px}
-.u-1d1dc4d1{margin-top:3px}
-.u-200a92a0{text-align:left}
-.u-20957c52{font-size:18px;margin-top:2px}
-.u-28f00506{border-radius:4px;height:6px}
-.u-2cbabd6c{font-size:28px}
-.u-2dab903f{padding:3px 0}
-.u-2ea04eea{color:#4caf7d}
-.u-31664877{text-transform:uppercase;letter-spacing:.4px}
-.u-35a11d6a{padding:30px}
-.u-3b76ebd1{min-width:60px}
-.u-3d4b0f59{background:none;padding:0}
-.u-3d558703{padding:7px 14px;flex-shrink:0}
-.u-3f9f96c6{min-width:0}
-.u-416c260c{padding:10px 0}
-.u-43ff79ff{line-height:1.7}
-.u-492a71fc{opacity:.6}
-.u-4960344c{padding-left:12px;border-left:1px dashed var(--border-2)}
-.u-4c23b32f{border-radius:4px;padding:2px 8px}
-.u-4d0151d9{padding:14px 16px;color:var(--fg-1);background:var(--bg-2)}
-.u-4ddbe905{white-space:nowrap}
-.u-4df3ea2d{width:16px;height:16px;accent-color:#1e7a3e}
-.u-50cd3bbf{padding:4px 10px;background:#1e7a3e;color:#fff;border-radius:4px}
-.u-511ac2fa{margin:2px 0}
-.u-5a561387{padding:3px 6px;border-radius:4px}
-.u-5cd105e1{flex-shrink:0}
-.u-6069bb57{padding:14px}
-.u-646de506{background:none;font-size:18px;padding:0 4px}
-.u-65dccb4c{text-overflow:ellipsis;white-space:nowrap}
-.u-67b29093{width:6px;height:6px;background:#f0a050;border-radius:50%;margin-left:5px}
-.u-716b3db7{padding:6px 0}
-.u-74e0942c{color:var(--red,#f06292)}
-.u-7b5f0231{color:var(--success);font-size:18px;margin-top:2px}
-.u-7b9f9868{background:var(--border);border-radius:4px;height:8px}
-.u-7e4ce7c5{color:#c00}
-.u-88efe206{max-width:400px}
-.u-890c13e6{padding:30px;color:#c00}
-.u-8bb2948c{font-size:9px;margin:6px 0}
-.u-8ead22a5{padding:4px 10px;background:#1e5a7a;color:#fff;border-radius:4px}
-.u-9d329304{border-radius:12px}
-.u-a94d207d{text-align:right;min-width:60px}
-.u-accfabec{border-top:1px solid var(--border)}
-.u-acd4aa44{min-width:32px}
-.u-ad4b16a3{grid-template-columns:repeat(2,1fr);gap:12px}
-.u-b0960a1c{background:#fee;color:#c00;padding:2px 8px;border-radius:4px}
-.u-b57c4dbb{display:inline-flex;gap:2px}
-.u-b5e73953{padding:4px 8px;border-radius:4px}
-.u-b7672836{background:#1e7a3e;color:#fff}
-.u-b901c742{background:#7a6b1e;color:#fff}
-.u-be09ba81{border-collapse:collapse}
-.u-c2647b7a{list-style:none;padding-left:0}
-.u-c288eda3{padding:14px;color:var(--warn)}
-.u-c78f4943{width:90px}
-.u-ca89036b{background:rgba(240,98,146,.10);border:1px solid var(--red,#f06292);color:var(--red,#f06292)}
-.u-cc617d82{gap:2px;height:70px}
-.u-ccf56278{width:36px;text-align:right}
-.u-ceda86b5{padding-left:14px;margin-top:2px}
-.u-ceecb8ce{font-size:8px;fill:var(--muted, #888);font-family:var(--font-mono, ui-monospace, monospace)}
-.u-d6f461d2{margin:3px 0;padding:6px 8px;border-bottom:1px dotted var(--border-2)}
-.u-d6f8832c{padding:4px 0;border-bottom:1px solid var(--border)}
-.u-d9d66a98{padding:4px 0 4px 18px}
-.u-da43aeb1{background:#4fc3f7}
-.u-e049a809{background:#7a1e1e;color:#fff}
-.u-e08d89f4{background:#efe;color:#080;padding:2px 8px;border-radius:4px}
-.u-e0936291{color:var(--red)}
-.u-e729a61a{background:var(--bg-1);border:1px solid var(--border-2);max-width:min(900px,90vw);max-height:85vh;box-shadow:0 8px 32px rgba(0,0,0,0.5)}
-.u-f005b881{margin-top:2px}
-.u-f1eb96f0{width:22px}
-.u-f3d75a59{max-height:120px;padding:8px;border-radius:4px}
-.u-f4bab274{padding:4px 10px;background:#444;color:#fff;border-radius:4px}
-.u-f6e3d7fe{text-align:right}
-.u-f758c5d0{max-width:320px}
-.u-f95e7372{color:var(--warn)}
-.u-fbe94ef8{gap:12px;padding:12px 16px;border-bottom:1px solid var(--border-2)}
-/* carried forward from earlier runs */
-.br-7{border-radius:7px}
-.c-text-2{color:var(--text-2)}
-.c-text-soft{color:var(--text-soft)}
-.d-block{display:block}
-.d-none{display:none}
-.font-ui{font-family:var(--font-ui)}
-.fs-14{font-size:14px}
-.fs-16{font-size:16px}
-.fs-inherit{font-size:inherit}
-.items-start{align-items:flex-start}
-.justify-center{justify-content:center}
-.justify-end{justify-content:flex-end}
-.ls-05{letter-spacing:.5px}
-.mb-12{margin-bottom:12px}
-.mb-16{margin-bottom:16px}
-.mb-20{margin-bottom:20px}
-.minw-220{min-width:220px}
-.ml-10{margin-left:10px}
-.ml-12{margin-left:12px}
-.ml-auto{margin-left:auto}
-.mr-3{margin-right:3px}
-.mt-10{margin-top:10px}
-.mt-12{margin-top:12px}
-.mt-20{margin-top:20px}
-.mt-4{margin-top:4px}
-.no-underline{text-decoration:none}
-.outline-none{outline:none}
 .p-12-20{padding:12px 20px}
+.p-16{padding:16px}
 .p-16-0{padding:16px 0}
 .p-16-20{padding:16px 20px}
+.p-3-10{padding:3px 10px}
+.p-6-10{padding:6px 10px}
 .p-6-12{padding:6px 12px}
 .p-7-10{padding:7px 10px}
+.p-8-10{padding:8px 10px}
 .p-8-12{padding:8px 12px}
+.p-8-20{padding:8px 20px}
 .p-9-12{padding:9px 12px}
 .pos-relative{position:relative}
 .resize-v{resize:vertical}
@@ -598,14 +530,19 @@ body::before {
 .u-051f894b{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:11px;max-height:280px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-family:var(--font-mono)}
 .u-062d4a88{margin-top:24px}
 .u-065d769b{display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:9999;align-items:flex-start;justify-content:center;overflow-y:auto;padding:40px 16px}
+.u-07bf82f0{margin:2px 0;padding:3px 6px 3px 18px;border-left:1px dashed var(--border-2)}
 .u-09020afe{font-size:12px;font-weight:600;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:5px 10px;cursor:pointer;color:var(--text-soft)}
 .u-0aece2c5{font-size:12px;margin-top:3px}
 .u-0b0be5ab{padding:8px;font-size:10px;color:var(--muted)}
+.u-0c8f2ccd{color:#f88}
 .u-0da9f7dd{flex:1;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:7px 9px;color:var(--text);font-size:12px;outline:none}
+.u-0f6e6c09{margin-top:1px}
+.u-0ff31430{padding:4px 10px;background:#7a1e1e;color:#fff;border-radius:4px}
 .u-1007d4c8{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px;min-height:260px;max-height:55vh;overflow:auto;display:flex;flex-direction:column;gap:10px;font-family:var(--font-ui)}
 .u-10cdfa29{background:var(--t-org)}
 .u-111a2a9b{display:flex;gap:8px;align-items:center;margin:8px 0 12px;flex-wrap:wrap}
 .u-11b78217{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:14px;min-height:300px;font-family:var(--font-mono);font-size:12px;max-height:60vh;overflow-y:auto}
+.u-12da9e4d{width:14px;height:14px}
 .u-1417170d{display:block;margin:14px 0 6px;font-size:12px;color:var(--text-soft);font-family:var(--font-mono)}
 .u-14449c57{padding:4px 10px;background:#1e7a3e;color:#fff;border:0;border-radius:4px;cursor:pointer;font-size:11px}
 .u-15397f03{flex:2;padding:10px;background:#1e5a7a;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer}
@@ -620,26 +557,36 @@ body::before {
 .u-1aab2bbb{flex:1;padding:9px;background:transparent;border:1px solid var(--border);border-radius:7px;color:var(--muted);font-size:13px;cursor:pointer}
 .u-1ad59c6e{color:var(--muted);word-break:break-all;margin-bottom:2px}
 .u-1addcfff{max-width:880px;width:92vw}
+.u-1b1ea0a5{text-transform:uppercase;letter-spacing:.3px}
 .u-1d182703{background:var(--t-document)}
+.u-1d1dc4d1{margin-top:3px}
 .u-1f02e31d{font-family:var(--font-mono);font-size:12px;white-space:pre-wrap;color:var(--text);max-height:400px;overflow-y:auto}
+.u-200a92a0{text-align:left}
 .u-2057e1f6{text-align:center;padding:18px}
 .u-2079cee6{font-size:12px;color:var(--muted-2);font-family:var(--font-mono);letter-spacing:.5px;display:inline-block;margin-top:6px;padding:2px 10px;border:1px solid var(--border-2);border-radius:4px}
+.u-20957c52{font-size:18px;margin-top:2px}
 .u-212754e8{display:flex;gap:10px;margin-top:18px}
 .u-2430bfe7{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--muted);font-size:14px;padding:4px 6px}
 .u-2519520b{min-height:0}
 .u-255ac621{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:32px;width:360px;max-width:92vw;box-shadow:0 24px 80px rgba(0,0,0,.7)}
 .u-26dfbfa2{opacity:.6;font-weight:400;text-transform:none;letter-spacing:0}
+.u-28f00506{border-radius:4px;height:6px}
 .u-299c14b8{background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:20px;max-width:820px;width:100%;max-height:85vh;overflow-y:auto}
 .u-2abd191f{white-space:pre-wrap;font-family:var(--font-mono);font-size:12px;background:var(--bg);padding:12px;border-radius:4px;max-height:50vh;overflow-y:auto}
 .u-2ac71257{padding:9px 16px;background:var(--accent);color:var(--on-accent);border:0;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600}
 .u-2ad1dbdc{flex:1;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
+.u-2cbabd6c{font-size:28px}
+.u-2dab903f{padding:3px 0}
 .u-2e05dbe3{cursor:pointer;font-size:11px;color:#4fc3f7;font-weight:600;user-select:none;display:inline-block;background:rgba(79,195,247,.10);padding:3px 9px;border-radius:6px;border:1px solid rgba(79,195,247,.30)}
 .u-2e56c4a1{cursor:pointer;font-size:11px;color:var(--muted);font-family:var(--font-mono);user-select:none;padding:2px 0}
+.u-2ea04eea{color:#4caf7d}
 .u-2ff2369d{background:var(--bg);border:1px solid var(--border);border-left:3px solid var(--danger);border-radius:6px;padding:10px 12px;font-size:11px;line-height:1.5;color:var(--text-soft);max-height:360px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:0}
+.u-31664877{text-transform:uppercase;letter-spacing:.4px}
 .u-31c2f318{padding:8px 14px;background:#1e7a3e;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px}
 .u-31db86e6{display:flex;flex-direction:column;gap:4px;max-height:55vh;overflow:auto}
 .u-34f48e04{flex:2;min-width:200px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
 .u-356897e8{color:var(--danger);font-size:11px;padding:8px;text-align:center}
+.u-35a11d6a{padding:30px}
 .u-3726dd17{display:none;margin-top:14px;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px}
 .u-3736917b{color:#4caf7d;font-weight:600;margin-right:6px}
 .u-38643f9d{font-size:11px;color:var(--muted);font-family:var(--font-mono);min-height:14px}
@@ -648,48 +595,68 @@ body::before {
 .u-392deb27{font-size:11px;color:#fc8;line-height:1.5;margin-bottom:6px}
 .u-3989efe8{font-size:12px;color:var(--muted);margin-bottom:24px}
 .u-3a00a1a8{width:100%;padding:9px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:7px;color:var(--text-soft);font-size:12px;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px}
+.u-3b76ebd1{min-width:60px}
 .u-3bde27cd{font-size:11px;color:var(--muted);font-family:var(--font-mono);margin-top:6px;min-height:14px}
 .u-3c0be829{padding:7px 12px;background:#1e5a7a;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:12px}
 .u-3cd4d6c4{padding:8px 16px;background:var(--accent);color:var(--on-accent);border:0;border-radius:8px;cursor:pointer;font-size:13px;font-weight:600}
 .u-3d31afaf{font-size:12px;color:var(--danger);min-height:18px;margin-bottom:12px;font-family:var(--font-mono)}
+.u-3d4b0f59{background:none;padding:0}
+.u-3d558703{padding:7px 14px;flex-shrink:0}
 .u-3d9db492{font-size:11px;color:var(--muted);font-family:var(--font-mono);display:block;margin:10px 0 4px}
 .u-3dfc2178{display:none;font-size:11px;color:var(--accent-fg);padding:2px 8px;border:1px solid var(--accent-fg);border-radius:6px;cursor:pointer}
 .u-3f0ee34f{margin-top:14px;padding:12px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;font-size:12px;color:var(--muted);line-height:1.6}
+.u-3f9f96c6{min-width:0}
 .u-3fc63d02{flex:1;padding:10px;background:var(--accent);border:none;border-radius:7px;color:var(--on-accent);font-size:12px;font-weight:600;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px}
 .u-415f6c14{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:4px 10px;border-radius:6px;font-size:12px}
+.u-416c260c{padding:10px 0}
 .u-4278e205{font-size:13px;color:var(--text);white-space:pre-line;line-height:1.55;margin-bottom:18px}
 .u-427e46c1{padding:10px 12px;font-size:11px;color:var(--muted);border-bottom:1px solid var(--border-2);display:flex;justify-content:space-between;align-items:center}
 .u-42ac55af{padding:14px;font-size:12px;color:#e66}
 .u-431df820{font-size:36px;font-weight:900;letter-spacing:-1px}
+.u-43ff79ff{line-height:1.7}
 .u-44ba397d{width:100%;margin-top:6px;padding:6px 10px;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;color:var(--text-soft);cursor:pointer;font-size:11px;font-weight:600;font-family:var(--font-mono);letter-spacing:.4px}
 .u-4552a90f{margin-top:14px;text-align:right}
 .u-4552fac5{flex:1;padding:9px;background:transparent;border:1px solid var(--danger);border-radius:7px;color:var(--danger);font-size:11px;font-weight:600;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px}
 .u-45d4b707{display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);align-items:flex-start;justify-content:center;z-index:9999;overflow-y:auto;padding:40px 16px}
+.u-492a71fc{opacity:.6}
+.u-4960344c{padding-left:12px;border-left:1px dashed var(--border-2)}
 .u-49f9b186{font-size:11px;padding:2px 7px;border-radius:4px;background:var(--surface-2);color:var(--muted)}
 .u-4b28c85b{display:flex;flex-direction:column;gap:6px;min-height:24px;margin-top:6px;font-family:var(--font-mono);font-size:12px}
 .u-4bf6e6cb{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:320}
+.u-4c23b32f{border-radius:4px;padding:2px 8px}
 .u-4c2e6fd3{background:transparent;border:0;color:var(--muted);cursor:pointer;font-size:20px}
 .u-4c8aa240{display:inline-flex;align-items:center;gap:6px;margin-top:6px;padding:4px 10px;border-radius:6px;background:rgba(239,68,68,.10);border:1px solid rgba(239,68,68,.45);font-size:11px;color:#fca5a5;font-family:var(--font-mono);letter-spacing:.3px}
+.u-4d0151d9{padding:14px 16px;color:var(--fg-1);background:var(--bg-2)}
+.u-4ddbe905{white-space:nowrap}
+.u-4df3ea2d{width:16px;height:16px;accent-color:#1e7a3e}
 .u-4e41ca5e{margin-bottom:20px;padding:20px;background:var(--surface);border:1px solid var(--border);border-radius:12px;text-align:center}
 .u-4e6a0b38{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:4px 10px;border-radius:6px;font-size:11px;cursor:pointer}
 .u-4ee85ded{max-height:200px;overflow:auto;background:var(--bg);border:1px solid var(--border-2);border-radius:6px;padding:10px;font-size:12px;white-space:pre-wrap;word-break:break-word}
 .u-50220fb6{font-size:9px;color:var(--accent-fg)}
+.u-50cd3bbf{padding:4px 10px;background:#1e7a3e;color:#fff;border-radius:4px}
+.u-511ac2fa{margin:2px 0}
 .u-54305035{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:32px;width:380px;max-width:92vw;box-shadow:0 24px 80px rgba(0,0,0,.7)}
 .u-559a9927{flex:1;padding:7px 10px;background:var(--accent);color:var(--on-accent);border:none;border-radius:6px;cursor:pointer;font-size:11px;font-weight:600;font-family:var(--font-mono);letter-spacing:.4px}
 .u-55f6adff{flex:1;padding:7px 10px;background:var(--surface-2);color:var(--text-soft);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:11px;font-weight:600;font-family:var(--font-mono);letter-spacing:.4px}
 .u-57cc855e{width:100%;padding:11px;background:var(--accent);border:none;border-radius:8px;color:var(--on-accent);font-size:14px;font-weight:600;cursor:pointer}
 .u-59298278{color:var(--muted);font-size:12px;padding:6px}
 .u-59bb6812{max-width:520px;width:92%;max-height:80vh;overflow-y:auto}
+.u-5a561387{padding:3px 6px;border-radius:4px}
 .u-5aa95d8f{flex:1;padding:11px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--muted);font-size:13px;cursor:pointer}
+.u-5cd105e1{flex-shrink:0}
 .u-5dad51e1{flex:1;min-width:160px;padding:7px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px}
 .u-5dcc4888{display:none;background:var(--accent-soft);border:1px solid var(--accent);color:var(--accent-fg);padding:4px 10px;border-radius:6px;font-size:11px;cursor:pointer;font-family:var(--font-ui)}
 .u-5ddb24b1{font-size:12px;color:var(--danger);min-height:18px;margin-bottom:10px;font-family:var(--font-mono)}
 .u-5efeca4c{color:var(--accent);font-weight:600;margin-right:6px}
 .u-5f31f7a4{margin-left:6px;padding:1px 8px;border-radius:4px;font-size:11px;background:var(--accent-soft);color:var(--accent-fg)}
 .u-5f42ab00{display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,.55);align-items:center;justify-content:center}
+.u-6069bb57{padding:14px}
 .u-60d69e07{color:var(--muted);font-size:11px;padding:8px;text-align:center}
 .u-6342850d{display:flex;justify-content:space-between;font-size:10px;color:var(--muted);width:100%;position:absolute;margin-top:24px;pointer-events:none}
+.u-646de506{background:none;font-size:18px;padding:0 4px}
+.u-65dccb4c{text-overflow:ellipsis;white-space:nowrap}
 .u-671ed45d{margin-top:14px;text-align:center;font-size:12px}
+.u-67b29093{width:6px;height:6px;background:#f0a050;border-radius:50%;margin-left:5px}
 .u-67e7f9a2{color:var(--muted);font-size:10px;margin-top:2px}
 .u-6812cd91{color:var(--danger,#e06)}
 .u-698d0f45{padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer}
@@ -698,16 +665,21 @@ body::before {
 .u-6bf30e00{border:1px solid var(--border);border-radius:7px;background:var(--bg);padding:8px;margin-bottom:18px;font-size:12px;max-height:30vh;overflow-y:auto}
 .u-6cdea84a{background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:24px;max-width:980px;width:100%;max-height:88vh;overflow-y:auto;box-shadow:0 24px 80px rgba(0,0,0,.6)}
 .u-6fd9cc46{padding:14px;font-size:12px;color:var(--muted)}
+.u-716b3db7{padding:6px 0}
 .u-72af977b{color:#f88;font-size:12px;padding:6px}
 .u-72fcb731{font-size:11px;color:var(--muted);line-height:1.55;margin-bottom:10px}
 .u-736ad3fd{padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px;min-width:150px}
 .u-740d5b33{display:flex;justify-content:space-between;align-items:center;gap:6px;padding:4px 16px;font-size:11px;flex-wrap:wrap}
 .u-74a68ab5{font-size:15px;font-weight:600;color:var(--accent-fg);font-family:var(--font-mono);letter-spacing:.4px}
 .u-74dfbddd{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:8px 10px;color:var(--text);font-size:12px;outline:none;box-sizing:border-box;font-family:var(--font-mono);resize:vertical}
+.u-74e0942c{color:var(--red,#f06292)}
 .u-78cb8b59{color:#4caf7d;font-size:11px}
 .u-79c3e149{flex:1;min-width:240px;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px;font-family:var(--font-mono)}
 .u-79f6fd5b{font-weight:600;font-size:13px;flex:1;min-width:0;word-break:break-all}
 .u-7afdde9c{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.u-7b5f0231{color:var(--success);font-size:18px;margin-top:2px}
+.u-7b9f9868{background:var(--border);border-radius:4px;height:8px}
+.u-7e4ce7c5{color:#c00}
 .u-7ff27f7b{max-width:560px;width:92vw}
 .u-800ac3bf{margin:6px 0 0 18px;padding:0;font-family:var(--font-ui)}
 .u-81e3f213{color:var(--muted);font-size:10px;font-family:var(--font-mono);width:50px}
@@ -718,10 +690,14 @@ body::before {
 .u-85503ffb{color:var(--muted);font-size:10px;margin-bottom:3px}
 .u-87f8977c{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:12px;margin-bottom:12px;font-family:var(--font-mono);font-size:12px;word-break:break-all;color:var(--text)}
 .u-8869ee63{display:grid;grid-template-columns:auto 1fr;column-gap:12px;row-gap:6px;margin-bottom:18px;font-size:12px;font-family:var(--font-mono)}
+.u-88efe206{max-width:400px}
+.u-890c13e6{padding:30px;color:#c00}
 .u-89bd09bd{flex:1;min-width:0}
 .u-89fcfdab{font-size:11px;padding:6px 12px;min-height:32px;margin-bottom:8px}
 .u-8a63b251{padding-right:40px}
+.u-8bb2948c{font-size:9px;margin:6px 0}
 .u-8bc9917b{text-align:left;background:var(--surface-2);border:1px solid var(--accent-soft, rgba(107,231,208,.30));border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:13px;transition:all .15s;width:100%;font-family:inherit}
+.u-8ead22a5{padding:4px 10px;background:#1e5a7a;color:#fff;border-radius:4px}
 .u-8f3a65ea{padding:36px;width:340px}
 .u-903cf72f{display:none;color:#1e7a3e;font-size:12px;margin-bottom:8px}
 .u-912cc26a{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--muted);font-size:14px;padding:2px 4px}
@@ -741,6 +717,7 @@ body::before {
 .u-9b09d1c6{white-space:pre-wrap;word-break:break-word;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:12px;font-size:12px;max-height:60vh;overflow:auto}
 .u-9bc5438a{flex:0 0 220px;min-width:190px;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px;display:flex;flex-direction:column;gap:8px}
 .u-9c8a81e2{flex:0 0 80px;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:7px 9px;color:var(--text);font-size:12px;outline:none}
+.u-9d329304{border-radius:12px}
 .u-9d5c9183{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin-bottom:20px}
 .u-9d72653d{flex:1;min-width:160px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px}
 .u-9e9e719b{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:8px}
@@ -752,53 +729,78 @@ body::before {
 .u-a345ace1{display:none;background:var(--surface-2);border:1px solid var(--accent);border-radius:8px;padding:12px;margin-bottom:14px;font-size:12px}
 .u-a4ecb3a2{background:var(--surface);border:1px solid var(--border);border-radius:10px;width:min(620px,92vw);max-height:82vh;display:flex;flex-direction:column;padding:16px;gap:10px}
 .u-a737cc80{font-size:11px;color:var(--muted);min-height:14px;margin-bottom:4px;font-family:var(--font-mono)}
+.u-a94d207d{text-align:right;min-width:60px}
 .u-a9962869{display:none;position:fixed;inset:0;background:rgba(4,6,10,.35);align-items:center;justify-content:center;z-index:400}
 .u-aa69727c{padding:12px 16px;background:var(--surface);border:1px solid var(--border);border-radius:8px;display:flex;flex-direction:column;gap:10px}
 .u-ab7defe6{white-space:pre-wrap;max-height:240px;overflow:auto;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:13px;font-family:var(--font-mono)}
 .u-abd6d905{flex:1;min-width:320px;display:flex;flex-direction:column;gap:12px}
+.u-accfabec{border-top:1px solid var(--border)}
+.u-acd4aa44{min-width:32px}
 .u-ad422ade{padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer}
+.u-ad4b16a3{grid-template-columns:repeat(2,1fr);gap:12px}
 .u-ae4f0321{color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .u-af524a3f{font-size:11px;color:var(--muted);font-family:var(--font-mono);word-break:break-all;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:6px}
 .u-b083d1b4{background:var(--bg);border:1px solid var(--border);border-left:3px solid var(--success);border-radius:6px;padding:10px 12px;font-size:11px;line-height:1.5;color:var(--text-soft);max-height:360px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:0}
+.u-b0960a1c{background:#fee;color:#c00;padding:2px 8px;border-radius:4px}
 .u-b193c0d0{display:flex;gap:8px;align-items:center;margin:10px 0;flex-wrap:wrap}
 .u-b269fdd3{font-size:12px;color:var(--danger);min-height:18px;margin-bottom:6px;font-family:var(--font-mono)}
 .u-b2ff889f{font-size:18px;font-weight:600;color:var(--accent-fg);margin-bottom:8px;letter-spacing:.3px}
 .u-b507437c{margin-top:8px;font-size:12px;color:var(--muted);line-height:1.55}
+.u-b57c4dbb{display:inline-flex;gap:2px}
+.u-b5e73953{padding:4px 8px;border-radius:4px}
 .u-b6b4121e{display:grid;grid-template-columns:auto 1fr auto;gap:8px;align-items:end}
 .u-b6bc178b{flex:2;padding:10px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;font-weight:600;cursor:pointer}
 .u-b7092eba{padding:4px 10px;background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;cursor:pointer;font-size:11px}
+.u-b7672836{background:#1e7a3e;color:#fff}
 .u-b7e2de6c{display:flex;justify-content:space-between;align-items:center;padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;font-family:var(--font-mono);background:var(--bg);border:1px solid var(--border)}
 .u-b87e02c4{text-align:left;background:rgba(76,175,125,.10);border:1px solid rgba(76,175,125,.45);border-radius:8px;padding:8px 12px;cursor:pointer;color:var(--text);font-size:12px;width:100%;font-family:inherit;transition:all .15s}
 .u-b8867a16{font-size:12px;font-family:var(--font-mono);color:var(--muted);min-height:20px;margin-top:8px;padding:8px;background:var(--bg);border-radius:6px;display:none}
+.u-b901c742{background:#7a6b1e;color:#fff}
 .u-ba3f4872{flex:1;overflow:auto;display:flex;flex-direction:column;gap:3px;min-height:200px;max-height:50vh}
 .u-bbdb0a17{padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;font-family:var(--font-mono);background:var(--bg);border:1px solid var(--border)}
 .u-bcdf512f{margin-top:14px;display:flex;gap:10px;justify-content:center}
 .u-bdf5e0da{font-size:12px;font-family:var(--font-mono);color:var(--muted);min-height:20px}
+.u-be09ba81{border-collapse:collapse}
 .u-be242e74{font-size:11px;color:var(--muted);font-family:var(--font-mono);margin-top:6px;min-height:13px}
 .u-be941e14{font-size:12px;color:#fc8;display:flex;align-items:center;gap:6px;cursor:pointer}
 .u-bf6a901f{background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:8px;margin-bottom:14px;max-height:280px;overflow-y:auto}
 .u-c0a9fd0e{padding:4px 8px;font-size:11px}
+.u-c2647b7a{list-style:none;padding-left:0}
+.u-c288eda3{padding:14px;color:var(--warn)}
 .u-c2d09fb1{background:var(--accent);height:100%;width:0%;transition:width .3s}
 .u-c50d1568{font-size:11px;padding:6px 12px;min-height:32px}
 .u-c5a8031d{display:none;position:fixed;inset:0;background:rgba(4,6,10,.35);display:flex;align-items:center;justify-content:center;z-index:300}
 .u-c6e02b13{display:grid;grid-template-columns:auto 1fr;gap:10px 12px;align-items:center}
+.u-c78f4943{width:90px}
 .u-c7f59426{margin:0 12px;padding:8px;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;color:var(--text-soft);font-size:12px;cursor:pointer;font-family:var(--font-ui)}
+.u-ca89036b{background:rgba(240,98,146,.10);border:1px solid var(--red,#f06292);color:var(--red,#f06292)}
 .u-caa31bf0{padding:5px 12px;font-size:11px}
 .u-caeb6867{display:flex;align-items:center;gap:10px;min-width:220px}
+.u-cc617d82{gap:2px;height:70px}
+.u-ccf56278{width:36px;text-align:right}
 .u-ce16bc45{padding:8px 10px;border-bottom:1px solid var(--border-2);font-size:11px}
+.u-ceda86b5{padding-left:14px;margin-top:2px}
+.u-ceecb8ce{font-size:8px;fill:var(--muted, #888);font-family:var(--font-mono, ui-monospace, monospace)}
 .u-cfa36ab5{align-self:flex-start;max-width:80%;background:var(--surface-2,#1e293b);color:var(--text);padding:8px 12px;border-radius:12px 12px 12px 4px;font-size:13px;white-space:pre-wrap;word-break:break-word}
 .u-d03fd082{align-self:flex-end;max-width:80%;background:var(--accent,#3b82f6);color:var(--on-accent,#fff);padding:8px 12px;border-radius:12px 12px 4px 12px;font-size:13px;white-space:pre-wrap;word-break:break-word}
 .u-d4099956{font-size:11px;color:var(--muted);margin-bottom:18px;line-height:1.5}
 .u-d40e04fd{background:var(--t-person)}
+.u-d6f461d2{margin:3px 0;padding:6px 8px;border-bottom:1px dotted var(--border-2)}
+.u-d6f8832c{padding:4px 0;border-bottom:1px solid var(--border)}
 .u-d755eb62{display:none;position:fixed;top:8px;left:8px;z-index:60;width:44px;height:44px;border:1px solid var(--border);background:var(--surface);color:var(--text);border-radius:8px;font-size:20px;cursor:pointer}
 .u-d7570ef8{font-size:11px;font-weight:700;padding:4px 8px}
 .u-d7d110ff{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border-2);padding-bottom:8px;margin-bottom:10px}
+.u-d9d66a98{padding:4px 0 4px 18px}
+.u-da43aeb1{background:#4fc3f7}
 .u-dc6eeb85{font-size:11px;color:var(--danger);min-height:14px;margin-bottom:8px;font-family:var(--font-mono)}
 .u-de1f41bc{padding:12px 0}
 .u-de414fa1{width:100%;padding:9px;background:var(--accent);border:none;border-radius:7px;color:var(--on-accent);font-size:12px;font-weight:600;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px;margin-bottom:18px}
 .u-de82cac5{font-size:11px;color:#8cf;margin-bottom:6px}
 .u-df897132{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:8px 10px;color:var(--text);font-size:12px;outline:none;box-sizing:border-box;resize:vertical}
 .u-dfa88652{font-size:11px;color:var(--muted);text-decoration:none;padding:4px 8px;border:1px dashed var(--border);border-radius:6px;cursor:pointer}
+.u-e049a809{background:#7a1e1e;color:#fff}
+.u-e08d89f4{background:#efe;color:#080;padding:2px 8px;border-radius:4px}
+.u-e0936291{color:var(--red)}
 .u-e0972e59{font-size:11px;font-family:var(--font-mono);color:var(--muted);min-height:16px;margin-bottom:8px}
 .u-e159df34{background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:20px;max-width:720px;width:100%;max-height:85vh;overflow-y:auto}
 .u-e1deb8fb{padding:8px 0}
@@ -808,6 +810,7 @@ body::before {
 .u-e5324176{background:none;border:none;color:var(--text-3);cursor:pointer;padding:2px 6px}
 .u-e56abdee{width:100%;padding:11px;background:var(--danger);border:none;border-radius:8px;color:#fff;font-size:14px;font-weight:600;cursor:pointer}
 .u-e6f429e1{padding:14px 18px;margin-bottom:20px;background:var(--surface);border:1px solid var(--border);border-radius:8px}
+.u-e729a61a{background:var(--bg-1);border:1px solid var(--border-2);max-width:min(900px,90vw);max-height:85vh;box-shadow:0 8px 32px rgba(0,0,0,0.5)}
 .u-e74ffa36{display:flex;gap:24px;flex-wrap:wrap;font-family:var(--font-mono);font-size:13px}
 .u-e87f4f41{background:rgba(255,183,77,.18);border:1px solid rgba(255,183,77,.60);border-radius:6px;padding:4px 10px;color:#ffd180;font-size:12px;cursor:pointer;font-family:inherit;font-weight:600;transition:all .15s}
 .u-e8a4793a{flex:1;min-width:180px;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px}
@@ -822,12 +825,23 @@ body::before {
 .u-f097a413{background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden}
 .u-f101c803{align-self:flex-start;max-width:90%;background:#5b1e1e;color:#fcc;padding:8px 12px;border-radius:8px;font-size:12px;font-family:var(--font-mono)}
 .u-f10d923e{color:#f88;font-size:10px}
+.u-f1eb96f0{width:22px}
 .u-f329ff85{flex:1;padding:10px;background:var(--surface-2);border:1px solid var(--border);border-radius:7px;color:var(--text-soft);font-size:12px;font-weight:600;cursor:pointer;font-family:var(--font-mono);letter-spacing:.4px}
+.u-f3d75a59{max-height:120px;padding:8px;border-radius:4px}
+.u-f4bab274{padding:4px 10px;background:#444;color:#fff;border-radius:4px}
 .u-f4ca3d4c{display:none;align-items:center;gap:8px;padding:6px 16px;border-bottom:1px solid var(--border-2);font-size:13px}
 .u-f6ccbcd3{background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:16px;font-size:12px;color:var(--text-soft);line-height:1.5}
+.u-f6e3d7fe{text-align:right}
+.u-f758c5d0{max-width:320px}
 .u-f7861f5e{flex:2;padding:9px;background:#1e7a3e;border:0;border-radius:7px;color:#fff;font-size:13px;cursor:pointer}
+.u-f95e7372{color:var(--warn)}
+.u-fbe94ef8{gap:12px;padding:12px 16px;border-bottom:1px solid var(--border-2)}
 .u-fd2f16b2{margin:6px 12px 0;padding:8px;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;color:var(--text-soft);font-size:12px;cursor:pointer;font-family:var(--font-ui)}
 .u-fe407230{flex:0 0 16px}
 .underline{text-decoration:underline}
+.va-middle{vertical-align:middle}
 .va-n2{vertical-align:-2px}
+.w-full{width:100%}
+.wb-word{word-break:break-word}
+.ws-pre-wrap{white-space:pre-wrap}
 /* ==== END generated inline-style migration (v0.6.1 CSP) ==== */

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v27-20260908-csp-admin">
+<link rel="stylesheet" href="/static/tokens.css?v=v30-20260908-csp-concat">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/scripts/migrate_inline_styles.py
+++ b/scripts/migrate_inline_styles.py
@@ -247,6 +247,41 @@ JS_FILES = [
 ]
 
 
+# Matches the join between two adjacent JS string literals inside a
+# captured attribute value: `' + '`, across newlines and indentation.
+# No backreference — a mismatched quote pair would leave a stray quote
+# behind, which resolve_literal_concat then rejects.
+_CONCAT_JOIN = re.compile(r"""['"]\s*\+\s*['"]""")
+
+
+def resolve_literal_concat(value: str):
+    """Join a style value split across adjacent JS string literals.
+
+    Markup assembled with ``+`` puts the attribute across several
+    literals::
+
+        '<div style="background:var(--surface);' +
+        'border-radius:10px">'
+
+    The captured value then carries the join text (``' + '``) as if it
+    were part of a declaration. Migrating that verbatim emitted a
+    truncated rule and silently dropped whatever followed the join —
+    which is why these were skipped outright until now (#1097).
+
+    A join between two LITERALS is removable: the value is static, it
+    is only written in pieces. A join around an expression
+    (``' + badgeStyle + '``) is not — that value exists only at
+    runtime.
+
+    Returns the joined value, or None when anything other than
+    literal-to-literal joins remains.
+    """
+    joined = _CONCAT_JOIN.sub("", value)
+    if "'" in joined or '"' in joined or "${" in joined or "+" in joined:
+        return None
+    return joined
+
+
 def normalise_decl(decl: str) -> str:
     """Normalise one ``prop:value`` declaration (semantics-preserving)."""
     decl = decl.strip()
@@ -334,11 +369,16 @@ def rewrite_tag(
     tag: str,
     components: Dict[str, List[str]],
     used_atoms: Dict[str, None],
+    style_override: str | None = None,
 ) -> str:
     m_style = _STYLE_RE.search(tag)
     if not m_style:
         return tag
-    new_classes = classes_for(m_style.group(1), components, used_atoms)
+    # ``style_override`` carries the value with literal concatenation
+    # joins removed; the span deleted below still covers the whole
+    # attribute, joins included, so the surrounding literals merge.
+    value = style_override if style_override is not None else m_style.group(1)
+    new_classes = classes_for(value, components, used_atoms)
     # remove the style attribute
     tag = tag[: m_style.start()] + tag[m_style.end():]
     if not new_classes:
@@ -412,8 +452,16 @@ def migrate_js(
         #                on chat.js:354, the one site in the file with
         #                this shape).
         if m_style and ("${" in val or "'" in val or '"' in val or " + " in val):
-            skipped[0] += 1
-            return tag
+            # A purely literal concatenation is still a static value —
+            # join it and carry on. Anything else (an interpolated
+            # expression, a template placeholder) cannot become a class.
+            resolved = resolve_literal_concat(val) if "${" not in val else None
+            if resolved is None:
+                skipped[0] += 1
+                return tag
+            done[0] += 1
+            return rewrite_tag(tag, components, used_atoms,
+                               style_override=resolved)
         done[0] += 1
         return rewrite_tag(tag, components, used_atoms)
 


### PR DESCRIPTION
## Summary

#1097 taught the tool to **skip** attributes split across a JS string concatenation, because migrating them verbatim emitted a truncated rule and silently dropped whatever followed the join. Skipping was the right call then. It is not the answer.

A join between two **literals** is removable — the value is static, it is just written in pieces:

```js
'<div style="background:var(--surface);' +
'border-radius:10px">'
```

A join around an **expression** is not (`' + badgeStyle + '`) — that value only exists at runtime.

`resolve_literal_concat()` joins the first kind and returns `None` for the second, so the guard now defers strictly less without giving up the fidelity that motivated it.

**38 sites converted**, mostly the time-travel modals, which build their markup entirely by concatenation.

## Two extra verifications

This rewrite deletes text from the middle of **JS expressions**, not from inside a template literal — the literals either side of a removed join have to merge into one valid literal.

1. **`node --check` on all 19 static JS files** → all parse.
2. **Computed-style comparison**, 28 unique pairs, class-rendered against the joined inline value → **28 of 28 identical**.

That comparison first reported **11 of 28**, which was the harness and not the code: the browser still held the previous `tokens.css`, so the newly generated `.u-*` rules were not in the loaded stylesheet. Bumping the cache buster and reloading gave 28/28.

Recorded because the failure mode looks exactly like a real one — missing `letter-spacing`, missing `border-bottom`, missing `padding`. A less careful pass would have "fixed" the CSS that was already correct.

- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**

## Phase 3.3 progress

| | sites |
|---|---:|
| start of phase | 479 |
| tool passes + hand passes so far | −428 |
| **remaining** | **51** |

All 51 interpolate an expression:

| file | sites |
|---|---:|
| `admin.js` | 22 |
| `change-requests.js` | 10 |
| `graph_editor.js` | 8 |
| `agent-chat.js` | 4 |
| four files with 1–3 each | 7 |

## Out of scope

- Those 51. Each needs the judgement #1101 applied to `chat.js` — check whether the interpolated value is really computed or merely enumerable, then class or CSSOM accordingly.
- The enforce flip, which comes last.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
