### PR TITLE
feat(v0.6.2): admin.js colour maps were never dynamic — 43 → 37

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v31-20260908-csp-arrayjoin">
+<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->
@@ -1323,7 +1323,7 @@
 <script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/llm-install.js"></script>
-<script src="/static/admin.js?v=v28-20260908-csp-fragments"></script>
+<script src="/static/admin.js?v=v32-20260908-csp-colormaps"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.6.1 — workspace badge in header. -->
 <script src="/static/workspace-badge.js"></script>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v31-20260908-csp-arrayjoin">
+<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v31-20260908-csp-arrayjoin">
+<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v31-20260908-csp-arrayjoin">
+<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -817,9 +817,12 @@ async function loadDashboard() {
     const cards = document.getElementById('dash-cards');
 
     // ── 통계 카드 ──────────────────────────────────────────
-    const avgColor  = (data.avg_elapsed > 20) ? 'var(--red,#f06292)' :
-                      (data.avg_elapsed > 10) ? 'var(--warn,#ffb74d)' : 'var(--accent)';
-    const blkColor  = data.blocked_count > 0 ? 'var(--warn,#ffb74d)' : 'var(--accent)';
+    // Classes, not colours. These fed style="color:${…}" attributes,
+    // which CSP blocks — and the values were never dynamic, just three
+    // fixed outcomes each. Palette lives in tokens.css.
+    const avgCls  = (data.avg_elapsed > 20) ? 'c-red' :
+                    (data.avg_elapsed > 10) ? 'c-warn' : 'c-accent';
+    const blkCls  = data.blocked_count > 0 ? 'c-warn' : 'c-accent';
 
     cards.innerHTML = `
       <div class="card">
@@ -834,12 +837,12 @@ async function loadDashboard() {
       </div>
       <div class="card">
         <div class="card-label">${t('dash.avg_elapsed')}</div>
-        <div class="card-value" style="color:${avgColor}">${data.avg_elapsed ?? '-'}s</div>
+        <div class="card-value ${avgCls}">${data.avg_elapsed ?? '-'}s</div>
         <div class="card-sub">${t('dash.subtext_avg')}</div>
       </div>
       <div class="card">
         <div class="card-label">${t('dash.blocked_count')}</div>
-        <div class="card-value" style="color:${blkColor}">${data.blocked_count ?? '-'}</div>
+        <div class="card-value ${blkCls}">${data.blocked_count ?? '-'}</div>
         <div class="card-sub">${t('dash.subtext_blocked')}</div>
       </div>
       <div class="card">
@@ -1980,7 +1983,7 @@ async function loadAudit() {
       const isBlock = it.blocked
         || /fail|rejected|blocked|denied|invalid/i.test(ev);
       const evCell = ev
-        ? `<span style="${isBlock ? 'color:#d97a7a' : 'color:var(--text)'}">${_auditEscapeHtml(ev)}</span>`
+        ? `<span class="${isBlock ? 'c-blocked' : 'c-text'}">${_auditEscapeHtml(ev)}</span>`
         : '<span class="c-muted">—</span>';
       return `
         <tr>
@@ -2988,7 +2991,7 @@ async function loadProposals() {
       return;
     }
 
-    const riskColor = { low:'var(--success)', medium:'var(--warn)', high:'var(--danger)' };
+    const riskCls = { low:'c-success', medium:'c-warn', high:'c-danger' };
     tbody.innerHTML = proposals.map(p => {
       const isWebLearn = p.type === 'knowledge_update' &&
                          p.metadata?.auto_action === 'web_learn';
@@ -3008,7 +3011,7 @@ async function loadProposals() {
 
       return `<tr>
         <td><span class="mono fs-10">${p.type}</span></td>
-        <td><span style="color:${riskColor[p.risk]||'var(--muted)'}">
+        <td><span class="${riskCls[p.risk] || 'c-muted'}">
           ${p.risk?.toUpperCase() || '-'}</span></td>
         <td class="fs-12 u-f758c5d0">${p.title}</td>
         <td class="mono">${p.created_at?.slice(0,16) || '-'}</td>
@@ -3152,7 +3155,7 @@ async function loadEvoReports() {
             <td class="mono">${r.executed_at?.slice(0,16) || '-'}</td>
             <td class="mono">${r.type || '-'}</td>
             <td class="fs-12">${r.title || '-'}</td>
-            <td style="color:${r.success ? 'var(--success)' : 'var(--danger)'}">
+            <td class="${r.success ? 'c-success' : 'c-danger'}">
               ${r.success ? '✅ Success' : '❌ Failed'}: ${(r.message||'').slice(0,40)}</td>
             <td class="mono">${r.elapsed_sec ?? '-'}s</td>
           </tr>`)
@@ -3172,14 +3175,14 @@ async function loadPerformance() {
     const perf = data.performance || {};
     const imp  = data.importance  || {};
 
-    const gradeColor = { A:'var(--success)', B:'var(--brand-2)',
-                         C:'var(--warn)', D:'var(--danger)', 'N/A':'var(--muted)' };
+    const gradeCls = { A:'c-success', B:'c-brand-2',
+                       C:'c-warn', D:'c-danger', 'N/A':'c-muted' };
     const last = await api('/admin/performance/history/?limit=1');
     const lastGrade = last.history?.[0]?.grade || 'N/A';
 
     document.getElementById('perf-cards').innerHTML = `
       <div class="card"><div class="card-label">${t('perf.grade')}</div>
-        <div class="card-value" style="color:${gradeColor[lastGrade]}">${lastGrade}</div></div>
+        <div class="card-value ${gradeCls[lastGrade] || 'c-muted'}">${lastGrade}</div></div>
       <div class="card"><div class="card-label">${t('perf.avg_retrieval')}</div>
         <div class="card-value accent">${((perf.avg_retrieval_score||0)*100).toFixed(0)}%</div></div>
       <div class="card"><div class="card-label">${t('perf.avg_speed')}</div>
@@ -3203,12 +3206,12 @@ async function loadPerfHistory() {
   try {
     const data  = await api('/admin/performance/history/?limit=10');
     const tbody = document.getElementById('perf-history-body');
-    const gradeColor = { A:'var(--success)', B:'var(--brand-2)',
-                         C:'var(--warn)', D:'var(--danger)' };
+    const gradeCls2 = { A:'c-success', B:'c-brand-2',
+                        C:'c-warn', D:'c-danger' };
     tbody.innerHTML = (data.history || []).map(h => `
       <tr>
         <td class="mono">${h.evaluated_at?.slice(0,16)||'-'}</td>
-        <td style="color:${gradeColor[h.grade]||'var(--muted)'}">
+        <td class="${gradeCls2[h.grade] || 'c-muted'}">
           <strong>${h.grade}</strong></td>
         <td class="mono">${h.total_score?.toFixed(1)||'-'}/100</td>
         <td class="mono">${((h.metrics?.avg_retrieval_score||0)*100).toFixed(0)}%</td>

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -851,3 +851,20 @@ body::before {
 .wb-word{word-break:break-word}
 .ws-pre-wrap{white-space:pre-wrap}
 /* ==== END generated inline-style migration (v0.6.1 CSP) ==== */
+
+/* ─────────────────────────────────────────────────────────────
+   Semantic text colours — hand-maintained, OUTSIDE the generated
+   block above (which is rebuilt from whatever the migration script
+   converts on a given run, so anything written inside it would be
+   dropped).
+   ─────────────────────────────────────────────────────────────
+   admin.js used to interpolate these straight into style attributes
+   via small lookup maps — riskColor, gradeColor and a few ternaries.
+   CSP blocks that, and the values were never really dynamic: each map
+   has three to five fixed outcomes. The maps now return class names.
+   ───────────────────────────────────────────────────────────── */
+.c-success { color: var(--success); }
+.c-warn    { color: var(--warn, #ffb74d); }
+.c-brand-2 { color: var(--brand-2); }
+.c-red     { color: var(--red, #f06292); }
+.c-blocked { color: #d97a7a; }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v31-20260908-csp-arrayjoin">
+<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->


### PR DESCRIPTION
## Summary

Six of `admin.js`'s interpolated attributes were `style="color:${…}"` where the value came from a **small lookup**:

| source | outcomes |
|---|---|
| `riskColor` | `{ low, medium, high }` — 3 |
| `gradeColor` | `{ A, B, C, D, N/A }` — 5 (defined twice) |
| `avgColor` | two thresholds — 3 |
| `blkColor` | a boolean — 2 |
| `r.success` | a boolean — 2 |
| `isBlock` | a boolean — 2 |

Same shape #1101 found in `chat.js`: **interpolated is not the same as computed.** The maps now hold class names and the palette lives in `tokens.css`, so nothing is interpolated into a style attribute.

Four semantic colours were missing — `c-success`, `c-warn`, `c-brand-2`, `c-red` — plus `c-blocked` for the one hard-coded `#d97a7a`. They go **outside** the generated block, because that block is rebuilt from whatever a migration run converts, and anything written inside it would be dropped on the next `--apply` (the failure #1097 fixed).

## Verification

Each class resolves to the colour the map used to interpolate, class-rendered against the original value:

> **9 of 9 identical** — and all nine *actually resolve* rather than falling back to a transparent default.

That second check matters on its own: a missing custom property would have compared equal to another missing one, so "identical" alone would not have caught a typo'd variable name.

- `node --check` → passes
- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**

## Phase 3.3 progress

| | sites |
|---|---:|
| start of phase | 479 |
| **remaining** | **37** |

`admin.js` is down to **16**, and what remains there is genuinely computed — bar widths, stroke widths, a drop-shadow built from a per-domain colour.

## Out of scope

The remaining 37, and the enforce flip that follows them.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
