### PR TITLE
feat(v0.6.2): a quote is an attribute boundary too — 37 → 26

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
+<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
+<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">
@@ -519,7 +519,7 @@
 <script src="/static/i18n.js?v=v26-20260908-csp-batch"></script>
 <script src="/static/auth.js"></script>
 <script src="/static/graph.js?v=v26-20260908-csp-batch"></script>
-<script src="/static/graph_editor.js?v=v30-20260908-csp-concat"></script>
+<script src="/static/graph_editor.js?v=v33-20260908-csp-tagre"></script>
 <script src="/static/graph_node_editor.js"></script>
 <script src="/static/a11y-modal.js" defer></script>
 <!-- v0.5 Track F.1 TT.a — Time-Travel picker UI shell (event-dispatch
@@ -538,13 +538,13 @@
      (RETRIEVE → EXPAND → VERIFY), filtered to the active time-travel
      cutoff. Loads after the picker (TT.a) + corpus renderer (TT.b)
      so the cutoff event has already wired the panel state. -->
-<script src="/static/time-travel-trace.js?v=v30-20260908-csp-concat"></script>
+<script src="/static/time-travel-trace.js?v=v33-20260908-csp-tagre"></script>
 <!-- v0.5 Track F.1 TT.d — Now-vs-T diff view. Renders a side-by-side
      modal comparing the audit-replay snapshot at the picker's T
      against the live audit-replay snapshot at "now". Loads last so
      it can hook the picker button + the `james:timetravel:*`
      events the prior shells dispatch. -->
-<script src="/static/time-travel-diff.js?v=v30-20260908-csp-concat"></script>
+<script src="/static/time-travel-diff.js?v=v33-20260908-csp-tagre"></script>
 <!-- v0.6 Phase 4 P4.4 — universal glossary tooltip script.
      Scans the page for elements with `data-glossary="<term>"` and
      attaches hover/focus tooltips with plain-Korean definitions. -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
+<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
+<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -156,18 +156,14 @@
     // Per-row actions: ✏️ (edit weight/note) and ✕ (delete this source only).
     var actions = '' +
       '<div class="d-flex flex-col gap-4 items-end">' +
-        '<button type="button" data-action="edit-src" data-idx="' + idx + '" ' +
+        '<button class="bg-transparent bd-1 c-text-soft cursor-pointer fs-11 u-622c5404" type="button" data-action="edit-src" data-idx="' + idx + '" ' +
                 'title="Edit this source" ' +
-                'style="background:transparent;border:1px solid var(--border);' +
-                       'color:var(--text-soft);width:24px;height:22px;' +
-                       'border-radius:4px;cursor:pointer;font-size:11px;line-height:1">' +
+                '>' +
           '수정' +
         '</button>' +
-        '<button type="button" data-action="del-src" data-idx="' + idx + '" ' +
+        '<button class="bg-transparent c-danger cursor-pointer fs-11 u-31384694" type="button" data-action="del-src" data-idx="' + idx + '" ' +
                 'title="Delete this source" ' +
-                'style="background:transparent;border:1px solid var(--danger);' +
-                       'color:var(--danger);width:24px;height:22px;' +
-                       'border-radius:4px;cursor:pointer;font-size:11px;line-height:1">' +
+                '>' +
           '✕' +
         '</button>' +
       '</div>';
@@ -193,38 +189,29 @@
     var w    = (typeof s.weight === 'number') ? s.weight.toFixed(2) : '0.50';
     var note = s.note ? String(s.note) : '';
     return '' +
-      '<div data-src-idx="' + idx + '" data-edit="1" ' +
-           'style="padding:6px 0;border-bottom:1px solid var(--border);' +
-                  'background:rgba(99,102,241,.05)">' +
+      '<div class="u-18c7c87c" data-src-idx="' + idx + '" data-edit="1" ' +
+           '>' +
         '<div class="d-flex gap-6 items-center font-mono fs-11 mb-6">' +
           roleBadge(s.role || '?') +
           '<span class="c-muted fs-10">editing #' + idx + '</span>' +
         '</div>' +
         '<div class="d-flex gap-6 items-center mb-4">' +
           '<label class="u-81e3f213">weight</label>' +
-          '<input type="number" min="0" max="1" step="0.05" value="' + w + '" ' +
+          '<input class="flex-1 bg-bg bd-1 c-text font-mono fs-11 u-5a561387" type="number" min="0" max="1" step="0.05" value="' + w + '" ' +
                  'data-edit-weight="' + idx + '" ' +
-                 'style="flex:1;background:var(--bg);border:1px solid var(--border);' +
-                        'color:var(--text);padding:3px 6px;border-radius:4px;' +
-                        'font-family:var(--font-mono);font-size:11px">' +
+                 '>' +
         '</div>' +
         '<div class="d-flex gap-6 items-center mb-6">' +
           '<label class="u-81e3f213">note</label>' +
-          '<input type="text" value="' + escapeHtml(note) + '" ' +
+          '<input class="flex-1 bg-bg bd-1 c-text font-mono fs-11 u-5a561387" type="text" value="' + escapeHtml(note) + '" ' +
                  'data-edit-note="' + idx + '" placeholder="(optional)" ' +
-                 'style="flex:1;background:var(--bg);border:1px solid var(--border);' +
-                        'color:var(--text);padding:3px 6px;border-radius:4px;' +
-                        'font-family:var(--font-mono);font-size:11px">' +
+                 '>' +
         '</div>' +
         '<div class="d-flex gap-6 justify-end">' +
-          '<button type="button" data-action="cancel-edit-src" data-idx="' + idx + '" ' +
-                  'style="background:transparent;border:1px solid var(--border);' +
-                         'color:var(--text-soft);padding:3px 10px;border-radius:4px;' +
-                         'cursor:pointer;font-size:11px">Cancel</button>' +
-          '<button type="button" data-action="save-edit-src" data-idx="' + idx + '" ' +
-                  'style="background:var(--accent);border:1px solid var(--accent);' +
-                         'color:#fff;padding:3px 10px;border-radius:4px;' +
-                         'cursor:pointer;font-size:11px">Save</button>' +
+          '<button class="bg-transparent bd-1 c-text-soft p-3-10 cursor-pointer fs-11 u-b6a17f66" type="button" data-action="cancel-edit-src" data-idx="' + idx + '" ' +
+                  '>Cancel</button>' +
+          '<button class="bg-accent p-3-10 cursor-pointer fs-11 u-7f92644d" type="button" data-action="save-edit-src" data-idx="' + idx + '" ' +
+                  '>Save</button>' +
         '</div>' +
       '</div>';
   }

--- a/frontend/static/time-travel-diff.js
+++ b/frontend/static/time-travel-diff.js
@@ -72,12 +72,8 @@
       'display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);' +
       'z-index:40;align-items:center;justify-content:center;padding:24px';
     div.innerHTML =
-      '<div id="' + MODAL_ID + '-card" class="modal-card" ' +
-      'style="background:var(--surface);border:1px solid var(--border);' +
-      'border-radius:10px;padding:18px 22px;max-width:720px;width:96%;' +
-      'max-height:84vh;overflow-y:auto;color:var(--text);' +
-      'font-family:var(--font-mono);font-size:12px;line-height:1.55;' +
-      'box-shadow:0 6px 22px rgba(0,0,0,.5)">' +
+      '<div id="' + MODAL_ID + '-card" class="modal-card bg-surface bd-1 ovy-auto c-text font-mono fs-12 u-1b4f1f9d" ' +
+      '>' +
       '<div id="' + MODAL_ID + '-body"></div>' +
       '</div>';
     document.body.appendChild(div);
@@ -143,13 +139,9 @@
 
   function closeButtonHtml() {
     return '<div class="u-4552a90f">' +
-           '<button type="button" data-action="diff-close" ' +
+           '<button class="bg-surface-2 bd-1 br-6 c-text-soft cursor-pointer fs-11 fw-600 font-mono u-8d4f1f00" type="button" data-action="diff-close" ' +
            'aria-label="Close diff modal" ' +
-           'style="padding:7px 14px;background:var(--surface-2);' +
-           'border:1px solid var(--border);border-radius:6px;' +
-           'color:var(--text-soft);cursor:pointer;font-size:11px;' +
-           'font-weight:600;font-family:var(--font-mono);' +
-           'letter-spacing:.4px">' +
+           '>' +
            escapeHtml(t('graph.timetravel.diff.close', 'Close')) +
            '</button></div>';
   }
@@ -161,9 +153,8 @@
     // (falls back to the empty filter), so this link is safe even
     // if the operator's admin.html hasn't yet learned the new hash.
     var href = '/admin?q=' + encodeURIComponent(edgeId) + '#audit';
-    return '<a href="' + href + '" target="_blank" rel="noopener" ' +
-           'style="color:var(--accent-fg);text-decoration:none;' +
-           'font-size:10px;margin-left:6px;opacity:.8" ' +
+    return '<a class="c-accent-fg no-underline fs-10 ml-6 u-62f51076" href="' + href + '" target="_blank" rel="noopener" ' +
+           ' ' +
            'aria-label="Open audit log for edge ' + safe + '">' +
            '[' + escapeHtml(t('graph.timetravel.diff.evidence',
                               'View audit evidence')) + ']</a>';

--- a/frontend/static/time-travel-trace.js
+++ b/frontend/static/time-travel-trace.js
@@ -246,10 +246,8 @@
 
     // v0.6.1 (gap ③) — jump to the swimlane flow view of this same trace.
     var toFlowBtn = traceId ?
-      ('<button id="trace-to-flow-btn" type="button" ' +
-       'style="font-size:10px;padding:4px 8px;margin-bottom:8px;cursor:pointer;' +
-       'background:var(--surface-2);border:1px solid var(--border);' +
-       'border-radius:6px;color:var(--text-soft)">' +
+      ('<button class="fs-10 mb-8 cursor-pointer bg-surface-2 bd-1 br-6 c-text-soft u-98aca85a" id="trace-to-flow-btn" type="button" ' +
+       '>' +
        escapeHtml(t('graph.timetravel.trace.to_flow', '추론 흐름으로 보기 →')) +
        '</button>') : '';
 

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -396,57 +396,57 @@ body::before {
  * CSP style-src without 'unsafe-inline' for the HTML surface. */
 /* atoms */
 .bd-1{border:1px solid var(--border)}
+.bg-accent{background:var(--accent)}
 .bg-bg{background:var(--bg)}
 .bg-surface{background:var(--surface)}
+.bg-surface-2{background:var(--surface-2)}
 .bg-transparent{background:transparent}
 .br-6{border-radius:6px}
-.c-muted{color:var(--muted)}
+.c-accent-fg{color:var(--accent-fg)}
+.c-danger{color:var(--danger)}
 .c-text{color:var(--text)}
 .c-text-soft{color:var(--text-soft)}
 .cursor-pointer{cursor:pointer}
-.d-flex{display:flex}
-.d-none{display:none}
 .flex-1{flex:1}
-.flex-wrap{flex-wrap:wrap}
 .font-mono{font-family:var(--font-mono)}
-.font-ui{font-family:var(--font-ui)}
 .fs-10{font-size:10px}
 .fs-11{font-size:11px}
 .fs-12{font-size:12px}
 .fw-600{font-weight:600}
-.gap-10{gap:10px}
-.gap-8{gap:8px}
-.items-center{align-items:center}
-.lh-15{line-height:1.5}
-.lh-16{line-height:1.6}
-.mt-8{margin-top:8px}
-.p-7-10{padding:7px 10px}
-.p-8-10{padding:8px 10px}
-.w-full{width:100%}
+.mb-8{margin-bottom:8px}
+.ml-6{margin-left:6px}
+.no-underline{text-decoration:none}
+.ovy-auto{overflow-y:auto}
+.p-3-10{padding:3px 10px}
 /* components (verbatim one-off styles) */
-.u-20d05c21{border:1px solid var(--border-2)}
-.u-2f275d5d{padding:7px 14px;background:rgba(239,68,68,.10);color:#fca5a5;border:1px solid rgba(239,68,68,.45);letter-spacing:.4px}
-.u-428449ff{padding:7px 14px;background:rgba(76,175,125,.15);color:#4caf7d;border:1px solid rgba(76,175,125,.45);letter-spacing:.4px}
-.u-4a93029a{min-width:140px}
-.u-53f47ba5{padding:3px 8px;border-radius:4px}
-.u-55858526{min-height:14px}
+.u-18c7c87c{padding:6px 0;border-bottom:1px solid var(--border);background:rgba(99,102,241,.05)}
+.u-1b4f1f9d{border-radius:10px;padding:18px 22px;max-width:720px;width:96%;max-height:84vh;line-height:1.55;box-shadow:0 6px 22px rgba(0,0,0,.5)}
+.u-31384694{border:1px solid var(--danger);width:24px;height:22px;border-radius:4px;line-height:1}
+.u-5a561387{padding:3px 6px;border-radius:4px}
+.u-622c5404{width:24px;height:22px;border-radius:4px;line-height:1}
+.u-62f51076{opacity:.8}
+.u-7f92644d{border:1px solid var(--accent);color:#fff;border-radius:4px}
+.u-8d4f1f00{padding:7px 14px;letter-spacing:.4px}
+.u-98aca85a{padding:4px 8px}
+.u-b6a17f66{border-radius:4px}
 /* carried forward from earlier runs */
 .accent-accent{accent-color:var(--accent)}
 .bd-0{border:0}
 .bd-none{border:none}
-.bg-accent{background:var(--accent)}
-.bg-surface-2{background:var(--surface-2)}
 .br-7{border-radius:7px}
 .br-8{border-radius:8px}
 .c-accent{color:var(--accent)}
-.c-accent-fg{color:var(--accent-fg)}
-.c-danger{color:var(--danger)}
+.c-muted{color:var(--muted)}
 .c-on-accent{color:var(--on-accent)}
 .c-text-2{color:var(--text-2)}
 .d-block{display:block}
+.d-flex{display:flex}
 .d-grid{display:grid}
 .d-inline-block{display:inline-block}
+.d-none{display:none}
 .flex-col{flex-direction:column}
+.flex-wrap{flex-wrap:wrap}
+.font-ui{font-family:var(--font-ui)}
 .fs-13{font-size:13px}
 .fs-14{font-size:14px}
 .fs-15{font-size:15px}
@@ -454,14 +454,19 @@ body::before {
 .fs-inherit{font-size:inherit}
 .fw-400{font-weight:400}
 .fw-700{font-weight:700}
+.gap-10{gap:10px}
 .gap-14{gap:14px}
 .gap-4{gap:4px}
 .gap-6{gap:6px}
+.gap-8{gap:8px}
+.items-center{align-items:center}
 .items-end{align-items:flex-end}
 .items-start{align-items:flex-start}
 .justify-between{justify-content:space-between}
 .justify-center{justify-content:center}
 .justify-end{justify-content:flex-end}
+.lh-15{line-height:1.5}
+.lh-16{line-height:1.6}
 .ls-0{letter-spacing:0}
 .ls-05{letter-spacing:.5px}
 .ls-1{letter-spacing:1px}
@@ -473,14 +478,12 @@ body::before {
 .mb-20{margin-bottom:20px}
 .mb-4{margin-bottom:4px}
 .mb-6{margin-bottom:6px}
-.mb-8{margin-bottom:8px}
 .minw-200{min-width:200px}
 .minw-220{min-width:220px}
 .minw-260{min-width:260px}
 .minw-280{min-width:280px}
 .ml-10{margin-left:10px}
 .ml-12{margin-left:12px}
-.ml-6{margin-left:6px}
 .ml-8{margin-left:8px}
 .ml-auto{margin-left:auto}
 .mr-3{margin-right:3px}
@@ -491,11 +494,10 @@ body::before {
 .mt-20{margin-top:20px}
 .mt-4{margin-top:4px}
 .mt-6{margin-top:6px}
-.no-underline{text-decoration:none}
+.mt-8{margin-top:8px}
 .outline-none{outline:none}
 .ov-auto{overflow:auto}
 .ov-hidden{overflow:hidden}
-.ovy-auto{overflow-y:auto}
 .p-10{padding:10px}
 .p-10-14{padding:10px 14px}
 .p-12-20{padding:12px 20px}
@@ -503,9 +505,10 @@ body::before {
 .p-16-0{padding:16px 0}
 .p-16-20{padding:16px 20px}
 .p-20{padding:20px}
-.p-3-10{padding:3px 10px}
 .p-6-10{padding:6px 10px}
 .p-6-12{padding:6px 12px}
+.p-7-10{padding:7px 10px}
+.p-8-10{padding:8px 10px}
 .p-8-12{padding:8px 12px}
 .p-8-20{padding:8px 20px}
 .p-9-12{padding:9px 12px}
@@ -558,6 +561,7 @@ body::before {
 .u-2057e1f6{text-align:center;padding:18px}
 .u-2079cee6{font-size:12px;color:var(--muted-2);font-family:var(--font-mono);letter-spacing:.5px;display:inline-block;margin-top:6px;padding:2px 10px;border:1px solid var(--border-2);border-radius:4px}
 .u-20957c52{font-size:18px;margin-top:2px}
+.u-20d05c21{border:1px solid var(--border-2)}
 .u-212754e8{display:flex;gap:10px;margin-top:18px}
 .u-2430bfe7{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--muted);font-size:14px;padding:4px 6px}
 .u-2519520b{min-height:0}
@@ -573,6 +577,7 @@ body::before {
 .u-2e05dbe3{cursor:pointer;font-size:11px;color:#4fc3f7;font-weight:600;user-select:none;display:inline-block;background:rgba(79,195,247,.10);padding:3px 9px;border-radius:6px;border:1px solid rgba(79,195,247,.30)}
 .u-2e56c4a1{cursor:pointer;font-size:11px;color:var(--muted);font-family:var(--font-mono);user-select:none;padding:2px 0}
 .u-2ea04eea{color:#4caf7d}
+.u-2f275d5d{padding:7px 14px;background:rgba(239,68,68,.10);color:#fca5a5;border:1px solid rgba(239,68,68,.45);letter-spacing:.4px}
 .u-2ff2369d{background:var(--bg);border:1px solid var(--border);border-left:3px solid var(--danger);border-radius:6px;padding:10px 12px;font-size:11px;line-height:1.5;color:var(--text-soft);max-height:360px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:0}
 .u-31664877{text-transform:uppercase;letter-spacing:.4px}
 .u-31c2f318{padding:8px 14px;background:#1e7a3e;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px}
@@ -605,6 +610,7 @@ body::before {
 .u-416c260c{padding:10px 0}
 .u-4278e205{font-size:13px;color:var(--text);white-space:pre-line;line-height:1.55;margin-bottom:18px}
 .u-427e46c1{padding:10px 12px;font-size:11px;color:var(--muted);border-bottom:1px solid var(--border-2);display:flex;justify-content:space-between;align-items:center}
+.u-428449ff{padding:7px 14px;background:rgba(76,175,125,.15);color:#4caf7d;border:1px solid rgba(76,175,125,.45);letter-spacing:.4px}
 .u-42ac55af{padding:14px;font-size:12px;color:#e66}
 .u-431df820{font-size:36px;font-weight:900;letter-spacing:-1px}
 .u-43ff79ff{line-height:1.7}
@@ -615,6 +621,7 @@ body::before {
 .u-492a71fc{opacity:.6}
 .u-4960344c{padding-left:12px;border-left:1px dashed var(--border-2)}
 .u-49f9b186{font-size:11px;padding:2px 7px;border-radius:4px;background:var(--surface-2);color:var(--muted)}
+.u-4a93029a{min-width:140px}
 .u-4b28c85b{display:flex;flex-direction:column;gap:6px;min-height:24px;margin-top:6px;font-family:var(--font-mono);font-size:12px}
 .u-4bf6e6cb{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:320}
 .u-4c23b32f{border-radius:4px;padding:2px 8px}
@@ -631,7 +638,9 @@ body::before {
 .u-50cd3bbf{padding:4px 10px;background:#1e7a3e;color:#fff;border-radius:4px}
 .u-511ac2fa{margin:2px 0}
 .u-519c6b2e{padding:2px 8px;border-radius:10px}
+.u-53f47ba5{padding:3px 8px;border-radius:4px}
 .u-54305035{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:32px;width:380px;max-width:92vw;box-shadow:0 24px 80px rgba(0,0,0,.7)}
+.u-55858526{min-height:14px}
 .u-559a9927{flex:1;padding:7px 10px;background:var(--accent);color:var(--on-accent);border:none;border-radius:6px;cursor:pointer;font-size:11px;font-weight:600;font-family:var(--font-mono);letter-spacing:.4px}
 .u-55f6adff{flex:1;padding:7px 10px;background:var(--surface-2);color:var(--text-soft);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:11px;font-weight:600;font-family:var(--font-mono);letter-spacing:.4px}
 .u-56876cf6{flex:0 0 80px;text-align:right}
@@ -639,7 +648,6 @@ body::before {
 .u-57cc855e{width:100%;padding:11px;background:var(--accent);border:none;border-radius:8px;color:var(--on-accent);font-size:14px;font-weight:600;cursor:pointer}
 .u-59298278{color:var(--muted);font-size:12px;padding:6px}
 .u-59bb6812{max-width:520px;width:92%;max-height:80vh;overflow-y:auto}
-.u-5a561387{padding:3px 6px;border-radius:4px}
 .u-5aa95d8f{flex:1;padding:11px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--muted);font-size:13px;cursor:pointer}
 .u-5c9e3ed5{padding:3px 0;border-bottom:1px dashed rgba(255,255,255,.05)}
 .u-5cd105e1{flex-shrink:0}
@@ -847,11 +855,11 @@ body::before {
 .underline{text-decoration:underline}
 .va-middle{vertical-align:middle}
 .va-n2{vertical-align:-2px}
+.w-full{width:100%}
 .wb-all{word-break:break-all}
 .wb-word{word-break:break-word}
 .ws-pre-wrap{white-space:pre-wrap}
 /* ==== END generated inline-style migration (v0.6.1 CSP) ==== */
-
 /* ─────────────────────────────────────────────────────────────
    Semantic text colours — hand-maintained, OUTSIDE the generated
    block above (which is rebuilt from whatever the migration script

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v32-20260908-csp-colormaps">
+<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/scripts/migrate_inline_styles.py
+++ b/scripts/migrate_inline_styles.py
@@ -367,8 +367,21 @@ def classes_for(
 # Matches a single opening tag that carries a ``style="..."`` attribute.
 # Attribute values in these files never contain ``>`` (verified), so
 # ``[^>]*`` correctly stops at the tag's own ``>``.
-_TAG_RE = re.compile(r"<[a-zA-Z][^>]*\sstyle=\"[^\"]*\"[^>]*>")
-_STYLE_RE = re.compile(r"\sstyle=\"([^\"]*)\"")
+#
+# A quote counts as a boundary as well as whitespace: in markup built by
+# concatenation the attribute often opens a fresh string literal, so the
+# character before ``style=`` is ``'``, not a space::
+#
+#     '<div class="modal-card" ' +
+#     'style="background:var(--surface);' +
+#
+# Requiring whitespace there left 11 such tags invisible to the tool.
+_TAG_RE = re.compile(r"""<[a-zA-Z][^>]*['"\s]style="[^"]*"[^>]*>""")
+
+# The boundary is a LOOKBEHIND here, so removing the attribute does not
+# take the quote with it — that quote opens the surrounding JS string
+# literal, and deleting it would leave the file unparseable.
+_STYLE_RE = re.compile(r"""(?<=['"\s])style="([^"]*)\"""")
 _CLASS_RE = re.compile(r"\sclass=\"([^\"]*)\"")
 _TAGNAME_RE = re.compile(r"^<([a-zA-Z][\w-]*)")
 


### PR DESCRIPTION
## Summary

Eleven tags were invisible to the tool for a reason that had **nothing to do with being dynamic**. `_TAG_RE` required whitespace before `style=`, but in markup built by concatenation the attribute usually *opens a fresh string literal*, so the character before it is a quote:

```js
'<div id="' + MODAL_ID + '-card" class="modal-card" ' +
'style="background:var(--surface);' +
```

A quote is as much an attribute boundary as a space, so both patterns now accept either.

## `_STYLE_RE` needed more care than `_TAG_RE`

It is used to **delete** the attribute — and that quote opens the surrounding JS string literal. Consuming it would leave the file unparseable.

The boundary is a **lookbehind** there, so the quote survives the removal and the literals either side merge cleanly.

## Verification

`node --check` on all 19 static JS files is what makes that claim checkable rather than asserted — **all parse**. Spot-reading the diffs confirms the shape: the class attribute lands on the tag, the opening quote stays, and `' + '>' +` is what is left where the style used to be.

- computed-style comparison → **10 of 10 identical**
- visual regression → **7/7 unchanged**, no console errors
- full local suite → **5,312 passed**

## Phase 3.3 progress

| | sites |
|---|---:|
| start of phase | 479 |
| **remaining** | **26** |

**The tool has now had every reasonable extension.** What is left interpolates a genuinely computed value:

- `admin.js` — bar widths, stroke widths, a per-domain drop-shadow
- `i18n.js` — two opacity/weight toggles built by concatenation around a boolean
- `change-requests.js` — style strings assembled in a variable (`' + badgeStyle + '`)
- `agent-chat.js` — a border colour from a call result

## Out of scope

Those 26, and the enforce flip that follows them.

## Quality Delta

`Quality delta: exempt (label: chore)` — presentation-layer migration; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
