### PR TITLE
docs(v0.6.2): session close 2026-09-08 — PR #1082–#1105

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 ## Where we are right now
 
 > **단일 진실원 (single source of truth)**:
-> **`docs/handovers/v0.6.2-restart-roadmap-2026-09-03.md`**.
+> **`docs/handovers/v0.6.2-session-close-2026-09-08.md`**.
+> (Phase 정의는 `v0.6.2-restart-roadmap-2026-09-03.md` 가 계속
+> 유효하고, 마감 문서가 진행 결과를 갱신합니다.)
 > 아래는 그 요약입니다. 충돌하면 로드맵 문서가 우선입니다.
 
 - **최신 공식 릴리스**: **v0.4.4** — DOI `10.5281/zenodo.20652679`.
@@ -157,7 +159,8 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 
 | Purpose | File |
 |---|---|
-| **🟢🟢🟢 NEXT SESSION ENTRY (이것부터 읽으세요 — 2026-09-03 재개 로드맵)** | **`docs/handovers/v0.6.2-restart-roadmap-2026-09-03.md`** (재개용 **단일 진실원**. §1 현재 상태 사실 확인 (main HEAD `df55e21` / 유휴 구간 / **CI 실패 5 건 실측 + 건별 판정** / rule #5 해소 + 1건 grandfather / 문서 최신성 편차 표) + §2 **Phase 1–7 재개 로드맵** (1 문서 동기화 ✅ → 2 CI 그린 복구 → 3 유휴 부채 청산 → 4 v0.6.1 정식 마감 → 5 측정 백로그 → 6 Fork A/B 전략 결정 (operator) → 7 v0.6 진입) + §3 #886–#1078 실제 진행 요약 + §5 재개 첫 세션 30 분 체크리스트 + §6 하지 말 것. **Phase 2 전에는 새 기능 PR 금지.**) |
+| **🟢🟢🟢 NEXT SESSION ENTRY (이것부터 — 2026-09-08 세션 마감)** | **`docs/handovers/v0.6.2-session-close-2026-09-08.md`** (PR #1082–#1105, 24건. **Phase 2 (CI 그린) 종료** — main `934e8f7` tests/lint/security 전부 success, 4,469 passed / 0 failed. rule #5 GRANDFATHERED **0건**, CI ignore 57→51. **Phase 3.3 CSP style-src 479 → 26** + 3.4 / 3.5 완료. LRB S2 는 결정 #1 (충돌 수리) 실행 — V/N/J 0.2500/0.5875/0.7625, **J−N 0.175 불변**, ⚠️ **결정 #2 (preprint 재베이스라인) 미결**. 3.1 / 3.2 + #1084 / #1091 은 **operator 실기기 dogfood 대기**. §5 검증 3종 (계산 스타일 대조 / visual regression / node --check) 과 §6 자기 정정 3건은 이어받을 것.) |
+| **🟢🟢 Phase 정의 원본 (2026-09-03 재개 로드맵)** | **`docs/handovers/v0.6.2-restart-roadmap-2026-09-03.md`** (재개용 **단일 진실원**. §1 현재 상태 사실 확인 (main HEAD `df55e21` / 유휴 구간 / **CI 실패 5 건 실측 + 건별 판정** / rule #5 해소 + 1건 grandfather / 문서 최신성 편차 표) + §2 **Phase 1–7 재개 로드맵** (1 문서 동기화 ✅ → 2 CI 그린 복구 → 3 유휴 부채 청산 → 4 v0.6.1 정식 마감 → 5 측정 백로그 → 6 Fork A/B 전략 결정 (operator) → 7 v0.6 진입) + §3 #886–#1078 실제 진행 요약 + §5 재개 첫 세션 30 분 체크리스트 + §6 하지 말 것. **Phase 2 전에는 새 기능 PR 금지.**) |
 | **🟢🟢 직전 기능 세션 close (2026-06-26, PR #1062–#1075)** | `docs/handovers/v0.6.1-session-close-2026-06-26.md` (CSP `style-src` HTML 이관 596 attrs + 모바일 업로드 UX + **이미지 인제스트 4 단 병목 수리** (비전 모델 라우팅 / 이진화 제거 / EasyOCR fallback / qwen2.5vl:7b / num_ctx 8192) + `/query/`·`/upload/` heartbeat 스트리밍 + detailed 답변 스타일. §4 operator open 2 건 (모바일 긴 질의 드롭 / detailed dogfood), §5 deferred, §3 서버 background 실행 금지 교훈.) |
 | **🟢🟢 v0.6.1 세션 close (2026-06-23, PR #992–#1037)** | `docs/handovers/v0.6.1-session-close-2026-06-23.md` (UI 8→5 페이지 통합 / de-emoji / 인트로 프론트도어 / 그래프 허브 / trace 링크 루프 / entity-edit cascade Phase 1-3 / **lifecycle live-consistency arc** / 비주얼 회귀 하네스 / 백로그 재측정.) |
 | **🟢🟢 lifecycle live-consistency arc (측정 근거)** | `docs/handovers/v0.6.1-measurement-fix-loop-2026-06-22.md` + `reports/research-runs/lifecycle-live-consistency-arc-20260622.md` (프로브 #1020 = 라이브 탐색이 lifecycle status 를 무시 → `relation_is_live()` 게이트. `core/graph` traversal streak 의 **유일한 승인된 예외** — kill-switch `JAMES_DISABLE_STATUS_FILTER`.) |

--- a/docs/handovers/v0.6.2-session-close-2026-09-08.md
+++ b/docs/handovers/v0.6.2-session-close-2026-09-08.md
@@ -1,0 +1,200 @@
+# v0.6.2 세션 마감 — 2026-09-08 (PR #1082–#1105, 24건)
+
+> **다음 세션 진입점.** rule #6 에 따라 사이클 상태의 원본은 이 문서입니다.
+> 직전 상태 문서는 `v0.6.2-restart-roadmap-2026-09-03.md` — 로드맵 Phase
+> 정의는 거기 그대로 유효하고, 이 문서가 **진행 결과**를 갱신합니다.
+>
+> **main HEAD**: `934e8f7`
+> **CI**: `tests` / `lint` / `security-scan` **전부 success**
+> (`4,469 passed / 0 failed`, run 34227991957)
+
+---
+
+## 1. 한 줄 요약
+
+**Phase 2 (CI 그린 복구, P0) 종료.** 2026-06-22 이후 처음으로 `main` 이
+완전 그린입니다. Phase 3 은 3.4 / 3.5 완료, **3.3 이 479 → 26** 까지
+진행됐고 3.1 / 3.2 는 운영자 실기기 확인 대기입니다.
+
+---
+
+## 2. 지금 상태 (사실)
+
+| 항목 | 값 |
+|---|---|
+| CI `tests` | **4,469 passed / 0 failed / 0 errors** (43초) |
+| 로컬 전체 스위트 | 5,312 passed / 0 failed |
+| CI `--ignore` 목록 | 57 → **51** |
+| rule #5 `GRANDFATHERED` | **0건** (vision-wire PR 이후 처음) |
+| JS 인라인 `style=` | 479 → **26** |
+| `core/retrieval` + `core/graph` traversal | 이번 세션 **0 라인** |
+| `core/reasoning` | `engine.py` 분할 1회 (#1083, STEP 7 A/B/A 측정 동반) |
+
+---
+
+## 3. Phase 별 진행
+
+### Phase 2 — CI 그린 복구 ✅ 종료
+
+| 항목 | 처리 |
+|---|---|
+| FixtureLock 3건 | #1082 — gitignore 된 픽스처를 무조건 assert 하던 구조 문제. skip + 경로 락으로 분리 |
+| mobile.css `!important` 29 → 20 | #1082 — 상한 유지, 증명 가능한 11개만 제거 |
+| **LRB S2 재현** | #1089 — operator 가 §7 **결정 #1 (충돌 수리)** 선택 |
+| **CI 무시 목록의 숨은 적색 8건** | #1088 — 범위 밖에서 발견, 8건 수리 + 6파일 un-ignore |
+
+**LRB S2 결과**: 정책 제목을 `Policy 16:` → `Policy Sixteen:` 로 풀어써
+질의의 시간 표현이 주입하던 숫자 토큰이 어떤 제목과도 맞지 않게 했습니다.
+충돌 셀 2/4 → **4/4**, 재실행 V/N/J = **0.2500 / 0.5875 / 0.7625**
+(발표값 0.225 / 0.5375 / 0.7125). 셋 다 올랐으므로 V < N < J 유지,
+**J − N 은 0.175 로 소수점 넷째 자리까지 동일**.
+
+> 🔴 **결정 #2 미결 (operator)**: preprint README / `.zenodo.json` /
+> v0.4.4 릴리스 노트는 **수리 전 수치를 그대로** 갖고 있습니다.
+> 발표 논문·발행 DOI 재베이스라인은 세션이 정할 사안이 아닙니다.
+> 테스트는 수리된 수치를 고정하고 docstring 에 이 괴리를 명시했습니다 —
+> **초록 = 저장소가 스스로를 재현, ≠ 논문을 재현**.
+
+### Phase 3 — 유휴 부채 청산 (부분)
+
+| # | 항목 | 상태 |
+|---|---|---|
+| 3.1 | 모바일 긴 질의 드롭 | 🟠 **operator 실기기 확인 대기.** 로드맵이 durable fix 를 *"여전히 드롭되면"* 조건부로 걸어 뒀고 그 테스트가 아직 없습니다. 미검증 전제 위에 짓지 않았습니다 |
+| 3.2 | detailed 모드 dogfood | 🟠 operator 확인 대기 |
+| 3.3 | CSP `style-src` enforce | 🟡 **479 → 26** (§4) |
+| 3.4 | 이미지/OCR 잔여 | ✅ #1091 |
+| 3.5 | 운영 룰 문서화 | ✅ #1090 |
+
+**3.4 정정**: 핸드오버는 `cv2 !ssize.empty()` 를 12MP 탓으로 적어 뒀는데
+**파일명**이었습니다. 같은 12MP 사진이 `photo_12mp.jpg` 로는 읽히고
+`사진_12메가.jpg` 로는 `cv2.imread` 가 `None` 을 반환합니다. except 가
+삼켜서 **한글 이름 업로드는 조용히 OCR 없이** 지나갔습니다.
+
+---
+
+## 4. Phase 3.3 상세 — 479 → 26
+
+#1062 가 HTML 인라인을 0으로 만든 뒤 남아 있던 JS 표면입니다.
+
+### 4.1 먼저 측정했습니다 (#1095)
+
+전용 포트에 enforce 서버를 띄워 실제로 확인:
+
+| 방식 | CSP 대상 |
+|---|---|
+| `el.style.x = …` / `cssText` / `setProperty` | **아님** |
+| innerHTML 의 `style="…"` / `setAttribute('style')` | **차단** |
+
+**CSP 는 CSSOM 을 관장하지 않습니다.** 로드맵의 "~493개"와 제가 처음
+말한 "684개"는 둘 다 틀렸고, 실제 작업면은 **479개**였습니다.
+
+### 4.2 도구 (`scripts/migrate_inline_styles.py`)
+
+#1062 의 HTML 전용 도구를 JS 로 확장했습니다. 확장 과정에서 **도구
+자체의 결함 2건**이 드러났습니다:
+
+1. **재실행이 CSS 를 파괴** — 블록이 매 실행 통째로 재생성되는데 수집은
+   "style 속성을 변환할 때"만 일어납니다. HTML 은 이미 마이그레이션돼
+   수집이 0 → **tokens.css 296 → 53, 아직 쓰이는 클래스 266개 삭제**.
+   다음 `--apply` 가 UI 전체를 무스타일로 만들 상태였습니다. → additive 로 수정
+2. **문자열 연결이 잘린 규칙 생성** — `.u-…{…font-size:12px;'` 로 선언 유실
+
+이후 확장: 리터럴 `+` 조인 해석 (#1102) → 배열 `,` 조인 (#1103) →
+따옴표를 속성 경계로 인정 (#1105) → atom/verbatim **하이브리드 분할** (#1099).
+
+### 4.3 남은 26개 — 전부 손 작업
+
+| 파일 | 수 | 성격 |
+|---|---:|---|
+| `admin.js` | 16 | 막대 폭 `${c.pct}%`, `stroke-width:${sw}`, 도메인별 drop-shadow |
+| `agent-chat.js` | 4 | 호출 결과 기반 테두리 색 |
+| `change-requests.js` | 2 | 변수에 조립된 스타일 문자열 (`' + badgeStyle + '`) |
+| `i18n.js` | 2 | boolean 기반 opacity/weight |
+| 기타 | 2 | a11y-modal 주석 1, time-travel-trace 1 |
+
+**작업 방법은 확립돼 있습니다** (#1101 / #1104): 보간된 값이 *열거
+가능한지* 먼저 확인 → 고정 집합이면 클래스, 진짜 계산값이면 `data-*` +
+CSSOM. 세 번 다 대부분이 열거 가능했습니다.
+
+### 4.4 enforce 플립은 마지막
+
+26 → 0 이 된 뒤 `JAMES_CSP_MODE=enforce` + `JAMES_CSP_USE_NONCE_STYLE=1`.
+그때 `mobile.css` 의 `[style*="min-width:…"]` 속성 선택자 절반과 남은
+`!important` 20개도 정리 가능합니다 (#1082 가 남긴 이유가 사라지므로).
+
+---
+
+## 5. 검증 방법 — 다음 세션이 이어받을 것
+
+매 PR 에 붙인 3종입니다. **시각 회귀만으로는 부족합니다.**
+
+1. **계산 스타일 대조** (세션 누적 ~300쌍) — 클래스 렌더 vs 원래 인라인을
+   *모든* 계산 속성으로 비교. 마크업 경로로 양쪽 동일하게 만들어야
+   속성 선택자가 같은 것을 봅니다
+2. **visual regression** `scripts/visual_regression.py` 7 페이지
+3. **`node --check`** — JS 표현식 중간을 삭제하는 변경일 때 필수
+
+### 대조가 실제로 잡은 것
+
+- **모바일 회귀** (#1099) — all-or-nothing 이 `min-width:280px` 를 불투명
+  해시 클래스에 묻어 폰에서 입력이 카드를 넘어갔습니다. **시각 회귀는
+  데스크톱 폭만 찍어서 못 봅니다**
+- **`.export-btn` 오탐** (#1101) — 짝을 잘못 지어 차이가 나 보였고,
+  고쳤다면 멀쩡한 걸 망가뜨렸습니다
+- **캐시된 tokens.css** (#1102) — `letter-spacing` 누락처럼 진짜 결함과
+  똑같이 보이는 실패
+- **색상 변수 미해석** (#1104) — "둘 다 없음"이 "일치"로 보이는 함정.
+  일치 여부와 **해석 여부**를 따로 검사해야 합니다
+
+---
+
+## 6. 이번 세션의 자기 정정 3건
+
+기록해 둡니다 — 같은 실수를 반복하지 않도록.
+
+1. **routes-helper 불변식** (#1088) — `route_paths(app) == {r.path for r in
+   app.routes}` 를 ground truth 로 놓았는데 `iter_routes` 는 의도적으로
+   wrapper 를 벗겨냅니다. CI 가 반증
+2. **patch 누수 처방** (#1092 → #1093) — `addClassCleanup` 은 unittest 의
+   `except Exception` 경로에서 도는데 pytest-timeout 의 `Failed` 는
+   **BaseException** 계열이라 안 탑니다. 프로브가 평범한 `Exception` 을
+   던져 통과했던 것. #1093 에서 `tearDownClass` 를 되살리는 2차 정정도
+3. **CSP 작업량** — "684개" 라고 말했다가 측정에서 479 로 정정
+
+---
+
+## 7. 남은 작업 (우선순위)
+
+### 7.1 operator 만 가능
+
+| 항목 | 무엇을 |
+|---|---|
+| **LRB 결정 #2** | preprint / `.zenodo.json` / v0.4.4 릴리스 노트의 수리 전 수치를 재베이스라인할지 각주로 남길지 |
+| **3.1 / 3.2 dogfood** | 폰에서 긴 질의 드롭 여부 (`JAMES_DISABLE_COGNITIVE_STAGES=1` 상태로 먼저), detailed 모드 원문 반환 |
+| **#1084 dogfood** | 프롬프트 캡 4000 → 16000 이 긴 근거 답변을 개선하는지. step7 축으로는 안 잡힙니다 |
+| **#1091 dogfood** | 한글 파일명 이미지 업로드에서 텍스트 추출 |
+| **Fork A/B 결정** | 로드맵 Phase 6, 판정 시점 ≈ 2026-12-13 |
+
+### 7.2 솔로 가능
+
+1. **Phase 3.3 잔여 26개** → 그다음 enforce 플립 (§4.3–4.4)
+2. **CI 무시 목록 51 → 축소** — workflow 가 이미 iteration plan 을 달고
+   있습니다. "DB or server setup" 그룹은 Ollama 를 기다릴 필요가 없습니다
+3. **Phase 4** — v0.6.1 사이클 정식 마감 (190 PR 이 태그 없이 떠 있음)
+4. **QVT 3축** — Graded Answer / Abstention F1 / Token Cost 미측정.
+   arm 당 ~70분, 디스크 baseline 은 `2a31b20`(5월)뿐이라 재캡처 필요
+
+---
+
+## 8. 운영 주의
+
+- **서버**: `JAMES_CSP_MODE` 기본값은 `report-only` 입니다. enforce 로
+  띄우면 지금도 style 위반이 남습니다 (§4.3 의 26개)
+- **세션이 서버를 띄울 때**: CLAUDE.md §"Running the JAMES server from a
+  session" 의 5조건 (#1090). 특히 `taskkill //IM python.exe` 금지 —
+  2026-06-26 사고의 절반이 그 정리 명령이었습니다
+- **`scripts/migrate_inline_styles.py --apply`** 는 HTML + `JS_FILES` 를
+  **한 실행에서** 처리해야 합니다. 블록이 통째로 재생성되므로 (§4.2-1)
+- **CI 무시 목록을 줄일 때**: 파일을 빼기 전에 `.env` 를 치우고
+  `OLLAMA_API_URL` 을 죽은 포트로 향하게 한 뒤 통과하는지 확인하세요
+  (#1088 이 6개를 그렇게 검증했습니다)


### PR DESCRIPTION
## Summary

Cycle state for the next session, per rule #6. The 2026-09-03 restart roadmap keeps the **Phase definitions**; this records what actually happened against them.

**Phase 2 (CI green restore, P0) is closed.** `main` `934e8f7` has `tests`, `lint` and `security-scan` all green — **4,469 passed / 0 failed**, first time since 2026-06-22.

| | |
|---|---|
| rule #5 `GRANDFATHERED` | **0 entries** |
| CI `--ignore` list | 57 → **51** |
| Phase 3.3 JS inline styles | 479 → **26** |
| Phase 3.4 / 3.5 | closed |

## Written so the next session inherits what is easy to lose

**What is still open, and whose call it is.** LRB decision #2 is untaken — the preprint, `.zenodo.json` and the v0.4.4 release notes still carry pre-repair figures, *deliberately*, because re-baselining a published paper is not a session's decision. Phase 3.1/3.2 and the #1084/#1091 dogfoods need a real device.

**The verification method, not just its result.** Visual regression alone is insufficient: it shoots desktop width and missed a mobile regression. The computed-style comparison caught that — plus a false positive I would have "fixed", a stale-cache failure that looked exactly like a real defect, and an unresolved custom property that compared equal to another unresolved one.

**The three self-corrections.** A wrong invariant CI disproved; a patch-leak remedy that never fired because pytest-timeout raises a `BaseException`; and a work estimate off by 200 sites until it was measured.

**The tool's two traps.** `--apply` regenerates the CSS block wholesale, so HTML and `JS_FILES` must run in one invocation — and it must never be re-run without reading §4.2 first.

## Entry pointer

Moves to this document; the previous row is demoted so the recency invariant #1081 added stays satisfied with a single `NEXT SESSION ENTRY` header.

## Verification

- `tests/test_v06_claude_md_entry_pointer.py` → 6 passed (all four invariants, recency included)
- full local suite → **5,312 passed**
- docs-only; no `core/` change

## Quality Delta

`Quality delta: exempt (label: docs)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
