### PR TITLE
feat(v0.6.2): the enumerable half of Phase 3.3's last 26 — 26 -> 10

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
+<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
+<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
+<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
+<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -514,12 +514,13 @@ function _firstRunRow(r, primary) {
   const desc = _escHtml(r.desc || r.description || '');
   const tag = _escHtml(r.tag || r.name || '');
   const stars = primary ? '● ' : '   ';
-  const bg = primary ? 'rgba(99,102,241,.10)' : 'transparent';
-  const border = primary ? 'border:1px solid var(--accent);' : 'border:1px solid var(--border);';
-  return `<div style="${border}background:${bg};border-radius:7px;padding:10px 12px;margin:4px 6px;
-                       display:flex;align-items:center;gap:10px;font-size:13px">
+  // `primary` is a boolean, so the background/border/colour it drove
+  // are two fixed appearances — a modifier class, not a style attribute
+  // (which CSP's style-src blocks).
+  const primaryCls = primary ? ' is-primary' : '';
+  return `<div class="first-run-row${primaryCls}">
     <div class="flex-1 u-3f9f96c6">
-      <div style="${primary?'color:var(--accent-fg);font-weight:600':''}">${stars}${tag}</div>
+      <div class="first-run-row-title">${stars}${tag}</div>
       <div class="fs-11 c-muted ov-hidden u-65dccb4c">
         ${desc}${sizeGB ? ' · ' + sizeGB : ''}
       </div>
@@ -1768,10 +1769,7 @@ async function openSessionTurns(sessionId, label) {
       const ts     = turn.created_at || turn.time || turn.timestamp || '';
       const tsShort = (ts || '').slice(0, 19).replace('T', ' ');
       return `
-        <div style="display:flex;flex-direction:column;gap:4px;
-                    background:${isUser ? 'rgba(124,106,247,.10)' : 'var(--bg)'};
-                    border-left:3px solid ${isUser ? '#7c6af7' : '#3da78a'};
-                    padding:10px 12px;border-radius:4px">
+        <div class="session-turn ${isUser ? 'is-user' : 'is-james'}">
           <div class="fs-10 c-muted font-mono d-flex justify-between">
             <span>${isUser ? 'user' : 'james'}${turn.mode ? ' · mode=' + escapeHtml(turn.mode) : ''}</span>
             <span>${escapeHtml(tsShort)}</span>
@@ -2078,18 +2076,10 @@ async function loadUploads(resetOffset = true) {
       const hasPrev = _uploadsOffset > 0;
       const hasNext = (_uploadsOffset + items.length) < total;
       pager.innerHTML = `
-        <button data-action="uploads-prev" ${hasPrev ? '' : 'disabled'}
-                style="padding:6px 14px;background:var(--surface-2);
-                       border:1px solid var(--border);border-radius:6px;
-                       color:var(--text);cursor:${hasPrev ? 'pointer' : 'not-allowed'};
-                       opacity:${hasPrev ? '1' : '0.4'};font-size:12px">
+        <button class="pager-btn" data-action="uploads-prev" ${hasPrev ? '' : 'disabled'}>
           ‹ 이전
         </button>
-        <button data-action="uploads-next" ${hasNext ? '' : 'disabled'}
-                style="padding:6px 14px;background:var(--surface-2);
-                       border:1px solid var(--border);border-radius:6px;
-                       color:var(--text);cursor:${hasNext ? 'pointer' : 'not-allowed'};
-                       opacity:${hasNext ? '1' : '0.4'};font-size:12px">
+        <button class="pager-btn" data-action="uploads-next" ${hasNext ? '' : 'disabled'}>
           다음 ›
         </button>`;
     }
@@ -4264,15 +4254,12 @@ async function loadLLMRecommend() {
       const purposes    = (m.purpose||[]).map(p => ({
         chat:'',retrieval:'',coding:'',multimodal:''
       }[p]||p)).join(' ');
-      const btnStyle = isInstalled
-        ? `background:#4caf7d;cursor:default`
-        : `background:var(--accent);cursor:pointer`;
+      // One boolean, two fixed appearances — modifier classes rather
+      // than a style attribute (CSP style-src).
+      const installedCls = isInstalled ? ' is-installed' : '';
       const btnLabel = isInstalled ? t('hw.llm_installed') : `${t('hw.llm_install_btn',{size:m.size_gb})}`;
-      const cardBg   = isInstalled ? 'rgba(76,175,125,.08)' : 'var(--surface)';
 
-      return `<div style="display:flex;align-items:center;gap:12px;padding:10px;
-                           margin-bottom:8px;border-radius:8px;
-                           background:${cardBg};border:1px solid var(--border)">
+      return `<div class="llm-card${installedCls}">
         <div class="flex-1">
           <div class="fw-700 fs-13">${m.name}</div>
           <div class="fs-11 c-muted u-f005b881">
@@ -4282,10 +4269,8 @@ async function loadLLMRecommend() {
         <div class="fs-11 c-muted u-a94d207d">
           ${m.size_gb}GB
         </div>
-        <button data-action="install-llm" data-model-name="${escapeHtml(m.name)}"
-                style="border:none;border-radius:6px;padding:5px 12px;
-                       font-size:11px;font-weight:600;color:#fff;
-                       ${btnStyle}" ${isInstalled?'disabled':''}>
+        <button class="llm-install-btn${installedCls}" data-action="install-llm"
+                data-model-name="${escapeHtml(m.name)}" ${isInstalled?'disabled':''}>
           ${btnLabel}
         </button>
       </div>`;

--- a/frontend/static/agent-chat.js
+++ b/frontend/static/agent-chat.js
@@ -237,20 +237,22 @@
       : _esc(call.error || 'error');
     // run_shell is the highest-risk tool — flag it with a warning border
     // + a ⚠ marker so the operator can spot a shell call at a glance.
+    // Two booleans here (is this a shell call, did it succeed) drove
+    // a border colour and a text colour. Both are fixed pairs, so they
+    // are modifier classes — CSP style-src blocks the attribute.
     const isShell = call.name === 'run_shell';
-    const border = isShell ? '#a16207' : 'var(--border,#334155)';
     const shellTag = isShell
       ? ` <span class="u-6b219d48" title="${_esc(_t('agentchat.shell_tag_title', '셸 명령 실행 — 운영자 허용 폴더 안에서만'))}">⚠ shell</span>`
       : '';
     _appendNode(`
-      <div style="align-self:flex-start;max-width:92%;background:var(--bg,#0f172a);border:1px solid ${border};border-radius:8px;padding:8px 12px;font-family:var(--font-mono);font-size:11px;color:var(--text)">
+      <div class="agent-call${isShell ? ' is-shell' : ''}">
         <div class="d-flex justify-between items-center mb-4">
           <span><strong>${okIcon} ${_esc(call.name)}</strong>${shellTag}
                 <span class="c-muted ml-6">iter ${call.iter || ''}</span></span>
           <span class="c-muted">${call.elapsed_ms != null ? call.elapsed_ms + ' ms' : ''}</span>
         </div>
         <div class="u-1ad59c6e">args: ${_esc(argsJson)}</div>
-        <div style="color:${call.ok ? 'var(--muted)' : '#fcc'};word-break:break-all">${detail}</div>
+        <div class="agent-call-detail${call.ok ? '' : ' is-err'}">${detail}</div>
       </div>
     `);
   }
@@ -310,16 +312,12 @@
     }
     box.innerHTML = _sessions.map(s => {
       const active = _activeSession && _activeSession.id === s.id;
-      return `<div data-action="agent-session-open" data-sid="${_esc(s.id)}"
-        style="display:flex;justify-content:space-between;align-items:center;gap:4px;
-        padding:6px 8px;border-radius:6px;cursor:pointer;font-size:12px;
-        background:${active ? 'var(--accent,#3b82f6)' : 'var(--bg)'};
-        color:${active ? '#fff' : 'var(--text)'};border:1px solid var(--border)">
+      return `<div class="agent-sess${active ? ' is-active' : ''}"
+        data-action="agent-session-open" data-sid="${_esc(s.id)}">
         <span class="u-7afdde9c">${_esc(s.title)}</span>
-        <button data-action="agent-session-del" data-sid="${_esc(s.id)}"
-          title="${_esc(_t('agentsess.del', '삭제'))}"
-          style="border:0;background:transparent;color:${active ? '#fff' : 'var(--muted)'};
-          cursor:pointer;font-size:12px;padding:0 2px">✕</button>
+        <button class="agent-sess-del" data-action="agent-session-del"
+          data-sid="${_esc(s.id)}"
+          title="${_esc(_t('agentsess.del', '삭제'))}">✕</button>
       </div>`;
     }).join('');
   }

--- a/frontend/static/change-requests.js
+++ b/frontend/static/change-requests.js
@@ -103,18 +103,20 @@
     return d + 'd ago';
   }
 
+  // Four fixed statuses, so four classes — the tinted background /
+  // text / border trio used to be interpolated into a style attribute,
+  // which CSP's style-src blocks. Palette lives in tokens.css.
+  var STATUS_CLASS = {
+    open:       'cr-status-open',
+    merged:     'cr-status-merged',
+    rejected:   'cr-status-rejected',
+    superseded: 'cr-status-superseded'
+  };
+
   function statusBadge(status) {
-    var colors = {
-      open:       'background:rgba(255,183,77,.12);color:#ffb74d;border:1px solid rgba(255,183,77,.35);',
-      merged:     'background:rgba(76,175,125,.12);color:#4caf7d;border:1px solid rgba(76,175,125,.35);',
-      rejected:   'background:rgba(239,68,68,.12);color:#fca5a5;border:1px solid rgba(239,68,68,.35);',
-      superseded: 'background:rgba(138,141,153,.12);color:var(--muted);border:1px solid rgba(138,141,153,.35);'
-    };
-    var style = colors[status] || colors.superseded;
-    return '<span style="' + style +
-           'padding:3px 9px;border-radius:6px;' +
-           'font-size:11px;font-family:var(--font-mono);' +
-           'letter-spacing:.3px">' + escHtml(status) + '</span>';
+    var cls = STATUS_CLASS[status] || STATUS_CLASS.superseded;
+    return '<span class="cr-status-badge ' + cls + '">' +
+           escHtml(status) + '</span>';
   }
 
   function renderRow(cr) {
@@ -411,18 +413,11 @@
     return map[why] || '(no explanation available)';
   }
 
-  function _ruleBadgeStyle(rule) {
-    if (rule === 'A_invalidate') {
-      return 'background:rgba(239,68,68,.12);color:#fca5a5;' +
-             'border:1px solid rgba(239,68,68,.45);';
-    }
-    if (rule === 'ignore') {
-      return 'background:rgba(138,141,153,.12);color:var(--muted);' +
-             'border:1px solid rgba(138,141,153,.35);';
-    }
+  function _ruleBadgeClass(rule) {
+    if (rule === 'A_invalidate') return 'cr-rule-invalidate';
+    if (rule === 'ignore')       return 'cr-rule-ignore';
     // B_supersede — accent-tinted (the most common path)
-    return 'background:rgba(107,231,208,.10);color:var(--accent-fg);' +
-           'border:1px solid rgba(107,231,208,.30);';
+    return 'cr-rule-supersede';
   }
 
   function _renderArbiterSlot(cr) {
@@ -430,15 +425,14 @@
     if (!slot) return;
     var result = _syntheticArbiterResult(cr);
     var explanation = _arbiterRuleExplanation(result.why);
-    var badgeStyle = _ruleBadgeStyle(result.rule);
+    var badgeClass = _ruleBadgeClass(result.rule);
     var explanationId = 'cr-arbiter-explanation-' + cr.cr_id;
     slot.innerHTML = [
       '<div class="d-flex items-center gap-10 flex-wrap font-mono fs-11">',
       '<span class="muted-12 font-mono">',
       'Contradiction classifier:',
       '</span>',
-      '<span style="' + badgeStyle + 'padding:3px 10px;',
-      'border-radius:6px;font-weight:600;letter-spacing:.4px">',
+      '<span class="cr-rule-badge ' + badgeClass + '">',
       escHtml(result.rule),
       '</span>',
       '<button class="bg-transparent bd-1 c-muted cursor-pointer fs-10 font-mono u-53f47ba5" data-action="cr-arbiter-toggle"',

--- a/frontend/static/graph_editor.js
+++ b/frontend/static/graph_editor.js
@@ -130,16 +130,19 @@
     if (el) el.textContent = msg || '';
   }
 
+  // A class per role, not an interpolated colour: CSP's style-src
+  // blocks the style attribute this used to build, and the value was
+  // never computed — five fixed roles. Palette lives in tokens.css.
+  var ROLE_CLASS = {
+    manual:  'source-role-manual',
+    extract: 'source-role-extract',
+    inverse: 'source-role-inverse',
+    legacy:  'source-role-legacy'
+  };
+
   function roleBadge(role) {
-    var color = 'var(--muted)';
-    if (role === 'manual')  color = 'var(--accent)';
-    if (role === 'extract') color = '#a5b4fc';
-    if (role === 'inverse') color = '#94a3b8';
-    if (role === 'legacy')  color = '#f59e0b';
-    return '<span style="display:inline-block;padding:1px 6px;border-radius:4px;' +
-           'background:rgba(255,255,255,.05);border:1px solid ' + color + ';' +
-           'color:' + color + ';font-size:10px;font-family:var(--font-mono);' +
-           'letter-spacing:.5px">' + role + '</span>';
+    var cls = ROLE_CLASS[role] || 'source-role-default';
+    return '<span class="source-role-badge ' + cls + '">' + role + '</span>';
   }
 
   // [Stage E.1, 2026-05-24] per-source row — view mode (✏️ + ✕ actions)

--- a/frontend/static/i18n.js
+++ b/frontend/static/i18n.js
@@ -2626,10 +2626,12 @@ function updateLangToggleDisplay() {
   var btns = document.querySelectorAll('[data-lang-toggle]');
   for (var i = 0; i < btns.length; i++) {
     var koActive = currentLang === 'ko';
+    // Active/inactive is a boolean, so the opacity + weight pair is a
+    // modifier class rather than a style attribute (CSP style-src).
     btns[i].innerHTML =
-      '<span style="opacity:' + (koActive ? 1 : 0.4) + ';font-weight:' + (koActive ? 700 : 400) + '">KO</span>' +
+      '<span class="lang-seg' + (koActive ? ' is-active' : '') + '">KO</span>' +
       '<span class="u-160ef599">|</span>' +
-      '<span style="opacity:' + (!koActive ? 1 : 0.4) + ';font-weight:' + (!koActive ? 700 : 400) + '">EN</span>';
+      '<span class="lang-seg' + (koActive ? '' : ' is-active') + '">EN</span>';
   }
 }
 

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -876,3 +876,208 @@ body::before {
 .c-brand-2 { color: var(--brand-2); }
 .c-red     { color: var(--red, #f06292); }
 .c-blocked { color: #d97a7a; }
+
+/* ─────────────────────────────────────────────────────────────
+   Phase 3.3 tail — the enumerable half of the last 26 JS-built
+   inline styles. Hand-maintained, OUTSIDE the generated block
+   above (which is rebuilt on every `--apply` run).
+
+   Each of these used to be interpolated into a `style="…"`
+   attribute that CSP's `style-src` blocks. In every case the
+   interpolated value came from a boolean or a lookup with three
+   to five outcomes — enumerable, not computed — so the outcomes
+   became modifier classes and the palette moved here.
+   ───────────────────────────────────────────────────────────── */
+
+/* graph_editor.js — per-source provenance badge (5 roles).
+   NOT `.role-badge`: that name is already taken by the login
+   chip in chat.css / tokens.css, and graph.html loads both. */
+.source-role-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, .05);
+  border: 1px solid var(--muted);
+  color: var(--muted);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  letter-spacing: .5px;
+}
+.source-role-manual  { border-color: var(--accent); color: var(--accent); }
+.source-role-extract { border-color: #a5b4fc; color: #a5b4fc; }
+.source-role-inverse { border-color: #94a3b8; color: #94a3b8; }
+.source-role-legacy  { border-color: #f59e0b; color: #f59e0b; }
+/* `.source-role-default` is the base appearance — no rule needed. */
+
+/* admin.js — first-run model recommendation row. */
+.first-run-row {
+  border: 1px solid var(--border);
+  background: transparent;
+  border-radius: 7px;
+  padding: 10px 12px;
+  margin: 4px 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+.first-run-row.is-primary {
+  border-color: var(--accent);
+  background: rgba(99, 102, 241, .10);
+}
+.first-run-row.is-primary .first-run-row-title {
+  color: var(--accent-fg);
+  font-weight: 600;
+}
+
+/* admin.js — uploads pager. `:disabled` already carries the state,
+   so the disabled appearance needs no class of its own. */
+.pager-btn {
+  padding: 6px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  opacity: 1;
+  font-size: 12px;
+}
+.pager-btn:disabled { cursor: not-allowed; opacity: .4; }
+
+/* admin.js — hardware LLM recommendation card + install button. */
+.llm-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.llm-card.is-installed { background: rgba(76, 175, 125, .08); }
+.llm-install-btn {
+  border: none;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  cursor: pointer;
+}
+.llm-install-btn.is-installed { background: #4caf7d; cursor: default; }
+
+/* admin.js — session transcript turn (user vs james). */
+.session-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  border-left: 3px solid transparent;
+}
+.session-turn.is-user {
+  background: rgba(124, 106, 247, .10);
+  border-left-color: #7c6af7;
+}
+.session-turn.is-james {
+  background: var(--bg);
+  border-left-color: #3da78a;
+}
+
+/* agent-chat.js — tool-call bubble and session list row. */
+.agent-call {
+  align-self: flex-start;
+  max-width: 92%;
+  background: var(--bg, #0f172a);
+  border: 1px solid var(--border, #334155);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text);
+}
+.agent-call.is-shell { border-color: #a16207; }
+.agent-call-detail { color: var(--muted); word-break: break-all; }
+.agent-call-detail.is-err { color: #fcc; }
+
+.agent-sess {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.agent-sess.is-active { background: var(--accent, #3b82f6); color: #fff; }
+.agent-sess-del {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+}
+.agent-sess.is-active .agent-sess-del { color: #fff; }
+
+/* change-requests.js — CR status badge (4 statuses). */
+.cr-status-badge {
+  padding: 3px 9px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  letter-spacing: .3px;
+}
+.cr-status-open {
+  background: rgba(255, 183, 77, .12);
+  color: #ffb74d;
+  border: 1px solid rgba(255, 183, 77, .35);
+}
+.cr-status-merged {
+  background: rgba(76, 175, 125, .12);
+  color: #4caf7d;
+  border: 1px solid rgba(76, 175, 125, .35);
+}
+.cr-status-rejected {
+  background: rgba(239, 68, 68, .12);
+  color: #fca5a5;
+  border: 1px solid rgba(239, 68, 68, .35);
+}
+.cr-status-superseded {
+  background: rgba(138, 141, 153, .12);
+  color: var(--muted);
+  border: 1px solid rgba(138, 141, 153, .35);
+}
+
+/* change-requests.js — contradiction-classifier rule badge. */
+.cr-rule-badge {
+  padding: 3px 10px;
+  border-radius: 6px;
+  font-weight: 600;
+  letter-spacing: .4px;
+}
+.cr-rule-invalidate {
+  background: rgba(239, 68, 68, .12);
+  color: #fca5a5;
+  border: 1px solid rgba(239, 68, 68, .45);
+}
+.cr-rule-ignore {
+  background: rgba(138, 141, 153, .12);
+  color: var(--muted);
+  border: 1px solid rgba(138, 141, 153, .35);
+}
+.cr-rule-supersede {
+  background: rgba(107, 231, 208, .10);
+  color: var(--accent-fg);
+  border: 1px solid rgba(107, 231, 208, .30);
+}
+
+/* i18n.js — KO | EN language toggle segments. */
+.lang-seg { opacity: .4; font-weight: 400; }
+.lang-seg.is-active { opacity: 1; font-weight: 700; }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v33-20260908-csp-tagre">
+<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->


### PR DESCRIPTION
## Summary

Phase 3.3's remaining surface was 26 sites. Sixteen of them interpolated
a value that was never actually computed — a boolean, or a lookup with
three to five outcomes. Same shape #1101 and #1104 found: *interpolated
is not the same as computed*. Those outcomes are now modifier classes
and the palette lives in `tokens.css`.

| file | site | what was interpolated |
|---|---|---|
| `graph_editor.js` | `roleBadge` | 5 provenance roles |
| `admin.js` | first-run row + title | `primary` boolean |
| `admin.js` | uploads pager ×2 | now handled by `:disabled` |
| `admin.js` | session transcript turn | user vs james |
| `admin.js` | LLM card + install button | `isInstalled` boolean |
| `agent-chat.js` | tool-call bubble | `run_shell` boolean |
| `agent-chat.js` | tool-call detail | `call.ok` boolean |
| `agent-chat.js` | session row + delete button | `active` boolean |
| `change-requests.js` | status badge | 4 statuses |
| `change-requests.js` | arbiter rule badge | 3 rules |
| `i18n.js` | KO \| EN toggle segments | `active` boolean |

The pager buttons already carry `disabled`, so their cursor/opacity pair
became a `:disabled` rule rather than a class of its own.

Named `.source-role-badge`, **not** `.role-badge` — that name is already
the login chip in `chat.css` / `tokens.css`, and `graph.html` loads both.

New rules go **outside** the generated block, per the #1097 failure
(the block is rebuilt from whatever a `--apply` run converts).

## Verification

**Computed-style comparison** — 34 pairs, each rendering the class
version and the *original inline value* through an identical markup
path, compared across every computed property. Run in all five page CSS
contexts (index / admin / graph / workspace / intro), because a class
can be overridden by a later stylesheet where an inline attribute could
not. **170 comparisons, 0 mismatches.**

Two things the comparison caught that equality alone would have hidden:

- The `-title` pairs were selecting the **outer row**, not the title:
  `A.querySelector('div > div')` matches `#A > .first-run-row` first.
  Both sides agreed because both were reading the same wrong element —
  the #1101 mis-pairing trap. With the target marked explicitly, the
  primary title resolves to `accent-fg` / `600` as the inline value did.
- **Resolution is checked separately from equality.** Every colour lands
  on a real value (`accent`, `muted`, `border`, `text`, `accent-fg`,
  `surface`, `surface-2`, `bg` all resolve); two *unresolved* custom
  properties would have compared equal to each other (#1104).

**`node --check`** passes on all five JS files.

**`tests/`** — 5,312 passed / 0 failed / 2 skipped.

**Live visual regression: not run.** It needs a server on `:8000`, none
is up, and per CLAUDE.md a session does not start one unasked. The
computed-style comparison covers these surfaces more directly in any
case — they are dynamic states (an installed LLM card, a shell tool
call, a merged CR badge) that a 7-page load capture never renders.

`tokens.css` cache buster bumped `v33` → `v34`.

## Out of scope

- The 8 genuinely computed sites left in `admin.js` (bar widths, a
  stroke width, a per-domain drop-shadow) — follow-up PR, `data-*` +
  CSSOM and one SVG presentation attribute.
- The `JAMES_CSP_MODE=enforce` flip, which waits for 26 → 0.

Phase 3.3: **26 → 10**, of which 2 are references inside comments.

Quality delta: exempt (label: chore) — presentation-layer migration; no
`core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
