### PR TITLE
feat(v0.6.2): the computed half — Phase 3.3 reaches 0 JS inline styles

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Admin</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
+<link rel="stylesheet" href="/static/tokens.css?v=v35-20260909-csp-cssom">
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Reasoning Graph</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
+<link rel="stylesheet" href="/static/tokens.css?v=v35-20260909-csp-cssom">
 <!-- v=v14-20260616 cache-bust: graph.css markdown render + conf chip
      + bottom-sheet panel on phones (v9 node-detail panel reorg). -->
 <link rel="stylesheet" href="/static/graph.css?v=v14-20260616">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
+<link rel="stylesheet" href="/static/tokens.css?v=v35-20260909-csp-cssom">
 <!-- v=v20-20260616 cache-bust: 대화 본문 명조체 (--font-serif) +
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title data-i18n="intro.page_title">SEKOS — Secure Enterprise Knowledge OS</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
+<link rel="stylesheet" href="/static/tokens.css?v=v35-20260909-csp-cssom">
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -812,6 +812,31 @@ async function api(path, method='GET', body=null) {
 }
 
 /* ── 대시보드 ── */
+/* ── CSSOM size helpers (CSP style-src) ─────────────────────────
+ * A width in percent or pixels derived from live data cannot become a
+ * class, and `style="width:…"` in injected markup is exactly what
+ * strict `style-src` blocks. CSSOM writes are NOT governed by CSP
+ * (measured 2026-09-08, #1095), so the value is carried on a data-*
+ * attribute through innerHTML and applied here afterwards.
+ *
+ * Both helpers are no-ops when the container holds no marked element,
+ * so callers do not need to guard.
+ */
+function _applyPctWidths(root) {
+  if (!root) return;
+  root.querySelectorAll('[data-pct]').forEach(el => {
+    el.style.width = el.dataset.pct + '%';
+  });
+}
+
+function _applySizedBars(root) {
+  if (!root) return;
+  root.querySelectorAll('[data-w][data-h]').forEach(el => {
+    el.style.width  = el.dataset.w + 'px';
+    el.style.height = el.dataset.h + 'px';
+  });
+}
+
 async function loadDashboard() {
   try {
     const data = await api('/admin/dashboard');
@@ -865,12 +890,12 @@ async function loadDashboard() {
     const chart = data.elapsed_chart || [];
     if (chart.length > 0) {
       const max_v = Math.max(...chart, 1);
+      const barW = Math.floor(280 / chart.length) - 2;
       const bars  = chart.map(v => {
         const h   = Math.max(4, Math.round((v / max_v) * 60));
-        const col = v > 20 ? '#f06292' : v > 10 ? '#ffb74d' : '#7c6af7';
-        return `<div title="${v}s" style="width:${Math.floor(280/chart.length)-2}px;
-          height:${h}px;background:${col};border-radius:2px 2px 0 0;
-          flex-shrink:0"></div>`;
+        const cls = v > 20 ? 'is-slow' : v > 10 ? 'is-mid' : 'is-fast';
+        return `<div class="dash-bar ${cls}" title="${v}s"
+          data-w="${barW}" data-h="${h}"></div>`;
       }).join('');
 
       const chartEl = document.getElementById('dash-chart');
@@ -885,6 +910,7 @@ async function loadDashboard() {
           <div class="d-flex items-end p-8-20 bg-bg br-6 bd-1 u-cc617d82">
             ${bars}
           </div>`;
+        _applySizedBars(chartEl);
       }
     }
 
@@ -3550,7 +3576,7 @@ function renderInteractiveRadar() {
     inner += `<path class="${cls}" d="M${p1.x.toFixed(1)},${p1.y.toFixed(1)}
                                        Q${tx.toFixed(1)},${ty.toFixed(1)}
                                        ${p2.x.toFixed(1)},${p2.y.toFixed(1)}"
-                    style="stroke-width:${sw}"/>`;
+                    data-sw="${sw}"/>`;
   });
 
   // ─── 5) 데이터 폴리곤 (값 영역) ──────────────────────────────
@@ -3574,6 +3600,11 @@ function renderInteractiveRadar() {
   });
 
   svg.innerHTML = inner;
+  // CSSOM, not a style attribute (CSP style-src) and not a
+  // presentation attribute (admin.css's .corr-edge rule would win).
+  svg.querySelectorAll('path[data-sw]').forEach(el => {
+    el.style.strokeWidth = el.dataset.sw;
+  });
 
   // ─── 7) Pointer events on vertices ───────────────────────────
   // [PR #157 패턴 준수] inline onclick 없이 addEventListener 로만.
@@ -4076,11 +4107,11 @@ function renderCapabilities(caps) {
         <span class="fs-12 font-mono c-accent">${c.pct}%</span>
       </div>
       <div class="ov-hidden u-7b9f9868">
-        <div style="width:${c.pct}%;height:100%;background:var(--accent);
-          border-radius:4px;transition:width .5s ease"></div>
+        <div class="capability-bar-fill" data-pct="${c.pct}"></div>
       </div>
       <div class="fs-10 c-muted u-1d1dc4d1"><span data-i18n="${c.desc_key || ''}">${c.desc}</span></div>
     </div>`).join('');
+  _applyPctWidths(el);
   // Re-translate freshly-injected data-i18n spans (matches the
   // loadCognitiveFlags / loadLlmSelections / buildProtectedCheckboxes
   // / loadPolicy pattern).
@@ -4109,14 +4140,11 @@ function _domainDonut(d) {
               stroke-linecap="round"
               transform="rotate(-90 ${cx} ${cy})"
               stroke-dasharray="${filled} ${circ}"
-              style="filter:drop-shadow(0 0 4px ${d.color}88);
-                     transition:stroke-dasharray .6s ease"/>
+              class="domain-donut-arc" data-glow="${d.color}"/>
       <!-- 중앙 레벨 숫자 -->
       <text x="${cx}" y="${cy + 1}" text-anchor="middle"
             dominant-baseline="middle"
-            style="font-size:20px;font-weight:900;fill:${d.color};
-                   font-family:var(--font-mono, ui-monospace, monospace);
-                   letter-spacing:-1px">${d.level}</text>
+            class="domain-donut-level" data-fill="${d.color}">${d.level}</text>
       <!-- "Lv" 레이블 -->
       <text class="ls-1 u-ceecb8ce" x="${cx}" y="${cy - 13}" text-anchor="middle"
            >LV</text>
@@ -4141,11 +4169,23 @@ function renderDomains(domains) {
             ${d.icon} <strong><span data-i18n="${d.label_key || ''}">${d.label}</span></strong>
           </div>
           <div class="fs-10 c-muted font-mono lh-16">
-            <div><span data-i18n="growth.next_level">다음까지</span> <strong style="color:${d.color}">${d.tier_pct ?? d.pct}%</strong></div>
+            <div><span data-i18n="growth.next_level">다음까지</span> <strong data-color="${d.color}">${d.tier_pct ?? d.pct}%</strong></div>
             <div>${d.wiki_count ?? 0} wiki · score ${d.score ?? 0}</div>
           </div>
         </div>
       </div>`).join('') + '</div>';
+  // The domain palette is server data (core/knowledge_tracker.py owns
+  // it), so these are not enumerable in the frontend — CSSOM rather
+  // than a class, which also keeps the palette in one place.
+  el.querySelectorAll('[data-glow]').forEach(n => {
+    n.style.filter = `drop-shadow(0 0 4px ${n.dataset.glow}88)`;
+  });
+  el.querySelectorAll('[data-fill]').forEach(n => {
+    n.style.fill = n.dataset.fill;
+  });
+  el.querySelectorAll('[data-color]').forEach(n => {
+    n.style.color = n.dataset.color;
+  });
   // Re-translate freshly-injected data-i18n spans.
   if (typeof applyTranslations === 'function') applyTranslations();
 }
@@ -4174,13 +4214,13 @@ async function loadHardware() {
         { key:'gpu',  spec: specs.gpu  || {} },
         { key:'disk', spec: specs.disk || {} },
       ];
-      const lvColor = lv => lv >= 9 ? '#f06292' : lv >= 7 ? '#7c6af7'
-                           : lv >= 5 ? '#4fc3f7' : lv >= 3 ? '#4caf7d' : '#aaa';
+      const lvClass = lv => lv >= 9 ? 'lv-5' : lv >= 7 ? 'lv-4'
+                          : lv >= 5 ? 'lv-3' : lv >= 3 ? 'lv-2' : 'lv-1';
 
       cardsEl.innerHTML = comps.map(({ key, spec }) => {
         const w   = spec.weapon || {};
         const lv  = spec.level  || 0;
-        const col = lvColor(lv);
+        const lvc = lvClass(lv);
         let detail = '';
         if (key==='cpu')  detail=`${spec.cores||'?'} cores · ${spec.freq_mhz||'?'}MHz ${spec.usage_pct!=null?`· ${spec.usage_pct}%`:''}`;
         if (key==='ram')  detail=`${spec.total_gb||'?'}GB total · ${spec.available_gb||'?'}GB free`;
@@ -4199,16 +4239,18 @@ async function loadHardware() {
               <div class="u-2cbabd6c">${w.icon||''}</div>
               <div><div class="fw-700 fs-15"${nameDi}>${w.name||'?'}</div>
                    <div class="fs-10 c-muted"${roleDi}>${w.role||key}</div></div>
-              <div style="margin-left:auto;font-size:26px;font-weight:900;color:${col};font-family:var(--font-mono)">
+              <div class="worker-level ${lvc}">
                 ${lv}<span class="fs-11 fw-400 c-muted">/10</span></div>
             </div>
             <div class="bg-bg ov-hidden mb-8 u-28f00506">
-              <div style="width:${Math.min(100,lv*10)}%;height:100%;background:${col};border-radius:4px;transition:width .8s;box-shadow:0 0 8px ${col}66"></div>
+              <div class="worker-level-bar ${lvc}"
+                   data-pct="${Math.min(100, lv * 10)}"></div>
             </div>
             <div class="fs-11 c-muted font-mono mb-4">${detail}</div>
             <div class="fs-11 c-text"${descDi}>${w.desc||''}</div>
           </div>`;
       }).join('');
+      _applyPctWidths(cardsEl);
       // Re-translate freshly-injected data-i18n spans so the active
       // lang takes effect immediately (matches the loadCognitiveFlags
       // / loadLlmSelections / buildProtectedCheckboxes / loadPolicy /

--- a/frontend/static/graph_node_editor.js
+++ b/frontend/static/graph_node_editor.js
@@ -81,12 +81,10 @@
     btn.type = 'button';
     btn.id = 'np-summary-edit-btn';
     btn.textContent = _t('graph.node.edit.button', '노드 편집');
-    btn.setAttribute('style',
-      'margin-top:10px;width:100%;padding:8px 10px;' +
-      'background:var(--surface-2);border:1px solid var(--border);' +
-      'border-radius:6px;color:var(--text-soft);font-size:12px;' +
-      'font-family:var(--font-mono);letter-spacing:.4px;cursor:pointer'
-    );
+    // A class. This was built by setting the style ATTRIBUTE, which
+    // strict style-src blocks exactly like an inline style in markup
+    // (unlike el.style.x, which is CSSOM and is not governed by CSP).
+    btn.className = 'node-edit-btn';
     btn.addEventListener('click', function () { openModal(data.entity_id); });
     host.appendChild(btn);
   }

--- a/frontend/static/tokens.css
+++ b/frontend/static/tokens.css
@@ -1081,3 +1081,88 @@ body::before {
 /* i18n.js — KO | EN language toggle segments. */
 .lang-seg { opacity: .4; font-weight: 400; }
 .lang-seg.is-active { opacity: 1; font-weight: 700; }
+
+/* ─────────────────────────────────────────────────────────────
+   Phase 3.3 tail, part 2 — the genuinely computed sites. The
+   value that really varies (a bar width, a stroke width, a
+   per-domain glow) is applied through CSSOM, which CSP does not
+   govern; everything around it that was static, or enumerable,
+   is a class here.
+   ───────────────────────────────────────────────────────────── */
+
+/* admin.js — dashboard elapsed-time bar chart. Width and height come
+   from the data (see `_applySizedBars`); the colour is three fixed
+   speed bands. */
+.dash-bar {
+  border-radius: 2px 2px 0 0;
+  flex-shrink: 0;
+}
+.dash-bar.is-slow { background: #f06292; }
+.dash-bar.is-mid  { background: #ffb74d; }
+.dash-bar.is-fast { background: #7c6af7; }
+
+/* admin.js — capability progress bar. Width via `_applyPctWidths`. */
+.capability-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width .5s ease;
+}
+
+/* admin.js — domain donut. `filter` and `fill` carry the per-domain
+   colour, which is server data (core/knowledge_tracker.py owns the
+   palette), so they are set via CSSOM rather than duplicated here. */
+.domain-donut-arc { transition: stroke-dasharray .6s ease; }
+.domain-donut-level {
+  font-size: 20px;
+  font-weight: 900;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: -1px;
+}
+
+/* admin.js — hardware worker level number and bar. Five fixed level
+   bands, so the colour is a class; only the bar width is computed. */
+.worker-level {
+  margin-left: auto;
+  font-size: 26px;
+  font-weight: 900;
+  font-family: var(--font-mono);
+}
+.worker-level.lv-5 { color: #f06292; }
+.worker-level.lv-4 { color: #7c6af7; }
+.worker-level.lv-3 { color: #4fc3f7; }
+.worker-level.lv-2 { color: #4caf7d; }
+.worker-level.lv-1 { color: #aaa; }
+
+.worker-level-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width .8s;
+}
+.worker-level-bar.lv-5 { background: #f06292; box-shadow: 0 0 8px #f0629266; }
+.worker-level-bar.lv-4 { background: #7c6af7; box-shadow: 0 0 8px #7c6af766; }
+.worker-level-bar.lv-3 { background: #4fc3f7; box-shadow: 0 0 8px #4fc3f766; }
+.worker-level-bar.lv-2 { background: #4caf7d; box-shadow: 0 0 8px #4caf7d66; }
+/* lv-1 has no glow on purpose: the original built the shadow colour by
+   appending "66" to the level colour, and for this band that colour was
+   the 4-char "#aaa" — "#aaa66" is not a valid hex colour, so the
+   declaration was dropped. Reproduced rather than quietly fixed. */
+.worker-level-bar.lv-1 { background: #aaa; }
+
+/* graph_node_editor.js — "노드 편집" button. Was built with
+   setAttribute('style', …), which sets the style ATTRIBUTE and so is
+   blocked by strict style-src exactly like an inline one in markup
+   (unlike el.style.x, which is CSSOM and is not governed by CSP). */
+.node-edit-btn {
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-soft);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  letter-spacing: .4px;
+  cursor: pointer;
+}

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#04060a">
 <title>Secure Enterprise Knowledge Operating System — Workspace</title>
-<link rel="stylesheet" href="/static/tokens.css?v=v34-20260909-csp-enumerable">
+<link rel="stylesheet" href="/static/tokens.css?v=v35-20260909-csp-cssom">
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->

--- a/scripts/migrate_inline_styles.py
+++ b/scripts/migrate_inline_styles.py
@@ -244,7 +244,28 @@ JS_FILES = [
     FRONTEND / "static" / "glossary.js",
     # 2026-09-08 — the last and largest, on its own pass.
     FRONTEND / "static" / "admin.js",
+    # Added 2026-09-09: these ten were never in the list, so the tool
+    # reported a per-file count for everything EXCEPT them. They hold
+    # no style attributes today; listing them means a new one shows up
+    # in the report instead of being invisible.
+    FRONTEND / "static" / "auth.js",
+    FRONTEND / "static" / "graph-tabs.js",
+    FRONTEND / "static" / "graph_node_editor.js",
+    FRONTEND / "static" / "index-init.js",
+    FRONTEND / "static" / "intro.js",
+    FRONTEND / "static" / "knowledge-rollback.js",
+    FRONTEND / "static" / "llm-install.js",
+    FRONTEND / "static" / "onboarding.js",
+    FRONTEND / "static" / "time-travel.js",
+    FRONTEND / "static" / "workspace-badge.js",
 ]
+
+# ``setAttribute('style', …)`` sets the style ATTRIBUTE, so strict
+# ``style-src`` blocks it exactly like an inline style in markup — but
+# it never looks like a tag, so the tag regex above cannot see it. It
+# is reported, never rewritten: the call site has to be read to know
+# whether it becomes a class or a CSSOM write.
+_SETATTR_STYLE_RE = re.compile(r"""setAttribute\(\s*['"]style['"]""")
 
 
 # Matches the join between two adjacent JS string literals inside a
@@ -580,17 +601,23 @@ def main() -> int:
         print(f"  {n:4d}  {page.relative_to(REPO)}")
 
     js_skipped = 0
+    setattr_sites = 0
     for jsf in JS_FILES:
         text = jsf.read_text(encoding="utf-8")
         new_text, n, sk = migrate_js(text, components, used_atoms)
+        sa = len(_SETATTR_STYLE_RE.findall(text))
         total += n
         js_skipped += sk
+        setattr_sites += sa
         rewrites[jsf] = new_text
-        print(f"  {n:4d}  {jsf.relative_to(REPO)}  ({sk} dynamic skipped)")
+        extra = f", {sa} setAttribute" if sa else ""
+        print(f"  {n:4d}  {jsf.relative_to(REPO)}  ({sk} dynamic skipped{extra})")
 
     print(f"\nTotal inline style attrs migrated: {total}")
     if js_skipped:
         print(f"Dynamic sites left for hand conversion: {js_skipped}")
+    if setattr_sites:
+        print(f"setAttribute('style') sites (also CSP-blocked): {setattr_sites}")
     print(f"Atoms used: {len(used_atoms)} / {len(ATOMS)} defined")
     print(f"Verbatim component classes: {len(components)}")
 


### PR DESCRIPTION
## Summary

The eight sites left in `admin.js` after #1107 are the ones whose value
really does vary. They carry it on a `data-*` attribute through
`innerHTML` and get it applied by **CSSOM** afterwards — CSSOM writes
are not governed by CSP (measured 2026-09-08, #1095). Everything around
the varying value that was static, or enumerable, became a class.

| site | computed | enumerable → class |
|---|---|---|
| dashboard bar chart | width, height | 3 speed bands |
| radar correlation edge | stroke width | — |
| capability bar | width | — |
| domain donut arc | glow colour (server data) | — |
| domain donut level | fill (server data) | font/letter-spacing |
| domain tier percent | colour (server data) | — |
| worker level number | — | 5 level bands |
| worker level bar | width | the same 5 bands |

Two deliberate choices:

- The radar edge is **not** a `stroke-width` presentation attribute.
  `.char-radar .corr-edge` sets `stroke-width` in `admin.css`, and a CSS
  rule beats a presentation attribute — only an inline value keeps
  winning the way the style attribute did. Verified against the
  `.active` variant, which sets `3.4`, and still computes `2.35px`.
- Domain colours stay in `core/knowledge_tracker.py` rather than being
  copied into `tokens.css` as six more classes. One palette, one owner.

## Two surfaces the tool never looked at

Sweeping for what a `--report` of 0 would still miss turned up:

- `graph_node_editor.js` built a button with `setAttribute('style', …)`.
  That sets the style **attribute**, so strict `style-src` blocks it
  exactly like an inline one in markup — but it never looks like a tag,
  so the tag regex could not see it. Fully static; now `.node-edit-btn`.
- **Ten JS files were never in `JS_FILES`**, so the per-file report
  covered everything except them. They hold no style attributes today.

Both are now in the tool: the ten files are listed, and the report
counts `setAttribute` style sites — so a clean run means the whole JS
surface is clean, not just the part the tag regex reaches.

## Verification

**Computed-style comparison** — 25 pairs through an identical markup
path, including the flex / overflow parents a percentage or flex-item
size depends on, with the *same* CSSOM pass `admin.js` runs after
`innerHTML`. Five page CSS contexts, **125 comparisons, every computed
property, zero mismatches**.

Application is checked separately from equality: a width still reading
`auto` means the `data-*` never landed, and two equally broken sides
would have compared equal.

The **lv-1 worker bar has no glow, on purpose**. The original built the
shadow colour by appending `66` to the level colour, and for that band
the colour was the 4-char `#aaa` — `#aaa66` is not a valid hex colour,
so the declaration was dropped. Reproduced rather than quietly fixed;
the comparison confirms both sides render no shadow.

Also checked that **`--apply` is still non-destructive** now that
nothing is left to collect (the #1097 failure mode): 462 rules before,
462 after, none lost, none added, no body changed — the run only
re-sorts them into the carried-forward bucket.

`node --check` passes, `tests/` 5,312 passed / 0 failed, `ruff` clean.
`tokens.css` cache buster `v34` → `v35`.

## Out of scope

- `JAMES_CSP_MODE=enforce` + `JAMES_CSP_USE_NONCE_STYLE=1` — next PR,
  along with the `mobile.css` `[style*="…"]` attribute selectors and the
  remaining `!important` entries that only existed because inline styles
  were still winning.
- Live visual regression: needs a server on `:8000`, none is up, and per
  CLAUDE.md a session does not start one unasked.

**Phase 3.3: 8 → 0.** The two remaining `style=` matches in the tree are
references inside comments.

Quality delta: exempt (label: chore) — presentation-layer migration; no
`core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
