### PR TITLE
feat(v0.6.2): graduate style-src — drop 'unsafe-inline', guard the surface

### DIFF
--- a/core/security/csp_nonce.py
+++ b/core/security/csp_nonce.py
@@ -33,18 +33,15 @@ UI #6 audit §4):
     ones see the unchanged `'self'`. Operators can set the flag
     today without any HTML rewrite.
 
-  * **`style-src`** contains `'unsafe-inline'` because 409 inline
-    ``style="..."`` attributes remain across the 4 HTML pages.
-    Adding `'nonce-<value>'` triggers CSP3 §6.6.2.4: modern
-    browsers ignore `'unsafe-inline'` when ANY nonce is present →
-    every inline attribute becomes a violation. Setting this flag
-    BEFORE the inline-style mass conversion **WILL break the UI**.
-    The flag exists to graduate cleanly once the migration lands.
+  * **`style-src`** no longer contains `'unsafe-inline'` — the
+    mass conversion (Option B of the UI #6 audit) finished
+    2026-09-09, so there is nothing left for it to permit. The
+    flag stays because it is still meaningful for inline
+    ``<style>`` ELEMENTS should any be introduced; it is a no-op
+    for style ATTRIBUTES, which a nonce cannot cover at all.
+    Setting it today only narrows `'self'` further.
 
-The split lets the operator graduate `script-src` to strict-mode
-nonce binding TODAY while leaving `style-src` for a later cycle
-that picks Option A (per-style nonce injection) or Option B (mass
-conversion to utility classes) from the UI #6 audit.
+The audit's Option A (per-style nonce injection) was not taken.
 
 ## Integration
 

--- a/core/security/headers.py
+++ b/core/security/headers.py
@@ -61,12 +61,15 @@ from typing import Dict, Final, Literal, Optional
 #   default-src 'self'      — local-first floor
 #   script-src 'self'       — v0.5 UI #4 PR #855 extracted last inline
 #                             script → strict mode safe
-#   style-src 'self'
-#     'unsafe-inline'       — 409 inline `style="..."` attributes still
-#                             remain; report-only mode lets us SEE
-#                             violations without breaking the UI.
-#                             Removed once nonce middleware OR mass
-#                             conversion lands.
+#   style-src 'self'       — graduated 2026-09-09. The mass conversion
+#                             finished: zero `style="..."` attributes in
+#                             the 5 served pages (#1062) and zero emitted
+#                             by JS (#1097-#1108), and no page carries an
+#                             inline <style> element. CSSOM writes
+#                             (`el.style.x`) are what remains and CSP does
+#                             not govern them (measured #1095).
+#                             tests/test_v06_csp_inline_style_migration.py
+#                             is the guard that keeps it true.
 #   img-src 'self' data:    — `data:` for inline SVG icons + brand-pulse
 #                             icons (chat.js `brainPulseSvg`)
 #   font-src 'self'
@@ -85,8 +88,7 @@ from typing import Dict, Final, Literal, Optional
 CSP_DIRECTIVES_DEFAULT: Final[Dict[str, str]] = {
     "default-src":     "'self'",
     "script-src":      "'self'",
-    "style-src":       "'self' 'unsafe-inline' "
-                       "https://fonts.googleapis.com",
+    "style-src":       "'self' https://fonts.googleapis.com",
     "img-src":         "'self' data:",
     "font-src":        "'self' https://fonts.gstatic.com",
     "connect-src":     "'self'",

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
 </head>
 <body>
 

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/reasoning-flow.css">
 <link rel="stylesheet" href="/static/knowledge-rollback.css">
-<link rel="stylesheet" href="/static/mobile.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
 </head>
 <body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
 <link rel="stylesheet" href="/static/chat.css?v=v29-20260908-csp-chat-dyn">
-<link rel="stylesheet" href="/static/mobile.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
 </head>
 <body>
 

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">
-<link rel="stylesheet" href="/static/mobile.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
 </head>
 <body>
 

--- a/frontend/static/admin.js
+++ b/frontend/static/admin.js
@@ -907,7 +907,7 @@ async function loadDashboard() {
               ${t('dash.chart_legend')}
             </span>
           </div>
-          <div class="d-flex items-end p-8-20 bg-bg br-6 bd-1 u-cc617d82">
+          <div class="dash-chart-bars d-flex items-end p-8-20 bg-bg br-6 bd-1 u-cc617d82">
             ${bars}
           </div>`;
         _applySizedBars(chartEl);

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -646,15 +646,10 @@
   }
 
   /* hardware 카드, 설정 카드 등 min-width 280/260/220px → 100% */
-  /* Both spellings, deliberately. The attribute selectors still carry
-     admin.js, whose inline styles have not been migrated yet; the class
-     selectors carry everything the CSP migration has already moved out
-     of the style attribute (chat.js as of 2026-09-08). Drop the
-     attribute half only once no JS injects these values any more. */
-  [style*="min-width:280px"],
-  [style*="min-width:260px"],
-  [style*="min-width:220px"],
-  [style*="min-width:200px"],
+  /* The four `[style*="min-width:…"]` selectors that used to lead this
+     rule are gone: nothing injects those values into a style attribute
+     any more (checked 2026-09-09 across every JS file and served page),
+     so they matched nothing. The class half carries all of it. */
   .minw-280, .minw-260, .minw-220, .minw-200 {
     min-width: 0 !important;
     width: 100%;
@@ -716,9 +711,13 @@
     font-size: 15px;
   }
 
-  /* dashboard 차트 — 너비 100% */
-  #dash-chart > div[style*="display:flex"],
-  #dash-chart > div[style*="display: flex"] {
+  /* dashboard 차트 — 너비 100%.
+     Was `#dash-chart > div[style*="display:flex"]`, which stopped
+     matching when #1099 moved that wrapper's inline style into classes
+     — the chart quietly lost its horizontal scroll on phones. Desktop-
+     width visual regression cannot see that, which is the same blind
+     spot #1099 itself found. Anchored to a stable class now. */
+  #dash-chart > .dash-chart-bars {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
   }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css?v=v25-20260908-csp-chatjs">
+<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
 </head>
 <body>
 

--- a/scripts/csp_enforce_probe.py
+++ b/scripts/csp_enforce_probe.py
@@ -1,0 +1,95 @@
+"""Load each served page under an ENFORCED CSP and count violations.
+
+Run it before flipping ``JAMES_CSP_MODE`` to ``enforce``:
+
+    pip install playwright && playwright install chromium
+    python scripts/csp_enforce_probe.py
+
+Exits non-zero on any style-src violation, and prints violations of the
+other directives too (they do not fail the run -- they are the operator's
+call, not this script's).
+
+No server is started. Playwright fulfils every request from disk against
+a synthetic origin, so `'self'` means something and the CSP header can be
+attached -- the same measurement #1095 made with a dedicated enforce
+server, without one running.
+
+Limit, stated plainly: there is no backend here, so the admin views that
+render from API data never draw. This proves the page shells and the JS
+that runs on load are clean; the dynamic views are covered by the
+computed-style pair comparisons and the source-level guard instead.
+"""
+import mimetypes
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+FRONTEND = REPO / "frontend"
+ORIGIN = "http://james.local"
+PAGES = ["index.html", "admin.html", "graph.html", "workspace.html", "intro.html"]
+
+# Built from the app's own directive table rather than a copy of it, so
+# the probe cannot drift into testing a policy the server never sends.
+sys.path.insert(0, str(REPO))
+from core.security.headers import CSP_DIRECTIVES_DEFAULT  # noqa: E402
+
+CSP = "; ".join(f"{k} {v}" for k, v in CSP_DIRECTIVES_DEFAULT.items())
+
+
+def handler(route, request):
+    url = request.url
+    if not url.startswith(ORIGIN):
+        route.fulfill(status=204, body="")
+        return
+    rel = url[len(ORIGIN):].split("?")[0].lstrip("/")
+    if rel == "":
+        rel = "index.html"
+    target = FRONTEND / rel
+    if not target.is_file():
+        # API calls and anything else: an empty JSON body, so page JS
+        # takes its error path rather than hanging.
+        route.fulfill(status=200, content_type="application/json", body="{}")
+        return
+    ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+    headers = {"Content-Type": ctype}
+    if target.suffix == ".html":
+        headers["Content-Security-Policy"] = CSP
+    route.fulfill(status=200, headers=headers, body=target.read_bytes())
+
+
+total = 0
+with sync_playwright() as pw:
+    browser = pw.chromium.launch()
+    for name in PAGES:
+        page = browser.new_page(viewport={"width": 1280, "height": 900})
+        violations = []
+        page.expose_function("__cspViolation", lambda d: violations.append(d))
+        page.add_init_script(
+            "document.addEventListener('securitypolicyviolation', e => {"
+            "  window.__cspViolation({directive: e.effectiveDirective,"
+            "    blocked: e.blockedURI, sample: (e.sample||'').slice(0,80),"
+            "    src: (e.sourceFile||'').split('/').pop(),"
+            "    line: e.lineNumber});"
+            "});")
+        page.route("**/*", handler)
+        page.goto(ORIGIN + "/" + name, wait_until="networkidle")
+        page.wait_for_timeout(1200)
+        style = [v for v in violations if v["directive"] == "style-src-attr"
+                 or v["directive"] == "style-src-elem"
+                 or v["directive"] == "style-src"]
+        other = [v for v in violations if v not in style]
+        total += len(style)
+        print("=" * 62)
+        print(f"{name}: style violations {len(style)}, other {len(other)}")
+        for v in style[:10]:
+            print("   STYLE", v)
+        for v in other[:6]:
+            print("   other", v)
+        page.close()
+    browser.close()
+
+print("=" * 62)
+print("TOTAL style-src violations under enforce:", total)
+sys.exit(1 if total else 0)

--- a/tests/test_v05_security_headers.py
+++ b/tests/test_v05_security_headers.py
@@ -123,15 +123,19 @@ class CspContentTests(unittest.TestCase):
         self.assertNotIn("unsafe-inline", script_part)
         self.assertNotIn("unsafe-eval", script_part)
 
-    def test_style_src_has_unsafe_inline_for_now(self):
-        # Documented in audit doc §3 — 409 inline `style="..."`
-        # attributes still present; style-src needs 'unsafe-inline'
-        # until nonce middleware OR mass conversion lands.
+    def test_style_src_has_no_unsafe_inline(self):
+        # Inverted 2026-09-09. The audit's Option B (mass conversion)
+        # finished: no `style="..."` attribute survives in the served
+        # pages or in JS-built markup, and no page carries an inline
+        # <style> element, so there is nothing left for 'unsafe-inline'
+        # to permit. tests/test_v06_csp_inline_style_migration.py is the
+        # guard that keeps that true; this asserts the payoff.
         self.assertIn("style-src", self.csp)
         style_part = next(
             (p for p in self.csp.split(";") if "style-src" in p), "",
         )
-        self.assertIn("'unsafe-inline'", style_part)
+        self.assertIn("'self'", style_part)
+        self.assertNotIn("'unsafe-inline'", style_part)
 
     def test_frame_ancestors_none(self):
         self.assertIn("frame-ancestors 'none'", self.csp)

--- a/tests/test_v06_csp_inline_style_migration.py
+++ b/tests/test_v06_csp_inline_style_migration.py
@@ -3,10 +3,15 @@
 The 5 served HTML pages (index / admin / graph / workspace / intro) had
 ~600 inline ``style="..."`` attributes relocated into CSS classes
 (atoms + verbatim components in ``tokens.css``) by
-``scripts/migrate_inline_styles.py``. This is the HTML half of the
-``style-src 'self'`` graduation (the JS-injected inline-style surface
-remains, so CSP is NOT yet flipped to enforce — see
-``docs/reviews/v0.5-ui-6-inline-style-audit.md``).
+``scripts/migrate_inline_styles.py``. That was the HTML half of the
+``style-src 'self'`` graduation; the JS-injected surface followed in
+#1097-#1108, and the directive dropped ``'unsafe-inline'`` once both
+were at zero (see ``docs/reviews/v0.5-ui-6-inline-style-audit.md``).
+
+Because the directive no longer permits inline styles, this guard is
+now load-bearing rather than advisory: a reintroduced ``style="..."``
+would be a broken UI under ``JAMES_CSP_MODE=enforce``, not a future
+inconvenience.
 
 This lock-test pins the result so a future edit that reintroduces an
 inline ``style="..."`` attribute on a served page is caught in CI
@@ -15,6 +20,12 @@ break the `style-src` procurement bar without anyone noticing).
 
 Covers:
   * Zero inline ``style="..."`` attributes in each of the 5 pages.
+  * Zero inline ``style="..."`` attributes emitted by any frontend JS
+    file, and zero ``setAttribute('style', …)`` call sites — that call
+    writes the style ATTRIBUTE, so ``style-src`` blocks it exactly like
+    one in markup, even though it looks nothing like a tag.
+  * No inline ``<style>`` element on a served page: ``style-src 'self'``
+    blocks those too, and none of the pages has ever had one.
   * ``tokens.css`` carries the generated migration block (markers).
   * ``.d-none`` is defined WITHOUT ``!important`` so JS that toggles
     ``el.style.display`` can still override it (the migration relies on
@@ -45,6 +56,20 @@ PAGES = [
 # An inline style attribute on an HTML tag: ``<... style="...">``.
 _STYLE_ATTR = re.compile(r'\sstyle="[^"]*"')
 
+# The same thing inside JS-built markup. The boundary is a quote as well
+# as whitespace, because template literals concatenate right up against
+# the attribute (`'…surface);' + 'style="…"'`).
+_JS_STYLE_ATTR = re.compile(r'''(?<=['"\s])style="[^"]*"''')
+_SETATTR_STYLE = re.compile(r'''setAttribute\(\s*['"]style['"]''')
+_STYLE_ELEMENT = re.compile(r"<style[\s>]", re.I)
+
+# Comments quote the banned patterns while explaining them, so they are
+# removed before scanning. Crude but sufficient here: no frontend file
+# contains a string literal holding "//" or "/*" outside a URL, and
+# "://" is guarded against explicitly.
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+_LINE_COMMENT = re.compile(r"(?<!:)//[^\n]*")
+
 
 class InlineStyleMigrationGuard(unittest.TestCase):
     def test_no_inline_style_attrs_on_served_pages(self):
@@ -60,6 +85,63 @@ class InlineStyleMigrationGuard(unittest.TestCase):
             "page(s) — relocate them to a class (run "
             "scripts/migrate_inline_styles.py --apply) so the CSP "
             "style-src migration stays intact: " + repr(offenders),
+        )
+
+    def test_no_inline_style_attrs_emitted_by_frontend_js(self):
+        """Every .js under frontend/static, not just the migrated ones.
+
+        The migration tool works from its own ``JS_FILES`` list, which
+        for a long time was missing ten files — so a clean report did
+        not mean a clean surface. This walks the directory instead.
+        """
+        offenders = {}
+        for js in sorted((FRONTEND / "static").glob("*.js")):
+            text = js.read_text(encoding="utf-8")
+            # Strip // and /* */ comments first: several of them quote
+            # the very pattern being banned while explaining the ban.
+            stripped = _BLOCK_COMMENT.sub("", text)
+            stripped = _LINE_COMMENT.sub("", stripped)
+            hits = _JS_STYLE_ATTR.findall(stripped)
+            if hits:
+                offenders[js.name] = len(hits)
+        self.assertEqual(
+            offenders, {},
+            "JS emits inline style=\"...\" attribute(s). style-src no "
+            "longer carries 'unsafe-inline', so these are blocked at "
+            "render: use a class when the value is enumerable, or a "
+            "data-* attribute plus a CSSOM write (el.style.x) when it "
+            "is genuinely computed. Offenders: " + repr(offenders),
+        )
+
+    def test_no_set_attribute_style_call_sites(self):
+        offenders = {}
+        for js in sorted((FRONTEND / "static").glob("*.js")):
+            text = js.read_text(encoding="utf-8")
+            stripped = _BLOCK_COMMENT.sub("", text)
+            stripped = _LINE_COMMENT.sub("", stripped)
+            hits = _SETATTR_STYLE.findall(stripped)
+            if hits:
+                offenders[js.name] = len(hits)
+        self.assertEqual(
+            offenders, {},
+            "setAttribute('style', ...) writes the style ATTRIBUTE, "
+            "which style-src blocks just like an inline one in markup "
+            "(el.style.x is CSSOM and is fine). Offenders: "
+            + repr(offenders),
+        )
+
+    def test_no_inline_style_elements_on_served_pages(self):
+        offenders = {}
+        for name in PAGES:
+            text = (FRONTEND / name).read_text(encoding="utf-8")
+            hits = _STYLE_ELEMENT.findall(text)
+            if hits:
+                offenders[name] = len(hits)
+        self.assertEqual(
+            offenders, {},
+            "Inline <style> element(s) on a served page — style-src "
+            "'self' blocks those as well: move the rules into a linked "
+            "stylesheet. Offenders: " + repr(offenders),
         )
 
     def test_tokens_css_has_generated_migration_block(self):

--- a/tests/test_v06_csp_nonce.py
+++ b/tests/test_v06_csp_nonce.py
@@ -276,8 +276,15 @@ class MiddlewareIntegrationTests(unittest.TestCase):
             r = c.get("/healthz")
             csp = self._csp_value(r.headers)
             self.assertRegex(csp, r"script-src[^;]*'nonce-[A-Za-z0-9_\-]{20,}'")
-            # style-src still carries 'unsafe-inline' (flag off)
-            self.assertIn("'unsafe-inline'", csp)
+            # style-src carries no nonce (flag off) and, since
+            # 2026-09-09, no 'unsafe-inline' either — the directive
+            # graduated to plain 'self' when the conversion finished.
+            style_src = next(
+                (p.strip() for p in csp.split(";")
+                 if p.strip().startswith("style-src ")), "",
+            )
+            self.assertNotIn("nonce-", style_src)
+            self.assertNotIn("'unsafe-inline'", style_src)
 
     def test_response_csp_carries_style_nonce_when_flag_set(self):
         with _patched_env(


### PR DESCRIPTION
## Summary

Both halves of the conversion are done — #1062 for the served pages,
#1097–#1108 for JS — so `style-src` has nothing left to permit:

```
- style-src 'self' 'unsafe-inline' https://fonts.googleapis.com
+ style-src 'self' https://fonts.googleapis.com
```

**Mode is untouched.** `JAMES_CSP_MODE` still defaults to `report-only`,
so this cannot break a running instance. It makes a regression *visible*
in the operator's console, and it means an operator who does flip to
enforce actually gets the protection instead of an opt-out list.

## Measured, not assumed

`scripts/csp_enforce_probe.py` (new) loads each served page under the
enforced header and counts violations. **No server is started** —
Playwright fulfils every request from disk against a synthetic origin,
so `'self'` means something. It is the #1095 measurement without a
listener. The policy is built from `CSP_DIRECTIVES_DEFAULT` rather than
a copy, so the probe cannot drift into testing a header the server never
sends.

**Zero `style-src` violations on all five pages.**

Its limit, stated: there is no backend, so admin views that render from
API data never draw. Those are covered by the computed-style pair
comparisons in #1107 / #1108 and by the guard below.

## 🔴 The probe found a different blocker for the mode flip

`graph.html` pulls three libraries from `unpkg.com` — `three`,
`3d-force-graph`, `d3-force-3d` — and **`script-src 'self'` blocks all
three**.

This is pre-existing and untouched here (`script-src` has been `'self'`
since #855), and harmless while the mode is `report-only`. But flipping
to `enforce` today would kill the 3D graph view. Vendoring them locally
is the local-first answer and is an operator call, not a side effect of
a style-src PR. Recorded so the flip is not walked into blind.

## Guard

The migration lock-test was advisory before — a reintroduced inline
style meant "the flip gets harder later". Now it means a broken UI under
enforce, so it is extended to the whole surface, and it walks
`frontend/static/*.js` **directly** rather than trusting the tool's file
list (which was missing ten files until #1108):

- zero `style="..."` emitted by any frontend JS file
- zero `setAttribute('style', …)` call sites
- zero inline `<style>` elements on a served page

Comments are stripped before scanning — several of them quote the very
pattern being banned while explaining the ban. **Each guard was checked
by injecting a probe of its own shape and confirming it fails**; all
three do.

## Two dead selectors, one hiding a mobile regression

`mobile.css` carried `[style*="min-width:…"]` ×4, kept because admin.js
still injected those values. Nothing does any more, so they matched
nothing — dropped; the `.minw-*` class half carries all of it.

`#dash-chart > div[style*="display:flex"]` was also dead, and **that one
mattered**: it stopped matching when #1099 moved that wrapper's inline
style into classes, so the dashboard chart quietly lost its horizontal
scroll on phones. Desktop-width visual regression cannot see it — the
same blind spot #1099 itself found. Re-anchored to a stable
`.dash-chart-bars` class.

## Verification

- `scripts/csp_enforce_probe.py` — 0 style-src violations, 5/5 pages
- `tests/` — **5,315 passed / 0 failed** (3 new guards)
- `ruff` clean; `node --check` passes
- `mobile.css` cache buster `v25` → `v26`

## Out of scope

- Flipping `JAMES_CSP_MODE` to `enforce` — operator decision, and
  blocked on the `unpkg.com` scripts above.
- Vendoring the three 3D-graph libraries.
- The 20 remaining `!important` entries in `mobile.css` (#1082 capped
  them deliberately).

Quality delta: exempt (label: chore) — presentation + header change; no
`core/` retrieval, graph or reasoning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
