### PR TITLE
fix(v0.6.2): the LRB fixture rebuild opened /dev/null on Windows

### DIFF
--- a/tests/_lrb_fixtures.py
+++ b/tests/_lrb_fixtures.py
@@ -19,6 +19,7 @@ Usage from a test module::
 """
 from __future__ import annotations
 
+import io
 import runpy
 import sys
 from pathlib import Path
@@ -55,7 +56,12 @@ def ensure_scenario(key: str) -> Path:
     # The builders print a short summary to stdout; keep it out of the
     # test report but let a real failure propagate.
     _FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
-    stdout, sys.stdout = sys.stdout, open("/dev/null", "w")
+    # Not "/dev/null": that path does not exist on Windows, and this
+    # branch only runs when the fixture is absent — which never happens
+    # in a checkout that already has it, so the failure stayed hidden
+    # until a fresh clone was tested on Windows. An in-memory sink needs
+    # no platform-specific path at all.
+    stdout, sys.stdout = sys.stdout, io.StringIO()
     try:
         runpy.run_path(str(script), run_name="__main__")
     finally:


### PR DESCRIPTION
## Summary

`tests/_lrb_fixtures.py` silences a fixture builder by swapping stdout
for `open("/dev/null", "w")`. **That path does not exist on Windows**,
so the rebuild raises `FileNotFoundError` before the builder ever runs.

It stayed hidden because the branch only runs when the fixture is
absent, and a working checkout has it. Found by running the suite in a
fresh worktree — where three LRB files failed at *collection*, on the
machine this project is developed on.

An in-memory sink needs no platform-specific path at all, so the fix is
`io.StringIO()` rather than `os.devnull`.

## Verification

In that same fresh worktree (no `.env`, `OLLAMA_API_URL` pointed at a
dead port, CI's two sentinel env vars):

- `tests/test_lrb_smoke.py`: collection error → **15 passed**
- full `tests/`: **5,312 passed / 0 failed**

Main checkout unchanged at 5,315 passed. `ruff` clean.

## Out of scope

The CI `--ignore` list itself — the same worktree run says all 51
ignored files now pass, which is a separate PR.

Quality delta: exempt (label: fix) — measurement-side fixture harness
correction; no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
