### PR TITLE
chore(v0.6.2): retire the CI --ignore list — all 51 files pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   pytest:
-    name: pytest (tests/ — externally-bound files excluded)
+    name: pytest (tests/ — full suite, no exclusions)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -50,64 +50,30 @@ jobs:
           python -m pytest tests/ \
             --tb=short -q \
             --timeout=30 \
-            -p no:cacheprovider \
-            \
-            `# --- LLM / Ollama service-bound (no CI Ollama service yet) ---` \
-            --ignore=tests/test_conversation_continuity.py \
-            --ignore=tests/test_first_run_wizard.py \
-            --ignore=tests/test_install_progress.py \
-            --ignore=tests/test_llm_catalog.py \
-            --ignore=tests/test_model_names_install.py \
-            --ignore=tests/test_model_resolver.py \
-            --ignore=tests/test_planner.py \
-            --ignore=tests/test_query_rewriter.py \
-            --ignore=tests/test_reasoning_trace_helpers.py \
-            --ignore=tests/test_reasoning_trace_schema.py \
-            --ignore=tests/test_reflection_loop.py \
-            --ignore=tests/test_replay_trace.py \
-            --ignore=tests/test_requirements_consistency.py \
-            --ignore=tests/test_verifier.py \
-            \
-            `# --- Admin / endpoint tests needing DB or server setup ---` \
-            --ignore=tests/test_a2_phase2_selected_model.py \
-            --ignore=tests/test_admin_audit_endpoint.py \
-            --ignore=tests/test_admin_entities.py \
-            --ignore=tests/test_admin_metrics.py \
-            --ignore=tests/test_admin_trace_endpoint.py \
-            --ignore=tests/test_admin_users_endpoints.py \
-            --ignore=tests/test_admin_wiki_resolve_relations.py \
-            --ignore=tests/test_api_key_middleware.py \
-            --ignore=tests/test_api_keys.py \
-            --ignore=tests/test_change_request_endpoints.py \
-            --ignore=tests/test_chat_mode_picker.py \
-            --ignore=tests/test_cleanup_web_noise.py \
-            --ignore=tests/test_code_surface_sqlite.py \
-            --ignore=tests/test_dashboard_audit_sqlite.py \
-            --ignore=tests/test_data_artifacts.py \
-            --ignore=tests/test_document_export.py \
-            --ignore=tests/test_evolution_audit_query.py \
-            --ignore=tests/test_evolution_bench_gate.py \
-            --ignore=tests/test_feature_registry.py \
-            --ignore=tests/test_file_mgmt_tab.py \
-            --ignore=tests/test_force_web_chip.py \
-            --ignore=tests/test_model_catalog_per_mode.py \
-            --ignore=tests/test_multimodal_trusted.py \
-            --ignore=tests/test_observability.py \
-            --ignore=tests/test_password_change.py \
-            --ignore=tests/test_password_reset_token.py \
-            --ignore=tests/test_phase_b_ingestion_sources.py \
-            --ignore=tests/test_phase_d_modify_cascade.py \
-            --ignore=tests/test_q2a_feature_wiring.py \
-            --ignore=tests/test_query_include_contexts.py \
-            --ignore=tests/test_scheduler.py \
-            --ignore=tests/test_self_evolution_gate.py \
-            --ignore=tests/test_signup_endpoint.py \
-            --ignore=tests/test_trace_prune.py \
-            --ignore=tests/test_upload_history.py \
-            --ignore=tests/test_web_search_admin_panel.py \
-            --ignore=tests/test_workspace_jobs.py
-        # Iteration plan: ignored files are tracked for incremental
-        # un-ignoring as their CI dependencies become available (Ollama
-        # service container) or as test isolation is improved (DB fixture
-        # cleanup, FastAPI TestClient app-factory pattern). Removing an
-        # entry from this list is itself the success signal.
+            -p no:cacheprovider
+        # The 51-entry --ignore list that used to live here is gone.
+        #
+        # The list carried an iteration plan: un-ignore each file as its
+        # CI dependency arrives (an Ollama service container) or as its
+        # isolation improves (DB fixture cleanup, TestClient app-factory).
+        # Measured 2026-09-09, that plan had already been overtaken — the
+        # files were passing and nobody had checked.
+        #
+        # How it was measured, since "it passes on my machine" is exactly
+        # what an ignore list is protection against: a detached git
+        # worktree, which has no .env because that file is untracked;
+        # OLLAMA_API_URL and OLLAMA_HOST pointed at a dead port so
+        # anything genuinely needing Ollama fails fast rather than
+        # reaching a running instance; and the environment stripped to 73
+        # fewer variables, dropping the real service keys (TAVILY_API_KEY
+        # among them) that a developer shell carries and a runner does
+        # not.
+        #
+        # Under those conditions: each of the 51 passes alone, and the
+        # whole tests/ directory passes together — 5,312 passed, 0
+        # failed, slowest test 6.6s against this 30s timeout.
+        #
+        # Two differences from this runner remain, which is why the CI
+        # run on the PR that removed the list is the real evidence:
+        # ubuntu vs Windows, and 3.11 vs 3.14. If a file has to come back,
+        # bring back that file — not the list.

--- a/tests/test_character_prompt_cleanup.py
+++ b/tests/test_character_prompt_cleanup.py
@@ -196,8 +196,9 @@ class PersonaEndpointTests(unittest.TestCase):
         "skipped in CI — `from server_llmwiki import app` pulls the "
         "vector store + HuggingFace model into memory, which routinely "
         "exceeds the 30s pytest-timeout on cache-miss runners. Local "
-        "runs cover this test; CI workflow already excludes other "
-        "server-import tests via --ignore=. See "
+        "runs cover this test. (The workflow no longer excludes any "
+        "file: the --ignore list this note used to point at was "
+        "measured obsolete and removed 2026-09-09.) See "
         "docs/handovers/v0.3.0-platform-track.md `CI pytest 3 fail` note.",
     )
     def test_persona_endpoint_still_registered(self):


### PR DESCRIPTION
## Summary

The workflow's 51-entry `--ignore` list is removed. It carried an
iteration plan — un-ignore each file as its CI dependency arrives (an
Ollama service container) or as its isolation improves (DB fixture
cleanup, TestClient app-factory). **That plan had already been
overtaken: the files were passing and nobody had checked.**

## How it was measured

"It passes on my machine" is exactly what an ignore list protects
against, so the measurement was built to remove that excuse:

- a **detached git worktree**, which has no `.env` — the file is
  untracked, so a fresh checkout is the same as a fresh clone
- `OLLAMA_API_URL` and `OLLAMA_HOST` pointed at a **dead port**, so
  anything genuinely needing Ollama fails fast instead of quietly
  reaching the instance running on this machine
- the environment **stripped to 73 fewer variables**, dropping the real
  service keys a developer shell carries and a runner does not
  (`TAVILY_API_KEY` among them — the config banner flipped to the
  DuckDuckGo fallback, so the strip demonstrably took effect)

Results under those conditions:

| check | result |
|---|---|
| each of the 51 run alone | **51 / 51 pass** |
| whole `tests/` together | **5,312 passed / 0 failed** |
| slowest test vs the 30s timeout | **6.6s** |

## What this PR's CI run is for

Two differences from the runner remain — **ubuntu vs Windows, 3.11 vs
3.14** — so the CI run on this PR is the real evidence, not the local
one. If a file has to come back, it comes back **by itself, not as a
list**; the removed block is replaced by a comment saying exactly that,
along with how the measurement was done.

## Also

- The CI skip in `test_character_prompt_cleanup.py` cited the
  `--ignore` list as precedent — updated. Its own reason (server import
  vs the 30s timeout on a cache-miss runner) is untouched.
- Job renamed from *"externally-bound files excluded"* to *"full suite,
  no exclusions"* — the name was the most visible part of the claim.

## Verification

- Local `tests/` (main checkout): 5,315 passed / 0 failed
- Worktree, minimal env: 5,312 passed / 0 failed
- `test.yml` parses as YAML; single `pytest` job

## Out of scope

Stacked on #1110, which fixes a Windows-only `/dev/null` in the LRB
fixture rebuild found by the same worktree run. That one does not
affect this PR's CI (Linux has `/dev/null`), but it is what let the
worktree run get far enough to produce these numbers.

Quality delta: exempt (label: ci) — workflow change, no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
