### PR TITLE
chore(v0.6.2): mobile.css drops its last 20 !important — proven redundant at mobile widths

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/admin.css">
 <!-- mobile-responsive overrides — kept after inline styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
+<link rel="stylesheet" href="/static/mobile.css?v=v27-20260910-no-important">
 </head>
 <body>
 

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/reasoning-flow.css">
 <link rel="stylesheet" href="/static/knowledge-rollback.css">
-<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
+<link rel="stylesheet" href="/static/mobile.css?v=v27-20260910-no-important">
 </head>
 <body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
      글자 크기 ↑ + 사이드바 메뉴 글자 ↑. Pin both stylesheets so a
      half-cached state can't mismatch + bring in tokens.css fresh. -->
 <link rel="stylesheet" href="/static/chat.css?v=v29-20260908-csp-chat-dyn">
-<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
+<link rel="stylesheet" href="/static/mobile.css?v=v27-20260910-no-important">
 </head>
 <body>
 

--- a/frontend/intro.html
+++ b/frontend/intro.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/onboarding.css">
 <link rel="stylesheet" href="/static/glossary.css">
 <link rel="stylesheet" href="/static/intro.css">
-<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
+<link rel="stylesheet" href="/static/mobile.css?v=v27-20260910-no-important">
 </head>
 <body>
 

--- a/frontend/static/mobile.css
+++ b/frontend/static/mobile.css
@@ -495,13 +495,18 @@
    *   - conv-action-chip 글자 크기 11 → 10.5, padding 4/10 → 3/8
    *   - mode-picker / model-picker select 폰트 11 → 10
    */
-  /* No !important below: chat.css declares these at the SAME
-   * specificity and loads BEFORE mobile.css on every page, so later
-   * position already wins (this file's header states that contract).
-   * Verified 2026-09-03: none of these elements is touched by a JS
-   * `.style.*` assignment or cssText, so no runtime inline style can
-   * outrank them either — that is what !important was actually for
-   * elsewhere in this file. */
+  /* No !important anywhere in this file since 2026-09-10. chat.css /
+   * admin.css / tokens.css declare the competing values at the SAME
+   * specificity and load BEFORE mobile.css on every page, so later
+   * position already wins (this file's header states that contract);
+   * the ID-selector rules below outrank class rules outright. The last
+   * twenty were kept only while inline style="…" attributes could
+   * still beat a class; those attributes are gone (CSP style-src
+   * graduation, #1062 / #1107–#1109) and no JS `.style.*` or cssText
+   * write touches the contested properties. Proven, not assumed:
+   * 36 targets × 3 viewports (375 / 480 / 768) computed-style
+   * identical with and without, and the mobile values demonstrably
+   * apply at 375 / 768 and yield to desktop values at 1280. */
   .conv-actions {
     padding: 2px 10px;
     gap: 4px;
@@ -558,9 +563,9 @@
   }
   .fb-btn {
     flex-shrink: 0;
-    padding: 6px 12px !important;
+    padding: 6px 12px;
     min-height: 32px;
-    font-size: 13px !important;
+    font-size: 13px;
   }
 
   /* 그래프 패스 / 메타 정보 — 폰트 살짝 작게 */
@@ -571,7 +576,7 @@
 
   /* admin nav — 모바일은 햄버거 토글 + 슬라이드 드로워 (item #2) */
   #admin-nav-toggle {
-    display: block !important;
+    display: block;
   }
   #admin-nav {
     position: fixed;
@@ -621,13 +626,13 @@
 
   /* 카드 그리드 → 단일 컬럼 */
   .cards {
-    display: grid !important;
-    grid-template-columns: 1fr 1fr !important;
-    gap: 8px !important;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
   }
-  .card { padding: 10px !important; }
+  .card { padding: 10px; }
   .card-label { font-size: 10px; }
-  .card-value { font-size: 18px !important; }
+  .card-value { font-size: 18px; }
   .card-sub { font-size: 10px; }
 
   /* 테이블 — 가로 스크롤 가능하게 */
@@ -651,21 +656,21 @@
      any more (checked 2026-09-09 across every JS file and served page),
      so they matched nothing. The class half carries all of it. */
   .minw-280, .minw-260, .minw-220, .minw-200 {
-    min-width: 0 !important;
+    min-width: 0;
     width: 100%;
   }
 
   /* entities/sessions 검색 입력 + 필터 — 한 줄 → 두 줄 */
   #entities-search, #entities-etype-filter {
     width: 100%;
-    min-width: 0 !important;
+    min-width: 0;
   }
   #entities-counter { width: 100%; text-align: right; }
 
   /* 페이징 버튼 — 터치 타겟 키움 */
   #entities-prev, #entities-next {
     min-height: 40px;
-    padding: 8px 16px !important;
+    padding: 8px 16px;
   }
 
   /* 상세 modal / 세션 turns modal — 풀화면 */
@@ -681,7 +686,7 @@
   #firstrun-wizard-modal,
   /* graph editor modals */
   #edge-edit-modal, #node-edit-modal {
-    padding: 12px !important;
+    padding: 12px;
   }
   #entity-detail-modal > div, #session-turns-modal > div,
   #login-modal > div, #admin-login-modal > div,
@@ -689,14 +694,14 @@
   #api-key-display-modal > div, #reset-token-display-modal > div,
   #firstrun-wizard-modal > div,
   #edge-edit-modal > div, #node-edit-modal > div {
-    max-width: 100% !important;
-    max-height: 92vh !important;
-    padding: 14px !important;
+    max-width: 100%;
+    max-height: 92vh;
+    padding: 14px;
     border-radius: 10px;
   }
   #entity-detail-body, #session-turns-body {
     font-size: 12px;
-    max-height: 65vh !important;
+    max-height: 65vh;
   }
 
   /* v0.5 UI #3 — skip-link touch target on mobile.
@@ -824,7 +829,7 @@
   .source-toggle button { padding: 4px 6px; font-size: 9px; }
 
   /* 카드 단일 컬럼 */
-  .cards { grid-template-columns: 1fr !important; }
+  .cards { grid-template-columns: 1fr; }
 
   /* 웰컴 — 폰 화면 작아서 아주 컴팩트하게 */
   .welcome-title { font-size: 18px; }

--- a/frontend/workspace.html
+++ b/frontend/workspace.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="/static/workspace.css">
 <!-- mobile-responsive overrides — kept after page styles so @media
      rules win at narrow viewports without !important on every line -->
-<link rel="stylesheet" href="/static/mobile.css?v=v26-20260909-dead-selectors">
+<link rel="stylesheet" href="/static/mobile.css?v=v27-20260910-no-important">
 </head>
 <body>
 

--- a/tests/test_mobile_responsive.py
+++ b/tests/test_mobile_responsive.py
@@ -181,20 +181,35 @@ class HtmlLinksMobileCssTests(unittest.TestCase):
 
 
 class AvoidsUnreachableCssTests(unittest.TestCase):
-    """Sanity: rules using !important should be limited to cases
-    where overriding inline-style is actually necessary."""
+    """mobile.css wins by cascade position, never by !important.
 
-    def test_no_excessive_important(self):
+    The file's header promised "no !important needed — same
+    specificity, later position" from the start; what actually kept
+    twenty of them alive was inline ``style="…"`` attributes, which
+    beat any class rule. Those attributes are gone (CSP style-src
+    graduation, #1062 / #1107–#1109), and on 2026-09-10 every
+    remaining declaration was proven redundant: 36 targets × 3
+    viewports (375 / 480 / 768) computed-style identical with and
+    without, and the mobile values demonstrably apply at 375 / 768
+    and yield to desktop values at 1280. The cap therefore drops
+    from "≤ 25" to **zero declarations** — a new one is a cascade
+    bug to fix, not a budget to spend.
+
+    Comments may still mention the token (this file's header does),
+    so declarations are counted, not substrings."""
+
+    def test_no_important_declarations(self):
         css = CSS_PATH.read_text(encoding="utf-8")
-        # Count !important occurrences. Inline-style overrides need
-        # this; a small number is fine. Excessive use indicates the
-        # cascade strategy is broken.
-        count = css.count("!important")
-        self.assertLessEqual(
-            count, 25,
-            f"!important used {count} times in mobile.css; aim for "
-            f"≤ 25 (inline-style overrides only). Restructure rules "
-            f"or rely on source-order cascade if higher."
+        # A declaration: the token followed by the end of a declaration.
+        # Comment mentions ("No !important needed") never are.
+        decls = re.findall(r"!important\s*[;}]", css)
+        self.assertEqual(
+            decls, [],
+            f"{len(decls)} !important declaration(s) in mobile.css. "
+            f"mobile.css loads last and its selectors already outrank "
+            f"or out-position every competitor; prove the cascade with "
+            f"a mobile-width computed-style comparison instead of "
+            f"forcing it."
         )
 
 


### PR DESCRIPTION
## Summary

`mobile.css` drops its last **20 `!important` declarations** — from
20 to **0** — and the cap test goes from "≤ 25" to **zero
declarations**.

The file's header promised *"no `!important` needed — same specificity,
later position"* from the start. What actually kept these twenty alive
was inline `style="…"` attributes, which beat any class rule. Those are
gone (CSP `style-src` graduation, #1062 / #1107–#1109), so the only
thing left for `!important` to beat was rules it already out-positions
or outranks.

## Why each one is redundant

| Target | Competes with | Why the cascade already wins |
|---|---|---|
| `.fb-btn` padding / font-size | `.export-btn` (chat.css), `.u-81f9b541` (tokens.css) | same specificity (0,1,0), both load before mobile.css |
| `#admin-nav-toggle` display | `.u-d755eb62 { display:none }` | ID (1,0,0) outranks class; toggling is `classList` on `#admin-nav`, never `.style` on the button |
| `.cards` grid / gap, `.card` padding, `.card-value` font-size | admin.css `.cards` / `.card` / `.card-value` | same specificity, admin.css loads before mobile.css; the 480 px `.cards` rule follows the 768 px one in-file |
| `.minw-{280,260,220,200}` min-width | tokens.css atoms | same specificity, tokens.css loads first; no compound selector anywhere |
| `#entities-search` / `-etype-filter` min-width, `#entities-prev` / `-next` padding | `.u-2ad1dbdc`, `.p-8-12`, `.u-698d0f45` | ID outranks class |
| 11 modals padding; `> div` max-width / max-height / padding; `#entity-detail-body`, `#session-turns-body` max-height | `.u-…` cards, `.modal`, `.modal-card`, `.u-2abd191f` | ID selectors outrank class; JS touches only `style.display`, never the contested properties |

No JS writes `padding` / `maxWidth` / `maxHeight` / `minWidth` /
`fontSize` / `gridTemplateColumns` / `gap` through `.style.*` on any of
these; the `cssText` sites are all freshly created toasts / overlays.

## Verification — at mobile widths, not desktop

Desktop-width visual regression cannot see this axis (the 2026-09-09
close §5-2 is the worked example), so the proof is a **computed-style
pair comparison at 375 / 480 / 768 px**: side A links the real
`mobile.css`, side B a copy with every `!important` stripped, both
rendering markup copied verbatim from the served pages and JS templates
in each page's real CSS context.

- **36 targets × 3 viewports = 108 comparisons, every computed
  property, 0 mismatches.**
- **Resolution checked separately** (two broken sides compare equal):
  without `!important`, at 375 / 768 the mobile values demonstrably
  apply — `display:block`, one / two grid columns, `padding 10px`,
  `font-size 18px`, `min-width 0`, `padding 12px / 14px`, `max-height
  92vh → 747 px` — and at 1280 the desktop values return (`none`, six
  columns, `20px`, `26px`, `280px`, `40px`, `720px`).
- The committed CSS **diffs from the proven stripped copy in comment
  lines only** (checked with `diff`).
- **The new zero-declaration guard was proven able to fail**: one
  injected `!important;` in a temp copy → 1 failure. Comment mentions
  are not counted (the header mentions the token), so the test counts
  declarations via `!important\s*[;}]`.

`tests/` **5,315 passed / 0 failed**, `ruff` clean, `mobile.css` cache
buster `v26` → `v27`.

## Out of scope

- The `unpkg.com` vendoring / `JAMES_CSP_MODE=enforce` flip (operator).
- Live visual regression — no server on `:8000`; per CLAUDE.md a
  session does not start one unasked. The mobile-width pair comparison
  is the stronger check for this change anyway.

Quality delta: exempt (label: chore) — CSS + test only; no `core/`
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
