### PR TITLE
docs(v0.6.2): record #1116 and the end of the server-free solo queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,10 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
   `ruff` / `bandit` 은 계속 초록.
   → 로드맵 **Phase 3 은 3.1 / 3.2 (operator dogfood) 만** 남았고,
   **Phase 4 (v0.6.1 정식 마감) 는 2026-09-10 에 종료**됐습니다.
-  다음 솔로 = `mobile.css` 잔여 `!important` 20개 → 로드맵 **Phase 5
-  측정 백로그**.
+  `mobile.css` 잔여 `!important` 도 #1116 으로 **20 → 0** (모바일 폭
+  계산 스타일 대조로 증명). **서버·LLM 없이 세션 혼자 할 수 있는 큐는
+  소진** — 다음은 로드맵 **Phase 5 측정 백로그 (operator-attended)**
+  이고, 시작은 operator 지시가 필요합니다.
 - **유지보수 4 PR** (#1077 #1078 08-19 / **#1079** 08-26 / **#1080** 08-28):
   v0.3.3 DOI 계보 정정, ruff F-class 해소, Ali 엔지니어링 4건 ①②③ 발송 +
   **uuid7 production 결함 수리** (`start_trace()` 가 Python 3.14 전용

--- a/docs/handovers/v0.6.1-close-2026-09-10.md
+++ b/docs/handovers/v0.6.1-close-2026-09-10.md
@@ -195,14 +195,23 @@ paired 측정을 앞세웠고 operator 승인이 있었습니다.
 
 ## 7. 남은 솔로 작업 (로드맵 Phase 5 이전)
 
-1. **`mobile.css` 잔여 `!important` 20개** — 인라인이 이기던 이유가
-   사라졌습니다. **모바일 폭에서 계산 스타일 대조 필수** (데스크톱 시각
-   회귀는 이 축을 못 봅니다 — 2026-09-09 마감 §5-2 가 실례)
+1. ~~**`mobile.css` 잔여 `!important` 20개**~~ — **✅ #1116 (2026-09-10)
+   20 → 0.** 모바일 폭(375/480/768) 계산 스타일 대조 36 대상 × 3 뷰포트
+   = 108 비교 불일치 0, 해석 여부 별도 확인 (375/768 에서 모바일 값 적용,
+   1280 에서 데스크톱 값 복귀). 캡 테스트는 "≤ 25" → **선언 0건**, 주입
+   프로브로 실패 가능함을 확인. `mobile.css` 는 이제 헤더의 약속대로
+   **캐스케이드 위치만으로** 이깁니다.
+
+   → **서버 없이 세션 혼자 할 수 있는 큐는 여기서 소진**됐습니다. 아래
+   둘은 LLM 실행이 필요한 **operator-attended** 항목입니다.
+
 2. **로드맵 Phase 5 측정 백로그** — Graph-RAG Step 2 cross-model (~14h) ·
    v0.2.3b 3-model matrix · D-alce real-NLI. 실행 규칙 (PYTHONPATH /
-   nohup 금지 / timeout 금지 / 서버 background 금지) 은 로드맵 §Phase 5
+   nohup 금지 / timeout 금지 / 서버 background 금지) 은 로드맵 §Phase 5.
+   **Ollama 와 시간이 필요하므로 operator 가 시작을 지시해야 합니다.**
 3. **QVT 3축** — Graded Answer / Abstention F1 / Token Cost 미측정,
-   디스크 baseline 은 `2a31b20`(5월)뿐이라 재캡처 필요
+   arm 당 ~70분, 디스크 baseline 은 `2a31b20`(5월)뿐이라 재캡처 필요.
+   위와 같은 이유로 operator-attended.
 
 ---
 


### PR DESCRIPTION
## Summary

Record-keeping after #1116, per rule #6 (state lives in the newest
handover; root docs point at it).

- `docs/handovers/v0.6.1-close-2026-09-10.md` §7 — the `mobile.css`
  `!important` item is struck through with its evidence (#1116, 20 → 0,
  108 mobile-width comparisons / 0 mismatches, guard proven to fail).
- The same section now says plainly what a fresh session would
  otherwise have to rediscover: **the work a session can do alone —
  without a server or an LLM — is exhausted.** What remains before
  Phase 6 is the Phase 5 measurement backlog and the QVT 3-axis
  capture, both **operator-attended** (Ollama, hours of wall-clock, and
  the no-`nohup` / no-`timeout` rules).
- `CLAUDE.md`'s next-step line is **rewritten** to match, not appended
  to.

## Verification

- `tests/` 5,315 passed / 0 failed
- `tests/test_v06_claude_md_entry_pointer.py` green

## Out of scope

Starting Phase 5 itself — that needs an operator to say go, because it
needs Ollama and hours on the operator's machine.

Quality delta: exempt (label: docs) — no `core/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
