### PR TITLE
docs(v0.6.2): Phase 5 — D-alce cross-NLI smoke, both legs, verdict applied

### DIFF
--- a/reports/external/alce/asqa-smoke-20260910T064201Z.result.json
+++ b/reports/external/alce/asqa-smoke-20260910T064201Z.result.json
@@ -1,0 +1,235 @@
+{
+  "benchmark": "alce-asqa",
+  "loader": "alce-asqa",
+  "producer": "alce-closed-corpus",
+  "split": "dev",
+  "n_queries": 20,
+  "n_rows": 20,
+  "n_errors": 0,
+  "elapsed_s": 387.151,
+  "started_at": "2026-09-10T06:35:34.670470+00:00",
+  "axes": [
+    {
+      "name": "citation_precision",
+      "score": 0.7938,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.8571,
+        "alce-asqa-7089015503030534342": 0.8333,
+        "alce-asqa-8793099883447006698": 1.0,
+        "alce-asqa--881464876144297194": 0.75,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.6667,
+        "alce-asqa--3322598412088356524": 0.0,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.6,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 1.0,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.8333,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.6,
+        "alce-asqa--6617858863213285972": 0.1667,
+        "alce-asqa--7031499911070053371": 1.0,
+        "alce-asqa--2419910984507145175": 0.8,
+        "alce-asqa-3228155858422343609": 1.0
+      },
+      "notes": "verifier=research-tier:MoritzLaurer/DeBERTa-v3-large-mnli-fever-anli-ling-wanli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    },
+    {
+      "name": "citation_recall",
+      "score": 0.8727,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 1.0,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 1.0,
+        "alce-asqa--881464876144297194": 0.6667,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 1.0,
+        "alce-asqa--3322598412088356524": 0.0,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.6667,
+        "alce-asqa-1562758409663917015": 1.0,
+        "alce-asqa-7813254335895169912": 1.0,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 1.0,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.6667,
+        "alce-asqa--6617858863213285972": 0.25,
+        "alce-asqa--7031499911070053371": 1.0,
+        "alce-asqa--2419910984507145175": 1.0,
+        "alce-asqa-3228155858422343609": 1.0
+      },
+      "notes": "verifier=research-tier:MoritzLaurer/DeBERTa-v3-large-mnli-fever-anli-ling-wanli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    }
+  ],
+  "rows": [
+    {
+      "id": "alce-asqa--7013890438520559398",
+      "answer": "The search results provide varying information regarding the highest goal totals in world football, with different records cited for different contexts [1][2][5].\n\n*   **Pelé's Goals:** FIFA recognizes Pelé's 1,281 goals as the highest total achieved by a professional footballer [1]. However, the Soccer Statistic Foundation (rssf) only acknowledges 767 goals for him, placing him third behind Josef Bican and Romario [1].\n*   **Josef Bican's Record:** The Rec.Sport.Soccer Statistics Foundation (RSSSF) estimates that Josef Bican scored at least 805 goals in all competitive matches, which would make him the most prolific scorer of all time [5].\n*   **Other Records:** Godfrey Chitalu is mentioned in relation to a record of 116 goals in a year, but FIFA stated it would not ratify his or Lionel Messi's records because they do not track domestic competitions [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7089015503030534342",
+      "answer": "The song \"The Sound of Silence,\" which was originally titled \"The Sounds of Silence,\" is by the American music duo Simon & Garfunkel [1][3]. Paul Simon wrote the song over several months spanning 1963 and 1964 [1][3]. The song was first recorded in an acoustic version for the album *Wednesday Morning, 3 A.M.* in March 1964 at Columbia Studios in New York City [1][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-8793099883447006698",
+      "answer": "The first-generation iPhone was officially announced on January 9, 2007, at the Macworld convention [2][4]. Following this announcement, the device was released in the United States on June 29, 2007 [1][2][3][5]. The initial iPhone combined Apple's first widescreen iPod with an internet communicator and the world's first mobile device featuring visual voicemail [3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--881464876144297194",
+      "answer": "The identical twin British actors James and Oliver Phelps are best known for portraying Fred and George Weasley in the *Harry Potter* film series [1][4]. The Phelps twins were cast as Fred and George Weasley after auditioning for the film *Harry Potter and the Philosopher's Stone* when they were 14 years old [3]. James and Oliver Phelps were born on February 25, 1986, in the Sutton Coldfield area of Birmingham, England [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1650309494326541834",
+      "answer": "Virginia has 34 state parks [1][2]. These parks, along with 17 state forests, are managed by the Department of Conservation and Recreation and the Department of Forestry [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-2378678654868379935",
+      "answer": "The search results provide details about performers at different years' Champions League finals, but they do not specify who performed at the 2018 men's Champions League Final. For instance, the 2018 UEFA Champions League Final was held at the NSC Olimpiyskiy Stadium in Kiev, Ukraine, on May 26, 2018, featuring a match between Liverpool and Real Madrid [4]. Other years featured different performers, such as Alicia Keys at the 2016 final [1], and Lipa with Sean Paul at the opening ceremony preceding the final in 2018 for the Women's Champions League [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--3322598412088356524",
+      "answer": "The provided search results do not contain information about who killed the man in *Thelma and Louise* [1][2][3][4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--4633355453516911545",
+      "answer": "Charlie Day portrays the character Charlie Kelly, who appears in the FX series *It's Always Sunny in Philadelphia* [1][2]. Charlie Kelly is a fictional character who is described as an easily excitable man-child [1]. He is also noted as being a co-owner at Paddy's [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7464414779466400769",
+      "answer": "The provided search results offer varying information regarding the total number of times the Lakers have won the Finals. One source notes that the Lakers and Celtics have won the two highest number of championships, with the Lakers having 16 titles and the Celtics having 17 [1][2]. Another source mentions that the Lakers won their 16th NBA title overall in 2010 [4]. Furthermore, one document details the Lakers winning in 2008 and 2010, noting that they won the 2010 NBA Finals in seven games [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1562758409663917015",
+      "answer": "Congress (INC) holds majority support in several Indian states, including Punjab, Chhattisgarh, Rajasthan, and Madhya Pradesh [2]. In addition, the party shares power in Karnataka and Puducherry with its alliance partner, Janata Dal (Secular) and Dravida [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7813254335895169912",
+      "answer": "The provided search results mention different individuals associated with the role of Fruma Sarah in *Fiddler on the Roof*.\n\n*   In 1971, Ruth Madoc played Fruma Sarah in the film adaptation of the musical *Fiddler on the Roof* [1].\n*   Separately, another actress played the role of Fruma Sarah during the 2015-2016 Broadway Revival of *Fiddler on the Roof* [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-732619765350082410",
+      "answer": "Toronto hosted the MLB All-Star Game in 1991 [1]. Specifically, the 62nd Major League Baseball All-Star Game took place on July 9, 1991, at SkyDome, which is the home stadium for the Toronto Blue Jays [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-6962706727076805207",
+      "answer": "Law enforcement agencies utilize a vehicle known as a bait car, which can also be called a decoy car, hot car, or trap car, to apprehend car thieves or those who steal items from vehicles [1][3]. These cars are equipped with audio/video surveillance technology, enabling remote monitoring and control [1][3]. For catching car thieves, the vehicles may include GPS tracking, and a \"kill switch\" might be installed to allow police to remotely lock all doors and disable the engine, thereby preventing escape [1][3].\n\nWhen a bait car is set up to catch thieves stealing items from cars, it might be disabled so it cannot be started and will contain specially prepared \"bait property\" [2]. These bait cars are often parked in areas with high rates of auto theft [2]. In some scenarios, the car is left unlocked with the keys in the ignition [2]. If the car is stolen, officers are immediately alerted and can monitor the vehicle, sending commands to control it, such as honking the horn, locking doors, or disabling the engine [2]. Furthermore, the bait property itself can be set up to be tracked and monitored [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3127369420834732535",
+      "answer": "The original run of *Jersey Shore* on MTV spanned from December 3, 2009, to December 20, 2012 [1][2]. However, the series was renewed for subsequent seasons [3][5]. For instance, MTV confirmed the series for a fourth and final season on April 24, 2014 [4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--8056895208806271453",
+      "answer": "The plane crash storyline appears in multiple seasons of *Grey's Anatomy*. Specifically, the episode \"One Flight Down\" features a plane crash in Seattle and references the tragic plane crash from season 8 [2][3]. Furthermore, the episode \"Flight\" is the final episode of the eighth season and involves six doctors surviving an aviation accident, during which character Lexie Grey dies [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-4131723857510142703",
+      "answer": "The provided search results do not state the current number of branches for the Oriental Bank of Commerce [1][3]. However, one document mentions that after the amalgamation of Global Trust Bank (GTB) on August 14, 2004, the acquisition increased OBC's branch total to 1092 [1]. Additionally, another document notes that Oriental Bank Corporation was a bank in India during the 19th century, having been established in Bombay, India, in 1842 under the name Bank of Western India [4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--6617858863213285972",
+      "answer": "The Rams franchise relocated from Los Angeles to St. Louis in 1995 [2][3]. Specifically, owner Georgia Frontiere announced the move to St. Louis on January 15, 1995 [5]. The team played in St. Louis, Missouri, as the St. Louis Rams from the 1995 through the 2015 seasons [2][3]. The Rams played their initial game in their St. Louis stadium, the Edward Jones Dome, on October 22, 1996 [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7031499911070053371",
+      "answer": "The provided search results do not state a specific date for the arrival of the Voortrekkers in South Africa; however, one source mentions that a 1916 film depicts the Boers' Great Trek occurring in the late 1830s [3]. Furthermore, the film also depicts the Battle of Blood River in 1838 [3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--2419910984507145175",
+      "answer": "Heath Ledger played the character Patrick in the film *10 Things I Hate About You* [3][4]. The film itself is a 1999 American teen romantic comedy-drama directed by Gil Junger [3][4]. In the story, the character Patrick is portrayed as a \"bad boy\" [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3228155858422343609",
+      "answer": "The provided search results describe Windows Live Movie Maker as a video editing software from Microsoft [1][2]. It was part of the Windows Essentials software suite [1][2]. While the results detail its features and updates, they do not explicitly state whether it was entirely free [1][2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    }
+  ],
+  "honest_tier": "research-tier: smoke n=20 with NLI adapter (deberta-v3-anli). STRONGER than string-containment fallback, but NOT ALCE-official-grade (T5-XXL TRUE NLI Mixture, GPU-only, remains deferred). Useful for cross-checking the fallback result and for paper methods cross-verifier robustness claims. Pre-reg: docs/research/cycle-gamma-c3-alce-smoke-preregistration-2026-06-11.md + docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md (verifier provenance).",
+  "verifier_grade": "research-tier-deberta-v3-anli",
+  "fixture_sha": "d72737ce7d46629d3504fc508f29ec0c270e0ddd5cff3fad69625d2c0e4be35b",
+  "n_docs_per_query": 5
+}

--- a/reports/external/alce/asqa-smoke-20260910T064312Z.result.json
+++ b/reports/external/alce/asqa-smoke-20260910T064312Z.result.json
@@ -1,0 +1,235 @@
+{
+  "benchmark": "alce-asqa",
+  "loader": "alce-asqa",
+  "producer": "alce-closed-corpus",
+  "split": "dev",
+  "n_queries": 20,
+  "n_rows": 20,
+  "n_errors": 0,
+  "elapsed_s": 53.11,
+  "started_at": "2026-09-10T06:42:19.532259+00:00",
+  "axes": [
+    {
+      "name": "citation_precision",
+      "score": 0.567,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 0.3333,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 0.6,
+        "alce-asqa--881464876144297194": 0.25,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.1429,
+        "alce-asqa--3322598412088356524": 0.0,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.4,
+        "alce-asqa-1562758409663917015": 0.5,
+        "alce-asqa-7813254335895169912": 0.5,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.5,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.25,
+        "alce-asqa--6617858863213285972": 0.3333,
+        "alce-asqa--7031499911070053371": 0.5,
+        "alce-asqa--2419910984507145175": 0.75,
+        "alce-asqa-3228155858422343609": 0.3636
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    },
+    {
+      "name": "citation_recall",
+      "score": 0.6981,
+      "n_queries": 20,
+      "per_query": {
+        "alce-asqa--7013890438520559398": 1.0,
+        "alce-asqa-7089015503030534342": 1.0,
+        "alce-asqa-8793099883447006698": 1.0,
+        "alce-asqa--881464876144297194": 0.3333,
+        "alce-asqa-1650309494326541834": 1.0,
+        "alce-asqa-2378678654868379935": 0.3333,
+        "alce-asqa--3322598412088356524": 0.0,
+        "alce-asqa--4633355453516911545": 1.0,
+        "alce-asqa--7464414779466400769": 0.3333,
+        "alce-asqa-1562758409663917015": 0.5,
+        "alce-asqa-7813254335895169912": 1.0,
+        "alce-asqa-732619765350082410": 1.0,
+        "alce-asqa-6962706727076805207": 1.0,
+        "alce-asqa-3127369420834732535": 0.5,
+        "alce-asqa--8056895208806271453": 1.0,
+        "alce-asqa-4131723857510142703": 0.3333,
+        "alce-asqa--6617858863213285972": 0.5,
+        "alce-asqa--7031499911070053371": 0.5,
+        "alce-asqa--2419910984507145175": 1.0,
+        "alce-asqa-3228155858422343609": 0.6667
+      },
+      "notes": "verifier=research-tier:roberta-large-mnli; is_alce_grade=False. DEFAULT FALLBACK — NOT ALCE-grade. Pass a real NLI verifier (e.g. T5-XXL TRUE NLI Mixture) for publishable ALCE scores."
+    }
+  ],
+  "rows": [
+    {
+      "id": "alce-asqa--7013890438520559398",
+      "answer": "The search results provide information regarding various records for top goalscorers, but do not definitively name one person with the absolute highest goals in world football.\n\n*   Pelé's 1,281 goals are recognized by FIFA as the highest total for a professional footballer, though the Soccer Statistic Foundation (rssf) only acknowledges 767 goals, placing him third behind Josef Bican (805) and Romario (772) [1].\n*   Josef Bican, a Czech-Austrian professional footballer, is estimated by the Rec.Sport.Soccer Statistics Foundation (RSSSF) to have scored at least 805 goals in all competitive matches, which would make him the most prolific scorer of all time [5].\n*   Godfrey Chitalu's record of 116 goals in a year during 1972 was claimed by the Football Association of Zambia, but FIFA officials stated they would not ratify records for domestic competitions, including Chitalu's [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7089015503030534342",
+      "answer": "The song \"The Sound of Silence\" is by the American music duo Simon & Garfunkel [1][3]. Paul Simon wrote the song over several months spanning 1963 and 1964 [1][3]. The original title of the song was \"The Sounds of Silence\" [1][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-8793099883447006698",
+      "answer": "The first iPhone was officially announced on January 9, 2007, at the Macworld convention [2][4]. Subsequently, the first version of the iPhone became publicly available on June 29, 2007, in select markets [1][3][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--881464876144297194",
+      "answer": "The identical twin British actors James and Oliver Phelps are best known for portraying Fred and George Weasley in the *Harry Potter* film series [1][4]. The Phelps twins were cast as Fred and George Weasley after auditioning for the film *Harry Potter and the Philosopher's Stone* when they were 14 years old [3]. James and Oliver Phelps were born on February 25, 1986, in the Sutton Coldfield area of Birmingham, England [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1650309494326541834",
+      "answer": "Virginia has 34 state parks [1][2]. Additionally, the state maintains 17 state forests, which are managed by the Department of Forestry and the Department of Conservation and Recreation [1][2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-2378678654868379935",
+      "answer": "The search results provide details about different years' Champions League Finals, but one document specifies the 2018 UEFA Champions League Final [4]. This final, which was the match for the 2017–18 UEFA Champions League, took place at the NSC Olimpiyskiy Stadium in Kiev, Ukraine, on May 26, 2018 [4]. However, the provided texts do not specify who performed at the opening ceremony for this particular final [1][2][3][4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--3322598412088356524",
+      "answer": "The provided search results do not contain information specifying who killed the man in *Thelma and Louise* [1][2][3][4][5]. However, one document mentions that a killer arrived at Rhyme's house and killed both Thelma and police Captain Howard Cheney, and this killer was revealed to be Richard Thompson, whose real name is Marcus Andrews [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--4633355453516911545",
+      "answer": "Charlie Day portrays the character Charlie Kelly, who is featured in the FX series *It's Always Sunny in Philadelphia* [1][2]. Charlie Kelly is a fictional character who is depicted as a co-owner of Paddy's [1][2]. The series follows the antics of \"The Gang,\" a group of friends who operate the bar Paddy's Pub in South Philadelphia [3][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7464414779466400769",
+      "answer": "The provided search results offer varying information regarding the total number of times the Lakers have won the Finals. One source notes that the Lakers and Celtics have won the two highest number of championships, with the Lakers having 16 titles and the Celtics having 17 [1][2]. Another source mentions the Lakers winning the 2010 NBA Finals [1][2]. Furthermore, one document states that the Lakers won three consecutive championships from 2000 to 2002, and then won in 2010 [5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-1562758409663917015",
+      "answer": "The Congress party (INC) holds majority support in several states, including Punjab, Chhattisgarh, Rajasthan, and Madhya Pradesh [2]. In Karnataka and Puducherry, the party shares power with its alliance partner, Janata Dal (Secular) and Dravida [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-7813254335895169912",
+      "answer": "The provided search results mention different individuals associated with the role of Fruma Sarah in *Fiddler on the Roof*.\n\n*   In 1971, Ruth Madoc portrayed Fruma Sarah in the film adaptation of the musical *Fiddler on the Roof* [1].\n*   Separately, an actress played the role of Fruma Sarah during the 2015-2016 Broadway Revival of *Fiddler on the Roof* [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-732619765350082410",
+      "answer": "Toronto hosted the MLB All-Star Game in 1991 [1]. Specifically, the 62nd Major League Baseball All-Star Game took place on July 9, 1991, at SkyDome, which is the home stadium for the Toronto Blue Jays [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-6962706727076805207",
+      "answer": "Law enforcement agencies utilize a vehicle known as a bait car, which can also be called a decoy car, hot car, or trap car, to apprehend car thieves or those who steal items from vehicles [1][3]. These vehicles are outfitted with various technologies, including audio/video surveillance and GPS tracking, allowing them to be remotely monitored and controlled [1][3]. For instance, a \"kill switch\" might be installed to enable police to remotely lock all doors and disable the engine, thereby preventing escape [1][3].\n\nWhen set up to catch thieves who steal items from cars, the bait car might be disabled so it cannot be started and will contain specially prepared \"bait property\" [2]. In some instances, the car is left unlocked with the keys in the ignition, and the bait car may be filled with valuable items to attract attention [2]. If the car is stolen, officers are immediately alerted and can use the monitoring capabilities to control the vehicle, such as honking the horn, locking doors, or disabling the engine [2]. Furthermore, the bait car can be part of a sting operation, or \"honey trap,\" to lure criminals into exposing themselves [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3127369420834732535",
+      "answer": "The original run of the *Jersey Shore* television series on MTV spanned from December 3, 2009, to December 20, 2012 [1][2]. However, later information indicates that MTV renewed the series for a fourth and final season on April 24, 2014 [4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--8056895208806271453",
+      "answer": "The plane crash storyline appeared in multiple seasons of *Grey's Anatomy*. Specifically, the eighth season featured an episode titled \"Flight,\" where six doctors survived an aviation accident, and Dr. Lexie Grey died [1][4]. Furthermore, the eleventh season included an episode called \"One Flight Down,\" which featured a plane crash in Seattle and revisited memories of the tragic plane crash from season 8, which resulted in the deaths of Mark Sloan and Lexie Grey [2][3].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-4131723857510142703",
+      "answer": "The provided search results do not state the current number of branches for the Oriental Bank of Commerce [1][3]. However, one document mentions that after the acquisition of Global Trust Bank (GTB) on August 14, 2004, the acquisition increased OBC's branch total to 1092 [1]. Another document notes that at one point, a bank's branches crossed 2000 [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--6617858863213285972",
+      "answer": "The Rams franchise relocated from Los Angeles to St. Louis in 1995 [2][3]. Specifically, owner Georgia Frontiere announced the move to St. Louis on January 15, 1995 [5]. The team played in St. Louis, Missouri, as the St. Louis Rams from the 1995 through the 2015 seasons [2][3]. The Rams' first game in their St. Louis stadium, the Edward Jones Dome, took place on October 22, 1996 [1].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--7031499911070053371",
+      "answer": "The provided search results do not state a specific date for the arrival of the Voortrekkers in South Africa; however, one source mentions a 1916 film that recounts the Boers' Great Trek during the late 1830s [3]. The official establishment of the Voortrekker movement is noted as dating from September 30, 1931 [2].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa--2419910984507145175",
+      "answer": "Heath Ledger played the character Patrick in the film *10 Things I Hate About You* [4]. The film is a 1999 American teen romantic comedy-drama directed by Gil Junger, which is a loose modernization of William Shakespeare's late-16th century comedy, *The Taming of the Shrew* [3][4]. In the story, Cameron attempts to get the \"bad boy\" Patrick to help him in order to date Bianca Stratford [4].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    },
+    {
+      "id": "alce-asqa-3228155858422343609",
+      "answer": "The provided search results describe Windows Movie Maker, which was formerly known as Windows Live Movie Maker [1][2]. This software was part of the Windows Essentials software suite [1][2]. While one result mentions that the software was available through the Windows Live Essentials suite [4][5], the search results do not explicitly state whether Microsoft Live Movie Maker was entirely free [1][2][3][4][5].",
+      "mode": "alce-closed-corpus",
+      "model": "gemma4:e4b",
+      "n_docs": 5,
+      "status": "ok"
+    }
+  ],
+  "honest_tier": "research-tier: smoke n=20 with NLI adapter (roberta-mnli). STRONGER than string-containment fallback, but NOT ALCE-official-grade (T5-XXL TRUE NLI Mixture, GPU-only, remains deferred). Useful for cross-checking the fallback result and for paper methods cross-verifier robustness claims. Pre-reg: docs/research/cycle-gamma-c3-alce-smoke-preregistration-2026-06-11.md + docs/research/v024-hr-nli-axis-preregistration-2026-06-11.md (verifier provenance).",
+  "verifier_grade": "research-tier-roberta-mnli",
+  "fixture_sha": "d72737ce7d46629d3504fc508f29ec0c270e0ddd5cff3fad69625d2c0e4be35b",
+  "n_docs_per_query": 5
+}

--- a/reports/research-runs/alce-d-cross-nli-smoke-20260910.md
+++ b/reports/research-runs/alce-d-cross-nli-smoke-20260910.md
@@ -1,0 +1,105 @@
+# D-alce — research-tier cross-NLI smoke, both legs (2026-09-10)
+
+Pre-registration: `docs/research/cycle-gamma-d-alce-research-tier-nli-preregistration-2026-06-12.md`
+(config unchanged since; no re-prereg needed per its §2 last row).
+Runner: `scripts/research/alce_smoke_run.py --n 20 --model gemma4:e4b
+--verifier {roberta-mnli,deberta-v3-anli}`. Fixture ASQA dev, front-slice
+n=20 (deterministic), top-5 ALCE-published passages, producer
+`ALCEClosedCorpusProducer` on Ollama gemma4:e4b.
+
+The RoBERTa leg had been run on 2026-06-21 / 06-22; the DeBERTa leg had
+never been run, so the prereg's verdict — which is a *pair* comparison —
+was still open. Both legs were run **today, back to back, same
+producer config**, so the pair is same-day.
+
+## 1. Results
+
+| Verifier | citation_precision | citation_recall | verifier_grade | honest tier |
+|---|---|---|---|---|
+| string-containment (fallback, 2026-06-11) | 0.8168 | 0.9067 | fallback-string-containment | ⭐ infra-only |
+| RoBERTa-large-MNLI (2026-06-21) | 0.6239 | 0.7344 | research-tier-roberta-mnli | ⭐ research-tier |
+| RoBERTa-large-MNLI (2026-06-22) | 0.5849 | 0.6825 | research-tier-roberta-mnli | ⭐ research-tier |
+| **RoBERTa-large-MNLI (2026-09-10)** | **0.5670** | **0.6981** | research-tier-roberta-mnli | ⭐ research-tier |
+| **DeBERTa-v3 (mnli-fever-anli-ling-wanli) (2026-09-10)** | **0.7938** | **0.8727** | research-tier-deberta-v3-anli | ⭐ research-tier |
+| T5-XXL TRUE NLI (ALCE-official) | — | — | — | DEFERRED, NOT RUN |
+
+Both same-day result files carry the prereg §3 fields (`verifier_grade`,
+`honest_tier`, `fixture_sha` = `d72737ce…`, n=20, errors 0/20):
+`reports/external/alce/asqa-smoke-20260910T064312Z.result.json` (RoBERTa),
+`…20260910T064201Z.result.json` (DeBERTa).
+
+## 2. Pre-registered verdict
+
+Same-day Δ (DeBERTa − RoBERTa): **precision +0.227, recall +0.175** — both
+above the prereg's 0.10 disagreement threshold.
+
+| Prereg §2 row | Fires? |
+|---|---|
+| RoBERTa = DeBERTa, both LOWER than string-containment | no — DeBERTa is not lower than RoBERTa |
+| **RoBERTa ≠ DeBERTa (Δ > 0.10) → cross-NLI disagreement** | **yes** |
+| RoBERTa = DeBERTa = string-containment (Δ < 0.05) | no |
+| a leg failed to load / 0 evaluations | no — 20/20 both legs |
+
+**Verdict (pre-registered wording): ⭐ research-tier infra validated +
+cross-NLI sensitivity finding.** Consequence, also pre-registered: the
+T5-XXL TRUE NLI cycle is the prerequisite before any research-tier ALCE
+number goes into the paper on its own — "without cross-checkpoint
+agreement, robustness is insufficient". Per §4, research-tier scores are
+only ever cited **as a pair**, never one verifier alone.
+
+## 3. What the disagreement looks like per query
+
+| Axis | DeBERTa higher (>0.05) | lower | tie | \|Δ\| ≥ 0.5 |
+|---|---|---|---|---|
+| citation_precision | 12 / 20 | 2 | 6 | 7 |
+| citation_recall | 8 / 20 | 1 | 11 | 4 |
+
+It is a systematic direction, not noise: DeBERTa returns ENTAILMENT for
+citation ⟹ sentence pairs that RoBERTa calls neutral/contradiction, on a
+third of the queries by half a point or more. The adapter treats both
+verifiers identically (`argmax == ENTAILMENT` → cited-and-supported;
+`eval/external/alce_nli_adapter.py:38`), so this is the checkpoints
+disagreeing, not a mapping difference. Note the ordering: DeBERTa
+(0.79 / 0.87) lands close to the string-containment fallback
+(0.82 / 0.91), RoBERTa far below it — which of the two is "right" is
+exactly what the ALCE-official T5-XXL verifier is for.
+
+Consistent with HR v0.2.4 (`lrb-v024-hr-n100-cross-nli-20260621.md`),
+where DeBERTa was also the more lenient checkpoint and the *ordering*
+across SUTs survived while absolute levels did not.
+
+## 4. Producer drift, bounded
+
+The June RoBERTa legs used answers generated in June; today's legs used
+answers generated today (the producer is an LLM; it is not cached). Same
+verifier, different day: aggregate moved **0.585 → 0.567 / 0.683 → 0.698**
+(≈ 0.02), while per-query |Δ| averaged 0.15 / 0.18. So the producer is
+noisy per query and stable in aggregate, and the 0.23 / 0.18 verifier gap
+is an order of magnitude larger than the day-to-day producer gap. The
+pair comparison stands on its own day regardless.
+
+## 5. What this does and does not license
+
+- Licensed: the sentence in a paper *methods* table that string-containment
+  is a lenient upper bound and that two research-tier NLI checkpoints
+  disagree by ~0.2 on ASQA citation support at n=20 — with both numbers
+  shown, per prereg §4.
+- Not licensed: any ALCE citation score for JAMES as a result claim. Not
+  ALCE-grade (T5-XXL deferred, GPU-only), not publication-N (n=20; F-alce
+  full N=300–1000 is gated behind this verdict per prereg §6 and is now
+  explicitly a T5-XXL-first decision).
+- E-alce (RAB preprint v1.4 "ALCE outer validation" section) is an
+  operator step after arXiv submission; the paired numbers above are what
+  it would cite.
+
+## 6. Wall clock
+
+DeBERTa leg 387 s (34 s producer + ~350 s CPU NLI, ~200 pairs); RoBERTa leg
+53 s. Both checkpoints were already in the HF cache from HR v0.2.4.
+
+## One line
+
+The two research-tier NLI checkpoints disagree by ~0.2 on ASQA citation
+support (RoBERTa 0.57 / 0.70, DeBERTa 0.79 / 0.87, same day, same answers);
+the pre-registered verdict is *infra validated + cross-NLI sensitivity*,
+and it moves T5-XXL from "deferred" to "prerequisite".


### PR DESCRIPTION
## Summary

Roadmap **Phase 5, item 3 (D-alce)**. The pre-registration
(`docs/research/cycle-gamma-d-alce-research-tier-nli-preregistration-2026-06-12.md`)
decides its verdict on a **pair** — RoBERTa-large-MNLI vs DeBERTa-v3-ANLI
on the same 20 ASQA queries. The RoBERTa leg had run in June; **the
DeBERTa leg had never run**, so the verdict was open. Both legs ran
today, back to back, same producer config.

| Verifier (2026-09-10) | citation_precision | citation_recall |
|---|---|---|
| RoBERTa-large-MNLI | 0.567 | 0.698 |
| DeBERTa-v3 (mnli-fever-anli-ling-wanli) | **0.794** | **0.873** |
| Δ | **+0.227** | **+0.175** |

Both above the prereg's 0.10 threshold → the pre-registered row that
fires is **"RoBERTa ≠ DeBERTa → cross-NLI disagreement → ⭐ research-tier
infra validated + cross-NLI sensitivity finding"**. Its pre-registered
consequence: **T5-XXL TRUE NLI moves from "deferred" to prerequisite**
before any research-tier ALCE number stands alone in the paper; research-
tier scores are cited only as a pair (prereg §4).

## Why it is a real disagreement

- **Directional, not noise**: DeBERTa scores higher on 12/20 queries for
  precision (2 lower), by ≥ 0.5 on 7 of them. Both verifiers are mapped
  identically by the adapter (`argmax == ENTAILMENT`), so the checkpoints
  themselves disagree.
- **Producer drift bounded**: same verifier, June vs today, moved the
  aggregate by ~0.02 while per-query |Δ| averaged 0.15 — an order of
  magnitude below the verifier gap. The pair comparison stands on its own
  day.
- Consistent with HR v0.2.4, where DeBERTa was also the lenient
  checkpoint and only the *ordering* survived cross-verifier.

## What this does and does not license

Licensed: a paper-*methods* statement that string-containment is a
lenient upper bound and that two research-tier checkpoints disagree by
~0.2 on ASQA citation support at n=20, with **both** numbers shown.
Not licensed: any ALCE citation score for JAMES as a result claim —
not ALCE-grade, not publication-N. F-alce (full N) is gated behind this
verdict and is now explicitly T5-XXL-first.

## Files

- `reports/research-runs/alce-d-cross-nli-smoke-20260910.md` — write-up
  with the full history table (fallback 06-11 → RoBERTa 06-21 / 06-22 /
  today → DeBERTa today), verdict matrix, per-query breakdown.
- `reports/external/alce/asqa-smoke-20260910T06{4312,4201}Z.result.json`
  — both legs, prereg §3 fields present (`verifier_grade`,
  `honest_tier`, `fixture_sha`, n=20, errors 0/20). `bench.jsonl` stays
  gitignored per convention.

## Verification

Prereg config unchanged (its §2 last row: retry without re-prereg is
allowed only when config is unchanged — it is). Both checkpoints were
already in the HF cache; DeBERTa leg 387 s, RoBERTa leg 53 s. Docs +
result JSONs only; `tests/` unaffected.

## Out of scope

- T5-XXL TRUE NLI (GPU-only, 11B) — a separate cycle, now a prerequisite.
- E-alce paper v1.4 section — operator, after arXiv submission.
- Next in the sequence: v0.2.3b publication-scale 3-model run (launching).

Quality delta: exempt (label: docs) — measurement write-up; no `core/`
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
