### PR TITLE
docs(v0.6.2): Phase 5 — v0.2.3b LLM-grounded S3 publication 3-model results + fixture ceiling self-catch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,16 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
   **Phase 4 (v0.6.1 정식 마감) 는 2026-09-10 에 종료**됐습니다.
   `mobile.css` 잔여 `!important` 도 #1116 으로 **20 → 0** (모바일 폭
   계산 스타일 대조로 증명). **서버·LLM 없이 세션 혼자 할 수 있는 큐는
-  소진** — 다음은 로드맵 **Phase 5 측정 백로그 (operator-attended)**
-  이고, 시작은 operator 지시가 필요합니다.
+  소진**됐고, 로드맵 **Phase 5 측정 백로그 3건은 2026-09-10 → 09-11 에
+  전부 실행**됐습니다 — Graph-RAG Step 2 cross-model (#1118 / #1119) ·
+  D-alce cross-NLI 양 leg (#1120) · **v0.2.3b LLM-grounded S3 publication
+  3-model** (9 셀 × n=1000, 20.4 h; **V<N<J 3/3, J−N +0.127 ~ +0.142**;
+  리포트 `reports/research-runs/lrb-v023b-3model-llm-grounded-publication-20260910.md`).
+  🔴 그 리포트 §4 **자기 catch**: S3 publication fixture 의 project-lead
+  질의 191건이 제목 충돌로 **어떤 SUT 도 R@1 0.288 을 못 넘는** 상한 —
+  발표된 token-mode 0.845 도 같은 fixture 입니다. 생성기 수정은 발표
+  수치를 바꾸므로 operator 결정 (마감 핸드오버 §6 #7). Phase 5 잔여 =
+  claude cloud leg + QVT 3축, 둘 다 operator-attended.
 - **유지보수 4 PR** (#1077 #1078 08-19 / **#1079** 08-26 / **#1080** 08-28):
   v0.3.3 DOI 계보 정정, ruff F-class 해소, Ali 엔지니어링 4건 ①②③ 발송 +
   **uuid7 production 결함 수리** (`start_trace()` 가 Python 3.14 전용
@@ -185,7 +193,7 @@ See `docs/ARCHITECTURE.md` for full design principles and non-goals.
 
 | Purpose | File |
 |---|---|
-| **🟢🟢🟢 NEXT SESSION ENTRY (이것부터 — 2026-09-10 v0.6.1 마감)** | **`docs/handovers/v0.6.1-close-2026-09-10.md`** (로드맵 **Phase 4 종료**. 태그 `v0.6.1` = v0.4.4 이후 태그 없이 떠 있던 **282 PR (#831–#1112)** 전부. §2 = 범위 실측과 이름-범위 불일치, §4 = **불변식 마감 실측** (`core/retrieval` 0 라인 / graph traversal 의도적 break / rule #5 예외 0 / rule #1 위반 0 / CI 5,309 passed), §5 = **이 마감이 하지 않은 것 5가지** (발표 수치 미변경 · DOI 미발행 · enforce 플립 안 함 · `v0.5` 소급 태그 안 함 · v0.6 진입 선언 안 함), §6 = operator 결정 6건, §7 = 남은 솔로 3건.) |
+| **🟢🟢🟢 NEXT SESSION ENTRY (이것부터 — 2026-09-10 v0.6.1 마감)** | **`docs/handovers/v0.6.1-close-2026-09-10.md`** (로드맵 **Phase 4 종료**. 태그 `v0.6.1` = v0.4.4 이후 태그 없이 떠 있던 **282 PR (#831–#1112)** 전부. §2 = 범위 실측과 이름-범위 불일치, §4 = **불변식 마감 실측** (`core/retrieval` 0 라인 / graph traversal 의도적 break / rule #5 예외 0 / rule #1 위반 0 / CI 5,309 passed), §5 = **이 마감이 하지 않은 것 5가지** (발표 수치 미변경 · DOI 미발행 · enforce 플립 안 함 · `v0.5` 소급 태그 안 함 · v0.6 진입 선언 안 함), §6 = operator 결정 7건 (#7 = S3.2 project-lead 제목 충돌 수정, 발표 수치 변경), §7 = 솔로 큐 소진 + **Phase 5 3/3 실행 기록 (2026-09-10 → 09-11)** — 잔여는 claude cloud leg + QVT 3축.) |
 | **🟢🟢 직전 세션 마감 (2026-09-09, PR #1107–#1111)** | `docs/handovers/v0.6.2-session-close-2026-09-09.md` (**Phase 3.3 종료** — JS 인라인 `style=` 26 → 0, CSP `style-src` 졸업, CI `--ignore` 51 → 0 (도는 테스트 4,469 → **5,309**). 🔴 enforce 플립의 남은 블로커 = `graph.html` 의 `unpkg.com` 스크립트 3종. 신규 `scripts/csp_enforce_probe.py`.) |
 | **🟢🟢 그 이전 세션 마감 (2026-09-08, PR #1082–#1105)** | `docs/handovers/v0.6.2-session-close-2026-09-08.md` (**Phase 2 (CI 그린) 종료** — 2026-06-22 이후 처음. rule #5 GRANDFATHERED 0건, CI ignore 57→51, CSP style-src 479 → 26. LRB S2 결정 #1 실행 — V/N/J 0.2500/0.5875/0.7625, **J−N 0.175 불변**, ⚠️ **결정 #2 (preprint 재베이스라인) 미결**. §5 검증 3종 + §6 자기 정정 3건.) |
 | **🟢🟢 Phase 정의 원본 (2026-09-03 재개 로드맵)** | **`docs/handovers/v0.6.2-restart-roadmap-2026-09-03.md`** (재개용 **단일 진실원**. §1 현재 상태 사실 확인 (main HEAD `df55e21` / 유휴 구간 / **CI 실패 5 건 실측 + 건별 판정** / rule #5 해소 + 1건 grandfather / 문서 최신성 편차 표) + §2 **Phase 1–7 재개 로드맵** (1 문서 동기화 ✅ → 2 CI 그린 복구 → 3 유휴 부채 청산 → 4 v0.6.1 정식 마감 → 5 측정 백로그 → 6 Fork A/B 전략 결정 (operator) → 7 v0.6 진입) + §3 #886–#1078 실제 진행 요약 + §5 재개 첫 세션 30 분 체크리스트 + §6 하지 말 것. **Phase 2 전에는 새 기능 PR 금지.**) |

--- a/docs/handovers/v0.6.1-close-2026-09-10.md
+++ b/docs/handovers/v0.6.1-close-2026-09-10.md
@@ -190,6 +190,7 @@ paired 측정을 앞세웠고 operator 승인이 있었습니다.
 | 4 | **`unpkg.com` 3종 vendoring** → enforce 플립 | 외부 의존성 추가 |
 | 5 | **dogfood 4건** (3.1 긴 질의 / 3.2 detailed / #1084 캡 / #1091 한글 파일명 OCR) | 실기기 필요 |
 | 6 | **Fork A/B** | 전략 |
+| 7 | **S3.2 project-lead 제목 충돌 수정** (`build_lrb_scenario_s3.py::make_project` 생성기) — 2026-09-10 v0.2.3b publication 리포트 §4 자기 catch | 발표된 S3 token-mode 0.845 (README / SUMMARY / preprint §4.6) 가 바뀝니다 — 결정 #1 과 같은 성격 |
 
 ---
 
@@ -205,10 +206,28 @@ paired 측정을 앞세웠고 operator 승인이 있었습니다.
    → **서버 없이 세션 혼자 할 수 있는 큐는 여기서 소진**됐습니다. 아래
    둘은 LLM 실행이 필요한 **operator-attended** 항목입니다.
 
-2. **로드맵 Phase 5 측정 백로그** — Graph-RAG Step 2 cross-model (~14h) ·
-   v0.2.3b 3-model matrix · D-alce real-NLI. 실행 규칙 (PYTHONPATH /
-   nohup 금지 / timeout 금지 / 서버 background 금지) 은 로드맵 §Phase 5.
-   **Ollama 와 시간이 필요하므로 operator 가 시작을 지시해야 합니다.**
+2. ~~**로드맵 Phase 5 측정 백로그**~~ — **✅ 3건 전부 실행 (2026-09-10 →
+   09-11)**. 실행 규칙 (PYTHONPATH / nohup 금지 / timeout 금지 / 서버
+   background 금지) 은 로드맵 §Phase 5 그대로 지켰습니다.
+   - Graph-RAG Step 2 cross-model — #1118 (집계기) / #1119 (Table 3.2),
+     5 h 24 min. `reports/research-runs/graph-rag-step2-cross-model-20260910.md`.
+   - D-alce cross-NLI 양 leg — #1120. DeBERTa − RoBERTa Δ > 0.10 →
+     prereg 의 cross-NLI disagreement 행 발동.
+     `reports/research-runs/alce-d-cross-nli-smoke-20260910.md`.
+   - v0.2.3b LLM-grounded **S3 publication** 3-model — 9 셀 × n=1000,
+     20 h 24 min, EXIT=0. **V<N<J 3/3, J−N +0.127 / +0.134 / +0.142
+     (전부 > +0.10), james temporal accuracy 0.994–1.000.** claude cloud
+     leg 는 미실행 (cloud backend 필요 — 6월 smoke 와 같은 제외) 이므로
+     prereg 의 4/4 행은 주장하지 않습니다.
+     `reports/research-runs/lrb-v023b-3model-llm-grounded-publication-20260910.md`.
+     🔴 **그 리포트 §4 자기 catch**: S3 publication fixture 의 project-lead
+     질의 191건 (19.1 %) 이 제목 충돌 (`make_project` 의 period-20 산술 →
+     100 부서에서 제목 50개가 5× 반복, 질의에 부서 없음) 때문에 **어떤
+     SUT 도 R@1 0.288 을 넘을 수 없는** 상한을 안고 있습니다 — 발표된
+     token-mode 0.845 도 같은 fixture 라 같은 상한입니다. 판정에는
+     보수적으로 작용합니다 (N 과 J 를 같은 값으로 누름). 생성기 수정
+     (S3.2) 은 발표 수치를 바꾸므로 §6 #7.
+   → Phase 5 잔여 = claude cloud leg (cloud backend, operator) + 아래 3.
 3. **QVT 3축** — Graded Answer / Abstention F1 / Token Cost 미측정,
    arm 당 ~70분, 디스크 baseline 은 `2a31b20`(5월)뿐이라 재캡처 필요.
    위와 같은 이유로 operator-attended.

--- a/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "james",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 5068.7178,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.982,
+      "R@10": 0.997,
+      "P@5": 0.1964,
+      "P@10": 0.0997,
+      "latency_s_mean": 5.068663,
+      "token_cost_mean": 326.2797,
+      "temporal_accuracy": 0.997,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.849,
+        "P@1": 0.849,
+        "temporal_accuracy_strict_top1": 0.849
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.97,
+        "R@10": 0.97,
+        "P@5": 0.194,
+        "P@10": 0.097,
+        "temporal_accuracy": 0.97,
+        "latency_s_mean": 5.371483,
+        "token_cost_mean": 424.145,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.95,
+        "R@10": 1.0,
+        "P@5": 0.19,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 5.277035,
+        "token_cost_mean": 374.445,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.992857,
+        "R@10": 1.0,
+        "P@5": 0.198571,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.965869,
+        "token_cost_mean": 298.5375,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.96,
+        "R@10": 1.0,
+        "P@5": 0.192,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.94,
+        "R@10": 0.94,
+        "P@5": 0.188,
+        "P@10": 0.094,
+        "temporal_accuracy": 0.94,
+        "R@1": 0.92
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.954545,
+        "R@10": 1.0,
+        "P@5": 0.190909,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.954545
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.893939,
+        "R@10": 1.0,
+        "P@5": 0.178788,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.227273
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T13:01:39.097299+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "naive-supersede",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 4207.003,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.809,
+      "R@10": 0.827,
+      "P@5": 0.1618,
+      "P@10": 0.0827,
+      "latency_s_mean": 4.206951,
+      "token_cost_mean": 316.8413,
+      "temporal_accuracy": 0.827,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.707,
+        "P@1": 0.707,
+        "temporal_accuracy_strict_top1": 0.707
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.21,
+        "R@10": 0.21,
+        "P@5": 0.042,
+        "P@10": 0.021,
+        "temporal_accuracy": 0.21,
+        "latency_s_mean": 4.214773,
+        "token_cost_mean": 371.99,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.465,
+        "R@10": 0.53,
+        "P@5": 0.093,
+        "P@10": 0.053,
+        "temporal_accuracy": 0.53,
+        "latency_s_mean": 4.216838,
+        "token_cost_mean": 353.33,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.992857,
+        "R@10": 1.0,
+        "P@5": 0.198571,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.203009,
+        "token_cost_mean": 298.5375,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.96,
+        "R@10": 1.0,
+        "P@5": 0.192,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.42,
+        "R@10": 0.42,
+        "P@5": 0.084,
+        "P@10": 0.042,
+        "temporal_accuracy": 0.42,
+        "R@1": 0.4
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.530303,
+        "R@10": 0.727273,
+        "P@5": 0.106061,
+        "P@10": 0.072727,
+        "temporal_accuracy": 0.727273,
+        "R@1": 0.530303
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 0.411765,
+        "R@10": 0.411765,
+        "P@5": 0.082353,
+        "P@10": 0.041176,
+        "temporal_accuracy": 0.411765,
+        "R@1": 0.411765
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.454545,
+        "R@10": 0.454545,
+        "P@5": 0.090909,
+        "P@10": 0.045455,
+        "temporal_accuracy": 0.454545,
+        "R@1": 0.257576
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T11:37:10.488758+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma3-12b-llm-grounded-20260910T064642Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "vanilla",
+  "model": "gemma3:12b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 4214.3294,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.945,
+      "R@10": 0.977,
+      "P@5": 0.189,
+      "P@10": 0.0977,
+      "latency_s_mean": 4.214278,
+      "token_cost_mean": 319.1263,
+      "temporal_accuracy": 0.977,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.595,
+        "P@1": 0.595,
+        "temporal_accuracy_strict_top1": 0.595
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.94,
+        "R@10": 0.94,
+        "P@5": 0.188,
+        "P@10": 0.094,
+        "temporal_accuracy": 0.94,
+        "latency_s_mean": 4.205109,
+        "token_cost_mean": 356.1975,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.79,
+        "R@10": 0.915,
+        "P@5": 0.158,
+        "P@10": 0.0915,
+        "temporal_accuracy": 0.915,
+        "latency_s_mean": 4.21752,
+        "token_cost_mean": 352.8075,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.99,
+        "R@10": 1.0,
+        "P@5": 0.198,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 4.214661,
+        "token_cost_mean": 304.2071,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.056
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.456
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.944,
+        "R@10": 1.0,
+        "P@5": 0.1888,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.88,
+        "R@10": 0.88,
+        "P@5": 0.176,
+        "P@10": 0.088,
+        "temporal_accuracy": 0.88,
+        "R@1": 0.42
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.909091,
+        "R@10": 0.924242,
+        "P@5": 0.181818,
+        "P@10": 0.092424,
+        "temporal_accuracy": 0.924242,
+        "R@1": 0.69697
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.588235
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.454545,
+        "R@10": 0.818182,
+        "P@5": 0.090909,
+        "P@10": 0.081818,
+        "temporal_accuracy": 0.818182,
+        "R@1": 0.257576
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T10:27:03.660150+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "james",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 3013.2853,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.991,
+      "R@10": 1.0,
+      "P@5": 0.1982,
+      "P@10": 0.1,
+      "latency_s_mean": 3.013229,
+      "token_cost_mean": 328.5428,
+      "temporal_accuracy": 1.0,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.848,
+        "P@1": 0.848,
+        "temporal_accuracy_strict_top1": 0.848
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.106085,
+        "token_cost_mean": 423.985,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.97,
+        "R@10": 1.0,
+        "P@5": 0.194,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.038445,
+        "token_cost_mean": 366.6075,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.995714,
+        "R@10": 1.0,
+        "P@5": 0.199143,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 2.992759,
+        "token_cost_mean": 304.0325,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.976
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.976,
+        "R@10": 1.0,
+        "P@5": 0.1952,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.909091
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.970588
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.909091,
+        "R@10": 1.0,
+        "P@5": 0.181818,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.272727
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T09:16:49.375241+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "naive-supersede",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 2992.0861,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.826,
+      "R@10": 0.829,
+      "P@5": 0.1652,
+      "P@10": 0.0829,
+      "latency_s_mean": 2.992035,
+      "token_cost_mean": 308.4817,
+      "temporal_accuracy": 0.829,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.714,
+        "P@1": 0.714,
+        "temporal_accuracy_strict_top1": 0.714
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.25,
+        "R@10": 0.25,
+        "P@5": 0.05,
+        "P@10": 0.025,
+        "temporal_accuracy": 0.25,
+        "latency_s_mean": 3.083836,
+        "token_cost_mean": 321.635,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.52,
+        "R@10": 0.52,
+        "P@5": 0.104,
+        "P@10": 0.052,
+        "temporal_accuracy": 0.52,
+        "latency_s_mean": 3.012985,
+        "token_cost_mean": 317.4775,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.995714,
+        "R@10": 1.0,
+        "P@5": 0.199143,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 2.972934,
+        "token_cost_mean": 304.0325,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.976
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.976,
+        "R@10": 1.0,
+        "P@5": 0.1952,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.5,
+        "R@10": 0.5,
+        "P@5": 0.1,
+        "P@10": 0.05,
+        "temporal_accuracy": 0.5,
+        "R@1": 0.5
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.69697,
+        "R@10": 0.69697,
+        "P@5": 0.139394,
+        "P@10": 0.069697,
+        "temporal_accuracy": 0.69697,
+        "R@1": 0.681818
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 0.411765,
+        "R@10": 0.411765,
+        "P@5": 0.082353,
+        "P@10": 0.041176,
+        "temporal_accuracy": 0.411765,
+        "R@1": 0.352941
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.454545,
+        "R@10": 0.454545,
+        "P@5": 0.090909,
+        "P@10": 0.045455,
+        "temporal_accuracy": 0.454545,
+        "R@1": 0.242424
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T08:26:36.136211+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-publication-gemma4-e4b-llm-grounded-20260910T064642Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "vanilla",
+  "model": "gemma4:e4b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 3002.0491,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.882,
+      "R@10": 0.985,
+      "P@5": 0.1764,
+      "P@10": 0.0985,
+      "latency_s_mean": 3.001995,
+      "token_cost_mean": 324.3537,
+      "temporal_accuracy": 0.985,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.502,
+        "P@1": 0.502,
+        "temporal_accuracy_strict_top1": 0.502
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 3.065588,
+        "token_cost_mean": 352.1375,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.805,
+        "R@10": 0.925,
+        "P@5": 0.161,
+        "P@10": 0.0925,
+        "temporal_accuracy": 0.925,
+        "latency_s_mean": 3.016942,
+        "token_cost_mean": 344.4737,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.887143,
+        "R@10": 1.0,
+        "P@5": 0.177429,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 2.98864,
+        "token_cost_mean": 314.6361,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.072
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.368,
+        "R@10": 1.0,
+        "P@5": 0.0736,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.08
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.94
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.52
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.954545,
+        "R@10": 0.954545,
+        "P@5": 0.190909,
+        "P@10": 0.095455,
+        "temporal_accuracy": 0.954545,
+        "R@1": 0.575758
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.455882
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.454545,
+        "R@10": 0.818182,
+        "P@5": 0.090909,
+        "P@10": 0.081818,
+        "temporal_accuracy": 0.818182,
+        "R@1": 0.242424
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T07:36:44.158808+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.james.result.json
+++ b/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.james.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "james",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 16967.4456,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.96,
+      "R@10": 0.994,
+      "P@5": 0.192,
+      "P@10": 0.0994,
+      "latency_s_mean": 16.967382,
+      "token_cost_mean": 334.991,
+      "temporal_accuracy": 0.994,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.784,
+        "P@1": 0.784,
+        "temporal_accuracy_strict_top1": 0.784
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.91,
+        "R@10": 0.95,
+        "P@5": 0.182,
+        "P@10": 0.095,
+        "temporal_accuracy": 0.95,
+        "latency_s_mean": 18.42816,
+        "token_cost_mean": 423.545,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.925,
+        "R@10": 1.0,
+        "P@5": 0.185,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 17.190589,
+        "token_cost_mean": 377.505,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.977143,
+        "R@10": 0.998571,
+        "P@5": 0.195429,
+        "P@10": 0.099857,
+        "temporal_accuracy": 0.998571,
+        "latency_s_mean": 16.694926,
+        "token_cost_mean": 310.1936,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.912
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.872,
+        "R@10": 0.992,
+        "P@5": 0.1744,
+        "P@10": 0.0992,
+        "temporal_accuracy": 0.992,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.82,
+        "R@10": 0.9,
+        "P@5": 0.164,
+        "P@10": 0.09,
+        "temporal_accuracy": 0.9,
+        "R@1": 0.38
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.909091,
+        "R@10": 1.0,
+        "P@5": 0.181818,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.651515
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.970588
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.863636,
+        "R@10": 1.0,
+        "P@5": 0.172727,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.151515
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-11T03:10:36.954627+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.naive-supersede.result.json
+++ b/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.naive-supersede.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "naive-supersede",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 16798.5899,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.801,
+      "R@10": 0.83,
+      "P@5": 0.1602,
+      "P@10": 0.083,
+      "latency_s_mean": 16.798529,
+      "token_cost_mean": 319.868,
+      "temporal_accuracy": 0.83,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.657,
+        "P@1": 0.657,
+        "temporal_accuracy_strict_top1": 0.657
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.17,
+        "R@10": 0.23,
+        "P@5": 0.034,
+        "P@10": 0.023,
+        "temporal_accuracy": 0.23,
+        "latency_s_mean": 17.541184,
+        "token_cost_mean": 354.2375,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.5,
+        "R@10": 0.54,
+        "P@5": 0.1,
+        "P@10": 0.054,
+        "temporal_accuracy": 0.54,
+        "latency_s_mean": 16.646756,
+        "token_cost_mean": 336.5437,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.977143,
+        "R@10": 0.998571,
+        "P@5": 0.195429,
+        "P@10": 0.099857,
+        "temporal_accuracy": 0.998571,
+        "latency_s_mean": 16.735799,
+        "token_cost_mean": 310.1936,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.912
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.872,
+        "R@10": 0.992,
+        "P@5": 0.1744,
+        "P@10": 0.0992,
+        "temporal_accuracy": 0.992,
+        "R@1": 0.256
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 0.0,
+        "R@10": 0.0,
+        "P@5": 0.0,
+        "P@10": 0.0,
+        "temporal_accuracy": 0.0,
+        "R@1": 0.0
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.34,
+        "R@10": 0.46,
+        "P@5": 0.068,
+        "P@10": 0.046,
+        "temporal_accuracy": 0.46,
+        "R@1": 0.04
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.666667,
+        "R@10": 0.757576,
+        "P@5": 0.133333,
+        "P@10": 0.075758,
+        "temporal_accuracy": 0.757576,
+        "R@1": 0.287879
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 0.411765,
+        "R@10": 0.411765,
+        "P@5": 0.082353,
+        "P@10": 0.041176,
+        "temporal_accuracy": 0.411765,
+        "R@1": 0.411765
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.424242,
+        "R@10": 0.454545,
+        "P@5": 0.084848,
+        "P@10": 0.045455,
+        "temporal_accuracy": 0.454545,
+        "R@1": 0.181818
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T22:27:49.797978+00:00"
+}

--- a/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.vanilla.result.json
+++ b/reports/external/lrb/v023b-s3-publication-mixtral-8x7b-llm-grounded-20260910T064642Z.vanilla.result.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "lrb",
+  "version": "v0.2.3b",
+  "scenario": "S3-publication",
+  "scenario_spec": "v0.2.3-draft-publication",
+  "scale_preset": "publication",
+  "sut": "vanilla",
+  "model": "mixtral:8x7b",
+  "mode": "llm-grounded",
+  "n_evaluations": 1000,
+  "elapsed_s": 17172.8793,
+  "fixture_sha": "662fc2b76b8aa484913081ad7b1a5db1819c45efd00dd719f7022635192b1a1c",
+  "honest_tier": "v0.2.3b S3-publication cross-model cell; deterministic axes (RAB H1). NOT publication. Pre-reg: docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md",
+  "axes": {
+    "overall": {
+      "R@5": 0.848,
+      "R@10": 0.982,
+      "P@5": 0.1696,
+      "P@10": 0.0982,
+      "latency_s_mean": 17.172677,
+      "token_cost_mean": 332.6667,
+      "temporal_accuracy": 0.982,
+      "n": 1000,
+      "exploratory": {
+        "R@1": 0.479,
+        "P@1": 0.479,
+        "temporal_accuracy_strict_top1": 0.479
+      }
+    },
+    "per_timestamp": {
+      "qt=52/vt=0": {
+        "R@5": 0.84,
+        "R@10": 0.97,
+        "P@5": 0.168,
+        "P@10": 0.097,
+        "temporal_accuracy": 0.97,
+        "latency_s_mean": 17.547786,
+        "token_cost_mean": 369.62,
+        "n": 100
+      },
+      "qt=52/vt=17": {
+        "R@5": 0.79,
+        "R@10": 0.925,
+        "P@5": 0.158,
+        "P@10": 0.0925,
+        "temporal_accuracy": 0.925,
+        "latency_s_mean": 16.90454,
+        "token_cost_mean": 357.3138,
+        "n": 200
+      },
+      "qt=52/vt=52": {
+        "R@5": 0.865714,
+        "R@10": 1.0,
+        "P@5": 0.173143,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "latency_s_mean": 17.195701,
+        "token_cost_mean": 320.3457,
+        "n": 700
+      }
+    },
+    "per_category": {
+      "current-contract": {
+        "n": 125,
+        "R@5": 0.944,
+        "R@10": 1.0,
+        "P@5": 0.1888,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.136
+      },
+      "current-director": {
+        "n": 125,
+        "R@5": 0.992,
+        "R@10": 1.0,
+        "P@5": 0.1984,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.968
+      },
+      "current-policy": {
+        "n": 125,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.0
+      },
+      "current-project-lead": {
+        "n": 125,
+        "R@5": 0.312,
+        "R@10": 1.0,
+        "P@5": 0.0624,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.064
+      },
+      "historical-early-contract": {
+        "n": 50,
+        "R@5": 0.98,
+        "R@10": 1.0,
+        "P@5": 0.196,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.94
+      },
+      "historical-early-director": {
+        "n": 50,
+        "R@5": 0.7,
+        "R@10": 0.94,
+        "P@5": 0.14,
+        "P@10": 0.094,
+        "temporal_accuracy": 0.94,
+        "R@1": 0.28
+      },
+      "historical-mid-director": {
+        "n": 66,
+        "R@5": 0.863636,
+        "R@10": 0.954545,
+        "P@5": 0.172727,
+        "P@10": 0.095455,
+        "temporal_accuracy": 0.954545,
+        "R@1": 0.348485
+      },
+      "historical-mid-policy": {
+        "n": 68,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 0.558824
+      },
+      "historical-mid-project-lead": {
+        "n": 66,
+        "R@5": 0.5,
+        "R@10": 0.818182,
+        "P@5": 0.1,
+        "P@10": 0.081818,
+        "temporal_accuracy": 0.818182,
+        "R@1": 0.166667
+      },
+      "never-stale-budget": {
+        "n": 200,
+        "R@5": 1.0,
+        "R@10": 1.0,
+        "P@5": 0.2,
+        "P@10": 0.1,
+        "temporal_accuracy": 1.0,
+        "R@1": 1.0
+      }
+    }
+  },
+  "started_at": "2026-09-10T17:47:51.576890+00:00"
+}

--- a/reports/research-runs/lrb-v023b-3model-llm-grounded-publication-20260910.md
+++ b/reports/research-runs/lrb-v023b-3model-llm-grounded-publication-20260910.md
@@ -1,0 +1,211 @@
+# LRB v0.2.3b — 3-model LLM-grounded S3 **publication** results (2026-09-10)
+
+Runner: `scripts/research/lrb_run_v023b_s3_cross_model.py
+--scale publication --modes llm-grounded --models gemma4:e4b,gemma3:12b,mixtral:8x7b`
+(run id `20260910T064642Z`).
+Prereg: `docs/research/lrb-v023b-s3-cross-model-preregistration-2026-06-12.md`
+(config unchanged since; verdict matrix §2 applies as written).
+Predecessor: `lrb-v023b-3model-llm-grounded-smoke-20260621.md` (same runner,
+`--scale smoke`, N=100).
+Roadmap: Phase 5 item 2 of `docs/handovers/v0.6.2-restart-roadmap-2026-09-03.md`
+— the last of the three Phase 5 measurement items (#1118/#1119 Graph-RAG
+Step 2 cross-model, #1120 D-alce cross-NLI).
+
+| | |
+|---|---|
+| Fixture | `eval/external/_fixtures/lrb/scenario_S3_publication.json`, sha `662fc2b7…` — byte-identical to the fixture behind the published token-mode 0.502 / 0.721 / 0.845 (`README.md`, `SUMMARY.md`; reproduced from the committed generator on 2026-09-03, `lrb-s3-collision-check-20260903.md` §2) |
+| Scale | S3 publication: 1000 initial docs / 5620 events / 1000 queries (100 departments) |
+| Cells | 3 SUTs × 3 local rerankers × 1 mode = **9**, n=1000 each, errors 0 |
+| Wall clock | 2026-09-10 15:46 → 2026-09-11 12:10 KST = **20 h 24 min** (gemma4 ≈ 50 min per cell, gemma3:12b 70–85 min, mixtral ≈ 4.7 h) |
+| Run rules | `PYTHONPATH` set, no `nohup`, no `timeout`, no server — Ollama only (roadmap §Phase 5) |
+| Log | `reports/research-runs/_v023b_publication_3model_20260910_1546.log` (gitignored; ends `EXIT=0`) |
+| 4th leg | `claude-haiku-4-5` **not run** — needs `JAMES_ENABLE_CLAUDE_BACKEND` + the cloud CLI; same exclusion as the smoke run |
+
+## 1. Gap table (R@1 = the fact that is correct *for the queried valid_time*, at rank 1)
+
+| reranker | vanilla | naive-supersede | **james** | V<N<J | **J−N** | J−V |
+|---|---|---|---|---|---|---|
+| gemma4:e4b   | 0.502 | 0.714 | **0.848** | ✅ | **+0.134** | +0.346 |
+| gemma3:12b   | 0.595 | 0.707 | **0.849** | ✅ | **+0.142** | +0.254 |
+| mixtral:8x7b | 0.479 | 0.657 | **0.784** | ✅ | **+0.127** | +0.305 |
+| *(ref) token-mode, same fixture (2026-06-12)* | *0.502* | *0.721* | *0.845* | *✅* | *+0.124* | *+0.343* |
+
+Temporal accuracy (gold in the top-10 at the queried valid_time): james
+**0.994–1.000**, naive-supersede **0.827–0.830**, vanilla 0.977–0.985.
+Per time-travel window, V / N / J:
+
+| window | n | gemma4:e4b | gemma3:12b | mixtral:8x7b |
+|---|---|---|---|---|
+| qt=52 / vt=0 (early)    | 100 | 1.000 / **0.250** / 1.000 | 0.940 / **0.210** / 0.970 | 0.970 / **0.230** / 0.950 |
+| qt=52 / vt=17 (mid)     | 200 | 0.925 / **0.520** / 1.000 | 0.915 / **0.530** / 1.000 | 0.925 / **0.540** / 1.000 |
+| qt=52 / vt=52 (current) | 700 | 1.000 / 1.000 / 1.000 | 1.000 / 1.000 / 1.000 | 1.000 / 0.999 / 0.999 |
+
+Cost axes: token_cost 308–335 chars/query and latency are the same across
+the three SUTs *within* a reranker (gemma4 3.0 s, gemma3:12b 4.2–5.1 s,
+mixtral 16.8–17.2 s). The SUT mechanism adds no cost; the reranker is the
+cost.
+
+## 2. Pre-registered verdict (prereg §2)
+
+| Leg | S3 pub R@1 V<N<J | J−N > +0.10 | Verdict |
+|---|---|---|---|
+| 1 gemma4:e4b (4B)          | ✅ | ✅ +0.134 | leg-clear |
+| 2 gemma3:12b (12B)         | ✅ | ✅ +0.142 | leg-clear |
+| 3 mixtral:8x7b (47B)       | ✅ | ✅ +0.127 | leg-clear |
+| 4 claude-haiku-4-5 (cloud) | not run | not run | **not attempted** |
+
+Every leg that was run is clear: **3/3 local legs; the 4th leg was not
+attempted.** The prereg composite row for "3/4" reads "⭐⭐ partial-tier +
+1 model artifact finding", but that row describes a *failing* model — here
+nothing failed, one leg was never measured, so there is no artifact to
+attribute. The honest composite is therefore **⭐⭐⭐ pattern + gap,
+cross-model (3 local rerankers) at publication scale, cloud leg open**.
+The 4/4 "PUBLICATION-TIER" row is *not* claimed. The secondary condition
+(J−N > +0.10 at every leg) is met 3/3.
+
+## 3. Findings
+
+1. **V<N<J holds 3/3 at N=1000 under LLM reranking; J−N = +0.127 …
+   +0.142.** With the smoke run (3/3 at N=100) and the token-mode ladder
+   (4/4 scale points), the ordering now reproduces across scale ×
+   reranker × mode. (The S2 llm-grounded legs in prereg §4 were measured
+   2026-06-11 on the pre-#1089 S2 fixture and have not been re-run; the
+   S3 claim does not rest on them.)
+
+2. **Backbone size still does not widen the gap.** mixtral 47B has the
+   smallest gap (+0.127) and the lowest james R@1 (0.784); the two gemma
+   cells are within 0.001 of each other on james. Same shape as the smoke
+   finding — the lift is the validity-window mechanism, not the model.
+
+3. **The two-axis story is exact at publication scale.** naive-supersede
+   buys its current-fact R@1 by deleting history: temporal accuracy
+   0.21–0.25 at vt=0 and 0.52–0.54 at vt=17. james keeps both axes (highest
+   R@1 *and* temporal accuracy 0.994–1.000). vanilla keeps history but
+   lets stale facts win rank 1 (V R@1 0.48–0.60).
+
+4. **The gap narrowed vs the smoke run (+0.21 / +0.22 / +0.14 → +0.134 /
+   +0.142 / +0.127) and james R@1 fell (0.95 / 0.98 / 0.85 → 0.848 / 0.849
+   / 0.784).** Both movements have a single cause — a fixture property,
+   §4 — not the reranker and not the SUT.
+
+## 4. Self-catch: the S3 publication fixture caps project-lead R@1 at 0.288 for *every* SUT
+
+Per-category R@1 (V / N / J). The smoke report did not tabulate this; the
+rule since S3.1 (`feedback_s31_self_correction_artifact_pattern`) is that
+no magnitude statement is made before it is.
+
+| category | n | gemma4:e4b | gemma3:12b | mixtral:8x7b | token-mode |
+|---|---|---|---|---|---|
+| current-contract            | 125 | 0.07 / 1.00 / 1.00 | 0.06 / 1.00 / 1.00 | 0.14 / 1.00 / 1.00 | 0.00 / 1.00 / 1.00 |
+| current-director            | 125 | 1.00 / 1.00 / 1.00 | 1.00 / 1.00 / 1.00 | 0.97 / 0.91 / 0.91 | 1.00 / 1.00 / 1.00 |
+| current-policy              | 125 | 0.00 / 0.98 / 0.98 | 0.46 / 1.00 / 1.00 | 0.00 / 1.00 / 1.00 | 0.00 / 0.98 / 0.98 |
+| **current-project-lead**    | 125 | 0.08 / **0.256** / **0.256** | 0.26 / **0.256** / **0.256** | 0.06 / **0.256** / **0.256** | 0.06 / **0.256** / **0.256** |
+| historical-early-contract   |  50 | 0.94 / 0.00 / 1.00 | 1.00 / 0.00 / 1.00 | 0.94 / 0.00 / 1.00 | 1.00 / 0.00 / 1.00 |
+| historical-early-director   |  50 | 0.52 / 0.50 / 1.00 | 0.42 / 0.40 / 0.92 | 0.28 / 0.04 / 0.38 | 0.50 / 0.50 / 1.00 |
+| historical-mid-director     |  66 | 0.58 / 0.68 / 0.91 | 0.70 / 0.53 / 0.95 | 0.35 / 0.29 / 0.65 | 0.76 / 0.76 / 1.00 |
+| historical-mid-policy       |  68 | 0.46 / 0.35 / 0.97 | 0.59 / 0.41 / 1.00 | 0.56 / 0.41 / 0.97 | 0.59 / 0.38 / 0.97 |
+| **historical-mid-project-lead** | 66 | 0.24 / 0.24 / **0.27** | 0.26 / 0.26 / **0.23** | 0.17 / 0.18 / **0.15** | 0.06 / 0.24 / **0.14** |
+| never-stale-budget          | 200 | 1.00 / 1.00 / 1.00 | 1.00 / 1.00 / 1.00 | 1.00 / 1.00 / 1.00 | 1.00 / 1.00 / 1.00 |
+
+Two categories — 191 of 1000 queries, 19.1 % — sit at ≈0.26 for **every**
+SUT, every reranker and the token scorer, with an *identical* 0.256
+(32/125) for N and J in all four current-project-lead columns. Identical
+numbers across four unrelated scorers are the signature of an oracle
+ceiling, not of retrieval behaviour, and the fixture confirms it:
+
+- `make_project` (`scripts/research/build_lrb_scenario_s3.py:237`) builds
+  the title from `PROJECT_VERBS[(dept_idx + prj_idx) % 20]` and
+  `PROJECT_NOUNS[(dept_idx*7 + prj_idx*3) % 20]`. Both indices are
+  periodic in `dept_idx` with period 20, so at 100 departments every
+  `(prj_idx, dept_idx mod 20)` title recurs **five times**. (The comment
+  above the function promises "400 unique project titles per dept"; the
+  arithmetic delivers 60 per corpus.) Measured on the fixture: 330
+  project docs, **70 unique titles** — 50 titles shared by 5 base
+  projects, 10 by 6–7 (the 30 new-project ingests reuse the vocabulary).
+- The project-lead query is `Who leads {ptitle}?` / `Who led {ptitle} 35
+  weeks ago?` — no department. So the 125 current-project-lead queries
+  have **18 distinct texts**, each carrying **5 distinct golds** (7 queries
+  per text). Identical input cannot produce gold-specific output, so **no
+  system — deterministic or stochastic — can exceed 0.288** (36/125: per
+  text, the most frequent gold) on that category, or **0.273** (18/66) on
+  historical-mid-project-lead. Every other category has a ceiling of
+  1.000 (all queries that share a text share one gold).
+- The ceiling is a function of department count. Smoke (10 depts): every
+  title unique, james 0.83–1.00 on these categories. Dev (30 depts): 10
+  titles collide 2×. Publication (100 depts): 50 collide 5×. This is why
+  the token-mode ladder's magnitude falls 0.930 → 0.913 → 0.845 while
+  R@10 stays 1.0 — the 2026-06-12 results doc §3 tabulated R@10, which
+  cannot see it — and why its follow-up "S3.2 vocabulary diversification
+  (… project-lead …)" was filed low-priority: the R@10 ceiling was
+  checked, the R@1 ceiling was not.
+
+**What this does and does not change.**
+
+- The pre-registered verdict is unchanged and, if anything, conservative:
+  the ceiling holds N and J to the same value, so it *compresses* J−N
+  (19.1 % of queries on which the james mechanism cannot show) rather
+  than inflating it.
+- The published token-mode figure 0.845 (README / SUMMARY / preprint §4.6)
+  carries the same ceiling — byte-identical fixture. **No published number
+  is edited here.**
+- The correct fix is generator-side (S3.2: make each project title unique
+  per department, or put the department in the query) — not a metric
+  reinterpretation, the same rule as S3.1 (#825) and the S2 repair
+  (#1089). Unlike S3.1, the affected figure is already published and
+  cited, so the fix changes a published number and is an **operator
+  decision** (close handover §6 #7). A guard `len(unique project titles)
+  == n_projects` in `tests/test_lrb_s3_generator.py` would make the next
+  density change fail loudly; it is benchmark-side too and is listed with
+  the decision rather than taken.
+
+Post-hoc and exploratory — **not a verdict input** — overall R@1
+recomputed on the 809 unambiguous queries:
+
+| reranker | V | N | J | J−N |
+|---|---|---|---|---|
+| gemma4:e4b   | 0.588 | 0.823 | 0.986 | +0.163 |
+| gemma3:12b   | 0.675 | 0.813 | 0.991 | +0.178 |
+| mixtral:8x7b | 0.569 | 0.758 | 0.917 | +0.159 |
+| token-mode   | 0.606 | 0.832 | 0.994 | +0.162 |
+
+The two project-lead categories account for 93 % / 95 % / 69 % of the
+james rank-1 misses (gemma4 / gemma3:12b / mixtral). The remaining mixtral
+misses are genuine reranker misses on the historical director windows
+(0.38 / 0.65) — the backbone finding of §3-2.
+
+## 5. Cross-scale × cross-model table (prereg §4 rows, filled)
+
+| Scenario × Mode × Model | V R@1 | N R@1 | J R@1 | V<N<J | Honest tier |
+|---|---|---|---|---|---|
+| S2 token (v0.2.1, repaired #1089) | 0.250 | 0.588 | 0.763 | yes | ⭐⭐⭐; decision #2 on the published 0.713 still open |
+| S3 pub token (v0.2.3) | 0.502 | 0.721 | 0.845 | yes | ⭐⭐⭐ pattern / ⭐⭐ magnitude (§4 ceiling) |
+| S2 llm-gr gemma4 (v0.2.1) | 0.488 | 0.563 | 0.725 | yes | ⭐⭐⭐ as measured 2026-06-11; pre-repair S2 fixture, not re-run |
+| S2 llm-gr gemma3:12b | 0.400 | 0.613 | 0.775 | yes | same |
+| S2 llm-gr mxtral | 0.375 | 0.625 | 0.838 | yes | same |
+| S2 llm-gr claude | 0.613 | 0.775 | 0.975 | yes | same |
+| **S3 pub llm-gr gemma4** | **0.502** | **0.714** | **0.848** | **yes** | ⭐⭐⭐ pattern + gap / ⭐⭐ magnitude (§4 ceiling) |
+| **S3 pub llm-gr gemma3:12b** | **0.595** | **0.707** | **0.849** | **yes** | same |
+| **S3 pub llm-gr mxtral** | **0.479** | **0.657** | **0.784** | **yes** | same |
+| S3 pub llm-gr claude | — | — | — | — | not run (cloud backend) |
+
+## 6. Honest caveats
+
+- Three local rerankers only; the cloud leg is open. The 4/4 row of the
+  prereg matrix is not claimed.
+- Absolute magnitudes are held down by the §4 ceiling on 19.1 % of
+  queries. Compare cells *within* this fixture; do not read 0.848 against
+  the smoke 0.95 or the S2 0.76 as a JAMES change.
+- LLM reranking is stochastic (~10 pp band, PR #819); each cell is one run
+  of 1000 queries. The gaps (+0.127 … +0.142) clear the band on the
+  primary axis; nothing finer is claimed.
+- Per-cell `result.json` committed; per-row `bench.jsonl` and the run log
+  are gitignored, as for every earlier LRB run.
+
+## 7. One-line
+
+At publication scale (N=1000) and under three distinct LLM rerankers, the
+JAMES validity-window mechanism keeps the R@1 ordering V<N<J (3/3) with
+J−N +0.13 … +0.14 and temporal accuracy ≥ 0.994 — and the absolute
+magnitudes are held down not by JAMES but by a fixture ceiling on
+project-lead queries that the published token-mode figure shares
+(generator fix = operator decision).


### PR DESCRIPTION
## Summary
- Records the last Phase 5 measurement item: v0.2.3b LLM-grounded S3 **publication** 3-model matrix (9 cells × n=1000, 20 h 24 min, `EXIT=0`), run 2026-09-10 → 09-11 under the roadmap §Phase 5 rules (no `nohup` / `timeout` / server).
- Result: **V<N<J 3/3**, J−N +0.134 / +0.142 / +0.127 (all > +0.10), james temporal accuracy 0.994–1.000. Pre-registered verdict: 3/3 local legs clear; the claude cloud leg was not attempted, so the 4/4 row is not claimed.
- **Self-catch (report §4)**: the S3 publication fixture caps project-lead R@1 at 0.288 for every SUT — `make_project` title arithmetic is periodic in `dept_idx` with period 20, so at 100 departments 50 titles recur 5×, and the query carries no department. 191/1000 queries; identical 0.256 for N and J under all four scorers (three rerankers + token mode). The published token-mode 0.845 shares the fixture and the ceiling. Verdict unaffected (the ceiling compresses J−N). A generator fix changes a published number → operator decision, added as close handover §6 #7.
- Commits the 9 per-cell `result.json` (`bench.jsonl` + log stay gitignored), the results report `reports/research-runs/lrb-v023b-3model-llm-grounded-publication-20260910.md`, and updates the close handover §6/§7 and the CLAUDE.md status bullet (Phase 5: 3/3 executed; remaining = cloud leg + QVT 3-axis).

## Verification
- `python -m pytest tests/test_v06_claude_md_entry_pointer.py tests/test_cr_docs_presence.py tests/test_lrb*.py` → 162 passed.
- Fixture sha in all 9 result files = sha256 of `eval/external/_fixtures/lrb/scenario_S3_publication.json` on disk (`662fc2b7…`), identical to the phase-b token-mode publication results.
- Ceiling derivation reproduced from the fixture JSON (18 distinct query texts × 5 golds → 36/125 = 0.288; 18/66 = 0.273); per-category and per-window tables recomputed from the result files.
- Markdown table shapes checked on all three edited docs.

## Out of scope
- No generator, fixture, scorer, or published-number change (README / SUMMARY / preprint untouched).
- No S2 llm-grounded re-run on the repaired fixture; no claude cloud leg.
- No preprint §4.7 integration (prereg §6 next phase; operator-gated together with LRB decision #2).
- `core/` untouched.

Quality delta: exempt (label: docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
