### PR TITLE
fix(v0.6.2): LRB reranker — count silent fallbacks to token order per query and per cell

### DIFF
--- a/eval/external/lrb/driver.py
+++ b/eval/external/lrb/driver.py
@@ -62,6 +62,10 @@ class QueryResult:
     retrieved: List[str]
     latency_s: float
     context_chars: int
+    # LLM-grounded mode only: True when the rerank call failed and the
+    # row silently kept token-overlap order (llm_rerank.RerankStats).
+    # Token-mode drivers leave the default.
+    rerank_fallback: bool = False
 
 
 @dataclass

--- a/eval/external/lrb/llm_rerank.py
+++ b/eval/external/lrb/llm_rerank.py
@@ -35,6 +35,31 @@ from typing import List, Sequence, Tuple
 # ──────────────────────────────────────────────────────────────────────
 
 
+class RerankStats:
+    """Process-wide counters for silent reranker fallbacks.
+
+    ``rerank()`` pads a failed LLM call with 0.0 scores, so the stable
+    sort hands back the token-overlap order and the row looks like any
+    other. Without these counters a throttled cloud CLI or a timed-out
+    Ollama call turns an "LLM-grounded" cell into token mode with no
+    trace (the 2026-06-11 claude cell with 0.0 s latencies, and 1 of
+    1000 mixtral vanilla rows on 2026-09-10, are the known cases).
+    Runners reset ``last_fallback`` before each query and copy it into
+    the per-query row; ``calls`` / ``fallbacks`` are per process.
+    """
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.calls = 0
+        self.fallbacks = 0
+        self.last_fallback = False
+
+
+STATS = RerankStats()
+
+
 def rerank(query: str,
            candidates: Sequence[Tuple[str, str, str]],
            *,
@@ -81,6 +106,15 @@ def rerank(query: str,
     # If the LLM produced fewer scores than candidates, pad with 0.0
     # (relevance unknown → end of list, but preserve token-overlap
     # rank by stable sort + index tie-break).
+    # Fallback accounting (2026-09-12): an empty score list means the LLM
+    # call failed (timeout / HTTP error / unparseable output) and this
+    # query silently degrades to token-overlap order below. Runners read
+    # STATS per query so a cell can say how many rows were LLM-reranked.
+    STATS.calls += 1
+    STATS.last_fallback = not scores
+    if not scores:
+        STATS.fallbacks += 1
+
     n = len(candidates)
     if len(scores) < n:
         scores = list(scores) + [0.0] * (n - len(scores))

--- a/scripts/research/lrb_run_v021_cross_model.py
+++ b/scripts/research/lrb_run_v021_cross_model.py
@@ -34,6 +34,7 @@ from typing import Any, Callable, Dict, List
 
 from eval.external.lrb.adapters import (
     JamesValidityAdapter, NaiveSupersedeAdapter, VanillaRagAdapter)
+from eval.external.lrb import llm_rerank
 from eval.external.lrb.cross_model import retrieve_at_cross_model
 from eval.external.lrb.driver import (
     fixture_sha, load_scenario, QueryResult, SutRunResult)
@@ -158,6 +159,9 @@ def _run_one_query(result: SutRunResult, adapter, q: dict, k: int,
                    ts_label: str, week: int,
                    gold_override=None) -> None:
     gold = gold_override if gold_override is not None else q["gold"]
+    # Reset before the call so a query whose pool was empty (no rerank
+    # call at all) is not tagged with the previous query's fallback.
+    llm_rerank.STATS.last_fallback = False
     t0 = time.perf_counter()
     retrieved = retrieve_at_cross_model(
         adapter, q["q"], k=k,
@@ -166,6 +170,7 @@ def _run_one_query(result: SutRunResult, adapter, q: dict, k: int,
         ollama_url=ollama_url, timeout=timeout)
     lat = time.perf_counter() - t0
     chars = adapter.retrieved_text_length(retrieved)
+    fallback = mode == "llm-grounded" and llm_rerank.STATS.last_fallback
     result.per_query.append(QueryResult(
         query_id=q["query_id"],
         timestamp=ts_label,
@@ -174,6 +179,7 @@ def _run_one_query(result: SutRunResult, adapter, q: dict, k: int,
         retrieved=retrieved,
         latency_s=lat,
         context_chars=chars,
+        rerank_fallback=fallback,
     ))
 
 
@@ -235,14 +241,16 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
     axes = score_run_phase_b(run, k_recall=k) if has_qt \
         else score_run_phase_a(run, k_recall=k)
     rows = [{
-        "query_id":      qr.query_id,
-        "timestamp":     qr.timestamp,
-        "gold":          qr.gold,
-        "retrieved":     qr.retrieved,
-        "latency_s":     qr.latency_s,
-        "context_chars": qr.context_chars,
+        "query_id":        qr.query_id,
+        "timestamp":       qr.timestamp,
+        "gold":            qr.gold,
+        "retrieved":       qr.retrieved,
+        "latency_s":       qr.latency_s,
+        "context_chars":   qr.context_chars,
+        "rerank_fallback": qr.rerank_fallback,
     } for qr in run.per_query]
     axes["per_category"] = per_category_breakdown(rows, qid_to_cat)
+    n_fallback = sum(1 for qr in run.per_query if qr.rerank_fallback)
 
     result = {
         "benchmark":     "lrb",
@@ -255,6 +263,11 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
         "n_evaluations": len(rows),
         "elapsed_s":     round(run.elapsed_s, 4),
         "fixture_sha":   sha,
+        # Rows whose LLM rerank call failed and silently kept the
+        # token-overlap order (see llm_rerank.RerankStats). 0 in token
+        # mode by construction.
+        "rerank_fallbacks": n_fallback,
+        "rerank_fallback_rate": round(n_fallback / max(1, len(rows)), 4),
         "honest_tier": (
             "v0.2.1 cross-model cell; deterministic scoring (RAB H1). "
             "NOT publication. Pre-reg: docs/research/lrb-v021-"
@@ -277,7 +290,8 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
     ov = result["axes"]["overall"]
     ex = ov["exploratory"]
     print(f"    R@10={ov['R@10']}  temporal_acc={ov['temporal_accuracy']}  "
-          f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s")
+          f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s  "
+          f"rerank_fallbacks={n_fallback}")
     return result
 
 

--- a/scripts/research/lrb_run_v023b_s3_cross_model.py
+++ b/scripts/research/lrb_run_v023b_s3_cross_model.py
@@ -94,14 +94,16 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
     # S3 has query_time always, so Phase B scorer applies.
     axes = v021.score_run_phase_b(run, k_recall=k)
     rows = [{
-        "query_id":      qr.query_id,
-        "timestamp":     qr.timestamp,
-        "gold":          qr.gold,
-        "retrieved":     qr.retrieved,
-        "latency_s":     qr.latency_s,
-        "context_chars": qr.context_chars,
+        "query_id":        qr.query_id,
+        "timestamp":       qr.timestamp,
+        "gold":            qr.gold,
+        "retrieved":       qr.retrieved,
+        "latency_s":       qr.latency_s,
+        "context_chars":   qr.context_chars,
+        "rerank_fallback": qr.rerank_fallback,
     } for qr in run.per_query]
     axes["per_category"] = v021.per_category_breakdown(rows, qid_to_cat)
+    n_fallback = sum(1 for qr in run.per_query if qr.rerank_fallback)
 
     result = {
         "benchmark":     "lrb",
@@ -115,6 +117,10 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
         "n_evaluations": len(rows),
         "elapsed_s":     round(run.elapsed_s, 4),
         "fixture_sha":   sha,
+        # Rows whose LLM rerank call failed and silently kept the
+        # token-overlap order (see llm_rerank.RerankStats).
+        "rerank_fallbacks": n_fallback,
+        "rerank_fallback_rate": round(n_fallback / max(1, len(rows)), 4),
         "honest_tier": (
             f"v0.2.3b S3-{scale} cross-model cell; deterministic axes "
             "(RAB H1). NOT publication. Pre-reg: docs/research/"
@@ -139,7 +145,8 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
     ov = result["axes"]["overall"]
     ex = ov["exploratory"]
     print(f"    R@10={ov['R@10']}  temporal_acc={ov['temporal_accuracy']}  "
-          f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s")
+          f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s  "
+          f"rerank_fallbacks={n_fallback}")
     return result
 
 

--- a/tests/test_lrb_v021_cross_model.py
+++ b/tests/test_lrb_v021_cross_model.py
@@ -225,3 +225,59 @@ def test_token_mode_s2_matches_the_repaired_fixture():
         axes = score_run(r)
         assert abs(axes["overall"]["exploratory"]["R@1"]
                     - expected_r1) < 1e-5
+
+
+# ── Reranker fallback accounting (2026-09-12) ─────────────────────────
+
+
+def test_rerank_counts_a_failed_llm_call_as_fallback(monkeypatch):
+    """An empty score list (timeout / HTTP error / garbage output) pads
+    every candidate with 0.0, so the stable sort returns the
+    token-overlap order. That row must be visible as a fallback."""
+    from eval.external.lrb import llm_rerank
+
+    llm_rerank.STATS.reset()
+    cands = [("d1", "t1", "x"), ("d2", "t2", "y")]
+
+    monkeypatch.setattr(llm_rerank, "_call_ollama", lambda *a, **k: [])
+    out = llm_rerank.rerank("q", cands, model="gemma4:e4b")
+    assert [d for d, _ in out] == ["d1", "d2"]
+    assert llm_rerank.STATS.calls == 1
+    assert llm_rerank.STATS.fallbacks == 1
+    assert llm_rerank.STATS.last_fallback is True
+
+    monkeypatch.setattr(llm_rerank, "_call_ollama",
+                        lambda *a, **k: [1.0, 9.0])
+    out = llm_rerank.rerank("q", cands, model="gemma4:e4b")
+    assert [d for d, _ in out] == ["d2", "d1"]
+    assert llm_rerank.STATS.calls == 2
+    assert llm_rerank.STATS.fallbacks == 1
+    assert llm_rerank.STATS.last_fallback is False
+
+
+def test_run_sut_records_per_query_fallback_and_matches_token_mode(monkeypatch):
+    """With a reranker that always fails, every llm-grounded row is
+    flagged and the retrieved lists equal token mode exactly; token
+    mode itself never flags."""
+    from eval.external.lrb import llm_rerank
+    from scripts.research.lrb_run_v021_cross_model import (
+        run_sut_cross_model)
+
+    sc = load_scenario(FIXTURE_S2)
+    sha = fixture_sha(FIXTURE_S2)
+    monkeypatch.setattr(llm_rerank, "_call_ollama", lambda *a, **k: [])
+
+    grounded = run_sut_cross_model(
+        JamesValidityAdapter, sc, sha, sut_name="t", mode="llm-grounded",
+        model="gemma4:e4b", ollama_url="http://127.0.0.1:9",
+        timeout=1.0, k=10)
+    token = run_sut_cross_model(
+        JamesValidityAdapter, sc, sha, sut_name="t", mode="token",
+        model="token-baseline", ollama_url="http://127.0.0.1:9",
+        timeout=1.0, k=10)
+
+    assert len(grounded.per_query) == len(token.per_query) == 80
+    assert all(q.rerank_fallback for q in grounded.per_query)
+    assert not any(q.rerank_fallback for q in token.per_query)
+    assert ([q.retrieved for q in grounded.per_query]
+            == [q.retrieved for q in token.per_query])


### PR DESCRIPTION
## Summary
- `eval/external/lrb/llm_rerank.py::rerank()` pads a failed LLM call (timeout / HTTP error / unparseable output) with 0.0 scores; the stable sort then returns the token-overlap order and the row is indistinguishable from a reranked one. A throttled cloud CLI or a timed-out Ollama call silently turns an "LLM-grounded" cell into token mode. Found while preparing the S3.2 LLM-grounded re-runs (3 local rerankers ≈ 20 h, claude cloud leg ≈ 12 h at ~14 s per call).
- **Known cases in committed artefacts** (audit by per-row latency ≥ 59.5 s = the 60 s timeout, across every `bench.jsonl` in `reports/external/lrb/`): the 2026-06-11 claude S2 cell `…T154519Z.vanilla` with 0.0 s latencies (all fallbacks; the run was redone at `…T154815Z`), and **1 of 1000 rows** in the 2026-09-10 mixtral vanilla publication cell (62.0 s). No other rows. So the #1121 numbers stand (1 row of 9000), but the mechanism had no accounting.
- **Change (additive, backward compatible)**: `llm_rerank.RerankStats` / `STATS` (`calls`, `fallbacks`, `last_fallback`); `driver.QueryResult.rerank_fallback` (default `False`, token-mode drivers untouched); the v021 and v023b runners reset `last_fallback` before each query, copy it into the per-query row (`bench.jsonl` `rerank_fallback`) and write `rerank_fallbacks` + `rerank_fallback_rate` into `result.json`; the per-cell summary line prints the count.
- Older `result.json` files simply lack the two keys; nothing reads them yet.

## Verification
- `tests/test_lrb_v021_cross_model.py` +2: a failed call is counted and keeps token order (then a good call is not counted); with an always-failing reranker every llm-grounded row on S2 is flagged and the retrieved lists equal token mode exactly, while token mode never flags.
- `pytest tests/test_lrb_v021_cross_model.py tests/test_lrb_smoke.py tests/test_lrb_phase_b.py tests/test_lrb_v024_hr.py tests/test_lrb_s3_generator.py` → 93 passed. `ruff check` clean on the five files.
- Live smoke through the real path: 2 S3 publication queries × JAMES × `claude-haiku-4-5` headless CLI → `fallback=False`, 14.7 s / 13.7 s, top-1 = gold on both, `STATS` calls 2 / fallbacks 0.

## Out of scope
- No scoring change; no published number changes. The S2 LLM-grounded re-run already in progress was started on the previous code and will be reported with the latency-based audit instead of the flag.
- `core/` untouched.

Quality delta: exempt (label: fix) — measurement-side accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
