### PR TITLE
fix(v0.6.2): LRB claude reranker — no CLAUDE.md context, tiny system prompt, UTF-8, no session files

### DIFF
--- a/eval/external/lrb/llm_rerank.py
+++ b/eval/external/lrb/llm_rerank.py
@@ -168,6 +168,14 @@ OLLAMA_MODEL_PREFIXES = ("gemma", "mixtral", "mistral", "llama", "qwen",
                           "phi", "deepseek")
 CLAUDE_MODEL_PREFIXES = ("claude-",)
 
+# Replaces the CLI's default (agentic, multi-thousand-token) system prompt
+# for the headless rerank call. The rerank prompt itself carries the
+# query, the candidates and the output contract.
+CLAUDE_CLI_SYSTEM_PROMPT = (
+    "You are a retrieval relevance scorer. Answer with the JSON object "
+    "the user asks for and nothing else."
+)
+
 
 def _is_ollama_model(model: str) -> bool:
     name = model.split(":")[0].lower()
@@ -231,6 +239,7 @@ def _call_claude_cli(prompt: str, *, model: str,
     pre-flighted via Direction α S4 measurement.
     """
     import os
+    import tempfile
     from pathlib import Path as _Path
 
     # Minimal env whitelist for Windows + claude CLI (Node-wrapped)
@@ -240,10 +249,6 @@ def _call_claude_cli(prompt: str, *, model: str,
                 "HOME", "ANTHROPIC_API_KEY"):
         if var in os.environ:
             base_env[var] = os.environ[var]
-
-    # cwd = project root (Claude Code auto-mode classifier rejects
-    # cwd outside project scope as "scope escalation").
-    project_root = _Path(__file__).resolve().parents[3]
 
     # On Windows, subprocess Popen can't find `claude` (which is a
     # shim) — it needs `claude.cmd` or shell=True. Use the .cmd
@@ -255,21 +260,43 @@ def _call_claude_cli(prompt: str, *, model: str,
         if npm_claude_cmd.exists():
             cmd_executable = str(npm_claude_cmd)
 
+    # 2026-09-12: run from a neutral directory OUTSIDE the repository
+    # with an explicit, tiny system prompt and no session persistence.
+    # With cwd = project root the CLI auto-discovered CLAUDE.md and every
+    # rerank call carried the whole project briefing (~12k tokens) as
+    # context: the S3 cloud leg burned the Max-plan window after ~200
+    # queries and the remaining 763 rows of the cell fell back to token
+    # order; the S2 claude leg the same evening was 237/240 rows token
+    # order; at least once the model answered the briefing instead of
+    # the prompt. (`--bare` would also skip CLAUDE.md, but it skips the
+    # OAuth login too — "Not logged in" on a Max-plan machine.)
+    neutral_cwd = _Path(tempfile.gettempdir()) / "lrb-claude-cwd"
+    neutral_cwd.mkdir(parents=True, exist_ok=True)
+
     try:
         proc = subprocess.run(
-            [cmd_executable, "-p", "--model", model],
+            [cmd_executable, "-p", "--model", model,
+             "--system-prompt", CLAUDE_CLI_SYSTEM_PROMPT,
+             "--no-session-persistence"],
             input=prompt,
             capture_output=True,
             text=True,
+            # 2026-09-12: the CLI writes UTF-8 (a usage-limit notice
+            # carries a curly apostrophe). Without an explicit encoding
+            # Windows decodes with cp949, the reader thread raises, and
+            # stdout comes back None — an AttributeError that escaped
+            # the except clause below and would have killed a 12 h run.
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
-            cwd=str(project_root),
+            cwd=str(neutral_cwd),
             env=base_env,
             shell=False,
         )
-        if proc.returncode != 0:
+        if proc.returncode != 0 or not proc.stdout:
             return []
         return _parse_scores(proc.stdout)
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+    except Exception:  # noqa: BLE001 — any failure is a counted fallback
         return []
 
 

--- a/tests/test_lrb_v021_cross_model.py
+++ b/tests/test_lrb_v021_cross_model.py
@@ -281,3 +281,67 @@ def test_run_sut_records_per_query_fallback_and_matches_token_mode(monkeypatch):
     assert not any(q.rerank_fallback for q in token.per_query)
     assert ([q.retrieved for q in grounded.per_query]
             == [q.retrieved for q in token.per_query])
+
+
+# ── claude CLI call hardening (2026-09-12) ────────────────────────────
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_claude_cli_call_runs_outside_the_repo_with_a_tiny_system_prompt(monkeypatch):
+    """The headless call must not auto-discover CLAUDE.md (cwd outside the
+    repository), must replace the default system prompt, must not persist
+    a session per call, and must decode UTF-8 explicitly. All four were
+    missing when the 2026-09-12 cloud leg burned its quota on project
+    context. `--bare` is deliberately NOT used: it skips the OAuth login."""
+    from eval.external.lrb import llm_rerank
+
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return _FakeProc(0, '{"scores": [3, 1]}')
+
+    monkeypatch.setattr(llm_rerank.subprocess, "run", fake_run)
+    out = llm_rerank._call_claude_cli("p", model="claude-haiku-4-5",
+                                      timeout=5.0)
+    assert out == [3.0, 1.0]
+    argv = seen["argv"]
+    assert "--bare" not in argv
+    assert argv[argv.index("--model") + 1] == "claude-haiku-4-5"
+    assert argv[argv.index("--system-prompt") + 1] == llm_rerank.CLAUDE_CLI_SYSTEM_PROMPT
+    assert "--no-session-persistence" in argv
+    assert seen["kwargs"]["encoding"] == "utf-8"
+    assert seen["kwargs"]["errors"] == "replace"
+    cwd = Path(seen["kwargs"]["cwd"]).resolve()
+    assert ROOT not in cwd.parents and cwd != ROOT
+    assert not (cwd / "CLAUDE.md").exists()
+
+
+def test_claude_cli_call_failures_become_fallbacks(monkeypatch):
+    """None stdout (a decode failure in the reader thread), a non-zero
+    exit, and an unexpected exception all return [] — which rerank()
+    then counts as a fallback — instead of propagating."""
+    from eval.external.lrb import llm_rerank
+
+    cases = [
+        lambda argv, **k: _FakeProc(0, None),
+        lambda argv, **k: _FakeProc(1, "usage limit reached"),
+        lambda argv, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    ]
+    for fake in cases:
+        monkeypatch.setattr(llm_rerank.subprocess, "run", fake)
+        assert llm_rerank._call_claude_cli(
+            "p", model="claude-haiku-4-5", timeout=5.0) == []
+
+    monkeypatch.setattr(llm_rerank.subprocess, "run", cases[0])
+    llm_rerank.STATS.reset()
+    out = llm_rerank.rerank("q", [("d1", "t", "x"), ("d2", "t", "y")],
+                            model="claude-haiku-4-5")
+    assert [d for d, _ in out] == ["d1", "d2"]
+    assert llm_rerank.STATS.fallbacks == 1


### PR DESCRIPTION
## Summary
- **What went wrong today.** `_call_claude_cli` ran with cwd = repository root, so `claude -p` auto-discovered `CLAUDE.md` and every rerank call carried the whole project briefing (~12k tokens). The S3 publication cloud leg (started 18:15 KST) burned the Max-plan window after ~200 queries: **763 / 1000** vanilla rows fell back to token order (5 s per failed call, visible thanks to #1123), the S2 claude leg that ran 19:41 to 20:02 was **237 / 240** rows identical to the token-mode top-10, and one probe answered the briefing instead of the prompt. Both claude runs are discarded; the local (Ollama) S2 cells are clean (20 to 48 of 80 rows identical to token order, which is ordinary agreement).
- **Second defect.** `text=True` without an encoding decodes cp949 on Windows; the usage-limit notice carries a curly apostrophe, the subprocess reader thread raised, `stdout` came back `None`, and the resulting `AttributeError` escaped the `except` clause. It would have killed a 12 h run.
- **Fix.** cwd = a neutral directory outside the repository (`%TEMP%/lrb-claude-cwd`, no `CLAUDE.md`); `--system-prompt` replaces the agentic default with two sentences; `--no-session-persistence`; `encoding="utf-8", errors="replace"`; any exception or empty stdout returns `[]`, which `rerank()` counts as a fallback. `--bare` was tried and rejected: it also skips the OAuth login (`Not logged in`).
- Result files of the contaminated claude cells are not committed.

## Verification
- `tests/test_lrb_v021_cross_model.py` +2 (37 passed with `test_lrb_smoke.py`): argv shape (`--system-prompt`, `--no-session-persistence`, no `--bare`), cwd outside the repo with no `CLAUDE.md`, UTF-8 kwargs; `None` stdout / non-zero exit / exception all become `[]` and are counted by `STATS`.
- `ruff check` clean.
- Live smoke through the real path after the change: 3 S3 publication queries × james × `claude-haiku-4-5`, **0 fallbacks**, 12 to 21 s per call, top-1 = gold on all three; the neutral cwd holds no session files afterwards.
- CLI variants probed directly: `--bare` → `Not logged in` (rc 1); neutral cwd + `--system-prompt` → JSON answer (rc 0).

## Out of scope
- No scoring change. The S2 and S3 claude legs are re-run after this lands (S2 first, ~35 min; S3 ~10 h); their reports follow with the S2 re-baseline PR.
- `core/` untouched.

Quality delta: exempt (label: fix) — measurement-side plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
