### PR TITLE
fix(v0.6.2): LRB claude reranker — wait for an exhausted usage window instead of falling back

### DIFF
--- a/eval/external/lrb/llm_rerank.py
+++ b/eval/external/lrb/llm_rerank.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from typing import List, Sequence, Tuple
@@ -55,6 +56,10 @@ class RerankStats:
         self.calls = 0
         self.fallbacks = 0
         self.last_fallback = False
+        # Cloud CLI only: how often, and for how long in total, this
+        # process slept for an exhausted usage window (2026-09-13).
+        self.quota_waits = 0
+        self.quota_wait_s = 0.0
 
 
 STATS = RerankStats()
@@ -176,6 +181,39 @@ CLAUDE_CLI_SYSTEM_PROMPT = (
     "the user asks for and nothing else."
 )
 
+# Quota-aware retry (2026-09-13). The Max-plan usage window is shared
+# with everything else the operator account does; when it runs out the
+# CLI returns in ~5 s with a notice and, without this, every remaining
+# row of a cell silently becomes token order (second S3 cloud leg,
+# 2026-09-12 night: 876 / 1000, 1000 / 1000 and 281 / 1000 rows). A call
+# whose answer looks like an exhausted window sleeps and retries; the
+# total sleep per process is capped so a persistent failure still ends
+# as counted fallbacks instead of a run that never finishes.
+QUOTA_PATTERNS = (
+    "usage limit", "rate limit", "limit reached", "reached your limit",
+    "resets at", "resets in", "try again later", "overloaded",
+    "too many requests", "429",
+)
+NO_RETRY_PATTERNS = (
+    "not logged in", "please run /login", "invalid api key",
+    "authentication_error", "unauthorized",
+)
+QUOTA_RETRY_SLEEP_S = 600.0
+QUOTA_MAX_WAIT_S = 12 * 3600.0
+_sleep = time.sleep  # monkeypatched in tests
+
+
+def _quota_exhausted(returncode: int, stdout: str, stderr: str) -> bool:
+    """True when the CLI answer looks like an exhausted usage window
+    (worth waiting for), False for a normal answer that merely failed
+    to parse or for a condition waiting will not clear."""
+    text = f"{stdout}\n{stderr}".lower()
+    if any(p in text for p in NO_RETRY_PATTERNS):
+        return False
+    if any(p in text for p in QUOTA_PATTERNS):
+        return True
+    return returncode != 0
+
 
 def _is_ollama_model(model: str) -> bool:
     name = model.split(":")[0].lower()
@@ -273,31 +311,44 @@ def _call_claude_cli(prompt: str, *, model: str,
     neutral_cwd = _Path(tempfile.gettempdir()) / "lrb-claude-cwd"
     neutral_cwd.mkdir(parents=True, exist_ok=True)
 
-    try:
-        proc = subprocess.run(
-            [cmd_executable, "-p", "--model", model,
-             "--system-prompt", CLAUDE_CLI_SYSTEM_PROMPT,
-             "--no-session-persistence"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            # 2026-09-12: the CLI writes UTF-8 (a usage-limit notice
-            # carries a curly apostrophe). Without an explicit encoding
-            # Windows decodes with cp949, the reader thread raises, and
-            # stdout comes back None — an AttributeError that escaped
-            # the except clause below and would have killed a 12 h run.
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout,
-            cwd=str(neutral_cwd),
-            env=base_env,
-            shell=False,
-        )
-        if proc.returncode != 0 or not proc.stdout:
+    argv = [cmd_executable, "-p", "--model", model,
+            "--system-prompt", CLAUDE_CLI_SYSTEM_PROMPT,
+            "--no-session-persistence"]
+    while True:
+        try:
+            proc = subprocess.run(
+                argv,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                # 2026-09-12: the CLI writes UTF-8 (a usage-limit notice
+                # carries a curly apostrophe). Without an explicit
+                # encoding Windows decodes with cp949, the reader thread
+                # raises, and stdout comes back None — an AttributeError
+                # that escaped the except clause and would have killed a
+                # 12 h run.
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+                cwd=str(neutral_cwd),
+                env=base_env,
+                shell=False,
+            )
+        except Exception:  # noqa: BLE001 — any failure is a counted fallback
             return []
-        return _parse_scores(proc.stdout)
-    except Exception:  # noqa: BLE001 — any failure is a counted fallback
-        return []
+        out = proc.stdout or ""
+        err = getattr(proc, "stderr", "") or ""
+        if proc.returncode == 0 and out:
+            scores = _parse_scores(out)
+            if scores:
+                return scores
+        if not _quota_exhausted(proc.returncode, out, err):
+            return []
+        if STATS.quota_wait_s >= QUOTA_MAX_WAIT_S:
+            return []
+        STATS.quota_waits += 1
+        STATS.quota_wait_s += QUOTA_RETRY_SLEEP_S
+        _sleep(QUOTA_RETRY_SLEEP_S)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/scripts/research/lrb_run_v021_cross_model.py
+++ b/scripts/research/lrb_run_v021_cross_model.py
@@ -232,10 +232,12 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
     print(f"  cell: scenario={scenario_label} sut={sut_name} "
           f"model={model} mode={mode}")
     factory = SUT_FACTORIES[sut_name]
+    wait0 = llm_rerank.STATS.quota_wait_s
     run = run_sut_cross_model(factory, scenario, sha, sut_name=sut_name,
                               mode=mode, model=model,
                               ollama_url=ollama_url, timeout=timeout,
                               k=k)
+    quota_wait = round(llm_rerank.STATS.quota_wait_s - wait0, 1)
     has_qt = bool(scenario["queries"]) and \
         "query_time" in scenario["queries"][0]
     axes = score_run_phase_b(run, k_recall=k) if has_qt \
@@ -268,6 +270,10 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
         # mode by construction.
         "rerank_fallbacks": n_fallback,
         "rerank_fallback_rate": round(n_fallback / max(1, len(rows)), 4),
+        # Seconds this cell spent sleeping for an exhausted cloud usage
+        # window (llm_rerank quota-aware retry). Included in elapsed_s
+        # and in the affected rows' latency_s; 0 for local rerankers.
+        "rerank_quota_wait_s": quota_wait,
         "honest_tier": (
             "v0.2.1 cross-model cell; deterministic scoring (RAB H1). "
             "NOT publication. Pre-reg: docs/research/lrb-v021-"
@@ -291,7 +297,7 @@ def run_cell(scenario_label: str, sut_name: str, model: str, mode: str,
     ex = ov["exploratory"]
     print(f"    R@10={ov['R@10']}  temporal_acc={ov['temporal_accuracy']}  "
           f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s  "
-          f"rerank_fallbacks={n_fallback}")
+          f"rerank_fallbacks={n_fallback}  quota_wait={quota_wait}s")
     return result
 
 

--- a/scripts/research/lrb_run_v023b_s3_cross_model.py
+++ b/scripts/research/lrb_run_v023b_s3_cross_model.py
@@ -87,10 +87,12 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
 
     print(f"  cell: scale={scale} sut={sut_name} model={model} mode={mode}")
     factory = v021.SUT_FACTORIES[sut_name]
+    wait0 = v021.llm_rerank.STATS.quota_wait_s
     run = v021.run_sut_cross_model(
         factory, scenario, sha,
         sut_name=sut_name, mode=mode, model=model,
         ollama_url=ollama_url, timeout=timeout, k=k)
+    quota_wait = round(v021.llm_rerank.STATS.quota_wait_s - wait0, 1)
     # S3 has query_time always, so Phase B scorer applies.
     axes = v021.score_run_phase_b(run, k_recall=k)
     rows = [{
@@ -121,6 +123,9 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
         # token-overlap order (see llm_rerank.RerankStats).
         "rerank_fallbacks": n_fallback,
         "rerank_fallback_rate": round(n_fallback / max(1, len(rows)), 4),
+        # Seconds this cell spent sleeping for an exhausted cloud usage
+        # window (llm_rerank quota-aware retry); 0 for local rerankers.
+        "rerank_quota_wait_s": quota_wait,
         "honest_tier": (
             f"v0.2.3b S3-{scale} cross-model cell; deterministic axes "
             "(RAB H1). NOT publication. Pre-reg: docs/research/"
@@ -146,7 +151,7 @@ def run_s3_cell(scale: str, sut_name: str, model: str, mode: str,
     ex = ov["exploratory"]
     print(f"    R@10={ov['R@10']}  temporal_acc={ov['temporal_accuracy']}  "
           f"R@1={ex['R@1']}  elapsed={result['elapsed_s']}s  "
-          f"rerank_fallbacks={n_fallback}")
+          f"rerank_fallbacks={n_fallback}  quota_wait={quota_wait}s")
     return result
 
 

--- a/tests/test_lrb_v021_cross_model.py
+++ b/tests/test_lrb_v021_cross_model.py
@@ -203,11 +203,12 @@ def test_token_mode_s2_matches_the_repaired_fixture():
     the headline gap survive it: V < N < J still holds and J − N is
     0.175 on both fixtures, unchanged to four decimals.
 
-    Until the preprint is re-baselined or footnoted — decision #2 in
-    that report, an operator call — papers/lrb-preprint/README.md,
-    .zenodo.json and the v0.4.4 release notes still carry the old
-    figures. Green here means the repository reproduces itself, not
-    that it reproduces the paper.
+    Decision #2 was taken as re-baseline on 2026-09-12 (PR #1125): the
+    preprint, papers/lrb-preprint/README.md and the pre-LOI materials now
+    carry these figures and the four LLM-grounded legs were re-run on the
+    repaired fixture (reports/research-runs/lrb-v021-s2-llm-grounded-
+    repaired-fixture-20260912.md). .zenodo.json keeps the v0.4.4 deposit
+    text and the v0.4.4 release notes carry an erratum line.
     """
     from scripts.research.lrb_run_v021_cross_model import (
         run_sut_cross_model)
@@ -329,9 +330,10 @@ def test_claude_cli_call_failures_become_fallbacks(monkeypatch):
     then counts as a fallback — instead of propagating."""
     from eval.external.lrb import llm_rerank
 
+    monkeypatch.setattr(llm_rerank, "_sleep", lambda s: None)
     cases = [
         lambda argv, **k: _FakeProc(0, None),
-        lambda argv, **k: _FakeProc(1, "usage limit reached"),
+        lambda argv, **k: _FakeProc(1, "Not logged in · Please run /login"),
         lambda argv, **k: (_ for _ in ()).throw(RuntimeError("boom")),
     ]
     for fake in cases:
@@ -345,3 +347,67 @@ def test_claude_cli_call_failures_become_fallbacks(monkeypatch):
                             model="claude-haiku-4-5")
     assert [d for d, _ in out] == ["d1", "d2"]
     assert llm_rerank.STATS.fallbacks == 1
+
+
+# ── quota-aware retry (2026-09-13) ────────────────────────────────────
+
+
+def test_claude_cli_waits_for_the_usage_window_then_succeeds(monkeypatch):
+    """An exhausted usage window used to turn the rest of a cell into
+    token order (876 / 1000 rows on the second S3 cloud leg). The call
+    now sleeps and retries, and the wait is counted."""
+    from eval.external.lrb import llm_rerank
+
+    llm_rerank.STATS.reset()
+    slept = []
+    monkeypatch.setattr(llm_rerank, "_sleep", lambda s: slept.append(s))
+    answers = [
+        _FakeProc(1, "You have hit your usage limit. Resets at 3pm."),
+        _FakeProc(1, "You have hit your usage limit. Resets at 3pm."),
+        _FakeProc(0, '{"scores": [2, 7]}'),
+    ]
+    monkeypatch.setattr(llm_rerank.subprocess, "run",
+                        lambda argv, **k: answers.pop(0))
+    out = llm_rerank._call_claude_cli("p", model="claude-haiku-4-5",
+                                      timeout=5.0)
+    assert out == [2.0, 7.0]
+    assert slept == [llm_rerank.QUOTA_RETRY_SLEEP_S] * 2
+    assert llm_rerank.STATS.quota_waits == 2
+    assert llm_rerank.STATS.quota_wait_s == 2 * llm_rerank.QUOTA_RETRY_SLEEP_S
+    llm_rerank.STATS.reset()
+
+
+def test_claude_cli_never_waits_on_login_errors_or_past_the_wait_budget(monkeypatch):
+    from eval.external.lrb import llm_rerank
+
+    slept = []
+    monkeypatch.setattr(llm_rerank, "_sleep", lambda s: slept.append(s))
+    llm_rerank.STATS.reset()
+
+    monkeypatch.setattr(llm_rerank.subprocess, "run",
+                        lambda argv, **k: _FakeProc(1, "Not logged in · Please run /login"))
+    assert llm_rerank._call_claude_cli("p", model="claude-haiku-4-5",
+                                       timeout=5.0) == []
+    assert slept == []
+
+    llm_rerank.STATS.quota_wait_s = llm_rerank.QUOTA_MAX_WAIT_S
+    monkeypatch.setattr(llm_rerank.subprocess, "run",
+                        lambda argv, **k: _FakeProc(1, "usage limit reached"))
+    assert llm_rerank._call_claude_cli("p", model="claude-haiku-4-5",
+                                       timeout=5.0) == []
+    assert slept == []
+    llm_rerank.STATS.reset()
+
+
+def test_conversational_answer_without_scores_is_a_plain_fallback(monkeypatch):
+    """rc 0 with prose and no JSON (the model answering the project
+    briefing) is a fallback, not a quota wait."""
+    from eval.external.lrb import llm_rerank
+
+    slept = []
+    monkeypatch.setattr(llm_rerank, "_sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(llm_rerank.subprocess, "run",
+                        lambda argv, **k: _FakeProc(0, "I notice an instruction in the context..."))
+    assert llm_rerank._call_claude_cli("p", model="claude-haiku-4-5",
+                                       timeout=5.0) == []
+    assert slept == []


### PR DESCRIPTION
## Summary
- **Second S3 cloud leg, also contaminated.** After #1124 removed the `CLAUDE.md` context, the clean S2 claude leg ran fine (0 fallbacks), but the S3 publication leg that followed it overnight still hit the Max-plan window: **876 / 1000** vanilla rows, **1000 / 1000** naive rows and **281 / 1000** james rows fell back to token order (the CLI returns in ~5 s while the window is exhausted). #1123 made it visible; nothing prevented it. All three cells are discarded (not committed).
- **Change.** `_call_claude_cli` now sleeps `QUOTA_RETRY_SLEEP_S` (10 min) and retries when the answer looks like an exhausted window (`usage limit`, `rate limit`, `resets at`, `429`, … or a non-zero exit that is not a login error). Login errors and conversational non-JSON answers remain immediate fallbacks. Total sleep per process is capped at `QUOTA_MAX_WAIT_S` (12 h); past it, calls fall back as before so a persistent failure still terminates with honest counts. `STATS` gains `quota_waits` / `quota_wait_s`; both runners write per-cell `rerank_quota_wait_s` into `result.json` (it is included in `elapsed_s` and in the affected rows `latency_s`) and print it in the cell summary.
- Refreshes the stale docstring of the S2 token-mode test (decision #2 was executed in #1125).

## Verification
- `tests/test_lrb_v021_cross_model.py` +3 (45 passed with `test_lrb_smoke.py` and `test_lrb_phase_b.py`): retry-then-success counts two waits and returns the scores; `Not logged in` never waits; past the budget never waits; rc 0 prose without JSON is a plain fallback. The existing failure test now uses a login error for its rc-1 case (a quota message would correctly wait).
- `ruff check` clean on the four files.
- Direct CLI probe right before opening this PR: rc 0, 7.9 s, JSON answer (window available); the S3 claude leg is relaunched after merge with this code.

## Out of scope
- No scoring change. Local (Ollama) legs unaffected (`rerank_quota_wait_s` = 0).
- `core/` untouched.

Quality delta: exempt (label: fix) — measurement-side plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
